### PR TITLE
[BUGFIX] Corriger l'utilisation du taux de capage dans le choix des épreuves (PIX-13712).

### DIFF
--- a/api/src/certification/flash-certification/domain/services/algorithm-methods/flash.js
+++ b/api/src/certification/flash-certification/domain/services/algorithm-methods/flash.js
@@ -84,7 +84,11 @@ function getCapacityAndErrorRateHistory({
 
   while (answerIndex < allAnswers.length) {
     answer = allAnswers[answerIndex];
-    const variationPercentForCurrentAnswer = variationPercentUntil >= answerIndex ? variationPercent : undefined;
+    const variationPercentForCurrentAnswer = _defineVariationPercentForCurrentAnswer(
+      variationPercent,
+      variationPercentUntil,
+      answerIndex,
+    );
 
     if (!_shouldUseDoubleMeasure({ doubleMeasuresUntil, answerIndex, answersLength: allAnswers.length })) {
       ({ latestCapacity, likelihood, normalizedPosteriori } = _singleMeasure({
@@ -120,6 +124,14 @@ function getCapacityAndErrorRateHistory({
   }
 
   return capacityHistory;
+}
+
+function _defineVariationPercentForCurrentAnswer(variationPercent, variationPercentUntil, answerIndex) {
+  if (!variationPercentUntil) {
+    return variationPercent;
+  }
+
+  return variationPercentUntil >= answerIndex ? variationPercent : undefined;
 }
 
 function _shouldUseDoubleMeasure({ doubleMeasuresUntil, answerIndex, answersLength }) {

--- a/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
@@ -579,6 +579,184 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         // then
         expect(results[0].answerId).to.equal(answerId);
       });
+
+      describe('when limiting the capacity variation', function () {
+        describe('when limiting to a given number of challenges', function () {
+          describe('when giving right answers', function () {
+            it('should return the limited capacities for the correct number of challenges', function () {
+              // given
+              const challenges = [
+                domainBuilder.buildChallenge({
+                  discriminant: 1.86350005965093,
+                  difficulty: 0.194712138508747,
+                }),
+
+                domainBuilder.buildChallenge({
+                  discriminant: 2.056,
+                  difficulty: 0.6973893,
+                }),
+
+                domainBuilder.buildChallenge({
+                  discriminant: 2.5689203,
+                  difficulty: 1.36973893,
+                }),
+              ];
+
+              const allAnswers = [
+                domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id }),
+                domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[1].id }),
+                domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[2].id }),
+              ];
+
+              const variationPercent = 0.5;
+              const variationPercentUntil = 1;
+
+              // when
+              const capacityAndErrorRateHistory = flash.getCapacityAndErrorRateHistory({
+                allAnswers,
+                challenges,
+                variationPercent,
+                variationPercentUntil,
+              });
+
+              // then
+              const capacities = capacityAndErrorRateHistory.map(({ capacity }) => capacity);
+              expect(capacities).to.deep.equal([0.5, 0.75, 1.7005749291039245]);
+            });
+          });
+
+          describe('when giving wrong answers', function () {
+            it('should return the limited capacities for the correct number of challenges', function () {
+              // given
+              const challenges = [
+                domainBuilder.buildChallenge({
+                  discriminant: 1.86350005965093,
+                  difficulty: 0.194712138508747,
+                }),
+
+                domainBuilder.buildChallenge({
+                  discriminant: 2.056,
+                  difficulty: 0.6973893,
+                }),
+
+                domainBuilder.buildChallenge({
+                  discriminant: 2.5689203,
+                  difficulty: 1.36973893,
+                }),
+              ];
+
+              const allAnswers = [
+                domainBuilder.buildAnswer({ result: AnswerStatus.KO, challengeId: challenges[0].id }),
+                domainBuilder.buildAnswer({ result: AnswerStatus.KO, challengeId: challenges[1].id }),
+                domainBuilder.buildAnswer({ result: AnswerStatus.KO, challengeId: challenges[2].id }),
+              ];
+
+              const variationPercent = 0.5;
+              const variationPercentUntil = 1;
+
+              // when
+              const capacityAndErrorRateHistory = flash.getCapacityAndErrorRateHistory({
+                allAnswers,
+                challenges,
+                variationPercent,
+                variationPercentUntil,
+              });
+
+              // then
+              const capacities = capacityAndErrorRateHistory.map(({ capacity }) => capacity);
+              expect(capacities).to.deep.equal([-0.5, -0.75, -1.5100020666768261]);
+            });
+          });
+        });
+
+        describe('when not limiting to a number of challenges', function () {
+          describe('when giving right answers', function () {
+            it('should return the unlimited capacities for all challenges', function () {
+              // given
+              const challenges = [
+                domainBuilder.buildChallenge({
+                  discriminant: 1.86350005965093,
+                  difficulty: 0.194712138508747,
+                }),
+
+                domainBuilder.buildChallenge({
+                  discriminant: 2.056,
+                  difficulty: 0.6973893,
+                }),
+
+                domainBuilder.buildChallenge({
+                  discriminant: 2.5689203,
+                  difficulty: 1.36973893,
+                }),
+              ];
+
+              const allAnswers = [
+                domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id }),
+                domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[1].id }),
+                domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[2].id }),
+              ];
+
+              const variationPercent = 0.5;
+              const variationPercentUntil = null;
+
+              // when
+              const capacityAndErrorRateHistory = flash.getCapacityAndErrorRateHistory({
+                allAnswers,
+                challenges,
+                variationPercent,
+                variationPercentUntil,
+              });
+
+              // then
+              const capacities = capacityAndErrorRateHistory.map(({ capacity }) => capacity);
+              expect(capacities).to.deep.equal([0.5, 0.75, 1.125]);
+            });
+          });
+
+          describe('when giving wrong answers', function () {
+            it('should return the unlimited capacities for all challenges', function () {
+              // given
+              const challenges = [
+                domainBuilder.buildChallenge({
+                  discriminant: 1.86350005965093,
+                  difficulty: 0.194712138508747,
+                }),
+
+                domainBuilder.buildChallenge({
+                  discriminant: 2.056,
+                  difficulty: 0.6973893,
+                }),
+
+                domainBuilder.buildChallenge({
+                  discriminant: 2.5689203,
+                  difficulty: 1.36973893,
+                }),
+              ];
+
+              const allAnswers = [
+                domainBuilder.buildAnswer({ result: AnswerStatus.KO, challengeId: challenges[0].id }),
+                domainBuilder.buildAnswer({ result: AnswerStatus.KO, challengeId: challenges[1].id }),
+                domainBuilder.buildAnswer({ result: AnswerStatus.KO, challengeId: challenges[2].id }),
+              ];
+
+              const variationPercent = 0.5;
+              const variationPercentUntil = null;
+
+              // when
+              const capacityAndErrorRateHistory = flash.getCapacityAndErrorRateHistory({
+                allAnswers,
+                challenges,
+                variationPercent,
+                variationPercentUntil,
+              });
+
+              // then
+              const capacities = capacityAndErrorRateHistory.map(({ capacity }) => capacity);
+              expect(capacities).to.deep.equal([-0.5, -0.75, -1.125]);
+            });
+          });
+        });
+      });
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème

