### PR TITLE
[FEATURE] Afficher les noms de classes sur 2 lignes avec ellipse

### DIFF
--- a/junior/app/styles/pages/school.scss
+++ b/junior/app/styles/pages/school.scss
@@ -46,8 +46,16 @@
 
     .item__title {
       position: relative;
-      top: 140px;
+      top: 138px;
+      left: 28%;
+      display: -webkit-box;
+      width: 44%;
+      overflow: hidden;
       font-weight: 800;
+      text-overflow: ellipsis;
+      word-break: break-word;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
     }
 
     @include device-is('desktop') {
@@ -59,6 +67,8 @@
       .item__title {
         position: relative;
         top: 175px;
+        left: 25%;
+        width: 50%;
       }
     }
   }

--- a/junior/app/templates/school/divisions.hbs
+++ b/junior/app/templates/school/divisions.hbs
@@ -2,7 +2,7 @@
 <RobotDialog>
   <Bubble @message={{t "pages.school.division-list.welcome" schoolName=@model.name}} />
 </RobotDialog>
-<div class="list list__divisions">
+<div class="list">
   {{#each @model.divisions as |division|}}
     <LinkTo @route="school.students" @query={{hash division=division}} class="divisions__item">
       <p class="item__title">{{division}}</p>

--- a/junior/app/templates/school/students.hbs
+++ b/junior/app/templates/school/students.hbs
@@ -3,7 +3,7 @@
   <Bubble @message={{t "pages.school.student-list.find-name" division=@model.division}} />
   <Bubble @message={{t "pages.school.student-list.back-to-divisions" backUrl=@model.schoolUrl}} />
 </RobotDialog>
-<div class="list list__students">
+<div class="list">
   {{#each @model.organizationLearners as |learner|}}
     <PixButton @triggerAction={{fn this.identifyUser learner}} class="students__item">
       <p>{{learner.displayName}}</p>


### PR DESCRIPTION
## :unicorn: Problème
Les noms de classes trop longs dépassaient des tuiles de classe.
![image (36)](https://github.com/user-attachments/assets/7e4cf2a0-3bfa-466d-9e81-d5318fb67183)


## :robot: Proposition
Afficher les noms de classe sur 2 lignes avec une ellipse si le nom est troooop long.

## :100: Pour tester
Depuis pix orga, importer une classe avec un nom long.
Dans Pix Junior, afficher la liste des classes de l'école.