### PR TITLE
[TECH] Use deep.members instead of deep.equal to avoid a flacky result (PIX-13663)

### DIFF
--- a/api/tests/integration/scripts/certification/rescore-certifications_test.js
+++ b/api/tests/integration/scripts/certification/rescore-certifications_test.js
@@ -14,12 +14,13 @@ describe('Integration | Scripts | Certification | rescore-certfication', functio
       .where({ name: 'CertificationRescoringByScriptJob' })
       .orderBy('createdon', 'asc');
 
-    expect(job1.data).to.deep.equal({
-      certificationCourseId: 1,
-    });
-
-    expect(job2.data).to.deep.equal({
-      certificationCourseId: 2,
-    });
+    expect([job1.data, job2.data]).to.have.deep.members([
+      {
+        certificationCourseId: 1,
+      },
+      {
+        certificationCourseId: 2,
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Flacky

## :robot: Proposition
Plus de flacky

## :100: Pour tester
🟢 
