### PR TITLE
[FEATURE] Générer en masse les identifiants des élèves (PIX-12975).

### DIFF
--- a/api/src/identity-access-management/application/http-error-mapper-configuration.js
+++ b/api/src/identity-access-management/application/http-error-mapper-configuration.js
@@ -5,6 +5,9 @@ import {
   DifferentExternalIdentifierError,
   MissingOrInvalidCredentialsError,
   MissingUserAccountError,
+  OrganizationLearnerDoesAlreadyHaveAnUsernameError,
+  OrganizationLearnerDoesNotBelongToOrganizationError,
+  OrganizationLearnerDoesNotHaveAPixAccountError,
   PasswordNotMatching,
   PasswordResetDemandNotFoundError,
   UserCantBeCreatedError,
@@ -28,6 +31,18 @@ const authenticationDomainErrorMappingConfiguration = [
   {
     name: MissingUserAccountError.name,
     httpErrorFn: (error) => new HttpErrors.BadRequestError(error.message),
+  },
+  {
+    name: OrganizationLearnerDoesAlreadyHaveAnUsernameError.name,
+    httpErrorFn: (error) => new HttpErrors.BadRequestError(error.message, error.code),
+  },
+  {
+    name: OrganizationLearnerDoesNotBelongToOrganizationError.name,
+    httpErrorFn: (error) => new HttpErrors.UnauthorizedError(error.message, error.code),
+  },
+  {
+    name: OrganizationLearnerDoesNotHaveAPixAccountError.name,
+    httpErrorFn: (error) => new HttpErrors.BadRequestError(error.message, error.code),
   },
   {
     name: PasswordNotMatching.name,

--- a/api/src/identity-access-management/application/routes.js
+++ b/api/src/identity-access-management/application/routes.js
@@ -4,6 +4,7 @@ import { oidcProviderAdminRoutes } from './oidc-provider/oidc-provider.admin.rou
 import { oidcProviderRoutes } from './oidc-provider/oidc-provider.route.js';
 import { passwordRoutes } from './password/password.route.js';
 import { samlRoutes } from './saml/saml.route.js';
+import { scoOrganizationLearnerRoutes } from './sco-organization-learner/sco-organization-learner.route.js';
 import { tokenRoutes } from './token/token.route.js';
 import { userAdminRoutes } from './user/user.admin.route.js';
 import { userRoutes } from './user/user.route.js';
@@ -16,6 +17,7 @@ const register = async function (server) {
     ...oidcProviderRoutes,
     ...passwordRoutes,
     ...samlRoutes,
+    ...scoOrganizationLearnerRoutes,
     ...tokenRoutes,
     ...userAdminRoutes,
     ...userRoutes,

--- a/api/src/identity-access-management/application/sco-organization-learner/sco-organization-learner.controller.js
+++ b/api/src/identity-access-management/application/sco-organization-learner/sco-organization-learner.controller.js
@@ -1,0 +1,35 @@
+import dayjs from 'dayjs';
+
+import { usecases as libUsecases } from '../../../../lib/domain/usecases/index.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { usecases } from '../../domain/usecases/index.js';
+
+const generateUsernamesFile = async function (request, h) {
+  const payload = request.payload.data.attributes;
+  const organizationId = payload['organization-id'];
+  const organizationLearnerIds = payload['organization-learner-ids'];
+
+  const generatedCsvContent = await DomainTransaction.execute(async () => {
+    const organizationLearnerUsernames = await usecases.generateUsernames({
+      organizationLearnerIds,
+      organizationId,
+    });
+    return libUsecases.generateResetOrganizationLearnersPasswordCsvContent({
+      organizationLearnersPasswordResets: organizationLearnerUsernames,
+    });
+  });
+
+  const dateWithTime = dayjs().locale('fr').format('YYYYMMDD_HHmm');
+  const generatedCsvContentFileName = `${dateWithTime}_organization_learner_usernames.csv`;
+
+  return h
+    .response(generatedCsvContent)
+    .header('content-type', 'text/csv;charset=utf-8')
+    .header('content-disposition', `attachment; filename=${generatedCsvContentFileName}`);
+};
+
+const scoOrganizationLearnerController = {
+  generateUsernamesFile,
+};
+
+export { scoOrganizationLearnerController };

--- a/api/src/identity-access-management/application/sco-organization-learner/sco-organization-learner.route.js
+++ b/api/src/identity-access-management/application/sco-organization-learner/sco-organization-learner.route.js
@@ -1,0 +1,39 @@
+import Joi from 'joi';
+
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
+import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { scoOrganizationLearnerController } from './sco-organization-learner.controller.js';
+
+export const scoOrganizationLearnerRoutes = [
+  {
+    method: 'POST',
+    path: '/api/sco-organization-learners/generate-usernames',
+    config: {
+      pre: [
+        {
+          method: securityPreHandlers.checkUserBelongsToScoOrganizationAndManagesStudents,
+          assign: 'belongsToScoOrganizationAndManageStudents',
+        },
+      ],
+      handler: (request, h) => scoOrganizationLearnerController.generateUsernamesFile(request, h),
+      validate: {
+        options: {
+          allowUnknown: true,
+        },
+        payload: Joi.object({
+          data: {
+            attributes: {
+              'organization-id': identifiersType.organizationId,
+              'organization-learner-ids': Joi.array().items(identifiersType.organizationLearnerId),
+            },
+          },
+        }),
+      },
+      notes: [
+        '- Génère un identifiant pour les élèves avec un mot de passe temporaire \n' +
+          "- La demande de génération d'identifiant doit être effectuée par un membre de l'organisation à laquelle appartiennent les élèves.",
+      ],
+      tags: ['api', 'sco-organization-learners'],
+    },
+  },
+];

--- a/api/src/identity-access-management/domain/errors.js
+++ b/api/src/identity-access-management/domain/errors.js
@@ -26,6 +26,30 @@ class MissingUserAccountError extends DomainError {
   }
 }
 
+class OrganizationLearnerDoesAlreadyHaveAnUsernameError extends DomainError {
+  constructor(message = "L'élève a déjà un identitfiant.", code = 'ORGANIZATION_LEARNER_DOES_ALREADY_HAVE_A_USERNAME') {
+    super(message, code);
+  }
+}
+
+class OrganizationLearnerDoesNotBelongToOrganizationError extends DomainError {
+  constructor(
+    message = "L'utilisateur n'est pas autorisé à modifier cet élève.",
+    code = 'ORGANIZATION_LEARNER_DOES_NOT_BELONG_TO_ORGANIZATION',
+  ) {
+    super(message, code);
+  }
+}
+
+class OrganizationLearnerDoesNotHaveAPixAccountError extends DomainError {
+  constructor(
+    message = "L'utilisateur ne peut pas modifier un élève qui n'a pas de compte Pix associé.",
+    code = 'ORGANIZATION_LEARNER_DOES_NOT_HAVE_A_PIX_ACCOUNT',
+  ) {
+    super(message, code);
+  }
+}
+
 class PasswordNotMatching extends DomainError {
   constructor(message = 'Wrong password.') {
     super(message);
@@ -64,6 +88,9 @@ export {
   DifferentExternalIdentifierError,
   MissingOrInvalidCredentialsError,
   MissingUserAccountError,
+  OrganizationLearnerDoesAlreadyHaveAnUsernameError,
+  OrganizationLearnerDoesNotBelongToOrganizationError,
+  OrganizationLearnerDoesNotHaveAPixAccountError,
   PasswordNotMatching,
   PasswordResetDemandNotFoundError,
   UserCantBeCreatedError,

--- a/api/src/identity-access-management/domain/usecases/generate-usernames.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/generate-usernames.usecase.js
@@ -1,0 +1,96 @@
+import { OrganizationLearnerPasswordResetDTO } from '../../../shared/domain/models/OrganizationLearnerPasswordResetDTO.js';
+import {
+  OrganizationLearnerDoesAlreadyHaveAnUsernameError,
+  OrganizationLearnerDoesNotBelongToOrganizationError,
+  OrganizationLearnerDoesNotHaveAPixAccountError,
+} from '../errors.js';
+
+export const generateUsernames = async function ({
+  organizationLearnerIds,
+  organizationId,
+  passwordGeneratorService,
+  cryptoService,
+  userReconciliationService,
+  userService,
+  authenticationMethodRepository,
+  userRepository,
+  organizationLearnerRepository,
+}) {
+  const updatedOrganizationLearners = [];
+  const organizationLearners = await organizationLearnerRepository.findByIds({ ids: organizationLearnerIds });
+  _checkIfOrganizationLearnersBelongsToOrganization(organizationLearners, organizationId);
+
+  const organizationLearnerUserIds = organizationLearners.map((organizationLearner) => organizationLearner.userId);
+  _checkIfOrganizationLearnersHaveAPixAccount(organizationLearnerUserIds);
+  const organizationLearnerUserAccounts = await userRepository.getByIds(organizationLearnerUserIds);
+  _checkIfUserAccountsHaveUsername(organizationLearnerUserAccounts);
+
+  for (const organizationLearner of organizationLearners) {
+    const organizationLearnerUserAccount = organizationLearnerUserAccounts.find(
+      (userAccount) => userAccount.id === organizationLearner.userId,
+    );
+    const username = await userReconciliationService.createUsernameByUser({
+      user: organizationLearner,
+      userRepository,
+    });
+    const hasStudentAccountAnIdentityProviderPIX = await authenticationMethodRepository.hasIdentityProviderPIX({
+      userId: organizationLearnerUserAccount.id,
+    });
+
+    if (hasStudentAccountAnIdentityProviderPIX) {
+      await userRepository.updateUsername({ id: organizationLearnerUserAccount.id, username });
+      updatedOrganizationLearners.push(
+        new OrganizationLearnerPasswordResetDTO({
+          division: organizationLearner.division,
+          lastName: organizationLearner.lastName,
+          firstName: organizationLearner.firstName,
+          username,
+          password: '',
+        }),
+      );
+    } else {
+      const generatedPassword = passwordGeneratorService.generateSimplePassword();
+      const hashedPassword = await cryptoService.hashPassword(generatedPassword);
+
+      await userService.updateUsernameAndAddPassword({
+        userId: organizationLearnerUserAccount.id,
+        username,
+        hashedPassword,
+        authenticationMethodRepository,
+        userRepository,
+      });
+      updatedOrganizationLearners.push(
+        new OrganizationLearnerPasswordResetDTO({
+          division: organizationLearner.division,
+          lastName: organizationLearner.lastName,
+          firstName: organizationLearner.firstName,
+          username,
+          password: generatedPassword,
+        }),
+      );
+    }
+  }
+  return updatedOrganizationLearners;
+};
+
+function _checkIfOrganizationLearnersBelongsToOrganization(organizationLearners, organizationId) {
+  const organizationLearnersBelongToOrganization = organizationLearners.every(
+    (organizationLearner) => organizationLearner.organizationId === organizationId,
+  );
+  if (!organizationLearnersBelongToOrganization) {
+    throw new OrganizationLearnerDoesNotBelongToOrganizationError();
+  }
+}
+
+function _checkIfOrganizationLearnersHaveAPixAccount(organizationLearnerUserIds) {
+  if (organizationLearnerUserIds.some((userId) => !userId)) {
+    throw new OrganizationLearnerDoesNotHaveAPixAccountError();
+  }
+}
+
+function _checkIfUserAccountsHaveUsername(userAccounts) {
+  const someUserAccountsHaveUsername = userAccounts.some((organizationLearner) => organizationLearner.username);
+  if (someUserAccountsHaveUsername) {
+    throw new OrganizationLearnerDoesAlreadyHaveAnUsernameError();
+  }
+}

--- a/api/src/identity-access-management/domain/usecases/index.js
+++ b/api/src/identity-access-management/domain/usecases/index.js
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 
 import { eventBus } from '../../../../lib/domain/events/index.js';
 import { mailService } from '../../../../lib/domain/services/mail-service.js';
+import * as passwordGeneratorService from '../../../../lib/domain/services/password-generator.js';
 import * as userReconciliationService from '../../../../lib/domain/services/user-reconciliation-service.js';
 import { oidcAuthenticationServiceRegistry } from '../../../../lib/domain/usecases/index.js';
 import * as campaignParticipationRepository from '../../../../lib/infrastructure/repositories/campaign-participation-repository.js';
@@ -62,6 +63,7 @@ const services = {
   cryptoService,
   mailService,
   oidcAuthenticationServiceRegistry,
+  passwordGeneratorService,
   pixAuthenticationService,
   refreshTokenService,
   resetPasswordService,

--- a/api/tests/identity-access-management/acceptance/application/sco-organization-learner/sco-organization-learner.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/sco-organization-learner/sco-organization-learner.route.test.js
@@ -1,0 +1,77 @@
+import { Membership } from '../../../../../src/shared/domain/models/index.js';
+import {
+  createServer,
+  databaseBuilder,
+  expect,
+  generateValidRequestAuthorizationHeader,
+} from '../../../../test-helper.js';
+
+describe('Acceptance | Identity Access Management | Application | Route | Sco Organization Learners', function () {
+  describe('POST /api/sco-organization-learners/generate-usernames', function () {
+    const organizationLearnerIds = [11, 12];
+    const hashedPassword = 'testHashedPassword';
+    let server, organizationId, adminUser, user1;
+
+    beforeEach(async function () {
+      server = await createServer();
+      organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true }).id;
+      adminUser = databaseBuilder.factory.buildUser.withRawPassword();
+      databaseBuilder.factory.buildMembership({
+        organizationId,
+        userId: adminUser.id,
+        organizationRole: Membership.roles.ADMIN,
+      });
+      user1 = databaseBuilder.factory.buildUser({ username: null });
+      databaseBuilder.factory.buildOrganizationLearner({
+        id: organizationLearnerIds[0],
+        organizationId,
+        userId: user1.id,
+      });
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
+        userId: user1.id,
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    it('returns a list of organization learners id, temporary password and username with an HTTP status code 200', async function () {
+      // given
+      const user2 = databaseBuilder.factory.buildUser({ username: null });
+      databaseBuilder.factory.buildOrganizationLearner({
+        id: organizationLearnerIds[1],
+        organizationId,
+        userId: user2.id,
+      });
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
+        userId: user2.id,
+        hashedPassword,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const { headers, payload, statusCode } = await server.inject({
+        method: 'POST',
+        url: '/api/sco-organization-learners/generate-usernames',
+        headers: { authorization: generateValidRequestAuthorizationHeader(adminUser.id) },
+        payload: {
+          data: {
+            attributes: {
+              'organization-id': organizationId,
+              'organization-learner-ids': organizationLearnerIds,
+            },
+          },
+        },
+      });
+
+      // then
+      expect(statusCode).to.equal(200);
+      expect(headers['content-type']).to.equal('text/csv;charset=utf-8');
+      expect(headers['content-disposition']).to.contains('_organization_learner_usernames.csv');
+
+      const [fileHeaders, firstRow, ...unusedRows] = payload.split('\n').map((row) => row.trim());
+      expect(fileHeaders).to.equal('"Classe";"Nom";"Prénom";"Identifiant";"Mot de passe"');
+      expect(firstRow).to.match(/^"3eme";"last-name";"first-name";"firstname.lastname0508";/);
+    });
+  });
+});

--- a/api/tests/identity-access-management/integration/application/sco-organization-learner/sco-organization-learner.controller.test.js
+++ b/api/tests/identity-access-management/integration/application/sco-organization-learner/sco-organization-learner.controller.test.js
@@ -1,0 +1,70 @@
+import dayjs from 'dayjs';
+
+import { usecases as libUsecases } from '../../../../../lib/domain/usecases/index.js';
+import { identityAccessManagementRoutes } from '../../../../../src/identity-access-management/application/routes.js';
+import { scoOrganizationLearnerController } from '../../../../../src/identity-access-management/application/sco-organization-learner/sco-organization-learner.controller.js';
+import { usecases } from '../../../../../src/identity-access-management/domain/usecases/index.js';
+import { expect, hFake, HttpTestServer, sinon } from '../../../../test-helper.js';
+
+describe('Integration | Identity Access Management | Application | Controller | Sco Organization Learner', function () {
+  let httpTestServer;
+  let routesUnderTest;
+  let clock;
+  const now = new Date('2024-03-02T15:00:00Z');
+
+  beforeEach(async function () {
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    routesUnderTest = identityAccessManagementRoutes[0];
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(routesUnderTest);
+
+    sinon.stub(usecases, 'generateUsernames');
+    sinon.stub(libUsecases, 'generateResetOrganizationLearnersPasswordCsvContent');
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
+  describe('#generateUsernamesFile', function () {
+    it('returns a 200 HTTP status code with a response', async function () {
+      // given
+      const request = {
+        payload: {
+          data: {
+            attributes: { 'organization-id': '1', 'organization-learner-ids': ['11', '12'] },
+          },
+        },
+      };
+      usecases.generateUsernames.resolves([
+        {
+          firstName: 'Simone',
+          lastName: 'Biles',
+          division: '4F',
+          username: 'simone.biles2024',
+          password: 'Pix12345',
+        },
+        {
+          username: 'rebeca.andrade2024',
+          firstName: 'Rebeca',
+          lastName: 'Andrade',
+          division: '4F',
+          password: '',
+        },
+      ]);
+      libUsecases.generateResetOrganizationLearnersPasswordCsvContent.resolves(
+        'division;lastName;firstName;username;password\n4F;Biles;Simone;simone.biles2024;Pix12345\n4F;Andrade;Rebeca;;rebeca.andrade2024;\n',
+      );
+      const expectedDate = dayjs(now).format('YYYYMMDD_HHmm');
+      const expectedGeneratedCsvContentFileName = `${expectedDate}_organization_learner_usernames.csv`;
+
+      // when
+      const { headers, statusCode } = await scoOrganizationLearnerController.generateUsernamesFile(request, hFake);
+
+      // then
+      expect(statusCode).to.equal(200);
+      expect(headers['content-type']).to.equal('text/csv;charset=utf-8');
+      expect(headers['content-disposition']).to.contains(expectedGeneratedCsvContentFileName);
+    });
+  });
+});

--- a/api/tests/identity-access-management/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/identity-access-management/unit/application/http-error-mapper-configuration_test.js
@@ -4,6 +4,9 @@ import {
   DifferentExternalIdentifierError,
   MissingOrInvalidCredentialsError,
   MissingUserAccountError,
+  OrganizationLearnerDoesAlreadyHaveAnUsernameError,
+  OrganizationLearnerDoesNotBelongToOrganizationError,
+  OrganizationLearnerDoesNotHaveAPixAccountError,
   PasswordNotMatching,
   PasswordResetDemandNotFoundError,
   UserCantBeCreatedError,
@@ -80,6 +83,63 @@ describe('Unit | Identity Access Management | Application | HttpErrorMapperConfi
 
       //then
       expect(error).to.be.instanceOf(HttpErrors.BadRequestError);
+    });
+  });
+
+  context('when mapping "OrganizationLearnerDoesAlreadyHaveAnUsernameError"', function () {
+    it('returns an BadRequestError Http Error', function () {
+      //given
+      const httpErrorMapper = authenticationDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === OrganizationLearnerDoesAlreadyHaveAnUsernameError.name,
+      );
+      const message = 'Test message error';
+      const code = 'CODE_ERROR';
+
+      //when
+      const error = httpErrorMapper.httpErrorFn(new OrganizationLearnerDoesAlreadyHaveAnUsernameError(message, code));
+
+      //then
+      expect(error).to.be.instanceOf(HttpErrors.BadRequestError);
+      expect(error.message).to.equal(message);
+      expect(error.code).to.equal(code);
+    });
+  });
+
+  context('when mapping "OrganizationLearnerDoesNotBelongToOrganizationError"', function () {
+    it('returns an BadRequestError Http Error', function () {
+      //given
+      const httpErrorMapper = authenticationDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === OrganizationLearnerDoesNotBelongToOrganizationError.name,
+      );
+      const message = 'Test message error';
+      const code = 'CODE_ERROR';
+
+      //when
+      const error = httpErrorMapper.httpErrorFn(new OrganizationLearnerDoesNotBelongToOrganizationError(message, code));
+
+      //then
+      expect(error).to.be.instanceOf(HttpErrors.UnauthorizedError);
+      expect(error.message).to.equal(message);
+      expect(error.code).to.equal(code);
+    });
+  });
+
+  context('when mapping "OrganizationLearnerDoesNotHaveAPixAccountError"', function () {
+    it('returns an BadRequestError Http Error', function () {
+      //given
+      const httpErrorMapper = authenticationDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === OrganizationLearnerDoesNotHaveAPixAccountError.name,
+      );
+      const message = 'Test message error';
+      const code = 'CODE_ERROR';
+
+      //when
+      const error = httpErrorMapper.httpErrorFn(new OrganizationLearnerDoesNotHaveAPixAccountError(message, code));
+
+      //then
+      expect(error).to.be.instanceOf(HttpErrors.BadRequestError);
+      expect(error.message).to.equal(message);
+      expect(error.code).to.equal(code);
     });
   });
 

--- a/api/tests/identity-access-management/unit/domain/usecases/generate-usernames.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/generate-usernames.usecase.test.js
@@ -1,0 +1,318 @@
+import {
+  OrganizationLearnerDoesAlreadyHaveAnUsernameError,
+  OrganizationLearnerDoesNotBelongToOrganizationError,
+  OrganizationLearnerDoesNotHaveAPixAccountError,
+} from '../../../../../src/identity-access-management/domain/errors.js';
+import { generateUsernames } from '../../../../../src/identity-access-management/domain/usecases/generate-usernames.usecase.js';
+import { OrganizationLearnerPasswordResetDTO } from '../../../../../src/shared/domain/models/OrganizationLearnerPasswordResetDTO.js';
+import { catchErr, expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Identity Access Management | Domain | UseCase | Generate Usernames', function () {
+  const generatedPassword = 'Pix12345';
+  const expectedUsername1 = 'simone.biles2024';
+  const expectedUsername2 = 'rebeca.andrade2024';
+
+  let passwordGeneratorService,
+    cryptoService,
+    userReconciliationService,
+    userService,
+    authenticationMethodRepository,
+    userRepository,
+    organizationLearnerRepository;
+
+  beforeEach(function () {
+    passwordGeneratorService = {
+      generateSimplePassword: sinon.stub().returns(generatedPassword),
+    };
+    cryptoService = {
+      hashPassword: sinon.stub(),
+    };
+    userReconciliationService = {
+      createUsernameByUser: sinon.stub(),
+    };
+    userService = {
+      updateUsernameAndAddPassword: sinon.stub(),
+    };
+    authenticationMethodRepository = {
+      hasIdentityProviderPIX: sinon.stub(),
+    };
+    userRepository = {
+      updateUsername: sinon.stub(),
+    };
+    organizationLearnerRepository = {
+      findByIds: sinon.stub(),
+    };
+  });
+
+  context('when a list of organization learners with an authentication method "Pix" is provided', function () {
+    it('creates usernames for all students', async function () {
+      // given
+      const organizationId = 1;
+      const usersIds = ['1', '2'];
+      const organizationLearnerIds = ['11', '22'];
+      const organizationLearners = [
+        {
+          id: organizationLearnerIds[0],
+          organizationId,
+          userId: usersIds[0],
+          division: '5G',
+          firstName: 'Simone',
+          lastName: 'Biles',
+        },
+        {
+          id: organizationLearnerIds[1],
+          organizationId,
+          userId: usersIds[1],
+          division: '3A',
+          firstName: 'Rebeca',
+          lastName: 'Andrade',
+        },
+      ];
+      const users = [
+        { id: usersIds[0], username: '' },
+        { id: usersIds[1], username: '' },
+      ];
+
+      organizationLearnerRepository.findByIds.resolves(organizationLearners);
+      userRepository.getByIds = sinon.stub().resolves(users);
+      authenticationMethodRepository.hasIdentityProviderPIX.resolves(true);
+      userReconciliationService.createUsernameByUser
+        .onFirstCall()
+        .resolves(expectedUsername1)
+        .onSecondCall()
+        .resolves(expectedUsername2);
+
+      // when
+      const result = await generateUsernames({
+        organizationLearnerIds,
+        organizationId,
+        passwordGeneratorService,
+        cryptoService,
+        userReconciliationService,
+        userService,
+        authenticationMethodRepository,
+        userRepository,
+        organizationLearnerRepository,
+      });
+
+      // then
+      expect(organizationLearnerRepository.findByIds).to.have.been.calledWithExactly({ ids: organizationLearnerIds });
+      expect(userRepository.getByIds).to.have.been.calledWithExactly(usersIds);
+      expect(userReconciliationService.createUsernameByUser).to.have.been.calledTwice;
+      expect(authenticationMethodRepository.hasIdentityProviderPIX).to.have.been.calledTwice;
+      expect(
+        userRepository.updateUsername.withArgs({
+          id: organizationLearners[0].userId,
+          username: expectedUsername1,
+        }),
+      ).to.have.been.calledOnce;
+      expect(
+        userRepository.updateUsername.withArgs({
+          id: organizationLearners[1].userId,
+          username: expectedUsername2,
+        }),
+      ).to.have.been.calledOnce;
+      expect(result).to.deepEqualArray([
+        new OrganizationLearnerPasswordResetDTO({
+          username: expectedUsername1,
+          division: '5G',
+          firstName: 'Simone',
+          lastName: 'Biles',
+          password: '',
+        }),
+        new OrganizationLearnerPasswordResetDTO({
+          username: expectedUsername2,
+          division: '3A',
+          firstName: 'Rebeca',
+          lastName: 'Andrade',
+          password: '',
+        }),
+      ]);
+    });
+  });
+
+  context(
+    'when a list of organization learners with an authentication method other than "pix" is provided',
+    function () {
+      it('creates usernames and temporary passwords', async function () {
+        // given
+        const organizationId = 1;
+        const usersIds = ['1', '2'];
+        const organizationLearnerIds = ['11', '22'];
+        const organizationLearners = [
+          {
+            id: organizationLearnerIds[0],
+            organizationId,
+            userId: usersIds[0],
+            division: '3B',
+            firstName: 'Simone',
+            lastName: 'Biles',
+          },
+          {
+            id: organizationLearnerIds[1],
+            organizationId,
+            userId: usersIds[1],
+            division: '3B',
+            firstName: 'Rebeca',
+            lastName: 'Andrade',
+          },
+        ];
+        const users = [
+          { id: usersIds[0], username: '' },
+          { id: usersIds[1], username: '' },
+        ];
+
+        organizationLearnerRepository.findByIds.resolves(organizationLearners);
+        userRepository.getByIds = sinon.stub().resolves(users);
+        authenticationMethodRepository.hasIdentityProviderPIX.resolves(false);
+        userReconciliationService.createUsernameByUser
+          .onFirstCall()
+          .resolves(expectedUsername1)
+          .onSecondCall()
+          .resolves(expectedUsername2);
+
+        // when
+        const result = await generateUsernames({
+          organizationLearnerIds,
+          organizationId,
+          passwordGeneratorService,
+          cryptoService,
+          userReconciliationService,
+          userService,
+          authenticationMethodRepository,
+          userRepository,
+          organizationLearnerRepository,
+        });
+
+        // then
+        expect(organizationLearnerRepository.findByIds).to.have.been.calledWithExactly({ ids: organizationLearnerIds });
+        expect(userRepository.getByIds).to.have.been.calledWithExactly(usersIds);
+        expect(userReconciliationService.createUsernameByUser).to.have.been.calledTwice;
+        expect(authenticationMethodRepository.hasIdentityProviderPIX).to.have.been.calledTwice;
+        expect(passwordGeneratorService.generateSimplePassword).to.have.been.calledTwice;
+        expect(cryptoService.hashPassword).to.have.been.calledWithExactly(generatedPassword);
+        expect(cryptoService.hashPassword).to.have.been.calledTwice;
+        expect(userService.updateUsernameAndAddPassword).to.have.been.calledTwice;
+        expect(result).to.deepEqualArray([
+          new OrganizationLearnerPasswordResetDTO({
+            username: expectedUsername1,
+            password: generatedPassword,
+            division: '3B',
+            firstName: 'Simone',
+            lastName: 'Biles',
+          }),
+          new OrganizationLearnerPasswordResetDTO({
+            username: expectedUsername2,
+            password: generatedPassword,
+            division: '3B',
+            firstName: 'Rebeca',
+            lastName: 'Andrade',
+          }),
+        ]);
+      });
+    },
+  );
+
+  context("when an organization learner doesn't have a pix account", function () {
+    it('throws an OrganizationLearnerDoesNotHaveAPixAccountError', async function () {
+      // given
+      const organizationId = 1;
+      const usersIds = ['1'];
+      const organizationLearnerIds = ['11', '22'];
+      const organizationLearners = [
+        { id: organizationLearnerIds[0], organizationId, userId: usersIds[0], division: '3B' },
+        { id: organizationLearnerIds[1], organizationId, userId: null, division: '3B' },
+      ];
+      const users = [{ id: usersIds[0], username: '' }];
+
+      organizationLearnerRepository.findByIds.resolves(organizationLearners);
+      userRepository.getByIds = sinon.stub().resolves(users);
+
+      // when
+      const error = await catchErr(generateUsernames)({
+        organizationLearnerIds,
+        organizationId,
+        passwordGeneratorService,
+        cryptoService,
+        userReconciliationService,
+        userService,
+        authenticationMethodRepository,
+        userRepository,
+        organizationLearnerRepository,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(OrganizationLearnerDoesNotHaveAPixAccountError);
+    });
+  });
+
+  context("when an organization learner doesn't belong to organization", function () {
+    it('throws an OrganizationLearnerDoesNotBelongToOrganizationError', async function () {
+      // given
+      const organizationId = 1;
+      const usersIds = ['1', '2'];
+      const organizationLearnerIds = ['11', '22'];
+      const organizationLearners = [
+        { id: organizationLearnerIds[0], organizationId, userId: usersIds[0], division: '3B' },
+        { id: organizationLearnerIds[1], organizationId: 2, userId: usersIds[1], division: '3B' },
+      ];
+
+      organizationLearnerRepository.findByIds.resolves(organizationLearners);
+
+      // when
+      const error = await catchErr(generateUsernames)({
+        organizationLearnerIds,
+        organizationId,
+        passwordGeneratorService,
+        cryptoService,
+        userReconciliationService,
+        userService,
+        authenticationMethodRepository,
+        userRepository,
+        organizationLearnerRepository,
+      });
+
+      // then
+      expect(organizationLearnerRepository.findByIds).to.have.been.calledWithExactly({ ids: organizationLearnerIds });
+      expect(error).to.be.instanceOf(OrganizationLearnerDoesNotBelongToOrganizationError);
+    });
+  });
+
+  context('when organization learner has an username', function () {
+    it('throws an OrganizationLearnerDoesAlreadyHaveAnUsernameError', async function () {
+      // given
+      const organizationId = 1;
+      const usersIds = ['1', '2'];
+      const organizationLearnerIds = ['11', '22'];
+      const organizationLearners = [
+        { id: organizationLearnerIds[0], organizationId, userId: usersIds[0], division: '3B' },
+        { id: organizationLearnerIds[1], organizationId, userId: usersIds[1], division: '3B' },
+      ];
+      const users = [
+        { id: usersIds[0], username: 'SunisaLee2024' },
+        { id: usersIds[1], username: 'KayliaNeymour2024' },
+      ];
+
+      organizationLearnerRepository.findByIds.resolves(organizationLearners);
+      userRepository.getByIds = sinon.stub().resolves(users);
+
+      // when
+      const error = await catchErr(generateUsernames)({
+        organizationLearnerIds,
+        organizationId,
+        passwordGeneratorService,
+        cryptoService,
+        userReconciliationService,
+        userService,
+        authenticationMethodRepository,
+        userRepository,
+        organizationLearnerRepository,
+      });
+
+      // then
+      expect(organizationLearnerRepository.findByIds).to.have.been.calledWithExactly({ ids: organizationLearnerIds });
+      expect(userRepository.getByIds).to.have.been.calledWithExactly(usersIds);
+      expect(error).to.be.instanceOf(OrganizationLearnerDoesAlreadyHaveAnUsernameError);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/generate-reset-organization-learners-password-cvs-content_test.js
+++ b/api/tests/unit/domain/usecases/generate-reset-organization-learners-password-cvs-content_test.js
@@ -17,12 +17,12 @@ describe('Unit | UseCases | Generate reset organization learners csv', function 
         division: '3A',
         lastName: 'Lô',
         firstName: 'Ismaël',
-        password: '123456@il',
+        password: '',
         username: 'ismaelLo',
       }),
     ];
     const expectedCsvContent =
-      'division;lastName;firstName;username;password\n3A;Brown;James;123456@jb\n3A;Lô;Ismaël;123456@il\n';
+      'division;lastName;firstName;username;password\n3A;Brown;James;jamesBrown;123456@jb\n3A;Lô;Ismaël;;ismaelLo;;\n';
     const writeCsvUtils = { getCsvContent: sinon.stub().resolves(expectedCsvContent) };
 
     // when

--- a/orga/app/adapters/sco-organization-participant.js
+++ b/orga/app/adapters/sco-organization-participant.js
@@ -27,4 +27,24 @@ export default class ScoOrganizationParticipantAdapter extends ApplicationAdapte
 
     return fileSaver.save({ fetcher: () => request });
   }
+
+  async generateOrganizationLearnersUsername({ fetch, fileSaver, organizationId, organizationLearnerIds, token }) {
+    const url = `${this.host}/${this.namespace}/sco-organization-learners/generate-usernames`;
+    const payload = JSON.stringify(
+      {
+        data: {
+          attributes: { 'organization-id': organizationId, 'organization-learner-ids': organizationLearnerIds },
+        },
+      },
+      null,
+      2,
+    );
+    const request = fetch(url, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: payload,
+    });
+
+    return fileSaver.save({ fetcher: () => request });
+  }
 }

--- a/orga/app/components/sco-organization-participant/action-bar.hbs
+++ b/orga/app/components/sco-organization-participant/action-bar.hbs
@@ -6,5 +6,8 @@
     <PixButton @triggerAction={{@openResetPasswordModal}} type="button">
       {{t "pages.sco-organization-participants.action-bar.reset-password-button"}}
     </PixButton>
+    <PixButton @triggerAction={{@openGenerateUsernameModal}} type="button">
+      {{t "pages.sco-organization-participants.action-bar.generate-username-button"}}
+    </PixButton>
   </:actions>
 </Ui::ActionBar>

--- a/orga/app/components/sco-organization-participant/generate-username-modal.hbs
+++ b/orga/app/components/sco-organization-participant/generate-username-modal.hbs
@@ -1,0 +1,30 @@
+<PixModal
+  @title={{t "pages.sco-organization-participants.generate-username-modal.title" htmlSafe=true}}
+  @showModal={{@showModal}}
+  @onCloseButtonClick={{@onCloseModal}}
+>
+  <:content>
+    <section class="reset-password-modal__content">
+      <PixMessage @type="warning" @withIcon={{true}}>{{t
+          "pages.sco-organization-participants.generate-username-modal.warning-message"
+        }}</PixMessage>
+      <p>{{t
+          "pages.sco-organization-participants.generate-username-modal.content-message-1"
+          totalSelectedStudents=@totalSelectedStudents
+          totalAffectedStudents=@totalAffectedStudents
+          htmlSafe=true
+        }}</p>
+      {{#if this.canGenerateSomeUsernames}}
+        <p>{{t "pages.sco-organization-participants.generate-username-modal.content-message-2"}}</p>
+      {{/if}}
+    </section>
+  </:content>
+  <:footer>
+    <PixButton @variant="secondary" @triggerAction={{@onCloseModal}}>
+      {{t "common.actions.cancel"}}
+    </PixButton>
+    <PixButton @triggerAction={{@onTriggerAction}} @isDisabled={{not this.canGenerateSomeUsernames}}>
+      {{t "common.actions.confirm"}}
+    </PixButton>
+  </:footer>
+</PixModal>

--- a/orga/app/components/sco-organization-participant/generate-username-modal.js
+++ b/orga/app/components/sco-organization-participant/generate-username-modal.js
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+
+export default class GenerateUsernameModal extends Component {
+  get canGenerateSomeUsernames() {
+    return this.args.totalAffectedStudents > 0;
+  }
+}

--- a/orga/app/components/sco-organization-participant/list.hbs
+++ b/orga/app/components/sco-organization-participant/list.hbs
@@ -45,6 +45,7 @@
               <ScoOrganizationParticipant::ActionBar
                 @count={{selectedStudents.length}}
                 @openResetPasswordModal={{fn this.openResetPasswordModal selectedStudents}}
+                @openGenerateUsernameModal={{fn this.openGenerateUsernameModal selectedStudents}}
               />
               <ScoOrganizationParticipant::ResetPasswordModal
                 @showModal={{this.showResetPasswordModal}}
@@ -52,6 +53,12 @@
                 @totalAffectedStudents={{this.affectedStudents.length}}
                 @onTriggerAction={{fn this.resetPasswordForStudents this.affectedStudents reset}}
                 @onCloseModal={{this.closeResetPasswordModal}}
+              />
+              <ScoOrganizationParticipant::GenerateUsernameModal
+                @showModal={{this.showGenerateUsernameModal}}
+                @totalSelectedStudents={{selectedStudents.length}}
+                @totalAffectedStudents={{this.affectedStudents.length}}
+                @onCloseModal={{this.closeGenerateUsernameModal}}
               />
             </InElement>
           {{/if}}

--- a/orga/app/components/sco-organization-participant/list.hbs
+++ b/orga/app/components/sco-organization-participant/list.hbs
@@ -58,6 +58,7 @@
                 @showModal={{this.showGenerateUsernameModal}}
                 @totalSelectedStudents={{selectedStudents.length}}
                 @totalAffectedStudents={{this.affectedStudents.length}}
+                @onTriggerAction={{fn this.generateUsernameForStudents this.affectedStudents reset}}
                 @onCloseModal={{this.closeGenerateUsernameModal}}
               />
             </InElement>

--- a/orga/app/components/sco-organization-participant/list.js
+++ b/orga/app/components/sco-organization-participant/list.js
@@ -20,6 +20,7 @@ export default class ScoList extends Component {
   @tracked student = null;
   @tracked isShowingAuthenticationMethodModal = false;
   @tracked showResetPasswordModal = false;
+  @tracked showGenerateUsernameModal = false;
   @tracked divisions;
 
   @tracked affectedStudents = [];
@@ -93,6 +94,23 @@ export default class ScoList extends Component {
   @action
   closeResetPasswordModal() {
     this.showResetPasswordModal = false;
+  }
+
+  @action
+  openGenerateUsernameModal(students, event) {
+    event.stopPropagation();
+    this.affectedStudents = students.filter(
+      (student) =>
+        !student.authenticationMethods.some(
+          (authenticationMethod) => authenticationMethod === 'identifiant' || authenticationMethod === 'empty',
+        ),
+    );
+    this.showGenerateUsernameModal = true;
+  }
+
+  @action
+  closeGenerateUsernameModal() {
+    this.showGenerateUsernameModal = false;
   }
 
   @action

--- a/orga/app/templates/authenticated/sco-organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/sco-organization-participants/list.hbs
@@ -19,5 +19,6 @@
     @divisionSort={{this.divisionSort}}
     @lastnameSort={{this.lastnameSort}}
     @hasComputeOrganizationLearnerCertificabilityEnabled={{this.hasComputeOrganizationLearnerCertificabilityEnabled}}
+    @refreshValues={{this.refresh}}
   />
 </div>

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -417,6 +417,15 @@ function routes() {
     return new Response(200, headers, csvContent);
   });
 
+  this.post('/sco-organization-learners/generate-usernames', () => {
+    const headers = {
+      'Content-Type': 'text/csv;charset=utf-8',
+      'Content-Disposition': 'attachment; filename=content.csv',
+    };
+    const csvContent = 'Identifiant;Mot de passe;Classe\nnewUsername;;1A\n';
+    return new Response(200, headers, csvContent);
+  });
+
   this.post('/sco-organization-learners/username-password-generation', (schema) => {
     return schema.dependentUsers.create({
       username: 'user.gar3112',

--- a/orga/tests/integration/components/sco-organization-participant/generate-username-modal-test.js
+++ b/orga/tests/integration/components/sco-organization-participant/generate-username-modal-test.js
@@ -1,0 +1,88 @@
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import { t } from 'ember-intl/test-support';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | ScoOrganizationParticipant::GenerateUsernameModal', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('When all students are eligible for the generation', function () {
+    test('render the content message and enable action button', async function (assert) {
+      // given
+      this.selectedStudents = [1, 2];
+      this.affectedStudents = [1, 2];
+
+      // when
+      const screen = await render(
+        hbs`
+            <ScoOrganizationParticipant::GenerateUsernameModal
+                    @showModal={{true}}
+                    @totalSelectedStudents={{this.selectedStudents.length}}
+                    @totalAffectedStudents={{this.affectedStudents.length}}
+            />`,
+      );
+
+      // then
+      const title = t('pages.sco-organization-participants.generate-username-modal.title', {
+        htmlSafe: true,
+      });
+      const strippedTitle = title.__string.replace(/<\/?[^>]+(>|$)/g, '');
+
+      assert.ok(
+        screen.getByRole('heading', {
+          name: strippedTitle,
+        }),
+      );
+      assert.dom(screen.getByText('2 élèves')).exists();
+      assert.dom(screen.getByText('2 identifiants')).exists();
+      assert
+        .dom(
+          screen.getByRole('button', {
+            name: t('common.actions.confirm'),
+          }),
+        )
+        .isNotDisabled();
+    });
+  });
+
+  module('When no students are eligible for the generation', function () {
+    test('render the content message and disable action button', async function (assert) {
+      // given
+      this.selectedStudents = [1, 2];
+      this.affectedStudents = [];
+
+      // when
+      const screen = await render(
+        hbs`
+            <ScoOrganizationParticipant::GenerateUsernameModal
+                    @showModal={{true}}
+                    @totalSelectedStudents={{this.selectedStudents.length}}
+                    @totalAffectedStudents={{this.affectedStudents.length}}
+            />`,
+      );
+
+      // then
+      const title = t('pages.sco-organization-participants.generate-username-modal.title', {
+        htmlSafe: true,
+      });
+      const strippedTitle = title.__string.replace(/<\/?[^>]+(>|$)/g, '');
+
+      assert.ok(
+        screen.getByRole('heading', {
+          name: strippedTitle,
+        }),
+      );
+      assert.dom(screen.getByText('2 élèves')).exists();
+      assert.dom(screen.getByText('aucun identifiant')).exists();
+      assert
+        .dom(
+          screen.getByRole('button', {
+            name: t('common.actions.confirm'),
+          }),
+        )
+        .isDisabled();
+    });
+  });
+});

--- a/orga/tests/integration/components/sco-organization-participant/list-test.js
+++ b/orga/tests/integration/components/sco-organization-participant/list-test.js
@@ -1866,5 +1866,319 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       assert.ok(modalTitle);
       assert.ok(confirmationButton);
     });
+
+    module('when the generate usernames modal is open', function () {
+      module('#errorNotifications', function () {
+        let notificationsStub;
+        module('when the user doesn’t belong to the organisation', function () {
+          test('displays an error notification', async function (assert) {
+            // given
+            const store = this.owner.lookup('service:store');
+            sinon.stub(store, 'adapterFor').returns({
+              generateOrganizationLearnersUsername: sinon
+                .stub()
+                .rejects([{ code: 'USER_DOES_NOT_BELONG_TO_ORGANIZATION' }]),
+            });
+            notificationsStub = this.owner.lookup('service:notifications');
+            sinon.stub(notificationsStub, 'sendError');
+
+            const students = [
+              { id: '1', firstName: 'Spider', lastName: 'Man', authenticationMethods: ['mediacentre'] },
+              { id: '2', firstName: 'Miles', lastName: 'Morales', authenticationMethods: ['email'] },
+            ];
+
+            this.set('students', students);
+
+            // when
+            const screen = await render(hbs`
+                <ScoOrganizationParticipant::List
+                        @students={{this.students}}
+                        @lastnameSort={{this.noop}}
+                        @sortByLastname={{this.noop}}
+                        @participationCountOrder={{this.noop}}
+                        @sortByParticipationCount={{this.noop}}
+                        @divisionSort={{this.noop}}
+                        @sortByDivision={{this.noop}}
+                        @onClickLearner={{this.noop}}
+                        @onFilter={{this.noop}}
+                        @searchFilter={{this.search}}
+                        @divisionsFilter={{this.divisions}}
+                        @connectionTypeFilter={{this.connectionTypes}}
+                        @certificabilityFilter={{this.certificability}}
+                />`);
+
+            const firstStudent = await screen.getAllByRole('checkbox')[1];
+            const secondStudent = await screen.getAllByRole('checkbox')[2];
+            await click(firstStudent);
+            await click(secondStudent);
+
+            const generateUsernamesButton = await screen.findByRole('button', {
+              name: t('pages.sco-organization-participants.action-bar.generate-username-button'),
+            });
+            await click(generateUsernamesButton);
+            await screen.findByRole('dialog');
+
+            const confirmationButton = await screen.findByRole('button', {
+              name: t('common.actions.confirm'),
+            });
+            await click(confirmationButton);
+
+            // then
+            sinon.assert.calledWith(
+              notificationsStub.sendError,
+              t('api-error-messages.student-password-reset.user-does-not-belong-to-organization-error'),
+            );
+            assert.ok(true);
+          });
+        });
+
+        module('when a student doesn’t belong to the organisation', function () {
+          test('displays an error notification', async function (assert) {
+            // given
+            const store = this.owner.lookup('service:store');
+            sinon.stub(store, 'adapterFor').returns({
+              generateOrganizationLearnersUsername: sinon
+                .stub()
+                .rejects([{ code: 'ORGANIZATION_LEARNER_DOES_NOT_BELONG_TO_ORGANIZATION' }]),
+            });
+            notificationsStub = this.owner.lookup('service:notifications');
+            sinon.stub(notificationsStub, 'sendError');
+
+            const students = [
+              { id: '1', firstName: 'Spider', lastName: 'Man', authenticationMethods: ['mediacentre'] },
+              { id: '2', firstName: 'Miles', lastName: 'Morales', authenticationMethods: ['email'] },
+            ];
+
+            this.set('students', students);
+
+            // when
+            const screen = await render(hbs`
+                <ScoOrganizationParticipant::List
+                        @students={{this.students}}
+                        @lastnameSort={{this.noop}}
+                        @sortByLastname={{this.noop}}
+                        @participationCountOrder={{this.noop}}
+                        @sortByParticipationCount={{this.noop}}
+                        @divisionSort={{this.noop}}
+                        @sortByDivision={{this.noop}}
+                        @onClickLearner={{this.noop}}
+                        @onFilter={{this.noop}}
+                        @searchFilter={{this.search}}
+                        @divisionsFilter={{this.divisions}}
+                        @connectionTypeFilter={{this.connectionTypes}}
+                        @certificabilityFilter={{this.certificability}}
+                />`);
+
+            const firstStudent = await screen.getAllByRole('checkbox')[1];
+            const secondStudent = await screen.getAllByRole('checkbox')[2];
+            await click(firstStudent);
+            await click(secondStudent);
+
+            const generateUsernamesButton = await screen.findByRole('button', {
+              name: t('pages.sco-organization-participants.action-bar.generate-username-button'),
+            });
+            await click(generateUsernamesButton);
+            await screen.findByRole('dialog');
+
+            const confirmationButton = await screen.findByRole('button', {
+              name: t('common.actions.confirm'),
+            });
+            await click(confirmationButton);
+
+            // then
+            sinon.assert.calledWith(
+              notificationsStub.sendError,
+              t('api-error-messages.student-password-reset.organization-learner-does-not-belong-to-organization-error'),
+            );
+            assert.ok(true);
+          });
+        });
+
+        module("when a student doesn't have a pix account", function () {
+          test('displays an error notification', async function (assert) {
+            // given
+            const store = this.owner.lookup('service:store');
+            sinon.stub(store, 'adapterFor').returns({
+              generateOrganizationLearnersUsername: sinon.stub().rejects([
+                {
+                  code: 'ORGANIZATION_LEARNER_DOES_NOT_HAVE_A_PIX_ACCOUNT',
+                },
+              ]),
+            });
+            notificationsStub = this.owner.lookup('service:notifications');
+            sinon.stub(notificationsStub, 'sendError');
+
+            const students = [
+              { id: '1', firstName: 'Spider', lastName: 'Man', authenticationMethods: ['empty'] },
+              { id: '2', firstName: 'Miles', lastName: 'Morales', authenticationMethods: ['email'] },
+            ];
+
+            this.set('students', students);
+
+            // when
+            const screen = await render(hbs`
+                <ScoOrganizationParticipant::List
+                        @students={{this.students}}
+                        @lastnameSort={{this.noop}}
+                        @sortByLastname={{this.noop}}
+                        @participationCountOrder={{this.noop}}
+                        @sortByParticipationCount={{this.noop}}
+                        @divisionSort={{this.noop}}
+                        @sortByDivision={{this.noop}}
+                        @onClickLearner={{this.noop}}
+                        @onFilter={{this.noop}}
+                        @searchFilter={{this.search}}
+                        @divisionsFilter={{this.divisions}}
+                        @connectionTypeFilter={{this.connectionTypes}}
+                        @certificabilityFilter={{this.certificability}}
+                />`);
+
+            const firstStudent = await screen.getAllByRole('checkbox')[1];
+            const secondStudent = await screen.getAllByRole('checkbox')[2];
+            await click(firstStudent);
+            await click(secondStudent);
+
+            const generateUsernamesButton = await screen.findByRole('button', {
+              name: t('pages.sco-organization-participants.action-bar.generate-username-button'),
+            });
+            await click(generateUsernamesButton);
+            await screen.findByRole('dialog');
+
+            const confirmationButton = await screen.findByRole('button', {
+              name: t('common.actions.confirm'),
+            });
+            await click(confirmationButton);
+
+            // then
+            sinon.assert.calledWith(
+              notificationsStub.sendError,
+              t('api-error-messages.student-username-generation.organization-learner-does-not-have-pix-account'),
+            );
+            assert.ok(true);
+          });
+        });
+
+        module('when a student already have a username', function () {
+          test('displays an error notification', async function (assert) {
+            // given
+            const store = this.owner.lookup('service:store');
+            sinon.stub(store, 'adapterFor').returns({
+              generateOrganizationLearnersUsername: sinon.stub().rejects([
+                {
+                  code: 'ORGANIZATION_LEARNER_DOES_ALREADY_HAVE_A_USERNAME',
+                },
+              ]),
+            });
+            notificationsStub = this.owner.lookup('service:notifications');
+            sinon.stub(notificationsStub, 'sendError');
+
+            const students = [
+              { id: '1', firstName: 'Spider', lastName: 'Man', authenticationMethods: ['mediacentre'] },
+              { id: '2', firstName: 'Miles', lastName: 'Morales', authenticationMethods: ['identifiant'] },
+            ];
+
+            this.set('students', students);
+
+            // when
+            const screen = await render(hbs`
+                <ScoOrganizationParticipant::List
+                        @students={{this.students}}
+                        @lastnameSort={{this.noop}}
+                        @sortByLastname={{this.noop}}
+                        @participationCountOrder={{this.noop}}
+                        @sortByParticipationCount={{this.noop}}
+                        @divisionSort={{this.noop}}
+                        @sortByDivision={{this.noop}}
+                        @onClickLearner={{this.noop}}
+                        @onFilter={{this.noop}}
+                        @searchFilter={{this.search}}
+                        @divisionsFilter={{this.divisions}}
+                        @connectionTypeFilter={{this.connectionTypes}}
+                        @certificabilityFilter={{this.certificability}}
+                />`);
+
+            const firstStudent = await screen.getAllByRole('checkbox')[1];
+            const secondStudent = await screen.getAllByRole('checkbox')[2];
+            await click(firstStudent);
+            await click(secondStudent);
+
+            const generateUsernamesButton = await screen.findByRole('button', {
+              name: t('pages.sco-organization-participants.action-bar.generate-username-button'),
+            });
+            await click(generateUsernamesButton);
+            await screen.findByRole('dialog');
+
+            const confirmationButton = await screen.findByRole('button', {
+              name: t('common.actions.confirm'),
+            });
+            await click(confirmationButton);
+
+            // then
+            sinon.assert.calledWith(
+              notificationsStub.sendError,
+              t('api-error-messages.student-username-generation.organization-learner-does-already-have-a-username'),
+            );
+            assert.ok(true);
+          });
+        });
+
+        module('when an unrelated error occurs', function () {
+          test('displays an error notification', async function (assert) {
+            // given
+            const store = this.owner.lookup('service:store');
+            sinon.stub(store, 'adapterFor').returns({
+              generateOrganizationLearnersUsername: sinon.stub().rejects([{ status: 500 }]),
+            });
+            notificationsStub = this.owner.lookup('service:notifications');
+            sinon.stub(notificationsStub, 'sendError');
+
+            const students = [
+              { id: '1', firstName: 'Spider', lastName: 'Man', authenticationMethods: ['mediacentre'] },
+              { id: '2', firstName: 'Miles', lastName: 'Morales', authenticationMethods: ['email'] },
+            ];
+
+            this.set('students', students);
+
+            // when
+            const screen = await render(hbs`
+                <ScoOrganizationParticipant::List
+                        @students={{this.students}}
+                        @lastnameSort={{this.noop}}
+                        @sortByLastname={{this.noop}}
+                        @participationCountOrder={{this.noop}}
+                        @sortByParticipationCount={{this.noop}}
+                        @divisionSort={{this.noop}}
+                        @sortByDivision={{this.noop}}
+                        @onClickLearner={{this.noop}}
+                        @onFilter={{this.noop}}
+                        @searchFilter={{this.search}}
+                        @divisionsFilter={{this.divisions}}
+                        @connectionTypeFilter={{this.connectionTypes}}
+                        @certificabilityFilter={{this.certificability}}
+                />`);
+
+            const firstStudent = await screen.getAllByRole('checkbox')[1];
+            const secondStudent = await screen.getAllByRole('checkbox')[2];
+            await click(firstStudent);
+            await click(secondStudent);
+
+            const generateUsernamesButton = await screen.findByRole('button', {
+              name: t('pages.sco-organization-participants.action-bar.generate-username-button'),
+            });
+            await click(generateUsernamesButton);
+            await screen.findByRole('dialog');
+
+            const confirmationButton = await screen.findByRole('button', {
+              name: t('common.actions.confirm'),
+            });
+            await click(confirmationButton);
+
+            // then
+            sinon.assert.called(notificationsStub.sendError);
+            assert.ok(true);
+          });
+        });
+      });
+    });
   });
 });

--- a/orga/tests/integration/components/sco-organization-participant/list-test.js
+++ b/orga/tests/integration/components/sco-organization-participant/list-test.js
@@ -42,17 +42,18 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
 
     // when
     const screen = await render(
-      hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-  @hasComputeOrganizationLearnerCertificabilityEnabled={{true}}
-/>`,
+      hbs`
+          <ScoOrganizationParticipant::List
+                  @students={{this.students}}
+                  @onFilter={{this.noop}}
+                  @searchFilter={{this.search}}
+                  @divisionsFilter={{this.divisions}}
+                  @connectionTypeFilter={{this.connectionTypes}}
+                  @certificabilityFilter={{this.certificability}}
+                  @onClickLearner={{this.noop}}
+                  @onResetFilter={{this.noop}}
+                  @hasComputeOrganizationLearnerCertificabilityEnabled={{true}}
+          />`,
     );
 
     // then
@@ -109,17 +110,18 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
 
     // when
     const screen = await render(
-      hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-  @hasComputeOrganizationLearnerCertificabilityEnabled={{true}}
-/>`,
+      hbs`
+          <ScoOrganizationParticipant::List
+                  @students={{this.students}}
+                  @onFilter={{this.noop}}
+                  @searchFilter={{this.search}}
+                  @divisionsFilter={{this.divisions}}
+                  @connectionTypeFilter={{this.connectionTypes}}
+                  @certificabilityFilter={{this.certificability}}
+                  @onClickLearner={{this.noop}}
+                  @onResetFilter={{this.noop}}
+                  @hasComputeOrganizationLearnerCertificabilityEnabled={{true}}
+          />`,
     );
 
     // then
@@ -153,17 +155,18 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
 
     // when
     const screen = await render(
-      hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-  @hasComputeOrganizationLearnerCertificabilityEnabled={{true}}
-/>`,
+      hbs`
+          <ScoOrganizationParticipant::List
+                  @students={{this.students}}
+                  @onFilter={{this.noop}}
+                  @searchFilter={{this.search}}
+                  @divisionsFilter={{this.divisions}}
+                  @connectionTypeFilter={{this.connectionTypes}}
+                  @certificabilityFilter={{this.certificability}}
+                  @onClickLearner={{this.noop}}
+                  @onResetFilter={{this.noop}}
+                  @hasComputeOrganizationLearnerCertificabilityEnabled={{true}}
+          />`,
     );
     // then
     assert.ok(screen.getByRole('link', { name: 'Michel', href: /\/eleves\/22/g }));
@@ -190,17 +193,18 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
 
     // when
     const screen = await render(
-      hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-  @hasComputeOrganizationLearnerCertificabilityEnabled={{true}}
-/>`,
+      hbs`
+          <ScoOrganizationParticipant::List
+                  @students={{this.students}}
+                  @onFilter={{this.noop}}
+                  @searchFilter={{this.search}}
+                  @divisionsFilter={{this.divisions}}
+                  @connectionTypeFilter={{this.connectionTypes}}
+                  @certificabilityFilter={{this.certificability}}
+                  @onClickLearner={{this.noop}}
+                  @onResetFilter={{this.noop}}
+                  @hasComputeOrganizationLearnerCertificabilityEnabled={{true}}
+          />`,
     );
 
     // then
@@ -223,17 +227,18 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
 
     // when
     const screen = await render(
-      hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-  @hasComputeOrganizationLearnerCertificabilityEnabled={{true}}
-/>`,
+      hbs`
+          <ScoOrganizationParticipant::List
+                  @students={{this.students}}
+                  @onFilter={{this.noop}}
+                  @searchFilter={{this.search}}
+                  @divisionsFilter={{this.divisions}}
+                  @connectionTypeFilter={{this.connectionTypes}}
+                  @certificabilityFilter={{this.certificability}}
+                  @onClickLearner={{this.noop}}
+                  @onResetFilter={{this.noop}}
+                  @hasComputeOrganizationLearnerCertificabilityEnabled={{true}}
+          />`,
     );
 
     // then
@@ -254,17 +259,18 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
 
     // when
     const screen = await render(
-      hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-  @hasComputeOrganizationLearnerCertificabilityEnabled={{true}}
-/>`,
+      hbs`
+          <ScoOrganizationParticipant::List
+                  @students={{this.students}}
+                  @onFilter={{this.noop}}
+                  @searchFilter={{this.search}}
+                  @divisionsFilter={{this.divisions}}
+                  @connectionTypeFilter={{this.connectionTypes}}
+                  @certificabilityFilter={{this.certificability}}
+                  @onClickLearner={{this.noop}}
+                  @onResetFilter={{this.noop}}
+                  @hasComputeOrganizationLearnerCertificabilityEnabled={{true}}
+          />`,
     );
 
     // then
@@ -285,16 +291,17 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
         this.set('certificability', []);
         this.set('search', null);
 
-        const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-/>`);
+        const screen = await render(hbs`
+            <ScoOrganizationParticipant::List
+                    @students={{this.students}}
+                    @onFilter={{this.noop}}
+                    @searchFilter={{this.search}}
+                    @divisionsFilter={{this.divisions}}
+                    @connectionTypeFilter={{this.connectionTypes}}
+                    @certificabilityFilter={{this.certificability}}
+                    @onClickLearner={{this.noop}}
+                    @onResetFilter={{this.noop}}
+            />`);
 
         // when
         await click(screen.getByLabelText('Rechercher par méthode de connexion'));
@@ -341,16 +348,17 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       this.set('search', null);
 
       await render(
-        hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.triggerFiltering}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-/>`,
+        hbs`
+            <ScoOrganizationParticipant::List
+                    @students={{this.students}}
+                    @onFilter={{this.triggerFiltering}}
+                    @searchFilter={{this.search}}
+                    @divisionsFilter={{this.divisions}}
+                    @connectionTypeFilter={{this.connectionTypes}}
+                    @certificabilityFilter={{this.certificability}}
+                    @onClickLearner={{this.noop}}
+                    @onResetFilter={{this.noop}}
+            />`,
       );
 
       // when
@@ -371,16 +379,17 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       this.set('certificability', []);
       this.set('search', null);
 
-      const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.triggerFiltering}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-/>`);
+      const screen = await render(hbs`
+          <ScoOrganizationParticipant::List
+                  @students={{this.students}}
+                  @onFilter={{this.triggerFiltering}}
+                  @searchFilter={{this.search}}
+                  @divisionsFilter={{this.divisions}}
+                  @connectionTypeFilter={{this.connectionTypes}}
+                  @certificabilityFilter={{this.certificability}}
+                  @onClickLearner={{this.noop}}
+                  @onResetFilter={{this.noop}}
+          />`);
 
       // when
       const select = await screen.getByPlaceholderText('Rechercher par classe');
@@ -405,16 +414,17 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       this.set('certificability', []);
       this.set('search', null);
 
-      const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.triggerFiltering}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-/>`);
+      const screen = await render(hbs`
+          <ScoOrganizationParticipant::List
+                  @students={{this.students}}
+                  @onFilter={{this.triggerFiltering}}
+                  @searchFilter={{this.search}}
+                  @divisionsFilter={{this.divisions}}
+                  @connectionTypeFilter={{this.connectionTypes}}
+                  @certificabilityFilter={{this.certificability}}
+                  @onClickLearner={{this.noop}}
+                  @onResetFilter={{this.noop}}
+          />`);
 
       // when
       await click(screen.getByLabelText('Rechercher par méthode de connexion'));
