### PR TITLE
[FEATURE] Ajout de la colonne relative au besoin d'une certification aménagée dans la table certification-candidates (PIX-13293)

### DIFF
--- a/api/db/database-builder/factory/build-certification-candidate.js
+++ b/api/db/database-builder/factory/build-certification-candidate.js
@@ -27,6 +27,7 @@ const buildCertificationCandidate = function ({
   billingMode = null,
   prepaymentCode = null,
   hasSeenCertificationInstructions = false,
+  accessibilityAdjustmentNeeded = false,
 } = {}) {
   sessionId = _.isUndefined(sessionId) ? buildSession().id : sessionId;
   userId = _.isUndefined(userId) ? buildUser().id : userId;
@@ -54,6 +55,7 @@ const buildCertificationCandidate = function ({
     billingMode,
     prepaymentCode,
     hasSeenCertificationInstructions,
+    accessibilityAdjustmentNeeded,
   };
 
   databaseBuffer.pushInsertable({
@@ -84,6 +86,7 @@ const buildCertificationCandidate = function ({
     billingMode,
     prepaymentCode,
     hasSeenCertificationInstructions,
+    accessibilityAdjustmentNeeded,
   };
 };
 

--- a/api/db/migrations/20240807091800_add_accessibility_adjusted_certification_needed_column_to_certification_candidates.js
+++ b/api/db/migrations/20240807091800_add_accessibility_adjusted_certification_needed_column_to_certification_candidates.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'certification-candidates';
+const COLUMN_NAME = 'accessibilityAdjustmentNeeded';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.boolean(COLUMN_NAME).defaultTo(false);
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/db/seeds/data/common/tooling/session-tooling.js
+++ b/api/db/seeds/data/common/tooling/session-tooling.js
@@ -168,6 +168,7 @@ async function createDraftSession({
     hasJoinSession: false,
     configSession,
     certificationCenterId,
+    version,
   });
 
   await databaseBuilder.commit();
@@ -519,6 +520,7 @@ async function createPublishedSession({
     hasJoinSession: true,
     configSession,
     certificationCenterId,
+    version,
   });
 
   const { coreProfileData, complementaryCertificationsProfileData } = await _makeCandidatesCertifiable({
@@ -593,6 +595,7 @@ function _addCertificationCandidatesToScoSession(
       authorizedToStart: false,
       billingMode: null,
       prepaymentCode: null,
+      accessibilityAdjustmentNeeded: (version === 3 && accessibilityAdjustedCertificationNeeds[index]) ?? false,
     });
     databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidate.id });
     certificationCandidates.push(candidate);
@@ -616,6 +619,7 @@ async function _registerCandidatesToSession({
   hasJoinSession,
   configSession,
   certificationCenterId,
+  version,
 }) {
   const certificationCandidates = [];
   if (_hasCertificationCandidatesToRegister(configSession)) {
@@ -634,6 +638,7 @@ async function _registerCandidatesToSession({
         prepaymentCode: null,
       },
     ];
+    const accessibilityAdjustedCertificationNeeds = [true, false];
 
     const complementaryCertificationIds = [null];
     if (configSession.hasComplementaryCertificationsToRegister) {
@@ -658,6 +663,8 @@ async function _registerCandidatesToSession({
         billingModes[i % billingModes.length];
 
       const randomExtraTimePercentage = extraTimePercentages[i % extraTimePercentages.length];
+      const randomAccessibilityAdjustedCertificationNeeded =
+        (version === 3 && accessibilityAdjustedCertificationNeeds[i]) ?? false;
 
       const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
         firstName: `firstname${i}-${sessionId}`,
@@ -678,6 +685,7 @@ async function _registerCandidatesToSession({
         authorizedToStart: false,
         billingMode: randomBillingMode,
         prepaymentCode: randomPrepaymentCode,
+        accessibilityAdjustmentNeeded: randomAccessibilityAdjustedCertificationNeeded,
       });
 
       databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: certificationCandidate.id });

--- a/api/db/seeds/data/team-certification/data-builder.js
+++ b/api/db/seeds/data/team-certification/data-builder.js
@@ -112,6 +112,7 @@ async function _createScoCertificationCenter({ databaseBuilder }) {
     updatedAt: new Date(),
     members: [{ id: SCO_CERTIFICATION_MANAGING_STUDENTS_CERTIFICATION_CENTER_USER_ID }],
     complementaryCertificationIds: [],
+    isV3Pilot: true,
   });
 }
 
@@ -306,6 +307,7 @@ async function _createScoSession({ databaseBuilder }) {
     room: '42',
     time: '12:00',
     createdAt: new Date(),
+    version: 3,
     configSession: {
       learnersToRegisterCount: 8,
     },

--- a/api/db/seeds/data/team-certification/data-builder.js
+++ b/api/db/seeds/data/team-certification/data-builder.js
@@ -427,7 +427,7 @@ async function _createSuccessCertifiableUser({ databaseBuilder }) {
 async function _createV3Session({
   databaseBuilder,
   configSession = {
-    candidatesToRegisterCount: 1,
+    candidatesToRegisterCount: 2,
     hasComplementaryCertificationsToRegister: false,
   },
 }) {

--- a/api/src/shared/domain/models/CertificationCandidate.js
+++ b/api/src/shared/domain/models/CertificationCandidate.js
@@ -44,6 +44,7 @@ const certificationCandidateParticipationJoiSchema = Joi.object({
   prepaymentCode: Joi.string().allow(null).optional(),
   subscriptions: Joi.array().items(subscriptionSchema).unique('type').required(),
   hasSeenCertificationInstructions: Joi.boolean().optional(),
+  accessibilityAdjustmentNeeded: Joi.boolean().optional(),
 });
 
 class CertificationCandidate {
@@ -78,6 +79,7 @@ class CertificationCandidate {
     prepaymentCode = null,
     subscriptions = [],
     hasSeenCertificationInstructions = false,
+    accessibilityAdjustmentNeeded = false,
   } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -102,6 +104,7 @@ class CertificationCandidate {
     this.billingMode = billingMode;
     this.prepaymentCode = prepaymentCode;
     this.hasSeenCertificationInstructions = hasSeenCertificationInstructions;
+    this.accessibilityAdjustmentNeeded = accessibilityAdjustmentNeeded;
 
     Object.defineProperty(this, 'complementaryCertification', {
       enumerable: true,

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
@@ -151,6 +151,7 @@ describe('Integration | Certification | Session | Repository | Candidate', funct
         billingMode: null,
         prepaymentCode: null,
         hasSeenCertificationInstructions: false,
+        accessibilityAdjustmentNeeded: false,
         subscriptions: [
           {
             type: SUBSCRIPTION_TYPES.CORE,

--- a/api/tests/tooling/domain-builder/factory/build-certification-candidate.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-candidate.js
@@ -25,6 +25,7 @@ const buildCertificationCandidate = function ({
   billingMode = null,
   prepaymentCode = null,
   subscriptions = [domainBuilder.buildCoreSubscription({ certificationCandidateId: 123 })],
+  accessibilityAdjustmentNeeded = false,
 } = {}) {
   return new CertificationCandidate({
     id,
@@ -50,6 +51,7 @@ const buildCertificationCandidate = function ({
     billingMode,
     prepaymentCode,
     subscriptions,
+    accessibilityAdjustmentNeeded,
   });
 };
 

--- a/api/tests/unit/domain/models/CertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidate_test.js
@@ -48,6 +48,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       complementaryCertification: null,
       subscriptions: [coreSubscription],
       hasSeenCertificationInstructions: false,
+      accessibilityAdjustmentNeeded: false,
     };
   });
 


### PR DESCRIPTION
## :unicorn: Problème
En préparation de la tâche consistant à afficher l'information qu'un candidat à besoin d'un aménagement durant sa certification, nous avons besoin de :
- rajouter une nouvelle colonne dans `certification-candidates` afin d'enregistrer cette donnée pour la suite de la fonctionnalité.
- Ajout dans les seeds, un candidat inscrit à un session de certification v3 ayant besoin d'un aménagement durant sa certification.

## :robot: Proposition
Ajouter une nouvelle colonne nommée `accessibilityAdjustedCertificationNeeded` dans la table `certification-candidates` et mettre à jours les seeds.

## :rainbow: Remarques
- Le wording a été valider au préalable avec le métier et le juridique.
- La migration concerne à ce jour 6 917 524 candidats inscrits en production (valeur `false` par défaut), il faudra s'assurer que la communication a été faite auprès des Captains pour en garantir le bon déroulement.

## :100: Pour tester
1. La migration s'exécute correctement.
2. Vérifier en base de données dans la table `certification-candidates` qu'au moins un candidat V3 PRO et SCO ont bien la colonne `accessibilityAdjustedCertificationNeeded` à `true`.