### PR TITLE
[BUGFIX] Empêcher l'accès au contenu d'un embed au lecteur d'écran avant de cliquer sur le bouton "Commencer"

### DIFF
--- a/mon-pix/app/components/challenge-embed-simulator.hbs
+++ b/mon-pix/app/components/challenge-embed-simulator.hbs
@@ -22,6 +22,7 @@
     <div class="embed__simulator {{unless this.isSimulatorLaunched 'blurred'}}">
       <iframe
         tabindex={{unless this.isSimulatorLaunched "-1"}}
+        aria-hidden={{unless this.isSimulatorLaunched "true"}}
         class="embed__iframe"
         src="{{@embedDocument.url}}"
         title="{{@embedDocument.title}}"


### PR DESCRIPTION
## :unicorn: Problème
Au lecteur d'écran, il n'est pas obligatoire de cliquer sur le bouton "Commencer" pour accéder au contenu de l'embed. Cela peut être gênant dans les épreuves où la séquence de lancement est importante pour réaliser la tâche demandée.

## :robot: Proposition
En plus de retirer le `tabindex="-1"` au lancement, placer un `aria-hidden="true"` qui exclu totalement l'iframe de la page tant que le bouton n'a pas été cliqué.

## :rainbow: Remarques
RAS

## :100: Pour tester
En utilisant VoiceOver.

### Avant
https://app.integration.pix.fr/challenges/challenge1UStKapjh40D5E/preview

#### Navigation par niveau de titre
1. `ctrl`+`opt`+`cmd`+`h` pour accéder au titre de niveau 1 "Épreuve pour l'évaluation"
2. `ctrl`+`opt`+`cmd`+`h` pour accéder au titre de niveau 2 "Consigne de l'épreuve"
3. `ctrl`+`opt`+`cmd`+`h` pour accéder au titre de niveau 1 "Réunion d'équipe" => on est dans le simulateur

#### Navigation en entrant dans la frame
1. Tabuler jusqu'au bouton "Commencer le simulateur"
2. `ctrl`+`opt`+`cmd`+`flèche bas` pour accéder au titre de niveau 1 du simulateur "Réunion d'équipe"

### Après
https://app-pr9718.review.pix.fr/challenges/challenge1UStKapjh40D5E/preview

#### Navigation par niveau de titre
1. `ctrl`+`opt`+`cmd`+`h` pour accéder au titre de niveau 1 "Épreuve pour l'évaluation"
3. `ctrl`+`opt`+`cmd`+`h` pour accéder au titre de niveau 2 "Consigne de l'épreuve"
4. `ctrl`+`opt`+`cmd`+`h` pour accéder au titre de niveau 2 "Valider ou passer"  => on n'est pas entré dans le simulateur

#### Navigation en entrant dans la frame
1. Tabuler jusqu'au bouton "Commencer le simulateur"
2. `ctrl`+`opt`+`cmd`+`flèche bas` pour constater qu'on passe au titre de niveau 2 d'après la simulation "Valider ou passer"
3. `ctrl`+`opt`+`cmd`+`flèche haut` pour constater qu'on revient au titre de niveau 2 d'avant la simulation "Consigne de l'épreuve" => on n'a pas accès au contenu du simulateur

#### Une fois le simulateur lancé
Le comportement doit être similaire à ce qu'on avait avant :)