### PR TITLE
[FEATURE] Script de reprise de données des utilisateurs anonymisés (PIX-4218)

### DIFF
--- a/api/src/identity-access-management/infrastructure/repositories/anonymized-user.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/anonymized-user.repository.js
@@ -1,0 +1,8 @@
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+
+async function findIds() {
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn('users').where({ hasBeenAnonymised: true }).pluck('id');
+}
+
+export const anonymizedUserRepository = { findIds };

--- a/api/src/identity-access-management/scripts/backfill-anonymized-users.js
+++ b/api/src/identity-access-management/scripts/backfill-anonymized-users.js
@@ -1,0 +1,22 @@
+import * as url from 'node:url';
+
+import { disconnect } from '../../../db/knex-database-connection.js';
+import { logger } from '../../shared/infrastructure/utils/logger.js';
+
+const modulePath = url.fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === modulePath;
+
+if (isLaunchedFromCommandLine) {
+  try {
+    await backfillAnonymizedUsers();
+  } catch (error) {
+    logger.error('\x1b[31mErreur : %s\x1b[0m', error.message);
+    process.exitCode = 1;
+  } finally {
+    disconnect();
+  }
+}
+
+export async function backfillAnonymizedUsers() {
+  //
+}

--- a/api/src/identity-access-management/scripts/backfill-anonymized-users.js
+++ b/api/src/identity-access-management/scripts/backfill-anonymized-users.js
@@ -1,7 +1,12 @@
 import * as url from 'node:url';
 
 import { disconnect } from '../../../db/knex-database-connection.js';
+import { usecases } from '../../../lib/domain/usecases/index.js';
+import { withTransaction } from '../../shared/domain/DomainTransaction.js';
+import { learningContentCache } from '../../shared/infrastructure/caches/learning-content-cache.js';
+import { temporaryStorage } from '../../shared/infrastructure/temporary-storage/index.js';
 import { logger } from '../../shared/infrastructure/utils/logger.js';
+import { anonymizedUserRepository } from '../infrastructure/repositories/anonymized-user.repository.js';
 
 const modulePath = url.fileURLToPath(import.meta.url);
 const isLaunchedFromCommandLine = process.argv[1] === modulePath;
@@ -13,10 +18,22 @@ if (isLaunchedFromCommandLine) {
     logger.error('\x1b[31mErreur : %s\x1b[0m', error.message);
     process.exitCode = 1;
   } finally {
-    disconnect();
+    await disconnect();
+    await learningContentCache.quit();
+    await temporaryStorage.quit();
   }
 }
 
 export async function backfillAnonymizedUsers() {
-  //
+  const anonymizedUserIds = await anonymizedUserRepository.findIds();
+
+  logger.info(`Total anonymized users to backfill: ${anonymizedUserIds.length}`);
+
+  let current = 1;
+  for (const anonymizedUserId of anonymizedUserIds) {
+    logger.info(`Backfill anonymized user ${current++}/${anonymizedUserIds.length}: "${anonymizedUserId}"`);
+    await withTransaction(usecases.anonymizeUser)({ userId: anonymizedUserId });
+  }
+
+  logger.info(`Anonymized users backfill finished.`);
 }

