### PR TITLE
[FEATURE] Ajout de 2 catégories aux Profiles Cibles (PIX-13511)

### DIFF
--- a/admin/app/models/target-profile.js
+++ b/admin/app/models/target-profile.js
@@ -12,6 +12,8 @@ export const categories = {
   CUSTOM: 'Parcours sur-mesure',
   PIX_PLUS: 'Pix+',
   SUBJECT: 'Thématiques',
+  TARGETED: 'Parcours ciblés',
+  BACK_TO_SCHOOL: 'Parcours de rentrée / 6e',
 };
 
 export const optionsCategoryList = formatList(categories);

--- a/admin/tests/integration/components/target-profiles/category_test.js
+++ b/admin/tests/integration/components/target-profiles/category_test.js
@@ -53,4 +53,20 @@ module('Integration | Component | TargetProfiles::Category', function (hooks) {
     // then
     assert.dom(screen.getByText('Autres')).exists();
   });
+
+  test('it should display the tag for type TARGETED', async function (assert) {
+    // when
+    const screen = await render(hbs`<TargetProfiles::Category @category='TARGETED' />`);
+
+    // then
+    assert.dom(screen.getByText('Parcours ciblés')).exists();
+  });
+
+  test('it should display the tag for type BACK_TO_SCHOOL', async function (assert) {
+    // when
+    const screen = await render(hbs`<TargetProfiles::Category @category='BACK_TO_SCHOOL' />`);
+
+    // then
+    assert.dom(screen.getByText('Parcours de rentrée / 6e')).exists();
+  });
 });

--- a/api/lib/domain/models/TargetProfile.js
+++ b/api/lib/domain/models/TargetProfile.js
@@ -6,6 +6,8 @@ const categories = {
   PIX_PLUS: 'PIX_PLUS',
   PREDEFINED: 'PREDEFINED',
   SUBJECT: 'SUBJECT',
+  TARGETED: 'TARGETED',
+  BACK_TO_SCHOOL: 'BACK_TO_SCHOOL',
 };
 
 class TargetProfile {

--- a/api/lib/domain/validators/target-profile/base-validation.js
+++ b/api/lib/domain/validators/target-profile/base-validation.js
@@ -23,6 +23,8 @@ const schema = Joi.object({
       categories.PIX_PLUS,
       categories.PREDEFINED,
       categories.SUBJECT,
+      categories.TARGETED,
+      categories.BACK_TO_SCHOOL,
     )
     .required()
     .error((errors) => first(errors))

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -500,13 +500,16 @@
         "profiles-collection-info-certificability-calculation": "The “Eligible for certification” status is updated automatically in the '<'a href=\"/eleves\" class=\"{linkClasses}\"'>'Students'</a>' tab."
       },
       "tags": {
+        "BACK_TO_SCHOOL": "Back to school",
         "COMPETENCES": "Pix Competences",
         "CUSTOM": "Created for you",
         "DISCIPLINE": "Schools",
         "OTHER": "Other",
         "PIX_PLUS": "Pix+",
         "PREDEFINED": "Ready-made",
-        "SUBJECT": "Subject"
+        "SUBJECT": "Subject",
+        "TARGETED": "Targeted"
+
       },
       "tags-title": "Filter:",
       "target-profiles-category-label": "Filter customised test by category",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -503,13 +503,15 @@
         "profiles-collection-info-certificability-calculation": "Le statut Certifiable est mis à jour automatiquement dans l’onglet '<'a href=\"/eleves\" class=\"{linkClasses}\"'>'Élèves'</a>'."
       },
       "tags": {
+        "BACK_TO_SCHOOL": "Parcours de rentrée / 6e",
         "COMPETENCES": "Les 16 compétences",
         "CUSTOM": "Parcours sur-mesure",
         "DISCIPLINE": "Disciplinaires",
         "OTHER": "Autres",
         "PIX_PLUS": "Pix+",
         "PREDEFINED": "Parcours prédéfinis",
-        "SUBJECT": "Thématiques"
+        "SUBJECT": "Thématiques",
+        "TARGETED": "Parcours ciblés"
       },
       "tags-title": "Filtrer la recherche :",
       "target-profiles-category-label": "Filtrer les parcours par catégories",


### PR DESCRIPTION
## :unicorn: Problème
Des utilisateurs aimeraient créer deux catégories de PC supplémentaires, car ils ont cette année plus d’une 50aine de PC à créer de types très variés. Ce qui serait super difficile à chercher pour un enseignant dans Pix Orga.

## :robot: Proposition
Afin d'éviter ça, nous allons donc rajouter deux catégories de PC : 
- Parcours de rentrée / 6e
- Parcours ciblés

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- se connecter à Pix Admin
- créer un profiles cibles avec la première catégorie
- créer un deuxième avec la 2e catégorie
- se connecter à Pix Orga avec un utilisateur de l'orga de référence dont vous avez donné l'identifiant pour créer les PC (si vous ne les avez pas définit comme public)
- créer une campagne avec chacun de PC créés 
- 🎉 