### PR TITLE
[BUGFIX] Renommer other de la clé par miscellaneous (PIX-13606).

### DIFF
--- a/mon-pix/app/components/certification-instructions/step-five.hbs
+++ b/mon-pix/app/components/certification-instructions/step-five.hbs
@@ -21,7 +21,7 @@
       {{t "pages.certification-instructions.steps.5.list.no-forum" htmlSafe=true}}
     </li>
     <li>
-      {{t "pages.certification-instructions.steps.5.list.other" htmlSafe=true}}
+      {{t "pages.certification-instructions.steps.5.list.miscellaneous" htmlSafe=true}}
     </li>
   </ul>
   <PixCheckbox {{on "change" this.onChange}}>

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -516,12 +516,12 @@
           "title": "Rules to observe",
           "checkbox-label": "By ticking this box, I recognise that I have taken note of these rules and I agree to comply with them.",
           "list": {
+            "miscellaneous": "'<strong>'Mobilise any other mean that would directly give the answer'</strong>', without having to do the work required by the instructions.",
             "no-artificial-intelligence": "'<strong>'Have recourse to an artificial intelligence system'</strong>' or to a chatbot",
             "no-cheat-sheet": "'<strong>'Use cheat sheets'</strong>' (physical or digital), spoiler resources or personal notes",
             "no-communication": "'<strong>'Communicate with someone else'</strong>', within the exam room or outside of it, by physical or electronic means",
             "no-connected-device": "'<strong>'Use a mobile phone or any other connected device'</strong>' (other than the computer used for the certification)",
-            "no-forum": "'<strong>'Peruse a self-help forum'</strong>' giving a direct answer to a question",
-            "other": "'<strong>'Mobilise any other mean that would directly give the answer'</strong>', without having to do the work required by the instructions."
+            "no-forum": "'<strong>'Peruse a self-help forum'</strong>' giving a direct answer to a question"
           },
           "text": "During the certification, it is forbidden to:"
         }

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -514,12 +514,12 @@
         "5": {
           "checkbox-label": "Al marcar esta casilla, reconozco que he leído estas normas y me comprometo a cumplirlas.",
           "list": {
+            "miscellaneous": "'<strong>'Movilizar cualquier otro medio que proporcione directamente la respuesta'</strong>', sin haber realizado el trabajo requerido por la instrucción.",
             "no-artificial-intelligence": "'<strong>'Utilizar un sistema de inteligencia artificial'</strong>' o un chatbot",
             "no-cheat-sheet": "'<strong>'Use cheat sheets'</strong>' (físicas o electrónicas), recursos de spoilers o notas personales.",
             "no-communication": "'<strong>'Comunicarse con otra persona'</strong>', dentro o fuera de la sala, por medios físicos o electrónicos.",
             "no-connected-device": "'<strong>'Utilizar un teléfono móvil o cualquier dispositivo conectado'</strong>' (distinto del ordenador utilizado en la certificación)",
-            "no-forum": "'<strong>'Consulta un foro de autoayuda'</strong>' proporcionando directamente la respuesta a un test",
-            "other": "'<strong>'Movilizar cualquier otro medio que proporcione directamente la respuesta'</strong>', sin haber realizado el trabajo requerido por la instrucción."
+            "no-forum": "'<strong>'Consulta un foro de autoayuda'</strong>' proporcionando directamente la respuesta a un test"
           },
           "text": "En certificación, está prohibido :",
           "title": "Normas que deben respetarse"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -516,12 +516,12 @@
           "title": "Règles à respecter",
           "checkbox-label": "En cochant cette case, je reconnais avoir pris connaissance de ces règles et je m’engage à les respecter.",
           "list": {
+            "miscellaneous": "'<strong>'Mobiliser tout autre moyen délivrant directement la réponse'</strong>', sans avoir effectué le travail requis par la consigne.",
             "no-artificial-intelligence": "'<strong>'Avoir recours à un système d’intelligence artificielle'</strong>' ou un chatbot",
             "no-cheat-sheet": "'<strong>'Utiliser des antisèches'</strong>' (physiques ou électroniques), des ressources de spoil ou des notes personnelles",
             "no-communication": "'<strong>'Communiquer avec quelqu’un d’autre'</strong>', dans la salle ou à l’extérieur, par voie physique ou électronique",
             "no-connected-device": "'<strong>'Utiliser un téléphone mobile ou tout appareil connecté'</strong>' (autre que l’ordinateur mobilisé dans le cadre de la certification)",
-            "no-forum": "'<strong>'Consulter un forum d’entraide'</strong>' apportant directement la réponse à une épreuve",
-            "other": "'<strong>'Mobiliser tout autre moyen délivrant directement la réponse'</strong>', sans avoir effectué le travail requis par la consigne."
+            "no-forum": "'<strong>'Consulter un forum d’entraide'</strong>' apportant directement la réponse à une épreuve"
           },
           "text": "En certification, il est interdit de :"
         }

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -514,12 +514,12 @@
         "5": {
           "checkbox-label": "Door dit vakje aan te kruisen, bevestig ik dat ik deze regels heb gelezen en me eraan zal houden.",
           "list": {
+            "miscellaneous": "'<strong>'Zet een ander middel in dat direct het antwoord geeft'</strong>', zonder het werk te hebben gedaan dat de instructie vereist.",
             "no-artificial-intelligence": "'<strong>'Gebruik een kunstmatig intelligentiesysteem'</strong>' of een chatbot",
             "no-cheat-sheet": "'<strong>'Gebruik spiekbriefjes'</strong>' (fysiek of elektronisch), spoilerbronnen of persoonlijke aantekeningen",
             "no-communication": "'<strong>'Communiceren met iemand anders'</strong>', binnen of buiten de kamer, met fysieke of elektronische middelen",
             "no-connected-device": "'<strong>'Gebruik een mobiele telefoon of een aangesloten apparaat'</strong>' (anders dan de computer die wordt gebruikt voor de certificering)",
-            "no-forum": "'<strong>'Raadpleeg een zelfhulpforum'</strong>' direct het antwoord geven op een test",
-            "other": "'<strong>'Zet een ander middel in dat direct het antwoord geeft'</strong>', zonder het werk te hebben gedaan dat de instructie vereist."
+            "no-forum": "'<strong>'Raadpleeg een zelfhulpforum'</strong>' direct het antwoord geven op een test"
           },
           "text": "In certificering is het verboden om :",
           "title": "Regels die moeten worden nageleefd"


### PR DESCRIPTION
## :unicorn: Problème
La clé des écrans d’instructions est indiquée par Phrase comme "unmentioned" alors qu'elle est bien utilisé par notre front. Ça ne génère pas de warning sur Pix App.

Cela provient du terme "other" dans notre clé qui est en réalité réservé.

## :robot: Proposition
Remplacer ce terme par miscellaneous

## :100: Pour tester
- Créer une session V3 avec [certifv3@example.net](mailto:certifv3@example.net) et ajouter un candidat
- Se réconcilier avec [certifiable-contenu-user@example.net](mailto:certifiable-contenu-user@example.net)
- Aller sur le 5e et dernier écran
- Vérifier que le texte ci-dessous s'affiche bien
- Si possible, vérifier en FR/EN/ES/NL

<img width="881" alt="Capture d’écran 2024-07-29 à 11 24 28" src="https://github.com/user-attachments/assets/1a28a06f-64a3-405b-a768-be8404e4687c">

