### PR TITLE
[FEATURE] Mise en place du SSO pour Agent Connect (PIX-13741)

### DIFF
--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
@@ -11,7 +11,7 @@ import * as oidcSerializer from '../../infrastructure/serializers/jsonapi/oidc-s
  * @return {Promise<*>}
  */
 async function authenticateOidcUser(request, h) {
-  const { code, identityProvider: identityProviderCode, state, audience } = request.deserializedPayload;
+  const { code, state, iss, identityProvider: identityProviderCode, audience } = request.deserializedPayload;
 
   const sessionState = request.yar.get('state', true);
   const nonce = request.yar.get('nonce', true);
@@ -24,10 +24,11 @@ async function authenticateOidcUser(request, h) {
   const result = await usecases.authenticateOidcUser({
     audience,
     code,
+    state,
+    iss,
     identityProviderCode,
     nonce,
     sessionState,
-    state,
   });
 
   if (result.isAuthenticationComplete) {

--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.route.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.route.js
@@ -70,6 +70,7 @@ export const oidcProviderRoutes = [
               identity_provider: Joi.string().required(),
               code: Joi.string().required(),
               state: Joi.string().required(),
+              iss: Joi.string().optional(),
               audience: Joi.string().valid('app', 'admin').optional(),
             },
           },

--- a/api/src/identity-access-management/domain/services/agent-connect-oidc-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/agent-connect-oidc-authentication-service.js
@@ -1,0 +1,13 @@
+import { OidcAuthenticationService } from './oidc-authentication-service.js';
+
+const AGENT_CONNECT_CLAIM_MAPPING = {
+  firstName: ['given_name'],
+  lastName: ['usual_name'],
+  externalIdentityId: ['sub'],
+};
+
+export class AgentConnectOidcAuthenticationService extends OidcAuthenticationService {
+  constructor(oidcProvider) {
+    super({ ...oidcProvider, claimMapping: AGENT_CONNECT_CLAIM_MAPPING });
+  }
+}

--- a/api/src/identity-access-management/domain/services/oidc-authentication-service-registry.js
+++ b/api/src/identity-access-management/domain/services/oidc-authentication-service-registry.js
@@ -1,6 +1,7 @@
 import { InvalidIdentityProviderError } from '../../../shared/domain/errors.js';
 import { cryptoService } from '../../../shared/domain/services/crypto-service.js';
 import { oidcProviderRepository } from '../../infrastructure/repositories/oidc-provider-repository.js';
+import { AgentConnectOidcAuthenticationService } from './agent-connect-oidc-authentication-service.js';
 import { CnfptOidcAuthenticationService } from './cnfpt-oidc-authentication-service.js';
 import { FwbOidcAuthenticationService } from './fwb-oidc-authentication-service.js';
 import { GoogleOidcAuthenticationService } from './google-oidc-authentication-service.js';
@@ -77,6 +78,8 @@ export class OidcAuthenticationServiceRegistry {
               return new PoleEmploiOidcAuthenticationService(oidcProvider);
             case 'CNFPT':
               return new CnfptOidcAuthenticationService(oidcProvider);
+            case 'AGENTCONNECT':
+              return new AgentConnectOidcAuthenticationService(oidcProvider);
             default:
               return new OidcAuthenticationService(oidcProvider);
           }

--- a/api/src/identity-access-management/domain/services/oidc-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/oidc-authentication-service.js
@@ -136,14 +136,14 @@ export class OidcAuthenticationService {
     return uuid;
   }
 
-  async exchangeCodeForTokens({ code, nonce, state, sessionState }) {
+  async exchangeCodeForTokens({ code, state, iss, nonce, sessionState }) {
     let tokenSet;
 
     try {
-      tokenSet = await this.client.callback(this.redirectUri, { code, state }, { nonce, state: sessionState });
+      tokenSet = await this.client.callback(this.redirectUri, { code, state, iss }, { nonce, state: sessionState });
     } catch (error) {
       _monitorOidcError(error.message, {
-        data: { code, nonce, organizationName: this.organizationName, sessionState, state },
+        data: { code, nonce, organizationName: this.organizationName, sessionState, state, iss },
         error,
         event: 'exchange-code-for-tokens',
       });

--- a/api/src/identity-access-management/domain/usecases/authenticate-oidc-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/authenticate-oidc-user.usecase.js
@@ -21,10 +21,11 @@ import { ForbiddenAccess } from '../../../shared/domain/errors.js';
 async function authenticateOidcUser({
   audience,
   code,
+  state,
+  iss,
   identityProviderCode,
   nonce,
   sessionState,
-  state,
   authenticationSessionService,
   oidcAuthenticationServiceRegistry,
   adminMemberRepository,
@@ -42,9 +43,10 @@ async function authenticateOidcUser({
 
   const sessionContent = await oidcAuthenticationService.exchangeCodeForTokens({
     code,
+    state,
+    iss,
     nonce,
     sessionState,
-    state,
   });
   const userInfo = await oidcAuthenticationService.getUserInfo({
     idToken: sessionContent.idToken,

--- a/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
@@ -9,6 +9,7 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
     const state = 'state';
     const identityProviderState = 'identityProviderState';
     const nonce = 'nonce';
+    const iss = 'https://issuer.url';
     const identityProvider = 'OIDC_EXAMPLE_NET';
     const pixAccessToken = 'pixAccessToken';
 
@@ -21,6 +22,7 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
           identityProvider,
           code,
           state: identityProviderState,
+          iss,
         },
         yar: { get: sinon.stub(), commit: sinon.stub() },
       };
@@ -50,6 +52,7 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
         nonce: 'nonce',
         sessionState: state,
         state: identityProviderState,
+        iss,
       });
       expect(request.yar.commit).to.have.been.calledOnce;
     });

--- a/api/tests/identity-access-management/unit/domain/services/agent-connect-oidc-authentication-service_test.js
+++ b/api/tests/identity-access-management/unit/domain/services/agent-connect-oidc-authentication-service_test.js
@@ -1,0 +1,33 @@
+import jsonwebtoken from 'jsonwebtoken';
+
+import { AgentConnectOidcAuthenticationService } from '../../../../../src/identity-access-management/domain/services/agent-connect-oidc-authentication-service.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Identity Access Management | Domain | Services | agent-connect-oidc-authentication-service', function () {
+  describe('#getUserInfo', function () {
+    it('returns user info for agent connect', async function () {
+      // given
+      const idToken = jsonwebtoken.sign(
+        {
+          given_name: 'givenName',
+          usual_name: 'familyName',
+          nonce: 'nonce-id',
+          sub: 'sub-id',
+        },
+        'secret',
+      );
+
+      const agentConnectOidcAuthenticationService = new AgentConnectOidcAuthenticationService({});
+
+      // when
+      const result = await agentConnectOidcAuthenticationService.getUserInfo({ idToken });
+
+      // then
+      expect(result).to.deep.equal({
+        firstName: 'givenName',
+        lastName: 'familyName',
+        externalIdentityId: 'sub-id',
+      });
+    });
+  });
+});

--- a/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service-registry_test.js
+++ b/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service-registry_test.js
@@ -1,5 +1,6 @@
 import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
 import { OidcProvider } from '../../../../../src/identity-access-management/domain/models/OidcProvider.js';
+import { AgentConnectOidcAuthenticationService } from '../../../../../src/identity-access-management/domain/services/agent-connect-oidc-authentication-service.js';
 import { CnfptOidcAuthenticationService } from '../../../../../src/identity-access-management/domain/services/cnfpt-oidc-authentication-service.js';
 import { FwbOidcAuthenticationService } from '../../../../../src/identity-access-management/domain/services/fwb-oidc-authentication-service.js';
 import { GoogleOidcAuthenticationService } from '../../../../../src/identity-access-management/domain/services/google-oidc-authentication-service.js';
@@ -240,6 +241,7 @@ describe('Unit | Identity Access Management | Domain | Services | oidc-authentic
             new OidcProvider({ identityProvider: 'GOOGLE' }),
             new OidcProvider({ identityProvider: 'POLE_EMPLOI' }),
             new OidcProvider({ identityProvider: 'CNFPT' }),
+            new OidcProvider({ identityProvider: 'AGENTCONNECT' }),
           ]);
 
         // when
@@ -247,7 +249,7 @@ describe('Unit | Identity Access Management | Domain | Services | oidc-authentic
         const services = oidcAuthenticationServiceRegistry.getAllOidcProviderServices();
 
         // then
-        expect(services.length).to.be.equal(5);
+        expect(services.length).to.be.equal(6);
 
         const genericService = services.find((service) => service.identityProvider === 'GENERIC');
         expect(genericService).not.to.be.empty;
@@ -268,6 +270,10 @@ describe('Unit | Identity Access Management | Domain | Services | oidc-authentic
         const cnfptService = services.find((service) => service.identityProvider === 'CNFPT');
         expect(cnfptService).not.to.be.empty;
         expect(cnfptService).to.be.instanceOf(CnfptOidcAuthenticationService);
+
+        const agentConnectService = services.find((service) => service.identityProvider === 'AGENTCONNECT');
+        expect(agentConnectService).not.to.be.empty;
+        expect(agentConnectService).to.be.instanceOf(AgentConnectOidcAuthenticationService);
       });
     });
   });

