### PR TITLE
[FEATURE] Changement de robot sur la page d'erreur lors d'une session inactive (Pix-13498)

### DIFF
--- a/junior/app/components/issue/template.hbs
+++ b/junior/app/components/issue/template.hbs
@@ -1,7 +1,7 @@
 {{! Cette page est affichée lorsqu'une erreur survient coté api. }}
 <div class="issue">
   <img src="/images/background-blob-error.svg" alt="error_background_image" class="blob" />
-  <RobotDialog @class="sad">
+  <RobotDialog @class={{if @class @class "sad"}}>
     <Bubble @message={{@message}} />
   </RobotDialog>
   <PixButton class="pix1d-button" @triggerAction={{this.goToHome}} @iconBefore="arrow-left">{{t

--- a/junior/app/templates/school-error.hbs
+++ b/junior/app/templates/school-error.hbs
@@ -1,2 +1,1 @@
-{{! Cette page est affichée lorsqu'on souhaite aller sur une URL qui n'existe pas coté front }}
-<Issue @message={{t "pages.school.not-found"}} />
+<Issue @message={{t "pages.school.not-found"}} @class="retry" />


### PR DESCRIPTION
## :unicorn: Problème
Besoin vital d'ajouter un nouveau robot lors d'une session inactive pour ne pas être trop "alarmiste"  auprès des enfants.


## :robot: Proposition
Ajouter un autre robot au milieu de son BLOB!

## :rainbow: Remarques
Il est mignon.

## :100: Pour tester
1/ Se connecter à pix junior.
2/ Rentrer le code d'une école avec une session inactive et voir le robot avec des "?"