### PR TITLE
[POC] Scoper le refresh token par application

### DIFF
--- a/api/src/identity-access-management/application/token/token.controller.js
+++ b/api/src/identity-access-management/application/token/token.controller.js
@@ -26,9 +26,14 @@ const createToken = async function (request, h, dependencies = { tokenService })
   let accessToken, refreshToken;
   let expirationDelaySeconds;
 
+  const audience = null; // TODO: Get audience from request (query param or header)
+
   if (request.payload.grant_type === 'refresh_token') {
     refreshToken = request.payload.refresh_token;
-    const accessTokenAndExpirationDelaySeconds = await usecases.createAccessTokenFromRefreshToken({ refreshToken });
+    const accessTokenAndExpirationDelaySeconds = await usecases.createAccessTokenFromRefreshToken({
+      refreshToken,
+      audience,
+    });
     accessToken = accessTokenAndExpirationDelaySeconds.accessToken;
     expirationDelaySeconds = accessTokenAndExpirationDelaySeconds.expirationDelaySeconds;
   } else if (request.payload.grant_type === 'password') {
@@ -41,6 +46,7 @@ const createToken = async function (request, h, dependencies = { tokenService })
       password,
       scope,
       source,
+      audience,
       localeFromCookie,
     });
     accessToken = tokensAndExpirationDelaySeconds.accessToken;

--- a/api/src/identity-access-management/domain/services/refresh-token-service.js
+++ b/api/src/identity-access-management/domain/services/refresh-token-service.js
@@ -30,17 +30,17 @@ async function findByUserId(userId) {
  * @typedef {function} createRefreshTokenFromUserId
  * @param {Object} params
  * @param {string} params.userId
- * @param {string} params.source
+ * @param {string} params.audience
  * @param {function} params.uuidGenerator
  * @return {Promise<string>}
  */
-async function createRefreshTokenFromUserId({ userId, source, uuidGenerator = randomUUID }) {
+async function createRefreshTokenFromUserId({ userId, audience, source, uuidGenerator = randomUUID }) {
   const expirationDelaySeconds = config.authentication.refreshTokenLifespanMs / 1000;
-  const refreshToken = `${_prefixForUser(userId)}${uuidGenerator()}`;
+  const refreshToken = [userId, audience, uuidGenerator()].filter(Boolean).join(':');
 
   await refreshTokenTemporaryStorage.save({
     key: refreshToken,
-    value: { type: 'refresh_token', userId, source },
+    value: { type: 'refresh_token', userId, audience, source },
     expirationDelaySeconds,
   });
   await userRefreshTokensTemporaryStorage.lpush({ key: userId, value: refreshToken });
@@ -58,8 +58,11 @@ async function createRefreshTokenFromUserId({ userId, source, uuidGenerator = ra
  * @param {string} params.refreshToken
  * @return {Promise<{expirationDelaySeconds: number, accessToken: string}>}
  */
-async function createAccessTokenFromRefreshToken({ refreshToken }) {
-  const { userId, source } = (await findByRefreshToken(refreshToken)) || {};
+async function createAccessTokenFromRefreshToken({ refreshToken, audience: targetAudience }) {
+  const { userId, source, audience } = (await findByRefreshToken(refreshToken)) || {};
+  if (audience && audience !== targetAudience) {
+    throw new UnauthorizedError('Refresh token is invalid', 'INVALID_REFRESH_TOKEN');
+  }
   if (!userId) throw new UnauthorizedError('Refresh token is invalid', 'INVALID_REFRESH_TOKEN');
   return tokenService.createAccessTokenFromUser(userId, source);
 }
@@ -106,7 +109,3 @@ export const refreshTokenService = {
   revokeRefreshToken,
   revokeRefreshTokensForUserId,
 };
-
-function _prefixForUser(userId) {
-  return `${userId}:`;
-}

--- a/api/src/identity-access-management/domain/usecases/authenticate-user.js
+++ b/api/src/identity-access-management/domain/usecases/authenticate-user.js
@@ -1,10 +1,10 @@
 import lodash from 'lodash';
 
-const { get } = lodash;
-
 import { PIX_ADMIN, PIX_ORGA } from '../../../authorization/domain/constants.js';
 import { ForbiddenAccess, LocaleFormatError, LocaleNotSupportedError } from '../../../shared/domain/errors.js';
 import { MissingOrInvalidCredentialsError, UserShouldChangePasswordError } from '../errors.js';
+
+const { get } = lodash;
 
 async function _checkUserAccessScope(scope, user, adminMemberRepository) {
   if (scope === PIX_ORGA.SCOPE && !user.isLinkedToOrganizations()) {
@@ -23,6 +23,7 @@ const authenticateUser = async function ({
   password,
   scope,
   source,
+  audience,
   username,
   localeFromCookie,
   refreshTokenService,
@@ -50,9 +51,14 @@ const authenticateUser = async function ({
     }
 
     await _checkUserAccessScope(scope, foundUser, adminMemberRepository);
-    const refreshToken = await refreshTokenService.createRefreshTokenFromUserId({ userId: foundUser.id, source });
+    const refreshToken = await refreshTokenService.createRefreshTokenFromUserId({
+      userId: foundUser.id,
+      source,
+      audience,
+    });
     const { accessToken, expirationDelaySeconds } = await refreshTokenService.createAccessTokenFromRefreshToken({
       refreshToken,
+      audience,
     });
 
     foundUser.setLocaleIfNotAlreadySet(localeFromCookie);

--- a/api/src/identity-access-management/domain/usecases/create-access-token-from-refresh-token.js
+++ b/api/src/identity-access-management/domain/usecases/create-access-token-from-refresh-token.js
@@ -1,5 +1,5 @@
-const createAccessTokenFromRefreshToken = async function ({ refreshToken, refreshTokenService }) {
-  return refreshTokenService.createAccessTokenFromRefreshToken({ refreshToken });
+const createAccessTokenFromRefreshToken = async function ({ refreshToken, audience, refreshTokenService }) {
+  return refreshTokenService.createAccessTokenFromRefreshToken({ refreshToken, audience });
 };
 
 export { createAccessTokenFromRefreshToken };


### PR DESCRIPTION
**Génération du refresh token**

- À la génération du refresh token, on souhaite qu’il soit scopé par rapport à l’application “émettrice”.

```
<user-id>:<audience>:xx-xx-xxx-xxx-xxxxx
```

- À la Première connexion, le refresh et access token sont créés en même temps (grant type: `password`)

- Stocké dans Redis:
  - clé `refresh-token`, valeur `{ userId: 123, source: pix, audience: app }`
  - `userId`, valeur refresh-token

- Limiter les refresh token par audience (TTL par audience) - Pas de le scope du POC

 

**Utilisation du refresh token**

- On envoie le `refresh-token` pour avoir un nouveau access token (grant type: `refresh token`)
  - Si ancien type de refresh token: fonctionnement actuel
  - Si nouveau type de refresh token, vérifier si on est dans le même scope d’application:
    - ok => on génère l’access token
    - ko => throw une erreur et déconnexion de l’utilisateur
