### PR TITLE
[TECH] Script temporaire de rescoring de complementaire (PIX-10340).

### DIFF
--- a/api/scripts/certification/rescore-complementary-certifications.js
+++ b/api/scripts/certification/rescore-complementary-certifications.js
@@ -1,0 +1,47 @@
+import 'dotenv/config';
+
+import * as url from 'node:url';
+
+import { disconnect } from '../../db/knex-database-connection.js';
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
+
+const modulePath = url.fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === modulePath;
+
+/**
+ * IMPORTANT
+ *
+ * This script is a TEMPORARY script, it is not crafter to be re-used in a context outside the one
+ * it has been made for
+ *
+ * IMPORTANT
+ *
+ * Usage : node scripts/certification/rescore-complementary-certifications.js 111[xxx,yyy,]
+ *
+ * @returns {number} process exit code
+ */
+async function main(certificationCourseIds) {
+  logger.info(`Rescoring ${certificationCourseIds.length} complementary certifications`);
+
+  return 0;
+}
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      const certificationCourseIds = process.argv[2]
+        .split(',')
+        .map((str) => parseInt(str, 10))
+        .filter(Number.isInteger);
+      const exitCode = await main(certificationCourseIds);
+      return exitCode;
+    } catch (error) {
+      logger.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+    }
+  }
+})();
+
+export { main };

--- a/api/scripts/certification/rescore-complementary-certifications.js
+++ b/api/scripts/certification/rescore-complementary-certifications.js
@@ -186,7 +186,7 @@ async function main({ certificationCourseIds = [], knex, eventDispatcher, logger
       const newComplementarySnapshot = await _snapshotCurrentScoring({ certificationCourseId, knex });
       complementaryRescoringCommand.complementaryAfterUpdate({
         statusAfterScript: newComplementarySnapshot.status,
-        complementaryAcquiredAfterScript: currentComplementarySnapshot.acquired,
+        complementaryAcquiredAfterScript: newComplementarySnapshot.acquired,
         badgeLevelAfterScript: newComplementarySnapshot.label,
         examinationDateAfterScript: newComplementarySnapshot.createdAt,
         certificationDateAfterScript: newComplementarySnapshot.publishedAt,

--- a/api/scripts/certification/rescore-complementary-certifications.js
+++ b/api/scripts/certification/rescore-complementary-certifications.js
@@ -158,6 +158,15 @@ async function main({ certificationCourseIds = [], knex, eventDispatcher, logger
       logger.info(`Rescoring certificationCourseId:[${complementaryRescoringCommand.certificationCourseId}] ...`);
       await _rescoreCertification({ complementaryRescoringCommand, eventDispatcher });
       complementaryRescoringCommand.updateSuccessfull();
+
+      const newComplementarySnapshot = await _snapshotCurrentScoring({ certificationCourseId, knex });
+      complementaryRescoringCommand.updateFailure({
+        statusBeforeScript: newComplementarySnapshot.status,
+        badgeLevelBeforeScript: newComplementarySnapshot.label,
+        examinationDateBeforeScript: newComplementarySnapshot.createdAt,
+        certificationDateBeforeScript: newComplementarySnapshot.publishedAt,
+        commentByAutoJuryBeforeScript: newComplementarySnapshot.commentByAutoJury,
+      });
     } catch (error) {
       logger.error(
         error,


### PR DESCRIPTION
## :unicorn: Problème

Des certifications complémentaires ont été passées avant l'application des nouvelles règles de scoring.

## :robot: Proposition
* Un script temporaire qui relance le scoring des complémentaires uniquement

## :rainbow: Remarques
Cela pourrait etre intéressant de vérifier le résultat des tests avec la question Metabase créée pour PIX-10341

## :100: Pour tester

* Mettre la RA en FT_ENABLE_PIX_PLUS_LOWER_LEVEL = false
* Positionner un compte sur un niveau de complémentaire maximum
* Passer une complémentaire et louper de peu le niveau N-1 (voir intervalles en base), publier les résultats
* Vérifier sur Pix App que la complémentaire est loupée
* Mettre la RA en FT_ENABLE_PIX_PLUS_LOWER_LEVEL = true et rédémarrer le container
* Déclencher le script (voir usage dans le script)
* Vérifier sur Pix App, rafraichir la page, que 
  * la date de publication n'a **pas** bougée
  * la complémentaire est acquise, au niveau inférieur du positionnement de l'utilisateur