### PR TITLE
[FEATURE] Ajoute un endpoint pour récupérer les statistiques des places de toutes les organisations (PIX-13553)

### DIFF
--- a/api/lib/infrastructure/repositories/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-repository.js
@@ -379,7 +379,8 @@ function _queryBuilderForCertificability({
  * @returns {Promise<ParticipantRepartition>}
  */
 const findAllLearnerWithAtLeastOneParticipationByOrganizationId = async function (organizationId) {
-  const result = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const result = await knexConn
     .select('users.isAnonymous')
     .distinct('view-active-organization-learners.id')
     .from('view-active-organization-learners')

--- a/api/src/prescription/organization-place/application/organization-place-controller.js
+++ b/api/src/prescription/organization-place/application/organization-place-controller.js
@@ -1,4 +1,6 @@
+import { usecases as libUsecases } from '../../../../lib/domain/usecases/index.js';
 import { usecases } from '../domain/usecases/index.js';
+import * as dataOrganizationPlacesStatisticsSerializer from '../infrastructure/serializers/json/data-organization-places-statistics-serializer.js';
 import * as organizationPlacesCapacitySerializer from '../infrastructure/serializers/jsonapi/organization-places-capacity-serializer.js';
 import * as organizationPlacesLotManagementSerializer from '../infrastructure/serializers/jsonapi/organization-places-lot-management-serializer.js';
 import * as organizationPlacesLotSerializer from '../infrastructure/serializers/jsonapi/organization-places-lot-serializer.js';
@@ -58,12 +60,29 @@ const getOrganizationPlacesStatistics = async function (
   return dependencies.organizationPlacesStatisticsSerializer.serialize(organizationPlacesStatistics);
 };
 
+const getDataOrganizationsPlacesStatistics = async function (
+  request,
+  h,
+  dependencies = {
+    dataOrganizationPlacesStatisticsSerializer,
+    getOrganizationPlacesStatistics: usecases.getOrganizationPlacesStatistics,
+    findPaginatedFilteredOrganizations: libUsecases.findPaginatedFilteredOrganizations,
+  },
+) {
+  const dataOrganizationPlacesStatistics = await usecases.getDataOrganizationsPlacesStatistics({
+    getOrganizationPlacesStatistics: dependencies.getOrganizationPlacesStatistics,
+    findPaginatedFilteredOrganizations: dependencies.findPaginatedFilteredOrganizations,
+  });
+  return dependencies.dataOrganizationPlacesStatisticsSerializer.serialize(dataOrganizationPlacesStatistics);
+};
+
 const organizationPlaceController = {
   createOrganizationPlacesLot,
   deleteOrganizationPlacesLot,
   findOrganizationPlacesLot,
   getOrganizationPlacesCapacity,
   getOrganizationPlacesStatistics,
+  getDataOrganizationsPlacesStatistics,
 };
 
 export { organizationPlaceController };

--- a/api/src/prescription/organization-place/application/organization-place-route.js
+++ b/api/src/prescription/organization-place/application/organization-place-route.js
@@ -146,7 +146,12 @@ const register = async (server) => {
       path: '/api/data/organization-places',
       config: {
         auth: 'jwt-pix-data',
-        handler: (request, h) => h.response(null).code(200),
+        handler: organizationPlaceController.getDataOrganizationsPlacesStatistics,
+        tags: ['api', 'organization-places', 'data'],
+        notes: [
+          '- **Cette route est restreinte a la stack data**\n' +
+            '- Elle permet la récuperation des statistiques de places de toutes les organisations',
+        ],
       },
     },
   ]);

--- a/api/src/prescription/organization-place/domain/read-models/DataOrganizationPlacesStatistics.js
+++ b/api/src/prescription/organization-place/domain/read-models/DataOrganizationPlacesStatistics.js
@@ -1,0 +1,33 @@
+export class DataOrganizationPlacesStatistics {
+  #placeStatistics;
+  #organization;
+
+  constructor({ placeStatistics, organization }) {
+    this.#placeStatistics = placeStatistics;
+    this.#organization = organization;
+  }
+
+  get organizationId() {
+    return this.#organization.id;
+  }
+
+  get organizationName() {
+    return this.#organization.name;
+  }
+
+  get organizationType() {
+    return this.#organization.type;
+  }
+
+  get organizationPlacesCount() {
+    return this.#placeStatistics.total;
+  }
+
+  get organizationOccupiedPlacesCount() {
+    return this.#placeStatistics.occupied;
+  }
+
+  get organizationActivePlacesLotCount() {
+    return this.#placeStatistics.placesLotsTotal;
+  }
+}

--- a/api/src/prescription/organization-place/domain/read-models/PlaceStatistics.js
+++ b/api/src/prescription/organization-place/domain/read-models/PlaceStatistics.js
@@ -22,9 +22,13 @@ export class PlaceStatistics {
     return new PlaceStatistics({ placesLots, placeRepartition, organizationId });
   }
 
+  get #activePlacesLots() {
+    return this.#placesLots.filter((placesLot) => placesLot.isActive);
+  }
+
   get total() {
     if (!this.#placesLots) return 0;
-    const activePlaces = this.#placesLots.filter((placesLot) => placesLot.isActive);
+    const activePlaces = this.#activePlacesLots;
     return _.sumBy(activePlaces, 'count');
   }
 
@@ -40,5 +44,9 @@ export class PlaceStatistics {
     const available = this.total - this.occupied;
     if (available < 0) return 0;
     return available;
+  }
+
+  get placesLotsTotal() {
+    return this.#activePlacesLots.length;
   }
 }

