### PR TITLE
[FEATURE] Ne pas afficher le bandeau de téléchargement pour les Import Onde (PIX-13539)

### DIFF
--- a/orga/app/components/import/download-import-template-link.gjs
+++ b/orga/app/components/import/download-import-template-link.gjs
@@ -14,7 +14,10 @@ export default class DownloadImportTemplateLink extends Component {
   }
 
   get showLink() {
-    return this.currentUser.hasLearnerImportFeature || this.currentUser.isSUPManagingStudents;
+    return (
+      !this.currentUser.canAccessMissionsPage &&
+      (this.currentUser.hasLearnerImportFeature || this.currentUser.isSUPManagingStudents)
+    );
   }
 
   <template>

--- a/orga/tests/integration/components/import/download-import-template-link_test.gjs
+++ b/orga/tests/integration/components/import/download-import-template-link_test.gjs
@@ -1,0 +1,70 @@
+import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import { t } from 'ember-intl/test-support';
+import DownloadImportTemplateLink from 'pix-orga/components/import/download-import-template-link';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | DownloadImportTemplateLink', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should be render when learner feature is enabled', async function (assert) {
+    // given
+    class CurrentUserStub extends Service {
+      hasLearnerImportFeature = true;
+      canAccessMissionsPage = false;
+      isSUPManagingStudents = false;
+      organization = {
+        id: 777,
+      };
+    }
+    this.owner.register('service:current-user', CurrentUserStub);
+
+    // when
+    const screen = await render(<template><DownloadImportTemplateLink /></template>);
+
+    // then
+    assert.ok(screen.getByRole('link', { name: t('pages.sup-organization-participants.actions.download-template') }));
+  });
+
+  test('it should be render when organization is SupManagingStudent', async function (assert) {
+    // given
+    class CurrentUserStub extends Service {
+      hasLearnerImportFeature = false;
+      canAccessMissionsPage = false;
+      isSUPManagingStudents = true;
+      organization = {
+        id: 777,
+      };
+    }
+    this.owner.register('service:current-user', CurrentUserStub);
+
+    // when
+    const screen = await render(<template><DownloadImportTemplateLink /></template>);
+
+    // then
+    assert.ok(screen.getByRole('link', { name: t('pages.sup-organization-participants.actions.download-template') }));
+  });
+
+  test('it should not render when organization can access mission page', async function (assert) {
+    // given
+    class CurrentUserStub extends Service {
+      hasLearnerImportFeature = true;
+      canAccessMissionsPage = true;
+      isSUPManagingStudents = false;
+      organization = {
+        id: 777,
+      };
+    }
+    this.owner.register('service:current-user', CurrentUserStub);
+
+    // when
+    const screen = await render(<template><DownloadImportTemplateLink /></template>);
+
+    // then
+    assert.notOk(
+      screen.queryByRole('link', { name: t('pages.sup-organization-participants.actions.download-template') }),
+    );
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
L'import ONDE ne se fera que via un fichier générer par un outils externe, il n'est pas nécessaire d'avoir un template

## :robot: Proposition
Cacher ce template seulement pour le contexte ONDE, lorsque nous aurons le besoin pour d'autre nous ferons l'implémentation via le fichier de configuration

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que l'import s'affiche toujours pour les orga autres que ONDE ayant la possibilité d'importer des apprenants.
Vérifier qu'il ne s'affiche pas pour les orga ONDE