### PR TITLE
[FEATURE] Ajouter un espacement entre les différents banners sur PixOrga (PIX-13560)

### DIFF
--- a/orga/app/components/banner/top-banners.gjs
+++ b/orga/app/components/banner/top-banners.gjs
@@ -1,0 +1,11 @@
+import Information from './information';
+import LanguageAvailability from './language-availability';
+import Survey from './survey';
+
+<template>
+  <div class="top-banners">
+    <Information />
+    <LanguageAvailability />
+    <Survey />
+  </div>
+</template>

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -18,6 +18,7 @@
 @import 'globals/titles';
 
 // components
+@import 'components/banner';
 @import 'components/certificability';
 @import 'components/ui';
 @import 'components/sco-organization-participant';

--- a/orga/app/styles/components/banner/index.scss
+++ b/orga/app/styles/components/banner/index.scss
@@ -1,0 +1,1 @@
+@import 'top-banners';

--- a/orga/app/styles/components/banner/top-banners.scss
+++ b/orga/app/styles/components/banner/top-banners.scss
@@ -1,0 +1,9 @@
+.top-banners {
+  & > * {
+    margin-bottom: var(--pix-spacing-2x);
+  }
+
+  & > *:last-child {
+    margin-bottom: 0;
+  }
+}

--- a/orga/app/templates/authenticated.hbs
+++ b/orga/app/templates/authenticated.hbs
@@ -7,9 +7,7 @@
     </header>
 
     <main class="main-content__body page">
-      <Banner::Information />
-      <Banner::LanguageAvailability />
-      <Banner::Survey />
+      <Banner::TopBanners />
       {{outlet}}
     </main>
 


### PR DESCRIPTION
## :unicorn: Problème
Si plusieurs banner s'affiche, elle n'ont aucun espace entre elle.

## :robot: Proposition
Ajouter un minimum d'espace afin de respirer un petit peu

## :rainbow: Remarques
Regroupement des banners dans un seul composant

## :100: Pour tester
Vérifier que sur l'orga SCO SIECLE avec le sondage d'activer qu'il y ai bien un espacement entre les deux banner