### PR TITLE
[TECH] POC d'une queue fast pour gérer les jobs d'answer (PIX-13816)

### DIFF
--- a/api/Procfile
+++ b/api/Procfile
@@ -6,3 +6,4 @@ postdeploy: npm run postdeploy
 # for more information
 web: exec node index.js
 worker: exec node worker.js
+fastWorker: exec node fast-worker.js

--- a/api/fast-worker.js
+++ b/api/fast-worker.js
@@ -1,0 +1,97 @@
+import 'dotenv/config';
+
+import * as url from 'node:url';
+
+import _ from 'lodash';
+import PgBoss from 'pg-boss';
+
+import * as knowledgeElementRepository from './lib/infrastructure/repositories/knowledge-element-repository.js';
+import { config } from './src/shared/config.js';
+import { SendSharedParticipationResultsToPoleEmploiHandler } from './src/shared/infrastructure/jobs/campaign-result/SendSharedParticipationResultsToPoleEmploiHandler.js';
+import { scheduleCpfJobs } from './src/shared/infrastructure/jobs/cpf-export/schedule-cpf-jobs.js';
+import { JobQueue } from './src/shared/infrastructure/jobs/JobQueue.js';
+import { MonitoredJobQueue } from './src/shared/infrastructure/jobs/monitoring/MonitoredJobQueue.js';
+import { logger } from './src/shared/infrastructure/utils/logger.js';
+
+async function startPgBoss() {
+  logger.info('Starting pg-boss');
+  const monitorStateIntervalSeconds = config.pgBoss.monitorStateIntervalSeconds;
+  const pgBoss = new PgBoss({
+    connectionString: process.env.DATABASE_URL,
+    max: config.pgBoss.connexionPoolMaxSize,
+    ...(monitorStateIntervalSeconds ? { monitorStateIntervalSeconds } : {}),
+    archiveFailedAfterSeconds: config.pgBoss.archiveFailedAfterSeconds,
+  });
+  pgBoss.on('monitor-states', (state) => {
+    logger.info({ event: 'pg-boss-state', name: 'global' }, { ...state, queues: undefined });
+    _.each(state.queues, (queueState, queueName) => {
+      logger.info({ event: 'pg-boss-state', name: queueName }, queueState);
+    });
+  });
+  pgBoss.on('error', (err) => {
+    logger.error({ event: 'pg-boss-error' }, err);
+  });
+  pgBoss.on('wip', (data) => {
+    logger.info({ event: 'pg-boss-wip' }, data);
+  });
+  await pgBoss.start();
+  return pgBoss;
+}
+
+function createMonitoredJobQueue(pgBoss) {
+  const jobQueue = new JobQueue(pgBoss);
+  const monitoredJobQueue = new MonitoredJobQueue(jobQueue);
+  process.on('SIGINT', async () => {
+    await monitoredJobQueue.stop();
+
+    // Make sure pgBoss stopped before quitting
+    pgBoss.on('stopped', () => {
+      // eslint-disable-next-line n/no-process-exit
+      process.exit(0);
+    });
+  });
+  return monitoredJobQueue;
+}
+
+class QuestJobHandler {
+  constructor({ knowledgeElementRepository }) {
+    this.knowledgeElementRepository = knowledgeElementRepository;
+  }
+
+  async handle(event) {
+    const { userId } = event;
+    await this.knowledgeElementRepository.findAllUniqValidatedByUserId(userId);
+  }
+
+  get name() {
+    return 'answer';
+  }
+}
+
+export { SendSharedParticipationResultsToPoleEmploiHandler };
+
+export async function runJobs(dependencies = { startPgBoss, createMonitoredJobQueue, scheduleCpfJobs }) {
+  const pgBoss = await dependencies.startPgBoss();
+  const monitoredJobQueue = dependencies.createMonitoredJobQueue(pgBoss);
+
+  monitoredJobQueue.performJob('answer', QuestJobHandler, {
+    knowledgeElementRepository,
+  });
+}
+
+const startInWebProcess = process.env.START_JOB_IN_WEB_PROCESS;
+const isTestEnv = process.env.NODE_ENV === 'test';
+const modulePath = url.fileURLToPath(import.meta.url);
+const isEntryPointFromOtherFile = process.argv[1] !== modulePath;
+
+if (!isTestEnv) {
+  if (!startInWebProcess || (startInWebProcess && isEntryPointFromOtherFile)) {
+    await runJobs();
+  } else {
+    logger.error(
+      'Worker process is started in the web process. Please unset the START_JOB_IN_WEB_PROCESS environment variable to start a dedicated worker process.',
+    );
+    // eslint-disable-next-line n/no-process-exit
+    process.exit(1);
+  }
+}

--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -1,3 +1,4 @@
+import { knex } from '../../../db/knex-database-connection.js';
 import { EmptyAnswerError } from '../../../src/evaluation/domain/errors.js';
 import { ForbiddenAccess } from '../../../src/shared/domain/errors.js';
 import {
@@ -8,6 +9,7 @@ import {
 } from '../../../src/shared/domain/errors.js';
 import { Examiner } from '../../../src/shared/domain/models/Examiner.js';
 import { KnowledgeElement } from '../../../src/shared/domain/models/KnowledgeElement.js';
+import { JobPgBoss } from '../../../src/shared/infrastructure/jobs/JobPgBoss.js';
 import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 
 const evaluateAnswer = function ({ challenge, answer, assessment, examiner: injectedExaminer }) {
@@ -234,6 +236,18 @@ const correctAnswerThenUpdateAssessment = async function ({
       assessmentId: assessment.id,
     });
   }
+
+  const job = new JobPgBoss(
+    {
+      name: 'answer',
+    },
+    knex,
+  );
+
+  await job.schedule({
+    userId,
+  });
+
   return answerSaved;
 };
 

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -140,6 +140,19 @@ const findSnapshotForUsers = async function (userIdsAndDates) {
   return _findSnapshotsForUsers(userIdsAndDates);
 };
 
