### PR TITLE
[FEATURE] Informer l'API qu'un embed auto a été réussi dans un module (PIX-13096)

### DIFF
--- a/mon-pix/app/components/module/element.gjs
+++ b/mon-pix/app/components/module/element.gjs
@@ -23,7 +23,7 @@ export default class ModulixElement extends Component {
     {{else if (eq @element.type "video")}}
       <VideoElement @video={{@element}} @openTranscription={{@openTranscription}} />
     {{else if (eq @element.type "embed")}}
-      <EmbedElement @embed={{@element}} />
+      <EmbedElement @embed={{@element}} @submitAnswer={{@submitAnswer}} />
     {{else if (eq @element.type "qcu")}}
       <QcuElement
         @element={{@element}}

--- a/mon-pix/app/components/module/element/embed.gjs
+++ b/mon-pix/app/components/module/element/embed.gjs
@@ -1,17 +1,19 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import { action } from '@ember/object';
-import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
 import { htmlUnsafe } from '../../../helpers/html-unsafe';
 import didInsert from '../../../modifiers/modifier-did-insert';
+import { isEmbedAllowedOrigin } from '../../../utils/embed-allowed-origins';
+import ModuleElement from './module-element';
 
-export default class ModulixEmbed extends Component {
+export default class ModulixEmbed extends ModuleElement {
   @tracked
   isSimulatorLaunched = false;
   embedHeight = this.args.embed.height;
   iframe;
+  messageHandler = null;
 
   @action
   setIframeHtmlElement(htmlElement) {
@@ -32,6 +34,32 @@ export default class ModulixEmbed extends Component {
   startSimulator() {
     this.isSimulatorLaunched = true;
     this.iframe.focus();
+
+    this.messageHandler = this._receiveEmbedMessage.bind(this);
+    window.addEventListener('message', this.messageHandler);
+  }
+
+  _receiveEmbedMessage(event) {
+    if (!isEmbedAllowedOrigin(event.origin)) return;
+    const message = this._getMessageFromEventData(event);
+    if (message && message.answer && message.from === 'pix') {
+      this.args.submitAnswer({
+        userResponse: [message.answer],
+        element: this.args.embed,
+      });
+    }
+  }
+
+  _getMessageFromEventData(event) {
+    if (typeof event.data === 'object') {
+      return event.data;
+    }
+
+    return {};
+  }
+
+  willDestroy() {
+    window.removeEventListener('message', this.messageHandler);
   }
 
   <template>

--- a/mon-pix/tests/integration/components/module/embed_test.gjs
+++ b/mon-pix/tests/integration/components/module/embed_test.gjs
@@ -3,6 +3,7 @@ import { clickByName, render } from '@1024pix/ember-testing-library';
 import { find } from '@ember/test-helpers';
 import ModulixEmbed from 'mon-pix/components/module/element/embed';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -94,6 +95,116 @@ module('Integration | Component | Module | Embed', function (hooks) {
       // then
       const iframe = screen.getByTitle(embed.title);
       assert.strictEqual(document.activeElement, iframe);
+    });
+
+    module('when a message is received', function () {
+      module('when message is not from pix', function () {
+        test('should not call the submitAnswer method', async function (assert) {
+          // given
+          const embed = {
+            id: 'id',
+            title: 'title',
+            isCompletionRequired: true,
+            url: 'https://embed-pix.com',
+            height: 800,
+          };
+          const submitAnswerStub = sinon.stub();
+          await render(<template><ModulixEmbed @embed={{embed}} @submitAnswer={{submitAnswerStub}} /></template>);
+          await clickByName(this.intl.t('pages.modulix.buttons.embed.start.ariaLabel'));
+
+          // when
+          const event = new MessageEvent('message', {
+            data: { answer: 'toto', from: 'nsa' },
+            origin: 'https://epreuves.pix.fr',
+          });
+          window.dispatchEvent(event);
+
+          // then
+          sinon.assert.notCalled(submitAnswerStub);
+          assert.ok(true);
+        });
+      });
+
+      module('when message is not an answer', function () {
+        test('should not call the submitAnswer method', async function (assert) {
+          // given
+          const embed = {
+            id: 'id',
+            title: 'title',
+            isCompletionRequired: true,
+            url: 'https://embed-pix.com',
+            height: 800,
+          };
+          const submitAnswerStub = sinon.stub();
+          await render(<template><ModulixEmbed @embed={{embed}} @submitAnswer={{submitAnswerStub}} /></template>);
+          await clickByName(this.intl.t('pages.modulix.buttons.embed.start.ariaLabel'));
+
+          // when
+          const event = new MessageEvent('message', {
+            data: { start: 'true', from: 'pix' },
+            origin: 'https://epreuves.pix.fr',
+          });
+          window.dispatchEvent(event);
+
+          // then
+          sinon.assert.notCalled(submitAnswerStub);
+          assert.ok(true);
+        });
+      });
+
+      module('when message origin is not allowed', function () {
+        test('should not call the submitAnswer method', async function (assert) {
+          // given
+          const embed = {
+            id: 'id',
+            title: 'title',
+            isCompletionRequired: true,
+            url: 'https://embed-pix.com',
+            height: 800,
+          };
+          const submitAnswerStub = sinon.stub();
+          await render(<template><ModulixEmbed @embed={{embed}} @submitAnswer={{submitAnswerStub}} /></template>);
+          await clickByName(this.intl.t('pages.modulix.buttons.embed.start.ariaLabel'));
+
+          // when
+          const event = new MessageEvent('message', {
+            data: { answer: 'toto', from: 'pix' },
+            origin: 'https://example.org',
+          });
+          window.dispatchEvent(event);
+
+          // then
+          sinon.assert.notCalled(submitAnswerStub);
+          assert.ok(true);
+        });
+      });
+
+      module('otherwise when everything is ok', function () {
+        test('should call the submitAnswer method', async function (assert) {
+          // given
+          const embed = {
+            id: 'id',
+            title: 'title',
+            isCompletionRequired: true,
+            url: 'https://embed-pix.com',
+            height: 800,
+          };
+          const submitAnswerStub = sinon.stub();
+          await render(<template><ModulixEmbed @embed={{embed}} @submitAnswer={{submitAnswerStub}} /></template>);
+          await clickByName(this.intl.t('pages.modulix.buttons.embed.start.ariaLabel'));
+
+          // when
+          const event = new MessageEvent('message', {
+            data: { answer: 'toto', from: 'pix' },
+            origin: 'https://epreuves.pix.fr',
+          });
+          window.dispatchEvent(event);
+
+          // then
+          sinon.assert.called(submitAnswerStub);
+          assert.ok(true);
+        });
+      });
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème

Lorsqu'un embed auto a été complété, nous voulons appeler l'API pour vérifier et enregistrer la réponse de l'utilisateur.

## :robot: Proposition

Écouter l'évènement "message" émis par l'embed, en extraire la réponse et la transmettre à l'API.

## :rainbow: Remarques

Le remplacement du bouton "Passer" par le bouton "Continuer" si la réponse est correcte sera à faire dans une autre pull request.

## :100: Pour tester

1. Ouvrir le didacticiel modulix
2. Passer les grains jusqu'au deuxième simulateur visio
3. Faire la manipulation correcte (couper le micro)
4. Constater que la réponse a été enregistrée dans la table `element-answers`
