### PR TITLE
[FEATURE] Enregistrer les retours d'embed dans l'api pour Modulix (PIX-13094) (PIX-13095)

### DIFF
--- a/api/src/devcomp/domain/models/EmbedCorrectionResponse.js
+++ b/api/src/devcomp/domain/models/EmbedCorrectionResponse.js
@@ -1,0 +1,15 @@
+import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.js';
+
+class EmbedCorrectionResponse {
+  constructor({ status, feedback, solution }) {
+    assertNotNullOrUndefined(status, 'The result is required for a embed response');
+    assertNotNullOrUndefined(feedback, 'The feedback is required for a embed response');
+    assertNotNullOrUndefined(solution, 'The id of the correct proposal is required for a embed response');
+
+    this.status = status;
+    this.feedback = feedback;
+    this.solution = solution;
+  }
+}
+
+export { EmbedCorrectionResponse };

--- a/api/src/devcomp/domain/models/EmbedCorrectionResponse.js
+++ b/api/src/devcomp/domain/models/EmbedCorrectionResponse.js
@@ -1,13 +1,12 @@
 import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.js';
 
 class EmbedCorrectionResponse {
-  constructor({ status, feedback, solution }) {
+  constructor({ status, solution }) {
     assertNotNullOrUndefined(status, 'The result is required for a embed response');
-    assertNotNullOrUndefined(feedback, 'The feedback is required for a embed response');
     assertNotNullOrUndefined(solution, 'The id of the correct proposal is required for a embed response');
 
     this.status = status;
-    this.feedback = feedback;
+    this.feedback = '';
     this.solution = solution;
   }
 }

--- a/api/src/devcomp/domain/models/element/Embed-for-answer-verification.js
+++ b/api/src/devcomp/domain/models/element/Embed-for-answer-verification.js
@@ -1,0 +1,57 @@
+import Joi from 'joi';
+
+import { EntityValidationError } from '../../../../shared/domain/errors.js';
+import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { EmbedCorrectionResponse } from '../EmbedCorrectionResponse.js';
+import { Feedbacks } from '../Feedbacks.js';
+import { ValidatorEmbed } from '../validator/ValidatorEmbed.js';
+import { Embed } from './Embed.js';
+
+class EmbedForAnswerVerification extends Embed {
+  userResponse;
+  constructor({ id, instruction, solution, feedbacks, validator, title, url, height }) {
+    super({ id, instruction, isCompletionRequired: true, title, url, height });
+
+    assertNotNullOrUndefined(solution, 'The solution is required for a verification embed');
+
+    this.solution = { value: solution };
+
+    if (feedbacks) {
+      this.feedbacks = new Feedbacks(feedbacks);
+    }
+
+    if (validator) {
+      this.validator = validator;
+    } else {
+      this.validator = new ValidatorEmbed({ solution: this.solution });
+    }
+  }
+
+  setUserResponse(userResponse) {
+    this.#validateUserResponseFormat(userResponse);
+    this.userResponse = userResponse;
+  }
+
+  assess() {
+    const validation = this.validator.assess({ answer: { value: this.userResponse } });
+
+    return new EmbedCorrectionResponse({
+      status: validation.result,
+      feedback: validation.result.isOK() ? this.feedbacks.valid : this.feedbacks.invalid,
+      solution: this.solution.value,
+    });
+  }
+
+  #validateUserResponseFormat(userResponse) {
+    const validUserResponseSchema = Joi.string()
+      .pattern(/^[a-z]+$/)
+      .required();
+
+    const { error } = validUserResponseSchema.validate(userResponse);
+    if (error) {
+      throw EntityValidationError.fromJoiErrors(error.details);
+    }
+  }
+}
+
+export { EmbedForAnswerVerification };

--- a/api/src/devcomp/domain/models/validator/ValidatorEmbed.js
+++ b/api/src/devcomp/domain/models/validator/ValidatorEmbed.js
@@ -1,0 +1,24 @@
+import solutionServiceEmbed from '../../services/solution-service-embed.js';
+import { Validation } from './Validation.js';
+import { Validator } from './Validator.js';
+
+/**
+ * Traduction: Vérificateur de réponse pour un embed
+ */
+class ValidatorEmbed extends Validator {
+  constructor({ solution, dependencies = { solutionServiceEmbed } } = {}) {
+    super({ solution });
+    this.dependencies = dependencies;
+  }
+
+  assess({ answer }) {
+    const result = this.dependencies.solutionServiceEmbed.match(answer.value, this.solution.value);
+
+    return new Validation({
+      result,
+      resultDetails: null,
+    });
+  }
+}
+
+export { ValidatorEmbed };

