### PR TITLE
[FEATURE] Ajouter un message d'alerte quand l'utilisateur ne saisit qu'une réponse dans un QCM. (Pix-13380)

### DIFF
--- a/junior/app/components/bubble/integration_test.js
+++ b/junior/app/components/bubble/integration_test.js
@@ -17,7 +17,7 @@ module('Integration | Component | Bubble', function (hooks) {
   test('displays bubble with a specific color', async function (assert) {
     this.set('color', 'success');
 
-    await render(hbs`<Bubble @color={{this.color}} />`);
+    await render(hbs`<Bubble @status={{this.color}} />`);
 
     assert.dom('.bubble--success').exists();
   });

--- a/junior/app/components/bubble/template.hbs
+++ b/junior/app/components/bubble/template.hbs
@@ -1,1 +1,1 @@
-<MarkdownToHtml ...attributes @markdown={{@message}} @class="bubble{{if @color (concat ' bubble--' @color)}}" />
+<MarkdownToHtml ...attributes @markdown={{@message}} @class="bubble{{if @status (concat ' bubble--' @status)}}" />

--- a/junior/app/components/challenge/challenge-item-qcm/component.js
+++ b/junior/app/components/challenge/challenge-item-qcm/component.js
@@ -1,4 +1,5 @@
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import labeledCheckboxes from 'junior/utils/labeled-checkboxes';
 import proposalsAsArray from 'junior/utils/proposals-as-array';
@@ -6,6 +7,7 @@ import { pshuffle } from 'junior/utils/pshuffle';
 import valueAsArrayOfBoolean from 'junior/utils/value-as-array-of-boolean';
 
 export default class ChallengeItemQcm extends Component {
+  @service intl;
   checkedValues = new Set();
 
   get labeledCheckboxes() {
@@ -29,5 +31,18 @@ export default class ChallengeItemQcm extends Component {
       document.getElementsByName(checkboxName)[0].parentNode.classList.add('pix-label--checked');
     }
     this.args.setAnswerValue(Array.from(this.checkedValues).join());
+    this._checkValidations();
+  }
+
+  _checkValidations() {
+    if (this._hasLessThanTwoValues()) {
+      this.args.setValidationWarning(this.intl.t('pages.challenge.qcm-error'));
+    } else {
+      this.args.setValidationWarning(null);
+    }
+  }
+
+  _hasLessThanTwoValues() {
+    return Array.from(this.checkedValues).length < 2;
   }
 }

--- a/junior/app/components/challenge/component.js
+++ b/junior/app/components/challenge/component.js
@@ -9,6 +9,8 @@ export default class Challenge extends Component {
   @tracked answerHasBeenValidated = false;
   @tracked answer = null;
   @tracked answerValue = null;
+  @tracked displayValidationWarning = false;
+  validationWarning = null;
 
   get disableCheckButton() {
     return this.answerValue === null || this.answerValue === '';
@@ -25,12 +27,20 @@ export default class Challenge extends Component {
     if (this.answer?.result === 'ko') {
       return 'sad';
     }
+    if (this.displayValidationWarning) {
+      return 'retry';
+    }
     return 'default';
   }
 
   @action
   setAnswerValue(value) {
     this.answerValue = value ?? null;
+  }
+
+  @action
+  setValidationWarning(errorValue) {
+    this.validationWarning = errorValue;
   }
 
   _createActivityAnswer(challenge) {
@@ -51,6 +61,13 @@ export default class Challenge extends Component {
 
   @action
   async validateAnswer() {
+    if (this.validationWarning) {
+      this.displayValidationWarning = true;
+      return;
+    } else {
+      this.displayValidationWarning = false;
+    }
+
     this.answer = this._createActivityAnswer(this.args.challenge);
     this.answer.value = this.answerValue;
     try {
@@ -82,7 +99,6 @@ export default class Challenge extends Component {
     this.answerHasBeenValidated = false;
     this.answerValue = null;
     this.answer = null;
-
     this.router.replaceWith('assessment.resume');
   }
 }

--- a/junior/app/components/challenge/item/template.hbs
+++ b/junior/app/components/challenge/item/template.hbs
@@ -49,6 +49,7 @@
         <Challenge::ChallengeItemQcm
           @challenge={{@challenge}}
           @setAnswerValue={{@setAnswerValue}}
+          @setValidationWarning={{@setValidationWarning}}
           @assessment={{@assessment}}
           @isDisabled={{@isDisabled}}
         />

--- a/junior/app/components/challenge/template.hbs
+++ b/junior/app/components/challenge/template.hbs
@@ -8,9 +8,13 @@
     {{#if (eq this.answer.result "ko")}}
       <Bubble @message={{t "pages.challenge.messages.wrong-answer"}} @color="error" aria-live="polite" />
     {{/if}}
+    {{#if this.displayValidationWarning}}
+      <Bubble @message={{this.validationWarning}} @color="warning" aria-live="polite" />
+    {{/if}}
   </RobotDialog>
   <Challenge::Item
     @setAnswerValue={{this.setAnswerValue}}
+    @setValidationWarning={{this.setValidationWarning}}
     @validateAnswer={{this.validateAnswer}}
     @skipChallenge={{this.skipChallenge}}
     @challenge={{@challenge}}

--- a/junior/app/components/challenge/template.hbs
+++ b/junior/app/components/challenge/template.hbs
@@ -3,13 +3,13 @@
   <RobotDialog @class={{this.robotMood}}>
     <Bubble @message={{@challenge.instruction}} />
     {{#if (eq this.answer.result "ok")}}
-      <Bubble @message={{t "pages.challenge.messages.correct-answer"}} @color="success" aria-live="polite" />
+      <Bubble @message={{t "pages.challenge.messages.correct-answer"}} @status="success" aria-live="polite" />
     {{/if}}
     {{#if (eq this.answer.result "ko")}}
-      <Bubble @message={{t "pages.challenge.messages.wrong-answer"}} @color="error" aria-live="polite" />
+      <Bubble @message={{t "pages.challenge.messages.wrong-answer"}} @status="error" aria-live="polite" />
     {{/if}}
     {{#if this.displayValidationWarning}}
-      <Bubble @message={{this.validationWarning}} @color="warning" aria-live="polite" />
+      <Bubble @message={{this.validationWarning}} @status="warning" aria-live="polite" />
     {{/if}}
   </RobotDialog>
   <Challenge::Item

--- a/junior/app/templates/assessment/results.hbs
+++ b/junior/app/templates/assessment/results.hbs
@@ -1,7 +1,7 @@
 {{page-title (t "pages.missions.end-page.title")}}
 <div class="mission-page">
   <RobotDialog @class="happy">
-    <Bubble @message={{t "pages.missions.end-page.congratulations"}} @color="success" />
+    <Bubble @message={{t "pages.missions.end-page.congratulations"}} @status="success" />
   </RobotDialog>
   <div class="mission-page__body">
     <MissionCard

--- a/junior/tests/acceptance/challenge-item-qcm_test.js
+++ b/junior/tests/acceptance/challenge-item-qcm_test.js
@@ -49,4 +49,16 @@ module('Acceptance | Displaying a QCM challenge', function (hooks) {
       assert.dom(screen.getByRole('button', { name: t('pages.challenge.actions.check') })).isDisabled();
     });
   });
+
+  module('when user select just one answer', function () {
+    test('should display warning message', async function (assert) {
+      // when
+      const screen = await visit(`/assessments/${assessment.id}/challenges`);
+      await click(screen.getByRole('checkbox', { name: 'Profil 1' }));
+      await click(screen.getByRole('button', { name: t('pages.challenge.actions.check') }));
+
+      // then
+      assert.dom(screen.getByText(t('pages.challenge.qcm-error'))).exists();
+    });
+  });
 });

--- a/junior/translations/fr.json
+++ b/junior/translations/fr.json
@@ -25,6 +25,7 @@
         "wrong-answer": "Mauvaise réponse. Tu peux passer à la suite."
       },
       "qcu-hint": "Sélectionne une seule réponse.",
+      "qcm-error": "Attention, sélectionne plusieurs réponses !",
       "qcm-hint": "Sélectionne plusieurs réponses."
     },
     "home": {


### PR DESCRIPTION
## :unicorn: Problème
Quand un utilisateur sélectionnait qu'une réponse dans un QCM et qu'il validait, il avait de facto faux car plusieurs réponses étaient attendues.

## :robot: Proposition
Afficher un message pour prévenir qu'il faut sélectionner au minimum 2 réponses dans un QCM

## :rainbow: Remarques
BSR: petit renommage d'attribut pour les bulle de dialogue. 

## :100: Pour tester
### Mode Preview
- Aller sur pix junior et aller voir ce challenge en preview `/challenges/challenge25hVneNbgqXxQi/preview` et sélectionner qu'une seule réponse et valider.

### Mode Parcours
- Commencer une mission et arriver sur un QCM et sélectionner qu'une seule réponse et valider.