### PR TITLE
[TECH] Utiliser les nouvelles variables pour les espacements sur Pix Certif (PIX-13708).

### DIFF
--- a/certif/app/styles/components/auth/toggable-login-form.scss
+++ b/certif/app/styles/components/auth/toggable-login-form.scss
@@ -1,13 +1,13 @@
 .login-form {
   display: flex;
   flex-direction: column;
-  gap: $pix-spacing-m;
+  gap: var(--pix-spacing-6x);
   max-width: 400px;
   padding: 0 2px;
   font-size: 0.875rem;
 
   &__information {
-    margin-bottom: $pix-spacing-s;
+    margin-bottom: var(--pix-spacing-4x);
     color: var(--pix-neutral-900);
     text-align: center;
 

--- a/certif/app/styles/components/dropdown.scss
+++ b/certif/app/styles/components/dropdown.scss
@@ -9,7 +9,7 @@
     padding: 0;
     overflow: hidden;
     background-color: var(--pix-neutral-0);
-    border-radius: $pix-spacing-xxs;
+    border-radius: var(--pix-spacing-1x);
     box-shadow: 1px 1px 3px 1px rgb(var(--pix-neutral-900) 0.13), 0 1px 1px 0 rgba($pix-neutral-110, 0.08);
   }
 
@@ -45,7 +45,7 @@
 
         &:focus,
         &:focus-visible {
-          border-radius: $pix-spacing-xxs;
+          border-radius: var(--pix-spacing-1x);
           outline: none;
           box-shadow: inset 0 0 0 1.6px var(--pix-primary-500);
         }

--- a/certif/app/styles/components/dropdown.scss
+++ b/certif/app/styles/components/dropdown.scss
@@ -10,7 +10,7 @@
     overflow: hidden;
     background-color: var(--pix-neutral-0);
     border-radius: var(--pix-spacing-1x);
-    box-shadow: 1px 1px 3px 1px rgb(var(--pix-neutral-900) 0.13), 0 1px 1px 0 rgba($pix-neutral-110, 0.08);
+    box-shadow: 1px 1px 3px 1px rgb(var(--pix-neutral-900) 0.13), 0 1px 1px 0 rgb(var(--pix-neutral-900) 0.08);
   }
 
   &__item {

--- a/certif/app/styles/components/login-form.scss
+++ b/certif/app/styles/components/login-form.scss
@@ -1,6 +1,6 @@
 .login {
   max-width: 500px;
-  margin-bottom: $pix-spacing-s;
+  margin-bottom: var(--pix-spacing-4x);
   padding: 20px 30px;
   background-color: var(--pix-neutral-0);
   border-radius: 10px;
@@ -40,7 +40,7 @@
   &__form {
     display: flex;
     flex-direction: column;
-    gap: $pix-spacing-s;
+    gap: var(--pix-spacing-4x);
   }
 }
 

--- a/certif/app/styles/components/login-or-register.scss
+++ b/certif/app/styles/components/login-or-register.scss
@@ -19,7 +19,7 @@
 
   &__language-switcher {
     @include device-is('mobile') {
-      margin-left: $pix-spacing-s;
+      margin-left: var(--pix-spacing-4x);
     }
   }
 }

--- a/certif/app/styles/components/login-session-supervisor/index.scss
+++ b/certif/app/styles/components/login-session-supervisor/index.scss
@@ -45,7 +45,7 @@
       &:focus,
       &:focus-visible {
         padding: 0 2px;
-        border-radius: $pix-spacing-xxs;
+        border-radius: var(--pix-spacing-1x);
         outline: none;
         box-shadow: inset 0 0 0 1.6px var(--pix-primary-500);
       }

--- a/certif/app/styles/components/members-list-item.scss
+++ b/certif/app/styles/components/members-list-item.scss
@@ -17,7 +17,7 @@
 
   &__managing-role {
     display:flex;
-    gap: $pix-spacing-s;
+    gap: var(--pix-spacing-4x);
   }
 
 }

