### PR TITLE
[FEATURE] Remonter les éléments Downloads dans un module (PIX-13768)

### DIFF
--- a/api/src/devcomp/domain/models/element/Download.js
+++ b/api/src/devcomp/domain/models/element/Download.js
@@ -1,0 +1,30 @@
+import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { Element } from './Element.js';
+
+class Download extends Element {
+  constructor({ id, files }) {
+    super({ id, type: 'download' });
+
+    this.#assertFilesIsAnArray(files);
+    this.#assertFilesAreNotEmpty(files);
+
+    files.forEach((file) => {
+      assertNotNullOrUndefined(file.url, 'The Download files should have an URL');
+      assertNotNullOrUndefined(file.format, 'The Download files should have a format');
+    });
+
+    this.files = files;
+  }
+
+  #assertFilesIsAnArray(files) {
+    if (!Array.isArray(files)) {
+      throw new Error('The Download files should be a list');
+    }
+  }
+
+  #assertFilesAreNotEmpty(files) {
+    if (files.length === 0) throw new Error('The files are required for a Download');
+  }
+}
+
+export { Download };

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -7,6 +7,7 @@ import { BlockText } from '../../domain/models/block/BlockText.js';
 import { ComponentElement } from '../../domain/models/component/ComponentElement.js';
 import { ComponentStepper } from '../../domain/models/component/ComponentStepper.js';
 import { Step } from '../../domain/models/component/Step.js';
+import { Download } from '../../domain/models/element/Download.js';
 import { Embed } from '../../domain/models/element/Embed.js';
 import { Image } from '../../domain/models/element/Image.js';
 import { QCM } from '../../domain/models/element/QCM.js';
@@ -82,6 +83,8 @@ export class ModuleFactory {
 
   static #buildElement(element) {
     switch (element.type) {
+      case 'download':
+        return ModuleFactory.#buildDownload(element);
       case 'embed':
         return ModuleFactory.#buildEmbed(element);
       case 'image':
@@ -103,6 +106,12 @@ export class ModuleFactory {
         });
         return undefined;
     }
+  }
+  static #buildDownload(element) {
+    return new Download({
+      id: element.id,
+      files: element.files,
+    });
   }
 
   static #buildEmbed(element) {

--- a/api/tests/devcomp/unit/domain/models/element/Download_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Download_test.js
@@ -1,0 +1,57 @@
+import { Download } from '../../../../../../src/devcomp/domain/models/element/Download.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | Element | Download', function () {
+  describe('#constructor', function () {
+    it('should create a Download and keep attributes', function () {
+      // given
+      const props = {
+        id: 'id',
+        files: [{ url: 'https://example.org', format: '.html' }],
+      };
+
+      // when
+      const download = new Download(props);
+
+      // then
+      expect(download.id).to.equal('id');
+      expect(download.files).to.equal(props.files);
+    });
+
+    describe('errors', function () {
+      describe('A Download without an id', function () {
+        it('should throw an error', function () {
+          expect(() => new Download({})).to.throw('The id is required for an element');
+        });
+      });
+
+      describe('A Download without files', function () {
+        it('should throw an error', function () {
+          expect(() => new Download({ id: '123' })).to.throw('The Download files should be a list');
+        });
+      });
+
+      describe('A Download with an empty list of files', function () {
+        it('should throw an error', function () {
+          expect(() => new Download({ id: '123', files: [] })).to.throw('The files are required for a Download');
+        });
+      });
+
+      describe('files', function () {
+        describe('A file with no URL', function () {
+          it('should throw an error', function () {
+            expect(() => new Download({ id: '123', files: [{}] })).to.throw('The Download files should have an URL');
+          });
+        });
+
+        describe('A file with no format', function () {
+          it('should throw an error', function () {
+            expect(() => new Download({ id: '123', files: [{ url: 'https://example.org' }] })).to.throw(
+              'The Download files should have a format',
+            );
+          });
+        });
+      });
+    });
+  });
+});

--- a/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
@@ -1,6 +1,7 @@
 import { ModuleInstantiationError } from '../../../../../src/devcomp/domain/errors.js';
 import { ComponentStepper } from '../../../../../src/devcomp/domain/models/component/ComponentStepper.js';
 import { Step } from '../../../../../src/devcomp/domain/models/component/Step.js';
+import { Download } from '../../../../../src/devcomp/domain/models/element/Download.js';
 import { Embed } from '../../../../../src/devcomp/domain/models/element/Embed.js';
 import { Image } from '../../../../../src/devcomp/domain/models/element/Image.js';
 import { QCM } from '../../../../../src/devcomp/domain/models/element/QCM.js';
@@ -451,6 +452,45 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         });
       });
 
