### PR TITLE
[FEATURE] Changement de wording sur l'envoi multiple à la création de campagne  (PIX-13605)

### DIFF
--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -485,7 +485,7 @@
       "legal-warning": "*In accordance with the French law governing computer technology and freedoms (“Informatique et Libertés”), and as data controller, please be careful not to ask for significant or identifying personal data unless it is absolutely necessary. Asking for social security numbers, as well as any sensitive data, is strictly prohibited.",
       "multiple-sendings": {
         "assessments": {
-          "info": "If you choose to allow multiple submissions, the participants will be able to take the test again 4 days after and submit their results several times by re-entering the campaign code. Within Pix Orga you will find the latest participation.",
+          "info": "If you choose to allow multiple submissions, the participants will be able to take the test again 4 days after and submit their results several times by re-entering the campaign code.",
           "question-label": "Do you want to allow participants to submit their results more than once?"
         },
         "info-title": "Multiple submissions",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -102,12 +102,12 @@
     "place-info": {
       "with-account": {
         "heading": "'<strong>'Le participant a un compte Pix :'</strong>'",
-        "message-description": "Vous pouvez Libérer des places en supprimant des participants depuis l'onglet Participants.",
+        "message-description": "Vous pouvez libérer des places en supprimant des participants depuis l'onglet Participants.",
         "message-main": "1 participant ayant au moins une participation à une campagne = 1 place occupée."
       },
       "without-account": {
         "heading": "'<strong>'Le participant n'a pas de compte Pix'</strong>' (campagne avec accès sans compte) :",
-        "message-description": "Vous pouvez Libérer ces places en supprimant des participations dans la campagne avec accès sans compte concernée ou supprimer la campagne.",
+        "message-description": "Vous pouvez libérer ces places en supprimant des participations dans la campagne avec accès sans compte concernée ou supprimer la campagne.",
         "message-main": "1 participation sans compte = 1 place occupée."
       }
     },
@@ -488,7 +488,7 @@
       "legal-warning": "* En vertu de la loi Informatique et libertés, et en tant que responsable de traitement, soyez attentifs à ne pas demander de donnée particulièrement identifiante ou signifiante si ce n’est pas absolument indispensable. Le numéro de sécurité sociale (NIR) est à proscrire ainsi que toute donnée sensible.",
       "multiple-sendings": {
         "assessments": {
-          "info": "Si vous choisissez l’envoi multiple, le participant pourra repasser la campagne 4 jours après et envoyer ses résultats plusieurs fois, en saisissant à nouveau le code. Au sein de Pix Orga, vous verrez sa dernière participation.",
+          "info": "Si vous choisissez l’envoi multiple, le participant pourra repasser la campagne 4 jours après et envoyer ses résultats plusieurs fois, en saisissant à nouveau le code.",
           "question-label": "Souhaitez-vous permettre aux participants d’envoyer plusieurs fois leurs résultats ?"
         },
         "info-title": "Envoi multiple",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -422,7 +422,7 @@
       "legal-warning": "* In overeenstemming met de Franse wet op gegevensbescherming en als verantwoordelijke voor de verwerking van de gegevens, vragen we niet naar bijzonder identificerende of belangrijke gegevens, tenzij dit absoluut noodzakelijk is. Het burgerservicenummer (BSN) moet worden vermeden, net als gevoelige gegevens.",
       "multiple-sendings": {
         "assessments": {
-          "info": "Als je ervoor kiest om meerdere inzendingen te verzenden, kan de deelnemer de campagne 4 dagen later opnieuw uitvoeren en zijn resultaten meerdere keren verzenden door de code opnieuw in te voeren. In Pix Orga zie je hun laatste inzending.",
+          "info": "Als je ervoor kiest om meerdere inzendingen te verzenden, kan de deelnemer de campagne 4 dagen later opnieuw uitvoeren en zijn resultaten meerdere keren verzenden door de code opnieuw in te voeren.",
           "question-label": "Wil je deelnemers toestaan hun resultaten meer dan één keer te versturen?"
         },
         "info-title": "Meervoudig verzenden",


### PR DESCRIPTION
## :unicorn: Problème
A la création d'une campagne à envoi multiple, on explique au prescripteur qu'il ne verra que la dernière participation du prescrit dans Orga. Ca n'est plus le cas depuis que l'on historise les participations partagées. 
![image (16) (1)](https://github.com/user-attachments/assets/892aa353-7fcf-4419-acb9-1cfe64f1c7e2)

## :robot: Proposition
Enlever la phrase 🙃 

## :100: Pour tester
On lit
On valide 🤞
