### PR TITLE
[FEATURE] Ajouter les CGU sur Pix Orga en NL (PIX-13241).

### DIFF
--- a/orga/app/components/terms-of-service/page-fr.hbs
+++ b/orga/app/components/terms-of-service/page-fr.hbs
@@ -4,7 +4,7 @@
   </div>
 
   <h1 class="terms-of-service-form__title">
-    Condition générales d'utilisation de la plateforme Pix Orga
+    Conditions générales d'utilisation de la plateforme Pix Orga
   </h1>
 
   <hr class="terms-of-service-form__line" />
@@ -201,8 +201,8 @@
     <p>
       La procédure de création d’un compte utilisateur comprend les étapes suivantes.
     </p>
+    <h3 class="terms-of-service-form-text__article-subtitle">Etape 1.</h3>
     <p>
-      <b>Etape 1.</b>
       L’utilisateur complète un formulaire internet sur la plateforme Pix.
     </p>
     <p>
@@ -223,8 +223,8 @@
       L’utilisateur doit valider, en cochant une case à cet effet qu’il a lu et qu’il accepte les conditions
       d’utilisation de la plateforme Pix.
     </p>
+    <h3 class="terms-of-service-form-text__article-subtitle">Etape 2.</h3>
     <p>
-      <b>Etape 2.</b>
       L’utilisateur se connecte à son compte utilisateur aux moyens de ses identifiants de connexion, étant rappelé que
       ces derniers sont personnels et confidentiels.
     </p>

