### PR TITLE
[TECH] Renommer les variables d'environnement du sondages PixOrga (PIX-13599)

### DIFF
--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -94,8 +94,8 @@ module.exports = function (environment) {
       },
       COOKIE_LOCALE_LIFESPAN_IN_SECONDS: 31536000, // 1 year in seconds
       APP_VERSION: process.env.SOURCE_VERSION || 'development',
-      SURVEY_LINK: process.env.SURVEY_LINK || null,
-      SURVEY_BANNER_ENABLED: Boolean(process.env.SURVEY_BANNER_ENABLED) || false,
+      SURVEY_LINK: process.env.SURVEY_ORGA_LINK || null,
+      SURVEY_BANNER_ENABLED: Boolean(process.env.SURVEY_ORGA_BANNER_ENABLED) || false,
     },
 
     fontawesome: {

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -95,7 +95,7 @@ module.exports = function (environment) {
       COOKIE_LOCALE_LIFESPAN_IN_SECONDS: 31536000, // 1 year in seconds
       APP_VERSION: process.env.SOURCE_VERSION || 'development',
       SURVEY_LINK: process.env.SURVEY_ORGA_LINK || null,
-      SURVEY_BANNER_ENABLED: Boolean(process.env.SURVEY_ORGA_BANNER_ENABLED) || false,
+      SURVEY_BANNER_ENABLED: _isFeatureEnabled(process.env.SURVEY_ORGA_BANNER_ENABLED),
     },
 
     fontawesome: {


### PR DESCRIPTION
## :unicorn: Problème
le SCOPE de la var d'env n'est pas très clair

## :robot: Proposition
Ajouter `ORGA` en plus afin de savoir que c'est la variable d'environnement pour les sondages sur PixOrga

## :rainbow: Remarques
RAS

## :100: Pour tester
Voir la banner sur la RA