### PR TITLE
[FEATURE] Afficher les éléments "Download" dans Modulix (PIX-12501)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -92,7 +92,8 @@
             "id": "901ccbaa-f4e6-4322-b863-8e8eab08a33a",
             "type": "download",
             "files": [
-              { "url": "https://images.pix.fr/modulix/adresse-ip-publique-et-vous/intro.jpg", "format": ".jpg" }
+              { "url": "https://dl.pix.fr/1641899675462/Pix_velos.xlsx", "format": ".xlsx" },
+              { "url": "https://dl.pix.fr/1641899675463/Pix_velos.ods", "format": ".ods" }
             ]
           }
         },

--- a/mon-pix/app/components/module/details.gjs
+++ b/mon-pix/app/components/module/details.gjs
@@ -18,7 +18,7 @@ export default class ModulixDetails extends Component {
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Détails du module : ${this.args.module.id}`,
-      'pix-event-name': `Clic sur le bouton Commencer`,
+      'pix-event-name': `Click sur le bouton Commencer`,
     });
     this.router.transitionTo('module.passage');
   }

--- a/mon-pix/app/components/module/details.gjs
+++ b/mon-pix/app/components/module/details.gjs
@@ -13,7 +13,7 @@ export default class ModulixDetails extends Component {
   @service metrics;
 
   @action
-  startModule() {
+  onModuleStart() {
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
@@ -37,7 +37,7 @@ export default class ModulixDetails extends Component {
           <p class="module-details-content-layout__description">{{@module.details.description}}</p>
 
           <div class="module-details-content-layout__link">
-            <PixButtonLink @href="#" {{on "click" this.startModule}} @model={{@module.id}} @size="large">{{t
+            <PixButtonLink @href="#" {{on "click" this.onModuleStart}} @model={{@module.id}} @size="large">{{t
                 "pages.modulix.details.startModule"
               }}</PixButtonLink>
           </div>

--- a/mon-pix/app/components/module/element.gjs
+++ b/mon-pix/app/components/module/element.gjs
@@ -20,36 +20,32 @@ export default class ModulixElement extends Component {
     {{#if (eq @element.type "text")}}
       <TextElement @text={{@element}} />
     {{else if (eq @element.type "image")}}
-      <ImageElement @image={{@element}} @openAlternativeText={{@openImageAlternativeText}} />
+      <ImageElement @image={{@element}} @onAlternativeTextOpen={{@onImageAlternativeTextOpen}} />
     {{else if (eq @element.type "video")}}
-      <VideoElement
-        @video={{@element}}
-        @openTranscription={{@openVideoTranscription}}
-        @clickOnPlayButton={{@clickOnPlayButton}}
-      />
+      <VideoElement @video={{@element}} @onTranscriptionOpen={{@onVideoTranscriptionOpen}} @onPlay={{@onVideoPlay}} />
     {{else if (eq @element.type "download")}}
-      <DownloadElement @download={{@element}} @onFileDownload={{@onFileDownload}} />
+      <DownloadElement @download={{@element}} @onDownload={{@onFileDownload}} />
     {{else if (eq @element.type "embed")}}
-      <EmbedElement @embed={{@element}} @submitAnswer={{@submitAnswer}} />
+      <EmbedElement @embed={{@element}} @onAnswer={{@onElementAnswer}} />
     {{else if (eq @element.type "qcu")}}
       <QcuElement
         @element={{@element}}
-        @submitAnswer={{@submitAnswer}}
-        @retryElement={{@retryElement}}
+        @onAnswer={{@onElementAnswer}}
+        @onRetry={{@onElementRetry}}
         @correction={{this.getLastCorrectionForElement @element}}
       />
     {{else if (eq @element.type "qcm")}}
       <QcmElement
         @element={{@element}}
-        @submitAnswer={{@submitAnswer}}
-        @retryElement={{@retryElement}}
+        @onAnswer={{@onElementAnswer}}
+        @onRetry={{@onElementRetry}}
         @correction={{this.getLastCorrectionForElement @element}}
       />
     {{else if (eq @element.type "qrocm")}}
       <QrocmElement
         @element={{@element}}
-        @submitAnswer={{@submitAnswer}}
-        @retryElement={{@retryElement}}
+        @onAnswer={{@onElementAnswer}}
+        @onRetry={{@onElementRetry}}
         @correction={{this.getLastCorrectionForElement @element}}
       />
     {{/if}}

--- a/mon-pix/app/components/module/element.gjs
+++ b/mon-pix/app/components/module/element.gjs
@@ -28,7 +28,7 @@ export default class ModulixElement extends Component {
         @clickOnPlayButton={{@clickOnPlayButton}}
       />
     {{else if (eq @element.type "download")}}
-      <DownloadElement @download={{@element}} />
+      <DownloadElement @download={{@element}} @onFileDownload={{@onFileDownload}} />
     {{else if (eq @element.type "embed")}}
       <EmbedElement @embed={{@element}} @submitAnswer={{@submitAnswer}} />
     {{else if (eq @element.type "qcu")}}

--- a/mon-pix/app/components/module/element/download.gjs
+++ b/mon-pix/app/components/module/element/download.gjs
@@ -9,8 +9,8 @@ import ModuleElement from './module-element';
 
 export default class ModulixDownload extends ModuleElement {
   @action
-  onFileDownload(downloadedFormat) {
-    this.args.onFileDownload({ elementId: this.args.download.id, downloadedFormat });
+  onDownload(downloadedFormat) {
+    this.args.onDownload({ elementId: this.args.download.id, downloadedFormat });
   }
 
   <template>
@@ -31,7 +31,7 @@ export default class ModulixDownload extends ModuleElement {
               @href="{{file.url}}"
               aria-label="{{t 'pages.modulix.download.label' format=file.format}}"
               download
-              {{on "click" (fn this.onFileDownload file.format)}}
+              {{on "click" (fn this.onDownload file.format)}}
             >
               {{t "pages.modulix.download.button"}}
             </PixButtonLink>

--- a/mon-pix/app/components/module/element/download.gjs
+++ b/mon-pix/app/components/module/element/download.gjs
@@ -1,10 +1,51 @@
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import { t } from 'ember-intl';
+
 import ModuleElement from './module-element';
 
 export default class ModulixDownload extends ModuleElement {
+  @action
+  onFileDownload(downloadedFormat) {
+    this.args.onFileDownload({ elementId: this.args.download.id, downloadedFormat });
+  }
+
   <template>
     <div class="element-download">
-      {{! template-lint-disable "no-bare-strings" }}
-      ELEMENT TÉLÉCHARGEMENT EN COURS DE DEVELOPPEMENT
+      <div class="element-download__intro">{{t "pages.modulix.download.intro"}}</div>
+      <p class="element-download__description">
+        {{t "pages.modulix.download.description"}}
+      </p>
+      <ul class="element-download__links-container">
+        {{#each @download.files as |file|}}
+          <li class="element-download__link">
+            <div class="element-download-link__format" aria-hidden="true">{{t
+                "pages.modulix.download.format"
+                format=file.format
+              }}</div>
+            <PixButtonLink
+              class="element-download-link__button"
+              @href="{{file.url}}"
+              aria-label="{{t 'pages.modulix.download.label' format=file.format}}"
+              download
+              {{on "click" (fn this.onFileDownload file.format)}}
+            >
+              {{t "pages.modulix.download.button"}}
+            </PixButtonLink>
+          </li>
+        {{/each}}
+      </ul>
+      <a
+        class="element-download__documentation-link link"
+        href="{{t 'pages.modulix.download.documentationLinkHref'}}"
+        target="_blank"
+      >
+        {{t "pages.modulix.download.documentationLinkLabel"}}
+        <FaIcon @icon="arrow-up-right-from-square" />
+      </a>
     </div>
   </template>
 }

--- a/mon-pix/app/components/module/element/embed.gjs
+++ b/mon-pix/app/components/module/element/embed.gjs
@@ -43,7 +43,7 @@ export default class ModulixEmbed extends ModuleElement {
     if (!isEmbedAllowedOrigin(event.origin)) return;
     const message = this._getMessageFromEventData(event);
     if (message && message.answer && message.from === 'pix') {
-      this.args.submitAnswer({
+      this.args.onAnswer({
         userResponse: [message.answer],
         element: this.args.embed,
       });

--- a/mon-pix/app/components/module/element/image.gjs
+++ b/mon-pix/app/components/module/element/image.gjs
@@ -16,7 +16,7 @@ export default class ModulixImageElement extends Component {
   @action
   showModal() {
     this.modalIsOpen = true;
-    this.args.openAlternativeText(this.args.image.id);
+    this.args.onAlternativeTextOpen(this.args.image.id);
   }
 
   @action

--- a/mon-pix/app/components/module/element/module-element.js
+++ b/mon-pix/app/components/module/element/module-element.js
@@ -54,11 +54,11 @@ export default class ModuleElement extends Component {
     this.resetAnswers();
     form.reset();
 
-    this.args.retryElement({ element: this.element });
+    this.args.onRetry({ element: this.element });
   }
 
   @action
-  async submitAnswer(event) {
+  async onAnswer(event) {
     event.preventDefault();
     this.shouldDisplayRequiredMessage = !this.canValidateElement;
     if (this.shouldDisplayRequiredMessage === true) {
@@ -66,6 +66,6 @@ export default class ModuleElement extends Component {
     }
     this.isOnRetryMode = false;
     const answerData = { userResponse: this.userResponse, element: this.element };
-    await this.args.submitAnswer(answerData);
+    await this.args.onAnswer(answerData);
   }
 }

--- a/mon-pix/app/components/module/element/qcm.hbs
+++ b/mon-pix/app/components/module/element/qcm.hbs
@@ -35,12 +35,7 @@
   {{/if}}
 
   {{#unless this.correction}}
-    <PixButton
-      @variant="success"
-      @type="submit"
-      class="element-qcm__verify-button"
-      @triggerAction={{this.submitAnswer}}
-    >
+    <PixButton @variant="success" @type="submit" class="element-qcm__verify-button" @triggerAction={{this.onAnswer}}>
       {{t "pages.modulix.buttons.activity.verify"}}
     </PixButton>
   {{/unless}}

--- a/mon-pix/app/components/module/element/qcu.hbs
+++ b/mon-pix/app/components/module/element/qcu.hbs
@@ -38,12 +38,7 @@
   {{/if}}
 
   {{#unless this.correction}}
-    <PixButton
-      @variant="success"
-      @type="submit"
-      class="element-qcu__verify-button"
-      @triggerAction={{this.submitAnswer}}
-    >
+    <PixButton @variant="success" @type="submit" class="element-qcu__verify-button" @triggerAction={{this.onAnswer}}>
       {{t "pages.modulix.buttons.activity.verify"}}
     </PixButton>
   {{/unless}}

--- a/mon-pix/app/components/module/element/qrocm.hbs
+++ b/mon-pix/app/components/module/element/qrocm.hbs
@@ -69,12 +69,7 @@
   {{/if}}
 
   {{#unless this.correction}}
-    <PixButton
-      @variant="success"
-      @type="submit"
-      class="element-qrocm__verify-button"
-      @triggerAction={{this.submitAnswer}}
-    >
+    <PixButton @variant="success" @type="submit" class="element-qrocm__verify-button" @triggerAction={{this.onAnswer}}>
       {{t "pages.modulix.buttons.activity.verify"}}
     </PixButton>
   {{/unless}}

--- a/mon-pix/app/components/module/element/video.gjs
+++ b/mon-pix/app/components/module/element/video.gjs
@@ -26,7 +26,7 @@ export default class ModulixVideoElement extends Component {
   @action
   showModal() {
     this.modalIsOpen = true;
-    this.args.openTranscription(this.args.video.id);
+    this.args.onTranscriptionOpen(this.args.video.id);
   }
 
   @action
@@ -51,7 +51,7 @@ export default class ModulixVideoElement extends Component {
       return;
     }
     this.videoWasStarted = true;
-    this.args.clickOnPlayButton({ elementId: this.args.video.id });
+    this.args.onPlay({ elementId: this.args.video.id });
   }
 
   <template>

--- a/mon-pix/app/components/module/grain.hbs
+++ b/mon-pix/app/components/module/grain.hbs
@@ -23,6 +23,7 @@
               @retryElement={{@retryElement}}
               @clickOnPlayButton={{@clickOnPlayButton}}
               @getLastCorrectionForElement={{this.getLastCorrectionForElement}}
+              @onFileDownload={{@onFileDownload}}
             />
           </div>
         {{else if (eq component.type "stepper")}}
@@ -38,6 +39,7 @@
               @openImageAlternativeText={{@openImageAlternativeText}}
               @openVideoTranscription={{@openVideoTranscription}}
               @clickOnPlayButton={{@clickOnPlayButton}}
+              @onFileDownload={{@onFileDownload}}
             />
           </div>
         {{/if}}

--- a/mon-pix/app/components/module/grain.hbs
+++ b/mon-pix/app/components/module/grain.hbs
@@ -17,11 +17,11 @@
           <div class="grain-card-content__element">
             <Module::Element
               @element={{component.element}}
-              @openImageAlternativeText={{@openImageAlternativeText}}
-              @openVideoTranscription={{@openVideoTranscription}}
-              @submitAnswer={{@submitAnswer}}
-              @retryElement={{@retryElement}}
-              @clickOnPlayButton={{@clickOnPlayButton}}
+              @onImageAlternativeTextOpen={{@onImageAlternativeTextOpen}}
+              @onVideoTranscriptionOpen={{@onVideoTranscriptionOpen}}
+              @onElementAnswer={{@onElementAnswer}}
+              @onElementRetry={{@onElementRetry}}
+              @onVideoPlay={{@onVideoPlay}}
               @getLastCorrectionForElement={{this.getLastCorrectionForElement}}
               @onFileDownload={{@onFileDownload}}
             />
@@ -30,15 +30,15 @@
           <div class="grain-card-content__stepper">
             <Module::Stepper
               @steps={{component.steps}}
-              @submitAnswer={{@submitAnswer}}
-              @retryElement={{@retryElement}}
+              @onElementAnswer={{@onElementAnswer}}
+              @onElementRetry={{@onElementRetry}}
               @passage={{@passage}}
               @getLastCorrectionForElement={{this.getLastCorrectionForElement}}
               @stepperIsFinished={{this.stepperIsFinished}}
-              @continueToNextStep={{@continueToNextStep}}
-              @openImageAlternativeText={{@openImageAlternativeText}}
-              @openVideoTranscription={{@openVideoTranscription}}
-              @clickOnPlayButton={{@clickOnPlayButton}}
+              @onStepperNextStep={{@onStepperNextStep}}
+              @onImageAlternativeTextOpen={{@onImageAlternativeTextOpen}}
+              @onVideoTranscriptionOpen={{@onVideoTranscriptionOpen}}
+              @onVideoPlay={{@onVideoPlay}}
               @onFileDownload={{@onFileDownload}}
             />
           </div>
@@ -48,7 +48,7 @@
 
     {{#if this.shouldDisplaySkipButton}}
       <footer class="grain-card__footer">
-        <PixButton @variant="tertiary" @triggerAction={{@skipAction}}>
+        <PixButton @variant="tertiary" @triggerAction={{@onGrainSkip}}>
           {{t "pages.modulix.buttons.grain.skip"}}
         </PixButton>
       </footer>
@@ -56,7 +56,7 @@
 
     {{#if this.shouldDisplayContinueButton}}
       <footer class="grain-card__footer">
-        <PixButton @variant="primary" @triggerAction={{@continueAction}}>
+        <PixButton @variant="primary" @triggerAction={{@onGrainContinue}}>
           {{t "pages.modulix.buttons.grain.continue"}}
         </PixButton>
       </footer>
@@ -64,7 +64,7 @@
 
     {{#if @shouldDisplayTerminateButton}}
       <footer class="grain-card__footer">
-        <PixButton @variant="primary" @triggerAction={{this.terminateAction}}>
+        <PixButton @variant="primary" @triggerAction={{this.onModuleTerminate}}>
           {{t "pages.modulix.buttons.grain.terminate"}}
         </PixButton>
       </footer>

--- a/mon-pix/app/components/module/grain.js
+++ b/mon-pix/app/components/module/grain.js
@@ -139,7 +139,7 @@ export default class ModuleGrain extends Component {
   }
 
   @action
-  terminateAction() {
-    this.args.terminateAction({ grainId: this.args.grain.id });
+  onModuleTerminate() {
+    this.args.onModuleTerminate({ grainId: this.args.grain.id });
   }
 }

--- a/mon-pix/app/components/module/passage.hbs
+++ b/mon-pix/app/components/module/passage.hbs
@@ -14,20 +14,20 @@
     {{#each this.grainsToDisplay as |grain index|}}
       <Module::Grain
         @grain={{grain}}
-        @retryElement={{this.trackRetry}}
+        @onElementRetry={{this.onElementRetry}}
         @passage={{@passage}}
         @transition={{this.grainTransition grain.id}}
-        @openImageAlternativeText={{this.openImageAlternativeText}}
-        @openVideoTranscription={{this.openVideoTranscription}}
-        @submitAnswer={{this.submitAnswer}}
-        @continueToNextStep={{this.continueToNextStep}}
+        @onImageAlternativeTextOpen={{this.onImageAlternativeTextOpen}}
+        @onVideoTranscriptionOpen={{this.onVideoTranscriptionOpen}}
+        @onElementAnswer={{this.onElementAnswer}}
+        @onStepperNextStep={{this.onStepperNextStep}}
         @canMoveToNextGrain={{this.grainCanMoveToNextGrain index}}
-        @continueAction={{this.continueToNextGrain}}
-        @skipAction={{this.skipToNextGrain}}
+        @onGrainContinue={{this.onGrainContinue}}
+        @onGrainSkip={{this.onGrainSkip}}
         @shouldDisplayTerminateButton={{this.grainShouldDisplayTerminateButton index}}
-        @terminateAction={{this.terminateModule}}
+        @onModuleTerminate={{this.onModuleTerminate}}
         @hasJustAppeared={{this.hasGrainJustAppeared index}}
-        @clickOnPlayButton={{this.clickOnPlayButton}}
+        @onVideoPlay={{this.onVideoPlay}}
         @onFileDownload={{this.onFileDownload}}
       />
     {{/each}}

--- a/mon-pix/app/components/module/passage.hbs
+++ b/mon-pix/app/components/module/passage.hbs
@@ -28,6 +28,7 @@
         @terminateAction={{this.terminateModule}}
         @hasJustAppeared={{this.hasGrainJustAppeared index}}
         @clickOnPlayButton={{this.clickOnPlayButton}}
+        @onFileDownload={{this.onFileDownload}}
       />
     {{/each}}
   </div>

--- a/mon-pix/app/components/module/passage.js
+++ b/mon-pix/app/components/module/passage.js
@@ -102,7 +102,7 @@ export default class ModulePassage extends Component {
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.id}`,
-      'pix-event-name': `Clic sur le bouton Terminer du grain : ${grainId}`,
+      'pix-event-name': `Click sur le bouton Terminer du grain : ${grainId}`,
     });
     return this.router.transitionTo('module.recap', this.args.module);
   }