--- a/orga/app/components/terms-of-service/page-nl.hbs
+++ b/orga/app/components/terms-of-service/page-nl.hbs
@@ -1,0 +1,735 @@
+<div>
+  <div class="terms-of-service-form__logo">
+    <img src="/pix-orga.svg" alt="" role="none" />
+  </div>
+
+  <h1 class="terms-of-service-form__title">
+    Algemene gebruiksvoorwaarden van het pix orga-platform
+  </h1>
+
+  <hr class="terms-of-service-form__line" />
+
+  <div class="terms-of-service-form__text">
+    <h2 class="terms-of-service-form-text__article-title">Artikel 1. Woord Vooraf</h2>
+    <p>
+      De Publieke Belangengroep (Groupement d’intérêt public - GIP) “Pix”, opgericht bij besluit van 27 april 2017 tot
+      goedkeuring van de oprichtingsovereenkomst van de publieke belangengroep “Pix”, met maatschappelijke zetel op 156,
+      boulevard Haussmann, 75008 Parijs (Frankrijk), heeft het Pix-platform ontwikkeld als onderdeel van een publiek
+      project in samenwerking met het Ministerie van Onderwijs en het Ministerie van Hoger Onderwijs, Onderzoek en
+      Innovatie.
+    </p>
+    <p>
+      Het Pix-platform is een online platform voor de evaluatie en certificering van digitale vaardigheden. Het doel van
+      het platform is het verhogen van het algemene niveau van kennis en digitale vaardigheden om zo bij te dragen aan
+      de digitale transformatie van de samenleving en de economie. Het platform is gebaseerd op het Europese
+      referentiekader DigComp, dat digitale vaardigheden definieert op acht (8) niveaus en in vijf (5) hoofddomeinen:
+    </p>
+    <ul>
+      <li>Informatie en gegevens;</li>
+      <li>Communicatie en samenwerking;</li>
+      <li>Creëren van inhoud;</li>
+      <li>Bescherming en beveiliging;</li>
+      <li>Milieu en digitalisering.</li>
+    </ul>
+    <p>
+      Het Pix Orga-platform is gebaseerd op het Pix-platform en biedt gebruikers (onder meer voorschrijvers) de
+      mogelijkheid om testcampagnes op te zetten voor diverse doelgroepen die begeleid worden in digitale vaardigheden.
+      Dit kan gaan om mensen die initiële of voortgezette opleidingen volgen in het kader van digitale
+      ondersteuningstrajecten of medewerkers van publieke of private organisaties. Het platform maakt het mogelijk om de
+      resultaten van het Pix-platform te verzamelen en te analyseren.
+    </p>
+    <p>
+      Het Pix Orga-platform is toegankelijk via volgende URL’s: orga.pix.fr en orga.pix.org.
+    </p>
+    <p>
+      Het biedt een besloten, gelimiteerde ruimte genaamd ‘organisatieruimte’ die aangemelde gebruikers toegang biedt
+      tot diensten op basis van hun kwalificatie als gebruiker (met daarbij ook voorschrijvers) of beheerder.
+    </p>
+    <h2 class="terms-of-service-form-text__article-title">Artikel 2. Definities</h2>
+    <ul>
+      <li>
+        “gebruikersvoorwaarden”: deze algemene gebruiksvoorwaarden van het Pix Orga-platform;
+      </li>
+    </ul>
+    <ul>
+      <li>
+        “organisatieruimte”: de ruimte gecreëerd door GIP Pix op verzoek van de organisatie;
+      </li>
+    </ul>
+    <ul>
+      <li>
+        “gegevens” : geheel van informatie van welke aard ook, gecommuniceerd door de organisatie en/of gebruikers onder
+        hun eigen verantwoordelijkheid, gehost door GIP Pix en bestemd voor verwerking in het kader van de uitvoering
+        van de diensten;
+      </li>
+    </ul>
+    <ul>
+      <li>
+        “aanmeldgegevens”: gebruikersnaam en wachtwoord, door een gebruiker persoonlijk en vertrouwelijk ingevoerd bij
+        het aanmaken van een gebruikersaccount dat toegang geeft tot de diensten via een beveiligde verbinding met het
+        Pix Orga-platform;
+      </li>
+    </ul>
+    <ul>
+      <li>
+        “organisatie”: de rechtspersoon die gemachtigd en bevoegd is om de diensten te gebruiken, dit eventueel in het
+        kader van een afzonderlijke overeenkomst met GIP Pix of met een derde partij, die de gebruiker heeft gemachtigd
+        om de organisatieruimte op het Pix Orga-platform te beheren;
+      </li>
+    </ul>
+    <ul>
+      <li>
+        “Pix-platform”: publiek platform voor het evalueren en certificeren van digitale vaardigheden, gebaseerd op een
+        IT-infrastructuur bestaande uit interfaces, databases en servers, en online toegankelijk in SaaS-modus. De
+        broncode ervan is onderworpen aan de vrije licentie GNU GPL V.3;
+      </li>
+    </ul>
+    <ul>
+      <li>
+        “Pix Orga-platform”: platform gebaseerd op het Pix-platform met een specifieke interface waarmee de organisatie
+        testcampagnes kan opzetten voor de betrokken gebruikers en de resultaten van het Pix-platform kan verzamelen en
+        analyseren; dit platform is toegankelijk via een online webportaal op een website die wordt beveiligd door GIP
+        Pix;
+      </li>
+    </ul>
+    <ul>
+      <li>
+        “diensten”: internettoegang in SaaS-modus tot de functies van het Pix Orga-platform door de gebruiker zoals
+        beschreven in het artikel “Presentatie van de diensten”;
+      </li>
+    </ul>
+    <ul>
+      <li>
+        “gebruiker”: elke natuurlijke persoon die een gebruikersaccount heeft aangemaakt onder de voorwaarden in het
+        artikel “Gebruikersaccount”, waarmee hij/zij toegang heeft tot de diensten van het Pix-platform en meer in het
+        bijzonder kan deelnemen aan testcampagnes;
+      </li>
+    </ul>
+    <ul>
+      <li>
+        “Pix Orga-gebruiker”: een gebruiker die toegang heeft tot ten minste een organisatieruimte en de functies voor
+        het beheer van campagnes en de analyse van resultaten, of tot de organisatieruimte, vanaf het Pix Orga-platform.
+      </li>
+    </ul>
+    <h2 class="terms-of-service-form-text__article-title">Artikel 3. Doel</h2>
+    <p>
+      Het doel van deze gebruiksvoorwaarden is het vastleggen van de gebruiks- en toegangsvoorwaarden van het Pix
+      Orga-platform, dat toegankelijk is op bovenstaand adres.
+    </p>
+    <h2 class="terms-of-service-form-text__article-title">Artikel 4. Aanvaarding en tegenwerpelijkheid</h2>
+    <h3 class="terms-of-service-form-text__article-subtitle">4.1 Aanvaarding</h3>
+    <p>
+      De gebruiker kan het Pix Orga-platform alleen gebruiken en de diensten alleen afnemen als hij/zij akkoord gaat met
+      deze gebruiksvoorwaarden.
+    </p>
+    <p>
+      Deze gebruiksvoorwaarden zijn voor elke gebruiker beschikbaar en toegankelijk op het Pix Orga-platform.
+    </p>
+    <p>
+      Voordat de gebruiker deze gebruiksvoorwaarden aanvaardt, verklaart hij/zij:
+    </p>
+    <ul>
+      <li>
+        meerderjarig te zijn op de dag van de registratie;
+      </li>
+      <li>
+        te beschikken over de rechtsbevoegdheid om de verplichtingen onder deze gebruiksvoorwaarden aan te gaan;
+      </li>
+      <li>
+        te beschikken over een geldig e-mailadres;
+      </li>
+      <li>
+        alle benodigde informatie van GIP Pix te hebben ontvangen over het gebruik van het Pix Orga-platform en de
+        aangeboden diensten en deze gebruiksvoorwaarden te hebben gelezen en zonder voorbehoud te hebben aanvaard;
+      </li>
+      <li>
+        te beschikken over alle technische vaardigheden die nodig zijn om normaal toegang te krijgen tot en gebruik te
+        maken van het Pix Orga-platform;
+      </li>
+      <li>
+        toe te zien op het naleven van de noodzakelijke technische vereisten.
+      </li>
+    </ul>
+    <p>
+      Het aanvaarden van deze gebruiksvoorwaarden gebeurt door een klik op de knop “Ik aanvaard de gebruiksvoorwaarden”
+      wanneer de gebruiker voor het eerst het Pix Orga-platform gebruikt, nadat hij/zij de volledige inhoud van deze
+      voorwaarden heeft gelezen. Deze klik vormt het bewijs dat de gebruiker de volledige inhoud van deze voorwaarden
+      heeft gelezen en ermee instemt.
+    </p>
+    <p>
+      De gebruiker kan de gebruiksvoorwaarden opslaan en afdrukken met behulp van de standaardfuncties van zijn/haar
+      browser of computer.
+    </p>
+    <p>
+      De gebruiker erkent dat toegang tot en gebruik van het Pix Orga-platform en de aangeboden diensten alleen mogelijk
+      is als alle voorschriften in deze gebruiksvoorwaarden worden nageleefd.
+    </p>
+    <h3 class="terms-of-service-form-text__article-subtitle">4.2 Tegenwerpelijkheid</h3>
+    <p>
+      Deze gebruiksvoorwaarden zijn bindend voor de gebruiker zodra hij/zij ze aanvaardt bij het aanmaken van een
+      gebruikersaccount of voordat hij/zij voor het eerst toegang krijgt tot de organisatieruimte.
+    </p>
+    <p>
+      In ieder geval worden de gebruiksvoorwaarden geacht gelezen en van toepassing te zijn op de datum waarop de
+      gebruiker voor het eerst de organisatieruimte gebruikt.
+    </p>
+    <p>
+      GIP Pix behoudt zich het recht voor om in deze gebruiksvoorwaarden alle wijzigingen aan te brengen die GIP Pix
+      nodig en nuttig acht.
+    </p>
+    <p>
+      Deze gebruiksvoorwaarden zijn van toepassing gedurende de gehele gebruiksperiode van het Pix Orga-platform en
+      blijven van kracht totdat ze worden vervangen door nieuwe gebruiksvoorwaarden.
+    </p>
+    <p>
+      GIP Pix verbindt zich ertoe de gebruiker op de hoogte te stellen van eventuele nieuwe gebruiksvoorwaarden. Elk
+      gebruik van het gebruikersaccount door de gebruiker na de wijziging ervan geldt als het aanvaarden van de nieuwe
+      gebruiksvoorwaarden.
+    </p>
+    <p>
+      De gebruiksvoorwaarden die online beschikbaar zijn op het Pix Orga-platform hebben voorrang op elke gedrukte
+      versie van eerdere datum.
+    </p>
+    <p>
+      De gebruiker kan op elk moment afzien van het gebruik van de organisatieruimte en de diensten, maar blijft
+      aansprakelijk voor elk eerder gebruik.
+    </p>
+    <h2 class="terms-of-service-form-text__article-title">Artikel 5. Gebruikersaccount</h2>
+    <p>
+      De procedure voor het aanmaken van een gebruikersaccount bestaat uit volgende stappen.
+    </p>
+
+    <h3 class="terms-of-service-form-text__article-subtitle">Stap 1.</h3>
+    <p>
+      De gebruiker vult een internetformulier in op het Pix-platform.
+    </p>
+    <p>
+      Verplichte gegevens zijn erop aangegeven met een asterisk (*) en omvatten: voornaam, achternaam, e-mailadres en
+      wachtwoord.
+    </p>
+    <p>
+      De gebruiker moet een geldig e-mailadres opgeven. Dit e-mailadres wordt gebruikt voor het verzenden van een
+      bevestigingsmail voor het aanmaken van het gebruikersaccount. Daarnaast moet de gebruiker een wachtwoord kiezen
+      dat voldoet aan volgende specificaties:
+    </p>
+    <ul>
+      <li>minimaal 8 tekens</li>
+      <li>minimaal één letter en één cijfer.</li>
+    </ul>
+    <p>
+      De gebruiker moet bevestigen dat hij/zij de gebruiksvoorwaarden van het Pix-platform heeft gelezen en aanvaard
+      door het daartoe voorziene vakje aan te vinken.
+    </p>
+    <h3 class="terms-of-service-form-text__article-subtitle">Stap 2.</h3>
+    <p>
+      De gebruiker meldt zich aan op zijn/haar gebruikersaccount met behulp van zijn/haar aanmeldgegevens. Deze zijn
+      persoonlijk en vertrouwelijk.
+    </p>
+    <p>
+      De gebruiker is als enige verantwoordelijk voor het bewaren en vertrouwelijk houden van zijn/haar wachtwoord en
+      dus ook voor de gevolgen van onbedoelde bekendmaking aan derden.
+    </p>
+    <p>
+      Elk gebruik van het gebruikersaccount met het gebruikerswachtwoord wordt verondersteld uitsluitend van de
+      gebruiker afkomstig te zijn.
+    </p>
+    <p>
+      De gebruiker moet elke diefstal van zijn/haar wachtwoord en elk gebruik door een derde waarvan hij/zij op de
+      hoogte is onmiddellijk melden aan support@pix.fr.
+    </p>
+    <p>
+      Het is mogelijk om het wachtwoord opnieuw in te stellen via het gebruikersaccount door te klikken op het tabblad
+      “Wachtwoord vergeten?” en vervolgens het e-mailadres in te voeren. Er wordt een e-mail naar de gebruiker gestuurd
+      om een nieuw wachtwoord in te stellen, dat ook moet voldoen aan bovengenoemde specificaties.
+    </p>
+    <h2 class="terms-of-service-form-text__article-title">Artikel 6. Organisatieruimte</h2>
+    <h3 class="terms-of-service-form-text__article-subtitle">6.1 Voorstelling van de diensten</h3>
+    <p>
+      De organisatieruimte biedt de gebruiker volgende diensten aan:
+    </p>
+    <ul>
+      <li>
+        evaluatiecampagnes uitwerken en uitvoeren,
+      </li>
+      <li>
+        evaluatiecampagnes beheren,
+      </li>
+      <li>
+        evaluatieresultaten analyseren.
+      </li>
+    </ul>
+    <h3 class="terms-of-service-form-text__article-subtitle">6.2 Toegang tot de organisatieruimte</h3>
+    <p>
+      GIP Pix stelt de gebruikerstoegang tot een Pix Orga-ruimte in.
+    </p>
+    <p>
+      Dit veronderstelt dat de gebruiker al een Pix-account heeft aangemaakt. Na het instellen van de toegang kan de
+      gebruiker zijn/haar organisatieruimte bereiken door zich aan te melden op orga.pix.fr of orga.pix.org.
+    </p>
+    <p>
+      Bij de eerste aanmelding op Pix Orga moet de gebruiker de Algemene Gebruiksvoorwaarden aanvaarden.
+    </p>
+    <h2 class="terms-of-service-form-text__article-title">Artikel 7. Toegang tot het Pix Orga-platform</h2>
+    <p>
+      Het Pix Orga-platform is normaal gesproken 24 uur per dag, 7 dagen per week toegankelijk.
+    </p>
+    <p>
+      GIP Pix behoudt zich het recht voor om de toegang tot de diensten volledig of gedeeltelijk te beperken (wat
+      invloed kan uitoefenen op de beschikbaarheid) om onderhoud aan het Pix Orga-platform uit te voeren in het kader
+      van vooraf geplande interventies. Dit onderhoud kan ook de servers en infrastructuren omvatten die worden gebruikt
+      om de diensten te leveren.
+    </p>
+    <p>
+      GIP Pix behoudt zich het recht voor om op elk moment zijn diensten, het gebruikersaccount, het uiterlijk en andere
+      aspecten van het Pix Orga-platform aan te vullen of te wijzigen, afhankelijk van technologische ontwikkelingen.
+    </p>
+    <p>
+      Het is de verantwoordelijkheid van de gebruiker om ervoor te zorgen dat de IT- en transmissiemiddelen die hij/zij
+      ter beschikking heeft, kunnen worden aangepast aan de ontwikkeling van het Pix Orga-platform en de door GIP Pix
+      aangeboden diensten.
+    </p>
+    <p>
+      In geval van onderbreking van het Pix Orga-platform of onmogelijkheid om dit te gebruiken, kan de gebruiker voor
+      meer informatie contact opnemen met de supportservice van GIP Pix via het volgende e-mailadres: support@pix.fr.
+    </p>
+    <h2 class="terms-of-service-form-text__article-title">Artikel 8. Technische specificaties</h2>
+    <p>
+      GIP Pix streeft ernaar een kwalitatief hoogwaardige dienst te leveren en zorgt ervoor dat gebruikers de
+      beschikbare diensten in de best mogelijke omstandigheden kunnen gebruiken.
+    </p>
+    <p>
+      GIP Pix heeft dus ten aanzien van de gebruiker, en dit volgens de normen en gebruiken in deze, bij het uitvoeren
+      van de dienst een middelenverbintenis, wat betekent dat de organisatie alle redelijke inspanningen zal leveren om
+      de dienst op een goede manier te leveren.
+    </p>
+    <p>
+      Rekening houdend met de aard en complexiteit van het internetnetwerk, en meer bepaald de technische prestaties en
+      responstijden voor het raadplegen, opvragen of overdragen van informatiegegevens, stelt GIP Pix alles in het werk,
+      in overeenstemming met de normen en gebruiken, om de toegang tot en het gebruik van het platform mogelijk te
+      maken. GIP Pix kan echter geen absolute toegankelijkheid of beschikbaarheid garanderen van het platform dat
+      toegang geeft tot de dienst.
+    </p>
+    <p>
+      GIP Pix kan niet aansprakelijk worden gesteld voor de werking van de IT-apparatuur van de gebruiker of voor diens
+      toegang tot het internet.
+    </p>
+    <p>
+      GIP Pix brengt de gebruiker op de hoogte van volgende technische vereisten voor de goede werking van het Pix
+      Orga-platform en de diensten:
+    </p>
+    <ul>
+      <li>
+        een internetbrowser in een recente versie (niet ouder dan twee jaar); Firefox, Internet Explorer 9 en later,
+        Edge, Chrome, Safari, Opera;
+      </li>
+      <li>
+        een betrouwbare internetverbinding.
+      </li>
+    </ul>
+    <h2 class="terms-of-service-form-text__article-title">Artikel 9. Gebruik</h2>
+    <p>
+      De gebruiker verbindt zich ertoe zijn/haar gebruikersaccount, de organisatieruimte, de diensten en in het algemeen
+      het Pix Orga-platform alleen te gebruiken volgens de voorwaarden in deze gebruiksvoorwaarden en bovendien:
+    </p>
+    <ul>
+      <li>
+        de organisatieruimte niet te misbruiken voor persoonlijke doeleinden of in strijd met het normale gebruik van de
+        diensten;
+      </li>
+      <li>
+        geen enkele daad van namaak te plegen.
+      </li>
+    </ul>
+    <p>
+      De gebruiker is verantwoordelijk voor het gebruik van zijn/haar gebruikersaccount, de organisatieruimte, de
+      diensten en in het algemeen het Pix Orga-platform. Hij/zij verbindt zich ertoe het gebruikersaccount eerlijk te
+      gebruiken, in overeenstemming met deze gebruiksvoorwaarden, de toepasselijke wetten en voorschriften, in het
+      bijzonder de wetten met betrekking tot intellectuele en industriële eigendom, de bescherming van persoonsgegevens
+      en de privacy.
+    </p>
+    <p>
+      De gebruiker verbindt zich ertoe om op geen enkele manier informatie over andere gebruikers te verzamelen, hetzij
+      handmatig of automatisch, met name e-mailadressen, zonder hun toestemming. Dit geldt vooral voor het verzenden van
+      ongewenste prospectie of spam, of het versturen van kettingmails.
+    </p>
+
+    <h2 class="terms-of-service-form-text__article-title">Artikel 10. Beveiliging</h2>
+
+    <p>
+      Elke frauduleuze toegang tot het Pix Orga-platform is verboden en strafbaar.
+    </p>
+    <p>
+      Rekening houdend met de complexiteit van het internet stelt GIP PIX alles in het werk om het Pix Orga-platform te
+      beveiligen volgens de normen en gebruiken. Echter, GIP Pix kan geen absolute veiligheid garanderen.
+    </p>
+    <p>
+      De gebruiker kan GIP Pix op de hoogte brengen van een storing van zijn/haar gebruikersaccount door een melding te
+      sturen naar: support@pix.org.
+    </p>
+    <p>
+      De gebruiker verbindt zich ertoe alle passende maatregelen te nemen, d.w.z. enerzijds regelmatig een back-up te
+      maken van zijn/haar eigen gegevens en anderzijds die gegevens en/of software en/of gebruikte apparaten te
+      beschermen tegen mogelijke virussen op het internet.
+    </p>
+
+    <h2 class="terms-of-service-form-text__article-title">Artikel 11. Onderhoud en ondersteuning</h2>
+
+    <h3 class="terms-of-service-form-text__article-subtitle">11.1 Ondersteuning en hulp voor Pix Orga-gebruikers</h3>
+    <p>
+      GIP Pix biedt uitsluitend technische ondersteuning aan Pix Orga-gebruikers. Het is de verantwoordelijkheid van de
+      gebruiker om eventuele storingen te melden in de diensten die worden waargenomen door de gebruiker zelf en/of door
+      standaardgebruikers die zijn uitgenodigd door de gebruiker.
+    </p>
+    <p>
+      Gebruikers kunnen de technische ondersteuning van GIP Pix bereiken per e-mail via support@pix.fr.
+    </p>
+    <p>
+      GIP Pix biedt verschillende ondersteunings- en hulpdiensten aan. De gebruiker kan op elk moment contact opnemen
+      met GIP Pix om de praktische details van deze diensten te bespreken in het kader van een afzonderlijke
+      overeenkomst.
+    </p>
+
+    <h3 class="terms-of-service-form-text__article-subtitle">11.2 Evolutief onderhoud</h3>
+    <p>
+      De diensten kunnen in de loop der tijd worden aangepast om in te spelen op technologische ontwikkelingen en de
+      behoeften van de gebruikers (organisaties en personen) van Pix Orga.
+    </p>
+    <p>
+      GIP Pix kan de diensten op elk moment upgraden.
+    </p>
+    <p>
+      Het is de verantwoordelijkheid van de organisatie en de gebruikers om hun informatiesysteem (hardware- en
+      software, zoals het bijwerken van het besturingssysteem of de browser) op eigen kosten te upgraden als de evolutie
+      van de diensten dit redelijkerwijs vereist om te voldoen aan technologische standaarden.
+    </p>
+    <p>
+      GIP Pix is niet aansprakelijk voor enige schade die voortvloeit uit het tijdelijk gedeeltelijk of volledig
+      onbeschikbaar zijn van de diensten door onderhoudswerkzaamheden.
+    </p>
+
+    <h2 class="terms-of-service-form-text__article-title">Artikel 12. Aansprakelijkheid</h2>
+
+    <h3 class="terms-of-service-form-text__article-subtitle">12.1 Aansprakelijkheid van de gebruiker</h3>
+    <p>
+      De gebruiker is volledig verantwoordelijk voor de toegang tot en het gebruik van het Pix Orga-platform, in
+      overeenstemming met de geldende Franse wetgeving en met deze gebruiksvoorwaarden. De gebruiker aanvaardt het
+      risico en de aansprakelijkheid voor het gebruik van het platform.
+    </p>
+    <p>
+      De gebruiker is volledig verantwoordelijk voor de wettigheid van de gegevens die hij/zij communiceert via het Pix
+      Orga-plaform en ontlast GIP Pix van elke aansprakelijkheid met betrekking tot deze gegevens.
+    </p>
+    <p>
+      De gebruiker is ook als enige verantwoordelijk voor alle activiteiten die plaatsvinden op het Pix Orga-platform
+      via zijn/haar gebruikersaccount.
+    </p>
+    <p>
+      De gebruiker verbindt zich ertoe de toegang en/of het gebruik dat andere gebruikers kunnen maken van het Pix
+      Orga-platform niet te verstoren en zich geen toegang te verschaffen tot de gebruikersruimten van derden.
+    </p>
+    <p>
+      Elke actie die op het Pix Orga-platform wordt uitgevoerd met de aanmeldgegevens van de gebruiker wordt beschouwd
+      als een handeling van de gebruiker zelf.
+    </p>
+    <p>
+      De gebruiker verbindt zich ertoe geen handelingen te verrichten die de IT-veiligheid van GIP Pix of andere
+      gebruikers kunnen schaden, in overeenstemming met het artikel “Beveiliging”.
+    </p>
+    <p>
+      De gebruiker verbindt zich ertoe de normale werking van zijn/haar gebruikersaccount, en in het algemeen van het
+      Pix Orga-platform, niet te verstoren of te onderbreken.
+    </p>
+    <p>
+      De gebruiker verbindt zich ertoe GIP Pix, zijn directeur, werknemers en andere medewerkers te vergoeden in geval
+      van klachten, acties, vervolgingen, veroordelingen als gevolg van de niet-naleving van de gebruiksvoorwaarden door
+      de gebruiker.
+    </p>
+
+    <h3 class="terms-of-service-form-text__article-subtitle">12.2 Aansprakelijkheid van GIP Pix</h3>
+    <p>
+      Rekening houdend met de diversiteit van de gegevensbronnen die de gebruiker betreffen, de manieren van raadpleging
+      en de termijnen voor het verzenden ervan, zal GIP Pix alles in het werk stellen om de algemene kwaliteit van de
+      verstrekte informatie en de relevantie ervan te waarborgen.
+    </p>
+    <p>
+      GIP Pix zal zich inspannen om de handelingen die onder zijn verantwoordelijkheid vallen met betrekking tot het
+      gebruikersaccount en de organisatieomgeving uit te voeren volgens de geldende normen en gebruiken.
+    </p>
+    <p>
+      GIP Pix kan niet verantwoordelijk worden gehouden voor de kwaliteit van de diensten die “as is” worden aangeboden.
+      De gebruiker aanvaardt dit.
+    </p>
+    <p>
+      Bovendien kan GIP Pix niet aansprakelijk worden gesteld in geval van:
+    </p>
+    <ul>
+      <li>
+        een tijdelijke of volledige onbeschikbaarheid van het Pix-platform of een deel ervan, of in het algemeen bij
+        enige verstoring van de prestaties
+      </li>
+      <li>
+        de onmogelijkheid om toegang te krijgen tot het Pix-platform, als gevolg van vernietiging van apparatuur,
+        cyberaanvallen of hacking, of als gevolg van niet-beschikbaarheid, schorsing of verbod, tijdelijk of definitief
+        en om welke reden dan ook, van de toegang tot het internet;
+      </li>
+      <li>
+        de onmogelijkheid om toegang te krijgen tot het Pix-platform, als gevolg van vernietiging van apparatuur,
+        cyberaanvallen of hacking, of als gevolg van niet-beschikbaarheid, schorsing of verbod, tijdelijk of definitief
+        en om welke reden dan ook, van de toegang tot het internet;
+      </li>
+      <li>
+        binnen de grenzen van de heersende wetgeving, eventuele indirecte schade, inclusief winstverlies, verlies van
+        gegevens of enig ander verlies van immateriële activa als gevolg van het gebruik van het Pix-platform of,
+        daarentegen, de onmogelijkheid om het te gebruiken;
+      </li>
+      <li>
+        een storing, het onbeschikbaar zijn van toegang, verkeerd gebruik, onjuiste configuratie van de computer of
+        mobiele apparaten van de gebruiker, of het gebruik van een browser of besturingssysteem dat door de gebruiker
+        zelden wordt gebruikt;
+      </li>
+      <li>
+        frauduleus of oneigenlijk gebruik of opzettelijke of onvrijwillige bekendmaking aan wie dan ook van de
+        toegangscodes die aan de gebruiker zijn toevertrouwd.
+      </li>
+    </ul>
+    <p>
+      De partijen komen overeen dat de gebruiker die door de gebruiker van Pix Orga is uitgenodigd voor een
+      evaluatiecampagne, zich tot de organisatie zal wenden voor enige vergoeding, met dien verstande dat:
+    </p>
+    <ul>
+      <li>
+        GIP Pix aansprakelijk kan worden gesteld, onder de voorwaarden van het gemeen recht, voor directe en
+        voorzienbare schade geleden door de gebruiker, met uitzondering van alle indirecte schade;
+      </li>
+      <li>
+        als indirecte schade wordt meer bepaald beschouwd: bedrijfsschade, verlies van gegevens, tijd, winst, omzet,
+        winstmarges, bestellingen, klanten, inkomsten of commerciële acties; of nog: schade aan het merkimago, verwachte
+        resultaten en acties van derden, zelfs als GIP Pix naar behoren op de hoogte was gebracht van het risico van het
+        optreden van dergelijke schade;
+      </li>
+      <li>
+        de aansprakelijkheid van GIP Pix is, in onderling overleg met de organisatie, en ongeacht de schadeveroorzakende
+        gebeurtenis, beperkt tot het bedrag exclusief belastingen van de prijs betaald door de organisatie voor de
+        diensten tijdens welke de schadeveroorzakende gebeurtenis zich heeft voorgedaan;
+      </li>
+      <li>
+        met wederzijdse instemming kan GIP Pix niet aansprakelijk worden gesteld als het gaat om diensten wanneer deze
+        gratis geleverd werden.
+      </li>
+    </ul>
+    <p>
+      Deze clausule blijft van toepassing in geval van nietigheid, ontbinding, opzegging of nietigverklaring van de
+      huidige contractuele relatie.
+    </p>
+
+    <h2 class="terms-of-service-form-text__article-title">Artikel 13. Intellectuele eigendom</h2>
+    <p>
+      GIP Pix is en blijft de exclusieve eigenaar van de beschermde elementen van het Pix-platform en het Pix
+      Orga-platform die niet onderworpen zijn aan een gratis licentie, volgens de bepalingen van de Franse wet op
+      intellectueel eigendom, met uitzondering van eventuele leermiddelen of tests die het eigendom van derden kunnen
+      zijn.
+    </p>
+    <p>
+      De eigendomsrechten van GIP Pix strekken zich in dit kader uit tot alle documentatie, databases van het Pix- en
+      Pix Orga-platform, evenals hun interfaces, inclusief de testproeven, zonder dat deze lijst uitputtend is.
+    </p>
+    <p>
+      Deze gebruiksvoorwaarden leiden niet tot een overdracht of toekenning van de intellectuele eigendomsrechten van
+      het Pix en Pix Orga-platform of de diensten aan de gebruikers.
+    </p>
+    <p>
+      Bijgevolg dienen de gebruikers zich te onthouden van elke handeling die direct of indirect inbreuk kan maken op de
+      intellectuele eigendomsrechten van GIP Pix of derden. In het bijzonder is het hen verboden om de diensten of de
+      pagina’s van de platformen Pix en Pix Orga te wijzigen, te kopiëren, te reproduceren, te downloaden, te
+      verspreiden, te verzenden, commercieel te exploiteren en/of op enigerlei wijze te distribueren, voor zover deze
+      beschermd zijn door een intellectueel eigendomsrecht voor hun onderdelen die niet vallen onder een open
+      source-licentie. Alleen gebruik in overeenstemming met het beoogde doel van het Pix Orga-platform is toegestaan.
+    </p>
+    <p>
+      Elk gebruik dat hiermee niet conform is of niet uitdrukkelijk is toegestaan door GIP Pix onder deze
+      gebruiksvoorwaarden, is onwettig.
+    </p>
+
+    <h2 class="terms-of-service-form-text__article-title">Artikel 14. Hyperlinks</h2>
+    <p>
+      GIP Pix behoudt zich het recht voor om op het Pix Orga-platform hyperlinks te plaatsen die toegang geven tot
+      andere webpagina’s dan deze van het Pix- en Pix Orga-platform.
+    </p>
+    <p>
+      GIP Pix wijst elke aansprakelijkheid af voor de inhoud van de informatie die door deze sites wordt verstrekt via
+      deze hyperlinks.
+    </p>
+    <p>
+      Gebruikers bezoeken sites van derden volledig op eigen verantwoordelijkheid.
+    </p>
+    <p>
+      Voor elke hyperlink op een site van derden die doorverwijst naar een internetpagina van het Pix-platform, is de
+      voorafgaande schriftelijke toestemming van GIP Pix vereist.
+    </p>
+
+    <h2 class="terms-of-service-form-text__article-title">Artikel 15. Persoonsgegevens</h2>
+    <p>
+      GIP Pix kan als verwerkingsverantwoordelijke persoonsgegevens verwerken die betrekking hebben op de identiteit van
+      een gebruiker, zoals: achterna(a)m(en), voorna(a)men, functie, entiteit en/of afdeling waaraan de gebruiker
+      verbonden is, professioneel e-mailadres, aanmeldgegevens, gebruiks-ID binnen de organisatie (met uitzondering van
+      gevoelige gegevens zoals gedefinieerd door de CNIL), en logs van verbindingen.
+    </p>
+    <p>
+      Bij het aanmaken van een gebruikersaccount wordt de gebruiker ervan op de hoogte gebracht dat de gegevens
+      gemarkeerd met een asterisk op het formulier dat de gegevens inzamelt, verplicht zijn. Als deze gegevens niet
+      worden verstrekt, kan het verzoek van de gebruiker mogelijk niet worden verwerkt of kan de verwerking ervan
+      vertraging oplopen.
+    </p>
+    <p>
+      Deze gegevens worden verwerkt voor de behoeften van GIP Pix met als enige doel het administratief beheer van de
+      diensten, inclusief:
+    </p>
+    <ul>
+      <li>
+        het beheer van de toegang tot het Pix Orga-platform;
+      </li>
+      <li>
+        het beheer en de opvolging van het gebruikersaccount en de organisatieruimte (aanmaken, wijzigen, verwijderen);
+      </li>
+      <li>
+        het beheer van verzoeken om toegang, rectificatie en bezwaar tegen de verwerking van persoonsgegevens van
+        betrokkenen;
+      </li>
+      <li>
+        de statistische opvolging van het gebruik van het Pix Orga-platform;
+      </li>
+      <li>
+        de statistische opvolging van gebruikers en hun competentieniveau.
+      </li>
+    </ul>
+    <p>
+      De gebruiker wordt daarbij op de hoogte gesteld van, en aanvaardt dat, zijn/haar gegevens voor bovengenoemde
+      doeleinden worden verwerkt.
+    </p>
+    <p>
+      Deze verwerking gebeurt op basis van de volgende rechtsgronden: uw toestemming (via het aanvaarden van deze
+      voorwaarden), de uitvoering van deze algemene voorwaarden en het legitieme belang van GIP Pix om
+      beheerverwerkingen uit te voeren die noodzakelijk zijn voor de ontwikkeling van zijn activiteiten.
+    </p>
+    <p>
+      Deze gegevens zijn bestemd voor de verwerkingsverantwoordelijke van GIP Pix, het gemachtigd personeel van deze
+      laatste en eventuele verwerkers.
+    </p>
+    <p>
+      De gegevens worden maximaal 5 jaar bewaard vanaf het laatste gebruik of de laatste toegang tot het
+      gebruikersaccount en/of de organisatieruimte, en worden gearchiveerd volgens de wettelijke verjaringstermijnen (5
+      jaar).
+    </p>
+    <p>
+      Elke persoon op wie de verwerking betrekking heeft, beschikt over het recht om gegevens op te vragen, in te zien,
+      te rectificeren en te laten verwijderen, het recht op de beperking van verwerking en de overdraagbaarheid van de
+      gegevens; en ook het recht om op legitieme gronden bezwaar te maken.
+    </p>
+    <p>
+      Daarnaast heeft de gebruiker het recht om specifieke en algemene richtlijnen te formuleren over de bewaring,
+      verwijdering en communicatie van zijn gegevens na zijn overlijden. Deze richtlijnen kunnen worden gericht aan een
+      derde die bij besluit wordt aangewezen.
+    </p>
+    <p>
+      Het meedelen van specifieke post-mortemrichtlijnen en de uitoefening van rechten kan gebeuren per e-mail via
+      volgend adres: dpo@pix.fr. In geval van twijfel over de identiteit van de gebruiker, wordt mogelijk een kopie van
+      een ondertekend identiteitsbewijs en aanvullende informatie gevraagd.
+    </p>
+    <p>
+      GIP Pix kan ook persoonsgegevens van gebruikers verwerken als verwerker van de organisatie.
+    </p>
+    <p>
+      Deze organisatie staat als verwerkingsverantwoordelijke in voor het naleven van haar verplichtingen inzake de
+      bescherming van persoonsgegevens, en, waar van toepassing, haar verplichtingen volgens de overeenkomst tussen de
+      organisatie en GIP Pix.
+    </p>
+
+    <h2 class="terms-of-service-form-text__article-title">Artikel 16. Cookies</h2>
+    <p>
+      De gebruiker wordt ervan op de hoogte gesteld dat tijdens het gebruik van het Pix Orga-platform een of meer
+      cookies automatisch op zijn/haar browser kunnen worden geïnstalleerd, ongeacht het type apparaat dat wordt
+      gebruikt (computer, tablet of telefoon). Dit gebeurt via een banner die informatie geeft over de doeleinden van de
+      cookies en die aangeeft dat doorgaan met browsen gelijkstaat aan instemmen met het plaatsen van cookies op
+      zijn/haar browser en/of mobiele telefoon.
+    </p>
+    <p>
+      Een cookie is een gegevensblok dat niet wordt gebruikt voor identificatiedoeleinden, maar dient om informatie over
+      het browsegedrag van de gebruiker op het platform op te slaan voor de statistische monitoring van het gebruik van
+      het PIX- platform.
+    </p>
+    <p>
+      Via de instellingen van de browser en/of mobiele telefoon kunnen gebruikers om op de hoogte worden gebracht van de
+      aanwezigheid van een of meer cookies en deze eventueel te weigeren. De gebruiker kan, indien gewenst, het gebruik
+      van cookies activeren of deactiveren door het selecteren van de passende instellingen in zijn browser en/of
+      mobiele telefoon.
+    </p>
+    <p>
+      De gebruiker wordt erop gewezen dat een dergelijke deactivering het gebruik van bepaalde functies van het Pix
+      Orga-platform kan verhinderen.
+    </p>
+    <p>
+      De gebruiker heeft recht op toegang, verwijdering en wijziging van de persoonsgegevens die via cookies zijn
+      gecommuniceerd onder de voorwaarden hierboven aangegeven in artikel 15.
+    </p>
+    <p>
+      Informatie over het gebruik van cookies door het online platform, hun beheer en verwijdering door de gebruiker, en
+      over het recht op toegang tot, intrekking en wijziging van de persoonsgegevens die via cookies zijn
+      gecommuniceerd, staat gedetailleerd beschreven in het cookiebeleid in de algemene voorwaarden van de websites
+      www.pix.fr en www.pix.org.
+    </p>
+
+    <h2 class="terms-of-service-form-text__article-title">Artikel 17. Beëindiging en opzegging</h2>
+
+    <h3 class="terms-of-service-form-text__article-subtitle">17.1 Uitschrijven</h3>
+    <p>
+      De toegang tot de organisatieruimte van de gebruiker blijft actief zolang de gebruiker zich aanmeldt op het Pix
+      Orga-platform en de diensten gebruikt. Wanneer een gebruiker zich gedurende een periode van twee (2) jaar niet
+      heeft aangemeld of geen gebruik heeft gemaakt van zijn account, kan GIP Pix de gegevens van de gebruiker
+      archiveren. Op vraag van de gebruiker kan het account opnieuw worden geactiveerd.
+    </p>
+
+    <h3 class="terms-of-service-form-text__article-subtitle">17.2 Schorsing en uitsluiting</h3>
+    <p>
+      Bij niet-naleving door de gebruiker van de gebruiksvoorwaarden behoudt GIP Pix zich het recht voor om, acht (8)
+      dagen na het verzenden van een e-mail aan de gebruiker waarin wordt verzocht om de gebruiksvoorwaarden na te
+      leven, de toegang tot het platform op te schorten zonder vergoeding of terugbetaling, totdat de reden voor de
+      opschorting is verdwenen.
+    </p>
+    <p>
+      Bij herhaaldelijke niet-naleving door de gebruiker van de gebruiksvoorwaarden behoudt GIP Pix zich het recht voor
+      om, acht (8) dagen na het verzenden van een e-mail aan de gebruiker waarin wordt verzocht om de
+      gebruiksvoorwaarden na te leven waaraan geen gevolg wordt gegeven, de registratie en het abonnement van de
+      gebruiker te beëindigen en de toegang tot zijn gebruikersaccount te beëindigen of de toegang tot een deel of alle
+      diensten te verbieden, zonder vergoeding of terugbetaling en onverminderd enige wettelijke actie die voor hem
+      openstaat.
+    </p>
+
+    <h2 class="terms-of-service-form-text__article-title">Article 18. Bewijsovereenkomst</h2>
+    <p>
+      Het online aanvaarden van deze gebruiksvoorwaarden via elektronische weg heeft tussen de partijen dezelfde
+      bewijskracht als een overeenkomst op papier.
+    </p>
+    <p>
+      De geautomatiseerde registers die worden bewaard in de computersystemen van GIP Pix onder redelijke
+      veiligheidsomstandigheden worden beschouwd als bewijs van de communicatie tussen de partijen. Ze gelden als bewijs
+      tot het tegendeel is bewezen.
+    </p>
+    <p>
+      De gebruiksvoorwaarden van het Pix Orga-platform worden gearchiveerd op een betrouwbare en duurzame drager die als
+      bewijs kan worden overgelegd.
+    </p>
+
+    <h2 class="terms-of-service-form-text__article-title">Artikel 19. Nietigheid</h2>
+    <p>
+      Indien een of meer bepalingen van deze gebruiksvoorwaarden ongeldig worden verklaard op grond van een wet, een
+      verordening of een definitieve beslissing van een bevoegde rechtbank, blijven de overige bepalingen volledig van
+      kracht en in voege.
+    </p>
+
+    <h2 class="terms-of-service-form-text__article-title">Artikel 20. Toepasselijk recht</h2>
+    <p>
+      De Franse wetgeving is van toepassing op deze gebruiksvoorwaarden. Dit geldt zowel voor de inhoudelijke als de
+      vormelijke regels, ongeacht de plaats van uitvoering van de wezenlijke of bijkomende verplichtingen.
+    </p>
+  </div>
+</div>

