### PR TITLE
[FEATURE] Passe directement à la dernière épreuves à jouer d'une mission déjà démarré depuis la page de liste des mission (PIX-13625)

### DIFF
--- a/junior/app/controllers/identified/missions/list.js
+++ b/junior/app/controllers/identified/missions/list.js
@@ -14,23 +14,23 @@ export default class List extends Controller {
   }
 
   @action
-  hasMissionStarted(missionId) {
+  isMissionStarted(missionId) {
     return this.model.organizationLearner.startedMissionIds?.includes(missionId);
   }
 
-  _getStatus(missionId) {
-    return this.hasMissionStarted(missionId) ? 'started' : 'to-start';
+  #getStatus(missionId) {
+    return this.isMissionStarted(missionId) ? 'started' : 'to-start';
   }
 
   @action
   getMissionLabelStatus(missionId) {
-    const status = this._getStatus(missionId);
+    const status = this.#getStatus(missionId);
     return this.intl.t(`pages.missions.list.status.${status}.label`);
   }
 
   @action
   getMissionButtonLabel(missionId) {
-    const status = this._getStatus(missionId);
+    const status = this.#getStatus(missionId);
     return this.intl.t(`pages.missions.list.status.${status}.button-label`);
   }
 
@@ -38,13 +38,22 @@ export default class List extends Controller {
     return this.currentLearner.learner.schoolUrl + '/students?division=' + this.model.organizationLearner.division;
   }
 
-  @action
-  goToMission(id) {
+  #disableCards() {
     const cards = document.getElementsByClassName('card');
     for (const card of cards) {
       card.classList.add('card--loading');
       card.setAttribute('disabled', '');
     }
-    this.router.transitionTo('identified.missions.mission', id);
+  }
+
+  @action
+  goToMission(missionId) {
+    this.#disableCards();
+
+    let route = 'identified.missions.mission';
+    if (this.isMissionStarted(missionId)) {
+      route += '.resume';
+    }
+    this.router.transitionTo(route, missionId);
   }
 }

--- a/junior/app/templates/identified/missions/list.hbs
+++ b/junior/app/templates/identified/missions/list.hbs
@@ -26,7 +26,7 @@
             @missionButtonLabel={{this.getMissionButtonLabel mission.id}}
             @title={{mission.name}}
             @areaCode={{mission.areaCode}}
-            @displayStartedIcon={{this.hasMissionStarted mission.id}}
+            @displayStartedIcon={{this.isMissionStarted mission.id}}
           />
         {{/if}}
       </PixButton>

--- a/junior/tests/acceptance/display-missions-list-test.js
+++ b/junior/tests/acceptance/display-missions-list-test.js
@@ -1,4 +1,6 @@
 import { visit, within } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import { currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 
 import { setupApplicationTest, t } from '../helpers';
@@ -61,5 +63,40 @@ module('Acceptance | Display missions list', function (hooks) {
         ),
       )
       .exists();
+  });
+  test('redirect to the challenge when user has already started the mission', async function (assert) {
+    this.server.create('mission', { id: '1', name: 'started_mission' });
+    this.server.create('mission', { id: '2', name: 'to_start_mission' });
+    this.server.create('challenge', { id: '1' });
+    const learner = this.server.create('organization-learner', {
+      name: 'learner',
+      startedMissionIds: ['1'],
+    });
+    identifyLearner(this.owner, { id: learner.id });
+
+    // when
+    const screen = await visit('/');
+    await click(screen.getByText('started_mission'));
+
+    // then
+    assert.strictEqual(currentURL(), '/assessments/1/challenges');
+  });
+
+  test('redirect to mission detail page when the user starts the mission', async function (assert) {
+    this.server.create('mission', { id: '1', name: 'started_mission' });
+    this.server.create('mission', { id: '2', name: 'to_start_mission' });
+
+    const learner = this.server.create('organization-learner', {
+      name: 'learner',
+      startedMissionIds: ['1'],
+    });
+    identifyLearner(this.owner, { id: learner.id });
+
+    // when
+    const screen = await visit('/');
+    await click(screen.getByText('to_start_mission'));
+
+    // then
+    assert.strictEqual(currentURL(), '/missions/2');
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Lorsqu'une mission est déjà démarrée, nous repassons par la page de détail de la mission.

## :robot: Proposition

Passer directement à l'épreuve où nous nous étions arrêtés.

## :rainbow: Remarques

## :100: Pour tester

- Démarrer une mission
- Changer d'URL pour repasser à la liste des missions
- Reprendre la mission
- Constaté que nous revenons bien, directement, à l'épreuve où nous avions arrêté. 
