### PR TITLE
[FEATURE] Modifier l'affichage des inscriptions en certification pour gérer la compatibilité coeur/complémentaire (PIX-11899)

### DIFF
--- a/api/src/certification/enrolment/domain/models/Subscription.js
+++ b/api/src/certification/enrolment/domain/models/Subscription.js
@@ -47,6 +47,10 @@ class Subscription {
   isComplementary() {
     return this.type === SUBSCRIPTION_TYPES.COMPLEMENTARY;
   }
+
+  get id() {
+    return `${this.certificationCandidateId}-${this.complementaryCertificationId ?? 'CORE'}`;
+  }
 }
 
 export { Subscription };

--- a/api/src/certification/enrolment/infrastructure/serializers/enrolled-candidate-serializer.js
+++ b/api/src/certification/enrolment/infrastructure/serializers/enrolled-candidate-serializer.js
@@ -30,10 +30,16 @@ const serialize = function (enrolledCandidates) {
       'birthINSEECode',
       'birthPostalCode',
       'complementaryCertification',
+      'subscriptions',
       'billingMode',
       'prepaymentCode',
       'hasSeenCertificationInstructions',
     ],
+    subscriptions: {
+      include: true,
+      ref: 'id',
+      attributes: ['complementaryCertificationId', 'type'],
+    },
   }).serialize(enrolledCandidates);
 };
 

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -203,6 +203,7 @@ const configuration = (function () {
       ),
       showNewResultPage: toBoolean(process.env.FT_SHOW_NEW_RESULT_PAGE),
       showExperimentalMissions: toBoolean(process.env.FT_SHOW_EXPERIMENTAL_MISSIONS),
+      isCoreComplementaryCompatibilityEnabled: toBoolean(process.env.FT_CORE_COMPLEMENTARY_COMPATIBILITY),
     },
     hapi: {
       options: {},
@@ -397,7 +398,11 @@ const configuration = (function () {
     config.featureToggles.isCertificationTokenScopeEnabled = false;
     config.featureToggles.isPixPlusLowerLeverEnabled = false;
     config.featureToggles.isTextToSpeechButtonEnabled = false;
+    config.featureToggles.deprecatePoleEmploiPushNotification = false;
     config.featureToggles.isNeedToAdjustCertificationAccessibilityEnabled = false;
+    config.featureToggles.showNewResultPage = false;
+    config.featureToggles.showExperimentalMissions = false;
+    config.featureToggles.isCoreComplementaryCompatibilityEnabled = false;
 
     config.mailing.enabled = false;
     config.mailing.provider = 'brevo';

--- a/api/tests/certification/enrolment/acceptance/application/certification-candidate-route_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/certification-candidate-route_test.js
@@ -71,7 +71,7 @@ describe('Acceptance | Controller | Session | certification-candidate-route', fu
       // then
       expect(response.statusCode).to.equal(200);
       expect(response.payload).to.equal(
-        '{"data":[{"type":"certification-candidates","id":"1001","attributes":{"first-name":"first-name","last-name":"last-name","birthdate":"2000-01-04","birth-province-code":null,"birth-city":"PARIS 1","birth-country":"France","email":"somemail@example.net","result-recipient-email":"somerecipientmail@example.net","external-id":"externalId","extra-time-percentage":0.3,"is-linked":true,"organization-learner-id":null,"sex":"M","birth-insee-code":"75101","birth-postal-code":null,"complementary-certification":{"id":10000006},"billing-mode":"PREPAID","prepayment-code":null}}]}',
+        '{"data":[{"type":"certification-candidates","id":"1001","attributes":{"first-name":"first-name","last-name":"last-name","birthdate":"2000-01-04","birth-province-code":null,"birth-city":"PARIS 1","birth-country":"France","email":"somemail@example.net","result-recipient-email":"somerecipientmail@example.net","external-id":"externalId","extra-time-percentage":0.3,"is-linked":true,"organization-learner-id":null,"sex":"M","birth-insee-code":"75101","birth-postal-code":null,"complementary-certification":{"id":10000006},"billing-mode":"PREPAID","prepayment-code":null},"relationships":{"subscriptions":{"data":[{"type":"subscriptions","id":"1001-CORE"},{"type":"subscriptions","id":"1001-10000006"}]}}}],"included":[{"type":"subscriptions","id":"1001-CORE","attributes":{"complementary-certification-id":null,"type":"CORE"}},{"type":"subscriptions","id":"1001-10000006","attributes":{"complementary-certification-id":10000006,"type":"COMPLEMENTARY"}}]}',
       );
     });
   });