--- a/api/src/devcomp/domain/services/solution-service-embed.js
+++ b/api/src/devcomp/domain/services/solution-service-embed.js
@@ -1,0 +1,10 @@
+import { AnswerStatus } from '../models/validator/AnswerStatus.js';
+
+const match = function (answer, solution) {
+  if (answer === solution) {
+    return AnswerStatus.OK;
+  }
+  return AnswerStatus.KO;
+};
+
+export default { match };

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -381,7 +381,7 @@
             "type": "embed",
             "isCompletionRequired": true,
             "title": "Simulateur de visioconférence - micro ouvert",
-            "url": "https://epreuves.pix.fr/visio/visio.html?mode=visio2",
+            "url": "https://epreuves.pix.fr/visio/visio.html?mode=modulix-didacticiel",
             "instruction": "<p>Vous participez à la visioconférence ci-dessous.</p><p>Il y a du bruit à côté de vous.</p><p>Coupez le son de votre micro pour ne pas déranger vos interlocuteurs.</p>",
             "solution": "toto",
             "height": 600

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -383,6 +383,7 @@
             "title": "Simulateur de visioconférence - micro ouvert",
             "url": "https://epreuves.pix.fr/visio/visio.html?mode=visio2",
             "instruction": "<p>Vous participez à la visioconférence ci-dessous.</p><p>Il y a du bruit à côté de vous.</p><p>Coupez le son de votre micro pour ne pas déranger vos interlocuteurs.</p>",
+            "solution": "toto",
             "height": 600
           }
         }

--- a/api/src/devcomp/infrastructure/factories/element-for-verification-factory.js
+++ b/api/src/devcomp/infrastructure/factories/element-for-verification-factory.js
@@ -1,5 +1,6 @@
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { ElementInstantiationError } from '../../domain/errors.js';
+import { EmbedForAnswerVerification } from '../../domain/models/element/Embed-for-answer-verification.js';
 import { QCMForAnswerVerification } from '../../domain/models/element/QCM-for-answer-verification.js';
 import { QCUForAnswerVerification } from '../../domain/models/element/QCU-for-answer-verification.js';
 import { QROCMForAnswerVerification } from '../../domain/models/element/QROCM-for-answer-verification.js';
@@ -16,6 +17,8 @@ export class ElementForVerificationFactory {
           return ElementForVerificationFactory.#buildQCUForAnswerVerification(elementData);
         case 'qrocm':
           return ElementForVerificationFactory.#buildQROCMForAnswerVerification(elementData);
+        case 'embed':
+          return ElementForVerificationFactory.#buildEmbedForAnswerVerification(elementData);
         default:
           logger.warn({
             event: 'module_element_type_not_handled_for_verification',
@@ -68,5 +71,9 @@ export class ElementForVerificationFactory {
       proposals: element.proposals,
       feedbacks: element.feedbacks,
     });
+  }
+
+  static #buildEmbedForAnswerVerification(element) {
+    return new EmbedForAnswerVerification(element);
   }
 }

--- a/api/tests/devcomp/unit/domain/models/EmbedCorrectionResponse_test.js
+++ b/api/tests/devcomp/unit/domain/models/EmbedCorrectionResponse_test.js
@@ -7,15 +7,14 @@ describe('Unit | Devcomp | Domain | Models | EmbedCorrectionResponse', function 
     it('should create a embed correction response and keep attributes', function () {
       // given
       const status = AnswerStatus.OK;
-      const feedback = 'Bien joué !';
 
       // when
-      const embedCorrectionResponse = new EmbedCorrectionResponse({ status, feedback, solution: 'toto' });
+      const embedCorrectionResponse = new EmbedCorrectionResponse({ status, solution: 'toto' });
 
       // then
       expect(embedCorrectionResponse).not.to.be.undefined;
       expect(embedCorrectionResponse.status).to.deep.equal(status);
-      expect(embedCorrectionResponse.feedback).to.equal(feedback);
+      expect(embedCorrectionResponse.feedback).to.equal('');
       expect(embedCorrectionResponse.solution).to.equal('toto');
     });
   });
