### PR TITLE
[TECH] Déplacer les validateurs dans le scope évaluation (PIX-13733)

### DIFF
--- a/api/src/evaluation/domain/models/Validator.js
+++ b/api/src/evaluation/domain/models/Validator.js
@@ -1,5 +1,5 @@
-import { AnswerStatus } from './AnswerStatus.js';
-import { Validation } from './Validation.js';
+import { AnswerStatus } from '../../../shared/domain/models/AnswerStatus.js';
+import { Validation } from '../../../shared/domain/models/Validation.js';
 
 /**
  * Traduction: Vérificateur de réponse par défaut

--- a/api/src/evaluation/domain/models/ValidatorAlwaysOK.js
+++ b/api/src/evaluation/domain/models/ValidatorAlwaysOK.js
@@ -1,5 +1,5 @@
-import { AnswerStatus } from './AnswerStatus.js';
-import { Validation } from './Validation.js';
+import { AnswerStatus } from '../../../shared/domain/models/AnswerStatus.js';
+import { Validation } from '../../../shared/domain/models/Validation.js';
 import { Validator } from './Validator.js';
 
 class ValidatorAlwaysOK extends Validator {

--- a/api/src/evaluation/domain/models/ValidatorQCM.js
+++ b/api/src/evaluation/domain/models/ValidatorQCM.js
@@ -1,5 +1,5 @@
 import * as solutionServiceQCM from '../../../../lib/domain/services/solution-service-qcm.js';
-import { Validation } from './Validation.js';
+import { Validation } from '../../../shared/domain/models/Validation.js';
 import { Validator } from './Validator.js';
 
 /**

--- a/api/src/evaluation/domain/models/ValidatorQCU.js
+++ b/api/src/evaluation/domain/models/ValidatorQCU.js
@@ -1,5 +1,5 @@
 import * as solutionServiceQCU from '../../../../lib/domain/services/solution-service-qcu.js';
-import { Validation } from './Validation.js';
+import { Validation } from '../../../shared/domain/models/Validation.js';
 import { Validator } from './Validator.js';
 
 /**

--- a/api/src/evaluation/domain/models/ValidatorQROC.js
+++ b/api/src/evaluation/domain/models/ValidatorQROC.js
@@ -1,5 +1,5 @@
 import * as solutionServiceQROC from '../../../../lib/domain/services/solution-service-qroc.js';
-import { Validation } from './Validation.js';
+import { Validation } from '../../../shared/domain/models/Validation.js';
 import { Validator } from './Validator.js';
 
 /**

--- a/api/src/evaluation/domain/models/ValidatorQROCMDep.js
+++ b/api/src/evaluation/domain/models/ValidatorQROCMDep.js
@@ -1,5 +1,5 @@
 import * as solutionServiceQROCMDep from '../../../../lib/domain/services/solution-service-qrocm-dep.js';
-import { Validation } from './Validation.js';
+import { Validation } from '../../../shared/domain/models/Validation.js';
 import { Validator } from './Validator.js';
 
 /**

--- a/api/src/evaluation/domain/models/ValidatorQROCMInd.js
+++ b/api/src/evaluation/domain/models/ValidatorQROCMInd.js
@@ -1,5 +1,5 @@
 import * as solutionServiceQROCMInd from '../../../../lib/domain/services/solution-service-qrocm-ind.js';
-import { Validation } from './Validation.js';
+import { Validation } from '../../../shared/domain/models/Validation.js';
 import { Validator } from './Validator.js';
 
 /**

--- a/api/src/shared/application/assessments/assessment-controller.js
+++ b/api/src/shared/application/assessments/assessment-controller.js
@@ -8,6 +8,7 @@ import { CertificationVersion } from '../../../certification/shared/domain/model
 import * as certificationChallengeRepository from '../../../certification/shared/infrastructure/repositories/certification-challenge-repository.js';
 import { usecases as devcompUsecases } from '../../../devcomp/domain/usecases/index.js';
 import { Answer } from '../../../evaluation/domain/models/Answer.js';
+import { ValidatorAlwaysOK } from '../../../evaluation/domain/models/ValidatorAlwaysOK.js';
 import * as competenceEvaluationSerializer from '../../../evaluation/infrastructure/serializers/jsonapi/competence-evaluation-serializer.js';
 import {
   extractLocaleFromRequest,
@@ -16,7 +17,6 @@ import {
 import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { AssessmentEndedError } from '../../domain/errors.js';
 import { Examiner } from '../../domain/models/Examiner.js';
-import { ValidatorAlwaysOK } from '../../domain/models/index.js';
 import * as assessmentRepository from '../../infrastructure/repositories/assessment-repository.js';
 import * as assessmentSerializer from '../../infrastructure/serializers/jsonapi/assessment-serializer.js';
 import * as challengeSerializer from '../../infrastructure/serializers/jsonapi/challenge-serializer.js';

--- a/api/src/shared/domain/models/Challenge.js
+++ b/api/src/shared/domain/models/Challenge.js
@@ -1,11 +1,11 @@
 import _ from 'lodash';
 
-import { Validator } from './Validator.js';
-import { ValidatorQCM } from './ValidatorQCM.js';
-import { ValidatorQCU } from './ValidatorQCU.js';
-import { ValidatorQROC } from './ValidatorQROC.js';
-import { ValidatorQROCMDep } from './ValidatorQROCMDep.js';
-import { ValidatorQROCMInd } from './ValidatorQROCMInd.js';
+import { Validator } from '../../../evaluation/domain/models/Validator.js';
+import { ValidatorQCM } from '../../../evaluation/domain/models/ValidatorQCM.js';
+import { ValidatorQCU } from '../../../evaluation/domain/models/ValidatorQCU.js';
+import { ValidatorQROC } from '../../../evaluation/domain/models/ValidatorQROC.js';
+import { ValidatorQROCMDep } from '../../../evaluation/domain/models/ValidatorQROCMDep.js';
+import { ValidatorQROCMInd } from '../../../evaluation/domain/models/ValidatorQROCMInd.js';
 
 const ChallengeType = Object.freeze({
   QCU: 'QCU',

--- a/api/src/shared/domain/models/index.js
+++ b/api/src/shared/domain/models/index.js
@@ -117,13 +117,6 @@ import { UserDetailsForAdmin } from './UserDetailsForAdmin.js';
 import { UserOrgaSettings } from './UserOrgaSettings.js';
 import { UserSavedTutorialWithTutorial } from './UserSavedTutorialWithTutorial.js';
 import { Validation } from './Validation.js';
-import { Validator } from './Validator.js';
-import { ValidatorAlwaysOK } from './ValidatorAlwaysOK.js';
-import { ValidatorQCM } from './ValidatorQCM.js';
-import { ValidatorQCU } from './ValidatorQCU.js';
-import { ValidatorQROC } from './ValidatorQROC.js';
-import { ValidatorQROCMDep } from './ValidatorQROCMDep.js';
-import { ValidatorQROCMInd } from './ValidatorQROCMInd.js';
 
 export {
   AccountRecoveryDemand,
@@ -249,11 +242,4 @@ export {
   UserSavedTutorialWithTutorial,
   UserToCreate,
   Validation,
-  Validator,
-  ValidatorAlwaysOK,
-  ValidatorQCM,
-  ValidatorQCU,
-  ValidatorQROC,
-  ValidatorQROCMDep,
-  ValidatorQROCMInd,
 };

--- a/api/tests/evaluation/unit/domain/models/ValidatorQCM_test.js
+++ b/api/tests/evaluation/unit/domain/models/ValidatorQCM_test.js
@@ -1,13 +1,13 @@
-import { AnswerStatus } from '../../../../src/shared/domain/models/AnswerStatus.js';
-import { Validation } from '../../../../src/shared/domain/models/Validation.js';
-import { ValidatorQCU } from '../../../../src/shared/domain/models/ValidatorQCU.js';
-import { domainBuilder, expect, sinon } from '../../../test-helper.js';
+import { ValidatorQCM } from '../../../../../src/evaluation/domain/models/ValidatorQCM.js';
+import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
+import { Validation } from '../../../../../src/shared/domain/models/Validation.js';
+import { domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
-describe('Unit | Domain | Models | ValidatorQCU', function () {
-  let solutionServiceQCUStub;
+describe('Unit | Domain | Models | ValidatorQCM', function () {
+  let solutionServiceQcmStub;
 
   beforeEach(function () {
-    solutionServiceQCUStub = {
+    solutionServiceQcmStub = {
       match: sinon.stub(),
     };
   });
@@ -20,13 +20,13 @@ describe('Unit | Domain | Models | ValidatorQCU', function () {
 
     beforeEach(function () {
       // given
-      solutionServiceQCUStub.match.returns(AnswerStatus.OK);
-      solution = domainBuilder.buildSolution({ type: 'QCU' });
+      solutionServiceQcmStub.match.returns(AnswerStatus.OK);
+      solution = domainBuilder.buildSolution({ type: 'QCM' });
 
       uncorrectedAnswer = domainBuilder.buildAnswer.uncorrected();
-      validator = new ValidatorQCU({
+      validator = new ValidatorQCM({
         solution: solution,
-        dependencies: { solutionServiceQCU: solutionServiceQCUStub },
+        dependencies: { solutionServiceQCM: solutionServiceQcmStub },
       });
 
       // when
@@ -35,7 +35,7 @@ describe('Unit | Domain | Models | ValidatorQCU', function () {
 
     it('should call solutionServiceQCU', function () {
       // then
-      expect(solutionServiceQCUStub.match).to.have.been.calledWithExactly(uncorrectedAnswer.value, solution.value);
+      expect(solutionServiceQcmStub.match).to.have.been.calledWithExactly(uncorrectedAnswer.value, solution.value);
     });
 
     it('should return a validation object with the returned status', function () {

--- a/api/tests/evaluation/unit/domain/models/ValidatorQCU_test.js
+++ b/api/tests/evaluation/unit/domain/models/ValidatorQCU_test.js
@@ -1,13 +1,13 @@
-import { AnswerStatus } from '../../../../src/shared/domain/models/AnswerStatus.js';
-import { Validation } from '../../../../src/shared/domain/models/Validation.js';
-import { ValidatorQCM } from '../../../../src/shared/domain/models/ValidatorQCM.js';
-import { domainBuilder, expect, sinon } from '../../../test-helper.js';
+import { ValidatorQCU } from '../../../../../src/evaluation/domain/models/ValidatorQCU.js';
+import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
+import { Validation } from '../../../../../src/shared/domain/models/Validation.js';
+import { domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
-describe('Unit | Domain | Models | ValidatorQCM', function () {
-  let solutionServiceQcmStub;
+describe('Unit | Domain | Models | ValidatorQCU', function () {
+  let solutionServiceQCUStub;
 
   beforeEach(function () {
-    solutionServiceQcmStub = {
+    solutionServiceQCUStub = {
       match: sinon.stub(),
     };
   });
@@ -20,13 +20,13 @@ describe('Unit | Domain | Models | ValidatorQCM', function () {
 
     beforeEach(function () {
       // given
-      solutionServiceQcmStub.match.returns(AnswerStatus.OK);
-      solution = domainBuilder.buildSolution({ type: 'QCM' });
+      solutionServiceQCUStub.match.returns(AnswerStatus.OK);
+      solution = domainBuilder.buildSolution({ type: 'QCU' });
 
       uncorrectedAnswer = domainBuilder.buildAnswer.uncorrected();
-      validator = new ValidatorQCM({
+      validator = new ValidatorQCU({
         solution: solution,
-        dependencies: { solutionServiceQCM: solutionServiceQcmStub },
+        dependencies: { solutionServiceQCU: solutionServiceQCUStub },
       });
 
       // when
@@ -35,7 +35,7 @@ describe('Unit | Domain | Models | ValidatorQCM', function () {
 
     it('should call solutionServiceQCU', function () {
       // then
-      expect(solutionServiceQcmStub.match).to.have.been.calledWithExactly(uncorrectedAnswer.value, solution.value);
+      expect(solutionServiceQCUStub.match).to.have.been.calledWithExactly(uncorrectedAnswer.value, solution.value);
     });
 
     it('should return a validation object with the returned status', function () {

--- a/api/tests/evaluation/unit/domain/models/ValidatorQROCMDep_test.js
+++ b/api/tests/evaluation/unit/domain/models/ValidatorQROCMDep_test.js
@@ -1,7 +1,7 @@
-import { AnswerStatus } from '../../../../src/shared/domain/models/AnswerStatus.js';
-import { Validation } from '../../../../src/shared/domain/models/Validation.js';
-import { ValidatorQROCMDep } from '../../../../src/shared/domain/models/ValidatorQROCMDep.js';
-import { domainBuilder, expect, sinon } from '../../../test-helper.js';
+import { ValidatorQROCMDep } from '../../../../../src/evaluation/domain/models/ValidatorQROCMDep.js';
+import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
+import { Validation } from '../../../../../src/shared/domain/models/Validation.js';
+import { domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Domain | Models | ValidatorQROCMDep', function () {
   let solutionServiceQROCMDepStub;

--- a/api/tests/evaluation/unit/domain/models/ValidatorQROCMInd_test.js
+++ b/api/tests/evaluation/unit/domain/models/ValidatorQROCMInd_test.js
@@ -1,7 +1,7 @@
-import { AnswerStatus } from '../../../../src/shared/domain/models/AnswerStatus.js';
-import { Validation } from '../../../../src/shared/domain/models/Validation.js';
-import { ValidatorQROCMInd } from '../../../../src/shared/domain/models/ValidatorQROCMInd.js';
-import { domainBuilder, expect, sinon } from '../../../test-helper.js';
+import { ValidatorQROCMInd } from '../../../../../src/evaluation/domain/models/ValidatorQROCMInd.js';
+import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
+import { Validation } from '../../../../../src/shared/domain/models/Validation.js';
+import { domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Domain | Models | ValidatorQROCMInd', function () {
   let solutionServiceQROCMIndStub;

--- a/api/tests/evaluation/unit/domain/models/ValidatorQROC_test.js
+++ b/api/tests/evaluation/unit/domain/models/ValidatorQROC_test.js
@@ -1,7 +1,7 @@
-import { AnswerStatus } from '../../../../src/shared/domain/models/AnswerStatus.js';
-import { Validation } from '../../../../src/shared/domain/models/Validation.js';
-import { ValidatorQROC } from '../../../../src/shared/domain/models/ValidatorQROC.js';
-import { domainBuilder, expect, sinon } from '../../../test-helper.js';
+import { ValidatorQROC } from '../../../../../src/evaluation/domain/models/ValidatorQROC.js';
+import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
+import { Validation } from '../../../../../src/shared/domain/models/Validation.js';
+import { domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Domain | Models | ValidatorQROC', function () {
   let solutionServiceQROCStub;

--- a/api/tests/evaluation/unit/domain/models/Validator_test.js
+++ b/api/tests/evaluation/unit/domain/models/Validator_test.js
@@ -1,7 +1,7 @@
-import { AnswerStatus } from '../../../../src/shared/domain/models/AnswerStatus.js';
-import { Validation } from '../../../../src/shared/domain/models/Validation.js';
-import { Validator } from '../../../../src/shared/domain/models/Validator.js';
-import { domainBuilder, expect } from '../../../test-helper.js';
+import { Validator } from '../../../../../src/evaluation/domain/models/Validator.js';
+import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
+import { Validation } from '../../../../../src/shared/domain/models/Validation.js';
+import { domainBuilder, expect } from '../../../../test-helper.js';
 
 describe('Unit | Domain | Models | Validator', function () {
   describe('#assess', function () {

--- a/api/tests/school/integration/domain/services/correct-answer_test.js
+++ b/api/tests/school/integration/domain/services/correct-answer_test.js
@@ -1,15 +1,11 @@
+import { ValidatorAlwaysOK } from '../../../../../src/evaluation/domain/models/ValidatorAlwaysOK.js';
 import { Assessment } from '../../../../../src/school/domain/models/Assessment.js';
 import { NotInProgressAssessmentError } from '../../../../../src/school/domain/school-errors.js';
 import { correctAnswer } from '../../../../../src/school/domain/services/correct-answer.js';
 import * as activityAnswerRepository from '../../../../../src/school/infrastructure/repositories/activity-answer-repository.js';
 import * as activityRepository from '../../../../../src/school/infrastructure/repositories/activity-repository.js';
 import { ChallengeNotAskedError, NotFoundError } from '../../../../../src/shared/domain/errors.js';
-import {
-  AnswerStatus,
-  Examiner,
-  Validation,
-  ValidatorAlwaysOK,
-} from '../../../../../src/shared/domain/models/index.js';
+import { AnswerStatus, Examiner, Validation } from '../../../../../src/shared/domain/models/index.js';
 import * as assessmentRepository from '../../../../../src/shared/infrastructure/repositories/assessment-repository.js';
 import * as challengeRepository from '../../../../../src/shared/infrastructure/repositories/challenge-repository.js';
 import {

--- a/api/tests/school/integration/domain/usecases/correct-preview-answer_test.js
+++ b/api/tests/school/integration/domain/usecases/correct-preview-answer_test.js
@@ -1,5 +1,6 @@
+import { ValidatorAlwaysOK } from '../../../../../src/evaluation/domain/models/ValidatorAlwaysOK.js';
 import { correctPreviewAnswer } from '../../../../../src/school/domain/usecases/correct-preview-answer.js';
-import { AnswerStatus, Examiner, ValidatorAlwaysOK } from '../../../../../src/shared/domain/models/index.js';
+import { AnswerStatus, Examiner } from '../../../../../src/shared/domain/models/index.js';
 import * as challengeRepository from '../../../../../src/shared/infrastructure/repositories/challenge-repository.js';
 import { domainBuilder, expect, knex, mockLearningContent } from '../../../../test-helper.js';
 import * as learningContentBuilder from '../../../../tooling/learning-content-builder/index.js';

--- a/api/tests/school/integration/domain/usecases/handle-activity-answer_test.js
+++ b/api/tests/school/integration/domain/usecases/handle-activity-answer_test.js
@@ -1,3 +1,4 @@
+import { ValidatorAlwaysOK } from '../../../../../src/evaluation/domain/models/ValidatorAlwaysOK.js';
 import { Activity } from '../../../../../src/school/domain/models/Activity.js';
 import { Assessment } from '../../../../../src/school/domain/models/Assessment.js';
 import { handleActivityAnswer } from '../../../../../src/school/domain/usecases/handle-activity-answer.js';
@@ -6,7 +7,7 @@ import * as activityRepository from '../../../../../src/school/infrastructure/re
 import * as missionAssessmentRepository from '../../../../../src/school/infrastructure/repositories/mission-assessment-repository.js';
 import * as missionRepository from '../../../../../src/school/infrastructure/repositories/mission-repository.js';
 import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
-import { Examiner, Validation, ValidatorAlwaysOK } from '../../../../../src/shared/domain/models/index.js';
+import { Examiner, Validation } from '../../../../../src/shared/domain/models/index.js';
 import * as assessmentRepository from '../../../../../src/shared/infrastructure/repositories/assessment-repository.js';
 import * as challengeRepository from '../../../../../src/shared/infrastructure/repositories/challenge-repository.js';
 import {

--- a/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 
+import { Validator } from '../../../../../src/evaluation/domain/models/Validator.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { Challenge } from '../../../../../src/shared/domain/models/Challenge.js';
-import { Validator } from '../../../../../src/shared/domain/models/Validator.js';
 import * as challengeRepository from '../../../../../src/shared/infrastructure/repositories/challenge-repository.js';
 import { catchErr, domainBuilder, expect, mockLearningContent } from '../../../../test-helper.js';
 

--- a/api/tests/tooling/domain-builder/factory/build-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge.js
@@ -1,5 +1,5 @@
+import { Validator } from '../../../../src/evaluation/domain/models/Validator.js';
 import { Challenge } from '../../../../src/shared/domain/models/Challenge.js';
-import { Validator } from '../../../../src/shared/domain/models/Validator.js';
 import { buildSkill } from './build-skill.js';
 
 const buildChallenge = function ({

--- a/api/tests/tooling/domain-builder/factory/build-validator.js
+++ b/api/tests/tooling/domain-builder/factory/build-validator.js
@@ -1,5 +1,5 @@
-import { Validator } from '../../../../src/shared/domain/models/Validator.js';
-import { ValidatorQCU } from '../../../../src/shared/domain/models/ValidatorQCU.js';
+import { Validator } from '../../../../src/evaluation/domain/models/Validator.js';
+import { ValidatorQCU } from '../../../../src/evaluation/domain/models/ValidatorQCU.js';
 import { buildSolution } from './build-solution.js';
 
 function buildValidator({ solution = buildSolution() } = {}) {

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -1,11 +1,11 @@
+import { Validator } from '../../../../src/evaluation/domain/models/Validator.js';
+import { ValidatorQCM } from '../../../../src/evaluation/domain/models/ValidatorQCM.js';
+import { ValidatorQCU } from '../../../../src/evaluation/domain/models/ValidatorQCU.js';
+import { ValidatorQROC } from '../../../../src/evaluation/domain/models/ValidatorQROC.js';
+import { ValidatorQROCMDep } from '../../../../src/evaluation/domain/models/ValidatorQROCMDep.js';
+import { ValidatorQROCMInd } from '../../../../src/evaluation/domain/models/ValidatorQROCMInd.js';
 import { Challenge } from '../../../../src/shared/domain/models/Challenge.js';
 import { Skill } from '../../../../src/shared/domain/models/Skill.js';
-import { Validator } from '../../../../src/shared/domain/models/Validator.js';
-import { ValidatorQCM } from '../../../../src/shared/domain/models/ValidatorQCM.js';
-import { ValidatorQCU } from '../../../../src/shared/domain/models/ValidatorQCU.js';
-import { ValidatorQROC } from '../../../../src/shared/domain/models/ValidatorQROC.js';
-import { ValidatorQROCMDep } from '../../../../src/shared/domain/models/ValidatorQROCMDep.js';
-import { ValidatorQROCMInd } from '../../../../src/shared/domain/models/ValidatorQROCMInd.js';
 import { domainBuilder, expect } from '../../../test-helper.js';
 
 describe('Unit | Domain | Models | Challenge', function () {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement les validateur sont dans le dossier shared. Hors cela fait partie du scope de l'équipe expérience d'évaluation

## :robot: Proposition
Les déplacer

## :rainbow: Remarques
Certains tests du scope school utilisent les validateurs.Cela me semble ok

## :100: Pour tester
tests ✅