+const findAllUniqValidatedByUserId = async function (userId) {
+  const validatedKnowledgeElements = await knex(tableName)
+    .where({
+      userId,
+      status: KnowledgeElement.StatusType.VALIDATED,
+    })
+    .orderBy('createdAt', 'desc');
+
+  return validatedKnowledgeElements.map(
+    (invalidatedKnowledgeElement) => new KnowledgeElement(invalidatedKnowledgeElement),
+  );
+};
+
 const findInvalidatedAndDirectByUserId = async function (userId) {
   const invalidatedKnowledgeElements = await knex(tableName)
     .where({
@@ -162,6 +175,7 @@ export {
   batchSave,
   countValidatedByCompetencesForOneUserWithinCampaign,
   countValidatedByCompetencesForUsersWithinCampaign,
+  findAllUniqValidatedByUserId,
   findInvalidatedAndDirectByUserId,
   findSnapshotForUsers,
   findSnapshotGroupedByCompetencesForUsers,

--- a/api/package.json
+++ b/api/package.json
@@ -156,6 +156,8 @@
     "dev": "nodemon index.js",
     "start": "node index.js",
     "start:watch": "npm run dev",
+    "start:job:fast": "node fast-worker.js",
+    "start:job:fast:watch": "nodemon fast-worker.js",
     "start:job": "node worker.js",
     "start:job:watch": "nodemon worker.js",
     "test": "NODE_ENV=test npm run db:prepare && npm run test:api",

--- a/api/scripts/insertJobs.js
+++ b/api/scripts/insertJobs.js
@@ -1,0 +1,17 @@
+import { knex } from '../db/knex-database-connection.js';
+import { JobPgBoss } from '../src/shared/infrastructure/jobs/JobPgBoss.js';
+
+const JOBS_COUNT = 50000;
+
+for (let i = 0; i < JOBS_COUNT; i++) {
+  const job = new JobPgBoss(
+    {
+      name: 'answer',
+    },
+    knex,
+  );
+
+  await job.schedule({
+    userId: 107371,
+  });
+}

--- a/api/scripts/insertJobs.js
+++ b/api/scripts/insertJobs.js
@@ -1,17 +1,31 @@
+import lodash from 'lodash';
+
 import { knex } from '../db/knex-database-connection.js';
-import { JobPgBoss } from '../src/shared/infrastructure/jobs/JobPgBoss.js';
 
-const JOBS_COUNT = 50000;
+const { range } = lodash;
 
-for (let i = 0; i < JOBS_COUNT; i++) {
-  const job = new JobPgBoss(
-    {
-      name: 'answer',
-    },
-    knex,
-  );
+const JOBS_COUNT = process.argv[2];
+const USER_ID = process.argv[3];
+const MAX = process.argv[4];
 
-  await job.schedule({
-    userId: 107371,
-  });
-}
+let seconds = 1;
+const max = MAX;
+const intervalId = setInterval(async () => {
+  console.log('batch: ' + seconds);
+
+  const jobs = range(Math.ceil(JOBS_COUNT / max)).map(() => ({
+    name: 'answer',
+    data: { userId: USER_ID },
+    on_complete: true,
+  }));
+
+  await knex.batchInsert('pgboss.job', jobs);
+
+  seconds++;
+
+  if (seconds > max) {
+    console.log('exit');
+    clearInterval(intervalId);
+    return process.exit();
+  }
+}, 1000);

--- a/api/worker.js
+++ b/api/worker.js
@@ -76,30 +76,11 @@ function createMonitoredJobQueue(pgBoss) {
   return monitoredJobQueue;
 }
 
-class QuestJobHandler {
-  constructor({ knowledgeElementRepository }) {
-    this.knowledgeElementRepository = knowledgeElementRepository;
-  }
-
-  async handle(event) {
-    const { userId } = event;
-    await this.knowledgeElementRepository.findAllUniqValidatedByUserId(userId);
-  }
-
-  get name() {
-    return 'answer';
-  }
-}
-
 export { SendSharedParticipationResultsToPoleEmploiHandler };
 
 export async function runJobs(dependencies = { startPgBoss, createMonitoredJobQueue, scheduleCpfJobs }) {
   const pgBoss = await dependencies.startPgBoss();
   const monitoredJobQueue = dependencies.createMonitoredJobQueue(pgBoss);
-
-  monitoredJobQueue.performJob('answer', QuestJobHandler, {
-    knowledgeElementRepository,
-  });
 
   monitoredJobQueue.performJob(LcmsRefreshCacheJob.name, LcmsRefreshCacheJobHandler, {
     learningContentDatasource,


### PR DESCRIPTION
## :unicorn: Problème
Pour le nouveau système de quête, nous avons besoin d'ajouter un nouveau traitement au moment où un utilisateur répond à une question. Il y a déjà un certain nombres de traitements effectués à ce moment là. On a donc décidé d'essayer de découpler l'enregistrement d'une réponse des autres traitements. 

## :robot: Proposition
Pour cela, on va se servir de PGBoss en ajoutant un job "answer" et un handler "Quest". 

## :rainbow: Remarques
Nous avons besoin de vérifier si le worker est capable d'absorber la charge d'une journée chargée chez Pix dans un temps raisonnable.

## :100: Pour tester

// TODO remplir avec la procédure