@@ -163,7 +163,7 @@ export default class ModulePassage extends Component {
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.id}`,
-      'pix-event-name': `Clic sur le bouton Play : ${elementId}`,
+      'pix-event-name': `Click sur le bouton Play : ${elementId}`,
     });
   }
 

--- a/mon-pix/app/components/module/passage.js
+++ b/mon-pix/app/components/module/passage.js
@@ -166,4 +166,14 @@ export default class ModulePassage extends Component {
       'pix-event-name': `Clic sur le bouton Play : ${elementId}`,
     });
   }
+
+  @action
+  async onFileDownload({ elementId, downloadedFormat }) {
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Modulix',
+      'pix-event-action': `Passage du module : ${this.args.module.id}`,
+      'pix-event-name': `Click sur le bouton Télécharger au format ${downloadedFormat} de ${elementId}`,
+    });
+  }
 }

--- a/mon-pix/app/components/module/passage.js
+++ b/mon-pix/app/components/module/passage.js
@@ -32,7 +32,7 @@ export default class ModulePassage extends Component {
   }
 
   @action
-  skipToNextGrain() {
+  onGrainSkip() {
     const currentGrain = this.displayableGrains[this.currentGrainIndex];
 
     this.addNextGrainToDisplay();
@@ -46,7 +46,7 @@ export default class ModulePassage extends Component {
   }
 
   @action
-  continueToNextGrain() {
+  onGrainContinue() {
     const currentGrain = this.displayableGrains[this.currentGrainIndex];
 
     this.addNextGrainToDisplay();
@@ -60,7 +60,7 @@ export default class ModulePassage extends Component {
   }
 
   @action
-  continueToNextStep(currentStepPosition) {
+  onStepperNextStep(currentStepPosition) {
     const currentGrain = this.displayableGrains[this.currentGrainIndex];
 
     this.metrics.add({
@@ -96,7 +96,7 @@ export default class ModulePassage extends Component {
   }
 
   @action
-  terminateModule({ grainId }) {
+  onModuleTerminate({ grainId }) {
     this.args.passage.terminate();
     this.metrics.add({
       event: 'custom-event',
@@ -108,7 +108,7 @@ export default class ModulePassage extends Component {
   }
 
   @action
-  async submitAnswer(answerData) {
+  async onElementAnswer(answerData) {
     await this.store
       .createRecord('element-answer', {
         userResponse: answerData.userResponse,
@@ -128,7 +128,7 @@ export default class ModulePassage extends Component {
   }
 
   @action
-  async trackRetry(answerData) {
+  async onElementRetry(answerData) {
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
@@ -138,7 +138,7 @@ export default class ModulePassage extends Component {
   }
 
   @action
-  async openImageAlternativeText(imageElementId) {
+  async onImageAlternativeTextOpen(imageElementId) {
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
@@ -148,7 +148,7 @@ export default class ModulePassage extends Component {
   }
 
   @action
-  async openVideoTranscription(videoElementId) {
+  async onVideoTranscriptionOpen(videoElementId) {
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
@@ -158,7 +158,7 @@ export default class ModulePassage extends Component {
   }
 
   @action
-  async clickOnPlayButton({ elementId }) {
+  async onVideoPlay({ elementId }) {
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',

--- a/mon-pix/app/components/module/step.gjs
+++ b/mon-pix/app/components/module/step.gjs
@@ -46,6 +46,7 @@ export default class ModulixStep extends Component {
               @openImageAlternativeText={{@openImageAlternativeText}}
               @openVideoTranscription={{@openVideoTranscription}}
               @clickOnPlayButton={{@clickOnPlayButton}}
+              @onFileDownload={{@onFileDownload}}
             />
           </div>
         {{/each}}

--- a/mon-pix/app/components/module/step.gjs
+++ b/mon-pix/app/components/module/step.gjs
@@ -40,12 +40,12 @@ export default class ModulixStep extends Component {
           <div class="grain-card-content__element">
             <Element
               @element={{element}}
-              @submitAnswer={{@submitAnswer}}
-              @retryElement={{@retryElement}}
+              @onElementAnswer={{@onElementAnswer}}
+              @onElementRetry={{@onElementRetry}}
               @getLastCorrectionForElement={{@getLastCorrectionForElement}}
-              @openImageAlternativeText={{@openImageAlternativeText}}
-              @openVideoTranscription={{@openVideoTranscription}}
-              @clickOnPlayButton={{@clickOnPlayButton}}
+              @onImageAlternativeTextOpen={{@onImageAlternativeTextOpen}}
+              @onVideoTranscriptionOpen={{@onVideoTranscriptionOpen}}
+              @onVideoPlay={{@onVideoPlay}}
               @onFileDownload={{@onFileDownload}}
             />
           </div>

--- a/mon-pix/app/components/module/stepper.gjs
+++ b/mon-pix/app/components/module/stepper.gjs
@@ -88,6 +88,7 @@ export default class ModulixStepper extends Component {
             @openImageAlternativeText={{@openImageAlternativeText}}
             @openVideoTranscription={{@openVideoTranscription}}
             @clickOnPlayButton={{@clickOnPlayButton}}
+            @onFileDownload={{@onFileDownload}}
           />
         {{/each}}
         {{#if this.shouldDisplayNextButton}}

--- a/mon-pix/app/components/module/stepper.gjs
+++ b/mon-pix/app/components/module/stepper.gjs
@@ -43,7 +43,7 @@ export default class ModulixStepper extends Component {
       this.args.stepperIsFinished();
     }
 
-    this.args.continueToNextStep(currentStepPosition);
+    this.args.onStepperNextStep(currentStepPosition);
   }
 
   get currentStepIndex() {
@@ -81,13 +81,13 @@ export default class ModulixStepper extends Component {
             @step={{step}}
             @currentStep={{inc index}}
             @totalSteps={{this.displayableSteps.length}}
-            @submitAnswer={{@submitAnswer}}
-            @retryElement={{@retryElement}}
+            @onElementAnswer={{@onElementAnswer}}
+            @onElementRetry={{@onElementRetry}}
             @getLastCorrectionForElement={{@getLastCorrectionForElement}}
             @hasJustAppeared={{this.hasStepJustAppeared index}}
-            @openImageAlternativeText={{@openImageAlternativeText}}
-            @openVideoTranscription={{@openVideoTranscription}}
-            @clickOnPlayButton={{@clickOnPlayButton}}
+            @onImageAlternativeTextOpen={{@onImageAlternativeTextOpen}}
+            @onVideoTranscriptionOpen={{@onVideoTranscriptionOpen}}
+            @onVideoPlay={{@onVideoPlay}}
             @onFileDownload={{@onFileDownload}}
           />
         {{/each}}

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -61,6 +61,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @import 'components/login-or-register';
 @import 'components/module/beta-banner';
 @import 'components/module/details';
+@import 'components/module/download';
 @import 'components/module/grain';
 @import 'components/module/grain/tag';
 @import 'components/module/objectives';

--- a/mon-pix/app/styles/components/module/_download.scss
+++ b/mon-pix/app/styles/components/module/_download.scss
@@ -1,0 +1,52 @@
+.element-download {
+  &__intro {
+    margin-bottom: var(--pix-spacing-2x);
+    font-weight: var(--pix-font-medium);
+  }
+
+  &__description {
+    @extend %pix-body-s;
+
+    color: var(--pix-neutral-500);
+  }
+
+  &__links-container {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    gap: var(--pix-spacing-2x);
+    margin: var(--pix-spacing-3x) 0;
+  }
+
+  &__link {
+    padding: var(--pix-spacing-6x) var(--pix-spacing-4x);
+    text-align: center;
+    background: var(--pix-neutral-0);
+    border: 1px solid var(--pix-neutral-100);
+    border-radius: 16px;
+  }
+
+  &__documentation-link {
+    @extend %pix-body-m;
+
+    color: var(--pix-info-700);
+  }
+}
+
+.element-download-intro {
+  &__info-icon {
+    color: var(--pix-neutral-500);
+  }
+}
+
+.element-download-link {
+  &__format {
+    @extend %pix-body-m;
+
+    margin-bottom: var(--pix-spacing-2x);
+    font-weight: var(--pix-font-medium);
+  }
+
+  &__button {
+    display: inline-block;
+  }
+}

--- a/mon-pix/app/styles/components/module/_passage.scss
+++ b/mon-pix/app/styles/components/module/_passage.scss
@@ -50,11 +50,6 @@
     }
   }
 
-  a {
-    color: revert;
-    text-decoration: revert;
-  }
-
   hr {
     width: 80%;
     border: 2px solid var(--pix-neutral-100);

--- a/mon-pix/app/templates/module-preview.hbs
+++ b/mon-pix/app/templates/module-preview.hbs
@@ -24,6 +24,7 @@
           @terminateAction={{this.noop}}
           @hasJustAppeared={{false}}
           @clickOnPlayButton={{this.noop}}
+          @onFileDownload={{this.noop}}
         />
       {{/each}}
     </div>

--- a/mon-pix/app/templates/module-preview.hbs
+++ b/mon-pix/app/templates/module-preview.hbs
@@ -10,20 +10,20 @@
       {{#each this.formattedModule.grains as |grain|}}
         <Module::Grain
           @grain={{grain}}
-          @retryElement={{this.noop}}
+          @onElementRetry={{this.noop}}
           @passage={{this.passage}}
           @transition={{this.grainTransition grain.id}}
-          @openImageAlternativeText={{this.noop}}
-          @openVideoTranscription={{this.noop}}
-          @submitAnswer={{this.noop}}
-          @continueToNextStep={{this.noop}}
+          @onImageAlternativeTextOpen={{this.noop}}
+          @onVideoTranscriptionOpen={{this.noop}}
+          @onElementAnswer={{this.noop}}
+          @onStepperNextStep={{this.noop}}
           @canMoveToNextGrain={{false}}
-          @continueAction={{this.noop}}
-          @skipAction={{this.noop}}
+          @onGrainContinue={{this.noop}}
+          @onGrainSkip={{this.noop}}
           @shouldDisplayTerminateButton={{false}}
-          @terminateAction={{this.noop}}
+          @onModuleTerminate={{this.noop}}
           @hasJustAppeared={{false}}
-          @clickOnPlayButton={{this.noop}}
+          @onVideoPlay={{this.noop}}
           @onFileDownload={{this.noop}}
         />
       {{/each}}

--- a/mon-pix/config/icons.js
+++ b/mon-pix/config/icons.js
@@ -9,6 +9,7 @@ module.exports = () => ({
     'arrow-left',
     'arrows-rotate',
     'arrow-up',
+    'arrow-up-right-from-square',
     'bars',
     'bookmark',
     'circle-stop',

--- a/mon-pix/mirage/routes/passages/index.js
+++ b/mon-pix/mirage/routes/passages/index.js
@@ -1,9 +1,9 @@
 import createPassage from './create-passage';
-import submitAnswer from './submit-answer';
+import onElementAnswer from './submit-answer';
 import terminatePassage from './terminate-passage';
 
 export default function index(config) {
   config.post('/passages', createPassage);
-  config.post('/passages/:passageId/answers', submitAnswer);
+  config.post('/passages/:passageId/answers', onElementAnswer);
   config.post('/passages/:passageId/terminate', terminatePassage);
 }

--- a/mon-pix/tests/integration/components/module/details-test.gjs
+++ b/mon-pix/tests/integration/components/module/details-test.gjs
@@ -62,7 +62,7 @@ module('Integration | Component | Module | Details', function (hooks) {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
         'pix-event-action': `Détails du module : ${module.id}`,
-        'pix-event-name': `Clic sur le bouton Commencer`,
+        'pix-event-name': `Click sur le bouton Commencer`,
       });
       assert.ok(true);
     });

--- a/mon-pix/tests/integration/components/module/download-test.gjs
+++ b/mon-pix/tests/integration/components/module/download-test.gjs
@@ -72,7 +72,7 @@ module('Integration | Component | Module | Element | Download', function (hooks)
   });
 
   module('when download button is clicked', function () {
-    test('should call onFileDownload prop with right argument', async function (assert) {
+    test('should call onDownload prop with right argument', async function (assert) {
       // given
       const downloadedFormat = '.pdf';
       const downloadElement = {
@@ -80,11 +80,9 @@ module('Integration | Component | Module | Element | Download', function (hooks)
         type: 'download',
         files: [{ format: downloadedFormat, url: 'https://example.org/modulix/placeholder-doc.pdf' }],
       };
-      const onFileDownloadStub = sinon.stub();
+      const onDownloadStub = sinon.stub();
       const screen = await render(
-        <template>
-          <ModuleElementDownload @download={{downloadElement}} @onFileDownload={{onFileDownloadStub}} />
-        </template>,
+        <template><ModuleElementDownload @download={{downloadElement}} @onDownload={{onDownloadStub}} /></template>,
       );
 
       //  when
@@ -97,7 +95,7 @@ module('Integration | Component | Module | Element | Download', function (hooks)
       downloadLink.click();
 
       // then
-      sinon.assert.calledWithExactly(onFileDownloadStub, {
+      sinon.assert.calledWithExactly(onDownloadStub, {
         elementId: downloadElement.id,
         downloadedFormat,
       });

--- a/mon-pix/tests/integration/components/module/download-test.gjs
+++ b/mon-pix/tests/integration/components/module/download-test.gjs
@@ -1,7 +1,7 @@
 import { render } from '@1024pix/ember-testing-library';
-import { findAll } from '@ember/test-helpers';
 import ModuleElementDownload from 'mon-pix/components/module/element/download';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -10,13 +10,98 @@ module('Integration | Component | Module | Element | Download', function (hooks)
 
   test('should display a Download', async function (assert) {
     // given
-    const downloadElement = { files: [{ url: 'https://example.org/image.jpg', format: '.jpg' }], type: 'download' };
+    const downloadElement = {
+      files: [
+        { url: 'https://example.org/image.jpg', format: '.jpg' },
+        { url: 'https://example.org/image.png', format: '.png' },
+      ],
+      type: 'download',
+    };
 
     //  when
     const screen = await render(<template><ModuleElementDownload @download={{downloadElement}} /></template>);
 
     // then
-    assert.ok(screen);
-    assert.strictEqual(findAll('.element-download').length, 1);
+    const pngDownloadLink = screen.getByRole('link', {
+      name: this.intl.t('pages.modulix.download.label', { format: '.png' }),
+    });
+    assert.dom(pngDownloadLink).hasAttribute('href', 'https://example.org/image.png');
+    assert.dom(pngDownloadLink).hasAttribute('download');
+
+    const jpgDownloadLink = screen.getByRole('link', {
+      name: this.intl.t('pages.modulix.download.label', { format: '.jpg' }),
+    });
+    assert.dom(jpgDownloadLink).hasAttribute('href', 'https://example.org/image.jpg');
+    assert.dom(jpgDownloadLink).hasAttribute('download');
+  });
+
+  test('should display links in the correct order', async function (assert) {
+    // given
+    const downloadElement = {
+      files: [
+        { url: 'https://example.org/image.jpg', format: '.jpg' },
+        { url: 'https://example.org/image.png', format: '.png' },
+      ],
+      type: 'download',
+    };
+
+    //  when
+    const screen = await render(<template><ModuleElementDownload @download={{downloadElement}} /></template>);
+
+    // then
+    const links = screen.getAllByRole('link');
+    assert.dom(links[0]).hasAttribute('href', 'https://example.org/image.jpg');
+    assert.dom(links[1]).hasAttribute('href', 'https://example.org/image.png');
+  });
+
+  test('should display a link to documentation', async function (assert) {
+    // given
+    const downloadElement = {
+      files: [{ url: 'https://example.org/image.jpg', format: '.jpg' }],
+      type: 'download',
+    };
+
+    //  when
+    const screen = await render(<template><ModuleElementDownload @download={{downloadElement}} /></template>);
+
+    // then
+    const documentationLink = screen.getByRole('link', {
+      name: this.intl.t('pages.modulix.download.documentationLinkLabel'),
+    });
+    assert.dom(documentationLink).hasAttribute('href', this.intl.t('pages.modulix.download.documentationLinkHref'));
+  });
+
+  module('when download button is clicked', function () {
+    test('should call onFileDownload prop with right argument', async function (assert) {
+      // given
+      const downloadedFormat = '.pdf';
+      const downloadElement = {
+        id: 'id',
+        type: 'download',
+        files: [{ format: downloadedFormat, url: 'https://example.org/modulix/placeholder-doc.pdf' }],
+      };
+      const onFileDownloadStub = sinon.stub();
+      const screen = await render(
+        <template>
+          <ModuleElementDownload @download={{downloadElement}} @onFileDownload={{onFileDownloadStub}} />
+        </template>,
+      );
+
+      //  when
+      const downloadLink = await screen.getByRole('link', {
+        name: this.intl.t('pages.modulix.download.label', { format: downloadedFormat }),
+      });
+      downloadLink.addEventListener('click', (event) => {
+        event.preventDefault();
+      });
+      downloadLink.click();
+
+      // then
+      sinon.assert.calledWithExactly(onFileDownloadStub, {
+        elementId: downloadElement.id,
+        downloadedFormat,
+      });
+      assert.ok(true);
+    });
   });
 });

--- a/mon-pix/tests/integration/components/module/element_test.gjs
+++ b/mon-pix/tests/integration/components/module/element_test.gjs
@@ -80,8 +80,10 @@ module('Integration | Component | Module | Element', function (hooks) {
     const screen = await render(<template><ModulixElement @element={{element}} /></template>);
 
     // then
-    const downloadElement = screen.getByText('ELEMENT TÉLÉCHARGEMENT EN COURS DE DEVELOPPEMENT');
-    assert.dom(downloadElement).exists();
+    const downloadElement = screen.getByRole('link', {
+      name: this.intl.t('pages.modulix.download.label', { format: '.jpg' }),
+    });
+    assert.dom(downloadElement).hasText(this.intl.t('pages.modulix.download.button'));
   });
 
   test('should display an element with an embed element', async function (assert) {

--- a/mon-pix/tests/integration/components/module/embed_test.gjs
+++ b/mon-pix/tests/integration/components/module/embed_test.gjs
@@ -99,7 +99,7 @@ module('Integration | Component | Module | Embed', function (hooks) {
 
     module('when a message is received', function () {
       module('when message is not from pix', function () {
-        test('should not call the submitAnswer method', async function (assert) {
+        test('should not call the onAnswer method', async function (assert) {
           // given
           const embed = {
             id: 'id',
@@ -108,8 +108,8 @@ module('Integration | Component | Module | Embed', function (hooks) {
             url: 'https://example.org',
             height: 800,
           };
-          const submitAnswerStub = sinon.stub();
-          await render(<template><ModulixEmbed @embed={{embed}} @submitAnswer={{submitAnswerStub}} /></template>);
+          const onElementAnswerStub = sinon.stub();
+          await render(<template><ModulixEmbed @embed={{embed}} @onAnswer={{onElementAnswerStub}} /></template>);
           await clickByName(this.intl.t('pages.modulix.buttons.embed.start.ariaLabel'));
 
           // when
@@ -120,13 +120,13 @@ module('Integration | Component | Module | Embed', function (hooks) {
           window.dispatchEvent(event);
 
           // then
-          sinon.assert.notCalled(submitAnswerStub);
+          sinon.assert.notCalled(onElementAnswerStub);
           assert.ok(true);
         });
       });
 
       module('when message is not an answer', function () {
-        test('should not call the submitAnswer method', async function (assert) {
+        test('should not call the onAnswer method', async function (assert) {
           // given
           const embed = {
             id: 'id',
@@ -135,8 +135,8 @@ module('Integration | Component | Module | Embed', function (hooks) {
             url: 'https://example.org',
             height: 800,
           };
-          const submitAnswerStub = sinon.stub();
-          await render(<template><ModulixEmbed @embed={{embed}} @submitAnswer={{submitAnswerStub}} /></template>);
+          const onElementAnswerStub = sinon.stub();
+          await render(<template><ModulixEmbed @embed={{embed}} @onAnswer={{onElementAnswerStub}} /></template>);
           await clickByName(this.intl.t('pages.modulix.buttons.embed.start.ariaLabel'));
 
           // when
@@ -147,13 +147,13 @@ module('Integration | Component | Module | Embed', function (hooks) {
           window.dispatchEvent(event);
 
           // then
-          sinon.assert.notCalled(submitAnswerStub);
+          sinon.assert.notCalled(onElementAnswerStub);
           assert.ok(true);
         });
       });
 
       module('when message origin is not allowed', function () {
-        test('should not call the submitAnswer method', async function (assert) {
+        test('should not call the onAnswer method', async function (assert) {
           // given
           const embed = {
             id: 'id',
@@ -162,8 +162,8 @@ module('Integration | Component | Module | Embed', function (hooks) {
             url: 'https://example.org',
             height: 800,
           };
-          const submitAnswerStub = sinon.stub();
-          await render(<template><ModulixEmbed @embed={{embed}} @submitAnswer={{submitAnswerStub}} /></template>);
+          const onElementAnswerStub = sinon.stub();
+          await render(<template><ModulixEmbed @embed={{embed}} @onAnswer={{onElementAnswerStub}} /></template>);
           await clickByName(this.intl.t('pages.modulix.buttons.embed.start.ariaLabel'));
 
           // when
@@ -174,13 +174,13 @@ module('Integration | Component | Module | Embed', function (hooks) {
           window.dispatchEvent(event);
 
           // then
-          sinon.assert.notCalled(submitAnswerStub);
+          sinon.assert.notCalled(onElementAnswerStub);
           assert.ok(true);
         });
       });
 
       module('otherwise when everything is ok', function () {
-        test('should call the submitAnswer method', async function (assert) {
+        test('should call the onAnswer method', async function (assert) {
           // given
           const embed = {
             id: 'id',
@@ -189,8 +189,8 @@ module('Integration | Component | Module | Embed', function (hooks) {
             url: 'https://example.org',
             height: 800,
           };
-          const submitAnswerStub = sinon.stub();
-          await render(<template><ModulixEmbed @embed={{embed}} @submitAnswer={{submitAnswerStub}} /></template>);
+          const onElementAnswerStub = sinon.stub();
+          await render(<template><ModulixEmbed @embed={{embed}} @onAnswer={{onElementAnswerStub}} /></template>);
           await clickByName(this.intl.t('pages.modulix.buttons.embed.start.ariaLabel'));
 
           // when
@@ -201,7 +201,7 @@ module('Integration | Component | Module | Embed', function (hooks) {
           window.dispatchEvent(event);
 
           // then
-          sinon.assert.called(submitAnswerStub);
+          sinon.assert.called(onElementAnswerStub);
           assert.ok(true);
         });
       });

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -427,8 +427,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
     });
   });
 
-  module('when continueAction is called', function () {
-    test('should call continueAction pass in argument', async function (assert) {
+  module('when onGrainContinue is called', function () {
+    test('should call onGrainContinue pass in argument', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
       const element = { type: 'text', isAnswerable: false };
@@ -439,25 +439,25 @@ module('Integration | Component | Module | Grain', function (hooks) {
       store.createRecord('module', { id: 'module-id', grains: [grain] });
       this.set('grain', grain);
 
-      const stubContinueAction = sinon.stub();
-      this.set('continueAction', stubContinueAction);
+      const stubonGrainContinue = sinon.stub();
+      this.set('onGrainContinue', stubonGrainContinue);
 
       // when
       await render(
         hbs`
           <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}}
