### PR TITLE
[FEATURE] Revue de la formulation des fonctionnalités pilotes sur Pix Admin (PIX-13531).

### DIFF
--- a/admin/app/components/certification-centers/habilitation-tag/index.hbs
+++ b/admin/app/components/certification-centers/habilitation-tag/index.hbs
@@ -1,4 +1,4 @@
-<li aria-label={{this.ariaLabel}}>
+<li aria-label={{@arialabel}}>
   <FaIcon class={{this.className}} @icon={{this.icon}} />
   {{@label}}
 </li>

--- a/admin/app/components/certification-centers/habilitation-tag/index.js
+++ b/admin/app/components/certification-centers/habilitation-tag/index.js
@@ -1,12 +1,6 @@
 import Component from '@glimmer/component';
 
 export default class HabilitationTag extends Component {
-  get ariaLabel() {
-    const { active, label } = this.args;
-
-    return `${active ? 'Habilité' : 'Non habilité'} pour ${label}`;
-  }
-
   get className() {
     const { active } = this.args;
 

--- a/admin/app/components/certification-centers/information-view.hbs
+++ b/admin/app/components/certification-centers/information-view.hbs
@@ -22,21 +22,26 @@
   <dd>{{@certificationCenter.dataProtectionOfficerEmail}}</dd>
 </dl>
 
-<span class="label">{{t "pages.certification-centers.information-view.feature-habilitations.title"}}</span>
+<span class="label">{{t "pages.certification-centers.information-view.pilot-features.title"}}</span>
 <ul class="certification-center-information-display__habilitations-list">
-  {{#each this.availableFeatureHabilitations as |feature|}}
-    <CertificationCenters::HabilitationTag @label={{feature.label}} @active={{feature.isPilot}} />
+  {{#each this.availablePilotFeatures as |feature|}}
+    <CertificationCenters::HabilitationTag
+      @label={{feature.label}}
+      @active={{feature.isPilot}}
+      @arialabel={{feature.ariaLabel}}
+    />
   {{/each}}
 </ul>
 
 <div class="certification-center-information-display__divider"></div>
 
-<span class="label">Habilitations aux certifications complémentaires</span>
+<span class="label">{{t "pages.certification-centers.information-view.habilitations.title"}}</span>
 <ul class="certification-center-information-display__habilitations-list">
   {{#each this.availableHabilitations as |habilitation|}}
     <CertificationCenters::HabilitationTag
       @label={{habilitation.label}}
-      @active={{contains habilitation this.habilitations}}
+      @active={{habilitation.isHabilitated}}
+      @arialabel={{habilitation.ariaLabel}}
     />
   {{/each}}
 </ul>

--- a/admin/app/components/certification-centers/information-view.js
+++ b/admin/app/components/certification-centers/information-view.js
@@ -13,23 +13,42 @@ export default class InformationView extends Component {
       this.habilitations = habilitations;
     });
   }
+
   get availableHabilitations() {
-    return this.args.availableHabilitations?.sortBy('id');
+    const habilitations = this.args.availableHabilitations?.sortBy('id') || [];
+    return habilitations.map((habilitation) => {
+      const isHabilitated = this.habilitations.includes(habilitation);
+      const label = habilitation.label;
+      const ariaLabel = this.intl.t(
+        `pages.certification-centers.information-view.habilitations.aria-label.${isHabilitated ? 'active' : 'inactive'}`,
+        { complementaryCertificationLabel: label },
+      );
+      return { isHabilitated, label, ariaLabel };
+    });
   }
 
-  get availableFeatureHabilitations() {
+  get availablePilotFeatures() {
     const isV3Pilot = this.args.certificationCenter.isV3Pilot;
-    const isV3PilotLabel = this.intl.t(
-      'pages.certification-centers.information-view.feature-habilitations.labels.is-v3-pilot',
+    const isV3PilotLabel = this.intl.t('pages.certification-centers.information-view.pilot-features.is-v3-pilot.label');
+    const isV3PilotAriaLabel = this.intl.t(
+      `pages.certification-centers.information-view.pilot-features.is-v3-pilot.aria-label.${isV3Pilot ? 'active' : 'inactive'}`,
     );
+
     const isComplementaryAlonePilot = this.args.certificationCenter.isComplementaryAlonePilot;
     const isComplementaryAlonePilotLabel = this.intl.t(
-      'pages.certification-centers.information-view.feature-habilitations.labels.is-complementary-alone-pilot',
+      'pages.certification-centers.information-view.pilot-features.is-complementary-alone-pilot.label',
+    );
+    const isComplementaryAlonePilotAriaLabel = this.intl.t(
+      `pages.certification-centers.information-view.pilot-features.is-complementary-alone-pilot.aria-label.${isComplementaryAlonePilot ? 'active' : 'inactive'}`,
     );
 
     return [
-      { isPilot: isV3Pilot, label: isV3PilotLabel },
-      { isPilot: isComplementaryAlonePilot, label: isComplementaryAlonePilotLabel },
+      { isPilot: isV3Pilot, label: isV3PilotLabel, ariaLabel: isV3PilotAriaLabel },
+      {
+        isPilot: isComplementaryAlonePilot,
+        label: isComplementaryAlonePilotLabel,
+        ariaLabel: isComplementaryAlonePilotAriaLabel,
+      },
     ];
   }
 

--- a/admin/tests/acceptance/authenticated/certification-centers/get-test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get-test.js
@@ -134,6 +134,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
       await clickByName('Enregistrer');
 
       // then
+      assert.dom(screen.getByText('Fonctionnalités pilotes')).exists();
       assert.dom(screen.getByText('Habilitations aux certifications complémentaires')).exists();
       assert.dom(screen.getByRole('heading', { name: 'nouveau nom', level: 2 })).exists();
       assert.dom(screen.getByText('Établissement supérieur')).exists();

--- a/admin/tests/integration/components/certification-centers/information-view-test.js
+++ b/admin/tests/integration/components/certification-centers/information-view-test.js
@@ -89,7 +89,13 @@ module('Integration | Component | certification-centers/information-view', funct
       );
 
       // then
-      assert.dom(screen.getByLabelText('Habilité pour pilote certification V3')).exists();
+      assert
+        .dom(
+          screen.getByLabelText(
+            this.intl.t('pages.certification-centers.information-view.pilot-features.is-v3-pilot.aria-label.active'),
+          ),
+        )
+        .exists();
     });
   });
 
@@ -110,7 +116,13 @@ module('Integration | Component | certification-centers/information-view', funct
       );
 
       // then
-      assert.dom(screen.getByLabelText('Non habilité pour pilote certification V3')).exists();
+      assert
+        .dom(
+          screen.getByLabelText(
+            this.intl.t('pages.certification-centers.information-view.pilot-features.is-v3-pilot.aria-label.inactive'),
+          ),
+        )
+        .exists();
     });
   });
 