+      it('should instantiate a Module with a ComponentElement which contains a Download Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              components: [
+                {
+                  type: 'element',
+                  element: {
+                    id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
+                    type: 'download',
+                    files: [{ url: 'https://example.org/modulix/file.pdf', format: '.pdf' }],
+                  },
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = ModuleFactory.build(moduleData);
+
+        // then
+        expect(module.grains[0].components[0].element).to.be.an.instanceOf(Download);
+      });
+
       it('should instantiate a Module with a ComponentElement which contains an Embed Element', function () {
         // given
         const moduleData = {
@@ -844,6 +884,53 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         expect(module.grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
         expect(module.grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
         expect(module.grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Video);
+      });
+
+      it('should instantiate a Module with a ComponentStepper which contains a Download Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              components: [
+                {
+                  type: 'stepper',
+                  steps: [
+                    {
+                      elements: [
+                        {
+                          id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
+                          type: 'download',
+                          files: [{ url: 'https://example.org/modulix/file.pdf', format: '.pdf' }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = ModuleFactory.build(moduleData);
+
+        // then
+        expect(module.grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
+        expect(module.grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
+        expect(module.grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Download);
       });
 
       it('should instantiate a Module with a ComponentStepper which contains an Embed Element', function () {

--- a/mon-pix/app/components/module/element.gjs
+++ b/mon-pix/app/components/module/element.gjs
@@ -1,6 +1,7 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { eq } from 'ember-truth-helpers';
+import DownloadElement from 'mon-pix/components/module/element/download';
 import EmbedElement from 'mon-pix/components/module/element/embed';
 import ImageElement from 'mon-pix/components/module/element/image';
 import QcmElement from 'mon-pix/components/module/element/qcm';
@@ -26,6 +27,8 @@ export default class ModulixElement extends Component {
         @openTranscription={{@openTranscription}}
         @clickOnPlayButton={{@clickOnPlayButton}}
       />
+    {{else if (eq @element.type "download")}}
+      <DownloadElement @download={{@element}} />
     {{else if (eq @element.type "embed")}}
       <EmbedElement @embed={{@element}} @submitAnswer={{@submitAnswer}} />
     {{else if (eq @element.type "qcu")}}

--- a/mon-pix/app/components/module/element/download.gjs
+++ b/mon-pix/app/components/module/element/download.gjs
@@ -1,0 +1,10 @@
+import ModuleElement from './module-element';
+
+export default class ModulixDownload extends ModuleElement {
+  <template>
+    <div class="element-download">
+      {{! template-lint-disable "no-bare-strings" }}
+      ELEMENT TÉLÉCHARGEMENT EN COURS DE DEVELOPPEMENT
+    </div>
+  </template>
+}

--- a/mon-pix/app/components/module/grain.js
+++ b/mon-pix/app/components/module/grain.js
@@ -8,7 +8,7 @@ export default class ModuleGrain extends Component {
 
   grain = this.args.grain;
 
-  static AVAILABLE_ELEMENT_TYPES = ['text', 'image', 'video', 'embed', 'qcu', 'qcm', 'qrocm'];
+  static AVAILABLE_ELEMENT_TYPES = ['text', 'image', 'video', 'download', 'embed', 'qcu', 'qcm', 'qrocm'];
   static AVAILABLE_GRAIN_TYPES = ['lesson', 'activity'];
 
   @tracked isStepperFinished = this.hasStepper === false;

--- a/mon-pix/tests/integration/components/module/download-test.gjs
+++ b/mon-pix/tests/integration/components/module/download-test.gjs
@@ -1,0 +1,22 @@
+import { render } from '@1024pix/ember-testing-library';
+import { findAll } from '@ember/test-helpers';
+import ModuleElementDownload from 'mon-pix/components/module/element/download';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Module | Element | Download', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('should display a Download', async function (assert) {
+    // given
+    const downloadElement = { files: [{ url: 'https://example.org/image.jpg', format: '.jpg' }], type: 'download' };
+
+    //  when
+    const screen = await render(<template><ModuleElementDownload @download={{downloadElement}} /></template>);
+
+    // then
+    assert.ok(screen);
+    assert.strictEqual(findAll('.element-download').length, 1);
+  });
+});

--- a/mon-pix/tests/integration/components/module/element_test.gjs
+++ b/mon-pix/tests/integration/components/module/element_test.gjs
@@ -63,6 +63,27 @@ module('Integration | Component | Module | Element', function (hooks) {
     assert.dom(screen.getByRole('button', { name: 'Afficher la transcription' })).exists();
   });
 
+  test('should display an element with an download element', async function (assert) {
+    // given
+    const element = {
+      id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
+      type: 'download',
+      files: [
+        {
+          url: 'https://example.org/image.jpg',
+          format: '.jpg',
+        },
+      ],
+    };
+
+    // when
+    const screen = await render(<template><ModulixElement @element={{element}} /></template>);
+
+    // then
+    const downloadElement = screen.getByText('ELEMENT TÉLÉCHARGEMENT EN COURS DE DEVELOPPEMENT');
+    assert.dom(downloadElement).exists();
+  });
+
   test('should display an element with an embed element', async function (assert) {
     // given
     const element = {


### PR DESCRIPTION
## :unicorn: Problème
L'API ne permet pas de récupérer les éléments Download dans Modulix.

## :robot: Proposition
Le permettre et afficher un placeholder pour les éléments Download.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier qu'on a un élément Download dans le 2nd grain du [didacticiel](https://app-pr9828.review.pix.fr/modules/didacticiel-modulix/passage).