@@ -23,14 +22,6 @@ describe('Unit | Devcomp | Domain | Models | EmbedCorrectionResponse', function 
   describe('A QCU correction response without status', function () {
     it('should throw an error', function () {
       expect(() => new EmbedCorrectionResponse({})).to.throw('The result is required for a embed response');
-    });
-  });
-
-  describe('A QCU correction response without feedback', function () {
-    it('should throw an error', function () {
-      expect(() => new EmbedCorrectionResponse({ status: AnswerStatus.OK })).to.throw(
-        'The feedback is required for a embed response',
-      );
     });
   });
 

--- a/api/tests/devcomp/unit/domain/models/EmbedCorrectionResponse_test.js
+++ b/api/tests/devcomp/unit/domain/models/EmbedCorrectionResponse_test.js
@@ -1,0 +1,44 @@
+import { EmbedCorrectionResponse } from '../../../../../src/devcomp/domain/models/EmbedCorrectionResponse.js';
+import { AnswerStatus } from '../../../../../src/devcomp/domain/models/validator/AnswerStatus.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | EmbedCorrectionResponse', function () {
+  describe('#constructor', function () {
+    it('should create a embed correction response and keep attributes', function () {
+      // given
+      const status = AnswerStatus.OK;
+      const feedback = 'Bien joué !';
+
+      // when
+      const embedCorrectionResponse = new EmbedCorrectionResponse({ status, feedback, solution: 'toto' });
+
+      // then
+      expect(embedCorrectionResponse).not.to.be.undefined;
+      expect(embedCorrectionResponse.status).to.deep.equal(status);
+      expect(embedCorrectionResponse.feedback).to.equal(feedback);
+      expect(embedCorrectionResponse.solution).to.equal('toto');
+    });
+  });
+
+  describe('A QCU correction response without status', function () {
+    it('should throw an error', function () {
+      expect(() => new EmbedCorrectionResponse({})).to.throw('The result is required for a embed response');
+    });
+  });
+
+  describe('A QCU correction response without feedback', function () {
+    it('should throw an error', function () {
+      expect(() => new EmbedCorrectionResponse({ status: AnswerStatus.OK })).to.throw(
+        'The feedback is required for a embed response',
+      );
+    });
+  });
+
+  describe('A QCU correction response without proposal id', function () {
+    it('should throw an error', function () {
+      expect(() => new EmbedCorrectionResponse({ status: AnswerStatus.OK, feedback: 'Bien joué !' })).to.throw(
+        'The id of the correct proposal is required for a embed response',
+      );
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/models/element/Embed-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Embed-for-answer-verification_test.js
@@ -1,0 +1,214 @@
+import { EmbedForAnswerVerification } from '../../../../../../src/devcomp/domain/models/element/Embed-for-answer-verification.js';
+import { EmbedCorrectionResponse } from '../../../../../../src/devcomp/domain/models/EmbedCorrectionResponse.js';
+import { Feedbacks } from '../../../../../../src/devcomp/domain/models/Feedbacks.js';
+import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | Element | EmbedForAnswerVerification', function () {
+  describe('#constructor', function () {
+    it('should instanciate a embed For Verification with right attributes', function () {
+      // Given
+      const feedbacks = { valid: 'valid', invalid: 'invalid' };
+      const solution = Symbol('solution');
+      const expectedSolution = { value: solution };
+
+      // When
+      const embed = new EmbedForAnswerVerification({
+        id: '123',
+        title: 'Embed instance',
+        instruction: 'instruction',
+        feedbacks,
+        solution,
+        url: 'http://embed.example.net',
+        height: 800,
+      });
+
+      // Then
+      expect(embed.id).equal('123');
+      expect(embed.instruction).equal('instruction');
+      expect(embed.solution).deep.equal(expectedSolution);
+      expect(embed.feedbacks).to.be.instanceof(Feedbacks);
+    });
+
+    describe('An embed For Verification without a solution', function () {
+      it('should throw an error', function () {
+        expect(
+          () =>
+            new EmbedForAnswerVerification({
+              id: '123',
+              title: 'Embed',
+              height: 800,
+              url: 'https://embed.example.net',
+              instruction: 'toto',
+            }),
+        ).to.throw('The solution is required for a verification embed');
+      });
+    });
+  });
+
+  describe('#assess', function () {
+    it('should return a EmbedCorrectionResponse for a valid answer', function () {
+      // given
+      const stubedIsOk = sinon.stub().returns(true);
+      const assessResult = { result: { isOK: stubedIsOk } };
+      const embedSolution = Symbol('correctSolution');
+      const userResponse = embedSolution;
+
+      const validator = {
+        assess: sinon.stub(),
+      };
+      const embed = new EmbedForAnswerVerification({
+        id: 'embed-id',
+        instruction: '',
+        title: 'Embed for a valid answer',
+        height: 800,
+        url: 'https://embed.example.net',
+        feedbacks: { valid: 'OK', invalid: 'KO' },
+        solution: embedSolution,
+        validator,
+      });
+      embed.userResponse = userResponse;
+
+      validator.assess
+        .withArgs({
+          answer: {
+            value: userResponse,
+          },
+        })
+        .returns(assessResult);
+
+      const expectedCorrection = {
+        status: assessResult.result,
+        feedback: embed.feedbacks.valid,
+        solution: embedSolution,
+      };
+
+      // when
+      const correction = embed.assess();
+
+      // then
+      expect(correction).to.deep.equal(expectedCorrection);
+      expect(correction).to.deepEqualInstance(new EmbedCorrectionResponse(expectedCorrection));
+    });
+
+    it('should return a EmbedCorrectionResponse for a invalid answer', function () {
+      // given
+      const stubedIsOk = sinon.stub().returns(false);
+      const assessResult = { result: { isOK: stubedIsOk } };
+      const embedSolution = Symbol('correctSolution');
+      const userResponse = 'wrongAnswer';
+
+      const validator = {
+        assess: sinon.stub(),
+      };
+      const embed = new EmbedForAnswerVerification({
+        id: 'embed-id',
+        title: 'Embed for an invalid answer',
+        height: 800,
+        url: 'https://embed.example.net',
+        instruction: '',
+        feedbacks: { valid: 'OK', invalid: 'KO' },
+        solution: embedSolution,
+        validator,
+      });
+      embed.userResponse = userResponse;
+
+      validator.assess
+        .withArgs({
+          answer: {
+            value: userResponse,
+          },
+        })
+        .returns(assessResult);
+
+      const expectedCorrection = {
+        status: assessResult.result,
+        feedback: embed.feedbacks.invalid,
+        solution: embedSolution,
+      };
+
+      // when
+      const correction = embed.assess();
+
+      // then
+      expect(correction).to.deep.equal(expectedCorrection);
+      expect(correction).to.deepEqualInstance(new EmbedCorrectionResponse(expectedCorrection));
+    });
+  });
+
+  describe('#setUserResponse', function () {
+    describe('if userResponse is valid', function () {
+      it('should return the user response value', function () {
+        // given;
+
+        const embed = new EmbedForAnswerVerification({
+          id: 'embed-id',
+          title: 'Embed',
+          height: 800,
+          url: 'https://embed.example.net',
+          instruction: '',
+          feedbacks: { valid: 'OK', invalid: 'KO' },
+          solution: 'toto',
+        });
+
+        // when
+        embed.setUserResponse('toto');
+
+        // then
+        expect(embed.userResponse).to.deep.equal('toto');
+      });
+    });
+
+    describe('if userResponse is not valid', function () {
+      const cases = [
+        {
+          case: 'When the response number is not a string',
+          userResponse: [1],
+        },
+        {
+          case: 'When the response is not a stringified number',
+          userResponse: ['not a number'],
+        },
+        {
+          case: 'When there are more than one response',
+          userResponse: ['1', '2'],
+        },
+        {
+          case: 'When list of responses is empty',
+          userResponse: [],
+        },
+        {
+          case: 'When response is not an array',
+          userResponse: {},
+        },
+        {
+          case: 'When the list of responses is undefined',
+          userResponse: undefined,
+        },
+      ];
+
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      cases.forEach((testCase) => {
+        it(`${testCase.case}, should throw error`, function () {
+          // given
+          const userResponse = testCase.userResponse;
+          const embedSolution = '1';
+
+          const embed = new EmbedForAnswerVerification({
+            id: 'embed-id',
+            title: 'Embed',
+            height: 800,
+            url: 'https://embed.example.net',
+            instruction: '',
+            feedbacks: { valid: 'OK', invalid: 'KO' },
+            solution: embedSolution,
+          });
+
+          // when/then
+          expect(() => embed.setUserResponse(userResponse)).to.throw(EntityValidationError);
+        });
+      });
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/models/element/Embed-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Embed-for-answer-verification_test.js
@@ -1,6 +1,5 @@
 import { EmbedForAnswerVerification } from '../../../../../../src/devcomp/domain/models/element/Embed-for-answer-verification.js';
 import { EmbedCorrectionResponse } from '../../../../../../src/devcomp/domain/models/EmbedCorrectionResponse.js';
-import { Feedbacks } from '../../../../../../src/devcomp/domain/models/Feedbacks.js';
 import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
 import { expect, sinon } from '../../../../../test-helper.js';
 
@@ -8,7 +7,6 @@ describe('Unit | Devcomp | Domain | Models | Element | EmbedForAnswerVerificatio
   describe('#constructor', function () {
     it('should instanciate a embed For Verification with right attributes', function () {
       // Given
-      const feedbacks = { valid: 'valid', invalid: 'invalid' };
       const solution = Symbol('solution');
       const expectedSolution = { value: solution };
 
@@ -17,7 +15,6 @@ describe('Unit | Devcomp | Domain | Models | Element | EmbedForAnswerVerificatio
         id: '123',
         title: 'Embed instance',
         instruction: 'instruction',
-        feedbacks,
         solution,
         url: 'http://embed.example.net',
         height: 800,
@@ -27,7 +24,6 @@ describe('Unit | Devcomp | Domain | Models | Element | EmbedForAnswerVerificatio
       expect(embed.id).equal('123');
       expect(embed.instruction).equal('instruction');
       expect(embed.solution).deep.equal(expectedSolution);
-      expect(embed.feedbacks).to.be.instanceof(Feedbacks);
     });
 
     describe('An embed For Verification without a solution', function () {
@@ -63,7 +59,6 @@ describe('Unit | Devcomp | Domain | Models | Element | EmbedForAnswerVerificatio
         title: 'Embed for a valid answer',
         height: 800,
         url: 'https://embed.example.net',
-        feedbacks: { valid: 'OK', invalid: 'KO' },
         solution: embedSolution,
         validator,
       });
@@ -79,7 +74,7 @@ describe('Unit | Devcomp | Domain | Models | Element | EmbedForAnswerVerificatio
 
       const expectedCorrection = {
         status: assessResult.result,
-        feedback: embed.feedbacks.valid,
+        feedback: '',
         solution: embedSolution,
       };
 
@@ -107,7 +102,6 @@ describe('Unit | Devcomp | Domain | Models | Element | EmbedForAnswerVerificatio
         height: 800,
         url: 'https://embed.example.net',
         instruction: '',
-        feedbacks: { valid: 'OK', invalid: 'KO' },
         solution: embedSolution,
         validator,
       });
@@ -123,7 +117,7 @@ describe('Unit | Devcomp | Domain | Models | Element | EmbedForAnswerVerificatio
 
       const expectedCorrection = {
         status: assessResult.result,
-        feedback: embed.feedbacks.invalid,
+        feedback: '',
         solution: embedSolution,
       };
 
@@ -147,12 +141,11 @@ describe('Unit | Devcomp | Domain | Models | Element | EmbedForAnswerVerificatio
           height: 800,
           url: 'https://embed.example.net',
           instruction: '',
-          feedbacks: { valid: 'OK', invalid: 'KO' },
           solution: 'toto',
         });
 
         // when
-        embed.setUserResponse('toto');
+        embed.setUserResponse(['toto']);
 
         // then
         expect(embed.userResponse).to.deep.equal('toto');
@@ -201,7 +194,6 @@ describe('Unit | Devcomp | Domain | Models | Element | EmbedForAnswerVerificatio
             height: 800,
             url: 'https://embed.example.net',
             instruction: '',
-            feedbacks: { valid: 'OK', invalid: 'KO' },
             solution: embedSolution,
           });
 

--- a/api/tests/devcomp/unit/domain/models/validator/ValidatorEmbed_test.js
+++ b/api/tests/devcomp/unit/domain/models/validator/ValidatorEmbed_test.js
@@ -1,0 +1,53 @@
+import { AnswerStatus } from '../../../../../../src/devcomp/domain/models/validator/AnswerStatus.js';
+import { Validation } from '../../../../../../src/devcomp/domain/models/validator/Validation.js';
+import { ValidatorEmbed } from '../../../../../../src/devcomp/domain/models/validator/ValidatorEmbed.js';
+import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+import * as devcompDomainBuilder from '../../../../tooling/domain-builder/factory/index.js';
+
+describe('Unit | Devcomp | Domain | Models | Validator | ValidatorQCU', function () {
+  let solutionServiceEmbedStub;
+
+  beforeEach(function () {
+    solutionServiceEmbedStub = {
+      match: sinon.stub(),
+    };
+  });
+
+  describe('#assess', function () {
+    let uncorrectedAnswer;
+    let validation;
+    let validator;
+    let solution;
+
+    beforeEach(function () {
+      // given
+      solutionServiceEmbedStub.match.returns(AnswerStatus.OK);
+      solution = devcompDomainBuilder.buildSolution({ type: 'embed' });
+
+      uncorrectedAnswer = domainBuilder.buildAnswer.uncorrected();
+      validator = new ValidatorEmbed({
+        solution: solution,
+        dependencies: { solutionServiceEmbed: solutionServiceEmbedStub },
+      });
+
+      // when
+      validation = validator.assess({ answer: uncorrectedAnswer });
+    });
+
+    it('should call solutionServiceEmbed', function () {
+      // then
+      expect(solutionServiceEmbedStub.match).to.have.been.calledWithExactly(uncorrectedAnswer.value, solution.value);
+    });
+
+    it('should return a validation object with the returned status', function () {
+      const expectedValidation = domainBuilder.buildValidation({
+        result: AnswerStatus.OK,
+        resultDetails: null,
+      });
+
+      // then
+      expect(validation).to.be.an.instanceOf(Validation);
+      expect(validation).to.deep.equal(expectedValidation);
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/services/solution-service-embed_test.js
+++ b/api/tests/devcomp/unit/domain/services/solution-service-embed_test.js
@@ -1,0 +1,15 @@
+import { AnswerStatus } from '../../../../../src/devcomp/domain/models/validator/AnswerStatus.js';
+import service from '../../../../../src/devcomp/domain/services/solution-service-embed.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Services | SolutionServiceEmbed ', function () {
+  describe('if solution type is embed', function () {
+    it('should return `AnswerStatus.OK` when answer and solution are equal', function () {
+      expect(service.match('same value', 'same value')).to.deep.equal(AnswerStatus.OK);
+    });
+
+    it('should return `AnswerStatus.KO` when answer and solution are different', function () {
+      expect(service.match('answer value', 'different solution value')).to.deep.equal(AnswerStatus.KO);
+    });
+  });
+});

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/embed.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/embed.js
@@ -9,6 +9,11 @@ const embedSchema = Joi.object({
   title: htmlNotAllowedSchema.required(),
   url: Joi.string().uri().required(),
   instruction: htmlSchema.optional(),
+  solution: Joi.alternatives().conditional('isCompletionRequired', {
+    is: true,
+    then: Joi.string().required(),
+    otherwise: Joi.any().forbidden(),
+  }),
   height: Joi.number().min(0).required(),
 }).required();
 

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/embed_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/embed_test.js
@@ -1,0 +1,88 @@
+import { catchErr, expect } from '../../../../../../../test-helper.js';
+import { embedSchema } from './index.js';
+
+describe('Unit | Infrastructure | Datasources | Learning Content | Module Datasource | Embed Element', function () {
+  describe('when embed isCompletionRequired is false', function () {
+    it('should pass if there is no solution key', async function () {
+      // given
+      const sampleEmbed = {
+        id: '9f9df53e-5a23-40b4-8906-b649b915928c',
+        type: 'embed',
+        isCompletionRequired: false,
+        title: 'My embed',
+        url: 'https://examples.com/embed.html',
+        instruction: 'Do something',
+        height: 100,
+      };
+
+      // when
+      await embedSchema.validateAsync(sampleEmbed);
+
+      // then
+      expect(true).to.be.true;
+    });
+
+    it('should throw if the solution key is present', async function () {
+      // given
+      const sampleEmbed = {
+        id: '9f9df53e-5a23-40b4-8906-b649b915928c',
+        type: 'embed',
+        isCompletionRequired: false,
+        title: 'My embed',
+        url: 'https://examples.com/embed.html',
+        instruction: 'Do something',
+        solution: 'tata',
+        height: 100,
+      };
+
+      // when
+      const error = await catchErr(embedSchema.validateAsync, embedSchema)(sampleEmbed);
+
+      // then
+      expect(error).to.be.an.instanceOf(Error);
+      expect(error.message).to.equal('"solution" is not allowed');
+    });
+  });
+
+  describe('when embed isCompletionRequired is true', function () {
+    it('should throw if there is no solution key', async function () {
+      // given
+      const sampleEmbed = {
+        id: '9f9df53e-5a23-40b4-8906-b649b915928c',
+        type: 'embed',
+        isCompletionRequired: true,
+        title: 'My embed',
+        url: 'https://examples.com/embed.html',
+        instruction: 'Do something',
+        height: 100,
+      };
+
+      // when
+      const error = await catchErr(embedSchema.validateAsync, embedSchema)(sampleEmbed);
+
+      // then
+      expect(error).to.be.an.instanceOf(Error);
+      expect(error.message).to.equal('"solution" is required');
+    });
+
+    it('should pass if the solution key is present', async function () {
+      // given
+      const sampleEmbed = {
+        id: '9f9df53e-5a23-40b4-8906-b649b915928c',
+        type: 'embed',
+        isCompletionRequired: true,
+        title: 'My embed',
+        url: 'https://examples.com/embed.html',
+        instruction: 'Do something',
+        solution: 'tata',
+        height: 100,
+      };
+
+      // when
+      await embedSchema.validateAsync(sampleEmbed);
+
+      // then
+      expect(true).to.be.true;
+    });
+  });
+});

--- a/api/tests/devcomp/unit/infrastructure/factories/element-for-verification-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/element-for-verification-factory_test.js
@@ -1,4 +1,5 @@
 import { ElementInstantiationError } from '../../../../../src/devcomp/domain/errors.js';
+import { EmbedForAnswerVerification } from '../../../../../src/devcomp/domain/models/element/Embed-for-answer-verification.js';
 import { QCMForAnswerVerification } from '../../../../../src/devcomp/domain/models/element/QCM-for-answer-verification.js';
 import { QCUForAnswerVerification } from '../../../../../src/devcomp/domain/models/element/QCU-for-answer-verification.js';
 import { QROCMForAnswerVerification } from '../../../../../src/devcomp/domain/models/element/QROCM-for-answer-verification.js';
@@ -61,6 +62,28 @@ describe('Unit | Devcomp | Infrastructure | Factories | ElementForVerification',
           });
         });
       });
+    });
+
+    it('should instantiate a EmbedForAnswerVerification when given a data of type "embed"', function () {
+      // given
+      const feedbacks = { valid: 'valid', invalid: 'invalid' };
+
+      const elementData = {
+        id: '123',
+        title: 'An embed',
+        instruction: 'instruction',
+        feedbacks,
+        type: 'embed',
+        solution: 'solution',
+        url: 'http://embed.example.net',
+        height: 800,
+      };
+
+      // when
+      const element = ElementForVerificationFactory.build(elementData);
+
+      // then
+      expect(element).to.be.an.instanceOf(EmbedForAnswerVerification);
     });
 
     it('should instantiate a QCUForAnswerVerification when given a data of type "qcu"', function () {

--- a/request-delete.http
+++ b/request-delete.http
@@ -1,0 +1,5 @@
+### GET request to example server
+GET https://examples.http-client.intellij.net/get$END$
+    ?generated-in=WebStorm
+
+###

--- a/request-delete.http
+++ b/request-delete.http
@@ -1,5 +1,0 @@
-### GET request to example server
-GET https://examples.http-client.intellij.net/get$END$
-    ?generated-in=WebStorm
-
-###


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on fait un embed qui n'indique pas si la réponse est bonne, il faut que l'API puisse comparer la solution proposé avec la bonne solution

## :robot: Proposition
Ajouter un build pour les embed dans l'API de Modulix.

## :rainbow: Remarques
RAS

## :100: Pour tester
En local, lancer l'api et pix-app. Tester ensuite les 2 requêtes dans le terminal:
### Succès
```shell
curl -X POST --location "http://localhost:4200/api/passages/2/answers" \
    -H "Content-Type: application/json" \
    -d '{
          "data": {
            "attributes": {
              "element-id": "0559b68c-68a5-4816-a06e-f1c743c391e3",
              "user-response": [
                "toto"
              ]
            }
          }
        }'
```

### Echec
```shell
curl -X POST --location "http://localhost:4200/api/passages/2/answers" \
    -H "Content-Type: application/json" \
    -d '{
          "data": {
            "attributes": {
              "element-id": "0559b68c-68a5-4816-a06e-f1c743c391e3",
              "user-response": [
                "tata"
              ]
            }
          }
        }'
```