### PR TITLE
[TECH] Déplace `YamlParsingError` vers les erreurs partagées de `src`

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -1,5 +1,5 @@
 import { UnableToAttachChildOrganizationToParentOrganizationError } from '../../src/organizational-entities/domain/errors.js';
-import { UserNotFoundError } from '../../src/shared/domain/errors.js';
+import { UserNotFoundError, YamlParsingError } from '../../src/shared/domain/errors.js';
 import * as DomainErrors from '../domain/errors.js';
 import * as errorSerializer from '../infrastructure/serializers/jsonapi/error-serializer.js';
 import { HttpErrors } from './http-errors.js';
@@ -256,7 +256,7 @@ function _mapToHttpError(error) {
     return new HttpErrors.BadRequestError(error.message);
   }
 
-  if (error instanceof DomainErrors.YamlParsingError) {
+  if (error instanceof YamlParsingError) {
     return new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta);
   }
 

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -732,12 +732,6 @@ class InvalidIdentityProviderError extends DomainError {
   }
 }
 
-class YamlParsingError extends DomainError {
-  constructor(message = "Une erreur s'est produite lors de l'interprétation des réponses.") {
-    super(message);
-  }
-}
-
 class InvalidExternalAPIResponseError extends DomainError {
   constructor(message = "L'API externe a renvoyé une réponse incorrecte.") {
     super(message);
@@ -948,5 +942,4 @@ export {
   UserOrgaSettingsCreationError,
   UserShouldNotBeReconciledOnAnotherAccountError,
   WrongDateFormatError,
-  YamlParsingError,
 };

--- a/api/lib/domain/services/solution-service-qrocm-dep.js
+++ b/api/lib/domain/services/solution-service-qrocm-dep.js
@@ -1,7 +1,7 @@
 import jsYaml from 'js-yaml';
 
+import { YamlParsingError } from '../../../src/shared/domain/errors.js';
 import { AnswerStatus } from '../../../src/shared/domain/models/AnswerStatus.js';
-import { YamlParsingError } from '../../domain/errors.js';
 import { getEnabledTreatments, useLevenshteinRatio } from './services-utils.js';
 import { validateAnswer } from './string-comparison-service.js';
 import { applyPreTreatments, applyTreatments } from './validation-treatments.js';

--- a/api/lib/domain/services/solution-service-qrocm-ind.js
+++ b/api/lib/domain/services/solution-service-qrocm-ind.js
@@ -2,10 +2,10 @@ import levenshtein from 'fast-levenshtein';
 import jsYaml from 'js-yaml';
 
 import { LEVENSHTEIN_DISTANCE_MAX_RATE } from '../../../src/shared/domain/constants.js';
+import { YamlParsingError } from '../../../src/shared/domain/errors.js';
 import { AnswerStatus } from '../../../src/shared/domain/models/AnswerStatus.js';
 import { _ } from '../../../src/shared/infrastructure/utils/lodash-utils.js';
 import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
-import { YamlParsingError } from '../../domain/errors.js';
 import { useLevenshteinRatio } from './services-utils.js';
 import { applyPreTreatments, applyTreatments } from './validation-treatments.js';
 

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -357,6 +357,12 @@ class UserNotFoundError extends NotFoundError {
   }
 }
 
+class YamlParsingError extends DomainError {
+  constructor(message = "Une erreur s'est produite lors de l'interprétation des réponses.") {
+    super(message);
+  }
+}
+
 export {
   AlreadyExistingEntityError,
   AlreadyRegisteredEmailError,
@@ -392,4 +398,5 @@ export {
   UserNotAuthorizedToUpdateEmailError,
   UserNotAuthorizedToUpdatePasswordError,
   UserNotFoundError,
+  YamlParsingError,
 };

--- a/api/tests/unit/domain/services/solution-service-qrocm-dep_test.js
+++ b/api/tests/unit/domain/services/solution-service-qrocm-dep_test.js
@@ -1,9 +1,9 @@
-import { YamlParsingError } from '../../../../lib/domain/errors.js';
 import {
   getCorrection,
   getCorrectionDetails,
   match,
 } from '../../../../lib/domain/services/solution-service-qrocm-dep.js';
+import { YamlParsingError } from '../../../../src/shared/domain/errors.js';
 import { AnswerStatus } from '../../../../src/shared/domain/models/AnswerStatus.js';
 import { catchErr, expect, sinon } from '../../../test-helper.js';
 

--- a/api/tests/unit/domain/services/solution-service-qrocm-ind_test.js
+++ b/api/tests/unit/domain/services/solution-service-qrocm-ind_test.js
@@ -1,5 +1,5 @@
-import { YamlParsingError } from '../../../../lib/domain/errors.js';
 import * as service from '../../../../lib/domain/services/solution-service-qrocm-ind.js';
+import { YamlParsingError } from '../../../../src/shared/domain/errors.js';
 import { AnswerStatus } from '../../../../src/shared/domain/models/AnswerStatus.js';
 import { catchErr, expect } from '../../../test-helper.js';
 


### PR DESCRIPTION
## :unicorn: Problème
cf https://github.com/1024pix/pix/blob/dev/docs/adr/0051-nouvelle-arborescence-api.md

## :robot: Proposition

Déplacer `YamlParsingError` vers `src/shared/domain/errors.js`

## :rainbow: Remarques


## :100: Pour tester

