### PR TITLE
[FEATURE] Ajouter un composant Tabs (PIX-12982).

### DIFF
--- a/mon-pix/app/components/tabs/index.gjs
+++ b/mon-pix/app/components/tabs/index.gjs
@@ -1,0 +1,194 @@
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { modifier } from 'ember-modifier';
+
+import TabItem from './tab-item';
+import TabPanel from './tab-panel';
+
+export default class TabsContainer extends Component {
+  @service elementHelper;
+
+  TabPanel = TabPanel;
+  TabItem = TabItem;
+
+  @tracked currentTabIndex = this.args.initialTabIndex || 0;
+  @tracked hasScrollableTablist = false;
+  @tracked isLeftArrowVisible = false;
+  @tracked isRightArrowVisible = false;
+
+  elements = {
+    tabs: null,
+    tablist: null,
+  };
+
+  onMount = modifier((element) => {
+    this.elements.tabs = element.querySelectorAll("[role='tab']");
+    this.elements.tablist = element.querySelector("[role='tablist'] > div");
+
+    this.handleResponsiveTablist();
+    window.addEventListener('resize', this.handleResponsiveTablist);
+
+    return () => {
+      window.removeEventListener('resize', this.handleResponsiveTablist);
+    };
+  });
+
+  get id() {
+    return this.args.id || `pix-tabs-${guidFor(this)}`;
+  }
+
+  @action
+  handleTablistKeyUp(event) {
+    if (['ArrowLeft', 'ArrowRight'].includes(event.key)) {
+      const currentTabIndex = [...this.elements.tabs].findIndex((tab) => {
+        return tab === document.activeElement;
+      });
+
+      let nextTabIndex;
+
+      switch (event.key) {
+        case 'ArrowRight':
+          if (currentTabIndex === this.elements.tabs.length - 1) {
+            nextTabIndex = 0;
+          } else {
+            nextTabIndex = currentTabIndex + 1;
+          }
+          break;
+        case 'ArrowLeft':
+          if (currentTabIndex === 0) {
+            nextTabIndex = this.elements.tabs.length - 1;
+          } else {
+            nextTabIndex = currentTabIndex - 1;
+          }
+          break;
+      }
+
+      const tabToFocus = document.getElementById(this.id + '-' + nextTabIndex);
+      tabToFocus.focus();
+
+      if (this.hasScrollableTablist) this.handleKeyupFocusScroll(tabToFocus);
+    }
+  }
+
+  @action
+  handleTabChange(tabIndex) {
+    if (tabIndex !== this.currentTabIndex) {
+      this.currentTabIndex = tabIndex;
+      this.args.onTabChange && this.args.onTabChange(tabIndex);
+    }
+  }
+
+  @action
+  handleResponsiveTablist() {
+    this.hasScrollableTablist = this.elements.tablist.scrollWidth > this.elements.tablist.clientWidth;
+
+    if (this.hasScrollableTablist) {
+      this.handleTablistArrowsVisibility();
+
+      const currentTab = this.elements.tabs[this.currentTabIndex];
+      this.scrollToTab(currentTab, 'instant');
+    } else {
+      this.isLeftArrowVisible = false;
+      this.isRightArrowVisible = false;
+    }
+  }
+
+  @action
+  handleTablistArrowsVisibility() {
+    const maxScrollLeft = this.elements.tablist.scrollWidth - this.elements.tablist.clientWidth;
+
+    switch (Math.round(this.elements.tablist.scrollLeft)) {
+      case 0:
+        this.isLeftArrowVisible = false;
+        this.isRightArrowVisible = true;
+        break;
+      case maxScrollLeft:
+        this.isLeftArrowVisible = true;
+        this.isRightArrowVisible = false;
+        break;
+      default:
+        this.isLeftArrowVisible = true;
+        this.isRightArrowVisible = true;
+    }
+  }
+
+  @action
+  handleLeftArrowButtonClick() {
+    const nextOverflowingTab = [...this.elements.tabs]
+      .reverse()
+      .find((tab) => tab.offsetLeft < this.elements.tablist.scrollLeft);
+
+    this.scrollToTab(nextOverflowingTab);
+  }
+
+  @action
+  handleRightArrowButtonClick() {
+    const nextOverflowingTab = [...this.elements.tabs].find((tab) => {
+      return tab.offsetLeft + tab.clientWidth > this.elements.tablist.scrollLeft + this.elements.tablist.clientWidth;
+    });
+
+    this.scrollToTab(nextOverflowingTab);
+  }
+
+  @action
+  handleKeyupFocusScroll(tabToFocus) {
+    const leftOverflowing = tabToFocus.offsetLeft - this.elements.tablist.scrollLeft < 0;
+    const rightOverflowing =
+      tabToFocus.offsetLeft + tabToFocus.clientWidth > tabToFocus.scrollLeft + this.elements.tablist.clientWidth;
+
+    if (leftOverflowing || rightOverflowing) {
+      if (tabToFocus.offsetLeft === 0) {
+        this.elements.tablist.scrollTo({
+          left: 0,
+          behavior: 'smooth',
+        });
+      } else {
+        this.scrollToTab(tabToFocus);
+      }
+    }
+  }
+
+  scrollToTab(tabToFocus, behavior = 'smooth') {
+    const centeredTabPosition =
+      tabToFocus.offsetLeft + 0.5 * tabToFocus.clientWidth - 0.5 * this.elements.tablist.clientWidth;
+
+    this.elements.tablist.scrollTo({
+      left: centeredTabPosition,
+      behavior: behavior,
+    });
+  }
+
+  <template>
+    {{! template-lint-disable no-invalid-interactive }}
+    <div class="pix-tabs" id={{this.id}} ...attributes {{this.onMount}}>
+      <div class="pix-tabs__tablist" role="tablist" aria-label={{@ariaLabel}} {{on "keyup" this.handleTablistKeyUp}}>
+        {{#if this.isLeftArrowVisible}}
+          <span
+            class="pix-tabs-tablist__scroll-button pix-tabs-tablist__scroll-button--left"
+            tabindex="-1"
+            {{on "click" this.handleLeftArrowButtonClick}}
+          />
+        {{/if}}
+        <div {{on "scroll" this.handleTablistArrowsVisibility}}>
+          {{yield
+            (component this.TabItem currentTab=this.currentTabIndex id=this.id onTabClick=this.handleTabChange)
+            to="tabs"
+          }}
+        </div>
+        {{#if this.isRightArrowVisible}}
+          <span
+            class="pix-tabs-tablist__scroll-button pix-tabs-tablist__scroll-button--right"
+            tabindex="-1"
+            {{on "click" this.handleRightArrowButtonClick}}
+          />
+        {{/if}}
+      </div>
+
+      {{yield (component this.TabPanel currentTab=this.currentTabIndex id=this.id) to="panels"}}
+    </div>
+  </template>
+}

--- a/mon-pix/app/components/tabs/tab-item.gjs
+++ b/mon-pix/app/components/tabs/tab-item.gjs
@@ -1,0 +1,20 @@
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { eq } from 'ember-truth-helpers';
+
+<template>
+  <button
+    class="pix-tabs__tab"
+    id="{{@id}}-{{@index}}"
+    type="button"
+    role="tab"
+    aria-selected={{if (eq @currentTab @index) "true" "false"}}
+    aria-controls="panel-{{@id}}-{{@index}}"
+    tabindex={{if (eq @currentTab @index) "0" "-1"}}
+    {{on "click" (fn @onTabClick @index)}}
+  >
+    <span>
+      {{yield}}
+    </span>
+  </button>
+</template>

--- a/mon-pix/app/components/tabs/tab-panel.gjs
+++ b/mon-pix/app/components/tabs/tab-panel.gjs
@@ -1,0 +1,14 @@
+import { eq, notEq } from 'ember-truth-helpers';
+
+<template>
+  <div
+    role="tabpanel"
+    class="pix-tabs__tabpanel"
+    id="panel-{{@id}}-{{@index}}"
+    tabindex={{if (eq @currentTab @index) "0" "-1"}}
+    aria-labelledby="{{@id}}-{{@index}}"
+    hidden={{notEq @currentTab @index}}
+  >
+    {{yield}}
+  </div>
+</template>

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -41,6 +41,7 @@
 @import 'components/comparison-window';
 @import 'components/choice-chip';
 @import 'components/reset-campaign-participation-modal';
+@import 'components/tabs';
 
 /* we need this to be before competence-card-default because of a mix
 of an adaptative/mobile-first approach — refactoring is welcome here */

--- a/mon-pix/app/styles/components/_tabs.scss
+++ b/mon-pix/app/styles/components/_tabs.scss
@@ -1,0 +1,124 @@
+.pix-tabs__tablist {
+  position: relative;
+  max-width: 100%;
+  overflow: hidden;
+  background-color: var(--pix-neutral-0);
+  border: 1px solid var(--pix-neutral-100);
+  border-radius: 5rem;
+
+  & > div {
+    display: flex;
+    align-items: center;
+    overflow: auto;
+    scrollbar-width: none;
+    scroll-behavior: smooth;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+}
+
+.pix-tabs__tab {
+  display: block;
+  flex: 1 1 min-content;
+  max-width: calc(100% - 4rem);
+  padding: 1rem var(--pix-spacing-8x);
+  color: var(--pix-neutral-900);
+  font-weight: var(--pix-font-bold);
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+  border-radius: 5rem;
+
+  & > span {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  &:focus,
+  &:hover {
+    background-color: var(--pix-neutral-20);
+  }
+
+  &:active {
+    background-color: var(--pix-neutral-100);
+  }
+
+  &[aria-selected='true'] {
+    background: var(--pix-secondary-500);
+  }
+}
+
+.pix-tabs-tablist__scroll-button {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 1;
+  width: 2rem;
+  cursor: pointer;
+
+  &::before {
+    position: absolute;
+    background-image: linear-gradient(
+      to right,
+      rgb(255 255 255 / 0%),
+      rgb(255 255 255 / 80%) 40%,
+      rgb(255 255 255 / 100%) 100%
+    );
+    content: '';
+    pointer-events: none;
+    inset: 0;
+  }
+
+  &::after {
+    position: absolute;
+    top: calc(50% - 0.33rem);
+    width: 0.75rem;
+    height: 0.75rem;
+    content: '';
+  }
+
+  &:hover::after {
+    border-color: var(--pix-neutral-500);
+  }
+
+  &--left {
+    left: 0;
+
+    &::before {
+      right: -50%;
+      transform: scaleX(-1);
+    }
+
+    &::after {
+      right: 0.25rem;
+      border-top: 2px solid var(--pix-neutral-900);
+      border-left: 2px solid var(--pix-neutral-900);
+      transform: rotate(-45deg);
+    }
+  }
+
+  &--right {
+    right: 0;
+
+    &::before {
+      left: -50%;
+    }
+
+    &::after {
+      left: 0.25rem;
+      border-top: 2px solid var(--pix-neutral-900);
+      border-right: 2px solid var(--pix-neutral-900);
+      transform: rotate(45deg);
+    }
+  }
+}
+
+@media (max-width: 760px) {
+  .pix-tabs__tab {
+    padding: 1rem;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+  }
+}

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -39,6 +39,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.2.0",
         "@glimmer/component": "^1.1.2",
         "@sentry/ember": "^8.0.0",
+        "@testing-library/user-event": "^14.5.2",
         "buffer": "^6.0.3",
         "dayjs": "^1.11.6",
         "dotenv": "^16.0.3",
@@ -11831,6 +11832,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.5.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -72,6 +72,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.2.0",
     "@glimmer/component": "^1.1.2",
     "@sentry/ember": "^8.0.0",
+    "@testing-library/user-event": "^14.5.2",
     "buffer": "^6.0.3",
     "dayjs": "^1.11.6",
     "dotenv": "^16.0.3",

--- a/mon-pix/tests/integration/components/tabs_test.js
+++ b/mon-pix/tests/integration/components/tabs_test.js
@@ -1,0 +1,353 @@
+import { render } from '@1024pix/ember-testing-library';
+import { click, tab } from '@ember/test-helpers';
+import userEvent from '@testing-library/user-event';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Integration | Component | Tabs', function (hooks) {
+  setupRenderingTest(hooks);
+
+  module('default behaviour', function (hooks) {
+    let screen;
+
+    hooks.beforeEach(async function () {
+      this.handleTabChange = sinon.spy();
+
+      screen = await render(hbs`
+        {{! template-lint-disable no-bare-strings }}
+        <Tabs @ariaLabel="Sample tabs" @onTabChange={{this.handleTabChange}}>
+          <:tabs as |Tab|>
+            <Tab @index={{0}}>First tab label</Tab>
+            <Tab @index={{1}}>Second tab label</Tab>
+            <Tab @index={{2}}>Third tab label</Tab>
+          </:tabs>
+
+          <:panels as |Panel|>
+            <Panel @index={{0}}>
+              <h2>First panel</h2>
+            </Panel>
+            <Panel @index={{1}}>
+              <h2>Second panel</h2>
+            </Panel>
+            <Panel @index={{2}}>
+              <h2>Third panel</h2>
+            </Panel>
+          </:panels>
+        </Tabs>`);
+    });
+
+    module('on first render', function () {
+      test('it displays the first tab', async function (assert) {
+        assert.dom(screen.getByRole('tablist')).hasAttribute('aria-label', 'Sample tabs');
+
+        assert.strictEqual(screen.getAllByRole('tab').length, 3);
+        assert.dom(screen.getByRole('tab', { name: 'First tab label' })).hasAttribute('aria-selected', 'true');
+        assert.dom(screen.getByRole('tab', { name: 'Second tab label' })).hasAttribute('aria-selected', 'false');
+        assert.dom(screen.getByRole('tab', { name: 'Third tab label' })).hasAttribute('aria-selected', 'false');
+
+        assert.strictEqual(screen.getAllByRole('tabpanel').length, 1);
+        assert.dom(screen.getByText('First panel')).exists();
+      });
+    });
+
+    module('on tab click', function () {
+      test('it displays the right tab and calls onTabChange', async function (assert) {
+        // when
+        await click(screen.getByRole('tab', { name: 'Second tab label' }));
+
+        // then
+        assert.dom(screen.getByRole('tab', { name: 'First tab label' })).hasAttribute('aria-selected', 'false');
+        assert.dom(screen.getByRole('tab', { name: 'Second tab label' })).hasAttribute('aria-selected', 'true');
+        assert.dom(screen.getByRole('tab', { name: 'Third tab label' })).hasAttribute('aria-selected', 'false');
+
+        assert.dom(screen.getByText('Second panel')).exists();
+
+        assert.ok(this.handleTabChange.calledOnce);
+        assert.ok(this.handleTabChange.calledWith(1));
+      });
+    });
+
+    module('on tab space keyup', function () {
+      test('it displays the right tab and calls onTabChange', async function (assert) {
+        // when
+        screen.getByRole('tab', { name: 'Second tab label' }).focus();
+
+        await userEvent.keyboard('[Space]');
+
+        // then
+        assert.dom(screen.getByRole('tab', { name: 'First tab label' })).hasAttribute('aria-selected', 'false');
+        assert.dom(screen.getByRole('tab', { name: 'Second tab label' })).hasAttribute('aria-selected', 'true');
+        assert.dom(screen.getByRole('tab', { name: 'Third tab label' })).hasAttribute('aria-selected', 'false');
+
+        assert.dom(screen.getByText('Second panel')).exists();
+
+        assert.ok(this.handleTabChange.calledOnce);
+        assert.ok(this.handleTabChange.calledWith(1));
+      });
+    });
+
+    module('on tablist right arrow keyup', function () {
+      module('when the initial focus is not on the last tab', function () {
+        test('focus goes to the next tab', async function (assert) {
+          // when
+          screen.getByRole('tab', { name: 'First tab label' }).focus();
+          await userEvent.keyboard('[ArrowRight]');
+
+          // then
+          assert.dom(screen.getByRole('tab', { name: 'Second tab label' })).isFocused();
+        });
+      });
+
+      module('when the initial focus is on the last tab', function () {
+        test('focus goes to the first tab', async function (assert) {
+          // when
+          screen.getByRole('tab', { name: 'Third tab label' }).focus();
+          await userEvent.keyboard('[ArrowRight]');
+
+          // then
+          assert.dom(screen.getByRole('tab', { name: 'First tab label' })).isFocused();
+        });
+      });
+    });
+
+    module('on tablist left arrow keyup', function () {
+      module('when the initial focus is not on the first tab', function () {
+        test('focus goes to the prev tab', async function (assert) {
+          // when
+          screen.getByRole('tab', { name: 'Third tab label' }).focus();
+          await userEvent.keyboard('[ArrowLeft]');
+
+          // then
+          assert.dom(screen.getByRole('tab', { name: 'Second tab label' })).isFocused();
+        });
+      });
+
+      module('when the initial focus is on the first tab', function () {
+        test('focus goes to the last tab', async function (assert) {
+          // when
+          screen.getByRole('tab', { name: 'First tab label' }).focus();
+          await userEvent.keyboard('[ArrowLeft]');
+          await userEvent.keyboard('[Enter]');
+
+          // then
+          assert.dom(screen.getByRole('tab', { name: 'Third tab label' })).isFocused();
+        });
+      });
+    });
+
+    module('when a tab is selected, on tabulation keyup', function () {
+      test('focus goes to the panel', async function (assert) {
+        // when
+        screen.getByRole('tab', { name: 'First tab label' }).focus();
+
+        await tab();
+
+        // then
+        assert.dom(screen.getByRole('tabpanel')).isFocused();
+      });
+    });
+  });
+
+  module('with initialTabIndex', function () {
+    test('it renders the tab with the given initial index', async function (assert) {
+      // when
+      const screen = await render(hbs`
+        {{! template-lint-disable no-bare-strings }}
+        <Tabs @ariaLabel="Sample tabs" @initialTabIndex={{1}}>
+          <:tabs as |Tab|>
+            <Tab @index={{0}}>First tab label</Tab>
+            <Tab @index={{1}}>Second tab label</Tab>
+            <Tab @index={{2}}>Third tab label</Tab>
+          </:tabs>
+
+          <:panels as |Panel|>
+            <Panel @index={{0}}>
+              <h2>First panel</h2>
+            </Panel>
+            <Panel @index={{1}}>
+              <h2>Second panel</h2>
+            </Panel>
+            <Panel @index={{2}}>
+              <h2>Third panel</h2>
+            </Panel>
+          </:panels>
+        </Tabs>`);
+
+      // then
+      assert.dom(screen.getByRole('tab', { name: 'First tab label' })).hasAttribute('aria-selected', 'false');
+      assert.dom(screen.getByRole('tab', { name: 'Second tab label' })).hasAttribute('aria-selected', 'true');
+      assert.dom(screen.getByRole('tab', { name: 'Third tab label' })).hasAttribute('aria-selected', 'false');
+
+      assert.strictEqual(screen.getAllByRole('tabpanel').length, 1);
+      assert.dom(screen.getByText('Second panel')).exists();
+    });
+  });
+
+  module('when the tablist is scrollable', function () {
+    module('when the first tab is fully visible', function () {
+      test('it renders only the right arrow button on the tablist', async function (assert) {
+        // when
+        const screen = await render(hbs`
+          {{! template-lint-disable no-bare-strings no-inline-styles }}
+          <Tabs @ariaLabel="Sample tabs" @initialTabIndex={{0}} style="width: 800px;">
+            <:tabs as |Tab|>
+              <Tab @index={{0}}>First tab label First tab label First tab label First tab label First tab label First tab label</Tab>
+              <Tab @index={{1}}>Second tab label Second tab label Second tab label Second tab label Second tab label Second tab label</Tab>
+              <Tab @index={{2}}>Third tab label Third tab label Third tab label Third tab label Third tab label Third tab label</Tab>
+            </:tabs>
+
+            <:panels as |Panel|>
+              <Panel @index={{0}}>
+                <h2>First panel</h2>
+              </Panel>
+              <Panel @index={{1}}>
+                <h2>Second panel</h2>
+              </Panel>
+              <Panel @index={{2}}>
+                <h2>Third panel</h2>
+              </Panel>
+            </:panels>
+          </Tabs>`);
+
+        // then
+        assert.strictEqual(screen.getByRole('tablist').children.length, 2);
+        assert.dom(screen.getByRole('tablist').children[1]).hasAttribute('tabindex', '-1');
+      });
+    });
+
+    module('when the scroll is not at edges', function () {
+      test('it renders the left and right arrow buttons on the tablist', async function (assert) {
+        // when
+        const screen = await render(hbs`
+          {{! template-lint-disable no-bare-strings no-inline-styles }}
+          <Tabs @ariaLabel="Sample tabs" @initialTabIndex={{1}} style="width: 800px;">
+            <:tabs as |Tab|>
+              <Tab @index={{0}}>First tab label First tab label First tab label First tab label First tab label First tab label</Tab>
+              <Tab @index={{1}}>Second tab label Second tab label Second tab label Second tab label Second tab label Second tab label</Tab>
+              <Tab @index={{2}}>Third tab label Third tab label Third tab label Third tab label Third tab label Third tab label</Tab>
+            </:tabs>
+
+            <:panels as |Panel|>
+              <Panel @index={{0}}>
+                <h2>First panel</h2>
+              </Panel>
+              <Panel @index={{1}}>
+                <h2>Second panel</h2>
+              </Panel>
+              <Panel @index={{2}}>
+                <h2>Third panel</h2>
+              </Panel>
+            </:panels>
+          </Tabs>`);
+
+        // then
+        assert.strictEqual(screen.getByRole('tablist').children.length, 3);
+        assert.dom(screen.getByRole('tablist').children[0]).hasAttribute('tabindex', '-1');
+        assert.dom(screen.getByRole('tablist').children[2]).hasAttribute('tabindex', '-1');
+      });
+    });
+
+    module('when the last tab is fully visible', function () {
+      test('it renders only the left arrow button on the tablist', async function (assert) {
+        // when
+        const screen = await render(hbs`
+          {{! template-lint-disable no-bare-strings no-inline-styles }}
+          <Tabs @ariaLabel="Sample tabs" @initialTabIndex={{2}}  style="width: 800px;">
+            <:tabs as |Tab|>
+              <Tab @index={{0}}>First tab label First tab label First tab label First tab label First tab label First tab label</Tab>
+              <Tab @index={{1}}>Second tab label Second tab label Second tab label Second tab label Second tab label Second tab label</Tab>
+              <Tab @index={{2}}>Third tab label Third tab label Third tab label Third tab label Third tab label Third tab label</Tab>
+            </:tabs>
+
+            <:panels as |Panel|>
+              <Panel @index={{0}}>
+                <h2>First panel</h2>
+              </Panel>
+              <Panel @index={{1}}>
+                <h2>Second panel</h2>
+              </Panel>
+              <Panel @index={{2}}>
+                <h2>Third panel</h2>
+              </Panel>
+            </:panels>
+          </Tabs>`);
+
+        // then
+        assert.strictEqual(screen.getByRole('tablist').children.length, 2);
+        assert.dom(screen.getByRole('tablist').children[0]).hasAttribute('tabindex', '-1');
+      });
+    });
+
+    module('on right arrow button click', function () {
+      test('it scrolls right', async function (assert) {
+        // when
+        const screen = await render(hbs`
+          {{! template-lint-disable no-bare-strings no-inline-styles }}
+          <Tabs @ariaLabel="Sample tabs" @initialTabIndex={{0}} style="width: 800px;">
+            <:tabs as |Tab|>
+              <Tab @index={{0}}>First tab label First tab label First tab label First tab label First tab label First tab label</Tab>
+              <Tab @index={{1}}>Second tab label Second tab label Second tab label Second tab label Second tab label Second tab label</Tab>
+              <Tab @index={{2}}>Third tab label Third tab label Third tab label Third tab label Third tab label Third tab label</Tab>
+            </:tabs>
+
+            <:panels as |Panel|>
+              <Panel @index={{0}}>
+                <h2>First panel</h2>
+              </Panel>
+              <Panel @index={{1}}>
+                <h2>Second panel</h2>
+              </Panel>
+              <Panel @index={{2}}>
+                <h2>Third panel</h2>
+              </Panel>
+            </:panels>
+          </Tabs>`);
+
+        // when
+        await click(screen.getByRole('tablist').children[1]);
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+
+        // then
+        const scrollPosition = screen.getByRole('tablist').querySelector('div').scrollLeft;
+        assert.notStrictEqual(scrollPosition, 0);
+      });
+    });
+
+    module('on left arrow button click', function () {
+      test('it scrolls left', async function (assert) {
+        // when
+        const screen = await render(hbs`
+          {{! template-lint-disable no-bare-strings no-inline-styles }}
+          <Tabs @ariaLabel="Sample tabs" @initialTabIndex={{1}} style="width: 800px;">
+            <:tabs as |Tab|>
+              <Tab @index={{0}}>First tab label First tab label First tab label First tab label First tab label First tab label</Tab>
+              <Tab @index={{1}}>Second tab label Second tab label Second tab label Second tab label Second tab label Second tab label</Tab>
+              <Tab @index={{2}}>Third tab label Third tab label Third tab label Third tab label Third tab label Third tab label</Tab>
+            </:tabs>
+
+            <:panels as |Panel|>
+              <Panel @index={{0}}>
+                <h2>First panel</h2>
+              </Panel>
+              <Panel @index={{1}}>
+                <h2>Second panel</h2>
+              </Panel>
+              <Panel @index={{2}}>
+                <h2>Third panel</h2>
+              </Panel>
+            </:panels>
+          </Tabs>`);
+
+        // when
+        await click(screen.getByRole('tablist').children[0]);
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+
+        // then
+        const scrollPosition = screen.getByRole('tablist').querySelector('div').scrollLeft;
+        assert.strictEqual(scrollPosition, 0);
+      });
+    });
+  });
+});


### PR DESCRIPTION
_Deuxième essai (problème de CI) : https://github.com/1024pix/pix/pull/9485_

## :unicorn: Problème
À l'heure actuelle, il n'existe pas de composant "onglets" dans PixApp.
Or, nous en aurons besoin pour la nouvelle page de fin de parcours.

## :robot: Proposition
Créer un composant Tab qui propose ces fonctionnalités : 
- Au focus dans les la liste des onglets, je peux naviguer avec les flèches gauche et droite et sélectionner l'onglet souhaité avec les touches "entrée" ou "espace".
- Une fois un onglet sélectionné, à la tabulation, le focus passe dans le panel associé.

- Sur un écran assez grand  :
  - Lorsque la place le permet, chacun des onglets fait la même taille

- Sur un écran trop petit pour afficher tous les onglets :
  - La liste des onglets devient scrollable horizontalement
  - Si l'intitulé d'un onglet est plus large que l'écran, alors une ellipse vient couper le texte
  - Des boutons fléchés (cliquables mais pas utilisables au clavier) apparaissent pour permettre de scroller dans la liste des onglets
  - À la navigation clavier avec les flèches gauche / droite, la scroll est optimisé pour toujours bien afficher le nouvel onglet focus

## 💻 Implémentation technique

Ce nouveau composant s'utilise comme ceci :

```hbs
<Tabs @ariaLabel="Un écran avec onglets" @initialTabIndex={{1}} @onTabChange={{this.handleTabChange}}>
  <:tabs as |Tab|>
    <Tab @index={{0}}>Intitulé de l'onglet 1</Tab>
    <Tab @index={{1}}>Onglet numéro 2</Tab>
  </:tabs>

  <:panels as |Panel|>
    <Panel @index={{0}}>
      <h2>Contenu du panel du premier onglet</h2>
    </Panel>
    <Panel @index={{1}}>
      <h2>Contenu du panel du second onglet</h2>
    </Panel>
  </:panels>
</Tabs>
```

ℹ️ On associe un onglet avec son panel grâce à la propriété `@index` présente sur chacun des composants.

ℹ️ La propriété `@initialTabIndex` permet de déterminer un onglet spécifique au chargement de la page.<br/>Elle est optionnelle. Si non renseignée, le premier onglet sera affiché.

ℹ️ `@onTabChange` permet de renseigner une méthode qui pourra avoir un paramètre qui est l'index du nouvel onglet sélectionné.

## :100: Pour tester

Vérifier les tests de ce composant