### PR TITLE
[TECH] Déplace `UserNotFoundError` vers `src`

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -1,4 +1,5 @@
 import { UnableToAttachChildOrganizationToParentOrganizationError } from '../../src/organizational-entities/domain/errors.js';
+import { UserNotFoundError } from '../../src/shared/domain/errors.js';
 import * as DomainErrors from '../domain/errors.js';
 import * as errorSerializer from '../infrastructure/serializers/jsonapi/error-serializer.js';
 import { HttpErrors } from './http-errors.js';
@@ -192,7 +193,7 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.UserNotAuthorizedToGetCampaignResultsError) {
     return new HttpErrors.ForbiddenError(error.message);
   }
-  if (error instanceof DomainErrors.UserNotFoundError) {
+  if (error instanceof UserNotFoundError) {
     return new HttpErrors.NotFoundError(error.message);
   }
   if (error instanceof DomainErrors.AlreadyRegisteredEmailAndUsernameError) {

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -672,20 +672,6 @@ class OrganizationLearnerNotFound extends NotFoundError {
   }
 }
 
-class UserNotFoundError extends NotFoundError {
-  constructor(message = 'Ce compte est introuvable.', code = 'USER_ACCOUNT_NOT_FOUND') {
-    super(message, code);
-  }
-
-  getErrorMessage() {
-    return {
-      data: {
-        id: ['Ce compte est introuvable.'],
-      },
-    };
-  }
-}
-
 class WrongDateFormatError extends DomainError {
   constructor(message = 'Format de date invalide.') {
     super(message);
@@ -958,7 +944,6 @@ export {
   UserNotAuthorizedToRemoveAuthenticationMethod,
   UserNotAuthorizedToUpdateCampaignError,
   UserNotAuthorizedToUpdateResourceError,
-  UserNotFoundError,
   UserNotMemberOfOrganizationError,
   UserOrgaSettingsCreationError,
   UserShouldNotBeReconciledOnAnotherAccountError,

--- a/api/lib/domain/usecases/authenticate-external-user.js
+++ b/api/lib/domain/usecases/authenticate-external-user.js
@@ -5,11 +5,8 @@ import {
   UserShouldChangePasswordError,
 } from '../../../src/identity-access-management/domain/errors.js';
 import { AuthenticationMethod } from '../../../src/identity-access-management/domain/models/AuthenticationMethod.js';
-import {
-  UnexpectedUserAccountError,
-  UserAlreadyExistsWithAuthenticationMethodError,
-  UserNotFoundError,
-} from '../errors.js';
+import { UserNotFoundError } from '../../../src/shared/domain/errors.js';
+import { UnexpectedUserAccountError, UserAlreadyExistsWithAuthenticationMethodError } from '../errors.js';
 
 async function authenticateExternalUser({
   username,

--- a/api/lib/domain/usecases/update-expired-password.js
+++ b/api/lib/domain/usecases/update-expired-password.js
@@ -3,9 +3,8 @@ import lodash from 'lodash';
 const { get } = lodash;
 
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../src/identity-access-management/domain/constants/identity-providers.js';
-import { ForbiddenAccess } from '../../../src/shared/domain/errors.js';
+import { ForbiddenAccess, UserNotFoundError } from '../../../src/shared/domain/errors.js';
 import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
-import { UserNotFoundError } from '../../domain/errors.js';
 
 const updateExpiredPassword = async function ({
   passwordResetToken,

--- a/api/lib/infrastructure/repositories/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-repository.js
@@ -1,12 +1,12 @@
 import { knex } from '../../../db/knex-database-connection.js';
 import { ORGANIZATION_FEATURE } from '../../../src/shared/domain/constants.js';
+import { UserNotFoundError } from '../../../src/shared/domain/errors.js';
 import { fetchPage } from '../../../src/shared/infrastructure/utils/knex-utils.js';
 import {
   NotFoundError,
   OrganizationLearnerCertificabilityNotUpdatedError,
   OrganizationLearnerNotFound,
   UserCouldNotBeReconciledError,
-  UserNotFoundError,
 } from '../../domain/errors.js';
 import { OrganizationLearner } from '../../domain/models/OrganizationLearner.js';
 import { OrganizationLearnerForAdmin } from '../../domain/read-models/OrganizationLearnerForAdmin.js';

--- a/api/src/certification/session-management/infrastructure/repositories/certification-officer-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/certification-officer-repository.js
@@ -1,5 +1,5 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
-import { UserNotFoundError } from '../../../../../lib/domain/errors.js';
+import { UserNotFoundError } from '../../../../shared/domain/errors.js';
 import { CertificationOfficer } from '../../domain/models/CertificationOfficer.js';
 
 const get = async function ({ userId }) {

--- a/api/src/identity-access-management/application/user/user-existence-verification-pre-handler.js
+++ b/api/src/identity-access-management/application/user/user-existence-verification-pre-handler.js
@@ -1,4 +1,4 @@
-import { UserNotFoundError } from '../../../../lib/domain/errors.js';
+import { UserNotFoundError } from '../../../shared/domain/errors.js';
 import * as errorSerializer from '../../../shared/infrastructure/serializers/jsonapi/validation-error-serializer.js';
 import * as userRepository from '../../infrastructure/repositories/user.repository.js';
 

--- a/api/src/identity-access-management/domain/services/sco-account-recovery.service.js
+++ b/api/src/identity-access-management/domain/services/sco-account-recovery.service.js
@@ -4,9 +4,9 @@ import {
   AccountRecoveryDemandExpired,
   MultipleOrganizationLearnersWithDifferentNationalStudentIdError,
   UserHasAlreadyLeftSCO,
-  UserNotFoundError,
 } from '../../../../lib/domain/errors.js';
 import { config } from '../../../shared/config.js';
+import { UserNotFoundError } from '../../../shared/domain/errors.js';
 
 const { uniqBy } = lodash;
 const { features } = config;

--- a/api/src/identity-access-management/infrastructure/repositories/user.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user.repository.js
@@ -1,9 +1,5 @@
 import { knex } from '../../../../db/knex-database-connection.js';
-import {
-  AlreadyExistingEntityError,
-  AlreadyRegisteredUsernameError,
-  UserNotFoundError,
-} from '../../../../lib/domain/errors.js';
+import { AlreadyExistingEntityError, AlreadyRegisteredUsernameError } from '../../../../lib/domain/errors.js';
 import { CertificationCenter } from '../../../../lib/domain/models/CertificationCenter.js';
 import { CertificationCenterMembership } from '../../../../lib/domain/models/CertificationCenterMembership.js';
 import { Membership } from '../../../../lib/domain/models/Membership.js';
@@ -12,7 +8,7 @@ import { OrganizationLearnerForAdmin } from '../../../../lib/domain/read-models/
 import { BookshelfUser } from '../../../../lib/infrastructure/orm-models/User.js';
 import { Organization } from '../../../organizational-entities/domain/models/Organization.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
-import { AlreadyRegisteredEmailError } from '../../../shared/domain/errors.js';
+import { AlreadyRegisteredEmailError, UserNotFoundError } from '../../../shared/domain/errors.js';
 import { fetchPage, isUniqConstraintViolated } from '../../../shared/infrastructure/utils/knex-utils.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../domain/constants/identity-providers.js';
 import * as OidcIdentityProviders from '../../domain/constants/oidc-identity-providers.js';

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -343,6 +343,20 @@ class CertificationCenterPilotFeaturesConflictError extends DomainError {
   }
 }
 
+class UserNotFoundError extends NotFoundError {
+  constructor(message = 'Ce compte est introuvable.', code = 'USER_ACCOUNT_NOT_FOUND') {
+    super(message, code);
+  }
+
+  getErrorMessage() {
+    return {
+      data: {
+        id: ['Ce compte est introuvable.'],
+      },
+    };
+  }
+}
+
 export {
   AlreadyExistingEntityError,
   AlreadyRegisteredEmailError,
@@ -377,4 +391,5 @@ export {
   UserNotAuthorizedToAccessEntityError,
   UserNotAuthorizedToUpdateEmailError,
   UserNotAuthorizedToUpdatePasswordError,
+  UserNotFoundError,
 };

--- a/api/src/team/infrastructure/repositories/prescriber-repository.js
+++ b/api/src/team/infrastructure/repositories/prescriber-repository.js
@@ -1,11 +1,10 @@
 import { knex } from '../../../../db/knex-database-connection.js';
-import { UserNotFoundError } from '../../../../lib/domain/errors.js';
 import { Membership } from '../../../../lib/domain/models/index.js';
 import { UserOrgaSettings } from '../../../../lib/domain/models/UserOrgaSettings.js';
-import { config } from '../../../../src/shared/config.js';
 import { Organization } from '../../../organizational-entities/domain/models/Organization.js';
 import { Tag } from '../../../organizational-entities/domain/models/Tag.js';
-import { ForbiddenAccess } from '../../../shared/domain/errors.js';
+import { config } from '../../../shared/config.js';
+import { ForbiddenAccess, UserNotFoundError } from '../../../shared/domain/errors.js';
 import { Prescriber } from '../../domain/read-models/Prescriber.js';
 
 /**

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/certification-officer-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/certification-officer-repository_test.js
@@ -1,6 +1,6 @@
-import { UserNotFoundError } from '../../../../../../lib/domain/errors.js';
 import { CertificationOfficer } from '../../../../../../src/certification/session-management/domain/models/CertificationOfficer.js';
 import * as certificationOfficerRepository from '../../../../../../src/certification/session-management/infrastructure/repositories/certification-officer-repository.js';
+import { UserNotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | Repository | CertificationOfficer', function () {

--- a/api/tests/devcomp/integration/application/passages/index_test.js
+++ b/api/tests/devcomp/integration/application/passages/index_test.js
@@ -1,4 +1,3 @@
-import { UserNotFoundError } from '../../../../../lib/domain/errors.js';
 import { passageController } from '../../../../../src/devcomp/application/passages/controller.js';
 import * as moduleUnderTest from '../../../../../src/devcomp/application/passages/index.js';
 import {
@@ -6,6 +5,7 @@ import {
   PassageDoesNotExistError,
   PassageTerminatedError,
 } from '../../../../../src/devcomp/domain/errors.js';
+import { UserNotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Devcomp | Application | Passage | Router | passage-router', function () {

--- a/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
@@ -1,6 +1,6 @@
-import { UserNotFoundError } from '../../../../../lib/domain/errors.js';
 import { ModuleDoesNotExistError } from '../../../../../src/devcomp/domain/errors.js';
 import { createPassage } from '../../../../../src/devcomp/domain/usecases/create-passage.js';
+import { UserNotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, expect, sinon } from '../../../../test-helper.js';
 

--- a/api/tests/identity-access-management/integration/application/account-recovery/account-recovery.controller.test.js
+++ b/api/tests/identity-access-management/integration/application/account-recovery/account-recovery.controller.test.js
@@ -1,6 +1,6 @@
-import { NotFoundError, UserNotFoundError } from '../../../../../lib/domain/errors.js';
 import { identityAccessManagementRoutes } from '../../../../../src/identity-access-management/application/routes.js';
 import { usecases } from '../../../../../src/identity-access-management/domain/usecases/index.js';
+import { NotFoundError, UserNotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
 const routesUnderTest = identityAccessManagementRoutes[0];

--- a/api/tests/identity-access-management/integration/application/oidc-provider.route.test.js
+++ b/api/tests/identity-access-management/integration/application/oidc-provider.route.test.js
@@ -1,10 +1,10 @@
-import { UserNotFoundError } from '../../../../lib/domain/errors.js';
 import { oidcProviderController } from '../../../../src/identity-access-management/application/oidc-provider/oidc-provider.controller.js';
 import { identityAccessManagementRoutes } from '../../../../src/identity-access-management/application/routes.js';
 import {
   AuthenticationKeyExpired,
   DifferentExternalIdentifierError,
 } from '../../../../src/identity-access-management/domain/errors.js';
+import { UserNotFoundError } from '../../../../src/shared/domain/errors.js';
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
 
 const routesUnderTest = identityAccessManagementRoutes[0];

--- a/api/tests/identity-access-management/integration/application/password/password.controller.test.js
+++ b/api/tests/identity-access-management/integration/application/password/password.controller.test.js
@@ -1,8 +1,8 @@
-import { UserNotFoundError } from '../../../../../lib/domain/errors.js';
 import { passwordController } from '../../../../../src/identity-access-management/application/password/password.controller.js';
 import { identityAccessManagementRoutes } from '../../../../../src/identity-access-management/application/routes.js';
 import { PasswordResetDemandNotFoundError } from '../../../../../src/identity-access-management/domain/errors.js';
 import { usecases } from '../../../../../src/identity-access-management/domain/usecases/index.js';
+import { UserNotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { InvalidTemporaryKeyError } from '../../../../../src/shared/domain/errors.js';
 import {
   catchErr,

--- a/api/tests/identity-access-management/integration/domain/usecases/create-reset-password-demand.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/create-reset-password-demand.usecase.test.js
@@ -1,9 +1,9 @@
-import { UserNotFoundError } from '../../../../../lib/domain/errors.js';
 import * as mailService from '../../../../../lib/domain/services/mail-service.js';
 import { resetPasswordService } from '../../../../../src/identity-access-management/domain/services/reset-password.service.js';
 import { createResetPasswordDemand } from '../../../../../src/identity-access-management/domain/usecases/create-reset-password-demand.usecase.js';
 import { resetPasswordDemandRepository } from '../../../../../src/identity-access-management/infrastructure/repositories/reset-password-demand.repository.js';
 import * as userRepository from '../../../../../src/identity-access-management/infrastructure/repositories/user.repository.js';
+import { UserNotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
 
 describe('Integration | Identity Access Management | Domain | UseCase | create-reset-password-demand', function () {

--- a/api/tests/identity-access-management/integration/domain/usecases/get-user-by-reset-password-demand.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/get-user-by-reset-password-demand.usecase.test.js
@@ -1,10 +1,10 @@
-import { UserNotFoundError } from '../../../../../lib/domain/errors.js';
 import { PasswordResetDemandNotFoundError } from '../../../../../src/identity-access-management/domain/errors.js';
 import { User } from '../../../../../src/identity-access-management/domain/models/User.js';
 import { resetPasswordService } from '../../../../../src/identity-access-management/domain/services/reset-password.service.js';
 import { getUserByResetPasswordDemand } from '../../../../../src/identity-access-management/domain/usecases/get-user-by-reset-password-demand.usecase.js';
 import { resetPasswordDemandRepository } from '../../../../../src/identity-access-management/infrastructure/repositories/reset-password-demand.repository.js';
 import * as userRepository from '../../../../../src/identity-access-management/infrastructure/repositories/user.repository.js';
+import { UserNotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { InvalidTemporaryKeyError } from '../../../../../src/shared/domain/errors.js';
 import { tokenService } from '../../../../../src/shared/domain/services/token-service.js';
 import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
@@ -1,11 +1,6 @@
 import lodash from 'lodash';
 const { each, map, times, pick } = lodash;
-import {
-  AlreadyExistingEntityError,
-  AlreadyRegisteredUsernameError,
-  NotFoundError,
-  UserNotFoundError,
-} from '../../../../../lib/domain/errors.js';
+import { AlreadyExistingEntityError, AlreadyRegisteredUsernameError } from '../../../../../lib/domain/errors.js';
 import { CertificationCenter } from '../../../../../lib/domain/models/CertificationCenter.js';
 import { CertificationCenterMembership } from '../../../../../lib/domain/models/CertificationCenterMembership.js';
 import { Membership } from '../../../../../lib/domain/models/Membership.js';
@@ -17,7 +12,7 @@ import * as OidcIdentityProviders from '../../../../../src/identity-access-manag
 import { User } from '../../../../../src/identity-access-management/domain/models/User.js';
 import * as userRepository from '../../../../../src/identity-access-management/infrastructure/repositories/user.repository.js';
 import { Organization } from '../../../../../src/organizational-entities/domain/models/Organization.js';
-import { AlreadyRegisteredEmailError } from '../../../../../src/shared/domain/errors.js';
+import { AlreadyRegisteredEmailError, UserNotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
 
 const expectedUserDetailsForAdminAttributes = [
@@ -608,7 +603,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         const result = await catchErr(userRepository.getByEmail)(emailThatDoesNotExist);
 
         // then
-        expect(result).to.be.instanceOf(NotFoundError);
+        expect(result).to.be.instanceOf(UserNotFoundError);
       });
 
       it('should return the user with email case insensitive', async function () {
@@ -1715,7 +1710,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
 
     it('should throw an error when the user does not exist by email', async function () {
       const err = await catchErr(userRepository.isUserExistingByEmail)('none');
-      expect(err).to.be.instanceOf(NotFoundError);
+      expect(err).to.be.instanceOf(UserNotFoundError);
     });
   });
 

--- a/api/tests/identity-access-management/unit/application/user-existence-verification_test.js
+++ b/api/tests/identity-access-management/unit/application/user-existence-verification_test.js
@@ -1,5 +1,5 @@
-import { UserNotFoundError } from '../../../../lib/domain/errors.js';
 import { userVerification } from '../../../../src/identity-access-management/application/user/user-existence-verification-pre-handler.js';
+import { UserNotFoundError } from '../../../../src/shared/domain/errors.js';
 import { expect, hFake, sinon } from '../../../test-helper.js';
 
 describe('Unit | Pre-handler | User Verification', function () {

--- a/api/tests/identity-access-management/unit/domain/services/pix-authentication-service_test.js
+++ b/api/tests/identity-access-management/unit/domain/services/pix-authentication-service_test.js
@@ -1,8 +1,8 @@
-import { UserNotFoundError } from '../../../../../lib/domain/errors.js';
 import { PasswordNotMatching } from '../../../../../src/identity-access-management/domain/errors.js';
 import { User } from '../../../../../src/identity-access-management/domain/models/User.js';
 import { UserLogin } from '../../../../../src/identity-access-management/domain/models/UserLogin.js';
 import { pixAuthenticationService } from '../../../../../src/identity-access-management/domain/services/pix-authentication-service.js';
+import { UserNotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Domain | Services | pix-authentication-service', function () {

--- a/api/tests/identity-access-management/unit/domain/services/sco-account-recovery.service.test.js
+++ b/api/tests/identity-access-management/unit/domain/services/sco-account-recovery.service.test.js
@@ -4,11 +4,10 @@ import {
   AccountRecoveryDemandExpired,
   MultipleOrganizationLearnersWithDifferentNationalStudentIdError,
   UserHasAlreadyLeftSCO,
-  UserNotFoundError,
 } from '../../../../../lib/domain/errors.js';
 import { scoAccountRecoveryService } from '../../../../../src/identity-access-management/domain/services/sco-account-recovery.service.js';
 import { config } from '../../../../../src/shared/config.js';
-import { AlreadyRegisteredEmailError } from '../../../../../src/shared/domain/errors.js';
+import { AlreadyRegisteredEmailError, UserNotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.js';
 const { features } = config;
 

--- a/api/tests/identity-access-management/unit/domain/usecases/authenticate-user_test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/authenticate-user_test.js
@@ -1,4 +1,3 @@
-import { UserNotFoundError } from '../../../../../lib/domain/errors.js';
 import { PIX_ADMIN, PIX_CERTIF, PIX_ORGA } from '../../../../../src/authorization/domain/constants.js';
 import {
   MissingOrInvalidCredentialsError,
@@ -6,6 +5,7 @@ import {
 } from '../../../../../src/identity-access-management/domain/errors.js';
 import { User } from '../../../../../src/identity-access-management/domain/models/User.js';
 import { authenticateUser } from '../../../../../src/identity-access-management/domain/usecases/authenticate-user.js';
+import { UserNotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { ForbiddenAccess } from '../../../../../src/shared/domain/errors.js';
 import { AdminMember } from '../../../../../src/shared/domain/models/AdminMember.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.js';

--- a/api/tests/identity-access-management/unit/domain/usecases/create-reset-password-demand.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/create-reset-password-demand.usecase.test.js
@@ -1,5 +1,5 @@
-import { UserNotFoundError } from '../../../../../lib/domain/errors.js';
 import { createResetPasswordDemand } from '../../../../../src/identity-access-management/domain/usecases/create-reset-password-demand.usecase.js';
+import { UserNotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Domain | UseCase | create-reset-password-demand', function () {

--- a/api/tests/identity-access-management/unit/domain/usecases/get-user-by-reset-password-demand.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/get-user-by-reset-password-demand.usecase.test.js
@@ -1,7 +1,7 @@
-import { UserNotFoundError } from '../../../../../lib/domain/errors.js';
 import { PasswordResetDemandNotFoundError } from '../../../../../src/identity-access-management/domain/errors.js';
 import { User } from '../../../../../src/identity-access-management/domain/models/User.js';
 import { getUserByResetPasswordDemand } from '../../../../../src/identity-access-management/domain/usecases/get-user-by-reset-password-demand.usecase.js';
+import { UserNotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { InvalidTemporaryKeyError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.js';
 

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -13,6 +13,7 @@ import {
   ForbiddenAccess,
   InvalidResultRecipientTokenError,
   InvalidTemporaryKeyError,
+  UserNotFoundError,
 } from '../../../src/shared/domain/errors.js';
 import { expect, HttpTestServer, sinon } from '../../test-helper.js';
 
@@ -209,7 +210,7 @@ describe('Integration | API | Controller Error', function () {
     });
 
     it('responds Not Found when a UserNotFoundError error occurs', async function () {
-      routeHandler.throws(new DomainErrors.UserNotFoundError('Ce compte est introuvable.'));
+      routeHandler.throws(new UserNotFoundError('Ce compte est introuvable.'));
       const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(NOT_FOUND_ERROR);

--- a/api/tests/integration/application/organization-invitations/organization-invitation-controller_test.js
+++ b/api/tests/integration/application/organization-invitations/organization-invitation-controller_test.js
@@ -1,6 +1,7 @@
 import * as moduleUnderTest from '../../../../lib/application/organization-invitations/index.js';
-import { AlreadyExistingInvitationError, NotFoundError, UserNotFoundError } from '../../../../lib/domain/errors.js';
+import { AlreadyExistingInvitationError, NotFoundError } from '../../../../lib/domain/errors.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
+import { UserNotFoundError } from '../../../../src/shared/domain/errors.js';
 import { serializer as scoOrganizationInvitationSerializer } from '../../../../src/team/infrastructure/serializers/jsonapi/sco-organization-invitation.serializer.js';
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
 

--- a/api/tests/integration/application/passwords/password-controller_test.js
+++ b/api/tests/integration/application/passwords/password-controller_test.js
@@ -1,6 +1,6 @@
 import * as moduleUnderTest from '../../../../lib/application/passwords/index.js';
-import { UserNotFoundError } from '../../../../lib/domain/errors.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
+import { UserNotFoundError } from '../../../../src/shared/domain/errors.js';
 import { ForbiddenAccess } from '../../../../src/shared/domain/errors.js';
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
 

--- a/api/tests/integration/domain/usecases/create-certification-center-membership-by-email_test.js
+++ b/api/tests/integration/domain/usecases/create-certification-center-membership-by-email_test.js
@@ -1,8 +1,9 @@
-import { AlreadyExistingEntityError, UserNotFoundError } from '../../../../lib/domain/errors.js';
+import { AlreadyExistingEntityError } from '../../../../lib/domain/errors.js';
 import { CertificationCenterMembership } from '../../../../lib/domain/models/CertificationCenterMembership.js';
 import { createCertificationCenterMembershipByEmail } from '../../../../lib/domain/usecases/create-certification-center-membership-by-email.js';
 import * as certificationCenterMembershipRepository from '../../../../lib/infrastructure/repositories/certification-center-membership-repository.js';
 import * as userRepository from '../../../../src/identity-access-management/infrastructure/repositories/user.repository.js';
+import { UserNotFoundError } from '../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, expect, knex } from '../../../test-helper.js';
 
 describe('Integration | UseCases | create-certification-center-membership-by-email', function () {

--- a/api/tests/integration/infrastructure/knex-database-connection_test.js
+++ b/api/tests/integration/infrastructure/knex-database-connection_test.js
@@ -1,6 +1,6 @@
 import { emptyAllTables, knex } from '../../../db/knex-database-connection.js';
-import { UserNotFoundError } from '../../../lib/domain/errors.js';
 import * as userRepository from '../../../src/identity-access-management/infrastructure/repositories/user.repository.js';
+import { UserNotFoundError } from '../../../src/shared/domain/errors.js';
 import { databaseBuilder, expect } from '../../test-helper.js';
 
 describe('Integration | Infrastructure | knex-database-connection', function () {

--- a/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -6,13 +6,13 @@ import {
   OrganizationLearnerCertificabilityNotUpdatedError,
   OrganizationLearnerNotFound,
   UserCouldNotBeReconciledError,
-  UserNotFoundError,
 } from '../../../../lib/domain/errors.js';
 import { OrganizationLearner } from '../../../../lib/domain/models/OrganizationLearner.js';
 import { OrganizationLearnerForAdmin } from '../../../../lib/domain/read-models/OrganizationLearnerForAdmin.js';
 import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
 import * as organizationLearnerRepository from '../../../../lib/infrastructure/repositories/organization-learner-repository.js';
 import { ORGANIZATION_FEATURE } from '../../../../src/shared/domain/constants.js';
+import { UserNotFoundError } from '../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, domainBuilder, expect, knex, sinon } from '../../../test-helper.js';
 
 describe('Integration | Infrastructure | Repository | organization-learner-repository', function () {

--- a/api/tests/team/integration/infrastructure/repositories/prescriber-repository_test.js
+++ b/api/tests/team/integration/infrastructure/repositories/prescriber-repository_test.js
@@ -1,12 +1,12 @@
 import bcrypt from 'bcrypt';
 
-import { UserNotFoundError } from '../../../../../lib/domain/errors.js';
 import { Membership } from '../../../../../lib/domain/models/Membership.js';
 import { UserOrgaSettings } from '../../../../../lib/domain/models/UserOrgaSettings.js';
 import { Organization } from '../../../../../src/organizational-entities/domain/models/Organization.js';
 import { Tag } from '../../../../../src/organizational-entities/domain/models/Tag.js';
 import { config as settings } from '../../../../../src/shared/config.js';
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
+import { UserNotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { ForbiddenAccess } from '../../../../../src/shared/domain/errors.js';
 import { Prescriber } from '../../../../../src/team/domain/read-models/Prescriber.js';
 import { prescriberRepository } from '../../../../../src/team/infrastructure/repositories/prescriber-repository.js';

--- a/api/tests/team/unit/domain/usecases/save-admin-member.usecase.test.js
+++ b/api/tests/team/unit/domain/usecases/save-admin-member.usecase.test.js
@@ -1,5 +1,5 @@
-import { UserNotFoundError } from '../../../../../lib/domain/errors.js';
 import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
+import { UserNotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { AdminMember } from '../../../../../src/shared/domain/models/AdminMember.js';
 import { AlreadyExistingAdminMemberError } from '../../../../../src/team/domain/errors.js';
 import { saveAdminMember } from '../../../../../src/team/domain/usecases/save-admin-member.usecase.js';

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -2,6 +2,7 @@ import * as errors from '../../../lib/domain/errors.js';
 import { NotEnoughDaysPassedBeforeResetCampaignParticipationError } from '../../../lib/domain/errors.js';
 import { AdminMemberError } from '../../../src/authorization/domain/errors.js';
 import { UnableToAttachChildOrganizationToParentOrganizationError } from '../../../src/organizational-entities/domain/errors.js';
+import { UserNotFoundError } from '../../../src/shared/domain/errors.js';
 import {
   CsvImportError,
   EntityValidationError,
@@ -75,7 +76,7 @@ describe('Unit | Domain | Errors', function () {
 
   describe('#UserNotFoundError', function () {
     it('should export a UserNotFoundError', function () {
-      expect(errors.UserNotFoundError).to.exist;
+      expect(UserNotFoundError).to.exist;
     });
 
     it('should have a getErrorMessage method', function () {
@@ -87,7 +88,7 @@ describe('Unit | Domain | Errors', function () {
       };
 
       // then
-      const userNotFoundError = new errors.UserNotFoundError();
+      const userNotFoundError = new UserNotFoundError();
       expect(userNotFoundError.getErrorMessage).to.be.a('function');
       expect(userNotFoundError.getErrorMessage()).to.eql(expectedErrorMessage);
     });

--- a/api/tests/unit/domain/usecases/authenticate-external-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-external-user_test.js
@@ -1,7 +1,6 @@
 import {
   UnexpectedUserAccountError,
   UserAlreadyExistsWithAuthenticationMethodError,
-  UserNotFoundError,
 } from '../../../../lib/domain/errors.js';
 import { authenticateExternalUser } from '../../../../lib/domain/usecases/authenticate-external-user.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../src/identity-access-management/domain/constants/identity-providers.js';
@@ -11,6 +10,7 @@ import {
   UserShouldChangePasswordError,
 } from '../../../../src/identity-access-management/domain/errors.js';
 import { AuthenticationMethod } from '../../../../src/identity-access-management/domain/models/AuthenticationMethod.js';
+import { UserNotFoundError } from '../../../../src/shared/domain/errors.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';
 
 describe('Unit | Application | UseCase | authenticate-external-user', function () {

--- a/api/tests/unit/domain/usecases/create-certification-center-membership-by-email_test.js
+++ b/api/tests/unit/domain/usecases/create-certification-center-membership-by-email_test.js
@@ -1,5 +1,6 @@
-import { AlreadyExistingEntityError, UserNotFoundError } from '../../../../lib/domain/errors.js';
+import { AlreadyExistingEntityError } from '../../../../lib/domain/errors.js';
 import { createCertificationCenterMembershipByEmail } from '../../../../lib/domain/usecases/create-certification-center-membership-by-email.js';
+import { UserNotFoundError } from '../../../../src/shared/domain/errors.js';
 import { catchErr, expect, sinon } from '../../../test-helper.js';
 
 describe('Unit | UseCase | create-certification-center-membership-by-email', function () {

--- a/api/tests/unit/domain/usecases/reassign-authentication-method-to-another-user_test.js
+++ b/api/tests/unit/domain/usecases/reassign-authentication-method-to-another-user_test.js
@@ -1,6 +1,7 @@
-import { AuthenticationMethodAlreadyExistsError, UserNotFoundError } from '../../../../lib/domain/errors.js';
+import { AuthenticationMethodAlreadyExistsError } from '../../../../lib/domain/errors.js';
 import { reassignAuthenticationMethodToAnotherUser } from '../../../../lib/domain/usecases/reassign-authentication-method-to-another-user.js';
 import * as OidcIdentityProviders from '../../../../src/identity-access-management/domain/constants/oidc-identity-providers.js';
+import { UserNotFoundError } from '../../../../src/shared/domain/errors.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';
 
 describe('Unit | UseCase | reassign-authentication-method-to-another-user', function () {

--- a/api/tests/unit/domain/usecases/update-expired-password_test.js
+++ b/api/tests/unit/domain/usecases/update-expired-password_test.js
@@ -1,6 +1,6 @@
-import { UserNotFoundError } from '../../../../lib/domain/errors.js';
 import { updateExpiredPassword } from '../../../../lib/domain/usecases/update-expired-password.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../src/identity-access-management/domain/constants/identity-providers.js';
+import { UserNotFoundError } from '../../../../src/shared/domain/errors.js';
 import { ForbiddenAccess } from '../../../../src/shared/domain/errors.js';
 import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';

--- a/api/tests/unit/domain/usecases/update-organization-learner-dependent-user-password_test.js
+++ b/api/tests/unit/domain/usecases/update-organization-learner-dependent-user-password_test.js
@@ -1,5 +1,5 @@
-import { UserNotFoundError } from '../../../../lib/domain/errors.js';
 import { updateOrganizationLearnerDependentUserPassword } from '../../../../lib/domain/usecases/update-organization-learner-dependent-user-password.js';
+import { UserNotFoundError } from '../../../../src/shared/domain/errors.js';
 import { UserNotAuthorizedToUpdatePasswordError } from '../../../../src/shared/domain/errors.js';
 import { catchErr, expect, sinon } from '../../../test-helper.js';
 


### PR DESCRIPTION
## :unicorn: Problème

cf https://github.com/1024pix/pix/blob/dev/docs/adr/0051-nouvelle-arborescence-api.md

## :robot: Proposition

Déplacer `UserNotFoundError` vers `src/shared/domain/error.js`

## :rainbow: Remarques


## :100: Pour tester
 ?
