### PR TITLE
[BUGFIX] Ne pas mettre a jour le champ campaignId quand on met a jour la campagn-participations (PIX-13644)

### DIFF
--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
@@ -18,7 +18,6 @@ const CAMPAIGN_PARTICIPATION_ATTRIBUTES = [
   'participantExternalId',
   'sharedAt',
   'status',
-  'campaignId',
   'userId',
   'organizationLearnerId',
   'deletedAt',


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'update d'une campaign-participations, nous mettions a jour le campaignId même si celui ci n'était pas présent. Donc il arrive des cas ou on se retrouve avec une participation sans campaignId. 

## :robot: Proposition
Enlever le campagnId de la mise a jour d'une campaign-participations

## :rainbow: Remarques
Sagissant d'un bugfix en prod, nous avons fait au plus rapide pour le corriger. Nous nous sommes notés le refacto à faire à plusieurs endroits car on ne devrait pas pouvoir instancier une CampaignParticipation sans campagne associée.

## :100: Pour tester
- Creer une campagne
- Participer a cette campagne
- Supprimer la campagne
- Constater en BDD que la participation a toujours un campaignId
- 🐕 🐈‍⬛ 
