### PR TITLE
[TECH] Remplacer Bluebird : all, filter, each par des fonctions natives

### DIFF
--- a/api/db/migrations/20180329113849_add-indexes-on-many-tables.js
+++ b/api/db/migrations/20180329113849_add-indexes-on-many-tables.js
@@ -1,5 +1,3 @@
-import Promise from 'bluebird';
-
 const indexes = {
   answers: ['assessmentId'],
   assessments: ['type'],

--- a/api/db/migrations/20220906142048_add-assessmentId-in-flash-assessments-results.js
+++ b/api/db/migrations/20220906142048_add-assessmentId-in-flash-assessments-results.js
@@ -1,4 +1,3 @@
-import bluebird from 'bluebird';
 const TABLE_NAME = 'flash-assessment-results';
 const COLUMN_NAME = 'assessmentId';
 
@@ -9,9 +8,10 @@ const up = async function (knex) {
     .select('answers.assessmentId', 'flash-assessment-results.id')
     .join('answers', 'answers.id', 'flash-assessment-results.answerId');
 
-  await bluebird.each(flashAssessmentResults, async function ({ assessmentId, id }) {
+  for (const flashAssessmentResult of flashAssessmentResults) {
+    const { assessmentId, id } = flashAssessmentResult;
     await knex(TABLE_NAME).update({ assessmentId }).where({ id });
-  });
+  }
 
   return knex.schema.alterTable(TABLE_NAME, function (table) {
     table.integer(COLUMN_NAME).notNullable().alter();

--- a/api/db/migrations/20220922141959_modify-messages-in-complementary-certification-badges.js
+++ b/api/db/migrations/20220922141959_modify-messages-in-complementary-certification-badges.js
@@ -1,5 +1,3 @@
-import bluebird from 'bluebird';
-
 import { badges } from '../constants.js';
 
 const {
@@ -31,7 +29,8 @@ const up = async function (knex) {
       PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
       PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
     ]);
-  await bluebird.each(badges, async ({ id, key }) => {
+  for (const badge of badges) {
+    const { id, key } = badge;
     let levelName;
     if ([PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE, PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE].includes(key)) {
       levelName = 'Initié (entrée dans le métier)';
@@ -59,7 +58,7 @@ const up = async function (knex) {
     await knex('complementary-certification-badges')
       .update({ certificateMessage, temporaryCertificateMessage })
       .where({ id });
-  });
+  }
 };
 // eslint-disable-next-line no-empty-function
 const down = function () {};

--- a/api/db/migrations/20220927073844_add-column-sticker-url-to-table-complementary-certification-badges.js
+++ b/api/db/migrations/20220927073844_add-column-sticker-url-to-table-complementary-certification-badges.js
@@ -1,5 +1,3 @@
-import bluebird from 'bluebird';
-
 const STICKERS_URL_BY_BADGE_KEY = {
   PIX_EMPLOI_CLEA: 'https://images.pix.fr/stickers/macaron_clea.pdf',
   PIX_EMPLOI_CLEA_V2: 'https://images.pix.fr/stickers/macaron_clea.pdf',
@@ -26,13 +24,14 @@ const up = async function (knex) {
 
   const certifiableBadges = await knex('badges').select('id', 'key').where({ isCertifiable: true });
 
-  await bluebird.each(certifiableBadges, async ({ id: badgeId, key }) => {
+  for (const certifiableBadge of certifiableBadges) {
+    const { id: badgeId, key } = certifiableBadge;
     if (STICKERS_URL_BY_BADGE_KEY[key]) {
       await knex('complementary-certification-badges')
         .update({ stickerUrl: STICKERS_URL_BY_BADGE_KEY[key] })
         .where({ badgeId });
     }
-  });
+  }
 };
 
 const down = async function (knex) {

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -1,5 +1,3 @@
-import bluebird from 'bluebird';
-
 import { SessionNotAccessible } from '../../../src/certification/session-management/domain/errors.js';
 import { ComplementaryCertificationCourse } from '../../../src/certification/session-management/domain/models/ComplementaryCertificationCourse.js';
 import { CertificationCourse } from '../../../src/certification/shared/domain/models/CertificationCourse.js';
@@ -190,30 +188,28 @@ async function _startNewCertification({
     userId,
   });
 
-  await bluebird.each(
-    highestCertifiableBadgeAcquisitions,
-    async ({
+  for (const highestCertifiableBadgeAcquisition of highestCertifiableBadgeAcquisitions) {
+    const {
       complementaryCertificationKey,
       complementaryCertificationId,
       complementaryCertificationBadgeId,
       campaignId,
       badgeKey,
-    }) => {
-      if (
-        certificationCenter.isHabilitated(complementaryCertificationKey) &&
-        certificationCandidate.isGranted(complementaryCertificationKey)
-      ) {
-        complementaryCertificationCourseData.push({ complementaryCertificationBadgeId, complementaryCertificationId });
-        const certificationChallenges = await certificationChallengesService.pickCertificationChallengesForPixPlus(
-          campaignId,
-          badgeKey,
-          userId,
-          locale,
-        );
-        challengesForCertification.push(...certificationChallenges);
-      }
-    },
-  );
+    } = highestCertifiableBadgeAcquisition;
+    if (
+      certificationCenter.isHabilitated(complementaryCertificationKey) &&
+      certificationCandidate.isGranted(complementaryCertificationKey)
+    ) {
+      complementaryCertificationCourseData.push({ complementaryCertificationBadgeId, complementaryCertificationId });
+      const certificationChallenges = await certificationChallengesService.pickCertificationChallengesForPixPlus(
+        campaignId,
+        badgeKey,
+        userId,
+        locale,
+      );
+      challengesForCertification.push(...certificationChallenges);
+    }
+  }
 
   let challengesForPixCertification = [];
   if (!CertificationVersion.isV3(version)) {

--- a/api/lib/infrastructure/repositories/tube-repository.js
+++ b/api/lib/infrastructure/repositories/tube-repository.js
@@ -1,4 +1,3 @@
-import bluebird from 'bluebird';
 import _ from 'lodash';
 
 import { Tube } from '../../../src/shared/domain/models/Tube.js';
@@ -26,9 +25,13 @@ function _toDomain({ tubeData, locale }) {
 }
 
 async function _findActive(tubes) {
-  return bluebird.filter(tubes, async ({ id: tubeId }) => {
-    const activeSkills = await skillDatasource.findActiveByTubeId(tubeId);
-    return activeSkills.length > 0;
+  const skillsByTubesIndex = await Promise.all(
+    tubes.map(async ({ id: tubeId }) => skillDatasource.findActiveByTubeId(tubeId)),
+  );
+
+  return tubes.filter((_, index) => {
+    const hasActiveSkills = skillsByTubesIndex[index].length > 0;
+    return hasActiveSkills;
   });
 }
 

--- a/api/src/certification/results/infrastructure/utils/pdf/certification-attestation-pdf.js
+++ b/api/src/certification/results/infrastructure/utils/pdf/certification-attestation-pdf.js
@@ -3,7 +3,6 @@ import * as url from 'node:url';
 
 import pdfLibFontkit from '@pdf-lib/fontkit';
 import axios from 'axios';
-import bluebird from 'bluebird';
 import dayjs from 'dayjs';
 import _ from 'lodash';
 import { PDFDocument, rgb } from 'pdf-lib';
@@ -113,9 +112,9 @@ async function _embedImages(pdfDocument, viewModels) {
     .map('url')
     .uniq()
     .value();
-  await bluebird.each(uniqStickerUrls, async (url) => {
+  for (const url of uniqStickerUrls) {
     embeddedImages[url] = await _embedCertificationImage(pdfDocument, url);
-  });
+  }
   return embeddedImages;
 }
 


### PR DESCRIPTION
## :unicorn: Problème

[Bluebird](https://github.com/petkaantonov/bluebird) est une librairie d’utilitaire autour des promesses, qui a été utilisée à Pix côté API principalement pour palier au manque de fonctionnalités autour des promesses natives NodeJS d’il y a quelques années.

Mais les promesses natives NodeJS ont énormément évoluées depuis ce qui rend en partie l’utilisation de Bluebird obsolète. De plus la librairie n’est plus maintenue, sa dernière release v3.7.2 date du 28/11/2019.

## :robot: Proposition

Remplacer `all`, `filter`, `each` par des fonctions natives.

**Fonction `bluebird.filter()`**
Peut être remplacé par la combinaison de `Array.filter + Promise.all`
```js
const results = await Promise.all(arr.map(filterFn))
return arr.filter((_, index) => results[index])
```

**Fonction `bluebird.all()`**
Peut être remplacé par `Promise.all`
```js
const results = await Promise.all(myIterable)
```

**Fonction `bluebird.each()`**
Peut être remplacé par `for...of`
```js
for (const [index, value] of arr.entries()) {
  await iteratorFn(value, index, arr.length)
}
```

## :rainbow: Remarques
- N/A

## :100: Pour tester

- La CI doit passer