@@ -435,16 +445,17 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       this.set('certificability', []);
       this.set('search', null);
 
-      const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.triggerFiltering}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-/>`);
+      const screen = await render(hbs`
+          <ScoOrganizationParticipant::List
+                  @students={{this.students}}
+                  @onFilter={{this.triggerFiltering}}
+                  @searchFilter={{this.search}}
+                  @divisionsFilter={{this.divisions}}
+                  @connectionTypeFilter={{this.connectionTypes}}
+                  @certificabilityFilter={{this.certificability}}
+                  @onClickLearner={{this.noop}}
+                  @onResetFilter={{this.noop}}
+          />`);
 
       // when
       const select = await screen.getByLabelText('Rechercher par certificabilité');
@@ -478,16 +489,17 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       this.set('certificability', []);
       this.set('search', null);
 
-      await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.triggerFiltering}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.resetFiltered}}
-/>`);
+      await render(hbs`
+          <ScoOrganizationParticipant::List
+                  @students={{this.students}}
+                  @onFilter={{this.triggerFiltering}}
+                  @searchFilter={{this.search}}
+                  @divisionsFilter={{this.divisions}}
+                  @connectionTypeFilter={{this.connectionTypes}}
+                  @certificabilityFilter={{this.certificability}}
+                  @onClickLearner={{this.noop}}
+                  @onResetFilter={{this.resetFiltered}}
+          />`);
 
       // when
       await clickByName('Effacer les filtres');
