### PR TITLE
[FEATURE] Ne pas pouvoir anonymiser un agent Pix (PIX-12137)

### DIFF
--- a/admin/app/components/users/user-overview.hbs
+++ b/admin/app/components/users/user-overview.hbs
@@ -195,14 +195,21 @@
           >
             Modifier
           </PixButton>
-          <PixButton
-            @size="small"
-            @variant="error"
-            @triggerAction={{this.toggleDisplayAnonymizeModal}}
-            @isDisabled={{@user.hasBeenAnonymised}}
-          >
-            Anonymiser cet utilisateur
-          </PixButton>
+
+          <PixTooltip @position="bottom" @hide={{not @user.isPixAgent}} @isInline="{{true}}">
+            <:triggerElement>
+              <PixButton
+                @size="small"
+                @variant="error"
+                @triggerAction={{this.toggleDisplayAnonymizeModal}}
+                @isDisabled={{this.isAnonymizationDisabled}}
+              >
+                Anonymiser cet utilisateur
+              </PixButton>
+            </:triggerElement>
+            <:tooltip>Vous ne pouvez pas anonymiser le compte d'un agent Pix.</:tooltip>
+          </PixTooltip>
+
           {{#if @user.userLogin.blockedAt}}
             <PixButton @variant="primary-bis" @triggerAction={{this.unblockUserAccount}} @size="small">
               Débloquer l'utilisateur

--- a/admin/app/components/users/user-overview.js
+++ b/admin/app/components/users/user-overview.js
@@ -74,6 +74,11 @@ export default class UserOverview extends Component {
     return this.locales;
   }
 
+  get isAnonymizationDisabled() {
+    const { hasBeenAnonymised, isPixAgent } = this.args.user;
+    return hasBeenAnonymised || isPixAgent;
+  }
+
   _formatValidatedTermsOfServiceText(date, hasValidatedTermsOfService) {
     const formattedDateText = date ? `, le ${dayjs(date).format('DD/MM/YYYY')}` : '';
     return hasValidatedTermsOfService ? `OUI${formattedDateText}` : 'NON';

--- a/admin/app/models/user.js
+++ b/admin/app/models/user.js
@@ -20,6 +20,7 @@ export default class User extends Model {
   @attr() emailConfirmedAt;
   @attr() hasBeenAnonymised;
   @attr() anonymisedByFullName;
+  @attr() isPixAgent;
 
   // includes
   @belongsTo('profile', { async: true, inverse: null }) profile;

--- a/admin/tests/integration/components/users/user-overview-test.js
+++ b/admin/tests/integration/components/users/user-overview-test.js
@@ -671,6 +671,36 @@ module('Integration | Component | users | user-overview', function (hooks) {
         });
       });
     });