--- a/api/src/prescription/organization-place/domain/usecases/get-data-organizations-places-statistics.js
+++ b/api/src/prescription/organization-place/domain/usecases/get-data-organizations-places-statistics.js
@@ -1,0 +1,18 @@
+import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { DataOrganizationPlacesStatistics } from '../read-models/DataOrganizationPlacesStatistics.js';
+
+const getDataOrganizationsPlacesStatistics = withTransaction(async function ({
+  organizationRepository,
+  getOrganizationPlacesStatistics,
+}) {
+  const organizationWithPlaces = await organizationRepository.getOrganizationsWithPlaces();
+
+  return Promise.all(
+    organizationWithPlaces.map(async (organization) => {
+      const placeStatistics = await getOrganizationPlacesStatistics({ organizationId: organization.id });
+      return new DataOrganizationPlacesStatistics({ placeStatistics, organization });
+    }),
+  );
+});
+
+export { getDataOrganizationsPlacesStatistics };

--- a/api/src/prescription/organization-place/infrastructure/repositories/organization-places-lot-repository.js
+++ b/api/src/prescription/organization-place/infrastructure/repositories/organization-places-lot-repository.js
@@ -1,4 +1,5 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { DeletedError, NotFoundError } from '../../../../shared/domain/errors.js';
 import { OrganizationPlacesLotManagement } from '../../domain/read-models/OrganizationPlacesLotManagement.js';
 import { PlacesLot } from '../../domain/read-models/PlacesLot.js';