@@ -513,18 +525,19 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
         this.set('certificability', []);
         this.set('search', null);
 
-        const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-  @participationCountOrder={{this.participationCountOrder}}
-  @sortByParticipationCount={{this.sortByParticipationCount}}
-/>`);
+        const screen = await render(hbs`
+            <ScoOrganizationParticipant::List
+                    @students={{this.students}}
+                    @onFilter={{this.noop}}
+                    @searchFilter={{this.search}}
+                    @divisionsFilter={{this.divisions}}
+                    @connectionTypeFilter={{this.connectionTypes}}
+                    @certificabilityFilter={{this.certificability}}
+                    @onClickLearner={{this.noop}}
+                    @onResetFilter={{this.noop}}
+                    @participationCountOrder={{this.participationCountOrder}}
+                    @sortByParticipationCount={{this.sortByParticipationCount}}
+            />`);
 
         // when
         await click(
@@ -550,18 +563,19 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
         this.set('certificability', []);
         this.set('search', null);
 
-        const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-  @participationCountOrder={{this.participationCountOrder}}
-  @sortByParticipationCount={{this.sortByParticipationCount}}
-/>`);
+        const screen = await render(hbs`
+            <ScoOrganizationParticipant::List
+                    @students={{this.students}}
+                    @onFilter={{this.noop}}
+                    @searchFilter={{this.search}}
+                    @divisionsFilter={{this.divisions}}
+                    @connectionTypeFilter={{this.connectionTypes}}
+                    @certificabilityFilter={{this.certificability}}
+                    @onClickLearner={{this.noop}}
+                    @onResetFilter={{this.noop}}
+                    @participationCountOrder={{this.participationCountOrder}}
+                    @sortByParticipationCount={{this.sortByParticipationCount}}
+            />`);
 
         // when
         await click(
@@ -587,18 +601,19 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
         this.set('certificability', []);
         this.set('search', null);
 
-        const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-  @participationCountOrder={{this.participationCountOrder}}
-  @sortByParticipationCount={{this.sortByParticipationCount}}
-/>`);
+        const screen = await render(hbs`
+            <ScoOrganizationParticipant::List
+                    @students={{this.students}}
+                    @onFilter={{this.noop}}
+                    @searchFilter={{this.search}}
+                    @divisionsFilter={{this.divisions}}
+                    @connectionTypeFilter={{this.connectionTypes}}
+                    @certificabilityFilter={{this.certificability}}
+                    @onClickLearner={{this.noop}}
+                    @onResetFilter={{this.noop}}
+                    @participationCountOrder={{this.participationCountOrder}}
+                    @sortByParticipationCount={{this.sortByParticipationCount}}
+            />`);
 
         // when
         await click(
@@ -627,18 +642,19 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
         this.set('certificability', []);
         this.set('search', null);
 
-        const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-  @lastnameSort={{this.lastnameSort}}
-  @sortByLastname={{this.sortByLastname}}
-/>`);
+        const screen = await render(hbs`
+            <ScoOrganizationParticipant::List
+                    @students={{this.students}}
+                    @onFilter={{this.noop}}
+                    @searchFilter={{this.search}}
+                    @divisionsFilter={{this.divisions}}
+                    @connectionTypeFilter={{this.connectionTypes}}
+                    @certificabilityFilter={{this.certificability}}
+                    @onClickLearner={{this.noop}}
+                    @onResetFilter={{this.noop}}
+                    @lastnameSort={{this.lastnameSort}}
+                    @sortByLastname={{this.sortByLastname}}
+            />`);
 
         // when
         await click(
@@ -662,18 +678,19 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
         this.set('certificability', []);
         this.set('search', null);
 
-        const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-  @lastnameSort={{this.lastnameSort}}
-  @sortByLastname={{this.sortByLastname}}
-/>`);
+        const screen = await render(hbs`
+            <ScoOrganizationParticipant::List
+                    @students={{this.students}}
+                    @onFilter={{this.noop}}
+                    @searchFilter={{this.search}}
+                    @divisionsFilter={{this.divisions}}
+                    @connectionTypeFilter={{this.connectionTypes}}
+                    @certificabilityFilter={{this.certificability}}
+                    @onClickLearner={{this.noop}}
+                    @onResetFilter={{this.noop}}
+                    @lastnameSort={{this.lastnameSort}}
+                    @sortByLastname={{this.sortByLastname}}
+            />`);
 
         // when
         await click(
@@ -697,18 +714,19 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
         this.set('certificability', []);
         this.set('search', null);
 
-        const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-  @lastnameSort={{this.lastnameSort}}
-  @sortByLastname={{this.sortByLastname}}
-/>`);
+        const screen = await render(hbs`
+            <ScoOrganizationParticipant::List
+                    @students={{this.students}}
+                    @onFilter={{this.noop}}
+                    @searchFilter={{this.search}}
+                    @divisionsFilter={{this.divisions}}
+                    @connectionTypeFilter={{this.connectionTypes}}
+                    @certificabilityFilter={{this.certificability}}
+                    @onClickLearner={{this.noop}}
+                    @onResetFilter={{this.noop}}
+                    @lastnameSort={{this.lastnameSort}}
+                    @sortByLastname={{this.sortByLastname}}
+            />`);
 
         // when
         await click(
@@ -735,18 +753,19 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
         this.set('certificability', []);
         this.set('search', null);
 
-        const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-  @divisionSort={{this.divisionSort}}
-  @sortByDivision={{this.sortByDivision}}
-/>`);
+        const screen = await render(hbs`
+            <ScoOrganizationParticipant::List
+                    @students={{this.students}}
+                    @onFilter={{this.noop}}
+                    @searchFilter={{this.search}}
+                    @divisionsFilter={{this.divisions}}
+                    @connectionTypeFilter={{this.connectionTypes}}
+                    @certificabilityFilter={{this.certificability}}
+                    @onClickLearner={{this.noop}}
+                    @onResetFilter={{this.noop}}
+                    @divisionSort={{this.divisionSort}}
+                    @sortByDivision={{this.sortByDivision}}
+            />`);
 
         // when
         await click(
@@ -770,18 +789,19 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
         this.set('certificability', []);
         this.set('search', null);
 
-        const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-  @divisionSort={{this.divisionSort}}
-  @sortByDivision={{this.sortByDivision}}
-/>`);
+        const screen = await render(hbs`
+            <ScoOrganizationParticipant::List
+                    @students={{this.students}}
+                    @onFilter={{this.noop}}
+                    @searchFilter={{this.search}}
+                    @divisionsFilter={{this.divisions}}
+                    @connectionTypeFilter={{this.connectionTypes}}
+                    @certificabilityFilter={{this.certificability}}
+                    @onClickLearner={{this.noop}}
+                    @onResetFilter={{this.noop}}
+                    @divisionSort={{this.divisionSort}}
+                    @sortByDivision={{this.sortByDivision}}
+            />`);
 
         // when
         await click(
@@ -805,18 +825,19 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
         this.set('certificability', []);
         this.set('search', null);
 
-        const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-  @divisionSort={{this.divisionSort}}
-  @sortByDivision={{this.sortByDivision}}
-/>`);
+        const screen = await render(hbs`
+            <ScoOrganizationParticipant::List
+                    @students={{this.students}}
+                    @onFilter={{this.noop}}
+                    @searchFilter={{this.search}}
+                    @divisionsFilter={{this.divisions}}
+                    @connectionTypeFilter={{this.connectionTypes}}
+                    @certificabilityFilter={{this.certificability}}
+                    @onClickLearner={{this.noop}}
+                    @onResetFilter={{this.noop}}
+                    @divisionSort={{this.divisionSort}}
+                    @sortByDivision={{this.sortByDivision}}
+            />`);
 
         // when
         await click(
@@ -846,16 +867,17 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       this.set('certificability', []);
       this.set('search', null);
 
-      screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-/>`);
+      screen = await render(hbs`
+          <ScoOrganizationParticipant::List
+                  @students={{this.students}}
+                  @onFilter={{this.noop}}
+                  @searchFilter={{this.search}}
+                  @divisionsFilter={{this.divisions}}
+                  @connectionTypeFilter={{this.connectionTypes}}
+                  @certificabilityFilter={{this.certificability}}
+                  @onClickLearner={{this.noop}}
+                  @onResetFilter={{this.noop}}
+          />`);
     });
 
     test('it should display dash for authentication method', async function (assert) {
@@ -892,16 +914,17 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       this.set('certificability', []);
       this.set('search', null);
 
-      const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-/>`);
+      const screen = await render(hbs`
+          <ScoOrganizationParticipant::List
+                  @students={{this.students}}
+                  @onFilter={{this.noop}}
+                  @searchFilter={{this.search}}
+                  @divisionsFilter={{this.divisions}}
+                  @connectionTypeFilter={{this.connectionTypes}}
+                  @certificabilityFilter={{this.certificability}}
+                  @onClickLearner={{this.noop}}
+                  @onResetFilter={{this.noop}}
+          />`);
 
       // when
       await clickByName(t('pages.sco-organization-participants.actions.show-actions'));
@@ -929,16 +952,17 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       this.set('certificability', []);
       this.set('search', null);
 
-      screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-/>`);
+      screen = await render(hbs`
+          <ScoOrganizationParticipant::List
+                  @students={{this.students}}
+                  @onFilter={{this.noop}}
+                  @searchFilter={{this.search}}
+                  @divisionsFilter={{this.divisions}}
+                  @connectionTypeFilter={{this.connectionTypes}}
+                  @certificabilityFilter={{this.certificability}}
+                  @onClickLearner={{this.noop}}
+                  @onResetFilter={{this.noop}}
+          />`);
     });
 
     test('it should display "Identifiant" as authentication method', async function (assert) {
@@ -974,16 +998,17 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       this.set('search', null);
 
       // when
-      screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-/>`);
+      screen = await render(hbs`
+          <ScoOrganizationParticipant::List
+                  @students={{this.students}}
+                  @onFilter={{this.noop}}
+                  @searchFilter={{this.search}}
+                  @divisionsFilter={{this.divisions}}
+                  @connectionTypeFilter={{this.connectionTypes}}
+                  @certificabilityFilter={{this.certificability}}
+                  @onClickLearner={{this.noop}}
+                  @onResetFilter={{this.noop}}
+          />`);
     });
 
     test('it should display "Adresse email" as authentication method', function (assert) {
@@ -1026,16 +1051,17 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       this.set('certificability', []);
       this.set('search', null);
 
-      const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-/>`);
+      const screen = await render(hbs`
+          <ScoOrganizationParticipant::List
+                  @students={{this.students}}
+                  @onFilter={{this.noop}}
+                  @searchFilter={{this.search}}
+                  @divisionsFilter={{this.divisions}}
+                  @connectionTypeFilter={{this.connectionTypes}}
+                  @certificabilityFilter={{this.certificability}}
+                  @onClickLearner={{this.noop}}
+                  @onResetFilter={{this.noop}}
+          />`);
 
       // then
       assert.ok(
@@ -1048,16 +1074,17 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
 
     test('it should display the action menu', async function (assert) {
       // when
-      const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-/>`);
+      const screen = await render(hbs`
+          <ScoOrganizationParticipant::List
+                  @students={{this.students}}
+                  @onFilter={{this.noop}}
+                  @searchFilter={{this.search}}
+                  @divisionsFilter={{this.divisions}}
+                  @connectionTypeFilter={{this.connectionTypes}}
+                  @certificabilityFilter={{this.certificability}}
+                  @onClickLearner={{this.noop}}
+                  @onResetFilter={{this.noop}}
+          />`);
 
       // then
       assert.ok(screen.getByRole('button', { name: t('pages.sco-organization-participants.actions.show-actions') }));
@@ -1072,16 +1099,17 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       ]);
 
       // when
-      const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-/>`);
+      const screen = await render(hbs`
+          <ScoOrganizationParticipant::List
+                  @students={{this.students}}
+                  @onFilter={{this.noop}}
+                  @searchFilter={{this.search}}
+                  @divisionsFilter={{this.divisions}}
+                  @connectionTypeFilter={{this.connectionTypes}}
+                  @certificabilityFilter={{this.certificability}}
+                  @onClickLearner={{this.noop}}
+                  @onResetFilter={{this.noop}}
+          />`);
 
       await click(screen.getByLabelText(t('components.certificability-tooltip.aria-label')));
 
@@ -1102,16 +1130,17 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       this.set('search', null);
 
       // when
-      const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-/>`);
+      const screen = await render(hbs`
+          <ScoOrganizationParticipant::List
+                  @students={{this.students}}
+                  @onFilter={{this.noop}}
+                  @searchFilter={{this.search}}
+                  @divisionsFilter={{this.divisions}}
+                  @connectionTypeFilter={{this.connectionTypes}}
+                  @certificabilityFilter={{this.certificability}}
+                  @onClickLearner={{this.noop}}
+                  @onResetFilter={{this.noop}}
+          />`);
 
       // then
       assert.ok(screen.getByText(t('pages.sco-organization-participants.table.empty')));
@@ -1130,16 +1159,17 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       this.set('search', null);
 
       // when
-      const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-  @onClickLearner={{this.noop}}
-  @onResetFilter={{this.noop}}
-/>`);
+      const screen = await render(hbs`
+          <ScoOrganizationParticipant::List
+                  @students={{this.students}}
+                  @onFilter={{this.noop}}
+                  @searchFilter={{this.search}}
+                  @divisionsFilter={{this.divisions}}
+                  @connectionTypeFilter={{this.connectionTypes}}
+                  @certificabilityFilter={{this.certificability}}
+                  @onClickLearner={{this.noop}}
+                  @onResetFilter={{this.noop}}
+          />`);
 
       // then
       assert.ok(screen.getByText(t('pages.sco-organization-participants.no-participants-action')));
@@ -1154,6 +1184,7 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       store = this.owner.lookup('service:store');
 
       const division = store.createRecord('division', { id: '3BF', name: '3BF' });
+
       class CurrentUserStub extends Service {
         prescriber = {};
         organization = store.createRecord('organization', {
@@ -1163,6 +1194,7 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
           isManagingStudents: true,
         });
       }
+
       this.owner.register('service:current-user', CurrentUserStub);
 
       const students = [{ id: '1', firstName: 'Spider', lastName: 'Man' }];
@@ -1173,21 +1205,22 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       this.set('certificability', []);
 
       // when
-      const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @lastnameSort={{this.noop}}
-  @sortByLastname={{this.noop}}
-  @participationCountOrder={{this.noop}}
-  @sortByParticipationCount={{this.noop}}
-  @divisionSort={{this.noop}}
-  @sortByDivision={{this.noop}}
-  @onClickLearner={{this.noop}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-/>`);
+      const screen = await render(hbs`
+          <ScoOrganizationParticipant::List
+                  @students={{this.students}}
+                  @lastnameSort={{this.noop}}
+                  @sortByLastname={{this.noop}}
+                  @participationCountOrder={{this.noop}}
+                  @sortByParticipationCount={{this.noop}}
+                  @divisionSort={{this.noop}}
+                  @sortByDivision={{this.noop}}
+                  @onClickLearner={{this.noop}}
+                  @onFilter={{this.noop}}
+                  @searchFilter={{this.search}}
+                  @divisionsFilter={{this.divisions}}
+                  @connectionTypeFilter={{this.connectionTypes}}
+                  @certificabilityFilter={{this.certificability}}
+          />`);
 
       const mainCheckbox = screen.getByRole('checkbox', {
         name: t('pages.sco-organization-participants.table.column.mainCheckbox'),
@@ -1239,21 +1272,22 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       this.set('students', students);
 
       // when
-      const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @lastnameSort={{this.noop}}
-  @sortByLastname={{this.noop}}
-  @participationCountOrder={{this.noop}}
-  @sortByParticipationCount={{this.noop}}
-  @divisionSort={{this.noop}}
-  @sortByDivision={{this.noop}}
-  @onClickLearner={{this.noop}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-/>`);
+      const screen = await render(hbs`
+          <ScoOrganizationParticipant::List
+                  @students={{this.students}}
+                  @lastnameSort={{this.noop}}
+                  @sortByLastname={{this.noop}}
+                  @participationCountOrder={{this.noop}}
+                  @sortByParticipationCount={{this.noop}}
+                  @divisionSort={{this.noop}}
+                  @sortByDivision={{this.noop}}
+                  @onClickLearner={{this.noop}}
+                  @onFilter={{this.noop}}
+                  @searchFilter={{this.search}}
+                  @divisionsFilter={{this.divisions}}
+                  @connectionTypeFilter={{this.connectionTypes}}
+                  @certificabilityFilter={{this.certificability}}
+          />`);
 
       const firstStudent = screen.getAllByRole('checkbox')[1];
       await click(firstStudent);
@@ -1277,21 +1311,22 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       this.set('students', students);
 
       // when
-      const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @lastnameSort={{this.noop}}
-  @sortByLastname={{this.noop}}
-  @participationCountOrder={{this.noop}}
-  @sortByParticipationCount={{this.noop}}
-  @divisionSort={{this.noop}}
-  @sortByDivision={{this.noop}}
-  @onClickLearner={{this.noop}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-/>`);
+      const screen = await render(hbs`
+          <ScoOrganizationParticipant::List
+                  @students={{this.students}}
+                  @lastnameSort={{this.noop}}
+                  @sortByLastname={{this.noop}}
+                  @participationCountOrder={{this.noop}}
+                  @sortByParticipationCount={{this.noop}}
+                  @divisionSort={{this.noop}}
+                  @sortByDivision={{this.noop}}
+                  @onClickLearner={{this.noop}}
+                  @onFilter={{this.noop}}
+                  @searchFilter={{this.search}}
+                  @divisionsFilter={{this.divisions}}
+                  @connectionTypeFilter={{this.connectionTypes}}
+                  @certificabilityFilter={{this.certificability}}
+          />`);
 
       const firstStudentToResetPassword = screen.getAllByRole('checkbox')[2];
       const secondStudentToResetPassword = screen.getAllByRole('checkbox')[3];
@@ -1330,21 +1365,22 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
           this.set('students', students);
 
           // when
-          const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @lastnameSort={{this.noop}}
-  @sortByLastname={{this.noop}}
-  @participationCountOrder={{this.noop}}
-  @sortByParticipationCount={{this.noop}}
-  @divisionSort={{this.noop}}
-  @sortByDivision={{this.noop}}
-  @onClickLearner={{this.noop}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-/>`);
+          const screen = await render(hbs`
+              <ScoOrganizationParticipant::List
+                      @students={{this.students}}
+                      @lastnameSort={{this.noop}}
+                      @sortByLastname={{this.noop}}
+                      @participationCountOrder={{this.noop}}
+                      @sortByParticipationCount={{this.noop}}
+                      @divisionSort={{this.noop}}
+                      @sortByDivision={{this.noop}}
+                      @onClickLearner={{this.noop}}
+                      @onFilter={{this.noop}}
+                      @searchFilter={{this.search}}
+                      @divisionsFilter={{this.divisions}}
+                      @connectionTypeFilter={{this.connectionTypes}}
+                      @certificabilityFilter={{this.certificability}}
+              />`);
           const student = await screen.getAllByRole('checkbox')[1];
           await click(student);
           const resetPasswordButton = await screen.findByRole('button', {
@@ -1379,21 +1415,22 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
           this.set('students', students);
 
           // when
-          const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @lastnameSort={{this.noop}}
-  @sortByLastname={{this.noop}}
-  @participationCountOrder={{this.noop}}
-  @sortByParticipationCount={{this.noop}}
-  @divisionSort={{this.noop}}
-  @sortByDivision={{this.noop}}
-  @onClickLearner={{this.noop}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-/>`);
+          const screen = await render(hbs`
+              <ScoOrganizationParticipant::List
+                      @students={{this.students}}
+                      @lastnameSort={{this.noop}}
+                      @sortByLastname={{this.noop}}
+                      @participationCountOrder={{this.noop}}
+                      @sortByParticipationCount={{this.noop}}
+                      @divisionSort={{this.noop}}
+                      @sortByDivision={{this.noop}}
+                      @onClickLearner={{this.noop}}
+                      @onFilter={{this.noop}}
+                      @searchFilter={{this.search}}
+                      @divisionsFilter={{this.divisions}}
+                      @connectionTypeFilter={{this.connectionTypes}}
+                      @certificabilityFilter={{this.certificability}}
+              />`);
           const firstStudent = await screen.getAllByRole('checkbox')[1];
           const secondStudent = await screen.getAllByRole('checkbox')[2];
           await click(firstStudent);
@@ -1429,21 +1466,22 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
           this.set('students', students);
 
           // when
-          const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @lastnameSort={{this.noop}}
-  @sortByLastname={{this.noop}}
-  @participationCountOrder={{this.noop}}
-  @sortByParticipationCount={{this.noop}}
-  @divisionSort={{this.noop}}
-  @sortByDivision={{this.noop}}
-  @onClickLearner={{this.noop}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-/>`);
+          const screen = await render(hbs`
+              <ScoOrganizationParticipant::List
+                      @students={{this.students}}
+                      @lastnameSort={{this.noop}}
+                      @sortByLastname={{this.noop}}
+                      @participationCountOrder={{this.noop}}
+                      @sortByParticipationCount={{this.noop}}
+                      @divisionSort={{this.noop}}
+                      @sortByDivision={{this.noop}}
+                      @onClickLearner={{this.noop}}
+                      @onFilter={{this.noop}}
+                      @searchFilter={{this.search}}
+                      @divisionsFilter={{this.divisions}}
+                      @connectionTypeFilter={{this.connectionTypes}}
+                      @certificabilityFilter={{this.certificability}}
+              />`);
 
           const firstStudent = await screen.getAllByRole('checkbox')[1];
           const secondStudent = await screen.getAllByRole('checkbox')[2];
@@ -1481,21 +1519,22 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
           this.set('students', students);
 
           // when
-          const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @lastnameSort={{this.noop}}
-  @sortByLastname={{this.noop}}
-  @participationCountOrder={{this.noop}}
-  @sortByParticipationCount={{this.noop}}
-  @divisionSort={{this.noop}}
-  @sortByDivision={{this.noop}}
-  @onClickLearner={{this.noop}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-/>`);
+          const screen = await render(hbs`
+              <ScoOrganizationParticipant::List
+                      @students={{this.students}}
+                      @lastnameSort={{this.noop}}
+                      @sortByLastname={{this.noop}}
+                      @participationCountOrder={{this.noop}}
+                      @sortByParticipationCount={{this.noop}}
+                      @divisionSort={{this.noop}}
+                      @sortByDivision={{this.noop}}
+                      @onClickLearner={{this.noop}}
+                      @onFilter={{this.noop}}
+                      @searchFilter={{this.search}}
+                      @divisionsFilter={{this.divisions}}
+                      @connectionTypeFilter={{this.connectionTypes}}
+                      @certificabilityFilter={{this.certificability}}
+              />`);
 
           const firstStudent = await screen.getAllByRole('checkbox')[1];
           const secondStudent = await screen.getAllByRole('checkbox')[2];
@@ -1539,21 +1578,22 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
               this.set('students', students);
 
               // when
-              const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @lastnameSort={{this.noop}}
-  @sortByLastname={{this.noop}}
-  @participationCountOrder={{this.noop}}
-  @sortByParticipationCount={{this.noop}}
-  @divisionSort={{this.noop}}
-  @sortByDivision={{this.noop}}
-  @onClickLearner={{this.noop}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-/>`);
+              const screen = await render(hbs`
+                  <ScoOrganizationParticipant::List
+                          @students={{this.students}}
+                          @lastnameSort={{this.noop}}
+                          @sortByLastname={{this.noop}}
+                          @participationCountOrder={{this.noop}}
+                          @sortByParticipationCount={{this.noop}}
+                          @divisionSort={{this.noop}}
+                          @sortByDivision={{this.noop}}
+                          @onClickLearner={{this.noop}}
+                          @onFilter={{this.noop}}
+                          @searchFilter={{this.search}}
+                          @divisionsFilter={{this.divisions}}
+                          @connectionTypeFilter={{this.connectionTypes}}
+                          @certificabilityFilter={{this.certificability}}
+                  />`);
 
               const firstStudent = await screen.getAllByRole('checkbox')[1];
               const secondStudent = await screen.getAllByRole('checkbox')[2];
@@ -1600,21 +1640,22 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
               this.set('students', students);
 
               // when
-              const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @lastnameSort={{this.noop}}
-  @sortByLastname={{this.noop}}
-  @participationCountOrder={{this.noop}}
-  @sortByParticipationCount={{this.noop}}
-  @divisionSort={{this.noop}}
-  @sortByDivision={{this.noop}}
-  @onClickLearner={{this.noop}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-/>`);
+              const screen = await render(hbs`
+                  <ScoOrganizationParticipant::List
+                          @students={{this.students}}
+                          @lastnameSort={{this.noop}}
+                          @sortByLastname={{this.noop}}
+                          @participationCountOrder={{this.noop}}
+                          @sortByParticipationCount={{this.noop}}
+                          @divisionSort={{this.noop}}
+                          @sortByDivision={{this.noop}}
+                          @onClickLearner={{this.noop}}
+                          @onFilter={{this.noop}}
+                          @searchFilter={{this.search}}
+                          @divisionsFilter={{this.divisions}}
+                          @connectionTypeFilter={{this.connectionTypes}}
+                          @certificabilityFilter={{this.certificability}}
+                  />`);
 
               const firstStudent = await screen.getAllByRole('checkbox')[1];
               const secondStudent = await screen.getAllByRole('checkbox')[2];
@@ -1665,21 +1706,22 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
               this.set('students', students);
 
               // when
-              const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @lastnameSort={{this.noop}}
-  @sortByLastname={{this.noop}}
-  @participationCountOrder={{this.noop}}
-  @sortByParticipationCount={{this.noop}}
-  @divisionSort={{this.noop}}
-  @sortByDivision={{this.noop}}
-  @onClickLearner={{this.noop}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-/>`);
+              const screen = await render(hbs`
+                  <ScoOrganizationParticipant::List
+                          @students={{this.students}}
+                          @lastnameSort={{this.noop}}
+                          @sortByLastname={{this.noop}}
+                          @participationCountOrder={{this.noop}}
+                          @sortByParticipationCount={{this.noop}}
+                          @divisionSort={{this.noop}}
+                          @sortByDivision={{this.noop}}
+                          @onClickLearner={{this.noop}}
+                          @onFilter={{this.noop}}
+                          @searchFilter={{this.search}}
+                          @divisionsFilter={{this.divisions}}
+                          @connectionTypeFilter={{this.connectionTypes}}
+                          @certificabilityFilter={{this.certificability}}
+                  />`);
 
               const firstStudent = await screen.getAllByRole('checkbox')[1];
               const secondStudent = await screen.getAllByRole('checkbox')[2];
@@ -1724,21 +1766,22 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
               this.set('students', students);
 
               // when
-              const screen = await render(hbs`<ScoOrganizationParticipant::List
-  @students={{this.students}}
-  @lastnameSort={{this.noop}}
-  @sortByLastname={{this.noop}}
-  @participationCountOrder={{this.noop}}
-  @sortByParticipationCount={{this.noop}}
-  @divisionSort={{this.noop}}
-  @sortByDivision={{this.noop}}
-  @onClickLearner={{this.noop}}
-  @onFilter={{this.noop}}
-  @searchFilter={{this.search}}
-  @divisionsFilter={{this.divisions}}
-  @connectionTypeFilter={{this.connectionTypes}}
-  @certificabilityFilter={{this.certificability}}
-/>`);
+              const screen = await render(hbs`
+                  <ScoOrganizationParticipant::List
+                          @students={{this.students}}
+                          @lastnameSort={{this.noop}}
+                          @sortByLastname={{this.noop}}
+                          @participationCountOrder={{this.noop}}
+                          @sortByParticipationCount={{this.noop}}
+                          @divisionSort={{this.noop}}
+                          @sortByDivision={{this.noop}}
+                          @onClickLearner={{this.noop}}
+                          @onFilter={{this.noop}}
+                          @searchFilter={{this.search}}
+                          @divisionsFilter={{this.divisions}}
+                          @connectionTypeFilter={{this.connectionTypes}}
+                          @certificabilityFilter={{this.certificability}}
+                  />`);
 
               const firstStudent = await screen.getAllByRole('checkbox')[1];
               const secondStudent = await screen.getAllByRole('checkbox')[2];
@@ -1763,6 +1806,65 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
           });
         });
       });
