### PR TITLE
[BUGFIX] Corrige un test flaky qui empêche la CI de passer sur PixOrga (PIX-13707).

### DIFF
--- a/orga/tests/integration/components/places/title-test.js
+++ b/orga/tests/integration/components/places/title-test.js
@@ -3,11 +3,22 @@ import dayjs from 'dayjs';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Places::Title', function (hooks) {
   setupIntlRenderingTest(hooks);
+
+  let clock;
+
+  hooks.beforeEach(function () {
+    clock = sinon.useFakeTimers({ now: new Date('2023-11-15') });
+  });
+
+  hooks.afterEach(function () {
+    clock.restore();
+  });
 
   test('it should display date of today', async function (assert) {
     // given


### PR DESCRIPTION
## :unicorn: Problème
La CI ne passe plus à cause d'un test ne déterministe utilisant une date (cf : https://app.circleci.com/pipelines/github/1024pix/pix/86261/workflows/d1f730fc-6450-4a7e-9cce-14ecf3ce5271/jobs/900820/tests).

## :robot: Proposition
On rend la date déterministe grâce à sinon.

## :rainbow: Remarques
Je corrige uniquement l'aspect flaky du test ici. On discutera côté Prescription du test et de l'implémentation du composant en dehors de cette PR.

## :100: Pour tester
La CI passe ✅ 
