### PR TITLE
[BUGFIX] Rendre accessible le texte de la tooltip en mode focus sur les épreuves (PIX-8075).

### DIFF
--- a/mon-pix/app/styles/components/_tooltip.scss
+++ b/mon-pix/app/styles/components/_tooltip.scss
@@ -89,10 +89,6 @@
     font-size: 1.125rem;
     font-family: $font-roboto;
     line-height: 1rem;
-
-    &--focused {
-      font-weight: $font-bold;
-    }
   }
 
   &__text {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -874,7 +874,7 @@
           "close": "Ok, got it",
           "focused": {
             "title": "Focus Mode",
-            "content": "'<p class=\"tooltip-tag-information__title--focused\">'Stay on this page to answer!'</p>' Do not use the internet or any application to answer. Any activity outside this zone will be detected."
+            "content": "'<strong class=\"tooltip-tag-information__title--focused\">'Stay on this page to answer!'</strong><br/>' Do not use the internet or any application to answer. Any activity outside this zone will be detected."
           },
           "other": {
             "title": "Free Mode",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -867,7 +867,7 @@
           "aria-label": "Mostrar la indicación en la prueba.",
           "close": "Lo he entendido",
           "focused": {
-            "content": "'<p class=\"tooltip-tag-information__title--focused\">'¡Quédate en esta página para responder!'</p>' No utilices internet ni ninguna aplicación para responder. Se detectará cualquier actividad fuera de la zona.",
+            "content": "'<strong class=\"tooltip-tag-information__title--focused\">'¡Quédate en esta página para responder!'</strong><br/>' No utilices internet ni ninguna aplicación para responder. Se detectará cualquier actividad fuera de la zona.",
             "title": "Modo enfoque"
           },
           "other": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -874,7 +874,7 @@
           "close": "J'ai compris",
           "focused": {
             "title": "Mode Focus",
-            "content": "'<p class=\"tooltip-tag-information__title--focused\">'Essayez de rester sur cette page pour répondre !'</p>' Cette question ne nécessite ni internet, ni application."
+            "content": "'<strong class=\"tooltip-tag-information__title--focused\">'Essayez de rester sur cette page pour répondre !'</strong><br/>' Cette question ne nécessite ni internet, ni application."
           },
           "other": {
             "title": "Mode Libre",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -867,7 +867,7 @@
           "aria-label": "Geef de indicatie op het bewijs weer.",
           "close": "Ik snap het.",
           "focused": {
-            "content": "'<p class=\"tooltip-tag-information__title--focused\">'Blijf op deze pagina om te reageren!'</p>' Gebruik geen internet of een app om te reageren. Elke activiteit buiten de zone wordt gedetecteerd.",
+            "content": "'<strong class=\"tooltip-tag-information__title--focused\">'Blijf op deze pagina om te reageren!'</strong><br/>' Gebruik geen internet of een app om te reageren. Elke activiteit buiten de zone wordt gedetecteerd.",
             "title": "Scherpstelmodus"
           },
           "other": {


### PR DESCRIPTION
## :unicorn: Problème
Présence d'un élément <p> à l'intérieur d'un élément <p>. Un élément <p> ne peut contenir que du contenu phrasé.

## :robot: Proposition
Mettre le contenu à mettre en avant dans une balise "strong" au sein de la balise paragraphe.

## :rainbow: Remarques
Je n'ai pas suivi la recommandation de correction présente sur le ticket.

## :100: Pour tester
- Se rendre sur Pix App
- Lancer l'application et aller sur une épreuve focus ( /challenges/rec2dRKsI4aBIsayz/preview ) 
- Constater que l'affichage de la popin de focus est resté le même, inspecter l'élément pour voir qu'on n'a plus 2 balises <p> imbriquées mais une balise <strong> au sein d'une balise <p>