### PR TITLE
[BUGFIX] corrige le format d'import sco fwb (PIX-13807)

### DIFF
--- a/api/db/migrations/20240808094545_fix-sco-fwb-import-format.js
+++ b/api/db/migrations/20240808094545_fix-sco-fwb-import-format.js
@@ -1,0 +1,91 @@
+import { IMPORT_KEY_FIELD } from '../../src/prescription/learner-management/domain/constants.js';
+
+const importFormatName = 'SCO-FWB';
+
+const up = async function (knex) {
+  await knex('organization-learner-import-formats')
+    .where({ name: importFormatName })
+    .update({
+      config: {
+        acceptedEncoding: ['utf8'],
+        unicityColumns: ['Nom', 'Prénom', 'Date de naissance (jj/mm/aaaa)'],
+        reconciliationMappingColumns: [
+          { key: 1, fieldId: 'reconcileField1', name: IMPORT_KEY_FIELD.COMMON_LASTNAME, position: 1 },
+          { key: 2, fieldId: 'reconcileField2', name: IMPORT_KEY_FIELD.COMMON_FIRSTNAME, position: 2 },
+          { key: 3, fieldId: 'reconcileField3', name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE, position: 3 },
+        ],
+        displayableColumns: [
+          {
+            key: 3,
+            position: 1,
+            name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE,
+          },
+          {
+            key: 4,
+            position: 2,
+            name: IMPORT_KEY_FIELD.COMMON_DIVISION,
+          },
+        ],
+        validationRules: {
+          formats: [
+            { key: 1, name: 'Nom', type: 'string', required: true },
+            { key: 2, name: 'Prénom', type: 'string', required: true },
+            { key: 3, name: 'Date de naissance (jj/mm/aaaa)', type: 'date', format: 'DD/MM/YYYY', required: true },
+            { key: 4, name: 'Classe', type: 'string', required: true },
+          ],
+        },
+        headers: [
+          { key: 1, name: 'Nom', property: 'lastName', required: true },
+          { key: 2, name: 'Prénom', property: 'firstName', required: true },
+          { key: 3, name: 'Date de naissance (jj/mm/aaaa)', required: true },
+          { key: 4, name: 'Classe', required: true },
+        ],
+      },
+      updatedAt: new Date(),
+    });
+};
+
+const down = async function (knex) {
+  await knex('organization-learner-import-formats')
+    .where({ name: importFormatName })
+    .update({
+      config: {
+        acceptedEncoding: ['utf8'],
+        unicityColumns: ['Nom', 'Prénom', 'Date de naissance (jj/mm/aaaa)'],
+        reconciliationMappingColumns: [
+          { key: 2, fieldId: 'reconcileField2', name: IMPORT_KEY_FIELD.COMMON_FIRSTNAME, position: 2 },
+          { key: 4, fieldId: 'reconcileField3', name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE, position: 3 },
+          { key: 1, fieldId: 'reconcileField1', name: IMPORT_KEY_FIELD.COMMON_LASTNAME, position: 1 },
+        ],
+        displayableColumns: [
+          {
+            key: 4,
+            position: 2,
+            name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE,
+          },
+          {
+            key: 3,
+            position: 1,
+            name: IMPORT_KEY_FIELD.COMMON_DIVISION,
+          },
+        ],
+        validationRules: {
+          formats: [
+            { key: 1, name: 'Nom', type: 'string', required: true },
+            { key: 2, name: 'Prénom', type: 'string', required: true },
+            { key: 3, name: 'Date de naissance (jj/mm/aaaa)', type: 'date', format: 'DD/MM/YYYY', required: true },
+            { key: 4, name: 'Classe', type: 'string', required: true },
+          ],
+        },
+        headers: [
+          { key: 1, name: 'Nom', property: 'lastName', required: true },
+          { key: 2, name: 'Prénom', property: 'firstName', required: true },
+          { key: 3, name: 'Date de naissance (jj/mm/aaaa)', required: true },
+          { key: 4, name: 'Classe', required: true },
+        ],
+      },
+      updatedAt: new Date(),
+    });
+};
+
+export { down, up };


### PR DESCRIPTION
## :unicorn: Problème
Une coquille c'est glissé dans le format suite à l'introduction des clé dans #9700. On a inversé la clé du champ date et celui du champ division pour la réconciliation (du coup le label affiché dans la page de réconciliation etait pas bon )  

## :robot: Proposition
on corrige le format

## :rainbow: Remarques
il faudrait se pencher sur le format pour voir comment éviter au mieux ce genre d'erreur (et éviter d'avoir à répéter / dupliquer la donnée à plusieurs endroit (ex: la prop name qui sert de label)

## :100: Pour tester 
jouer la migration qui contient l'import sco-fwb  manuellement
sur admin
- ajouter l'import sco fwb a une orga
sur orga 
- se connecter sur l'orga avec l'import sco-fwb
- créer une campagne 
- faire un import
sur pix
- se connecter avec learneremail1005_0@example.net
- acceder à la campagne créé
- se réconcilier avec succès