--- a/orga/app/controllers/terms-of-service.js
+++ b/orga/app/controllers/terms-of-service.js
@@ -3,6 +3,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
+const DUTCH_LOCALE = 'nl';
 const ENGLISH_LOCALE = 'en';
 
 export default class TermOfServiceController extends Controller {
@@ -10,6 +11,7 @@ export default class TermOfServiceController extends Controller {
   @service intl;
   @service router;
 
+  @tracked isDutchLocale = this.intl.primaryLocale === DUTCH_LOCALE;
   @tracked isEnglishLocale = this.intl.primaryLocale === ENGLISH_LOCALE;
 
   @action

--- a/orga/app/services/url.js
+++ b/orga/app/services/url.js
@@ -24,6 +24,7 @@ export default class Url extends Service {
     CGU: {
       en: '/terms-and-conditions',
       fr: '/conditions-generales-d-utilisation',
+      nl: '/algemene-gebruiksvoorwaarden',
     },
     DATA_PROTECTION_POLICY: {
       en: '/personal-data-protection-policy',
@@ -59,8 +60,8 @@ export default class Url extends Service {
   }
 
   get cguUrl() {
-    const { en, fr } = this.SHOWCASE_WEBSITE_LOCALE_PATH.CGU;
-    return this._computeShowcaseWebsiteUrl({ en, fr });
+    const { en, fr, nl } = this.SHOWCASE_WEBSITE_LOCALE_PATH.CGU;
+    return this._computeShowcaseWebsiteUrl({ en, fr, nl });
   }
 
   get dataProtectionPolicyUrl() {
@@ -110,7 +111,7 @@ export default class Url extends Service {
       case ENGLISH_LOCALE:
         return `${PIX_ORG_DOMAIN_EN_LOCALE}${englishPath}`;
       case DUTCH_LOCALE:
-        return dutchPath ? `${PIX_ORG_DOMAIN_NL_LOCALE}${dutchPath}` : `${PIX_ORG_DOMAIN_EN_LOCALE}${englishPath}`;
+        return `${PIX_ORG_DOMAIN_NL_LOCALE}${dutchPath}`;
       default:
         return 'https://pix.org/fr/mentions-legales';
     }

--- a/orga/app/styles/pages/authenticated/terms-of-service.scss
+++ b/orga/app/styles/pages/authenticated/terms-of-service.scss
@@ -59,6 +59,20 @@
     @include device-is('mobile') {
       margin: 20px 0;
     }
+
+    p,
+    li {
+      margin-bottom: $pix-spacing-s;
+    }
+
+    ul {
+      list-style: inside;
+    }
+
+    h2,
+    h3 {
+      margin-bottom: $pix-spacing-m;
+    }
   }
 
   &__actions {
@@ -77,7 +91,7 @@
 
 .terms-of-service-form-text {
   &__article-title {
-    @extend %pix-title-xs;
+    @extend %pix-title-s;
   }
 
   &__article-subtitle {

--- a/orga/app/templates/terms-of-service.hbs
+++ b/orga/app/templates/terms-of-service.hbs
@@ -5,6 +5,8 @@
 
     {{#if this.isEnglishLocale}}
       <TermsOfService::PageEn />
+    {{else if this.isDutchLocale}}
+      <TermsOfService::PageNl />
     {{else}}
       <TermsOfService::PageFr />
     {{/if}}

--- a/orga/tests/acceptance/join_test.js
+++ b/orga/tests/acceptance/join_test.js
@@ -197,7 +197,7 @@ module('Acceptance | join', function (hooks) {
 
         // then
         assert.strictEqual(currentURL(), '/cgu');
-        assert.ok(screen.getByText("Condition générales d'utilisation de la plateforme Pix Orga"));
+        assert.ok(screen.getByText("Conditions générales d'utilisation de la plateforme Pix Orga"));
       });
 
       test('does not show menu nor top bar', async function (assert) {

--- a/orga/tests/acceptance/terms-of-service_test.js
+++ b/orga/tests/acceptance/terms-of-service_test.js
@@ -1,5 +1,5 @@
-import { clickByName } from '@1024pix/ember-testing-library';
-import { currentURL, visit } from '@ember/test-helpers';
+import { clickByName, visit } from '@1024pix/ember-testing-library';
+import { currentURL } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupApplicationTest } from 'ember-qunit';
 import { currentSession } from 'ember-simple-auth/test-support';
@@ -28,6 +28,29 @@ module('Acceptance | terms-of-service', function (hooks) {
       prescriber = createPrescriberWithPixOrgaTermsOfService({ pixOrgaTermsOfServiceAccepted: false });
 
       await authenticateSession(prescriber.id);
+    });
+
+    [
+      {
+        locale: 'en',
+        title: 'Terms and Conditions of use of the Pix Orga plateform',
+      },
+      {
+        locale: 'nl',
+        title: 'Algemene gebruiksvoorwaarden van het pix orga-platform',
+      },
+      {
+        locale: 'fr',
+        title: "Conditions générales d'utilisation de la plateforme Pix Orga",
+      },
+    ].forEach(({ locale, title }) => {
+      test(`displays the ${locale} language version of cgu page`, async function (assert) {
+        // when
+        const screen = await visit(`/cgu?lang=${locale}`);
+
+        // then
+        assert.ok(screen.getByRole('heading', { name: title }));
+      });
     });
 
     test('redirects to campaign list after saving terms of service acceptation', async function (assert) {

--- a/orga/tests/acceptance/terms-of-service_test.js
+++ b/orga/tests/acceptance/terms-of-service_test.js
@@ -14,7 +14,7 @@ module('Acceptance | terms-of-service', function (hooks) {
 
   let prescriber;
 
-  test('it should redirect user to login page if not logged in', async function (assert) {
+  test('redirects user to login page if not logged in', async function (assert) {
     // when
     await visit('/cgu');
 
@@ -30,7 +30,7 @@ module('Acceptance | terms-of-service', function (hooks) {
       await authenticateSession(prescriber.id);
     });
 
-    test('it should redirect to campaign list after saving terms of service acceptation', async function (assert) {
+    test('redirects to campaign list after saving terms of service acceptation', async function (assert) {
       // given
       await visit('/cgu');
 
@@ -41,7 +41,7 @@ module('Acceptance | terms-of-service', function (hooks) {
       assert.strictEqual(currentURL(), '/campagnes/les-miennes');
     });
 
-    test('it should not be possible to visit another page if cgu are not accepted', async function (assert) {
+    test('blocks the visit of another page if cgu are not accepted', async function (assert) {
       // given
       await visit('/cgu');
 
@@ -60,7 +60,7 @@ module('Acceptance | terms-of-service', function (hooks) {
       await authenticateSession(prescriber.id);
     });
 
-    test('it should redirect to campaign list', async function (assert) {
+    test('redirects to campaign list', async function (assert) {
       // when
       await visit('/cgu');
 

--- a/orga/tests/unit/services/url_test.js
+++ b/orga/tests/unit/services/url_test.js
@@ -179,7 +179,7 @@ module('Unit | Service | url', function (hooks) {
         },
         {
           primaryLocale: 'nl',
-          expectedUrl: 'https://pix.org/en/terms-and-conditions',
+          expectedUrl: 'https://pix.org/nl-be/algemene-gebruiksvoorwaarden',
         },
       ].forEach(({ primaryLocale, expectedUrl }) => {
         test(`returns "pix.org" ${primaryLocale} url when locale is ${primaryLocale}`, function (assert) {


### PR DESCRIPTION
## :unicorn: Problème
L'ajout de la langue néerlandaise a été fait sur Pix Orga mais les CGU n'ont pas été traduites.

## :robot: Proposition
Ajouter une nouvelle page de CGU en néerlandais.

## :100: Pour tester
- Se connecter sur Pix Orga avec le compte `allorga@pix.fr`
- Dans la partie `Equipe` envoyer une invitation à une adresse mail dont vous avez l'accès
- Cliquez sur le lien et inscrivez vous en sélectionnant la langue nl
- Une fois inscrit, constater que la page des cgu s'affiche et dans la bonne langue