--- a/api/tests/certification/enrolment/acceptance/application/enrolment-route_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/enrolment-route_test.js
@@ -124,6 +124,8 @@ describe('Certification | Enrolment | Acceptance | Application | Routes | enrolm
         sinon.assert.match(response.result, {
           data: [
             {
+              type: 'certification-candidates',
+              id: sinon.match.string,
               attributes: {
                 'billing-mode': null,
                 'prepayment-code': null,
@@ -144,8 +146,26 @@ describe('Certification | Enrolment | Acceptance | Application | Routes | enrolm
                 sex: 'M',
                 'complementary-certification': null,
               },
+              relationships: {
+                subscriptions: {
+                  data: [
+                    {
+                      type: 'subscriptions',
+                      id: sinon.match.string,
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+          included: [
+            {
+              type: 'subscriptions',
               id: sinon.match.string,
-              type: 'certification-candidates',
+              attributes: {
+                type: 'CORE',
+                'complementary-certification-id': null,
+              },
             },
           ],
         });

--- a/api/tests/certification/enrolment/unit/infrastructure/serializers/enrolled-candidate-serializer_test.js
+++ b/api/tests/certification/enrolment/unit/infrastructure/serializers/enrolled-candidate-serializer_test.js
@@ -1,4 +1,5 @@
 import * as serializer from '../../../../../../src/certification/enrolment/infrastructure/serializers/enrolled-candidate-serializer.js';
+import { SUBSCRIPTION_TYPES } from '../../../../../../src/certification/shared/domain/constants.js';
 import { CertificationCandidate } from '../../../../../../src/shared/domain/models/index.js';
 import { domainBuilder, expect } from '../../../../../test-helper.js';
 
@@ -51,7 +52,27 @@ describe('Certification | Enrolment | Unit | Serializer | enrolled-candidate-ser
             sex: enrolledCandidate.sex,
             'complementary-certification': null,
           },
+          relationships: {
+            subscriptions: {
+              data: [
+                {
+                  type: 'subscriptions',
+                  id: `${enrolledCandidate.id}-CORE`,
+                },
+              ],
+            },
+          },
         },
+        included: [
+          {
+            type: 'subscriptions',
+            id: `${enrolledCandidate.id}-CORE`,
+            attributes: {
+              'complementary-certification-id': null,
+              type: SUBSCRIPTION_TYPES.CORE,
+            },
+          },
+        ],
       };
 
       // when
@@ -83,6 +104,9 @@ describe('Certification | Enrolment | Unit | Serializer | enrolled-candidate-ser
         billingMode: CertificationCandidate.BILLING_MODES.PAID,
         prepaymentCode: 'somePrepaymentCode1',
         subscriptions: [
+          domainBuilder.certification.enrolment.buildCoreSubscription({
+            certificationCandidateId: 123,
+          }),
           domainBuilder.certification.enrolment.buildComplementarySubscription({
             certificationCandidateId: 123,
             complementaryCertificationId: 456,
@@ -112,10 +136,42 @@ describe('Certification | Enrolment | Unit | Serializer | enrolled-candidate-ser
             'organization-learner-id': enrolledCandidate.organizationLearnerId,
             sex: enrolledCandidate.sex,
             'complementary-certification': {
-              id: enrolledCandidate.subscriptions[0].complementaryCertificationId,
+              id: enrolledCandidate.subscriptions[1].complementaryCertificationId,
+            },
+          },
+          relationships: {
+            subscriptions: {
+              data: [
+                {
+                  type: 'subscriptions',
+                  id: `${enrolledCandidate.id}-CORE`,
+                },
+                {
+                  type: 'subscriptions',
+                  id: `${enrolledCandidate.id}-456`,
+                },
+              ],
             },
           },
         },
+        included: [
+          {
+            type: 'subscriptions',
+            id: `${enrolledCandidate.id}-CORE`,
+            attributes: {
+              'complementary-certification-id': null,
+              type: SUBSCRIPTION_TYPES.CORE,
+            },
+          },
+          {
+            type: 'subscriptions',
+            id: `${enrolledCandidate.id}-456`,
+            attributes: {
+              'complementary-certification-id': 456,
+              type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
+            },
+          },
+        ],
       };
 
       // when

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -30,6 +30,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
             'is-need-to-adjust-certification-accessibility-enabled': false,
             'show-new-result-page': false,
             'show-experimental-missions': false,
+            'is-core-complementary-compatibility-enabled': false,
           },
         },
       };

--- a/certif/app/components/certification-candidate-details-modal/index.gjs
+++ b/certif/app/components/certification-candidate-details-modal/index.gjs
@@ -9,6 +9,7 @@ import { formatPercentage } from 'pix-certif/helpers/format-percentage';
 
 import Row from './row';
 
+const TRANSLATE_PREFIX = 'pages.sessions.detail.candidates';
 const FIELDS = [
   {
     label: 'labels.candidate.birth-name',
@@ -66,22 +67,6 @@ export default class CertificationCandidateDetailsModal extends Component {
   @service intl;
 
   @action
-  formatComplementaryCertificationLabel(id) {
-    const complementaryCertificationId = parseInt(id);
-
-    if (complementaryCertificationId < 0) {
-      return '-';
-    }
-    const complementaryCertificationList = this.args.complementaryCertifications ?? [];
-
-    const candidateComplementaryCertification = complementaryCertificationList.find(
-      (complementaryCertification) => complementaryCertification.id === complementaryCertificationId,
-    );
-
-    return candidateComplementaryCertification?.label || '-';
-  }
-
-  @action
   getRowLabel(label) {
     return this.intl.t(`common.${label}`);
   }
@@ -92,6 +77,23 @@ export default class CertificationCandidateDetailsModal extends Component {
 
     return transform(value) || value || '-';
   }
+
+  getSubscriptionsStr = (candidate) => {
+    const complementaryCertificationList = this.args.complementaryCertifications ?? [];
+    const subscriptionLabels = [];
+
+    for (const subscription of candidate.subscriptions) {
+      if (subscription.isCore) subscriptionLabels.unshift(this.intl.t(`${TRANSLATE_PREFIX}.list.subscriptions.core`));
+      else {
+        const candidateComplementaryCertification = complementaryCertificationList.find(
+          (complementaryCertification) => complementaryCertification.id === subscription.complementaryCertificationId,
+        );
+        subscriptionLabels.push(candidateComplementaryCertification?.label || '-');
+      }
+    }
+
+    return subscriptionLabels.join(', ');
+  };
 
   <template>
     <PixModal
@@ -115,12 +117,10 @@ export default class CertificationCandidateDetailsModal extends Component {
               @value={{this.getRowValue 'prepaymentCode'}}
             />
           {{/if}}
-          {{#if @displayComplementaryCertification}}
-            <Row
-              @label={{t 'common.forms.certification-labels.additional-certification'}}
-              @value={{this.formatComplementaryCertificationLabel @candidate.complementaryCertification.id}}
-            />
-          {{/if}}
+          <Row
+            @label={{t 'common.forms.certification-labels.selected-subscriptions'}}
+            @value={{this.getSubscriptionsStr @candidate}}
+          />
         </ul>
       </:content>
 

--- a/certif/app/components/certification-candidate-details-modal/index.gjs
+++ b/certif/app/components/certification-candidate-details-modal/index.gjs
@@ -78,7 +78,7 @@ export default class CertificationCandidateDetailsModal extends Component {
     return transform(value) || value || '-';
   }
 
-  getSubscriptionsStr = (candidate) => {
+  computeSubscriptionsText = (candidate) => {
     const complementaryCertificationList = this.args.complementaryCertifications ?? [];
     const subscriptionLabels = [];
 
@@ -123,7 +123,7 @@ export default class CertificationCandidateDetailsModal extends Component {
           {{/if}}
           <Row
             @label={{t 'common.forms.certification-labels.selected-subscriptions'}}
-            @value={{this.getSubscriptionsStr @candidate}}
+            @value={{this.computeSubscriptionsText @candidate}}
           />
         </ul>
       </:content>

--- a/certif/app/components/certification-candidate-details-modal/index.gjs
+++ b/certif/app/components/certification-candidate-details-modal/index.gjs
@@ -82,13 +82,17 @@ export default class CertificationCandidateDetailsModal extends Component {
     const complementaryCertificationList = this.args.complementaryCertifications ?? [];
     const subscriptionLabels = [];
 
-    for (const subscription of candidate.subscriptions) {
-      if (subscription.isCore) subscriptionLabels.unshift(this.intl.t(`${TRANSLATE_PREFIX}.list.subscriptions.core`));
-      else {
-        const candidateComplementaryCertification = complementaryCertificationList.find(
-          (complementaryCertification) => complementaryCertification.id === subscription.complementaryCertificationId,
-        );
-        subscriptionLabels.push(candidateComplementaryCertification?.label || '-');
+    if (candidate.hasDualCertificationSubscriptionCoreClea(complementaryCertificationList)) {
+      subscriptionLabels.push(this.intl.t(`${TRANSLATE_PREFIX}.list.subscriptions.dual-core-clea`));
+    } else {
+      for (const subscription of candidate.subscriptions) {
+        if (subscription.isCore) subscriptionLabels.unshift(this.intl.t(`${TRANSLATE_PREFIX}.list.subscriptions.core`));
+        else {
+          const candidateComplementaryCertification = complementaryCertificationList.find(
+            (complementaryCertification) => complementaryCertification.id === subscription.complementaryCertificationId,
+          );
+          subscriptionLabels.push(candidateComplementaryCertification?.label || '-');
+        }
       }
     }
 

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -68,6 +68,24 @@
             {{#if @displayComplementaryCertification}}
               <th>{{t "common.forms.certification-labels.additional-certification"}}</th>
             {{/if}}
+              <th>
+                {{t "common.forms.certification-labels.selected-subscriptions"}}
+                {{#if this.showCompatibilityTooltip}}
+                  <PixTooltip @position="right"  @id="tooltip-compatibility-subscription">
+                    <:triggerElement>
+                      <PixIconButton
+                        @icon="info"
+                        aria-label="{{t 'pages.sessions.detail.candidates.list.compatibility-tooltip-arialabel'}}"
+                        aria-disabled="true"
+                        aria-describedby="tooltip-compatibility-subscription"
+                        @withBackground={{true}}
+                        @size="small"
+                      />
+                    </:triggerElement>
+                    <:tooltip>{{t "pages.sessions.detail.candidates.list.actions.delete.tooltip"}}</:tooltip>
+                  </PixTooltip>
+                {{/if}}
+              </th>
           </tr>
         </thead>
         <tbody>
@@ -98,6 +116,9 @@
                   {{this.formatComplementaryCertificationLabel candidate.complementaryCertification.id}}
                 </td>
               {{/if}}
+              <td>
+                {{this.getSubscriptionsStr candidate}}
+              </td>
               <td>
                 <div class="certification-candidates-actions">
                   {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -66,22 +66,19 @@
               </th>
             {{/if}}
             <th>
-              {{t "common.forms.certification-labels.selected-subscriptions"}}
-              {{#if this.showCompatibilityTooltip}}
-                <PixTooltip @position="right" @id="tooltip-compatibility-subscription">
-                  <:triggerElement>
-                    <PixIconButton
-                      @icon="info"
-                      aria-label="{{t 'pages.sessions.detail.candidates.list.compatibility-tooltip-arialabel'}}"
-                      aria-disabled="true"
-                      aria-describedby="tooltip-compatibility-subscription"
-                      @withBackground={{true}}
-                      @size="small"
-                    />
-                  </:triggerElement>
-                  <:tooltip>{{t "pages.sessions.detail.candidates.list.compatibility-tooltip"}}</:tooltip>
-                </PixTooltip>
-              {{/if}}
+              <span class="certification-candidates-table__selected-subscriptions">
+                {{t "common.forms.certification-labels.selected-subscriptions"}}
+                {{#if this.showCompatibilityTooltip}}
+                  <PixTooltip @id="tooltip-compatibility-subscription" @position="bottom" @isWide={{true}}>
+                    <:triggerElement>
+                      <FaIcon @icon="circle-info" tabindex="0" aria-describedby="tooltip-compatibility-subscription" />
+                    </:triggerElement>
+                    <:tooltip>
+                      {{t "pages.sessions.detail.candidates.list.compatibility-tooltip"}}
+                    </:tooltip>
+                  </PixTooltip>
+                {{/if}}
+              </span>
             </th>
           </tr>
         </thead>

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -65,27 +65,24 @@
                 {{t "common.forms.certification-labels.pricing"}}
               </th>
             {{/if}}
-            {{#if @displayComplementaryCertification}}
-              <th>{{t "common.forms.certification-labels.additional-certification"}}</th>
-            {{/if}}
-              <th>
-                {{t "common.forms.certification-labels.selected-subscriptions"}}
-                {{#if this.showCompatibilityTooltip}}
-                  <PixTooltip @position="right"  @id="tooltip-compatibility-subscription">
-                    <:triggerElement>
-                      <PixIconButton
-                        @icon="info"
-                        aria-label="{{t 'pages.sessions.detail.candidates.list.compatibility-tooltip-arialabel'}}"
-                        aria-disabled="true"
-                        aria-describedby="tooltip-compatibility-subscription"
-                        @withBackground={{true}}
-                        @size="small"
-                      />
-                    </:triggerElement>
-                    <:tooltip>{{t "pages.sessions.detail.candidates.list.actions.delete.tooltip"}}</:tooltip>
-                  </PixTooltip>
-                {{/if}}
-              </th>
+            <th>
+              {{t "common.forms.certification-labels.selected-subscriptions"}}
+              {{#if this.showCompatibilityTooltip}}
+                <PixTooltip @position="right" @id="tooltip-compatibility-subscription">
+                  <:triggerElement>
+                    <PixIconButton
+                      @icon="info"
+                      aria-label="{{t 'pages.sessions.detail.candidates.list.compatibility-tooltip-arialabel'}}"
+                      aria-disabled="true"
+                      aria-describedby="tooltip-compatibility-subscription"
+                      @withBackground={{true}}
+                      @size="small"
+                    />
+                  </:triggerElement>
+                  <:tooltip>{{t "pages.sessions.detail.candidates.list.actions.delete.tooltip"}}</:tooltip>
+                </PixTooltip>
+              {{/if}}
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -111,11 +108,6 @@
                 </td>
               {{/if}}
 
-              {{#if @displayComplementaryCertification}}
-                <td>
-                  {{this.formatComplementaryCertificationLabel candidate.complementaryCertification.id}}
-                </td>
-              {{/if}}
               <td>
                 {{this.getSubscriptionsStr candidate}}
               </td>
@@ -183,7 +175,6 @@
     @showModal={{this.shouldDisplayCertificationCandidateModal}}
     @closeModal={{this.closeCertificationCandidateDetailsModal}}
     @candidate={{this.certificationCandidateInDetailsModal}}
-    @displayComplementaryCertification={{@displayComplementaryCertification}}
     @complementaryCertifications={{@complementaryCertifications}}
     @shouldDisplayPaymentOptions={{@shouldDisplayPaymentOptions}}
   />

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -79,7 +79,7 @@
                       @size="small"
                     />
                   </:triggerElement>
-                  <:tooltip>{{t "pages.sessions.detail.candidates.list.actions.delete.tooltip"}}</:tooltip>
+                  <:tooltip>{{t "pages.sessions.detail.candidates.list.compatibility-tooltip"}}</:tooltip>
                 </PixTooltip>
               {{/if}}
             </th>
@@ -109,7 +109,7 @@
               {{/if}}
 
               <td>
-                {{this.getSubscriptionsStr candidate}}
+                {{this.computeSubscriptionsText candidate}}
               </td>
               <td>
                 <div class="certification-candidates-actions">

--- a/certif/app/components/enrolled-candidates.js
+++ b/certif/app/components/enrolled-candidates.js
@@ -36,22 +36,6 @@ export default class EnrolledCandidates extends Component {
   }
 
   @action
-  formatComplementaryCertificationLabel(id) {
-    const complementaryCertificationId = parseInt(id);
-
-    if (complementaryCertificationId < 0) {
-      return '-';
-    }
-    const complementaryCertificationList = this.args.complementaryCertifications ?? [];
-
-    const candidateComplementaryCertification = complementaryCertificationList.find(
-      (complementaryCertification) => complementaryCertification.id === complementaryCertificationId,
-    );
-
-    return candidateComplementaryCertification?.label || '-';
-  }
-
-  @action
   addCertificationCandidateInStaging() {
     let addedAttributes = {};
     if (this.args.shouldDisplayPaymentOptions) {

--- a/certif/app/components/enrolled-candidates.js
+++ b/certif/app/components/enrolled-candidates.js
@@ -215,13 +215,17 @@ export default class EnrolledCandidates extends Component {
     const complementaryCertificationList = this.args.complementaryCertifications ?? [];
     const subscriptionLabels = [];
 
-    for (const subscription of candidate.subscriptions) {
-      if (subscription.isCore) subscriptionLabels.unshift(this.intl.t(`${TRANSLATE_PREFIX}.list.subscriptions.core`));
-      else {
-        const candidateComplementaryCertification = complementaryCertificationList.find(
-          (complementaryCertification) => complementaryCertification.id === subscription.complementaryCertificationId,
-        );
-        subscriptionLabels.push(candidateComplementaryCertification?.label || '-');
+    if (candidate.hasDualCertificationSubscriptionCoreClea(complementaryCertificationList)) {
+      subscriptionLabels.push(this.intl.t(`${TRANSLATE_PREFIX}.list.subscriptions.dual-core-clea`));
+    } else {
+      for (const subscription of candidate.subscriptions) {
+        if (subscription.isCore) subscriptionLabels.unshift(this.intl.t(`${TRANSLATE_PREFIX}.list.subscriptions.core`));
+        else {
+          const candidateComplementaryCertification = complementaryCertificationList.find(
+            (complementaryCertification) => complementaryCertification.id === subscription.complementaryCertificationId,
+          );
+          subscriptionLabels.push(candidateComplementaryCertification?.label || '-');
+        }
       }
     }
 

--- a/certif/app/components/enrolled-candidates.js
+++ b/certif/app/components/enrolled-candidates.js
@@ -211,7 +211,7 @@ export default class EnrolledCandidates extends Component {
     return this.featureToggles.featureToggles?.isCoreComplementaryCompatibilityEnabled;
   }
 
-  getSubscriptionsStr = (candidate) => {
+  computeSubscriptionsText = (candidate) => {
     const complementaryCertificationList = this.args.complementaryCertifications ?? [];
     const subscriptionLabels = [];
 

--- a/certif/app/components/enrolled-candidates.js
+++ b/certif/app/components/enrolled-candidates.js
@@ -9,6 +9,7 @@ const TRANSLATE_PREFIX = 'pages.sessions.detail.candidates';
 
 export default class EnrolledCandidates extends Component {
   @service store;
+  @service featureToggles;
   @service intl;
   @service notifications;
   @tracked candidatesInStaging = [];
@@ -221,4 +222,25 @@ export default class EnrolledCandidates extends Component {
       ) !== undefined
     );
   }
+
+  get showCompatibilityTooltip() {
+    return this.featureToggles.featureToggles?.isCoreComplementaryCompatibilityEnabled;
+  }
+
+  getSubscriptionsStr = (candidate) => {
+    const complementaryCertificationList = this.args.complementaryCertifications ?? [];
+    const subscriptionLabels = [];
+
+    for (const subscription of candidate.subscriptions) {
+      if (subscription.isCore) subscriptionLabels.unshift(this.intl.t(`${TRANSLATE_PREFIX}.list.subscriptions.core`));
+      else {
+        const candidateComplementaryCertification = complementaryCertificationList.find(
+          (complementaryCertification) => complementaryCertification.id === subscription.complementaryCertificationId,
+        );
+        subscriptionLabels.push(candidateComplementaryCertification?.label || '-');
+      }
+    }
+
+    return subscriptionLabels.join(', ');
+  };
 }

--- a/certif/app/components/members-list.js
+++ b/certif/app/components/members-list.js
@@ -5,7 +5,6 @@ import { tracked } from '@glimmer/tracking';
 
 export default class MembersList extends Component {
   @service currentUser;
-  @service featureToggles;
   @service intl;
   @service notifications;
   @service session;

--- a/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
@@ -52,10 +52,6 @@ export default class CertificationCandidatesController extends Controller {
     await this.reloadCertificationCandidate();
   }
 
-  get shouldDisplayComplementaryCertificationsHabilitations() {
-    return this.currentUser.currentAllowedCertificationCenterAccess.hasHabilitations;
-  }
-
   get shouldDisplayPaymentOptions() {
     return this._currentCertificationCenterIsNotSco();
   }

--- a/certif/app/controllers/authenticated/sessions/import.js
+++ b/certif/app/controllers/authenticated/sessions/import.js
@@ -8,7 +8,6 @@ import ENV from 'pix-certif/config/environment';
 export default class ImportController extends Controller {
   @service fileSaver;
   @service session;
-  @service featureToggles;
   @service notifications;
   @service intl;
   @service currentUser;

--- a/certif/app/controllers/authenticated/team/list.js
+++ b/certif/app/controllers/authenticated/team/list.js
@@ -5,7 +5,6 @@ import { tracked } from '@glimmer/tracking';
 
 export default class AuthenticatedTeamListController extends Controller {
   @service currentUser;
-  @service featureToggles;
   @service router;
   @service notifications;
   @service intl;

--- a/certif/app/models/certification-candidate.js
+++ b/certif/app/models/certification-candidate.js
@@ -44,4 +44,10 @@ export default class CertificationCandidate extends Model {
 
     return '-';
   }
+
+  hasDualCertificationSubscriptionCoreClea(centerHabilitations) {
+    const hasCoreSubscription = this.subscriptions.some((sub) => sub.isCore);
+    const hasCleaSubscription = this.subscriptions.some((sub) => sub.isClea(centerHabilitations));
+    return hasCoreSubscription && hasCleaSubscription;
+  }
 }

--- a/certif/app/models/certification-candidate.js
+++ b/certif/app/models/certification-candidate.js
@@ -1,5 +1,5 @@
 import { service } from '@ember/service';
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class CertificationCandidate extends Model {
   @service intl;
@@ -21,6 +21,8 @@ export default class CertificationCandidate extends Model {
   @attr('string') billingMode;
   @attr('string') prepaymentCode;
   @attr complementaryCertification;
+
+  @hasMany('subscription', { async: false, inverse: null }) subscriptions;
 
   get genderLabel() {
     const candidateGender = this.sex;

--- a/certif/app/models/feature-toggle.js
+++ b/certif/app/models/feature-toggle.js
@@ -1,3 +1,5 @@
-import Model from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 
-export default class FeatureToggle extends Model {}
+export default class FeatureToggle extends Model {
+  @attr('boolean') isCoreComplementaryCompatibilityEnabled;
+}

--- a/certif/app/models/session-enrolment.js
+++ b/certif/app/models/session-enrolment.js
@@ -6,7 +6,6 @@ export const CREATED = 'created';
 
 export default class Session extends Model {
   @service session;
-  @service featureToggles;
   @service intl;
 
   @attr('string') address;

--- a/certif/app/models/session-management.js
+++ b/certif/app/models/session-management.js
@@ -9,7 +9,6 @@ export const PROCESSED = 'processed';
 
 export default class Session extends Model {
   @service session;
-  @service featureToggles;
   @service intl;
 
   @attr('string') status;

--- a/certif/app/models/subscription.js
+++ b/certif/app/models/subscription.js
@@ -1,17 +1,26 @@
 import Model, { attr } from '@ember-data/model';
 
+export const SUBSCRIPTION_TYPES = Object.freeze({
+  CORE: 'CORE',
+  COMPLEMENTARY: 'COMPLEMENTARY',
+});
+
+export const COMPLEMENTARY_KEYS = Object.freeze({
+  CLEA: 'CLEA',
+});
+
 export default class SubscriptionModel extends Model {
   @attr('number') complementaryCertificationId;
   @attr('string') type;
 
   get isCore() {
-    return this.type === 'CORE';
+    return this.type === SUBSCRIPTION_TYPES.CORE;
   }
 
   isClea(centerHabilitations) {
     const matchingHabilitation = centerHabilitations.find(
       (habilitation) => habilitation.id === this.complementaryCertificationId,
     );
-    return matchingHabilitation?.key === 'CLEA' ?? false;
+    return matchingHabilitation?.key === COMPLEMENTARY_KEYS.CLEA ?? false;
   }
 }

--- a/certif/app/models/subscription.js
+++ b/certif/app/models/subscription.js
@@ -7,4 +7,11 @@ export default class SubscriptionModel extends Model {
   get isCore() {
     return this.type === 'CORE';
   }
+
+  isClea(centerHabilitations) {
+    const matchingHabilitation = centerHabilitations.find(
+      (habilitation) => habilitation.id === this.complementaryCertificationId,
+    );
+    return matchingHabilitation?.key === 'CLEA' ?? false;
+  }
 }

--- a/certif/app/models/subscription.js
+++ b/certif/app/models/subscription.js
@@ -1,0 +1,10 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class SubscriptionModel extends Model {
+  @attr('number') complementaryCertificationId;
+  @attr('string') type;
+
+  get isCore() {
+    return this.type === 'CORE';
+  }
+}

--- a/certif/app/routes/authenticated/team/list.js
+++ b/certif/app/routes/authenticated/team/list.js
@@ -1,6 +1,7 @@
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import { COMPLEMENTARY_KEYS } from 'pix-certif/models/subscription';
 
 export default class AuthenticatedTeamListRoute extends Route {
   @service currentUser;
@@ -19,7 +20,7 @@ export default class AuthenticatedTeamListRoute extends Route {
 
     const hasCleaHabilitation = this.store
       .peekRecord('allowed-certification-center-access', certificationCenterId)
-      .habilitations?.some((habilitation) => habilitation.key === 'CLEA');
+      .habilitations?.some((habilitation) => habilitation.key === COMPLEMENTARY_KEYS.CLEA);
 
     return {
       invitations,

--- a/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
@@ -158,6 +158,14 @@
   box-sizing: content-box;
 }
 
+.certification-candidates-table__selected-subscriptions {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+  width: 100px;
+  box-sizing: content-box;
+}
+
 .certification-candidates-actions {
   position: relative;
   display: flex;

--- a/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
+++ b/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
@@ -10,7 +10,6 @@
       @certificationCandidates={{this.certificationCandidates}}
       @reloadCertificationCandidate={{this.reloadCertificationCandidateInController}}
       @countries={{this.countries}}
-      @displayComplementaryCertification={{this.displayComplementaryCertification}}
       @complementaryCertifications={{this.currentUser.currentAllowedCertificationCenterAccess.habilitations}}
     />
   {{/if}}
@@ -28,7 +27,6 @@
     @certificationCandidates={{this.certificationCandidates}}
     @reloadCertificationCandidate={{this.reloadCertificationCandidateInController}}
     @countries={{this.countries}}
-    @displayComplementaryCertification={{this.shouldDisplayComplementaryCertificationsHabilitations}}
     @shouldDisplayPaymentOptions={{this.shouldDisplayPaymentOptions}}
     @complementaryCertifications={{this.currentUser.currentAllowedCertificationCenterAccess.habilitations}}
   />

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -98,6 +98,7 @@ function routes() {
 
   this.get('/sessions/:id/certification-candidates', function (schema, request) {
     const sessionId = request.params.id;
+
     return schema.certificationCandidates.where({ sessionId });
   });
 

--- a/certif/mirage/factories/certification-candidate.js
+++ b/certif/mirage/factories/certification-candidate.js
@@ -64,7 +64,8 @@ export default Factory.extend({
   },
 
   afterCreate(candidate, server) {
-    if (candidate.subscriptions.models.length === 0) {
+    const hasSubscriptions = candidate.subscriptions?.models?.length ?? false;
+    if (!hasSubscriptions) {
       const coreSubscription = server.create('subscription', {
         type: 'CORE',
         complementaryCertificationId: null,

--- a/certif/mirage/factories/certification-candidate.js
+++ b/certif/mirage/factories/certification-candidate.js
@@ -62,4 +62,16 @@ export default Factory.extend({
   birthPostalCode() {
     return '35400';
   },
+
+  afterCreate(candidate, server) {
+    if (candidate.subscriptions.models.length === 0) {
+      const coreSubscription = server.create('subscription', {
+        type: 'CORE',
+        complementaryCertificationId: null,
+      });
+      candidate.update({
+        subscriptions: [coreSubscription],
+      });
+    }
+  },
 });

--- a/certif/mirage/factories/certification-candidate.js
+++ b/certif/mirage/factories/certification-candidate.js
@@ -1,4 +1,5 @@
 import { Factory } from 'miragejs';
+import { SUBSCRIPTION_TYPES } from 'pix-certif/models/subscription';
 
 export default Factory.extend({
   firstName() {
@@ -67,7 +68,7 @@ export default Factory.extend({
     const hasSubscriptions = candidate.subscriptions?.models?.length ?? false;
     if (!hasSubscriptions) {
       const coreSubscription = server.create('subscription', {
-        type: 'CORE',
+        type: SUBSCRIPTION_TYPES.CORE,
         complementaryCertificationId: null,
       });
       candidate.update({

--- a/certif/mirage/serializers/certification-candidate.js
+++ b/certif/mirage/serializers/certification-candidate.js
@@ -1,0 +1,7 @@
+import ApplicationSerializer from './application';
+
+const include = ['subscriptions'];
+
+export default ApplicationSerializer.extend({
+  include,
+});

--- a/certif/tests/acceptance/session-details-certification-candidates-test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates-test.js
@@ -168,7 +168,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
           .exists();
         assert.dom(screen.getByRole('cell', { name: 'EXTERNAL-ID' })).exists();
         assert.dom(screen.getByRole('cell', { name: 'Certification Pix' })).exists();
-        assert.strictEqual(screen.getAllByRole('cell', { name: 'Pix+Droit' }).length, 2);
+        assert.strictEqual(screen.getAllByRole('cell', { name: 'Pix+Droit' }).length, 1);
       });
 
       module('when the details button is clicked', function () {
@@ -183,6 +183,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
           assert.dom(screen.getByText('Commune de naissance')).exists();
           assert.dom(within(modal).getByText('France')).exists();
           assert.dom(within(modal).getByText('Homme')).exists();
+          assert.dom(within(modal).getByText('Pix+Droit')).exists();
         });
       });
 
@@ -592,56 +593,6 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
               const table = screen.getByRole('table');
               const rows = await within(table).findAllByRole('row');
               assert.dom(within(rows[1]).getByRole('cell', { name: 'Prépayée 12345' })).exists();
-            });
-          });
-
-          module('when certificationPointOfContact has habilitations', function (hooks) {
-            const complementaryCertificationLabel = 'Lancer de hache';
-            let allowedCertificationCenterAccess;
-            let certificationPointOfContact;
-            let session;
-
-            hooks.beforeEach(async () => {
-              allowedCertificationCenterAccess = server.create('allowed-certification-center-access', {
-                isAccessBlockedCollege: false,
-                isAccessBlockedLycee: false,
-                isAccessBlockedAEFE: false,
-                isAccessBlockedAgri: false,
-                habilitations: [{ id: 0, label: complementaryCertificationLabel, key: 'COMP_1' }],
-              });
-              certificationPointOfContact = server.create('certification-point-of-contact', {
-                firstName: 'Lena',
-                lastName: 'Rine',
-                allowedCertificationCenterAccesses: [allowedCertificationCenterAccess],
-                pixCertifTermsOfServiceAccepted: true,
-              });
-              session = server.create('session-enrolment', {
-                certificationCenterId: allowedCertificationCenterAccess.id,
-              });
-              server.create('session-management', {
-                id: session.id,
-              });
-              server.createList('country', 2, { code: '99100' });
-              await authenticateSession(certificationPointOfContact.id);
-            });
-
-            test('it should add a new candidate with complementary certifications', async function (assert) {
-              // when
-              const screen = await visit(`/sessions/${session.id}/candidats`);
-              await click(screen.getByRole('button', { name: 'Inscrire un candidat' }));
-              await screen.findByRole('dialog');
-              await _fillFormWithCorrectData(screen);
-              await click(screen.getByRole('radio', { name: complementaryCertificationLabel }));
-              await click(screen.getByRole('button', { name: 'Inscrire le candidat' }));
-              await settled();
-
-              // then
-              const table = screen.getByRole('table', {
-                name: 'Liste des candidats inscrits à la session, triée par nom de naissance, avec un lien pour voir les détails du candidat et la possibilité de supprimer un candidat dans la dernière colonne.',
-              });
-
-              const rows = await within(table).findAllByRole('row');
-              assert.dom(within(rows[1]).getByRole('cell', { name: complementaryCertificationLabel })).exists();
             });
           });
         });

--- a/certif/tests/acceptance/session-details-certification-candidates-test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates-test.js
@@ -3,6 +3,7 @@ import { click, currentURL, fillIn, find, settled, triggerEvent } from '@ember/t
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIntl } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { SUBSCRIPTION_TYPES } from 'pix-certif/models/subscription';
 import { module, test } from 'qunit';
 
 import { authenticateSession } from '../helpers/test-init';
@@ -113,11 +114,11 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
           certificationCenterId: allowedCertificationCenterAccess.id,
         });
         const coreSubscription = server.create('subscription', {
-          type: 'CORE',
+          type: SUBSCRIPTION_TYPES.CORE,
           complementaryCertificationId: null,
         });
         const complementarySubscription = server.create('subscription', {
-          type: 'COMPLEMENTARY',
+          type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
           complementaryCertificationId,
         });
         server.create('certification-candidate', {

--- a/certif/tests/acceptance/team/list/list-test.js
+++ b/certif/tests/acceptance/team/list/list-test.js
@@ -5,6 +5,7 @@ import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { currentSession } from 'ember-simple-auth/test-support';
 import { Response } from 'miragejs';
+import { COMPLEMENTARY_KEYS } from 'pix-certif/models/subscription';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -105,7 +106,10 @@ module('Acceptance | authenticated | team', function (hooks) {
                 'ADMIN',
               );
               server.create('member', { firstName: 'Lili', lastName: 'Dupont', isReferer: false });
-              server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
+              server.create('allowed-certification-center-access', {
+                id: 1,
+                habilitations: [{ key: COMPLEMENTARY_KEYS.CLEA }],
+              });
               await authenticateSession(certificationPointOfContact.id);
 
               // when
@@ -146,7 +150,10 @@ module('Acceptance | authenticated | team', function (hooks) {
                   'ADMIN',
                 );
                 server.create('member', { firstName: 'Lili', lastName: 'Dupont', isReferer: false });
-                server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
+                server.create('allowed-certification-center-access', {
+                  id: 1,
+                  habilitations: [{ key: COMPLEMENTARY_KEYS.CLEA }],
+                });
                 await authenticateSession(certificationPointOfContact.id);
 
                 // when
@@ -177,7 +184,10 @@ module('Acceptance | authenticated | team', function (hooks) {
                     'ADMIN',
                   );
                   server.create('member', { firstName: 'Lili', lastName: 'Dupont', isReferer: false, role: 'MEMBER' });
-                  server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
+                  server.create('allowed-certification-center-access', {
+                    id: 1,
+                    habilitations: [{ key: COMPLEMENTARY_KEYS.CLEA }],
+                  });
                   await authenticateSession(certificationPointOfContact.id);
 
                   // when
@@ -215,7 +225,10 @@ module('Acceptance | authenticated | team', function (hooks) {
                 'ADMIN',
                 true,
               );
-              server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
+              server.create('allowed-certification-center-access', {
+                id: 1,
+                habilitations: [{ key: COMPLEMENTARY_KEYS.CLEA }],
+              });
               await authenticateSession(certificationPointOfContact.id);
 
               // when
@@ -234,7 +247,10 @@ module('Acceptance | authenticated | team', function (hooks) {
                 'ADMIN',
                 true,
               );
-              server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
+              server.create('allowed-certification-center-access', {
+                id: 1,
+                habilitations: [{ key: COMPLEMENTARY_KEYS.CLEA }],
+              });
               await authenticateSession(certificationPointOfContact.id);
 
               // when
@@ -266,7 +282,10 @@ module('Acceptance | authenticated | team', function (hooks) {
               );
               server.create('member', { firstName: 'Jamal', lastName: 'Opié', isReferer: true });
               server.create('member', { firstName: 'Jean', lastName: 'Ticipe', isReferer: false });
-              server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
+              server.create('allowed-certification-center-access', {
+                id: 1,
+                habilitations: [{ key: COMPLEMENTARY_KEYS.CLEA }],
+              });
               await authenticateSession(certificationPointOfContact.id);
 
               // when
@@ -472,7 +491,10 @@ module('Acceptance | authenticated | team', function (hooks) {
                 'MEMBER',
               );
               server.create('member', { firstName: 'Lili', lastName: 'Dupont', isReferer: false });
-              server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
+              server.create('allowed-certification-center-access', {
+                id: 1,
+                habilitations: [{ key: COMPLEMENTARY_KEYS.CLEA }],
+              });
               await authenticateSession(certificationPointOfContact.id);
 
               // when
@@ -501,7 +523,10 @@ module('Acceptance | authenticated | team', function (hooks) {
               );
               server.create('member', { firstName: 'Jamal', lastName: 'Opié', isReferer: true });
               server.create('member', { firstName: 'Jean', lastName: 'Ticipe', isReferer: false });
-              server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
+              server.create('allowed-certification-center-access', {
+                id: 1,
+                habilitations: [{ key: COMPLEMENTARY_KEYS.CLEA }],
+              });
               await authenticateSession(certificationPointOfContact.id);
 
               // when

--- a/certif/tests/integration/components/certification-candidate-details-modal/index-test.gjs
+++ b/certif/tests/integration/components/certification-candidate-details-modal/index-test.gjs
@@ -1,5 +1,4 @@
 import { render } from '@1024pix/ember-testing-library';
-import EmberObject from '@ember/object';
 import { click } from '@ember/test-helpers';
 import CertificationCandidateDetailsModal from 'pix-certif/components/certification-candidate-details-modal';
 import { module, test } from 'qunit';
@@ -13,6 +12,10 @@ module('Integration | Component | certification-candidate-details-modal', functi
   test('it shows candidate details with complementary certification', async function (assert) {
     // given
     const store = this.owner.lookup('service:store');
+    const pixEduSubscription = store.createRecord('subscription', {
+      type: 'COMPLEMENTARY',
+      complementaryCertificationId: 1,
+    });
     const candidate = store.createRecord('certification-candidate', {
       firstName: 'Jean-Paul',
       lastName: 'Candidat',
@@ -26,9 +29,7 @@ module('Integration | Component | certification-candidate-details-modal', functi
       birthInseeCode: 76255,
       birthPostalCode: 76260,
       sex: 'F',
-      complementaryCertification: {
-        id: 1,
-      },
+      subscriptions: [pixEduSubscription],
     });
 
     const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
@@ -44,7 +45,6 @@ module('Integration | Component | certification-candidate-details-modal', functi
           @closeModal={{closeModalStub}}
           @showModal={{true}}
           @candidate={{candidate}}
-          @displayComplementaryCertification={{true}}
           @complementaryCertifications={{currentAllowedCertificationCenterAccess.habilitations}}
         />
       </template>,
@@ -71,6 +71,10 @@ module('Integration | Component | certification-candidate-details-modal', functi
     test('it displays a dash', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
+      const coreSubscription = store.createRecord('subscription', {
+        type: 'CORE',
+        complementaryCertificationId: null,
+      });
       const candidate = store.createRecord('certification-candidate', {
         firstName: undefined,
         lastName: undefined,
@@ -81,7 +85,7 @@ module('Integration | Component | certification-candidate-details-modal', functi
         resultRecipientEmail: undefined,
         externalId: undefined,
         extraTimePercentage: undefined,
-        complementaryCertification: null,
+        subscriptions: [coreSubscription],
       });
 
       const closeModalStub = sinon.stub();
@@ -93,13 +97,12 @@ module('Integration | Component | certification-candidate-details-modal', functi
             @closeModal={{closeModalStub}}
             @showModal={{true}}
             @candidate={{candidate}}
-            @displayComplementaryCertification={{true}}
           />
         </template>,
       );
 
       // then
-      assert.strictEqual(screen.getAllByText('-').length, 13);
+      assert.strictEqual(screen.getAllByText('-').length, 12);
     });
   });
 
@@ -107,6 +110,10 @@ module('Integration | Component | certification-candidate-details-modal', functi
     test('it shows candidate details with payement options', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
+      const coreSubscription = store.createRecord('subscription', {
+        type: 'CORE',
+        complementaryCertificationId: null,
+      });
       const candidate = store.createRecord('certification-candidate', {
         firstName: 'Jean-Paul',
         lastName: 'Candidat',
@@ -123,6 +130,7 @@ module('Integration | Component | certification-candidate-details-modal', functi
         complementaryCertification: null,
         billingMode: 'PREPAID',
         prepaymentCode: 'prep123',
+        subscriptions: [coreSubscription],
       });
 
       const closeModalStub = sinon.stub();
@@ -133,7 +141,6 @@ module('Integration | Component | certification-candidate-details-modal', functi
           <CertificationCandidateDetailsModal
             @closeModal={{closeModalStub}}
             @candidate={{candidate}}
-            @displayComplementaryCertification={{false}}
             @shouldDisplayPaymentOptions={{true}}
           />
         </template>,
@@ -162,6 +169,10 @@ module('Integration | Component | certification-candidate-details-modal', functi
     test('it shows candidate details without payement options', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
+      const coreSubscription = store.createRecord('subscription', {
+        type: 'CORE',
+        complementaryCertificationId: null,
+      });
       const candidate = store.createRecord('certification-candidate', {
         firstName: 'Jean-Paul',
         lastName: 'Candidat',
@@ -178,6 +189,7 @@ module('Integration | Component | certification-candidate-details-modal', functi
         complementaryCertification: null,
         billingMode: 'PREPAID',
         prepaymentCode: 'prep123',
+        subscriptions: [coreSubscription],
       });
 
       const closeModalStub = sinon.stub();
@@ -188,7 +200,6 @@ module('Integration | Component | certification-candidate-details-modal', functi
           <CertificationCandidateDetailsModal
             @closeModal={{closeModalStub}}
             @candidate={{candidate}}
-            @displayComplementaryCertification={{false}}
             @shouldDisplayPaymentOptions={{false}}
           />
         </template>,
@@ -216,7 +227,8 @@ module('Integration | Component | certification-candidate-details-modal', functi
   module('when top close button is clicked', () => {
     test('it closes candidate details modal', async function (assert) {
       // given
-      const candidate = EmberObject.create({});
+      const store = this.owner.lookup('service:store');
+      const candidate = store.createRecord('certification-candidate', { subscriptions: [] });
       const closeModalStub = sinon.stub();
 
       // when
@@ -241,7 +253,8 @@ module('Integration | Component | certification-candidate-details-modal', functi
   module('when bottom close button is clicked', () => {
     test('it also closes candidate details modal', async function (assert) {
       // given
-      const candidate = EmberObject.create({});
+      const store = this.owner.lookup('service:store');
+      const candidate = store.createRecord('certification-candidate', { subscriptions: [] });
       const closeModalStub = sinon.stub();
 
       // when

--- a/certif/tests/integration/components/certification-candidate-details-modal/index-test.gjs
+++ b/certif/tests/integration/components/certification-candidate-details-modal/index-test.gjs
@@ -67,6 +67,55 @@ module('Integration | Component | certification-candidate-details-modal', functi
     assert.dom(screen.getByText('Pix+Edu')).exists();
   });
 
+  test('it shows specific label when candidate subscribed to dual certification core/clea', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const cleaSubscription = store.createRecord('subscription', {
+      type: 'COMPLEMENTARY',
+      complementaryCertificationId: 1,
+    });
+    const coreSubscription = store.createRecord('subscription', {
+      type: 'CORE',
+      complementaryCertificationId: null,
+    });
+    const candidate = store.createRecord('certification-candidate', {
+      firstName: 'Jean-Paul',
+      lastName: 'Candidat',
+      birthCity: 'Eu',
+      birthCountry: 'France',
+      email: 'jeanpauldeu@pix.fr',
+      resultRecipientEmail: 'suric@animal.fr',
+      externalId: '12345',
+      birthdate: '2000-12-25',
+      extraTimePercentage: 0.1,
+      birthInseeCode: 76255,
+      birthPostalCode: 76260,
+      sex: 'F',
+      subscriptions: [cleaSubscription, coreSubscription],
+    });
+
+    const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+      habilitations: [{ id: 1, label: 'Cléanum', key: 'CLEA' }],
+    });
+
+    const closeModalStub = sinon.stub();
+
+    // when
+    const screen = await render(
+      <template>
+        <CertificationCandidateDetailsModal
+          @closeModal={{closeModalStub}}
+          @showModal={{true}}
+          @candidate={{candidate}}
+          @complementaryCertifications={{currentAllowedCertificationCenterAccess.habilitations}}
+        />
+      </template>,
+    );
+
+    // then
+    assert.dom(screen.getByText('Double Certification Pix-CléA Numérique')).exists();
+  });
+
   module('when candidate has missing data', () => {
     test('it displays a dash', async function (assert) {
       // given

--- a/certif/tests/integration/components/certification-candidate-details-modal/index-test.gjs
+++ b/certif/tests/integration/components/certification-candidate-details-modal/index-test.gjs
@@ -1,6 +1,7 @@
 import { render } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
 import CertificationCandidateDetailsModal from 'pix-certif/components/certification-candidate-details-modal';
+import { COMPLEMENTARY_KEYS, SUBSCRIPTION_TYPES } from 'pix-certif/models/subscription';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -13,7 +14,7 @@ module('Integration | Component | certification-candidate-details-modal', functi
     // given
     const store = this.owner.lookup('service:store');
     const pixEduSubscription = store.createRecord('subscription', {
-      type: 'COMPLEMENTARY',
+      type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
       complementaryCertificationId: 1,
     });
     const candidate = store.createRecord('certification-candidate', {
@@ -71,11 +72,11 @@ module('Integration | Component | certification-candidate-details-modal', functi
     // given
     const store = this.owner.lookup('service:store');
     const cleaSubscription = store.createRecord('subscription', {
-      type: 'COMPLEMENTARY',
+      type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
       complementaryCertificationId: 1,
     });
     const coreSubscription = store.createRecord('subscription', {
-      type: 'CORE',
+      type: SUBSCRIPTION_TYPES.CORE,
       complementaryCertificationId: null,
     });
     const candidate = store.createRecord('certification-candidate', {
@@ -95,7 +96,7 @@ module('Integration | Component | certification-candidate-details-modal', functi
     });
 
     const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
-      habilitations: [{ id: 1, label: 'Cléanum', key: 'CLEA' }],
+      habilitations: [{ id: 1, label: 'Cléanum', key: COMPLEMENTARY_KEYS.CLEA }],
     });
 
     const closeModalStub = sinon.stub();
@@ -121,7 +122,7 @@ module('Integration | Component | certification-candidate-details-modal', functi
       // given
       const store = this.owner.lookup('service:store');
       const coreSubscription = store.createRecord('subscription', {
-        type: 'CORE',
+        type: SUBSCRIPTION_TYPES.CORE,
         complementaryCertificationId: null,
       });
       const candidate = store.createRecord('certification-candidate', {
@@ -160,7 +161,7 @@ module('Integration | Component | certification-candidate-details-modal', functi
       // given
       const store = this.owner.lookup('service:store');
       const coreSubscription = store.createRecord('subscription', {
-        type: 'CORE',
+        type: SUBSCRIPTION_TYPES.CORE,
         complementaryCertificationId: null,
       });
       const candidate = store.createRecord('certification-candidate', {
@@ -219,7 +220,7 @@ module('Integration | Component | certification-candidate-details-modal', functi
       // given
       const store = this.owner.lookup('service:store');
       const coreSubscription = store.createRecord('subscription', {
-        type: 'CORE',
+        type: SUBSCRIPTION_TYPES.CORE,
         complementaryCertificationId: null,
       });
       const candidate = store.createRecord('certification-candidate', {

--- a/certif/tests/integration/components/enrolled-candidates-test.js
+++ b/certif/tests/integration/components/enrolled-candidates-test.js
@@ -382,12 +382,13 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
   @certificationCandidates={{this.certificationCandidates}}
   @countries={{this.countries}}
 />`);
-      await click(screen.getByLabelText("Informations concernant l'inscription en certification."));
+      const tooltipLabel = screen.getByText(t('pages.sessions.detail.candidates.list.compatibility-tooltip'), {
+        options: { exact: false },
+      });
+      await click(tooltipLabel);
 
       // then
-      assert
-        .dom(screen.getByText("Le passage des certifications Pix et Pix+ s'effectue dans deux sessions distinctes."))
-        .exists();
+      assert.dom(tooltipLabel).isVisible();
     });
   });
 });

--- a/certif/tests/integration/components/enrolled-candidates-test.js
+++ b/certif/tests/integration/components/enrolled-candidates-test.js
@@ -3,6 +3,7 @@ import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
+import { COMPLEMENTARY_KEYS, SUBSCRIPTION_TYPES } from 'pix-certif/models/subscription';
 import { module, test } from 'qunit';
 
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
@@ -52,9 +53,12 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
   test('it displays candidate information', async function (assert) {
     // given
     const complementaryCertificationId = 2;
-    const coreSubscription = store.createRecord('subscription', { type: 'CORE', complementaryCertificationId: null });
+    const coreSubscription = store.createRecord('subscription', {
+      type: SUBSCRIPTION_TYPES.CORE,
+      complementaryCertificationId: null,
+    });
     const complementarySubscription = store.createRecord('subscription', {
-      type: 'COMPLEMENTARY',
+      type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
       complementaryCertificationId,
     });
     const candidate = _buildCertificationCandidate({
@@ -99,9 +103,12 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
   test('it displays specific subscription text when candidate subscribed to dual certification core/clea', async function (assert) {
     // given
     const cleaCertificationId = 2;
-    const coreSubscription = store.createRecord('subscription', { type: 'CORE', complementaryCertificationId: null });
+    const coreSubscription = store.createRecord('subscription', {
+      type: SUBSCRIPTION_TYPES.CORE,
+      complementaryCertificationId: null,
+    });
     const complementarySubscription = store.createRecord('subscription', {
-      type: 'COMPLEMENTARY',
+      type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
       complementaryCertificationId: cleaCertificationId,
     });
     const candidate = _buildCertificationCandidate({
@@ -111,7 +118,7 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
     const complementaryCertification = {
       id: cleaCertificationId,
       label: 'cléa num',
-      key: 'CLEA',
+      key: COMPLEMENTARY_KEYS.CLEA,
     };
 
     const countries = store.createRecord('country', { name: 'CANADA', code: 99401 });

--- a/certif/tests/integration/components/enrolled-candidates-test.js
+++ b/certif/tests/integration/components/enrolled-candidates-test.js
@@ -21,6 +21,7 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
     //given
     const candidate = _buildCertificationCandidate({
       birthdate: new Date('2019-04-28'),
+      subscriptions: [],
     });
 
     const certificationCandidate = store.createRecord('certification-candidate', candidate);
@@ -48,12 +49,19 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
 
   test('it displays candidate information', async function (assert) {
     // given
+    const complementaryCertificationId = 2;
+    const coreSubscription = store.createRecord('subscription', { type: 'CORE', complementaryCertificationId: null });
+    const complementarySubscription = store.createRecord('subscription', {
+      type: 'COMPLEMENTARY',
+      complementaryCertificationId,
+    });
     this.set('displayComplementaryCertification', true);
     const candidate = _buildCertificationCandidate({
       birthdate: new Date('2019-04-28'),
+      subscriptions: [coreSubscription, complementarySubscription],
     });
     const complementaryCertification = {
-      id: 2,
+      id: complementaryCertificationId,
       label: 'Pix+Droit',
     };
 
@@ -82,6 +90,7 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
     assert.dom(screen.getByRole('cell', { name: certificationCandidate.resultRecipientEmail })).exists();
     assert.dom(screen.getByRole('cell', { name: '30 %' })).exists();
     assert.dom(screen.getByRole('cell', { name: 'Pix+Droit' })).exists();
+    assert.dom(screen.getByRole('cell', { name: 'Certification Pix, Pix+Droit' })).exists();
     assert.dom(screen.queryByRole('cell', { name: certificationCandidate.birthCity })).doesNotExist();
     assert.dom(screen.queryByRole('cell', { name: certificationCandidate.birthProvinceCode })).doesNotExist();
     assert.dom(screen.queryByRole('cell', { name: certificationCandidate.birthCountry })).doesNotExist();
@@ -93,6 +102,7 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
     this.set('displayComplementaryCertification', true);
     const candidate = _buildCertificationCandidate({
       complementaryCertification: null,
+      subscriptions: [],
     });
 
     const countries = store.createRecord('country', { name: 'CANADA', code: 99401 });
@@ -115,7 +125,9 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
 
   test('it should display details button', async function (assert) {
     // given
-    const candidate = _buildCertificationCandidate({});
+    const candidate = _buildCertificationCandidate({
+      subscriptions: [],
+    });
     const certificationCandidates = [candidate];
     const countries = store.createRecord('country', { name: 'CANADA', code: 99401 });
 
@@ -140,9 +152,9 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
   test('it display candidates with delete disabled button if linked', async function (assert) {
     // given
     const certificationCandidates = [
-      _buildCertificationCandidate({ firstName: 'Riri', lastName: 'Duck', isLinked: false }),
-      _buildCertificationCandidate({ firstName: 'Fifi', lastName: 'Duck', isLinked: true }),
-      _buildCertificationCandidate({ firstName: 'Loulou', lastName: 'Duck', isLinked: false }),
+      _buildCertificationCandidate({ firstName: 'Riri', lastName: 'Duck', isLinked: false, subscriptions: [] }),
+      _buildCertificationCandidate({ firstName: 'Fifi', lastName: 'Duck', isLinked: true, subscriptions: [] }),
+      _buildCertificationCandidate({ firstName: 'Loulou', lastName: 'Duck', isLinked: false, subscriptions: [] }),
     ];
     const countries = store.createRecord('country', { name: 'CANADA', code: 99401 });
 
@@ -175,6 +187,7 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
       const candidate = _buildCertificationCandidate({
         billingMode: 'PREPAID',
         prepaymentCode: 'CODE01',
+        subscriptions: [],
       });
 
       const certificationCandidate = store.createRecord('certification-candidate', candidate);
@@ -256,7 +269,9 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
   ].forEach(({ shouldDisplayPrescriptionScoStudentRegistrationFeature, shouldColumnsBeEmpty, it }) =>
     test(it, async function (assert) {
       // given
-      const candidate = _buildCertificationCandidate({});
+      const candidate = _buildCertificationCandidate({
+        subscriptions: [],
+      });
       const countries = store.createRecord('country', { name: 'CANADA', code: 99401 });
 
       this.set('countries', [countries]);
@@ -305,6 +320,7 @@ function _buildCertificationCandidate({
   },
   billingMode = null,
   prepaymentCode = null,
+  subscriptions,
 }) {
   return {
     id,
@@ -322,5 +338,6 @@ function _buildCertificationCandidate({
     complementaryCertification,
     billingMode,
     prepaymentCode,
+    subscriptions,
   };
 }

--- a/certif/tests/integration/components/enrolled-candidates-test.js
+++ b/certif/tests/integration/components/enrolled-candidates-test.js
@@ -55,7 +55,6 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
       type: 'COMPLEMENTARY',
       complementaryCertificationId,
     });
-    this.set('displayComplementaryCertification', true);
     const candidate = _buildCertificationCandidate({
       birthdate: new Date('2019-04-28'),
       subscriptions: [coreSubscription, complementarySubscription],
@@ -77,7 +76,6 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
       hbs`<EnrolledCandidates
   @sessionId='1'
   @certificationCandidates={{this.certificationCandidates}}
-  @displayComplementaryCertification={{this.displayComplementaryCertification}}
   @countries={{this.countries}}
   @complementaryCertifications={{this.complementaryCertifications}}
 />`,
@@ -89,38 +87,11 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
     assert.dom(screen.getByRole('cell', { name: certificationCandidate.firstName })).exists();
     assert.dom(screen.getByRole('cell', { name: certificationCandidate.resultRecipientEmail })).exists();
     assert.dom(screen.getByRole('cell', { name: '30 %' })).exists();
-    assert.dom(screen.getByRole('cell', { name: 'Pix+Droit' })).exists();
     assert.dom(screen.getByRole('cell', { name: 'Certification Pix, Pix+Droit' })).exists();
     assert.dom(screen.queryByRole('cell', { name: certificationCandidate.birthCity })).doesNotExist();
     assert.dom(screen.queryByRole('cell', { name: certificationCandidate.birthProvinceCode })).doesNotExist();
     assert.dom(screen.queryByRole('cell', { name: certificationCandidate.birthCountry })).doesNotExist();
     assert.dom(screen.queryByRole('cell', { name: certificationCandidate.email })).doesNotExist();
-  });
-
-  test('it displays a dash where there is no certification', async function (assert) {
-    // given
-    this.set('displayComplementaryCertification', true);
-    const candidate = _buildCertificationCandidate({
-      complementaryCertification: null,
-      subscriptions: [],
-    });
-
-    const countries = store.createRecord('country', { name: 'CANADA', code: 99401 });
-    const certificationCandidate = store.createRecord('certification-candidate', candidate);
-
-    this.set('certificationCandidates', [certificationCandidate]);
-    this.set('countries', [countries]);
-
-    // when
-    const screen = await renderScreen(hbs`<EnrolledCandidates
-  @sessionId='1'
-  @certificationCandidates={{this.certificationCandidates}}
-  @displayComplementaryCertification={{this.displayComplementaryCertification}}
-  @countries={{this.countries}}
-/>`);
-
-    // then
-    assert.dom(screen.getByRole('cell', { name: '-' })).exists();
   });
 
   test('it should display details button', async function (assert) {

--- a/certif/tests/unit/controllers/authenticated/sessions/details/certification-candidates-test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/details/certification-candidates-test.js
@@ -38,34 +38,6 @@ module('Unit | Controller | authenticated/sessions/details/certification-candida
     });
   });
 
-  module('#get shouldDisplayComplementaryCertificationsHabilitations', function () {
-    test('should return false if center has no complementary certification habilitation', function (assert) {
-      // given
-      _stubCurrentCenter(this, store, { habilitations: [] });
-      const controller = this.owner.lookup('controller:authenticated/sessions/details/certification-candidates');
-
-      // when
-      const shouldDisplayComplementaryCertificationsHabilitations =
-        controller.shouldDisplayComplementaryCertificationsHabilitations;
-
-      // then
-      assert.false(shouldDisplayComplementaryCertificationsHabilitations);
-    });
-
-    test('should return true and center has complementary certifications', function (assert) {
-      // given
-      _stubCurrentCenter(this, store, { habilitations: ['Pix+Edu'] });
-      const controller = this.owner.lookup('controller:authenticated/sessions/details/certification-candidates');
-
-      // when
-      const shouldDisplayComplementaryCertificationsHabilitations =
-        controller.shouldDisplayComplementaryCertificationsHabilitations;
-
-      // then
-      assert.true(shouldDisplayComplementaryCertificationsHabilitations);
-    });
-  });
-
   module('#get shouldDisplayPaymentOptions', function () {
     test('should return false if center is sco', function (assert) {
       // given

--- a/certif/tests/unit/models/certification-candidate-test.js
+++ b/certif/tests/unit/models/certification-candidate-test.js
@@ -1,5 +1,6 @@
 import { setupTest } from 'ember-qunit';
 import pick from 'lodash/pick';
+import { COMPLEMENTARY_KEYS, SUBSCRIPTION_TYPES } from 'pix-certif/models/subscription';
 import { module, test } from 'qunit';
 
 import setupIntlForModels from '../../helpers/setup-intl';
@@ -109,15 +110,15 @@ module('Unit | Model | certification-candidate', function (hooks) {
         {
           id: 123,
           label: 'Certif cléa',
-          key: 'CLEA',
+          key: COMPLEMENTARY_KEYS.CLEA,
         },
       ];
       const coreSubscription = store.createRecord('subscription', {
-        type: 'CORE',
+        type: SUBSCRIPTION_TYPES.CORE,
         complementaryCertificationId: null,
       });
       const cleaSubscription = store.createRecord('subscription', {
-        type: 'COMPLEMENTARY',
+        type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
         complementaryCertificationId: 123,
       });
       const candidate = store.createRecord('certification-candidate', {
@@ -140,15 +141,15 @@ module('Unit | Model | certification-candidate', function (hooks) {
         {
           id: cleaId,
           label: 'Certif cléa',
-          key: 'CLEA',
+          key: COMPLEMENTARY_KEYS.CLEA,
         },
       ];
       const coreSubscription = store.createRecord('subscription', {
-        type: 'CORE',
+        type: SUBSCRIPTION_TYPES.CORE,
         complementaryCertificationId: null,
       });
       const otherSubscription = store.createRecord('subscription', {
-        type: 'COMPLEMENTARY',
+        type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
         complementaryCertificationId: notCleaId,
       });
       const candidate = store.createRecord('certification-candidate', {
@@ -169,11 +170,11 @@ module('Unit | Model | certification-candidate', function (hooks) {
         {
           id: 123,
           label: 'Certif cléa',
-          key: 'CLEA',
+          key: COMPLEMENTARY_KEYS.CLEA,
         },
       ];
       const cleaSubscription = store.createRecord('subscription', {
-        type: 'COMPLEMENTARY',
+        type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
         complementaryCertificationId: 123,
       });
       const candidate = store.createRecord('certification-candidate', {

--- a/certif/tests/unit/models/certification-candidate-test.js
+++ b/certif/tests/unit/models/certification-candidate-test.js
@@ -101,6 +101,91 @@ module('Unit | Model | certification-candidate', function (hooks) {
     });
   });
 
+  module('hasDualCertificationSubscriptionCoreClea', function () {
+    test('it should return true when candidate has subscribed to both clea and core', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const habilitations = [
+        {
+          id: 123,
+          label: 'Certif cléa',
+          key: 'CLEA',
+        },
+      ];
+      const coreSubscription = store.createRecord('subscription', {
+        type: 'CORE',
+        complementaryCertificationId: null,
+      });
+      const cleaSubscription = store.createRecord('subscription', {
+        type: 'COMPLEMENTARY',
+        complementaryCertificationId: 123,
+      });
+      const candidate = store.createRecord('certification-candidate', {
+        subscriptions: [coreSubscription, cleaSubscription],
+      });
+
+      // when
+      const hasDual = candidate.hasDualCertificationSubscriptionCoreClea(habilitations);
+
+      // then
+      assert.true(hasDual);
+    });
+
+    test('it should return false when candidate has subscribed to core but not clea', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const habilitations = [
+        {
+          id: 123,
+          label: 'Certif cléa',
+          key: 'CLEA',
+        },
+      ];
+      const coreSubscription = store.createRecord('subscription', {
+        type: 'CORE',
+        complementaryCertificationId: null,
+      });
+      const otherSubscription = store.createRecord('subscription', {
+        type: 'COMPLEMENTARY',
+        complementaryCertificationId: 124,
+      });
+      const candidate = store.createRecord('certification-candidate', {
+        subscriptions: [coreSubscription, otherSubscription],
+      });
+
+      // when
+      const hasDual = candidate.hasDualCertificationSubscriptionCoreClea(habilitations);
+
+      // then
+      assert.false(hasDual);
+    });
+
+    test('it should return false when candidate has subscribed to clea but not core', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const habilitations = [
+        {
+          id: 123,
+          label: 'Certif cléa',
+          key: 'CLEA',
+        },
+      ];
+      const cleaSubscription = store.createRecord('subscription', {
+        type: 'COMPLEMENTARY',
+        complementaryCertificationId: 123,
+      });
+      const candidate = store.createRecord('certification-candidate', {
+        subscriptions: [cleaSubscription],
+      });
+
+      // when
+      const hasDual = candidate.hasDualCertificationSubscriptionCoreClea(habilitations);
+
+      // then
+      assert.false(hasDual);
+    });
+  });
+
   function _pickModelData(certificationCandidate) {
     return pick(certificationCandidate, [
       'firstName',

--- a/certif/tests/unit/models/certification-candidate-test.js
+++ b/certif/tests/unit/models/certification-candidate-test.js
@@ -134,9 +134,11 @@ module('Unit | Model | certification-candidate', function (hooks) {
     test('it should return false when candidate has subscribed to core but not clea', function (assert) {
       // given
       const store = this.owner.lookup('service:store');
+      const cleaId = 123;
+      const notCleaId = 124;
       const habilitations = [
         {
-          id: 123,
+          id: cleaId,
           label: 'Certif cléa',
           key: 'CLEA',
         },
@@ -147,7 +149,7 @@ module('Unit | Model | certification-candidate', function (hooks) {
       });
       const otherSubscription = store.createRecord('subscription', {
         type: 'COMPLEMENTARY',
-        complementaryCertificationId: 124,
+        complementaryCertificationId: notCleaId,
       });
       const candidate = store.createRecord('certification-candidate', {
         subscriptions: [coreSubscription, otherSubscription],

--- a/certif/tests/unit/models/subscription-test.js
+++ b/certif/tests/unit/models/subscription-test.js
@@ -1,4 +1,5 @@
 import { setupTest } from 'ember-qunit';
+import { COMPLEMENTARY_KEYS, SUBSCRIPTION_TYPES } from 'pix-certif/models/subscription';
 import { module, test } from 'qunit';
 
 import setupIntlForModels from '../../helpers/setup-intl';
@@ -15,11 +16,11 @@ module('Unit | Model | subscription', function (hooks) {
         {
           id: 123,
           label: 'Certif cléa',
-          key: 'CLEA',
+          key: COMPLEMENTARY_KEYS.CLEA,
         },
       ];
       const cleaSubscription = store.createRecord('subscription', {
-        type: 'COMPLEMENTARY',
+        type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
         complementaryCertificationId: 123,
       });
 
@@ -39,11 +40,11 @@ module('Unit | Model | subscription', function (hooks) {
         {
           id: cleaId,
           label: 'Certif cléa',
-          key: 'CLEA',
+          key: COMPLEMENTARY_KEYS.CLEA,
         },
       ];
       const otherSubscription = store.createRecord('subscription', {
-        type: 'COMPLEMENTARY',
+        type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
         complementaryCertificationId: notCleaId,
       });
 
@@ -61,11 +62,11 @@ module('Unit | Model | subscription', function (hooks) {
         {
           id: 123,
           label: 'Certif cléa',
-          key: 'CLEA',
+          key: COMPLEMENTARY_KEYS.CLEA,
         },
       ];
       const coreSubscription = store.createRecord('subscription', {
-        type: 'CORE',
+        type: SUBSCRIPTION_TYPES.CORE,
         complementaryCertificationId: null,
       });
 
@@ -82,7 +83,7 @@ module('Unit | Model | subscription', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
       const coreSubscription = store.createRecord('subscription', {
-        type: 'CORE',
+        type: SUBSCRIPTION_TYPES.CORE,
         complementaryCertificationId: null,
       });
 
@@ -97,7 +98,7 @@ module('Unit | Model | subscription', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
       const otherSubscription = store.createRecord('subscription', {
-        type: 'COMPLEMENTARY',
+        type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
         complementaryCertificationId: 123,
       });
 

--- a/certif/tests/unit/models/subscription-test.js
+++ b/certif/tests/unit/models/subscription-test.js
@@ -1,0 +1,77 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import setupIntlForModels from '../../helpers/setup-intl';
+
+module('Unit | Model | subscription', function (hooks) {
+  setupTest(hooks);
+  setupIntlForModels(hooks);
+
+  module('isClea', function () {
+    test('it should return true when subscription is CLEA', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const habilitations = [
+        {
+          id: 123,
+          label: 'Certif cléa',
+          key: 'CLEA',
+        },
+      ];
+      const cleaSubscription = store.createRecord('subscription', {
+        type: 'COMPLEMENTARY',
+        complementaryCertificationId: 123,
+      });
+
+      // when
+      const isClea = cleaSubscription.isClea(habilitations);
+
+      // then
+      assert.true(isClea);
+    });
+
+    test('it should return false when subscription is complementary but not CLEA', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const habilitations = [
+        {
+          id: 123,
+          label: 'Certif cléa',
+          key: 'CLEA',
+        },
+      ];
+      const otherSubscription = store.createRecord('subscription', {
+        type: 'COMPLEMENTARY',
+        complementaryCertificationId: 124,
+      });
+
+      // when
+      const isClea = otherSubscription.isClea(habilitations);
+
+      // then
+      assert.false(isClea);
+    });
+
+    test('it should return false when subscription is CORE', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const habilitations = [
+        {
+          id: 123,
+          label: 'Certif cléa',
+          key: 'CLEA',
+        },
+      ];
+      const coreSubscription = store.createRecord('subscription', {
+        type: 'CORE',
+        complementaryCertificationId: null,
+      });
+
+      // when
+      const isClea = coreSubscription.isClea(habilitations);
+
+      // then
+      assert.false(isClea);
+    });
+  });
+});

--- a/certif/tests/unit/models/subscription-test.js
+++ b/certif/tests/unit/models/subscription-test.js
@@ -33,16 +33,18 @@ module('Unit | Model | subscription', function (hooks) {
     test('it should return false when subscription is complementary but not CLEA', function (assert) {
       // given
       const store = this.owner.lookup('service:store');
+      const cleaId = 123;
+      const notCleaId = 124;
       const habilitations = [
         {
-          id: 123,
+          id: cleaId,
           label: 'Certif cléa',
           key: 'CLEA',
         },
       ];
       const otherSubscription = store.createRecord('subscription', {
         type: 'COMPLEMENTARY',
-        complementaryCertificationId: 124,
+        complementaryCertificationId: notCleaId,
       });
 
       // when
@@ -72,6 +74,38 @@ module('Unit | Model | subscription', function (hooks) {
 
       // then
       assert.false(isClea);
+    });
+  });
+
+  module('get isCore', function () {
+    test('it should return true when subscription is CORE', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const coreSubscription = store.createRecord('subscription', {
+        type: 'CORE',
+        complementaryCertificationId: null,
+      });
+
+      // when
+      const isCore = coreSubscription.isCore;
+
+      // then
+      assert.true(isCore);
+    });
+
+    test('it should return false when subscription is not core', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const otherSubscription = store.createRecord('subscription', {
+        type: 'COMPLEMENTARY',
+        complementaryCertificationId: 123,
+      });
+
+      // when
+      const isCore = otherSubscription.isCore;
+
+      // then
+      assert.false(isCore);
     });
   });
 });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -595,7 +595,8 @@
             "compatibility-tooltip-arialabel": "Information regarding candidate enrolment",
             "empty": "Awaiting candidates",
             "subscriptions": {
-              "core": "Pix Certification"
+              "core": "Pix Certification",
+              "dual-core-clea": "Dual Certification Pix-CléA Numérique"
             },
             "with-details-description": "List of candidates enrolled in the session, ordered by birth name, with a link to see the candidate’s details and the possibility to delete a candidate in the last column.",
             "without-details-description": "List of candidates enrolled in the session, ordered by birth name, with the possibility to delete a candidate in the last column."

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -110,7 +110,8 @@
         "extratime": "Extra time",
         "extratime-percentage": "Extra time (%)",
         "prepayment-code": "Prepayment code",
-        "pricing": "Pricing of Pix’s share"
+        "pricing": "Pricing of Pix’s share",
+        "selected-subscriptions": "Selected certification"
       },
       "login": {
         "choose-language-aria-label": "Select a language",
@@ -590,7 +591,12 @@
                 "label": "Enrol candidates"
               }
             },
+            "compatibility-tooltip": "The Pix and Pix+ certifications can only be taken in two separate sessions.",
+            "compatibility-tooltip-arialabel": "Information regarding candidate enrolment",
             "empty": "Awaiting candidates",
+            "subscriptions": {
+              "core": "Pix Certification"
+            },
             "with-details-description": "List of candidates enrolled in the session, ordered by birth name, with a link to see the candidate’s details and the possibility to delete a candidate in the last column.",
             "without-details-description": "List of candidates enrolled in the session, ordered by birth name, with the possibility to delete a candidate in the last column."
           },

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -110,7 +110,8 @@
         "extratime": "Temps majoré",
         "extratime-percentage": "Temps majoré (%)",
         "prepayment-code": "Code de prépaiement",
-        "pricing": "Tarification part Pix"
+        "pricing": "Tarification part Pix",
+        "selected-subscriptions": "Certification sélectionnée"
       },
       "login": {
         "choose-language-aria-label": "Sélectionnez une langue",
@@ -590,7 +591,12 @@
                 "label": "Inscrire des candidats"
               }
             },
+            "compatibility-tooltip": "Le passage des certifications Pix et Pix+ s'effectue dans deux sessions distinctes.",
+            "compatibility-tooltip-arialabel": "Informations concernant l'inscription en certification.",
             "empty": "En attente de candidats",
+            "subscriptions": {
+              "core": "Certification Pix"
+            },
             "with-details-description": "Liste des candidats inscrits à la session, triée par nom de naissance, avec un lien pour voir les détails du candidat et la possibilité de supprimer un candidat dans la dernière colonne.",
             "without-details-description": "Liste des candidats inscrits à la session, triée par nom de naissance, avec la possibilité de supprimer un candidat dans la dernière colonne."
           },

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -595,7 +595,8 @@
             "compatibility-tooltip-arialabel": "Informations concernant l'inscription en certification.",
             "empty": "En attente de candidats",
             "subscriptions": {
-              "core": "Certification Pix"
+              "core": "Certification Pix",
+              "dual-core-clea": "Double Certification Pix-CléA Numérique"
             },
             "with-details-description": "Liste des candidats inscrits à la session, triée par nom de naissance, avec un lien pour voir les détails du candidat et la possibilité de supprimer un candidat dans la dernière colonne.",
             "without-details-description": "Liste des candidats inscrits à la session, triée par nom de naissance, avec la possibilité de supprimer un candidat dans la dernière colonne."


### PR DESCRIPTION
## :unicorn: Problème
En vue de la compatibilité coeur/complémentaire, on souhaite expliciter le fait de s'inscrire simplement en coeur ou en complémentaire.
Aujourd'hui, cette info n'est pas claire dans le tableau des candidats et dans la modale de détails.

## :robot: Proposition
Remplacer la colonne conditionnelle "Certification complémentaire" par une colonne permanente "Certification sélectionnée".
Cette colonne va fonctionner pour les sessions du passé (plusieurs subscriptions) et pour les sessions post 4 novembre (inscription individuelle).

## :rainbow: Remarques

## :100: Pour tester
Tester les affichages sur la liste de candidats ET détails d'un candidat
