### PR TITLE
[BUGFIX] Permettre le rechargement du bon model lors du changement d'organisation (PIX-13573)

### DIFF
--- a/orga/app/components/layout/topbar.hbs
+++ b/orga/app/components/layout/topbar.hbs
@@ -1,5 +1,5 @@
 <div class="topbar">
   <Layout::OrganizationPlacesOrCreditInfo @placesCount={{@placesCount}} />
   <Layout::SchoolSessionManagement />
-  <Layout::UserLoggedMenu class="topbar__user-logged-menu" @refreshAuthenticatedModel={{@refreshAuthenticatedModel}} />
+  <Layout::UserLoggedMenu class="topbar__user-logged-menu" @onChangeOrganization={{@onChangeOrganization}} />
 </div>

--- a/orga/app/components/layout/user-logged-menu.js
+++ b/orga/app/components/layout/user-logged-menu.js
@@ -56,7 +56,7 @@ export default class UserLoggedMenu extends Component {
     this.router.replaceWith('authenticated', { queryParams });
 
     await this.currentUser.load();
-    this.args.refreshAuthenticatedModel();
+    this.args.onChangeOrganization();
 
     this.closeMenu();
   }

--- a/orga/app/controllers/authenticated.js
+++ b/orga/app/controllers/authenticated.js
@@ -7,7 +7,7 @@ export default class AuthenticatedController extends Controller {
   @service store;
 
   @action
-  refreshAuthenticatedModel() {
-    this.send('refreshModel');
+  onChangeOrganization() {
+    this.send('refreshAuthenticatedModel');
   }
 }

--- a/orga/app/routes/authenticated.js
+++ b/orga/app/routes/authenticated.js
@@ -31,7 +31,7 @@ export default class AuthenticatedRoute extends Route {
   }
 
   @action
-  refreshModel() {
+  refreshAuthenticatedModel() {
     this.refresh();
   }
 }

--- a/orga/app/templates/authenticated.hbs
+++ b/orga/app/templates/authenticated.hbs
@@ -3,7 +3,7 @@
 
   <div class="main-content">
     <header>
-      <Layout::Topbar @placesCount={{@model.available}} @refreshAuthenticatedModel={{this.refreshAuthenticatedModel}} />
+      <Layout::Topbar @placesCount={{@model.available}} @onChangeOrganization={{this.onChangeOrganization}} />
     </header>
 
     <main class="main-content__body page">

--- a/orga/tests/integration/components/layout/user-logged-menu_test.js
+++ b/orga/tests/integration/components/layout/user-logged-menu_test.js
@@ -95,7 +95,7 @@ module('Integration | Component | Layout::UserLoggedMenu', function (hooks) {
 
   test('should redirect to authenticated route before reload the current user', async function (assert) {
     const replaceWithStub = sinon.stub();
-    const refreshAuthenticatedModel = sinon.stub();
+    const onChangeOrganization = sinon.stub();
 
     class RouterStub extends Service {
       replaceWith = replaceWithStub;
@@ -107,17 +107,15 @@ module('Integration | Component | Layout::UserLoggedMenu', function (hooks) {
         return { save() {} };
       }
     }
-    this.set('refreshAuthenticatedModel', refreshAuthenticatedModel);
+    this.set('onChangeOrganization', onChangeOrganization);
     this.owner.register('service:router', RouterStub);
     this.owner.register('service:store', StoreStub);
 
-    const screen = await render(
-      hbs`<Layout::UserLoggedMenu @refreshAuthenticatedModel={{this.refreshAuthenticatedModel}} />`,
-    );
+    const screen = await render(hbs`<Layout::UserLoggedMenu @onChangeOrganization={{this.onChangeOrganization}} />`);
     await clickByName('Ouvrir le menu utilisateur');
     await click(screen.getByRole('button', { name: `${organization2.name} (${organization2.externalId})` }));
 
     sinon.assert.callOrder(replaceWithStub, loadStub);
-    assert.ok(refreshAuthenticatedModel.calledOnce);
+    assert.ok(onChangeOrganization.calledOnce);
   });
 });

--- a/orga/tests/unit/controllers/authenticated_test.js
+++ b/orga/tests/unit/controllers/authenticated_test.js
@@ -11,8 +11,8 @@ module('Unit | Controller | authenticated', function (hooks) {
     controller.send = sinon.stub();
 
     // when
-    controller.refreshAuthenticatedModel();
+    controller.onChangeOrganization();
     // then
-    assert.true(controller.send.calledWithExactly('refreshModel'));
+    assert.true(controller.send.calledWithExactly('refreshAuthenticatedModel'));
   });
 });

--- a/orga/tests/unit/routes/authenticated_test.js
+++ b/orga/tests/unit/routes/authenticated_test.js
@@ -129,14 +129,14 @@ module('Unit | Route | authenticated', function (hooks) {
     });
   });
 
-  module('refreshModel', function () {
+  module('refreshAuthenticatedModel', function () {
     test('should call refresh', async function (assert) {
       // given
       const route = this.owner.lookup('route:authenticated');
       route.refresh = sinon.stub();
 
       // when
-      route.refreshModel();
+      route.refreshAuthenticatedModel();
 
       // then
       assert.ok(route.refresh.called);


### PR DESCRIPTION
## :unicorn: Problème
Le refresh model ne fonctionne plus pour voir le total des places d'une organization

## :robot: Proposition
Nommer explicitement la function que l'on souhaite utiliser afin de ne pas se tromper de model que l'on refresh

## :rainbow: Remarques
RAS

## :100: Pour tester
Changer d'organization vers la PRO_NOT_MANAGING et vérifier que nous voyons le reste de place dans le bandeau ainsi que dans  la page des places.