### PR TITLE
[TECH] Remplacer bluebird.map (avec concurrence) par des fonctions natives

### DIFF
--- a/api/db/seeds/data/common/tooling/target-profile-tooling.js
+++ b/api/db/seeds/data/common/tooling/target-profile-tooling.js
@@ -1,6 +1,6 @@
-import bluebird from 'bluebird';
 import _ from 'lodash';
 
+import { PromiseUtils } from '../../../../../src/shared/infrastructure/utils/promise-utils.js';
 import * as learningContent from './learning-content.js';
 
 export { createBadge, createStages, createTargetProfile };
@@ -52,7 +52,7 @@ async function createTargetProfile({
 }) {
   if (!frameworkNames) {
     const allCompetences = await learningContent.getAllCompetences();
-    await bluebird.map(
+    await PromiseUtils.map(
       allCompetences,
       async (competence) => {
         if (!tubeIdsByFramework[competence.origin]) tubeIdsByFramework[competence.origin] = [];

--- a/api/db/seeds/data/common/tooling/training-tooling.js
+++ b/api/db/seeds/data/common/tooling/training-tooling.js
@@ -1,6 +1,6 @@
-import bluebird from 'bluebird';
 import _ from 'lodash';
 
+import { PromiseUtils } from '../../../../../src/shared/infrastructure/utils/promise-utils.js';
 import * as learningContent from './learning-content.js';
 
 export { createTraining };
@@ -54,7 +54,7 @@ async function createTraining({
 }) {
   if (!frameworkNames) {
     const allCompetences = await learningContent.getAllCompetences();
-    await bluebird.map(
+    await PromiseUtils.map(
       allCompetences,
       async (competence) => {
         if (!tubeIdsByFramework[competence.origin]) tubeIdsByFramework[competence.origin] = [];

--- a/api/lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js
+++ b/api/lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js
@@ -11,6 +11,7 @@ import {
 } from '../../../src/shared/domain/errors.js';
 import { Organization, OrganizationForAdmin, OrganizationTag } from '../../../src/shared/domain/models/index.js';
 import * as codeGenerator from '../../../src/shared/domain/services/code-generator.js';
+import { PromiseUtils } from '../../../src/shared/infrastructure/utils/promise-utils.js';
 import { CONCURRENCY_HEAVY_OPERATIONS } from '../../infrastructure/constants.js';
 import { DomainTransaction } from '../../infrastructure/DomainTransaction.js';
 import { monitoringTools } from '../../infrastructure/monitoring-tools.js';
@@ -86,7 +87,7 @@ const createOrganizationsWithTagsAndTargetProfiles = async function ({
 export { createOrganizationsWithTagsAndTargetProfiles };
 
 async function _createOrganizations({ transformedOrganizationsData, organizationForAdminRepository }) {
-  return bluebird.map(transformedOrganizationsData, async (organizationToCreate) => {
+  return PromiseUtils.map(transformedOrganizationsData, async (organizationToCreate) => {
     try {
       const createdOrganization = await organizationForAdminRepository.save(organizationToCreate.organization);
       return {
@@ -146,7 +147,7 @@ async function _updateSchoolsWithCodes({ createdOrganizations, schoolRepository 
       ({ createdOrganization }) => createdOrganization.type === 'SCO-1D',
     );
 
-    await bluebird.map(
+    await PromiseUtils.map(
       filteredOrganizations,
       async ({ createdOrganization }) => {
         const code = await codeGenerator.generate(schoolRepository, pendingCodes);

--- a/api/lib/domain/usecases/get-certification-point-of-contact.js
+++ b/api/lib/domain/usecases/get-certification-point-of-contact.js
@@ -2,9 +2,8 @@
  * @typedef {import('./index.js').CenterRepository} CenterRepository
  * @typedef {import('../../../src/certification/enrolment/domain/models/Center.js').Center} Center
  */
-import bluebird from 'bluebird';
-
 import { CONCURRENCY_HEAVY_OPERATIONS } from '../../../src/shared/infrastructure/constants.js';
+import { PromiseUtils } from '../../../src/shared/infrastructure/utils/promise-utils.js';
 
 /**
  * @param {Object} params
@@ -38,7 +37,7 @@ export { getCertificationPointOfContact };
  * @returns {Array<Center>}
  */
 const _getCenters = async ({ authorizedCenterIds = [], centerRepository }) => {
-  return bluebird.map(authorizedCenterIds, (id) => centerRepository.getById({ id }), {
+  return PromiseUtils.map(authorizedCenterIds, (id) => centerRepository.getById({ id }), {
     concurrency: CONCURRENCY_HEAVY_OPERATIONS,
   });
 };

--- a/api/scripts/certification/generate-certificate-verification-code.js
+++ b/api/scripts/certification/generate-certificate-verification-code.js
@@ -3,12 +3,12 @@ import 'dotenv/config';
 
 import * as url from 'node:url';
 
-import bluebird from 'bluebird';
 import yargs from 'yargs';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 import * as verifyCertificateCodeService from '../../lib/domain/services/verify-certificate-code-service.js';
 import * as certificationRepository from '../../lib/infrastructure/repositories/certification-repository.js';
+import { PromiseUtils } from '../../src/shared/infrastructure/utils/promise-utils.js';
 
 const uniqueConstraintViolationCode = '23505';
 const DEFAULT_COUNT = 20000;
@@ -61,7 +61,7 @@ async function _do({ count, concurrency }) {
 
   console.log('\tGénération des codes de vérification des certifications...');
   let failedGenerations = 0;
-  await bluebird.map(
+  await PromiseUtils.map(
     eligibleCertificationIds,
     async (certificationId) => {
       try {

--- a/api/scripts/certification/generate-certification-results.js
+++ b/api/scripts/certification/generate-certification-results.js
@@ -3,10 +3,9 @@ import { disconnect, knex } from '../../db/knex-database-connection.js';
 const ASSESSMENT_COUNT = parseInt(process.env.ASSESSMENT_COUNT) || 100;
 import * as url from 'node:url';
 
-import bluebird from 'bluebird';
-
 import * as scoringCertificationService from '../../src/certification/shared/domain/services/scoring-certification-service.js';
 import * as certificationAssessmentRepository from '../../src/certification/shared/infrastructure/repositories/certification-assessment-repository.js';
+import { PromiseUtils } from '../../src/shared/infrastructure/utils/promise-utils.js';
 
 async function _retrieveLastScoredAssessmentIds() {
   const result = await knex.raw(
@@ -23,7 +22,7 @@ async function _retrieveLastScoredAssessmentIds() {
 }
 
 async function _computeScore(assessmentIds) {
-  const scores = await bluebird.map(
+  const scores = await PromiseUtils.map(
     assessmentIds,
     async (assessmentId) => {
       try {

--- a/api/scripts/certification/generate-last-assessments-score.js
+++ b/api/scripts/certification/generate-last-assessments-score.js
@@ -6,10 +6,9 @@ const ASSESSMENT_COUNT = parseInt(process.env.ASSESSMENT_COUNT) || 100;
 const ASSESSMENT_ID = parseInt(process.env.ASSESSMENT_ID) || null;
 import * as url from 'node:url';
 
-import bluebird from 'bluebird';
-
 import * as scoringCertificationService from '../../src/certification/shared/domain/services/scoring-certification-service.js';
 import * as certificationAssessmentRepository from '../../src/certification/shared/infrastructure/repositories/certification-assessment-repository.js';
+import { PromiseUtils } from '../../src/shared/infrastructure/utils/promise-utils.js';
 
 async function _retrieveLastScoredAssessmentIds() {
   const result = await knex.raw(
@@ -34,7 +33,7 @@ async function _retrieveLastScoredAssessmentIds() {
 }
 
 async function _computeScore(assessmentIds) {
-  const scores = await bluebird.map(
+  const scores = await PromiseUtils.map(
     assessmentIds,
     async (assessmentId) => {
       try {

--- a/api/scripts/certification/trigger-autojury-on-finalized-sessions.js
+++ b/api/scripts/certification/trigger-autojury-on-finalized-sessions.js
@@ -1,7 +1,5 @@
 import * as url from 'node:url';
 
-import bluebird from 'bluebird';
-
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 import { handleAutoJury } from '../../lib/domain/events/handle-auto-jury.js';
 import { eventDispatcher } from '../../lib/domain/events/index.js';
@@ -11,6 +9,7 @@ import * as certificationCourseRepository from '../../src/certification/shared/i
 import * as certificationIssueReportRepository from '../../src/certification/shared/infrastructure/repositories/certification-issue-report-repository.js';
 import * as challengeRepository from '../../src/shared/infrastructure/repositories/challenge-repository.js';
 import { logger } from '../../src/shared/infrastructure/utils/logger.js';
+import { PromiseUtils } from '../../src/shared/infrastructure/utils/promise-utils.js';
 
 const IS_FROM_SCRATCH = process.env.IS_FROM_SCRATCH === 'true';
 const AUDIT_TABLE = 'autojury-script-audit';
@@ -45,7 +44,7 @@ async function _retrieveFinalizedUnpublishedUnassignedSessionsData() {
 
 async function _triggerAutoJuryFromEvents(events) {
   console.error(`\nWork in progress (${events.length})...`);
-  return await bluebird.map(
+  return await PromiseUtils.map(
     events,
     async (event) => {
       try {

--- a/api/scripts/data-generation/generate-certif-cli.js
+++ b/api/scripts/data-generation/generate-certif-cli.js
@@ -19,6 +19,7 @@ import { learningContentCache } from '../../src/shared/infrastructure/caches/lea
 import * as skillRepository from '../../src/shared/infrastructure/repositories/skill-repository.js';
 import { temporaryStorage } from '../../src/shared/infrastructure/temporary-storage/index.js';
 import { logger } from '../../src/shared/infrastructure/utils/logger.js';
+import { PromiseUtils } from '../../src/shared/infrastructure/utils/promise-utils.js';
 import {
   makeUserCleaCertifiable,
   makeUserPixCertifiable,
@@ -125,7 +126,7 @@ async function _updateDatabaseBuilderSequenceNumber() {
 
 async function _getMaxSequenceId() {
   const sequences = await knex('information_schema.sequences').pluck('sequence_name');
-  const maxValues = await bluebird.map(sequences, (sequence) => knex(sequence).select('last_value').first());
+  const maxValues = await PromiseUtils.map(sequences, (sequence) => knex(sequence).select('last_value').first());
   const { last_value: max } = maxBy(maxValues, 'last_value');
   return max;
 }

--- a/api/scripts/prod/compute-participation-results.js
+++ b/api/scripts/prod/compute-participation-results.js
@@ -18,6 +18,7 @@ import { disconnect, knex } from '../../db/knex-database-connection.js';
 import { constants } from '../../lib/infrastructure/constants.js';
 import * as placementProfileService from '../../src/shared/domain/services/placement-profile-service.js';
 import * as competenceRepository from '../../src/shared/infrastructure/repositories/competence-repository.js';
+import { PromiseUtils } from '../../src/shared/infrastructure/utils/promise-utils.js';
 
 const concurrency = parseInt(process.argv[2]);
 let count;
@@ -41,7 +42,7 @@ async function computeParticipantResultsShared(concurrency = 1) {
   total = uniqueCampaigns.length;
   _log(`Campagnes à traiter ${total}`);
 
-  await bluebird.map(uniqueCampaigns, _updateCampaignParticipations, { concurrency });
+  await PromiseUtils.map(uniqueCampaigns, _updateCampaignParticipations, { concurrency });
 }
 
 async function _updateCampaignParticipations(campaign) {

--- a/api/scripts/prod/create-profiles-collection-campaigns.js
+++ b/api/scripts/prod/create-profiles-collection-campaigns.js
@@ -1,12 +1,11 @@
 import * as url from 'node:url';
 
-import bluebird from 'bluebird';
-
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 import * as campaignUpdateValidator from '../../src/prescription/campaign/domain/validators/campaign-update-validator.js';
 import * as campaignRepository from '../../src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js';
 import { CampaignTypes } from '../../src/prescription/shared/domain/constants.js';
 import * as codeGenerator from '../../src/shared/domain/services/code-generator.js';
+import { PromiseUtils } from '../../src/shared/infrastructure/utils/promise-utils.js';
 import { parseCsvWithHeader } from '../helpers/csvHelpers.js';
 
 function checkData(campaignData) {
@@ -29,7 +28,7 @@ function checkData(campaignData) {
 
 async function prepareCampaigns(campaignsData) {
   const generatedList = [];
-  const campaigns = await bluebird.map(
+  const campaigns = await PromiseUtils.map(
     campaignsData,
     async (campaignData) => {
       const campaign = {

--- a/api/scripts/prod/generate-knowledge-element-snapshots-for-campaigns.js
+++ b/api/scripts/prod/generate-knowledge-element-snapshots-for-campaigns.js
@@ -1,12 +1,12 @@
 import * as url from 'node:url';
 
-import bluebird from 'bluebird';
 import yargs from 'yargs';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 import * as knowledgeElementRepository from '../../lib/infrastructure/repositories/knowledge-element-repository.js';
 import * as knowledgeElementSnapshotRepository from '../../lib/infrastructure/repositories/knowledge-element-snapshot-repository.js';
 import { AlreadyExistingEntityError } from '../../src/shared/domain/errors.js';
+import { PromiseUtils } from '../../src/shared/infrastructure/utils/promise-utils.js';
 
 const DEFAULT_MAX_SNAPSHOT_COUNT = 5000;
 const DEFAULT_CONCURRENCY = 3;
@@ -68,7 +68,7 @@ async function generateKnowledgeElementSnapshots(
   concurrency,
   dependencies = { knowledgeElementRepository, knowledgeElementSnapshotRepository },
 ) {
-  return bluebird.map(
+  return PromiseUtils.map(
     campaignParticipationData,
     async (campaignParticipation) => {
       const { userId, sharedAt } = campaignParticipation;

--- a/api/src/certification/complementary-certification/domain/usecases/send-target-profile-notifications.js
+++ b/api/src/certification/complementary-certification/domain/usecases/send-target-profile-notifications.js
@@ -1,7 +1,6 @@
-import bluebird from 'bluebird';
-
 import { CONCURRENCY_HEAVY_OPERATIONS } from '../../../../shared/infrastructure/constants.js';
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
+import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 const EVENT_NAME = 'attach-target-profile-certif';
 
 export { sendTargetProfileNotifications };
@@ -18,7 +17,7 @@ async function sendTargetProfileNotifications({
 
   if (emails.length) {
     let sucessCounter = 0;
-    await bluebird.map(
+    await PromiseUtils.map(
       emails,
       async (email) => {
         const result = await mailService.sendNotificationToOrganizationMembersForTargetProfileDetached({

--- a/api/src/certification/complementary-certification/infrastructure/serializers/jsonapi/complementary-certification-badge-serializer.js
+++ b/api/src/certification/complementary-certification/infrastructure/serializers/jsonapi/complementary-certification-badge-serializer.js
@@ -1,7 +1,7 @@
-import bluebird from 'bluebird';
 import jsonapiSerializer from 'jsonapi-serializer';
 
 import { CONCURRENCY_HEAVY_OPERATIONS } from '../../../../../shared/infrastructure/constants.js';
+import { PromiseUtils } from '../../../../../shared/infrastructure/utils/promise-utils.js';
 
 const { Deserializer } = jsonapiSerializer;
 
@@ -13,7 +13,7 @@ const deserialize = async function (json) {
   const { complementaryCertificationBadges: complementaryCertificationBadgesToDeserialize } =
     deserializedComplementaryCertification;
 
-  deserializedComplementaryCertification.complementaryCertificationBadges = await bluebird.map(
+  deserializedComplementaryCertification.complementaryCertificationBadges = await PromiseUtils.map(
     complementaryCertificationBadgesToDeserialize,
     async (complementaryCertificationBadgesToDeserialize) =>
       await deserialize.deserialize(complementaryCertificationBadgesToDeserialize),

--- a/api/src/certification/session-management/domain/usecases/get-session-for-supervising.js
+++ b/api/src/certification/session-management/domain/usecases/get-session-for-supervising.js
@@ -1,7 +1,7 @@
-import bluebird from 'bluebird';
 import dayjs from 'dayjs';
 
 import { CONCURRENCY_HEAVY_OPERATIONS } from '../../../../shared/infrastructure/constants.js';
+import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 import { DEFAULT_SESSION_DURATION_MINUTES } from '../../../shared/domain/constants.js';
 
 /**
@@ -25,7 +25,7 @@ const getSessionForSupervising = async function ({
   const sessionForSupervising = await sessionForSupervisingRepository.get({ id: sessionId });
   const activatedCompanionCertificationCandidateIds = await temporaryCompanionStorageService.getBySessionId(sessionId);
 
-  await bluebird.map(
+  await PromiseUtils.map(
     sessionForSupervising.certificationCandidates,
     _computeComplementaryCertificationEligibility(certificationBadgesService),
     { concurrency: CONCURRENCY_HEAVY_OPERATIONS },

--- a/api/src/certification/session-management/domain/usecases/integrate-cpf-processing-receipts.js
+++ b/api/src/certification/session-management/domain/usecases/integrate-cpf-processing-receipts.js
@@ -3,10 +3,9 @@
  *
  * @typedef {import('../../../shared/domain/usecases/index.js').CpfCertificationResultRepository} CpfCertificationResultRepository
  */
-import bluebird from 'bluebird';
-
 import { CONCURRENCY_HEAVY_OPERATIONS } from '../../../../../lib/infrastructure/constants.js';
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
+import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 
 /**
  * @param {Object} params
@@ -43,7 +42,7 @@ export { integrateCpfProccessingReceipts };
 async function _updateCertificationCourses({ cpfReceipt, cpfReceiptsStorage, cpfCertificationResultRepository }) {
   const cpfInfos = await cpfReceiptsStorage.getCpfInfosByReceipt({ cpfReceipt });
 
-  await bluebird.map(cpfInfos, async (cpfInfos) => cpfCertificationResultRepository.updateCpfInfos({ cpfInfos }), {
+  await PromiseUtils.map(cpfInfos, async (cpfInfos) => cpfCertificationResultRepository.updateCpfInfos({ cpfInfos }), {
     concurrency: CONCURRENCY_HEAVY_OPERATIONS,
   });
   logger.info('%d certification courses updated from CPF receipt %s', cpfInfos.length, cpfReceipt.filename);

--- a/api/src/certification/session-management/infrastructure/storage/cpf-exports-storage.js
+++ b/api/src/certification/session-management/infrastructure/storage/cpf-exports-storage.js
@@ -1,7 +1,6 @@
-import bluebird from 'bluebird';
-
 import { CONCURRENCY_HEAVY_OPERATIONS } from '../../../../../lib/infrastructure/constants.js';
 import { config } from '../../../../shared/config.js';
+import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 import { S3ObjectStorageProvider } from '../../../../shared/storage/infrastructure/providers/S3ObjectStorageProvider.js';
 
 class CpfExportsStorage {
@@ -16,7 +15,7 @@ class CpfExportsStorage {
   }
 
   async preSignFiles({ keys, expiresIn = config.cpf.storage.cpfExports.commands.preSignedExpiresIn }) {
-    return bluebird.map(
+    return PromiseUtils.map(
       keys,
       (key) => {
         return this.#client.preSignFile({ key, expiresIn });

--- a/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-profiles-collection-export.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-profiles-collection-export.js
@@ -1,4 +1,3 @@
-import bluebird from 'bluebird';
 import _ from 'lodash';
 
 import {
@@ -6,7 +5,9 @@ import {
   CONCURRENCY_HEAVY_OPERATIONS,
 } from '../../../../../../lib/infrastructure/constants.js';
 import * as csvSerializer from '../../../../../shared/infrastructure/serializers/csv/csv-serializer.js';
+import { PromiseUtils } from '../../../../../shared/infrastructure/utils/promise-utils.js';
 import { CampaignProfilesCollectionResultLine } from '../../exports/campaigns/campaign-profiles-collection-result-line.js';
+
 class CampaignProfilesCollectionExport {
   constructor(outputStream, organization, campaign, competences, translate) {
     this.stream = outputStream;
@@ -29,7 +30,7 @@ class CampaignProfilesCollectionExport {
       constants.CHUNK_SIZE_CAMPAIGN_RESULT_PROCESSING,
     );
 
-    return bluebird.map(
+    return PromiseUtils.map(
       campaignParticipationResultDataChunks,
       async (campaignParticipationResultDataChunk) => {
         const placementProfiles = await this._getUsersPlacementProfiles(

--- a/api/src/school/scripts/create-school-learners.js
+++ b/api/src/school/scripts/create-school-learners.js
@@ -1,6 +1,5 @@
 import * as url from 'node:url';
 
-import bluebird from 'bluebird';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
@@ -11,6 +10,7 @@ import { ORGANIZATION_FEATURE } from '../../shared/domain/constants.js';
 import * as codeGenerator from '../../shared/domain/services/code-generator.js';
 import * as organizationRepository from '../../shared/infrastructure/repositories/organization-repository.js';
 import { logger } from '../../shared/infrastructure/utils/logger.js';
+import { PromiseUtils } from '../../shared/infrastructure/utils/promise-utils.js';
 
 const STUDENT_NAMES = [
   { firstName: 'Ichigo', lastName: 'Hara-Masuda' },
@@ -75,7 +75,7 @@ async function buildLearners({ organizationId, quantity = STUDENT_NAMES.length }
     quantity = STUDENT_NAMES.length;
   }
   logger.info('Create learners for organization.');
-  await bluebird.map(STUDENT_NAMES.slice(0, quantity), async (studentName) => {
+  await PromiseUtils.map(STUDENT_NAMES.slice(0, quantity), async (studentName) => {
     await knex('organization-learners').insert({
       organizationId,
       firstName: studentName.firstName,

--- a/api/src/shared/application/security-pre-handlers.js
+++ b/api/src/shared/application/security-pre-handlers.js
@@ -1,4 +1,3 @@
-import bluebird from 'bluebird';
 import jsonapiSerializer from 'jsonapi-serializer';
 import lodash from 'lodash';
 
@@ -9,6 +8,7 @@ import * as isSchoolSessionActive from '../../school/application/usecases/is-sch
 import { ForbiddenAccess, NotFoundError } from '../domain/errors.js';
 import { Organization } from '../domain/models/index.js';
 import * as organizationRepository from '../infrastructure/repositories/organization-repository.js';
+import { PromiseUtils } from '../infrastructure/utils/promise-utils.js';
 import * as checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationIdUseCase from './usecases/check-user-is-admin-of-certification-center-with-certification-center-invitation-id.js';
 import * as checkUserIsAdminOfCertificationCenterWithCertificationCenterMembershipIdUseCase from './usecases/check-user-is-admin-of-certification-center-with-certification-center-membership-id.js';
 import * as checkAdminMemberHasRoleCertifUseCase from './usecases/checkAdminMemberHasRoleCertif.js';
@@ -656,7 +656,7 @@ async function checkAuthorizationToAccessCampaign(
 
 function hasAtLeastOneAccessOf(securityChecks) {
   return async (request, h) => {
-    const responses = await bluebird.map(securityChecks, (securityCheck) => securityCheck(request, h));
+    const responses = await PromiseUtils.map(securityChecks, (securityCheck) => securityCheck(request, h));
     const hasAccess = responses.some((response) => !response.source?.errors);
     return hasAccess ? hasAccess : _replyForbiddenError(h);
   };
@@ -664,7 +664,7 @@ function hasAtLeastOneAccessOf(securityChecks) {
 
 function validateAllAccess(securityChecks) {
   return async (request, h) => {
-    const responses = await bluebird.map(securityChecks, (securityCheck) => securityCheck(request, h));
+    const responses = await PromiseUtils.map(securityChecks, (securityCheck) => securityCheck(request, h));
     const hasAccess = responses.every((response) => !response.source?.errors);
     return hasAccess ? hasAccess : _replyForbiddenError(h);
   };

--- a/api/src/shared/infrastructure/utils/promise-utils.js
+++ b/api/src/shared/infrastructure/utils/promise-utils.js
@@ -1,0 +1,44 @@
+/**
+ * Asynchronously maps over an array of values with a concurrency limit.
+ *
+ * @param {Array} array - The array of values to be mapped.
+ * @param {Function} mapper - A function that takes a value and its index, and returns a promise or value.
+ * @param {Object} [options] - Optional configuration object.
+ * @param {number} [options.concurrency=Infinity] - The maximum number of concurrent promises created by the mapper function.
+ *
+ * @returns {Promise<Array>} A promise that resolves to an array of mapped results.
+ *
+ */
+function map(array, mapper, { concurrency = Infinity } = {}) {
+  let index = 0;
+  let concurrentPromises = 0;
+
+  const results = new Array(array.length);
+
+  return new Promise((resolve, reject) => {
+    const next = () => {
+      if (index >= array.length) {
+        if (concurrentPromises === 0) resolve(results);
+        return;
+      }
+
+      const currentIndex = index++;
+
+      concurrentPromises++;
+      Promise.resolve(mapper(array[currentIndex], currentIndex)).then(
+        (result) => {
+          results[currentIndex] = result;
+          concurrentPromises--;
+          next();
+        },
+        (err) => reject(err),
+      );
+
+      if (concurrentPromises < concurrency) next();
+    };
+
+    next();
+  });
+}
+
+export const PromiseUtils = { map };

--- a/api/tests/shared/unit/infrastructure/utils/promise-utils_test.js
+++ b/api/tests/shared/unit/infrastructure/utils/promise-utils_test.js
@@ -1,0 +1,72 @@
+import { PromiseUtils } from '../../../../../src/shared/infrastructure/utils/promise-utils.js';
+import { catchErr, expect, sinon } from '../../../../test-helper.js';
+
+describe('#map', function () {
+  it('maps', async function () {
+    const arr = [1, 2, 3];
+    const callback = sinon.spy((v) => Promise.resolve(v + 1));
+
+    const result = await PromiseUtils.map(arr, callback);
+
+    expect(callback).to.have.been.calledThrice;
+    expect(result).to.deep.equal([2, 3, 4]);
+  });
+
+  it('rejects if an error occurred', async function () {
+    const arr = [1, 2, 3];
+    const callback = sinon.spy(() => Promise.reject('boo'));
+
+    const error = await catchErr(PromiseUtils.map)(arr, callback);
+
+    expect(error).to.be.equal('boo');
+  });
+
+  describe('concurrency limit', function () {
+    let currentConcurrentExecutions;
+    let maxConcurrentExecutions;
+    let concurrentCallback;
+
+    beforeEach(function () {
+      currentConcurrentExecutions = 0;
+      maxConcurrentExecutions = 0;
+
+      concurrentCallback = async (item) => {
+        currentConcurrentExecutions++;
+        maxConcurrentExecutions = Math.max(maxConcurrentExecutions, currentConcurrentExecutions);
+        const result = await Promise.resolve(item);
+        currentConcurrentExecutions--;
+        return result;
+      };
+    });
+
+    it('respects concurrency limit', async function () {
+      const arr = [1, 2, 3, 4, 5, 6];
+      const concurrency = 2;
+
+      const result = await PromiseUtils.map(arr, concurrentCallback, { concurrency });
+
+      expect(result).to.deep.equal(arr);
+      expect(maxConcurrentExecutions).to.be.equal(concurrency);
+    });
+
+    it('handles concurrency of 1 correctly', async function () {
+      const arr = [1, 2, 3, 4, 5, 6];
+      const concurrency = 1;
+
+      const result = await PromiseUtils.map(arr, concurrentCallback, { concurrency });
+
+      expect(result).to.deep.equal(arr);
+      expect(maxConcurrentExecutions).to.be.equal(concurrency);
+    });
+
+    it('handles no concurrency limit', async function () {
+      const arr = [1, 2, 3, 4, 5, 6];
+      const concurrency = Infinity;
+
+      const result = await PromiseUtils.map(arr, concurrentCallback, { concurrency });
+
+      expect(result).to.deep.equal(arr);
+      expect(maxConcurrentExecutions).to.be.equal(arr.length);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

[Bluebird](https://github.com/petkaantonov/bluebird) est une librairie d’utilitaire autour des promesses, qui a été utilisée à Pix côté API principalement pour palier au manque de fonctionnalités autour des promesses natives NodeJS d’il y a quelques années.

Mais les promesses natives NodeJS ont énormément évoluées depuis ce qui rend en partie l’utilisation de Bluebird obsolète. De plus la librairie n’est plus maintenue, sa dernière release v3.7.2 date du 28/11/2019.

## :robot: Proposition

Remplacer `map` par des fonctions natives et gestion de la concurrence.

Création d'un fichier `PromiseUtils` avec une fonction `map`:
```js
PromiseUtils.map(array, asynCallback, { concurrency: 2 })
```

Remplacer les `bluebird.map` par `PromiseUtils.map` dans tous les fichiers de l'api

## :rainbow: Remarques
- N/A

## :100: Pour tester

- La CI doit passer
