### PR TITLE
[TECH] Pouvoir définir la priorité dans les jobs PgBoss (PIX-13972)

### DIFF
--- a/api/src/shared/infrastructure/jobs/JobPgBoss.js
+++ b/api/src/shared/infrastructure/jobs/JobPgBoss.js
@@ -6,6 +6,7 @@ class JobPgBoss {
     this.retryBackoff = config.retryBackoff || false;
     this.expireIn = config.expireIn || '00:15:00';
     this.queryBuilder = queryBuilder;
+    this.priority = config.priority || 0;
   }
 
   async schedule(data) {
@@ -17,6 +18,7 @@ class JobPgBoss {
       expirein: this.expireIn,
       data,
       on_complete: true,
+      priority: this.priority,
     });
   }
 

--- a/api/src/shared/infrastructure/jobs/JobPriority.js
+++ b/api/src/shared/infrastructure/jobs/JobPriority.js
@@ -1,0 +1,10 @@
+/**
+ * Job priority. Higher numbers have, um, higher priority
+ * @see https://github.com/timgit/pg-boss/blob/master/docs/readme.md#insertjobs
+ * @readonly
+ * @enum {number}
+ */
+export const JobPriority = Object.freeze({
+  DEFAULT: 0,
+  HIGH: 1,
+});

--- a/api/tests/shared/integration/infrastructure/jobs/JobPgBoss_test.js
+++ b/api/tests/shared/integration/infrastructure/jobs/JobPgBoss_test.js
@@ -1,27 +1,35 @@
 import { JobPgBoss as Job } from '../../../../../src/shared/infrastructure/jobs/JobPgBoss.js';
 import { expect, knex } from '../../../../test-helper.js';
+import { jobs } from '../../../../tooling/jobs/expect-job.js';
 
 describe('Integration | Infrastructure | Jobs | JobPgBoss', function () {
   it('schedule a job and create in db with given config', async function () {
     // given
     const name = 'JobTest';
     const expectedParams = { jobParam: 1 };
-    const job = new Job({ name, retryLimit: 2, retryDelay: 10, retryBackoff: true, expireIn: '00:00:30' }, knex);
+    const retryLimit = 2;
+    const retryDelay = 10;
+    const retryBackoff = true;
+    const expireIn = '00:00:30';
+    const priority = 1;
+
+    const job = new Job({ name, retryLimit, retryDelay, retryBackoff, expireIn, priority }, knex);
 
     // when
     await job.schedule(expectedParams);
 
-    const result = await knex
-      .select(knex.raw(`retrylimit, retrydelay, retrybackoff, data, expirein::varchar`))
-      .from('pgboss.job')
-      .where('name', 'JobTest')
+    const result = await jobs(name)
+      .select(knex.raw(`priority, retrylimit, retrydelay, retrybackoff, data, expirein::varchar`))
       .first();
 
     // then
-    expect(result.retrylimit).to.equal(2);
-    expect(result.retrydelay).to.equal(10);
-    expect(result.retrybackoff).to.equal(true);
-    expect(result.expirein).to.equal('00:00:30');
-    expect(result.data).to.deep.equal(expectedParams);
+    expect(result).to.deep.contains({
+      data: expectedParams,
+      expirein: expireIn,
+      priority,
+      retrydelay: retryDelay,
+      retrylimit: retryLimit,
+      retrybackoff: retryBackoff,
+    });
   });
 });

--- a/api/tests/shared/integration/infrastructure/jobs/JobPgBoss_test.js
+++ b/api/tests/shared/integration/infrastructure/jobs/JobPgBoss_test.js
@@ -1,5 +1,7 @@
+import { EntityValidationError } from '../../../../../src/shared/domain/errors.js';
 import { JobPgBoss as Job } from '../../../../../src/shared/infrastructure/jobs/JobPgBoss.js';
-import { expect, knex } from '../../../../test-helper.js';
+import { JobPriority } from '../../../../../src/shared/infrastructure/jobs/JobPriority.js';
+import { catchErrSync, expect, knex } from '../../../../test-helper.js';
 import { jobs } from '../../../../tooling/jobs/expect-job.js';
 
 describe('Integration | Infrastructure | Jobs | JobPgBoss', function () {
@@ -11,7 +13,7 @@ describe('Integration | Infrastructure | Jobs | JobPgBoss', function () {
     const retryDelay = 10;
     const retryBackoff = true;
     const expireIn = '00:00:30';
-    const priority = 1;
+    const priority = JobPriority.HIGH;
 
     const job = new Job({ name, retryLimit, retryDelay, retryBackoff, expireIn, priority }, knex);
 
@@ -31,5 +33,22 @@ describe('Integration | Infrastructure | Jobs | JobPgBoss', function () {
       retrylimit: retryLimit,
       retrybackoff: retryBackoff,
     });
+  });
+
+  it('reject unexpected priority value', async function () {
+    // given
+    const priority = 999;
+
+    // when
+    const error = catchErrSync(({ priority }, knex) => new Job({ priority }, knex))({ priority }, knex);
+
+    // then
+    expect(error).to.be.instanceOf(EntityValidationError);
+    expect(error.invalidAttributes).to.deep.equal([
+      {
+        attribute: 'priority',
+        message: '"priority" must be one of [0, 1]',
+      },
+    ]);
   });
 });

--- a/api/tests/tooling/jobs/expect-job.js
+++ b/api/tests/tooling/jobs/expect-job.js
@@ -1,6 +1,6 @@
 import { knex } from '../../test-helper.js';
 
-async function jobs(jobName) {
+function jobs(jobName) {
   return knex('pgboss.job').where({ name: jobName });
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, il n'est pas possible de définir la priorité sur les job pg-boss.

## :robot: Proposition
Ajouter la possibilité de passer un champ `priority` lors de la création d'un Job.
La doc dessus : https://github.com/timgit/pg-boss/blob/master/docs/readme.md#sendname-data-options

## :rainbow: Remarques
Une "enum" `JobPriority` a été crée pour définir les priorités possibles. 

## :100: Pour tester
- La CI est au vert
