### PR TITLE
[FIX] Dupliquer la categorie du profil cible (PIX-13525) 

### DIFF
--- a/api/src/shared/domain/models/TargetProfile.js
+++ b/api/src/shared/domain/models/TargetProfile.js
@@ -16,6 +16,7 @@ class TargetProfile {
     name,
     imageUrl,
     isPublic,
+    category,
     isSimplifiedAccess,
     outdated,
     stages,
@@ -27,6 +28,7 @@ class TargetProfile {
     this.name = name;
     this.imageUrl = imageUrl;
     this.isPublic = isPublic;
+    this.category = category;
     this.isSimplifiedAccess = isSimplifiedAccess;
     this.outdated = outdated;
     this.stages = stages;

--- a/api/tests/integration/domain/usecases/copy-target-profile_test.js
+++ b/api/tests/integration/domain/usecases/copy-target-profile_test.js
@@ -1,12 +1,15 @@
 import { copyTargetProfile } from '../../../../lib/domain/usecases/copy-target-profile.js';
 import * as targetProfileRepository from '../../../../lib/infrastructure/repositories/target-profile-repository.js';
+import { categories } from '../../../../src/shared/domain/models/TargetProfile.js';
 import { databaseBuilder, expect, knex } from '../../../test-helper.js';
 
 describe('Integration | UseCases | copy-target-profile', function () {
   describe('when the target profile exists', function () {
     it('should copy the target profile', async function () {
       // given
-      const originTargetProfile = databaseBuilder.factory.buildTargetProfile();
+      const originTargetProfile = databaseBuilder.factory.buildTargetProfile({
+        category: categories.PIX_PLUS,
+      });
       const firstBadge = databaseBuilder.factory.buildBadge({ key: 'FOO', targetProfileId: originTargetProfile.id });
       const secondBadge = databaseBuilder.factory.buildBadge({ key: 'BAR', targetProfileId: originTargetProfile.id });
 


### PR DESCRIPTION
## :unicorn: Problème
Nous avons develope une fonctionalite qui  permet a un administrateur de dupliquer un profil cible. Seulement il semble que la categorie ne soit pas dupliquee.

## :robot: Proposition
Faire mieux.

## :100: Pour tester
Se rendre sur l'admin de RA.
Dupliquer un profil cible qui n'a pas une categorie "autre", en modifier un si besoin.
Constater que la categorie a bien ete prise en compte dans la duplication.
