### PR TITLE
[BUGFIX] Certains évenements de tracking Modulix renvoient `undefined` (PIX-13579)

### DIFF
--- a/mon-pix/app/components/module/element.gjs
+++ b/mon-pix/app/components/module/element.gjs
@@ -19,7 +19,7 @@ export default class ModulixElement extends Component {
     {{#if (eq @element.type "text")}}
       <TextElement @text={{@element}} />
     {{else if (eq @element.type "image")}}
-      <ImageElement @image={{@element}} @moduleId={{@grain.module.id}} />
+      <ImageElement @image={{@element}} @openAlternativeText={{@openImageAlternativeText}} />
     {{else if (eq @element.type "video")}}
       <VideoElement @video={{@element}} @moduleId={{@grain.module.id}} />
     {{else if (eq @element.type "embed")}}

--- a/mon-pix/app/components/module/element.gjs
+++ b/mon-pix/app/components/module/element.gjs
@@ -21,7 +21,7 @@ export default class ModulixElement extends Component {
     {{else if (eq @element.type "image")}}
       <ImageElement @image={{@element}} @openAlternativeText={{@openImageAlternativeText}} />
     {{else if (eq @element.type "video")}}
-      <VideoElement @video={{@element}} @moduleId={{@grain.module.id}} />
+      <VideoElement @video={{@element}} @openTranscription={{@openTranscription}} />
     {{else if (eq @element.type "embed")}}
       <EmbedElement @embed={{@element}} />
     {{else if (eq @element.type "qcu")}}

--- a/mon-pix/app/components/module/element/image.js
+++ b/mon-pix/app/components/module/element/image.js
@@ -1,11 +1,9 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 export default class ModuleImage extends Component {
   @tracked modalIsOpen = false;
-  @service metrics;
 
   get hasAlternativeText() {
     return this.args.image.alternativeText.length > 0;
@@ -14,12 +12,7 @@ export default class ModuleImage extends Component {
   @action
   showModal() {
     this.modalIsOpen = true;
-    this.metrics.add({
-      event: 'custom-event',
-      'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.moduleId}`,
-      'pix-event-name': `Click sur le bouton alternative textuelle : ${this.args.image.id}`,
-    });
+    this.args.openAlternativeText(this.args.image.id);
   }
 
   @action

--- a/mon-pix/app/components/module/element/video.js
+++ b/mon-pix/app/components/module/element/video.js
@@ -21,12 +21,7 @@ export default class ModuleVideo extends Component {
   @action
   showModal() {
     this.modalIsOpen = true;
-    this.metrics.add({
-      event: 'custom-event',
-      'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.moduleId}`,
-      'pix-event-name': `Clic sur le bouton transcription : ${this.args.video.id}`,
-    });
+    this.args.openTranscription(this.args.video.id);
   }
 
   @action

--- a/mon-pix/app/components/module/grain.hbs
+++ b/mon-pix/app/components/module/grain.hbs
@@ -18,6 +18,7 @@
             <Module::Element
               @element={{component.element}}
               @openImageAlternativeText={{@openImageAlternativeText}}
+              @openTranscription={{@openTranscription}}
               @submitAnswer={{@submitAnswer}}
               @retryElement={{@retryElement}}
               @getLastCorrectionForElement={{this.getLastCorrectionForElement}}

--- a/mon-pix/app/components/module/grain.hbs
+++ b/mon-pix/app/components/module/grain.hbs
@@ -17,6 +17,7 @@
           <div class="grain-card-content__element">
             <Module::Element
               @element={{component.element}}
+              @openImageAlternativeText={{@openImageAlternativeText}}
               @submitAnswer={{@submitAnswer}}
               @retryElement={{@retryElement}}
               @getLastCorrectionForElement={{this.getLastCorrectionForElement}}

--- a/mon-pix/app/components/module/passage.hbs
+++ b/mon-pix/app/components/module/passage.hbs
@@ -17,6 +17,7 @@
         @retryElement={{this.trackRetry}}
         @passage={{@passage}}
         @transition={{this.grainTransition grain.id}}
+        @openImageAlternativeText={{this.openImageAlternativeText}}
         @submitAnswer={{this.submitAnswer}}
         @continueToNextStep={{this.continueToNextStep}}
         @canMoveToNextGrain={{this.grainCanMoveToNextGrain index}}

--- a/mon-pix/app/components/module/passage.hbs
+++ b/mon-pix/app/components/module/passage.hbs
@@ -18,6 +18,7 @@
         @passage={{@passage}}
         @transition={{this.grainTransition grain.id}}
         @openImageAlternativeText={{this.openImageAlternativeText}}
+        @openTranscription={{this.openTranscription}}
         @submitAnswer={{this.submitAnswer}}
         @continueToNextStep={{this.continueToNextStep}}
         @canMoveToNextGrain={{this.grainCanMoveToNextGrain index}}

--- a/mon-pix/app/components/module/passage.js
+++ b/mon-pix/app/components/module/passage.js
@@ -140,4 +140,14 @@ export default class ModulePassage extends Component {
       'pix-event-name': `Click sur le bouton alternative textuelle : ${imageElementId}`,
     });
   }
+
+  @action
+  async openTranscription(videoElementId) {
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Modulix',
+      'pix-event-action': `Passage du module : ${this.args.module.id}`,
+      'pix-event-name': `Click sur le bouton transcription : ${videoElementId}`,
+    });
+  }
 }

--- a/mon-pix/app/components/module/passage.js
+++ b/mon-pix/app/components/module/passage.js
@@ -130,4 +130,14 @@ export default class ModulePassage extends Component {
       'pix-event-name': `Click sur le bouton réessayer de l'élément : ${answerData.element.id}`,
     });
   }
+
+  @action
+  async openImageAlternativeText(imageElementId) {
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Modulix',
+      'pix-event-action': `Passage du module : ${this.args.module.id}`,
+      'pix-event-name': `Click sur le bouton alternative textuelle : ${imageElementId}`,
+    });
+  }
 }