+    });
+
+    test('opens the generate usernames modal', async function (assert) {
+      // given
+      const studentEligible = {
+        id: '1',
+        firstName: 'Simone',
+        lastName: 'Biles',
+        authenticationMethods: ['mediacentre'],
+      };
+      const studentNotEligible = {
+        id: '3',
+        firstName: 'Alice',
+        lastName: 'Damato',
+        authenticationMethods: ['identifiant'],
+      };
+      const students = [studentEligible, studentNotEligible];
+
+      this.set('students', students);
+
+      // when
+      const screen = await render(hbs`
+          <ScoOrganizationParticipant::List
+                  @students={{this.students}}
+                  @lastnameSort={{this.noop}}
+                  @sortByLastname={{this.noop}}
+                  @participationCountOrder={{this.noop}}
+                  @sortByParticipationCount={{this.noop}}
+                  @divisionSort={{this.noop}}
+                  @sortByDivision={{this.noop}}
+                  @onClickLearner={{this.noop}}
+                  @onFilter={{this.noop}}
+                  @searchFilter={{this.search}}
+                  @divisionsFilter={{this.divisions}}
+                  @connectionTypeFilter={{this.connectionTypes}}
+                  @certificabilityFilter={{this.certificability}}
+          />`);
+
+      const selectAllStudentsCheckbox = screen.getAllByRole('checkbox')[0];
+      await click(selectAllStudentsCheckbox);
+
+      const generateUsernameButton = await screen.findByRole('button', {
+        name: t('pages.sco-organization-participants.action-bar.generate-username-button'),
+      });
+      await click(generateUsernameButton);
+
+      await screen.findByRole('dialog');
+
+      const modalTitle = await screen.findByRole('heading', {
+        level: 1,
+        name: striptags(t('pages.sco-organization-participants.generate-username-modal.title')),
+      });
+      const confirmationButton = await screen.findByRole('button', {
+        name: t('common.actions.confirm'),
+      });
+
+      // then
+      assert.ok(modalTitle);
+      assert.ok(confirmationButton);
     });
   });
 });