@@ -29,7 +30,8 @@ const findByOrganizationId = async function (organizationId) {
 
 //On utilise pas le findByOrganizationId car c'est un aggregat avec la table users, et les regles métiers ne sont pas utiles ici
 const findAllByOrganizationId = async function (organizationId) {
-  const placesLots = await knex('organization-places')
+  const knexConn = DomainTransaction.getConnection();
+  const placesLots = await knexConn('organization-places')
     .select('count', 'activationDate', 'expirationDate', 'deletedAt')
     .where({ organizationId });
   return placesLots.map((e) => new PlacesLot(e));

--- a/api/src/prescription/organization-place/infrastructure/serializers/json/data-organization-places-statistics-serializer.js
+++ b/api/src/prescription/organization-place/infrastructure/serializers/json/data-organization-places-statistics-serializer.js
@@ -1,0 +1,12 @@
+const serialize = function (dataOrganizationPlacesStatistics) {
+  return dataOrganizationPlacesStatistics.map((dataOrganizationPlacesStatistic) => ({
+    organization_id: dataOrganizationPlacesStatistic.organizationId,
+    organization_type: dataOrganizationPlacesStatistic.organizationType,
+    organization_name: dataOrganizationPlacesStatistic.organizationName,
+    organization_places_count: dataOrganizationPlacesStatistic.organizationPlacesCount,
+    organization_occupied_places_count: dataOrganizationPlacesStatistic.organizationOccupiedPlacesCount,
+    organization_active_places_lot_count: dataOrganizationPlacesStatistic.organizationActivePlacesLotCount,
+  }));
+};
+
+export { serialize };

--- a/api/src/shared/infrastructure/repositories/organization-repository.js
+++ b/api/src/shared/infrastructure/repositories/organization-repository.js
@@ -194,6 +194,18 @@ const findPaginatedFilteredByTargetProfile = async function ({ targetProfileId, 
   return { models: organizations, pagination };
 };
 
+const getOrganizationsWithPlaces = async function () {
+  const knexConn = DomainTransaction.getConnection();
+  const organizations = await knexConn('organizations')
+    .select('organizations.id', 'name', 'type')
+    .innerJoin('organization-places', 'organizations.id', 'organization-places.organizationId')
+    .whereNotNull('organization-places.count')
+    .whereNull('archivedAt')
+    .distinct();
+
+  return organizations.map((organization) => _toDomain(organization));
+};
+
 export {
   create,
   findActiveScoOrganizationsByExternalId,
@@ -203,6 +215,7 @@ export {
   findScoOrganizationsByUai,
   get,
   getIdByCertificationCenterId,
+  getOrganizationsWithPlaces,
   getScoOrganizationByExternalId,
   update,
 };

--- a/api/src/shared/infrastructure/repositories/organization-repository.js
+++ b/api/src/shared/infrastructure/repositories/organization-repository.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import { knex } from '../../../../db/knex-database-connection.js';
 import { Organization } from '../../../organizational-entities/domain/models/Organization.js';
 import { Tag } from '../../../organizational-entities/domain/models/Tag.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { NotFoundError } from '../../domain/errors.js';
 import { fetchPage } from '../utils/knex-utils.js';
 
@@ -171,7 +172,10 @@ const findActiveScoOrganizationsByExternalId = async function (externalId) {
 };
 
 const findPaginatedFiltered = async function ({ filter, page }) {
-  const query = knex(ORGANIZATIONS_TABLE_NAME).modify(_setSearchFiltersForQueryBuilder, filter).orderBy('name', 'ASC');
+  const knexConn = DomainTransaction.getConnection();
+  const query = knexConn(ORGANIZATIONS_TABLE_NAME)
+    .modify(_setSearchFiltersForQueryBuilder, filter)
+    .orderBy('name', 'ASC');
 
   const { results, pagination } = await fetchPage(query, page);
   const organizations = results.map((model) => _toDomain(model));

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -1046,4 +1046,174 @@ describe('Integration | Repository | Organization', function () {
       });
     });
   });
+
+  describe('#getOrganizationsWithPlaces', function () {
+    it('should only return organizations not archived', async function () {
+      // given
+      const superAdminUserId = databaseBuilder.factory.buildUser().id;
+
+      const firstOrganization = databaseBuilder.factory.buildOrganization({
+        type: 'SCO',
+        name: 'Organization of the dark side',
+        archivedAt: null,
+        isArchived: false,
+      });
+
+      databaseBuilder.factory.buildOrganizationPlace({
+        count: 3,
+        organizationId: firstOrganization.id,
+        activationDate: new Date(),
+        expirationDate: new Date(),
+        createdBy: superAdminUserId,
+        createdAt: new Date(),
+        deletedAt: null,
+        deletedBy: null,
+      });
+
+      const secondOrganization = databaseBuilder.factory.buildOrganization({
+        type: 'SCO',
+        name: 'Organization of the BRIGHT side',
+        archivedAt: new Date(),
+        isArchived: true,
+      });
+
+      databaseBuilder.factory.buildOrganizationPlace({
+        count: 3,
+        organizationId: secondOrganization.id,
+        activationDate: new Date(),
+        expirationDate: new Date(),
+        createdBy: superAdminUserId,
+        createdAt: new Date(),
+        deletedAt: null,
+        deletedBy: null,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const organizationsWithPlaces = await organizationRepository.getOrganizationsWithPlaces();
+
+      // then
+      expect(organizationsWithPlaces.length).to.equal(1);
+      expect(organizationsWithPlaces[0]).to.be.instanceOf(Organization);
+      expect(organizationsWithPlaces[0].id).to.equal(firstOrganization.id);
+      expect(organizationsWithPlaces[0].name).to.equal(firstOrganization.name);
+      expect(organizationsWithPlaces[0].type).to.equal(firstOrganization.type);
+    });
+
+    it('should only return organizations with places', async function () {
+      // given
+      const superAdminUserId = databaseBuilder.factory.buildUser().id;
+
+      const firstOrganization = databaseBuilder.factory.buildOrganization({
+        type: 'SCO',
+        name: 'Organization of the dark side',
+        archivedAt: null,
+        isArchived: false,
+      });
+
+      databaseBuilder.factory.buildOrganizationPlace({
+        count: 3,
+        organizationId: firstOrganization.id,
+        activationDate: new Date(),
+        expirationDate: new Date(),
+        createdBy: superAdminUserId,
+        createdAt: new Date(),
+        deletedAt: null,
+        deletedBy: null,
+      });
+
+      databaseBuilder.factory.buildOrganization({
+        type: 'SCO',
+        name: 'Organization of the rainbow side',
+        archivedAt: null,
+        isArchived: false,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const organizationsWithPlaces = await organizationRepository.getOrganizationsWithPlaces();
+
+      // then
+      expect(organizationsWithPlaces.length).to.equal(1);
+      expect(organizationsWithPlaces[0]).to.be.instanceOf(Organization);
+      expect(organizationsWithPlaces[0].id).to.equal(firstOrganization.id);
+      expect(organizationsWithPlaces[0].name).to.equal(firstOrganization.name);
+      expect(organizationsWithPlaces[0].type).to.equal(firstOrganization.type);
+    });
+
+    it('should return only once an organization with many placeLots', async function () {
+      // given
+      const superAdminUserId = databaseBuilder.factory.buildUser().id;
+
+      const firstOrganization = databaseBuilder.factory.buildOrganization({
+        type: 'SCO',
+        name: 'Organization of the dark side',
+        archivedAt: null,
+        isArchived: false,
+      });
+
+      databaseBuilder.factory.buildOrganizationPlace({
+        count: 3,
+        organizationId: firstOrganization.id,
+        activationDate: new Date(),
+        expirationDate: new Date(),
+        createdBy: superAdminUserId,
+        createdAt: new Date(),
+        deletedAt: null,
+        deletedBy: null,
+      });
+
+      databaseBuilder.factory.buildOrganizationPlace({
+        count: 25,
+        organizationId: firstOrganization.id,
+        activationDate: new Date(),
+        expirationDate: new Date(),
+        createdBy: superAdminUserId,
+        createdAt: new Date(),
+        deletedAt: null,
+        deletedBy: null,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const organizationsWithPlaces = await organizationRepository.getOrganizationsWithPlaces();
+
+      // then
+      expect(organizationsWithPlaces.length).to.equal(1);
+    });
+
+    it('should not return organization with null place count', async function () {
+      // given
+      const superAdminUserId = databaseBuilder.factory.buildUser().id;
+
+      const firstOrganization = databaseBuilder.factory.buildOrganization({
+        type: 'SCO',
+        name: 'Organization of the dark side',
+        archivedAt: null,
+        isArchived: false,
+      });
+
+      databaseBuilder.factory.buildOrganizationPlace({
+        count: null,
+        organizationId: firstOrganization.id,
+        activationDate: new Date(),
+        expirationDate: new Date(),
+        createdBy: superAdminUserId,
+        createdAt: new Date(),
+        deletedAt: null,
+        deletedBy: null,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const organizationsWithPlaces = await organizationRepository.getOrganizationsWithPlaces();
+
+      // then
+      expect(organizationsWithPlaces.length).to.equal(0);
+    });
+  });
 });

--- a/api/tests/prescription/organization-place/integration/domain/usecases/get-data-organizations-places-statistics_test.js
+++ b/api/tests/prescription/organization-place/integration/domain/usecases/get-data-organizations-places-statistics_test.js
@@ -1,0 +1,66 @@
+import { getDataOrganizationsPlacesStatistics } from '../../../../../../src/prescription/organization-place/domain/usecases/get-data-organizations-places-statistics.js';
+import { usecases as organizationPlacesUsecases } from '../../../../../../src/prescription/organization-place/domain/usecases/index.js';
+import * as organizationRepository from '../../../../../../src/shared/infrastructure/repositories/organization-repository.js';
+import { databaseBuilder, expect, sinon } from '../../../../../test-helper.js';
+
+describe('Integration | UseCases | get-data-organizations-places-statistics', function () {
+  let clock;
+  const now = new Date('2021-05-01');
+
+  beforeEach(async function () {
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+  });
+
+  afterEach(async function () {
+    clock.restore();
+  });
+
+  it('should return places statistics for all organizations', async function () {
+    // given
+    const firstOrganization = databaseBuilder.factory.buildOrganization({
+      id: 1,
+      name: 'Mon collège',
+      type: 'SCO',
+    });
+    const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({
+      organizationId: firstOrganization.id,
+    }).id;
+    const campaignId = databaseBuilder.factory.buildCampaign({ organizationId: firstOrganization.id }).id;
+    databaseBuilder.factory.buildCampaignParticipation({ campaignId, organizationLearnerId });
+    databaseBuilder.factory.buildOrganizationPlace({
+      count: 10,
+      organizationId: firstOrganization.id,
+      activationDate: new Date('2021-04-01'),
+      expirationDate: new Date('2021-05-15'),
+    });
+    const secondOrganization = databaseBuilder.factory.buildOrganization({ id: 2, name: 'Pole Emploi', type: 'PRO' });
+    databaseBuilder.factory.buildOrganizationPlace({
+      count: 5,
+      organizationId: secondOrganization.id,
+      activationDate: new Date('2021-04-01'),
+      expirationDate: new Date('2021-05-15'),
+    });
+    await databaseBuilder.commit();
+
+    // when
+    const dataOrganizationsPlacesStatistics = await getDataOrganizationsPlacesStatistics({
+      getOrganizationPlacesStatistics: organizationPlacesUsecases.getOrganizationPlacesStatistics,
+      organizationRepository,
+    });
+
+    // then
+    expect(dataOrganizationsPlacesStatistics[0].organizationId).to.equal(firstOrganization.id);
+    expect(dataOrganizationsPlacesStatistics[0].organizationActivePlacesLotCount).to.equal(1);
+    expect(dataOrganizationsPlacesStatistics[0].organizationPlacesCount).to.equal(10);
+    expect(dataOrganizationsPlacesStatistics[0].organizationOccupiedPlacesCount).to.equal(1);
+    expect(dataOrganizationsPlacesStatistics[0].organizationName).to.equal('Mon collège');
+    expect(dataOrganizationsPlacesStatistics[0].organizationType).to.equal('SCO');
+
+    expect(dataOrganizationsPlacesStatistics[1].organizationId).to.equal(secondOrganization.id);
+    expect(dataOrganizationsPlacesStatistics[1].organizationActivePlacesLotCount).to.equal(1);
+    expect(dataOrganizationsPlacesStatistics[1].organizationPlacesCount).to.equal(5);
+    expect(dataOrganizationsPlacesStatistics[1].organizationName).to.equal('Pole Emploi');
+    expect(dataOrganizationsPlacesStatistics[1].organizationType).to.equal('PRO');
+    expect(dataOrganizationsPlacesStatistics[1].organizationOccupiedPlacesCount).to.equal(0);
+  });
+});

--- a/api/tests/prescription/organization-place/unit/application/organization-place-controller_test.js
+++ b/api/tests/prescription/organization-place/unit/application/organization-place-controller_test.js
@@ -133,4 +133,49 @@ describe('Unit | Application | organization-place-controller', function () {
       });
     });
   });
+
+  describe('#getDataOrganizationsPlacesStatistics', function () {
+    it('should call the usecase and serialize the response', async function () {
+      // given
+      const request = {};
+      const dataOrganizationPlacesStatistics = Symbol('dataOrganizationPlacesStatistics');
+      const dataOrganizationPlacesStatisticsSerialized = Symbol('dataOrganizationPlacesStatisticsSerialized');
+
+      const getOrganizationPlacesStatisticsStub = sinon.stub();
+      const findPaginatedFilteredOrganizationsStub = sinon.stub();
+
+      sinon.stub(usecases, 'getDataOrganizationsPlacesStatistics');
+
+      usecases.getDataOrganizationsPlacesStatistics
+        .withArgs({
+          getOrganizationPlacesStatistics: getOrganizationPlacesStatisticsStub,
+          findPaginatedFilteredOrganizations: findPaginatedFilteredOrganizationsStub,
+        })
+        .resolves(dataOrganizationPlacesStatistics);
+
+      const dataOrganizationPlacesStatisticsSerializerStub = {
+        serialize: sinon.stub(),
+      };
+
+      dataOrganizationPlacesStatisticsSerializerStub.serialize
+        .withArgs(dataOrganizationPlacesStatistics)
+        .returns(dataOrganizationPlacesStatisticsSerialized);
+
+      const dependencies = {
+        dataOrganizationPlacesStatisticsSerializer: dataOrganizationPlacesStatisticsSerializerStub,
+        getOrganizationPlacesStatistics: getOrganizationPlacesStatisticsStub,
+        findPaginatedFilteredOrganizations: findPaginatedFilteredOrganizationsStub,
+      };
+
+      // when
+      const result = await organizationPlaceController.getDataOrganizationsPlacesStatistics(
+        request,
+        hFake,
+        dependencies,
+      );
+
+      // then
+      expect(result).to.equal(dataOrganizationPlacesStatisticsSerialized);
+    });
+  });
 });

--- a/api/tests/prescription/organization-place/unit/domain/read-models/DataOrganizationPlacesStatistics_test.js
+++ b/api/tests/prescription/organization-place/unit/domain/read-models/DataOrganizationPlacesStatistics_test.js
@@ -1,0 +1,47 @@
+import { Organization } from '../../../../../../src/organizational-entities/domain/models/Organization.js';
+import { DataOrganizationPlacesStatistics } from '../../../../../../src/prescription/organization-place/domain/read-models/DataOrganizationPlacesStatistics.js';
+import { PlacesLot } from '../../../../../../src/prescription/organization-place/domain/read-models/PlacesLot.js';
+import { PlaceStatistics } from '../../../../../../src/prescription/organization-place/domain/read-models/PlaceStatistics.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | Domain | ReadModels | DataOrganizationPlacesStatistics', function () {
+  let clock;
+  const now = new Date('2021-05-01');
+
+  beforeEach(async function () {
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+  });
+
+  afterEach(async function () {
+    clock.restore();
+  });
+
+  it('create DataOrganizationPlacesStatistics', function () {
+    const organization = new Organization({
+      id: 1,
+      name: 'OrganizationName',
+      type: 'SCO',
+    });
+    const placeStatistics = new PlaceStatistics({
+      placesLots: [
+        new PlacesLot({
+          count: 10,
+          expirationDate: new Date('2022-05-02'),
+          activationDate: new Date('2019-04-01'),
+          deletedAt: null,
+        }),
+      ],
+      placeRepartition: { totalUnRegisteredParticipant: 0, totalRegisteredParticipant: 2 },
+      organizationId: organization.id,
+    });
+
+    const dataOrganizationPlacesStatistics = new DataOrganizationPlacesStatistics({ placeStatistics, organization });
+
+    expect(dataOrganizationPlacesStatistics.organizationId).to.equal(organization.id);
+    expect(dataOrganizationPlacesStatistics.organizationName).to.equal(organization.name);
+    expect(dataOrganizationPlacesStatistics.organizationType).to.equal(organization.type);
+    expect(dataOrganizationPlacesStatistics.organizationPlacesCount).to.equal(10);
+    expect(dataOrganizationPlacesStatistics.organizationOccupiedPlacesCount).to.equal(2);
+    expect(dataOrganizationPlacesStatistics.organizationActivePlacesLotCount).to.equal(1);
+  });
+});

