### PR TITLE
[BUGFIX] Corriger les routes PATCH memberships/:id admin et non admin (PIX-13609)

### DIFF
--- a/api/src/team/domain/usecases/index.js
+++ b/api/src/team/domain/usecases/index.js
@@ -2,6 +2,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import * as mailService from '../../../../lib/domain/services/mail-service.js';
+import * as certificationCenterMembershipRepository from '../../../../lib/infrastructure/repositories/certification-center-membership-repository.js';
 import * as membershipRepository from '../../../../lib/infrastructure/repositories/membership-repository.js';
 import * as sharedMembershipRepository from '../../../../src/shared/infrastructure/repositories/membership-repository.js';
 import * as organizationRepository from '../../../../src/shared/infrastructure/repositories/organization-repository.js';
@@ -23,6 +24,7 @@ const path = dirname(fileURLToPath(import.meta.url));
 
 const dependencies = {
   adminMemberRepository,
+  certificationCenterMembershipRepository,
   certificationCenterRepository,
   certificationCenterInvitationRepository,
   prescriberRepository,

--- a/api/tests/acceptance/application/memberships/membership-controller_test.js
+++ b/api/tests/acceptance/application/memberships/membership-controller_test.js
@@ -24,7 +24,7 @@ describe('Acceptance | Controller | membership-controller', function () {
 
     beforeEach(async function () {
       const externalId = 'externalId';
-      organizationId = databaseBuilder.factory.buildOrganization({ externalId }).id;
+      organizationId = databaseBuilder.factory.buildOrganization({ externalId, type: 'SCO' }).id;
       const adminUserId = databaseBuilder.factory.buildUser().id;
       databaseBuilder.factory.buildMembership({
         organizationId,
@@ -46,6 +46,132 @@ describe('Acceptance | Controller | membership-controller', function () {
       options = {
         method: 'PATCH',
         url: `/api/memberships/${membershipId}`,
+        payload: {
+          data: {
+            id: membershipId.toString(),
+            type: 'memberships',
+            attributes: {
+              'organization-role': newOrganizationRole,
+            },
+            relationships: {
+              user: {
+                data: {
+                  type: 'users',
+                  id: userId,
+                },
+              },
+              organization: {
+                data: {
+                  type: 'organizations',
+                  id: organizationId,
+                },
+              },
+            },
+          },
+        },
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(adminUserId),
+        },
+      };
+    });
+
+    context('Success cases', function () {
+      it('should return the updated membership and add certification center membership', async function () {
+        // given
+        const expectedMembership = {
+          data: {
+            type: 'memberships',
+            id: membershipId.toString(),
+            attributes: {
+              'organization-role': newOrganizationRole,
+            },
+            relationships: {
+              user: {
+                data: {
+                  type: 'users',
+                  id: userId.toString(),
+                },
+              },
+              organization: {
+                data: {
+                  type: 'organizations',
+                  id: organizationId.toString(),
+                },
+              },
+            },
+          },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(_.omit(response.result, 'included')).to.deep.equal(expectedMembership);
+      });
+    });
+
+    context('Error cases', function () {
+      it('should respond with a 403 if user is not admin of membership organization', async function () {
+        // given
+        const notAdminUserId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildMembership({
+          organizationId,
+          userId: notAdminUserId,
+          organizationRole: Membership.roles.MEMBER,
+        });
+        await databaseBuilder.commit();
+
+        options.headers.authorization = generateValidRequestAuthorizationHeader(notAdminUserId);
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+
+      it('should respond with a 400 if membership does not exist', async function () {
+        // given
+        options.url = '/api/memberships/NOT_NUMERIC';
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+        const firstError = response.result.errors[0];
+        expect(firstError.detail).to.equal('"id" must be a number');
+      });
+    });
+  });
+
+  describe('PATCH /api/admin/memberships/{id}', function () {
+    let options;
+    let adminUserId;
+    let userId;
+    let organizationId;
+    let membershipId;
+    let newOrganizationRole;
+
+    beforeEach(async function () {
+      const externalId = 'externalId';
+      adminUserId = databaseBuilder.factory.buildUser.withRole().id;
+      organizationId = databaseBuilder.factory.buildOrganization({ externalId, type: 'SCO' }).id;
+      userId = databaseBuilder.factory.buildUser().id;
+      membershipId = databaseBuilder.factory.buildMembership({
+        organizationId,
+        userId,
+        organizationRole: Membership.roles.MEMBER,
+      }).id;
+      databaseBuilder.factory.buildCertificationCenter({ externalId });
+
+      await databaseBuilder.commit();
+
+      newOrganizationRole = Membership.roles.ADMIN;
+      options = {
+        method: 'PATCH',
+        url: `/api/admin/memberships/${membershipId}`,
         payload: {
           data: {
             id: membershipId.toString(),


### PR DESCRIPTION
## :unicorn: Problème
Une erreur a été remontée de la recette au sujet du _repository_ `certificationCenterMembershipRepository` non injecté dans le contexte de Team.
Les routes `PATCH /api/memberships/{id}` et `PATCH /api/admin/memberships/{id}` sont impactées car elles utilisent le même controlleur appelant le même usecase.

## :robot: Proposition
Injecter le repository dans le contexte de Team.
Mettre à jour les tests d'acceptance lié à aux deux routes impactées (on n'a dû créer le test pour la route admin)

## :rainbow: Remarques
Seule la route `PATCH /api/memberships/{id}` était testée en acceptance. Mais son setup ne permettait pas d'atteindre la ligne du usecase sur laquelle le repository en défaut devait être utilisé.

## :100: Pour tester

### Pix Admin

1. Se connecter à [Pix Admin](https://admin-pr9699.review.pix.fr/) avec le compte superadmin@example.net
2. Modifier le rôle d'un utilisateur
3. Constater le toast de succès

### Pix Orga

1. Se connecter à [Pix Orga](https://orga-pr9699.review.pix.fr/) avec le compte avec le compte member-orga@example.net
2. Modifier le rôle d'un utilisateur de votre organisation
3. Constater le toast de succès