--- a/orga/tests/unit/adapters/sco-organization-participant-test.js
+++ b/orga/tests/unit/adapters/sco-organization-participant-test.js
@@ -64,4 +64,44 @@ module('Unit | Adapters | sco-organization-participant', function (hooks) {
       assert.ok(true);
     });
   });
+  module('#generateOrganizationLearnersUsername', function () {
+    test('generate organization learners usernames and saves a CSV file', async function (assert) {
+      // given
+      const fetch = sinon.stub().resolves();
+      const fileSaver = { save: sinon.stub().resolves() };
+      const organizationId = 1;
+      const organizationLearnerIds = [23, 789];
+      const token = 'best token ever';
+      adapter.host = 'pix.local';
+      adapter.namespace = 'api';
+
+      // when
+      await adapter.generateOrganizationLearnersUsername({
+        fetch,
+        fileSaver,
+        organizationId,
+        organizationLearnerIds,
+        token,
+      });
+
+      // then
+      const expectedUrl = `${adapter.host}/${adapter.namespace}/sco-organization-learners/generate-usernames`;
+      const expectedOptions = {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify(
+          {
+            data: {
+              attributes: { 'organization-id': organizationId, 'organization-learner-ids': organizationLearnerIds },
+            },
+          },
+          null,
+          2,
+        ),
+      };
+      sinon.assert.calledWith(fetch, expectedUrl, expectedOptions);
+      sinon.assert.calledOnce(fileSaver.save);
+      assert.ok(true);
+    });
+  });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -41,6 +41,10 @@
       "organization-learner-without-username-error": "Some of the selected students no longer have a username. Please refresh this page.",
       "user-does-not-belong-to-organization-error": "You no longer have the rights for this organisation."
     },
