### PR TITLE
[BUGFIX] Utiliser "acceptedFormat" pour le message d'erreur de la date quand celui-ci est founi (PIX-13507)

### DIFF
--- a/orga/app/services/error-messages.js
+++ b/orga/app/services/error-messages.js
@@ -66,7 +66,13 @@ export default class ErrorMessagesService extends Service {
   getErrorMessage(code, meta) {
     if (!code) return;
     const i18nKey = ERROR_MESSAGES[code];
+
     if (!i18nKey) return;
+    // TODO : Remove this when all import will be on generic import
+    if (code === 'FIELD_DATE_FORMAT' && !meta.acceptedFormat) {
+      meta.acceptedFormat = this.intl.primaryLocale === 'fr' ? 'jj/mm/aaaa' : 'dd/mm/yyyy';
+    }
+
     return this.intl.t(i18nKey, this._formatMeta(meta));
   }
 }

--- a/orga/tests/unit/services/error-messages_test.js
+++ b/orga/tests/unit/services/error-messages_test.js
@@ -1,4 +1,4 @@
-import { t } from 'ember-intl/test-support';
+import { setLocale, t } from 'ember-intl/test-support';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -117,5 +117,65 @@ module('Unit | Service | Error messages', function (hooks) {
         valids: `A${t('api-error-messages.or-separator')}B`,
       }),
     );
+  });
+
+  module('csv format error', function () {
+    module('FIELD_DATE_FORMAT', function () {
+      test('should return the message when error code is found without acceptedFormat', function (assert) {
+        // Given
+        const errorMessages = this.owner.lookup('service:errorMessages');
+
+        // When
+        const message = errorMessages.getErrorMessage('FIELD_DATE_FORMAT', { line: 2, field: 'toto' });
+        // Then
+        assert.strictEqual(
+          message,
+          t('api-error-messages.student-csv-import.field-date-format', {
+            line: 2,
+            field: 'toto',
+            acceptedFormat: 'jj/mm/aaaa',
+          }),
+        );
+      });
+
+      test('should return the en message when error code is found without acceptedFormat', function (assert) {
+        // Given
+        setLocale(['en']);
+        const errorMessages = this.owner.lookup('service:errorMessages');
+
+        // When
+        const message = errorMessages.getErrorMessage('FIELD_DATE_FORMAT', { line: 2, field: 'toto' });
+        // Then
+        assert.strictEqual(
+          message,
+          t('api-error-messages.student-csv-import.field-date-format', {
+            line: 2,
+            field: 'toto',
+            acceptedFormat: 'dd/mm/yyyy',
+          }),
+        );
+      });
+
+      test('should return the message when error code is found given acceptedFormat', function (assert) {
+        // Given
+        const errorMessages = this.owner.lookup('service:errorMessages');
+
+        // When
+        const message = errorMessages.getErrorMessage('FIELD_DATE_FORMAT', {
+          line: 2,
+          field: 'toto',
+          acceptedFormat: 'withthisformat',
+        });
+        // Then
+        assert.strictEqual(
+          message,
+          t('api-error-messages.student-csv-import.field-date-format', {
+            line: 2,
+            field: 'toto',
+            acceptedFormat: 'withthisformat',
+          }),
+        );
+      });
+    });
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -22,7 +22,7 @@
       "bad-csv-format": "The file must be in csv format with comma or semicolon separator.",
       "encoding-not-supported": "File encoding not supported.",
       "field-bad-values": "Row {line} : The field “{field}” must be “{valids}”.",
-      "field-date-format": "Row {line} : The field “{field}” must be in the format dd/mm/yyyy.",
+      "field-date-format": "Row {line} : The field “{field}” must be in the format “{acceptedFormat}”.",
       "field-email-format": "Row {line} : The field “{field}” must be a valid email address.",
       "field-length": "Row {line} : The field “{field}” must contain {limit} characters.",
       "field-max-length": "Row {line} : The field “{field}” must contain less than {limit} characters.",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -22,7 +22,7 @@
       "bad-csv-format": "Le fichier doit être au format csv avec séparateur virgule ou point-virgule.",
       "encoding-not-supported": "Encodage du fichier non supporté.",
       "field-bad-values": "Ligne {line} : Le champ “{field}” doit être “{valids}”.",
-      "field-date-format": "Ligne {line} : Le champ “{field}” doit être au format jj/mm/aaaa.",
+      "field-date-format": "Ligne {line} : Le champ “{field}” doit être au format “{acceptedFormat}”.",
       "field-email-format": "Ligne {line} : Le champ “{field}” doit être une adresse email valide.",
       "field-length": "Ligne {line} : Le champ “{field}” doit faire {limit} caractères.",
       "field-max-length": "Ligne {line} : Le champ “{field}” doit être inférieur à {limit} caractères.",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -22,7 +22,7 @@
       "bad-csv-format": "Het bestand moet in csv-formaat zijn met als scheidingsteken komma’s of puntkomma's.",
       "encoding-not-supported": "Bestandscodering niet ondersteund.",
       "field-bad-values": "Regel {line}: Het veld \"{field}\" moet zijn \"{valids}\".",
-      "field-date-format": "Regel {line}: Het veld \"{field}\" moet het format dd/mm/jjjj hebben.",
+      "field-date-format": "Regel {line}: Het veld \"{field}\" moet het format \"{acceptedFormat}\" hebben.",
       "field-email-format": "Regel {line}: Het veld \"{field}\" moet een geldig e-mailadres zijn.",
       "field-length": "Regel {line}: Het veld \"{field}\" moet {limit} karakters lang zijn.",
       "field-max-length": "Regel {line}: Het veld \"{field}\" moet minder dan {limit} tekens zijn.",


### PR DESCRIPTION
## :unicorn: Problème
le message d'erreur de la date ne correspond pas au format fourni par l'API

## :robot: Proposition
Utiliser le acceptedFormat lorsque celui ci est nécessaire, sinon utiliser des valeurs par défaut ( ISO import non générique)

## :rainbow: Remarques
RAS

## :100: Pour tester
Faire un import à format et vérifier que le format d'erreur est bien formatté
Faire un import fregata et vérifier que le format d'erreur est bien formatté