### PR TITLE
[FEATURE] Ajouter dans le didacticiel un simulateur avec auto-complétion (PIX-13093)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -370,6 +370,25 @@
       ]
     },
     {
+      "id": "e8db3f90-4259-4d54-9113-1c56da726d8d",
+      "type": "activity",
+      "title": "Embed auto",
+      "components": [
+        {
+          "type": "element",
+          "element": {
+            "id": "0559b68c-68a5-4816-a06e-f1c743c391e3",
+            "type": "embed",
+            "isCompletionRequired": true,
+            "title": "Simulateur de visioconférence - micro ouvert",
+            "url": "https://epreuves.pix.fr/visio/visio.html?mode=visio2",
+            "instruction": "<p>Vous participez à la visioconférence ci-dessous.</p><p>Il y a du bruit à côté de vous.</p><p>Coupez le son de votre micro pour ne pas déranger vos interlocuteurs.</p>",
+            "height": 600
+          }
+        }
+      ]
+    },
+    {
       "id": "7cf75e70-8749-4392-8081-f2c02badb0fb",
       "type": "activity",
       "title": "Le nom de ce produit",

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/embed.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/embed.js
@@ -5,7 +5,7 @@ import { htmlNotAllowedSchema, htmlSchema, uuidSchema } from '../utils.js';
 const embedSchema = Joi.object({
   id: uuidSchema,
   type: Joi.string().valid('embed').required(),
-  isCompletionRequired: Joi.boolean().valid(false).required(),
+  isCompletionRequired: Joi.boolean().required(),
   title: htmlNotAllowedSchema.required(),
   url: Joi.string().uri().required(),
   instruction: htmlSchema.optional(),

--- a/high-level-tests/e2e/cypress/integration/pix-app/modulix-a11y.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/modulix-a11y.feature
@@ -19,6 +19,7 @@ Fonctionnalité: Accessibilité de Modulix
     Quand je vais au grain suivant
     Quand je vais au grain suivant
     Quand je vais au grain suivant
+    Quand je vais au grain suivant
     Alors la page devrait être accessible
     Quand je clique sur "Terminer"
     Et que j'attends 500 ms


### PR DESCRIPTION
## :unicorn: Problème
Après avoir implémenté un simulateur sans complétion dans Modulix, nous avons besoin d'ajouter des simulateurs avec auto-complétion. 

## :robot: Proposition
Ajouter un embed-auto dans le didacticiel Modulix.

## :rainbow: Remarques
Mise à jour du schema de validation Joi d'un embed.

## :100: Pour tester
### Tests de non régression fonctionnels
1. Se rendre sur [le didacticiel](https://app-pr9623.review.pix.fr/modules/didacticiel-modulix)
2. Parcourir le module
3. Vérifier que rien n'est cassé

### Tests de non régression contribution
1. Récupérer cette branche en local
2. Lancer le script npm run modulix:test
3. S'assurer que tous les tests passent au vert