+    "student-username-generation": {
+      "organization-learner-does-not-have-pix-account": "Certains des élèves sélectionnés n'ont plus de compte Pix. Veuillez rafraichir la page.",
+      "organization-learner-does-already-have-a-username": "Certains des élèves sélectionnés ont déjà un identifiant. Veuillez rafraichir la page."
+    },
     "student-xml-import": {
       "birth-city-code-required-for-french-student": "Student with {nationalStudentId} INE has no birth city code filled out. This field is mandatory for each student born in France.",
       "birthdate-required": "Student with {nationalStudentId} INE has no date of birth filled out. This field is mandatory for each student.",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1169,7 +1169,8 @@
       "title": "{count, plural, =0 {Students} =1 {Student ({count})} other {Students ({count})}}",
       "action-bar": {
         "information": "{count, plural, =1 {{count} student selected} other {{count} students selected}}",
-        "reset-password-button": "Reset passwords for selected students"
+        "reset-password-button": "Reset passwords for selected students",
+        "generate-username-button": "Générer les identifiants pour les élèves séléctionnés"
       },
       "actions": {
         "manage-account": "Manage the account",
@@ -1243,7 +1244,8 @@
         }
       },
       "messages": {
-        "password-reset-success": "The password reset of the selected students has been done successfuly."
+        "password-reset-success": "The password reset of the selected students has been done successfuly.",
+        "generate-username-success": "La génération des identifiants des élèves sélectionnés a été effectuée."
       },
       "no-participants": "No students yet!",
       "no-participants-action": "The administrator must import the students database by clicking on the import button.",