-                         @continueAction={{this.continueAction}} />`,
+                         @onGrainContinue={{this.onGrainContinue}} />`,
       );
       await clickByName('Continuer');
 
       // then
-      sinon.assert.calledOnce(stubContinueAction);
+      sinon.assert.calledOnce(stubonGrainContinue);
       assert.ok(true);
     });
   });
 
-  module('when skipAction is called', function () {
-    test('should call skipAction pass in argument', async function (assert) {
+  module('when onGrainSkip is called', function () {
+    test('should call onGrainSkip pass in argument', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
       const element = { type: 'qcu', isAnswerable: true };
@@ -467,28 +467,28 @@ module('Integration | Component | Module | Grain', function (hooks) {
       const passage = store.createRecord('passage');
       this.set('passage', passage);
 
-      const skipActionStub = sinon.stub();
-      this.set('skipAction', skipActionStub);
+      const onGrainSkipStub = sinon.stub();
+      this.set('onGrainSkip', onGrainSkipStub);
 
-      this.set('continueAction', () => {});
+      this.set('onGrainContinue', () => {});
 
       // when
       await render(
         hbs`
           <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}}
-                         @continueAction={{this.continueAction}} @skipAction={{this.skipAction}}
+                         @onGrainContinue={{this.onGrainContinue}} @onGrainSkip={{this.onGrainSkip}}
                          @passage={{this.passage}} />`,
       );
       await clickByName(this.intl.t('pages.modulix.buttons.grain.skip'));
 
       // then
-      sinon.assert.calledOnce(skipActionStub);
+      sinon.assert.calledOnce(onGrainSkipStub);
       assert.ok(true);
     });
   });
 
-  module('when retryElement is called', function () {
-    test('should call retryElement pass in argument', async function (assert) {
+  module('when onElementRetry is called', function () {
+    test('should call onElementRetry pass in argument', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
       const element = { id: 'qcu-id', type: 'qcu', isAnswerable: true };
@@ -497,20 +497,20 @@ module('Integration | Component | Module | Grain', function (hooks) {
       const passage = store.createRecord('passage');
       this.set('passage', passage);
 
-      const retryElementStub = sinon.stub().withArgs({ element });
-      this.set('retryElement', retryElementStub);
+      const onElementRetryStub = sinon.stub().withArgs({ element });
+      this.set('onElementRetry', onElementRetryStub);
 
       const correction = store.createRecord('correction-response', { status: 'ko' });
       store.createRecord('element-answer', { elementId: element.id, correction, passage });
 
       // when
       await render(hbs`
-        <Module::Grain @grain={{this.grain}} @retryElement={{this.retryElement}} @canMoveToNextGrain={{true}}
+        <Module::Grain @grain={{this.grain}} @onElementRetry={{this.onElementRetry}} @canMoveToNextGrain={{true}}
                        @passage={{this.passage}} />`);
       await clickByName(this.intl.t('pages.modulix.buttons.activity.retry'));
 
       // then
-      sinon.assert.calledOnce(retryElementStub);
+      sinon.assert.calledOnce(onElementRetryStub);
       assert.ok(true);
     });
   });
@@ -537,7 +537,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
     });
 
     module('When we verify an answerable element', function () {
-      test('should call the submitAnswer action', async function (assert) {
+      test('should call the onElementAnswer action', async function (assert) {
         // given
         const steps = [
           {
@@ -566,7 +566,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
           },
         ];
         function getLastCorrectionForElementStub() {}
-        const submitAnswerStub = sinon.stub();
+        const onElementAnswerStub = sinon.stub();
         const store = this.owner.lookup('service:store');
         const grain = store.createRecord('grain', {
           title: 'Grain title',
@@ -581,22 +581,22 @@ module('Integration | Component | Module | Grain', function (hooks) {
         passage.getLastCorrectionForElement = getLastCorrectionForElementStub;
         this.set('grain', grain);
         this.set('passage', passage);
-        this.set('submitAnswer', submitAnswerStub);
+        this.set('onElementAnswer', onElementAnswerStub);
 
         // when
         await render(hbs`
-          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @submitAnswer={{this.submitAnswer}} />`);
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @onElementAnswer={{this.onElementAnswer}} />`);
 
         // then
         await clickByName('radio1');
         await clickByName(this.intl.t('pages.modulix.buttons.activity.verify'));
-        sinon.assert.calledOnce(submitAnswerStub);
+        sinon.assert.calledOnce(onElementAnswerStub);
         assert.ok(true);
       });
     });
 
     module('When we retry an answerable element', function () {
-      test('should call the retryElement action', async function (assert) {
+      test('should call the onElementRetry action', async function (assert) {
         // given
         const steps = [
           {
@@ -624,7 +624,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
             ],
           },
         ];
-        const retryElementStub = sinon.stub();
+        const onElementRetryStub = sinon.stub();
         const store = this.owner.lookup('service:store');
         const grain = store.createRecord('grain', {
           title: 'Grain title',
@@ -648,16 +648,16 @@ module('Integration | Component | Module | Grain', function (hooks) {
         });
         this.set('grain', grain);
         this.set('passage', passage);
-        this.set('retryElement', retryElementStub);
+        this.set('onElementRetry', onElementRetryStub);
 
         // when
         await render(hbs`
-          <Module::Grain @grain={{this.grain}} @passage={{this.passage}}  @retryElement={{this.retryElement}} />`);
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}}  @onElementRetry={{this.onElementRetry}} />`);
 
         // then
         await clickByName('radio1');
         await clickByName(this.intl.t('pages.modulix.buttons.activity.retry'));
-        sinon.assert.calledOnce(retryElementStub);
+        sinon.assert.calledOnce(onElementRetryStub);
         assert.ok(true);
       });
     });
@@ -701,15 +701,15 @@ module('Integration | Component | Module | Grain', function (hooks) {
           });
 
           const passage = store.createRecord('passage');
-          const retryElementStub = sinon.stub();
+          const onElementRetryStub = sinon.stub();
 
           this.set('grain', grain);
           this.set('passage', passage);
-          this.set('retryElement', retryElementStub);
+          this.set('onElementRetry', onElementRetryStub);
 
           // when
           const screen = await render(hbs`
-          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}}  />`);
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @onElementRetry={{this.onElementRetry}}  />`);
 
           // then
           assert.dom(screen.getByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') })).exists();
@@ -751,15 +751,15 @@ module('Integration | Component | Module | Grain', function (hooks) {
           });
 
           const passage = store.createRecord('passage');
-          const retryElementStub = sinon.stub();
+          const onElementRetryStub = sinon.stub();
 
           this.set('grain', grain);
           this.set('passage', passage);
-          this.set('retryElement', retryElementStub);
+          this.set('onElementRetry', onElementRetryStub);
 
           // when
           const screen = await render(hbs`
-          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}}  />`);
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @onElementRetry={{this.onElementRetry}}  />`);
 
           // then
           assert
@@ -770,15 +770,15 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       module('when there is no more steps to display', function (hooks) {
         let passage;
-        let retryElementStub;
-        let continueToNextStepStub;
+        let onElementRetryStub;
+        let onStepperNextStepStub;
         let store;
 
         hooks.beforeEach(function () {
           store = this.owner.lookup('service:store');
           passage = store.createRecord('passage');
-          retryElementStub = sinon.stub();
-          continueToNextStepStub = sinon.stub();
+          onElementRetryStub = sinon.stub();
+          onStepperNextStepStub = sinon.stub();
         });
 
         test('should display continue button', async function (assert) {
@@ -818,12 +818,12 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
           this.set('grain', grain);
           this.set('passage', passage);
-          this.set('retryElement', retryElementStub);
-          this.set('continueToNextStep', continueToNextStepStub);
+          this.set('onElementRetry', onElementRetryStub);
+          this.set('onStepperNextStep', onStepperNextStepStub);
 
           // when
           const screen = await render(hbs`
-          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}} @continueToNextStep={{this.continueToNextStep}} />`);
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @onElementRetry={{this.onElementRetry}} @onStepperNextStep={{this.onStepperNextStep}} />`);
           await clickByName(this.intl.t('pages.modulix.buttons.stepper.next.ariaLabel'));
 
           // then
@@ -869,12 +869,12 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
           this.set('grain', grain);
           this.set('passage', passage);
-          this.set('retryElement', retryElementStub);
-          this.set('continueToNextStep', continueToNextStepStub);
+          this.set('onElementRetry', onElementRetryStub);
+          this.set('onStepperNextStep', onStepperNextStepStub);
 
           // when
           const screen = await render(hbs`
-          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}} @continueToNextStep={{this.continueToNextStep}} />`);
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @onElementRetry={{this.onElementRetry}} @onStepperNextStep={{this.onStepperNextStep}} />`);
           await clickByName(this.intl.t('pages.modulix.buttons.stepper.next.ariaLabel'));
 
           // then
@@ -888,15 +888,15 @@ module('Integration | Component | Module | Grain', function (hooks) {
     module('when there are answerable elements in stepper', function () {
       module('when user response is not verified', function (hooks) {
         let passage;
-        let retryElementStub;
-        let continueToNextStepStub;
+        let onElementRetryStub;
+        let onStepperNextStepStub;
         let store;
 
         hooks.beforeEach(function () {
           store = this.owner.lookup('service:store');
           passage = store.createRecord('passage');
-          retryElementStub = sinon.stub();
-          continueToNextStepStub = sinon.stub();
+          onElementRetryStub = sinon.stub();
+          onStepperNextStepStub = sinon.stub();
         });
 
         module('when there are still steps to display', function () {
@@ -938,12 +938,12 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
             this.set('grain', grain);
             this.set('passage', passage);
-            this.set('retryElement', retryElementStub);
-            this.set('continueToNextStep', continueToNextStepStub);
+            this.set('onElementRetry', onElementRetryStub);
+            this.set('onStepperNextStep', onStepperNextStepStub);
 
             // when
             const screen = await render(hbs`
-          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}} @continueToNextStep={{this.continueToNextStep}} />`);
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @onElementRetry={{this.onElementRetry}} @onStepperNextStep={{this.onStepperNextStep}} />`);
 
             // then
             assert.dom(screen.getByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') })).exists();
@@ -987,12 +987,12 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
             this.set('grain', grain);
             this.set('passage', passage);
-            this.set('retryElement', retryElementStub);
-            this.set('continueToNextStep', continueToNextStepStub);
+            this.set('onElementRetry', onElementRetryStub);
+            this.set('onStepperNextStep', onStepperNextStepStub);
 
             // when
             const screen = await render(hbs`
-          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}} @continueToNextStep={{this.continueToNextStep}} />`);
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @onElementRetry={{this.onElementRetry}} @onStepperNextStep={{this.onStepperNextStep}} />`);
 
             // then
             assert
@@ -1041,12 +1041,12 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
               this.set('grain', grain);
               this.set('passage', passage);
-              this.set('retryElement', retryElementStub);
-              this.set('continueToNextStep', continueToNextStepStub);
+              this.set('onElementRetry', onElementRetryStub);
+              this.set('onStepperNextStep', onStepperNextStepStub);
 
               // when
               const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}} @continueToNextStep={{this.continueToNextStep}} />`);
+            <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @onElementRetry={{this.onElementRetry}} @onStepperNextStep={{this.onStepperNextStep}} />`);
               await clickByName(this.intl.t('pages.modulix.buttons.stepper.next.ariaLabel'));
 
               // then
@@ -1093,12 +1093,12 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
               this.set('grain', grain);
               this.set('passage', passage);
-              this.set('retryElement', retryElementStub);
-              this.set('continueToNextStep', continueToNextStepStub);
+              this.set('onElementRetry', onElementRetryStub);
+              this.set('onStepperNextStep', onStepperNextStepStub);
 
               // when
               const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}} @continueToNextStep={{this.continueToNextStep}} />`);
+            <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @onElementRetry={{this.onElementRetry}} @onStepperNextStep={{this.onStepperNextStep}} />`);
               await clickByName(this.intl.t('pages.modulix.buttons.stepper.next.ariaLabel'));
 
               // then
@@ -1159,15 +1159,15 @@ module('Integration | Component | Module | Grain', function (hooks) {
               correction,
               passage,
             });
-            const retryElementStub = sinon.stub();
+            const onElementRetryStub = sinon.stub();
 
             this.set('grain', grain);
             this.set('passage', passage);
-            this.set('retryElement', retryElementStub);
+            this.set('onElementRetry', onElementRetryStub);
 
             // when
             const screen = await render(hbs`
-          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}}  />`);
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @onElementRetry={{this.onElementRetry}}  />`);
 
             // then
             assert.dom(screen.getByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') })).exists();
@@ -1219,15 +1219,15 @@ module('Integration | Component | Module | Grain', function (hooks) {
               correction,
               passage,
             });
-            const retryElementStub = sinon.stub();
+            const onElementRetryStub = sinon.stub();
 
             this.set('grain', grain);
             this.set('passage', passage);
-            this.set('retryElement', retryElementStub);
+            this.set('onElementRetry', onElementRetryStub);
 
             // when
             const screen = await render(hbs`
-          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}}  />`);
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @onElementRetry={{this.onElementRetry}}  />`);
 
             // then
             assert
@@ -1238,15 +1238,15 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
         module('when there is no more steps to display', function (hooks) {
           let passage;
-          let retryElementStub;
-          let continueToNextStepStub;
+          let onElementRetryStub;
+          let onStepperNextStepStub;
           let store;
 
           hooks.beforeEach(function () {
             store = this.owner.lookup('service:store');
             passage = store.createRecord('passage');
-            retryElementStub = sinon.stub();
-            continueToNextStepStub = sinon.stub();
+            onElementRetryStub = sinon.stub();
+            onStepperNextStepStub = sinon.stub();
           });
           module('when the last step contains an answerable element', function () {
             test('should not display skip button', async function (assert) {
@@ -1298,12 +1298,12 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
               this.set('grain', grain);
               this.set('passage', passage);
-              this.set('retryElement', retryElementStub);
-              this.set('continueToNextStep', continueToNextStepStub);
+              this.set('onElementRetry', onElementRetryStub);
+              this.set('onStepperNextStep', onStepperNextStepStub);
 
               // when
               const screen = await render(hbs`
-                <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}} @continueToNextStep={{this.continueToNextStep}} />`);
+                <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @onElementRetry={{this.onElementRetry}} @onStepperNextStep={{this.onStepperNextStep}} />`);
 
               await clickByName(this.intl.t('pages.modulix.buttons.stepper.next.ariaLabel'));
 
@@ -1359,16 +1359,16 @@ module('Integration | Component | Module | Grain', function (hooks) {
                 correction,
                 passage,
               });
-              const retryElementStub = sinon.stub();
+              const onElementRetryStub = sinon.stub();
 
               this.set('grain', grain);
               this.set('passage', passage);
-              this.set('retryElement', retryElementStub);
-              this.set('continueToNextStep', continueToNextStepStub);
+              this.set('onElementRetry', onElementRetryStub);
+              this.set('onStepperNextStep', onStepperNextStepStub);
 
               // when
               const screen = await render(hbs`
-                <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}} @continueToNextStep={{this.continueToNextStep}} />`);
+                <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @onElementRetry={{this.onElementRetry}} @onStepperNextStep={{this.onStepperNextStep}} />`);
 
               await clickByName(this.intl.t('pages.modulix.buttons.stepper.next.ariaLabel'));
 

--- a/mon-pix/tests/integration/components/module/image_test.gjs
+++ b/mon-pix/tests/integration/components/module/image_test.gjs
@@ -39,12 +39,12 @@ module('Integration | Component | Module | Image', function (hooks) {
       alt: 'alt text',
       alternativeText,
     };
-    const openAlternativeTextStub = sinon.stub();
+    const onImageAlternativeTextOpenStub = sinon.stub();
 
     //  when
     const screen = await render(
       <template>
-        <ModulixImageElement @image={{imageElement}} @openAlternativeText={{openAlternativeTextStub}} />
+        <ModulixImageElement @image={{imageElement}} @onAlternativeTextOpen={{onImageAlternativeTextOpenStub}} />
       </template>,
     );
 
@@ -52,7 +52,7 @@ module('Integration | Component | Module | Image', function (hooks) {
     await click(screen.getByRole('button', { name: "Afficher l'alternative textuelle" }));
     assert.ok(await screen.findByRole('dialog'));
     assert.ok(screen.getByText(alternativeText));
-    assert.ok(openAlternativeTextStub.calledOnce);
+    assert.ok(onImageAlternativeTextOpenStub.calledOnce);
   });
 
   test('should not be able to open the modal if there is no alternative instruction', async function (assert) {

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -777,7 +777,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
         'pix-event-action': `Passage du module : ${module.id}`,
-        'pix-event-name': `Clic sur le bouton Play : ${videoElement.id}`,
+        'pix-event-name': `Click sur le bouton Play : ${videoElement.id}`,
       });
       assert.ok(true);
     });
@@ -817,7 +817,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
           event: 'custom-event',
           'pix-event-category': 'Modulix',
           'pix-event-action': `Passage du module : ${module.id}`,
-          'pix-event-name': `Clic sur le bouton Play : ${videoElement.id}`,
+          'pix-event-name': `Click sur le bouton Play : ${videoElement.id}`,
         });
         assert.ok(true);
       });
@@ -947,7 +947,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
         'pix-event-action': `Passage du module : ${module.id}`,
-        'pix-event-name': `Clic sur le bouton Terminer du grain : ${grain.id}`,
+        'pix-event-name': `Click sur le bouton Terminer du grain : ${grain.id}`,
       });
       assert.ok(true);
     });

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -247,8 +247,8 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await clickByName(continueButtonName);
 
       // then
-      const grainsAfterContinueAction = screen.getAllByRole('article');
-      assert.strictEqual(grainsAfterContinueAction.length, 2);
+      const grainsAfteronGrainContinue = screen.getAllByRole('article');
+      assert.strictEqual(grainsAfteronGrainContinue.length, 2);
     });
 
     test('should give focus on the last grain when appearing', async function (assert) {
@@ -274,18 +274,18 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await clickByName(continueButtonName);
 
       // then
-      const grainsAfterOneContinueActions = screen.getAllByRole('article');
-      assert.strictEqual(grainsAfterOneContinueActions.length, 2);
-      const secondGrain = grainsAfterOneContinueActions.at(-1);
+      const grainsAfterOneonGrainContinues = screen.getAllByRole('article');
+      assert.strictEqual(grainsAfterOneonGrainContinues.length, 2);
+      const secondGrain = grainsAfterOneonGrainContinues.at(-1);
       assert.strictEqual(document.activeElement, secondGrain);
 
       // when
       await clickByName(continueButtonName);
 
       // then
-      const grainsAfterTwoContinueActions = screen.getAllByRole('article');
-      assert.strictEqual(grainsAfterTwoContinueActions.length, 3);
-      const thirdGrain = grainsAfterTwoContinueActions.at(-1);
+      const grainsAfterTwoonGrainContinues = screen.getAllByRole('article');
+      assert.strictEqual(grainsAfterTwoonGrainContinues.length, 3);
+      const thirdGrain = grainsAfterTwoonGrainContinues.at(-1);
       assert.strictEqual(document.activeElement, thirdGrain);
     });
 
