### PR TITLE
[FEATURE] Afficher le bouton `Continuer` ou `Passer` avec les Embeds auto (PIX-13640)

### DIFF
--- a/api/src/devcomp/domain/models/element/Embed.js
+++ b/api/src/devcomp/domain/models/element/Embed.js
@@ -15,6 +15,7 @@ class Embed extends Element {
     this.url = url;
     this.instruction = instruction;
     this.height = height;
+    this.isAnswerable = this.isCompletionRequired;
   }
 }
 

--- a/api/tests/devcomp/unit/domain/models/element/Embed_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Embed_test.js
@@ -9,7 +9,7 @@ describe('Unit | Devcomp | Domain | Models | Element | Embed', function () {
         id: 'id',
         isCompletionRequired: false,
         title: 'title',
-        url: 'https://embed.com',
+        url: 'https://example.org',
         instruction: '<p>instruction</p>',
         height: 150,
       };
@@ -22,7 +22,7 @@ describe('Unit | Devcomp | Domain | Models | Element | Embed', function () {
       expect(embed.type).to.equal('embed');
       expect(embed.isCompletionRequired).to.equal(false);
       expect(embed.title).to.equal('title');
-      expect(embed.url).to.equal('https://embed.com');
+      expect(embed.url).to.equal('https://example.org');
       expect(embed.instruction).to.equal('<p>instruction</p>');
       expect(embed.height).to.equal(150);
     });
@@ -33,7 +33,7 @@ describe('Unit | Devcomp | Domain | Models | Element | Embed', function () {
         const props = {
           id: 'id',
           title: 'title',
-          url: 'https://embed.com',
+          url: 'https://example.org',
           isCompletionRequired: false,
           height: 150,
         };
@@ -50,7 +50,7 @@ describe('Unit | Devcomp | Domain | Models | Element | Embed', function () {
         const props = {
           id: 'id',
           title: 'title',
-          url: 'https://embed.com',
+          url: 'https://example.org',
           isCompletionRequired: true,
           height: 150,
         };
@@ -95,7 +95,7 @@ describe('Unit | Devcomp | Domain | Models | Element | Embed', function () {
       describe('An embed without a height', function () {
         it('should throw an error', function () {
           expect(
-            () => new Embed({ id: 'id', isCompletionRequired: false, title: 'title', url: 'https://embed.com' }),
+            () => new Embed({ id: 'id', isCompletionRequired: false, title: 'title', url: 'https://example.org' }),
           ).to.throw('The height is required for an embed');
         });
       });

--- a/api/tests/devcomp/unit/domain/models/element/Embed_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Embed_test.js
@@ -27,6 +27,42 @@ describe('Unit | Devcomp | Domain | Models | Element | Embed', function () {
       expect(embed.height).to.equal(150);
     });
 
+    describe('isAnswerable', function () {
+      it('should be false when isCompletionRequired is false', function () {
+        // given
+        const props = {
+          id: 'id',
+          title: 'title',
+          url: 'https://embed.com',
+          isCompletionRequired: false,
+          height: 150,
+        };
+
+        // when
+        const embed = new Embed(props);
+
+        // then
+        expect(embed.isAnswerable).to.equal(false);
+      });
+
+      it('should be true when isCompletionRequired is true', function () {
+        // given
+        const props = {
+          id: 'id',
+          title: 'title',
+          url: 'https://embed.com',
+          isCompletionRequired: true,
+          height: 150,
+        };
+
+        // when
+        const embed = new Embed(props);
+
+        // then
+        expect(embed.isAnswerable).to.equal(true);
+      });
+    });
+
     describe('errors', function () {
       describe('An embed without an id', function () {
         it('should throw an error', function () {

--- a/mon-pix/tests/integration/components/module/embed_test.gjs
+++ b/mon-pix/tests/integration/components/module/embed_test.gjs
@@ -16,7 +16,7 @@ module('Integration | Component | Module | Embed', function (hooks) {
       id: 'id',
       title: 'title',
       isCompletionRequired: false,
-      url: 'https://embed-pix.com',
+      url: 'https://example.org',
       instruction: "<p>Instruction de l'embed</p>",
       height: 800,
     };
@@ -44,7 +44,7 @@ module('Integration | Component | Module | Embed', function (hooks) {
       id: 'id',
       title: 'title',
       isCompletionRequired: false,
-      url: 'https://embed-pix.com',
+      url: 'https://example.org',
       height: 800,
     };
 
@@ -62,7 +62,7 @@ module('Integration | Component | Module | Embed', function (hooks) {
         id: 'id',
         title: 'title',
         isCompletionRequired: false,
-        url: 'https://embed-pix.com',
+        url: 'https://example.org',
         height: 800,
       };
 
@@ -84,7 +84,7 @@ module('Integration | Component | Module | Embed', function (hooks) {
         id: 'id',
         title: 'title',
         isCompletionRequired: false,
-        url: 'https://embed-pix.com',
+        url: 'https://example.org',
         height: 800,
       };
       const screen = await render(<template><ModulixEmbed @embed={{embed}} /></template>);
@@ -105,7 +105,7 @@ module('Integration | Component | Module | Embed', function (hooks) {
             id: 'id',
             title: 'title',
             isCompletionRequired: true,
-            url: 'https://embed-pix.com',
+            url: 'https://example.org',
             height: 800,
           };
           const submitAnswerStub = sinon.stub();
@@ -132,7 +132,7 @@ module('Integration | Component | Module | Embed', function (hooks) {
             id: 'id',
             title: 'title',
             isCompletionRequired: true,
-            url: 'https://embed-pix.com',
+            url: 'https://example.org',
             height: 800,
           };
           const submitAnswerStub = sinon.stub();
@@ -159,7 +159,7 @@ module('Integration | Component | Module | Embed', function (hooks) {
             id: 'id',
             title: 'title',
             isCompletionRequired: true,
-            url: 'https://embed-pix.com',
+            url: 'https://example.org',
             height: 800,
           };
           const submitAnswerStub = sinon.stub();
@@ -186,7 +186,7 @@ module('Integration | Component | Module | Embed', function (hooks) {
             id: 'id',
             title: 'title',
             isCompletionRequired: true,
-            url: 'https://embed-pix.com',
+            url: 'https://example.org',
             height: 800,
           };
           const submitAnswerStub = sinon.stub();
@@ -215,7 +215,7 @@ module('Integration | Component | Module | Embed', function (hooks) {
         id: 'id',
         title: 'title',
         isCompletionRequired: false,
-        url: 'https://embed-pix.com',
+        url: 'https://example.org',
         height: 800,
       };
       const screen = await render(<template><ModulixEmbed @embed={{embed}} /></template>);

--- a/mon-pix/tests/unit/components/module/embed_test.gjs
+++ b/mon-pix/tests/unit/components/module/embed_test.gjs
@@ -14,7 +14,7 @@ module('Unit | Component | Module | Embed', function (hooks) {
         id: 'id',
         title: 'title',
         isCompletionRequired: false,
-        url: 'https://embed-pix.com',
+        url: 'https://example.org',
         height: 800,
       };
       const component = createGlimmerComponent('module/element/embed', {
@@ -37,7 +37,7 @@ module('Unit | Component | Module | Embed', function (hooks) {
         id: 'id',
         title: 'title',
         isCompletionRequired: false,
-        url: 'https://embed-pix.com',
+        url: 'https://example.org',
         height: 800,
       };
       const component = createGlimmerComponent('module/element/embed', {


### PR DESCRIPTION
## :unicorn: Problème
Le bouton `Passer` ne s'affichait pas avant la complétion des Embeds auto. Le bouton `Continuer` était toujours présent.

## :robot: Proposition
Assigner la propriété `isAnswerable` au modèle Embed, et la rendre liée à son autre propriété `isCompletionRequired`.

## :rainbow: Remarques

Nous avons remplacé des urls potentiellement existantes comme "embed.com" dans les tests par des fausses urls utilisant des domaines de tests.

## :100: Pour tester
- Se rendre sur [le didacticiel](https://app-pr9732.review.pix.fr/modules/didacticiel-modulix/passage)
- Passer les grains jusqu'à arriver au deuxième Embed de visioconférence
- Constater que le bouton `Passer` est visible
- Compléter l'Embed
- Constater que le bouton `Passer` a été remplacé par un bouton `Continuer`