@@ -1254,6 +1256,12 @@
         "content-message-2": "Un fichier CSV sera généré contenant les identifiants ainsi que les mots de passe à usage unique.",
         "content-message-3": "Communiquez ces nouveaux mots de passe à usage unique aux élèves. Lorsqu'ils se connecteront avec ce mot de passe, Pix leur demandera d'en saisir un nouveau.",
         "warning-message": "Seuls les mots de passe des accès par identifiants peuvent être réinitialisés. Les accès par adresse email et Mediacentre ne seront pas impactés."
+      },
+      "generate-username-modal": {
+        "title": "Génération des <strong>identifiants</strong> des élèves avec <strong>un compte Pix</strong>",
+        "content-message-1": "Sur {totalSelectedStudents, plural, =1 {<strong>{totalSelectedStudents} élève</strong> sélectionné} other {<strong>{totalSelectedStudents} élèves</strong> sélectionnés}}, {totalAffectedStudents, plural, =0 {<strong>aucun identifiant</strong> ne sera généré} =1 {<strong>{totalAffectedStudents} identifiant</strong> sera généré} other {<strong>{totalAffectedStudents} identifiants</strong> seront générés}}.",
+        "content-message-2": "Un fichier CSV contenant les identifiants ainsi que les mots de passe à usage unique sera généré.",
+        "warning-message": "Seuls les élèves ayant déjà un compte PIX auront un identifiant généré. Si l'élève n’a pas de compte PIX ou si l'élève a déjà un identifiant, alors aucun nouvel identifiant ne sera généré."
       },
       "table": {
         "column": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1177,7 +1177,8 @@
       "title": "{count, plural, =0 {Élèves} =1 {Élève ({count})} other {Élèves ({count})}}",
       "action-bar": {
         "information": "{count, plural, =1 {{count} élève sélectionné} other {{count} élèves sélectionnés}}",
-        "reset-password-button": "Réinitialiser les mots de passe des élèves sélectionnés"
+        "reset-password-button": "Réinitialiser les mots de passe des élèves sélectionnés",
+        "generate-username-button": "Générer les identifiants pour les élèves séléctionnés"
       },
       "actions": {
         "manage-account": "Gérer le compte",
@@ -1251,7 +1252,8 @@
         }
       },
       "messages": {
-        "password-reset-success": "La réinitialisation des mots de passe des élèves sélectionnés a été effectuée."
+        "password-reset-success": "La réinitialisation des mots de passe des élèves sélectionnés a été effectuée.",
+        "generate-username-success": "La génération des identifiants des élèves sélectionnés a été effectuée."
       },
       "no-participants": "Aucun élève pour l’instant !",
       "no-participants-action": "L’administrateur doit importer la base élèves en cliquant sur le bouton importer.",