--- a/api/tests/identity-access-management/acceptance/scripts/backfill-anonymized-users.script.test.js
+++ b/api/tests/identity-access-management/acceptance/scripts/backfill-anonymized-users.script.test.js
@@ -4,14 +4,29 @@ import { databaseBuilder, expect, knex } from '../../../test-helper.js';
 describe('Acceptance | Identity Access Management | Scripts | backfill-anonymized-users', function () {
   it('backfills the anonymized users', async function () {
     // given
-    const oldAnonymizedUser = databaseBuilder.factory.buildUser({ hasBeenAnonymised: true, firstName: 'Jane' });
+    const admin = databaseBuilder.factory.buildUser.withRole();
+    const legacyAnonymizedUser = databaseBuilder.factory.buildUser({
+      firstName: 'Jane',
+      hasBeenAnonymised: true,
+      hasBeenAnonymisedBy: admin.id,
+    });
+    const userNotAnonymized = databaseBuilder.factory.buildUser({
+      firstName: 'Jack',
+      hasBeenAnonymised: false,
+    });
     await databaseBuilder.commit();
 
     // when
     await backfillAnonymizedUsers();
 
     // then
-    const anonymizedUser = await knex('users').where({ id: oldAnonymizedUser.id }).first();
+    const anonymizedUser = await knex('users').where({ id: legacyAnonymizedUser.id }).first();
     expect(anonymizedUser.firstName).to.be.equal('(anonymised)');
+    expect(anonymizedUser.hasBeenAnonymised).to.be.true;
+    expect(anonymizedUser.hasBeenAnonymisedBy).to.be.equal(admin.id);
+
+    const notAnonymizedUser = await knex('users').where({ id: userNotAnonymized.id }).first();
+    expect(notAnonymizedUser.firstName).to.be.equal('Jack');
+    expect(notAnonymizedUser.hasBeenAnonymised).to.be.false;
   });
 });

--- a/api/tests/identity-access-management/acceptance/scripts/backfill-anonymized-users.script.test.js
+++ b/api/tests/identity-access-management/acceptance/scripts/backfill-anonymized-users.script.test.js
@@ -1,0 +1,17 @@
+import { backfillAnonymizedUsers } from '../../../../src/identity-access-management/scripts/backfill-anonymized-users.js';
+import { databaseBuilder, expect, knex } from '../../../test-helper.js';
+
+describe('Acceptance | Identity Access Management | Scripts | backfill-anonymized-users', function () {
+  it('backfills the anonymized users', async function () {
+    // given
+    const oldAnonymizedUser = databaseBuilder.factory.buildUser({ hasBeenAnonymised: true, firstName: 'Jane' });
+    await databaseBuilder.commit();
+
+    // when
+    await backfillAnonymizedUsers();
+
+    // then
+    const anonymizedUser = await knex('users').where({ id: oldAnonymizedUser.id }).first();
+    expect(anonymizedUser.firstName).to.be.equal('(anonymised)');
+  });
+});

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/anonymized-user.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/anonymized-user.repository.test.js
@@ -1,0 +1,19 @@
+import { anonymizedUserRepository } from '../../../../../src/identity-access-management/infrastructure/repositories/anonymized-user.repository.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Integration | Identity Access Management | Infrastructure | Repository | Anonymized User', function () {
+  describe('#findIds', function () {
+    it('returns anonymized user ids', async function () {
+      // given
+      databaseBuilder.factory.buildUser();
+      const anonymizedUser = databaseBuilder.factory.buildUser({ hasBeenAnonymised: true });
+      await databaseBuilder.commit();
+
+      // when
+      const anonymizedUserIds = await anonymizedUserRepository.findIds();
+
+      // then
+      expect(anonymizedUserIds).to.be.deep.equal([anonymizedUser.id]);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Plusieurs modifications ont été effectuées sur les règles d'anonymisation des utilisateurs. Nous devons appliquer ces règles sur les utilisateurs déjà anonymisés.

## :robot: Proposition

Création d'un script pour appliquer toutes les règles d'anonymisation sur tous les users qui ont déjà été anonymisés (`users.hasbeenAnonymised=true`).

Quelques particularités spécifiques au script:
- `users.hasBeenAnonymisedBy` ne doit pas être modifié
- pas de mise à jour ou pas d’ajout de log sur `pix-audit-logger`

## :rainbow: Remarques

- N/A

## :100: Pour tester

Exécuter la commande dans le dossier `api`:
```
node src/identity-access-management/scripts/backfill-anonymized-users.js
```

Ce type de logs doit apparaître:
```
[09:33:37] INFO: Total anonymized users to backfill: 2
[09:33:37] INFO: Backfill anonymized user 1/2: "101577"
[09:33:37] INFO: Backfill anonymized user 2/2: "101580"
[09:33:37] INFO: Anonymized users backfill finished.
```

> Les nouvelles règles d'anonymisation sont appliquées sur les utilisateurs déjà anonymisés.