Suite à un test en recette, il s'est avéré que le capage de la capacité ne fonctionne pas comme cela est attendu.

Pour rappel, le capage de la capacité est utilisé afin de lisser la difficulté ressentie lors d'un test de certification et empêche l'algo de sélection d'épreuve de choisir des épreuves considérées comme trop difficiles pour le candidat.

Si l'on prend l'exemple de l'image ci-dessous, et si l'on se base sur les faits suivants :
- La valeur de capage utilisée dans l'environnement dans lequel ce test a eu lieu est égale à **30%** 
- La valeur par défaut d'un candidat au début de son test de la capacité est de **-3**

![image](https://github.com/user-attachments/assets/73d6afb4-6cbd-4814-b914-7a436436a3fb)

Nous pouvons remarquer que la capacité obtenue après la première question (`-2.1`) est bien comprise entre environ `-3 + (-3 * 0.3) = -3.9` et `-3 + (-3 * 0.3) = -2.1`
Mais que cela ne se vérifie pas pour la seconde capacité (`-1.1`) qui n'est quant à elle pas comprise entre `-2.1 + (-2.1 * 0.3) = -2.73` et `-2.1 - (-2.1 * 0.3) = -1.47`

☣️ Dans les faits c'est un peu plus complexe que ça et d'autres règles entrent en jeu dans le capage, altérant un peu les valeurs finales entre lesquelles se trouve la capacité du candidat à chaque question (et que vous pourrez trouver dans la PR #7377 , voir **Remarques**) mais vous vous devriez avoir saisi l'idée avec le descriptif précédent.

### Origine du problème

Après vérification, il s'avère que l'erreur provient de la valeur `variationPercentForCurrentAnswer` obtenue à l'aide de la formule suivante : 

```js
variationPercentForCurrentAnswer = variationPercentUntil >= answerIndex ? variationPercent : undefined
```

Dans le cas du passage d'épreuves dans un environnement non simulé (tel que la recette ou la prod), la variable `variationPercentUntil` est `null`
Lors de l'obtention de la capacité suite à la première question: 
`variationPercentForCurrentAnswer = variationPercent` car `null >= 0` renvoie `true` en JS.
Lors de l'obtention des capacités pour les questions suivantes : 
`variationPercentForCurrentAnswer = undefined` car à partir de `null >= 1`, la valeur renvoyée est `false`

Cappant ainsi uniquement la capacité de la première question.

## :robot: Proposition

1. On fait en sorte de capper la capacité pour un nombre donné de questions uniquement si la variable `variationPercentUntil` n'est pas nulle.
2. Sinon, on cappe pour l'intégralité des questions posées en certification.

## :rainbow: Remarques

Pour obtenir plus d'informations quant au calcul du capage de la capacité, vous pouvez vous référer à cette PR #7377 

## :100: Pour tester

- Créer une session de certification V3 avec `certifv3@example.net` et ajouter un candidat
- Passer le test avec `certifiable-contenu-user@example.net` et répondre à l'intégralité des questions
- Une fois le test terminé, munissez vous du `certificationCourseId` de votre test (vous pourrez le retrouver dans la page dédiée à la session dans pix-admin)
- Avec celui-ci et grâce à la requête suivante, vérifier que chacune des capacités des questions auxquelles vous avez répondues ne soit pas 50% plus élevée (en cas de bonne réponse) ou 50% plus faible (en cas de mauvaise réponse) à la capacité obtenue à la question précédente.

⚠️ Le pourcentage de cappage dans le cadre de cette RA est bien de 50% et non de 30% comme dans le test utilisé dans la description du problème.

```sql
SELECT cc.id, ccc.capacity 
FROM "certification-challenge-capacities" ccc 
JOIN "certification-challenges" cc ON cc.id = ccc."certificationChallengeId" 
WHERE cc."courseId" = $certifCourseId 
ORDER BY cc.id;
```
