### PR TITLE
[TECH] Augmenter le timeout de 2 tests longs (flakies)

### DIFF
--- a/api/tests/integration/infrastructure/knex-database-connection_test.js
+++ b/api/tests/integration/infrastructure/knex-database-connection_test.js
@@ -13,6 +13,9 @@ describe('Integration | Infrastructure | knex-database-connection', function () 
   });
 
   it('should empty all tables', async function () {
+    // Increase the test timeout because the table truncate can be long to respond sometimes.
+    this.timeout(5000);
+
     // given
     const { id } = databaseBuilder.factory.buildUser();
     await databaseBuilder.commit();

--- a/api/tests/shared/acceptance/application/swagger_test.js
+++ b/api/tests/shared/acceptance/application/swagger_test.js
@@ -1,11 +1,13 @@
 import { createServer, expect } from '../../../test-helper.js';
 
 describe('Acceptance | Controller | swagger', function () {
+  // Increase the test timeout because swagger.json endpoints can be long to generate/respond.
+  this.timeout(5000);
+
   let server;
 
   beforeEach(async function () {
     server = await createServer();
-    this.timeout(3000);
   });
 
   describe('GET /api/swagger.json', function () {
@@ -17,6 +19,7 @@ describe('Acceptance | Controller | swagger', function () {
           url: '/api/swagger.json',
           headers: {},
         };
+
         // when
         const response = await server.inject(options);
 

--- a/api/tests/tooling/server/hapi-server-with-test-oidc-provider.js
+++ b/api/tests/tooling/server/hapi-server-with-test-oidc-provider.js
@@ -43,7 +43,7 @@ const openIdConfigurationResponse = {
 async function createServerWithTestOidcProvider() {
   nock('https://oidc.example.net').get('/.well-known/openid-configuration').reply(200, openIdConfigurationResponse);
 
-  const oidcProviderServices = [
+  await oidcAuthenticationServiceRegistry.loadOidcProviderServices([
     new OidcAuthenticationService({
       accessTokenLifespanMs: 60000,
       clientId: 'client',
@@ -59,11 +59,9 @@ async function createServerWithTestOidcProvider() {
       slug: 'oidc-example-net',
       source: 'oidcexamplenet',
     }),
-  ];
+  ]);
 
-  await oidcAuthenticationServiceRegistry.loadOidcProviderServices(oidcProviderServices);
-
-  return createServer({ oidcProviderServices });
+  return createServer();
 }
 
 export { createServerWithTestOidcProvider };


### PR DESCRIPTION
## :unicorn: Problème

L'analyse CircleCI des tests les plus flaky concernent:
- `api/tests/shared/acceptance/application/swagger_test.js`
- `api/tests/integration/infrastructure/knex-database-connection_test.js`

Ces 2 tests dépassent parfois le timeout de base des tests (2 secondes):
```
Error: Timeout of 2000ms exceeded.
```

## :robot: Proposition

Après vérification, il semble que pour ces 2 tests, il est "normal" que l'on atteigne le seuil de 2 secondes. 
- la génération swagger de l'api est volumineux et prend du temps
- le truncate de toutes les tables de la base nécessite un grand nombre de requêtes et transactions

On augmente donc le seuil de timeout uniquement pour ces tests en ajoutant une explication du changement de timeout.


## :rainbow: Remarques

Un commit a été ajouté pour supprimer du code, qui n'était pas utile dans le fichier:
```
api/tests/tooling/server/hapi-server-with-test-oidc-provider.js
```


## :100: Pour tester

La CI doit passer et le nombre de flakies (dans CircleCI) doit diminuer dans les semaines à venir.
