### PR TITLE
[BUGFIX] Épreuves timées : traduction du temps imparti (PIX-13514)

### DIFF
--- a/mon-pix/app/components/timed-challenge-instructions.js
+++ b/mon-pix/app/components/timed-challenge-instructions.js
@@ -1,25 +1,23 @@
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import isInteger from 'lodash/isInteger';
 
 export default class TimedChallengeInstructions extends Component {
+  @service intl;
+
   get allocatedTime() {
-    return _formatTime(this.args.time);
+    if (!isInteger(this.args.time)) {
+      return '';
+    }
+
+    const minutes = _getMinutes(this.args.time);
+    const seconds = _getSeconds(this.args.time);
+
+    let allocatedTime = this.intl.t('pages.timed-challenge-instructions.time.minutes', { minutes });
+    if (minutes && seconds) allocatedTime += this.intl.t('pages.timed-challenge-instructions.time.and');
+    allocatedTime += this.intl.t('pages.timed-challenge-instructions.time.seconds', { seconds });
+    return allocatedTime;
   }
-}
-
-function _formatTime(time) {
-  if (!isInteger(time)) {
-    return '';
-  }
-
-  const minutes = _getMinutes(time);
-  const seconds = _getSeconds(time);
-
-  const formattedMinutes = _pluralize('minute', minutes);
-  const formattedSeconds = _pluralize('seconde', seconds);
-  const joiningWord = !minutes || !seconds ? '' : ' et ';
-
-  return `${formattedMinutes}${joiningWord}${formattedSeconds}`;
 }
 
 function _getMinutes(time) {
@@ -28,11 +26,4 @@ function _getMinutes(time) {
 
 function _getSeconds(time) {
   return time % 60;
-}
-
-function _pluralize(word, count) {
-  if (!count) {
-    return '';
-  }
-  return count > 1 ? `${count} ${word}s` : `${count} ${word}`;
 }

--- a/mon-pix/tests/unit/components/timed-challenge-instructions_test.js
+++ b/mon-pix/tests/unit/components/timed-challenge-instructions_test.js
@@ -2,9 +2,11 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
+import setupIntl from '../../helpers/setup-intl';
 
 module('Unit | Component | timed-challenge-instructions', function (hooks) {
   setupTest(hooks);
+  setupIntl(hooks);
 
   let component;
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1699,7 +1699,12 @@
     "timed-challenge-instructions": {
       "action": "Start the challenge",
       "primary": "You have '<span class=\"timed-challenge-instructions__time\">'{time}'</span>' to complete the next question.",
-      "secondary": "You can continue answering after this, but the question will not be marked as correct."
+      "secondary": "You can continue answering after this, but the question will not be marked as correct.",
+      "time": {
+        "and": " and ",
+        "minutes": "{minutes, plural, =0 {} =1 {# minute} other {# minutes}}",
+        "seconds": "{seconds, plural, =0 {} =1 {# second} other {# seconds}}"
+      }
     },
     "training": {
       "editor": "Training provided by",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1699,7 +1699,12 @@
     "timed-challenge-instructions": {
       "action": "Empezar la prueba",
       "primary": "Dispondrás de '<span class=\"timed-challenge-instructions__time\">'{time}'</span>' para superar la siguiente pregunta.",
-      "secondary": "Podrás seguir respondiendo después, pero la pregunta no se considerará acertada."
+      "secondary": "Podrás seguir respondiendo después, pero la pregunta no se considerará acertada.",
+      "time": {
+        "and": " y ",
+        "minutes": "{minutes, plural, =0 {} =1 {# minuto} other {# minutos}}",
+        "seconds": "{seconds, plural, =0 {} =1 {# segundo} other {# segundos}}"
+      }
     },
     "training": {
       "editor": "Contenido formativo propuesto por",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1724,27 +1724,22 @@
       "pages": {
         "page0": {
           "explanation": "Si no conoces una respuesta, probablemente esté en Internet.",
-          "icon": "icn-recherche.svg",
           "title": "Puedes buscar en internet..."
         },
         "page1": {
           "explanation": "Si aparece esta imagen, ¡utiliza solo tus conocimientos! No debes utilizar Internet ni ningún software.",
-          "icon": "icn-focus.svg",
           "title": "... excepto para ciertas preguntas"
         },
         "page2": {
           "explanation": "Tómate el tiempo que necesites para completar el test. Si una pregunta está cronometrada, se te indicará.",
-          "icon": "icn-temps.svg",
           "title": "¡Sin límite de tiempo!"
         },
         "page3": {
           "explanation": "Accede a tutoriales para aprender más sobre cada pregunta y progresar.",
-          "icon": "icn-tutos.svg",
           "title": "Tutoriales para aprender"
         },
         "page4": {
           "explanation": "Pix adapta la dificultad de las preguntas en función de tus respuestas.",
-          "icon": "icn-algo.svg",
           "title": "Un nivel adecuado de dificultad"
         }
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1699,7 +1699,12 @@
     "timed-challenge-instructions": {
       "action": "Commencer l'épreuve",
       "primary": "Vous disposerez de '<span class=\"timed-challenge-instructions__time\">'{time}'</span>' pour réussir la question suivante.",
-      "secondary": "Vous pourrez continuer à répondre ensuite, mais la question ne sera pas considérée comme réussie."
+      "secondary": "Vous pourrez continuer à répondre ensuite, mais la question ne sera pas considérée comme réussie.",
+      "time": {
+        "and": " et ",
+        "minutes": "{minutes, plural, =0 {} =1 {# minute} other {# minutes}}",
+        "seconds": "{seconds, plural, =0 {} =1 {# seconde} other {# secondes}}"
+      }
     },
     "training": {
       "editor": "Contenu formatif proposé par",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1699,7 +1699,12 @@
     "timed-challenge-instructions": {
       "action": "De test beginnen",
       "primary": "Je hebt '<span class=\"timed-challenge-instructies__time\">'{time}'</span>' om de volgende vraag te beantwoorden.",
-      "secondary": "Als je doorgaat wordt de opdracht niet als voltooid beschouwd."
+      "secondary": "Als je doorgaat wordt de opdracht niet als voltooid beschouwd.",
+      "time": {
+        "and": " en ",
+        "minutes": "{minutes, plural, =0 {} =1 {# minuut} other {# minuten}}",
+        "seconds": "{seconds, plural, =0 {} =1 {# seconde} other {# seconden}}"
+      }
     },
     "training": {
       "editor": "Inhoud van de training voorgesteld door",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1724,27 +1724,22 @@
       "pages": {
         "page0": {
           "explanation": "Als je het antwoord niet weet, vind je het vast wel op\n.",
-          "icon": "icn-recherche.svg",
           "title": "Je kunt op internet zoeken ..."
         },
         "page1": {
           "explanation": "Als deze afbeelding wordt weergegeven, gebruik dan alleen je eigen kennis!\nJe mag het internet of je software niet gebruiken.",
-          "icon": "icn-focus.svg",
           "title": "... behalve voor bepaalde vragen"
         },
         "page2": {
           "explanation": "Neem zoveel tijd als je nodig hebt om de cursus te voltooien.\nAls een vraag een tijdslimiet heeft, wordt dit aangegeven.",
-          "icon": "icn-temps.svg",
           "title": "Geen tijdslimiet!"
         },
         "page3": {
           "explanation": "Ga naar tutorials om meer te leren\nover elke vraag en boek vooruitgang.",
-          "icon": "icn-tutos.svg",
           "title": "Tutorials om te leren"
         },
         "page4": {
           "explanation": "Afhankelijk van je antwoorden past\nPix de moeilijkheidsgraad van de vragen aan.",
-          "icon": "icn-algo.svg",
           "title": "De juiste moeilijkheidsgraad"
         }
       },


### PR DESCRIPTION
## :unicorn: Problème

Dans le message affiché sur les épreuves timées :

> Vous disposerez de 2 minutes pour réussir la question suivante.

Le temps imparti n’est pas traduisibles.

## :robot: Proposition

Créer des clés de traduction pour le temps imparti.

## :rainbow: Remarques

N/A

## :100: Pour tester

Sur la RA, prévisualiser une épreuve timée dans différentes langues et vérifier que le message est correct.