### PR TITLE
[TECH] Déplace les `orm-models` vers `src`

### DIFF
--- a/api/lib/infrastructure/repositories/certification-center-membership-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-membership-repository.js
@@ -10,10 +10,10 @@ import {
 } from '../../../src/shared/domain/errors.js';
 import { CertificationCenter } from '../../../src/shared/domain/models/CertificationCenter.js';
 import { CertificationCenterMembership } from '../../../src/shared/domain/models/CertificationCenterMembership.js';
+import { BookshelfCertificationCenterMembership } from '../../../src/shared/infrastructure/orm-models/CertificationCenterMembership.js';
 import * as bookshelfToDomainConverter from '../../../src/shared/infrastructure/utils/bookshelf-to-domain-converter.js';
 import * as knexUtils from '../../../src/shared/infrastructure/utils/knex-utils.js';
 import { DomainTransaction } from '../DomainTransaction.js';
-import { BookshelfCertificationCenterMembership } from '../orm-models/CertificationCenterMembership.js';
 
 const CERTIFICATION_CENTER_MEMBERSHIP_TABLE_NAME = 'certification-center-memberships';
 

--- a/api/lib/infrastructure/repositories/membership-repository.js
+++ b/api/lib/infrastructure/repositories/membership-repository.js
@@ -3,10 +3,10 @@ import { User } from '../../../src/identity-access-management/domain/models/User
 import { Organization } from '../../../src/organizational-entities/domain/models/Organization.js';
 import { MembershipCreationError, MembershipUpdateError, NotFoundError } from '../../../src/shared/domain/errors.js';
 import { Membership } from '../../../src/shared/domain/models/Membership.js';
+import { BookshelfMembership } from '../../../src/shared/infrastructure/orm-models/Membership.js';
 import * as bookshelfToDomainConverter from '../../../src/shared/infrastructure/utils/bookshelf-to-domain-converter.js';
 import * as knexUtils from '../../../src/shared/infrastructure/utils/knex-utils.js';
 import { DomainTransaction } from '../DomainTransaction.js';
-import { BookshelfMembership } from '../orm-models/Membership.js';
 
 const DEFAULT_PAGE_SIZE = 10;
 const DEFAULT_PAGE_NUMBER = 1;

--- a/api/src/certification/enrolment/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/certification-candidate-repository.js
@@ -3,13 +3,13 @@ import _ from 'lodash';
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { PGSQL_UNIQUE_CONSTRAINT_VIOLATION_ERROR } from '../../../../../db/pgsql-errors.js';
 import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';
-import { BookshelfCertificationCandidate } from '../../../../../lib/infrastructure/orm-models/CertificationCandidate.js';
-import { CertificationCandidate } from '../../../../../src/shared/domain/models/CertificationCandidate.js';
 import {
   CertificationCandidateCreationOrUpdateError,
   CertificationCandidateMultipleUserLinksWithinSessionError,
   NotFoundError,
 } from '../../../../shared/domain/errors.js';
+import { CertificationCandidate } from '../../../../shared/domain/models/CertificationCandidate.js';
+import { BookshelfCertificationCandidate } from '../../../../shared/infrastructure/orm-models/CertificationCandidate.js';
 import * as bookshelfToDomainConverter from '../../../../shared/infrastructure/utils/bookshelf-to-domain-converter.js';
 import { normalize } from '../../../../shared/infrastructure/utils/string-utils.js';
 import { CompanionPingInfo } from '../../domain/models/CompanionPingInfo.js';

--- a/api/src/certification/shared/infrastructure/repositories/certification-center-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-center-repository.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 
 import { knex } from '../../../../../db/knex-database-connection.js';
-import { BookshelfCertificationCenter } from '../../../../../lib/infrastructure/orm-models/CertificationCenter.js';
+import { BookshelfCertificationCenter } from '../../../../../src/shared/infrastructure/orm-models/CertificationCenter.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { CertificationCenter } from '../../../../shared/domain/models/CertificationCenter.js';
 import { ComplementaryCertification } from '../../../complementary-certification/domain/models/ComplementaryCertification.js';

--- a/api/src/certification/shared/infrastructure/repositories/certification-report-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-report-repository.js
@@ -2,8 +2,8 @@ import bluebird from 'bluebird';
 import _ from 'lodash';
 
 import { Bookshelf } from '../../../../../lib/infrastructure/bookshelf.js';
