### PR TITLE
[FEATURE] Supporte des petits différences dans le nom / prénom lors de la réconciliation (PIX-13626)

### DIFF
--- a/api/src/prescription/learner-management/domain/usecases/index.js
+++ b/api/src/prescription/learner-management/domain/usecases/index.js
@@ -1,6 +1,7 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import * as userReconciliationService from '../../../../../lib/domain/services/user-reconciliation-service.js';
 import * as campaignRepository from '../../../../../lib/infrastructure/repositories/campaign-repository.js';
 import * as membershipRepository from '../../../../../lib/infrastructure/repositories/membership-repository.js';
 import * as organizationFeatureApi from '../../../../organizational-entities/application/api/organization-features-api.js';
@@ -13,6 +14,7 @@ import * as organizationLearnerImportFormatRepository from '../../infrastructure
 import * as organizationLearnerRepository from '../../infrastructure/repositories/organization-learner-repository.js';
 import * as supOrganizationLearnerRepository from '../../infrastructure/repositories/sup-organization-learner-repository.js';
 import { importStorage } from '../../infrastructure/storage/import-storage.js';
+
 const dependencies = {
   campaignRepository,
   campaignParticipationRepository,
@@ -24,6 +26,7 @@ const dependencies = {
   organizationImportRepository,
   supOrganizationLearnerRepository,
   organizationFeatureApi,
+  userReconciliationService,
 };
 
 const path = dirname(fileURLToPath(import.meta.url));

--- a/api/src/prescription/learner-management/domain/usecases/reconcile-common-organization-learner.js
+++ b/api/src/prescription/learner-management/domain/usecases/reconcile-common-organization-learner.js
@@ -60,8 +60,8 @@ const reconcileCommonOrganizationLearner = async function ({
 
   const learnerToReconcile = matchingLearners.find((matchingLearner) => matchingLearner.id === learnerId);
 
-  learnerToReconcile.reconcileUser(userId);
-  organizationLearnerRepository.update(learnerToReconcile);
+  await learnerToReconcile.reconcileUser(userId);
+  await organizationLearnerRepository.update(learnerToReconcile);
 };
 
 export { reconcileCommonOrganizationLearner };

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
@@ -113,16 +113,8 @@ const findAllCommonOrganizationLearnerByReconciliationInfos = async function ({
     .select('firstName', 'lastName', 'id', 'attributes', 'userId')
     .where({ organizationId, isDisabled: false });
 
-  if (reconciliationInformations.attributes) {
-    query.whereJsonSupersetOf('attributes', reconciliationInformations.attributes);
-  }
-
-  if (reconciliationInformations.firstName) {
-    query.where('firstName', reconciliationInformations.firstName);
-  }
-
-  if (reconciliationInformations.lastName) {
-    query.where('lastName', reconciliationInformations.lastName);
+  if (reconciliationInformations) {
+    query.whereJsonSupersetOf('attributes', reconciliationInformations);
   }
 
   const result = await query;

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -1317,9 +1317,9 @@ describe('Integration | Repository | Organization Learner Management | Organizat
     });
 
     describe('matching cases', function () {
-      it('if use only attributes data to reconcile user to the correct learner', async function () {
+      it('if use attributes data to match users', async function () {
         // given
-        const organizationLeaner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+        const organizationLearner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
           firstName: 'Amandine',
           lastName: 'AheurFix',
           attributes: {
@@ -1336,148 +1336,60 @@ describe('Integration | Repository | Organization Learner Management | Organizat
         const matchingLearner = await findAllCommonOrganizationLearnerByReconciliationInfos({
           organizationId,
           reconciliationInformations: {
-            attributes: {
-              hobby: 'manger',
-              'date de naissance': '2021-01-01',
-            },
-          },
-        });
-
-        // then
-        expect(matchingLearner).to.deep.equal([
-          new CommonOrganizationLearner({
-            firstName: organizationLeaner.firstName,
-            lastName: organizationLeaner.lastName,
-            organizationId: organizationLeaner.organizationId,
-            id: organizationLeaner.id,
-            ...organizationLeaner.attributes,
-          }),
-        ]);
-      });
-
-      it('if use attributes and firstName to reconcile user to the correct learner', async function () {
-        // given
-        const organizationLeaner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
-          firstName: 'Amandine',
-          lastName: 'AheurFix',
-          attributes: {
-            'date de naissance': '2021-01-01',
             hobby: 'manger',
-          },
-          userId: null,
-          organizationId,
-        });
-
-        await databaseBuilder.commit();
-
-        // when
-        const matchingLearner = await findAllCommonOrganizationLearnerByReconciliationInfos({
-          organizationId,
-          reconciliationInformations: {
-            firstName: organizationLeaner.firstName,
-            attributes: {
-              hobby: 'manger',
-            },
-          },
-        });
-
-        // then
-        expect(matchingLearner).to.deep.equal([
-          new CommonOrganizationLearner({
-            firstName: organizationLeaner.firstName,
-            lastName: organizationLeaner.lastName,
-            organizationId: organizationLeaner.organizationId,
-            id: organizationLeaner.id,
-            ...organizationLeaner.attributes,
-          }),
-        ]);
-      });
-
-      it('if use attributes and lastName to reconcile user to the correct learner', async function () {
-        // given
-        const organizationLeaner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
-          firstName: 'Edgar',
-          lastName: 'AheurFix',
-          attributes: {
             'date de naissance': '2021-01-01',
-            hobby: 'manger',
-          },
-          userId: null,
-          organizationId,
-        });
-
-        await databaseBuilder.commit();
-
-        // when
-        const matchingLearner = await findAllCommonOrganizationLearnerByReconciliationInfos({
-          organizationId,
-          reconciliationInformations: {
-            lastName: organizationLeaner.lastName,
-            attributes: {
-              'date de naissance': '2021-01-01',
-            },
           },
         });
 
         // then
         expect(matchingLearner).to.deep.equal([
           new CommonOrganizationLearner({
-            firstName: organizationLeaner.firstName,
-            lastName: organizationLeaner.lastName,
-            organizationId: organizationLeaner.organizationId,
-            id: organizationLeaner.id,
-            ...organizationLeaner.attributes,
-          }),
-        ]);
-      });
-
-      it('if use lasntName and firstName to reconcile user to the correct learner', async function () {
-        // given
-        const organizationLeaner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
-          firstName: 'Amandine',
-          lastName: 'AheurFix',
-          attributes: {
-            'date de naissance': '2021-01-01',
-            hobby: 'manger',
-          },
-          userId: null,
-          organizationId,
-        });
-
-        await databaseBuilder.commit();
-
-        // when
-        const matchingLearner = await findAllCommonOrganizationLearnerByReconciliationInfos({
-          organizationId,
-          reconciliationInformations: {
-            firstName: organizationLeaner.firstName,
-            lastName: organizationLeaner.lastName,
-          },
-        });
-
-        // then
-        expect(matchingLearner).to.deep.equal([
-          new CommonOrganizationLearner({
-            firstName: organizationLeaner.firstName,
-            lastName: organizationLeaner.lastName,
-            organizationId: organizationLeaner.organizationId,
-            id: organizationLeaner.id,
-            ...organizationLeaner.attributes,
+            firstName: organizationLearner.firstName,
+            lastName: organizationLearner.lastName,
+            organizationId: organizationLearner.organizationId,
+            id: organizationLearner.id,
+            ...organizationLearner.attributes,
           }),
         ]);
       });
     });
 
     describe('no matching cases', function () {
-      it('if learner is in another organization', async function () {
+      it('if learner has no matching infos', async function () {
         // given
-        const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
-        const organizationLeaner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+        databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
           firstName: 'Amandine',
           lastName: 'AheurFix',
           attributes: {
             'date de naissance': '2020-01-01',
-            hobby: 'manger',
+            hobby: 'Attendre',
+          },
+          organizationId,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const matchingLearner = await findAllCommonOrganizationLearnerByReconciliationInfos({
+          organizationId,
+          reconciliationInformations: {
+            hobby: 'Rire',
+          },
+        });
+
+        // then
+        expect(matchingLearner).to.deep.equal([]);
+      });
+
+      it('if learner is in another organization', async function () {
+        // given
+        const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+        databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+          firstName: 'Amandine',
+          lastName: 'AheurFix',
+          attributes: {
+            'date de naissance': '2020-01-01',
+            hobby: 'Attendre',
           },
           organizationId: otherOrganizationId,
         });
@@ -1488,10 +1400,7 @@ describe('Integration | Repository | Organization Learner Management | Organizat
         const matchingLearner = await findAllCommonOrganizationLearnerByReconciliationInfos({
           organizationId,
           reconciliationInformations: {
-            firstName: organizationLeaner.firstName,
-            attributes: {
-              hobby: 'manger',
-            },
+            hobby: 'Attendre',
           },
         });
 
@@ -1501,13 +1410,13 @@ describe('Integration | Repository | Organization Learner Management | Organizat
 
       it('if learner is deleted', async function () {
         // given
-        const organizationLeaner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+        databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
           firstName: 'Amandine',
           lastName: 'AheurFix',
           deletedAt: new Date('2020-01-01'),
           attributes: {
             'date de naissance': '2020-01-01',
-            hobby: 'manger',
+            hobby: 'Attendre',
           },
           organizationId,
         });
@@ -1518,10 +1427,7 @@ describe('Integration | Repository | Organization Learner Management | Organizat
         const matchingLearner = await findAllCommonOrganizationLearnerByReconciliationInfos({
           organizationId,
           reconciliationInformations: {
-            firstName: organizationLeaner.firstName,
-            attributes: {
-              hobby: 'manger',
-            },
+            hobby: 'Attendre',
           },
         });
 
@@ -1531,13 +1437,13 @@ describe('Integration | Repository | Organization Learner Management | Organizat
 
       it('if learner is disabled', async function () {
         // given
-        const organizationLeaner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+        databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
           firstName: 'Amandine',
           lastName: 'AheurFix',
           isDisabled: true,
           attributes: {
             'date de naissance': '2020-01-01',
-            hobby: 'manger',
+            hobby: 'Attendre',
           },
           organizationId,
         });
@@ -1548,10 +1454,8 @@ describe('Integration | Repository | Organization Learner Management | Organizat
         const matchingLearner = await findAllCommonOrganizationLearnerByReconciliationInfos({
           organizationId,
           reconciliationInformations: {
-            firstName: organizationLeaner.firstName,
-            attributes: {
-              hobby: 'manger',
-            },
+            'date de naissance': '2020-01-01',
+            hobby: 'Attendre',
           },
         });
 


### PR DESCRIPTION
## :unicorn: Problème
Lors de la réconciliation d'un prescrit issu d'un import à format, l'utilisateur est obligé de saisir strictement le même prénom / nom que celui renseigné lors de l'import. 

## :robot: Proposition
Utiliser la service de réconciliation qui permet d'identifier le bon prescrit en supportant les petites erreurs typographiques tels des changement d'accents, de casse et de petites typo

## :rainbow: Remarques
On a modifier la méthode `findAllCommonOrganizationLearnerByReconciliationInfos` pour quelle ne base plus sur le nom / prénom mais seulement sur les infos de réconciliations pour ensuite que ce soit le service de réconciliation qui identifie le bon prescrit.

## :100: Pour tester
**Sur orga**:
- Faire un import avec le fichier Generic_import
- Voir `Odile De ré` dans la liste des prescrits
 **Sur MonPix**:
- Se connecter avec learneremail1005_1@example.net
- cliquer sur j'ai un code
- entrer `PROGENCOL`
- Saisir des infos de réconciliations 
  - prénom "odile"
  - nom "de re"
  - date de naissance : "25/09/1999"