### PR TITLE
[BUGFIX] Réparer l'affichage des réponses au rechargement d'un écran intermédiaire (PIX-13688).

### DIFF
--- a/mon-pix/app/routes/assessments/checkpoint.js
+++ b/mon-pix/app/routes/assessments/checkpoint.js
@@ -6,6 +6,8 @@ export default class CheckpointRoute extends Route {
   }
 
   async afterModel(assessment) {
+    await assessment.hasMany('answers').reload();
+
     if (assessment.isCompetenceEvaluation || assessment.isForCampaign) {
       await assessment.belongsTo('progression').reload();
     }

--- a/mon-pix/tests/unit/routes/assessments/checkpoint-test.js
+++ b/mon-pix/tests/unit/routes/assessments/checkpoint-test.js
@@ -13,6 +13,7 @@ module('Unit | Route | Assessments | Checkpoint', function (hooks) {
       const assessment = {
         isCompetenceEvaluation: true,
         belongsTo: sinon.stub().returns({ reload: reloadStub }),
+        hasMany: sinon.stub().returns({ reload: sinon.stub().resolves() }),
       };
 
       // when
@@ -33,6 +34,7 @@ module('Unit | Route | Assessments | Checkpoint', function (hooks) {
       const assessment = {
         isForCampaign: true,
         belongsTo: sinon.stub().returns({ reload: reloadStub }),
+        hasMany: sinon.stub().returns({ reload: sinon.stub().resolves() }),
       };
 
       // when


### PR DESCRIPTION
## :unicorn: Problème

Dans un écran intermédiaire de parcours, au rechargement de la page, les réponses n'étaient plus affichées.

## :robot: Proposition

Recharger les réponses dans l'`afterModel` de la route `checkpoint.js` pour assurer le chargement des données.

## :100: Pour tester

- Lancer un parcours
- atteindre un écran intermédiaire
- recharger la page
- ✅ attester que l'écran s'affiche comme souhaité.
