### PR TITLE
[FEATURE] Modifier le verbe valider par vérifier dans l'e-mail de création de compte (PIX-13612)

### DIFF
--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -351,11 +351,11 @@
       "askForHelp": "Any questions? We’re here to help, contact us",
       "disclaimer": "If you did not create this account, you can ask its deletion",
       "doNotAnswer": "This is an automated email message, please do not reply.",
-      "goToPix": "Validate my email address",
+      "goToPix": "Verify my email address",
       "helpdeskLinkLabel": "here",
       "moreOn": "More on",
       "pixPresentation": "Pix is the online public service to assess, develop and certify your digital skills.",
-      "subtitle": "Thank you for creating your account. There is one last step to secure your account: validating your email address.",
+      "subtitle": "Thank you for creating your account. There is one last step to secure your account: verifying your email address.",
       "subtitleDescription": "It is very simple, please click on the button below and login to your Pix account.",
       "title": "Hello {firstName},"
     },

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -365,11 +365,11 @@
       "askForHelp": "Besoin d’aide, contactez-nous",
       "disclaimer": "Si vous n'êtes pas à l’origine de cette création de compte, vous pouvez en demander la suppression",
       "doNotAnswer": "Ceci est un e-mail automatique, merci de ne pas y répondre.",
-      "goToPix": "Je valide mon adresse e-mail",
+      "goToPix": "Je vérifie mon adresse e-mail",
       "helpdeskLinkLabel": "ici",
       "moreOn": "En savoir plus sur",
       "pixPresentation": "Pix est le service public en ligne pour évaluer, développer et certifier ses compétences numériques.",
-      "subtitle": "Merci d'avoir créé votre compte. Il reste une étape pour sécuriser votre compte en validant votre adresse e-mail.",
+      "subtitle": "Merci d'avoir créé votre compte. Il reste une étape pour sécuriser votre compte en vérifiant votre adresse e-mail.",
       "subtitleDescription": "C'est très simple, il vous suffit de cliquer sur le bouton ci-dessous et de vous connecter à votre compte Pix.",
       "title": "Bonjour {firstName},"
     },


### PR DESCRIPTION
## :unicorn: Problème

Rendre cohérent les verbes utilisés entre l'e-mail de création de compte et le bandeau affiché dans Mon Compte. Actuellement, on parle de "Valider" dans l'e-mail de création de compte et de "Vérifier" dans le bandeau affiché dans Mon Compte.

## :robot: Proposition

Modifier en FR et EN le terme "valider" en "vérifier"

## :rainbow: Remarques

Aucun problème pour ES et NL

## :100: Pour tester
En FR et EN : 
- Se créer un compte PIX 
- Dans l'e-mail de bienvenue, vérifier que le verbe "valider" a été modifié en "vérifier" et "validate" a été transformé en "verify"