### PR TITLE
[FEATURE] Ajouter un élément "download" dans le didacticiel modulix (PIX-13748)

### DIFF
--- a/api/scripts/modulix/get-sample-download-element.js
+++ b/api/scripts/modulix/get-sample-download-element.js
@@ -1,0 +1,3 @@
+import { getDownloadSample } from '../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/download.sample.js';
+
+console.log(JSON.stringify(getDownloadSample(), null, 2));

--- a/api/scripts/modulix/get-sample-embed-element.js
+++ b/api/scripts/modulix/get-sample-embed-element.js
@@ -1,0 +1,3 @@
+import { getEmbedSample } from '../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/embed.sample.js';
+
+console.log(JSON.stringify(getEmbedSample(), null, 2));

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -82,6 +82,50 @@
       ]
     },
     {
+      "id": "b14df125-82d5-4d55-a660-7b34cd9ea1ab",
+      "type": "activity",
+      "title": "Un fichier à télécharger",
+      "components": [
+        {
+          "type": "element",
+          "element": {
+            "id": "901ccbaa-f4e6-4322-b863-8e8eab08a33a",
+            "type": "download",
+            "files": [
+              { "url": "https://images.pix.fr/modulix/adresse-ip-publique-et-vous/intro.jpg", "format": ".jpg" }
+            ]
+          }
+        },
+        {
+          "type": "element",
+          "element": {
+            "id": "31106aeb-8346-44a6-8ed4-ebaa2106a373",
+            "type": "qcu",
+            "instruction": "<p>Quelle type de recette souhaite obtenir l'utilisateur dans l'image&nbsp;?</p>",
+            "proposals": [
+              {
+                "id": "1",
+                "content": "Des recettes de lasagne"
+              },
+              {
+                "id": "2",
+                "content": "Des recettes de paté en croute"
+              },
+              {
+                "id": "3",
+                "content": "Des recettes végétariennes"
+              }
+            ],
+            "feedbacks": {
+              "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p> L'image contient bien une recherche de recettes végétariennes.</p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Avez-vous téléchargé l'image jointe&nbsp;?</p>"
+            },
+            "solution": "3"
+          }
+        }
+      ]
+    },
+    {
       "id": "73ac3644-7637-4cee-86d4-1a75f53f0b9c",
       "type": "lesson",
       "title": "Vidéo de présentation de Pix",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/download.sample.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/download.sample.js
@@ -1,0 +1,14 @@
+import { randomUUID } from 'node:crypto';
+
+export function getDownloadSample() {
+  return {
+    id: randomUUID(),
+    type: 'download',
+    files: [
+      {
+        url: 'https://images.pix.fr/modulix/placeholder-image.svg',
+        format: '.svg',
+      },
+    ],
+  };
+}

--- a/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/embed.sample.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/embed.sample.js
@@ -1,0 +1,15 @@
+import { randomUUID } from 'node:crypto';
+
+export function getEmbedSample() {
+  return {
+    id: randomUUID(),
+    type: 'embed',
+    isCompletionRequired: true,
+    title: 'Simulateur de visioconférence - micro ouvert',
+    url: 'https://epreuves.pix.fr/visio/visio.html?mode=modulix-didacticiel',
+    instruction:
+      '<p>Vous participez à la visioconférence ci-dessous.</p><p>Il y a du bruit à côté de vous.</p><p>Coupez le son de votre micro pour ne pas déranger vos interlocuteurs.</p>',
+    solution: 'toto',
+    height: 600,
+  };
+}

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/download.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/download.js
@@ -1,0 +1,16 @@
+import Joi from 'joi';
+
+import { uuidSchema } from '../utils.js';
+
+const downloadElementSchema = Joi.object({
+  id: uuidSchema,
+  type: Joi.string().valid('download').required(),
+  files: Joi.array()
+    .items({
+      url: Joi.string().uri({ scheme: 'https' }).required(),
+      format: Joi.string().required(),
+    })
+    .required(),
+}).required();
+
+export { downloadElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/embed.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/embed.js
@@ -2,7 +2,7 @@ import Joi from 'joi';
 
 import { htmlNotAllowedSchema, htmlSchema, uuidSchema } from '../utils.js';
 
-const embedSchema = Joi.object({
+const embedElementSchema = Joi.object({
   id: uuidSchema,
   type: Joi.string().valid('embed').required(),
   isCompletionRequired: Joi.boolean().required(),
@@ -17,4 +17,4 @@ const embedSchema = Joi.object({
   height: Joi.number().min(0).required(),
 }).required();
 
-export { embedSchema };
+export { embedElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/embed_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/embed_test.js
@@ -1,5 +1,5 @@
 import { catchErr, expect } from '../../../../../../../test-helper.js';
-import { embedSchema } from './index.js';
+import { embedElementSchema } from './index.js';
 
 describe('Unit | Infrastructure | Datasources | Learning Content | Module Datasource | Embed Element', function () {
   describe('when embed isCompletionRequired is false', function () {
@@ -16,7 +16,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
       };
 
       // when
-      await embedSchema.validateAsync(sampleEmbed);
+      await embedElementSchema.validateAsync(sampleEmbed);
 
       // then
       expect(true).to.be.true;
@@ -36,7 +36,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
       };
 
       // when
-      const error = await catchErr(embedSchema.validateAsync, embedSchema)(sampleEmbed);
+      const error = await catchErr(embedElementSchema.validateAsync, embedElementSchema)(sampleEmbed);
 
       // then
       expect(error).to.be.an.instanceOf(Error);
@@ -58,7 +58,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
       };
 
       // when
-      const error = await catchErr(embedSchema.validateAsync, embedSchema)(sampleEmbed);
+      const error = await catchErr(embedElementSchema.validateAsync, embedElementSchema)(sampleEmbed);
 
       // then
       expect(error).to.be.an.instanceOf(Error);
@@ -79,7 +79,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
       };
 
       // when
-      await embedSchema.validateAsync(sampleEmbed);
+      await embedElementSchema.validateAsync(sampleEmbed);
 
       // then
       expect(true).to.be.true;

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/index.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/index.js
@@ -1,3 +1,4 @@
+import { downloadElementSchema } from './download.js';
 import { embedSchema } from './embed.js';
 import { imageElementSchema } from './image.js';
 import { qcmElementSchema } from './qcm.js';
@@ -9,6 +10,7 @@ import { videoElementSchema } from './video.js';
 export {
   blockInputSchema,
   blockSelectSchema,
+  downloadElementSchema,
   embedSchema,
   imageElementSchema,
   qcmElementSchema,

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/index.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/index.js
@@ -1,5 +1,5 @@
 import { downloadElementSchema } from './download.js';
-import { embedSchema } from './embed.js';
+import { embedElementSchema } from './embed.js';
 import { imageElementSchema } from './image.js';
 import { qcmElementSchema } from './qcm.js';
 import { qcuElementSchema } from './qcu.js';
@@ -11,7 +11,7 @@ export {
   blockInputSchema,
   blockSelectSchema,
   downloadElementSchema,
-  embedSchema,
+  embedElementSchema,
   imageElementSchema,
   qcmElementSchema,
   qcuElementSchema,

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -1,3 +1,4 @@
+import { getDownloadSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/download.sample.js';
 import { getImageSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/image.sample.js';
 import { getQcmSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/qcm.sample.js';
 import { getQcuSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/qcu.sample.js';
@@ -8,6 +9,7 @@ import { expect } from '../../../../../../test-helper.js';
 import {
   blockInputSchema,
   blockSelectSchema,
+  downloadElementSchema,
   imageElementSchema,
   qcmElementSchema,
   qcuElementSchema,
@@ -20,6 +22,15 @@ import { grainSchema, moduleDetailsSchema, moduleSchema } from './module.js';
 
 describe('Unit | Infrastructure | Datasources | Learning Content | Module Datasource | format validation', function () {
   describe('when element has a valid structure', function () {
+    it('should validate sample download structure', async function () {
+      try {
+        await downloadElementSchema.validateAsync(getDownloadSample(), { abortEarly: false });
+      } catch (joiError) {
+        const formattedError = joiErrorParser.format(joiError);
+        expect(joiError).to.equal(undefined, formattedError);
+      }
+    });
+
     it('should validate sample image structure', async function () {
       try {
         await imageElementSchema.validateAsync(getImageSample(), { abortEarly: false });

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -1,4 +1,5 @@
 import { getDownloadSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/download.sample.js';
+import { getEmbedSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/embed.sample.js';
 import { getImageSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/image.sample.js';
 import { getQcmSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/qcm.sample.js';
 import { getQcuSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/qcu.sample.js';
@@ -10,6 +11,7 @@ import {
   blockInputSchema,
   blockSelectSchema,
   downloadElementSchema,
+  embedElementSchema,
   imageElementSchema,
   qcmElementSchema,
   qcuElementSchema,
@@ -25,6 +27,15 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
     it('should validate sample download structure', async function () {
       try {
         await downloadElementSchema.validateAsync(getDownloadSample(), { abortEarly: false });
+      } catch (joiError) {
+        const formattedError = joiErrorParser.format(joiError);
+        expect(joiError).to.equal(undefined, formattedError);
+      }
+    });
+
+    it('should validate sample embed structure', async function () {
+      try {
+        await embedElementSchema.validateAsync(getEmbedSample(), { abortEarly: false });
       } catch (joiError) {
         const formattedError = joiErrorParser.format(joiError);
         expect(joiError).to.equal(undefined, formattedError);

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module.js
@@ -2,7 +2,7 @@ import Joi from 'joi';
 
 import {
   downloadElementSchema,
-  embedSchema,
+  embedElementSchema,
   imageElementSchema,
   qcmElementSchema,
   qcuElementSchema,
@@ -33,7 +33,7 @@ const elementSchema = Joi.alternatives().conditional('.type', {
     { is: 'qcm', then: qcmElementSchema },
     { is: 'qrocm', then: qrocmElementSchema },
     { is: 'video', then: videoElementSchema },
-    { is: 'embed', then: embedSchema },
+    { is: 'embed', then: embedElementSchema },
     { is: 'download', then: downloadElementSchema },
   ],
 });

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module.js
@@ -1,6 +1,7 @@
 import Joi from 'joi';
 
 import {
+  downloadElementSchema,
   embedSchema,
   imageElementSchema,
   qcmElementSchema,
@@ -33,6 +34,7 @@ const elementSchema = Joi.alternatives().conditional('.type', {
     { is: 'qrocm', then: qrocmElementSchema },
     { is: 'video', then: videoElementSchema },
     { is: 'embed', then: embedSchema },
+    { is: 'download', then: downloadElementSchema },
   ],
 });
 

--- a/high-level-tests/e2e/cypress/integration/pix-app/modulix-a11y.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/modulix-a11y.feature
@@ -20,6 +20,7 @@ Fonctionnalité: Accessibilité de Modulix
     Quand je vais au grain suivant
     Quand je vais au grain suivant
     Quand je vais au grain suivant
+    Quand je vais au grain suivant
     Alors la page devrait être accessible
     Quand je clique sur "Terminer"
     Et que j'attends 500 ms


### PR DESCRIPTION
## :unicorn: Problème
Nous débutons l'implémentation au sein de Modulix de téléchargement de fichiers. Mais nous n'avons pas encore cette typologie d'élément dans le référentiel.

## :robot: Proposition
Ajouter cette typologie d'élément dans le référentiel.

## :rainbow: Remarques
Ajout du script de génération d'exemple d'élément `embed` via `node ./scripts/modulix/get-sample-embed-element.js`.

## :100: Pour tester
- Vérifier qu'on a ajouté un nouveau type d'élément "download" qui contient les champs vus ensemble.
- Vérifier qu'un nouveau grain apparaît dans le didacticiel de la RA - mais sans téléchargement (puisque ce n'est pas encore supporté).
- Vérifier qu'on peut générer un nouveau type d'élément "download" peut être généré avec `node ./scripts/modulix/get-sample-download-element.js`
