### PR TITLE
[FEATURE] Ajout d'un feature toggle pour conditionner l'affichage des missions expérimentales (Pix-13585).

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -767,6 +767,13 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: false
 # FT_SHOW_NEW_RESULT_PAGE=false
 
+# Consider experimental missions as active
+#
+# presence: optional
+# type: boolean
+# default: false
+# FT_SHOW_EXPERIMENTAL_MISSIONS=false
+
 # =====
 # CPF
 # =====

--- a/api/src/school/infrastructure/repositories/mission-repository.js
+++ b/api/src/school/infrastructure/repositories/mission-repository.js
@@ -1,3 +1,4 @@
+import { config } from '../../../shared/config.js';
 import { LOCALE } from '../../../shared/domain/constants.js';
 import { getTranslatedKey } from '../../../shared/domain/services/get-translated-text.js';
 import { Mission } from '../../domain/models/Mission.js';
@@ -32,7 +33,12 @@ async function get(id, locale = { locale: FRENCH_FRANCE }) {
 
 async function findAllActiveMissions(locale = { locale: FRENCH_FRANCE }) {
   const allMissions = await missionDatasource.list();
-  const allActiveMissions = allMissions.filter((mission) => mission.status === 'ACTIVE');
+  const allActiveMissions = allMissions.filter((mission) => {
+    return (
+      mission.status === 'VALIDATED' ||
+      (config.featureToggles.showExperimentalMissions && mission.status === 'EXPERIMENTAL')
+    );
+  });
   return allActiveMissions.map((missionData) => _toDomain(missionData, locale));
 }
 

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -202,6 +202,7 @@ const configuration = (function () {
         process.env.FT_ENABLE_NEED_TO_ADJUST_CERTIFICATION_ACCESSIBILITY,
       ),
       showNewResultPage: toBoolean(process.env.FT_SHOW_NEW_RESULT_PAGE),
+      showExperimentalMissions: toBoolean(process.env.FT_SHOW_EXPERIMENTAL_MISSIONS),
     },
     hapi: {
       options: {},

--- a/api/tests/school/integration/domain/usecases/find-all-active-missions_test.js
+++ b/api/tests/school/integration/domain/usecases/find-all-active-missions_test.js
@@ -1,10 +1,11 @@
 import { Mission } from '../../../../../src/school/domain/models/Mission.js';
 import { usecases } from '../../../../../src/school/domain/usecases/index.js';
+import { config } from '../../../../../src/shared/config.js';
 import { databaseBuilder, expect, mockLearningContent } from '../../../../test-helper.js';
 import * as learningContentBuilder from '../../../../tooling/learning-content-builder/index.js';
 
 describe('Integration | UseCases | find-all-active-missions', function () {
-  it('return empty array without missions from LCMS', async function () {
+  it('returns empty array without missions from LCMS', async function () {
     const expectedMissions = [];
 
     mockLearningContent({
@@ -15,63 +16,168 @@ describe('Integration | UseCases | find-all-active-missions', function () {
     expect(returnedMissions).to.deep.equal(expectedMissions);
   });
 
-  it('return active missions from LCMS', async function () {
-    const activeMission = learningContentBuilder.buildMission({
-      id: 12,
-      name_i18n: { fr: 'truc' },
-      competenceId: 'competenceId',
-      thematicId: 'thematicId',
-      status: 'ACTIVE',
-      learningObjectives_i18n: { fr: 'Il était une fois' },
-      validatedObjectives_i18n: { fr: 'Bravo ! tu as réussi !' },
+  context('when FT_SHOW_EXPERIMENTAL_MISSION is false', function () {
+    beforeEach(function () {
+      config.featureToggles.showExperimentalMissions = false;
     });
 
-    const inactiveMission = learningContentBuilder.buildMission({
-      id: 13,
-      name_i18n: { fr: 'truc' },
-      competenceId: 'competenceId',
-      thematicId: 'thematicId',
-      status: 'INACTIVE',
-      learningObjectives_i18n: { fr: 'Il était une fois' },
-      validatedObjectives_i18n: { fr: 'Bravo ! tu as réussi !' },
+    it('returns validated missions from LCMS', async function () {
+      const validatedMission = learningContentBuilder.buildMission({
+        id: 12,
+        name_i18n: { fr: 'truc' },
+        competenceId: 'competenceId',
+        thematicId: 'thematicId',
+        status: 'VALIDATED',
+        learningObjectives_i18n: { fr: 'Il était une fois' },
+        validatedObjectives_i18n: { fr: 'Bravo ! tu as réussi !' },
+      });
+
+      const experimentalMission = learningContentBuilder.buildMission({
+        id: 13,
+        name_i18n: { fr: 'truc' },
+        competenceId: 'competenceId',
+        thematicId: 'thematicId',
+        status: 'EXPERIMENTAL',
+        learningObjectives_i18n: { fr: 'Il était une fois' },
+        validatedObjectives_i18n: { fr: 'Bravo ! tu as réussi !' },
+      });
+
+      const inactiveMission = learningContentBuilder.buildMission({
+        id: 14,
+        name_i18n: { fr: 'truc' },
+        competenceId: 'competenceId',
+        thematicId: 'thematicId',
+        status: 'INACTIVE',
+        learningObjectives_i18n: { fr: 'Il était une fois' },
+        validatedObjectives_i18n: { fr: 'Bravo ! tu as réussi !' },
+      });
+
+      const area = learningContentBuilder.buildArea({
+        code: 3,
+        competenceIds: ['competenceId'],
+      });
+
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+      const competence = {
+        id: 'competenceId',
+        index: '4.5',
+        name_i18n: {
+          fr: 'Competence',
+        },
+      };
+
+      mockLearningContent({
+        missions: [validatedMission, experimentalMission, inactiveMission],
+        areas: [area],
+        competences: [competence],
+      });
+
+      const expectedMission = new Mission({
+        id: 12,
+        name: 'truc',
+        competenceId: 'competenceId',
+        thematicId: 'thematicId',
+        competenceName: '4.5 Competence',
+        status: 'ACTIVE',
+        areaCode: 3,
+        learningObjectives: 'Il était une fois',
+        validatedObjectives: 'Bravo ! tu as réussi !',
+        startedBy: '',
+      });
+      const expectedMissions = [expectedMission];
+      const returnedMissions = await usecases.findAllActiveMissions({ organizationId });
+
+      expect(returnedMissions).to.deep.equal(expectedMissions);
+    });
+  });
+
+  context('when FT_SHOW_EXPERIMENTAL_MISSION is true', function () {
+    beforeEach(function () {
+      config.featureToggles.showExperimentalMissions = true;
     });
 
-    const area = learningContentBuilder.buildArea({
-      code: 3,
-      competenceIds: ['competenceId'],
+    it('returns validated and experimental missions from LCMS', async function () {
+      const validatedMission = learningContentBuilder.buildMission({
+        id: 12,
+        name_i18n: { fr: 'truc' },
+        competenceId: 'competenceId',
+        thematicId: 'thematicId',
+        status: 'VALIDATED',
+        learningObjectives_i18n: { fr: 'Il était une fois' },
+        validatedObjectives_i18n: { fr: 'Bravo ! tu as réussi !' },
+      });
+
+      const experimentalMission = learningContentBuilder.buildMission({
+        id: 13,
+        name_i18n: { fr: 'truc' },
+        competenceId: 'competenceId',
+        thematicId: 'thematicId',
+        status: 'EXPERIMENTAL',
+        learningObjectives_i18n: { fr: 'Il était une fois' },
+        validatedObjectives_i18n: { fr: 'Bravo ! tu as réussi !' },
+      });
+
+      const inactiveMission = learningContentBuilder.buildMission({
+        id: 14,
+        name_i18n: { fr: 'truc' },
+        competenceId: 'competenceId',
+        thematicId: 'thematicId',
+        status: 'INACTIVE',
+        learningObjectives_i18n: { fr: 'Il était une fois' },
+        validatedObjectives_i18n: { fr: 'Bravo ! tu as réussi !' },
+      });
+
+      const area = learningContentBuilder.buildArea({
+        code: 3,
+        competenceIds: ['competenceId'],
+      });
+
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+      const competence = {
+        id: 'competenceId',
+        index: '4.5',
+        name_i18n: {
+          fr: 'Competence',
+        },
+      };
+
+      mockLearningContent({
+        missions: [validatedMission, experimentalMission, inactiveMission],
+        areas: [area],
+        competences: [competence],
+      });
+
+      const expectedMissions = [
+        new Mission({
+          id: 12,
+          name: 'truc',
+          competenceId: 'competenceId',
+          thematicId: 'thematicId',
+          competenceName: '4.5 Competence',
+          status: 'ACTIVE',
+          areaCode: 3,
+          learningObjectives: 'Il était une fois',
+          validatedObjectives: 'Bravo ! tu as réussi !',
+          startedBy: '',
+        }),
+        new Mission({
+          id: 13,
+          name: 'truc',
+          competenceId: 'competenceId',
+          thematicId: 'thematicId',
+          competenceName: '4.5 Competence',
+          status: 'EXPERIMENTAL',
+          areaCode: 3,
+          learningObjectives: 'Il était une fois',
+          validatedObjectives: 'Bravo ! tu as réussi !',
+          startedBy: '',
+        }),
+      ];
+      const returnedMissions = await usecases.findAllActiveMissions({ organizationId });
+
+      expect(returnedMissions).to.deep.equal(expectedMissions);
     });
-
-    const organizationId = databaseBuilder.factory.buildOrganization().id;
-
-    const competence = {
-      id: 'competenceId',
-      index: '4.5',
-      name_i18n: {
-        fr: 'Competence',
-      },
-    };
-
-    mockLearningContent({
-      missions: [activeMission, inactiveMission],
-      areas: [area],
-      competences: [competence],
-    });
-
-    const expectedMission = new Mission({
-      id: 12,
-      name: 'truc',
-      competenceId: 'competenceId',
-      thematicId: 'thematicId',
-      competenceName: '4.5 Competence',
-      status: 'ACTIVE',
-      areaCode: 3,
-      learningObjectives: 'Il était une fois',
-      validatedObjectives: 'Bravo ! tu as réussi !',
-      startedBy: '',
-    });
-    const expectedMissions = [expectedMission];
-    const returnedMissions = await usecases.findAllActiveMissions({ organizationId });
-
-    expect(returnedMissions).to.deep.equal(expectedMissions);
   });
 });

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -29,6 +29,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
             'is-text-to-speech-button-enabled': false,
             'is-need-to-adjust-certification-accessibility-enabled': false,
             'show-new-result-page': false,
+            'show-experimental-missions': false,
           },
         },
       };


### PR DESCRIPTION
## :unicorn: Problème
En prod (qui n'existe pas encore) nous voulons afficher seulement les missions qui ont un status Validated.

## :robot: Proposition
Ajouter une feature Toggle qui affiche sur les environnement integration/recette les mission Validated / Experimental

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter sur orga de la RA.
Observer que les missions Expérimentale et validated sont visible.
Changer la variable d'environnement `FT_SHOW_EXPERIMENTAL_MISSIONS` à `false`.
Redémarrer l'API.
Vérifier que les missions expérimentales ne sont plus visibles.