### PR TITLE
[FEATURE] Ajout d'une API interne pour récupérer les prescrits et leurs participations (PIX-13815).

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-participation-overview-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-overview-repository.js
@@ -3,6 +3,7 @@ import { CampaignParticipationStatuses, CampaignTypes } from '../../../src/presc
 import { constants } from '../../../src/shared/domain/constants.js';
 import { CampaignParticipationOverview } from '../../../src/shared/domain/read-models/CampaignParticipationOverview.js';
 import { fetchPage } from '../../../src/shared/infrastructure/utils/knex-utils.js';
+import { DomainTransaction } from '../DomainTransaction.js';
 
 const findByUserIdWithFilters = async function ({ userId, states, page }) {
   const queryBuilder = _findByUserId({ userId });
@@ -24,7 +25,9 @@ const findByUserIdWithFilters = async function ({ userId, states, page }) {
 export { findByUserIdWithFilters };
 
 function _findByUserId({ userId }) {
-  return knex
+  const knexConn = DomainTransaction.getConnection();
+
+  return knexConn
     .with('campaign-participation-overviews', (qb) => {
       qb.select({
         id: 'campaign-participations.id',

--- a/api/lib/infrastructure/repositories/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-repository.js
@@ -80,7 +80,8 @@ const findByOrganizationIdAndUpdatedAtOrderByDivision = async function ({ organi
 };
 
 const findByUserId = async function ({ userId }) {
-  const rawOrganizationLearners = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const rawOrganizationLearners = await knexConn
     .select('*')
     .from('view-active-organization-learners')
     .where({ userId })

--- a/api/src/prescription/organization-learner/application/api/organization-learners-with-participations-api.js
+++ b/api/src/prescription/organization-learner/application/api/organization-learners-with-participations-api.js
@@ -1,0 +1,66 @@
+import { usecases } from '../../domain/usecases/index.js';
+import { OrganizationLearnerWithParticipations } from './read-models/OrganizationLearnerWithParticipations.js';
+
+/**
+ * @module OrganizationLearnerWithParticipationsApi
+ */
+
+/**
+ * @typedef FindPayload
+ * @type {object}
+ * @property {Array<number>} userIds
+ */
+
+/**
+ * @typedef OrganizationLearner
+ * @type {object}
+ * @property {number} id
+ * @property {string} MEFCode
+ */
+
+/**
+ * @typedef Organization
+ * @type {object}
+ * @property {boolean} isManagingStudents
+ * @property {Array<string>} tags
+ * @property {string} type
+ */
+
+/**
+ * @typedef Participations
+ * @type {object}
+ * @property {number} targetProfileId
+ */
+
+/**
+ * @typedef OrganizationLearnerWithParticipations
+ * @type {object}
+ * @property {OrganizationLearner} organizationLearner
+ * @property {Organization} organization
+ * @property {Array<Participations>} participations
+ */
+
+/**
+ * @function
+ * @name find
+ * @description
+ * Récupère les organizations-learners avec leurs participations à partir d'une liste d'ids d'utilisateurs
+ * @param {FindPayload} payload
+ * @returns {Promise<Array<OrganizationLearnerWithParticipations>>}
+ */
+export async function find({ userIds }) {
+  const organizationLearnersWithParticipations = await usecases.findOrganizationLearnersWithParticipations({
+    userIds,
+  });
+
+  return organizationLearnersWithParticipations.map(
+    ({ organizationLearner, organization, participations, tagNames }) => {
+      return new OrganizationLearnerWithParticipations({
+        organizationLearner,
+        organization,
+        participations,
+        tagNames,
+      });
+    },
+  );
+}

--- a/api/src/prescription/organization-learner/application/api/read-models/OrganizationLearnerWithParticipations.js
+++ b/api/src/prescription/organization-learner/application/api/read-models/OrganizationLearnerWithParticipations.js
@@ -1,0 +1,14 @@
+export class OrganizationLearnerWithParticipations {
+  constructor({ organizationLearner, organization, participations, tagNames }) {
+    this.organizationLearner = {
+      id: organizationLearner.id,
+      MEFCode: organizationLearner.MEFCode,
+    };
+    this.organization = {
+      isManagingStudents: organization.isManagingStudents,
+      tags: tagNames,
+      type: organization.type,
+    };
+    this.participations = participations.map(({ targetProfileId }) => ({ targetProfileId }));
+  }
+}

--- a/api/src/prescription/organization-learner/domain/usecases/find-organization-learners-with-participations.js
+++ b/api/src/prescription/organization-learner/domain/usecases/find-organization-learners-with-participations.js
@@ -1,0 +1,37 @@
+import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
+
+const findOrganizationLearnersWithParticipations = withTransaction(async function ({
+  userIds,
+  campaignParticipationOverviewRepository,
+  organizationRepository,
+  libOrganizationLearnerRepository,
+  tagRepository,
+}) {
+  const organizationLearners = (
+    await Promise.all(
+      userIds.map((userId) => {
+        return libOrganizationLearnerRepository.findByUserId({ userId });
+      }),
+    )
+  ).flat();
+
+  return Promise.all(
+    organizationLearners.map(async (organizationLearner) => {
+      const organization = await organizationRepository.get(organizationLearner.organizationId);
+      const participations = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+        userId: organizationLearner.userId,
+        page: { number: 1, size: 1000 },
+      });
+      const tags = await tagRepository.findByIds(organization.tags.map((tag) => tag.id));
+
+      return {
+        organizationLearner,
+        organization,
+        participations: participations.campaignParticipationOverviews,
+        tagNames: tags.map((tag) => tag.name),
+      };
+    }),
+  );
+});
+
+export { findOrganizationLearnersWithParticipations };

--- a/api/src/prescription/organization-learner/domain/usecases/index.js
+++ b/api/src/prescription/organization-learner/domain/usecases/index.js
@@ -1,13 +1,17 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import * as campaignParticipationOverviewRepository from '../../../../../lib/infrastructure/repositories/campaign-participation-overview-repository.js';
 /** TODO
  * Internal API Needed For
  * campaignRepository.getByCode
  * groupRepository.findByOrganizationId
  */
 import * as campaignRepository from '../../../../../lib/infrastructure/repositories/campaign-repository.js';
+import * as libOrganizationLearnerRepository from '../../../../../lib/infrastructure/repositories/organization-learner-repository.js';
 import * as organizationFeaturesAPI from '../../../../organizational-entities/application/api/organization-features-api.js';
+import { tagRepository } from '../../../../organizational-entities/infrastructure/repositories/tag.repository.js';
+import * as organizationRepository from '../../../../shared/infrastructure/repositories/organization-repository.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as groupRepository from '../../../campaign/infrastructure/repositories/group-repository.js';
@@ -23,13 +27,17 @@ const dependencies = {
   groupRepository,
   supOrganizationParticipantRepository,
   scoOrganizationParticipantRepository,
+  libOrganizationLearnerRepository,
+  organizationRepository,
   organizationParticipantRepository,
   organizationLearnerActivityRepository,
   organizationLearnerRepository,
-  registrationOrganizationLearnerRepository,
   organizationLearnerImportFormatRepository,
   organizationFeaturesAPI,
   campaignRepository,
+  campaignParticipationOverviewRepository,
+  registrationOrganizationLearnerRepository,
+  tagRepository,
 };
 
 const path = dirname(fileURLToPath(import.meta.url));

--- a/api/src/shared/infrastructure/repositories/organization-repository.js
+++ b/api/src/shared/infrastructure/repositories/organization-repository.js
@@ -103,7 +103,9 @@ const update = async function (organization) {
 };
 
 const get = async function (id) {
-  const organizationDB = await knex(ORGANIZATIONS_TABLE_NAME).where({ id }).first();
+  const knexConn = DomainTransaction.getConnection();
+
+  const organizationDB = await knexConn(ORGANIZATIONS_TABLE_NAME).where({ id }).first();
   if (!organizationDB) {
     throw new NotFoundError(`Not found organization for ID ${id}`);
   }

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/find-organization-learners-with-participations_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/find-organization-learners-with-participations_test.js
@@ -1,0 +1,115 @@
+import * as campaignParticipationOverviewRepository from '../../../../../../lib/infrastructure/repositories/campaign-participation-overview-repository.js';
+import * as libOrganizationLearnerRepository from '../../../../../../lib/infrastructure/repositories/organization-learner-repository.js';
+import { Organization } from '../../../../../../src/organizational-entities/domain/models/Organization.js';
+import { tagRepository } from '../../../../../../src/organizational-entities/infrastructure/repositories/tag.repository.js';
+import { findOrganizationLearnersWithParticipations } from '../../../../../../src/prescription/organization-learner/domain/usecases/find-organization-learners-with-participations.js';
+import { OrganizationLearner } from '../../../../../../src/shared/domain/models/OrganizationLearner.js';
+import { CampaignParticipationOverview } from '../../../../../../src/shared/domain/read-models/CampaignParticipationOverview.js';
+import * as organizationRepository from '../../../../../../src/shared/infrastructure/repositories/organization-repository.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Integration | UseCases | find-organization-learners-with-participations', function () {
+  it('should return a distinct organization learners list', async function () {
+    // given
+    const user1 = databaseBuilder.factory.buildUser();
+    const organization1 = databaseBuilder.factory.buildOrganization();
+    const organization2 = databaseBuilder.factory.buildOrganization();
+
+    const organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner({
+      userId: user1.id,
+      organizationId: organization1.id,
+      division: '5eme',
+    });
+    const organizationLearner1bis = databaseBuilder.factory.buildOrganizationLearner({
+      userId: user1.id,
+      organizationId: organization2.id,
+      division: '5eme',
+    });
+
+    const user2 = databaseBuilder.factory.buildUser();
+    const organizationLearner2 = databaseBuilder.factory.buildOrganizationLearner({
+      userId: user2.id,
+      organizationId: organization2.id,
+      division: '5eme',
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    const organizationLearnersWithParticipations = await findOrganizationLearnersWithParticipations({
+      userIds: [user1.id, user2.id],
+      campaignParticipationOverviewRepository,
+      organizationRepository,
+      libOrganizationLearnerRepository,
+      tagRepository,
+    });
+
+    // then
+    expect(organizationLearnersWithParticipations).to.have.lengthOf(3);
+
+    const organizationLearnersIds = organizationLearnersWithParticipations.map(
+      (organizationLearnersWithParticipations) => organizationLearnersWithParticipations.organizationLearner.id,
+    );
+    expect(organizationLearnersIds).to.have.members([
+      organizationLearner1.id,
+      organizationLearner1bis.id,
+      organizationLearner2.id,
+    ]);
+  });
+
+  it('should return organization learners list and their campaign participations', async function () {
+    // given
+    const organization = databaseBuilder.factory.buildOrganization();
+    const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+      userId: databaseBuilder.factory.buildUser().id,
+      organizationId: organization.id,
+      division: '5eme',
+    });
+    const tag = databaseBuilder.factory.buildTag();
+    databaseBuilder.factory.buildOrganizationTag({ organizationId: organization.id, tagId: tag.id });
+
+    const campaignParticipation1 = databaseBuilder.factory.buildCampaignParticipation({
+      campaignId: databaseBuilder.factory.buildCampaign({ organizationId: organization.id }).id,
+      organizationLearnerId: organizationLearner.id,
+      userId: organizationLearner.userId,
+    });
+
+    const campaignParticipation2 = databaseBuilder.factory.buildCampaignParticipation({
+      campaignId: databaseBuilder.factory.buildCampaign({ organizationId: organization.id }).id,
+      organizationLearnerId: organizationLearner.id,
+      userId: organizationLearner.userId,
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    const organizationLearnersWithParticipations = await findOrganizationLearnersWithParticipations({
+      userIds: [organizationLearner.userId],
+      campaignParticipationOverviewRepository,
+      organizationRepository,
+      libOrganizationLearnerRepository,
+      tagRepository,
+    });
+
+    // then
+    expect(organizationLearnersWithParticipations).to.have.lengthOf(1);
+
+    expect(organizationLearnersWithParticipations[0].organizationLearner).to.be.an.instanceOf(OrganizationLearner);
+    expect(organizationLearnersWithParticipations[0].organizationLearner.id).to.equal(organizationLearner.id);
+
+    expect(organizationLearnersWithParticipations[0].organization).to.be.an.instanceOf(Organization);
+    expect(organizationLearnersWithParticipations[0].organization.id).to.equal(organization.id);
+
+    expect(organizationLearnersWithParticipations[0].participations).to.have.lengthOf(2);
+    expect(organizationLearnersWithParticipations[0].participations[0]).to.be.an.instanceOf(
+      CampaignParticipationOverview,
+    );
+    expect(organizationLearnersWithParticipations[0].participations[1]).to.be.an.instanceOf(
+      CampaignParticipationOverview,
+    );
+    const participationOverviewIds = organizationLearnersWithParticipations[0].participations.map(
+      (participation) => participation.id,
+    );
+    expect(participationOverviewIds).to.have.members([campaignParticipation1.id, campaignParticipation2.id]);
+  });
+});

--- a/api/tests/prescription/organization-learner/unit/application/api/models/OrganizationLearnerWithParticipations_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/api/models/OrganizationLearnerWithParticipations_test.js
@@ -1,0 +1,39 @@
+import { OrganizationLearnerWithParticipations } from '../../../../../../../src/prescription/organization-learner/application/api/read-models/OrganizationLearnerWithParticipations.js';
+import { domainBuilder, expect } from '../../../../../../test-helper.js';
+
+describe('Unit | Application| API | Models | OrganizationLearnerWithParticipations', function () {
+  it('should return attributes from user', function () {
+    // given
+    const tagNames = ['tag1', 'tag2'];
+    const organization = domainBuilder.buildOrganization();
+    const organizationLearner = domainBuilder.buildOrganizationLearner();
+    const participationsList = [
+      domainBuilder.buildCampaignParticipationOverview(),
+      domainBuilder.buildCampaignParticipationOverview(),
+    ];
+
+    // when
+    const organizationLearnerWithParticipations = new OrganizationLearnerWithParticipations({
+      organizationLearner,
+      organization,
+      participations: participationsList,
+      tagNames,
+    });
+
+    // then
+    expect(organizationLearnerWithParticipations).to.have.keys('organizationLearner', 'organization', 'participations');
+    expect(organizationLearnerWithParticipations.organizationLearner).to.deep.equal({
+      id: organizationLearner.id,
+      MEFCode: organizationLearner.MEFCode,
+    });
+    expect(organizationLearnerWithParticipations.organization).to.deep.equal({
+      isManagingStudents: organization.isManagingStudents,
+      tags: tagNames,
+      type: organization.type,
+    });
+    expect(organizationLearnerWithParticipations.participations).to.deep.have.members([
+      { targetProfileId: participationsList[0].targetProfileId },
+      { targetProfileId: participationsList[1].targetProfileId },
+    ]);
+  });
+});

--- a/api/tests/prescription/organization-learner/unit/application/api/organization-learners-with-participations-api_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/api/organization-learners-with-participations-api_test.js
@@ -1,0 +1,65 @@
+import * as organizationLearnersWithParticipationsApi from '../../../../../../src/prescription/organization-learner/application/api/organization-learners-with-participations-api.js';
+import { OrganizationLearnerWithParticipations } from '../../../../../../src/prescription/organization-learner/application/api/read-models/OrganizationLearnerWithParticipations.js';
+import { usecases } from '../../../../../../src/prescription/organization-learner/domain/usecases/index.js';
+import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | API | Organization Learner With Participations', function () {
+  describe('#find', function () {
+    it('should call the usecase and return OrganizationLearnerWithParticipations list', async function () {
+      // given
+      const userIds = [1, 2];
+
+      const organization1 = domainBuilder.buildOrganization();
+      const organizationLearner1 = domainBuilder.buildOrganizationLearner();
+      const organization2 = domainBuilder.buildOrganization();
+      const organizationLearner2 = domainBuilder.buildOrganizationLearner();
+      const participations = [
+        domainBuilder.buildCampaignParticipationOverview(),
+        domainBuilder.buildCampaignParticipationOverview(),
+      ];
+      const tagNames = ['tagName1', 'tagName1'];
+
+      const useCaseStub = sinon.stub(usecases, 'findOrganizationLearnersWithParticipations');
+      useCaseStub.withArgs({ userIds }).resolves([
+        { organizationLearner: organizationLearner1, organization: organization1, participations, tagNames },
+        { organizationLearner: organizationLearner2, organization: organization2, participations, tagNames },
+      ]);
+
+      // when
+      const apiResponse = await organizationLearnersWithParticipationsApi.find({ userIds });
+
+      // then
+      expect(useCaseStub.calledOnce).to.be.true;
+
+      expect(apiResponse.length).to.equal(2);
+      expect(apiResponse[0]).to.be.instanceOf(OrganizationLearnerWithParticipations);
+      expect(apiResponse[1]).to.be.instanceOf(OrganizationLearnerWithParticipations);
+      expect(apiResponse).to.deep.have.members([
+        {
+          organizationLearner: {
+            id: organizationLearner1.id,
+            MEFCode: organizationLearner1.MEFCode,
+          },
+          organization: {
+            isManagingStudents: organization1.isManagingStudents,
+            tags: tagNames,
+            type: organization1.type,
+          },
+          participations: participations.map(({ targetProfileId }) => ({ targetProfileId })),
+        },
+        {
+          organizationLearner: {
+            id: organizationLearner2.id,
+            MEFCode: organizationLearner2.MEFCode,
+          },
+          organization: {
+            isManagingStudents: organization2.isManagingStudents,
+            tags: tagNames,
+            type: organization2.type,
+          },
+          participations: participations.map(({ targetProfileId }) => ({ targetProfileId })),
+        },
+      ]);
+    });
+  });
+});

--- a/api/tests/prescription/organization-learner/unit/domain/usecases/find-organization-learners-with-participations_test.js
+++ b/api/tests/prescription/organization-learner/unit/domain/usecases/find-organization-learners-with-participations_test.js
@@ -1,0 +1,54 @@
+import { _getCampaignParticipationOverviewsWithoutPagination } from '../../../../../../src/prescription/organization-learner/domain/usecases/find-organization-learners-with-participations.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | UseCase | find-organization-learners-with-participations', function () {
+  context('#_getCampaignParticipationOverviewsWithoutPagination', function () {
+    it('should return all campaign participations', async function () {
+      // given
+      const userId = 1234;
+      const campaignParticipationOverviewRepository = {
+        findByUserIdWithFilters: sinon.stub(),
+      };
+
+      const campaignParticipationOverview1 = {
+        id: 1234,
+        userId,
+      };
+      const campaignParticipationOverview2 = {
+        id: 1235,
+        userId,
+      };
+
+      campaignParticipationOverviewRepository.findByUserIdWithFilters
+        .withArgs({
+          userId,
+          page: { number: 1, size: 100 },
+        })
+        .resolves({
+          campaignParticipationOverviews: [campaignParticipationOverview1],
+          pagination: { pageSize: 100, pageCount: 2, rowCount: 110, page: 1 },
+        });
+      campaignParticipationOverviewRepository.findByUserIdWithFilters
+        .withArgs({
+          userId,
+          page: { number: 2, size: 100 },
+        })
+        .resolves({
+          campaignParticipationOverviews: [campaignParticipationOverview2],
+          pagination: { pageSize: 100, pageCount: 2, rowCount: 110, page: 2 },
+        });
+
+      // when
+      const campaignParticipationOverviews = await _getCampaignParticipationOverviewsWithoutPagination({
+        userId,
+        campaignParticipationOverviewRepository,
+      });
+
+      // then
+      expect(campaignParticipationOverviews).to.be.deep.have.members([
+        campaignParticipationOverview1,
+        campaignParticipationOverview2,
+      ]);
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-campaign-participation-overview.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-participation-overview.js
@@ -1,0 +1,41 @@
+import { CampaignParticipationStatuses } from '../../../../src/prescription/shared/domain/constants.js';
+import { CampaignParticipationOverview } from '../../../../src/shared/domain/read-models/CampaignParticipationOverview.js';
+const { SHARED } = CampaignParticipationStatuses;
+
+const buildCampaignParticipationOverview = function ({
+  id = 1,
+  createdAt = new Date('2020-01-01'),
+  targetProfileId = 1,
+  sharedAt = new Date('2020-02-01'),
+  organizationName = 'My organization',
+  status = SHARED,
+  campaignId = 1,
+  campaignCode = 'ABCD12',
+  campaignTitle = 'My campaign',
+  masteryRate = null,
+  totalStagesCount = 1,
+  validatedStagesCount = 1,
+  validatedSkillsCount = 1,
+  disabledAt = null,
+} = {}) {
+  const isShared = status === SHARED;
+  return new CampaignParticipationOverview({
+    id,
+    createdAt,
+    targetProfileId,
+    isShared,
+    sharedAt,
+    organizationName,
+    status,
+    campaignId,
+    campaignCode,
+    campaignTitle,
+    masteryRate,
+    validatedSkillsCount,
+    totalStagesCount,
+    validatedStagesCount,
+    disabledAt,
+  });
+};
+
+export { buildCampaignParticipationOverview };

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -23,6 +23,7 @@ import { buildCampaignManagement } from './build-campaign-management.js';
 import { buildCampaignParticipation } from './build-campaign-participation.js';
 import { buildCampaignParticipationForUserManagement } from './build-campaign-participation-for-user-management.js';
 import { buildCampaignParticipationInfo } from './build-campaign-participation-info.js';
+import { buildCampaignParticipationOverview } from './build-campaign-participation-overview.js';
 import { buildCampaignParticipationResult } from './build-campaign-participation-result.js';
 import { buildCampaignReport } from './build-campaign-report.js';
 import { buildCampaignToJoin } from './build-campaign-to-join.js';
@@ -261,6 +262,7 @@ export {
   buildCampaignParticipation,
   buildCampaignParticipationForUserManagement,
   buildCampaignParticipationInfo,
+  buildCampaignParticipationOverview,
   buildCampaignParticipationResult,
   buildCampaignReport,
   buildCampaignToJoin,


### PR DESCRIPTION
## :unicorn: Problème

Pour vérifier si des utilisateurs répondent bien aux pré-requis d'une quête, on a besoin d'informations sur leurs participations à des campagnes spécifiques.

## :robot: Proposition

Avoir une API interne qui, à partir d'une liste d'identifiants d'utilisateurs, renvoie les infos des prescrits et leurs participations à des campagnes pas encore partagées.

## :100: Pour tester

✅ Vérifier les tests
