### PR TITLE
[FEATURE] Ajouter le contenu de l'onglet Récompenses (PIX-12984).

### DIFF
--- a/api/db/seeds/data/team-evaluation/users/eval-campaign-with-badges.js
+++ b/api/db/seeds/data/team-evaluation/users/eval-campaign-with-badges.js
@@ -76,7 +76,7 @@ export default async function initUser(databaseBuilder) {
     {
       altMessage: '1 RT non-certifiable, acquis et valide',
       imageUrl: 'https://images.pix.fr/badges/Pix_plus_Droit- Pret-certif_Bronze--Initie.svg',
-      message: '1 RT non-certifiable, acquis et valide',
+      message: '1 RT non-certifiable, acquis et valide **avec markdown**',
       title: '1 RT non-certifiable, acquis et valide',
       isCertifiable: false,
       isAlwaysVisible: false,
@@ -109,7 +109,7 @@ export default async function initUser(databaseBuilder) {
     {
       altMessage: '1 RT certifiable, acquis et valide',
       imageUrl: 'https://images.pix.fr/badges/Badge_Pixome%CC%80tre-plane%CC%80te.svg',
-      message: '1 RT certifiable, acquis et valide',
+      message: '1 RT certifiable, acquis et valide **avec markdown**',
       title: '1 RT certifiable, acquis et valide',
       isCertifiable: true,
       isAlwaysVisible: false,

--- a/mon-pix/app/components/campaigns/assessment/skill-review/evaluation-results-tabs/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/skill-review/evaluation-results-tabs/index.gjs
@@ -15,7 +15,7 @@ import Trainings from './trainings';
 
     <:panels as |Panel|>
       <Panel @index={{0}}>
-        <Rewards />
+        <Rewards @badges={{@badges}} />
       </Panel>
       <Panel @index={{1}}>
         <ResultsDetails />

--- a/mon-pix/app/components/campaigns/assessment/skill-review/evaluation-results-tabs/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/skill-review/evaluation-results-tabs/index.gjs
@@ -1,3 +1,4 @@
+import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
 import Tabs from '../../../../tabs';
@@ -5,24 +6,42 @@ import ResultsDetails from './results-details';
 import Rewards from './rewards';
 import Trainings from './trainings';
 
-<template>
-  <Tabs class="evaluation-results-tabs" @ariaLabel={{t "pages.skill-review.tabs.aria-label"}} @initialTabIndex={{0}}>
-    <:tabs as |Tab|>
-      <Tab @index={{0}}>{{t "pages.skill-review.tabs.rewards.tab-label"}}</Tab>
-      <Tab @index={{1}}>{{t "pages.skill-review.tabs.results-details.tab-label"}}</Tab>
-      <Tab @index={{2}}>{{t "pages.skill-review.tabs.trainings.tab-label"}}</Tab>
-    </:tabs>
+export default class EvaluationResultsTabs extends Component {
+  get showRewardsTab() {
+    return this.args.badges.length > 0;
+  }
 
-    <:panels as |Panel|>
-      <Panel @index={{0}}>
-        <Rewards @badges={{@badges}} />
-      </Panel>
-      <Panel @index={{1}}>
-        <ResultsDetails />
-      </Panel>
-      <Panel @index={{2}}>
-        <Trainings />
-      </Panel>
-    </:panels>
-  </Tabs>
-</template>
+  get initialTabIndex() {
+    return this.showRewardsTab ? 0 : 1;
+  }
+
+  <template>
+    <Tabs
+      class="evaluation-results-tabs"
+      @ariaLabel={{t "pages.skill-review.tabs.aria-label"}}
+      @initialTabIndex={{this.initialTabIndex}}
+    >
+      <:tabs as |Tab|>
+        {{#if this.showRewardsTab}}
+          <Tab @index={{0}}>{{t "pages.skill-review.tabs.rewards.tab-label"}}</Tab>
+        {{/if}}
+        <Tab @index={{1}}>{{t "pages.skill-review.tabs.results-details.tab-label"}}</Tab>
+        <Tab @index={{2}}>{{t "pages.skill-review.tabs.trainings.tab-label"}}</Tab>
+      </:tabs>
+
+      <:panels as |Panel|>
+        {{#if this.showRewardsTab}}
+          <Panel @index={{0}}>
+            <Rewards @badges={{@badges}} />
+          </Panel>
+        {{/if}}
+        <Panel @index={{1}}>
+          <ResultsDetails />
+        </Panel>
+        <Panel @index={{2}}>
+          <Trainings />
+        </Panel>
+      </:panels>
+    </Tabs>
+  </template>
+}

--- a/mon-pix/app/components/campaigns/assessment/skill-review/evaluation-results-tabs/rewards.gjs
+++ b/mon-pix/app/components/campaigns/assessment/skill-review/evaluation-results-tabs/rewards.gjs
@@ -1,6 +1,0 @@
-import { t } from 'ember-intl';
-
-<template>
-  <h2 class="evaluation-results-tab__title">{{t "pages.skill-review.tabs.rewards.title"}}</h2>
-  <p class="evaluation-results-tab__description">{{t "pages.skill-review.tabs.rewards.description"}}</p>
-</template>

--- a/mon-pix/app/components/campaigns/assessment/skill-review/evaluation-results-tabs/rewards/badge.gjs
+++ b/mon-pix/app/components/campaigns/assessment/skill-review/evaluation-results-tabs/rewards/badge.gjs
@@ -1,0 +1,95 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixProgressGauge from '@1024pix/pix-ui/components/pix-progress-gauge';
+import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+import { modifier } from 'ember-modifier';
+
+import MarkdownToHtml from '../../../../../../components/markdown-to-html';
+
+export default class RewardsBadge extends Component {
+  @tracked isDescriptionShrinked = true;
+
+  @action
+  toggleDescriptionShrink() {
+    this.isDescriptionShrinked = !this.isDescriptionShrinked;
+  }
+
+  onDescriptionMount = modifier((element) => {
+    this.handleShowMoreVisibility(element);
+    window.addEventListener('resize', () => this.handleShowMoreVisibility(element));
+
+    return () => {
+      window.removeEventListener('resize', () => this.handleShowMoreVisibility(element));
+    };
+  });
+
+  handleShowMoreVisibility = (element) => {
+    const isTextFullyVisible = element.scrollWidth <= element.clientWidth;
+    const hasShrinkedClass = element.classList.contains('evaluation-results-tab-badge__description--shrinked');
+    const hasOneLinerClass = element.classList.contains('evaluation-results-tab-badge__description--one-liner');
+
+    if (hasShrinkedClass && isTextFullyVisible) {
+      element.classList.add('evaluation-results-tab-badge__description--one-liner');
+    } else if (hasOneLinerClass) {
+      element.classList.remove('evaluation-results-tab-badge__description--one-liner');
+    }
+  };
+
+  <template>
+    <li
+      class={{if
+        @badge.isAcquired
+        "evaluation-results-tab__badge"
+        "evaluation-results-tab__badge evaluation-results-tab__badge--not-acquired"
+      }}
+      title={{t
+        (if
+          @badge.isAcquired
+          "pages.skill-review.badge-card.acquired-full"
+          "pages.skill-review.badge-card.not-acquired-full"
+        )
+      }}
+    >
+      <div class="evaluation-results-tab-badge__image-container">
+        <img class="evaluation-results-tab-badge__image" src={{@badge.imageUrl}} alt="" />
+      </div>
+      <div class="evaluation-results-tab-badge__content">
+        <h3 class="evaluation-results-tab-badge__title">
+          {{@badge.title}}
+        </h3>
+        {{#if @badge.isCertifiable}}
+          <PixTag class="evaluation-results-tab-badge__certifiable" @color={{if @badge.isAcquired "success" "neutral"}}>
+            {{t "pages.skill-review.badge-card.certifiable"}}
+          </PixTag>
+        {{/if}}
+        <MarkdownToHtml
+          @class="evaluation-results-tab-badge__description
+            {{if this.isDescriptionShrinked 'evaluation-results-tab-badge__description--shrinked'}}"
+          {{this.onDescriptionMount}}
+          @markdown={{@badge.message}}
+        />
+        <PixButton
+          class="evaluation-results-tab-badge__show-more"
+          @triggerAction={{this.toggleDescriptionShrink}}
+          @variant="tertiary"
+          @size="small"
+        >
+          {{#if this.isDescriptionShrinked}}
+            {{t "common.actions.show-more"}}
+          {{else}}
+            {{t "common.actions.show-less"}}
+          {{/if}}
+        </PixButton>
+        {{#unless @badge.isAcquired}}
+          <PixProgressGauge
+            class="evaluation-results-tab-badge__progress-gauge"
+            @value={{@badge.acquisitionPercentage}}
+          />
+        {{/unless}}
+      </div>
+    </li>
+  </template>
+}

--- a/mon-pix/app/components/campaigns/assessment/skill-review/evaluation-results-tabs/rewards/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/skill-review/evaluation-results-tabs/rewards/index.gjs
@@ -1,0 +1,53 @@
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+
+import RewardsBadge from './badge';
+
+export default class Rewards extends Component {
+  getFilteredAndSortedBadges(acquisitionStatus) {
+    return this.args.badges
+      .toArray()
+      .filter(({ isAcquired }) => isAcquired === acquisitionStatus)
+      .sort((a, b) => b.isCertifiable - a.isCertifiable);
+  }
+
+  get acquiredBadges() {
+    return this.getFilteredAndSortedBadges(true);
+  }
+
+  get notAcquiredBadges() {
+    return this.getFilteredAndSortedBadges(false);
+  }
+
+  <template>
+    <h2 class="evaluation-results-tab__title">
+      {{t "pages.skill-review.tabs.rewards.title"}}
+    </h2>
+    <p class="evaluation-results-tab__description">
+      {{t "pages.skill-review.tabs.rewards.description"}}
+    </p>
+    {{#if this.acquiredBadges.length}}
+      <h2 class="evaluation-results-tab__badges-title evaluation-results-tab__badges-title--acquired">
+        <FaIcon @icon="circle-check" />
+        {{t "pages.skill-review.badge-card.acquired"}}
+      </h2>
+      <ul class="evaluation-results-tab__badges-list">
+        {{#each this.acquiredBadges as |badge|}}
+          <RewardsBadge @badge={{badge}} />
+        {{/each}}
+      </ul>
+    {{/if}}
+    {{#if this.notAcquiredBadges.length}}
+      <h2 class="evaluation-results-tab__badges-title evaluation-results-tab__badges-title--not-acquired">
+        <FaIcon @icon="circle-xmark" />
+        {{t "pages.skill-review.badge-card.not-acquired"}}
+      </h2>
+      <ul class="evaluation-results-tab__badges-list">
+        {{#each this.notAcquiredBadges as |badge|}}
+          <RewardsBadge @badge={{badge}} />
+        {{/each}}
+      </ul>
+    {{/if}}
+  </template>
+}

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results.gjs
@@ -14,6 +14,6 @@ import EvaluationResultsTabs from '../../../campaigns/assessment/skill-review/ev
         {{t "common.actions.quit"}}
       </LinkTo>
     </header>
-    <EvaluationResultsTabs />
+    <EvaluationResultsTabs @badges={{@model.campaignParticipationResult.campaignParticipationBadges}} />
   </div>
 </template>

--- a/mon-pix/app/styles/components/campaigns/assessment/skill-review/evaluation-results-tabs/rewards.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/skill-review/evaluation-results-tabs/rewards.scss
@@ -1,0 +1,89 @@
+.evaluation-results-tab__badges-title {
+  @extend %pix-title-xs;
+
+  display: flex;
+  gap: var(--pix-spacing-2x);
+  align-items: center;
+  margin-top: var(--pix-spacing-8x);
+
+  &--acquired svg {
+    color: var(--pix-success-700);
+  }
+
+  &--not-acquired svg {
+    color: var(--pix-neutral-800);
+  }
+}
+
+.evaluation-results-tab__badge {
+  display: grid;
+  grid-template-columns: 10rem 1fr;
+  margin-top: var(--pix-spacing-4x);
+  overflow: hidden;
+  background-color: var(--pix-neutral-0);
+  border: 1px solid var(--pix-neutral-100);
+  border-radius: 1rem;
+}
+
+.evaluation-results-tab-badge__image-container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pix-spacing-3x);
+  align-items: center;
+  justify-content: center;
+  padding: var(--pix-spacing-2x) var(--pix-spacing-6x);
+  text-align: center;
+  background-color: var(--pix-success-50);
+}
+
+.evaluation-results-tab-badge__image {
+  width: 5rem;
+  height: 5rem;
+  object-fit: contain;
+  object-position: center;
+}
+
+.evaluation-results-tab__badge--not-acquired {
+  .evaluation-results-tab-badge__image-container {
+    background-color: var(--pix-neutral-20);
+  }
+
+  .evaluation-results-tab-badge__image {
+    filter: grayscale(100%);
+  }
+}
+
+.evaluation-results-tab-badge__content {
+  padding: var(--pix-spacing-4x);
+  overflow: hidden;
+}
+
+.evaluation-results-tab-badge__title {
+  @extend %pix-title-xs;
+}
+
+.evaluation-results-tab-badge__certifiable {
+  margin: var(--pix-spacing-2x) 0;
+}
+
+.evaluation-results-tab-badge__description {
+  @extend %pix-body-s;
+
+  margin-top: var(--pix-spacing-2x);
+  color: var(--pix-neutral-500);
+
+  &--shrinked {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+}
+
+.evaluation-results-tab-badge__description--one-liner + .evaluation-results-tab-badge__show-more {
+  display: none;
+}
+
+.evaluation-results-tab-badge__progress-gauge {
+  max-width: 19rem;
+  margin-top: var(--pix-spacing-4x);
+}

--- a/mon-pix/app/styles/components/campaigns/index.scss
+++ b/mon-pix/app/styles/components/campaigns/index.scss
@@ -1,2 +1,3 @@
 @import 'assessment/skill-review/share-badge-icons';
+@import 'assessment/skill-review/evaluation-results-tabs/rewards';
 @import 'invited/learner-reconciliation';

--- a/mon-pix/app/styles/pages/_evaluation-results.scss
+++ b/mon-pix/app/styles/pages/_evaluation-results.scss
@@ -59,11 +59,11 @@
 .evaluation-results-tab__title {
   @extend %pix-title-s;
 
-  margin-top: var(--pix-spacing-6x);
+  margin-top: var(--pix-spacing-10x);
 }
 
 .evaluation-results-tab__description {
-  @extend %pix-body-s;
+  @extend %pix-body-m;
 
   margin-top: var(--pix-spacing-2x);
   color: var(--pix-neutral-500);

--- a/mon-pix/tests/integration/components/campaigns/assessment/skill-review/evaluation-results-tabs-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/skill-review/evaluation-results-tabs-test.js
@@ -7,33 +7,71 @@ import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering'
 module('Integration | Components | Campaigns | Assessment | Skill Review | Evaluation Results Tabs', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it should display a tablist with three tabs', async function (assert) {
-    // given
-    this.set('badges', []);
+  module('when there are rewards and trainings', function (hooks) {
+    hooks.beforeEach(function () {
+      const store = this.owner.lookup('service:store');
+      const acquiredBadge = store.createRecord('badge', { isAcquired: true });
+      this.set('badges', [acquiredBadge]);
+    });
 
-    // when
-    const screen = await render(
-      hbs`<Campaigns::Assessment::SkillReview::EvaluationResultsTabs @badges={{this.badges}} />`,
-    );
+    test('it should display a tablist with three tabs', async function (assert) {
+      // when
+      const screen = await render(
+        hbs`<Campaigns::Assessment::SkillReview::EvaluationResultsTabs @badges={{this.badges}} />`,
+      );
 
-    // then
-    assert.dom(screen.getByRole('tablist', { name: this.intl.t('pages.skill-review.tabs.aria-label') })).exists();
-    assert.strictEqual(screen.getAllByRole('tab').length, 3);
-    assert.dom(screen.getByRole('tab', { name: this.intl.t('pages.skill-review.tabs.rewards.tab-label') }));
-    assert.dom(screen.getByRole('tab', { name: this.intl.t('pages.skill-review.tabs.results-details.tab-label') }));
-    assert.dom(screen.getByRole('tab', { name: this.intl.t('pages.skill-review.tabs.trainings.tab-label') }));
+      // then
+      assert.dom(screen.getByRole('tablist', { name: this.intl.t('pages.skill-review.tabs.aria-label') })).exists();
+      assert.strictEqual(screen.getAllByRole('tab').length, 3);
+      assert.dom(screen.getByRole('tab', { name: this.intl.t('pages.skill-review.tabs.rewards.tab-label') }));
+      assert.dom(screen.getByRole('tab', { name: this.intl.t('pages.skill-review.tabs.results-details.tab-label') }));
+      assert.dom(screen.getByRole('tab', { name: this.intl.t('pages.skill-review.tabs.trainings.tab-label') }));
+    });
+
+    test('it should display the rewards tab first', async function (assert) {
+      // when
+      const screen = await render(
+        hbs`<Campaigns::Assessment::SkillReview::EvaluationResultsTabs @badges={{this.badges}} />`,
+      );
+
+      // then
+      assert
+        .dom(screen.getByRole('heading', { name: this.intl.t('pages.skill-review.tabs.rewards.title') }))
+        .isVisible();
+    });
   });
 
-  test('it should display the rewards tab first', async function (assert) {
-    // given
-    this.set('badges', []);
+  module('when there are no rewards', function () {
+    test('it should not display the rewards tab', async function (assert) {
+      // given
+      this.set('badges', []);
 
-    // when
-    const screen = await render(
-      hbs`<Campaigns::Assessment::SkillReview::EvaluationResultsTabs @badges={{this.badges}} />`,
-    );
+      // when
+      const screen = await render(
+        hbs`<Campaigns::Assessment::SkillReview::EvaluationResultsTabs @badges={{this.badges}} />`,
+      );
 
-    // then
-    assert.dom(screen.getByRole('heading', { name: this.intl.t('pages.skill-review.tabs.rewards.title') })).isVisible();
+      // then
+      assert.dom(screen.getByRole('tablist', { name: this.intl.t('pages.skill-review.tabs.aria-label') })).exists();
+      assert.strictEqual(screen.getAllByRole('tab').length, 2);
+      assert.notOk(screen.queryByRole('tab', { name: this.intl.t('pages.skill-review.tabs.rewards.tab-label') }));
+      assert.dom(screen.getByRole('tab', { name: this.intl.t('pages.skill-review.tabs.results-details.tab-label') }));
+      assert.dom(screen.getByRole('tab', { name: this.intl.t('pages.skill-review.tabs.trainings.tab-label') }));
+    });
+
+    test('it should display the results details tab first', async function (assert) {
+      // given
+      this.set('badges', []);
+
+      // when
+      const screen = await render(
+        hbs`<Campaigns::Assessment::SkillReview::EvaluationResultsTabs @badges={{this.badges}} />`,
+      );
+
+      // then
+      assert
+        .dom(screen.getByRole('heading', { name: this.intl.t('pages.skill-review.tabs.results-details.title') }))
+        .isVisible();
+    });
   });
 });

--- a/mon-pix/tests/integration/components/campaigns/assessment/skill-review/evaluation-results-tabs-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/skill-review/evaluation-results-tabs-test.js
@@ -8,8 +8,13 @@ module('Integration | Components | Campaigns | Assessment | Skill Review | Evalu
   setupIntlRenderingTest(hooks);
 
   test('it should display a tablist with three tabs', async function (assert) {
+    // given
+    this.set('badges', []);
+
     // when
-    const screen = await render(hbs`<Campaigns::Assessment::SkillReview::EvaluationResultsTabs />`);
+    const screen = await render(
+      hbs`<Campaigns::Assessment::SkillReview::EvaluationResultsTabs @badges={{this.badges}} />`,
+    );
 
     // then
     assert.dom(screen.getByRole('tablist', { name: this.intl.t('pages.skill-review.tabs.aria-label') })).exists();
@@ -17,5 +22,18 @@ module('Integration | Components | Campaigns | Assessment | Skill Review | Evalu
     assert.dom(screen.getByRole('tab', { name: this.intl.t('pages.skill-review.tabs.rewards.tab-label') }));
     assert.dom(screen.getByRole('tab', { name: this.intl.t('pages.skill-review.tabs.results-details.tab-label') }));
     assert.dom(screen.getByRole('tab', { name: this.intl.t('pages.skill-review.tabs.trainings.tab-label') }));
+  });
+
+  test('it should display the rewards tab first', async function (assert) {
+    // given
+    this.set('badges', []);
+
+    // when
+    const screen = await render(
+      hbs`<Campaigns::Assessment::SkillReview::EvaluationResultsTabs @badges={{this.badges}} />`,
+    );
+
+    // then
+    assert.dom(screen.getByRole('heading', { name: this.intl.t('pages.skill-review.tabs.rewards.title') })).isVisible();
   });
 });

--- a/mon-pix/tests/integration/components/campaigns/assessment/skill-review/rewards/rewards-badge-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/skill-review/rewards/rewards-badge-test.js
@@ -1,0 +1,184 @@
+import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-rendering';
+
+module('Integration | Components | Campaigns | Assessment | Evaluation Results Rewards Tab | Badge', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('global badge behaviour', function () {
+    test('it should display acquired badge content', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const acquiredBadge = store.createRecord('campaign-participation-badge', {
+        title: 'Badge title',
+        message: 'Congrats, you won a badge',
+        isAcquired: true,
+        isCertifiable: false,
+      });
+
+      this.set('badge', acquiredBadge);
+
+      // when
+      const screen = await render(
+        hbs`<Campaigns::Assessment::SkillReview::EvaluationResultsTabs::Rewards::Badge @badge={{this.badge}} />`,
+      );
+
+      // then
+      assert
+        .dom(screen.getByRole('listitem', { name: this.intl.t('pages.skill-review.badge-card.acquired-full') }))
+        .isVisible();
+
+      assert.dom(screen.getByAltText('')).isVisible();
+      assert.dom(screen.getByText(acquiredBadge.title)).isVisible();
+      assert.notOk(screen.queryByText(this.intl.t('pages.skill-review.badge-card.certifiable')));
+      assert.dom(screen.getByText(acquiredBadge.message)).isVisible();
+    });
+
+    module('when badge has a markdown message', function () {
+      test('it should display the message as html', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+
+        const badge = store.createRecord('campaign-participation-badge', {
+          message: '[markdown link](https://pix.fr)',
+          isAcquired: true,
+        });
+
+        this.set('badge', badge);
+
+        // when
+        const screen = await render(
+          hbs`<Campaigns::Assessment::SkillReview::EvaluationResultsTabs::Rewards::Badge @badge={{this.badge}} />`,
+        );
+
+        // then
+        assert.dom(screen.getByRole('link', { name: 'markdown link' })).isVisible();
+      });
+    });
+
+    module('when badge is certifiable', function () {
+      test('it should display a certifiable tag', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+
+        const certifiableBadge = store.createRecord('campaign-participation-badge', {
+          isAcquired: true,
+          isCertifiable: true,
+        });
+
+        this.set('badge', certifiableBadge);
+
+        // when
+        const screen = await render(
+          hbs`<Campaigns::Assessment::SkillReview::EvaluationResultsTabs::Rewards::Badge @badge={{this.badge}} />`,
+        );
+
+        // then
+        assert.dom(screen.getByText(this.intl.t('pages.skill-review.badge-card.certifiable'))).isVisible();
+      });
+    });
+  });
+
+  module('when badge is not acquired', function () {
+    test('it should display a progress bar', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const notAcquiredBadge = store.createRecord('campaign-participation-badge', {
+        title: 'Badge title',
+        message: 'Not acquired badge',
+        isAcquired: false,
+        isCertifiable: false,
+        acquisitionPercentage: 60,
+      });
+
+      this.set('badge', notAcquiredBadge);
+
+      // when
+      const screen = await render(
+        hbs`<Campaigns::Assessment::SkillReview::EvaluationResultsTabs::Rewards::Badge @badge={{this.badge}} />`,
+      );
+
+      // then
+      assert
+        .dom(screen.getByRole('listitem', { name: this.intl.t('pages.skill-review.badge-card.not-acquired-full') }))
+        .isVisible();
+      assert.dom(screen.getByAltText('')).isVisible();
+      assert.dom(screen.getByText(notAcquiredBadge.title)).isVisible();
+      assert.notOk(screen.queryByText(this.intl.t('pages.skill-review.badge-card.certifiable')));
+      assert.dom(screen.getByText(notAcquiredBadge.message)).isVisible();
+      assert.dom(screen.getByRole('progressbar')).isVisible();
+    });
+
+    module('when badge is certifiable', function () {
+      test('it should display a certifiable tag', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+
+        const certifiableBadge = store.createRecord('campaign-participation-badge', {
+          isAcquired: false,
+          isCertifiable: true,
+          acquisitionPercentage: 60,
+        });
+
+        this.set('badge', certifiableBadge);
+
+        // when
+        const screen = await render(
+          hbs`<Campaigns::Assessment::SkillReview::EvaluationResultsTabs::Rewards::Badge @badge={{this.badge}} />`,
+        );
+
+        // then
+        assert.dom(screen.getByText(this.intl.t('pages.skill-review.badge-card.certifiable'))).isVisible();
+      });
+    });
+  });
+
+  module('when badge message is too long', function (hooks) {
+    let screen;
+
+    hooks.beforeEach(async function () {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const longMessage =
+        'lorem ipsum dolor sit amet consectetur adipisicing elit. Dolorum, quia voluptate. Quam, voluptas. Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolorum, quia voluptate. Quam, voluptas.';
+
+      const longMessageBadge = store.createRecord('campaign-participation-badge', {
+        message: longMessage,
+        isAcquired: true,
+      });
+
+      this.set('badge', longMessageBadge);
+
+      // when
+      screen = await render(
+        hbs`<Campaigns::Assessment::SkillReview::EvaluationResultsTabs::Rewards::Badge @badge={{this.badge}} />`,
+      );
+    });
+
+    test('it should display a show-more button', async function (assert) {
+      // then
+      assert.ok(
+        screen
+          .getByText(/lorem ipsum dolor/)
+          .parentNode.classList.toString()
+          .includes('--shrinked'),
+      );
+      assert.dom(screen.getByRole('button', { name: this.intl.t('common.actions.show-more') })).isVisible();
+    });
+
+    test('it should toggle message ellispsis and button label', async function (assert) {
+      // when
+      await click(screen.queryByRole('button', { name: this.intl.t('common.actions.show-more') }));
+
+      // then
+      assert.strictEqual(screen.getByText(/lorem ipsum dolor/).parentNode.classList.length, 1);
+      assert.dom(screen.getByRole('button', { name: this.intl.t('common.actions.show-less') })).isVisible();
+    });
+  });
+});

--- a/mon-pix/tests/integration/components/campaigns/assessment/skill-review/rewards/rewards-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/skill-review/rewards/rewards-test.js
@@ -1,0 +1,140 @@
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-rendering';
+
+module('Integration | Components | Campaigns | Assessment | Evaluation Results Tabs | Rewards', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display acquired and not acquired badges', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+
+    const badgeAcquired1 = store.createRecord('campaign-participation-badge', {
+      isAcquired: true,
+    });
+
+    const badgeAcquired2 = store.createRecord('campaign-participation-badge', {
+      isAcquired: true,
+    });
+
+    const badgeNotAcquired1 = store.createRecord('campaign-participation-badge', {
+      isAcquired: false,
+      acquisitionPercentage: 30,
+    });
+
+    const badgeNotAcquired2 = store.createRecord('campaign-participation-badge', {
+      isAcquired: false,
+      acquisitionPercentage: 70,
+    });
+
+    this.set('badges', [badgeAcquired1, badgeAcquired2, badgeNotAcquired1, badgeNotAcquired2]);
+
+    // when
+    const screen = await render(
+      hbs`<Campaigns::Assessment::SkillReview::EvaluationResultsTabs::Rewards @badges={{this.badges}} />`,
+    );
+
+    // then
+    assert.dom(screen.getByRole('heading', { name: this.intl.t('pages.skill-review.tabs.rewards.title') })).isVisible();
+    assert.dom(screen.getByText(this.intl.t('pages.skill-review.tabs.rewards.description'))).isVisible();
+
+    assert
+      .dom(screen.getByRole('heading', { name: this.intl.t('pages.skill-review.badge-card.acquired') }))
+      .isVisible();
+    assert.strictEqual(
+      screen.getAllByRole('listitem', { name: this.intl.t('pages.skill-review.badge-card.acquired-full') }).length,
+      2,
+    );
+
+    assert
+      .dom(screen.getByRole('heading', { name: this.intl.t('pages.skill-review.badge-card.not-acquired') }))
+      .isVisible();
+    assert.strictEqual(
+      screen.getAllByRole('listitem', { name: this.intl.t('pages.skill-review.badge-card.not-acquired-full') }).length,
+      2,
+    );
+  });
+
+  module('in acquired badges list', function () {
+    test('it should display certifiable badge first', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const acquiredBadge = store.createRecord('campaign-participation-badge', {
+        isAcquired: true,
+        isCertifiable: true,
+      });
+
+      const notCertifiableBadge1 = store.createRecord('campaign-participation-badge', {
+        isAcquired: true,
+        isCertifiable: false,
+      });
+      const notCertifiableBadge2 = store.createRecord('campaign-participation-badge', {
+        isAcquired: true,
+        isCertifiable: false,
+      });
+
+      this.set('badges', [notCertifiableBadge1, acquiredBadge, notCertifiableBadge2]);
+
+      // when
+      const screen = await render(
+        hbs`<Campaigns::Assessment::SkillReview::EvaluationResultsTabs::Rewards @badges={{this.badges}} />`,
+      );
+
+      // then
+      const acquiredBadges = screen.getAllByRole('listitem', {
+        name: this.intl.t('pages.skill-review.badge-card.acquired-full'),
+      });
+      const firstBadgeItem = acquiredBadges[0];
+
+      assert.strictEqual(
+        screen.getByText(this.intl.t('pages.skill-review.badge-card.certifiable')).closest('li'),
+        firstBadgeItem,
+      );
+    });
+  });
+
+  module('in not acquired badges list', function () {
+    test('it should display certifiable badge first', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const certifiableBadge = store.createRecord('campaign-participation-badge', {
+        isAcquired: false,
+        isCertifiable: true,
+        acquisitionPercentage: 60,
+      });
+
+      const notCertifiableBadge1 = store.createRecord('campaign-participation-badge', {
+        isAcquired: false,
+        isCertifiable: false,
+        acquisitionPercentage: 60,
+      });
+      const notCertifiableBadge2 = store.createRecord('campaign-participation-badge', {
+        isAcquired: false,
+        isCertifiable: false,
+        acquisitionPercentage: 60,
+      });
+
+      this.set('badges', [notCertifiableBadge1, certifiableBadge, notCertifiableBadge2]);
+
+      // when
+      const screen = await render(
+        hbs`<Campaigns::Assessment::SkillReview::EvaluationResultsTabs::Rewards @badges={{this.badges}} />`,
+      );
+
+      // then
+      const notAcquiredBadges = screen.getAllByRole('listitem', {
+        name: this.intl.t('pages.skill-review.badge-card.not-acquired-full'),
+      });
+      const firstBadgeItem = notAcquiredBadges[0];
+
+      assert.strictEqual(
+        screen.getByText(this.intl.t('pages.skill-review.badge-card.certifiable')).closest('li'),
+        firstBadgeItem,
+      );
+    });
+  });
+});

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/evaluation-results-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/evaluation-results-test.js
@@ -7,7 +7,9 @@ import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering'
 module('Integration | Components | Routes | Campaigns | Assessment | Evaluation Results', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it should display a header', async function (assert) {
+  let screen;
+
+  hooks.beforeEach(async function () {
     // given
     const store = this.owner.lookup('service:store');
 
@@ -15,19 +17,21 @@ module('Integration | Components | Routes | Campaigns | Assessment | Evaluation 
       title: 'Campaign title',
     });
 
-    this.set('model', { campaign });
+    this.set('model', {
+      campaign,
+      campaignParticipationResult: { campaignParticipationBadges: [] },
+    });
 
     // when
-    const screen = await render(hbs`<Routes::Campaigns::Assessment::EvaluationResults @model={{this.model}} />`);
+    screen = await render(hbs`<Routes::Campaigns::Assessment::EvaluationResults @model={{this.model}} />`);
+  });
 
+  test('it should display a header', async function (assert) {
     // then
     assert.dom(screen.getByRole('heading', { name: 'Campaign title' })).exists();
   });
 
-  test('it should display a tablist with three tabs', async function (assert) {
-    // when
-    const screen = await render(hbs`<Routes::Campaigns::Assessment::EvaluationResults />`);
-
+  test('it should display a tablist', async function (assert) {
     // then
     assert.dom(screen.getByRole('tablist', { name: this.intl.t('pages.skill-review.tabs.aria-label') })).exists();
   });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -42,6 +42,8 @@
       "confirm": "Confirm",
       "lets-go": "Let's go!",
       "quit": "Exit",
+      "show-less": "Show less",
+      "show-more": "Show more",
       "sign-out": "Sign out",
       "stay": "Stay",
       "validate": "Validate"
@@ -1632,7 +1634,10 @@
       "already-shared": "Thank you, your results have been submitted!",
       "badge-card": {
         "acquired": "Awarded",
+        "acquired-full": "Badge awarded",
+        "certifiable": "Certifying",
         "not-acquired": "Not awarded",
+        "not-acquired-full": "Badge not awarded",
         "progress-bar-label": "Badge result percentage"
       },
       "badges-title": "Your thematic results",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -42,6 +42,8 @@
       "confirm": "Confirmar",
       "lets-go": "¡Empecemos!",
       "quit": "Salir",
+      "show-less": "Mostrar menos",
+      "show-more": "Mostrar más",
       "sign-out": "Desconectarse",
       "stay": "Quedarse",
       "validate": "Validar"
@@ -1622,7 +1624,10 @@
       "already-shared": "¡Gracias, tus resultados se han enviado correctamente!",
       "badge-card": {
         "acquired": "Aprobado",
+        "acquired-full": "Resultado temático aprobado",
+        "certifiable": "Certificado",
         "not-acquired": "No has aprobado",
+        "not-acquired-full": "Resultado temático no has aprobado",
         "progress-bar-label": "Porcentaje de éxito del resultado temático"
       },
       "badges-title": "Tus resultados temáticos",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -42,6 +42,8 @@
       "confirm": "Confirmer",
       "lets-go": "C'est parti !",
       "quit": "Quitter",
+      "show-less": "Afficher moins",
+      "show-more": "Afficher plus",
       "sign-out": "Se déconnecter",
       "stay": "Rester",
       "validate": "Valider"
@@ -1632,7 +1634,10 @@
       "already-shared": "Merci, vos résultats ont bien été envoyés !",
       "badge-card": {
         "acquired": "Obtenu",
+        "acquired-full": "Résultat thématique obtenu",
+        "certifiable": "Certifiant",
         "not-acquired": "Non obtenu",
+        "not-acquired-full": "Résultat thématique non obtenu",
         "progress-bar-label": "Pourcentage de réussite du résultat thématique"
       },
       "badges-title": "Vos résultats thématiques",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -42,6 +42,8 @@
       "confirm": "Bevestig",
       "lets-go": "Laten we gaan!",
       "quit": "Verlaat",
+      "show-less": "Laat minder zien",
+      "show-more": "Laat meer zien",
       "sign-out": "Log uit.",
       "stay": "Blijf",
       "validate": "Valideer"
@@ -1622,7 +1624,10 @@
       "already-shared": "Bedankt, je resultaten zijn verzonden!",
       "badge-card": {
         "acquired": "Verkregen",
+        "acquired-full": "Thematisch resultaat verkregen",
+        "certifiable": "Certificaathouder",
         "not-acquired": "Niet verkregen",
+        "not-acquired-full": "Thematisch resultaat is niet verkregen",
         "progress-bar-label": "Percentage succesvolle resultaten"
       },
       "badges-title": "Je thematische resultaten",


### PR DESCRIPTION
## :unicorn: Problème

Dans la nouvelle page de fin de parcours, les onglets n'ont pour l'instant aucun contenu

## :robot: Proposition

Intégrer le contenu de l'onglet "Récompenses".

## 🌈 Remarques

Vérifier la présence de l'affichage conditionnel de l'onglet dans le code: 
> S'il n'y a pas de RT, alors on affiche pas l'onglet "Récompenses"

## :100: Pour tester

- Se connecter avec `eval-sco@example.net`	
- Visiter la [page de fin de parcours](https://app-pr9780.review.pix.fr/campagnes/EVALBADGE/evaluation/resultats)
- Vérifier que le contenu de l'onglet "Récompenses" est conforme à l'attendu (voir design) : 
  - Badges acquis / non-acquis
  - Tags "Certifiant" (les badges certifiants sont en tête de liste)
  - Toggler "Afficher plus" sous un message trop long
  - Barres de progression pour les badges non-acquis