--- a/mon-pix/tests/integration/components/module/image_test.gjs
+++ b/mon-pix/tests/integration/components/module/image_test.gjs
@@ -1,7 +1,8 @@
 import { render } from '@1024pix/ember-testing-library';
 import { click, findAll } from '@ember/test-helpers';
-import { hbs } from 'ember-cli-htmlbars';
+import ModulixImageElement from 'mon-pix/components/module/element/image';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -19,10 +20,8 @@ module('Integration | Component | Module | Image', function (hooks) {
       alternativeText: 'alternative instruction',
     };
 
-    this.set('image', imageElement);
-
     //  when
-    const screen = await render(hbs`<Module::Element::Image @image={{this.image}}/>`);
+    const screen = await render(<template><ModulixImageElement @image={{imageElement}} /></template>);
 
     // then
     assert.ok(screen);
@@ -40,16 +39,20 @@ module('Integration | Component | Module | Image', function (hooks) {
       alt: 'alt text',
       alternativeText,
     };
-
-    this.set('image', imageElement);
+    const openAlternativeTextStub = sinon.stub();
 
     //  when
-    const screen = await render(hbs`<Module::Element::Image @image={{this.image}}/>`);
+    const screen = await render(
+      <template>
+        <ModulixImageElement @image={{imageElement}} @openAlternativeText={{openAlternativeTextStub}} />
+      </template>,
+    );
 
     // then
     await click(screen.getByRole('button', { name: "Afficher l'alternative textuelle" }));
     assert.ok(await screen.findByRole('dialog'));
     assert.ok(screen.getByText(alternativeText));
+    assert.ok(openAlternativeTextStub.calledOnce);
   });
 
   test('should not be able to open the modal if there is no alternative instruction', async function (assert) {
@@ -60,10 +63,8 @@ module('Integration | Component | Module | Image', function (hooks) {
       alternativeText: '',
     };
 
-    this.set('image', imageElement);
-
     //  when
-    const screen = await render(hbs`<Module::Element::Image @image={{this.image}}/>`);
+    const screen = await render(<template><ModulixImageElement @image={{imageElement}} /></template>);
 
     // then
     const alternativeTextButton = await screen.queryByRole('button', { name: "Afficher l'alternative textuelle" });

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -463,6 +463,41 @@ module('Integration | Component | Module | Passage', function (hooks) {
     });
   });
 
+  module('when user opens an video transcription modal', function () {
+    test('should push metrics event', async function (assert) {
+      // given
+      const metrics = this.owner.lookup('service:metrics');
+      metrics.add = sinon.stub();
+
+      // given
+      const store = this.owner.lookup('service:store');
+      const element = {
+        id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
+        type: 'video',
+        title: 'Vidéo de présentation de Pix',
+        url: 'https://videos.pix.fr/modulix/didacticiel/presentation.mp4',
+        subtitles: '',
+        transcription: '<p>transcription</p>',
+      };
+      const grain = store.createRecord('grain', { title: 'Grain title', components: [{ type: 'element', element }] });
+      const module = store.createRecord('module', { id: 'module-id', title: 'Module title', grains: [grain] });
+      const passage = store.createRecord('passage');
+
+      // when
+      await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
+      await clickByName('Afficher la transcription');
+
+      // then
+      sinon.assert.calledWithExactly(metrics.add, {
+        event: 'custom-event',
+        'pix-event-category': 'Modulix',
+        'pix-event-action': `Passage du module : ${module.id}`,
+        'pix-event-name': `Click sur le bouton transcription : ${element.id}`,
+      });
+      assert.ok(true);
+    });
+  });
+
   module('when user click on next step button', function () {
     test('should push event', async function (assert) {
       // given

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -429,6 +429,40 @@ module('Integration | Component | Module | Passage', function (hooks) {
     });
   });
 
+  module('when user opens an image alternative text modal', function () {
+    test('should push metrics event', async function (assert) {
+      // given
+      const metrics = this.owner.lookup('service:metrics');
+      metrics.add = sinon.stub();
+
+      // given
+      const store = this.owner.lookup('service:store');
+      const element = {
+        id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
+        type: 'image',
+        url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg',
+        alt: "Dessin détaillé dans l'alternative textuelle",
+        alternativeText: "Dessin d'un ordinateur dans un univers spatial.",
+      };
+      const grain = store.createRecord('grain', { title: 'Grain title', components: [{ type: 'element', element }] });
+      const module = store.createRecord('module', { id: 'module-id', title: 'Module title', grains: [grain] });
+      const passage = store.createRecord('passage');
+
+      // when
+      await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
+      await clickByName("Afficher l'alternative textuelle");
+
+      // then
+      sinon.assert.calledWithExactly(metrics.add, {
+        event: 'custom-event',
+        'pix-event-category': 'Modulix',
+        'pix-event-action': `Passage du module : ${module.id}`,
+        'pix-event-name': `Click sur le bouton alternative textuelle : ${element.id}`,
+      });
+      assert.ok(true);
+    });
+  });
+
   module('when user click on next step button', function () {
     test('should push event', async function (assert) {
       // given

--- a/mon-pix/tests/integration/components/module/video_test.gjs
+++ b/mon-pix/tests/integration/components/module/video_test.gjs
@@ -1,7 +1,8 @@
 import { render } from '@1024pix/ember-testing-library';
 import { click, findAll } from '@ember/test-helpers';
-import { hbs } from 'ember-cli-htmlbars';
+import ModulixVideoElement from 'mon-pix/components/module/element/video';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -19,10 +20,8 @@ module('Integration | Component | Module | Video', function (hooks) {
       transcription: '',
     };
 
-    this.set('video', videoElement);
-
     //  when
-    const screen = await render(hbs`<Module::Element::Video @video={{this.video}}/>`);
+    const screen = await render(<template><ModulixVideoElement @video={{videoElement}} /></template>);
 
     // then
     assert.ok(screen);
@@ -41,10 +40,8 @@ module('Integration | Component | Module | Video', function (hooks) {
       transcription: 'transcription',
     };
 
-    this.set('video', videoElement);
-
     //  when
-    await render(hbs`<Module::Element::Video @video={{this.video}}/>`);
+    await render(<template><ModulixVideoElement @video={{videoElement}} /></template>);
 
     // then
     assert.dom('video > track').exists();
@@ -61,10 +58,8 @@ module('Integration | Component | Module | Video', function (hooks) {
       transcription: 'transcription',
     };
 
-    this.set('video', videoElement);
-
     //  when
-    await render(hbs`<Module::Element::Video @video={{this.video}}/>`);
+    await render(<template><ModulixVideoElement @video={{videoElement}} /></template>);
 
     // then
     assert.dom('video > track').doesNotExist();
@@ -80,33 +75,33 @@ module('Integration | Component | Module | Video', function (hooks) {
       subtitles: 'subtitles',
       transcription: 'transcription',
     };
-
-    this.set('video', videoElement);
+    const openTranscriptionStub = sinon.stub();
 
     //  when
-    const screen = await render(hbs`<Module::Element::Video @video={{this.video}}/>`);
+    const screen = await render(
+      <template><ModulixVideoElement @video={{videoElement}} @openTranscription={{openTranscriptionStub}} /></template>,
+    );
 
     // then
     await click(screen.getByRole('button', { name: 'Afficher la transcription' }));
     assert.ok(await screen.findByRole('dialog'));
     assert.ok(screen.getByText('transcription'));
+    assert.ok(openTranscriptionStub.calledOnce);
   });
 
   test('should not be able to open the modal if there is no transcription', async function (assert) {
     // given
     const url = 'https://videos.pix.fr/modulix/placeholder-video.mp4';
 
-    const video = {
+    const videoElement = {
       url,
       title: 'title',
       subtitles: 'subtitles',
       transcription: '',
     };
 
-    this.set('video', video);
-
     //  when
-    const screen = await render(hbs`<Module::Element::Video @video={{this.video}}/>`);
+    const screen = await render(<template><ModulixVideoElement @video={{videoElement}} /></template>);
 
     // then
     const transcriptionButton = await screen.queryByRole('button', { name: 'Afficher la transcription' });

--- a/mon-pix/tests/unit/components/module/image_test.gjs
+++ b/mon-pix/tests/unit/components/module/image_test.gjs
@@ -33,7 +33,7 @@ module('Unit | Component | Module | Image', function (hooks) {
       // given
       const image = { id: 'image-id' };
 
-      const component = createGlimmerComponent('module/element/image', { image });
+      const component = createGlimmerComponent('module/element/image', { image, openAlternativeText: sinon.stub() });
       assert.false(component.modalIsOpen);
 
       // when
@@ -41,31 +41,6 @@ module('Unit | Component | Module | Image', function (hooks) {
 
       // then
       assert.true(component.modalIsOpen);
-    });
-
-    test('should call metrics service', async function (assert) {
-      // given
-      const image = { id: 'image-id' };
-      const moduleId = 'module-id';
-
-      const metrics = this.owner.lookup('service:metrics');
-      metrics.add = sinon.stub();
-
-      const component = createGlimmerComponent('module/element/image', { image, moduleId });
-      assert.false(component.modalIsOpen);
-
-      // when
-      component.showModal();
-
-      // then
-      assert.true(
-        metrics.add.calledWithExactly({
-          event: 'custom-event',
-          'pix-event-category': 'Modulix',
-          'pix-event-action': `Passage du module : ${moduleId}`,
-          'pix-event-name': `Click sur le bouton alternative textuelle : ${image.id}`,
-        }),
-      );
     });
   });
 
@@ -75,7 +50,7 @@ module('Unit | Component | Module | Image', function (hooks) {
         // given
         const image = { id: 'image-id' };
 
-        const component = createGlimmerComponent('module/element/image', { image });
+        const component = createGlimmerComponent('module/element/image', { image, openAlternativeText: sinon.stub() });
         assert.false(component.modalIsOpen);
 
         component.showModal();

--- a/mon-pix/tests/unit/components/module/video_test.gjs
+++ b/mon-pix/tests/unit/components/module/video_test.gjs
@@ -78,7 +78,7 @@ module('Unit | Component | Module | Video', function (hooks) {
       const metrics = this.owner.lookup('service:metrics');
       metrics.add = () => {};
 
-      const component = createGlimmerComponent('module/element/video', { video });
+      const component = createGlimmerComponent('module/element/video', { video, openTranscription: sinon.stub() });
       assert.false(component.modalIsOpen);
 
       // when
@@ -86,31 +86,6 @@ module('Unit | Component | Module | Video', function (hooks) {
 
       // then
       assert.true(component.modalIsOpen);
-    });
-
-    test('should call metrics service', async function (assert) {
-      // given
-      const video = { id: 'video-id' };
-      const moduleId = 'module-id';
-
-      const metrics = this.owner.lookup('service:metrics');
-      metrics.add = sinon.stub();
-
-      const component = createGlimmerComponent('module/element/video', { video, moduleId });
-      assert.false(component.modalIsOpen);
-
-      // when
-      component.showModal();
-
-      // then
-      assert.true(
-        metrics.add.calledWithExactly({
-          event: 'custom-event',
-          'pix-event-category': 'Modulix',
-          'pix-event-action': `Passage du module : ${moduleId}`,
-          'pix-event-name': `Clic sur le bouton transcription : ${video.id}`,
-        }),
-      );
     });
   });
 
@@ -120,7 +95,7 @@ module('Unit | Component | Module | Video', function (hooks) {
         // given
         const video = { id: 'video-id' };
 
-        const component = createGlimmerComponent('module/element/video', { video });
+        const component = createGlimmerComponent('module/element/video', { video, openTranscription: sinon.stub() });
         assert.false(component.modalIsOpen);
 
         component.showModal();


### PR DESCRIPTION
## :unicorn: Problème
Les événements envoyés de tracking sur les éléments Image et vidéo pour informer respectivement
- que l’alternative textuelle est ouverte
- que la transcription est ouverte

ne fonctionnent pas bien. Le slug du module est incorrect dans ces événements.

## :robot: Proposition
Remonter les événements de tracking au même endroits que les autres : dans le passage.

## :rainbow: Remarques
Petite migration .gjs de nos fichiers de tests.

## :100: Pour tester
La RA a été configurée en mode débug du tracking, on doit pouvoir visualiser tous les événements qui passent via [cette URL](https://app-pr9659.review.pix.fr/modules/bien-ecrire-son-adresse-mail/passage?mtmPreviewMode=vTthsYIi).

Vérifier que les événements de tracking de ces 2 features ne contiennent plus `undefined`.