@@ -1262,6 +1264,12 @@
         "content-message-2": "Un fichier CSV contenant les identifiants ainsi que les mots de passe à usage unique sera généré.",
         "content-message-3": "Communiquez ces nouveaux mots de passe à usage unique aux élèves. Lorsqu'ils se connecteront avec ce mot de passe, Pix leur demandera d'en saisir un nouveau.",
         "warning-message": "Seuls les mots de passe des accès par identifiant peuvent être réinitialisés. Les accès par adresse email et Mediacentre ne sont pas impactés."
+      },
+      "generate-username-modal": {
+        "title": "Génération des <strong>identifiants</strong> des élèves avec <strong>un compte Pix</strong>",
+        "content-message-1": "Sur {totalSelectedStudents, plural, =1 {<strong>{totalSelectedStudents} élève</strong> sélectionné} other {<strong>{totalSelectedStudents} élèves</strong> sélectionnés}}, {totalAffectedStudents, plural, =0 {<strong>aucun identifiant</strong> ne sera généré} =1 {<strong>{totalAffectedStudents} identifiant</strong> sera généré} other {<strong>{totalAffectedStudents} identifiants</strong> seront générés}}.",
+        "content-message-2": "Un fichier CSV contenant les identifiants ainsi que les mots de passe à usage unique sera généré.",
+        "warning-message": "Seuls les élèves ayant déjà un compte PIX auront un identifiant généré. Si l'élève n’a pas de compte PIX ou si l'élève a déjà un identifiant, alors aucun nouvel identifiant ne sera généré."
       },
       "table": {
         "column": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -41,6 +41,10 @@
       "organization-learner-without-username-error": "Certains des élèves sélectionnés n'ont plus d'identifiant. Veuillez rafraichir la page.",
       "user-does-not-belong-to-organization-error": "Vous n'avez plus les droits pour cette organisation."
     },
+    "student-username-generation": {
+      "organization-learner-does-not-have-pix-account": "Certains des élèves sélectionnés n'ont plus de compte Pix. Veuillez rafraichir la page.",
+      "organization-learner-does-already-have-a-username": "Certains des élèves sélectionnés ont déjà un identifiant. Veuillez rafraichir la page."
+    },
     "student-xml-import": {
       "birth-city-code-required-for-french-student": "L'élève ayant pour INE {nationalStudentId} n'a pas de champ code commune de naissance renseigné. Il est obligatoire pour chaque élève né en France.",
       "birthdate-required": "L’élève ayant pour INE {nationalStudentId} n’a pas le champ date de naissance renseigné. Il est obligatoire pour chaque élève.",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -852,33 +852,33 @@
       },
       "list": {
         "aria-label": "Opdracht",
-          "banner": {
-            "copypaste-container": {
-              "abstract": "Begin je missies met je leerlingen door een sessie te activeren met de bovenstaande knop en deze te gebruiken ",
-              "button": {
-                "success": "Gekopieerd !",
-                "tooltip": "Kopieercode"
-              }
-            },
-            "step1": {
-              "admin": {
-                "head": "Stap 1:",
-                "link": "Importeer de leerlingendatabase",
-                "tail": "<b>vanuit Onde</b> (exporteerbaar bestand in het menu Lijsten & documenten > Extracties > Schoolleerlingen of hun begeleiders)."
-              },
-              "non-admin": "Stap 1: <b>Vraag de Pix Orga beheerder </b>&nbsp in jouw ruimte om de studenten te importeren."
-            },
-            "step2": {
-              "title": "Stap 2: Om leerlingen toegang te geven tot de Pix Junior ruimte van jouw school, kun je :",
-              "option1": "de link&nbsp<a href=\"{pixJuniorUrl}\">junior.pix.fr</a>&nbspgebruiken. Elke keer dat je verbinding maakt, wordt de code van je school gevraagd.",
-              "option2": {
-                "body": "of gebruik de directe link &nbsp<a href=\"{pixJuniorUrl}\" target=_blank >junior.pix.fr/schools/{code}</a>",
-                "hint": "Je kunt deze bladwijzer op je computer opslaan."
-              }
-            },
-            "step3": "Stap 3: <b> Activeer de Pix Junior sessie </b> met de bovenstaande knop. <b>Doe dit voor elke sessie met je leerlingen</b>.",
-            "welcome": "Om Pix Junior te gebruiken :"
+        "banner": {
+          "copypaste-container": {
+            "abstract": "Begin je missies met je leerlingen door een sessie te activeren met de bovenstaande knop en deze te gebruiken ",
+            "button": {
+              "success": "Gekopieerd !",
+              "tooltip": "Kopieercode"
+            }
           },
+          "step1": {
+            "admin": {
+              "head": "Stap 1:",
+              "link": "Importeer de leerlingendatabase",
+              "tail": "<b>vanuit Onde</b> (exporteerbaar bestand in het menu Lijsten & documenten > Extracties > Schoolleerlingen of hun begeleiders)."
+            },
+            "non-admin": "Stap 1: <b>Vraag de Pix Orga beheerder </b>&nbsp in jouw ruimte om de studenten te importeren."
+          },
+          "step2": {
+            "title": "Stap 2: Om leerlingen toegang te geven tot de Pix Junior ruimte van jouw school, kun je :",
+            "option1": "de link&nbsp<a href=\"{pixJuniorUrl}\">junior.pix.fr</a>&nbspgebruiken. Elke keer dat je verbinding maakt, wordt de code van je school gevraagd.",
+            "option2": {
+              "body": "of gebruik de directe link &nbsp<a href=\"{pixJuniorUrl}\" target=_blank >junior.pix.fr/schools/{code}</a>",
+              "hint": "Je kunt deze bladwijzer op je computer opslaan."
+            }
+          },
+          "step3": "Stap 3: <b> Activeer de Pix Junior sessie </b> met de bovenstaande knop. <b>Doe dit voor elke sessie met je leerlingen</b>.",
+          "welcome": "Om Pix Junior te gebruiken :"
+        },
         "caption": "Lijst van opdrachten",
         "empty-state": "Er zijn geen opdrachten",
         "headers": {
@@ -1135,7 +1135,8 @@
     "sco-organization-participants": {
       "action-bar": {
         "information": "{count, plural, =1 {{count} geselecteerde student} other {{count} geselecteerde studenten}}",
-        "reset-password-button": "Reset de wachtwoorden van geselecteerde studenten"
+        "reset-password-button": "Reset de wachtwoorden van geselecteerde studenten",
+        "generate-username-button": "Générer les identifiants pour les élèves séléctionnés"
       },
       "actions": {
         "manage-account": "Account beheren",
@@ -1213,7 +1214,8 @@
         "title": "Het Pix-account van de student beheren"
       },
       "messages": {
-        "password-reset-success": "De wachtwoorden van de geselecteerde studenten zijn gereset."
+        "password-reset-success": "De wachtwoorden van de geselecteerde studenten zijn gereset.",
+        "generate-username-success": "La génération des identifiants des élèves sélectionnés a été effectuée."
       },
       "no-participants": "Tot nu toe geen studenten!",
       "no-participants-action": "De beheerder moet de studentendatabase importeren door op de knop importeren te klikken.",
@@ -1224,6 +1226,12 @@
         "content-message-3": "Communiceer deze nieuwe eenmalige wachtwoorden aan de studenten. Wanneer ze inloggen met dit wachtwoord, zal Pix hen vragen een nieuw wachtwoord in te voeren.",
         "title": "<strong>Wachtwoorden</strong> van studenten opnieuw instellen met <strong>gebruikersnaam</strong>.",
         "warning-message": "Alleen inlogwachtwoorden kunnen opnieuw worden ingesteld. Toegang via e-mailadres en Mediacentrum worden niet beïnvloed."
+      },
+      "generate-username-modal": {
+        "title": "Génération des <strong>identifiants</strong> des élèves avec <strong>un compte Pix</strong>",
+        "content-message-1": "Sur {totalSelectedStudents, plural, =1 {<strong>{totalSelectedStudents} élève</strong> sélectionné} other {<strong>{totalSelectedStudents} élèves</strong> sélectionnés}}, {totalAffectedStudents, plural, =0 {<strong>aucun identifiant</strong> ne sera généré} =1 {<strong>{totalAffectedStudents} identifiant</strong> sera généré} other {<strong>{totalAffectedStudents} identifiants</strong> seront générés}}.",
+        "content-message-2": "Un fichier CSV contenant les identifiants ainsi que les mots de passe à usage unique sera généré.",
+        "warning-message": "Seuls les élèves ayant déjà un compte PIX auront un identifiant généré. Si l'élève n’a pas de compte PIX ou si l'élève a déjà un identifiant, alors aucun nouvel identifiant ne sera généré."
       },
       "table": {
         "column": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -41,6 +41,10 @@
       "organization-learner-without-username-error": "Sommige van de geselecteerde studenten hebben geen gebruikersnaam meer. Vernieuw de pagina.",
       "user-does-not-belong-to-organization-error": "Je hebt niet langer de rechten voor deze organisatie."
     },
+    "student-username-generation": {
+      "organization-learner-does-not-have-pix-account": "Certains des élèves sélectionnés n'ont plus de compte Pix. Veuillez rafraichir la page.",
+      "organization-learner-does-already-have-a-username": "Certains des élèves sélectionnés ont déjà un identifiant. Veuillez rafraichir la page."
+    },
     "student-xml-import": {
       "birth-city-code-required-for-french-student": "Een student met INE {nationalStudentId} heeft geen geboorteplaatscodeveld. Het is verplicht voor alle studenten die in Frankrijk geboren zijn.",
       "birthdate-required": "Bij de student met de ID {nationalStudentId} is het veld geboortedatum niet ingevuld. Dit is verplicht voor elke leerling.",


### PR DESCRIPTION
## :unicorn: Problème
Beaucoup de demandes de la part des utilisateurs pour générer en masse des identifiants pour les élèves SCO (sous conditions). Actuellement, les professeurs doivent se rendre dans la pop-up de gestion des élèves et générer l’identifiant un par un.

## :robot: Proposition
A l’instar de la fonctionnalité pour gérer des mots de passe en masse présente pour les orgas SCO (sous conditions), on veut pouvoir séléctionner les utilisateurs avec les checkboxs présentes et générer des identifiants en masse. La fonctionnalité de génération d’un identifiant à l’unité est déjà présente côté Pix Orga.

A la première sélection d’un élève → bandeau s’affiche en bas proposant les 2 fonctionnalités

Conditions à respecter pour générer un identifiant :
- orga type = SCO
- "ismanagingstudent" = TRUE
- seulement sur les élèves qui ont déjà un compte PIX (avec connexion GAR ou e-mail)
- ne pas régénérer un identifiant si l'élève a déjà un identifiant


## :rainbow: Remarques
Création du dossier sco-organization-learners dans le dossier src/IAM, est ce le meilleur endroit ?

### TODO
- [x] revoir tests erreurs routes (check avec anonymisation file)
- [ ] revoir tests erreurs controllers (check avec reset-password file)
- [ ] gérer la traduction (une ancienne manquante)
- [ ] Ne faire qu'un seul usecase pour tous les cas de générations d'identifiant / mot de passe (garder uniquement [api/lib/domain/usecases/generate-username-with-temporary-password.js](https://github.com/1024pix/pix/blob/dev/api/lib/domain/usecases/generate-username-with-temporary-password.js) ?
- [ ] Ajouter un paramètre au usecase forceTemporaryPasswordGeneration afin de gérer le cas sur cette PR (réinitialisation des identifiants & mdp en masse)
- [ ] Appeler ce usecase dans une boucle dans le controller

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

Différences entre les fonctionnalités de génération d'identifiant unitaire vs génération d'identifiants en masse : 
- unitairement : (cas actuel) Si l'élève n'a pas d'accès mail --> découplement car l'élève a déjà un mot de passe / Si l'élève a un accès Mediacentre --> pas de découplement, car l'élève n'a pas de mot de passe. La génération d'identifiant est associée à la génération d'un mot de passe provisoire.
- en masse : les deux fonctionnalités ne sont pas découplées : la génération d'identifiants et de mots de passe provisoires se fait en même temps.



