### PR TITLE
[BUGFIX] Suppression de la colonne accessibilityAdjustmentNeeded  dans la table certification-candidates (PIX-XXX)

### DIFF
--- a/api/db/database-builder/factory/build-certification-candidate.js
+++ b/api/db/database-builder/factory/build-certification-candidate.js
@@ -27,7 +27,6 @@ const buildCertificationCandidate = function ({
   billingMode = null,
   prepaymentCode = null,
   hasSeenCertificationInstructions = false,
-  accessibilityAdjustmentNeeded = false,
 } = {}) {
   sessionId = _.isUndefined(sessionId) ? buildSession().id : sessionId;
   userId = _.isUndefined(userId) ? buildUser().id : userId;
@@ -55,7 +54,6 @@ const buildCertificationCandidate = function ({
     billingMode,
     prepaymentCode,
     hasSeenCertificationInstructions,
-    accessibilityAdjustmentNeeded,
   };
 
   databaseBuffer.pushInsertable({
@@ -86,7 +84,6 @@ const buildCertificationCandidate = function ({
     billingMode,
     prepaymentCode,
     hasSeenCertificationInstructions,
-    accessibilityAdjustmentNeeded,
   };
 };
 

--- a/api/db/migrations/20240813133008_drop-column-accessibility-adjustment-needed-in-certification-candidates.js
+++ b/api/db/migrations/20240813133008_drop-column-accessibility-adjustment-needed-in-certification-candidates.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'certification-candidates';
+const COLUMN_NAME = 'accessibilityAdjustmentNeeded';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.boolean(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
@@ -151,7 +151,6 @@ describe('Integration | Certification | Session | Repository | Candidate', funct
         billingMode: null,
         prepaymentCode: null,
         hasSeenCertificationInstructions: false,
-        accessibilityAdjustmentNeeded: false,
         subscriptions: [
           {
             type: SUBSCRIPTION_TYPES.CORE,


### PR DESCRIPTION
## :unicorn: Problème
Une migration rajoutant la colonne `accessibilityAdjustmentNeeded` dans la table `certification-candidates` a été préalablement exécutée [dans une précédente PR](https://github.com/1024pix/pix/pull/9815). L'ajout d'un `defaultTo` dans la migration rend celle-ci assez lourde, car elle doit mettre à jour la totalité des lignes présentent dans la table `certification-candidates` qui en compte à date un peu moins de 7 millions.

Cette dernière ayant échoué, il convient de rétablir au plus vite la stabilité de la base de données ainsi que de l'API.

## :robot: Proposition
- Ajouter une migration supprimant la colonne accessibilityAdjustmentNeeded dans la table certification-candidates
- rétablir les seeds pour permettre à l'API de build correctement sur tous les environnements.

## :rainbow: Remarques
- La suppression de la colonne ne doit pas altérer l'ajout de candidat (vérifier au préalable)
- La migration contient un `down` qui rajoute cette même colonne (**cette fois sans le defaultTo**) pour permettre le bon déroulement du rollback de la migration précédente qui elle vient supprimer cette colonne.

## :100: Pour tester
- Exécuter la migration
- Exécuter les seeds pour constater que tout se déroule bien
- Se connecter à Pix Certif avec le compte certifV3@example.net (mais possible également de tester avec un compte PRO V2 ou un compte SCO)
- Créer une session
- Ajouter un candidat via la modale, constater qu'il n'y a pas d'erreur
- Ajouter un candidat via l'import ODS, constater qu'il n'y a pas d'erreur
