### PR TITLE
[TECH] Sauvegarder en même temps les knowledge elements reset dans le cadre d'une remise à zéro

### DIFF
--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 
 import { knex } from '../../../db/knex-database-connection.js';
-import { KnowledgeElement } from '../../domain/models/KnowledgeElement.js';
+import { KnowledgeElement } from '../../domain/models/index.js';
 import { DomainTransaction } from '../../infrastructure/DomainTransaction.js';
 import * as knowledgeElementSnapshotRepository from './knowledge-element-snapshot-repository.js';
 
@@ -79,12 +79,6 @@ const findUniqByUserIds = function (userIds) {
       return { userId, knowledgeElements };
     }),
   );
-};
-
-const save = async function (knowledgeElement) {
-  const knowledgeElementToSave = _.omit(knowledgeElement, ['id', 'createdAt']);
-  const [savedKnowledgeElement] = await knex(tableName).insert(knowledgeElementToSave).returning('*');
-  return new KnowledgeElement(savedKnowledgeElement);
 };
 
 const batchSave = async function ({ knowledgeElements, domainTransaction = DomainTransaction.emptyTransaction() }) {
@@ -184,5 +178,4 @@ export {
   findUniqByUserIdGroupedByCompetenceId,
   findUniqByUserIds,
   findValidatedGroupedByTubesWithinCampaign,
-  save,
 };

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -84,7 +84,8 @@ const findUniqByUserIds = function (userIds) {
 const batchSave = async function ({ knowledgeElements, domainTransaction = DomainTransaction.emptyTransaction() }) {
   const knexConn = domainTransaction.knexTransaction || knex;
   const knowledgeElementsToSave = knowledgeElements.map((ke) => _.omit(ke, ['id', 'createdAt']));
-  await knexConn.batchInsert(tableName, knowledgeElementsToSave);
+  const savedKnowledgeElements = await knexConn.batchInsert(tableName, knowledgeElementsToSave).returning('*');
+  return savedKnowledgeElements.map((ke) => new KnowledgeElement(ke));
 };
 
 const findUniqByUserId = function ({ userId, limitDate, domainTransaction }) {

--- a/api/src/evaluation/domain/services/scorecard-service.js
+++ b/api/src/evaluation/domain/services/scorecard-service.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import { KnowledgeElement } from '../../../../lib/domain/models/KnowledgeElement.js';
+import { KnowledgeElement } from '../../../../lib/domain/models/index.js';
 import { Assessment } from '../../../shared/domain/models/Assessment.js';
 import { CompetenceEvaluation } from '../models/CompetenceEvaluation.js';
 import { Scorecard } from '../models/Scorecard.js';
@@ -80,15 +80,8 @@ async function _resetKnowledgeElements({ userId, competenceId, knowledgeElementR
     userId,
     competenceId,
   });
-  const resetKnowledgeElementsPromises = _.map(knowledgeElements, (knowledgeElement) =>
-    _resetKnowledgeElement({ knowledgeElement, knowledgeElementRepository }),
-  );
-  return Promise.all(resetKnowledgeElementsPromises);
-}
-
-function _resetKnowledgeElement({ knowledgeElement, knowledgeElementRepository }) {
-  const resetKe = KnowledgeElement.reset(knowledgeElement);
-  return knowledgeElementRepository.save(resetKe);
+  const resetKnowledgeElements = knowledgeElements.map(KnowledgeElement.reset);
+  return knowledgeElementRepository.batchSave({ knowledgeElements: resetKnowledgeElements });
 }
 
 function _resetCompetenceEvaluation({ userId, competenceId, competenceEvaluationRepository }) {

--- a/api/tests/evaluation/unit/domain/services/scorecard-service_test.js
+++ b/api/tests/evaluation/unit/domain/services/scorecard-service_test.js
@@ -3,7 +3,7 @@ import {
   CampaignParticipationStatuses,
   CompetenceEvaluation,
 } from '../../../../../lib/domain/models/index.js';
-import { KnowledgeElement } from '../../../../../lib/domain/models/KnowledgeElement.js';
+import { KnowledgeElement } from '../../../../../lib/domain/models/index.js';
 import { Scorecard } from '../../../../../src/evaluation/domain/models/Scorecard.js';
 import * as scorecardService from '../../../../../src/evaluation/domain/services/scorecard-service.js';
 import { domainBuilder, expect, sinon } from '../../../../test-helper.js';
@@ -126,7 +126,7 @@ describe('Unit | Service | ScorecardService', function () {
         domainBuilder.buildKnowledgeElement({ id: 2, skillId: secondSkillId }),
       ];
       knowledgeElementRepository = {
-        save: sinon.stub(),
+        batchSave: sinon.stub(),
         findUniqByUserIdAndCompetenceId: sinon.stub(),
       };
       assessmentRepository = {
@@ -157,8 +157,9 @@ describe('Unit | Service | ScorecardService', function () {
           .withArgs({ userId, competenceId, status: CompetenceEvaluation.statuses.RESET })
           .resolves(updatedCompetenceEvaluation);
 
-        knowledgeElementRepository.save.withArgs(firstResetKe).resolves(resetKnowledgeElement1);
-        knowledgeElementRepository.save.withArgs(secondResetKe).resolves(resetKnowledgeElement2);
+        knowledgeElementRepository.batchSave
+          .withArgs({ knowledgeElements: [firstResetKe, secondResetKe] })
+          .resolves([resetKnowledgeElement1, resetKnowledgeElement2]);
 
         [resetKnowledgeElements, resetCampaignParticipation, resetCompetenceEvaluation] =
           await scorecardService.resetScorecard({
@@ -188,8 +189,10 @@ describe('Unit | Service | ScorecardService', function () {
         it('should reset each knowledge elements', async function () {
           // given
           const shouldResetCompetenceEvaluation = false;
-          knowledgeElementRepository.save.withArgs(firstResetKe).resolves(resetKnowledgeElement1);
-          knowledgeElementRepository.save.withArgs(secondResetKe).resolves(resetKnowledgeElement2);
+
+          knowledgeElementRepository.batchSave
+            .withArgs({ knowledgeElements: [firstResetKe, secondResetKe] })
+            .resolves([resetKnowledgeElement1, resetKnowledgeElement2]);
 
           // when
           [resetKnowledgeElements, resetCampaignParticipation] = await scorecardService.resetScorecard({
@@ -269,8 +272,9 @@ describe('Unit | Service | ScorecardService', function () {
           campaignParticipationId: campaignParticipation2.id,
         });
 
-        knowledgeElementRepository.save.withArgs(firstResetKe).resolves(firstResetKe);
-        knowledgeElementRepository.save.withArgs(secondResetKe).resolves(secondResetKe);
+        knowledgeElementRepository.batchSave
+          .withArgs({ knowledgeElements: [firstResetKe, secondResetKe] })
+          .resolves([firstResetKe, secondResetKe]);
 
         // when
         campaignParticipationRepository = {
@@ -440,8 +444,9 @@ describe('Unit | Service | ScorecardService', function () {
           const resetKe1 = KnowledgeElement.reset(resetKnowledgeElement1);
           const resetKe2 = KnowledgeElement.reset(resetKnowledgeElement2);
 
-          knowledgeElementRepository.save.withArgs(resetKnowledgeElement1).resolves(resetKe1);
-          knowledgeElementRepository.save.withArgs(resetKnowledgeElement2).resolves(resetKe2);
+          knowledgeElementRepository.batchSave
+            .withArgs({ knowledgeElements: [resetKnowledgeElement1, resetKnowledgeElement2] })
+            .resolves([resetKe1, resetKe2]);
 
           //when
           [resetKnowledgeElements, resetCampaignParticipation] = await scorecardService.resetScorecard({
@@ -471,14 +476,15 @@ describe('Unit | Service | ScorecardService', function () {
           abortByAssessmentId: sinon.stub(),
         };
         knowledgeElementRepository = {
-          save: sinon.stub(),
+          batchSave: sinon.stub(),
           findUniqByUserIdAndCompetenceId: sinon.stub(),
         };
 
         assessmentRepository.findNotAbortedCampaignAssessmentsByUserId.withArgs(userId).resolves(null);
 
-        knowledgeElementRepository.save.withArgs(firstResetKe).resolves(resetKnowledgeElement1);
-        knowledgeElementRepository.save.withArgs(secondResetKe).resolves(resetKnowledgeElement2);
+        knowledgeElementRepository.batchSave
+          .withArgs({ knowledgeElements: [firstResetKe, secondResetKe] })
+          .resolves([resetKnowledgeElement1, resetKnowledgeElement2]);
 
         knowledgeElementRepository.findUniqByUserIdAndCompetenceId
           .withArgs({ userId, competenceId })

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -1,42 +1,11 @@
 import _ from 'lodash';
 
-import { KnowledgeElement } from '../../../../lib/domain/models/KnowledgeElement.js';
+import { KnowledgeElement } from '../../../../lib/domain/models/index.js';
 import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
 import * as knowledgeElementRepository from '../../../../lib/infrastructure/repositories/knowledge-element-repository.js';
 import { databaseBuilder, domainBuilder, expect, knex, sinon } from '../../../test-helper.js';
 
 describe('Integration | Repository | knowledgeElementRepository', function () {
-  describe('#save', function () {
-    let knowledgeElementToSave;
-
-    beforeEach(function () {
-      // given
-      const userId = databaseBuilder.factory.buildUser({}).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({ userId }).id;
-      const answerId = databaseBuilder.factory.buildAnswer({ assessmentId }).id;
-      knowledgeElementToSave = domainBuilder.buildKnowledgeElement({
-        userId,
-        assessmentId,
-        answerId,
-        competenceId: 'recABC',
-      });
-      knowledgeElementToSave.id = undefined;
-
-      return databaseBuilder.commit();
-    });
-
-    it('should save the knowledgeElement in db', async function () {
-      // when
-      await knowledgeElementRepository.save(knowledgeElementToSave);
-
-      // then
-      let actualKnowledgeElement = await knex.select('*').from('knowledge-elements').first();
-      actualKnowledgeElement = _.omit(actualKnowledgeElement, ['id', 'intId', 'createdAt', 'updatedAt']);
-      const expectedKnowledgeElement = _.omit(knowledgeElementToSave, ['id', 'createdAt', 'updatedAt']);
-      expect(actualKnowledgeElement).to.deep.equal(expectedKnowledgeElement);
-    });
-  });
-
   describe('#batchSave', function () {
     let knowledgeElementsToSave;
 

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -38,15 +38,14 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
 
     it('should save all the knowledgeElements in db', async function () {
       // when
-      await knowledgeElementRepository.batchSave({ knowledgeElements: knowledgeElementsToSave });
+      const savedKnowledgeElements = await knowledgeElementRepository.batchSave({
+        knowledgeElements: knowledgeElementsToSave,
+      });
 
       // then
-      let actualKnowledgeElements = await knex.select('*').from('knowledge-elements');
-      actualKnowledgeElements = actualKnowledgeElements.map((ke) => _.omit(ke, ['id', 'createdAt', 'updatedAt']));
-      const expectedKnowledgeElements = knowledgeElementsToSave.map((ke) =>
-        _.omit(ke, ['id', 'createdAt', 'updatedAt']),
-      );
-      expect(actualKnowledgeElements).to.deep.equal(expectedKnowledgeElements);
+      expect(savedKnowledgeElements.length).to.equal(2);
+      expect(savedKnowledgeElements[0]).to.deepEqualInstanceOmitting(knowledgeElementsToSave[0], ['createdAt', 'id']);
+      expect(savedKnowledgeElements[1]).to.deepEqualInstanceOmitting(knowledgeElementsToSave[1], ['createdAt', 'id']);
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -46,6 +46,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       expect(savedKnowledgeElements.length).to.equal(2);
       expect(savedKnowledgeElements[0]).to.deepEqualInstanceOmitting(knowledgeElementsToSave[0], ['createdAt', 'id']);
       expect(savedKnowledgeElements[1]).to.deepEqualInstanceOmitting(knowledgeElementsToSave[1], ['createdAt', 'id']);
+      expect(savedKnowledgeElements[0].createdAt).to.deep.equal(savedKnowledgeElements[1].createdAt);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on remet à zéro une compétence ou qu'on recommence une campagne, on va venir "reset" les knowledge-elements concernés. Cela se passe dans le `scorecard-service`.
L'insertion des nouveaux knowledge-elements "reset" se fait par une combinaison d'un `Promise.all` avec l'appel à `knowledgeElementRepository.save`, ce qui est dommage pour plusieurs raisons :
- Consommation excessive de connexions du pool de connexions vers la BDD
- Pas de transaction
- Date de création des knowledge-elements légèrement différente pour chacun.

 Ce qui est dommage car quand il s'agit par exemple d'insérer un groupe de knowledge-elements quand on répond à des questions, là ils sont sauvegardés en même temps, même transaction, même date

## :robot: Proposition
Remplacer la combinaison d'un `Promise.all` avec l'appel à `knowledgeElementRepository.save`.
Au passage on supprime la méthode `knowledgeElementRepository.save` qui n'était utilisée qu'ici.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
Non rég sur la remise à zéro
