### PR TITLE
[FEATURE] Anonymiser les info user login d'un utilisateur (PIX-11569)

### DIFF
--- a/api/lib/domain/usecases/anonymize-user.js
+++ b/api/lib/domain/usecases/anonymize-user.js
@@ -10,6 +10,7 @@ const anonymizeUser = async function ({
   organizationLearnerRepository,
   refreshTokenService,
   resetPasswordDemandRepository,
+  userLoginRepository,
   domainTransaction,
   adminMemberRepository,
 }) {
@@ -48,6 +49,8 @@ const anonymizeUser = async function ({
 
   await organizationLearnerRepository.dissociateAllStudentsByUserId({ userId, domainTransaction });
 
+  await _anonymizeUserLogin(user.id, { userLoginRepository });
+
   await userRepository.updateUserDetailsForAdministration({
     id: userId,
     userAttributes: anonymizedUser,
@@ -63,5 +66,14 @@ const anonymizeUser = async function ({
 
   return event;
 };
+
+async function _anonymizeUserLogin(userId, { userLoginRepository }) {
+  const userLogin = await userLoginRepository.findByUserId(userId);
+  if (!userLogin) return;
+
+  const anonymizedUserLogin = userLogin.anonymize();
+
+  await userLoginRepository.update(anonymizedUserLogin);
+}
 
 export { anonymizeUser };

--- a/api/lib/domain/usecases/anonymize-user.js
+++ b/api/lib/domain/usecases/anonymize-user.js
@@ -17,9 +17,14 @@ const anonymizeUser = async function ({
     firstName: '(anonymised)',
     lastName: '(anonymised)',
     email: null,
+    emailConfirmedAt: null,
     username: null,
     hasBeenAnonymised: true,
     hasBeenAnonymisedBy: updatedByUserId,
+    lastTermsOfServiceValidatedAt: null,
+    lastPixOrgaTermsOfServiceValidatedAt: null,
+    lastPixCertifTermsOfServiceValidatedAt: null,
+    lastDataProtectionPolicySeenAt: null,
     updatedAt: new Date(),
   };
 

--- a/api/src/identity-access-management/domain/models/UserLogin.js
+++ b/api/src/identity-access-management/domain/models/UserLogin.js
@@ -55,6 +55,14 @@ class UserLogin {
   isUserMarkedAsBlocked() {
     return !!this.blockedAt;
   }
+
+  anonymize() {
+    return new UserLogin({
+      ...this,
+      temporaryBlockedUntil: null,
+      blockedAt: null,
+    });
+  }
 }
 
 export { UserLogin };

--- a/api/src/shared/infrastructure/repositories/user-login-repository.js
+++ b/api/src/shared/infrastructure/repositories/user-login-repository.js
@@ -1,6 +1,7 @@
 import { knex } from '../../../../db/knex-database-connection.js';
 import { UserLogin } from '../../../identity-access-management/domain/models/UserLogin.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 
 const USER_LOGINS_TABLE_NAME = 'user-logins';
 
@@ -36,8 +37,10 @@ const create = async function (userLogin) {
 };
 
 const update = async function (userLogin) {
+  const knexCtx = DomainTransaction.getConnection();
+
   userLogin.updatedAt = new Date();
-  const [userLoginDTO] = await knex(USER_LOGINS_TABLE_NAME)
+  const [userLoginDTO] = await knexCtx(USER_LOGINS_TABLE_NAME)
     .where({ id: userLogin.id })
     .update(userLogin)
     .returning('*');

--- a/api/tests/unit/domain/models/UserLogin_test.js
+++ b/api/tests/unit/domain/models/UserLogin_test.js
@@ -283,4 +283,19 @@ describe('Unit | Domain | Models | UserLogin', function () {
       expect(userLogin.blockedAt).to.be.null;
     });
   });
+
+  describe('#anonymize', function () {
+    it('anonymizes user login info', function () {
+      // given
+      const userLogin = new UserLogin({ id: 1, temporaryBlockedUntil: new Date(), blockedAt: new Date() });
+
+      // when
+      const result = userLogin.anonymize();
+
+      // then
+      expect(result.id).to.be.equal(1);
+      expect(result.temporaryBlockedUntil).to.be.null;
+      expect(result.blockedAt).to.be.null;
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/anonymize-user_test.js
+++ b/api/tests/unit/domain/usecases/anonymize-user_test.js
@@ -1,4 +1,5 @@
 import { UserAnonymized } from '../../../../lib/domain/events/UserAnonymized.js';
+import { UserLogin } from '../../../../lib/domain/models/index.js';
 import { anonymizeUser } from '../../../../lib/domain/usecases/anonymize-user.js';
 import { expect, sinon } from '../../../test-helper.js';
 
@@ -20,7 +21,8 @@ describe('Unit | UseCase | anonymize-user', function () {
       disables all user's organisation memberships,
       disables all user's certification center memberships,
       disables all user's student prescriptions,
-      and anonymize user`, async function () {
+      anonimizes user login info
+      and anonymizes user`, async function () {
     // given
     const userId = 1;
     const userEmail = 'user@example.com';
@@ -56,8 +58,12 @@ describe('Unit | UseCase | anonymize-user', function () {
       updateUserDetailsForAdministration: sinon.stub(),
       getUserDetailsForAdmin: sinon.stub(),
     };
-    userRepository.get.withArgs(userId).resolves({ email: userEmail });
+    userRepository.get.withArgs(userId).resolves({ id: userId, email: userEmail });
     userRepository.getUserDetailsForAdmin.withArgs(userId).resolves(expectedAnonymizedUser);
+
+    const userLogin = new UserLogin();
+    const userLoginRepository = { findByUserId: sinon.stub(), update: sinon.stub() };
+    userLoginRepository.findByUserId.withArgs(userId).resolves(userLogin);
 
     const authenticationMethodRepository = { removeAllAuthenticationMethodsByUserId: sinon.stub() };
     const refreshTokenService = { revokeRefreshTokensForUserId: sinon.stub() };
@@ -78,8 +84,9 @@ describe('Unit | UseCase | anonymize-user', function () {
       certificationCenterMembershipRepository,
       organizationLearnerRepository,
       resetPasswordDemandRepository,
-      domainTransaction,
       adminMemberRepository,
+      userLoginRepository,
+      domainTransaction,
     });
 
     // then
@@ -89,27 +96,36 @@ describe('Unit | UseCase | anonymize-user', function () {
       userId,
       domainTransaction,
     });
+
     expect(refreshTokenService.revokeRefreshTokensForUserId).to.have.been.calledWithExactly({ userId });
+
     expect(resetPasswordDemandRepository.removeAllByEmail).to.have.been.calledWithExactly(userEmail);
+
     expect(membershipRepository.disableMembershipsByUserId).to.have.been.calledWithExactly({
       userId,
       updatedByUserId,
       domainTransaction,
     });
+
     expect(certificationCenterMembershipRepository.disableMembershipsByUserId).to.have.been.calledWithExactly({
-      updatedByUserId,
       userId,
+      updatedByUserId,
       domainTransaction,
     });
+
     expect(userRepository.updateUserDetailsForAdministration).to.have.been.calledWithExactly({
       id: userId,
       userAttributes: anonymizedUser,
       domainTransaction,
     });
+
     expect(organizationLearnerRepository.dissociateAllStudentsByUserId).to.have.been.calledWithExactly({
       userId,
       domainTransaction,
     });
+
+    expect(userLoginRepository.update).to.have.been.calledWith(userLogin.anonymize());
+
     expect(adminMemberRepository.get).to.have.been.calledWithExactly({ userId: updatedByUserId });
   });
 });

--- a/api/tests/unit/domain/usecases/anonymize-user_test.js
+++ b/api/tests/unit/domain/usecases/anonymize-user_test.js
@@ -30,9 +30,14 @@ describe('Unit | UseCase | anonymize-user', function () {
       firstName: '(anonymised)',
       lastName: '(anonymised)',
       email: null,
+      emailConfirmedAt: null,
       username: null,
       hasBeenAnonymised: true,
       hasBeenAnonymisedBy: 2,
+      lastTermsOfServiceValidatedAt: null,
+      lastPixOrgaTermsOfServiceValidatedAt: null,
+      lastPixCertifTermsOfServiceValidatedAt: null,
+      lastDataProtectionPolicySeenAt: null,
       updatedAt: now,
     };
     const expectedAnonymizedUser = Symbol('anonymized user');


### PR DESCRIPTION
## :unicorn: Problème

Les données de type `timestamps` ne sont pas anonymisées actuellement.

## :robot: Proposition

Mettre à `null` les données suivantes d'un utilisateurs (table `users`):
- `users.lastTermsOfServiceValidatedAt`
- `users.emailConfirmedAt`
- `users.lastPixOrgaTermsOfServiceValidatedAt`
- `users.lastPixCertifTermsOfServiceValidatedAt`
- `users.lastDataProtectionPolicySeenAt`

Mettre à `null` les données suivantes d'un utilisateurs (table `user-logins`):
- `user-logins.blockedAt`
- `user-logins.temporaryBlockedUntil`

## :rainbow: Remarques
- Ajout de `DomainTransaction.getConnection()` sur `userLoginRepository.update`

## :100: Pour tester
1. Se connecter à Pix Admin avec `superadmin@example.net`
2. Chercher un utilisateur et aller sur sa page
3. Cliquer sur "Anonymiser" et confirmer

Vérifier si les données suivantes sont à `null`:
> Table `users`:
> - `users.lastTermsOfServiceValidatedAt`
> - `users.emailConfirmedAt`
> - `users.lastPixOrgaTermsOfServiceValidatedAt`
> - `users.lastPixCertifTermsOfServiceValidatedAt`
> - `users.lastDataProtectionPolicySeenAt`
> 
> Table `user-logins`:
> - `user-logins.blockedAt`
> - `user-logins.temporaryBlockedUntil`