### PR TITLE
[FEATURE] Intégrer des composants Pix UI sur l'accueil de Pix App

### DIFF
--- a/mon-pix/app/components/dashboard/section.hbs
+++ b/mon-pix/app/components/dashboard/section.hbs
@@ -5,11 +5,12 @@
       <p class="dashboard-section__subtitle">{{@subtitle}}</p>
     </div>
     {{#if this.hasLink}}
-      <LinkTo
+      <PixButtonLink
         @route={{@linkRoute}}
         class="dashboard-section__button"
+        @variant="secondary"
         aria-label={{@ariaLabelLink}}
-      >{{@linkText}}</LinkTo>
+      >{{@linkText}}</PixButtonLink>
     {{/if}}
   </div>
 

--- a/mon-pix/app/components/new-information.hbs
+++ b/mon-pix/app/components/new-information.hbs
@@ -9,16 +9,16 @@
       {{#if @linkText}}
         {{#if (eq @linkDisplayType "button")}}
           {{#if @code}}
-            <LinkTo
+            <PixButtonLink
               @route="{{@linkTo}}"
               @model={{@code}}
-              class="new-information-content-text__button button button--extra-thin button--link"
-            >{{@linkText}}</LinkTo>
+              class="new-information-content-text__button"
+            >{{@linkText}}</PixButtonLink>
           {{else}}
-            <LinkTo
+            <PixButtonLink
               @route="{{@linkTo}}"
-              class="new-information-content-text__button button button--extra-thin button--link"
-            >{{@linkText}}</LinkTo>
+              class="new-information-content-text__button"
+            >{{@linkText}}</PixButtonLink>
           {{/if}}
         {{else}}
           <a
@@ -35,8 +35,12 @@
   </div>
 
   {{#if @closeAction}}
-    <button class="new-information__close {{@textColorClass}}" {{on "click" @closeAction}} type="button">
-      <FaIcon @icon="xmark" /><span class="sr-only">{{t "common.new-information-banner.close-label"}}</span>
-    </button>
+    <PixIconButton
+      @icon="xmark"
+      @ariaLabel={{t "common.new-information-banner.close-label"}}
+      @triggerAction={{@closeAction}}
+      @withBackground={{true}}
+      class="new-information__close"
+    />
   {{/if}}
 </div>

--- a/mon-pix/app/styles/components/_new-information.scss
+++ b/mon-pix/app/styles/components/_new-information.scss
@@ -23,14 +23,6 @@
 
   &__close {
     align-self: flex-end;
-    padding: 3px 10px 6px;
-    font-size: 1.5rem;
-    background-color: transparent;
-    border: none;
-
-    &:hover {
-      cursor: pointer;
-    }
 
     @include device-is('tablet') {
       align-self: flex-start;
@@ -119,11 +111,6 @@
   &__button {
     display: inline-table;
     margin-top: 20px;
-    padding: 10px 20px;
-
-    @include device-is('tablet') {
-      margin: 0;
-    }
   }
 
   &__link {

--- a/mon-pix/app/styles/components/dashboard/_content.scss
+++ b/mon-pix/app/styles/components/dashboard/_content.scss
@@ -97,7 +97,7 @@
         padding: 40px 0 47px;
 
         & > .new-information {
-          padding: 20px 5px 20px 0;
+          padding: var(--pix-spacing-6x) var(--pix-spacing-4x);
         }
       }
     }

--- a/mon-pix/app/styles/components/dashboard/_content.scss
+++ b/mon-pix/app/styles/components/dashboard/_content.scss
@@ -187,15 +187,6 @@
 
   &__button {
     display: none;
-    padding: 10px 16px;
-    color: $pix-neutral-90;
-    font-size: 0.875rem;
-    border: 1px solid $pix-neutral-50;
-    border-radius: 4px;
-
-    &:hover {
-      background-color: darken($pix-neutral-10, 5%);
-    }
 
     @include device-is('tablet') {
       display: block;

--- a/mon-pix/app/styles/components/dashboard/_content.scss
+++ b/mon-pix/app/styles/components/dashboard/_content.scss
@@ -19,10 +19,13 @@
   }
 
   &__score {
-    @include add-dashboard-content-separator;
+    // stylelint-disable-next-line no-duplicate-selectors
+    & {
+      @include add-dashboard-content-separator;
 
-    grid-area: score;
-    margin-bottom: 20px;
+      grid-area: score;
+      margin-bottom: 20px;
+    }
   }
 
   &__main {
@@ -57,11 +60,14 @@
     }
 
     &__certif {
-      @include add-dashboard-content-separator;
+      // stylelint-disable-next-line no-duplicate-selectors
+      & {
+        @include add-dashboard-content-separator;
 
-      grid-area: certif;
-      height: 100%;
-      margin-bottom: 24px;
+        grid-area: certif;
+        height: 100%;
+        margin-bottom: 24px;
+      }
     }
 
     &__main {
@@ -91,10 +97,13 @@
       grid-area: main;
 
       .dashboard-banner {
-        @include add-dashboard-content-separator;
+        // stylelint-disable-next-line no-duplicate-selectors
+        & {
+          @include add-dashboard-content-separator;
 
-        display: block;
-        padding: 40px 0 47px;
+          display: block;
+          padding: 40px 0 47px;
+        }
 
         & > .new-information {
           padding: var(--pix-spacing-6x) var(--pix-spacing-4x);
@@ -193,9 +202,12 @@
     }
   }
 
-  @include add-dashboard-content-separator;
+  // stylelint-disable-next-line no-duplicate-selectors
+  & {
+    @include add-dashboard-content-separator;
 
-  padding: 24px 0;
+    padding: 24px 0;
+  }
 
   &:last-child {
     border-bottom: none;


### PR DESCRIPTION
## :unicorn: Problème
La page d'accueil de Pix App est assez ancienne et n'utilise pas des composants communs existants dans Pix UI.

## :robot: Proposition
Utiliser des briques communes pour améliorer l'expérience globale, probablement avant des refontes plus profondes.

## :rainbow: Remarques
:warning: Pour que ce soit plus facile à retrouver j'ai fait une petite manip pour afficher tous les bandeaux impactés (ce qui fait casser les tests auto), il ne faudra pas oublier de supprimer le commit lié.

Des logs d'erreur de conflit entre SASS/CSS ont été corrigés également, voir https://github.com/1024pix/pix-ui/pull/707 pour les explications.

## :100: Pour tester
Sur [la RA](https://app-pr9769.review.pix.fr/), une fois connecté.
- Vérifier sur la page d'accueil que les 3 bannières d'informations sont plus proches de notre design actuel,
  1. Pour "découvrir le tableau de bord",
  2. Pour finaliser une campagne d'envoi de profil,
  3. Pour aller plus loin quand les compétences recommandées ont été terminées.
- Pareil sur la bannière d'annonce du niveau 7 dans la pages,
- Plus bas sur la page d'accueil, vérifiez que les boutons d'accès à "Tous les parcours" et/ou "Toutes les compétences" sont plus proches de notre design actuel.