### PR TITLE
[FEATURE] Ajoute un script pour convertir le schema Joi des Modulix en JSON Schema (PIX-13620) (PIX-13781)

### DIFF
--- a/api/scripts/modulix/convert-joi-schema-to-json-schema.js
+++ b/api/scripts/modulix/convert-joi-schema-to-json-schema.js
@@ -1,0 +1,6 @@
+import { convertJoiToJsonSchema } from '../../src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js';
+import { moduleSchema } from '../../tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module.js';
+
+const jsonSchema = JSON.stringify(convertJoiToJsonSchema(moduleSchema), null, 2);
+
+console.log(`export const schema = ${jsonSchema};`);

--- a/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
@@ -1,0 +1,205 @@
+import Joi from 'joi';
+
+const logger = console;
+
+export function convertJoiToJsonSchema(joiSchema) {
+  if (!Joi.isSchema(joiSchema)) {
+    throw new Error('Not a Joi schema');
+  }
+
+  return convertFromType(joiSchema.describe());
+}
+
+function convertFromType(joiDescribedSchema) {
+  switch (joiDescribedSchema.type) {
+    case 'boolean':
+      return convertBoolean();
+    case 'string':
+      return convertString(joiDescribedSchema);
+    case 'number':
+      return convertNumber(joiDescribedSchema);
+    case 'array':
+      return convertArray(joiDescribedSchema);
+    case 'object':
+      return convertObject(joiDescribedSchema);
+    case 'alternatives':
+      return convertAlternatives(joiDescribedSchema);
+    default:
+      logger.warn('Unsupported type', joiDescribedSchema.type);
+  }
+}
+
+function convertBoolean() {
+  return { type: 'boolean' };
+}
+
+function convertString(joiStringDescribedSchema) {
+  const jsonSchema = { type: 'string' };
+  const rules = joiStringDescribedSchema.rules;
+
+  const emailRule = findRule(rules, 'email');
+  if (emailRule !== undefined) {
+    jsonSchema.format = 'email';
+  }
+
+  const guidRule = findRule(rules, 'guid');
+  if (guidRule !== undefined) {
+    jsonSchema.format = 'uuid';
+  }
+
+  const uriRule = findRule(rules, 'uri');
+  if (uriRule !== undefined) {
+    jsonSchema.format = 'uri';
+  }
+
+  const minRule = findRule(rules, 'min');
+  if (minRule !== undefined) {
+    jsonSchema.minLength = minRule.args.limit;
+  }
+
+  const maxRule = findRule(rules, 'max');
+  if (maxRule !== undefined) {
+    jsonSchema.maxLength = maxRule.args.limit;
+  }
+
+  const patternRule = findRule(rules, 'pattern');
+  if (patternRule) {
+    if (!patternRule.args.options?.invert) {
+      jsonSchema.pattern = convertRegex(patternRule.args.regex.toString());
+
+      const customErrorMessage = getCustomErrorMessage(rules);
+      if (customErrorMessage !== undefined) {
+        jsonSchema.errorMessage = customErrorMessage;
+      }
+    }
+  }
+
+  if (joiStringDescribedSchema.allow?.length > 0) {
+    const enumValues = joiStringDescribedSchema.allow.filter((allow) => allow.length > 0);
+    if (enumValues.length > 0) {
+      jsonSchema.enum = enumValues;
+    }
+  }
+
+  return jsonSchema;
+}
+
+function convertNumber(joiNumberDescribedSchema) {
+  const jsonSchema = { type: 'number' };
+  const rules = joiNumberDescribedSchema.rules;
+
+  const integerRule = findRule(rules, 'integer');
+  if (integerRule !== undefined) {
+    jsonSchema.type = 'integer';
+  }
+
+  const signRule = findRule(rules, 'sign');
+  if (signRule !== undefined) {
+    if (signRule.args.sign === 'positive') {
+      jsonSchema.minimum = 1;
+    } else {
+      jsonSchema.maximum = -1;
+    }
+  }
+
+  const minRule = findRule(rules, 'min');
+  if (minRule !== undefined) {
+    jsonSchema.minimum = minRule.args.limit;
+  }
+
+  const maxRule = findRule(rules, 'max');
+  if (maxRule !== undefined) {
+    jsonSchema.maximum = maxRule.args.limit;
+  }
+
+  return jsonSchema;
+}
+
+function convertArray(joiArrayDescribedSchema) {
+  const jsonSchema = { type: 'array' };
+  const rules = joiArrayDescribedSchema.rules;
+
+  const minRule = findRule(rules, 'min');
+  if (minRule !== undefined) {
+    jsonSchema.minItems = minRule.args.limit;
+  }
+
+  const uniqueRule = findRule(rules, 'unique');
+  if (uniqueRule !== undefined) {
+    jsonSchema.uniqueItems = true;
+  }
+
+  if (joiArrayDescribedSchema.items) {
+    jsonSchema.items = {};
+
+    for (const item of joiArrayDescribedSchema.items) {
+      jsonSchema.items = convertFromType(item);
+    }
+  }
+
+  return jsonSchema;
+}
+
+function convertObject(joiObjectDescribedSchema) {
+  const jsonSchema = { type: 'object' };
+
+  if (joiObjectDescribedSchema.keys) {
+    const properties = {};
+    const required = [];
+
+    for (const [key, value] of Object.entries(joiObjectDescribedSchema.keys)) {
+      properties[key] = convertFromType(value);
+
+      if (hasFlag(value?.flags, 'presence', 'required')) {
+        required.push(key);
+      }
+    }
+
+    if (properties && Object.keys(properties).length > 0) {
+      jsonSchema.properties = properties;
+    }
+
+    if (required && required.length > 0) {
+      jsonSchema.required = required;
+    }
+
+    jsonSchema.additionalProperties = hasFlag(joiObjectDescribedSchema.flags, 'unknown', true);
+  }
+
+  return jsonSchema;
+}
+
+function convertAlternatives(joiAlternativesDescribedSchema) {
+  const oneOf = joiAlternativesDescribedSchema.matches.flatMap((match) => {
+    if (match.ref !== undefined) {
+      if (match.switch !== undefined) {
+        return match.switch.map((s) => convertFromType(s.then));
+      } else {
+        logger.warn('Unsupported conditional schema is/then/otherwise');
+      }
+    } else {
+      return convertFromType(match.schema);
+    }
+  });
+
+  return { oneOf };
+}
+
+function convertRegex(regex) {
+  return regex.slice(1, -1).replace(/\\d/g, '[0-9]');
+}
+
+function getCustomErrorMessage(rules) {
+  return rules?.find((rule) => rule.message?.template?.length > 0)?.message.template;
+}
+
+function findRule(rules, ruleName) {
+  return rules?.find((rule) => rule.name === ruleName);
+}
+
+function hasFlag(flags, flagName, flagValue) {
+  if (flags !== undefined) {
+    return Object.entries(flags).some(([name, value]) => flagName === name && flagValue === value);
+  }
+  return false;
+}

