### PR TITLE
[BUGFIX] Ajout d'une traduction pour le message d'erreur lors de l'inscription à plusieurs certifications complémentaires (PIX-13867)

### DIFF
--- a/certif/tests/integration/components/sessions-import/step-two-section-test.js
+++ b/certif/tests/integration/components/sessions-import/step-two-section-test.js
@@ -133,6 +133,10 @@ module('Integration | Component | Import::StepTwoSection', function (hooks) {
         error: 'CANDIDATE_RESULT_RECIPIENT_EMAIL_NOT_VALID',
         expectedMessage: 'Donnée du champ "E-mail du destinataire des résultats (formateur, enseignant…)" invalide',
       },
+      {
+        error: 'CANDIDATE_WRONG_SUBSCRIPTIONS_COMPATIBILITY',
+        expectedMessage: "Vous ne pouvez pas inscrire un candidat à plus d'une certification complémentaire",
+      },
       { error: 'SESSION_ADDRESS_REQUIRED', expectedMessage: 'Champ obligatoire "Nom du site" manquant' },
       { error: 'SESSION_ROOM_REQUIRED', expectedMessage: 'Champ obligatoire "Nom de la salle" manquant' },
       { error: 'SESSION_DATE_REQUIRED', expectedMessage: 'Champ obligatoire "Date de session" manquant' },

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -66,6 +66,7 @@
         "CANDIDATE_SESSION_ID_REQUIRED": "The field \"Session No.\" is required",
         "CANDIDATE_SEX_NOT_VALID": "The field \"Gender\" accepts the values \"M\" for a man or \"F\" for a woman",
         "CANDIDATE_SEX_REQUIRED": "The field \"Gender\" is required",
+        "CANDIDATE_WRONG_SUBSCRIPTIONS_COMPATIBILITY": "You cannot register a candidate for more than one complementary certification",
         "DUPLICATE_CANDIDATE": "Please delete duplicate candidate(s) before re-uploading"
       },
       "gateway-timeout-error": "The service is being slow. Please try again later.",
@@ -758,6 +759,7 @@
               "CANDIDATE_RESULT_RECIPIENT_EMAIL_NOT_VALID": "Donnée du champ \"E-mail du destinataire des résultats (formateur, enseignant…)\" invalide",
               "CANDIDATE_SEX_NOT_VALID": "Donnée du champ \"Sexe\" invalide (format accepté \"M\"/\"F\")",
               "CANDIDATE_SEX_REQUIRED": "Champ obligatoire \"Sexe\" manquant",
+              "CANDIDATE_WRONG_SUBSCRIPTIONS_COMPATIBILITY": "You cannot register a candidate for more than one complementary certification",
               "INFORMATION_NOT_ALLOWED_WITH_SESSION_ID": "Numéro de session fourni, veuillez supprimer les informations de session associées",
               "SESSION_ADDRESS_REQUIRED": "Champ obligatoire \"Nom du site\" manquant",
               "SESSION_DATE_NOT_VALID": "Donnée du champ \"Date de session\" invalide (format accepté JJ/MM/AAAA)",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -66,6 +66,7 @@
         "CANDIDATE_SESSION_ID_REQUIRED": "Le champ \"Numéro de session\" est obligatoire",
         "CANDIDATE_SEX_NOT_VALID": "Le champ \"Sexe\" accepte les valeurs \"M\" pour un homme ou \"F\" pour une femme",
         "CANDIDATE_SEX_REQUIRED": "Le champ \"Sexe\" est obligatoire",
+        "CANDIDATE_WRONG_SUBSCRIPTIONS_COMPATIBILITY": "Vous ne pouvez pas inscrire un candidat à plus d'une certification complémentaire",
         "DUPLICATE_CANDIDATE": "Veuillez supprimer le(s) doublon(s) de candidats avant de réimporter."
       },
       "gateway-timeout-error": "Le service subit des ralentissements. Veuillez réessayer ultérieurement.",
@@ -758,6 +759,7 @@
               "CANDIDATE_RESULT_RECIPIENT_EMAIL_NOT_VALID": "Donnée du champ \"E-mail du destinataire des résultats (formateur, enseignant…)\" invalide",
               "CANDIDATE_SEX_NOT_VALID": "Donnée du champ \"Sexe\" invalide (format accepté \"M\"/\"F\")",
               "CANDIDATE_SEX_REQUIRED": "Champ obligatoire \"Sexe\" manquant",
+              "CANDIDATE_WRONG_SUBSCRIPTIONS_COMPATIBILITY": "Vous ne pouvez pas inscrire un candidat à plus d'une certification complémentaire",
               "INFORMATION_NOT_ALLOWED_WITH_SESSION_ID": "Numéro de session fourni, veuillez supprimer les informations de session associées",
               "SESSION_ADDRESS_REQUIRED": "Champ obligatoire \"Nom du site\" manquant",
               "SESSION_DATE_NOT_VALID": "Donnée du champ \"Date de session\" invalide (format accepté JJ/MM/AAAA)",


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on inscrit un candidat à plusieurs certifications complémentaires (dans le cadre de la compatibilité), un message d'erreur obscur est affiché à l'utilisateur

## :robot: Proposition
Ajouter les traductions.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
Feature Toggle ON :
FT_CORE_COMPLEMENTARY_COMPATIBILITY=true (normalement de base sur les RA)

Importer un fichier ods avec un candidat avec inscription sur plusieurs certifs complémentaires et vérifier que le message d'erreur est OK