--- a/certif/app/styles/components/register-form.scss
+++ b/certif/app/styles/components/register-form.scss
@@ -1,11 +1,11 @@
 .register-form {
   display: flex;
   flex-direction: column;
-  gap: $pix-spacing-m;
+  gap: var(--pix-spacing-6x);
   max-width: 400px;
 
   &__information {
-    margin-bottom: $pix-spacing-s;
+    margin-bottom: var(--pix-spacing-4x);
     color: var(--pix-neutral-900);
     text-align: center;
 

--- a/certif/app/styles/components/session-supervising/candidate-in-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-in-list.scss
@@ -14,7 +14,7 @@
   }
 
   &__confirm-button {
-    margin-top: $pix-spacing-s;
+    margin-top: var(--pix-spacing-4x);
   }
 
   &__details {
@@ -38,14 +38,14 @@
     border-radius: 12px;
     font-size: 0.75rem;
     font-weight: $font-normal;
-    margin-top: $pix-spacing-xs;
-    padding: $pix-spacing-xxs 0;
+    margin-top: var(--pix-spacing-2x);
+    padding: var(--pix-spacing-1x) 0;
 
     @include device-is('tablet') {
       margin-top: 0;
       position: absolute;
-      right: $pix-spacing-s;
-      top: $pix-spacing-xxs;
+      right: var(--pix-spacing-4x);
+      top: var(--pix-spacing-1x);
     }
 
     &--ongoing-alert {
@@ -99,7 +99,7 @@
   }
 
   &__eligibility {
-    margin-top: $pix-spacing-xxs;
+    margin-top: var(--pix-spacing-1x);
   }
 }
 
@@ -112,8 +112,8 @@
 .session-supervising-candidate-in-list-details-time {
   display: flex;
   align-items: center;
-  margin-top: $pix-spacing-xs;
-  gap: $pix-spacing-xs;
+  margin-top: var(--pix-spacing-2x);
+  gap: var(--pix-spacing-2x);
   width: fit-content;
 
   @include device-is('mobile') {
@@ -126,7 +126,7 @@
   }
 
   &__text {
-    padding: 6px $pix-spacing-xs;
+    padding: 6px var(--pix-spacing-2x);
     background-color: var(--pix-neutral-500);
     border-radius: 8px;
     color: var(--pix-neutral-0);

--- a/certif/app/styles/components/team/invitations-list-item.scss
+++ b/certif/app/styles/components/team/invitations-list-item.scss
@@ -1,5 +1,5 @@
 .invitations-list-item__actions {
   display: flex;
-  gap: $pix-spacing-m;
+  gap: var(--pix-spacing-6x);
   width: 38px;
 }

--- a/certif/app/styles/components/user-logged-menu.scss
+++ b/certif/app/styles/components/user-logged-menu.scss
@@ -17,7 +17,7 @@
   }
 
   &:focus {
-    border-radius: $pix-spacing-xxs;
+    border-radius: var(--pix-spacing-1x);
     outline: none;
     box-shadow: inset 0 0 0 1.6px var(--pix-primary-500);
   }
@@ -27,7 +27,7 @@
     flex-direction: column;
     justify-content: center;
     height: 100%;
-    padding-right: $pix-spacing-xs;
+    padding-right: var(--pix-spacing-2x);
     font-weight: 700;
     font-size: 0.875rem;
     line-height: 1.1rem;

--- a/certif/app/styles/globals/forms.scss
+++ b/certif/app/styles/globals/forms.scss
@@ -29,12 +29,12 @@
 .form {
   display: flex;
   flex-direction: column;
-  margin-bottom: $pix-spacing-l;
+  margin-bottom: var(--pix-spacing-8x);
 
   &__field {
     display: flex;
     flex-direction: column;
-    margin: $pix-spacing-s 0;
+    margin: var(--pix-spacing-4x) 0;
 
     @include device-is('desktop') {
       width: 500px;
@@ -51,7 +51,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-top: $pix-spacing-l;
+    margin-top: var(--pix-spacing-8x);
 
     @include device-is('desktop') {
       max-width: 500px;

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -7,7 +7,7 @@
   &__title {
     display: flex;
     align-items: center;
-    gap: $pix-spacing-xs;
+    gap: var(--pix-spacing-2x);
 
     > svg {
       color: var(--pix-neutral-500);
@@ -29,15 +29,15 @@
     }
 
     .pix-message--warning {
-      margin-top: $pix-spacing-s;
+      margin-top: var(--pix-spacing-4x);
     }
   }
 
   &__section--download {
     display: flex;
     flex-direction: column;
-    padding: $pix-spacing-m;
-    gap: $pix-spacing-m;
+    padding: var(--pix-spacing-6x);
+    gap: var(--pix-spacing-6x);
 
     .pix-message__content {
       color: var(--pix-neutral-800);
@@ -63,7 +63,7 @@
 
   &__section--link-buttons {
     display: flex;
-    gap: $pix-spacing-s;
+    gap: var(--pix-spacing-4x);
   }
 }
 

--- a/certif/app/styles/pages/authenticated/sessions/list-items.scss
+++ b/certif/app/styles/pages/authenticated/sessions/list-items.scss
@@ -23,7 +23,7 @@
 
 .session-list-header__actions {
   display: flex;
-  gap: $pix-spacing-xs;
+  gap: var(--pix-spacing-2x);
 }
 
 .new-session-icon {

--- a/certif/app/styles/pages/authenticated/sessions/no-session-panel.scss
+++ b/certif/app/styles/pages/authenticated/sessions/no-session-panel.scss
@@ -6,7 +6,7 @@
   text-align: center;
 
   @include device-is('mobile') {
-    padding: $pix-spacing-xxs 0 $pix-spacing-xxs 0;
+    padding: var(--pix-spacing-1x) 0 var(--pix-spacing-1x) 0;
   }
 
   &__icon {

--- a/certif/app/styles/pages/authenticated/team.scss
+++ b/certif/app/styles/pages/authenticated/team.scss
@@ -8,12 +8,12 @@
   &__header-admin-buttons {
     display: flex;
     justify-content: flex-end;
-    gap: $pix-spacing-s;
+    gap: var(--pix-spacing-4x);
   }
 
   &__tabs {
     display: flex;
-    margin-bottom: $pix-spacing-m;
+    margin-bottom: var(--pix-spacing-6x);
   }
 
   &__no-referer-container {

--- a/certif/app/styles/pages/authenticated/team/invite.scss
+++ b/certif/app/styles/pages/authenticated/team/invite.scss
@@ -1,10 +1,10 @@
 .team-invite-page {
   @extend %pix-body-s;
 
-  margin-top: $pix-spacing-s;
+  margin-top: var(--pix-spacing-4x);
 
   &__form {
-    margin-top: $pix-spacing-l;
+    margin-top: var(--pix-spacing-8x);
   }
 }
 

--- a/certif/app/styles/pages/terms-of-service.scss
+++ b/certif/app/styles/pages/terms-of-service.scss
@@ -47,7 +47,7 @@
 
     p,
     li {
-      margin-bottom: $pix-spacing-s;
+      margin-bottom: var(--pix-spacing-4x);
     }
 
     ul {
@@ -56,7 +56,7 @@
 
     h2,
     h3 {
-      margin-bottom: $pix-spacing-m;
+      margin-bottom: var(--pix-spacing-6x);
     }
   }
 


### PR DESCRIPTION
## :unicorn: Problème
La plupart des variables SCSS mises à disposition par Pix UI sont maintenant des propriétés custom CSS. Pour bénéficier des évolutions des ces design tokens, il est bon d'utiliser ces nouvelles variables.

## :robot: Proposition
 Migrer les variables d'espacement
```shell
. ./node_modules/@1024pix/pix-ui/scripts/migrate-spacing-scss-vars-to-css-vars.sh
```

## :rainbow: Remarques
d'après https://github.com/1024pix/pix/pull/9762

## :100: Pour tester
Parcourir Pix Certif et vérifier que les espacements sont propres ✨
