### PR TITLE
[BUGFIX] Le updatedAt des learners ne se met pas forcément à jour lors de leur activation/désactivation (pix-13711)

### DIFF
--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participant-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participant-repository.js
@@ -68,7 +68,7 @@ async function _createNewOrganizationLearner(organizationLearner) {
     if (existingOrganizationLearner) {
       if (existingOrganizationLearner.isDisabled) {
         await knexConnection('organization-learners')
-          .update({ isDisabled: false })
+          .update({ isDisabled: false, updatedAt: new Date() })
           .where({ id: existingOrganizationLearner.id })
           .returning('id');
       }

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participant-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participant-repository_test.js
@@ -693,18 +693,19 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
           await campaignParticipantRepository.save({ campaignParticipant });
         });
 
-        const { isDisabled: expectedEnabledLearner } = await knex('organization-learners')
-          .select('isDisabled')
+        const expectedEnabledLearner = await knex('organization-learners')
+          .select('isDisabled', 'updatedAt')
           .where('id', learnerDisabled.id)
           .first();
 
-        const { isDisabled: expectedDisabledLearner } = await knex('organization-learners')
+        const expectedDisabledLearner = await knex('organization-learners')
           .select('isDisabled')
           .where('id', otherLearnerDisabled.id)
           .first();
 
-        expect(expectedEnabledLearner).to.be.false;
-        expect(expectedDisabledLearner).to.be.true;
+        expect(expectedEnabledLearner.isDisabled).to.be.false;
+        expect(expectedEnabledLearner.updatedAt).to.not.be.deep.equal(learnerDisabled.updatedAt);
+        expect(expectedDisabledLearner.isDisabled).to.be.true;
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Ce n'est pas normal que la colonne isDisable de la table `organization-learners` passe à `true` sans que les colonnes d'horodatage comme `updatedAt` ne soit mise à jour !

## :robot: Proposition
Corriger le bug

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