--- a/api/tests/prescription/organization-place/unit/domain/read-models/PlaceStatistics_test.js
+++ b/api/tests/prescription/organization-place/unit/domain/read-models/PlaceStatistics_test.js
@@ -191,4 +191,54 @@ describe('Unit | Domain | ReadModels | PlaceStatistics', function () {
       expect(error.message).to.equal("L'organisation ne peut pas avoir de statistiques sur ses lots de places.");
     });
   });
+
+  describe('#placesLotsTotal', function () {
+    it('should return 0 when there are no active places lots', function () {
+      const statistics = new PlaceStatistics();
+
+      expect(statistics.placesLotsTotal).to.equal(0);
+    });
+
+    it('should return total when there is a active places lot', function () {
+      const statistics = new PlaceStatistics({
+        placesLots: [
+          new PlacesLot({
+            count: 3,
+            expirationDate: new Date('2021-05-02'),
+            activationDate: new Date('2021-04-01'),
+            deletedAt: null,
+          }),
+        ],
+      });
+
+      expect(statistics.placesLotsTotal).to.equal(1);
+    });
+
+    it('should return total when there are active places lots', function () {
+      const statistics = new PlaceStatistics({
+        placesLots: [
+          new PlacesLot({
+            count: 1,
+            expirationDate: new Date('2021-05-02'),
+            activationDate: new Date('2021-04-01'),
+            deletedAt: null,
+          }),
+          new PlacesLot({
+            count: 10,
+            expirationDate: new Date('2021-05-02'),
+            activationDate: new Date('2021-04-01'),
+            deletedAt: null,
+          }),
+          new PlacesLot({
+            count: 10,
+            expirationDate: new Date('2020-05-02'),
+            activationDate: new Date('2019-04-01'),
+            deletedAt: null,
+          }),
+        ],
+      });
+
+      expect(statistics.placesLotsTotal).to.equal(2);
+    });
+  });
 });