@@ -591,7 +591,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
 
       const module = store.createRecord('module', { id: '1', title: 'Module title', grains: [grain] });
       const passage = store.createRecord('passage');
-      const continueToNextStepButtonName = this.intl.t('pages.modulix.buttons.stepper.next.ariaLabel');
+      const onStepperNextStepButtonName = this.intl.t('pages.modulix.buttons.stepper.next.ariaLabel');
 
       await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
 
@@ -599,7 +599,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       metrics.add = sinon.stub();
 
       // when
-      await clickByName(continueToNextStepButtonName);
+      await clickByName(onStepperNextStepButtonName);
 
       // then
       sinon.assert.calledWithExactly(metrics.add, {

--- a/mon-pix/tests/integration/components/module/qcm-test.js
+++ b/mon-pix/tests/integration/components/module/qcm-test.js
@@ -61,9 +61,9 @@ module('Integration | Component | Module | QCM', function (hooks) {
     };
     this.set('el', qcmElement);
     const userResponse = [answeredProposal[0].id, answeredProposal[1].id];
-    const givenSubmitAnswerSpy = sinon.spy();
-    this.set('submitAnswer', givenSubmitAnswerSpy);
-    const screen = await render(hbs`<Module::Element::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}} />`);
+    const givenonElementAnswerSpy = sinon.spy();
+    this.set('onAnswer', givenonElementAnswerSpy);
+    const screen = await render(hbs`<Module::Element::Qcm @element={{this.el}} @onAnswer={{this.onAnswer}} />`);
     const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
 
     // when
@@ -72,7 +72,7 @@ module('Integration | Component | Module | QCM', function (hooks) {
     await click(verifyButton);
 
     // then
-    sinon.assert.calledWith(givenSubmitAnswerSpy, { userResponse, element: qcmElement });
+    sinon.assert.calledWith(givenonElementAnswerSpy, { userResponse, element: qcmElement });
     assert.ok(true);
   });
 
@@ -88,10 +88,10 @@ module('Integration | Component | Module | QCM', function (hooks) {
       ],
       type: 'qcm',
     };
-    const submitAnswerSpy = sinon.spy();
+    const onElementAnswerSpy = sinon.spy();
     this.set('el', qcmElement);
-    this.set('submitAnswer', submitAnswerSpy);
-    const screen = await render(hbs`<Module::Element::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}} />`);
+    this.set('onAnswer', onElementAnswerSpy);
+    const screen = await render(hbs`<Module::Element::Qcm @element={{this.el}} @onAnswer={{this.onAnswer}} />`);
 
     // when
     await click(screen.getByLabelText('checkbox1'));
@@ -99,7 +99,7 @@ module('Integration | Component | Module | QCM', function (hooks) {
 
     // then
     assert.dom(screen.getByRole('alert')).exists();
-    sinon.assert.notCalled(submitAnswerSpy);
+    sinon.assert.notCalled(onElementAnswerSpy);
   });
 
   test('should hide the error message when QCM is validated with response', async function (assert) {
@@ -114,10 +114,10 @@ module('Integration | Component | Module | QCM', function (hooks) {
       ],
       type: 'qcm',
     };
-    const givenSubmitAnswerStub = function () {};
-    this.set('submitAnswer', givenSubmitAnswerStub);
+    const givenonElementAnswerStub = function () {};
+    this.set('onAnswer', givenonElementAnswerStub);
     this.set('el', qcmElement);
-    const screen = await render(hbs`<Module::Element::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}} />`);
+    const screen = await render(hbs`<Module::Element::Qcm @element={{this.el}} @onAnswer={{this.onAnswer}} />`);
 
     // when
     await click(screen.queryByRole('button', { name: 'Vérifier' }));
@@ -139,15 +139,11 @@ module('Integration | Component | Module | QCM', function (hooks) {
     });
 
     prepareContextRecords.call(this, store, correctionResponse);
-    this.set('submitAnswer', () => {});
+    this.set('onAnswer', () => {});
 
     // when
     const screen = await render(
-      hbs`<Module::Element::Qcm
-  @element={{this.el}}
-  @submitAnswer={{this.submitAnswer}}
-  @correction={{this.correctionResponse}}
-/>`,
+      hbs`<Module::Element::Qcm @element={{this.el}} @onAnswer={{this.onAnswer}} @correction={{this.correctionResponse}} />`,
     );
 
     // then
@@ -169,15 +165,11 @@ module('Integration | Component | Module | QCM', function (hooks) {
     });
 
     prepareContextRecords.call(this, store, correctionResponse);
-    this.set('submitAnswer', () => {});
+    this.set('onAnswer', () => {});
 
     // when
     const screen = await render(
-      hbs`<Module::Element::Qcm
-  @element={{this.el}}
-  @submitAnswer={{this.submitAnswer}}
-  @correction={{this.correctionResponse}}
-/>`,
+      hbs`<Module::Element::Qcm @element={{this.el}} @onAnswer={{this.onAnswer}} @correction={{this.correctionResponse}} />`,
     );
 
     // then
@@ -200,15 +192,11 @@ module('Integration | Component | Module | QCM', function (hooks) {
     });
 
     prepareContextRecords.call(this, store, correctionResponse);
-    this.set('submitAnswer', () => {});
+    this.set('onAnswer', () => {});
 
     // when
     const screen = await render(
-      hbs`<Module::Element::Qcm
-  @element={{this.el}}
-  @submitAnswer={{this.submitAnswer}}
-  @correction={{this.correctionResponse}}
-/>`,
+      hbs`<Module::Element::Qcm @element={{this.el}} @onAnswer={{this.onAnswer}} @correction={{this.correctionResponse}} />`,
     );
 
     // then
@@ -225,15 +213,11 @@ module('Integration | Component | Module | QCM', function (hooks) {
     });
 
     prepareContextRecords.call(this, store, correctionResponse);
-    this.set('submitAnswer', () => {});
+    this.set('onAnswer', () => {});
 
     // when
     const screen = await render(
-      hbs`<Module::Element::Qcm
-  @element={{this.el}}
-  @submitAnswer={{this.submitAnswer}}
-  @correction={{this.correctionResponse}}
-/>`,
+      hbs`<Module::Element::Qcm @element={{this.el}} @onAnswer={{this.onAnswer}} @correction={{this.correctionResponse}} />`,
     );
 
     // then
@@ -252,15 +236,11 @@ module('Integration | Component | Module | QCM', function (hooks) {
     });
 
     prepareContextRecords.call(this, store, correctionResponse);
-    this.set('submitAnswer', () => {});
+    this.set('onAnswer', () => {});
 
     // when
     const screen = await render(
-      hbs`<Module::Element::Qcm
-  @element={{this.el}}
-  @submitAnswer={{this.submitAnswer}}
-  @correction={{this.correctionResponse}}
-/>`,
+      hbs`<Module::Element::Qcm @element={{this.el}} @onAnswer={{this.onAnswer}} @correction={{this.correctionResponse}} />`,
     );
 
     // then

--- a/mon-pix/tests/integration/components/module/qcu-test.js
+++ b/mon-pix/tests/integration/components/module/qcu-test.js
@@ -21,10 +21,10 @@ module('Integration | Component | Module | QCU', function (hooks) {
       ],
       type: 'qcu',
     };
-    const givenSubmitAnswerStub = sinon.stub();
+    const givenonElementAnswerStub = sinon.stub();
     this.set('el', qcuElement);
-    this.set('submitAnswer', givenSubmitAnswerStub);
-    const screen = await render(hbs`<Module::Element::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}} />`);
+    this.set('onAnswer', givenonElementAnswerStub);
+    const screen = await render(hbs`<Module::Element::Qcu @element={{this.el}} @onAnswer={{this.onAnswer}} />`);
 
     // then
     assert.ok(screen);
@@ -55,9 +55,9 @@ module('Integration | Component | Module | QCU', function (hooks) {
     };
     this.set('el', qcuElement);
     const userResponse = [answeredProposal.id];
-    const givenSubmitAnswerSpy = sinon.spy();
-    this.set('submitAnswer', givenSubmitAnswerSpy);
-    const screen = await render(hbs`<Module::Element::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}} />`);
+    const givenonElementAnswerSpy = sinon.spy();
+    this.set('onAnswer', givenonElementAnswerSpy);
+    const screen = await render(hbs`<Module::Element::Qcu @element={{this.el}} @onAnswer={{this.onAnswer}} />`);
     const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
 
     // when
@@ -65,7 +65,7 @@ module('Integration | Component | Module | QCU', function (hooks) {
     await click(verifyButton);
 
     // then
-    sinon.assert.calledWith(givenSubmitAnswerSpy, { userResponse, element: qcuElement });
+    sinon.assert.calledWith(givenonElementAnswerSpy, { userResponse, element: qcuElement });
     assert.ok(true);
   });
 
@@ -80,17 +80,17 @@ module('Integration | Component | Module | QCU', function (hooks) {
       ],
       type: 'qcu',
     };
-    const submitAnswerSpy = sinon.spy();
+    const onElementAnswerSpy = sinon.spy();
     this.set('el', qcuElement);
-    this.set('submitAnswer', submitAnswerSpy);
-    const screen = await render(hbs`<Module::Element::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}} />`);
+    this.set('onAnswer', onElementAnswerSpy);
+    const screen = await render(hbs`<Module::Element::Qcu @element={{this.el}} @onAnswer={{this.onAnswer}} />`);
 
     // when
     await click(screen.queryByRole('button', { name: 'Vérifier' }));
 
     // then
     assert.dom(screen.getByRole('alert')).exists();
-    sinon.assert.notCalled(submitAnswerSpy);
+    sinon.assert.notCalled(onElementAnswerSpy);
   });
 
   test('should hide the error message when QCU is validated with response', async function (assert) {
@@ -104,10 +104,10 @@ module('Integration | Component | Module | QCU', function (hooks) {
       ],
       type: 'qcu',
     };
-    const givenSubmitAnswerStub = function () {};
-    this.set('submitAnswer', givenSubmitAnswerStub);
+    const givenonElementAnswerStub = function () {};
+    this.set('onAnswer', givenonElementAnswerStub);
     this.set('el', qcuElement);
-    const screen = await render(hbs`<Module::Element::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}} />`);
+    const screen = await render(hbs`<Module::Element::Qcu @element={{this.el}} @onAnswer={{this.onAnswer}} />`);
 
     // when
     await click(screen.queryByRole('button', { name: 'Vérifier' }));
@@ -129,15 +129,11 @@ module('Integration | Component | Module | QCU', function (hooks) {
     });
 
     prepareContextRecords.call(this, store, correctionResponse);
-    this.set('submitAnswer', () => {});
+    this.set('onAnswer', () => {});
 
     // when
     const screen = await render(
-      hbs`<Module::Element::Qcu
-  @element={{this.el}}
-  @submitAnswer={{this.submitAnswer}}
-  @correction={{this.correctionResponse}}
-/>`,
+      hbs`<Module::Element::Qcu @element={{this.el}} @onAnswer={{this.onAnswer}} @correction={{this.correctionResponse}} />`,
     );
 
     // then
@@ -158,15 +154,11 @@ module('Integration | Component | Module | QCU', function (hooks) {
     });
 
     prepareContextRecords.call(this, store, correctionResponse);
-    this.set('submitAnswer', () => {});
+    this.set('onAnswer', () => {});
 
     // when
     const screen = await render(
-      hbs`<Module::Element::Qcu
-  @element={{this.el}}
-  @submitAnswer={{this.submitAnswer}}
-  @correction={{this.correctionResponse}}
-/>`,
+      hbs`<Module::Element::Qcu @element={{this.el}} @onAnswer={{this.onAnswer}} @correction={{this.correctionResponse}} />`,
     );
 
     // then
@@ -187,15 +179,11 @@ module('Integration | Component | Module | QCU', function (hooks) {
     });
 
     prepareContextRecords.call(this, store, correctionResponse);
-    this.set('submitAnswer', () => {});
+    this.set('onAnswer', () => {});
 
     // when
     const screen = await render(
-      hbs`<Module::Element::Qcu
-  @element={{this.el}}
-  @submitAnswer={{this.submitAnswer}}
-  @correction={{this.correctionResponse}}
-/>`,
+      hbs`<Module::Element::Qcu @element={{this.el}} @onAnswer={{this.onAnswer}} @correction={{this.correctionResponse}} />`,
     );
 
     // then
@@ -212,15 +200,11 @@ module('Integration | Component | Module | QCU', function (hooks) {
     });
 
     prepareContextRecords.call(this, store, correctionResponse);
-    this.set('submitAnswer', () => {});
+    this.set('onAnswer', () => {});
 
     // when
     const screen = await render(
-      hbs`<Module::Element::Qcu
-  @element={{this.el}}
-  @submitAnswer={{this.submitAnswer}}
-  @correction={{this.correctionResponse}}
-/>`,
+      hbs`<Module::Element::Qcu @element={{this.el}} @onAnswer={{this.onAnswer}} @correction={{this.correctionResponse}} />`,
     );
 
     // then
@@ -239,15 +223,11 @@ module('Integration | Component | Module | QCU', function (hooks) {
     });
 
     prepareContextRecords.call(this, store, correctionResponse);
-    this.set('submitAnswer', () => {});
+    this.set('onAnswer', () => {});
 
     // when
     const screen = await render(
-      hbs`<Module::Element::Qcu
-  @element={{this.el}}
-  @submitAnswer={{this.submitAnswer}}
-  @correction={{this.correctionResponse}}
-/>`,
+      hbs`<Module::Element::Qcu @element={{this.el}} @onAnswer={{this.onAnswer}} @correction={{this.correctionResponse}} />`,
     );
 
     // then

--- a/mon-pix/tests/integration/components/module/qrocm-test.js
+++ b/mon-pix/tests/integration/components/module/qrocm-test.js
@@ -235,12 +235,10 @@ module('Integration | Component | Module | QROCM', function (hooks) {
       ],
       type: 'qrocm',
     };
-    const givenSubmitAnswerStub = function () {};
-    this.set('submitAnswer', givenSubmitAnswerStub);
+    const givenonElementAnswerStub = function () {};
+    this.set('onAnswer', givenonElementAnswerStub);
     this.set('el', qrocm);
-    const screen = await render(
-      hbs`<Module::Element::Qrocm @element={{this.el}} @submitAnswer={{this.submitAnswer}} />`,
-    );
+    const screen = await render(hbs`<Module::Element::Qrocm @element={{this.el}} @onAnswer={{this.onAnswer}} />`);
 
     // when
     await click(screen.queryByRole('button', { name: 'Vérifier' }));
@@ -281,11 +279,9 @@ module('Integration | Component | Module | QROCM', function (hooks) {
       };
       this.set('el', qrocm);
       const userResponse = 'user-response';
-      const givenSubmitAnswerSpy = sinon.spy();
-      this.set('submitAnswer', givenSubmitAnswerSpy);
-      const screen = await render(
-        hbs`<Module::Element::Qrocm @element={{this.el}} @submitAnswer={{this.submitAnswer}} />`,
-      );
+      const givenonElementAnswerSpy = sinon.spy();
+      this.set('onAnswer', givenonElementAnswerSpy);
+      const screen = await render(hbs`<Module::Element::Qrocm @element={{this.el}} @onAnswer={{this.onAnswer}} />`);
       const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
 
       // when
@@ -293,7 +289,7 @@ module('Integration | Component | Module | QROCM', function (hooks) {
       await click(verifyButton);
 
       // then
-      sinon.assert.calledWith(givenSubmitAnswerSpy, {
+      sinon.assert.calledWith(givenonElementAnswerSpy, {
         userResponse: [
           {
             input: 'symbole',
@@ -334,11 +330,9 @@ module('Integration | Component | Module | QROCM', function (hooks) {
       };
       this.set('el', qrocm);
       const userResponse = { input: 'premiere-partie', answer: '2' };
-      const givenSubmitAnswerSpy = sinon.spy();
-      this.set('submitAnswer', givenSubmitAnswerSpy);
-      const screen = await render(
-        hbs`<Module::Element::Qrocm @element={{this.el}} @submitAnswer={{this.submitAnswer}} />`,
-      );
+      const givenonElementAnswerSpy = sinon.spy();
+      this.set('onAnswer', givenonElementAnswerSpy);
+      const screen = await render(hbs`<Module::Element::Qrocm @element={{this.el}} @onAnswer={{this.onAnswer}} />`);
       const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
 
       // when
@@ -352,7 +346,7 @@ module('Integration | Component | Module | QROCM', function (hooks) {
       await click(verifyButton);
 
       // then
-      sinon.assert.calledWith(givenSubmitAnswerSpy, { userResponse: [userResponse], element: qrocm });
+      sinon.assert.calledWith(givenonElementAnswerSpy, { userResponse: [userResponse], element: qrocm });
       assert.ok(true);
     });
   });
@@ -367,15 +361,11 @@ module('Integration | Component | Module | QROCM', function (hooks) {
       solution: 'solution',
     });
     prepareContextRecords.call(this, store, correctionResponse);
-    this.set('submitAnswer', () => {});
+    this.set('onAnswer', () => {});
 
     // when
     const screen = await render(
-      hbs`<Module::Element::Qrocm
-  @element={{this.el}}
-  @submitAnswer={{this.submitAnswer}}
-  @correction={{this.correctionResponse}}
-/>`,
+      hbs`<Module::Element::Qrocm @element={{this.el}} @onAnswer={{this.onAnswer}} @correction={{this.correctionResponse}} />`,
     );
 
     // then
@@ -393,15 +383,11 @@ module('Integration | Component | Module | QROCM', function (hooks) {
       solution: 'solution',
     });
     prepareContextRecords.call(this, store, correctionResponse);
-    this.set('submitAnswer', () => {});
+    this.set('onAnswer', () => {});
 
     // when
     const screen = await render(
-      hbs`<Module::Element::Qrocm
-  @element={{this.el}}
-  @submitAnswer={{this.submitAnswer}}
-  @correction={{this.correctionResponse}}
-/>`,
+      hbs`<Module::Element::Qrocm @element={{this.el}} @onAnswer={{this.onAnswer}} @correction={{this.correctionResponse}} />`,
     );
 
     // then
@@ -420,15 +406,11 @@ module('Integration | Component | Module | QROCM', function (hooks) {
     });
 
     prepareContextRecords.call(this, store, correctionResponse);
-    this.set('submitAnswer', () => {});
+    this.set('onAnswer', () => {});
 
     // when
     const screen = await render(
-      hbs`<Module::Element::Qrocm
-  @element={{this.el}}
-  @submitAnswer={{this.submitAnswer}}
-  @correction={{this.correctionResponse}}
-/>`,
+      hbs`<Module::Element::Qrocm @element={{this.el}} @onAnswer={{this.onAnswer}} @correction={{this.correctionResponse}} />`,
     );
 
     // then
@@ -472,15 +454,11 @@ module('Integration | Component | Module | QROCM', function (hooks) {
     });
     this.set('el', qrocm);
     this.set('correctionResponse', correctionResponse);
-    this.set('submitAnswer', () => {});
+    this.set('onAnswer', () => {});
 
     // when
     const screen = await render(
-      hbs`<Module::Element::Qrocm
-  @element={{this.el}}
-  @submitAnswer={{this.submitAnswer}}
-  @correction={{this.correctionResponse}}
-/>`,
+      hbs`<Module::Element::Qrocm @element={{this.el}} @onAnswer={{this.onAnswer}} @correction={{this.correctionResponse}} />`,
     );
 
     // then
@@ -499,15 +477,11 @@ module('Integration | Component | Module | QROCM', function (hooks) {
     });
 
     prepareContextRecords.call(this, store, correctionResponse);
-    this.set('submitAnswer', () => {});
+    this.set('onAnswer', () => {});
 
     // when
     const screen = await render(
-      hbs`<Module::Element::Qrocm
-  @element={{this.el}}
-  @submitAnswer={{this.submitAnswer}}
-  @correction={{this.correctionResponse}}
-/>`,
+      hbs`<Module::Element::Qrocm @element={{this.el}} @onAnswer={{this.onAnswer}} @correction={{this.correctionResponse}} />`,
     );
 
     // then
@@ -526,15 +500,11 @@ module('Integration | Component | Module | QROCM', function (hooks) {
     });
 
     prepareContextRecords.call(this, store, correctionResponse);
-    this.set('submitAnswer', () => {});
+    this.set('onAnswer', () => {});
 
     // when
     const screen = await render(
-      hbs`<Module::Element::Qrocm
-  @element={{this.el}}
-  @submitAnswer={{this.submitAnswer}}
-  @correction={{this.correctionResponse}}
-/>`,
+      hbs`<Module::Element::Qrocm @element={{this.el}} @onAnswer={{this.onAnswer}} @correction={{this.correctionResponse}} />`,
     );
 
     // then

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -98,7 +98,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
       });
 
       module('When we verify an answerable element', function () {
-        test('should call the submitAnswer action', async function (assert) {
+        test('should call the onElementAnswer action', async function (assert) {
           // given
           const steps = [
             {
@@ -127,7 +127,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             },
           ];
           function getLastCorrectionForElementStub() {}
-          const submitAnswerStub = sinon.stub();
+          const onElementAnswerStub = sinon.stub();
           const store = this.owner.lookup('service:store');
           const passage = store.createRecord('passage');
           passage.getLastCorrectionForElement = getLastCorrectionForElementStub;
@@ -138,7 +138,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
               <ModulixStepper
                 @passage={{passage}}
                 @steps={{steps}}
-                @submitAnswer={{submitAnswerStub}}
+                @onElementAnswer={{onElementAnswerStub}}
                 @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
               />
             </template>,
@@ -147,13 +147,13 @@ module('Integration | Component | Module | Stepper', function (hooks) {
           // then
           await clickByName('radio1');
           await clickByName(this.intl.t('pages.modulix.buttons.activity.verify'));
-          sinon.assert.calledOnce(submitAnswerStub);
+          sinon.assert.calledOnce(onElementAnswerStub);
           assert.ok(true);
         });
       });
 
       module('When we retry an answerable element', function () {
-        test('should call the retryElement action', async function (assert) {
+        test('should call the onElementRetry action', async function (assert) {
           // given
           const steps = [
             {
@@ -181,7 +181,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
               ],
             },
           ];
-          const retryElementStub = sinon.stub();
+          const onElementRetryStub = sinon.stub();
           const store = this.owner.lookup('service:store');
           const passage = store.createRecord('passage');
           const correctionResponse = store.createRecord('correction-response', {
@@ -207,7 +207,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
               <ModulixStepper
                 @passage={{passage}}
                 @steps={{steps}}
-                @retryElement={{retryElementStub}}
+                @onElementRetry={{onElementRetryStub}}
                 @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
               />
             </template>,
@@ -216,7 +216,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
           // then
           await clickByName('radio1');
           await clickByName(this.intl.t('pages.modulix.buttons.activity.retry'));
-          sinon.assert.calledOnce(retryElementStub);
+          sinon.assert.calledOnce(onElementRetryStub);
           assert.ok(true);
         });
       });
@@ -470,14 +470,14 @@ module('Integration | Component | Module | Stepper', function (hooks) {
         ];
 
         function stepperIsFinished() {}
-        function continueToNextStepStub() {}
+        function onStepperNextStepStub() {}
 
         const screen = await render(
           <template>
             <ModulixStepper
               @steps={{steps}}
               @stepperIsFinished={{stepperIsFinished}}
-              @continueToNextStep={{continueToNextStepStub}}
+              @onStepperNextStep={{onStepperNextStepStub}}
             />
           </template>,
         );
@@ -513,14 +513,14 @@ module('Integration | Component | Module | Stepper', function (hooks) {
         ];
 
         function stepperIsFinished() {}
-        function continueToNextStepStub() {}
+        function onStepperNextStepStub() {}
 
         const screen = await render(
           <template>
             <ModulixStepper
               @steps={{steps}}
               @stepperIsFinished={{stepperIsFinished}}
-              @continueToNextStep={{continueToNextStepStub}}
+              @onStepperNextStep={{onStepperNextStepStub}}
             />
           </template>,
         );

--- a/mon-pix/tests/integration/components/module/video_test.gjs
+++ b/mon-pix/tests/integration/components/module/video_test.gjs
@@ -76,18 +76,20 @@ module('Integration | Component | Module | Video', function (hooks) {
       subtitles: 'subtitles',
       transcription: 'transcription',
     };
-    const openTranscriptionStub = sinon.stub();
+    const onVideoTranscriptionOpenStub = sinon.stub();
 
     //  when
     const screen = await render(
-      <template><ModulixVideoElement @video={{videoElement}} @openTranscription={{openTranscriptionStub}} /></template>,
+      <template>
+        <ModulixVideoElement @video={{videoElement}} @onTranscriptionOpen={{onVideoTranscriptionOpenStub}} />
+      </template>,
     );
 
     // then
     await click(screen.getByRole('button', { name: 'Afficher la transcription' }));
     assert.ok(await screen.findByRole('dialog'));
     assert.ok(screen.getByText('transcription'));
-    assert.ok(openTranscriptionStub.calledOnce);
+    assert.ok(onVideoTranscriptionOpenStub.calledOnce);
   });
 
   test('should not be able to open the modal if there is no transcription', async function (assert) {
@@ -131,7 +133,7 @@ module('Integration | Component | Module | Video', function (hooks) {
   });
 
   module('when the video is played', function () {
-    test('should call clickOnPlayButton prop with right argument', async function (assert) {
+    test('should call onPlay prop with right argument', async function (assert) {
       // given
       const videoElement = {
         id: 'id',
@@ -141,12 +143,8 @@ module('Integration | Component | Module | Video', function (hooks) {
         transcription: '',
         poster: 'https://example.org/modulix/video-poster.jpg',
       };
-      const clickOnPlayButtonStub = sinon.stub();
-      await render(
-        <template>
-          <ModulixVideoElement @video={{videoElement}} @clickOnPlayButton={{clickOnPlayButtonStub}} />
-        </template>,
-      );
+      const onVideoPlayStub = sinon.stub();
+      await render(<template><ModulixVideoElement @video={{videoElement}} @onPlay={{onVideoPlayStub}} /></template>);
       const video = find(`#${videoElement.id}`);
 
       //  when
@@ -155,13 +153,13 @@ module('Integration | Component | Module | Video', function (hooks) {
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       // then
-      sinon.assert.calledWithExactly(clickOnPlayButtonStub, {
+      sinon.assert.calledWithExactly(onVideoPlayStub, {
         elementId: videoElement.id,
       });
       assert.ok(true);
     });
 
-    test('should call clickOnPlayButton prop only once', async function (assert) {
+    test('should call onPlay prop only once', async function (assert) {
       // given
       const videoElement = {
         id: 'id',
@@ -171,12 +169,8 @@ module('Integration | Component | Module | Video', function (hooks) {
         transcription: '',
         poster: 'https://example.org/modulix/video-poster.jpg',
       };
-      const clickOnPlayButtonStub = sinon.stub();
-      await render(
-        <template>
-          <ModulixVideoElement @video={{videoElement}} @clickOnPlayButton={{clickOnPlayButtonStub}} />
-        </template>,
-      );
+      const onVideoPlayStub = sinon.stub();
+      await render(<template><ModulixVideoElement @video={{videoElement}} @onPlay={{onVideoPlayStub}} /></template>);
       const video = find(`#${videoElement.id}`);
 
       //  when
@@ -187,7 +181,7 @@ module('Integration | Component | Module | Video', function (hooks) {
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       // then
-      sinon.assert.calledOnce(clickOnPlayButtonStub);
+      sinon.assert.calledOnce(onVideoPlayStub);
       assert.ok(true);
     });
   });

--- a/mon-pix/tests/unit/components/module/image_test.gjs
+++ b/mon-pix/tests/unit/components/module/image_test.gjs
@@ -33,7 +33,7 @@ module('Unit | Component | Module | Image', function (hooks) {
       // given
       const image = { id: 'image-id' };
 
-      const component = createGlimmerComponent('module/element/image', { image, openAlternativeText: sinon.stub() });
+      const component = createGlimmerComponent('module/element/image', { image, onAlternativeTextOpen: sinon.stub() });
       assert.false(component.modalIsOpen);
 
       // when
@@ -50,7 +50,10 @@ module('Unit | Component | Module | Image', function (hooks) {
         // given
         const image = { id: 'image-id' };
 
-        const component = createGlimmerComponent('module/element/image', { image, openAlternativeText: sinon.stub() });
+        const component = createGlimmerComponent('module/element/image', {
+          image,
+          onAlternativeTextOpen: sinon.stub(),
+        });
         assert.false(component.modalIsOpen);
 
         component.showModal();

--- a/mon-pix/tests/unit/components/module/video_test.gjs
+++ b/mon-pix/tests/unit/components/module/video_test.gjs
@@ -78,7 +78,10 @@ module('Unit | Component | Module | Video', function (hooks) {
       const metrics = this.owner.lookup('service:metrics');
       metrics.add = () => {};
 
-      const component = createGlimmerComponent('module/element/video', { video, openTranscription: sinon.stub() });
+      const component = createGlimmerComponent('module/element/video', {
+        video,
+        onTranscriptionOpen: sinon.stub(),
+      });
       assert.false(component.modalIsOpen);
 
       // when
@@ -95,7 +98,10 @@ module('Unit | Component | Module | Video', function (hooks) {
         // given
         const video = { id: 'video-id' };
 
-        const component = createGlimmerComponent('module/element/video', { video, openTranscription: sinon.stub() });
+        const component = createGlimmerComponent('module/element/video', {
+          video,
+          onTranscriptionOpen: sinon.stub(),
+        });
         assert.false(component.modalIsOpen);
 
         component.showModal();

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1355,6 +1355,15 @@
         "objectives": "Objectives",
         "startModule": "Start module"
       },
+      "download": {
+        "button": "Download",
+        "description": "Choose the format according to the software you are using. If you're not sure, choose the first file, which is compatible with most software.",
+        "documentationLinkHref": "https://pix.org/en/help-how-to-open-modify-find-a-downloaded-file-in-a-pix-question",
+        "documentationLinkLabel": "How do I open, modify or retrieve this file?",
+        "format": "{format} format ",
+        "intro": "Choose the file format you would like to use.",
+        "label": "Download file in {format} format"
+      },
       "grain": {
         "tag": {
           "activity": "activity",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1346,6 +1346,15 @@
         "objectives": "Objetivos",
         "startModule": "Iniciar el módulo"
       },
+      "download": {
+        "button": "Descargar",
+        "description": "Elija el formato en función del software que utilice. Si no estás seguro, elige el primer archivo, que es compatible con la mayoría de los programas.",
+        "documentationLinkHref": "https://pix.org/en/help-how-to-open-modify-find-a-downloaded-file-in-a-pix-question",
+        "documentationLinkLabel": "¿Cómo puedo abrir, modificar o recuperar este archivo?",
+        "intro": "Elija el formato de archivo que desea utilizar.",
+        "label": "Descargar archivo en formato {format}",
+        "format": "formato {format}"
+      },
       "grain": {
         "tag": {
           "activity": "Actividad",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1355,6 +1355,15 @@
         "objectives": "Objectifs",
         "startModule": "Commencer le module"
       },
+      "download": {
+        "button": "Télécharger",
+        "description": "Choisissez le format selon le logiciel que vous utilisez. Si vous hésitez, choisissez le premier fichier, il est compatible avec la plupart des logiciels.",
+        "documentationLinkHref": "https://pix.org/fr/aide-ouvrir-modifier-retrouver-un-fichier-telecharge-depuis-une-question-pix",
+        "documentationLinkLabel": "Comment ouvrir, modifier ou retrouver ce fichier ?",
+        "format": "Format {format}",
+        "intro": "Choisissez le format de fichier que vous voulez utiliser.",
+        "label": "Télécharger le fichier au format {format}"
+      },
       "grain": {
         "tag": {
           "activity": "activité",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1346,6 +1346,15 @@
         "objectives": "Doelstellingen",
         "startModule": "De module starten"
       },
+      "download": {
+        "button": "Downloaden",
+        "description": "Kies het formaat volgens de software die je gebruikt. Als je het niet zeker weet, kies dan het eerste bestand, dat compatibel is met de meeste software.",
+        "documentationLinkHref": "https://pix.org/en/help-how-to-open-modify-find-a-downloaded-file-in-a-pix-question",
+        "documentationLinkLabel": "Hoe kan ik dit bestand openen, wijzigen of ophalen?",
+        "intro": "Kies het te gebruiken bestandsformaat.",
+        "label": "Downloaden bestand in {format} formaat",
+        "format": "{format} formaat"
+      },
       "grain": {
         "tag": {
           "activity": "activiteit",


### PR DESCRIPTION
## :unicorn: Problème

Les élément de type download existent dans l'API, mais ne sont pas encore affichés par Pix App.

## :robot: Proposition

Afficher les éléments de type download dans Pix App.

## :rainbow: Remarques

On en profite pour réaligner les noms des évènements de tracking qui diffèrent un peu, ainsi que les noms des méthodes qu'on préfixe par `on`.

## :100: Pour tester

[Ouvrir le didacticiel](https://app-pr9835.review.pix.fr/modules/didacticiel-modulix/passage) et constater le bon affichage de l'élément download.