-import { BookshelfAssessment } from '../../../../../lib/infrastructure/orm-models/Assessment.js';
-import { BookshelfCertificationCourse } from '../../../../../lib/infrastructure/orm-models/CertificationCourse.js';
+import { BookshelfAssessment } from '../../../../shared/infrastructure/orm-models/Assessment.js';
+import { BookshelfCertificationCourse } from '../../../../shared/infrastructure/orm-models/CertificationCourse.js';
 import * as bookshelfToDomainConverter from '../../../../shared/infrastructure/utils/bookshelf-to-domain-converter.js';
 import { ComplementaryCertificationCourse } from '../../../session-management/domain/models/ComplementaryCertificationCourse.js';
 import { CertificationCourseUpdateError } from '../../domain/errors.js';

--- a/api/src/certification/shared/infrastructure/repositories/certification-report-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-report-repository.js
@@ -1,7 +1,7 @@
 import bluebird from 'bluebird';
 import _ from 'lodash';
 
-import { Bookshelf } from '../../../../../lib/infrastructure/bookshelf.js';
+import { Bookshelf } from '../../../../shared/infrastructure/bookshelf.js';
 import { BookshelfAssessment } from '../../../../shared/infrastructure/orm-models/Assessment.js';
 import { BookshelfCertificationCourse } from '../../../../shared/infrastructure/orm-models/CertificationCourse.js';
 import * as bookshelfToDomainConverter from '../../../../shared/infrastructure/utils/bookshelf-to-domain-converter.js';

--- a/api/src/identity-access-management/infrastructure/repositories/user.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user.repository.js
@@ -1,5 +1,5 @@
 import { knex } from '../../../../db/knex-database-connection.js';
-import { BookshelfUser } from '../../../../lib/infrastructure/orm-models/User.js';
+import { BookshelfUser } from '../../../../src/shared/infrastructure/orm-models/User.js';
 import { Organization } from '../../../organizational-entities/domain/models/Organization.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import {

--- a/api/src/organizational-entities/infrastructure/repositories/certification-center.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/certification-center.repository.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import { BookshelfCertificationCenter } from '../../../../lib/infrastructure/orm-models/CertificationCenter.js';
+import { BookshelfCertificationCenter } from '../../../../src/shared/infrastructure/orm-models/CertificationCenter.js';
 import { ComplementaryCertification } from '../../../certification/complementary-certification/domain/models/ComplementaryCertification.js';
 import { CertificationCenter } from '../../../shared/domain/models/index.js';
 

--- a/api/src/shared/infrastructure/bookshelf.js
+++ b/api/src/shared/infrastructure/bookshelf.js
@@ -2,7 +2,7 @@ import bookshelf from 'bookshelf';
 import _ from 'lodash';
 import validator from 'validator';
 