--- a/api/tests/prescription/organization-place/unit/infrastructure/serializers/json/data-organization-places-statistics-serializer_test.js
+++ b/api/tests/prescription/organization-place/unit/infrastructure/serializers/json/data-organization-places-statistics-serializer_test.js
@@ -1,0 +1,54 @@
+import * as dataOrganizationPlaceStatisticsSerializer from '../../../../../../../src/prescription/organization-place/infrastructure/serializers/json/data-organization-places-statistics-serializer.js';
+import { expect } from '../../../../../../test-helper.js';
+
+describe('Unit | Serializer | JSON | data-organization-places-statistics-serializer', function () {
+  describe('#serialize', function () {
+    it('should convert an array of PlaceStatistics model object into an array of JSON data', function () {
+      // given
+      const firstPlacesStatistics = {
+        organizationId: 1,
+        organizationName: 'organizationName',
+        organizationType: 'SCO',
+        organizationPlacesCount: 10,
+        organizationOccupiedPlacesCount: 2,
+        organizationActivePlacesLotCount: 1,
+      };
+
+      const secondPlacesStatistics = {
+        organizationId: 2,
+        organizationName: 'secondOrganizationName',
+        organizationType: 'PRO',
+        organizationPlacesCount: 5,
+        organizationOccupiedPlacesCount: 1,
+        organizationActivePlacesLotCount: 1,
+      };
+
+      const dataOrganizationPlacesStatistics = [firstPlacesStatistics, secondPlacesStatistics];
+
+      const expectedJSON = [
+        {
+          organization_id: firstPlacesStatistics.organizationId,
+          organization_type: firstPlacesStatistics.organizationType,
+          organization_name: firstPlacesStatistics.organizationName,
+          organization_places_count: firstPlacesStatistics.organizationPlacesCount,
+          organization_occupied_places_count: firstPlacesStatistics.organizationOccupiedPlacesCount,
+          organization_active_places_lot_count: firstPlacesStatistics.organizationActivePlacesLotCount,
+        },
+        {
+          organization_id: secondPlacesStatistics.organizationId,
+          organization_type: secondPlacesStatistics.organizationType,
+          organization_name: secondPlacesStatistics.organizationName,
+          organization_places_count: secondPlacesStatistics.organizationPlacesCount,
+          organization_occupied_places_count: secondPlacesStatistics.organizationOccupiedPlacesCount,
+          organization_active_places_lot_count: secondPlacesStatistics.organizationActivePlacesLotCount,
+        },
+      ];
+
+      // when
+      const json = dataOrganizationPlaceStatisticsSerializer.serialize(dataOrganizationPlacesStatistics);
+
+      // then
+      expect(json).to.deep.equal(expectedJSON);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre des tech days API-DATA nous avons creer de la config pour avoir un token applicatif, maintenant, il faut mettre a disposition de l'équipe DATA un endpoint pour récuperer les statistiques de places de toutes les organisations

## :robot: Proposition
Creer un endpoint pour permettre cette récupération

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
Lancer le script python de DATA et vérifier que le endpoint retourne bien les données des seeds
🐈‍⬛ 
🐕 
🐶 
