### PR TITLE
[FEATURE] Ajout d'un onglet support dans le menu de gauche pour une organization SCO-1D (Pix-13142)

### DIFF
--- a/orga/app/components/layout/sidebar.hbs
+++ b/orga/app/components/layout/sidebar.hbs
@@ -61,6 +61,19 @@
         {{t "navigation.main.documentation"}}
       </a>
     {{/if}}
+    {{#if this.shouldDisplayMissionsEntry}}
+      <a
+        href="https://pix.fr/support/enseignement-scolaire/1er-degre"
+        target="_blank"
+        class="sidebar-nav__item"
+        rel="noopener noreferrer"
+      >
+        <span class="sidebar-nav__item-icon">
+          <FaIcon @icon="circle-question" alt="{{t 'navigation.main.support'}}-icon" role="none" />
+        </span>
+        {{t "navigation.main.support"}}
+      </a>
+    {{/if}}
 
   </nav>
 </aside>

--- a/orga/tests/integration/components/layout/sidebar_test.js
+++ b/orga/tests/integration/components/layout/sidebar_test.js
@@ -104,6 +104,20 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
 
       assert.notOk(screen.queryByText(t('navigation.main.places')));
     });
+
+    test('should not display Support menu if canAccessMissionsPage is false', async function (assert) {
+      class CurrentUserStub extends Service {
+        organization = Object.create({ id: 5 });
+        canAccessMissionsPage = false;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+      const intl = this.owner.lookup('service:intl');
+      intl.setLocale(['fr', 'fr']);
+
+      const screen = await render(hbs`<Layout::Sidebar />`);
+
+      assert.dom(screen.queryByRole('link', { name: t('navigation.main.support') })).doesNotExist();
+    });
   });
 
   module('When the user is from a PRO organization', function () {
@@ -273,6 +287,23 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
       const screen = await render(hbs`<Layout::Sidebar />`);
 
       assert.dom(screen.getByText('Missions')).exists();
+    });
+
+    test('should display Support menu', async function (assert) {
+      class CurrentUserStub extends Service {
+        organization = Object.create({ id: 5 });
+        canAccessMissionsPage = true;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+      const intl = this.owner.lookup('service:intl');
+      intl.setLocale(['fr', 'fr']);
+
+      const screen = await render(hbs`<Layout::Sidebar />`);
+
+      assert.strictEqual(
+        screen.getByRole('link', { name: t('navigation.main.support') }).href,
+        'https://pix.fr/support/enseignement-scolaire/1er-degre',
+      );
     });
 
     test('should not display Campagne and Participants menus', async function (assert) {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -329,6 +329,7 @@
       "places": "Seats",
       "sco-organization-participants": "Students",
       "sup-organization-participants": "Students",
+      "support": "Help desk",
       "team": "Team"
     },
     "places": {
@@ -894,7 +895,7 @@
           "step1": {
             "admin": {
               "head": "Step 1 : <b>Please</b>",
-              "link": "importer the student database",
+              "link": "import the student database",
               "tail": "<b>from Onde</b> (exportable file in the Lists & documents Extractions > School students or their supervisors menu)."
             },
             "non-admin": "Step1 : <b>Ask the Pix Orga administrator</b> in your area to import students"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -332,6 +332,7 @@
       "places": "Places",
       "sco-organization-participants": "Élèves",
       "sup-organization-participants": "Étudiants",
+      "support": "Centre d'aide",
       "team": "Équipe"
     },
     "places": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -308,6 +308,7 @@
       "places": "Plaatsen",
       "sco-organization-participants": "Leerlingen",
       "sup-organization-participants": "Studenten",
+      "support": "Hulpcentrum",
       "team": "Team"
     },
     "pix-orga": "Pix Orga",


### PR DESCRIPTION
## :unicorn: Problème
Il manque une redirection vers un support dédié.

## :robot: Proposition
Ajouter un onglet qui redirige vers le support.

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter sur la RA d'orga et observer que lorsque l'on est sur une organisation SCO-1D, il y a un onglet support fonctionnel :) 