### PR TITLE
[TECH] Supprimer tous les arguments de transactions inutiles

### DIFF
--- a/api/lib/application/certification-courses/certification-course-controller.js
+++ b/api/lib/application/certification-courses/certification-course-controller.js
@@ -44,9 +44,8 @@ const save = async function (request, h, dependencies = { extractLocaleFromReque
   const sessionId = request.payload.data.attributes['session-id'];
   const locale = dependencies.extractLocaleFromRequest(request);
 
-  const { created, certificationCourse } = await DomainTransaction.execute((domainTransaction) => {
+  const { created, certificationCourse } = await DomainTransaction.execute(() => {
     return usecases.retrieveLastOrCreateCertificationCourse({
-      domainTransaction,
       sessionId,
       accessCode,
       userId,

--- a/api/lib/application/organizations-administration/organization-administration-controller.js
+++ b/api/lib/application/organizations-administration/organization-administration-controller.js
@@ -11,10 +11,9 @@ const updateOrganizationInformation = async function (
 ) {
   const organizationDeserialized = dependencies.organizationForAdminSerializer.deserialize(request.payload);
 
-  const organizationUpdated = await DomainTransaction.execute(function (domainTransaction) {
+  const organizationUpdated = await DomainTransaction.execute(function () {
     return usecases.updateOrganizationInformation({
       organization: organizationDeserialized,
-      domainTransaction,
     });
   });
   return h.response(dependencies.organizationForAdminSerializer.serialize(organizationUpdated));

--- a/api/lib/application/sco-organization-learners/sco-organization-learner-controller.js
+++ b/api/lib/application/sco-organization-learners/sco-organization-learner-controller.js
@@ -186,12 +186,11 @@ const updateOrganizationLearnersPassword = async function (request, h) {
   const organizationId = payload['organization-id'];
   const organizationLearnersId = payload['organization-learners-id'];
 
-  const generatedCsvContent = await DomainTransaction.execute(async (domainTransaction) => {
+  const generatedCsvContent = await DomainTransaction.execute(async () => {
     const organizationLearnersPasswordResets = await usecases.resetOrganizationLearnersPassword({
       userId,
       organizationId,
       organizationLearnersId,
-      domainTransaction,
     });
     return usecases.generateResetOrganizationLearnersPasswordCsvContent({
       organizationLearnersPasswordResets,

--- a/api/lib/application/target-profiles/target-profile-controller.js
+++ b/api/lib/application/target-profiles/target-profile-controller.js
@@ -31,11 +31,10 @@ const updateTargetProfile = async function (request, h, dependencies = { usecase
   const targetProfileId = request.params.id;
   const attributesToUpdate = dependencies.targetProfileSerializer.deserialize(request.payload);
 
-  await DomainTransaction.execute(async (domainTransaction) => {
+  await DomainTransaction.execute(async () => {
     await dependencies.usecases.updateTargetProfile({
       id: targetProfileId,
       attributesToUpdate,
-      domainTransaction,
     });
   });
 
@@ -45,10 +44,9 @@ const updateTargetProfile = async function (request, h, dependencies = { usecase
 const createTargetProfile = async function (request) {
   const targetProfileCreationCommand = targetProfileSerializer.deserialize(request.payload);
 
-  const targetProfileId = await DomainTransaction.execute(async (domainTransaction) => {
+  const targetProfileId = await DomainTransaction.execute(async () => {
     return usecases.createTargetProfile({
       targetProfileCreationCommand,
-      domainTransaction,
     });
   });
   return targetProfileSerializer.serializeId(targetProfileId);

--- a/api/lib/domain/usecases/anonymize-user.js
+++ b/api/lib/domain/usecases/anonymize-user.js
@@ -10,7 +10,6 @@ const anonymizeUser = async function ({
   organizationLearnerRepository,
   refreshTokenService,
   resetPasswordDemandRepository,
-  domainTransaction,
   adminMemberRepository,
 }) {
   const anonymizedUser = {
@@ -25,7 +24,7 @@ const anonymizeUser = async function ({
 
   const user = await userRepository.get(userId);
 
-  await authenticationMethodRepository.removeAllAuthenticationMethodsByUserId({ userId, domainTransaction });
+  await authenticationMethodRepository.removeAllAuthenticationMethodsByUserId({ userId });
 
   await refreshTokenService.revokeRefreshTokensForUserId({ userId });
 
@@ -33,20 +32,18 @@ const anonymizeUser = async function ({
     await resetPasswordDemandRepository.removeAllByEmail(user.email);
   }
 
-  await membershipRepository.disableMembershipsByUserId({ userId, updatedByUserId, domainTransaction });
+  await membershipRepository.disableMembershipsByUserId({ userId, updatedByUserId });
 
   await certificationCenterMembershipRepository.disableMembershipsByUserId({
     updatedByUserId,
     userId,
-    domainTransaction,
   });
 
-  await organizationLearnerRepository.dissociateAllStudentsByUserId({ userId, domainTransaction });
+  await organizationLearnerRepository.dissociateAllStudentsByUserId({ userId });
 
   await userRepository.updateUserDetailsForAdministration({
     id: userId,
     userAttributes: anonymizedUser,
-    domainTransaction,
   });
 
   const adminMember = await adminMemberRepository.get({ userId: updatedByUserId });

--- a/api/lib/domain/usecases/complete-assessment.js
+++ b/api/lib/domain/usecases/complete-assessment.js
@@ -4,26 +4,22 @@ import { AssessmentCompleted } from '../events/AssessmentCompleted.js';
 
 const completeAssessment = async function ({
   assessmentId,
-  domainTransaction,
   campaignParticipationBCRepository,
   assessmentRepository,
   locale,
 }) {
-  const assessment = await assessmentRepository.get(assessmentId, domainTransaction);
+  const assessment = await assessmentRepository.get(assessmentId);
 
   if (assessment.isCompleted()) {
     throw new AlreadyRatedAssessmentError();
   }
 
-  await assessmentRepository.completeByAssessmentId(assessmentId, domainTransaction);
+  await assessmentRepository.completeByAssessmentId(assessmentId);
 
   if (assessment.campaignParticipationId) {
     const { TO_SHARE } = CampaignParticipationStatuses;
 
-    await campaignParticipationBCRepository.update(
-      { id: assessment.campaignParticipationId, status: TO_SHARE },
-      domainTransaction,
-    );
+    await campaignParticipationBCRepository.update({ id: assessment.campaignParticipationId, status: TO_SHARE });
   }
 
   const assessmentCompleted = new AssessmentCompleted({

--- a/api/lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js
+++ b/api/lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js
@@ -80,17 +80,10 @@ const createOrganizationsWithTagsAndTargetProfiles = async function ({
 
 export { createOrganizationsWithTagsAndTargetProfiles };
 
-async function _createOrganizations({
-  transformedOrganizationsData,
-  domainTransaction,
-  organizationForAdminRepository,
-}) {
+async function _createOrganizations({ transformedOrganizationsData, organizationForAdminRepository }) {
   return bluebird.map(transformedOrganizationsData, async (organizationToCreate) => {
     try {
-      const createdOrganization = await organizationForAdminRepository.save(
-        organizationToCreate.organization,
-        domainTransaction,
-      );
+      const createdOrganization = await organizationForAdminRepository.save(organizationToCreate.organization);
       return {
         createdOrganization,
         organizationToCreate,

--- a/api/lib/domain/usecases/create-target-profile.js
+++ b/api/lib/domain/usecases/create-target-profile.js
@@ -3,7 +3,6 @@ import { TargetProfileForCreation } from '../models/TargetProfileForCreation.js'
 
 const createTargetProfile = async function ({
   targetProfileCreationCommand,
-  domainTransaction,
   targetProfileRepository,
   organizationRepository,
 }) {
@@ -18,7 +17,6 @@ const createTargetProfile = async function ({
 
   return targetProfileRepository.create({
     targetProfileForCreation,
-    domainTransaction,
   });
 };
 

--- a/api/lib/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
+++ b/api/lib/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
@@ -86,12 +86,11 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
       const reconciliationUserId = error.meta.userId;
       const identityProvider = NON_OIDC_IDENTITY_PROVIDERS.GAR.code;
 
-      await DomainTransaction.execute(async (domainTransaction) => {
+      await DomainTransaction.execute(async () => {
         await authenticationMethodRepository.updateExternalIdentifierByUserIdAndIdentityProvider({
           externalIdentifier: samlId,
           userId: reconciliationUserId,
           identityProvider,
-          domainTransaction,
         });
 
         const authenticationComplement = new AuthenticationMethod.GARAuthenticationComplement({
@@ -102,12 +101,10 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
           authenticationComplement,
           userId: reconciliationUserId,
           identityProvider,
-          domainTransaction,
         });
         const organizationLearner = await organizationLearnerRepository.reconcileUserToOrganizationLearner({
           userId: reconciliationUserId,
           organizationLearnerId: matchedOrganizationLearner.id,
-          domainTransaction,
         });
         userId = organizationLearner.userId;
       });

--- a/api/lib/domain/usecases/handle-badge-acquisition.js
+++ b/api/lib/domain/usecases/handle-badge-acquisition.js
@@ -2,7 +2,6 @@ import _ from 'lodash';
 
 const handleBadgeAcquisition = async function ({
   assessment,
-  domainTransaction,
   badgeForCalculationRepository,
   badgeAcquisitionRepository,
   knowledgeElementRepository,
@@ -12,14 +11,12 @@ const handleBadgeAcquisition = async function ({
     const associatedBadges = await _fetchPossibleCampaignAssociatedBadges(
       campaignParticipationId,
       badgeForCalculationRepository,
-      domainTransaction,
     );
     if (_.isEmpty(associatedBadges)) {
       return;
     }
     const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({
       userId: assessment.userId,
-      domainTransaction,
     });
 
     const obtainedBadgesByUser = associatedBadges.filter((badge) => badge.shouldBeObtained(knowledgeElements));
@@ -33,17 +30,13 @@ const handleBadgeAcquisition = async function ({
     });
 
     if (!_.isEmpty(badgeAcquisitionsToCreate)) {
-      await badgeAcquisitionRepository.createOrUpdate({ badgeAcquisitionsToCreate, domainTransaction });
+      await badgeAcquisitionRepository.createOrUpdate({ badgeAcquisitionsToCreate });
     }
   }
 };
 
-function _fetchPossibleCampaignAssociatedBadges(
-  campaignParticipationId,
-  badgeForCalculationRepository,
-  domainTransaction,
-) {
-  return badgeForCalculationRepository.findByCampaignParticipationId({ campaignParticipationId, domainTransaction });
+function _fetchPossibleCampaignAssociatedBadges(campaignParticipationId, badgeForCalculationRepository) {
+  return badgeForCalculationRepository.findByCampaignParticipationId({ campaignParticipationId });
 }
 
 export { handleBadgeAcquisition };

--- a/api/lib/domain/usecases/organizations-administration/update-organization-information.js
+++ b/api/lib/domain/usecases/organizations-administration/update-organization-information.js
@@ -1,11 +1,6 @@
-const updateOrganizationInformation = async function ({
-  organization,
-  organizationForAdminRepository,
-  tagRepository,
-  domainTransaction,
-}) {
-  const existingOrganization = await organizationForAdminRepository.get(organization.id, domainTransaction);
-  const tagsToUpdate = await tagRepository.findByIds(organization.tagIds, domainTransaction);
+const updateOrganizationInformation = async function ({ organization, organizationForAdminRepository, tagRepository }) {
+  const existingOrganization = await organizationForAdminRepository.get(organization.id);
+  const tagsToUpdate = await tagRepository.findByIds(organization.tagIds);
 
   existingOrganization.updateWithDataProtectionOfficerAndTags(
     organization,
@@ -13,9 +8,9 @@ const updateOrganizationInformation = async function ({
     tagsToUpdate,
   );
 
-  await organizationForAdminRepository.update(existingOrganization, domainTransaction);
+  await organizationForAdminRepository.update(existingOrganization);
 
-  return organizationForAdminRepository.get(organization.id, domainTransaction);
+  return organizationForAdminRepository.get(organization.id);
 };
 
 export { updateOrganizationInformation };

--- a/api/lib/domain/usecases/reset-organization-learners-password.js
+++ b/api/lib/domain/usecases/reset-organization-learners-password.js
@@ -9,7 +9,6 @@ const resetOrganizationLearnersPassword = async function ({
   organizationId,
   organizationLearnersId,
   userId,
-  domainTransaction,
   cryptoService,
   passwordGenerator,
   authenticationMethodRepository,
@@ -65,7 +64,6 @@ const resetOrganizationLearnersPassword = async function ({
 
   await authenticationMethodRepository.batchUpdatePasswordThatShouldBeChanged({
     usersToUpdateWithNewPassword,
-    domainTransaction,
   });
 
   return organizationLearnersPasswordResets;

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -18,7 +18,6 @@ import {
 const { features } = config;
 
 const retrieveLastOrCreateCertificationCourse = async function ({
-  domainTransaction,
   accessCode,
   sessionId,
   userId,
@@ -52,7 +51,6 @@ const retrieveLastOrCreateCertificationCourse = async function ({
     await certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId({
       userId,
       sessionId,
-      domainTransaction,
     });
 
   _validateCandidateIsAuthorizedToStart(certificationCandidate, existingCertificationCourse);
@@ -84,7 +82,6 @@ const retrieveLastOrCreateCertificationCourse = async function ({
   }
 
   return _startNewCertification({
-    domainTransaction,
     sessionId,
     userId,
     certificationCandidate,
@@ -145,7 +142,6 @@ async function _blockCandidateFromRestartingWithoutExplicitValidation(
 }
 
 async function _startNewCertification({
-  domainTransaction,
   sessionId,
   userId,
   certificationCandidate,
@@ -178,7 +174,6 @@ async function _startNewCertification({
     certificationCourseRepository,
     userId,
     sessionId,
-    domainTransaction,
   );
   if (certificationCourseCreatedMeanwhile) {
     return {
@@ -193,7 +188,6 @@ async function _startNewCertification({
 
   const highestCertifiableBadgeAcquisitions = await certificationBadgesService.findStillValidBadgeAcquisitions({
     userId,
-    domainTransaction,
   });
 
   await bluebird.each(
@@ -236,7 +230,6 @@ async function _startNewCertification({
     assessmentRepository,
     userId,
     certificationChallenges: challengesForCertification,
-    domainTransaction,
     verifyCertificateCodeService,
     complementaryCertificationCourseData,
     version,
@@ -244,16 +237,10 @@ async function _startNewCertification({
   });
 }
 
-async function _getCertificationCourseIfCreatedMeanwhile(
-  certificationCourseRepository,
-  userId,
-  sessionId,
-  domainTransaction,
-) {
+async function _getCertificationCourseIfCreatedMeanwhile(certificationCourseRepository, userId, sessionId) {
   return certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId({
     userId,
     sessionId,
-    domainTransaction,
   });
 }
 
@@ -265,7 +252,6 @@ async function _createCertificationCourse({
   userId,
   certificationChallenges,
   complementaryCertificationCourseData,
-  domainTransaction,
   version,
   lang,
 }) {
@@ -286,14 +272,13 @@ async function _createCertificationCourse({
 
   const savedCertificationCourse = await certificationCourseRepository.save({
     certificationCourse: newCertificationCourse,
-    domainTransaction,
   });
 
   const newAssessment = Assessment.createForCertificationCourse({
     userId,
     certificationCourseId: savedCertificationCourse.getId(),
   });
-  const savedAssessment = await assessmentRepository.save({ assessment: newAssessment, domainTransaction });
+  const savedAssessment = await assessmentRepository.save({ assessment: newAssessment });
 
   const certificationCourse = savedCertificationCourse.withAssessment(savedAssessment);
 

--- a/api/lib/domain/usecases/stages/handle-stage-acquisition.js
+++ b/api/lib/domain/usecases/stages/handle-stage-acquisition.js
@@ -29,7 +29,6 @@ import * as defaultGetMasteryPercentageService from '../../services/get-mastery-
  */
 const handleStageAcquisition = async function ({
   assessment,
-  domainTransaction,
   stageRepository = defaultStageRepository,
   skillRepository = defaultSkillRepository,
   campaignRepository = defaultCampaignRepository,
@@ -86,12 +85,7 @@ const handleStageAcquisition = async function ({
 
   if (!stagesToStore.length) return;
 
-  await stageAcquisitionRepository.saveStages(
-    stagesToStore,
-    assessment.userId,
-    campaignParticipation.id,
-    domainTransaction?.knexTransaction,
-  );
+  await stageAcquisitionRepository.saveStages(stagesToStore, assessment.userId, campaignParticipation.id);
 };
 
 /**

--- a/api/lib/domain/usecases/stages/handle-stage-acquisition.js
+++ b/api/lib/domain/usecases/stages/handle-stage-acquisition.js
@@ -13,7 +13,6 @@ import * as defaultGetMasteryPercentageService from '../../services/get-mastery-
 
 /**
  * @param {Assessment} assessment
- * @param {DomainTransaction} domainTransaction
  * @param stageRepository
  * @param skillRepository
  * @param campaignRepository

--- a/api/lib/domain/usecases/stages/handle-stage-acquisition.js
+++ b/api/lib/domain/usecases/stages/handle-stage-acquisition.js
@@ -43,15 +43,9 @@ const handleStageAcquisition = async function ({
 }) {
   if (!assessment.isForCampaign()) return;
 
-  const campaignParticipation = await campaignParticipationRepository.get(
-    assessment.campaignParticipationId,
-    domainTransaction,
-  );
+  const campaignParticipation = await campaignParticipationRepository.get(assessment.campaignParticipationId);
 
-  const stagesForThisCampaign = await stageRepository.getByCampaignParticipationId(
-    campaignParticipation.id,
-    domainTransaction?.knexTransaction,
-  );
+  const stagesForThisCampaign = await stageRepository.getByCampaignParticipationId(campaignParticipation.id);
 
   if (!stagesForThisCampaign.length) return;
 
@@ -68,7 +62,6 @@ const handleStageAcquisition = async function ({
     }),
     campaignRepository.findSkillIdsByCampaignParticipationId({
       campaignParticipationId: assessment.campaignParticipationId,
-      domainTransaction,
     }),
   ]);
 
@@ -76,7 +69,6 @@ const handleStageAcquisition = async function ({
 
   const alreadyAcquiredStagesIds = await stageAcquisitionRepository.getStageIdsByCampaignParticipation(
     campaignParticipation.id,
-    domainTransaction?.knexTransaction,
   );
 
   const validatedKnowledgeElements = knowledgeElements.filter(({ isValidated }) => isValidated);

--- a/api/lib/domain/usecases/update-last-question-state.js
+++ b/api/lib/domain/usecases/update-last-question-state.js
@@ -5,12 +5,11 @@ const updateLastQuestionState = async function ({
   assessmentId,
   lastQuestionState,
   challengeId,
-  domainTransaction,
   assessmentRepository,
   challengeRepository,
 }) {
   if (lastQuestionState === Assessment.statesOfLastQuestion.FOCUSEDOUT && challengeId !== undefined) {
-    const challenge = await challengeRepository.get(challengeId, domainTransaction);
+    const challenge = await challengeRepository.get(challengeId);
     if (!challenge.focused) {
       logger.warn(
         {
@@ -24,7 +23,7 @@ const updateLastQuestionState = async function ({
       return;
     }
 
-    const assessment = await assessmentRepository.get(assessmentId, domainTransaction);
+    const assessment = await assessmentRepository.get(assessmentId);
     if (challengeId !== assessment.lastChallengeId) {
       logger.warn(
         {
@@ -42,7 +41,6 @@ const updateLastQuestionState = async function ({
   return assessmentRepository.updateLastQuestionState({
     id: assessmentId,
     lastQuestionState,
-    domainTransaction,
   });
 };
 

--- a/api/lib/domain/usecases/update-organization-identity-provider-for-campaigns.js
+++ b/api/lib/domain/usecases/update-organization-identity-provider-for-campaigns.js
@@ -4,16 +4,15 @@ async function updateOrganizationIdentityProviderForCampaigns({
   identityProviderForCampaigns,
   organizationId,
   organizationForAdminRepository,
-  domainTransaction,
 }) {
-  const existingOrganization = await organizationForAdminRepository.get(organizationId, domainTransaction);
+  const existingOrganization = await organizationForAdminRepository.get(organizationId);
 
   if (!existingOrganization) {
     throw new OrganizationNotFoundError();
   }
   existingOrganization.updateIdentityProviderForCampaigns(identityProviderForCampaigns);
 
-  await organizationForAdminRepository.update(existingOrganization, domainTransaction);
+  await organizationForAdminRepository.update(existingOrganization);
 }
 
 export { updateOrganizationIdentityProviderForCampaigns };

--- a/api/lib/domain/usecases/update-target-profile.js
+++ b/api/lib/domain/usecases/update-target-profile.js
@@ -3,13 +3,12 @@ const updateTargetProfile = async function ({
   attributesToUpdate,
   targetProfileForAdminRepository,
   targetProfileForUpdateRepository,
-  domainTransaction,
 }) {
-  const targetProfileForAdmin = await targetProfileForAdminRepository.get({ id, domainTransaction });
+  const targetProfileForAdmin = await targetProfileForAdminRepository.get({ id });
 
   targetProfileForAdmin.update(attributesToUpdate);
 
-  return targetProfileForUpdateRepository.update(targetProfileForAdmin, domainTransaction);
+  return targetProfileForUpdateRepository.update(targetProfileForAdmin);
 };
 
 export { updateTargetProfile };

--- a/api/lib/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler.js
+++ b/api/lib/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler.js
@@ -1,7 +1,6 @@
 import cronParser from 'cron-parser';
 import dayjs from 'dayjs';
 
-import { knex } from '../../../../db/knex-database-connection.js';
 import { withTransaction } from '../../../../src/shared/domain/DomainTransaction.js';
 import { ComputeCertificabilityJob } from './ComputeCertificabilityJob.js';
 import { ScheduleComputeOrganizationLearnersCertificabilityJob } from './ScheduleComputeOrganizationLearnersCertificabilityJob.js';

--- a/api/lib/infrastructure/repositories/badge-acquisition-repository.js
+++ b/api/lib/infrastructure/repositories/badge-acquisition-repository.js
@@ -5,11 +5,8 @@ import { DomainTransaction } from '../DomainTransaction.js';
 
 const BADGE_ACQUISITIONS_TABLE = 'badge-acquisitions';
 
-const createOrUpdate = async function ({
-  badgeAcquisitionsToCreate = [],
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
-  const knexConn = domainTransaction.knexTransaction || knex;
+const createOrUpdate = async function ({ badgeAcquisitionsToCreate = [] }) {
+  const knexConn = DomainTransaction.getConnection();
   return bluebird.mapSeries(badgeAcquisitionsToCreate, async ({ badgeId, userId, campaignParticipationId }) => {
     const alreadyCreatedBadgeAcquisition = await knexConn(BADGE_ACQUISITIONS_TABLE)
       .select('id')
@@ -24,20 +21,13 @@ const createOrUpdate = async function ({
   });
 };
 
-const getAcquiredBadgeIds = async function ({
-  badgeIds,
-  userId,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
-  const knexConn = domainTransaction.knexTransaction || knex;
+const getAcquiredBadgeIds = async function ({ badgeIds, userId }) {
+  const knexConn = DomainTransaction.getConnection();
   return knexConn(BADGE_ACQUISITIONS_TABLE).pluck('badgeId').where({ userId }).whereIn('badgeId', badgeIds);
 };
 
-const getAcquiredBadgesByCampaignParticipations = async function ({
-  campaignParticipationsIds,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
-  const knexConn = domainTransaction.knexTransaction || knex;
+const getAcquiredBadgesByCampaignParticipations = async function ({ campaignParticipationsIds }) {
+  const knexConn = DomainTransaction.getConnection();
   const badges = await knexConn('badges')
     .distinct('badges.id')
     .select('badge-acquisitions.campaignParticipationId AS campaignParticipationId', 'badges.*')

--- a/api/lib/infrastructure/repositories/badge-for-calculation-repository.js
+++ b/api/lib/infrastructure/repositories/badge-for-calculation-repository.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 
-import { knex } from '../../../db/knex-database-connection.js';
 import { SCOPES } from '../../domain/models/BadgeDetails.js';
 import { BadgeCriterionForCalculation, BadgeForCalculation } from '../../domain/models/index.js';
 import { DomainTransaction } from '../DomainTransaction.js';
@@ -8,11 +7,8 @@ import * as campaignRepository from './campaign-repository.js';
 
 export { findByCampaignId, findByCampaignParticipationId, getByCertifiableBadgeAcquisition };
 
-const findByCampaignParticipationId = async function ({
-  campaignParticipationId,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
-  const knexConn = domainTransaction?.knexTransaction || knex;
+const findByCampaignParticipationId = async function ({ campaignParticipationId }) {
+  const knexConn = DomainTransaction.getConnection();
   const badgesDTO = await knexConn('badges')
     .select('badges.id')
     .join('target-profiles', 'target-profiles.id', 'badges.targetProfileId')
@@ -30,7 +26,6 @@ const findByCampaignParticipationId = async function ({
 
   const campaignSkills = await campaignRepository.findSkillsByCampaignParticipationId({
     campaignParticipationId,
-    domainTransaction,
   });
   const campaignSkillIds = campaignSkills.map(({ id }) => id);
   const campaignSkillsByTube = _.groupBy(campaignSkills, 'tubeId');
@@ -49,8 +44,8 @@ const findByCampaignParticipationId = async function ({
   return _.compact(badges);
 };
 
-const findByCampaignId = async function ({ campaignId, domainTransaction = DomainTransaction.emptyTransaction() }) {
-  const knexConn = domainTransaction?.knexTransaction || knex;
+const findByCampaignId = async function ({ campaignId }) {
+  const knexConn = DomainTransaction.getConnection();
   const badgesDTO = await knexConn('badges')
     .select('badges.id')
     .join('target-profiles', 'target-profiles.id', 'badges.targetProfileId')
@@ -67,7 +62,6 @@ const findByCampaignId = async function ({ campaignId, domainTransaction = Domai
 
   const campaignSkills = await campaignRepository.findSkills({
     campaignId,
-    domainTransaction,
   });
   const campaignSkillIds = campaignSkills.map(({ id }) => id);
   const campaignSkillsByTube = _.groupBy(campaignSkills, 'tubeId');
@@ -86,13 +80,11 @@ const findByCampaignId = async function ({ campaignId, domainTransaction = Domai
   return _.compact(badges);
 };
 
-const getByCertifiableBadgeAcquisition = async function ({
-  certifiableBadgeAcquisition,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
+const getByCertifiableBadgeAcquisition = async function ({ certifiableBadgeAcquisition }) {
+  const knexConn = DomainTransaction.getConnection();
   const badgeId = certifiableBadgeAcquisition.badgeId;
   const campaignId = certifiableBadgeAcquisition.campaignId;
-  const knexConn = domainTransaction?.knexTransaction || knex;
+
   const badgeDTO = await knexConn('badges')
     .select('badges.id')
     .join('target-profiles', 'target-profiles.id', 'badges.targetProfileId')
@@ -109,7 +101,6 @@ const getByCertifiableBadgeAcquisition = async function ({
 
   const campaignSkills = await campaignRepository.findSkills({
     campaignId,
-    domainTransaction,
   });
   const campaignSkillIds = campaignSkills.map(({ id }) => id);
   const campaignSkillsByTube = _.groupBy(campaignSkills, 'tubeId');

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -33,8 +33,8 @@ const getCodeOfLastParticipationToProfilesCollectionCampaignForUser = async func
   return result?.code || null;
 };
 
-const get = async function (id, domainTransaction = DomainTransaction.emptyTransaction()) {
-  const knexConn = domainTransaction.knexTransaction || knex;
+const get = async function (id) {
+  const knexConn = DomainTransaction.getConnection();
   const campaignParticipation = await knexConn('campaign-participations').where({ id }).first();
   const campaign = await knexConn('campaigns').where({ id: campaignParticipation.campaignId }).first();
   const assessments = await knexConn('assessments').where({ campaignParticipationId: id });

--- a/api/lib/infrastructure/repositories/certifiable-badge-acquisition-repository.js
+++ b/api/lib/infrastructure/repositories/certifiable-badge-acquisition-repository.js
@@ -9,12 +9,8 @@ const BADGE_ACQUISITIONS_TABLE = 'badge-acquisitions';
 /**
  * @returns {Array<CertifiableBadgeAcquisition>} highest complementary certification badges a user acquired
  */
-const findHighestCertifiable = async function ({
-  userId,
-  limitDate = new Date(),
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
-  const knexConn = domainTransaction.knexTransaction || knex;
+const findHighestCertifiable = async function ({ userId, limitDate = new Date() }) {
+  const knexConn = DomainTransaction.getConnection();
   const certifiableBadgeAcquisitions = await knexConn
     .with('user-badges', (qb) => {
       qb.from(BADGE_ACQUISITIONS_TABLE)

--- a/api/lib/infrastructure/repositories/certification-center-membership-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-membership-repository.js
@@ -236,12 +236,8 @@ const getRefererByCertificationCenterId = async function ({ certificationCenterI
   return _toDomain(refererCertificationCenterMembership);
 };
 
-const disableMembershipsByUserId = async function ({
-  userId,
-  updatedByUserId,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
-  const knexConn = domainTransaction.knexTransaction ?? knex;
+const disableMembershipsByUserId = async function ({ userId, updatedByUserId }) {
+  const knexConn = DomainTransaction.getConnection();
   await knexConn(CERTIFICATION_CENTER_MEMBERSHIP_TABLE_NAME)
     .whereNull('disabledAt')
     .andWhere({ userId })

--- a/api/lib/infrastructure/repositories/competence-mark-repository.js
+++ b/api/lib/infrastructure/repositories/competence-mark-repository.js
@@ -6,9 +6,9 @@ function _toDomain(competenceMark) {
   return new CompetenceMark(competenceMark);
 }
 
-const save = async function (competenceMark, domainTransaction = DomainTransaction.emptyTransaction()) {
+const save = async function (competenceMark) {
   await competenceMark.validate();
-  const knexConn = domainTransaction.knexTransaction || knex;
+  const knexConn = DomainTransaction.getConnection();
   const [savedCompetenceMark] = await knexConn('competence-marks')
     .insert(competenceMark)
     .onConflict('id')

--- a/api/lib/infrastructure/repositories/flash-assessment-result-repository.js
+++ b/api/lib/infrastructure/repositories/flash-assessment-result-repository.js
@@ -1,27 +1,21 @@
-import { knex } from '../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../DomainTransaction.js';
 
 const TABLE_NAME = 'flash-assessment-results';
 
-const save = async function ({
-  answerId,
-  estimatedLevel,
-  errorRate,
-  assessmentId,
-  domainTransaction: { knexTransaction } = DomainTransaction.emptyTransaction(),
-}) {
-  const query = knex(TABLE_NAME).insert({
+const save = async function ({ answerId, estimatedLevel, errorRate, assessmentId }) {
+  const knexConn = DomainTransaction.getConnection();
+
+  return knexConn(TABLE_NAME).insert({
     answerId,
     estimatedLevel,
     errorRate,
     assessmentId,
   });
-  if (knexTransaction) query.transacting(knexTransaction);
-  return query;
 };
 
 const getLatestByAssessmentId = async function (assessmentId) {
-  return knex(TABLE_NAME).where({ assessmentId }).orderBy('id', 'desc').limit(1).first();
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn(TABLE_NAME).where({ assessmentId }).orderBy('id', 'desc').limit(1).first();
 };
 
 export { getLatestByAssessmentId, save };

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -20,12 +20,8 @@ function _applyFilters(knowledgeElements) {
   return _dropResetKnowledgeElements(uniqsMostRecentPerSkill);
 }
 
-function _findByUserIdAndLimitDateQuery({
-  userId,
-  limitDate,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
-  const knexConn = domainTransaction.knexTransaction || knex;
+function _findByUserIdAndLimitDateQuery({ userId, limitDate }) {
+  const knexConn = DomainTransaction.getConnection();
   return knexConn(tableName).where((qb) => {
     qb.where({ userId });
     if (limitDate) {
@@ -34,8 +30,8 @@ function _findByUserIdAndLimitDateQuery({
   });
 }
 
-async function _findAssessedByUserIdAndLimitDateQuery({ userId, limitDate, domainTransaction }) {
-  const knowledgeElementRows = await _findByUserIdAndLimitDateQuery({ userId, limitDate, domainTransaction });
+async function _findAssessedByUserIdAndLimitDateQuery({ userId, limitDate }) {
+  const knowledgeElementRows = await _findByUserIdAndLimitDateQuery({ userId, limitDate });
 
   const knowledgeElements = _.map(
     knowledgeElementRows,
@@ -87,14 +83,14 @@ const save = async function (knowledgeElement) {
   return new KnowledgeElement(savedKnowledgeElement);
 };
 
-const batchSave = async function ({ knowledgeElements, domainTransaction = DomainTransaction.emptyTransaction() }) {
-  const knexConn = domainTransaction.knexTransaction || knex;
+const batchSave = async function ({ knowledgeElements }) {
+  const knexConn = DomainTransaction.getConnection();
   const knowledgeElementsToSave = knowledgeElements.map((ke) => _.omit(ke, ['id', 'createdAt']));
   await knexConn.batchInsert(tableName, knowledgeElementsToSave);
 };
 
-const findUniqByUserId = function ({ userId, limitDate, domainTransaction }) {
-  return _findAssessedByUserIdAndLimitDateQuery({ userId, limitDate, domainTransaction });
+const findUniqByUserId = function ({ userId, limitDate }) {
+  return _findAssessedByUserIdAndLimitDateQuery({ userId, limitDate });
 };
 
 const findUniqByUserIdAndAssessmentId = async function ({ userId, assessmentId }) {
@@ -108,12 +104,8 @@ const findUniqByUserIdAndAssessmentId = async function ({ userId, assessmentId }
   return _applyFilters(knowledgeElements);
 };
 
-const findUniqByUserIdAndCompetenceId = async function ({
-  userId,
-  competenceId,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
-  const knowledgeElements = await _findAssessedByUserIdAndLimitDateQuery({ userId, domainTransaction });
+const findUniqByUserIdAndCompetenceId = async function ({ userId, competenceId }) {
+  const knowledgeElements = await _findAssessedByUserIdAndLimitDateQuery({ userId });
   return knowledgeElements.filter((knowledgeElement) => knowledgeElement.competenceId === competenceId);
 };
 

--- a/api/lib/infrastructure/repositories/knowledge-element-snapshot-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-snapshot-repository.js
@@ -18,14 +18,9 @@ function _toKnowledgeElementCollection({ snapshot } = {}) {
   );
 }
 
-const save = async function ({
-  userId,
-  snappedAt,
-  knowledgeElements,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
+const save = async function ({ userId, snappedAt, knowledgeElements }) {
   try {
-    const knexConn = domainTransaction.knexTransaction || knex;
+    const knexConn = DomainTransaction.getConnection();
     return await knexConn('knowledge-element-snapshots').insert({
       userId,
       snappedAt,

--- a/api/lib/infrastructure/repositories/membership-repository.js
+++ b/api/lib/infrastructure/repositories/membership-repository.js
@@ -146,12 +146,8 @@ const updateById = async function ({ id, membership }) {
   return bookshelfToDomainConverter.buildDomainObject(BookshelfMembership, updatedMembershipWithUserAndOrganization);
 };
 
-const disableMembershipsByUserId = async function ({
-  userId,
-  updatedByUserId,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
-  const knexConn = domainTransaction.knexTransaction ?? knex;
+const disableMembershipsByUserId = async function ({ userId, updatedByUserId }) {
+  const knexConn = DomainTransaction.getConnection();
   await knexConn('memberships').where({ userId }).update({ disabledAt: new Date(), updatedByUserId });
 };
 

--- a/api/lib/infrastructure/repositories/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-repository.js
@@ -46,8 +46,8 @@ const findByIds = async function ({ ids }) {
   return rawOrganizationLearners.map((rawOrganizationLearner) => new OrganizationLearner(rawOrganizationLearner));
 };
 
-const findByOrganizationId = function ({ organizationId }, transaction = DomainTransaction.emptyTransaction()) {
-  const knexConn = transaction.knexTransaction || knex;
+const findByOrganizationId = function ({ organizationId }) {
+  const knexConn = DomainTransaction.getConnection();
   return knexConn('view-active-organization-learners')
     .where({ organizationId })
     .orderByRaw('LOWER("lastName") ASC, LOWER("firstName") ASC')
@@ -98,16 +98,12 @@ const isOrganizationLearnerIdLinkedToUserAndSCOOrganization = async function ({ 
   return Boolean(exist);
 };
 
-const _reconcileOrganizationLearners = async function (
-  studentsToImport,
-  allOrganizationLearnersInSameOrganization,
-  domainTransaction,
-) {
+const _reconcileOrganizationLearners = async function (studentsToImport, allOrganizationLearnersInSameOrganization) {
   const nationalStudentIdsFromFile = studentsToImport
     .map((organizationLearnerData) => organizationLearnerData.nationalStudentId)
     .filter(Boolean);
   const organizationLearnersWithSameNationalStudentIdsAsImported =
-    await studentRepository.findReconciledStudentsByNationalStudentId(nationalStudentIdsFromFile, domainTransaction);
+    await studentRepository.findReconciledStudentsByNationalStudentId(nationalStudentIdsFromFile);
 
   organizationLearnersWithSameNationalStudentIdsAsImported.forEach((organizationLearner) => {
     const alreadyReconciledStudentToImport = studentsToImport.find(

--- a/api/lib/infrastructure/repositories/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-repository.js
@@ -303,14 +303,12 @@ async function countByOrganizationsWhichNeedToComputeCertificability({
   onlyNotComputed = false,
   fromUserActivityDate,
   toUserActivityDate,
-  domainTransaction,
 } = {}) {
   const queryBuilder = _queryBuilderForCertificability({
     fromUserActivityDate,
     toUserActivityDate,
     skipLoggedLastDayCheck,
     onlyNotComputed,
-    domainTransaction,
   });
   const [{ count }] = await queryBuilder.count('view-active-organization-learners.id');
   return count;
@@ -323,14 +321,12 @@ function findByOrganizationsWhichNeedToComputeCertificability({
   toUserActivityDate,
   skipLoggedLastDayCheck = false,
   onlyNotComputed = false,
-  domainTransaction,
 } = {}) {
   const queryBuilder = _queryBuilderForCertificability({
     fromUserActivityDate,
     toUserActivityDate,
     skipLoggedLastDayCheck,
     onlyNotComputed,
-    domainTransaction,
   });
 
   return queryBuilder

--- a/api/lib/infrastructure/repositories/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-repository.js
@@ -146,13 +146,9 @@ const findByOrganizationIdAndBirthdate = async function ({ organizationId, birth
   return rawOrganizationLearners.map((rawOrganizationLearner) => new OrganizationLearner(rawOrganizationLearner));
 };
 
-const reconcileUserToOrganizationLearner = async function ({
-  userId,
-  organizationLearnerId,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
+const reconcileUserToOrganizationLearner = async function ({ userId, organizationLearnerId }) {
   try {
-    const knexConn = domainTransaction.knexTransaction ?? knex;
+    const knexConn = DomainTransaction.getConnection();
     const [rawOrganizationLearner] = await knexConn('organization-learners')
       .where({ id: organizationLearnerId })
       .where('isDisabled', false)
@@ -216,11 +212,8 @@ const dissociateUserFromOrganizationLearner = async function (organizationLearne
   await _queryBuilderDissociation(knex).where({ id: organizationLearnerId });
 };
 
-const dissociateAllStudentsByUserId = async function ({
-  userId,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
-  const knexConn = domainTransaction.knexTransaction ?? knex;
+const dissociateAllStudentsByUserId = async function ({ userId }) {
+  const knexConn = DomainTransaction.getConnection();
   await _queryBuilderDissociation(knexConn)
     .where({ userId })
     .whereIn(
@@ -267,12 +260,8 @@ const getLatestOrganizationLearner = async function ({ nationalStudentId, birthd
   return organizationLearner;
 };
 
-const updateUserIdWhereNull = async function ({
-  organizationLearnerId,
-  userId,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
-  const knexConn = domainTransaction.knexTransaction || knex;
+const updateUserIdWhereNull = async function ({ organizationLearnerId, userId }) {
+  const knexConn = DomainTransaction.getConnection();
   const [rawOrganizationLearner] = await knexConn('organization-learners')
     .where({ id: organizationLearnerId, userId: null })
     .update({ userId, updatedAt: knex.fn.now() })
@@ -362,9 +351,8 @@ function _queryBuilderForCertificability({
   toUserActivityDate,
   skipLoggedLastDayCheck,
   onlyNotComputed,
-  domainTransaction,
 }) {
-  const knexConn = domainTransaction.knexTransaction || knex;
+  const knexConn = DomainTransaction.getConnection();
   return knexConn('view-active-organization-learners')
     .join(
       'organization-features',

--- a/api/lib/infrastructure/repositories/organization-tag-repository.js
+++ b/api/lib/infrastructure/repositories/organization-tag-repository.js
@@ -25,8 +25,8 @@ const create = async function (organizationTag) {
   }
 };
 
-const batchCreate = async function (organizationsTags, domainTransaction = DomainTransaction.emptyTransaction()) {
-  const knexConn = domainTransaction.knexTransaction || knex;
+const batchCreate = async function (organizationsTags) {
+  const knexConn = DomainTransaction.getConnection();
 
   return knexConn.batchInsert('organization-tags', organizationsTags);
 };

--- a/api/lib/infrastructure/repositories/pgboss-repository.js
+++ b/api/lib/infrastructure/repositories/pgboss-repository.js
@@ -1,8 +1,7 @@
-import { knex } from '../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../DomainTransaction.js';
 
-function insert(jobs, domainTransaction = DomainTransaction.emptyTransaction()) {
-  const knexConn = domainTransaction.knexTransaction || knex;
+function insert(jobs) {
+  const knexConn = DomainTransaction.getConnection();
   return knexConn('pgboss.job').insert(jobs);
 }
 

--- a/api/lib/infrastructure/repositories/student-repository.js
+++ b/api/lib/infrastructure/repositories/student-repository.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 
-import { knex } from '../../../db/knex-database-connection.js';
 import { Student } from '../../domain/models/Student.js';
 import { DomainTransaction } from '../DomainTransaction.js';
 
@@ -25,11 +24,8 @@ const _toStudents = function (results) {
   return students;
 };
 
-const findReconciledStudentsByNationalStudentId = async function (
-  nationalStudentIds,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-) {
-  const knexConn = domainTransaction.knexTransaction || knex;
+const findReconciledStudentsByNationalStudentId = async function (nationalStudentIds) {
+  const knexConn = DomainTransaction.getConnection();
   const results = await knexConn
     .select({
       nationalStudentId: 'view-active-organization-learners.nationalStudentId',

--- a/api/lib/infrastructure/repositories/tag-repository.js
+++ b/api/lib/infrastructure/repositories/tag-repository.js
@@ -35,7 +35,7 @@ const findAll = async function () {
   return rows.map((row) => new Tag(row));
 };
 
-const findByIds = async function (tagIds, domainTransaction) {
+const findByIds = async function (tagIds) {
   const knexConn = DomainTransaction.getConnection();
   const rows = await knexConn('tags').whereIn('id', tagIds);
   return rows.map((row) => new Tag(row));

--- a/api/lib/infrastructure/repositories/tag-repository.js
+++ b/api/lib/infrastructure/repositories/tag-repository.js
@@ -7,6 +7,7 @@ const { omit } = lodash;
 
 import { knex } from '../../../db/knex-database-connection.js';
 import { Tag } from '../../../src/organizational-entities/domain/models/Tag.js';
+import { DomainTransaction } from '../../../src/shared/domain/DomainTransaction.js';
 
 const create = async function (tag) {
   try {
@@ -35,7 +36,7 @@ const findAll = async function () {
 };
 
 const findByIds = async function (tagIds, domainTransaction) {
-  const knexConn = domainTransaction.knexTransaction;
+  const knexConn = DomainTransaction.getConnection();
   const rows = await knexConn('tags').whereIn('id', tagIds);
   return rows.map((row) => new Tag(row));
 };

--- a/api/lib/infrastructure/repositories/target-profile-for-update-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-for-update-repository.js
@@ -1,11 +1,10 @@
-import { knex } from '../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../DomainTransaction.js';
 
 const TARGET_PROFILE_TABLE_NAME = 'target-profiles';
 const TARGET_PROFILE_TUBES_TABLE_NAME = 'target-profile_tubes';
 
-const update = async function (targetProfile, domainTransaction = DomainTransaction.emptyTransaction()) {
-  const knexConn = domainTransaction?.knexTransaction || (await knex.transaction());
+const update = async function (targetProfile) {
+  const knexConn = DomainTransaction.getConnection();
 
   const {
     id: targetProfileId,
@@ -35,10 +34,6 @@ const update = async function (targetProfile, domainTransaction = DomainTransact
 
     await knexConn(TARGET_PROFILE_TUBES_TABLE_NAME).delete().where({ targetProfileId });
     await knexConn(TARGET_PROFILE_TUBES_TABLE_NAME).insert(tubesData);
-  }
-
-  if (!domainTransaction?.knexTransaction) {
-    await knexConn.commit();
   }
 };
 

--- a/api/lib/infrastructure/repositories/target-profile-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-repository.js
@@ -8,8 +8,8 @@ import { TargetProfile } from '../../domain/models/index.js';
 import { DomainTransaction } from '../DomainTransaction.js';
 
 const TARGET_PROFILE_TABLE = 'target-profiles';
-const create = async function ({ targetProfileForCreation, domainTransaction = DomainTransaction.emptyTransaction() }) {
-  const knexConn = domainTransaction.knexTransaction || knex;
+const create = async function ({ targetProfileForCreation }) {
+  const knexConn = DomainTransaction.getConnection();
   const targetProfileRawData = _.pick(targetProfileForCreation, [
     'name',
     'category',
@@ -32,8 +32,8 @@ const create = async function ({ targetProfileForCreation, domainTransaction = D
   return targetProfileId;
 };
 
-const get = async function (id, domainTransaction = DomainTransaction.emptyTransaction()) {
-  const knexConn = domainTransaction.knexTransaction || knex;
+const get = async function (id) {
+  const knexConn = DomainTransaction.getConnection();
   const targetProfile = await knexConn('target-profiles').where({ id }).first();
   const badges = await knexConn('badges').where('targetProfileId', id);
 
@@ -44,10 +44,10 @@ const get = async function (id, domainTransaction = DomainTransaction.emptyTrans
   return new TargetProfile({ ...targetProfile, badges: badges.map((badge) => new Badge(badge)) });
 };
 
-const getTubesByTargetProfileId = async (targetProfileId, { knexTransaction } = DomainTransaction.emptyTransaction()) =>
-  await (knexTransaction ?? knex)('target-profile_tubes')
-    .select('tubeId', 'level')
-    .where('targetProfileId', targetProfileId);
+const getTubesByTargetProfileId = async (targetProfileId) => {
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn('target-profile_tubes').select('tubeId', 'level').where('targetProfileId', targetProfileId);
+};
 
 const findByIds = async function (targetProfileIds) {
   const targetProfiles = await knex('target-profiles').whereIn('id', targetProfileIds);
@@ -68,13 +68,11 @@ const findOrganizationIds = async function (targetProfileId) {
   return targetProfileShares.map((targetProfileShare) => targetProfileShare.organizationId);
 };
 
-const hasTubesWithLevels = async function (
-  { targetProfileId, tubesWithLevels },
-  { knexTransaction } = DomainTransaction.emptyTransaction(),
-) {
+const hasTubesWithLevels = async function ({ targetProfileId, tubesWithLevels }) {
+  const knexConn = DomainTransaction.getConnection();
   const tubeIds = tubesWithLevels.map(({ id }) => id);
 
-  const result = await (knexTransaction ?? knex)('target-profile_tubes')
+  const result = await knexConn('target-profile_tubes')
     .whereIn('tubeId', tubeIds)
     .andWhere('targetProfileId', targetProfileId);
 

--- a/api/lib/infrastructure/repositories/target-profile-share-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-share-repository.js
@@ -1,13 +1,8 @@
-import { knex } from '../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../DomainTransaction.js';
 
-const batchAddTargetProfilesToOrganization = async function (
-  organizationTargetProfiles,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-) {
-  await knex
-    .batchInsert('target-profile-shares', organizationTargetProfiles)
-    .transacting(domainTransaction.knexTransaction);
+const batchAddTargetProfilesToOrganization = async function (organizationTargetProfiles) {
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn.batchInsert('target-profile-shares', organizationTargetProfiles);
 };
 
 export { batchAddTargetProfilesToOrganization };

--- a/api/lib/infrastructure/repositories/target-profile-summary-for-admin-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-summary-for-admin-repository.js
@@ -45,8 +45,8 @@ const findByOrganization = async function ({ organizationId }) {
   return results.map((attributes) => new TargetProfileSummaryForAdmin(attributes));
 };
 
-const findByTraining = async function ({ trainingId, domainTransaction = DomainTransaction.emptyTransaction() }) {
-  const knexConn = domainTransaction?.knexTransaction || knex;
+const findByTraining = async function ({ trainingId }) {
+  const knexConn = DomainTransaction.getConnection();
 
   const results = await knexConn('target-profiles')
     .select({

--- a/api/lib/infrastructure/repositories/target-profile-training-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-training-repository.js
@@ -1,13 +1,8 @@
-import { knex } from '../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../DomainTransaction.js';
 const TABLE_NAME = 'target-profile-trainings';
 
-const create = async function ({
-  trainingId,
-  targetProfileIds,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
-  const knexConn = domainTransaction?.knexTransaction || knex;
+const create = async function ({ trainingId, targetProfileIds }) {
+  const knexConn = DomainTransaction.getConnection();
   const targetProfileTrainingsToInsert = targetProfileIds.map((targetProfileId) => {
     return { trainingId, targetProfileId };
   });

--- a/api/scripts/create-badge-criteria-for-specified-badge.js
+++ b/api/scripts/create-badge-criteria-for-specified-badge.js
@@ -48,8 +48,8 @@ function checkCriteriaFormat(criteria) {
   });
 }
 
-async function _createBadgeCriterion(badgeCriterion, domainTransaction) {
-  return badgeCriteriaRepository.save({ badgeCriterion: { ...badgeCriterion } }, domainTransaction);
+async function _createBadgeCriterion(badgeCriterion) {
+  return badgeCriteriaRepository.save({ badgeCriterion: { ...badgeCriterion } });
 }
 
 const modulePath = url.fileURLToPath(import.meta.url);
@@ -71,9 +71,9 @@ async function main() {
   console.log('BadgeCriteria schema ok');
 
   console.log('Saving badge criteria... ');
-  return DomainTransaction.execute(async (domainTransaction) => {
+  return DomainTransaction.execute(async () => {
     await bluebird.mapSeries(jsonFile.criteria, (badgeCriterion) => {
-      return _createBadgeCriterion({ ...badgeCriterion, badgeId: jsonFile.badgeId }, domainTransaction);
+      return _createBadgeCriterion({ ...badgeCriterion, badgeId: jsonFile.badgeId });
     });
   });
 }

--- a/api/src/certification/complementary-certification/domain/usecases/attach-badges.js
+++ b/api/src/certification/complementary-certification/domain/usecases/attach-badges.js
@@ -51,7 +51,7 @@ const attachBadges = async function ({
     });
   });
 
-  await DomainTransaction.execute(async (domainTransaction) => {
+  await DomainTransaction.execute(async () => {
     if (targetProfileIdToDetach) {
       const relatedComplementaryCertificationBadgesIds =
         await complementaryCertificationBadgesRepository.getAllIdsByTargetProfileId({
@@ -61,14 +61,12 @@ const attachBadges = async function ({
       await _detachExistingComplementaryCertificationBadge({
         complementaryCertificationBadgesRepository,
         relatedComplementaryCertificationBadgesIds,
-        domainTransaction,
       });
     }
 
     await _attachNewComplementaryCertificationBadges({
       complementaryCertificationBadgesRepository,
       complementaryCertificationBadges,
-      domainTransaction,
     });
   });
 };
@@ -90,11 +88,9 @@ function _isRequiredInformationMissing(complementaryCertificationBadgesToAttachD
 async function _attachNewComplementaryCertificationBadges({
   complementaryCertificationBadgesRepository,
   complementaryCertificationBadges,
-  domainTransaction,
 }) {
   return complementaryCertificationBadgesRepository.attach({
     complementaryCertificationBadges,
-    domainTransaction,
   });
 }
 
@@ -105,7 +101,6 @@ async function _attachNewComplementaryCertificationBadges({
 async function _detachExistingComplementaryCertificationBadge({
   complementaryCertificationBadgesRepository,
   relatedComplementaryCertificationBadgesIds,
-  domainTransaction,
 }) {
   if (relatedComplementaryCertificationBadgesIds.length === 0) {
     throw new NotFoundError('No badges for this target profile.');
@@ -113,7 +108,6 @@ async function _detachExistingComplementaryCertificationBadge({
 
   await complementaryCertificationBadgesRepository.detachByIds({
     complementaryCertificationBadgeIds: relatedComplementaryCertificationBadgesIds,
-    domainTransaction,
   });
 }
 

--- a/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-badge-repository.js
+++ b/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-badge-repository.js
@@ -19,9 +19,7 @@ const getAllIdsByTargetProfileId = async function ({ targetProfileId }) {
 
 const detachByIds = async function ({ complementaryCertificationBadgeIds }) {
   const knexConn = DomainTransaction.getConnection();
-
   const now = new Date();
-
   return knexConn('complementary-certification-badges')
     .whereIn('id', complementaryCertificationBadgeIds)
     .update({ detachedAt: now });

--- a/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-badge-repository.js
+++ b/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-badge-repository.js
@@ -5,7 +5,9 @@ import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { ComplementaryCertificationBadge } from '../../domain/models/ComplementaryCertificationBadge.js';
 
 const getAllIdsByTargetProfileId = async function ({ targetProfileId }) {
-  const complementaryCertificationBadgesIds = await knex('badges')
+  const knexConn = DomainTransaction.getConnection();
+
+  const complementaryCertificationBadgesIds = await knexConn('badges')
     .select('complementary-certification-badges')
     .leftJoin('complementary-certification-badges', 'complementary-certification-badges.badgeId', 'badges.id')
     .leftJoin('target-profiles', 'target-profiles.id', 'badges.targetProfileId')
@@ -15,8 +17,8 @@ const getAllIdsByTargetProfileId = async function ({ targetProfileId }) {
   return complementaryCertificationBadgesIds;
 };
 
-const detachByIds = async function ({ complementaryCertificationBadgeIds, domainTransaction }) {
-  const knexConn = domainTransaction.knexTransaction;
+const detachByIds = async function ({ complementaryCertificationBadgeIds }) {
+  const knexConn = DomainTransaction.getConnection();
 
   const now = new Date();
 
@@ -25,8 +27,8 @@ const detachByIds = async function ({ complementaryCertificationBadgeIds, domain
     .update({ detachedAt: now });
 };
 
-const attach = async function ({ domainTransaction, complementaryCertificationBadges }) {
-  const knexConn = domainTransaction.knexTransaction;
+const attach = async function ({ complementaryCertificationBadges }) {
+  const knexConn = DomainTransaction.getConnection();
   const createdAt = new Date();
 
   for (const complementaryCertificationBadge of complementaryCertificationBadges) {
@@ -75,8 +77,9 @@ const getAllWithSameTargetProfile = async function (complementaryCertificationBa
   return complementaryCertificationBadges.map(_toDomain);
 };
 
-const isRelatedToCertification = async function (badgeId, { knexTransaction } = DomainTransaction.emptyTransaction()) {
-  const complementaryCertificationBadge = await (knexTransaction ?? knex)('complementary-certification-badges')
+const isRelatedToCertification = async function (badgeId) {
+  const knexConn = DomainTransaction.getConnection();
+  const complementaryCertificationBadge = await knexConn('complementary-certification-badges')
     .where({ badgeId })
     .first();
   return !!complementaryCertificationBadge;

--- a/api/src/certification/course/domain/usecases/update-jury-comment.js
+++ b/api/src/certification/course/domain/usecases/update-jury-comment.js
@@ -24,10 +24,9 @@ const updateJuryComment = async function ({
   assessmentResultRepository,
   competenceMarkRepository,
 }) {
-  await DomainTransaction.execute(async (domainTransaction) => {
+  await DomainTransaction.execute(async () => {
     const latestAssessmentResult = await courseAssessmentResultRepository.getLatestAssessmentResult({
       certificationCourseId,
-      domainTransaction,
     });
 
     const updatedAssessmentResult = latestAssessmentResult.clone();
@@ -38,14 +37,10 @@ const updateJuryComment = async function ({
     const { id: assessmentResultId } = await assessmentResultRepository.save({
       certificationCourseId,
       assessmentResult: updatedAssessmentResult,
-      domainTransaction,
     });
 
     for (const competenceMark of latestAssessmentResult.competenceMarks) {
-      await competenceMarkRepository.save(
-        new CompetenceMark({ ...competenceMark, assessmentResultId }),
-        domainTransaction,
-      );
+      await competenceMarkRepository.save(new CompetenceMark({ ...competenceMark, assessmentResultId }));
     }
   });
 };

--- a/api/src/certification/course/infrastructure/repositories/course-assessment-result-repository.js
+++ b/api/src/certification/course/infrastructure/repositories/course-assessment-result-repository.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { AssessmentResult } from '../../../../shared/domain/models/AssessmentResult.js';
@@ -38,11 +37,8 @@ function _toDomain({ assessmentResultDTO, competencesMarksDTO }) {
   });
 }
 
-const getLatestAssessmentResult = async function ({
-  certificationCourseId,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
-  const knexConn = domainTransaction.knexTransaction || knex;
+const getLatestAssessmentResult = async function ({ certificationCourseId }) {
+  const knexConn = DomainTransaction.getConnection();
 
   const latestAssessmentResult = await knexConn('certification-courses-last-assessment-results')
     .select('assessment-results.*')

--- a/api/src/certification/enrolment/domain/usecases/import-certification-candidates-from-candidates-import-sheet.js
+++ b/api/src/certification/enrolment/domain/usecases/import-certification-candidates-from-candidates-import-sheet.js
@@ -38,13 +38,12 @@ const importCertificationCandidatesFromCandidatesImportSheet = async function ({
       certificationCenterRepository,
     });
 
-  await DomainTransaction.execute(async (domainTransaction) => {
-    await certificationCandidateRepository.deleteBySessionId({ sessionId, domainTransaction });
+  await DomainTransaction.execute(async () => {
+    await certificationCandidateRepository.deleteBySessionId({ sessionId });
     await bluebird.mapSeries(certificationCandidates, function (certificationCandidate) {
       return certificationCandidateRepository.saveInSession({
         certificationCandidate,
         sessionId,
-        domainTransaction,
       });
     });
   });

--- a/api/src/certification/enrolment/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/session-repository.js
@@ -6,8 +6,8 @@ import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.j
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { SessionEnrolment } from '../../domain/models/SessionEnrolment.js';
 
-const save = async function ({ session, domainTransaction = DomainTransaction.emptyTransaction() }) {
-  const knexConn = domainTransaction.knexTransaction ?? knex;
+const save = async function ({ session }) {
+  const knexConn = DomainTransaction.getConnection();
   const [savedSession] = await knexConn('sessions')
     .insert({
       accessCode: session.accessCode,

--- a/api/src/certification/session-management/domain/usecases/unfinalize-session.js
+++ b/api/src/certification/session-management/domain/usecases/unfinalize-session.js
@@ -16,9 +16,9 @@ const unfinalizeSession = async function ({ sessionId, sessionRepository, finali
     throw new SessionAlreadyPublishedError();
   }
 
-  return DomainTransaction.execute(async (domainTransaction) => {
-    await finalizedSessionRepository.remove({ sessionId, domainTransaction });
-    await sessionRepository.unfinalize({ id: sessionId, domainTransaction });
+  return DomainTransaction.execute(async () => {
+    await finalizedSessionRepository.remove({ sessionId });
+    await sessionRepository.unfinalize({ id: sessionId });
   });
 };
 

--- a/api/src/certification/session-management/infrastructure/repositories/finalized-session-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/finalized-session-repository.js
@@ -10,8 +10,8 @@ const save = async function ({ finalizedSession }) {
   return finalizedSession;
 };
 
-const remove = async function ({ sessionId, domainTransaction = DomainTransaction.emptyTransaction() }) {
-  const knexConn = domainTransaction.knexTransaction ?? knex;
+const remove = async function ({ sessionId }) {
+  const knexConn = DomainTransaction.getConnection();
   return knexConn('finalized-sessions').where({ sessionId }).delete();
 };
 

--- a/api/src/certification/session-management/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/session-repository.js
@@ -49,8 +49,8 @@ const finalize = async function ({ id, examinerGlobalComment, hasIncident, hasJo
   return new SessionManagement(finalizedSession);
 };
 
-const unfinalize = async function ({ id, domainTransaction = DomainTransaction.emptyTransaction() }) {
-  const knexConn = domainTransaction.knexTransaction ?? knex;
+const unfinalize = async function ({ id }) {
+  const knexConn = DomainTransaction.getConnection();
   const updates = await knexConn('sessions')
     .where({ id })
     .update({ finalizedAt: null, assignedCertificationOfficerId: null });

--- a/api/src/certification/shared/domain/services/certification-badges-service.js
+++ b/api/src/certification/shared/domain/services/certification-badges-service.js
@@ -10,20 +10,18 @@ import * as knowledgeElementRepository from '../../../../../lib/infrastructure/r
 
 const findStillValidBadgeAcquisitions = async function ({
   userId,
-  domainTransaction,
   limitDate = new Date(),
   dependencies = { certifiableBadgeAcquisitionRepository, knowledgeElementRepository, badgeForCalculationRepository },
 }) {
-  return _findBadgeAcquisitions({ userId, domainTransaction, limitDate, shouldGetOutdated: false, dependencies });
+  return _findBadgeAcquisitions({ userId, limitDate, shouldGetOutdated: false, dependencies });
 };
 
 const findLatestBadgeAcquisitions = async function ({
   userId,
-  domainTransaction,
   limitDate = new Date(),
   dependencies = { certifiableBadgeAcquisitionRepository, knowledgeElementRepository, badgeForCalculationRepository },
 }) {
-  return _findBadgeAcquisitions({ userId, domainTransaction, limitDate, shouldGetOutdated: true, dependencies });
+  return _findBadgeAcquisitions({ userId, limitDate, shouldGetOutdated: true, dependencies });
 };
 
 /**
@@ -37,7 +35,6 @@ const findLatestBadgeAcquisitions = async function ({
  */
 const _findBadgeAcquisitions = async function ({
   userId,
-  domainTransaction,
   limitDate = new Date(),
   shouldGetOutdated = false,
   dependencies = { certifiableBadgeAcquisitionRepository, knowledgeElementRepository, badgeForCalculationRepository },
@@ -45,14 +42,12 @@ const _findBadgeAcquisitions = async function ({
   const highestCertifiableBadgeAcquisitions =
     await dependencies.certifiableBadgeAcquisitionRepository.findHighestCertifiable({
       userId,
-      domainTransaction,
       limitDate,
     });
 
   const knowledgeElements = await dependencies.knowledgeElementRepository.findUniqByUserId({
     userId,
     limitDate,
-    domainTransaction,
   });
 
   const badgeAcquisitions = await bluebird.mapSeries(

--- a/api/src/certification/shared/infrastructure/repositories/certification-assessment-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-assessment-repository.js
@@ -71,11 +71,8 @@ const get = async function (id) {
   });
 };
 
-const getByCertificationCourseId = async function ({
-  certificationCourseId,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
-  const knexConn = domainTransaction.knexTransaction || knex;
+const getByCertificationCourseId = async function ({ certificationCourseId }) {
+  const knexConn = DomainTransaction.getConnection();
   const certificationAssessmentRow = await knexConn('assessments')
     .join('certification-courses', 'certification-courses.id', 'assessments.certificationCourseId')
     .select({

--- a/api/src/certification/shared/infrastructure/repositories/certification-challenge-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-challenge-repository.js
@@ -9,7 +9,8 @@ const logContext = {
   type: 'repository',
 };
 
-const save = async function ({ certificationChallenge, domainTransaction = DomainTransaction.emptyTransaction() }) {
+const save = async function ({ certificationChallenge }) {
+  const knexConn = DomainTransaction.getConnection();
   const certificationChallengeToSave = new CertificationChallenge({
     challengeId: certificationChallenge.challengeId,
     competenceId: certificationChallenge.competenceId,
@@ -20,7 +21,6 @@ const save = async function ({ certificationChallenge, domainTransaction = Domai
     difficulty: certificationChallenge.difficulty,
     discriminant: certificationChallenge.discriminant,
   });
-  const knexConn = domainTransaction.knexTransaction || knex;
   const [savedCertificationChallenge] = await knexConn('certification-challenges')
     .insert(certificationChallengeToSave)
     .returning('*');

--- a/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
@@ -14,8 +14,8 @@ import { CertificationCourse } from '../../domain/models/CertificationCourse.js'
 import { CertificationIssueReport } from '../../domain/models/CertificationIssueReport.js';
 import * as certificationChallengeRepository from './certification-challenge-repository.js';
 
-async function save({ certificationCourse, domainTransaction = DomainTransaction.emptyTransaction() }) {
-  const knexConn = domainTransaction.knexTransaction || knex;
+async function save({ certificationCourse }) {
+  const knexConn = DomainTransaction.getConnection();
 
   const certificationCourseToSaveDTO = _adaptModelToDb(certificationCourse);
   const [{ id: certificationCourseId }] = await knexConn('certification-courses')
@@ -41,11 +41,10 @@ async function save({ certificationCourse, domainTransaction = DomainTransaction
     };
     return certificationChallengeRepository.save({
       certificationChallenge: certificationChallengeWithCourseId,
-      domainTransaction,
     });
   });
 
-  return get({ id: certificationCourseId, domainTransaction });
+  return get({ id: certificationCourseId });
 }
 
 const _findCertificationCourse = async function (id, knexConn = knex) {
@@ -60,8 +59,8 @@ const _findAllChallenges = async function (certificationCourseId, knexConn = kne
   return knexConn('certification-challenges').where({ courseId: certificationCourseId });
 };
 
-async function get({ id, domainTransaction = DomainTransaction.emptyTransaction() }) {
-  const knexConn = domainTransaction.knexTransaction || knex;
+async function get({ id }) {
+  const knexConn = DomainTransaction.getConnection();
   const certificationCourseDTO = await _findCertificationCourse(id, knexConn);
 
   if (!certificationCourseDTO) {
@@ -141,12 +140,8 @@ async function getSessionId({ id }) {
   return row.sessionId;
 }
 
-async function findOneCertificationCourseByUserIdAndSessionId({
-  userId,
-  sessionId,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
-  const knexConn = domainTransaction.knexTransaction ?? knex;
+async function findOneCertificationCourseByUserIdAndSessionId({ userId, sessionId }) {
+  const knexConn = DomainTransaction.getConnection();
 
   const certificationCourseDTO = await knexConn('certification-courses')
     .where({ userId, sessionId })

--- a/api/src/devcomp/application/trainings/training-controller.js
+++ b/api/src/devcomp/application/trainings/training-controller.js
@@ -46,13 +46,12 @@ const createOrUpdateTrigger = async function (request, h, dependencies = { train
   const { trainingId } = request.params;
   const { threshold, tubes, type } = await dependencies.trainingTriggerSerializer.deserialize(request.payload);
 
-  const createdOrUpdatedTrainingTrigger = await DomainTransaction.execute(async (domainTransaction) => {
+  const createdOrUpdatedTrainingTrigger = await DomainTransaction.execute(async () => {
     return usecases.createOrUpdateTrainingTrigger({
       trainingId,
       threshold,
       tubes,
       type,
-      domainTransaction,
     });
   });
 

--- a/api/src/devcomp/domain/usecases/create-or-update-training-trigger.js
+++ b/api/src/devcomp/domain/usecases/create-or-update-training-trigger.js
@@ -3,17 +3,15 @@ const createOrUpdateTrainingTrigger = async function ({
   tubes,
   type,
   threshold,
-  domainTransaction,
   trainingRepository,
   trainingTriggerRepository,
 }) {
-  await trainingRepository.get({ trainingId, domainTransaction });
+  await trainingRepository.get({ trainingId });
   return trainingTriggerRepository.createOrUpdate({
     trainingId,
     triggerTubesForCreation: tubes,
     type,
     threshold,
-    domainTransaction,
   });
 };
 

--- a/api/src/devcomp/domain/usecases/create-training.js
+++ b/api/src/devcomp/domain/usecases/create-training.js
@@ -1,5 +1,5 @@
-const createTraining = function ({ training, domainTransaction, trainingRepository }) {
-  return trainingRepository.create({ training, domainTransaction });
+const createTraining = function ({ training, trainingRepository }) {
+  return trainingRepository.create({ training });
 };
 
 export { createTraining };

--- a/api/src/devcomp/domain/usecases/handle-training-recommendation.js
+++ b/api/src/devcomp/domain/usecases/handle-training-recommendation.js
@@ -5,7 +5,6 @@ const handleTrainingRecommendation = async function ({
   knowledgeElementRepository,
   trainingRepository,
   userRecommendedTrainingRepository,
-  domainTransaction,
 }) {
   if (!assessment.isForCampaign()) {
     return;
@@ -14,7 +13,6 @@ const handleTrainingRecommendation = async function ({
   const trainings = await trainingRepository.findWithTriggersByCampaignParticipationIdAndLocale({
     campaignParticipationId,
     locale,
-    domainTransaction,
   });
 
   if (trainings.length === 0) {
@@ -23,11 +21,9 @@ const handleTrainingRecommendation = async function ({
 
   const campaignSkills = await campaignRepository.findSkillsByCampaignParticipationId({
     campaignParticipationId,
-    domainTransaction,
   });
   const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({
     userId: assessment.userId,
-    domainTransaction,
   });
 
   for (const training of trainings) {
@@ -36,7 +32,6 @@ const handleTrainingRecommendation = async function ({
         userId: assessment.userId,
         trainingId: training.id,
         campaignParticipationId,
-        domainTransaction,
       });
     }
   }

--- a/api/src/devcomp/infrastructure/repositories/element-answer-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/element-answer-repository.js
@@ -1,15 +1,8 @@
-import { knex } from '../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { ElementAnswer } from '../../domain/models/ElementAnswer.js';
 
-const save = async function ({
-  passageId,
-  elementId,
-  value,
-  correction,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
-  const knexConn = domainTransaction?.knexTransaction || knex;
+const save = async function ({ passageId, elementId, value, correction }) {
+  const knexConn = DomainTransaction.getConnection();
   const [returnedElementAnswer] = await knexConn('element-answers')
     .insert({
       passageId,

--- a/api/src/devcomp/infrastructure/repositories/passage-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/passage-repository.js
@@ -1,10 +1,9 @@
-import { knex } from '../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { Passage } from '../../domain/models/Passage.js';
 
-const save = async ({ moduleId, userId, domainTransaction = DomainTransaction.emptyTransaction() }) => {
-  const knexConn = domainTransaction?.knexTransaction || knex;
+const save = async ({ moduleId, userId }) => {
+  const knexConn = DomainTransaction.getConnection();
   const [passage] = await knexConn('passages')
     .insert({
       moduleId,
@@ -17,8 +16,8 @@ const save = async ({ moduleId, userId, domainTransaction = DomainTransaction.em
   return _toDomain(passage);
 };
 
-const get = async ({ passageId, domainTransaction = DomainTransaction.emptyTransaction() }) => {
-  const knexConn = domainTransaction?.knexTransaction || knex;
+const get = async ({ passageId }) => {
+  const knexConn = DomainTransaction.getConnection();
   const passage = await knexConn('passages').where({ id: passageId }).first();
   if (!passage) {
     throw new NotFoundError();
@@ -27,8 +26,8 @@ const get = async ({ passageId, domainTransaction = DomainTransaction.emptyTrans
   return _toDomain(passage);
 };
 
-const update = async ({ passage, domainTransaction = DomainTransaction.emptyTransaction() }) => {
-  const knexConn = domainTransaction?.knexTransaction || knex;
+const update = async ({ passage }) => {
+  const knexConn = DomainTransaction.getConnection();
   const [updatedPassage] = await knexConn('passages')
     .where({ id: passage.id })
     .update({

--- a/api/src/devcomp/infrastructure/repositories/training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/training-repository.js
@@ -1,6 +1,5 @@
 import lodash from 'lodash';
 
-import { knex } from '../../../../db/knex-database-connection.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
 import { TrainingTrigger } from '../../../../lib/domain/models/index.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
@@ -15,8 +14,8 @@ const { pick } = lodash;
 
 const TABLE_NAME = 'trainings';
 
-async function get({ trainingId, domainTransaction = DomainTransaction.emptyTransaction() }) {
-  const knexConn = domainTransaction?.knexTransaction || knex;
+async function get({ trainingId }) {
+  const knexConn = DomainTransaction.getConnection();
   const training = await knexConn(TABLE_NAME).where({ id: trainingId }).first();
   if (!training) {
     throw new NotFoundError(`Not found training for ID ${trainingId}`);
@@ -27,8 +26,8 @@ async function get({ trainingId, domainTransaction = DomainTransaction.emptyTran
   return _toDomain(training, targetProfileTrainings);
 }
 
-async function getWithTriggersForAdmin({ trainingId, domainTransaction = DomainTransaction.emptyTransaction() }) {
-  const knexConn = domainTransaction?.knexTransaction || knex;
+async function getWithTriggersForAdmin({ trainingId }) {
+  const knexConn = DomainTransaction.getConnection();
   const trainingDTO = await knexConn(TABLE_NAME).where({ id: trainingId }).first();
   if (!trainingDTO) {
     throw new NotFoundError(`Not found training for ID ${trainingId}`);
@@ -36,13 +35,13 @@ async function getWithTriggersForAdmin({ trainingId, domainTransaction = DomainT
 
   const targetProfileTrainings = await knexConn('target-profile-trainings').where('trainingId', trainingDTO.id);
 
-  const trainingTriggers = await trainingTriggerRepository.findByTrainingIdForAdmin({ trainingId, domainTransaction });
+  const trainingTriggers = await trainingTriggerRepository.findByTrainingIdForAdmin({ trainingId });
 
   return _toDomainForAdmin({ training: trainingDTO, targetProfileTrainings, trainingTriggers });
 }
 
-async function findPaginatedSummaries({ filter, page, domainTransaction = DomainTransaction.emptyTransaction() }) {
-  const knexConn = domainTransaction?.knexTransaction || knex;
+async function findPaginatedSummaries({ filter, page }) {
+  const knexConn = DomainTransaction.getConnection();
   const query = knexConn(TABLE_NAME)
     .select(
       'trainings.id',
@@ -71,12 +70,8 @@ async function findPaginatedSummaries({ filter, page, domainTransaction = Domain
   return { trainings: trainingSummaries, pagination };
 }
 
-async function findPaginatedSummariesByTargetProfileId({
-  targetProfileId,
-  page,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
-  const knexConn = domainTransaction?.knexTransaction || knex;
+async function findPaginatedSummariesByTargetProfileId({ targetProfileId, page }) {
+  const knexConn = DomainTransaction.getConnection();
   const query = knexConn(TABLE_NAME)
     .select(
       'trainings.id',
@@ -107,12 +102,8 @@ async function findPaginatedSummariesByTargetProfileId({
   return { trainings, pagination };
 }
 
-async function findWithTriggersByCampaignParticipationIdAndLocale({
-  campaignParticipationId,
-  locale,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
-  const knexConn = domainTransaction?.knexTransaction || knex;
+async function findWithTriggersByCampaignParticipationIdAndLocale({ campaignParticipationId, locale }) {
+  const knexConn = DomainTransaction.getConnection();
   const trainingsDTO = await knexConn(TABLE_NAME)
     .select('trainings.*')
     .join('target-profile-trainings', `${TABLE_NAME}.id`, 'trainingId')
@@ -131,7 +122,6 @@ async function findWithTriggersByCampaignParticipationIdAndLocale({
     trainingsDTO.map(async (training) => {
       const trainingTriggers = await trainingTriggerRepository.findByTrainingId({
         trainingId: training.id,
-        domainTransaction,
       });
       training.trainingTriggers = trainingTriggers;
       return _toDomain(training, targetProfileTrainings);
@@ -139,8 +129,8 @@ async function findWithTriggersByCampaignParticipationIdAndLocale({
   );
 }
 
-async function create({ training, domainTransaction = DomainTransaction.emptyTransaction() }) {
-  const knexConn = domainTransaction?.knexTransaction || knex;
+async function create({ training }) {
+  const knexConn = DomainTransaction.getConnection();
   const pickedAttributes = pick(training, [
     'title',
     'link',
@@ -154,7 +144,7 @@ async function create({ training, domainTransaction = DomainTransaction.emptyTra
   return new TrainingForAdmin(createdTraining);
 }
 
-async function update({ id, attributesToUpdate, domainTransaction = DomainTransaction.emptyTransaction() }) {
+async function update({ id, attributesToUpdate }) {
   const pickedAttributesToUpdate = pick(attributesToUpdate, [
     'title',
     'link',
@@ -165,7 +155,7 @@ async function update({ id, attributesToUpdate, domainTransaction = DomainTransa
     'editorLogoUrl',
     'isDisabled',
   ]);
-  const knexConn = domainTransaction?.knexTransaction || knex;
+  const knexConn = DomainTransaction.getConnection();
   const [updatedTraining] = await knexConn(TABLE_NAME)
     .where({ id })
     .update({ ...pickedAttributesToUpdate, updatedAt: new Date() })
@@ -176,13 +166,8 @@ async function update({ id, attributesToUpdate, domainTransaction = DomainTransa
   return _toDomainForAdmin({ training: updatedTraining, targetProfileTrainings });
 }
 
-async function findPaginatedByUserId({
-  userId,
-  locale,
-  page,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
-  const knexConn = domainTransaction?.knexTransaction || knex;
+async function findPaginatedByUserId({ userId, locale, page }) {
+  const knexConn = DomainTransaction.getConnection();
   const query = knexConn(TABLE_NAME)
     .select('trainings.*')
     .distinct('trainings.id')

--- a/api/src/devcomp/infrastructure/repositories/user-recommended-training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/user-recommended-training-repository.js
@@ -1,28 +1,18 @@
-import { knex } from '../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { UserRecommendedTraining } from '../../domain/read-models/UserRecommendedTraining.js';
 
 const TABLE_NAME = 'user-recommended-trainings';
 
-const save = function ({
-  userId,
-  trainingId,
-  campaignParticipationId,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
-  const knexConn = domainTransaction?.knexTransaction || knex;
+const save = function ({ userId, trainingId, campaignParticipationId }) {
+  const knexConn = DomainTransaction.getConnection();
   return knexConn(TABLE_NAME)
     .insert({ userId, trainingId, campaignParticipationId })
     .onConflict(['userId', 'trainingId', 'campaignParticipationId'])
     .merge({ updatedAt: knexConn.fn.now() });
 };
 
-const findByCampaignParticipationId = async function ({
-  campaignParticipationId,
-  locale,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
-  const knexConn = domainTransaction?.knexTransaction || knex;
+const findByCampaignParticipationId = async function ({ campaignParticipationId, locale }) {
+  const knexConn = DomainTransaction.getConnection();
   const trainings = await knexConn(TABLE_NAME)
     .select('trainings.*')
     .innerJoin('trainings', 'trainings.id', `${TABLE_NAME}.trainingId`)
@@ -31,8 +21,8 @@ const findByCampaignParticipationId = async function ({
   return trainings.map(_toDomain);
 };
 
-const hasRecommendedTrainings = async function ({ userId, domainTransaction = DomainTransaction.emptyTransaction() }) {
-  const knexConn = domainTransaction?.knexTransaction || knex;
+const hasRecommendedTrainings = async function ({ userId }) {
+  const knexConn = DomainTransaction.getConnection();
   const result = await knexConn(TABLE_NAME).select(1).where({ userId }).first();
   return Boolean(result);
 };

--- a/api/src/evaluation/application/competence-evaluations/competence-evaluation-controller.js
+++ b/api/src/evaluation/application/competence-evaluations/competence-evaluation-controller.js
@@ -19,11 +19,10 @@ const improve = async function (request, h, dependencies = { competenceEvaluatio
   const userId = request.auth.credentials.userId;
   const competenceId = request.payload.competenceId;
 
-  const competenceEvaluation = await DomainTransaction.execute(async (domainTransaction) => {
+  const competenceEvaluation = await DomainTransaction.execute(async () => {
     const competenceEvaluation = await usecases.improveCompetenceEvaluation({
       competenceId,
       userId,
-      domainTransaction,
     });
     return competenceEvaluation;
   });

--- a/api/src/evaluation/domain/services/get-competence-level.js
+++ b/api/src/evaluation/domain/services/get-competence-level.js
@@ -4,7 +4,6 @@ import * as scoringService from './scoring/scoring-service.js';
 const getCompetenceLevel = async function ({
   userId,
   competenceId,
-  domainTransaction,
 
   dependencies = {
     knowledgeElementRepository,
@@ -14,7 +13,6 @@ const getCompetenceLevel = async function ({
   const knowledgeElements = await dependencies.knowledgeElementRepository.findUniqByUserIdAndCompetenceId({
     userId,
     competenceId,
-    domainTransaction,
   });
   const { currentLevel } = dependencies.scoringService.calculateScoringInformationForCompetence({ knowledgeElements });
   return currentLevel;

--- a/api/src/evaluation/domain/usecases/improve-competence-evaluation.js
+++ b/api/src/evaluation/domain/usecases/improve-competence-evaluation.js
@@ -8,12 +8,10 @@ const improveCompetenceEvaluation = async function ({
   assessmentRepository,
   userId,
   competenceId,
-  domainTransaction,
 }) {
   let competenceEvaluation = await competenceEvaluationRepository.getByCompetenceIdAndUserId({
     competenceId,
     userId,
-    domainTransaction,
     forUpdate: true,
   });
 
@@ -29,12 +27,11 @@ const improveCompetenceEvaluation = async function ({
 
   const assessment = Assessment.createImprovingForCompetenceEvaluation({ userId, competenceId });
 
-  const { id: assessmentId } = await assessmentRepository.save({ assessment, domainTransaction });
+  const { id: assessmentId } = await assessmentRepository.save({ assessment });
 
   competenceEvaluation = await competenceEvaluationRepository.updateAssessmentId({
     currentAssessmentId: competenceEvaluation.assessmentId,
     newAssessmentId: assessmentId,
-    domainTransaction,
   });
 
   return { ...competenceEvaluation, assessmentId };

--- a/api/src/evaluation/infrastructure/repositories/badge-criteria-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/badge-criteria-repository.js
@@ -22,10 +22,9 @@ const save = async function ({ badgeCriterion }) {
   await knexConnection(TABLE_NAME).insert(data);
 };
 
-const saveAll = async function (badgeCriteria, { knexTransaction } = DomainTransaction.emptyTransaction()) {
-  const savedBadgeCriteria = await (knexTransaction ?? knex)(TABLE_NAME)
-    .insert(badgeCriteria.map(adaptModelToDb))
-    .returning('*');
+const saveAll = async function (badgeCriteria) {
+  const knexConn = DomainTransaction.getConnection();
+  const savedBadgeCriteria = await knexConn(TABLE_NAME).insert(badgeCriteria.map(adaptModelToDb)).returning('*');
   return savedBadgeCriteria.map((badgeCriteria) => new BadgeCriterion(badgeCriteria));
 };
 
@@ -43,8 +42,9 @@ const updateCriterion = async function (id, attributesToUpdate) {
   return new BadgeCriterion(updatedCriterion);
 };
 
-const findAllByBadgeId = async (badgeId, { knexTransaction } = DomainTransaction.emptyTransaction()) => {
-  const badgeCriteria = await (knexTransaction ?? knex)(TABLE_NAME).where('badgeId', badgeId);
+const findAllByBadgeId = async (badgeId) => {
+  const knexConn = DomainTransaction.getConnection();
+  const badgeCriteria = await knexConn(TABLE_NAME).where('badgeId', badgeId);
   return badgeCriteria.map((badgeCriteria) => new BadgeCriterion(badgeCriteria));
 };
 

--- a/api/src/evaluation/infrastructure/repositories/competence-evaluation-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/competence-evaluation-repository.js
@@ -6,8 +6,8 @@ import { NotFoundError } from '../../../shared/domain/errors.js';
 import { Assessment } from '../../../shared/domain/models/Assessment.js';
 import { CompetenceEvaluation } from '../../domain/models/CompetenceEvaluation.js';
 
-const save = async function ({ competenceEvaluation, domainTransaction = DomainTransaction.emptyTransaction() }) {
-  const knexConn = domainTransaction.knexTransaction || knex;
+const save = async function ({ competenceEvaluation }) {
+  const knexConn = DomainTransaction.getConnection();
   const foundCompetenceEvaluation = await _getByCompetenceIdAndUserId({
     competenceId: competenceEvaluation.competenceId,
     userId: competenceEvaluation.userId,
@@ -35,12 +35,8 @@ const updateStatusByUserIdAndCompetenceId = async function ({ userId, competence
   return _toDomain({ competenceEvaluation, assessment: null });
 };
 
-const updateAssessmentId = async function ({
-  currentAssessmentId,
-  newAssessmentId,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
-  const knexConn = domainTransaction.knexTransaction || knex;
+const updateAssessmentId = async function ({ currentAssessmentId, newAssessmentId }) {
+  const knexConn = DomainTransaction.getConnection();
   const [competenceEvaluation] = await knexConn('competence-evaluations')
     .where({ assessmentId: currentAssessmentId })
     .update({ assessmentId: newAssessmentId })
@@ -63,10 +59,10 @@ const getByAssessmentId = async function (assessmentId) {
 const getByCompetenceIdAndUserId = async function ({
   competenceId,
   userId,
-  domainTransaction = DomainTransaction.emptyTransaction(),
+
   forUpdate = false,
 }) {
-  const knexConn = domainTransaction.knexTransaction || knex;
+  const knexConn = DomainTransaction.getConnection();
   const competenceEvaluation = await _getByCompetenceIdAndUserId({
     competenceId,
     userId,
@@ -104,12 +100,8 @@ const findByAssessmentId = async function (assessmentId) {
   return competenceEvaluations.map((competenceEvaluation) => _toDomain({ competenceEvaluation, assessment: null }));
 };
 
-const existsByCompetenceIdAndUserId = async function ({
-  competenceId,
-  userId,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
-  const knexConn = domainTransaction.knexTransaction || knex;
+const existsByCompetenceIdAndUserId = async function ({ competenceId, userId }) {
+  const knexConn = DomainTransaction.getConnection();
   const competenceEvaluation = await _getByCompetenceIdAndUserId({ competenceId, userId, knexConn });
   return competenceEvaluation ? true : false;
 };

--- a/api/src/evaluation/infrastructure/repositories/stage-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/stage-repository.js
@@ -94,19 +94,19 @@ const getByCampaignParticipationId = async (campaignParticipationId, knexConnect
  * this is convenient for campaign overviews
  *
  * @param {[number]} targetProfileIds
- * @param knexConnection
  *
  * @returns Promise<Stage[]>
  */
-const getByTargetProfileIds = async (targetProfileIds, { knexTransaction } = DomainTransaction.emptyTransaction()) => {
-  const knexConnection = knexTransaction ?? knex;
+const getByTargetProfileIds = async (targetProfileIds) => {
+  const knexConnection = DomainTransaction.getConnection();
   return toDomain(
     await knexConnection('stages').select('stages.*').whereIn('stages.targetProfileId', targetProfileIds),
   );
 };
 
 const update = async ({ id, attributesToUpdate }) => {
-  const [stageToUpdate] = await knex('stages')
+  const knexConnection = DomainTransaction.getConnection();
+  const [stageToUpdate] = await knexConnection('stages')
     .where({ id })
     .update({ ...attributesToUpdate, updatedAt: new Date() })
     .returning('*');
@@ -114,8 +114,8 @@ const update = async ({ id, attributesToUpdate }) => {
   return new Stage(stageToUpdate);
 };
 
-const saveAll = async (stages, { knexTransaction } = DomainTransaction.emptyTransaction()) => {
-  const knexConnection = knexTransaction ?? knex;
+const saveAll = async (stages) => {
+  const knexConnection = DomainTransaction.getConnection();
   const createdStages = await knexConnection('stages').insert(stages).returning('*');
   return toDomain(createdStages);
 };

--- a/api/src/evaluation/infrastructure/repositories/stage-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/stage-repository.js
@@ -1,4 +1,3 @@
-import { knex } from '../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { Stage } from '../../domain/models/Stage.js';

--- a/api/src/evaluation/infrastructure/repositories/stage-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/stage-repository.js
@@ -26,25 +26,22 @@ const toDomain = (stageData) =>
     return new Stage(data);
   });
 
-/**
- * @param knexConnection
- * @returns {*}
- */
-const buildBaseQuery = (knexConnection) =>
-  knexConnection('stages')
+const buildBaseQuery = (knexConnection) => {
+  return knexConnection('stages')
     .select('stages.*')
     .join('campaigns', 'campaigns.targetProfileId', 'stages.targetProfileId')
     .orderBy(['stages.threshold', 'stages.level']);
+};
 
 /**
  * Return a stage for a given id
  *
  * @param {number} id
- * @param knexConnection
  *
  * @returns Promise<Stage>
  */
-const get = async (id, knexConnection = knex) => {
+const get = async (id) => {
+  const knexConnection = DomainTransaction.getConnection();
   const [stage] = await knexConnection('stages').select('stages.*').where({ id });
 
   if (!stage) throw new NotFoundError('Erreur, palier introuvable');
@@ -56,38 +53,41 @@ const get = async (id, knexConnection = knex) => {
  * Return stages for multiple campaign ids
  *
  * @param {number[]} campaignIds
- * @param knexConnection
  *
  * @returns Promise<Stage[]>
  */
-const getByCampaignIds = async (campaignIds, knexConnection = knex) =>
-  toDomain(await buildBaseQuery(knexConnection).whereIn('campaigns.id', campaignIds));
+const getByCampaignIds = async (campaignIds) => {
+  const knexConnection = DomainTransaction.getConnection();
+  return toDomain(await buildBaseQuery(knexConnection).whereIn('campaigns.id', campaignIds));
+};
 
 /**
  * Return stages for one campaign id
  *
  * @param {number} campaignId
- * @param knexConnection
  *
  * @returns Promise<Stage[]>
  */
-const getByCampaignId = async (campaignId, knexConnection = knex) =>
-  toDomain(await buildBaseQuery(knexConnection).where('campaigns.id', campaignId));
+const getByCampaignId = async (campaignId) => {
+  const knexConnection = DomainTransaction.getConnection();
+  return toDomain(await buildBaseQuery(knexConnection).where('campaigns.id', campaignId));
+};
 
 /**
  * Return campaign stages for a campaign participation id
  *
  * @param {number} campaignParticipationId
- * @param knexConnection
  *
  * @returns Promise<Stage[]>
  */
-const getByCampaignParticipationId = async (campaignParticipationId, knexConnection = knex) =>
-  toDomain(
+const getByCampaignParticipationId = async (campaignParticipationId) => {
+  const knexConnection = DomainTransaction.getConnection();
+  return toDomain(
     await buildBaseQuery(knexConnection)
       .join('campaign-participations', 'campaign-participations.campaignId', 'campaigns.id')
       .where('campaign-participations.id', campaignParticipationId),
   );
+};
 
 /**
  * Return campaign stages for several target profile ids,

--- a/api/src/identity-access-management/application/account-recovery/account-recovery.controller.js
+++ b/api/src/identity-access-management/application/account-recovery/account-recovery.controller.js
@@ -30,11 +30,10 @@ const updateUserAccountFromRecoveryDemand = async function (request, h) {
   const temporaryKey = request.payload.data.attributes['temporary-key'];
   const password = request.payload.data.attributes.password;
 
-  await DomainTransaction.execute(async (domainTransaction) => {
+  await DomainTransaction.execute(async () => {
     await usecases.updateUserForAccountRecovery({
       password,
       temporaryKey,
-      domainTransaction,
     });
   });
 

--- a/api/src/identity-access-management/application/anonymization/anonymization.admin.controller.js
+++ b/api/src/identity-access-management/application/anonymization/anonymization.admin.controller.js
@@ -14,8 +14,8 @@ async function anonymizeGarData(request, h) {
 
   const userIds = await GarAnonymizationParser.getCsvData(filePath);
 
-  const result = await DomainTransaction.execute(async (domainTransaction) => {
-    return await usecases.anonymizeGarAuthenticationMethods({ userIds, adminMemberId, domainTransaction });
+  const result = await DomainTransaction.execute(async () => {
+    return await usecases.anonymizeGarAuthenticationMethods({ userIds, adminMemberId });
   });
 
   return h.response(anonymizeGarResultSerializer.serialize(result)).code(200);

--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.admin.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.admin.controller.js
@@ -12,10 +12,8 @@ import * as oidcProviderSerializer from '../../infrastructure/serializers/jsonap
 async function createInBatch(request, h) {
   const oidcProviders = request.payload;
 
-  await DomainTransaction.execute((domainTransaction) => {
-    return Promise.all(
-      oidcProviders.map((oidcProvider) => usecases.addOidcProvider({ ...oidcProvider, domainTransaction })),
-    );
+  await DomainTransaction.execute(() => {
+    return Promise.all(oidcProviders.map((oidcProvider) => usecases.addOidcProvider({ ...oidcProvider })));
   });
 
   return h.response().code(204);

--- a/api/src/identity-access-management/domain/services/oidc-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/oidc-authentication-service.js
@@ -218,8 +218,8 @@ export class OidcAuthenticationService {
   }) {
     let createdUserId;
 
-    await DomainTransaction.execute(async (domainTransaction) => {
-      createdUserId = (await userToCreateRepository.create({ user, domainTransaction })).id;
+    await DomainTransaction.execute(async () => {
+      createdUserId = (await userToCreateRepository.create({ user })).id;
 
       const authenticationComplement = this.createAuthenticationComplement({ userInfo });
       const authenticationMethod = new AuthenticationMethod({
@@ -228,7 +228,7 @@ export class OidcAuthenticationService {
         externalIdentifier: externalIdentityId,
         authenticationComplement,
       });
-      await authenticationMethodRepository.create({ authenticationMethod, domainTransaction });
+      await authenticationMethodRepository.create({ authenticationMethod });
     });
 
     return createdUserId;

--- a/api/src/identity-access-management/domain/services/pole-emploi-oidc-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/pole-emploi-oidc-authentication-service.js
@@ -33,8 +33,8 @@ export class PoleEmploiOidcAuthenticationService extends OidcAuthenticationServi
   }) {
     let createdUserId;
 
-    await DomainTransaction.execute(async (domainTransaction) => {
-      createdUserId = (await userToCreateRepository.create({ user, domainTransaction })).id;
+    await DomainTransaction.execute(async () => {
+      createdUserId = (await userToCreateRepository.create({ user })).id;
 
       const authenticationMethod = new AuthenticationMethod({
         identityProvider: this.identityProvider,
@@ -42,7 +42,7 @@ export class PoleEmploiOidcAuthenticationService extends OidcAuthenticationServi
         externalIdentifier: externalIdentityId,
         authenticationComplement: this.createAuthenticationComplement({ sessionContent }),
       });
-      await authenticationMethodRepository.create({ authenticationMethod, domainTransaction });
+      await authenticationMethodRepository.create({ authenticationMethod });
     });
 
     return createdUserId;

--- a/api/src/identity-access-management/domain/usecases/add-oidc-provider.js
+++ b/api/src/identity-access-management/domain/usecases/add-oidc-provider.js
@@ -1,5 +1,3 @@
-import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
-
 /**
  * @typedef {import ('../usecases/index.js').OidcProviderRepository} OidcProviderRepository
  */
@@ -25,7 +23,6 @@ import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
  * @param {string} params.slug
  * @param {string} params.source
  * @param {OidcProviderRepository} params.oidcProviderRepository
- * @param {DomainTransaction} params.domainTransaction
  * @param {CryptoService} params.cryptoService
  * @returns {Promise<void>}
  */
@@ -51,7 +48,6 @@ const addOidcProvider = async function ({
   oidcProviderRepository,
   cryptoService,
   addOidcProviderValidator,
-  domainTransaction = DomainTransaction.emptyTransaction(),
 }) {
   addOidcProviderValidator.validate({
     accessTokenLifespan,
@@ -76,29 +72,26 @@ const addOidcProvider = async function ({
 
   const encryptedClientSecret = await cryptoService.encrypt(clientSecret);
 
-  await oidcProviderRepository.create(
-    {
-      accessTokenLifespan,
-      additionalRequiredProperties,
-      claimsToStore,
-      clientId,
-      enabled,
-      enabledForPixAdmin,
-      encryptedClientSecret,
-      extraAuthorizationUrlParameters,
-      identityProvider,
-      openidClientExtraMetadata,
-      openidConfigurationUrl,
-      organizationName,
-      postLogoutRedirectUri,
-      redirectUri,
-      scope,
-      shouldCloseSession,
-      slug,
-      source,
-    },
-    { domainTransaction },
-  );
+  await oidcProviderRepository.create({
+    accessTokenLifespan,
+    additionalRequiredProperties,
+    claimsToStore,
+    clientId,
+    enabled,
+    enabledForPixAdmin,
+    encryptedClientSecret,
+    extraAuthorizationUrlParameters,
+    identityProvider,
+    openidClientExtraMetadata,
+    openidConfigurationUrl,
+    organizationName,
+    postLogoutRedirectUri,
+    redirectUri,
+    scope,
+    shouldCloseSession,
+    slug,
+    source,
+  });
 };
 
 export { addOidcProvider };

--- a/api/src/identity-access-management/domain/usecases/anonymize-gar-authentication-methods.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/anonymize-gar-authentication-methods.usecase.js
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 
 import { config } from '../../../shared/config.js';
-import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { GarAuthenticationMethodAnonymized } from '../models/GarAuthenticationMethodAnonymized.js';
 
 const USER_IDS_BATCH_SIZE = 1000;
@@ -21,17 +20,13 @@ export const anonymizeGarAuthenticationMethods = async function ({
   adminMemberId,
   authenticationMethodRepository,
   garAnonymizedBatchEventsLoggingJob,
-  domainTransaction = DomainTransaction.emptyTransaction(),
 }) {
   const userIdBatches = _.chunk(userIds, userIdsBatchSize);
 
   let garAnonymizedUserCount = 0;
 
   for (const userIdsBatch of userIdBatches) {
-    const { garAnonymizedUserIds } = await authenticationMethodRepository.anonymizeByUserIds(
-      { userIds: userIdsBatch },
-      { domainTransaction },
-    );
+    const { garAnonymizedUserIds } = await authenticationMethodRepository.anonymizeByUserIds({ userIds: userIdsBatch });
     garAnonymizedUserCount += garAnonymizedUserIds.length;
 
     if (config.auditLogger.isEnabled) {

--- a/api/src/identity-access-management/domain/usecases/anonymize-gar-authentication-methods.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/anonymize-gar-authentication-methods.usecase.js
@@ -10,7 +10,6 @@ const USER_IDS_BATCH_SIZE = 1000;
  * @param {Object} params
  * @param {Array<string>} params.userIds
  * @param {AuthenticationMethodRepository} params.authenticationMethodRepository
- * @param {DomainTransaction} params.domainTransaction
  * @param {GarAnonymizedBatchEventsLoggingJob} params.garAnonymizedBatchEventsLoggingJob
  * @return {Promise<{garAnonymizedUserCount: number, total: number}>}
  */

--- a/api/src/identity-access-management/domain/usecases/update-user-for-account-recovery.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/update-user-for-account-recovery.usecase.js
@@ -10,7 +10,6 @@ import { AuthenticationMethod } from '../models/AuthenticationMethod.js';
  *   userRepository: UserRepository,
  *   cryptoService: CryptoService,
  *   scoAccountRecoveryService: ScoAccountRecoveryService,
- *   domainTransaction: DomainTransaction,
  * }} params
  * @return {Promise<void>}
  */
@@ -18,7 +17,6 @@ export const updateUserForAccountRecovery = async function ({
   password,
   temporaryKey,
   userRepository,
-  domainTransaction,
   authenticationMethodRepository,
   accountRecoveryDemandRepository,
   scoAccountRecoveryService,
@@ -34,13 +32,10 @@ export const updateUserForAccountRecovery = async function ({
   const hasAnAuthenticationMethodFromPix = await authenticationMethodRepository.hasIdentityProviderPIX({ userId });
 
   if (hasAnAuthenticationMethodFromPix) {
-    await authenticationMethodRepository.updateChangedPassword(
-      {
-        userId,
-        hashedPassword,
-      },
-      domainTransaction,
-    );
+    await authenticationMethodRepository.updateChangedPassword({
+      userId,
+      hashedPassword,
+    });
   } else {
     const authenticationMethodFromPix = new AuthenticationMethod({
       userId,
@@ -50,12 +45,9 @@ export const updateUserForAccountRecovery = async function ({
         shouldChangePassword: false,
       }),
     });
-    await authenticationMethodRepository.create(
-      {
-        authenticationMethod: authenticationMethodFromPix,
-      },
-      domainTransaction,
-    );
+    await authenticationMethodRepository.create({
+      authenticationMethod: authenticationMethodFromPix,
+    });
   }
 
   const now = new Date();
@@ -69,7 +61,6 @@ export const updateUserForAccountRecovery = async function ({
   await userRepository.updateWithEmailConfirmed({
     id: userId,
     userAttributes: userValuesToUpdate,
-    domainTransaction,
   });
-  await accountRecoveryDemandRepository.markAsBeingUsed(temporaryKey, domainTransaction);
+  await accountRecoveryDemandRepository.markAsBeingUsed(temporaryKey);
 };

--- a/api/src/identity-access-management/infrastructure/repositories/account-recovery-demand.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/account-recovery-demand.repository.js
@@ -42,12 +42,9 @@ const save = async function (accountRecoveryDemand) {
   return _toDomain(result[0]);
 };
 
-const markAsBeingUsed = async function (temporaryKey, { knexTransaction } = DomainTransaction.emptyTransaction()) {
-  const query = knex('account-recovery-demands')
-    .where({ temporaryKey })
-    .update({ used: true, updatedAt: knex.fn.now() });
-  if (knexTransaction) query.transacting(knexTransaction);
-  return query;
+const markAsBeingUsed = async function (temporaryKey) {
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn('account-recovery-demands').where({ temporaryKey }).update({ used: true, updatedAt: knex.fn.now() });
 };
 
 export const accountRecoveryDemandRepository = { findByTemporaryKey, findByUserId, markAsBeingUsed, save };

--- a/api/src/identity-access-management/infrastructure/repositories/authentication-method.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/authentication-method.repository.js
@@ -253,14 +253,10 @@ const batchUpdatePasswordThatShouldBeChanged = function ({ usersToUpdateWithNewP
 /**
  * @param {number[]} userIds
  * @param {Object} dependencies
- * @param {DomainTransaction} dependencies.domainTransaction
  * @returns {Promise<{garAnonymizedUserIds: number}>}
  */
-const anonymizeByUserIds = async function (
-  { userIds },
-  dependencies = { domainTransaction: DomainTransaction.emptyTransaction() },
-) {
-  const knexConn = dependencies.domainTransaction.knexTransaction ?? knex;
+const anonymizeByUserIds = async function ({ userIds }) {
+  const knexConn = DomainTransaction.getConnection();
 
   const anonymizedUserIdBatch = await knexConn(AUTHENTICATION_METHODS_TABLE)
     .whereIn('userId', userIds)

--- a/api/src/identity-access-management/infrastructure/repositories/oidc-provider-repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/oidc-provider-repository.js
@@ -31,14 +31,10 @@ const OIDC_PROVIDERS_TABLE_NAME = 'oidc-providers';
  * @param {string} oidcProviderProperties.slug
  * @param {string} oidcProviderProperties.source
  * @param {Object} dependencies
- * @param {DomainTransaction} dependencies.domainTransaction
  * @returns {Promise<any[]>}
  */
-const create = async function (
-  oidcProviderProperties,
-  dependencies = { domainTransaction: DomainTransaction.emptyTransaction() },
-) {
-  const knexConn = dependencies.domainTransaction.knexTransaction ?? knex;
+const create = async function (oidcProviderProperties) {
+  const knexConn = DomainTransaction.getConnection();
   try {
     const result = await knexConn(OIDC_PROVIDERS_TABLE_NAME).insert(oidcProviderProperties).returning('*');
     return result;

--- a/api/src/identity-access-management/infrastructure/repositories/user-to-create.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user-to-create.repository.js
@@ -1,4 +1,3 @@
-import { knex } from '../../../../db/knex-database-connection.js';
 import { PGSQL_UNIQUE_CONSTRAINT_VIOLATION_ERROR } from '../../../../db/pgsql-errors.js';
 import { STUDENT_RECONCILIATION_ERRORS } from '../../../../lib/domain/constants.js';
 import { OrganizationLearnerAlreadyLinkedToUserError } from '../../../../lib/domain/errors.js';
@@ -11,8 +10,8 @@ import { User } from '../../domain/models/User.js';
  * @property domainTransaction
  * @return {Promise<User|OrganizationLearnerAlreadyLinkedToUserError>}
  */
-const create = async function ({ user, domainTransaction = DomainTransaction.emptyTransaction() }) {
-  const knexConnection = domainTransaction.knexTransaction || knex;
+const create = async function ({ user }) {
+  const knexConnection = DomainTransaction.getConnection();
 
   if (user.username) {
     return await _createWithUsername({ knexConnection, user });

--- a/api/src/identity-access-management/infrastructure/repositories/user-to-create.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user-to-create.repository.js
@@ -7,7 +7,6 @@ import { User } from '../../domain/models/User.js';
 /**
  * @param {Object} data
  * @property user
- * @property domainTransaction
  * @return {Promise<User|OrganizationLearnerAlreadyLinkedToUserError>}
  */
 const create = async function ({ user }) {

--- a/api/src/identity-access-management/infrastructure/repositories/user.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user.repository.js
@@ -218,16 +218,11 @@ const update = async function (properties) {
   await knex('users').where({ id: userId }).update(data);
 };
 
-const updateWithEmailConfirmed = function ({
-  id,
-  userAttributes,
-  domainTransaction: { knexTransaction } = DomainTransaction.emptyTransaction(),
-}) {
-  const query = knex('users')
+const updateWithEmailConfirmed = function ({ id, userAttributes }) {
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn('users')
     .where({ id })
     .update({ ...userAttributes, updatedAt: new Date() });
-  if (knexTransaction) query.transacting(knexTransaction);
-  return query;
 };
 
 const checkIfEmailIsAvailable = async function (email) {
@@ -250,13 +245,9 @@ const updateEmail = async function ({ id, email }) {
   return new User(updatedUserEmail);
 };
 
-const updateUserDetailsForAdministration = async function ({
-  id,
-  userAttributes,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
+const updateUserDetailsForAdministration = async function ({ id, userAttributes }) {
   try {
-    const knexConn = domainTransaction.knexTransaction ?? knex;
+    const knexConn = DomainTransaction.getConnection();
     const [userDTO] = await knexConn('users')
       .where({ id })
       .update({ ...userAttributes, updatedAt: new Date() })
@@ -357,8 +348,8 @@ const isUsernameAvailable = async function (username) {
   return username;
 };
 
-const updateUsername = async function ({ id, username, domainTransaction = DomainTransaction.emptyTransaction() }) {
-  const knexConn = domainTransaction.knexTransaction || knex;
+const updateUsername = async function ({ id, username }) {
+  const knexConn = DomainTransaction.getConnection();
   const [updatedUsername] = await knexConn('users')
     .where({ id })
     .update({ username, updatedAt: new Date() })

--- a/api/src/identity-access-management/infrastructure/repositories/user.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user.repository.js
@@ -77,7 +77,8 @@ const getByUsernameOrEmailWithRolesAndPassword = async function (username) {
  * @throws {UserNotFoundError}
  */
 const get = async function (userId) {
-  const foundUser = await knex('users').where('id', userId).first();
+  const knexConn = DomainTransaction.getConnection();
+  const foundUser = await knexConn('users').where('id', userId).first();
   if (!foundUser) throw new UserNotFoundError(`User not found for ID ${userId}`);
   return new User(foundUser);
 };

--- a/api/src/organizational-entities/domain/usecases/update-organizations-in-batch.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/update-organizations-in-batch.usecase.js
@@ -71,19 +71,16 @@ export const updateOrganizationsInBatch = async function ({ filePath, organizati
 
   if (organizationBatchUpdateDtos.length === 0) return;
 
-  await DomainTransaction.execute(async (domainTransaction) => {
+  await DomainTransaction.execute(async () => {
     await Promise.all(
       organizationBatchUpdateDtos.map(async (organizationBatchUpdateDto) => {
         await checkOrganizationUpdate(organizationBatchUpdateDto, organizationForAdminRepository);
 
         try {
-          const organization = await organizationForAdminRepository.get(
-            organizationBatchUpdateDto.id,
-            domainTransaction,
-          );
+          const organization = await organizationForAdminRepository.get(organizationBatchUpdateDto.id);
           organization.updateFromOrganizationBatchUpdateDto(organizationBatchUpdateDto);
 
-          await organizationForAdminRepository.update(organization, domainTransaction);
+          await organizationForAdminRepository.update(organization);
         } catch (error) {
           throw new OrganizationBatchUpdateError({
             meta: { organizationId: organizationBatchUpdateDto.id },

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -63,7 +63,6 @@ const findChildrenByParentOrganizationId = async function (parentOrganizationId)
 /**
  * @type {function}
  * @param {string|number} id
- * @param {DomainTransaction} domainTransaction
  * @return {Promise<OrganizationForAdmin|NotFoundError>}
  */
 const get = async function (id) {
@@ -185,7 +184,6 @@ const save = async function (organization) {
 /**
  * @type {function}
  * @param {OrganizationForAdmin} organization
- * @param {DomainTransaction} domainTransaction
  * @return {Promise<void>}
  */
 const update = async function (organization) {

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -66,8 +66,8 @@ const findChildrenByParentOrganizationId = async function (parentOrganizationId)
  * @param {DomainTransaction} domainTransaction
  * @return {Promise<OrganizationForAdmin|NotFoundError>}
  */
-const get = async function (id, domainTransaction = DomainTransaction.emptyTransaction()) {
-  const knexConn = domainTransaction.knexTransaction ?? knex;
+const get = async function (id) {
+  const knexConn = DomainTransaction.getConnection();
   const organization = await knexConn(ORGANIZATIONS_TABLE_NAME)
     .select({
       id: 'organizations.id',
@@ -159,8 +159,8 @@ const get = async function (id, domainTransaction = DomainTransaction.emptyTrans
  * @param {OrganizationForAdmin} organization
  * @return {Promise<OrganizationForAdmin>}
  */
-const save = async function (organization, domainTransaction = DomainTransaction.emptyTransaction()) {
-  const knexConn = domainTransaction.knexTransaction ?? knex;
+const save = async function (organization) {
+  const knexConn = DomainTransaction.getConnection();
   const data = _.pick(organization, [
     'name',
     'type',
@@ -188,8 +188,8 @@ const save = async function (organization, domainTransaction = DomainTransaction
  * @param {DomainTransaction} domainTransaction
  * @return {Promise<void>}
  */
-const update = async function (organization, domainTransaction = DomainTransaction.emptyTransaction()) {
-  const knexConn = domainTransaction.knexTransaction ?? knex;
+const update = async function (organization) {
+  const knexConn = DomainTransaction.getConnection();
   const organizationRawData = _.pick(organization, [
     'credit',
     'documentationUrl',

--- a/api/src/prescription/campaign-participation/application/campaign-participation-controller.js
+++ b/api/src/prescription/campaign-participation/application/campaign-participation-controller.js
@@ -57,12 +57,11 @@ const getCampaignAssessmentParticipation = async function (request) {
 const deleteParticipation = async function (request, h) {
   const { userId } = request.auth.credentials;
   const { id, campaignParticipationId } = request.params;
-  await DomainTransaction.execute(async (domainTransaction) => {
+  await DomainTransaction.execute(async () => {
     await usecases.deleteCampaignParticipation({
       userId,
       campaignId: id,
       campaignParticipationId,
-      domainTransaction,
     });
   });
   return h.response({}).code(204);

--- a/api/src/prescription/campaign-participation/application/learner-participation-controller.js
+++ b/api/src/prescription/campaign-participation/application/learner-participation-controller.js
@@ -9,11 +9,9 @@ const save = async function (request, h, dependencies = { campaignParticipationS
   const userId = request.auth.credentials.userId;
   const campaignParticipation = await dependencies.campaignParticipationSerializer.deserialize(request.payload);
 
-  const { event, campaignParticipation: campaignParticipationCreated } = await DomainTransaction.execute(
-    (domainTransaction) => {
-      return usecases.startCampaignParticipation({ campaignParticipation, userId, domainTransaction });
-    },
-  );
+  const { event, campaignParticipation: campaignParticipationCreated } = await DomainTransaction.execute(() => {
+    return usecases.startCampaignParticipation({ campaignParticipation, userId });
+  });
 
   events.eventDispatcher
     .dispatch(event)
@@ -43,11 +41,10 @@ const beginImprovement = async function (request) {
   const userId = request.auth.credentials.userId;
   const campaignParticipationId = request.params.campaignParticipationId;
 
-  return DomainTransaction.execute(async (domainTransaction) => {
+  return DomainTransaction.execute(async () => {
     await usecases.beginCampaignParticipationImprovement({
       campaignParticipationId,
       userId,
-      domainTransaction,
     });
     return null;
   });

--- a/api/src/prescription/campaign-participation/domain/usecases/begin-campaign-participation-improvement.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/begin-campaign-participation-improvement.js
@@ -7,9 +7,8 @@ const beginCampaignParticipationImprovement = async function ({
   userId,
   assessmentRepository,
   campaignParticipationRepository,
-  domainTransaction,
 }) {
-  const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId, domainTransaction);
+  const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId);
   if (campaignParticipation.userId !== userId) {
     throw new UserNotAuthorizedToAccessEntityError();
   }
@@ -19,14 +18,14 @@ const beginCampaignParticipationImprovement = async function ({
   }
 
   campaignParticipation.improve();
-  await campaignParticipationRepository.update(campaignParticipation, domainTransaction);
+  await campaignParticipationRepository.update(campaignParticipation);
 
   if (campaignParticipation.lastAssessment.isImproving && !campaignParticipation.lastAssessment.isCompleted()) {
     return null;
   }
 
   const assessment = Assessment.createImprovingForCampaign({ userId, campaignParticipationId });
-  await assessmentRepository.save({ assessment, domainTransaction });
+  await assessmentRepository.save({ assessment });
 };
 
 export { beginCampaignParticipationImprovement };

--- a/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation.js
@@ -3,7 +3,6 @@ import bluebird from 'bluebird';
 const deleteCampaignParticipation = async function ({
   userId,
   campaignId,
-  domainTransaction,
   campaignParticipationId,
   campaignParticipationRepository,
 }) {
@@ -11,13 +10,12 @@ const deleteCampaignParticipation = async function ({
     await campaignParticipationRepository.getAllCampaignParticipationsInCampaignForASameLearner({
       campaignId,
       campaignParticipationId,
-      domainTransaction,
     });
 
   await bluebird.mapSeries(campaignParticipations, async (campaignParticipation) => {
     campaignParticipation.delete(userId);
     const { id, deletedAt, deletedBy } = campaignParticipation;
-    await campaignParticipationRepository.remove({ id, deletedAt, deletedBy, domainTransaction });
+    await campaignParticipationRepository.remove({ id, deletedAt, deletedBy });
   });
 };
 

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
@@ -7,7 +7,6 @@ import * as knowledgeElementRepository from '../../../../../lib/infrastructure/r
 import * as knowledgeElementSnapshotRepository from '../../../../../lib/infrastructure/repositories/knowledge-element-snapshot-repository.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { Assessment } from '../../../../shared/domain/models/Assessment.js';
-import { ApplicationTransaction } from '../../../shared/infrastructure/ApplicationTransaction.js';
 import { CampaignParticipation } from '../../domain/models/CampaignParticipation.js';
 import { AvailableCampaignParticipation } from '../../domain/read-models/AvailableCampaignParticipation.js';
 
@@ -52,8 +51,8 @@ const batchUpdate = async function (campaignParticipations) {
   return Promise.all(campaignParticipations.map((campaignParticipation) => update(campaignParticipation)));
 };
 
-const get = async function (id, domainTransaction) {
-  const knexConn = ApplicationTransaction.getConnection(domainTransaction);
+const get = async function (id) {
+  const knexConn = DomainTransaction.getConnection();
 
   const campaignParticipation = await knexConn.from('campaign-participations').where({ id }).first();
   const campaign = await knexConn.from('campaigns').where({ id: campaignParticipation.campaignId }).first();
@@ -67,7 +66,7 @@ const get = async function (id, domainTransaction) {
 };
 
 const getByCampaignIds = async function (campaignIds) {
-  const knexConn = ApplicationTransaction.getConnection();
+  const knexConn = DomainTransaction.getConnection();
   const campaignParticipations = await knexConn('campaign-participations')
     .whereNull('deletedAt')
     .whereIn('campaignId', campaignIds);

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
@@ -27,24 +27,21 @@ const CAMPAIGN_PARTICIPATION_ATTRIBUTES = [
 ];
 
 const updateWithSnapshot = async function (campaignParticipation) {
-  const domainTransaction = ApplicationTransaction.getTransactionAsDomainTransaction();
   await this.update(campaignParticipation);
 
   const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({
     userId: campaignParticipation.userId,
     limitDate: campaignParticipation.sharedAt,
-    domainTransaction,
   });
   await knowledgeElementSnapshotRepository.save({
     userId: campaignParticipation.userId,
     snappedAt: campaignParticipation.sharedAt,
     knowledgeElements,
-    domainTransaction,
   });
 };
 
-const update = async function (campaignParticipation, domainTransaction) {
-  const knexConn = ApplicationTransaction.getConnection(domainTransaction);
+const update = async function (campaignParticipation) {
+  const knexConn = DomainTransaction.getConnection();
 
   await knexConn('campaign-participations')
     .where({ id: campaignParticipation.id })

--- a/api/src/prescription/learner-management/application/organization-learners-controller.js
+++ b/api/src/prescription/learner-management/application/organization-learners-controller.js
@@ -6,11 +6,10 @@ const deleteOrganizationLearners = async function (request, h) {
   const authenticatedUserId = request.auth.credentials.userId;
   const listLearners = request.payload.listLearners;
 
-  await DomainTransaction.execute(async (domainTransaction) => {
+  await DomainTransaction.execute(async () => {
     await usecases.deleteOrganizationLearners({
       organizationLearnerIds: listLearners,
       userId: authenticatedUserId,
-      domainTransaction,
     });
   });
   return h.response().code(200);

--- a/api/src/prescription/learner-management/domain/usecases/add-or-update-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/add-or-update-organization-learners.js
@@ -18,7 +18,7 @@ async function addOrUpdateOrganizationLearners({
   const errors = [];
   const organizationImport = await organizationImportRepository.get(organizationImportId);
 
-  return DomainTransaction.execute(async (domainTransaction) => {
+  return DomainTransaction.execute(async () => {
     try {
       const readableStream = await importStorage.readFile({ filename: organizationImport.filename });
       const siecleFileStreamer = await SiecleFileStreamer.create(readableStream, organizationImport.encoding);
@@ -31,7 +31,6 @@ async function addOrUpdateOrganizationLearners({
       const nationalStudentIdData = organizationLearnerData.map((learner) => learner.nationalStudentId);
 
       await organizationLearnerRepository.disableAllOrganizationLearnersInOrganization({
-        domainTransaction,
         organizationId: organizationImport.organizationId,
         nationalStudentIds: nationalStudentIdData,
       });
@@ -40,7 +39,6 @@ async function addOrUpdateOrganizationLearners({
         return organizationLearnerRepository.addOrUpdateOrganizationOfOrganizationLearners(
           chunk,
           organizationImport.organizationId,
-          domainTransaction,
         );
       });
     } catch (error) {
@@ -48,7 +46,7 @@ async function addOrUpdateOrganizationLearners({
       throw error;
     } finally {
       organizationImport.process({ errors });
-      await organizationImportRepository.save(organizationImport, domainTransaction);
+      await organizationImportRepository.save(organizationImport);
       await importStorage.deleteFile({ filename: organizationImport.filename });
     }
   });

--- a/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
@@ -3,15 +3,13 @@ const deleteOrganizationLearners = async function ({
   userId,
   organizationLearnerRepository,
   campaignParticipationRepository,
-  domainTransaction,
 }) {
   await campaignParticipationRepository.removeByOrganizationLearnerIds({
     organizationLearnerIds,
     userId,
-    domainTransaction,
   });
 
-  await organizationLearnerRepository.removeByIds({ organizationLearnerIds, userId, domainTransaction });
+  await organizationLearnerRepository.removeByIds({ organizationLearnerIds, userId });
 };
 
 export { deleteOrganizationLearners };

--- a/api/src/prescription/learner-management/domain/usecases/import-organization-learners-from-siecle-csv-format.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-organization-learners-from-siecle-csv-format.js
@@ -17,7 +17,7 @@ const importOrganizationLearnersFromSIECLECSVFormat = async function ({
 }) {
   let organizationImport;
   const errors = [];
-  return DomainTransaction.execute(async (domainTransaction) => {
+  return DomainTransaction.execute(async () => {
     try {
       organizationImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
 
@@ -36,17 +36,12 @@ const importOrganizationLearnersFromSIECLECSVFormat = async function ({
       const nationalStudentIdData = organizationLearnerData.map((learner) => learner.nationalStudentId, []);
 
       await organizationLearnerRepository.disableAllOrganizationLearnersInOrganization({
-        domainTransaction,
         organizationId,
         nationalStudentIds: nationalStudentIdData,
       });
 
       await bluebird.mapSeries(organizationLearnersChunks, (chunk) => {
-        return organizationLearnerRepository.addOrUpdateOrganizationOfOrganizationLearners(
-          chunk,
-          organizationId,
-          domainTransaction,
-        );
+        return organizationLearnerRepository.addOrUpdateOrganizationOfOrganizationLearners(chunk, organizationId);
       });
     } catch (error) {
       errors.push(error);

--- a/api/src/prescription/learner-management/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/campaign-participation-repository.js
@@ -1,6 +1,8 @@
-const removeByOrganizationLearnerIds = function ({ organizationLearnerIds, userId, domainTransaction }) {
-  return domainTransaction
-    .knexTransaction('campaign-participations')
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+
+const removeByOrganizationLearnerIds = function ({ organizationLearnerIds, userId }) {
+  const knexConnection = DomainTransaction.getConnection();
+  return knexConnection('campaign-participations')
     .whereIn('organizationLearnerId', organizationLearnerIds)
     .whereNull('deletedAt')
     .update({ deletedAt: new Date(), deletedBy: userId });

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-import-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-import-repository.js
@@ -48,8 +48,8 @@ function _stringifyErrors(errors) {
   return JSON.stringify(errorsWithProperties);
 }
 
-const save = async function (organizationImport, domainTransaction = DomainTransaction.emptyTransaction()) {
-  let knexConn = ApplicationTransaction.getConnection(domainTransaction);
+const save = async function (organizationImport) {
+  let knexConn = DomainTransaction.getConnection();
 
   const attributes = { ...organizationImport, errors: _stringifyErrors(organizationImport.errors) };
   if (attributes.errors) {

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
@@ -3,35 +3,28 @@ import _ from 'lodash';
 import { OrganizationLearnersCouldNotBeSavedError } from '../../../../../lib/domain/errors.js';
 import { OrganizationLearner } from '../../../../../lib/domain/models/index.js';
 import * as organizationLearnerRepository from '../../../../../lib/infrastructure/repositories/organization-learner-repository.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { ApplicationTransaction } from '../../../shared/infrastructure/ApplicationTransaction.js';
 import { CommonOrganizationLearner } from '../../domain/models/CommonOrganizationLearner.js';
 
-const removeByIds = function ({ organizationLearnerIds, userId, domainTransaction }) {
-  return domainTransaction
-    .knexTransaction('organization-learners')
+const removeByIds = function ({ organizationLearnerIds, userId }) {
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn('organization-learners')
     .whereIn('id', organizationLearnerIds)
     .whereNull('deletedAt')
     .update({ deletedAt: new Date(), deletedBy: userId });
 };
 
-const disableAllOrganizationLearnersInOrganization = async function ({
-  domainTransaction,
-  organizationId,
-  nationalStudentIds,
-}) {
-  const knexConn = domainTransaction.knexTransaction;
+const disableAllOrganizationLearnersInOrganization = async function ({ organizationId, nationalStudentIds }) {
+  const knexConn = DomainTransaction.getConnection();
   await knexConn('organization-learners')
     .where({ organizationId, isDisabled: false })
     .whereNotIn('nationalStudentId', nationalStudentIds)
     .update({ isDisabled: true, updatedAt: knexConn.raw('CURRENT_TIMESTAMP') });
 };
 
-const addOrUpdateOrganizationOfOrganizationLearners = async function (
-  organizationLearnerDatas,
-  organizationId,
-  domainTransaction,
-) {
-  const knexConn = domainTransaction.knexTransaction;
+const addOrUpdateOrganizationOfOrganizationLearners = async function (organizationLearnerDatas, organizationId) {
+  const knexConn = DomainTransaction.getConnection();
   const organizationLearnersFromFile = organizationLearnerDatas.map(
     (organizationLearnerData) =>
       new OrganizationLearner({
@@ -39,15 +32,11 @@ const addOrUpdateOrganizationOfOrganizationLearners = async function (
         organizationId,
       }),
   );
-  const existingOrganizationLearners = await organizationLearnerRepository.findByOrganizationId(
-    { organizationId },
-    domainTransaction,
-  );
+  const existingOrganizationLearners = await organizationLearnerRepository.findByOrganizationId({ organizationId });
 
   const reconciledOrganizationLearnersToImport = await organizationLearnerRepository._reconcileOrganizationLearners(
     organizationLearnersFromFile,
     existingOrganizationLearners,
-    domainTransaction,
   );
 
   try {

--- a/api/src/prescription/organization-learner/infrastructure/repositories/registration-organization-learner-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/registration-organization-learner-repository.js
@@ -1,14 +1,10 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { OrganizationLearner } from '../../../../../lib/domain/models/OrganizationLearner.js';
-import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 
-const findOneByUserIdAndOrganizationId = async function ({
-  userId,
-  organizationId,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
-  const organizationLearner = await knex('view-active-organization-learners')
-    .transacting(domainTransaction)
+const findOneByUserIdAndOrganizationId = async function ({ userId, organizationId }) {
+  const knexConn = DomainTransaction.getConnection();
+
+  const organizationLearner = await knexConn('view-active-organization-learners')
     .where({ userId, organizationId })
     .first('*');
   if (!organizationLearner) return null;

--- a/api/src/school/domain/services/correct-answer.js
+++ b/api/src/school/domain/services/correct-answer.js
@@ -11,9 +11,8 @@ const correctAnswer = async function ({
   activityRepository,
   assessmentRepository,
   examiner: injectedExaminer,
-  domainTransaction,
 } = {}) {
-  const assessment = await assessmentRepository.get(assessmentId, domainTransaction);
+  const assessment = await assessmentRepository.get(assessmentId);
 
   if (assessment.state !== Assessment.states.STARTED) {
     throw new NotInProgressAssessmentError(assessmentId);
@@ -23,7 +22,7 @@ const correctAnswer = async function ({
     throw new ChallengeNotAskedError();
   }
 
-  const activityId = (await activityRepository.getLastActivity(assessmentId, domainTransaction)).id;
+  const activityId = (await activityRepository.getLastActivity(assessmentId)).id;
   const challenge = await challengeRepository.get(activityAnswer.challengeId);
   const examiner = injectedExaminer ?? new Examiner({ validator: challenge.validator });
   const correctedAnswer = examiner.evaluate({
@@ -31,7 +30,7 @@ const correctAnswer = async function ({
     challengeFormat: challenge.format,
   });
 
-  return await activityAnswerRepository.save({ ...correctedAnswer, activityId }, domainTransaction);
+  return await activityAnswerRepository.save({ ...correctedAnswer, activityId });
 };
 
 export { correctAnswer };

--- a/api/src/school/domain/services/init-mission-activity.js
+++ b/api/src/school/domain/services/init-mission-activity.js
@@ -8,15 +8,14 @@ export async function initMissionActivity({
   activityRepository,
   missionAssessmentRepository,
   missionRepository,
-  domainTransaction,
 }) {
   if (lastActivity?.status === Activity.status.STARTED) {
     return lastActivity;
   }
-  const { missionId } = await missionAssessmentRepository.getByAssessmentId(assessmentId, domainTransaction);
+  const { missionId } = await missionAssessmentRepository.getByAssessmentId(assessmentId);
   const mission = await missionRepository.get(missionId);
 
-  const activities = await activityRepository.getAllByAssessmentId(assessmentId, domainTransaction);
+  const activities = await activityRepository.getAllByAssessmentId(assessmentId);
   const activityInfo = getNextActivityInfo({ activities, stepCount: mission.stepCount });
 
   if (activityInfo === END_OF_MISSION) {
@@ -36,5 +35,5 @@ export async function initMissionActivity({
     alternativeVersion,
   });
 
-  return activityRepository.save(activity, domainTransaction);
+  return activityRepository.save(activity);
 }

--- a/api/src/school/domain/services/update-assessment.js
+++ b/api/src/school/domain/services/update-assessment.js
@@ -1,8 +1,8 @@
 import { Activity } from '../models/Activity.js';
 
-export async function updateAssessment({ assessmentId, lastActivity, assessmentRepository, domainTransaction }) {
+export async function updateAssessment({ assessmentId, lastActivity, assessmentRepository }) {
   const terminatedStatuses = [Activity.status.SUCCEEDED, Activity.status.SKIPPED, Activity.status.FAILED];
   if (terminatedStatuses.includes(lastActivity.status)) {
-    await assessmentRepository.completeByAssessmentId(assessmentId, domainTransaction);
+    await assessmentRepository.completeByAssessmentId(assessmentId);
   }
 }

--- a/api/src/school/domain/services/update-current-activity.js
+++ b/api/src/school/domain/services/update-current-activity.js
@@ -7,33 +7,23 @@ export async function updateCurrentActivity({
   activityAnswerRepository,
   missionAssessmentRepository,
   missionRepository,
-  domainTransaction,
 }) {
-  const lastActivity = await activityRepository.getLastActivity(assessmentId, domainTransaction);
-  const answers = await activityAnswerRepository.findByActivity(lastActivity.id, domainTransaction);
+  const lastActivity = await activityRepository.getLastActivity(assessmentId);
+  const answers = await activityAnswerRepository.findByActivity(lastActivity.id);
   const lastAnswer = answers.at(-1);
 
   if (lastAnswer.result.isOK() || lastActivity.isTutorial) {
-    const { missionId } = await missionAssessmentRepository.getByAssessmentId(assessmentId, domainTransaction);
+    const { missionId } = await missionAssessmentRepository.getByAssessmentId(assessmentId);
     const mission = await missionRepository.get(missionId);
     if (_isActivityFinished(mission, lastActivity, answers)) {
-      return activityRepository.updateStatus(
-        { activityId: lastActivity.id, status: Activity.status.SUCCEEDED },
-        domainTransaction,
-      );
+      return activityRepository.updateStatus({ activityId: lastActivity.id, status: Activity.status.SUCCEEDED });
     }
     return lastActivity;
   }
   if (lastAnswer.result.isKO()) {
-    return activityRepository.updateStatus(
-      { activityId: lastActivity.id, status: Activity.status.FAILED },
-      domainTransaction,
-    );
+    return activityRepository.updateStatus({ activityId: lastActivity.id, status: Activity.status.FAILED });
   }
-  return activityRepository.updateStatus(
-    { activityId: lastActivity.id, status: Activity.status.SKIPPED },
-    domainTransaction,
-  );
+  return activityRepository.updateStatus({ activityId: lastActivity.id, status: Activity.status.SKIPPED });
 }
 
 function _isActivityFinished(mission, lastActivity, answers) {

--- a/api/src/school/domain/usecases/handle-activity-answer.js
+++ b/api/src/school/domain/usecases/handle-activity-answer.js
@@ -15,7 +15,7 @@ const handleActivityAnswer = async function ({
   missionAssessmentRepository,
   missionRepository,
 }) {
-  return DomainTransaction.execute(async (domainTransaction) => {
+  return DomainTransaction.execute(async () => {
     const correctedAnswer = await correctAnswer({
       activityAnswer,
       assessmentId,
@@ -24,7 +24,6 @@ const handleActivityAnswer = async function ({
       activityAnswerRepository,
       activityRepository,
       examiner,
-      domainTransaction,
     });
 
     let lastActivity = await updateCurrentActivity({
@@ -33,7 +32,6 @@ const handleActivityAnswer = async function ({
       activityRepository,
       missionAssessmentRepository,
       missionRepository,
-      domainTransaction,
     });
 
     lastActivity = await initMissionActivity({
@@ -42,14 +40,12 @@ const handleActivityAnswer = async function ({
       activityRepository,
       missionAssessmentRepository,
       missionRepository,
-      domainTransaction,
     });
 
     await updateAssessment({
       lastActivity,
       assessmentId,
       assessmentRepository,
-      domainTransaction,
     });
 
     return correctedAnswer;

--- a/api/src/school/domain/usecases/play-mission.js
+++ b/api/src/school/domain/usecases/play-mission.js
@@ -39,21 +39,19 @@ async function _startMission({
   missionAssessmentRepository,
   missionRepository,
 }) {
-  return DomainTransaction.execute(async (domainTransaction) => {
-    const assessment = await createAssessment({ assessmentRepository, domainTransaction });
+  return DomainTransaction.execute(async () => {
+    const assessment = await createAssessment({ assessmentRepository });
     const missionAssessment = await createMissionAssessment({
       assessmentId: assessment.id,
       missionId,
       organizationLearnerId,
       missionAssessmentRepository,
-      domainTransaction,
     });
     await initMissionActivity({
       assessmentId: assessment.id,
       activityRepository,
       missionAssessmentRepository,
       missionRepository,
-      domainTransaction,
     });
     return new Assessment({ ...assessment, ...missionAssessment });
   });
@@ -70,14 +68,13 @@ async function createMissionAssessment({
   missionId,
   organizationLearnerId,
   missionAssessmentRepository,
-  domainTransaction,
 }) {
   const missionAssessment = new MissionAssessment({
     missionId,
     assessmentId,
     organizationLearnerId,
   });
-  await missionAssessmentRepository.save({ missionAssessment, domainTransaction });
+  await missionAssessmentRepository.save({ missionAssessment });
 
   return missionAssessment;
 }

--- a/api/src/school/domain/usecases/play-mission.js
+++ b/api/src/school/domain/usecases/play-mission.js
@@ -57,10 +57,10 @@ async function _startMission({
   });
 }
 
-async function createAssessment({ assessmentRepository, domainTransaction }) {
+async function createAssessment({ assessmentRepository }) {
   const assessmentData = Assessment.createForPix1dMission();
 
-  return assessmentRepository.save({ assessment: assessmentData, domainTransaction });
+  return assessmentRepository.save({ assessment: assessmentData });
 }
 
 async function createMissionAssessment({

--- a/api/src/school/infrastructure/repositories/activity-answer-repository.js
+++ b/api/src/school/infrastructure/repositories/activity-answer-repository.js
@@ -1,7 +1,6 @@
 import jsYaml from 'js-yaml';
 import _ from 'lodash';
 
-import { knex } from '../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import * as answerStatusDatabaseAdapter from '../../../shared/infrastructure/adapters/answer-status-database-adapter.js';
 import { ActivityAnswer } from '../../domain/models/ActivityAnswer.js';
@@ -27,14 +26,14 @@ function _toDomainArray(answerDTOs) {
 
 const COLUMNS = Object.freeze(['id', 'challengeId', 'activityId', 'value', 'result', 'resultDetails']);
 
-const findByActivity = async function (activityId, domainTransaction = DomainTransaction.emptyTransaction()) {
-  const knexConn = domainTransaction.knexTransaction || knex;
+const findByActivity = async function (activityId) {
+  const knexConn = DomainTransaction.getConnection();
   const answerDTOs = await knexConn.select(COLUMNS).from('activity-answers').where({ activityId }).orderBy('createdAt');
   return _toDomainArray(answerDTOs);
 };
 
-const save = async function (answer, domainTransaction = DomainTransaction.emptyTransaction()) {
-  const knexConn = domainTransaction.knexTransaction || knex;
+const save = async function (answer) {
+  const knexConn = DomainTransaction.getConnection();
   const answerForDB = _adaptAnswerToDb(answer);
   const [savedAnswerDTO] = await knexConn('activity-answers').insert(answerForDB).returning(COLUMNS);
   return _toDomain(savedAnswerDTO);

--- a/api/src/school/infrastructure/repositories/activity-repository.js
+++ b/api/src/school/infrastructure/repositories/activity-repository.js
@@ -1,38 +1,34 @@
-import { knex } from '../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { Activity } from '../../domain/models/Activity.js';
 import { ActivityNotFoundError } from '../../domain/school-errors.js';
 
-const save = async function (activity, domainTransaction = DomainTransaction.emptyTransaction()) {
-  const knexConnection = domainTransaction.knexTransaction || knex;
-  const [savedAttributes] = await knexConnection('activities').insert(activity).returning('*');
+const save = async function (activity) {
+  const knexConn = DomainTransaction.getConnection();
+  const [savedAttributes] = await knexConn('activities').insert(activity).returning('*');
   return new Activity(savedAttributes);
 };
 
-const updateStatus = async function ({ activityId, status }, domainTransaction = DomainTransaction.emptyTransaction()) {
-  const knexConnection = domainTransaction.knexTransaction || knex;
-  const [updatedActivity] = await knexConnection('activities')
-    .update({ status })
-    .where('id', activityId)
-    .returning('*');
+const updateStatus = async function ({ activityId, status }) {
+  const knexConn = DomainTransaction.getConnection();
+  const [updatedActivity] = await knexConn('activities').update({ status }).where('id', activityId).returning('*');
   if (!updatedActivity) {
     throw new ActivityNotFoundError(`There is no activity corresponding to the id: ${activityId}`);
   }
   return new Activity(updatedActivity);
 };
 
-const getLastActivity = async function (assessmentId, domainTransaction = DomainTransaction.emptyTransaction()) {
-  const knexConnection = domainTransaction.knexTransaction || knex;
-  const activity = await knexConnection('activities').where({ assessmentId }).orderBy('createdAt', 'DESC').first();
+const getLastActivity = async function (assessmentId) {
+  const knexConn = DomainTransaction.getConnection();
+  const activity = await knexConn('activities').where({ assessmentId }).orderBy('createdAt', 'DESC').first();
   if (!activity) {
     throw new ActivityNotFoundError(`No activity found for the assessment: ${assessmentId}`);
   }
   return new Activity(activity);
 };
 
-const getAllByAssessmentId = async function (assessmentId, domainTransaction = DomainTransaction.emptyTransaction()) {
-  const knexConnection = domainTransaction.knexTransaction || knex;
-  const dbActivities = await knexConnection('activities').where({ assessmentId }).orderBy('createdAt', 'DESC');
+const getAllByAssessmentId = async function (assessmentId) {
+  const knexConn = DomainTransaction.getConnection();
+  const dbActivities = await knexConn('activities').where({ assessmentId }).orderBy('createdAt', 'DESC');
 
   return dbActivities.map((activity) => new Activity(activity));
 };

--- a/api/src/school/infrastructure/repositories/mission-assessment-repository.js
+++ b/api/src/school/infrastructure/repositories/mission-assessment-repository.js
@@ -5,14 +5,14 @@ import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { Assessment } from '../../../shared/domain/models/Assessment.js';
 import { MissionAssessment } from '../models/mission-assessment.js';
 
-const save = async function ({ missionAssessment, domainTransaction = DomainTransaction.emptyTransaction() }) {
-  const knexConnection = domainTransaction.knexTransaction || knex;
-  await knexConnection('mission-assessments').insert({ ...missionAssessment });
+const save = async function ({ missionAssessment }) {
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn('mission-assessments').insert({ ...missionAssessment });
 };
 
-const getByAssessmentId = async function (assessmentId, domainTransaction = DomainTransaction.emptyTransaction()) {
-  const knexConnection = domainTransaction.knexTransaction || knex;
-  const rawAssessmentMission = await knexConnection('mission-assessments')
+const getByAssessmentId = async function (assessmentId) {
+  const knexConn = DomainTransaction.getConnection();
+  const rawAssessmentMission = await knexConn('mission-assessments')
     .where({ assessmentId: assessmentId })
     .returning('*')
     .first();

--- a/api/src/school/infrastructure/repositories/school-repository.js
+++ b/api/src/school/infrastructure/repositories/school-repository.js
@@ -4,8 +4,8 @@ import { Division } from '../../domain/models/Division.js';
 import { School } from '../../domain/models/School.js';
 import { SchoolNotFoundError } from '../../domain/school-errors.js';
 
-const save = async function ({ organizationId, code, domainTransaction = DomainTransaction.emptyTransaction() }) {
-  const knexConn = domainTransaction.knexTransaction ?? knex;
+const save = async function ({ organizationId, code }) {
+  const knexConn = DomainTransaction.getConnection();
   await knexConn('schools').insert({ organizationId, code }).returning('*');
 };
 

--- a/api/src/shared/application/assessments/assessment-controller.js
+++ b/api/src/shared/application/assessments/assessment-controller.js
@@ -95,11 +95,11 @@ const completeAssessment = async function (request) {
   const locale = extractLocaleFromRequest(request);
   let event;
 
-  await DomainTransaction.execute(async (domainTransaction) => {
-    const result = await usecases.completeAssessment({ assessmentId, domainTransaction, locale });
-    await usecases.handleBadgeAcquisition({ assessment: result.assessment, domainTransaction });
-    await usecases.handleStageAcquisition({ assessment: result.assessment, domainTransaction });
-    await devcompUsecases.handleTrainingRecommendation({ assessment: result.assessment, locale, domainTransaction });
+  await DomainTransaction.execute(async () => {
+    const result = await usecases.completeAssessment({ assessmentId, locale });
+    await usecases.handleBadgeAcquisition({ assessment: result.assessment });
+    await usecases.handleStageAcquisition({ assessment: result.assessment });
+    await devcompUsecases.handleTrainingRecommendation({ assessment: result.assessment, locale });
     event = result.event;
   });
 
@@ -113,8 +113,8 @@ const updateLastChallengeState = async function (request) {
   const lastQuestionState = request.params.state;
   const challengeId = request.payload?.data?.attributes?.['challenge-id'];
 
-  await DomainTransaction.execute(async (domainTransaction) => {
-    await usecases.updateLastQuestionState({ assessmentId, challengeId, lastQuestionState, domainTransaction });
+  await DomainTransaction.execute(async () => {
+    await usecases.updateLastQuestionState({ assessmentId, challengeId, lastQuestionState });
   });
 
   return null;

--- a/api/src/shared/domain/services/user-service.js
+++ b/api/src/shared/domain/services/user-service.js
@@ -19,8 +19,8 @@ async function createUserWithPassword({
   let savedUser;
   const userToAdd = UserToCreate.create(user);
 
-  await DomainTransaction.execute(async (domainTransaction) => {
-    savedUser = await userToCreateRepository.create({ user: userToAdd, domainTransaction });
+  await DomainTransaction.execute(async () => {
+    savedUser = await userToCreateRepository.create({ user: userToAdd });
 
     const authenticationMethod = _buildPasswordAuthenticationMethod({
       userId: savedUser.id,
@@ -29,7 +29,6 @@ async function createUserWithPassword({
 
     await authenticationMethodRepository.create({
       authenticationMethod,
-      domainTransaction,
     });
   });
 
@@ -51,12 +50,11 @@ async function updateUsernameAndAddPassword({
   authenticationMethodRepository,
   userRepository,
 }) {
-  return DomainTransaction.execute(async (domainTransaction) => {
-    await userRepository.updateUsername({ id: userId, username, domainTransaction });
+  return DomainTransaction.execute(async () => {
+    await userRepository.updateUsername({ id: userId, username });
     return authenticationMethodRepository.createPasswordThatShouldBeChanged({
       userId,
       hashedPassword,
-      domainTransaction,
     });
   });
 }
@@ -82,12 +80,11 @@ async function createAndReconcileUserToOrganizationLearner({
 }) {
   const userToAdd = UserToCreate.create(user);
 
-  return DomainTransaction.execute(async (domainTransaction) => {
+  return DomainTransaction.execute(async () => {
     let authenticationMethod;
 
     const createdUser = await userToCreateRepository.create({
       user: userToAdd,
-      domainTransaction,
     });
 
     if (samlId) {
@@ -104,13 +101,11 @@ async function createAndReconcileUserToOrganizationLearner({
 
     await authenticationMethodRepository.create({
       authenticationMethod,
-      domainTransaction,
     });
 
     await organizationLearnerRepository.updateUserIdWhereNull({
       organizationLearnerId,
       userId: createdUser.id,
-      domainTransaction,
     });
 
     return createdUser.id;

--- a/api/src/shared/domain/usecases/delete-unassociated-badge.js
+++ b/api/src/shared/domain/usecases/delete-unassociated-badge.js
@@ -9,12 +9,9 @@ const deleteUnassociatedBadge = async function ({
   badgeRepository,
   complementaryCertificationBadgeRepository,
 }) {
-  return DomainTransaction.execute(async (domainTransaction) => {
-    const isAssociated = await badgeRepository.isAssociated(badgeId, domainTransaction);
-    const isRelatedToCertification = await complementaryCertificationBadgeRepository.isRelatedToCertification(
-      badgeId,
-      domainTransaction,
-    );
+  return DomainTransaction.execute(async () => {
+    const isAssociated = await badgeRepository.isAssociated(badgeId);
+    const isRelatedToCertification = await complementaryCertificationBadgeRepository.isRelatedToCertification(badgeId);
 
     if (isAssociated) {
       throw new AcquiredBadgeForbiddenDeletionError();
@@ -24,7 +21,7 @@ const deleteUnassociatedBadge = async function ({
       throw new CertificationBadgeForbiddenDeletionError();
     }
 
-    return badgeRepository.remove(badgeId, domainTransaction);
+    return badgeRepository.remove(badgeId);
   });
 };
 export { deleteUnassociatedBadge };

--- a/api/src/shared/infrastructure/repositories/assessment-result-repository.js
+++ b/api/src/shared/infrastructure/repositories/assessment-result-repository.js
@@ -40,11 +40,7 @@ function _toDomain({ assessmentResultDTO, competencesMarksDTO }) {
   });
 }
 
-const save = async function ({
-  certificationCourseId,
-  assessmentResult,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
+const save = async function ({ certificationCourseId, assessmentResult }) {
   const { pixScore, reproducibilityRate, status, emitter, commentByJury, id, juryId, assessmentId } = assessmentResult;
   const commentByAutoJury = _getCommentByAutoJury(assessmentResult);
 
@@ -52,7 +48,7 @@ const save = async function ({
     throw new MissingAssessmentId();
   }
   try {
-    const knexConn = domainTransaction.knexTransaction || knex;
+    const knexConn = DomainTransaction.getConnection();
     const [savedAssessmentResultData] = await knexConn('assessment-results')
       .insert({
         pixScore,

--- a/api/src/shared/infrastructure/repositories/target-profile-for-admin-repository.js
+++ b/api/src/shared/infrastructure/repositories/target-profile-for-admin-repository.js
@@ -17,8 +17,8 @@ import { StageCollection } from '../../domain/models/target-profile-management/S
 import * as competenceRepository from './competence-repository.js';
 import * as skillRepository from './skill-repository.js';
 
-const get = async function ({ id, locale = FRENCH_FRANCE }, domainTransaction = DomainTransaction.emptyTransaction()) {
-  const knexConn = domainTransaction?.knexTransaction || knex;
+const get = async function ({ id, locale = FRENCH_FRANCE }) {
+  const knexConn = DomainTransaction.getConnection();
 
   const targetProfileDTO = await knexConn('target-profiles')
     .select(

--- a/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-badge-repository_test.js
+++ b/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-badge-repository_test.js
@@ -83,10 +83,9 @@ describe('Integration | Infrastructure | Repository | Certification | Complement
         await databaseBuilder.commit();
 
         // when
-        await DomainTransaction.execute(async (domainTransaction) => {
+        await DomainTransaction.execute(async () => {
           await complementaryCertificationBadgeRepository.detachByIds({
             complementaryCertificationBadgeIds: [123, 456],
-            domainTransaction,
           });
         });
 
@@ -149,10 +148,9 @@ describe('Integration | Infrastructure | Repository | Certification | Complement
       await databaseBuilder.commit();
 
       // when
-      await DomainTransaction.execute(async (domainTransaction) => {
+      await DomainTransaction.execute(async () => {
         await complementaryCertificationBadgeRepository.attach({
           complementaryCertificationBadges: badgesToAttach,
-          domainTransaction,
         });
       });
 

--- a/api/tests/certification/complementary-certification/unit/domain/usecases/attach-badges_test.js
+++ b/api/tests/certification/complementary-certification/unit/domain/usecases/attach-badges_test.js
@@ -179,11 +179,8 @@ describe('Unit | UseCase | attach-badges', function () {
     context('when complementary certification badges are already attached to the profile', function () {
       it('should detach old complementary certification badges', async function () {
         // given
-        const domainTransaction = {
-          knexTransaction: Symbol('transaction'),
-        };
         sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
-          return callback(domainTransaction);
+          return callback();
         });
         const badge1 = domainBuilder.buildBadge({ id: 123 });
         const badge2 = domainBuilder.buildBadge({ id: 456 });
@@ -219,17 +216,13 @@ describe('Unit | UseCase | attach-badges', function () {
         // then
         expect(complementaryCertificationBadgesRepository.detachByIds).to.have.been.calledWithExactly({
           complementaryCertificationBadgeIds: [1, 2],
-          domainTransaction,
         });
       });
 
       it('should attach new complementary certification badges', async function () {
         // given
-        const domainTransaction = {
-          knexTransaction: Symbol('transaction'),
-        };
         sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
-          return callback(domainTransaction);
+          return callback();
         });
         const badge1 = domainBuilder.buildBadge({ id: 123 });
 
@@ -279,7 +272,6 @@ describe('Unit | UseCase | attach-badges', function () {
         });
         expect(complementaryCertificationBadgesRepository.attach).to.have.been.calledWithExactly({
           complementaryCertificationBadges: [newComplementaryCertificationBadge],
-          domainTransaction,
         });
       });
     });
@@ -287,11 +279,8 @@ describe('Unit | UseCase | attach-badges', function () {
     context('when there are no complementary certification badges already attached to the profile', function () {
       it('should attach new complementary certification badges', async function () {
         // given
-        const domainTransaction = {
-          knexTransaction: Symbol('transaction'),
-        };
         sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
-          return callback(domainTransaction);
+          return callback();
         });
         const badge1 = domainBuilder.buildBadge({ id: 123 });
 
@@ -341,12 +330,10 @@ describe('Unit | UseCase | attach-badges', function () {
         });
         expect(complementaryCertificationBadgesRepository.attach).to.have.been.calledWithExactly({
           complementaryCertificationBadges: [newComplementaryCertificationBadge],
-          domainTransaction,
         });
 
         expect(complementaryCertificationBadgesRepository.attach).to.have.been.calledWithExactly({
           complementaryCertificationBadges: [newComplementaryCertificationBadge],
-          domainTransaction,
         });
 
         expect(complementaryCertificationBadgesRepository.detachByIds).not.to.have.been.called;

--- a/api/tests/certification/complementary-certification/unit/domain/usecases/attach-badges_test.js
+++ b/api/tests/certification/complementary-certification/unit/domain/usecases/attach-badges_test.js
@@ -344,11 +344,8 @@ describe('Unit | UseCase | attach-badges', function () {
   context('when there is no badges associated to target profile', function () {
     it('should throw an error', async function () {
       // given
-      const domainTransaction = {
-        knexTransaction: Symbol('transaction'),
-      };
       sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
-        return callback(domainTransaction);
+        return callback();
       });
       const badge1 = domainBuilder.buildBadge({ id: 123 });
       const badge2 = domainBuilder.buildBadge({ id: 456 });

--- a/api/tests/certification/course/unit/domain/usecases/update-jury-comment_test.js
+++ b/api/tests/certification/course/unit/domain/usecases/update-jury-comment_test.js
@@ -5,14 +5,9 @@ import { AssessmentResult } from '../../../../../../src/shared/domain/models/Ass
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | update-jury-comment', function () {
-  let domainTransaction;
-
   beforeEach(function () {
-    domainTransaction = {
-      knexTransaction: Symbol('transaction'),
-    };
     sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
-      return callback(domainTransaction);
+      return callback();
     });
   });
 
@@ -47,7 +42,6 @@ describe('Unit | UseCase | update-jury-comment', function () {
     // then
     expect(courseAssessmentResultRepository.getLatestAssessmentResult).to.have.been.calledOnceWith({
       certificationCourseId,
-      domainTransaction,
     });
     expect(assessmentResultRepository.save).to.have.been.calledOnceWith({
       certificationCourseId,
@@ -60,7 +54,6 @@ describe('Unit | UseCase | update-jury-comment', function () {
           commentByJury: assessmentResultCommentByJury,
         }),
       ),
-      domainTransaction,
     });
     expect(competenceMarkRepository.save).to.have.been.calledOnceWith(
       sinon.match.instanceOf(CompetenceMark).and(
@@ -69,7 +62,6 @@ describe('Unit | UseCase | update-jury-comment', function () {
           assessmentResultId: newAssessmentResult.id,
         }),
       ),
-      domainTransaction,
     );
   });
 });

--- a/api/tests/certification/enrolment/unit/domain/usecases/create-sessions_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/create-sessions_test.js
@@ -81,8 +81,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
           temporarySessionsStorageForMassImportService.getByKeyAndUserId.resolves(temporaryCachedSessions);
           const sessionCreatorId = 1234;
           const cachedValidatedSessionsKey = 'uuid';
-          const domainTransaction = Symbol('trx');
-          sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda(domainTransaction));
+          sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
           sessionRepository.save.resolves({ id: 1234 });
 
           // when
@@ -95,7 +94,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
 
           // then
           const expectedSession = new SessionEnrolment({ ...temporaryCachedSessions[0], createdBy: sessionCreatorId });
-          expect(sessionRepository.save).to.have.been.calledOnceWith({ session: expectedSession, domainTransaction });
+          expect(sessionRepository.save).to.have.been.calledOnceWith({ session: expectedSession });
           expect(certificationCandidateRepository.saveInSession).to.not.have.been.called;
         });
       });
@@ -126,8 +125,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
           ];
           temporarySessionsStorageForMassImportService.getByKeyAndUserId.resolves(temporaryCachedSessions);
           const cachedValidatedSessionsKey = 'uuid';
-          const domainTransaction = Symbol('trx');
-          sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda(domainTransaction));
+          sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
           sessionRepository.save.resolves({ id: 1234 });
 
           // when
@@ -140,11 +138,10 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
 
           // then
           const expectedSession = new SessionEnrolment({ ...temporaryCachedSessions[0], createdBy: sessionCreatorId });
-          expect(sessionRepository.save).to.have.been.calledOnceWith({ session: expectedSession, domainTransaction });
+          expect(sessionRepository.save).to.have.been.calledOnceWith({ session: expectedSession });
           expect(certificationCandidateRepository.saveInSession).to.have.been.calledOnceWith({
             sessionId: 1234,
             certificationCandidate,
-            domainTransaction,
           });
         });
       });
@@ -174,8 +171,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
           ];
           temporarySessionsStorageForMassImportService.getByKeyAndUserId.resolves(temporaryCachedSessions);
           const cachedValidatedSessionsKey = 'uuid';
-          const domainTransaction = Symbol('trx');
-          sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda(domainTransaction));
+          sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
           sessionRepository.save.resolves({ id: 1234 });
 
           // when
@@ -192,7 +188,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
             version: CERTIFICATION_VERSIONS.V3,
             createdBy: sessionCreatorId,
           });
-          expect(sessionRepository.save).to.have.been.calledOnceWith({ session: expectedSession, domainTransaction });
+          expect(sessionRepository.save).to.have.been.calledOnceWith({ session: expectedSession });
         });
       });
 
@@ -222,8 +218,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
           temporarySessionsStorageForMassImportService.getByKeyAndUserId.resolves(temporaryCachedSessions);
 
           const cachedValidatedSessionsKey = 'uuid';
-          const domainTransaction = Symbol('trx');
-          sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda(domainTransaction));
+          sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
           sessionRepository.save.resolves({ id: 1234 });
 
           // when
@@ -240,7 +235,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
             version: CERTIFICATION_VERSIONS.V2,
             createdBy: sessionCreatorId,
           });
-          expect(sessionRepository.save).to.have.been.calledOnceWith({ session: expectedSession, domainTransaction });
+          expect(sessionRepository.save).to.have.been.calledOnceWith({ session: expectedSession });
         });
       });
     });
@@ -260,8 +255,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
         temporarySessionsStorageForMassImportService.getByKeyAndUserId.resolves(temporaryCachedSessions);
         const sessionCreatorId = 1234;
         const cachedValidatedSessionsKey = 'uuid';
-        const domainTransaction = Symbol('trx');
-        sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda(domainTransaction));
+        sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
 
         // when
         await createSessions({
@@ -274,12 +268,10 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
         // then
         expect(certificationCandidateRepository.deleteBySessionId).to.have.been.calledOnceWith({
           sessionId: 1234,
-          domainTransaction,
         });
         expect(certificationCandidateRepository.saveInSession).to.have.been.calledOnceWith({
           sessionId: 1234,
           certificationCandidate,
-          domainTransaction,
         });
       });
     });
@@ -298,8 +290,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
       temporarySessionsStorageForMassImportService.getByKeyAndUserId.resolves(temporaryCachedSessions);
       const sessionCreatorId = 1234;
       const cachedValidatedSessionsKey = 'uuid';
-      const domainTransaction = Symbol('trx');
-      sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda(domainTransaction));
+      sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
 
       // when
       await createSessions({

--- a/api/tests/certification/enrolment/unit/domain/usecases/import-certification-candidates-from-candidates-import-sheet_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/import-certification-candidates-from-candidates-import-sheet_test.js
@@ -14,7 +14,6 @@ describe('Unit | UseCase | import-certification-candidates-from-attendance-sheet
   let complementaryCertificationRepository;
   let certificationCenterRepository;
   let sessionRepository;
-  let domainTransaction;
 
   beforeEach(function () {
     certificationCandidateRepository = {
@@ -35,9 +34,8 @@ describe('Unit | UseCase | import-certification-candidates-from-attendance-sheet
     certificationCpfCityRepository = Symbol('certificationCpfCityRepository');
     complementaryCertificationRepository = Symbol('complementaryCertificationRepository');
     certificationCenterRepository = Symbol('certificationCenterRepository');
-    domainTransaction = Symbol('domainTransaction');
     sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => {
-      return lambda(domainTransaction);
+      return lambda();
     });
   });
 
@@ -122,12 +120,10 @@ describe('Unit | UseCase | import-certification-candidates-from-attendance-sheet
           // then
           expect(certificationCandidateRepository.deleteBySessionId).to.have.been.calledWithExactly({
             sessionId,
-            domainTransaction,
           });
           expect(certificationCandidateRepository.saveInSession).to.have.been.calledWithExactly({
             certificationCandidate,
             sessionId,
-            domainTransaction,
           });
           expect(
             certificationCandidateRepository.deleteBySessionId.calledBefore(

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/finalized-session-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/finalized-session-repository_test.js
@@ -147,7 +147,7 @@ describe('Integration | Repository | Finalized-session', function () {
 
         // when
         await DomainTransaction.execute(async (domainTransaction) => {
-          await finalizedSessionRepository.remove({ sessionId: 1234, domainTransaction });
+          await finalizedSessionRepository.remove({ sessionId: 1234 });
           return domainTransaction.knexTransaction.rollback();
         });
 

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/session-repository_test.js
@@ -260,7 +260,7 @@ describe('Integration | Repository | Certification | session | SessionManagement
 
         // when
         await DomainTransaction.execute(async (domainTransaction) => {
-          await sessionRepository.unfinalize({ id: 99, domainTransaction });
+          await sessionRepository.unfinalize({ id: 99 });
           return domainTransaction.knexTransaction.rollback();
         });
 

--- a/api/tests/certification/session-management/unit/domain/usecases/unfinalize-session_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/unfinalize-session_test.js
@@ -26,14 +26,12 @@ describe('Unit | UseCase | unfinalize-session', function () {
       // then
       expect(sessionRepository.unfinalize).to.have.been.calledWithMatch({
         id: 99,
-        domainTransaction: sinon.match.object,
       });
 
       expect(sessionRepository.isPublished).to.have.been.calledWithMatch({ id: 99 });
 
       expect(finalizedSessionRepository.remove).to.have.been.calledWithMatch({
         sessionId: 99,
-        domainTransaction: sinon.match.object,
       });
     });
   });

--- a/api/tests/certification/shared/integration/domain/services/certification-badges-service_test.js
+++ b/api/tests/certification/shared/integration/domain/services/certification-badges-service_test.js
@@ -101,8 +101,8 @@ describe('Integration | Service | Certification-Badges Service', function () {
       mockLearningContent(learningContentObjects);
 
       // when
-      const badgeAcquisitions = await DomainTransaction.execute(async (domainTransaction) => {
-        return certificationBadgesService.findStillValidBadgeAcquisitions({ userId, domainTransaction });
+      const badgeAcquisitions = await DomainTransaction.execute(async () => {
+        return certificationBadgesService.findStillValidBadgeAcquisitions({ userId });
       });
 
       // then
@@ -163,8 +163,8 @@ describe('Integration | Service | Certification-Badges Service', function () {
           mockLearningContent(learningContentObjects);
 
           // when
-          const badgeAcquisitions = await DomainTransaction.execute(async (domainTransaction) => {
-            return certificationBadgesService.findStillValidBadgeAcquisitions({ userId, domainTransaction });
+          const badgeAcquisitions = await DomainTransaction.execute(async () => {
+            return certificationBadgesService.findStillValidBadgeAcquisitions({ userId });
           });
 
           // then
@@ -225,11 +225,10 @@ describe('Integration | Service | Certification-Badges Service', function () {
           mockLearningContent(learningContentObjects);
 
           // when
-          const badgeAcquisitions = await DomainTransaction.execute(async (domainTransaction) => {
+          const badgeAcquisitions = await DomainTransaction.execute(async () => {
             return certificationBadgesService.findStillValidBadgeAcquisitions({
               userId,
               limitDate: new Date('2022-01-02'),
-              domainTransaction,
             });
           });
 

--- a/api/tests/certification/shared/unit/domain/services/certification-badges-service_test.js
+++ b/api/tests/certification/shared/unit/domain/services/certification-badges-service_test.js
@@ -7,7 +7,6 @@ describe('Unit | Service | certification-badges-service', function () {
       // given
       const userId = 123;
       const limitDate = new Date();
-      const domainTransaction = Symbol('domainTransaction');
       const highestBadgeAcquisition1 = domainBuilder.buildCertifiableBadgeAcquisition({ badgeId: 1 });
       const highestBadgeAcquisition2 = domainBuilder.buildCertifiableBadgeAcquisition({ badgeId: 2 });
       const highestBadgeAcquisition3 = domainBuilder.buildCertifiableBadgeAcquisition({ badgeId: 3 });
@@ -25,7 +24,7 @@ describe('Unit | Service | certification-badges-service', function () {
         findHighestCertifiable: sinon.stub(),
       };
       certifiableBadgeAcquisitionRepository.findHighestCertifiable
-        .withArgs({ userId, domainTransaction, limitDate })
+        .withArgs({ userId, limitDate })
         .resolves([highestBadgeAcquisition1, highestBadgeAcquisition2, highestBadgeAcquisition3]);
 
       const knowledgeElementRepository = {
@@ -51,7 +50,6 @@ describe('Unit | Service | certification-badges-service', function () {
       // when
       const stillValidBadgeAcquisitions = await certificationBadgesService.findStillValidBadgeAcquisitions({
         userId,
-        domainTransaction,
         limitDate,
         dependencies: {
           certifiableBadgeAcquisitionRepository,
@@ -69,7 +67,6 @@ describe('Unit | Service | certification-badges-service', function () {
         // given
         const userId = 123;
         const limitDate = new Date();
-        const domainTransaction = Symbol('domainTransaction');
         const highestBadgeAcquisition1 = domainBuilder.buildCertifiableBadgeAcquisition({
           badgeId: 1,
           isOutdated: true,
@@ -81,7 +78,7 @@ describe('Unit | Service | certification-badges-service', function () {
           findHighestCertifiable: sinon.stub(),
         };
         certifiableBadgeAcquisitionRepository.findHighestCertifiable
-          .withArgs({ userId, domainTransaction, limitDate })
+          .withArgs({ userId, limitDate })
           .resolves([highestBadgeAcquisition1]);
 
         const knowledgeElementRepository = {
@@ -94,7 +91,6 @@ describe('Unit | Service | certification-badges-service', function () {
         // when
         const stillValidBadgeAcquisitions = await certificationBadgesService.findStillValidBadgeAcquisitions({
           userId,
-          domainTransaction,
           limitDate,
           shouldGetOutdated: false,
           dependencies: {
@@ -116,7 +112,6 @@ describe('Unit | Service | certification-badges-service', function () {
       // given
       const userId = 123;
       const limitDate = new Date();
-      const domainTransaction = Symbol('domainTransaction');
       const highestBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
         badgeId: 1,
         isDetached: true,
@@ -128,7 +123,7 @@ describe('Unit | Service | certification-badges-service', function () {
         findHighestCertifiable: sinon.stub(),
       };
       certifiableBadgeAcquisitionRepository.findHighestCertifiable
-        .withArgs({ userId, domainTransaction, limitDate })
+        .withArgs({ userId, limitDate })
         .resolves([highestBadgeAcquisition]);
 
       const knowledgeElementRepository = {
@@ -145,7 +140,6 @@ describe('Unit | Service | certification-badges-service', function () {
       // when
       const badgeAcquisitions = await certificationBadgesService.findLatestBadgeAcquisitions({
         userId,
-        domainTransaction,
         limitDate,
         dependencies: {
           certifiableBadgeAcquisitionRepository,

--- a/api/tests/devcomp/unit/application/trainings/training-controller_test.js
+++ b/api/tests/devcomp/unit/application/trainings/training-controller_test.js
@@ -269,9 +269,8 @@ describe('Unit | Devcomp | Application | Trainings | Controller | training-contr
         tubes: Symbol('tubes'),
       };
 
-      const domainTransaction = Symbol();
       sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
-        return callback(domainTransaction);
+        return callback();
       });
 
       const createdTrigger = Symbol('createdTrigger');
@@ -300,7 +299,6 @@ describe('Unit | Devcomp | Application | Trainings | Controller | training-contr
         threshold: deserializedTrigger.threshold,
         type: deserializedTrigger.type,
         tubes: deserializedTrigger.tubes,
-        domainTransaction,
       });
       expect(result).to.be.equal(serializedTrigger);
     });

--- a/api/tests/devcomp/unit/domain/usecases/create-or-update-training-trigger_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/create-or-update-training-trigger_test.js
@@ -17,14 +17,12 @@ describe('Unit | Devcomp | Domain | UseCases | create-or-update-training-trigger
   context('when training does not exist', function () {
     it('should throw an error when training does not exist', async function () {
       // given
-      const domainTransaction = Symbol('domainTransaction');
       const trainingId = Symbol('trainingId');
-      trainingRepository.get.withArgs({ trainingId, domainTransaction }).throws(new Error('Not Found'));
+      trainingRepository.get.withArgs({ trainingId }).throws(new Error('Not Found'));
 
       // when
       const error = await catchErr(createOrUpdateTrainingTrigger)({
         trainingId,
-        domainTransaction,
         trainingRepository,
       });
 
@@ -37,7 +35,6 @@ describe('Unit | Devcomp | Domain | UseCases | create-or-update-training-trigger
   context('when training exists', function () {
     it('should call create or update trigger repository method', async function () {
       // given
-      const domainTransaction = Symbol('domainTransaction');
       const trainingId = Symbol('trainingId');
       const tubes = Symbol('tubes');
       const type = Symbol('type');
@@ -52,7 +49,6 @@ describe('Unit | Devcomp | Domain | UseCases | create-or-update-training-trigger
         tubes,
         type,
         threshold,
-        domainTransaction,
         trainingRepository,
         trainingTriggerRepository,
       });
@@ -63,7 +59,6 @@ describe('Unit | Devcomp | Domain | UseCases | create-or-update-training-trigger
         triggerTubesForCreation: tubes,
         type,
         threshold,
-        domainTransaction,
       });
       expect(result).to.equal(expectedTrainingTrigger);
     });

--- a/api/tests/devcomp/unit/domain/usecases/create-training_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/create-training_test.js
@@ -5,7 +5,6 @@ describe('Unit | Devcomp | Domain | UseCases | create-training', function () {
   it('should call training repository to create the training', async function () {
     // given
     const training = Symbol('training');
-    const domainTransaction = Symbol('domain-transaction');
     const repositoryResult = Symbol('repository-result');
 
     const trainingRepositoryStub = {
@@ -13,12 +12,11 @@ describe('Unit | Devcomp | Domain | UseCases | create-training', function () {
     };
 
     // when
-    const result = await createTraining({ training, domainTransaction, trainingRepository: trainingRepositoryStub });
+    const result = await createTraining({ training, trainingRepository: trainingRepositoryStub });
 
     // then
     expect(trainingRepositoryStub.create).to.have.been.calledWithExactly({
       training,
-      domainTransaction,
     });
     expect(result).to.equal(repositoryResult);
   });

--- a/api/tests/devcomp/unit/domain/usecases/handle-training-recommendation_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/handle-training-recommendation_test.js
@@ -21,7 +21,6 @@ describe('Unit | Devcomp | Domain | UseCases | handle-training-recommendation', 
         // given
         const locale = Symbol('locale');
         const campaignParticipationId = Symbol('campaign-participation-id');
-        const domainTransaction = Symbol('domain-transaction');
         const assessment = domainBuilder.buildAssessment.ofTypeCampaign({ campaignParticipationId });
         const campaignRepository = { findSkillsByCampaignParticipationId: sinon.stub() };
         const knowledgeElementRepository = { findUniqByUserId: sinon.stub() };
@@ -30,7 +29,6 @@ describe('Unit | Devcomp | Domain | UseCases | handle-training-recommendation', 
         campaignRepository.findSkillsByCampaignParticipationId
           .withArgs({
             campaignParticipationId,
-            domainTransaction,
           })
           .resolves(campaignSkills);
 
@@ -38,7 +36,6 @@ describe('Unit | Devcomp | Domain | UseCases | handle-training-recommendation', 
         knowledgeElementRepository.findUniqByUserId
           .withArgs({
             userId: assessment.userId,
-            domainTransaction,
           })
           .resolves(knowledgeElements);
 
@@ -53,7 +50,6 @@ describe('Unit | Devcomp | Domain | UseCases | handle-training-recommendation', 
           .withArgs({
             campaignParticipationId,
             locale,
-            domainTransaction,
           })
           .resolves(trainings);
 
@@ -65,7 +61,6 @@ describe('Unit | Devcomp | Domain | UseCases | handle-training-recommendation', 
           knowledgeElementRepository,
           trainingRepository,
           userRecommendedTrainingRepository,
-          domainTransaction,
         });
 
         // then
@@ -74,13 +69,11 @@ describe('Unit | Devcomp | Domain | UseCases | handle-training-recommendation', 
           userId: assessment.userId,
           trainingId: 1,
           campaignParticipationId,
-          domainTransaction,
         });
         expect(saveStub.secondCall).to.have.been.calledWithExactly({
           userId: assessment.userId,
           trainingId: 2,
           campaignParticipationId,
-          domainTransaction,
         });
       });
     });
@@ -89,7 +82,6 @@ describe('Unit | Devcomp | Domain | UseCases | handle-training-recommendation', 
       it('should not create user-recommended-training for user', async function () {
         // given
         const locale = Symbol('locale');
-        const domainTransaction = Symbol('domain-transaction');
         const campaignParticipationId = Symbol('campaign-participation-id');
         const assessment = domainBuilder.buildAssessment.ofTypeCampaign({ campaignParticipationId });
         const trainings = [];
@@ -102,14 +94,12 @@ describe('Unit | Devcomp | Domain | UseCases | handle-training-recommendation', 
           assessment,
           trainingRepository,
           userRecommendedTrainingRepository,
-          domainTransaction,
         });
 
         // then
         expect(findWithTriggersByCampaignParticipationIdAndLocaleStub).to.have.been.calledWithExactly({
           campaignParticipationId,
           locale,
-          domainTransaction,
         });
         expect(saveStub).to.have.been.callCount(0);
       });
@@ -137,7 +127,6 @@ describe('Unit | Devcomp | Domain | UseCases | handle-training-recommendation', 
       // given
       const locale = Symbol('locale');
       const campaignParticipationId = Symbol('campaign-participation-id');
-      const domainTransaction = Symbol('domain-transaction');
       const assessment = domainBuilder.buildAssessment.ofTypeCampaign({ campaignParticipationId });
       const campaignRepository = { findSkillsByCampaignParticipationId: sinon.stub() };
       const knowledgeElementRepository = { findUniqByUserId: sinon.stub() };
@@ -152,7 +141,6 @@ describe('Unit | Devcomp | Domain | UseCases | handle-training-recommendation', 
         knowledgeElementRepository,
         trainingRepository,
         userRecommendedTrainingRepository,
-        domainTransaction,
       });
 
       // then

--- a/api/tests/evaluation/integration/infrastructure/repositories/competence-evaluation-repository_test.js
+++ b/api/tests/evaluation/integration/infrastructure/repositories/competence-evaluation-repository_test.js
@@ -28,8 +28,8 @@ describe('Integration | Repository | Competence Evaluation', function () {
       });
 
       // when
-      const savedCompetenceEvaluation = await DomainTransaction.execute(async (domainTransaction) =>
-        competenceEvaluationRepository.save({ competenceEvaluation: competenceEvaluationToSave, domainTransaction }),
+      const savedCompetenceEvaluation = await DomainTransaction.execute(async () =>
+        competenceEvaluationRepository.save({ competenceEvaluation: competenceEvaluationToSave }),
       );
 
       // then
@@ -52,8 +52,8 @@ describe('Integration | Repository | Competence Evaluation', function () {
       });
 
       // when
-      const savedCompetenceEvaluation = await DomainTransaction.execute(async (domainTransaction) =>
-        competenceEvaluationRepository.save({ competenceEvaluation: competenceEvaluationToSave, domainTransaction }),
+      const savedCompetenceEvaluation = await DomainTransaction.execute(async () =>
+        competenceEvaluationRepository.save({ competenceEvaluation: competenceEvaluationToSave }),
       );
 
       // then
@@ -78,13 +78,13 @@ describe('Integration | Repository | Competence Evaluation', function () {
         status: STARTED,
         userId: assessment.userId,
       });
-      await DomainTransaction.execute(async (domainTransaction) =>
-        competenceEvaluationRepository.save({ competenceEvaluation: competenceEvaluationToSave, domainTransaction }),
+      await DomainTransaction.execute(async () =>
+        competenceEvaluationRepository.save({ competenceEvaluation: competenceEvaluationToSave }),
       );
 
       // when
-      const savedCompetenceEvaluation = await DomainTransaction.execute(async (domainTransaction) =>
-        competenceEvaluationRepository.save({ competenceEvaluation: competenceEvaluationToSave, domainTransaction }),
+      const savedCompetenceEvaluation = await DomainTransaction.execute(async () =>
+        competenceEvaluationRepository.save({ competenceEvaluation: competenceEvaluationToSave }),
       );
 
       // then

--- a/api/tests/evaluation/unit/domain/services/get-competence-level_test.js
+++ b/api/tests/evaluation/unit/domain/services/get-competence-level_test.js
@@ -9,14 +9,12 @@ describe('Unit | Domain | Service | Get Competence Level', function () {
     let knowledgeElementRepository;
     let competenceId;
     let knowledgeElements;
-    let domainTransaction;
     let scoringService;
 
     beforeEach(async function () {
       // given
       competenceId = 'competenceId';
       knowledgeElements = Symbol('knowledgeElements');
-      domainTransaction = Symbol('domainTransaction');
       knowledgeElementRepository = {
         findUniqByUserIdAndCompetenceId: sinon.stub().resolves(knowledgeElements),
       };
@@ -28,7 +26,6 @@ describe('Unit | Domain | Service | Get Competence Level', function () {
       competenceLevel = await getCompetenceLevel({
         userId,
         competenceId,
-        domainTransaction,
         dependencies: {
           knowledgeElementRepository,
           scoringService,
@@ -41,7 +38,6 @@ describe('Unit | Domain | Service | Get Competence Level', function () {
       expect(knowledgeElementRepository.findUniqByUserIdAndCompetenceId).to.be.calledWith({
         userId,
         competenceId,
-        domainTransaction,
       });
     });
 

--- a/api/tests/identity-access-management/integration/domain/usecases/update-user-for-account-recovery.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/update-user-for-account-recovery.usecase.test.js
@@ -23,7 +23,7 @@ describe('Integration | Identity Access Management | Domain | UseCase | update-u
 
       // when
       await catchErr(async () => {
-        await DomainTransaction.execute(async (domainTransaction) => {
+        await DomainTransaction.execute(async () => {
           await updateUserForAccountRecovery({
             password,
             temporaryKey: accountRecovery.temporaryKey,
@@ -31,7 +31,6 @@ describe('Integration | Identity Access Management | Domain | UseCase | update-u
             authenticationMethodRepository,
             accountRecoveryDemandRepository,
             cryptoService,
-            domainTransaction,
           });
           throw new Error('an error occurs within the domain transaction');
         });

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/account-recovery-demand.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/account-recovery-demand.repository.test.js
@@ -172,8 +172,8 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
 
         // when
         await catchErr(async () => {
-          await DomainTransaction.execute(async (domainTransaction) => {
-            await accountRecoveryDemandRepository.markAsBeingUsed(temporaryKey, domainTransaction);
+          await DomainTransaction.execute(async () => {
+            await accountRecoveryDemandRepository.markAsBeingUsed(temporaryKey);
             throw new Error('Error occurs in transaction');
           });
         });

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/authentication-method.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/authentication-method.repository.test.js
@@ -126,8 +126,8 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
 
       // when
       await catchErr(async function () {
-        await DomainTransaction.execute(async (domainTransaction) => {
-          await authenticationMethodRepository.create({ authenticationMethod, domainTransaction });
+        await DomainTransaction.execute(async () => {
+          await authenticationMethodRepository.create({ authenticationMethod });
           throw new Error('Error occurs in transaction');
         });
       })();
@@ -248,11 +248,8 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
 
       // when
       await catchErr(async function () {
-        await DomainTransaction.execute(async (domainTransaction) => {
-          await authenticationMethodRepository.updateChangedPassword(
-            { userId, hashedPassword: 'coucou' },
-            domainTransaction,
-          );
+        await DomainTransaction.execute(async () => {
+          await authenticationMethodRepository.updateChangedPassword({ userId, hashedPassword: 'coucou' });
           throw new Error('Error occurs in transaction');
         });
       })();
@@ -604,11 +601,10 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
 
       // when
       await catchErr(async function () {
-        await DomainTransaction.execute(async (domainTransaction) => {
+        await DomainTransaction.execute(async () => {
           await authenticationMethodRepository.updatePasswordThatShouldBeChanged({
             userId,
             hashedPassword: newHashedPassword,
-            domainTransaction,
           });
           throw new Error('Error occurs in transaction');
         });
@@ -690,11 +686,10 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
     it('should be DomainTransaction compliant', async function () {
       // when
       await catchErr(async function () {
-        await DomainTransaction.execute(async (domainTransaction) => {
+        await DomainTransaction.execute(async () => {
           await authenticationMethodRepository.createPasswordThatShouldBeChanged({
             userId,
             hashedPassword: newHashedPassword,
-            domainTransaction,
           });
           throw new Error('Error occurs in transaction');
         });
@@ -1227,10 +1222,9 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
 
         // when
         await catchErr(async function () {
-          await DomainTransaction.execute(async (domainTransaction) => {
+          await DomainTransaction.execute(async () => {
             await authenticationMethodRepository.batchUpdatePasswordThatShouldBeChanged({
               usersToUpdateWithNewPassword,
-              domainTransaction,
             });
             throw new Error('Error occurs in transaction');
           });

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
@@ -1382,8 +1382,8 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
 
         // when
         await catchErr(async () => {
-          await DomainTransaction.execute(async (domainTransaction) => {
-            await userRepository.updateWithEmailConfirmed({ id: userInDb.id, userAttributes }, domainTransaction);
+          await DomainTransaction.execute(async () => {
+            await userRepository.updateWithEmailConfirmed({ id: userInDb.id, userAttributes });
             throw new Error('Error occurs in transaction');
           });
         });

--- a/api/tests/identity-access-management/unit/application/account-recovery/account-recovery.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/account-recovery/account-recovery.controller.test.js
@@ -89,7 +89,6 @@ describe('Unit | Identity Access Management | Application | Controller | account
       // given
       const user = domainBuilder.buildUser({ id: 1 });
       const temporaryKey = 'validTemporaryKey';
-      const domainTransaction = Symbol();
 
       const request = {
         params: {
@@ -107,7 +106,7 @@ describe('Unit | Identity Access Management | Application | Controller | account
 
       sinon.stub(usecases, 'updateUserForAccountRecovery').resolves();
       sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => {
-        return lambda(domainTransaction);
+        return lambda();
       });
 
       // when
@@ -117,7 +116,6 @@ describe('Unit | Identity Access Management | Application | Controller | account
       expect(usecases.updateUserForAccountRecovery).calledWithMatch({
         password: user.password,
         temporaryKey,
-        domainTransaction,
       });
       expect(response.statusCode).to.equal(204);
     });

--- a/api/tests/identity-access-management/unit/application/anonymization.admin.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/anonymization.admin.controller.test.js
@@ -43,8 +43,7 @@ describe('Unit | Identity Access Management | Application | Controller | Admin |
       sinon.stub(GarAnonymizationParser, 'getCsvData').resolves([1, 4, 6, 15, 78]);
       sinon.stub(usecases, 'anonymizeGarAuthenticationMethods').resolves({ anonymizedUserCount, total });
 
-      const domainTransaction = Symbol('domain transaction');
-      sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda(domainTransaction));
+      sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
 
       sinon.stub(anonymizeGarResultSerializer, 'serialize').returns(expectedJSON);
     });

--- a/api/tests/identity-access-management/unit/application/oidc-provider.admin.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/oidc-provider.admin.controller.test.js
@@ -50,10 +50,9 @@ describe('Unit | Identity Access Management | Application | Controller | Admin |
         },
         payload: [oidcProvider1, oidcProvider2],
       };
-      const domainTransaction = Symbol('domain-transaction');
 
       sinon.stub(usecases, 'addOidcProvider').resolves();
-      sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda(domainTransaction));
+      sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
 
       // when
       const response = await oidcProviderAdminController.createInBatch(request, hFake);
@@ -79,7 +78,6 @@ describe('Unit | Identity Access Management | Application | Controller | Admin |
           logoutUrl: 'https://idp-1.fr/compte/deconnexion',
           afterLogoutUrl: 'https://app.dev.pix.fr',
         },
-        domainTransaction,
       });
       expect(usecases.addOidcProvider.getCall(1)).to.have.been.calledWith({
         identityProvider: 'IDP_2',
@@ -95,7 +93,6 @@ describe('Unit | Identity Access Management | Application | Controller | Admin |
         openidConfigurationUrl: 'https://idp-2.fr/connexion/oauth2/.well-known/openid-configuration',
         redirectUri: 'https://app.dev.pix.fr/connexion/idp-2',
         shouldCloseSession: true,
-        domainTransaction,
       });
       expect(response.statusCode).to.equal(204);
     });

--- a/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service_test.js
+++ b/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service_test.js
@@ -760,12 +760,10 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
 
   describe('#createUserAccount', function () {
     let userToCreateRepository, authenticationMethodRepository;
-    let domainTransaction;
 
     beforeEach(function () {
-      domainTransaction = Symbol();
       sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => {
-        return lambda(domainTransaction);
+        return lambda();
       });
 
       userToCreateRepository = {
@@ -785,7 +783,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       });
       const userInfo = {};
       const userId = 1;
-      userToCreateRepository.create.withArgs({ user, domainTransaction }).resolves({ id: userId });
+      userToCreateRepository.create.withArgs({ user }).resolves({ id: userId });
 
       const identityProvider = 'genericOidcProviderCode';
       const expectedAuthenticationMethod = new AuthenticationMethod({
@@ -807,7 +805,6 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       // then
       expect(authenticationMethodRepository.create).to.have.been.calledWithExactly({
         authenticationMethod: expectedAuthenticationMethod,
-        domainTransaction,
       });
       expect(result).to.equal(userId);
     });
@@ -822,7 +819,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         });
         const userInfo = {};
         const userId = 1;
-        userToCreateRepository.create.withArgs({ user, domainTransaction }).resolves({ id: userId });
+        userToCreateRepository.create.withArgs({ user }).resolves({ id: userId });
 
         const identityProvider = 'genericOidcProviderCode';
         const expectedAuthenticationMethod = new AuthenticationMethod({
@@ -844,7 +841,6 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         // then
         expect(authenticationMethodRepository.create).to.have.been.calledWithExactly({
           authenticationMethod: expectedAuthenticationMethod,
-          domainTransaction,
         });
       });
     });
@@ -861,7 +857,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         const claimsToStoreWithValues = { employeeNumber: 'some-opaque-value', studentGroup: 'another-opaque-value' };
         const userInfo = { ...claimsToStoreWithValues };
         const userId = 1;
-        userToCreateRepository.create.withArgs({ user, domainTransaction }).resolves({ id: userId });
+        userToCreateRepository.create.withArgs({ user }).resolves({ id: userId });
 
         const identityProvider = 'genericOidcProviderCode';
         const expectedAuthenticationMethod = new AuthenticationMethod({
@@ -884,7 +880,6 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         // then
         expect(authenticationMethodRepository.create).to.have.been.calledWithExactly({
           authenticationMethod: expectedAuthenticationMethod,
-          domainTransaction,
         });
       });
     });

--- a/api/tests/identity-access-management/unit/domain/usecases/add-oidc-provider_test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/add-oidc-provider_test.js
@@ -4,9 +4,6 @@ import { expect, sinon } from '../../../../test-helper.js';
 describe('Unit | Identity Access Management | Domain | UseCases | add-oidc-provider', function () {
   it('creates an OIDC Provider in the oidc-provider-repository', async function () {
     // given
-    const domainTransaction = {
-      knexTransaction: null,
-    };
     const oidcProviderRepository = {
       create: sinon.stub(),
     };
@@ -56,7 +53,6 @@ describe('Unit | Identity Access Management | Domain | UseCases | add-oidc-provi
       oidcProviderRepository,
       cryptoService,
       addOidcProviderValidator,
-      domainTransaction,
     });
 
     // then
@@ -81,8 +77,6 @@ describe('Unit | Identity Access Management | Domain | UseCases | add-oidc-provi
       source: 'oidcexamplenet',
     });
     expect(cryptoService.encrypt).to.have.been.calledWithExactly('secret');
-    expect(oidcProviderRepository.create).to.have.been.calledWithExactly(expectedOidcProviderProperties, {
-      domainTransaction,
-    });
+    expect(oidcProviderRepository.create).to.have.been.calledWithExactly(expectedOidcProviderProperties);
   });
 });

--- a/api/tests/identity-access-management/unit/domain/usecases/anonymize-gar-authentication-methods.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/anonymize-gar-authentication-methods.usecase.test.js
@@ -9,16 +9,14 @@ const { ROLES } = PIX_ADMIN;
 
 describe('Unit | Identity Access Management | Domain | UseCase | anonymize-gar-authentication-methods', function () {
   let clock;
-  let domainTransaction;
   let garAnonymizedBatchEventsLoggingJob;
 
   beforeEach(function () {
     const now = new Date('2023-08-17');
     clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     garAnonymizedBatchEventsLoggingJob = { schedule: sinon.stub().resolves() };
-    domainTransaction = Symbol('domain transaction');
     sinon.stub(config.auditLogger, 'isEnabled').value(true);
-    sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda(domainTransaction));
+    sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
   });
 
   afterEach(function () {
@@ -47,7 +45,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | anonymize-gar-a
       userIdsBatchSize: 1,
       adminMemberId,
       authenticationMethodRepository,
-      domainTransaction,
       garAnonymizedBatchEventsLoggingJob,
     });
 
@@ -73,7 +70,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | anonymize-gar-a
       adminMemberId,
       authenticationMethodRepository,
       garAnonymizedBatchEventsLoggingJob,
-      domainTransaction,
     });
 
     // then
@@ -104,7 +100,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | anonymize-gar-a
       adminMemberId,
       authenticationMethodRepository,
       garAnonymizedBatchEventsLoggingJob,
-      domainTransaction,
     });
 
     // then

--- a/api/tests/identity-access-management/unit/domain/usecases/update-user-for-account-recovery.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/update-user-for-account-recovery.usecase.test.js
@@ -48,7 +48,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | update-user-for
       // given
       const password = 'pix123';
       const hashedPassword = 'hashedpassword';
-      const domainTransaction = Symbol();
 
       const user = domainBuilder.buildUser({ id: 1234, email: null });
 
@@ -56,7 +55,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | update-user-for
       cryptoService.hashPassword.withArgs(password).resolves(hashedPassword);
       authenticationMethodRepository.hasIdentityProviderPIX.withArgs({ userId: user.id }).resolves(false);
       sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => {
-        return lambda(domainTransaction);
+        return lambda();
       });
 
       // when
@@ -67,7 +66,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | update-user-for
         scoAccountRecoveryService,
         cryptoService,
         accountRecoveryDemandRepository,
-        domainTransaction,
       });
 
       // then
@@ -79,12 +77,9 @@ describe('Unit | Identity Access Management | Domain | UseCase | update-user-for
         }),
         userId: user.id,
       });
-      expect(authenticationMethodRepository.create).to.have.been.calledWithExactly(
-        {
-          authenticationMethod: expectedAuthenticationMethodFromPix,
-        },
-        domainTransaction,
-      );
+      expect(authenticationMethodRepository.create).to.have.been.calledWithExactly({
+        authenticationMethod: expectedAuthenticationMethodFromPix,
+      });
     });
   });
 
@@ -93,7 +88,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | update-user-for
       // given
       const password = 'pix123';
       const hashedPassword = 'hashedpassword';
-      const domainTransaction = Symbol();
 
       const user = domainBuilder.buildUser({
         id: 1234,
@@ -105,7 +99,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | update-user-for
       cryptoService.hashPassword.withArgs(password).resolves(hashedPassword);
       authenticationMethodRepository.hasIdentityProviderPIX.withArgs({ userId: user.id }).resolves(true);
       sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => {
-        return lambda(domainTransaction);
+        return lambda();
       });
 
       // when
@@ -116,17 +110,13 @@ describe('Unit | Identity Access Management | Domain | UseCase | update-user-for
         scoAccountRecoveryService,
         cryptoService,
         accountRecoveryDemandRepository,
-        domainTransaction,
       });
 
       // then
-      expect(authenticationMethodRepository.updateChangedPassword).to.have.been.calledWithExactly(
-        {
-          userId: user.id,
-          hashedPassword,
-        },
-        domainTransaction,
-      );
+      expect(authenticationMethodRepository.updateChangedPassword).to.have.been.calledWithExactly({
+        userId: user.id,
+        hashedPassword,
+      });
     });
   });
 
@@ -138,7 +128,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | update-user-for
       const hashedPassword = 'hashedpassword';
       const newEmail = 'newemail@example.net';
       const emailConfirmedAt = new Date();
-      const domainTransaction = Symbol();
 
       const user = domainBuilder.buildUser({
         id: 1234,
@@ -163,12 +152,10 @@ describe('Unit | Identity Access Management | Domain | UseCase | update-user-for
       });
       const userAttributes = { cgu: true, email: newEmail, emailConfirmedAt };
 
-      userRepository.updateWithEmailConfirmed
-        .withArgs({ id: user.id, userAttributes, domainTransaction })
-        .resolves(userUpdate);
+      userRepository.updateWithEmailConfirmed.withArgs({ id: user.id, userAttributes }).resolves(userUpdate);
 
       sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => {
-        return lambda(domainTransaction);
+        return lambda();
       });
 
       // when
@@ -180,14 +167,10 @@ describe('Unit | Identity Access Management | Domain | UseCase | update-user-for
         scoAccountRecoveryService,
         cryptoService,
         accountRecoveryDemandRepository,
-        domainTransaction,
       });
 
       // then
-      expect(accountRecoveryDemandRepository.markAsBeingUsed).to.have.been.calledWithExactly(
-        temporaryKey,
-        domainTransaction,
-      );
+      expect(accountRecoveryDemandRepository.markAsBeingUsed).to.have.been.calledWithExactly(temporaryKey);
     });
   });
 
@@ -198,7 +181,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | update-user-for
     const hashedPassword = 'hashedpassword';
     const newEmail = 'newemail@example.net';
     const emailConfirmedAt = now;
-    const domainTransaction = Symbol();
 
     const user = domainBuilder.buildUser({
       id: 1234,
@@ -218,7 +200,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | update-user-for
     userRepository.updateWithEmailConfirmed.resolves(userUpdate);
 
     sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => {
-      return lambda(domainTransaction);
+      return lambda();
     });
 
     // when
@@ -230,7 +212,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | update-user-for
       scoAccountRecoveryService,
       cryptoService,
       accountRecoveryDemandRepository,
-      domainTransaction,
     });
 
     // then
@@ -242,7 +223,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | update-user-for
         emailConfirmedAt: now,
         lastTermsOfServiceValidatedAt: now,
       },
-      domainTransaction,
     };
     expect(userRepository.updateWithEmailConfirmed).to.have.been.calledWithExactly(expectedParams);
   });

--- a/api/tests/integration/domain/usecases/complete-assessment_test.js
+++ b/api/tests/integration/domain/usecases/complete-assessment_test.js
@@ -38,7 +38,6 @@ describe('Integration | Usecase | Complete Assessment', function () {
           // when
           await completeAssessment({
             assessmentId,
-            domainTransaction,
             campaignParticipationBCRepository,
             assessmentRepository,
           });

--- a/api/tests/integration/domain/usecases/copy-target-profile-badges_test.js
+++ b/api/tests/integration/domain/usecases/copy-target-profile-badges_test.js
@@ -83,11 +83,9 @@ describe('Integration | UseCases | copy-badges', function () {
       await databaseBuilder.commit();
 
       // when
-      const domainTransaction = DomainTransaction.getConnection();
       await copyTargetProfileBadges({
         originTargetProfileId,
         destinationTargetProfileId,
-        domainTransaction,
         badgeRepository,
         badgeCriteriaRepository,
       });

--- a/api/tests/integration/domain/usecases/copy-target-profile-badges_test.js
+++ b/api/tests/integration/domain/usecases/copy-target-profile-badges_test.js
@@ -2,7 +2,7 @@ import { SCOPES } from '../../../../lib/domain/models/BadgeDetails.js';
 import { copyTargetProfileBadges } from '../../../../lib/domain/usecases/copy-target-profile-badges.js';
 import * as badgeCriteriaRepository from '../../../../src/evaluation/infrastructure/repositories/badge-criteria-repository.js';
 import * as badgeRepository from '../../../../src/evaluation/infrastructure/repositories/badge-repository.js';
-import { DomainTransaction, withTransaction } from '../../../../src/shared/domain/DomainTransaction.js';
+import { withTransaction } from '../../../../src/shared/domain/DomainTransaction.js';
 import { catchErr, databaseBuilder, expect, knex } from '../../../test-helper.js';
 
 describe('Integration | UseCases | copy-badges', function () {

--- a/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
+++ b/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
@@ -8,7 +8,6 @@ import {
 import { Membership } from '../../../../lib/domain/models/Membership.js';
 import { createOrganizationsWithTagsAndTargetProfiles } from '../../../../lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js';
 import * as organizationValidator from '../../../../lib/domain/validators/organization-with-tags-and-target-profiles-script.js';
-import { DomainTransaction as domainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
 import * as dataProtectionOfficerRepository from '../../../../lib/infrastructure/repositories/data-protection-officer-repository.js';
 import * as organizationTagRepository from '../../../../lib/infrastructure/repositories/organization-tag-repository.js';
 import * as tagRepository from '../../../../lib/infrastructure/repositories/tag-repository.js';
@@ -50,7 +49,6 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
 
         // when
         const error = await catchErr(createOrganizationsWithTagsAndTargetProfiles)({
-          domainTransaction,
           organizations,
           organizationRepository,
           organizationForAdminRepository,
@@ -90,7 +88,6 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
 
         // when
         const error = await catchErr(createOrganizationsWithTagsAndTargetProfiles)({
-          domainTransaction,
           organizations: organizationsWithEmptyValues,
           organizationRepository,
           organizationForAdminRepository,
@@ -192,7 +189,6 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
 
         // when
         const error = await catchErr(createOrganizationsWithTagsAndTargetProfiles)({
-          domainTransaction,
           organizations: organizationsWithTagsWithOneMissingExternalId,
           organizationRepository,
           organizationForAdminRepository,
@@ -266,7 +262,6 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
 
         // when
         const error = await catchErr(createOrganizationsWithTagsAndTargetProfiles)({
-          domainTransaction,
           organizations: organizationsWithTagsWithOneMissingName,
           organizationRepository,
           organizationForAdminRepository,
@@ -343,7 +338,6 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
 
         // when
         const error = await catchErr(createOrganizationsWithTagsAndTargetProfiles)({
-          domainTransaction,
           organizations: organizationsWithTagsNotExists,
           organizationRepository,
           organizationForAdminRepository,
@@ -423,7 +417,6 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
 
       // when
       await createOrganizationsWithTagsAndTargetProfiles({
-        domainTransaction,
         organizations: organizationsWithTagsAlreadyExist,
         organizationRepository,
         organizationForAdminRepository,
@@ -522,7 +515,6 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
 
       // when
       const error = await catchErr(createOrganizationsWithTagsAndTargetProfiles)({
-        domainTransaction,
         organizations: organizationsWithNonExistingTargetProfile,
         organizationRepository,
         organizationForAdminRepository,
@@ -601,7 +593,6 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
 
       // when
       await createOrganizationsWithTagsAndTargetProfiles({
-        domainTransaction,
         organizations: organizationsWithExistingTargetProfiles,
         organizationRepository,
         organizationForAdminRepository,
@@ -688,7 +679,6 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
 
       // when
       await createOrganizationsWithTagsAndTargetProfiles({
-        domainTransaction,
         organizations: organizationsWithInvitationRole,
         organizationRepository,
         organizationForAdminRepository,
@@ -737,7 +727,6 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
 
       // when
       const createdOrganizations = await createOrganizationsWithTagsAndTargetProfiles({
-        domainTransaction,
         organizations,
         organizationRepository,
         organizationForAdminRepository,
@@ -805,7 +794,6 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
 
       // when
       await createOrganizationsWithTagsAndTargetProfiles({
-        domainTransaction,
         organizations,
         organizationRepository,
         organizationForAdminRepository,
@@ -868,7 +856,6 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
 
       // when
       await createOrganizationsWithTagsAndTargetProfiles({
-        domainTransaction,
         organizations,
         organizationRepository,
         organizationForAdminRepository,

--- a/api/tests/integration/domain/usecases/handle-badge-acquisition_test.js
+++ b/api/tests/integration/domain/usecases/handle-badge-acquisition_test.js
@@ -115,7 +115,6 @@ describe('Integration | Usecase | Handle Badge Acquisition', function () {
           // when
           await usecases.handleBadgeAcquisition({
             assessment,
-            domainTransaction,
           });
 
           // then

--- a/api/tests/integration/domain/usecases/handle-stage-acquisition_test.js
+++ b/api/tests/integration/domain/usecases/handle-stage-acquisition_test.js
@@ -150,7 +150,6 @@ describe('Integration | Usecase | Handle Stage Acquisition', function () {
             // when
             await usecases.handleStageAcquisition({
               assessment,
-              domainTransaction,
             });
 
             // then

--- a/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
@@ -23,10 +23,9 @@ describe('Integration | Repository | Badge Acquisition', function () {
 
     it('should persist the badge acquisition in db', async function () {
       // when
-      await DomainTransaction.execute(async (domainTransaction) => {
+      await DomainTransaction.execute(async () => {
         return badgeAcquisitionRepository.createOrUpdate({
           badgeAcquisitionsToCreate: [badgeAcquisitionToCreate],
-          domainTransaction,
         });
       });
 
@@ -46,10 +45,9 @@ describe('Integration | Repository | Badge Acquisition', function () {
       await databaseBuilder.commit();
 
       // when
-      await DomainTransaction.execute(async (domainTransaction) => {
+      await DomainTransaction.execute(async () => {
         return badgeAcquisitionRepository.createOrUpdate({
           badgeAcquisitionToCreate: [badgeAcquisitionToCreate],
-          domainTransaction,
         });
       });
 
@@ -63,7 +61,7 @@ describe('Integration | Repository | Badge Acquisition', function () {
       expect(result[0].createdAt).to.not.equal(result[0].updatedAt);
     });
 
-    context('when no domainTransaction is passed in parameters', function () {
+    context('when no  is passed in parameters', function () {
       it('should use knex instead to persist the badge acquisition', async function () {
         // when
         await badgeAcquisitionRepository.createOrUpdate({
@@ -95,11 +93,10 @@ describe('Integration | Repository | Badge Acquisition', function () {
 
     it('should check that the user has acquired the badge', async function () {
       // when
-      const acquiredBadgeIds = await DomainTransaction.execute(async (domainTransaction) => {
+      const acquiredBadgeIds = await DomainTransaction.execute(async () => {
         return badgeAcquisitionRepository.getAcquiredBadgeIds({
           userId,
           badgeIds: [badgeId],
-          domainTransaction,
         });
       });
 
@@ -109,15 +106,15 @@ describe('Integration | Repository | Badge Acquisition', function () {
 
     it('should check that the user has not acquired the badge', async function () {
       // when
-      const acquiredBadgeIds = await DomainTransaction.execute(async (domainTransaction) => {
-        return badgeAcquisitionRepository.getAcquiredBadgeIds({ userId, badgeIds: [-1], domainTransaction });
+      const acquiredBadgeIds = await DomainTransaction.execute(async () => {
+        return badgeAcquisitionRepository.getAcquiredBadgeIds({ userId, badgeIds: [-1] });
       });
 
       // then
       expect(acquiredBadgeIds.length).to.equal(0);
     });
 
-    context('when no domainTransaction is passed in parameters', function () {
+    context('when no  is passed in parameters', function () {
       it('should use knex instead to return acquired badges', async function () {
         // when
         const acquiredBadgesIds = await badgeAcquisitionRepository.getAcquiredBadgeIds({
@@ -166,10 +163,9 @@ describe('Integration | Repository | Badge Acquisition', function () {
 
       it('should return badge ids acquired by user for a campaignParticipation', async function () {
         // when
-        const acquiredBadgesByCampaignParticipations = await DomainTransaction.execute(async (domainTransaction) => {
+        const acquiredBadgesByCampaignParticipations = await DomainTransaction.execute(async () => {
           return badgeAcquisitionRepository.getAcquiredBadgesByCampaignParticipations({
             campaignParticipationsIds: [campaignParticipationId],
-            domainTransaction,
           });
         });
 
@@ -179,7 +175,7 @@ describe('Integration | Repository | Badge Acquisition', function () {
         expect(acquiredBadgesByCampaignParticipations[campaignParticipationId].length).to.eq(2);
       });
 
-      context('when no domainTransaction is passed in parameters', function () {
+      context('when no  is passed in parameters', function () {
         it('should use knex instead to return badge ids acquired by user for a campaignParticipation', async function () {
           // when
           const acquiredBadgesByCampaignParticipations =
@@ -241,10 +237,9 @@ describe('Integration | Repository | Badge Acquisition', function () {
       it('should return badge ids acquired by user for a campaignParticipation', async function () {
         // when
         const campaignParticipationsIds = [campaignParticipationId1, campaignParticipationId2];
-        const acquiredBadgesByCampaignParticipations = await DomainTransaction.execute(async (domainTransaction) => {
+        const acquiredBadgesByCampaignParticipations = await DomainTransaction.execute(async () => {
           return badgeAcquisitionRepository.getAcquiredBadgesByCampaignParticipations({
             campaignParticipationsIds,
-            domainTransaction,
           });
         });
         // then
@@ -309,10 +304,9 @@ describe('Integration | Repository | Badge Acquisition', function () {
       it('should return badge ids acquired by user for a campaignParticipation', async function () {
         // when
         const campaignParticipationsIds = [campaignParticipationId];
-        const acquiredBadgesByCampaignParticipations = await DomainTransaction.execute(async (domainTransaction) => {
+        const acquiredBadgesByCampaignParticipations = await DomainTransaction.execute(async () => {
           return badgeAcquisitionRepository.getAcquiredBadgesByCampaignParticipations({
             campaignParticipationsIds,
-            domainTransaction,
           });
         });
 

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -310,8 +310,8 @@ describe('Integration | Repository | Campaign Participation', function () {
       const expectedAssessmentIds = campaignParticipationAssessments.map(({ id }) => id);
 
       // when
-      const foundCampaignParticipation = await DomainTransaction.execute((domainTransaction) => {
-        return campaignParticipationRepository.get(campaignParticipationId, domainTransaction);
+      const foundCampaignParticipation = await DomainTransaction.execute(() => {
+        return campaignParticipationRepository.get(campaignParticipationId);
       });
       const assessmentIds = foundCampaignParticipation.assessments.map(({ id }) => id);
 

--- a/api/tests/integration/infrastructure/repositories/certifiable-badge-acquisition-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certifiable-badge-acquisition-repository_test.js
@@ -32,10 +32,9 @@ describe('Integration | Repository | Certifiable Badge Acquisition', function ()
         await databaseBuilder.commit();
 
         // when
-        const certifiableBadgesAcquiredByUser = await DomainTransaction.execute(async (domainTransaction) => {
+        const certifiableBadgesAcquiredByUser = await DomainTransaction.execute(async () => {
           return certifiableBadgeAcquisitionRepository.findHighestCertifiable({
             userId: user.id,
-            domainTransaction,
           });
         });
 

--- a/api/tests/integration/infrastructure/repositories/certifiable-badge-acquisition-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certifiable-badge-acquisition-repository_test.js
@@ -133,10 +133,9 @@ describe('Integration | Repository | Certifiable Badge Acquisition', function ()
         await databaseBuilder.commit();
 
         // when
-        const certifiableBadgesAcquiredByUser = await DomainTransaction.execute(async (domainTransaction) => {
+        const certifiableBadgesAcquiredByUser = await DomainTransaction.execute(async () => {
           return certifiableBadgeAcquisitionRepository.findHighestCertifiable({
             userId: user.id,
-            domainTransaction,
           });
         });
 
@@ -221,10 +220,9 @@ describe('Integration | Repository | Certifiable Badge Acquisition', function ()
           await databaseBuilder.commit();
 
           // when
-          const certifiableBadgesAcquiredByUser = await DomainTransaction.execute(async (domainTransaction) => {
+          const certifiableBadgesAcquiredByUser = await DomainTransaction.execute(async () => {
             return certifiableBadgeAcquisitionRepository.findHighestCertifiable({
               userId,
-              domainTransaction,
             });
           });
 
@@ -277,10 +275,9 @@ describe('Integration | Repository | Certifiable Badge Acquisition', function ()
             await databaseBuilder.commit();
 
             // when
-            const certifiableBadgesAcquiredByUser = await DomainTransaction.execute(async (domainTransaction) => {
+            const certifiableBadgesAcquiredByUser = await DomainTransaction.execute(async () => {
               return certifiableBadgeAcquisitionRepository.findHighestCertifiable({
                 userId,
-                domainTransaction,
               });
             });
 
@@ -336,10 +333,9 @@ describe('Integration | Repository | Certifiable Badge Acquisition', function ()
             await databaseBuilder.commit();
 
             // when
-            const certifiableBadgesAcquiredByUser = await DomainTransaction.execute(async (domainTransaction) => {
+            const certifiableBadgesAcquiredByUser = await DomainTransaction.execute(async () => {
               return certifiableBadgeAcquisitionRepository.findHighestCertifiable({
                 userId,
-                domainTransaction,
               });
             });
 
@@ -375,10 +371,10 @@ describe('Integration | Repository | Certifiable Badge Acquisition', function ()
           await databaseBuilder.commit();
 
           // when
-          const certifiableBadgesAcquiredByUser = await DomainTransaction.execute(async (domainTransaction) => {
+          const certifiableBadgesAcquiredByUser = await DomainTransaction.execute(async () => {
             return certifiableBadgeAcquisitionRepository.findHighestCertifiable({
               userId,
-              domainTransaction,
+
               limitDate: new Date('2021-01-01'),
             });
           });
@@ -405,10 +401,9 @@ describe('Integration | Repository | Certifiable Badge Acquisition', function ()
         await databaseBuilder.commit();
 
         // when
-        const certifiableBadgesAcquiredByUser = await DomainTransaction.execute(async (domainTransaction) => {
+        const certifiableBadgesAcquiredByUser = await DomainTransaction.execute(async () => {
           return certifiableBadgeAcquisitionRepository.findHighestCertifiable({
             userId: userWithoutCertifiableBadge.id,
-            domainTransaction,
           });
         });
 

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -138,7 +138,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       // when
       const knowledgeElementsFound = await DomainTransaction.execute(async (domainTransaction) => {
         await domainTransaction.knexTransaction('knowledge-elements').insert(extraKnowledgeElement);
-        return knowledgeElementRepository.findUniqByUserId({ userId, domainTransaction });
+        return knowledgeElementRepository.findUniqByUserId({ userId });
       });
 
       // then

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-snapshot-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-snapshot-repository_test.js
@@ -69,8 +69,8 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
         const knowledgeElements = [knowledgeElement1];
         await databaseBuilder.commit();
 
-        await DomainTransaction.execute((domainTransaction) => {
-          return knowledgeElementSnapshotRepository.save({ userId, snappedAt, knowledgeElements, domainTransaction });
+        await DomainTransaction.execute(() => {
+          return knowledgeElementSnapshotRepository.save({ userId, snappedAt, knowledgeElements });
         });
 
         const actualUserSnapshot = await knex.select('*').from('knowledge-element-snapshots').first();
@@ -99,8 +99,8 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
         await databaseBuilder.commit();
 
         try {
-          await DomainTransaction.execute(async (domainTransaction) => {
-            await knowledgeElementSnapshotRepository.save({ userId, snappedAt, knowledgeElements, domainTransaction });
+          await DomainTransaction.execute(async () => {
+            await knowledgeElementSnapshotRepository.save({ userId, snappedAt, knowledgeElements });
             throw new Error();
           });
           // eslint-disable-next-line no-empty

--- a/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -1350,11 +1350,10 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       await databaseBuilder.commit();
 
       // when
-      const result = await DomainTransaction.execute(async (domainTransaction) => {
+      const result = await DomainTransaction.execute(async () => {
         return organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability({
           fromUserActivityDate,
           toUserActivityDate,
-          domainTransaction,
         });
       });
 
@@ -1370,10 +1369,9 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       await databaseBuilder.commit();
 
       // when
-      const result = await DomainTransaction.execute(async (domainTransaction) => {
+      const result = await DomainTransaction.execute(async () => {
         return organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability({
           fromUserActivityDate,
-          domainTransaction,
         });
       });
 
@@ -1390,10 +1388,9 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       await databaseBuilder.commit();
 
       // when
-      const result = await DomainTransaction.execute(async (domainTransaction) => {
+      const result = await DomainTransaction.execute(async () => {
         return organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability({
           fromUserActivityDate,
-          domainTransaction,
         });
       });
 
@@ -1417,11 +1414,10 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
         await databaseBuilder.commit();
 
         // when
-        const result = await DomainTransaction.execute(async (domainTransaction) => {
+        const result = await DomainTransaction.execute(async () => {
           return organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability({
             fromUserActivityDate,
             skipLoggedLastDayCheck: true,
-            domainTransaction,
           });
         });
 
@@ -1437,11 +1433,10 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
         await databaseBuilder.commit();
 
         // when
-        const result = await DomainTransaction.execute(async (domainTransaction) => {
+        const result = await DomainTransaction.execute(async () => {
           return organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability({
             fromUserActivityDate,
             skipLoggedLastDayCheck: true,
-            domainTransaction,
           });
         });
 
@@ -1459,12 +1454,11 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
         await databaseBuilder.commit();
 
         // when
-        const result = await DomainTransaction.execute(async (domainTransaction) => {
+        const result = await DomainTransaction.execute(async () => {
           return organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability({
             fromUserActivityDate,
             skipLoggedLastDayCheck: false,
             onlyNotComputed: true,
-            domainTransaction,
           });
         });
 
@@ -1480,12 +1474,11 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
         await databaseBuilder.commit();
 
         // when
-        const result = await DomainTransaction.execute(async (domainTransaction) => {
+        const result = await DomainTransaction.execute(async () => {
           return organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability({
             fromUserActivityDate,
             skipLoggedLastDayCheck: true,
             onlyNotComputed: true,
-            domainTransaction,
           });
         });
 
@@ -1502,12 +1495,11 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
         await databaseBuilder.commit();
 
         // when
-        const result = await DomainTransaction.execute(async (domainTransaction) => {
+        const result = await DomainTransaction.execute(async () => {
           return organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability({
             fromUserActivityDate,
             skipLoggedLastDayCheck: true,
             onlyNotComputed: true,
-            domainTransaction,
           });
         });
 
@@ -1561,9 +1553,8 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       await databaseBuilder.commit();
 
       // when
-      const result = await DomainTransaction.execute(async (domainTransaction) => {
+      const result = await DomainTransaction.execute(async () => {
         return organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
-          domainTransaction,
           fromUserActivityDate,
           toUserActivityDate,
         });
@@ -1581,9 +1572,8 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       await databaseBuilder.commit();
 
       // when
-      const result = await DomainTransaction.execute(async (domainTransaction) => {
+      const result = await DomainTransaction.execute(async () => {
         return organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
-          domainTransaction,
           fromUserActivityDate,
           toUserActivityDate,
         });
@@ -1601,9 +1591,8 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       await databaseBuilder.commit();
 
       // when
-      const result = await DomainTransaction.execute(async (domainTransaction) => {
+      const result = await DomainTransaction.execute(async () => {
         return organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
-          domainTransaction,
           fromUserActivityDate,
           toUserActivityDate,
         });
@@ -1620,9 +1609,8 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       await databaseBuilder.commit();
 
       // when
-      const result = await DomainTransaction.execute(async (domainTransaction) => {
+      const result = await DomainTransaction.execute(async () => {
         return organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
-          domainTransaction,
           fromUserActivityDate,
           toUserActivityDate,
         });
@@ -1641,9 +1629,8 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       await databaseBuilder.commit();
 
       // when
-      const result = await DomainTransaction.execute(async (domainTransaction) => {
+      const result = await DomainTransaction.execute(async () => {
         return organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
-          domainTransaction,
           fromUserActivityDate,
           toUserActivityDate,
         });
@@ -1674,10 +1661,10 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
         await databaseBuilder.commit();
 
         // when
-        const result = await DomainTransaction.execute(async (domainTransaction) => {
+        const result = await DomainTransaction.execute(async () => {
           return organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
             skipLoggedLastDayCheck: true,
-            domainTransaction,
+
             fromUserActivityDate,
             toUserActivityDate,
           });
@@ -1698,12 +1685,11 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
         await databaseBuilder.commit();
 
         // when
-        const result = await DomainTransaction.execute(async (domainTransaction) => {
+        const result = await DomainTransaction.execute(async () => {
           return organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
             fromUserActivityDate,
             toUserActivityDate,
             skipLoggedLastDayCheck: true,
-            domainTransaction,
           });
         });
 
@@ -1723,13 +1709,12 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
         await databaseBuilder.commit();
 
         // when
-        const result = await DomainTransaction.execute(async (domainTransaction) => {
+        const result = await DomainTransaction.execute(async () => {
           return organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
             fromUserActivityDate,
             toUserActivityDate,
             skipLoggedLastDayCheck: true,
             onlyNotComputed: true,
-            domainTransaction,
           });
         });
 
@@ -1749,13 +1734,12 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
         await databaseBuilder.commit();
 
         // when
-        const result = await DomainTransaction.execute(async (domainTransaction) => {
+        const result = await DomainTransaction.execute(async () => {
           return organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
             fromUserActivityDate,
             toUserActivityDate,
             skipLoggedLastDayCheck: true,
             onlyNotComputed: true,
-            domainTransaction,
           });
         });
 
@@ -1775,13 +1759,12 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
         await databaseBuilder.commit();
 
         // when
-        const result = await DomainTransaction.execute(async (domainTransaction) => {
+        const result = await DomainTransaction.execute(async () => {
           return organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
             fromUserActivityDate,
             toUserActivityDate,
             skipLoggedLastDayCheck: false,
             onlyNotComputed: true,
-            domainTransaction,
           });
         });
 
@@ -1811,12 +1794,11 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       await databaseBuilder.commit();
 
       // when
-      const result = await DomainTransaction.execute(async (domainTransaction) => {
+      const result = await DomainTransaction.execute(async () => {
         return organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
           fromUserActivityDate,
           toUserActivityDate,
           limit: 3,
-          domainTransaction,
         });
       });
 
@@ -1834,12 +1816,11 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       await databaseBuilder.commit();
 
       // when
-      const result = await DomainTransaction.execute(async (domainTransaction) => {
+      const result = await DomainTransaction.execute(async () => {
         return organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
           fromUserActivityDate,
           toUserActivityDate,
           limit: 1,
-          domainTransaction,
         });
       });
 
@@ -1859,12 +1840,11 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       await databaseBuilder.commit();
 
       // when
-      const result = await DomainTransaction.execute(async (domainTransaction) => {
+      const result = await DomainTransaction.execute(async () => {
         return organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
           fromUserActivityDate,
           toUserActivityDate,
           offset: 1,
-          domainTransaction,
         });
       });
 

--- a/api/tests/integration/infrastructure/repositories/tag-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tag-repository_test.js
@@ -94,9 +94,7 @@ describe('Integration | Repository | TagRepository', function () {
       const expectedResult = [tag1];
 
       // when
-      const result = await DomainTransaction.execute(async (domainTransaction) =>
-        tagRepository.findByIds([tag1.id, unknownId], domainTransaction),
-      );
+      const result = await DomainTransaction.execute(async () => tagRepository.findByIds([tag1.id, unknownId]));
 
       // then
       expect(result).to.be.deep.equal(expectedResult);

--- a/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
@@ -24,10 +24,9 @@ describe('Integration | Repository | Target-profile', function () {
       });
 
       // when
-      const targetProfileId = await DomainTransaction.execute(async (domainTransaction) => {
+      const targetProfileId = await DomainTransaction.execute(async () => {
         return targetProfileRepository.create({
           targetProfileForCreation,
-          domainTransaction,
         });
       });
 
@@ -68,10 +67,9 @@ describe('Integration | Repository | Target-profile', function () {
       });
 
       // when
-      const targetProfileId = await DomainTransaction.execute(async (domainTransaction) => {
+      const targetProfileId = await DomainTransaction.execute(async () => {
         return targetProfileRepository.create({
           targetProfileForCreation,
-          domainTransaction,
         });
       });
 
@@ -96,10 +94,9 @@ describe('Integration | Repository | Target-profile', function () {
 
       // when
       try {
-        await DomainTransaction.execute(async (domainTransaction) => {
+        await DomainTransaction.execute(async () => {
           await targetProfileRepository.create({
             targetProfileForCreation,
-            domainTransaction,
           });
           throw new Error();
         });

--- a/api/tests/organizational-entities/unit/domain/usecases/update-organizations-in-batch.usecase.test.js
+++ b/api/tests/organizational-entities/unit/domain/usecases/update-organizations-in-batch.usecase.test.js
@@ -10,16 +10,13 @@ import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransa
 import { catchErr, createTempFile, domainBuilder, expect, removeTempFile, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Organizational Entities | Domain | UseCase | update-organizations-in-batch', function () {
-  let domainTransaction, filePath, organizationForAdminRepository;
+  let filePath, organizationForAdminRepository;
   const csvHeaders =
     'Organization ID;Organization Name;Organization External ID;Organization Parent ID;Organization Identity Provider Code;Organization Documentation URL;Organization Province Code;DPO Last Name;DPO First Name;DPO E-mail';
 
   beforeEach(function () {
-    domainTransaction = {
-      knexTransaction: Symbol('transaction'),
-    };
     sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
-      return callback(domainTransaction);
+      return callback();
     });
 
     organizationForAdminRepository = {
@@ -91,8 +88,8 @@ describe('Unit | Organizational Entities | Domain | UseCase | update-organizatio
       // then
       expect(DomainTransaction.execute).to.have.been.called;
       expect(organizationForAdminRepository.get).to.have.been.callCount(2);
-      expect(organizationForAdminRepository.get.getCall(0)).to.have.been.calledWithExactly('1', domainTransaction);
-      expect(organizationForAdminRepository.get.getCall(1)).to.have.been.calledWithExactly('2', domainTransaction);
+      expect(organizationForAdminRepository.get.getCall(0)).to.have.been.calledWithExactly('1');
+      expect(organizationForAdminRepository.get.getCall(1)).to.have.been.calledWithExactly('2');
     });
 
     it('calls n times "organizationForAdminRepository.update" to update an organization', async function () {
@@ -116,11 +113,9 @@ describe('Unit | Organizational Entities | Domain | UseCase | update-organizatio
       expect(organizationForAdminRepository.update).to.have.been.callCount(2);
       expect(organizationForAdminRepository.update.getCall(0)).to.have.been.calledWithExactly(
         expectedFirstOrganization,
-        domainTransaction,
       );
       expect(organizationForAdminRepository.update.getCall(1)).to.have.been.calledWithExactly(
         expectedSecondOrganization,
-        domainTransaction,
       );
     });
   });

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/begin-campaign-participation-improvement_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/begin-campaign-participation-improvement_test.js
@@ -19,13 +19,12 @@ describe('Integration | UseCase | begin-campaign-participation-improvement', fun
     });
     await databaseBuilder.commit();
 
-    await DomainTransaction.execute(async (domainTransaction) => {
+    await DomainTransaction.execute(async () => {
       await beginCampaignParticipationImprovement({
         campaignParticipationRepository,
         assessmentRepository,
         campaignParticipationId: campaignParticipation.id,
         userId: campaignParticipation.userId,
-        domainTransaction,
       });
     });
 

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/delete-campaign-participation-for-admin_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/delete-campaign-participation-for-admin_test.js
@@ -24,11 +24,10 @@ describe('Integration | UseCases | delete-campaign-participation-for-admin', fun
     await databaseBuilder.commit();
 
     // when
-    await DomainTransaction.execute((domainTransaction) => {
+    await DomainTransaction.execute(() => {
       return deleteCampaignParticipationForAdmin({
         userId: adminUserId,
         campaignParticipationId: campaignParticipationToDelete.id,
-        domainTransaction,
         campaignRepository,
         campaignParticipationRepository,
       });

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/delete-campaign-participation_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/delete-campaign-participation_test.js
@@ -23,13 +23,12 @@ describe('Integration | UseCases | delete-campaign-participation', function () {
     await databaseBuilder.commit();
 
     // when
-    await DomainTransaction.execute((domainTransaction) => {
+    await DomainTransaction.execute(() => {
       return deleteCampaignParticipation({
         userId: adminUserId,
         campaignId,
         campaignParticipationId: campaignParticipationToDelete.id,
         campaignParticipationRepository,
-        domainTransaction,
       });
     });
 

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/start-campaign-participation_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/start-campaign-participation_test.js
@@ -12,11 +12,10 @@ describe('Integration | UseCases | startCampaignParticipation', function () {
     await databaseBuilder.commit();
     const campaignParticipation = { campaignId };
 
-    const { campaignParticipation: startedParticipation } = await DomainTransaction.execute((domainTransaction) => {
+    const { campaignParticipation: startedParticipation } = await DomainTransaction.execute(() => {
       return usecases.startCampaignParticipation({
         userId,
         campaignParticipation,
-        domainTransaction,
       });
     });
 

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participant-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participant-repository_test.js
@@ -44,11 +44,11 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
       await databaseBuilder.commit();
 
-      const campaignParticipant = await DomainTransaction.execute(async (domainTransaction) => {
+      const campaignParticipant = await DomainTransaction.execute(async () => {
         return campaignParticipantRepository.get({
           userId,
           campaignId: campaign.id,
-          domainTransaction,
+
           organizationFeatureAPI,
         });
       });
@@ -98,11 +98,11 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
         await databaseBuilder.commit();
 
-        const campaignParticipant = await DomainTransaction.execute(async (domainTransaction) => {
+        const campaignParticipant = await DomainTransaction.execute(async () => {
           return campaignParticipantRepository.get({
             userId,
             campaignId: campaignToStartParticipation.id,
-            domainTransaction,
+
             organizationFeatureAPI,
           });
         });
@@ -121,11 +121,11 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
         await databaseBuilder.commit();
 
-        const campaignParticipant = await DomainTransaction.execute(async (domainTransaction) => {
+        const campaignParticipant = await DomainTransaction.execute(async () => {
           return campaignParticipantRepository.get({
             userId,
             campaignId: campaignToStartParticipation.id,
-            domainTransaction,
+
             organizationFeatureAPI,
           });
         });
@@ -154,11 +154,11 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
         await databaseBuilder.commit();
 
-        const campaignParticipant = await DomainTransaction.execute(async (domainTransaction) => {
+        const campaignParticipant = await DomainTransaction.execute(async () => {
           return campaignParticipantRepository.get({
             userId,
             campaignId: campaignToStartParticipation.id,
-            domainTransaction,
+
             organizationFeatureAPI,
           });
         });
@@ -179,11 +179,11 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
         await databaseBuilder.commit();
 
-        const campaignParticipant = await DomainTransaction.execute(async (domainTransaction) => {
+        const campaignParticipant = await DomainTransaction.execute(async () => {
           return campaignParticipantRepository.get({
             userId,
             campaignId: campaignToStartParticipation.id,
-            domainTransaction,
+
             organizationFeatureAPI,
           });
         });
@@ -204,11 +204,11 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
         await databaseBuilder.commit();
 
-        const campaignParticipant = await DomainTransaction.execute(async (domainTransaction) => {
+        const campaignParticipant = await DomainTransaction.execute(async () => {
           return campaignParticipantRepository.get({
             userId,
             campaignId: campaignToStartParticipation.id,
-            domainTransaction,
+
             organizationFeatureAPI,
           });
         });
@@ -236,11 +236,11 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
             await databaseBuilder.commit();
 
-            const campaignParticipant = await DomainTransaction.execute(async (domainTransaction) => {
+            const campaignParticipant = await DomainTransaction.execute(async () => {
               return campaignParticipantRepository.get({
                 userId,
                 campaignId: campaignToStartParticipation.id,
-                domainTransaction,
+
                 organizationFeatureAPI,
               });
             });
@@ -264,11 +264,11 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
               await databaseBuilder.commit();
 
-              const campaignParticipant = await DomainTransaction.execute(async (domainTransaction) => {
+              const campaignParticipant = await DomainTransaction.execute(async () => {
                 return campaignParticipantRepository.get({
                   userId,
                   campaignId: campaignToStartParticipation.id,
-                  domainTransaction,
+
                   organizationFeatureAPI,
                 });
               });
@@ -295,11 +295,11 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
             await databaseBuilder.commit();
 
-            const campaignParticipant = await DomainTransaction.execute(async (domainTransaction) => {
+            const campaignParticipant = await DomainTransaction.execute(async () => {
               return campaignParticipantRepository.get({
                 userId,
                 campaignId: campaignToStartParticipation.id,
-                domainTransaction,
+
                 organizationFeatureAPI,
               });
             });
@@ -326,11 +326,11 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
               await databaseBuilder.commit();
 
-              const campaignParticipant = await DomainTransaction.execute(async (domainTransaction) => {
+              const campaignParticipant = await DomainTransaction.execute(async () => {
                 return campaignParticipantRepository.get({
                   userId,
                   campaignId: campaignToStartParticipation.id,
-                  domainTransaction,
+
                   organizationFeatureAPI,
                 });
               });
@@ -370,11 +370,11 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
                 await databaseBuilder.commit();
 
-                const campaignParticipant = await DomainTransaction.execute(async (domainTransaction) => {
+                const campaignParticipant = await DomainTransaction.execute(async () => {
                   return campaignParticipantRepository.get({
                     userId,
                     campaignId: campaignToStartParticipation.id,
-                    domainTransaction,
+
                     organizationFeatureAPI,
                   });
                 });
@@ -403,11 +403,11 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
           await databaseBuilder.commit();
 
-          const campaignParticipant = await DomainTransaction.execute(async (domainTransaction) => {
+          const campaignParticipant = await DomainTransaction.execute(async () => {
             return campaignParticipantRepository.get({
               userId,
               campaignId: campaignToStartParticipation.id,
-              domainTransaction,
+
               organizationFeatureAPI,
             });
           });
@@ -430,11 +430,11 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
           await databaseBuilder.commit();
 
-          const campaignParticipant = await DomainTransaction.execute(async (domainTransaction) => {
+          const campaignParticipant = await DomainTransaction.execute(async () => {
             return campaignParticipantRepository.get({
               userId,
               campaignId: campaignToStartParticipation.id,
-              domainTransaction,
+
               organizationFeatureAPI,
             });
           });
@@ -471,11 +471,11 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
         await databaseBuilder.commit();
 
-        const campaignParticipant = await DomainTransaction.execute(async (domainTransaction) => {
+        const campaignParticipant = await DomainTransaction.execute(async () => {
           return campaignParticipantRepository.get({
             userId,
             campaignId: campaignToStartParticipation.id,
-            domainTransaction,
+
             organizationFeatureAPI,
           });
         });
@@ -522,11 +522,11 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
         await databaseBuilder.commit();
 
-        const campaignParticipant = await DomainTransaction.execute(async (domainTransaction) => {
+        const campaignParticipant = await DomainTransaction.execute(async () => {
           return campaignParticipantRepository.get({
             userId,
             campaignId: campaignToStartParticipation.id,
-            domainTransaction,
+
             organizationFeatureAPI,
           });
         });
@@ -551,11 +551,11 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
         await databaseBuilder.commit();
 
-        const campaignParticipant = await DomainTransaction.execute(async (domainTransaction) => {
+        const campaignParticipant = await DomainTransaction.execute(async () => {
           return campaignParticipantRepository.get({
             userId,
             campaignId: campaign.id,
-            domainTransaction,
+
             organizationFeatureAPI,
           });
         });
@@ -568,11 +568,11 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
         await databaseBuilder.commit();
 
-        const campaignParticipant = await DomainTransaction.execute(async (domainTransaction) => {
+        const campaignParticipant = await DomainTransaction.execute(async () => {
           return campaignParticipantRepository.get({
             userId,
             campaignId: campaign.id,
-            domainTransaction,
+
             organizationFeatureAPI,
           });
         });
@@ -585,11 +585,11 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
         await databaseBuilder.commit();
 
-        const campaignParticipant = await DomainTransaction.execute(async (domainTransaction) => {
+        const campaignParticipant = await DomainTransaction.execute(async () => {
           return campaignParticipantRepository.get({
             userId,
             campaignId: campaign.id,
-            domainTransaction,
+
             organizationFeatureAPI,
           });
         });
@@ -604,11 +604,11 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
       await databaseBuilder.commit();
 
       const error = await catchErr(() => {
-        return DomainTransaction.execute(async (domainTransaction) => {
+        return DomainTransaction.execute(async () => {
           await campaignParticipantRepository.get({
             userId,
             campaignId: 12,
-            domainTransaction,
+
             organizationFeatureAPI,
           });
         });
@@ -636,8 +636,8 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
         isManagingStudents: false,
       });
 
-      const id = await DomainTransaction.execute(async (domainTransaction) => {
-        return campaignParticipantRepository.save({ campaignParticipant, domainTransaction });
+      const id = await DomainTransaction.execute(async () => {
+        return campaignParticipantRepository.save({ campaignParticipant });
       });
 
       const [campaignParticipationId] = await knex('campaign-participations').pluck('id');
@@ -674,8 +674,8 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
       it('creates a campaign participation', async function () {
         // when
-        await DomainTransaction.execute(async (domainTransaction) => {
-          await campaignParticipantRepository.save({ campaignParticipant, domainTransaction });
+        await DomainTransaction.execute(async () => {
+          await campaignParticipantRepository.save({ campaignParticipant });
         });
 
         const campaignParticipation = await knex('campaign-participations')
@@ -689,8 +689,8 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
       it('enabled only the learner assigned to the campaign participant', async function () {
         // when
-        await DomainTransaction.execute(async (domainTransaction) => {
-          await campaignParticipantRepository.save({ campaignParticipant, domainTransaction });
+        await DomainTransaction.execute(async () => {
+          await campaignParticipantRepository.save({ campaignParticipant });
         });
 
         const { isDisabled: expectedEnabledLearner } = await knex('organization-learners')
@@ -717,8 +717,8 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
           isManagingStudents: false,
         });
 
-        await DomainTransaction.execute(async (domainTransaction) => {
-          await campaignParticipantRepository.save({ campaignParticipant, domainTransaction });
+        await DomainTransaction.execute(async () => {
+          await campaignParticipantRepository.save({ campaignParticipant });
         });
 
         const campaignParticipation = await knex('campaign-participations')
@@ -738,8 +738,8 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
           isManagingStudents: false,
         });
 
-        await DomainTransaction.execute(async (domainTransaction) => {
-          await campaignParticipantRepository.save({ campaignParticipant, domainTransaction });
+        await DomainTransaction.execute(async () => {
+          await campaignParticipantRepository.save({ campaignParticipant });
         });
 
         const assessments = await knex('assessments');
@@ -763,11 +763,12 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
         });
 
         //WHEN
-        await DomainTransaction.execute(async (domainTransaction) => {
-          await campaignParticipantRepository.save({ campaignParticipant, domainTransaction });
+        await DomainTransaction.execute(async () => {
+          await campaignParticipantRepository.save({ campaignParticipant });
         });
 
         //THEN
+
         const campaignParticipation = await knex('campaign-participations')
           .select(['id', ...campaignParticipationDBAttributes])
           .first();
@@ -805,11 +806,12 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
         campaignParticipant.start({ participantExternalId: null });
 
         //WHEN
-        await DomainTransaction.execute(async (domainTransaction) => {
-          await campaignParticipantRepository.save({ campaignParticipant, domainTransaction });
+        await DomainTransaction.execute(async () => {
+          await campaignParticipantRepository.save({ campaignParticipant });
         });
 
         //THEN
+
         const campaignParticipation = await knex('campaign-participations').select('organizationLearnerId').first();
         expect(campaignParticipation.organizationLearnerId).to.equal(organizationLearnerId);
       });
@@ -836,11 +838,12 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
         campaignParticipant.start({ participantExternalId: null });
 
         //WHEN
-        await DomainTransaction.execute(async (domainTransaction) => {
-          await campaignParticipantRepository.save({ campaignParticipant, domainTransaction });
+        await DomainTransaction.execute(async () => {
+          await campaignParticipantRepository.save({ campaignParticipant });
         });
 
         //THEN
+
         const organizationLearner = await knex('organization-learners')
           .select('firstName', 'lastName', 'userId', 'organizationId')
           .first();
@@ -872,11 +875,12 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
         campaignParticipant.start({ participantExternalId: null });
 
         //WHEN
-        await DomainTransaction.execute(async (domainTransaction) => {
-          await campaignParticipantRepository.save({ campaignParticipant, domainTransaction });
+        await DomainTransaction.execute(async () => {
+          await campaignParticipantRepository.save({ campaignParticipant });
         });
 
         //THEN
+
         const campaignParticipation = await knex('campaign-participations').select('organizationLearnerId').first();
         const organizationLearner = await knex('organization-learners').select('id').first();
         expect(campaignParticipation.organizationLearnerId).to.equal(organizationLearner.id);
@@ -916,11 +920,12 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
         campaignParticipant.start({ participantExternalId: null });
 
         //WHEN
-        await DomainTransaction.execute(async (domainTransaction) => {
-          await campaignParticipantRepository.save({ campaignParticipant, domainTransaction });
+        await DomainTransaction.execute(async () => {
+          await campaignParticipantRepository.save({ campaignParticipant });
         });
 
         //THEN
+
         const campaignParticipation = await knex('campaign-participations')
           .select('isImproved')
           .where({ id: previousCampaignParticipationForUserId })
@@ -972,11 +977,12 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
         campaignParticipant.start({ participantExternalId: null });
 
         //WHEN
-        await DomainTransaction.execute(async (domainTransaction) => {
-          await campaignParticipantRepository.save({ campaignParticipant, domainTransaction });
+        await DomainTransaction.execute(async () => {
+          await campaignParticipantRepository.save({ campaignParticipant });
         });
 
         //THEN
+
         const campaignParticipations = await knex('campaign-participations').pluck('id').where({ isImproved: true });
 
         expect(campaignParticipations).to.deep.equal([previousCampaignParticipationForUserId]);
@@ -992,8 +998,8 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
           isManagingStudents: false,
         });
 
-        await DomainTransaction.execute(async (domainTransaction) => {
-          await campaignParticipantRepository.save({ campaignParticipant, domainTransaction });
+        await DomainTransaction.execute(async () => {
+          await campaignParticipantRepository.save({ campaignParticipant });
         });
 
         const campaignParticipation = await knex('campaign-participations')
@@ -1034,8 +1040,8 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
           isManagingStudents: false,
         });
 
-        const id = await DomainTransaction.execute(async (domainTransaction) => {
-          return campaignParticipantRepository.save({ campaignParticipant, domainTransaction });
+        const id = await DomainTransaction.execute(async () => {
+          return campaignParticipantRepository.save({ campaignParticipant });
         });
 
         const startedParticipation = await knex('campaign-participations').where('id', id).first();
@@ -1073,8 +1079,8 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
           //WHEN
           const error = await catchErr(() => {
-            return DomainTransaction.execute(async (domainTransaction) => {
-              await campaignParticipantRepository.save({ campaignParticipant, domainTransaction });
+            return DomainTransaction.execute(async () => {
+              await campaignParticipantRepository.save({ campaignParticipant });
             });
           })();
 
@@ -1109,8 +1115,8 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
           //WHEN
           const error = await catchErr(() => {
-            return DomainTransaction.execute(async (domainTransaction) => {
-              await campaignParticipantRepository.save({ campaignParticipant, domainTransaction });
+            return DomainTransaction.execute(async () => {
+              await campaignParticipantRepository.save({ campaignParticipant });
             });
           })();
 
@@ -1128,10 +1134,10 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
         });
 
         const error = await catchErr(() => {
-          return DomainTransaction.execute(async (domainTransaction) => {
+          return DomainTransaction.execute(async () => {
             await Promise.all([
-              campaignParticipantRepository.save({ campaignParticipant, domainTransaction }),
-              campaignParticipantRepository.save({ campaignParticipant, domainTransaction }),
+              campaignParticipantRepository.save({ campaignParticipant }),
+              campaignParticipantRepository.save({ campaignParticipant }),
             ]);
           });
         })();
@@ -1171,8 +1177,8 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
         //WHEN
         await catchErr(() => {
-          return DomainTransaction.execute(async (domainTransaction) => {
-            await campaignParticipantRepository.save({ campaignParticipant, domainTransaction });
+          return DomainTransaction.execute(async () => {
+            await campaignParticipantRepository.save({ campaignParticipant });
           });
         })();
 

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -148,8 +148,8 @@ describe('Integration | Repository | Campaign Participation', function () {
 
     it('should return a campaign participation object', async function () {
       // when
-      const foundCampaignParticipation = await DomainTransaction.execute(async (domainTransaction) => {
-        return campaignParticipationRepository.get(campaignParticipationId, domainTransaction);
+      const foundCampaignParticipation = await DomainTransaction.execute(async () => {
+        return campaignParticipationRepository.get(campaignParticipationId);
       });
 
       // then
@@ -159,8 +159,8 @@ describe('Integration | Repository | Campaign Participation', function () {
 
     it('should return a null object for sharedAt when the campaign-participation is not shared', async function () {
       // when
-      const foundCampaignParticipation = await DomainTransaction.execute(async (domainTransaction) => {
-        return campaignParticipationRepository.get(campaignParticipationNotSharedId, domainTransaction);
+      const foundCampaignParticipation = await DomainTransaction.execute(async () => {
+        return campaignParticipationRepository.get(campaignParticipationNotSharedId);
       });
 
       // then
@@ -172,8 +172,8 @@ describe('Integration | Repository | Campaign Participation', function () {
       const expectedAssessmentIds = campaignParticipationAssessments.map(({ id }) => id);
 
       // when
-      const foundCampaignParticipation = await DomainTransaction.execute(async (domainTransaction) => {
-        return campaignParticipationRepository.get(campaignParticipationId, domainTransaction);
+      const foundCampaignParticipation = await DomainTransaction.execute(async () => {
+        return campaignParticipationRepository.get(campaignParticipationId);
       });
 
       const assessmentIds = foundCampaignParticipation.assessments.map(({ id }) => id);
@@ -184,8 +184,8 @@ describe('Integration | Repository | Campaign Participation', function () {
 
     it('returns the campaign of campaignParticipation', async function () {
       // when
-      const foundCampaignParticipation = await DomainTransaction.execute(async (domainTransaction) => {
-        return campaignParticipationRepository.get(campaignParticipationId, domainTransaction);
+      const foundCampaignParticipation = await DomainTransaction.execute(async () => {
+        return campaignParticipationRepository.get(campaignParticipationId);
       });
 
       // then
@@ -197,8 +197,8 @@ describe('Integration | Repository | Campaign Participation', function () {
       const expectedAssessmentIds = campaignParticipationAssessments.map(({ id }) => id);
 
       // when
-      const foundCampaignParticipation = await DomainTransaction.execute((domainTransaction) => {
-        return campaignParticipationRepository.get(campaignParticipationId, domainTransaction);
+      const foundCampaignParticipation = await DomainTransaction.execute(() => {
+        return campaignParticipationRepository.get(campaignParticipationId);
       });
 
       const assessmentIds = foundCampaignParticipation.assessments.map(({ id }) => id);
@@ -263,15 +263,12 @@ describe('Integration | Repository | Campaign Participation', function () {
 
       await databaseBuilder.commit();
 
-      await DomainTransaction.execute(async (domainTransaction) => {
-        await campaignParticipationRepository.update(
-          {
-            ...campaignParticipationToUpdate,
-            sharedAt: new Date('2021-01-01'),
-            status: SHARED,
-          },
-          domainTransaction,
-        );
+      await DomainTransaction.execute(async () => {
+        await campaignParticipationRepository.update({
+          ...campaignParticipationToUpdate,
+          sharedAt: new Date('2021-01-01'),
+          status: SHARED,
+        });
       });
 
       const campaignParticipation = await knex('campaign-participations')
@@ -293,14 +290,11 @@ describe('Integration | Repository | Campaign Participation', function () {
 
       await databaseBuilder.commit();
 
-      const error = await DomainTransaction.execute(async (domainTransaction) => {
-        return catchErr(campaignParticipationRepository.update)(
-          {
-            ...campaignParticipationToUpdate,
-            campaignId,
-          },
-          domainTransaction,
-        );
+      const error = await DomainTransaction.execute(async () => {
+        return catchErr(campaignParticipationRepository.update)({
+          ...campaignParticipationToUpdate,
+          campaignId,
+        });
       });
 
       expect(error.constraint).to.equals('one_active_participation_by_learner');
@@ -385,11 +379,10 @@ describe('Integration | Repository | Campaign Participation', function () {
         await databaseBuilder.commit();
 
         const error = await catchErr(async function () {
-          await DomainTransaction.execute(async (domainTransaction) => {
+          await DomainTransaction.execute(async () => {
             await campaignParticipationRepository.getAllCampaignParticipationsInCampaignForASameLearner({
               campaignId,
               campaignParticipationId: campaignParticipationToDelete.id,
-              domainTransaction,
             });
           });
         })();
@@ -415,11 +408,10 @@ describe('Integration | Repository | Campaign Participation', function () {
 
         await databaseBuilder.commit();
 
-        const participations = await DomainTransaction.execute((domainTransaction) => {
+        const participations = await DomainTransaction.execute(() => {
           return campaignParticipationRepository.getAllCampaignParticipationsInCampaignForASameLearner({
             campaignId,
             campaignParticipationId: campaignParticipationToDelete.id,
-            domainTransaction,
           });
         });
 
@@ -443,12 +435,11 @@ describe('Integration | Repository | Campaign Participation', function () {
         campaignParticipation.deletedAt = new Date('2022-11-01T23:00:00Z');
         campaignParticipation.deletedBy = ownerId;
 
-        await DomainTransaction.execute((domainTransaction) => {
+        await DomainTransaction.execute(() => {
           return campaignParticipationRepository.remove({
             id: campaignParticipation.id,
             deletedAt: campaignParticipation.deletedAt,
             deletedBy: campaignParticipation.deletedBy,
-            domainTransaction,
           });
         });
 
@@ -475,11 +466,10 @@ describe('Integration | Repository | Campaign Participation', function () {
 
         await databaseBuilder.commit();
 
-        const participations = await DomainTransaction.execute((domainTransaction) => {
+        const participations = await DomainTransaction.execute(() => {
           return campaignParticipationRepository.getAllCampaignParticipationsInCampaignForASameLearner({
             campaignId,
             campaignParticipationId: campaignParticipationToDelete.id,
-            domainTransaction,
           });
         });
 
@@ -509,11 +499,10 @@ describe('Integration | Repository | Campaign Participation', function () {
 
         await databaseBuilder.commit();
 
-        const participations = await DomainTransaction.execute((domainTransaction) => {
+        const participations = await DomainTransaction.execute(() => {
           return campaignParticipationRepository.getAllCampaignParticipationsInCampaignForASameLearner({
             campaignId,
             campaignParticipationId: campaignParticipationToDelete.id,
-            domainTransaction,
           });
         });
 

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 
 import { NotFoundError } from '../../../../../../lib/domain/errors.js';
-import { DomainTransaction } from '../../../../../../lib/infrastructure/DomainTransaction.js';
+import { DomainTransaction, withTransaction } from '../../../../../../lib/infrastructure/DomainTransaction.js';
 import { CampaignParticipation } from '../../../../../../src/prescription/campaign-participation/domain/models/CampaignParticipation.js';
 import { AvailableCampaignParticipation } from '../../../../../../src/prescription/campaign-participation/domain/read-models/AvailableCampaignParticipation.js';
 import * as campaignParticipationRepository from '../../../../../../src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js';
@@ -81,9 +81,7 @@ describe('Integration | Repository | Campaign Participation', function () {
       it('should save a snapshot using a transaction', async function () {
         campaignParticipation.sharedAt = new Date();
 
-        await ApplicationTransaction.execute(async () => {
-          await campaignParticipationRepository.updateWithSnapshot(campaignParticipation);
-        });
+        await withTransaction(async () => campaignParticipationRepository.updateWithSnapshot(campaignParticipation))();
 
         const snapshotInDB = await knex.select('id').from('knowledge-element-snapshots');
         expect(snapshotInDB).to.have.length(1);
@@ -93,10 +91,10 @@ describe('Integration | Repository | Campaign Participation', function () {
         campaignParticipation.sharedAt = new Date();
 
         try {
-          await ApplicationTransaction.execute(async () => {
+          await withTransaction(async () => {
             await campaignParticipationRepository.updateWithSnapshot(campaignParticipation);
             throw new Error();
-          });
+          })();
           // eslint-disable-next-line no-empty
         } catch (error) {}
 

--- a/api/tests/prescription/campaign-participation/unit/application/campaign-participation-controller_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/campaign-participation-controller_test.js
@@ -219,10 +219,9 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
         params: { id: campaignId, campaignParticipationId },
         auth: { credentials: { userId } },
       };
-      const domainTransaction = Symbol();
 
       sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => {
-        return lambda(domainTransaction);
+        return lambda();
       });
       sinon.stub(usecases, 'deleteCampaignParticipation');
       usecases.deleteCampaignParticipation.resolves();
@@ -235,7 +234,6 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
         campaignParticipationId,
         campaignId,
         userId,
-        domainTransaction,
       });
     });
   });

--- a/api/tests/prescription/campaign-participation/unit/application/learner-participation-controller_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/learner-participation-controller_test.js
@@ -249,11 +249,10 @@ describe('Unit | Application | Controller | Learner-Participation', function () 
         params: { campaignParticipationId },
         auth: { credentials: { userId } },
       };
-      const domainTransaction = Symbol();
 
       sinon.stub(usecases, 'beginCampaignParticipationImprovement');
       sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => {
-        return lambda(domainTransaction);
+        return lambda();
       });
       usecases.beginCampaignParticipationImprovement.resolves();
 
@@ -264,7 +263,6 @@ describe('Unit | Application | Controller | Learner-Participation', function () 
       expect(usecases.beginCampaignParticipationImprovement).to.have.been.calledOnceWith({
         campaignParticipationId,
         userId,
-        domainTransaction,
       });
     });
   });

--- a/api/tests/prescription/campaign-participation/unit/domain/usecases/delete-campaign-participation_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/usecases/delete-campaign-participation_test.js
@@ -23,7 +23,6 @@ describe('Unit | UseCase | delete-campaign-participation', function () {
       remove: sinon.stub(),
     };
     const campaignParticipationId = 1234;
-    const domainTransaction = Symbol('domainTransaction');
     const campaignId = domainBuilder.buildCampaign().id;
     const ownerId = domainBuilder.buildUser().id;
     const organizationLearnerId = domainBuilder.buildOrganizationLearner().id;
@@ -48,7 +47,6 @@ describe('Unit | UseCase | delete-campaign-participation', function () {
       .withArgs({
         campaignId,
         campaignParticipationId,
-        domainTransaction,
       })
       .resolves(campaignParticipations);
 
@@ -58,7 +56,6 @@ describe('Unit | UseCase | delete-campaign-participation', function () {
       campaignId,
       campaignParticipationId,
       campaignParticipationRepository,
-      domainTransaction,
     });
 
     //then
@@ -73,7 +70,6 @@ describe('Unit | UseCase | delete-campaign-participation', function () {
         id: deletedCampaignParticipation.id,
         deletedAt: deletedCampaignParticipation.deletedAt,
         deletedBy: deletedCampaignParticipation.deletedBy,
-        domainTransaction,
       });
     });
   });

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -27,11 +27,10 @@ describe('Integration | Repository | Organization Learners Management | Campaign
       await databaseBuilder.commit();
 
       // when
-      await DomainTransaction.execute(async (domainTransaction) => {
+      await DomainTransaction.execute(async () => {
         await removeByOrganizationLearnerIds({
           organizationLearnerIds: [organizationLearnerId],
           userId,
-          domainTransaction,
         });
       });
       // then
@@ -58,11 +57,10 @@ describe('Integration | Repository | Organization Learners Management | Campaign
       await databaseBuilder.commit();
 
       // when
-      await DomainTransaction.execute(async (domainTransaction) => {
+      await DomainTransaction.execute(async () => {
         await removeByOrganizationLearnerIds({
           organizationLearnerIds: [organizationLearnerId1, organizationLearnerId2],
           userId,
-          domainTransaction,
         });
       });
 
@@ -86,11 +84,10 @@ describe('Integration | Repository | Organization Learners Management | Campaign
       await databaseBuilder.commit();
 
       // when
-      await DomainTransaction.execute(async (domainTransaction) => {
+      await DomainTransaction.execute(async () => {
         await removeByOrganizationLearnerIds({
           organizationLearnerIds: [organizationLearnerId],
           userId,
-          domainTransaction,
         });
       });
       // then

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-import-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-import-repository_test.js
@@ -2,7 +2,7 @@ import { IMPORT_STATUSES } from '../../../../../../src/prescription/learner-mana
 import { OrganizationImport } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationImport.js';
 import * as organizationImportRepository from '../../../../../../src/prescription/learner-management/infrastructure/repositories/organization-import-repository.js';
 import { ApplicationTransaction } from '../../../../../../src/prescription/shared/infrastructure/ApplicationTransaction.js';
-import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
+import { DomainTransaction, withTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { catchErr, databaseBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Integration | Repository | Organization Learner Management | Organization Import', function () {
@@ -92,11 +92,12 @@ describe('Integration | Repository | Organization Learner Management | Organizat
 
       const organizationImport = OrganizationImport.create({ organizationId, createdBy: userId });
       organizationImport.upload({ filename: 'test.csv', encoding: 'utf8' });
+
       try {
-        await ApplicationTransaction.execute(async () => {
+        await withTransaction(async () => {
           await organizationImportRepository.save(organizationImport);
           throw new Error();
-        });
+        })();
         // eslint-disable-next-line no-empty
       } catch (e) {}
 

--- a/api/tests/prescription/learner-management/unit/domain/usecases/add-or-update-organization-learners_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/add-or-update-organization-learners_test.js
@@ -13,7 +13,6 @@ describe('Unit | UseCase | add-or-update-organization-learners', function () {
   let readableSymbol;
   let parserStub;
   let streamerSymbol;
-  let domainTransaction;
   let organizationImportStub;
 
   beforeEach(function () {
@@ -29,9 +28,8 @@ describe('Unit | UseCase | add-or-update-organization-learners', function () {
       save: sinon.stub(),
     };
 
-    domainTransaction = Symbol();
     sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
-      return callback(domainTransaction);
+      return callback();
     });
     readableSymbol = Symbol('readable');
     importStorageStub = {
@@ -70,7 +68,6 @@ describe('Unit | UseCase | add-or-update-organization-learners', function () {
     });
 
     expect(organizationLearnerRepositoryStub.disableAllOrganizationLearnersInOrganization).to.have.been.calledWith({
-      domainTransaction,
       organizationId,
       nationalStudentIds: ['INE1', 'INE2', 'INE3'],
     });
@@ -83,17 +80,13 @@ describe('Unit | UseCase | add-or-update-organization-learners', function () {
         { lastName: 'Student2', nationalStudentId: 'INE2' },
       ],
       organizationId,
-      domainTransaction,
     ]);
     expect(
       organizationLearnerRepositoryStub.addOrUpdateOrganizationOfOrganizationLearners.getCall(1).args,
-    ).to.deep.equal([[{ lastName: 'Student3', nationalStudentId: 'INE3' }], organizationId, domainTransaction]);
+    ).to.deep.equal([[{ lastName: 'Student3', nationalStudentId: 'INE3' }], organizationId]);
 
     expect(organizationImportStub.process).to.have.been.calledWith({ errors: [] });
-    expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(
-      organizationImportStub,
-      domainTransaction,
-    );
+    expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(organizationImportStub);
 
     expect(importStorageStub.deleteFile).to.have.been.calledWithExactly({ filename: organizationImportStub.filename });
   });

--- a/api/tests/prescription/learner-management/unit/domain/usecases/delete-organization-learners_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/delete-organization-learners_test.js
@@ -17,7 +17,6 @@ describe('Unit | UseCase | Organization Learners Management | Delete Organizatio
   it('should delete organization learners and their participations', async function () {
     // given
     const userId = 777;
-    const domainTransaction = Symbol('transaction');
     const organizationLearnerIds = [123, 456, 789];
 
     // when
@@ -26,20 +25,17 @@ describe('Unit | UseCase | Organization Learners Management | Delete Organizatio
       userId,
       campaignParticipationRepository,
       organizationLearnerRepository,
-      domainTransaction,
     });
 
     // then
     expect(campaignParticipationRepository.removeByOrganizationLearnerIds).to.have.been.calledWithExactly({
       organizationLearnerIds,
       userId,
-      domainTransaction,
     });
 
     expect(organizationLearnerRepository.removeByIds).to.have.been.calledWithExactly({
       organizationLearnerIds,
       userId,
-      domainTransaction,
     });
   });
 });

--- a/api/tests/prescription/learner-management/unit/domain/usecases/import-organization-learners-from-siecle-csv-format_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/import-organization-learners-from-siecle-csv-format_test.js
@@ -7,7 +7,6 @@ import { catchErr, expect, sinon } from '../../../../../test-helper.js';
 describe('Unit | UseCase | importOrganizationLearnersFromSIECLECSVFormat', function () {
   let organizationId,
     learners,
-    domainTransaction,
     i18n,
     s3Filename,
     encoding,
@@ -50,11 +49,8 @@ describe('Unit | UseCase | importOrganizationLearnersFromSIECLECSVFormat', funct
 
     OrganizationLearnerParser.buildParser = sinon.stub();
 
-    domainTransaction = {
-      knexTransaction: Symbol('transaction'),
-    };
     sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
-      return callback(domainTransaction);
+      return callback();
     });
 
     learners = [{ nationalStudentId: 1 }, { nationalStudentId: 2 }, { nationalStudentId: 3 }];
@@ -79,7 +75,6 @@ describe('Unit | UseCase | importOrganizationLearnersFromSIECLECSVFormat', funct
 
       expect(
         organizationLearnerRepositoryStub.disableAllOrganizationLearnersInOrganization.calledWithExactly({
-          domainTransaction,
           organizationId,
           nationalStudentIds: [1, 2, 3],
         }),
@@ -94,7 +89,6 @@ describe('Unit | UseCase | importOrganizationLearnersFromSIECLECSVFormat', funct
         organizationLearnerRepositoryStub.addOrUpdateOrganizationOfOrganizationLearners.calledWithExactly(
           learners,
           organizationId,
-          domainTransaction,
         ),
         'organizationLearnerRepositoryStub.addOrUpdateOrganizationOfOrganizationLearners',
       ).to.be.true;

--- a/api/tests/shared/integration/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/assessment-repository_test.js
@@ -444,8 +444,8 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
 
     it('should complete an assessment if not already existing and commited', async function () {
       // when
-      await DomainTransaction.execute(async (domainTransaction) => {
-        await assessmentRepository.completeByAssessmentId(assessmentId, domainTransaction);
+      await DomainTransaction.execute(async () => {
+        await assessmentRepository.completeByAssessmentId(assessmentId);
       });
 
       // then
@@ -459,8 +459,8 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
     it('should not complete an assessment if not already existing but rolled back', async function () {
       // when
       catchErr(async () => {
-        await DomainTransaction.execute(async (domainTransaction) => {
-          await assessmentRepository.completeByAssessmentId(assessmentId, domainTransaction);
+        await DomainTransaction.execute(async () => {
+          await assessmentRepository.completeByAssessmentId(assessmentId);
           throw new Error('an error occurs within the domain transaction');
         });
       });
@@ -635,8 +635,8 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
       const lastQuestionState = 'timeout';
 
       // when
-      await DomainTransaction.execute(async (domainTransaction) => {
-        await assessmentRepository.updateLastQuestionState({ id: assessment.id, lastQuestionState, domainTransaction });
+      await DomainTransaction.execute(async () => {
+        await assessmentRepository.updateLastQuestionState({ id: assessment.id, lastQuestionState });
       });
 
       // then
@@ -653,11 +653,10 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
         let result;
 
         // when
-        await DomainTransaction.execute(async (domainTransaction) => {
+        await DomainTransaction.execute(async () => {
           result = await assessmentRepository.updateLastQuestionState({
             id: notExistingAssessmentId,
             lastQuestionState: 'timeout',
-            domainTransaction,
           });
         });
 

--- a/api/tests/shared/unit/application/assessments/assessment-controller_test.js
+++ b/api/tests/shared/unit/application/assessments/assessment-controller_test.js
@@ -61,16 +61,15 @@ describe('Unit | Controller | assessment-controller', function () {
   });
 
   describe('#completeAssessment', function () {
-    let domainTransaction, assessmentId, assessment, assessmentCompletedEvent, locale;
+    let assessmentId, assessment, assessmentCompletedEvent, locale;
 
     beforeEach(function () {
-      domainTransaction = Symbol('domainTransaction');
       assessmentId = 2;
       assessmentCompletedEvent = new AssessmentCompleted();
       assessment = Symbol('completed-assessment');
       locale = 'fr-fr';
       sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => {
-        return lambda(domainTransaction);
+        return lambda();
       });
 
       sinon.stub(usecases, 'completeAssessment');
@@ -90,7 +89,7 @@ describe('Unit | Controller | assessment-controller', function () {
       await assessmentController.completeAssessment({ params: { id: assessmentId } });
 
       // then
-      expect(usecases.completeAssessment).to.have.been.calledWithExactly({ assessmentId, domainTransaction, locale });
+      expect(usecases.completeAssessment).to.have.been.calledWithExactly({ assessmentId, locale });
     });
 
     it('should call the handleBadgeAcquisition use case', async function () {
@@ -98,7 +97,7 @@ describe('Unit | Controller | assessment-controller', function () {
       await assessmentController.completeAssessment({ params: { id: assessmentId } });
 
       // then
-      expect(usecases.handleBadgeAcquisition).to.have.been.calledWithExactly({ assessment, domainTransaction });
+      expect(usecases.handleBadgeAcquisition).to.have.been.calledWithExactly({ assessment });
     });
 
     it('should call the handleTrainingRecommendation use case', async function () {
@@ -112,7 +111,6 @@ describe('Unit | Controller | assessment-controller', function () {
       expect(devcompUsecases.handleTrainingRecommendation).to.have.been.calledWithExactly({
         assessment,
         locale,
-        domainTransaction,
       });
     });
 

--- a/api/tests/shared/unit/domain/usecases/delete-unassociated-badge_test.js
+++ b/api/tests/shared/unit/domain/usecases/delete-unassociated-badge_test.js
@@ -7,7 +7,6 @@ import { deleteUnassociatedBadge } from '../../../../../src/shared/domain/usecas
 import { catchErr, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | UseCase | delete-unassociated-badge', function () {
-  let domainTransaction;
   let badgeId;
   let badgeRepository;
   let complementaryCertificationBadgeRepository;
@@ -20,9 +19,8 @@ describe('Unit | UseCase | delete-unassociated-badge', function () {
     };
     complementaryCertificationBadgeRepository = { isRelatedToCertification: sinon.stub() };
 
-    domainTransaction = Symbol('domainTransaction');
     sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => {
-      return lambda(domainTransaction);
+      return lambda();
     });
   });
 

--- a/api/tests/unit/application/organizations-administration/organization-administration-controller_test.js
+++ b/api/tests/unit/application/organizations-administration/organization-administration-controller_test.js
@@ -60,9 +60,8 @@ describe('Unit | Application | Organizations | organization-administration-contr
       const dependencies = {
         organizationForAdminSerializer: organizationForAdminSerializerStub,
       };
-      const domainTransaction = Symbol('domainTransaction');
       sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
-        return callback(domainTransaction);
+        return callback();
       });
 
       dependencies.organizationForAdminSerializer.deserialize

--- a/api/tests/unit/application/organizations-administration/organization-administration-controller_test.js
+++ b/api/tests/unit/application/organizations-administration/organization-administration-controller_test.js
@@ -69,7 +69,7 @@ describe('Unit | Application | Organizations | organization-administration-contr
         .withArgs(request.payload)
         .returns(organizationDeserialized);
       usecases.updateOrganizationInformation
-        .withArgs({ organization: organizationDeserialized, domainTransaction })
+        .withArgs({ organization: organizationDeserialized })
         .resolves(updatedOrganization);
       dependencies.organizationForAdminSerializer.serialize
         .withArgs(updatedOrganization)

--- a/api/tests/unit/application/target-profiles/target-profile-controller_test.js
+++ b/api/tests/unit/application/target-profiles/target-profile-controller_test.js
@@ -8,7 +8,6 @@ describe('Unit | Controller | target-profile-controller', function () {
   describe('#createTargetProfile', function () {
     it('should succeed', async function () {
       // given
-      const domainTransaction = Symbol('domainTr');
       sinon.stub(usecases, 'createTargetProfile');
       const targetProfileCreationCommand = {
         name: 'targetProfileName',
@@ -23,10 +22,9 @@ describe('Unit | Controller | target-profile-controller', function () {
       sinon.stub(DomainTransaction, 'execute').callsFake(() => {
         return usecases.createTargetProfile({
           targetProfileCreationCommand,
-          domainTransaction,
         });
       });
-      usecases.createTargetProfile.withArgs({ targetProfileCreationCommand, domainTransaction }).resolves(123);
+      usecases.createTargetProfile.withArgs({ targetProfileCreationCommand }).resolves(123);
       const request = {
         payload: {
           data: {
@@ -80,9 +78,7 @@ describe('Unit | Controller | target-profile-controller', function () {
             deserialize: sinon.stub().returns(attributesToUpdate),
           },
         };
-
-        const domainTransaction = Symbol('domain transaction');
-        sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda(domainTransaction));
+        sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
 
         // when
         const response = await targetProfileController.updateTargetProfile(request, hFake, dependencies);
@@ -93,7 +89,6 @@ describe('Unit | Controller | target-profile-controller', function () {
         expect(dependencies.usecases.updateTargetProfile).to.have.been.calledOnceWithExactly({
           id: request.params.id,
           attributesToUpdate,
-          domainTransaction,
         });
       });
     });

--- a/api/tests/unit/domain/usecases/anonymize-user_test.js
+++ b/api/tests/unit/domain/usecases/anonymize-user_test.js
@@ -42,9 +42,6 @@ describe('Unit | UseCase | anonymize-user', function () {
       role,
     });
 
-    const domainTransaction = {
-      knexTransaction: Symbol('transaction'),
-    };
 
     const userRepository = {
       get: sinon.stub(),
@@ -73,7 +70,6 @@ describe('Unit | UseCase | anonymize-user', function () {
       certificationCenterMembershipRepository,
       organizationLearnerRepository,
       resetPasswordDemandRepository,
-      domainTransaction,
       adminMemberRepository,
     });
 
@@ -82,28 +78,23 @@ describe('Unit | UseCase | anonymize-user', function () {
 
     expect(authenticationMethodRepository.removeAllAuthenticationMethodsByUserId).to.have.been.calledWithExactly({
       userId,
-      domainTransaction,
     });
     expect(refreshTokenService.revokeRefreshTokensForUserId).to.have.been.calledWithExactly({ userId });
     expect(resetPasswordDemandRepository.removeAllByEmail).to.have.been.calledWithExactly(userEmail);
     expect(membershipRepository.disableMembershipsByUserId).to.have.been.calledWithExactly({
       userId,
       updatedByUserId,
-      domainTransaction,
     });
     expect(certificationCenterMembershipRepository.disableMembershipsByUserId).to.have.been.calledWithExactly({
       updatedByUserId,
       userId,
-      domainTransaction,
     });
     expect(userRepository.updateUserDetailsForAdministration).to.have.been.calledWithExactly({
       id: userId,
       userAttributes: anonymizedUser,
-      domainTransaction,
     });
     expect(organizationLearnerRepository.dissociateAllStudentsByUserId).to.have.been.calledWithExactly({
       userId,
-      domainTransaction,
     });
     expect(adminMemberRepository.get).to.have.been.calledWithExactly({ userId: updatedByUserId });
   });

--- a/api/tests/unit/domain/usecases/anonymize-user_test.js
+++ b/api/tests/unit/domain/usecases/anonymize-user_test.js
@@ -42,7 +42,6 @@ describe('Unit | UseCase | anonymize-user', function () {
       role,
     });
 
-
     const userRepository = {
       get: sinon.stub(),
       updateUserDetailsForAdministration: sinon.stub(),

--- a/api/tests/unit/domain/usecases/complete-assessment_test.js
+++ b/api/tests/unit/domain/usecases/complete-assessment_test.js
@@ -10,12 +10,10 @@ import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js'
 describe('Unit | UseCase | complete-assessment', function () {
   let assessmentRepository;
   let campaignParticipationBCRepository;
-  let domainTransaction;
   const now = new Date('2019-01-01T05:06:07Z');
   let clock;
 
   beforeEach(function () {
-    domainTransaction = Symbol('domainTransaction');
     assessmentRepository = {
       get: _.noop,
       completeByAssessmentId: _.noop,
@@ -41,14 +39,13 @@ describe('Unit | UseCase | complete-assessment', function () {
         id: assessmentId,
         state: 'completed',
       });
-      sinon.stub(assessmentRepository, 'get').withArgs(assessmentId, domainTransaction).resolves(completedAssessment);
+      sinon.stub(assessmentRepository, 'get').withArgs(assessmentId).resolves(completedAssessment);
     });
 
     it('should return an AlreadyRatedAssessmentError', async function () {
       // when
       const err = await catchErr(completeAssessment)({
         assessmentId,
-        domainTransaction,
         assessmentRepository,
         campaignParticipationBCRepository,
       });
@@ -72,7 +69,7 @@ describe('Unit | UseCase | complete-assessment', function () {
       // eslint-disable-next-line mocha/no-setup-in-describe
       context(`common behavior when assessment is of type ${assessment.type}`, function () {
         beforeEach(function () {
-          sinon.stub(assessmentRepository, 'get').withArgs(assessment.id, domainTransaction).resolves(assessment);
+          sinon.stub(assessmentRepository, 'get').withArgs(assessment.id).resolves(assessment);
           sinon.stub(assessmentRepository, 'completeByAssessmentId').resolves();
         });
 
@@ -80,21 +77,18 @@ describe('Unit | UseCase | complete-assessment', function () {
           // when
           await completeAssessment({
             assessmentId: assessment.id,
-            domainTransaction,
             assessmentRepository,
             campaignParticipationBCRepository,
           });
 
           // then
-          expect(assessmentRepository.completeByAssessmentId.calledWithExactly(assessment.id, domainTransaction)).to.be
-            .true;
+          expect(assessmentRepository.completeByAssessmentId.calledWithExactly(assessment.id)).to.be.true;
         });
 
         it('should return a AssessmentCompleted event', async function () {
           // when
           const result = await completeAssessment({
             assessmentId: assessment.id,
-            domainTransaction,
             assessmentRepository,
             campaignParticipationBCRepository,
           });
@@ -112,14 +106,13 @@ describe('Unit | UseCase | complete-assessment', function () {
       it('should return a AssessmentCompleted event with a userId and targetProfileId', async function () {
         const assessment = _buildCampaignAssessment();
 
-        sinon.stub(assessmentRepository, 'get').withArgs(assessment.id, domainTransaction).resolves(assessment);
+        sinon.stub(assessmentRepository, 'get').withArgs(assessment.id).resolves(assessment);
         sinon.stub(assessmentRepository, 'completeByAssessmentId').resolves();
         sinon.stub(campaignParticipationBCRepository, 'get').resolves({ id: 1 });
         sinon.stub(campaignParticipationBCRepository, 'update').resolves();
         // when
         const result = await completeAssessment({
           assessmentId: assessment.id,
-          domainTransaction,
           assessmentRepository,
           campaignParticipationBCRepository,
         });
@@ -132,23 +125,22 @@ describe('Unit | UseCase | complete-assessment', function () {
         const assessment = _buildCampaignAssessment();
         const { TO_SHARE } = CampaignParticipationStatuses;
 
-        sinon.stub(assessmentRepository, 'get').withArgs(assessment.id, domainTransaction).resolves(assessment);
+        sinon.stub(assessmentRepository, 'get').withArgs(assessment.id).resolves(assessment);
         sinon.stub(assessmentRepository, 'completeByAssessmentId').resolves();
         sinon.stub(campaignParticipationBCRepository, 'update').resolves();
         // when
         await completeAssessment({
           assessmentId: assessment.id,
-          domainTransaction,
           assessmentRepository,
           campaignParticipationBCRepository,
         });
 
         // then
         expect(
-          campaignParticipationBCRepository.update.calledWithExactly(
-            { id: assessment.campaignParticipationId, status: TO_SHARE },
-            domainTransaction,
-          ),
+          campaignParticipationBCRepository.update.calledWithExactly({
+            id: assessment.campaignParticipationId,
+            status: TO_SHARE,
+          }),
         ).to.be.true;
       });
     });
@@ -157,13 +149,12 @@ describe('Unit | UseCase | complete-assessment', function () {
       it('should return a AssessmentCompleted event with certification flag', async function () {
         const assessment = _buildCertificationAssessment();
 
-        sinon.stub(assessmentRepository, 'get').withArgs(assessment.id, domainTransaction).resolves(assessment);
+        sinon.stub(assessmentRepository, 'get').withArgs(assessment.id).resolves(assessment);
         sinon.stub(assessmentRepository, 'completeByAssessmentId').resolves();
         sinon.stub(campaignParticipationBCRepository, 'update').resolves();
         // when
         const result = await completeAssessment({
           assessmentId: assessment.id,
-          domainTransaction,
           assessmentRepository,
           campaignParticipationBCRepository,
         });

--- a/api/tests/unit/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
+++ b/api/tests/unit/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
@@ -57,7 +57,7 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
     };
 
     domainTransaction.execute = (lambda) => {
-      return lambda(Symbol());
+      return lambda();
     };
 
     organizationInvitationService.createProOrganizationInvitation.resolves();
@@ -113,7 +113,6 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
 
         // when
         const error = await catchErr(createOrganizationsWithTagsAndTargetProfiles)({
-          domainTransaction,
           organizations: [firstOrganization, secondOrganization],
           organizationRepository: organizationRepositoryStub,
           organizationForAdminRepository: organizationForAdminRepositoryStub,
@@ -161,7 +160,6 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
 
         // when
         const error = await catchErr(createOrganizationsWithTagsAndTargetProfiles)({
-          domainTransaction,
           organizations: [firstOrganization],
           organizationRepository: organizationRepositoryStub,
           organizationForAdminRepository: organizationForAdminRepositoryStub,
@@ -204,7 +202,6 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
 
     // when
     await createOrganizationsWithTagsAndTargetProfiles({
-      domainTransaction,
       organizations: organizations,
       organizationRepository: organizationRepositoryStub,
       organizationForAdminRepository: organizationForAdminRepositoryStub,
@@ -291,7 +288,6 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
 
     // when
     await createOrganizationsWithTagsAndTargetProfiles({
-      domainTransaction,
       organizations: [organizationPRO, organizationSCO],
       organizationRepository: organizationRepositoryStub,
       organizationForAdminRepository: organizationForAdminRepositoryStub,
@@ -355,7 +351,6 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
 
     // when
     await createOrganizationsWithTagsAndTargetProfiles({
-      domainTransaction,
       organizations: [firstOrganization, secondOrganization],
       organizationRepository: organizationRepositoryStub,
       organizationForAdminRepository: organizationForAdminRepositoryStub,
@@ -404,7 +399,6 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
 
     // when
     await createOrganizationsWithTagsAndTargetProfiles({
-      domainTransaction,
       organizations: [firstOrganization, secondOrganization],
       organizationRepository: organizationRepositoryStub,
       organizationForAdminRepository: organizationForAdminRepositoryStub,
@@ -460,7 +454,6 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
 
     // when
     await createOrganizationsWithTagsAndTargetProfiles({
-      domainTransaction,
       organizations: [firstOrganization, secondOrganization],
       organizationRepository: organizationRepositoryStub,
       organizationForAdminRepository: organizationForAdminRepositoryStub,
@@ -514,7 +507,6 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
 
     // when
     await createOrganizationsWithTagsAndTargetProfiles({
-      domainTransaction,
       organizations: [firstOrganizationWithAdminRole, secondOrganizationWithMemberRole],
       organizationRepository: organizationRepositoryStub,
       organizationForAdminRepository: organizationForAdminRepositoryStub,
@@ -568,7 +560,6 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
 
       // when
       await createOrganizationsWithTagsAndTargetProfiles({
-        domainTransaction,
         organizations: [organizationWithoutEmail],
         organizationRepository: organizationRepositoryStub,
         organizationForAdminRepository: organizationForAdminRepositoryStub,

--- a/api/tests/unit/domain/usecases/create-target-profile_test.js
+++ b/api/tests/unit/domain/usecases/create-target-profile_test.js
@@ -18,7 +18,6 @@ describe('Unit | UseCase | create-target-profile', function () {
 
   it('should throw a TargetProfileCannotBeCreated error with non existant owner organization', async function () {
     // given
-    const domainTransaction = Symbol('DomainTransaction');
     organizationRepositoryStub.get.rejects(new Error());
 
     // when
@@ -36,7 +35,6 @@ describe('Unit | UseCase | create-target-profile', function () {
 
     const error = await catchErr(createTargetProfile)({
       targetProfileCreationCommand,
-      domainTransaction,
       targetProfileRepository: targetProfileRepositoryStub,
       organizationRepository: organizationRepositoryStub,
     });
@@ -48,7 +46,7 @@ describe('Unit | UseCase | create-target-profile', function () {
   it('should create target profile with tubes by passing over creation command', async function () {
     // given
     organizationRepositoryStub.get.resolves();
-    const domainTransaction = Symbol('DomainTransaction');
+
     const expectedTargetProfileForCreation = domainBuilder.buildTargetProfileForCreation({
       name: 'myFirstTargetProfile',
       category: categories.SUBJECT,
@@ -75,7 +73,6 @@ describe('Unit | UseCase | create-target-profile', function () {
     };
     await createTargetProfile({
       targetProfileCreationCommand,
-      domainTransaction,
       targetProfileRepository: targetProfileRepositoryStub,
       organizationRepository: organizationRepositoryStub,
     });
@@ -83,14 +80,13 @@ describe('Unit | UseCase | create-target-profile', function () {
     // then
     expect(targetProfileRepositoryStub.create).to.have.been.calledWithExactly({
       targetProfileForCreation: expectedTargetProfileForCreation,
-      domainTransaction,
     });
   });
 
   it('should return the created target profile ID', async function () {
     // given
     organizationRepositoryStub.get.resolves();
-    const domainTransaction = Symbol('DomainTransaction');
+
     const expectedTargetProfileForCreation = domainBuilder.buildTargetProfileForCreation({
       name: 'myFirstTargetProfile',
       category: categories.SUBJECT,
@@ -104,7 +100,6 @@ describe('Unit | UseCase | create-target-profile', function () {
     targetProfileRepositoryStub.create
       .withArgs({
         targetProfileForCreation: expectedTargetProfileForCreation,
-        domainTransaction,
       })
       .resolves(123);
 
@@ -122,7 +117,6 @@ describe('Unit | UseCase | create-target-profile', function () {
     };
     const targetProfileId = await createTargetProfile({
       targetProfileCreationCommand,
-      domainTransaction,
       targetProfileRepository: targetProfileRepositoryStub,
       organizationRepository: organizationRepositoryStub,
     });

--- a/api/tests/unit/domain/usecases/handle-badge-acquisition_test.js
+++ b/api/tests/unit/domain/usecases/handle-badge-acquisition_test.js
@@ -2,7 +2,6 @@ import { handleBadgeAcquisition } from '../../../../lib/domain/usecases/handle-b
 import { domainBuilder, expect, sinon } from '../../../test-helper.js';
 
 describe('Unit | UseCase | handle-badge-acquisition', function () {
-  let domainTransaction;
   let badgeForCalculationRepository, badgeAcquisitionRepository, knowledgeElementRepository;
   let args;
 
@@ -10,12 +9,10 @@ describe('Unit | UseCase | handle-badge-acquisition', function () {
     badgeForCalculationRepository = { findByCampaignParticipationId: sinon.stub() };
     knowledgeElementRepository = { findUniqByUserId: sinon.stub() };
     badgeAcquisitionRepository = { createOrUpdate: sinon.stub() };
-    domainTransaction = Symbol('domainTransaction');
     args = {
       badgeForCalculationRepository,
       knowledgeElementRepository,
       badgeAcquisitionRepository,
-      domainTransaction,
     };
   });
 
@@ -48,9 +45,7 @@ describe('Unit | UseCase | handle-badge-acquisition', function () {
     context('when campaign has no badges', function () {
       it('should not attempt to create any badge acquisition', async function () {
         // given
-        badgeForCalculationRepository.findByCampaignParticipationId
-          .withArgs({ campaignParticipationId, domainTransaction })
-          .resolves([]);
+        badgeForCalculationRepository.findByCampaignParticipationId.withArgs({ campaignParticipationId }).resolves([]);
         knowledgeElementRepository.findUniqByUserId.rejects('I should not be called');
 
         // when
@@ -73,10 +68,10 @@ describe('Unit | UseCase | handle-badge-acquisition', function () {
       it('should create or update badge acquisitions of obtained badges', async function () {
         // given
         badgeForCalculationRepository.findByCampaignParticipationId
-          .withArgs({ campaignParticipationId, domainTransaction })
+          .withArgs({ campaignParticipationId })
           .resolves([badgeObtained1, badgeNotObtained2, badgeObtained3]);
         knowledgeElementRepository.findUniqByUserId
-          .withArgs({ userId, domainTransaction })
+          .withArgs({ userId })
           .resolves([domainBuilder.buildKnowledgeElement()]);
 
         // when
@@ -90,7 +85,6 @@ describe('Unit | UseCase | handle-badge-acquisition', function () {
         expect(badgeAcquisitionRepository.createOrUpdate).to.have.been.calledOnce;
         expect(badgeAcquisitionRepository.createOrUpdate.firstCall).to.have.been.calledWithExactly({
           badgeAcquisitionsToCreate,
-          domainTransaction,
         });
       });
     });

--- a/api/tests/unit/domain/usecases/improve-competence-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/improve-competence-evaluation_test.js
@@ -4,8 +4,6 @@ import { improveCompetenceEvaluation } from '../../../../src/evaluation/domain/u
 import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';
 
-const domainTransaction = Symbol('DomainTransaction');
-
 describe('Unit | UseCase | Improve Competence Evaluation', function () {
   let competenceEvaluation, userId, competenceEvaluationRepository, assessmentRepository;
   let getCompetenceLevel;
@@ -54,14 +52,12 @@ describe('Unit | UseCase | Improve Competence Evaluation', function () {
       getCompetenceLevel,
       userId,
       competenceId,
-      domainTransaction,
     });
 
     // then
     expect(competenceEvaluationRepository.getByCompetenceIdAndUserId).to.be.calledWith({
       competenceId,
       userId,
-      domainTransaction,
       forUpdate: true,
     });
   });
@@ -74,11 +70,10 @@ describe('Unit | UseCase | Improve Competence Evaluation', function () {
       getCompetenceLevel,
       userId,
       competenceId,
-      domainTransaction,
     });
 
     // then
-    expect(assessmentRepository.save).to.be.calledWith({ assessment: expectedAssessment, domainTransaction });
+    expect(assessmentRepository.save).to.be.calledWith({ assessment: expectedAssessment });
   });
 
   it('should update competence evaluation with newly created assessment', async function () {
@@ -89,14 +84,12 @@ describe('Unit | UseCase | Improve Competence Evaluation', function () {
       getCompetenceLevel,
       userId,
       competenceId,
-      domainTransaction,
     });
 
     // then
     expect(competenceEvaluationRepository.updateAssessmentId).to.be.calledWith({
       currentAssessmentId: competenceEvaluation.assessmentId,
       newAssessmentId: assessmentId,
-      domainTransaction,
     });
   });
 
@@ -112,7 +105,6 @@ describe('Unit | UseCase | Improve Competence Evaluation', function () {
       getCompetenceLevel,
       userId,
       competenceId,
-      domainTransaction,
     });
 
     // then
@@ -132,7 +124,6 @@ describe('Unit | UseCase | Improve Competence Evaluation', function () {
         getCompetenceLevel,
         userId,
         competenceId,
-        domainTransaction,
       });
 
       // then
@@ -166,7 +157,6 @@ describe('Unit | UseCase | Improve Competence Evaluation', function () {
         getCompetenceLevel,
         userId,
         competenceId,
-        domainTransaction,
       });
 
       // then

--- a/api/tests/unit/domain/usecases/organizations-administration/update-organization-information_test.js
+++ b/api/tests/unit/domain/usecases/organizations-administration/update-organization-information_test.js
@@ -28,28 +28,23 @@ describe('Unit | UseCase | organizations-administration | update-organization-in
     organizationForAdminRepository.get.onCall(0).returns(existingOrganizationForAdmin);
     const updatedOrganization = domainBuilder.buildOrganizationForAdmin({ organizationId: givenOrganization.id });
     organizationForAdminRepository.get.onCall(1).returns(updatedOrganization);
-    const domainTransaction = Symbol('domainTransaction');
     const tagsToUpdate = Symbol('tagsToUpdate');
-    tagRepository.findByIds.withArgs(givenOrganization.tagIds, domainTransaction).resolves(tagsToUpdate);
+    tagRepository.findByIds.withArgs(givenOrganization.tagIds).resolves(tagsToUpdate);
     // when
     const result = await updateOrganizationInformation({
       organization: givenOrganization,
       organizationForAdminRepository,
       tagRepository,
-      domainTransaction,
     });
 
     // then
-    expect(organizationForAdminRepository.get).to.have.been.calledWithExactly(givenOrganization.id, domainTransaction);
+    expect(organizationForAdminRepository.get).to.have.been.calledWithExactly(givenOrganization.id);
     expect(existingOrganizationForAdmin.updateWithDataProtectionOfficerAndTags).to.have.been.calledWithExactly(
       givenOrganization,
       givenOrganization.dataProtectionOfficer,
       tagsToUpdate,
     );
-    expect(organizationForAdminRepository.update).to.have.been.calledWithExactly(
-      existingOrganizationForAdmin,
-      domainTransaction,
-    );
+    expect(organizationForAdminRepository.update).to.have.been.calledWithExactly(existingOrganizationForAdmin);
     expect(result).to.equal(updatedOrganization);
   });
 

--- a/api/tests/unit/domain/usecases/reset-organization-learners-password_test.js
+++ b/api/tests/unit/domain/usecases/reset-organization-learners-password_test.js
@@ -42,7 +42,6 @@ describe('Unit | UseCases | Reset organization learners password', function () {
             { userId: studentIds[0], hashedPassword },
             { userId: studentIds[1], hashedPassword },
           ];
-          const domainTransaction = Symbol('transaction');
 
           organizationLearnerRepository.findByIds = sinon.stub().resolves(organizationLearnersId);
           userRepository.getByIds = sinon.stub().resolves(users);
@@ -53,7 +52,6 @@ describe('Unit | UseCases | Reset organization learners password', function () {
             organizationId,
             organizationLearnersId,
             userId,
-            domainTransaction,
             authenticationMethodRepository,
             organizationLearnerRepository,
             userRepository,
@@ -67,7 +65,6 @@ describe('Unit | UseCases | Reset organization learners password', function () {
           expect(cryptoService.hashPassword).to.have.been.callCount(2);
           expect(authenticationMethodRepository.batchUpdatePasswordThatShouldBeChanged).to.have.been.calledWithExactly({
             usersToUpdateWithNewPassword: userIdHashedPassword,
-            domainTransaction,
           });
           expect(organizationLearnersPasswordResets).to.have.deep.members([
             new OrganizationLearnerPasswordResetDTO({

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -19,7 +19,6 @@ import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js'
 describe('Unit | UseCase | retrieve-last-or-create-certification-course', function () {
   let clock;
   let now;
-  let domainTransaction;
   let verificationCode;
 
   const sessionRepository = {};
@@ -55,7 +54,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
   beforeEach(function () {
     now = new Date('2019-01-01T05:06:07Z');
     clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    domainTransaction = Symbol('someDomainTransaction');
     verificationCode = Symbol('verificationCode');
 
     assessmentRepository.save = sinon.stub();
@@ -90,7 +88,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
       // when
       const error = await catchErr(retrieveLastOrCreateCertificationCourse)({
-        domainTransaction,
         sessionId: 1,
         accessCode: 'accessCode',
         userId: 2,
@@ -117,7 +114,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
         // when
         const error = await catchErr(retrieveLastOrCreateCertificationCourse)({
-          domainTransaction,
           sessionId: 1,
           accessCode: 'accessCode',
           userId: 2,
@@ -155,7 +151,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
             // when
             const error = await catchErr(retrieveLastOrCreateCertificationCourse)({
-              domainTransaction: Symbol('someDomainTransaction'),
               sessionId: 1,
               accessCode: 'accessCode',
               userId: 2,
@@ -171,7 +166,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
         context('when the user tries to go back to the session without authorization', function () {
           it('should throw a CandidateNotAuthorizedToResumeCertificationTestError', async function () {
             // given
-            const domainTransaction = Symbol('someDomainTransaction');
             const foundSession = domainBuilder.certification.sessionManagement.buildSession.created({
               id: 1,
               accessCode: 'accessCode',
@@ -190,12 +184,11 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
             const existingCertificationCourse = domainBuilder.buildCertificationCourse({ userId: 2, sessionId: 1 });
             certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-              .withArgs({ userId: 2, sessionId: 1, domainTransaction })
+              .withArgs({ userId: 2, sessionId: 1 })
               .resolves(existingCertificationCourse);
 
             // when
             const error = await catchErr(retrieveLastOrCreateCertificationCourse)({
-              domainTransaction,
               sessionId: 1,
               accessCode: 'accessCode',
               userId: 2,
@@ -213,7 +206,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
         context('when the user is not connected with the correct account', function () {
           it('should throw a CandidateNotAuthorizedToJoinSessionError xxx', async function () {
             // given
-            const domainTransaction = Symbol('someDomainTransaction');
             const foundSession = domainBuilder.certification.sessionManagement.buildSession.created({
               id: 1,
               accessCode: 'accessCode',
@@ -236,7 +228,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
             // when
             const error = await catchErr(retrieveLastOrCreateCertificationCourse)({
-              domainTransaction,
               sessionId: 1,
               accessCode: 'accessCode',
               userId: 5,
@@ -252,7 +243,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
         context('when a certification course with provided userId and sessionId already exists', function () {
           it('return existing certification course and unauthorize candidate to start', async function () {
             // given
-            const domainTransaction = Symbol('someDomainTransaction');
             const foundSession = domainBuilder.certification.sessionManagement.buildSession.created({
               id: 1,
               accessCode: 'accessCode',
@@ -271,12 +261,11 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
             const existingCertificationCourse = domainBuilder.buildCertificationCourse({ userId: 2, sessionId: 1 });
             certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-              .withArgs({ userId: 2, sessionId: 1, domainTransaction })
+              .withArgs({ userId: 2, sessionId: 1 })
               .resolves(existingCertificationCourse);
 
             // when
             const result = await retrieveLastOrCreateCertificationCourse({
-              domainTransaction,
               sessionId: 1,
               accessCode: 'accessCode',
               userId: 2,
@@ -302,8 +291,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
           context('when the user is not certifiable', function () {
             it('should throw a UserNotAuthorizedToCertifyError', async function () {
               // given
-              const domainTransaction = Symbol('someDomainTransaction');
-
               const foundSession = domainBuilder.certification.sessionManagement.buildSession.created({
                 id: 1,
                 accessCode: 'accessCode',
@@ -320,7 +307,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
               );
 
               certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                .withArgs({ userId: 2, sessionId: 1, domainTransaction })
+                .withArgs({ userId: 2, sessionId: 1 })
                 .resolves(null);
 
               const competences = [{ id: 'rec123' }, { id: 'rec456' }];
@@ -333,7 +320,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
               // when
               const error = await catchErr(retrieveLastOrCreateCertificationCourse)({
-                domainTransaction,
                 sessionId: 1,
                 accessCode: 'accessCode',
                 userId: 2,
@@ -354,7 +340,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
             context('when a certification course has been created meanwhile', function () {
               it('should return it with flag created marked as false', async function () {
                 // given
-                const domainTransaction = Symbol('someDomainTransaction');
                 const foundSession = domainBuilder.certification.sessionManagement.buildSession.created({
                   id: 1,
                   accessCode: 'accessCode',
@@ -371,7 +356,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                 );
 
                 certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                  .withArgs({ userId: 2, sessionId: 1, domainTransaction })
+                  .withArgs({ userId: 2, sessionId: 1 })
                   .onCall(0)
                   .resolves(null);
 
@@ -390,13 +375,12 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                   sessionId: 1,
                 });
                 certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                  .withArgs({ userId: 2, sessionId: 1, domainTransaction })
+                  .withArgs({ userId: 2, sessionId: 1 })
                   .onCall(1)
                   .resolves(certificationCourseCreatedMeanwhile);
 
                 // when
                 const result = await retrieveLastOrCreateCertificationCourse({
-                  domainTransaction,
                   sessionId: 1,
                   accessCode: 'accessCode',
                   userId: 2,
@@ -417,8 +401,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
             context('when a certification still has not been created meanwhile', function () {
               it('should return it with flag created marked as true with related resources', async function () {
                 // given
-                const domainTransaction = Symbol('someDomainTransaction');
-
                 const foundSession = domainBuilder.certification.sessionManagement.buildSession.created({
                   id: 1,
                   accessCode: 'accessCode',
@@ -436,7 +418,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                   .resolves(foundCertificationCandidate);
 
                 certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                  .withArgs({ userId: 2, sessionId: 1, domainTransaction })
+                  .withArgs({ userId: 2, sessionId: 1 })
                   .resolves(null);
 
                 const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
@@ -453,9 +435,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                 const certificationCenter = domainBuilder.buildCertificationCenter({ habilitations: [] });
                 certificationCenterRepository.getBySessionId.resolves(certificationCenter);
 
-                certificationBadgesService.findStillValidBadgeAcquisitions
-                  .withArgs({ userId: 2, domainTransaction })
-                  .resolves([]);
+                certificationBadgesService.findStillValidBadgeAcquisitions.withArgs({ userId: 2 }).resolves([]);
 
                 // TODO: extraire jusqu'à la ligne 387 dans une fonction ?
                 const certificationCourseToSave = CertificationCourse.from({
@@ -468,7 +448,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                   certificationCourseToSave.toDTO(),
                 );
                 certificationCourseRepository.save
-                  .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
+                  .withArgs({ certificationCourse: certificationCourseToSave })
                   .resolves(savedCertificationCourse);
 
                 const assessmentToSave = new Assessment({
@@ -480,13 +460,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                   method: Assessment.methods.CERTIFICATION_DETERMINED,
                 });
                 const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
-                assessmentRepository.save
-                  .withArgs({ assessment: assessmentToSave, domainTransaction })
-                  .resolves(savedAssessment);
+                assessmentRepository.save.withArgs({ assessment: assessmentToSave }).resolves(savedAssessment);
 
                 // when
                 const result = await retrieveLastOrCreateCertificationCourse({
-                  domainTransaction,
                   sessionId: 1,
                   accessCode: 'accessCode',
                   userId: 2,
@@ -510,7 +487,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                   it('should not create a certification', async function () {
                     // given
                     const userId = 2;
-                    const domainTransaction = Symbol('someDomainTransaction');
 
                     const foundSession = domainBuilder.certification.sessionManagement.buildSession.created({
                       id: 1,
@@ -530,7 +506,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       .resolves(foundCertificationCandidate);
 
                     certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                      .withArgs({ userId, sessionId: 1, domainTransaction })
+                      .withArgs({ userId, sessionId: 1 })
                       .resolves(null);
 
                     const certificationCenter = domainBuilder.buildCertificationCenter({
@@ -546,7 +522,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
                     // when
                     const error = await catchErr(await retrieveLastOrCreateCertificationCourse)({
-                      domainTransaction,
                       sessionId: 1,
                       accessCode: 'accessCode',
                       userId,
@@ -564,7 +539,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                   it('should create a certification', async function () {
                     // given
                     const userId = 2;
-                    const domainTransaction = Symbol('someDomainTransaction');
 
                     const foundSession = domainBuilder.certification.sessionManagement.buildSession.created({
                       id: 1,
@@ -584,7 +558,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       .resolves(foundCertificationCandidate);
 
                     certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                      .withArgs({ userId, sessionId: 1, domainTransaction })
+                      .withArgs({ userId, sessionId: 1 })
                       .resolves(null);
 
                     _buildPlacementProfileWithTwoChallenges({
@@ -600,9 +574,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                     });
                     certificationCenterRepository.getBySessionId.resolves(certificationCenter);
 
-                    certificationBadgesService.findStillValidBadgeAcquisitions
-                      .withArgs({ userId, domainTransaction })
-                      .resolves([]);
+                    certificationBadgesService.findStillValidBadgeAcquisitions.withArgs({ userId }).resolves([]);
 
                     const user = domainBuilder.buildUser({ id: userId });
                     userRepository.get.withArgs(userId).resolves(user);
@@ -623,7 +595,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                     );
 
                     certificationCourseRepository.save
-                      .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
+                      .withArgs({ certificationCourse: certificationCourseToSave })
                       .resolves(savedCertificationCourse);
 
                     const assessmentToSave = new Assessment({
@@ -636,13 +608,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                     });
 
                     const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
-                    assessmentRepository.save
-                      .withArgs({ assessment: assessmentToSave, domainTransaction })
-                      .resolves(savedAssessment);
+                    assessmentRepository.save.withArgs({ assessment: assessmentToSave }).resolves(savedAssessment);
 
                     // when
                     const { created, certificationCourse } = await retrieveLastOrCreateCertificationCourse({
-                      domainTransaction,
                       sessionId: 1,
                       accessCode: 'accessCode',
                       userId,
@@ -679,7 +648,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         complementaryCertificationKey: complementaryCertification.key,
                         complementaryCertificationBadgeId: 100,
                       });
-                      const domainTransaction = Symbol('someDomainTransaction');
 
                       const foundSession = domainBuilder.certification.sessionManagement.buildSession.created({
                         id: 1,
@@ -688,7 +656,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       sessionRepository.get.withArgs({ id: 1 }).resolves(foundSession);
 
                       certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                        .withArgs({ userId: 2, sessionId: 1, domainTransaction })
+                        .withArgs({ userId: 2, sessionId: 1 })
                         .resolves(null);
 
                       const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
@@ -724,7 +692,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       const challengePlus3 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
 
                       certificationBadgesService.findStillValidBadgeAcquisitions
-                        .withArgs({ userId: 2, domainTransaction })
+                        .withArgs({ userId: 2 })
                         .resolves([certifiableBadgeAcquisition]);
 
                       certificationChallengesService.pickCertificationChallengesForPixPlus
@@ -756,7 +724,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         },
                       ];
                       certificationCourseRepository.save
-                        .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
+                        .withArgs({ certificationCourse: certificationCourseToSave })
                         .resolves(savedCertificationCourse);
 
                       const assessmentToSave = new Assessment({
@@ -768,13 +736,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         method: Assessment.methods.CERTIFICATION_DETERMINED,
                       });
                       const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
-                      assessmentRepository.save
-                        .withArgs({ assessment: assessmentToSave, domainTransaction })
-                        .resolves(savedAssessment);
+                      assessmentRepository.save.withArgs({ assessment: assessmentToSave }).resolves(savedAssessment);
 
                       // when
                       const result = await retrieveLastOrCreateCertificationCourse({
-                        domainTransaction,
                         sessionId: 1,
                         accessCode: 'accessCode',
                         userId: 2,
@@ -805,8 +770,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         complementaryCertificationBadgeId: 100,
                       });
 
-                      const domainTransaction = Symbol('someDomainTransaction');
-
                       const foundSession = domainBuilder.certification.sessionManagement.buildSession.created({
                         id: 1,
                         accessCode: 'accessCode',
@@ -814,7 +777,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       sessionRepository.get.withArgs({ id: 1 }).resolves(foundSession);
 
                       certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                        .withArgs({ userId: 2, sessionId: 1, domainTransaction })
+                        .withArgs({ userId: 2, sessionId: 1 })
                         .resolves(null);
 
                       const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
@@ -850,7 +813,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       const challengePlus3 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
 
                       certificationBadgesService.findStillValidBadgeAcquisitions
-                        .withArgs({ userId: 2, domainTransaction })
+                        .withArgs({ userId: 2 })
                         .resolves([certifiableBadgeAcquisition]);
 
                       certificationChallengesService.pickCertificationChallengesForPixPlus
@@ -881,7 +844,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         },
                       ];
                       certificationCourseRepository.save
-                        .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
+                        .withArgs({ certificationCourse: certificationCourseToSave })
                         .resolves(savedCertificationCourse);
 
                       const assessmentToSave = new Assessment({
@@ -893,13 +856,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         method: Assessment.methods.CERTIFICATION_DETERMINED,
                       });
                       const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
-                      assessmentRepository.save
-                        .withArgs({ assessment: assessmentToSave, domainTransaction })
-                        .resolves(savedAssessment);
+                      assessmentRepository.save.withArgs({ assessment: assessmentToSave }).resolves(savedAssessment);
 
                       // when
                       const result = await retrieveLastOrCreateCertificationCourse({
-                        domainTransaction,
                         sessionId: 1,
                         accessCode: 'accessCode',
                         userId: 2,
@@ -923,7 +883,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         const complementaryCertification = domainBuilder.buildComplementaryCertification({
                           key: 'PIX+TEST',
                         });
-                        const domainTransaction = Symbol('someDomainTransaction');
 
                         const foundSession = domainBuilder.certification.sessionManagement.buildSession.created({
                           id: 1,
@@ -932,7 +891,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         sessionRepository.get.withArgs({ id: 1 }).resolves(foundSession);
 
                         certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                          .withArgs({ userId: 2, sessionId: 1, domainTransaction })
+                          .withArgs({ userId: 2, sessionId: 1 })
                           .resolves(null);
 
                         const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
@@ -963,9 +922,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         });
                         certificationCenterRepository.getBySessionId.resolves(certificationCenter);
 
-                        certificationBadgesService.findStillValidBadgeAcquisitions
-                          .withArgs({ userId: 2, domainTransaction })
-                          .resolves([]);
+                        certificationBadgesService.findStillValidBadgeAcquisitions.withArgs({ userId: 2 }).resolves([]);
 
                         const certificationCourseToSave = CertificationCourse.from({
                           certificationCandidate: foundCertificationCandidate,
@@ -978,7 +935,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                           certificationCourseToSave.toDTO(),
                         );
                         certificationCourseRepository.save
-                          .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
+                          .withArgs({ certificationCourse: certificationCourseToSave })
                           .resolves(savedCertificationCourse);
 
                         const assessmentToSave = new Assessment({
@@ -990,13 +947,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                           method: Assessment.methods.CERTIFICATION_DETERMINED,
                         });
                         const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
-                        assessmentRepository.save
-                          .withArgs({ assessment: assessmentToSave, domainTransaction })
-                          .resolves(savedAssessment);
+                        assessmentRepository.save.withArgs({ assessment: assessmentToSave }).resolves(savedAssessment);
 
                         // when
                         const result = await retrieveLastOrCreateCertificationCourse({
-                          domainTransaction,
                           sessionId: 1,
                           accessCode: 'accessCode',
                           userId: 2,
@@ -1029,8 +983,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                           complementaryCertificationBadgeId: 100,
                         });
 
-                        const domainTransaction = Symbol('someDomainTransaction');
-
                         const foundSession = domainBuilder.certification.sessionManagement.buildSession.created({
                           id: 1,
                           accessCode: 'accessCode',
@@ -1038,7 +990,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         sessionRepository.get.withArgs({ id: 1 }).resolves(foundSession);
 
                         certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                          .withArgs({ userId: 2, sessionId: 1, domainTransaction })
+                          .withArgs({ userId: 2, sessionId: 1 })
                           .resolves(null);
 
                         const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
@@ -1070,7 +1022,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         certificationCenterRepository.getBySessionId.resolves(certificationCenter);
 
                         certificationBadgesService.findStillValidBadgeAcquisitions
-                          .withArgs({ userId: 2, domainTransaction })
+                          .withArgs({ userId: 2 })
                           .resolves([certifiableBadgeAcquisition]);
 
                         certificationChallengesService.pickCertificationChallengesForPixPlus
@@ -1101,7 +1053,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                           },
                         ];
                         certificationCourseRepository.save
-                          .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
+                          .withArgs({ certificationCourse: certificationCourseToSave })
                           .resolves(savedCertificationCourse);
 
                         const assessmentToSave = new Assessment({
@@ -1113,13 +1065,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                           method: Assessment.methods.CERTIFICATION_DETERMINED,
                         });
                         const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
-                        assessmentRepository.save
-                          .withArgs({ assessment: assessmentToSave, domainTransaction })
-                          .resolves(savedAssessment);
+                        assessmentRepository.save.withArgs({ assessment: assessmentToSave }).resolves(savedAssessment);
 
                         // when
                         const result = await retrieveLastOrCreateCertificationCourse({
-                          domainTransaction,
                           sessionId: 1,
                           accessCode: 'accessCode',
                           userId: 2,
@@ -1151,8 +1100,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         badgeKey: badge.key,
                       });
 
-                      const domainTransaction = Symbol('someDomainTransaction');
-
                       const foundSession = domainBuilder.certification.sessionManagement.buildSession.created({
                         id: 1,
                         accessCode: 'accessCode',
@@ -1160,7 +1107,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       sessionRepository.get.withArgs({ id: 1 }).resolves(foundSession);
 
                       certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                        .withArgs({ userId: 2, sessionId: 1, domainTransaction })
+                        .withArgs({ userId: 2, sessionId: 1 })
                         .resolves(null);
 
                       const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
@@ -1192,7 +1139,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       certificationCenterRepository.getBySessionId.resolves(certificationCenter);
 
                       certificationBadgesService.findStillValidBadgeAcquisitions
-                        .withArgs({ userId: 2, domainTransaction })
+                        .withArgs({ userId: 2 })
                         .resolves([badgeAcquisition]);
 
                       const certificationCourseToSave = CertificationCourse.from({
@@ -1207,7 +1154,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         certificationCourseToSave.toDTO(),
                       );
                       certificationCourseRepository.save
-                        .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
+                        .withArgs({ certificationCourse: certificationCourseToSave })
                         .resolves(savedCertificationCourse);
 
                       const assessmentToSave = new Assessment({
@@ -1219,13 +1166,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         method: Assessment.methods.CERTIFICATION_DETERMINED,
                       });
                       const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
-                      assessmentRepository.save
-                        .withArgs({ assessment: assessmentToSave, domainTransaction })
-                        .resolves(savedAssessment);
+                      assessmentRepository.save.withArgs({ assessment: assessmentToSave }).resolves(savedAssessment);
 
                       // when
                       const result = await retrieveLastOrCreateCertificationCourse({
-                        domainTransaction,
                         sessionId: 1,
                         accessCode: 'accessCode',
                         userId: 2,
@@ -1252,7 +1196,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       userid: 2,
                       badge: domainBuilder.buildBadge({ isCertifiable: true }),
                     });
-                    const domainTransaction = Symbol('someDomainTransaction');
 
                     const foundSession = domainBuilder.certification.sessionManagement.buildSession.created({
                       id: 1,
@@ -1261,7 +1204,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                     sessionRepository.get.withArgs({ id: 1 }).resolves(foundSession);
 
                     certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                      .withArgs({ userId: 2, sessionId: 1, domainTransaction })
+                      .withArgs({ userId: 2, sessionId: 1 })
                       .resolves(null);
 
                     const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
@@ -1293,7 +1236,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                     certificationCenterRepository.getBySessionId.resolves(certificationCenter);
 
                     certificationBadgesService.findStillValidBadgeAcquisitions
-                      .withArgs({ userId: 2, domainTransaction })
+                      .withArgs({ userId: 2 })
                       .resolves([badgeAcquisition]);
 
                     const certificationCourseToSave = CertificationCourse.from({
@@ -1307,7 +1250,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       certificationCourseToSave.toDTO(),
                     );
                     certificationCourseRepository.save
-                      .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
+                      .withArgs({ certificationCourse: certificationCourseToSave })
                       .resolves(savedCertificationCourse);
 
                     const assessmentToSave = new Assessment({
@@ -1319,13 +1262,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       method: Assessment.methods.CERTIFICATION_DETERMINED,
                     });
                     const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
-                    assessmentRepository.save
-                      .withArgs({ assessment: assessmentToSave, domainTransaction })
-                      .resolves(savedAssessment);
+                    assessmentRepository.save.withArgs({ assessment: assessmentToSave }).resolves(savedAssessment);
 
                     // when
                     const result = await retrieveLastOrCreateCertificationCourse({
-                      domainTransaction,
                       sessionId: 1,
                       accessCode: 'accessCode',
                       userId: 2,

--- a/api/tests/unit/domain/usecases/update-last-question-state_test.js
+++ b/api/tests/unit/domain/usecases/update-last-question-state_test.js
@@ -6,7 +6,6 @@ describe('Unit | UseCase | update-last-question-state', function () {
   const assessmentId = 'assessmentId';
   const focusedChallengeId = 'focusedChallengeId';
   const notFocusedChallengeId = 'notFocusedChallengeId';
-  let domainTransaction;
   let challengeRepository;
   let assessmentRepository;
   let lastQuestionState;
@@ -14,7 +13,6 @@ describe('Unit | UseCase | update-last-question-state', function () {
   let notFocusedChallenge;
 
   beforeEach(function () {
-    domainTransaction = Symbol('domainTransaction');
     challengeRepository = {
       get: sinon.stub(),
     };
@@ -41,16 +39,13 @@ describe('Unit | UseCase | update-last-question-state', function () {
 
     it('should call assessmentRepository.updateLastQuestionState', async function () {
       // Given
-      assessmentRepository.updateLastQuestionState
-        .withArgs({ id: assessmentId, lastQuestionState, domainTransaction })
-        .resolves();
+      assessmentRepository.updateLastQuestionState.withArgs({ id: assessmentId, lastQuestionState }).resolves();
 
       // When
       await updateLastQuestionState({
         assessmentId,
         lastQuestionState,
         challengeId: focusedChallengeId,
-        domainTransaction,
         assessmentRepository,
         challengeRepository,
       });
@@ -67,14 +62,14 @@ describe('Unit | UseCase | update-last-question-state', function () {
 
     it('should return early when challengeId is not provided', async function () {
       // Given
-      challengeRepository.get.withArgs(notFocusedChallengeId, domainTransaction).resolves(notFocusedChallenge);
+      challengeRepository.get.withArgs(notFocusedChallengeId).resolves(notFocusedChallenge);
 
       // When
       await updateLastQuestionState({
         assessmentId,
         lastQuestionState,
         challengeId: undefined,
-        domainTransaction,
+
         assessmentRepository,
         challengeRepository,
       });
@@ -86,14 +81,14 @@ describe('Unit | UseCase | update-last-question-state', function () {
 
     it('should early return if challenge is not focused', async function () {
       // Given
-      challengeRepository.get.withArgs(notFocusedChallengeId, domainTransaction).resolves(notFocusedChallenge);
+      challengeRepository.get.withArgs(notFocusedChallengeId).resolves(notFocusedChallenge);
 
       // When
       await updateLastQuestionState({
         assessmentId,
         lastQuestionState,
         challengeId: notFocusedChallengeId,
-        domainTransaction,
+
         assessmentRepository,
         challengeRepository,
       });
@@ -105,21 +100,21 @@ describe('Unit | UseCase | update-last-question-state', function () {
     context('when challenge is focused', function () {
       it('should return early if the provided challenge id differs from assessment.lastChallengeId in repository', async function () {
         // Given
-        challengeRepository.get.withArgs(focusedChallengeId, domainTransaction).resolves(focusedChallenge);
+        challengeRepository.get.withArgs(focusedChallengeId).resolves(focusedChallenge);
 
         const assessment = domainBuilder.buildAssessment({
           id: assessmentId,
           lastChallengeId: notFocusedChallengeId,
           state: 'started',
         });
-        assessmentRepository.get.withArgs(assessmentId, domainTransaction).resolves(assessment);
+        assessmentRepository.get.withArgs(assessmentId).resolves(assessment);
 
         // When
         await updateLastQuestionState({
           assessmentId,
           lastQuestionState,
           challengeId: focusedChallengeId,
-          domainTransaction,
+
           assessmentRepository,
           challengeRepository,
         });
@@ -130,25 +125,23 @@ describe('Unit | UseCase | update-last-question-state', function () {
 
       it('should call assessmentRepository.updateLastQuestionState when the challenge id equals assessment.lastChallengeId', async function () {
         // Given
-        challengeRepository.get.withArgs(focusedChallengeId, domainTransaction).resolves(focusedChallenge);
+        challengeRepository.get.withArgs(focusedChallengeId).resolves(focusedChallenge);
 
         const assessment = domainBuilder.buildAssessment({
           id: assessmentId,
           lastChallengeId: focusedChallengeId,
           state: 'started',
         });
-        assessmentRepository.get.withArgs(assessmentId, domainTransaction).resolves(assessment);
+        assessmentRepository.get.withArgs(assessmentId).resolves(assessment);
 
-        assessmentRepository.updateLastQuestionState
-          .withArgs({ id: assessmentId, lastQuestionState, domainTransaction })
-          .resolves();
+        assessmentRepository.updateLastQuestionState.withArgs({ id: assessmentId, lastQuestionState }).resolves();
 
         // When
         await updateLastQuestionState({
           assessmentId,
           lastQuestionState,
           challengeId: focusedChallengeId,
-          domainTransaction,
+
           assessmentRepository,
           challengeRepository,
         });

--- a/api/tests/unit/domain/usecases/update-organization-identity-provider-for-campaigns_test.js
+++ b/api/tests/unit/domain/usecases/update-organization-identity-provider-for-campaigns_test.js
@@ -8,7 +8,6 @@ describe('Unit | UseCase | Update organization identityProviderForCampaigns', fu
     context('when updating only "identityProviderForCampaigns" property', function () {
       it('updates only "identityProviderForCampaigns" property and returns updated organization domain object', async function () {
         // given
-        const domainTransaction = Symbol('domainTransaction');
         const organization = domainBuilder.buildOrganization();
         const organizationForAdminRepository = {
           get: sinon.stub().resolves(new OrganizationForAdmin({ ...organization })),
@@ -21,17 +20,13 @@ describe('Unit | UseCase | Update organization identityProviderForCampaigns', fu
           organizationId: organization.id,
           identityProviderForCampaigns: organization.identityProviderForCampaigns,
           organizationForAdminRepository,
-          domainTransaction,
         });
 
         // then
-        expect(organizationForAdminRepository.get).to.have.been.calledWithExactly(organization.id, domainTransaction);
-        expect(organizationForAdminRepository.update).to.have.been.calledWithMatch(
-          {
-            identityProviderForCampaigns: organization.identityProviderForCampaigns,
-          },
-          domainTransaction,
-        );
+        expect(organizationForAdminRepository.get).to.have.been.calledWithExactly(organization.id);
+        expect(organizationForAdminRepository.update).to.have.been.calledWithMatch({
+          identityProviderForCampaigns: organization.identityProviderForCampaigns,
+        });
       });
     });
   });
@@ -39,7 +34,6 @@ describe('Unit | UseCase | Update organization identityProviderForCampaigns', fu
   context('when organization does not exists', function () {
     it('throws an OrganizationNotFoundError', async function () {
       // given
-      const domainTransaction = Symbol('domainTransaction');
       const organizationForAdminRepository = { get: sinon.stub().resolves(), update: sinon.stub().resolves() };
       const organization = domainBuilder.buildOrganization();
 
@@ -48,11 +42,10 @@ describe('Unit | UseCase | Update organization identityProviderForCampaigns', fu
         organizationId: organization.id,
         identityProviderForCampaigns: organization.identityProviderForCampaigns,
         organizationForAdminRepository,
-        domainTransaction,
       });
 
       // then
-      expect(organizationForAdminRepository.get).to.have.been.calledWithExactly(organization.id, domainTransaction);
+      expect(organizationForAdminRepository.get).to.have.been.calledWithExactly(organization.id);
       expect(organizationForAdminRepository.update).to.not.have.been.called;
       expect(error).to.be.an.instanceOf(OrganizationNotFoundError);
     });

--- a/api/tests/unit/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler_test.js
+++ b/api/tests/unit/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler_test.js
@@ -9,7 +9,6 @@ dayjs.extend(timezone);
 
 describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCertificabilityJobHandler', function () {
   context('#handle', function () {
-    let domainTransaction;
     let pgBossRepository;
     let organizationLearnerRepository;
     let logger;
@@ -19,7 +18,6 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
     let toUserActivityDate;
 
     beforeEach(function () {
-      const transaction = Symbol('domainTransaction');
       sinon
         .stub(knex, 'transaction')
         .withArgs(sinon.match.func, { isolationLevel: 'repeatable read' })
@@ -47,10 +45,6 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
         .second(0)
         .millisecond(0)
         .toDate();
-
-      domainTransaction = {
-        knexTransaction: transaction,
-      };
 
       pgBossRepository = {
         insert: sinon.stub(),
@@ -83,7 +77,6 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
           toUserActivityDate,
           skipLoggedLastDayCheck,
           onlyNotComputed,
-          domainTransaction,
         })
         .resolves(3);
       organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability
@@ -94,7 +87,6 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
           offset: 0,
           skipLoggedLastDayCheck,
           onlyNotComputed,
-          domainTransaction,
         })
         .resolves([1, 2]);
       organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability
@@ -105,7 +97,6 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
           offset: 2,
           skipLoggedLastDayCheck,
           onlyNotComputed,
-          domainTransaction,
         })
         .resolves([3]);
       const scheduleComputeOrganizationLearnersCertificabilityJobHandler =
@@ -158,7 +149,6 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
           toUserActivityDate,
           skipLoggedLastDayCheck,
           onlyNotComputed,
-          domainTransaction,
         })
         .resolves(3);
       organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability
@@ -169,7 +159,6 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
           offset: 0,
           skipLoggedLastDayCheck,
           onlyNotComputed,
-          domainTransaction,
         })
         .resolves([1, 2]);
       organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability
@@ -180,7 +169,6 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
           offset: 2,
           skipLoggedLastDayCheck,
           onlyNotComputed,
-          domainTransaction,
         })
         .resolves([3]);
       const scheduleComputeOrganizationLearnersCertificabilityJobHandler =
@@ -241,7 +229,6 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
           toUserActivityDate,
           skipLoggedLastDayCheck,
           onlyNotComputed,
-          domainTransaction,
         })
         .resolves(30);
 
@@ -254,7 +241,6 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
             toUserActivityDate,
             skipLoggedLastDayCheck,
             onlyNotComputed,
-            domainTransaction,
           })
           .resolves([index * limit + 1, index * limit + 2, index * limit + 3]);
       }
@@ -295,7 +281,6 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
             on_complete: true,
           },
         ]);
-        expect(pgBossRepository.insert.getCall(index).args[1]).to.be.deep.equal(domainTransaction);
       }
     });
   });

--- a/api/tests/unit/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler_test.js
+++ b/api/tests/unit/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler_test.js
@@ -22,7 +22,7 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
         .stub(knex, 'transaction')
         .withArgs(sinon.match.func, { isolationLevel: 'repeatable read' })
         .callsFake((lambda) => {
-          return lambda(transaction);
+          return lambda();
         });
 
       const now = dayjs('2023-10-02T21:00:01').tz('Europe/Paris').toDate();


### PR DESCRIPTION
![8xye23](https://github.com/user-attachments/assets/e7da1d6f-cf9d-4fed-bd7a-2d074d13a9ea)

## :unicorn: Problème
Suite a [cette PR](https://github.com/1024pix/pix/pull/9423) il n'est plus necessaire de passer la transaction en argument.
On peut directement la recuperer depuis l'appel ```getConnection()``` de l'object ```DomainTransaction```.
Seulement maintenant les deux solutions coexistent et on a encore des ```domainTransaction``` partout.

## :robot: Proposition
Cette PR supprime une grade majorité de ces paramètres et utilise la méthode ```getConnection()``` dans les repositories
qui acceptaient une transaction en argument.

## :100: Pour tester
Tests au vert ? 🤷🏼 

## :rainbow: Remarques
- Je n'ai pas compris l'utilite de ```ApplicationTransaction``` alors je n'y ai pas touche. il y a quelques occurrences ici et la.
- Je n'ai pas non plus voulu toucher aux events parce que c'est une partie que je maitrise mal mais il sera toujours possible de le faire plus tard.