--- a/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
@@ -81,6 +81,10 @@ function convertString(joiStringDescribedSchema) {
     }
   }
 
+  return handleNonStandardStringProperties(joiStringDescribedSchema, jsonSchema);
+}
+
+function handleNonStandardStringProperties(joiStringDescribedSchema, jsonSchema) {
   if (joiStringDescribedSchema.externals?.length > 0) {
     if (joiStringDescribedSchema.externals[0].method.name === 'htmlValidation') {
       jsonSchema.format = 'jodit';

--- a/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
@@ -173,7 +173,10 @@ function convertAlternatives(joiAlternativesDescribedSchema) {
   const oneOf = joiAlternativesDescribedSchema.matches.flatMap((match) => {
     if (match.ref !== undefined) {
       if (match.switch !== undefined) {
-        return match.switch.map((s) => convertFromType(s.then));
+        return match.switch.map((s) => ({
+          title: s.then.keys.type.allow[0],
+          ...convertFromType(s.then),
+        }));
       } else {
         logger.warn('Unsupported conditional schema is/then/otherwise');
       }

--- a/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
@@ -81,6 +81,12 @@ function convertString(joiStringDescribedSchema) {
     }
   }
 
+  if (joiStringDescribedSchema.externals?.length > 0) {
+    if (joiStringDescribedSchema.externals[0].method.name === 'htmlValidation') {
+      jsonSchema.format = 'jodit';
+    }
+  }
+
   return jsonSchema;
 }
 

--- a/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
@@ -179,10 +179,7 @@ function convertAlternatives(joiAlternativesDescribedSchema) {
   const oneOf = joiAlternativesDescribedSchema.matches.flatMap((match) => {
     if (match.ref !== undefined) {
       if (match.switch !== undefined) {
-        return match.switch.map((s) => ({
-          title: s.then.keys.type.allow[0],
-          ...convertFromType(s.then),
-        }));
+        return match.switch.map(getAlternativeSwitchCaseJsonSchema);
       } else {
         logger.warn('Unsupported conditional schema is/then/otherwise');
       }
@@ -200,6 +197,21 @@ function convertRegex(regex) {
 
 function getCustomErrorMessage(rules) {
   return rules?.find((rule) => rule.message?.template?.length > 0)?.message.template;
+}
+
+function getAlternativeSwitchCaseJsonSchema(switchCase) {
+  const childJsonSchema = convertFromType(switchCase.then);
+
+  const optionalTitle = getOptionalTitleBasedOnKey(switchCase.then, 'type');
+  if (optionalTitle !== undefined) {
+    childJsonSchema.title = optionalTitle;
+  }
+
+  return childJsonSchema;
+}
+
+function getOptionalTitleBasedOnKey(joiDescribedObject, keyName) {
+  return joiDescribedObject.keys[keyName]?.allow[0];
 }
 
 function findRule(rules, ruleName) {

--- a/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
@@ -308,6 +308,64 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
 
     describe('Joi.alternatives.conditional', function () {
       it('should convert conditional deep ref switch is/then to JSON Schema', function () {
+        const joiSchema = Joi.alternatives().conditional('.sport', {
+          switch: [
+            {
+              is: 'handball',
+              then: Joi.object({
+                sport: Joi.string().valid('handball').required(),
+                value: Joi.string().required(),
+              }),
+            },
+            {
+              is: 'volleyball',
+              then: Joi.object({
+                sport: Joi.string().valid('volleyball').required(),
+                value: Joi.number().required(),
+              }),
+            },
+          ],
+        });
+
+        const jsonSchema = convertJoiToJsonSchema(joiSchema);
+
+        expect(joiSchema.validate({ sport: 'handball', value: 'hello' }).error).to.be.undefined;
+        expect(joiSchema.validate({ sport: 'volleyball', value: 132 }).error).to.be.undefined;
+        expect(jsonSchema).to.deep.equal({
+          oneOf: [
+            {
+              additionalProperties: false,
+              properties: {
+                sport: {
+                  enum: ['handball'],
+                  type: 'string',
+                },
+                value: {
+                  type: 'string',
+                },
+              },
+              required: ['sport', 'value'],
+              type: 'object',
+            },
+            {
+              additionalProperties: false,
+              properties: {
+                sport: {
+                  enum: ['volleyball'],
+                  type: 'string',
+                },
+                value: {
+                  type: 'number',
+                },
+              },
+              required: ['sport', 'value'],
+              type: 'object',
+            },
+          ],
+        });
+      });
+
+      it('should convert conditional deep ref switch is/then to JSON Schema and add title if a .type property exists', function () {
         const joiSchema = Joi.alternatives().conditional('.type', {
           switch: [
             {

--- a/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
@@ -98,6 +98,20 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
         expect(jsonSchema).to.deep.equal({ type: 'string', enum: ['Hello'] });
       });
     });
+
+    describe('external', function () {
+      describe('htmlValidation', function () {
+        it('should convert Joi.string.external(htmlValidation) to JSON Schema with format jodit', function () {
+          // eslint-disable-next-line no-empty-function
+          function htmlValidation() {}
+          const joiSchema = Joi.string().external(htmlValidation);
+
+          const jsonSchema = convertJoiToJsonSchema(joiSchema);
+
+          expect(jsonSchema).to.deep.equal({ type: 'string', format: 'jodit' });
+        });
+      });
+    });
   });
 
   describe('number', function () {

--- a/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
@@ -1,0 +1,355 @@
+import Joi from 'joi';
+
+import { convertJoiToJsonSchema } from '../../../../../../src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
+
+describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema', function () {
+  it('should throw if not Joi', function () {
+    const error = catchErrSync(convertJoiToJsonSchema)({});
+
+    expect(error.message).to.equal('Not a Joi schema');
+  });
+
+  describe('boolean', function () {
+    it('should convert Joi.boolean to JSON Schema', function () {
+      const joiSchema = Joi.boolean();
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'boolean' });
+    });
+  });
+
+  describe('string', function () {
+    it('should convert Joi.string to JSON Schema', function () {
+      const joiSchema = Joi.string();
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'string' });
+    });
+
+    it('should convert Joi.string.min to JSON Schema with minLength', function () {
+      const joiSchema = Joi.string().min(8);
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'string', minLength: 8 });
+    });
+
+    it('should convert Joi.string.max to JSON Schema with maxLength', function () {
+      const joiSchema = Joi.string().max(32);
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'string', maxLength: 32 });
+    });
+
+    it('should convert Joi.string.email to JSON Schema with format email', function () {
+      const joiSchema = Joi.string().email();
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'string', format: 'email' });
+    });
+
+    it('should convert Joi.string.uri to JSON Schema with format uri', function () {
+      const joiSchema = Joi.string().uri();
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'string', format: 'uri' });
+    });
+
+    it('should convert Joi.string.guid to JSON Schema with format uuid', function () {
+      const joiSchema = Joi.string().guid({ version: 'uuidv4' });
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'string', format: 'uuid' });
+    });
+
+    describe('regex', function () {
+      it('should convert Joi.string.regex(d) to JSON Schema with converted pattern', function () {
+        const joiSchema = Joi.string().regex(/^\d+$/);
+        const jsonSchema = convertJoiToJsonSchema(joiSchema);
+        expect(jsonSchema).to.deep.equal({ type: 'string', pattern: '^[0-9]+$' });
+      });
+
+      it('should convert Joi.string.regex(*) to JSON Schema with given pattern', function () {
+        const joiSchema = Joi.string().regex(/^[a-z0-9-]+$/);
+        const jsonSchema = convertJoiToJsonSchema(joiSchema);
+        expect(jsonSchema).to.deep.equal({ type: 'string', pattern: '^[a-z0-9-]+$' });
+      });
+
+      it('should convert Joi.string.regex(*, invert) to JSON Schema with no pattern', function () {
+        const joiSchema = Joi.string().regex(/<.*?>/, { invert: true });
+        const jsonSchema = convertJoiToJsonSchema(joiSchema);
+        expect(jsonSchema).to.deep.equal({ type: 'string' });
+      });
+
+      it('should convert Joi.string.regex.message to JSON Schema with errorMessage', function () {
+        const joiSchema = Joi.string().regex(/abc/).message('{{:#label}} failed custom validation');
+        const jsonSchema = convertJoiToJsonSchema(joiSchema);
+        expect(jsonSchema).to.deep.equal({
+          type: 'string',
+          pattern: 'abc',
+          errorMessage: '{{:#label}} failed custom validation',
+        });
+      });
+    });
+
+    describe('allow', function () {
+      it('should convert Joi.string.allow(empty) to JSON Schema with no enum', function () {
+        const joiSchema = Joi.string().allow('');
+        const jsonSchema = convertJoiToJsonSchema(joiSchema);
+        expect(jsonSchema).to.deep.equal({ type: 'string' });
+      });
+
+      it('should convert Joi.string.allow(*) to JSON Schema with enum', function () {
+        const joiSchema = Joi.string().allow('Hello');
+        const jsonSchema = convertJoiToJsonSchema(joiSchema);
+        expect(jsonSchema).to.deep.equal({ type: 'string', enum: ['Hello'] });
+      });
+    });
+  });
+
+  describe('number', function () {
+    it('should convert Joi.number to JSON Schema', function () {
+      const joiSchema = Joi.number();
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'number' });
+    });
+
+    it('should convert Joi.number.integer to JSON Schema with type integer', function () {
+      const joiSchema = Joi.number().integer();
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'integer' });
+    });
+
+    it('should convert Joi.number.positive to JSON Schema with minimum 1', function () {
+      const joiSchema = Joi.number().positive();
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'number', minimum: 1 });
+    });
+
+    it('should convert Joi.number.negative to JSON Schema with maximum -1', function () {
+      const joiSchema = Joi.number().negative();
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'number', maximum: -1 });
+    });
+
+    it('should convert Joi.number.min to JSON Schema with minimum', function () {
+      const joiSchema = Joi.number().min(0);
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'number', minimum: 0 });
+    });
+
+    it('should convert Joi.number.max to JSON Schema with maximum', function () {
+      const joiSchema = Joi.number().max(150);
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'number', maximum: 150 });
+    });
+  });
+
+  describe('array', function () {
+    it('should convert Joi.array to JSON Schema', function () {
+      const joiSchema = Joi.array();
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'array' });
+    });
+
+    it('should convert Joi.array.min to JSON Schema with minItems', function () {
+      const joiSchema = Joi.array().min(3);
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'array', minItems: 3 });
+    });
+
+    it('should convert Joi.array.unique to JSON Schema with uniqueItems', function () {
+      const joiSchema = Joi.array().unique();
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'array', uniqueItems: true });
+    });
+
+    describe('items', function () {
+      it('should convert Joi.array.items(string) to JSON Schema with items string', function () {
+        const joiSchema = Joi.array().items(Joi.string());
+        const jsonSchema = convertJoiToJsonSchema(joiSchema);
+        expect(jsonSchema).to.deep.equal({ type: 'array', items: { type: 'string' } });
+      });
+
+      it('should convert Joi.array.items(number) to JSON Schema with items number', function () {
+        const joiSchema = Joi.array().items(Joi.number());
+        const jsonSchema = convertJoiToJsonSchema(joiSchema);
+        expect(jsonSchema).to.deep.equal({ type: 'array', items: { type: 'number' } });
+      });
+
+      it('should convert Joi.array.items(object) to JSON Schema with items object', function () {
+        const joiSchema = Joi.array().items(Joi.object());
+        const jsonSchema = convertJoiToJsonSchema(joiSchema);
+        expect(jsonSchema).to.deep.equal({ type: 'array', items: { type: 'object' } });
+      });
+
+      it('should convert Joi.array.items(array) to JSON Schema with items array', function () {
+        const joiSchema = Joi.array().items(Joi.array());
+        const jsonSchema = convertJoiToJsonSchema(joiSchema);
+        expect(jsonSchema).to.deep.equal({ type: 'array', items: { type: 'array' } });
+      });
+    });
+  });
+
+  describe('object', function () {
+    it('should convert Joi.object to JSON Schema', function () {
+      const joiSchema = Joi.object();
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(joiSchema.validate({ name: 'John', age: 30, additional: 'property' }).error).to.be.undefined;
+      expect(jsonSchema).to.deep.equal({ type: 'object' });
+    });
+
+    it('should convert Joi.object.keys to JSON Schema with no additionalProperties', function () {
+      const joiSchema = Joi.object({});
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(joiSchema.validate({ additional: 'property' }).error).not.to.be.undefined;
+      expect(jsonSchema).to.deep.equal({ type: 'object', additionalProperties: false });
+    });
+
+    it('should convert Joi.object.keys.unknown to JSON Schema with additionalProperties', function () {
+      const joiSchema = Joi.object({}).unknown();
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(joiSchema.validate({ additional: 'property' }).error).to.be.undefined;
+      expect(jsonSchema).to.deep.equal({ type: 'object', additionalProperties: true });
+    });
+
+    it('should convert Joi.object.keys to JSON Schema with properties', function () {
+      const joiSchema = Joi.object({
+        name: Joi.string(),
+        age: Joi.number(),
+      });
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'number' },
+        },
+        additionalProperties: false,
+      });
+    });
+
+    it('should convert Joi.object.keys.required to JSON Schema with required properties', function () {
+      const joiSchema = Joi.object({
+        name: Joi.string().required(),
+        age: Joi.number(),
+      });
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'number' },
+        },
+        required: ['name'],
+        additionalProperties: false,
+      });
+    });
+
+    it('should convert Joi.object with nested Joi.object to nested JSON Schema', function () {
+      const joiSchema = Joi.object({
+        address: Joi.object({
+          street: Joi.string(),
+          city: Joi.string(),
+        }),
+      });
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({
+        type: 'object',
+        properties: {
+          address: {
+            type: 'object',
+            properties: {
+              street: { type: 'string' },
+              city: { type: 'string' },
+            },
+            additionalProperties: false,
+          },
+        },
+        additionalProperties: false,
+      });
+    });
+
+    it('should convert Joi.object with nested Joi.array to nested JSON Schema', function () {
+      const joiSchema = Joi.object({
+        addresses: Joi.array().items(Joi.string()),
+      });
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({
+        type: 'object',
+        properties: {
+          addresses: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+        },
+        additionalProperties: false,
+      });
+    });
+  });
+
+  describe('alternatives', function () {
+    it('should convert Joi.alternatives.try to JSON Schema', function () {
+      const joiSchema = Joi.alternatives().try(Joi.string(), Joi.number());
+
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+
+      expect(joiSchema.validate('string').error).to.be.undefined;
+      expect(joiSchema.validate(123).error).to.be.undefined;
+      expect(jsonSchema).to.deep.equal({ oneOf: [{ type: 'string' }, { type: 'number' }] });
+    });
+
+    describe('Joi.alternatives.conditional', function () {
+      it('should convert conditional deep ref switch is/then to JSON Schema', function () {
+        const joiSchema = Joi.alternatives().conditional('.type', {
+          switch: [
+            {
+              is: 'handball',
+              then: Joi.object({
+                type: Joi.string().valid('handball').required(),
+                value: Joi.string().required(),
+              }),
+            },
+            {
+              is: 'volleyball',
+              then: Joi.object({
+                type: Joi.string().valid('volleyball').required(),
+                value: Joi.number().required(),
+              }),
+            },
+          ],
+        });
+
+        const jsonSchema = convertJoiToJsonSchema(joiSchema);
+
+        expect(joiSchema.validate({ type: 'handball', value: 'hello' }).error).to.be.undefined;
+        expect(joiSchema.validate({ type: 'volleyball', value: 132 }).error).to.be.undefined;
+        expect(jsonSchema).to.deep.equal({
+          oneOf: [
+            {
+              additionalProperties: false,
+              properties: {
+                type: {
+                  enum: ['handball'],
+                  type: 'string',
+                },
+                value: {
+                  type: 'string',
+                },
+              },
+              required: ['type', 'value'],
+              type: 'object',
+            },
+            {
+              additionalProperties: false,
+              properties: {
+                type: {
+                  enum: ['volleyball'],
+                  type: 'string',
+                },
+                value: {
+                  type: 'number',
+                },
+              },
+              required: ['type', 'value'],
+              type: 'object',
+            },
+          ],
+        });
+      });
+    });
+  });
+});

