### PR TITLE
[FEATURE] Anonymiser les info user login d'un utilisateur (PIX-11569)

### DIFF
--- a/api/lib/domain/usecases/anonymize-user.js
+++ b/api/lib/domain/usecases/anonymize-user.js
@@ -72,7 +72,7 @@ async function _anonymizeUserLogin(userId, userLoginRepository) {
 
   const anonymizedUserLogin = userLogin.anonymize();
 
-  await userLoginRepository.update(anonymizedUserLogin);
+  await userLoginRepository.update(anonymizedUserLogin, { preventUpdatedAt: true });
 }
 
 export { anonymizeUser };

--- a/api/lib/domain/usecases/anonymize-user.js
+++ b/api/lib/domain/usecases/anonymize-user.js
@@ -10,6 +10,7 @@ const anonymizeUser = async function ({
   organizationLearnerRepository,
   refreshTokenService,
   resetPasswordDemandRepository,
+  userLoginRepository,
   domainTransaction,
   adminMemberRepository,
 }) {
@@ -25,7 +26,6 @@ const anonymizeUser = async function ({
     lastPixOrgaTermsOfServiceValidatedAt: null,
     lastPixCertifTermsOfServiceValidatedAt: null,
     lastDataProtectionPolicySeenAt: null,
-    updatedAt: new Date(),
   };
 
   const user = await userRepository.get(userId);
@@ -48,6 +48,8 @@ const anonymizeUser = async function ({
 
   await organizationLearnerRepository.dissociateAllStudentsByUserId({ userId, domainTransaction });
 
+  await _anonymizeUserLogin(user.id, userLoginRepository);
+
   await userRepository.updateUserDetailsForAdministration({
     id: userId,
     userAttributes: anonymizedUser,
@@ -63,5 +65,14 @@ const anonymizeUser = async function ({
 
   return event;
 };
+
+async function _anonymizeUserLogin(userId, userLoginRepository) {
+  const userLogin = await userLoginRepository.findByUserId(userId);
+  if (!userLogin) return;
+
+  const anonymizedUserLogin = userLogin.anonymize();
+
+  await userLoginRepository.update(anonymizedUserLogin);
+}
 
 export { anonymizeUser };

--- a/api/lib/domain/usecases/anonymize-user.js
+++ b/api/lib/domain/usecases/anonymize-user.js
@@ -17,9 +17,14 @@ const anonymizeUser = async function ({
     firstName: '(anonymised)',
     lastName: '(anonymised)',
     email: null,
+    emailConfirmedAt: null,
     username: null,
     hasBeenAnonymised: true,
     hasBeenAnonymisedBy: updatedByUserId,
+    lastTermsOfServiceValidatedAt: null,
+    lastPixOrgaTermsOfServiceValidatedAt: null,
+    lastPixCertifTermsOfServiceValidatedAt: null,
+    lastDataProtectionPolicySeenAt: null,
     updatedAt: new Date(),
   };
 

--- a/api/lib/domain/usecases/anonymize-user.js
+++ b/api/lib/domain/usecases/anonymize-user.js
@@ -50,11 +50,13 @@ const anonymizeUser = async function ({
 
   await _anonymizeUserLogin(user.id, userLoginRepository);
 
-  await userRepository.updateUserDetailsForAdministration({
-    id: userId,
-    userAttributes: anonymizedUser,
-    domainTransaction,
-  });
+  await userRepository.updateUserDetailsForAdministration(
+    {
+      id: userId,
+      userAttributes: anonymizedUser,
+    },
+    { preventUpdatedAt: true },
+  );
 
   const adminMember = await adminMemberRepository.get({ userId: updatedByUserId });
   const event = new UserAnonymized({

--- a/api/src/identity-access-management/domain/models/UserLogin.js
+++ b/api/src/identity-access-management/domain/models/UserLogin.js
@@ -55,6 +55,14 @@ class UserLogin {
   isUserMarkedAsBlocked() {
     return !!this.blockedAt;
   }
+
+  anonymize() {
+    return new UserLogin({
+      ...this,
+      temporaryBlockedUntil: null,
+      blockedAt: null,
+    });
+  }
 }
 
 export { UserLogin };

--- a/api/src/identity-access-management/infrastructure/repositories/user.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user.repository.js
@@ -255,17 +255,15 @@ const updateEmail = async function ({ id, email }) {
   return new User(updatedUserEmail);
 };
 
-const updateUserDetailsForAdministration = async function ({
-  id,
-  userAttributes,
-  domainTransaction = DomainTransaction.emptyTransaction(),
-}) {
+const updateUserDetailsForAdministration = async function ({ id, userAttributes }, { preventUpdatedAt } = {}) {
+  const knexConn = DomainTransaction.getConnection();
+
   try {
-    const knexConn = domainTransaction.knexTransaction ?? knex;
-    const [userDTO] = await knexConn('users')
-      .where({ id })
-      .update({ ...userAttributes, updatedAt: new Date() })
-      .returning('*');
+    if (!preventUpdatedAt) {
+      userAttributes.updatedAt = new Date();
+    }
+
+    const [userDTO] = await knexConn('users').where({ id }).update(userAttributes).returning('*');
 
     if (!userDTO) {
       throw new UserNotFoundError(`User not found for ID ${id}`);

--- a/api/src/identity-access-management/infrastructure/repositories/user.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user.repository.js
@@ -81,7 +81,8 @@ const getByUsernameOrEmailWithRolesAndPassword = async function (username) {
  * @throws {UserNotFoundError}
  */
 const get = async function (userId) {
-  const foundUser = await knex('users').where('id', userId).first();
+  const knexConn = DomainTransaction.getConnection();
+  const foundUser = await knexConn('users').where('id', userId).first();
   if (!foundUser) throw new UserNotFoundError(`User not found for ID ${userId}`);
   return new User(foundUser);
 };

--- a/api/src/shared/infrastructure/repositories/user-login-repository.js
+++ b/api/src/shared/infrastructure/repositories/user-login-repository.js
@@ -1,6 +1,7 @@
 import { knex } from '../../../../db/knex-database-connection.js';
 import { UserLogin } from '../../../identity-access-management/domain/models/UserLogin.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 
 const USER_LOGINS_TABLE_NAME = 'user-logins';
 
@@ -17,7 +18,8 @@ function _toDomain(userLoginDTO) {
 }
 
 const findByUserId = async function (userId) {
-  const userLoginDTO = await knex.from(USER_LOGINS_TABLE_NAME).where({ userId }).first();
+  const knexConn = DomainTransaction.getConnection();
+  const userLoginDTO = await knexConn.from(USER_LOGINS_TABLE_NAME).where({ userId }).first();
   return userLoginDTO ? _toDomain(userLoginDTO) : null;
 };
 
@@ -36,8 +38,10 @@ const create = async function (userLogin) {
 };
 
 const update = async function (userLogin) {
+  const knexConn = DomainTransaction.getConnection();
+
   userLogin.updatedAt = new Date();
-  const [userLoginDTO] = await knex(USER_LOGINS_TABLE_NAME)
+  const [userLoginDTO] = await knexConn(USER_LOGINS_TABLE_NAME)
     .where({ id: userLogin.id })
     .update(userLogin)
     .returning('*');

--- a/api/src/shared/infrastructure/repositories/user-login-repository.js
+++ b/api/src/shared/infrastructure/repositories/user-login-repository.js
@@ -37,10 +37,13 @@ const create = async function (userLogin) {
   return _toDomain(userLoginDTO);
 };
 
-const update = async function (userLogin) {
+const update = async function (userLogin, { preventUpdatedAt } = {}) {
   const knexConn = DomainTransaction.getConnection();
 
-  userLogin.updatedAt = new Date();
+  if (!preventUpdatedAt) {
+    userLogin.updatedAt = new Date();
+  }
+
   const [userLoginDTO] = await knexConn(USER_LOGINS_TABLE_NAME)
     .where({ id: userLogin.id })
     .update(userLogin)

--- a/api/tests/shared/integration/infrastructure/repositories/user-login-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/user-login-repository_test.js
@@ -93,7 +93,7 @@ describe('Integration | Shared | Infrastructure | Repositories | UserLoginReposi
       clock.restore();
     });
 
-    it('should return the updated user-login', async function () {
+    it('returns the updated user-login', async function () {
       // given
       const temporaryBlockedUntil = new Date('2022-10-10');
       databaseBuilder.factory.buildUserLogin();
@@ -120,6 +120,22 @@ describe('Integration | Shared | Infrastructure | Repositories | UserLoginReposi
         blockedAt: null,
         createdAt: userLoginInDB.createdAt,
         updatedAt: now,
+      });
+    });
+
+    describe('when the preventUpdatedAt option is true', function () {
+      it('does not change updatedAt on the updated user login', async function () {
+        // given
+        databaseBuilder.factory.buildUserLogin();
+        const userLoginInDB = databaseBuilder.factory.buildUserLogin();
+        const userLoginToUpdate = new UserLogin({ id: userLoginInDB.id, updatedAt: '2022-10-10' });
+        await databaseBuilder.commit();
+
+        // when
+        const result = await userLoginRepository.update(userLoginToUpdate, { preventUpdatedAt: true });
+
+        // then
+        expect(result.updatedAt).to.deep.equal(new Date('2022-10-10'));
       });
     });
   });

--- a/api/tests/unit/domain/models/UserLogin_test.js
+++ b/api/tests/unit/domain/models/UserLogin_test.js
@@ -283,4 +283,19 @@ describe('Unit | Domain | Models | UserLogin', function () {
       expect(userLogin.blockedAt).to.be.null;
     });
   });
+
+  describe('#anonymize', function () {
+    it('anonymizes user login info', function () {
+      // given
+      const userLogin = new UserLogin({ id: 1, temporaryBlockedUntil: new Date(), blockedAt: new Date() });
+
+      // when
+      const result = userLogin.anonymize();
+
+      // then
+      expect(result.id).to.be.equal(1);
+      expect(result.temporaryBlockedUntil).to.be.null;
+      expect(result.blockedAt).to.be.null;
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/anonymize-user_test.js
+++ b/api/tests/unit/domain/usecases/anonymize-user_test.js
@@ -30,9 +30,14 @@ describe('Unit | UseCase | anonymize-user', function () {
       firstName: '(anonymised)',
       lastName: '(anonymised)',
       email: null,
+      emailConfirmedAt: null,
       username: null,
       hasBeenAnonymised: true,
       hasBeenAnonymisedBy: 2,
+      lastTermsOfServiceValidatedAt: null,
+      lastPixOrgaTermsOfServiceValidatedAt: null,
+      lastPixCertifTermsOfServiceValidatedAt: null,
+      lastDataProtectionPolicySeenAt: null,
       updatedAt: now,
     };
     const expectedAnonymizedUser = Symbol('anonymized user');

--- a/api/tests/unit/domain/usecases/anonymize-user_test.js
+++ b/api/tests/unit/domain/usecases/anonymize-user_test.js
@@ -127,7 +127,9 @@ describe('Unit | UseCase | anonymize-user', function () {
       domainTransaction,
     });
 
-    expect(userLoginRepository.update).to.have.been.calledWith(userLogin.anonymize());
+    expect(userLoginRepository.update).to.have.been.calledWithExactly(userLogin.anonymize(), {
+      preventUpdatedAt: true,
+    });
 
     expect(adminMemberRepository.get).to.have.been.calledWithExactly({ userId: updatedByUserId });
   });


### PR DESCRIPTION
## :unicorn: Problème

Les données de type `timestamps` ne sont pas anonymisées actuellement.

## :robot: Proposition

Mettre à `null` les données suivantes d'un utilisateurs (table `users`):
- `users.lastTermsOfServiceValidatedAt`
- `users.emailConfirmedAt`
- `users.lastPixOrgaTermsOfServiceValidatedAt`
- `users.lastPixCertifTermsOfServiceValidatedAt`
- `users.lastDataProtectionPolicySeenAt`

Mettre à `null` les données suivantes d'un utilisateurs (table `user-logins`):
- `user-logins.blockedAt`
- `user-logins.temporaryBlockedUntil`

## :rainbow: Remarques
- Ajout de `DomainTransaction.getConnection()` sur `userLoginRepository.update`

## :100: Pour tester
1. Se connecter à Pix Admin avec `superadmin@example.net`
2. Chercher un utilisateur et aller sur sa page
3. Cliquer sur "Anonymiser" et confirmer

Vérifier si les données suivantes sont à `null`:
> Table `users`:
> - `users.lastTermsOfServiceValidatedAt`
> - `users.emailConfirmedAt`
> - `users.lastPixOrgaTermsOfServiceValidatedAt`
> - `users.lastPixCertifTermsOfServiceValidatedAt`
> - `users.lastDataProtectionPolicySeenAt`
> 
> Table `user-logins`:
> - `user-logins.blockedAt`
> - `user-logins.temporaryBlockedUntil`