+
+    module('when the displayed user is a Pix agent', function (hooks) {
+      let user = null;
+
+      hooks.beforeEach(function () {
+        user = EmberObject.create({
+          lastName: 'Harry',
+          firstName: 'John',
+          email: 'john.harry@gmail.com',
+          isPixAgent: true,
+        });
+      });
+
+      test('shows the anonymize button as disabled', async function (assert) {
+        // given
+        this.set('user', user);
+
+        // when
+        const screen = await render(hbs`<Users::UserOverview @user={{this.user}} />`);
+
+        // then
+        const anonymizeButton = await screen.findByRole('button', { name: 'Anonymiser cet utilisateur' });
+        assert.dom(anonymizeButton).isDisabled();
+
+        const anonymizationDisabledTooltip = await screen.getByText(
+          "Vous ne pouvez pas anonymiser le compte d'un agent Pix.",
+        );
+        assert.dom(anonymizationDisabledTooltip).exists();
+      });
+    });
   });
 
   module('When the admin member does not have access to users actions scope', function () {

--- a/api/lib/infrastructure/serializers/jsonapi/user-details-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-details-for-admin-serializer.js
@@ -38,6 +38,7 @@ const serialize = function (usersDetailsForAdmin) {
       'organizationMemberships',
       'certificationCenterMemberships',
       'userLogin',
+      'isPixAgent',
     ],
     organizationLearners: {
       ref: 'id',

--- a/api/src/identity-access-management/infrastructure/repositories/user.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user.repository.js
@@ -141,7 +141,14 @@ const getUserDetailsForAdmin = async function (userId) {
     .where({ userId })
     .orderBy('id');
 
-  return _fromKnexDTOToUserDetailsForAdmin({ userDTO, organizationLearnersDTO, authenticationMethodsDTO });
+  const pixAdminRolesDTO = await knex('pix-admin-roles').where({ userId });
+
+  return _fromKnexDTOToUserDetailsForAdmin({
+    userDTO,
+    organizationLearnersDTO,
+    authenticationMethodsDTO,
+    pixAdminRolesDTO,
+  });
 };
 
 const findPaginatedFiltered = async function ({ filter, page }) {
@@ -472,7 +479,12 @@ export {
   updateWithEmailConfirmed,
 };
 
-function _fromKnexDTOToUserDetailsForAdmin({ userDTO, organizationLearnersDTO, authenticationMethodsDTO }) {
+function _fromKnexDTOToUserDetailsForAdmin({
+  userDTO,
+  organizationLearnersDTO,
+  authenticationMethodsDTO,
+  pixAdminRolesDTO,
+}) {
   const organizationLearners = organizationLearnersDTO.map(
     (organizationLearnerDTO) =>
       new OrganizationLearnerForAdmin({
@@ -538,6 +550,7 @@ function _fromKnexDTOToUserDetailsForAdmin({ userDTO, organizationLearnersDTO, a
     createdAt: userDTO.createdAt,
     anonymisedByFirstName: userDTO.anonymisedByFirstName,
     anonymisedByLastName: userDTO.anonymisedByLastName,
+    isPixAgent: pixAdminRolesDTO.length > 0,
   });
 }
 

--- a/api/src/shared/domain/models/UserDetailsForAdmin.js
+++ b/api/src/shared/domain/models/UserDetailsForAdmin.js
@@ -26,6 +26,7 @@ class UserDetailsForAdmin {
       hasBeenAnonymised,
       anonymisedByFirstName,
       anonymisedByLastName,
+      isPixAgent,
     } = {},
     dependencies = { localeService },
   ) {
@@ -56,6 +57,7 @@ class UserDetailsForAdmin {
     this.updatedAt = updatedAt;
     this.anonymisedByFirstName = anonymisedByFirstName;
     this.anonymisedByLastName = anonymisedByLastName;
+    this.isPixAgent = isPixAgent;
   }
 
   get anonymisedByFullName() {

--- a/api/tests/acceptance/application/users/users-controller-get-user-details-for-admin_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-user-details-for-admin_test.js
@@ -99,6 +99,7 @@ describe('Acceptance | Controller | users-controller-get-user-details-for-admin'
           username: user.username,
           'has-been-anonymised': false,
           'anonymised-by-full-name': null,
+          'is-pix-agent': false,
         });
 
         expect(response.result.data.relationships).to.deep.equal({

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
@@ -1118,6 +1118,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         expect(userDetailsForAdmin.lastLoggedAt).to.deep.equal(lastLoggedAt);
         expect(userDetailsForAdmin.emailConfirmedAt).to.deep.equal(emailConfirmedAt);
         expect(userDetailsForAdmin.hasBeenAnonymised).to.be.false;
+        expect(userDetailsForAdmin.isPixAgent).to.be.false;
       });
 
       it('should return a UserNotFoundError if no user is found', async function () {
@@ -1303,6 +1304,21 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
             temporaryBlockedUntil: null,
             failureCount: 5,
           });
+        });
+      });
+
+      context('when user is a Pix agent', function () {
+        it('returns the user with isPixAgent true', async function () {
+          // given
+          const userInDB = databaseBuilder.factory.buildUser.withRole({ role: 'SUPPORT' });
+          await databaseBuilder.commit();
+
+          // when
+          const userDetailsForAdmin = await userRepository.getUserDetailsForAdmin(userInDB.id);
+
+          // then
+          expect(userDetailsForAdmin.id).to.equal(userInDB.id);
+          expect(userDetailsForAdmin.isPixAgent).to.be.true;
         });
       });
     });

--- a/api/tests/tooling/domain-builder/factory/build-user-details-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-user-details-for-admin.js
@@ -24,6 +24,7 @@ const buildUserDetailsForAdmin = function ({
   userLogin = [],
   hasBeenAnonymised = false,
   hasBeenAnonymisedBy = null,
+  isPixAgent = false,
 } = {}) {
   return new UserDetailsForAdmin({
     id,
@@ -49,6 +50,7 @@ const buildUserDetailsForAdmin = function ({
     userLogin,
     hasBeenAnonymised,
     hasBeenAnonymisedBy,
+    isPixAgent,
   });
 };
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-details-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-details-for-admin-serializer_test.js
@@ -48,6 +48,7 @@ describe('Unit | Serializer | JSONAPI | user-details-for-admin-serializer', func
             'email-confirmed-at': now,
             'has-been-anonymised': false,
             'anonymised-by-full-name': null,
+            'is-pix-agent': false,
           },
           relationships: {
             'certification-center-memberships': {


### PR DESCRIPTION
## :unicorn: Problème

Si l’utilisateur est un agent Pix alors on ne devrait pas permettre l’anonymisation de ce user via pix admin. 

## :robot: Proposition

1. Pour identifier un agent Pix: voir si le user a, ou a un jour eu, un accès à Pix Admin (via la table `pix-admin-roles`)
2. Désactiver le bouton anonymisation avec un tooltip indiquant qu’on ne peut anonymiser le compte d’un admin Pix.

![image](https://github.com/user-attachments/assets/3b66036d-0574-4c5a-9e4c-326f28d18184)


## :100: Pour tester

- Se connecter à Pix Admin avec le compte `superadmin@example.net`
- Rechercher un utilisateur classique (ex: "Bob Leponge")
  > Vérifier que le bouton "Anonymiser cet utilisateur" est cliquable
- Rechercher un utilisateur Agent Pix (ex: "Admin Support")
  > Vérifier que le bouton "Anonymiser cet utilisateur" est désactivé avec un tooltip