### PR TITLE
[TECH] :recycle: Déménagement de `monitoring_tools` vers `src/shared`

### DIFF
--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -6,8 +6,8 @@ import _ from 'lodash';
 const { get } = _;
 import perf_hooks from 'node:perf_hooks';
 
-import { monitoringTools } from '../lib/infrastructure/monitoring-tools.js';
 import { config } from '../src/shared/config.js';
+import { monitoringTools } from '../src/shared/infrastructure/monitoring-tools.js';
 import { logger } from '../src/shared/infrastructure/utils/logger.js';
 
 const { performance } = perf_hooks;

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -21,6 +21,7 @@ import * as flashAlgorithmConfigurationRepository from '../../../src/certificati
 import * as authenticationMethodRepository from '../../../src/identity-access-management/infrastructure/repositories/authentication-method.repository.js';
 import * as userRepository from '../../../src/identity-access-management/infrastructure/repositories/user.repository.js';
 import { config } from '../../../src/shared/config.js';
+import { monitoringTools as MonitoringTools } from '../../../src/shared/infrastructure/monitoring-tools.js';
 import * as answerRepository from '../../../src/shared/infrastructure/repositories/answer-repository.js';
 import * as assessmentRepository from '../../../src/shared/infrastructure/repositories/assessment-repository.js';
 import * as assessmentResultRepository from '../../../src/shared/infrastructure/repositories/assessment-result-repository.js';
@@ -35,7 +36,6 @@ import { EventDispatcher } from '../../infrastructure/events/EventDispatcher.js'
 import { EventDispatcherLogger } from '../../infrastructure/events/EventDispatcherLogger.js';
 import * as disabledPoleEmploiNotifier from '../../infrastructure/externals/pole-emploi/disabled-pole-emploi-notifier.js';
 import * as poleEmploiNotifier from '../../infrastructure/externals/pole-emploi/pole-emploi-notifier.js';
-import { monitoringTools as MonitoringTools } from '../../infrastructure/monitoring-tools.js';
 import * as badgeAcquisitionRepository from '../../infrastructure/repositories/badge-acquisition-repository.js';
 import * as campaignParticipationRepository from '../../infrastructure/repositories/campaign-participation-repository.js';
 import * as campaignParticipationResultRepository from '../../infrastructure/repositories/campaign-participation-result-repository.js';

--- a/api/lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js
+++ b/api/lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js
@@ -10,10 +10,10 @@ import {
 } from '../../../src/shared/domain/errors.js';
 import { Organization, OrganizationForAdmin, OrganizationTag } from '../../../src/shared/domain/models/index.js';
 import * as codeGenerator from '../../../src/shared/domain/services/code-generator.js';
+import { monitoringTools } from '../../../src/shared/infrastructure/monitoring-tools.js';
 import { PromiseUtils } from '../../../src/shared/infrastructure/utils/promise-utils.js';
 import { CONCURRENCY_HEAVY_OPERATIONS } from '../../infrastructure/constants.js';
 import { DomainTransaction } from '../../infrastructure/DomainTransaction.js';
-import { monitoringTools } from '../../infrastructure/monitoring-tools.js';
 
 const SEPARATOR = '_';
 

--- a/api/lib/domain/usecases/send-shared-participation-results-to-pole-emploi.js
+++ b/api/lib/domain/usecases/send-shared-participation-results-to-pole-emploi.js
@@ -1,8 +1,8 @@
 import { PoleEmploiSending } from '../../../src/shared/domain/models/PoleEmploiSending.js';
+import * as monitoringTools from '../../../src/shared/infrastructure/monitoring-tools.js';
 import { PoleEmploiPayload } from '../../infrastructure/externals/pole-emploi/PoleEmploiPayload.js';
 import * as httpErrorsHelper from '../../infrastructure/http/errors-helper.js';
 import { httpAgent } from '../../infrastructure/http/http-agent.js';
