### PR TITLE
[FEATURE] Ajoute un temps minimal à l'import pour que l'utilisateur voit le loader (PIX-13437)

### DIFF
--- a/orga/app/controllers/authenticated/import-organization-participants.js
+++ b/orga/app/controllers/authenticated/import-organization-participants.js
@@ -48,6 +48,14 @@ export default class ImportController extends Controller {
     });
   }
 
+  _wait(ms) {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve();
+      }, ms);
+    });
+  }
+
   _initializeUpload() {
     if (this.isLoading) return;
 
@@ -72,7 +80,8 @@ export default class ImportController extends Controller {
     window.addEventListener('beforeunload', confirmBeforeClose);
 
     try {
-      await func(adapter, organizationId);
+      // We add a minimal import time to avoid flashing loader to users
+      await Promise.all([await func(adapter, organizationId), await this._wait(750)]);
     } finally {
       this.send('refreshModel');
       this.isLoading = false;

--- a/orga/app/controllers/authenticated/import-organization-participants.js
+++ b/orga/app/controllers/authenticated/import-organization-participants.js
@@ -18,73 +18,34 @@ export default class ImportController extends Controller {
 
   @action
   async importSupStudents(files) {
-    this._initializeUpload();
-
-    const adapter = this.store.adapterFor('organization-learners-import');
-    const organizationId = this.currentUser.organization.id;
-
-    try {
+    await this._makeOnImport(async (adapter, organizationId) => {
       await adapter.addStudentsCsv(organizationId, files);
       this.send('refreshGroups');
-    } finally {
-      this.send('refreshModel');
-      this.isLoading = false;
-    }
-  }
-
-  @action
-  async importScoStudents(files) {
-    this._initializeUpload();
-
-    const adapter = this.store.adapterFor('organization-learners-import');
-    const organizationId = this.currentUser.organization.id;
-    const format = this.currentUser.isAgriculture ? 'csv' : 'xml';
-
-    const confirmBeforeClose = (event) => {
-      event.preventDefault();
-      return (event.returnValue = '');
-    };
-    window.addEventListener('beforeunload', confirmBeforeClose);
-
-    try {
-      await adapter.importStudentsSiecle(organizationId, files, format);
-      this.send('refreshDivisions');
-    } finally {
-      this.isLoading = false;
-      this.send('refreshModel');
-      window.removeEventListener('beforeunload', confirmBeforeClose);
-    }
+    });
   }
 
   @action
   async replaceStudents(files) {
-    this._initializeUpload();
-
-    const adapter = this.store.adapterFor('organization-learners-import');
-    const organizationId = this.currentUser.organization.id;
-
-    try {
+    await this._makeOnImport(async (adapter, organizationId) => {
       await adapter.replaceStudentsCsv(organizationId, files);
       this.send('refreshGroups');
-    } finally {
-      this.send('refreshModel');
-      this.isLoading = false;
-    }
+    });
+  }
+
+  @action
+  async importScoStudents(files) {
+    await this._makeOnImport(async (adapter, organizationId) => {
+      const format = this.currentUser.isAgriculture ? 'csv' : 'xml';
+      await adapter.importStudentsSiecle(organizationId, files, format);
+      this.send('refreshDivisions');
+    });
   }
 
   @action
   async importOrganizationLearners(files) {
-    this._initializeUpload;
-
-    const adapter = this.store.adapterFor('organization-learners-import');
-    const organizationId = this.currentUser.organization.id;
-
-    try {
+    await this._makeOnImport(async (adapter, organizationId) => {
       await adapter.importOrganizationLearners(organizationId, files);
-    } finally {
-      this.send('refreshModel');
-      this.isLoading = false;
-    }
+    });
   }
 
   _initializeUpload() {
@@ -96,6 +57,27 @@ export default class ImportController extends Controller {
     this.errors = null;
     this.warnings = null;
     this.warningBanner = null;
+  }
+
+  async _makeOnImport(func) {
+    this._initializeUpload();
+
+    const adapter = this.store.adapterFor('organization-learners-import');
+    const organizationId = this.currentUser.organization.id;
+
+    const confirmBeforeClose = (event) => {
+      event.preventDefault();
+      return (event.returnValue = '');
+    };
+    window.addEventListener('beforeunload', confirmBeforeClose);
+
+    try {
+      await func(adapter, organizationId);
+    } finally {
+      this.send('refreshModel');
+      this.isLoading = false;
+      window.removeEventListener('beforeunload', confirmBeforeClose);
+    }
   }
 
   get participantListRoute() {


### PR DESCRIPTION
## :unicorn: Problème
On a eu des retours d'utilisateurs n'ayant pas le temps de voir l'indicateur de chargement de l'import. Cela les incite à penser que ça n'a pas fonctionné correctement et il retente d'importer plusieurs fois.

## :robot: Proposition
On ajoute un temps minimal pour l'affichage de l'indicateur de chargement de 750ms pour que les utilisateurs aient bien le temps de voir qu'il s'est effectivement passé quelque chose.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
La CI est verte ✅ 
On peut vérifier que tous les imports fonctionnent toujours correctement à cause du refacto.