-import { knex } from '../../db/knex-database-connection.js';
+import { knex } from '../../../db/knex-database-connection.js';
 const bookshelfWithKnex = bookshelf(knex);
 
 validator.isRequired = function (value) {

--- a/api/src/shared/infrastructure/orm-models/Answer.js
+++ b/api/src/shared/infrastructure/orm-models/Answer.js
@@ -1,6 +1,6 @@
 import './Assessment.js';
 
-import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
+import { Bookshelf } from '../bookshelf.js';
 
 const modelName = 'Answer';
 

--- a/api/src/shared/infrastructure/orm-models/Answer.js
+++ b/api/src/shared/infrastructure/orm-models/Answer.js
@@ -1,6 +1,6 @@
 import './Assessment.js';
 
-import { Bookshelf } from '../bookshelf.js';
+import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
 
 const modelName = 'Answer';
 

--- a/api/src/shared/infrastructure/orm-models/Assessment.js
+++ b/api/src/shared/infrastructure/orm-models/Assessment.js
@@ -3,7 +3,7 @@ import './User.js';
 import './KnowledgeElement.js';
 import './CampaignParticipation.js';
 
-import { Bookshelf } from '../bookshelf.js';
+import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
 
 const modelName = 'Assessment';
 

--- a/api/src/shared/infrastructure/orm-models/Assessment.js
+++ b/api/src/shared/infrastructure/orm-models/Assessment.js
@@ -3,7 +3,7 @@ import './User.js';
 import './KnowledgeElement.js';
 import './CampaignParticipation.js';
 
-import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
+import { Bookshelf } from '../bookshelf.js';
 
 const modelName = 'Assessment';
 

--- a/api/src/shared/infrastructure/orm-models/AuthenticationMethod.js
+++ b/api/src/shared/infrastructure/orm-models/AuthenticationMethod.js
@@ -1,6 +1,6 @@
 import './User.js';
 
-import { Bookshelf } from '../bookshelf.js';
+import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
 
 const modelName = 'AuthenticationMethod';
 

--- a/api/src/shared/infrastructure/orm-models/AuthenticationMethod.js
+++ b/api/src/shared/infrastructure/orm-models/AuthenticationMethod.js
@@ -1,6 +1,6 @@
 import './User.js';
 
-import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
+import { Bookshelf } from '../bookshelf.js';
 
 const modelName = 'AuthenticationMethod';
 

--- a/api/src/shared/infrastructure/orm-models/Badge.js
+++ b/api/src/shared/infrastructure/orm-models/Badge.js
@@ -1,6 +1,6 @@
 import './TargetProfile.js';
 
-import { Bookshelf } from '../bookshelf.js';
+import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
 
 const modelName = 'Badge';
 

--- a/api/src/shared/infrastructure/orm-models/Badge.js
+++ b/api/src/shared/infrastructure/orm-models/Badge.js
@@ -1,6 +1,6 @@
 import './TargetProfile.js';
 
-import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
+import { Bookshelf } from '../bookshelf.js';
 
 const modelName = 'Badge';
 

--- a/api/src/shared/infrastructure/orm-models/Campaign.js
+++ b/api/src/shared/infrastructure/orm-models/Campaign.js
@@ -4,7 +4,7 @@ import './Organization.js';
 import './TargetProfile.js';
 import './User.js';
 
-import { Bookshelf } from '../bookshelf.js';
+import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
 
 const modelName = 'Campaign';
 

--- a/api/src/shared/infrastructure/orm-models/Campaign.js
+++ b/api/src/shared/infrastructure/orm-models/Campaign.js
@@ -4,7 +4,7 @@ import './Organization.js';
 import './TargetProfile.js';
 import './User.js';
 
-import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
+import { Bookshelf } from '../bookshelf.js';
 
 const modelName = 'Campaign';
 

--- a/api/src/shared/infrastructure/orm-models/CampaignParticipation.js
+++ b/api/src/shared/infrastructure/orm-models/CampaignParticipation.js
@@ -2,7 +2,7 @@ import './Assessment.js';
 import './Campaign.js';
 import './User.js';
 
-import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
+import { Bookshelf } from '../bookshelf.js';
 
 const modelName = 'CampaignParticipation';
 

--- a/api/src/shared/infrastructure/orm-models/CampaignParticipation.js
+++ b/api/src/shared/infrastructure/orm-models/CampaignParticipation.js
@@ -2,7 +2,7 @@ import './Assessment.js';
 import './Campaign.js';
 import './User.js';
 
-import { Bookshelf } from '../bookshelf.js';
+import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
 
 const modelName = 'CampaignParticipation';
 

--- a/api/src/shared/infrastructure/orm-models/CertificationCandidate.js
+++ b/api/src/shared/infrastructure/orm-models/CertificationCandidate.js
@@ -1,7 +1,7 @@
 import './Session.js';
 import './User.js';
 
-import { Bookshelf } from '../bookshelf.js';
+import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
 
 const modelName = 'CertificationCandidate';
 

--- a/api/src/shared/infrastructure/orm-models/CertificationCandidate.js
+++ b/api/src/shared/infrastructure/orm-models/CertificationCandidate.js
@@ -1,7 +1,7 @@
 import './Session.js';
 import './User.js';
 
-import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
+import { Bookshelf } from '../bookshelf.js';
 
 const modelName = 'CertificationCandidate';
 

--- a/api/src/shared/infrastructure/orm-models/CertificationCenter.js
+++ b/api/src/shared/infrastructure/orm-models/CertificationCenter.js
@@ -1,6 +1,6 @@
 import './ComplementaryCertification.js';
 
-import { Bookshelf } from '../bookshelf.js';
+import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
 
 const modelName = 'CertificationCenter';
 

--- a/api/src/shared/infrastructure/orm-models/CertificationCenter.js
+++ b/api/src/shared/infrastructure/orm-models/CertificationCenter.js
@@ -1,6 +1,6 @@
 import './ComplementaryCertification.js';
 
-import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
+import { Bookshelf } from '../bookshelf.js';
 
 const modelName = 'CertificationCenter';
 

--- a/api/src/shared/infrastructure/orm-models/CertificationCenterMembership.js
+++ b/api/src/shared/infrastructure/orm-models/CertificationCenterMembership.js
@@ -1,7 +1,7 @@
 import './CertificationCenter.js';
 import './User.js';
 
-import { Bookshelf } from '../bookshelf.js';
+import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
 
 const modelName = 'CertificationCenterMembership';
 

--- a/api/src/shared/infrastructure/orm-models/CertificationCenterMembership.js
+++ b/api/src/shared/infrastructure/orm-models/CertificationCenterMembership.js
@@ -1,7 +1,7 @@
 import './CertificationCenter.js';
 import './User.js';
 
-import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
+import { Bookshelf } from '../bookshelf.js';
 
 const modelName = 'CertificationCenterMembership';
 

--- a/api/src/shared/infrastructure/orm-models/CertificationChallenge.js
+++ b/api/src/shared/infrastructure/orm-models/CertificationChallenge.js
@@ -1,4 +1,4 @@
-import { Bookshelf } from '../bookshelf.js';
+import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
 
 const modelName = 'CertificationChallenge';
 

--- a/api/src/shared/infrastructure/orm-models/CertificationChallenge.js
+++ b/api/src/shared/infrastructure/orm-models/CertificationChallenge.js
@@ -1,4 +1,4 @@
-import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
+import { Bookshelf } from '../bookshelf.js';
 
 const modelName = 'CertificationChallenge';
 

--- a/api/src/shared/infrastructure/orm-models/CertificationCourse.js
+++ b/api/src/shared/infrastructure/orm-models/CertificationCourse.js
@@ -4,7 +4,7 @@ import './CertificationIssueReport.js';
 import './ComplementaryCertificationCourse.js';
 import './Session.js';
 
-import { Bookshelf } from '../bookshelf.js';
+import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
 
 const modelName = 'CertificationCourse';
 

--- a/api/src/shared/infrastructure/orm-models/CertificationCourse.js
+++ b/api/src/shared/infrastructure/orm-models/CertificationCourse.js
@@ -4,7 +4,7 @@ import './CertificationIssueReport.js';
 import './ComplementaryCertificationCourse.js';
 import './Session.js';
 
-import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
+import { Bookshelf } from '../bookshelf.js';
 
 const modelName = 'CertificationCourse';
 

--- a/api/src/shared/infrastructure/orm-models/CertificationIssueReport.js
+++ b/api/src/shared/infrastructure/orm-models/CertificationIssueReport.js
@@ -1,4 +1,4 @@
-import { Bookshelf } from '../bookshelf.js';
+import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
 
 const modelName = 'CertificationIssueReport';
 

--- a/api/src/shared/infrastructure/orm-models/CertificationIssueReport.js
+++ b/api/src/shared/infrastructure/orm-models/CertificationIssueReport.js
@@ -1,4 +1,4 @@
-import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
+import { Bookshelf } from '../bookshelf.js';
 
 const modelName = 'CertificationIssueReport';
 

--- a/api/src/shared/infrastructure/orm-models/ComplementaryCertification.js
+++ b/api/src/shared/infrastructure/orm-models/ComplementaryCertification.js
@@ -1,4 +1,4 @@
-import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
+import { Bookshelf } from '../bookshelf.js';
 
 const modelName = 'ComplementaryCertification';
 

--- a/api/src/shared/infrastructure/orm-models/ComplementaryCertification.js
+++ b/api/src/shared/infrastructure/orm-models/ComplementaryCertification.js
@@ -1,4 +1,4 @@
-import { Bookshelf } from '../bookshelf.js';
+import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
 
 const modelName = 'ComplementaryCertification';
 

--- a/api/src/shared/infrastructure/orm-models/ComplementaryCertificationCourse.js
+++ b/api/src/shared/infrastructure/orm-models/ComplementaryCertificationCourse.js
@@ -1,4 +1,4 @@
-import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
+import { Bookshelf } from '../bookshelf.js';
 
 const modelName = 'ComplementaryCertificationCourse';
 

--- a/api/src/shared/infrastructure/orm-models/ComplementaryCertificationCourse.js
+++ b/api/src/shared/infrastructure/orm-models/ComplementaryCertificationCourse.js
@@ -1,4 +1,4 @@
-import { Bookshelf } from '../bookshelf.js';
+import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
 
 const modelName = 'ComplementaryCertificationCourse';
 

--- a/api/src/shared/infrastructure/orm-models/KnowledgeElement.js
+++ b/api/src/shared/infrastructure/orm-models/KnowledgeElement.js
@@ -1,7 +1,7 @@
 import './Assessment.js';
 import './User.js';
 
-import { Bookshelf } from '../bookshelf.js';
+import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
 
 const modelName = 'KnowledgeElement';
 

--- a/api/src/shared/infrastructure/orm-models/KnowledgeElement.js
+++ b/api/src/shared/infrastructure/orm-models/KnowledgeElement.js
@@ -1,7 +1,7 @@
 import './Assessment.js';
 import './User.js';
 
-import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
+import { Bookshelf } from '../bookshelf.js';
 
 const modelName = 'KnowledgeElement';
 

--- a/api/src/shared/infrastructure/orm-models/Membership.js
+++ b/api/src/shared/infrastructure/orm-models/Membership.js
@@ -1,14 +1,14 @@
-import './User.js';
 import './Organization.js';
+import './User.js';
 
-import { Bookshelf } from '../bookshelf.js';
+import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
 
-const modelName = 'OrganizationLearner';
+const modelName = 'Membership';
 
-const BookshelfOrganizationLearner = Bookshelf.model(
+const BookshelfMembership = Bookshelf.model(
   modelName,
   {
-    tableName: 'organization-learners',
+    tableName: 'memberships',
     hasTimestamps: ['createdAt', 'updatedAt'],
 
     user() {
@@ -24,4 +24,4 @@ const BookshelfOrganizationLearner = Bookshelf.model(
   },
 );
 
-export { BookshelfOrganizationLearner };
+export { BookshelfMembership };

--- a/api/src/shared/infrastructure/orm-models/Membership.js
+++ b/api/src/shared/infrastructure/orm-models/Membership.js
@@ -1,7 +1,7 @@
 import './Organization.js';
 import './User.js';
 
-import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
+import { Bookshelf } from '../bookshelf.js';
 
 const modelName = 'Membership';
 

--- a/api/src/shared/infrastructure/orm-models/Organization.js
+++ b/api/src/shared/infrastructure/orm-models/Organization.js
@@ -1,6 +1,6 @@
 import './Tag.js';
 
-import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
+import { Bookshelf } from '../bookshelf.js';
 
 const modelName = 'Organization';
 

--- a/api/src/shared/infrastructure/orm-models/Organization.js
+++ b/api/src/shared/infrastructure/orm-models/Organization.js
@@ -1,6 +1,6 @@
 import './Tag.js';
 
-import { Bookshelf } from '../bookshelf.js';
+import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
 
 const modelName = 'Organization';
 

--- a/api/src/shared/infrastructure/orm-models/OrganizationLearner.js
+++ b/api/src/shared/infrastructure/orm-models/OrganizationLearner.js
@@ -1,14 +1,14 @@
-import './Organization.js';
 import './User.js';
+import './Organization.js';
 
-import { Bookshelf } from '../bookshelf.js';
+import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
 
-const modelName = 'Membership';
+const modelName = 'OrganizationLearner';
 
-const BookshelfMembership = Bookshelf.model(
+const BookshelfOrganizationLearner = Bookshelf.model(
   modelName,
   {
-    tableName: 'memberships',
+    tableName: 'organization-learners',
     hasTimestamps: ['createdAt', 'updatedAt'],
 
     user() {
@@ -24,4 +24,4 @@ const BookshelfMembership = Bookshelf.model(
   },
 );
 
-export { BookshelfMembership };
+export { BookshelfOrganizationLearner };

--- a/api/src/shared/infrastructure/orm-models/OrganizationLearner.js
+++ b/api/src/shared/infrastructure/orm-models/OrganizationLearner.js
@@ -1,7 +1,7 @@
 import './User.js';
 import './Organization.js';
 
-import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
+import { Bookshelf } from '../bookshelf.js';
 
 const modelName = 'OrganizationLearner';
 

--- a/api/src/shared/infrastructure/orm-models/Session.js
+++ b/api/src/shared/infrastructure/orm-models/Session.js
@@ -1,6 +1,6 @@
 import './CertificationCandidate.js';
 
-import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
+import { Bookshelf } from '../bookshelf.js';
 
 const modelName = 'Session';
 

--- a/api/src/shared/infrastructure/orm-models/Session.js
+++ b/api/src/shared/infrastructure/orm-models/Session.js
@@ -1,6 +1,6 @@
 import './CertificationCandidate.js';
 
-import { Bookshelf } from '../bookshelf.js';
+import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
 
 const modelName = 'Session';
 

--- a/api/src/shared/infrastructure/orm-models/Stage.js
+++ b/api/src/shared/infrastructure/orm-models/Stage.js
@@ -1,4 +1,4 @@
-import { Bookshelf } from '../bookshelf.js';
+import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
 
 const modelName = 'Stage';
 import './TargetProfile.js';

--- a/api/src/shared/infrastructure/orm-models/Stage.js
+++ b/api/src/shared/infrastructure/orm-models/Stage.js
@@ -1,4 +1,4 @@
-import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
+import { Bookshelf } from '../bookshelf.js';
 
 const modelName = 'Stage';
 import './TargetProfile.js';

--- a/api/src/shared/infrastructure/orm-models/Tag.js
+++ b/api/src/shared/infrastructure/orm-models/Tag.js
@@ -1,4 +1,4 @@
-import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
+import { Bookshelf } from '../bookshelf.js';
 
 const modelName = 'Tag';
 

--- a/api/src/shared/infrastructure/orm-models/Tag.js
+++ b/api/src/shared/infrastructure/orm-models/Tag.js
@@ -1,4 +1,4 @@
-import { Bookshelf } from '../bookshelf.js';
+import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
 
 const modelName = 'Tag';
 

--- a/api/src/shared/infrastructure/orm-models/TargetProfile.js
+++ b/api/src/shared/infrastructure/orm-models/TargetProfile.js
@@ -2,7 +2,7 @@ import './Badge.js';
 import './Stage.js';
 import './Organization.js';
 
-import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
+import { Bookshelf } from '../bookshelf.js';
 
 const modelName = 'TargetProfile';
 

--- a/api/src/shared/infrastructure/orm-models/TargetProfile.js
+++ b/api/src/shared/infrastructure/orm-models/TargetProfile.js
@@ -2,7 +2,7 @@ import './Badge.js';
 import './Stage.js';
 import './Organization.js';
 
-import { Bookshelf } from '../bookshelf.js';
+import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
 
 const modelName = 'TargetProfile';
 

--- a/api/src/shared/infrastructure/orm-models/User.js
+++ b/api/src/shared/infrastructure/orm-models/User.js
@@ -6,7 +6,7 @@ import './UserOrgaSettings.js';
 import './OrganizationLearner.js';
 import './AuthenticationMethod.js';
 
-import { Bookshelf } from '../bookshelf.js';
+import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
 
 const modelName = 'User';
 

--- a/api/src/shared/infrastructure/orm-models/User.js
+++ b/api/src/shared/infrastructure/orm-models/User.js
@@ -6,7 +6,7 @@ import './UserOrgaSettings.js';
 import './OrganizationLearner.js';
 import './AuthenticationMethod.js';
 
-import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
+import { Bookshelf } from '../bookshelf.js';
 
 const modelName = 'User';
 

--- a/api/src/shared/infrastructure/orm-models/UserOrgaSettings.js
+++ b/api/src/shared/infrastructure/orm-models/UserOrgaSettings.js
@@ -1,7 +1,7 @@
 import './User.js';
 import './Organization.js';
 
-import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
+import { Bookshelf } from '../bookshelf.js';
 
 const modelName = 'UserOrgaSettings';
 

--- a/api/src/shared/infrastructure/orm-models/UserOrgaSettings.js
+++ b/api/src/shared/infrastructure/orm-models/UserOrgaSettings.js
@@ -1,7 +1,7 @@
 import './User.js';
 import './Organization.js';
 
-import { Bookshelf } from '../bookshelf.js';
+import { Bookshelf } from '../../../../lib/infrastructure/bookshelf.js';
 
 const modelName = 'UserOrgaSettings';
 

--- a/api/src/shared/infrastructure/repositories/membership-repository.js
+++ b/api/src/shared/infrastructure/repositories/membership-repository.js
@@ -1,4 +1,4 @@
-import { BookshelfMembership } from '../../../../lib/infrastructure/orm-models/Membership.js';
+import { BookshelfMembership } from '../../../../src/shared/infrastructure/orm-models/Membership.js';
 import * as bookshelfToDomainConverter from '../utils/bookshelf-to-domain-converter.js';
 
 const findByUserId = function ({ userId }) {

--- a/api/tests/acceptance/scripts/add-many-divisions-and-students-to-sco-organization_test.js
+++ b/api/tests/acceptance/scripts/add-many-divisions-and-students-to-sco-organization_test.js
@@ -1,5 +1,5 @@
-import { knex } from '../../../lib/infrastructure/bookshelf.js';
 import { addManyDivisionsAndStudentsToScoCertificationCenter } from '../../../scripts/data-generation/add-many-divisions-and-students-to-sco-organization.js';
+import { knex } from '../../../src/shared/infrastructure/bookshelf.js';
 import { BookshelfOrganizationLearner } from '../../../src/shared/infrastructure/orm-models/OrganizationLearner.js';
 import { databaseBuilder, expect } from '../../test-helper.js';
 

--- a/api/tests/acceptance/scripts/add-many-divisions-and-students-to-sco-organization_test.js
+++ b/api/tests/acceptance/scripts/add-many-divisions-and-students-to-sco-organization_test.js
@@ -1,6 +1,6 @@
 import { knex } from '../../../lib/infrastructure/bookshelf.js';
-import { BookshelfOrganizationLearner } from '../../../lib/infrastructure/orm-models/OrganizationLearner.js';
 import { addManyDivisionsAndStudentsToScoCertificationCenter } from '../../../scripts/data-generation/add-many-divisions-and-students-to-sco-organization.js';
+import { BookshelfOrganizationLearner } from '../../../src/shared/infrastructure/orm-models/OrganizationLearner.js';
 import { databaseBuilder, expect } from '../../test-helper.js';
 
 describe('Acceptance | Scripts | add-many-divisions-and-students-to-sco-organization', function () {

--- a/api/tests/acceptance/scripts/add-many-students-to-sco-certification-center_test.js
+++ b/api/tests/acceptance/scripts/add-many-students-to-sco-certification-center_test.js
@@ -1,5 +1,5 @@
-import { BookshelfOrganizationLearner } from '../../../lib/infrastructure/orm-models/OrganizationLearner.js';
 import { addManyStudentsToScoCertificationCenter } from '../../../scripts/data-generation/add-many-students-to-sco-certification-center.js';
+import { BookshelfOrganizationLearner } from '../../../src/shared/infrastructure/orm-models/OrganizationLearner.js';
 import { databaseBuilder, expect } from '../../test-helper.js';
 
 describe('Acceptance | Scripts | add-many-students-to-sco-certification-centers.js', function () {

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -1,9 +1,9 @@
 import _ from 'lodash';
 
-import { BookshelfCertificationCourse } from '../../../../../../lib/infrastructure/orm-models/CertificationCourse.js';
 import { CertificationCourse } from '../../../../../../src/certification/shared/domain/models/CertificationCourse.js';
 import * as certificationCourseRepository from '../../../../../../src/certification/shared/infrastructure/repositories/certification-course-repository.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
+import { BookshelfCertificationCourse } from '../../../../../../src/shared/infrastructure/orm-models/CertificationCourse.js';
 import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | Repository | Certification Course', function () {

--- a/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
@@ -1,7 +1,6 @@
 import lodash from 'lodash';
 const { omit, pick } = lodash;
 
-import { BookshelfCertificationCenterMembership } from '../../../../lib/infrastructure/orm-models/CertificationCenterMembership.js';
 import * as certificationCenterMembershipRepository from '../../../../lib/infrastructure/repositories/certification-center-membership-repository.js';
 import { User } from '../../../../src/identity-access-management/domain/models/User.js';
 import {
@@ -14,6 +13,7 @@ import {
   CERTIFICATION_CENTER_MEMBERSHIP_ROLES,
   CertificationCenterMembership,
 } from '../../../../src/shared/domain/models/CertificationCenterMembership.js';
+import { BookshelfCertificationCenterMembership } from '../../../../src/shared/infrastructure/orm-models/CertificationCenterMembership.js';
 import { catchErr, databaseBuilder, domainBuilder, expect, knex, sinon } from '../../../test-helper.js';
 
 describe('Integration | Repository | Certification Center Membership', function () {

--- a/api/tests/integration/infrastructure/repositories/complementary-certification-course-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/complementary-certification-course-result-repository_test.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 
-import { knex } from '../../../../lib/infrastructure/bookshelf.js';
 import * as complementaryCertificationCourseResultRepository from '../../../../lib/infrastructure/repositories/complementary-certification-course-result-repository.js';
 import { ComplementaryCertificationCourseResult } from '../../../../src/certification/shared/domain/models/ComplementaryCertificationCourseResult.js';
+import { knex } from '../../../../src/shared/infrastructure/bookshelf.js';
 import { databaseBuilder, domainBuilder, expect } from '../../../test-helper.js';
 
 describe('Integration | Repository | complementary-certification-courses-result-repository', function () {

--- a/api/tests/integration/infrastructure/repositories/complementary-certification-habilitation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/complementary-certification-habilitation-repository_test.js
@@ -1,5 +1,5 @@
-import { knex } from '../../../../lib/infrastructure/bookshelf.js';
 import * as complementaryCertificationHabilitationRepository from '../../../../lib/infrastructure/repositories/complementary-certification-habilitation-repository.js';
+import { knex } from '../../../../src/shared/infrastructure/bookshelf.js';
 import { databaseBuilder, expect } from '../../../test-helper.js';
 
 describe('Integration | Infrastructure | Repository | complementary-certification-habilitation-repository', function () {

--- a/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
+++ b/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
@@ -1,4 +1,3 @@
-import { BookshelfCertificationCenterMembership } from '../../../lib/infrastructure/orm-models/CertificationCenterMembership.js';
 import {
   createCertificationCenterMemberships,
   fetchCertificationCenterMembershipsByExternalId,
@@ -7,6 +6,7 @@ import {
   prepareDataForInsert,
 } from '../../../scripts/create-certification-center-memberships-from-organization-admins.js';
 import { Membership } from '../../../src/shared/domain/models/Membership.js';
+import { BookshelfCertificationCenterMembership } from '../../../src/shared/infrastructure/orm-models/CertificationCenterMembership.js';
 import { databaseBuilder, expect } from '../../test-helper.js';
 
 describe('Integration | Scripts | create-certification-center-memberships-from-organization-admins.js', function () {

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-post_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-post_test.js
@@ -1,4 +1,4 @@
-import { BookshelfAssessment } from '../../../../../lib/infrastructure/orm-models/Assessment.js';
+import { BookshelfAssessment } from '../../../../../src/shared/infrastructure/orm-models/Assessment.js';
 import {
   createServer,
   databaseBuilder,

--- a/api/tests/shared/integration/infrastructure/utils/bookshelf-to-domain-converter_test.js
+++ b/api/tests/shared/integration/infrastructure/utils/bookshelf-to-domain-converter_test.js
@@ -1,13 +1,13 @@
-import { BookshelfCampaign } from '../../../../../lib/infrastructure/orm-models/Campaign.js';
-import { BookshelfCampaignParticipation } from '../../../../../lib/infrastructure/orm-models/CampaignParticipation.js';
-import { BookshelfOrganization } from '../../../../../lib/infrastructure/orm-models/Organization.js';
-import { BookshelfUser } from '../../../../../lib/infrastructure/orm-models/User.js';
 import { User } from '../../../../../src/identity-access-management/domain/models/User.js';
 import { Organization } from '../../../../../src/organizational-entities/domain/models/Organization.js';
 import { Tag } from '../../../../../src/organizational-entities/domain/models/Tag.js';
 import { KnowledgeElement } from '../../../../../src/shared/domain/models/KnowledgeElement.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
 import { TargetProfile } from '../../../../../src/shared/domain/models/TargetProfile.js';
+import { BookshelfCampaign } from '../../../../../src/shared/infrastructure/orm-models/Campaign.js';
+import { BookshelfCampaignParticipation } from '../../../../../src/shared/infrastructure/orm-models/CampaignParticipation.js';
+import { BookshelfOrganization } from '../../../../../src/shared/infrastructure/orm-models/Organization.js';
+import { BookshelfUser } from '../../../../../src/shared/infrastructure/orm-models/User.js';
 import * as bookshelfToDomainConverter from '../../../../../src/shared/infrastructure/utils/bookshelf-to-domain-converter.js';
 import { databaseBuilder, expect } from '../../../../test-helper.js';
 

--- a/api/tests/shared/integration/infrastructure/utils/knex-utils_test.js
+++ b/api/tests/shared/integration/infrastructure/utils/knex-utils_test.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import { knex } from '../../../../../lib/infrastructure/bookshelf.js';
+import { knex } from '../../../../../src/shared/infrastructure/bookshelf.js';
 import { DEFAULT_PAGINATION, fetchPage } from '../../../../../src/shared/infrastructure/utils/knex-utils.js';
 import { databaseBuilder, expect } from '../../../../test-helper.js';
 

--- a/api/tests/shared/unit/infrastructure/serializers/jsonapi/validation-error-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/jsonapi/validation-error-serializer_test.js
@@ -1,4 +1,4 @@
-import { Bookshelf } from '../../../../../../lib/infrastructure/bookshelf.js';
+import { Bookshelf } from '../../../../../../src/shared/infrastructure/bookshelf.js';
 import * as serializer from '../../../../../../src/shared/infrastructure/serializers/jsonapi/validation-error-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 


### PR DESCRIPTION
## :unicorn: Problème

cf https://github.com/1024pix/pix/blob/dev/docs/adr/0051-nouvelle-arborescence-api.md

## :robot: Proposition

Déplacer le répertoire `orm-models` vers `src`

## :rainbow: Remarques


## :100: Pour tester