--- a/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service_test.js
+++ b/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service_test.js
@@ -337,6 +337,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         const openidConfigurationUrl = Symbol('openidConfigurationUrl');
         const code = 'code';
         const nonce = 'nonce';
+        const iss = 'https://issuer.url';
         const sessionState = 'sessionState';
         const state = 'state';
         const errorThrown = new Error('Fails to get tokens');
@@ -363,7 +364,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         const error = await catchErr(
           oidcAuthenticationService.exchangeCodeForTokens,
           oidcAuthenticationService,
-        )({ code, nonce, sessionState, state });
+        )({ code, state, iss, nonce, sessionState });
 
         // then
         expect(error).to.be.instanceOf(OidcError);
@@ -372,10 +373,11 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
           context: 'oidc',
           data: {
             code,
+            state,
+            iss,
             nonce,
             organizationName: 'Oidc Example',
             sessionState,
-            state,
           },
           error: {
             name: errorThrown.name,

--- a/api/tests/identity-access-management/unit/domain/usecases/authenticate-oidc-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/authenticate-oidc-user.usecase.test.js
@@ -113,6 +113,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
         sessionState: 'state',
         state: 'state',
         nonce: 'nonce',
+        iss: 'https://issuer.url',
         identityProviderCode: 'OIDC_EXAMPLE_NET',
         oidcAuthenticationServiceRegistry,
         authenticationSessionService,
@@ -128,8 +129,9 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
       );
       expect(oidcAuthenticationService.exchangeCodeForTokens).to.have.been.calledOnceWithExactly({
         code: 'code',
-        sessionState: 'state',
         state: 'state',
+        iss: 'https://issuer.url',
+        sessionState: 'state',
         nonce: 'nonce',
       });
     });