-import * as monitoringTools from '../../infrastructure/monitoring-tools.js';
 
 const sendSharedParticipationResultsToPoleEmploi = async ({
   campaignParticipationId,

--- a/api/lib/infrastructure/events/EventHandlerDependenciesBuilder.js
+++ b/api/lib/infrastructure/events/EventHandlerDependenciesBuilder.js
@@ -1,4 +1,4 @@
-import { monitoringTools } from '../monitoring-tools.js';
+import { monitoringTools } from '../../../src/shared/infrastructure/monitoring-tools.js';
 
 function build(classToInstanciate) {
   const dependencies = _buildDependencies();

--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -4,7 +4,7 @@ import axios from 'axios';
 
 const { performance } = perf_hooks;
 
-import { monitoringTools } from '../monitoring-tools.js';
+import { monitoringTools } from '../../../src/shared/infrastructure/monitoring-tools.js';
 
 class HttpResponse {
   constructor({ code, data, isSuccessful }) {

--- a/api/server.js
+++ b/api/server.js
@@ -5,7 +5,6 @@ import { parse } from 'neoqs';
 import { setupErrorHandling } from './config/server-setup-error-handling.js';
 import { knex } from './db/knex-database-connection.js';
 import { authentication } from './lib/infrastructure/authentication.js';
-import { monitoringTools } from './lib/infrastructure/monitoring-tools.js';
 import { routes } from './lib/routes.js';
 import {
   attachTargetProfileRoutes,
@@ -29,6 +28,7 @@ import { organizationPlaceRoutes } from './src/prescription/organization-place/r
 import { targetProfileRoutes } from './src/prescription/target-profile/routes.js';
 import { schoolRoutes } from './src/school/routes.js';
 import { config } from './src/shared/config.js';
+import { monitoringTools } from './src/shared/infrastructure/monitoring-tools.js';
 import { plugins } from './src/shared/infrastructure/plugins/index.js';
 import { deserializer } from './src/shared/infrastructure/serializers/jsonapi/deserializer.js';
 // bounded context migration

--- a/api/src/certification/shared/infrastructure/repositories/certification-challenge-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-challenge-repository.js
@@ -5,7 +5,7 @@ import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTrans
 import {
   logErrorWithCorrelationIds,
   logInfoWithCorrelationIds,
-} from '../../../../../lib/infrastructure/monitoring-tools.js';
+} from '../../../../../src/shared/infrastructure/monitoring-tools.js';
 import { AssessmentEndedError } from '../../../../shared/domain/errors.js';
 import { CertificationChallenge } from '../../../../shared/domain/models/CertificationChallenge.js';
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';

--- a/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
@@ -4,7 +4,7 @@ import { knex } from '../../../../../db/knex-database-connection.js';
 import {
   logErrorWithCorrelationIds,
   logInfoWithCorrelationIds,
-} from '../../../../../lib/infrastructure/monitoring-tools.js';
+} from '../../../../../src/shared/infrastructure/monitoring-tools.js';
 import { config } from '../../../../shared/config.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';

--- a/api/src/identity-access-management/domain/services/oidc-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/oidc-authentication-service.js
@@ -5,12 +5,12 @@ import lodash from 'lodash';
 import ms from 'ms';
 import { Issuer } from 'openid-client';
 
-import { monitoringTools } from '../../../../lib/infrastructure/monitoring-tools.js';
 import { config } from '../../../shared/config.js';
 import { OIDC_ERRORS } from '../../../shared/domain/constants.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { OidcError, OidcMissingFieldsError } from '../../../shared/domain/errors.js';
 import { AuthenticationMethod, AuthenticationSessionContent } from '../../../shared/domain/models/index.js';
+import { monitoringTools } from '../../../shared/infrastructure/monitoring-tools.js';
 import { temporaryStorage } from '../../../shared/infrastructure/temporary-storage/index.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { DEFAULT_CLAIM_MAPPING } from '../constants/oidc-identity-providers.js';

--- a/api/src/identity-access-management/domain/usecases/validate-user-account-email.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/validate-user-account-email.usecase.js
@@ -1,5 +1,5 @@
-import { monitoringTools } from '../../../../lib/infrastructure/monitoring-tools.js';
 import { config } from '../../../shared/config.js';
+import { monitoringTools } from '../../../shared/infrastructure/monitoring-tools.js';
 
 /**
  * @param {{

--- a/api/src/prescription/campaign-participation/application/jobs/participation-completed-job-controller.js
+++ b/api/src/prescription/campaign-participation/application/jobs/participation-completed-job-controller.js
@@ -36,6 +36,8 @@ export class ParticipationCompletedJobController extends JobController {
       targetProfileRepository,
       userRepository,
       poleEmploiNotifier,
+      httpAgent,
+      monitoringTools,
     },
   }) {
     const { campaignParticipationId } = data;
@@ -60,9 +62,9 @@ export class ParticipationCompletedJobController extends JobController {
       });
       const response = await dependencies.poleEmploiNotifier.notify(user.id, payload, {
         authenticationMethodRepository: dependencies.authenticationMethodRepository,
-        httpAgent,
+        httpAgent: dependencies.httpAgent,
         httpErrorsHelper,
-        monitoringTools,
+        monitoringTools: dependencies.monitoringTools,
       });
 
       const poleEmploiSending = PoleEmploiSending.buildForParticipationFinished({

--- a/api/src/prescription/campaign-participation/application/jobs/participation-completed-job-controller.js
+++ b/api/src/prescription/campaign-participation/application/jobs/participation-completed-job-controller.js
@@ -2,11 +2,11 @@ import * as poleEmploiNotifier from '../../../../../lib/infrastructure/externals
 import { PoleEmploiPayload } from '../../../../../lib/infrastructure/externals/pole-emploi/PoleEmploiPayload.js';
 import * as httpErrorsHelper from '../../../../../lib/infrastructure/http/errors-helper.js';
 import { httpAgent } from '../../../../../lib/infrastructure/http/http-agent.js';
-import { monitoringTools } from '../../../../../lib/infrastructure/monitoring-tools.js';
 import * as campaignParticipationRepository from '../../../../../lib/infrastructure/repositories/campaign-participation-repository.js';
 import * as campaignRepository from '../../../../../lib/infrastructure/repositories/campaign-repository.js';
 import * as poleEmploiSendingRepository from '../../../../../lib/infrastructure/repositories/pole-emploi-sending-repository.js';
 import * as targetProfileRepository from '../../../../../lib/infrastructure/repositories/target-profile-repository.js';
+import { monitoringTools } from '../../../../../src/shared/infrastructure/monitoring-tools.js';
 import { assessmentRepository } from '../../../../certification/session-management/infrastructure/repositories/index.js';
 import * as authenticationMethodRepository from '../../../../identity-access-management/infrastructure/repositories/authentication-method.repository.js';
 import * as userRepository from '../../../../identity-access-management/infrastructure/repositories/user.repository.js';

--- a/api/src/prescription/campaign-participation/application/jobs/participation-started-job-controller.js
+++ b/api/src/prescription/campaign-participation/application/jobs/participation-started-job-controller.js
@@ -2,7 +2,6 @@ import * as poleEmploiNotifier from '../../../../../lib/infrastructure/externals
 import { PoleEmploiPayload } from '../../../../../lib/infrastructure/externals/pole-emploi/PoleEmploiPayload.js';
 import * as httpErrorsHelper from '../../../../../lib/infrastructure/http/errors-helper.js';
 import { httpAgent } from '../../../../../lib/infrastructure/http/http-agent.js';
-import { monitoringTools } from '../../../../../lib/infrastructure/monitoring-tools.js';
 import * as campaignRepository from '../../../../../lib/infrastructure/repositories/campaign-repository.js';
 import * as poleEmploiSendingRepository from '../../../../../lib/infrastructure/repositories/pole-emploi-sending-repository.js';
 import * as targetProfileRepository from '../../../../../lib/infrastructure/repositories/target-profile-repository.js';
@@ -10,6 +9,7 @@ import * as authenticationMethodRepository from '../../../../identity-access-man
 import * as userRepository from '../../../../identity-access-management/infrastructure/repositories/user.repository.js';
 import { JobController } from '../../../../shared/application/jobs/job-controller.js';
 import { PoleEmploiSending } from '../../../../shared/domain/models/index.js';
+import { monitoringTools } from '../../../../shared/infrastructure/monitoring-tools.js';
 import * as organizationRepository from '../../../../shared/infrastructure/repositories/organization-repository.js';
 import { ParticipationStartedJob } from '../../domain/models/ParticipationStartedJob.js';
 import * as campaignParticipationRepository from '../../infrastructure/repositories/campaign-participation-repository.js';

--- a/api/src/prescription/campaign-participation/application/learner-participation-controller.js
+++ b/api/src/prescription/campaign-participation/application/learner-participation-controller.js
@@ -1,5 +1,5 @@
 import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
-import { monitoringTools } from '../../../../lib/infrastructure/monitoring-tools.js';
+import { monitoringTools } from '../../../shared/infrastructure/monitoring-tools.js';
 import { ApplicationTransaction } from '../../shared/infrastructure/ApplicationTransaction.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as campaignParticipationSerializer from '../infrastructure/serializers/jsonapi/campaign-participation-serializer.js';

--- a/api/src/prescription/learner-management/application/sco-organization-management-controller.js
+++ b/api/src/prescription/learner-management/application/sco-organization-management-controller.js
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 
-import { logErrorWithCorrelationIds } from '../../../../lib/infrastructure/monitoring-tools.js';
 import { FileValidationError } from '../../../../src/shared/domain/errors.js';
+import { logErrorWithCorrelationIds } from '../../../../src/shared/infrastructure/monitoring-tools.js';
 import { usecases } from '../domain/usecases/index.js';
 import { OrganizationLearnerParser } from '../infrastructure/serializers/csv/organization-learner-parser.js';
 

--- a/api/src/prescription/learner-management/application/sup-organization-management-controller.js
+++ b/api/src/prescription/learner-management/application/sup-organization-management-controller.js
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 
-import { logErrorWithCorrelationIds } from '../../../../lib/infrastructure/monitoring-tools.js';
+import { logErrorWithCorrelationIds } from '../../../../src/shared/infrastructure/monitoring-tools.js';
 import { tokenService } from '../../../shared/domain/services/token-service.js';
 import { usecases } from '../domain/usecases/index.js';
 import { SupOrganizationLearnerParser } from '../infrastructure/serializers/csv/sup-organization-learner-parser.js';

--- a/api/src/prescription/learner-management/domain/usecases/index.js
+++ b/api/src/prescription/learner-management/domain/usecases/index.js
@@ -3,9 +3,9 @@ import { fileURLToPath } from 'node:url';
 
 import { eventBus } from '../../../../../lib/domain/events/index.js';
 import * as userReconciliationService from '../../../../../lib/domain/services/user-reconciliation-service.js';
-import { logErrorWithCorrelationIds } from '../../../../../lib/infrastructure/monitoring-tools.js';
 import * as campaignRepository from '../../../../../lib/infrastructure/repositories/campaign-repository.js';
 import * as membershipRepository from '../../../../../lib/infrastructure/repositories/membership-repository.js';
+import { logErrorWithCorrelationIds } from '../../../../../src/shared/infrastructure/monitoring-tools.js';
 import * as organizationFeatureApi from '../../../../organizational-entities/application/api/organization-features-api.js';
 import * as organizationRepository from '../../../../shared/infrastructure/repositories/organization-repository.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';

--- a/api/src/prescription/learner-management/domain/usecases/upload-siecle-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/upload-siecle-file.js
@@ -1,6 +1,6 @@
 import fs from 'node:fs/promises';
 
-import { logErrorWithCorrelationIds } from '../../../../../lib/infrastructure/monitoring-tools.js';
+import { logErrorWithCorrelationIds } from '../../../../../src/shared/infrastructure/monitoring-tools.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { detectEncoding } from '../../infrastructure/utils/xml/detect-encoding.js';
 import * as zip from '../../infrastructure/utils/xml/zip.js';

--- a/api/src/prescription/learner-management/infrastructure/storage/import-storage.js
+++ b/api/src/prescription/learner-management/infrastructure/storage/import-storage.js
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { logErrorWithCorrelationIds } from '../../../../../lib/infrastructure/monitoring-tools.js';
+import { logErrorWithCorrelationIds } from '../../../../../src/shared/infrastructure/monitoring-tools.js';
 import { config } from '../../../../shared/config.js';
 import { FileValidationError } from '../../../../shared/domain/errors.js';
 import { S3ObjectStorageProvider } from '../../../../shared/storage/infrastructure/providers/S3ObjectStorageProvider.js';

--- a/api/src/prescription/learner-management/infrastructure/utils/xml/detect-encoding.js
+++ b/api/src/prescription/learner-management/infrastructure/utils/xml/detect-encoding.js
@@ -3,8 +3,8 @@ import * as fs from 'node:fs/promises';
 
 import xmlBufferTostring from 'xml-buffer-tostring';
 
-import { logErrorWithCorrelationIds } from '../../../../../../lib/infrastructure/monitoring-tools.js';
 import { FileValidationError } from '../../../../../shared/domain/errors.js';
+import { logErrorWithCorrelationIds } from '../../../../../shared/infrastructure/monitoring-tools.js';
 
 const { xmlEncoding } = xmlBufferTostring;
 const { Buffer } = buffer;

--- a/api/src/prescription/learner-management/infrastructure/utils/xml/siecle-file-streamer.js
+++ b/api/src/prescription/learner-management/infrastructure/utils/xml/siecle-file-streamer.js
@@ -2,8 +2,8 @@ import iconv from 'iconv-lite';
 import _ from 'lodash';
 import sax from 'sax';
 
-import { logErrorWithCorrelationIds } from '../../../../../../lib/infrastructure/monitoring-tools.js';
 import { FileValidationError } from '../../../../../shared/domain/errors.js';
+import { logErrorWithCorrelationIds } from '../../../../../shared/infrastructure/monitoring-tools.js';
 import { SiecleXmlImportError } from '../../../domain/errors.js';
 
 /*

--- a/api/src/prescription/learner-management/infrastructure/utils/xml/zip.js
+++ b/api/src/prescription/learner-management/infrastructure/utils/xml/zip.js
@@ -9,8 +9,8 @@ import Path from 'node:path';
 import { fileTypeFromFile } from 'file-type';
 import StreamZip from 'node-stream-zip';
 
-import { logErrorWithCorrelationIds } from '../../../../../../lib/infrastructure/monitoring-tools.js';
 import { FileValidationError } from '../../../../../shared/domain/errors.js';
+import { logErrorWithCorrelationIds } from '../../../../../shared/infrastructure/monitoring-tools.js';
 
 const VALID_FILE_NAME_REGEX = /^([^.][^/]*\/)*[^./][^/]*\.xml$/;
 const ZIP = 'application/zip';

--- a/api/src/shared/infrastructure/monitoring-tools.js
+++ b/api/src/shared/infrastructure/monitoring-tools.js
@@ -1,13 +1,13 @@
 import Request from '@hapi/hapi/lib/request.js';
 import lodash from 'lodash';
 
-import { config } from '../../src/shared/config.js';
+import { config } from '../config.js';
 
 const { get, set, update, omit } = lodash;
 import async_hooks from 'node:async_hooks';
 
-import { logger } from '../../src/shared/infrastructure/utils/logger.js';
-import * as requestResponseUtils from '../../src/shared/infrastructure/utils/request-response-utils.js';
+import { logger } from './utils/logger.js';
+import * as requestResponseUtils from './utils/request-response-utils.js';
 
 const { AsyncLocalStorage } = async_hooks;
 

--- a/api/src/shared/infrastructure/plugins/pino.js
+++ b/api/src/shared/infrastructure/plugins/pino.js
@@ -2,7 +2,7 @@ import crypto from 'node:crypto';
 
 import { stdSerializers } from 'pino';
 
-import { monitoringTools } from '../../../../lib/infrastructure/monitoring-tools.js';
+import { monitoringTools } from '../../../../src/shared/infrastructure/monitoring-tools.js';
 import { config } from '../../config.js';
 import { logger } from '../utils/logger.js';
 

--- a/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service_test.js
+++ b/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service_test.js
@@ -2,7 +2,6 @@ import jsonwebtoken from 'jsonwebtoken';
 import ms from 'ms';
 import { Issuer } from 'openid-client';
 
-import { monitoringTools } from '../../../../../lib/infrastructure/monitoring-tools.js';
 import { OidcAuthenticationService } from '../../../../../src/identity-access-management/domain/services/oidc-authentication-service.js';
 import { config as settings } from '../../../../../src/shared/config.js';
 import { OIDC_ERRORS } from '../../../../../src/shared/domain/constants.js';
@@ -13,6 +12,7 @@ import {
   AuthenticationSessionContent,
   UserToCreate,
 } from '../../../../../src/shared/domain/models/index.js';
+import { monitoringTools } from '../../../../../src/shared/infrastructure/monitoring-tools.js';
 import { catchErr, catchErrSync, expect, sinon } from '../../../../test-helper.js';
 
 const uuidV4Regex = /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i;

--- a/api/tests/identity-access-management/unit/domain/usecases/validate-user-account-email.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/validate-user-account-email.usecase.test.js
@@ -1,5 +1,5 @@
-import { monitoringTools } from '../../../../../lib/infrastructure/monitoring-tools.js';
 import { validateUserAccountEmail } from '../../../../../src/identity-access-management/domain/usecases/validate-user-account-email.usecase.js';
+import { monitoringTools } from '../../../../../src/shared/infrastructure/monitoring-tools.js';
 import { domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Domain | UseCase | validate-user-account-email', function () {

--- a/api/tests/integration/infrastructure/knex-database-performance-monitoring_test.js
+++ b/api/tests/integration/infrastructure/knex-database-performance-monitoring_test.js
@@ -1,6 +1,6 @@
 import { knex } from '../../../db/knex-database-connection.js';
-import { asyncLocalStorage } from '../../../lib/infrastructure/monitoring-tools.js';
 import { config } from '../../../src/shared/config.js';
+import { asyncLocalStorage } from '../../../src/shared/infrastructure/monitoring-tools.js';
 import { expect, sinon } from '../../test-helper.js';
 const selectQuery = knex.raw('SELECT 1 as value');
 

--- a/api/tests/integration/infrastructure/plugins/pino_test.js
+++ b/api/tests/integration/infrastructure/plugins/pino_test.js
@@ -2,8 +2,8 @@ import { Writable } from 'node:stream';
 
 import pino from 'pino';
 
-import { monitoringTools } from '../../../../lib/infrastructure/monitoring-tools.js';
 import { config } from '../../../../src/shared/config.js';
+import { monitoringTools } from '../../../../src/shared/infrastructure/monitoring-tools.js';
 import * as pinoPlugin from '../../../../src/shared/infrastructure/plugins/pino.js';
 import { expect, generateValidRequestAuthorizationHeader, HttpTestServer, sinon } from '../../../test-helper.js';
 

--- a/api/tests/prescription/campaign-participation/integration/application/jobs/participation-started-job-controller_test.js
+++ b/api/tests/prescription/campaign-participation/integration/application/jobs/participation-started-job-controller_test.js
@@ -1,6 +1,5 @@
 import * as httpErrorsHelper from '../../../../../../lib/infrastructure/http/errors-helper.js';
 import { httpAgent } from '../../../../../../lib/infrastructure/http/http-agent.js';
-import { monitoringTools } from '../../../../../../lib/infrastructure/monitoring-tools.js';
 import * as campaignParticipationRepository from '../../../../../../lib/infrastructure/repositories/campaign-participation-repository.js';
 import * as campaignRepository from '../../../../../../lib/infrastructure/repositories/campaign-repository.js';
 import * as poleEmploiSendingRepository from '../../../../../../lib/infrastructure/repositories/pole-emploi-sending-repository.js';
@@ -8,6 +7,7 @@ import * as targetProfileRepository from '../../../../../../lib/infrastructure/r
 import * as userRepository from '../../../../../../src/identity-access-management/infrastructure/repositories/user.repository.js';
 import { ParticipationStartedJobController } from '../../../../../../src/prescription/campaign-participation/application/jobs/participation-started-job-controller.js';
 import { ParticipationStartedJob } from '../../../../../../src/prescription/campaign-participation/domain/models/ParticipationStartedJob.js';
+import { monitoringTools } from '../../../../../../src/shared/infrastructure/monitoring-tools.js';
 import * as assessmentRepository from '../../../../../../src/shared/infrastructure/repositories/assessment-repository.js';
 import * as organizationRepository from '../../../../../../src/shared/infrastructure/repositories/organization-repository.js';
 import {

--- a/api/tests/prescription/campaign-participation/unit/application/jobs/participation-completed-job-controller_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/jobs/participation-completed-job-controller_test.js
@@ -1,10 +1,10 @@
 import { PoleEmploiPayload } from '../../../../../../lib/infrastructure/externals/pole-emploi/PoleEmploiPayload.js';
 import * as httpErrorsHelper from '../../../../../../lib/infrastructure/http/errors-helper.js';
 import { httpAgent } from '../../../../../../lib/infrastructure/http/http-agent.js';
-import { monitoringTools } from '../../../../../../lib/infrastructure/monitoring-tools.js';
 import { ParticipationCompletedJobController } from '../../../../../../src/prescription/campaign-participation/application/jobs/participation-completed-job-controller.js';
 import { ParticipationCompletedJob } from '../../../../../../src/prescription/campaign-participation/domain/models/ParticipationCompletedJob.js';
-import { PoleEmploiSending } from '../../../../../../src/shared/domain/models/index.js';
+import { PoleEmploiSending } from '../../../../../../src/shared/domain/models/PoleEmploiSending.js';
+import * as monitoringTools from '../../../../../../src/shared/infrastructure/monitoring-tools.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | Prescription | Application | Jobs | ParticipationCompletedJobController', function () {

--- a/api/tests/prescription/campaign-participation/unit/application/jobs/participation-completed-job-controller_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/jobs/participation-completed-job-controller_test.js
@@ -1,10 +1,8 @@
 import { PoleEmploiPayload } from '../../../../../../lib/infrastructure/externals/pole-emploi/PoleEmploiPayload.js';
 import * as httpErrorsHelper from '../../../../../../lib/infrastructure/http/errors-helper.js';
-import { httpAgent } from '../../../../../../lib/infrastructure/http/http-agent.js';
 import { ParticipationCompletedJobController } from '../../../../../../src/prescription/campaign-participation/application/jobs/participation-completed-job-controller.js';
 import { ParticipationCompletedJob } from '../../../../../../src/prescription/campaign-participation/domain/models/ParticipationCompletedJob.js';
 import { PoleEmploiSending } from '../../../../../../src/shared/domain/models/PoleEmploiSending.js';
-import * as monitoringTools from '../../../../../../src/shared/infrastructure/monitoring-tools.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | Prescription | Application | Jobs | ParticipationCompletedJobController', function () {
@@ -20,7 +18,9 @@ describe('Unit | Prescription | Application | Jobs | ParticipationCompletedJobCo
       userRepository,
       poleEmploiNotifier,
       poleEmploiSendingRepository,
-      authenticationMethodRepository;
+      authenticationMethodRepository,
+      httpAgent,
+      monitoringTools;
 
     beforeEach(function () {
       campaignId = Symbol('campaignId');
@@ -28,6 +28,8 @@ describe('Unit | Prescription | Application | Jobs | ParticipationCompletedJobCo
       organizationId = Symbol('organizationId');
       assessmentId = Symbol('assessmentId');
 
+      httpAgent = sinon.stub();
+      monitoringTools = sinon.stub();
       assessmentRepository = { get: sinon.stub() };
       campaignRepository = { get: sinon.stub() };
       campaignParticipationRepository = { get: sinon.stub() };
@@ -52,6 +54,8 @@ describe('Unit | Prescription | Application | Jobs | ParticipationCompletedJobCo
         poleEmploiNotifier,
         poleEmploiSendingRepository,
         authenticationMethodRepository,
+        httpAgent,
+        monitoringTools,
       };
 
       expectedResults = new PoleEmploiPayload({

--- a/api/tests/unit/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
+++ b/api/tests/unit/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
@@ -3,12 +3,12 @@
 import { PGSQL_FOREIGN_KEY_VIOLATION_ERROR } from '../../../../db/pgsql-errors.js';
 import { createOrganizationsWithTagsAndTargetProfiles } from '../../../../lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js';
 import { DomainTransaction as domainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
-import { monitoringTools } from '../../../../lib/infrastructure/monitoring-tools.js';
 import { ObjectValidationError, OrganizationTagNotFound } from '../../../../src/shared/domain/errors.js';
 import { InvalidInputDataError } from '../../../../src/shared/domain/errors.js';
 import { OrganizationForAdmin } from '../../../../src/shared/domain/models/index.js';
 import { Membership } from '../../../../src/shared/domain/models/Membership.js';
 import { OrganizationTag } from '../../../../src/shared/domain/models/OrganizationTag.js';
+import { monitoringTools } from '../../../../src/shared/infrastructure/monitoring-tools.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';
 
 describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', function () {

--- a/api/tests/unit/domain/usecases/send-shared-participation-results-to-pole-emploi_test.js
+++ b/api/tests/unit/domain/usecases/send-shared-participation-results-to-pole-emploi_test.js
@@ -2,8 +2,8 @@ import { sendSharedParticipationResultsToPoleEmploi } from '../../../../lib/doma
 import { PoleEmploiPayload } from '../../../../lib/infrastructure/externals/pole-emploi/PoleEmploiPayload.js';
 import * as httpErrorsHelper from '../../../../lib/infrastructure/http/errors-helper.js';
 import { httpAgent } from '../../../../lib/infrastructure/http/http-agent.js';
-import * as monitoringTools from '../../../../lib/infrastructure/monitoring-tools.js';
 import { PoleEmploiSending } from '../../../../src/shared/domain/models/PoleEmploiSending.js';
+import * as monitoringTools from '../../../../src/shared/infrastructure/monitoring-tools.js';
 import { domainBuilder, expect, sinon } from '../../../test-helper.js';
 
 describe('Unit | Domain | UseCase | send-shared-participation-results-to-pole-emploi', function () {

--- a/api/tests/unit/infrastructure/http/http-agent_test.js
+++ b/api/tests/unit/infrastructure/http/http-agent_test.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 import { httpAgent } from '../../../../lib/infrastructure/http/http-agent.js';
-import { monitoringTools } from '../../../../lib/infrastructure/monitoring-tools.js';
+import { monitoringTools } from '../../../../src/shared/infrastructure/monitoring-tools.js';
 import { expect, sinon } from '../../../test-helper.js';
 
 const { post, get } = httpAgent;


### PR DESCRIPTION
## :unicorn: Problème

cf https://github.com/1024pix/pix/blob/dev/docs/adr/0051-nouvelle-arborescence-api.md

## :robot: Proposition

Déplacer `monitoring_tools.js` vers `src/shared`

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
