### PR TITLE
[FEATURE] Revoir le design du bouton "Suivant" du Stepper Modulix (PIX-13636)

### DIFF
--- a/mon-pix/app/components/module/stepper.gjs
+++ b/mon-pix/app/components/module/stepper.gjs
@@ -88,13 +88,15 @@ export default class ModulixStepper extends Component {
           />
         {{/each}}
         {{#if this.shouldDisplayNextButton}}
-          <PixButton
-            aria-label="{{t 'pages.modulix.buttons.stepper.next.ariaLabel'}}"
-            @variant="primary"
-            @iconAfter="arrow-down"
-            @triggerAction={{this.displayNextStep}}
-          >{{t "pages.modulix.buttons.stepper.next.name"}}
-          </PixButton>
+          <div class="stepper__next">
+            <PixButton
+              aria-label="{{t 'pages.modulix.buttons.stepper.next.ariaLabel'}}"
+              @variant="primary"
+              @iconAfter="arrow-down"
+              @triggerAction={{this.displayNextStep}}
+              class="stepper-next__button"
+            >{{t "pages.modulix.buttons.stepper.next.name"}}</PixButton>
+          </div>
         {{/if}}
       {{/if}}
     </div>

--- a/mon-pix/app/styles/components/module/_stepper.scss
+++ b/mon-pix/app/styles/components/module/_stepper.scss
@@ -7,7 +7,8 @@
     justify-content: center;
     width: 100%;
 
-    &::before, &::after {
+    &::before,
+    &::after {
       flex: 1;
       height: 2px;
       background: var(--pix-neutral-100);
@@ -39,11 +40,30 @@
       margin: var(--pix-spacing-1x) 0 var(--pix-spacing-4x) 0;
     }
   }
+
+  &__next {
+    display: flex;
+    gap: var(--pix-spacing-4x);
+    align-items: center;
+
+    &::before,
+    &::after {
+      flex-grow: 1;
+      border-top: 3px dotted var(--pix-neutral-100);
+      content: '';
+    }
+  }
 }
 
 .stepper-step-position {
   &__content {
     padding: var(--pix-spacing-1x) var(--pix-spacing-4x);
     color: var(--pix-neutral-800);
+  }
+}
+
+.stepper-next {
+  &__button {
+    width: 190px;
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Le bouton "Suivant" dans le Stepper de Modulix est trop mis en avant.

## :robot: Proposition
Le mettre en retrait en rétrécissant le CTA et ajoutant des traits pointillés autours.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier sur [le didacticiel](https://app-pr9716.review.pix.fr/modules/didacticiel-modulix/passage) que le Stepper est tout joli ✨  et fonctionne toujours.
