### PR TITLE
[TECH] Ajout de trace d'erreur pour le simulateur de certification (PIX-13575).

### DIFF
--- a/api/src/certification/flash-certification/domain/models/AssessmentSimulator.js
+++ b/api/src/certification/flash-certification/domain/models/AssessmentSimulator.js
@@ -1,3 +1,5 @@
+import { logger } from '../../../../shared/infrastructure/utils/logger.js';
+
 export class AssessmentSimulator {
   constructor({ getStrategy }) {
     this.getStrategy = getStrategy;
@@ -19,11 +21,13 @@ export class AssessmentSimulator {
         stepIndex = simulatorStepResult.nextStepIndex;
         challengesAnswers.push(...simulatorStepResult.challengeAnswers);
         result.push(...simulatorStepResult.results);
-      } catch (err) {
+      } catch (error) {
+        logger.error(error);
         break;
       }
     }
 
+    logger.trace({ result }, 'AssessmentSimulator result');
     return result;
   }
 }


### PR DESCRIPTION
## :unicorn: Problème

Echec lors du rescoring de certification V3

## :robot: Proposition

Il manque des traces pour analyser le soucis

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
* CICD au vert