--- a/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
@@ -320,6 +320,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
         expect(jsonSchema).to.deep.equal({
           oneOf: [
             {
+              title: 'handball',
               additionalProperties: false,
               properties: {
                 type: {
@@ -334,6 +335,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
               type: 'object',
             },
             {
+              title: 'volleyball',
               additionalProperties: false,
               properties: {
                 type: {

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/embed.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/embed.js
@@ -9,7 +9,7 @@ const embedElementSchema = Joi.object({
   title: htmlNotAllowedSchema.required(),
   url: Joi.string().uri().required(),
   instruction: htmlSchema.optional(),
-  solution: Joi.alternatives().conditional('isCompletionRequired', {
+  solution: Joi.when('isCompletionRequired', {
     is: true,
     then: Joi.string().required(),
     otherwise: Joi.any().forbidden(),

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qrocm.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qrocm.js
@@ -47,7 +47,15 @@ const qrocmElementSchema = Joi.object({
   type: Joi.string().valid('qrocm').required(),
   instruction: htmlSchema.required(),
   proposals: Joi.array()
-    .items(Joi.alternatives().try(blockTextSchema, blockInputSchema, blockSelectSchema))
+    .items(
+      Joi.alternatives().conditional('.type', {
+        switch: [
+          { is: 'text', then: blockTextSchema },
+          { is: 'input', then: blockInputSchema },
+          { is: 'select', then: blockSelectSchema },
+        ],
+      }),
+    )
     .required(),
   feedbacks: Joi.object({
     valid: htmlSchema,

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/utils.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/utils.js
@@ -6,7 +6,9 @@ const uuidSchema = Joi.string().guid({ version: 'uuidv4' }).required();
 const proposalIdSchema = Joi.string().regex(/^\d+$/);
 
 const htmlValidate = new HtmlValidate();
-const htmlSchema = Joi.string().external(async (value, helpers) => {
+const htmlSchema = Joi.string().external(htmlValidation);
+
+async function htmlValidation(value, helpers) {
   if (!value) {
     return;
   }
@@ -16,7 +18,7 @@ const htmlSchema = Joi.string().external(async (value, helpers) => {
   if (!report.valid) {
     return helpers.message('htmlvalidationerror', { value: report });
   }
-});
+}
 
 const htmlNotAllowedSchema = Joi.string()
   .regex(/<.*?>/, { invert: true })


### PR DESCRIPTION
## :unicorn: Problème
On utilise [JSON Editor](https://github.com/json-editor/json-editor) pour réaliser les contenus de Modulix. JSON Editor demande du [JSON Schema](https://json-schema.org/) pour générer un formulaire pour des utilisateurs finaux.

La structure technique `.json` des modules est validé contre un schéma Joi.

## :robot: Proposition
Pour faciliter la création de contenus, permettre d'exporter un JSON Schema depuis le schéma Modulix.

Ce script npm permet de générer le schéma :
```shell
node ./scripts/modulix/convert-joi-schema-to-json-schema.js
```

Ce qui loggera le résultat. Au choix on peut par exemple le copier dans le presse papier avec un ` | pbcopy` ou le stocker dans un fichier avec ` > modulix.json-schema.js`.

Pour le remettre à jour le schéma de [Modulix Editor](https://github.com/1024pix/modulix-editor), on peut copier ce fichier :
```shell
cp modulix.json-schema.js ../../modulix-editor
```

## :rainbow: Remarques
En l'état, la conversion joi-to-json-schema est "opiniated", par exemple :
- utiliser le champ "type" des alternatives pour remplir le nom du champ des dropdowns de Modulix Editor,
- mettre en place un "format" non standard "jodit" pour utiliser le wysiwyg côté Modulix Editor.

Il y a d'autres opportunités d'améliorations d'UX pour nos usages mais cela empêche la généricité de cette brique : est-ce qu'on peut faire mieux ?

## :100: Pour tester
Vérifier que les scripts fonctionnent correctement et qu'on retrouve le même contenu que ce qu'il y a sur [modulix-editor](https://github.com/1024pix/modulix-editor/blob/main/modulix.json-schema.js).
