### PR TITLE
[BUGFIX] Corriger la réinitialisation d'un QCM Modulix lors du clic sur le bouton Réessayer

### DIFF
--- a/mon-pix/app/components/module/element/module-element.js
+++ b/mon-pix/app/components/module/element/module-element.js
@@ -46,11 +46,12 @@ export default class ModuleElement extends Component {
   }
 
   @action
-  retry(button) {
+  retry(event) {
     this.isOnRetryMode = true;
 
     this.resetAnswers();
-    const form = button.target.parentElement;
+    const retryButton = event.target;
+    const form = retryButton.parentElement;
     form.reset();
 
     this.args.retryElement({ element: this.element });

--- a/mon-pix/app/components/module/element/module-element.js
+++ b/mon-pix/app/components/module/element/module-element.js
@@ -48,7 +48,7 @@ export default class ModuleElement extends Component {
   @action
   retry(event) {
     const retryButton = event.target;
-    const form = retryButton.parentElement;
+    const form = retryButton.form;
 
     this.isOnRetryMode = true;
     this.resetAnswers();

--- a/mon-pix/app/components/module/element/module-element.js
+++ b/mon-pix/app/components/module/element/module-element.js
@@ -47,11 +47,11 @@ export default class ModuleElement extends Component {
 
   @action
   retry(event) {
-    this.isOnRetryMode = true;
-
-    this.resetAnswers();
     const retryButton = event.target;
     const form = retryButton.parentElement;
+
+    this.isOnRetryMode = true;
+    this.resetAnswers();
     form.reset();
 
     this.args.retryElement({ element: this.element });


### PR DESCRIPTION
## :unicorn: Problème

Parfois, lorsqu'on clique sur le bouton "Réessayer" après avoir répondu faux à un QCM dans Modulix, le formulaire n'est pas correctement réinitialisé, les cases restent cochées (mais sont considérées comme décochées si on clique à nouveau sur Vérifier).

Le bug semble survenir de façon très aléatoire et est donc difficile à reproduire.


https://github.com/user-attachments/assets/a908947d-135c-4e1c-b473-9fe60cfad1d5

## :brain: Analyse

Lorsqu'on parvient à reproduire le bug, l'erreur suivante apparaît dans la console :

> Uncaught (in promise) TypeError: e.target.parentElement.reset is not a function
    at W.retry (module-element.js:54:10)
    at u.triggerAction (pix-button.js:41:23)
    at HTMLButtonElement.a (helpers.ts:98:17)

L'erreur est levée dans la méthode `retry`, qui execute la méthode `reset` du formulaire, qui est l'élément parent du bouton Réessayer :

```js
  @action
  retry(button) {
    this.isOnRetryMode = true;

    this.resetAnswers();
    const form = button.target.parentElement;
    form.reset();

    this.args.retryElement({ element: this.element });
  }
```

L'hypothèse est que, parfois, au moment où l'instruction `form.reset()` est exécutée, le bouton est déjà masqué, il n'est donc plus dans le DOM et n'a pas de parent: `parentElement` est donc `undefined` et n'a pas de méthode `reset`.

Comme le masquage du bouton **Réessayer** est déclenchée par la première ligne de la méthode `this.isOnRetryMode = true;` donc avant l'appel à`form.reset`, le bug devrait survenir systématiquement (si l'execution du code était synchrone), mais sans doute grace au petit délai dû au rafraichissement du DOM, cela fonctionne dans la plupart des cas, car au moment où `form.reset` est executé, le bouton n'a pas encore eu le temps de disparaître.

Pour vérifier l'hypothèse, nous avons ajouté un délai artificiel avant l'appel à `form.reset`:

```js
  @action
  retry(button) {
    this.isOnRetryMode = true;

    this.resetAnswers();
    window.setTimeout(function() {
      const form = button.target.parentElement;
      form.reset();
    }, 1);

    this.args.retryElement({ element: this.element });
  }
```

Dans ce cas, le bug survient dans 100 % des cas.

## :robot: Proposition

Récupérer l'élément `form` avant le masquage du bouton de manière à être sûr qu'il soit disponible au moment où la méthode `reset` est éxecutée.

## :rainbow: Remarques

Lorsque nous avons réussi à reproduire le problème en local, l'erreur était légèrement différente qu'en production : `parentElement` était `null` plutôt que `undefined`. Nous supposons que c'est dû la manière dont le code est compilé.

## :100: Pour tester

Le bug survenant de manière très aléatoire, il est difficile de vérifier qu'il est corrigé, mais on peut au moins faire un test de non-regression.

Sur un module contenant un QCM (par exemple LLM), aller jusqu'au QCM, répondre faux, cliquer sur réessayer, et constater que la modalité est bien réinitialisée.