@@ -131,7 +143,15 @@ module('Integration | Component | certification-centers/information-view', funct
       );
 
       // then
-      assert.dom(screen.getByLabelText('Habilité pour pilote séparation Pix/Pix+')).exists();
+      assert
+        .dom(
+          screen.getByLabelText(
+            this.intl.t(
+              'pages.certification-centers.information-view.pilot-features.is-complementary-alone-pilot.aria-label.active',
+            ),
+          ),
+        )
+        .exists();
     });
   });
 
@@ -152,7 +172,15 @@ module('Integration | Component | certification-centers/information-view', funct
       );
 
       // then
-      assert.dom(screen.getByLabelText('Non habilité pour pilote séparation Pix/Pix+')).exists();
+      assert
+        .dom(
+          screen.getByLabelText(
+            this.intl.t(
+              'pages.certification-centers.information-view.pilot-features.is-complementary-alone-pilot.aria-label.inactive',
+            ),
+          ),
+        )
+        .exists();
     });
   });
 });

--- a/admin/tests/unit/components/certification-centers/habilitation-tag/index-test.js
+++ b/admin/tests/unit/components/certification-centers/habilitation-tag/index-test.js
@@ -7,24 +7,19 @@ import createGlimmerComponent from '../../../../helpers/create-glimmer-component
 module('Unit | Component | certification-centers/habilitation-tag', function (hooks) {
   setupTest(hooks);
 
-  test('it should return the correct label, icon and classname when the center is habilited', function (assert) {
+  test('it should return the correct icon and classname when the center is habilited', function (assert) {
     const component = createGlimmerComponent('component:certification-centers/habilitation-tag', {
       active: true,
-      label: 'Mon centre bien habilité',
     });
-
-    assert.strictEqual(component.ariaLabel, 'Habilité pour Mon centre bien habilité');
     assert.strictEqual(component.className, 'granted-habilitation-icon');
     assert.strictEqual(component.icon, 'circle-check');
   });
 
-  test('it should return the correct label, icon and classname when the center is NOT habilited', function (assert) {
+  test('it should return the correct icon and classname when the center is NOT habilited', function (assert) {
     const component = createGlimmerComponent('component:certification-centers/habilitation-tag', {
       active: false,
-      label: 'Mon centre pas habilité',
     });
 
-    assert.strictEqual(component.ariaLabel, 'Non habilité pour Mon centre pas habilité');
     assert.strictEqual(component.className, 'non-granted-habilitation-icon');
     assert.strictEqual(component.icon, 'circle-xmark');
   });

--- a/admin/tests/unit/components/certification-centers/information-view-test.js
+++ b/admin/tests/unit/components/certification-centers/information-view-test.js
@@ -11,14 +11,14 @@ module('Unit | Component | certification-centers/information-view', function (ho
     test('it should return a sorted list of available habilitations', async function (assert) {
       // given
       const component = createGlimmerComponent('component:certification-centers/information-view', {
-        availableHabilitations: [{ id: 321 }, { id: 21 }, { id: 1 }],
+        availableHabilitations: [{ id: 321, label: 'Habilitation A' }, { id: 21 }, { id: 1, label: 'Habilitation B' }],
         certificationCenter: { id: 1 },
       });
 
       // when & then
       assert.strictEqual(component.availableHabilitations.length, 3);
-      assert.strictEqual(component.availableHabilitations[0].id, 1);
-      assert.strictEqual(component.availableHabilitations[2].id, 321);
+      assert.strictEqual(component.availableHabilitations[0].label, 'Habilitation B');
+      assert.strictEqual(component.availableHabilitations[2].label, 'Habilitation A');
     });
   });
 

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -305,11 +305,28 @@
     },
     "certification-centers": {
       "information-view": {
-        "feature-habilitations": {
-          "title": "Feature habilitations",
-          "labels": {
-            "is-complementary-alone-pilot": "Pix/Pix+ separation pilot",
-            "is-v3-pilot": "V3 certification pilot"
+        "habilitations": {
+          "title": "Habilitated to the following complementary certifications",
+          "aria-label": {
+            "active": "Habilitated to {complementaryCertificationLabel}",
+            "inactive": "Not habilitated to {complementaryCertificationLabel}"
+          }
+        },
+        "pilot-features": {
+          "title": "Pilot features",
+          "is-complementary-alone-pilot": {
+            "aria-label": {
+              "active": "is pilot Pix/Pix+ compatibility test phase",
+              "inactive": "not Pix/Pix+ compatibility test phase"
+            },
+            "label": "Pix/Pix+ compatibility test phase"
+          },
+          "is-v3-pilot": {
+            "aria-label": {
+              "active": "is V3 certification pilot",
+              "inactive": "is not V3 certification pilot"
+            },
+            "label": "V3 certification pilot"
           }
         }
       },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -315,11 +315,28 @@
     },
     "certification-centers": {
       "information-view": {
-        "feature-habilitations": {
-          "title": "Habilitations aux fonctionnalités pilotes",
-          "labels": {
-            "is-complementary-alone-pilot": "pilote séparation Pix/Pix+",
-            "is-v3-pilot": "pilote certification V3"
+        "habilitations": {
+          "title": "Habilitations aux certifications complémentaires",
+          "aria-label": {
+            "active": "Habilité pour {complementaryCertificationLabel}",
+            "inactive": "Non habilité pour {complementaryCertificationLabel}"
+          }
+        },
+        "pilot-features": {
+          "title": "Fonctionnalités pilotes",
+          "is-complementary-alone-pilot": {
+            "aria-label": {
+              "active": "Est pilote phase test compatibilité Pix v3 / Pix+",
+              "inactive": "N'est pas phase test compatibilité Pix v3 / Pix+"
+            },
+            "label": "phase test compatibilité Pix v3 / Pix+"
+          },
+          "is-v3-pilot": {
+            "aria-label": {
+              "active": "Est pilote certification V3",
+              "inactive": "N'est pas pilote certification V3"
+            },
+            "label": "pilote certification V3"
           }
         }
       },


### PR DESCRIPTION
## :unicorn: Problème
Des réflexions sur la compatibilité Pix v3 et Pix+ menées fin mai début juin ont mené également à l’abandon de la phase pilote de séparation Pix/Pix+ initialement prévue pour fonctionner avec la v2.

L'épix “Séparation Pix/Pix+” qui fonctionnait avec la v2 a d’ailleurs été abandonnée et remodelée en “Compatibilité Pix v3 et Pix+”.

On s'est rendu compte aussi par là que la désignation sur Pix Admin de ces fonctionnalités pilotes était confusante.

## :robot: Proposition

Encadré rouge sur la capture d'écran : modifier le wording “Habilitations aux fonctionnalités pilotes” en juste “Fonctionnalités pilotes” car il s’agit là plutôt de FT en réalité plutôt qu’une habilitation dans le sens d’un droit qui a été accordé en plus à ces CDC pour faire passer un type de complémentaire

Encadré jaune sur la capture d'écran : modifier le wording dans Pix Admin en changeant “pilote séparation Pix/Pix+” en “phase test compatibilité Pix v3 / Pix+”

![image](https://github.com/user-attachments/assets/371499e4-4729-4fa1-8e55-d30993663911)


## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
* Sur Pix Admin avec `superadmin@example.net`, aller voir un centre de certification
  * Exemple : certification-centers/7304
* Vérifier le wording  par rapport à la demande (voir section précèdentes)
* Tenter des modifications, pour chaque modification, vérifier que l'état de l'icone + du wording est cohérent, vérifier aussi le aria-label associé (via outils d'accessibilité)
  * passer un centre V2 en V3
  * sur un centre V2, activer / désactiver des habiliations complémentaires