--- a/mon-pix/app/authenticators/oidc.js
+++ b/mon-pix/app/authenticators/oidc.js
@@ -12,7 +12,7 @@ export default class OidcAuthenticator extends BaseAuthenticator {
   @service oidcIdentityProviders;
   @service session;
 
-  async authenticate({ code, state, identityProviderSlug, authenticationKey, hostSlug }) {
+  async authenticate({ code, state, iss, identityProviderSlug, authenticationKey, hostSlug }) {
     const request = {
       method: 'POST',
       headers: {
@@ -35,6 +35,7 @@ export default class OidcAuthenticator extends BaseAuthenticator {
         identity_provider: identityProvider.code,
         code,
         state,
+        iss,
       };
 
       if (this.session.isAuthenticated) {

--- a/mon-pix/app/routes/authentication/login-oidc.js
+++ b/mon-pix/app/routes/authentication/login-oidc.js
@@ -39,7 +39,7 @@ export default class LoginOidcRoute extends Route {
     const queryParams = transition.to.queryParams;
     const identityProviderSlug = params.identity_provider_slug;
     if (queryParams.code) {
-      return this._handleCallbackRequest(queryParams.code, queryParams.state, identityProviderSlug);
+      return this._handleCallbackRequest(queryParams.code, queryParams.state, queryParams.iss, identityProviderSlug);
     }
   }
 
@@ -62,11 +62,12 @@ export default class LoginOidcRoute extends Route {
     this.session.set('data.nextURL', undefined);
   }
 
-  async _handleCallbackRequest(code, state, identityProviderSlug) {
+  async _handleCallbackRequest(code, state, iss, identityProviderSlug) {
     try {
       await this.session.authenticate('authenticator:oidc', {
         code,
         state,
+        iss,
         identityProviderSlug,
         hostSlug: 'token',
       });


### PR DESCRIPTION
## :unicorn: Problème

La mise en place du SSO Agent Connect nécessite des modifications de la brique générique SSO pour répondre à plusieurs problème lors de son intégration

- **[PB 1]** Suite aux tests avec le SSO Agent Connect, on a une erreur à la connexion:
```
Unprocessable entity
422
iss missing from the response
```

- **[PB 2]** Une fois le premier problème corrigé, cette erreur apparaissait à la connexion:
```
Unprocessable entity
422
Unexpected token 'e', "eyJhbGciOi"... is not valid JSON
```

- **[PB 3]** La correspondance des claims n'est pas générique pour Agent Connect, le `familyName` doit être mappé sur le claim `usual_name`

## :robot: Proposition

**[CORRECTION PB 1]** 

Cette erreur est déclenchée par la librarie `openid-client` au moment de l'appel au `callback` OIDC lors de l'échange pour la récupération de token:
```js
client.callback(this.redirectUri, { code, state }, { nonce, state: sessionState });
```

Ce comportement est dû à la fonctionnalité de l'IDP:
```
"authorization_response_iss_parameter_supported": true
```

Cette erreur est [un comportement normal](https://github.com/panva/node-openid-client/issues/647#issuecomment-1864278333) lorsque cette configuration est présente sur l'IDP.

Il semble que la fonction `callback` du client devrait prendre tous les paramètres envoyés par la requête d'authorization:
```js
const params = client.callbackParams(req);
const tokenSet = await client.callback('https://client.example.com/callback', params, { nonce, state: sessionState  });
```

Or ce n'est pas le cas aujourd'hui, on ne récupère que `code` et `state`. Le paramètre `iss` qui est présent en query params, n'est pas récupéré et n'est pas fournie au `client.callback`

**[CORRECTION PB 2]** 

Cette erreur est déclenchée par la librarie `openid-client` au moment de l'appel à `userinfo` pour la récupération de info utilisateurs:

```js
userInfo = await this.client.userinfo(accessToken);
```

En regardant, le code source de `openid-client`, il semble que ce soit lié à l'algo de chiffrement utilisé par Agent connect sur les user info:

```js
const jwt = !!(this.userinfo_signed_response_alg || this.userinfo_encrypted_response_alg);
```

En regardant l'implementation exemple fournie par AgentConnect [dans ce repo](https://github.com/numerique-gouv/moncomptepro-test-client) (qui utilise également `openid-client` 🎉) Il semble qu'ils configure le client avec ces informations sur l'algo de chiffrement:

```js
  return new mcpIssuer.Client({
    client_id: process.env.MCP_CLIENT_ID,
    client_secret: process.env.MCP_CLIENT_SECRET,
    redirect_uris: [redirectUri],
    response_types: ["code"],
    id_token_signed_response_alg: process.env.MCP_ID_TOKEN_SIGNED_RESPONSE_ALG,
    userinfo_signed_response_alg:
      process.env.MCP_USERINFO_SIGNED_RESPONSE_ALG || null,
  });
```
[source](https://github.com/numerique-gouv/moncomptepro-test-client/blob/cdc7a0e88b462cec0c1a187c4a249375fdd4fb9c/index.js#L27-L35)

En modifiant la configuration de l'OIDC provider Agent Connect, en utilisant la propriété `openidClientExtraMetadata`, ça fonctionne 🎉

```json
{
  "identityProvider": "AGENTCONNECT",
  ...
  "openidClientExtraMetadata": {
    "id_token_signed_response_alg": "RS256",
    "userinfo_signed_response_alg": "RS256"
  }
}
```

**[CORRECTION PB 3]** 

Implémentation d'une correspondance des claims spécifiques pour Agent Connect avec le `familyName` mappé sur le claim `usual_name`

## :rainbow: Remarques

- N/A

## :100: Pour tester

**Testable uniquement en local et en recette**

1. Récupérer le fichier OIDC_PROVIDERS.json avec la configuration de AgentConnect pour l'environnement de dev et le charger via l'interface d'admin.
2. Se connecter sur `https://app.dev.pix.fr/connexion/agent-connect`
3. Utiliser un compte de test
> Vous êtes connecté

