### PR TITLE
[BUGFIX] Affichage d'un deuxième onglet lors du téléchargement d'un document depuis un iPad/iPhone (PIX-13737)

### DIFF
--- a/mon-pix/app/components/challenge-statement.hbs
+++ b/mon-pix/app/components/challenge-statement.hbs
@@ -47,13 +47,7 @@
 
       {{#if @challenge.hasSingleAttachment}}
         <div class="challenge-statement__action">
-          <a
-            class="challenge-statement__action-link"
-            href="{{get this.orderedAttachments '0'}}"
-            target="_blank"
-            rel="noopener noreferrer"
-            download
-          >
+          <a class="challenge-statement__action-link" href="{{get this.orderedAttachments '0'}}" download>
             <span class="challenge-statement__action-label">{{t
                 "pages.challenge.statement.file-download.actions.download"
               }}</span>
@@ -105,13 +99,7 @@
           {{/each}}
         </ul>
         <div class="challenge-statement__action">
-          <a
-            class="challenge-statement__action-link"
-            href="{{this.selectedAttachmentUrl}}"
-            target="_blank"
-            rel="noopener noreferrer"
-            download
-          >
+          <a class="challenge-statement__action-link" href="{{this.selectedAttachmentUrl}}" download>
             <span class="challenge-statement__action-label">{{t
                 "pages.challenge.statement.file-download.actions.download"
               }}</span>

--- a/mon-pix/tests/integration/components/challenge-statement-test.js
+++ b/mon-pix/tests/integration/components/challenge-statement-test.js
@@ -604,11 +604,12 @@ module('Integration | Component | ChallengeStatement', function (hooks) {
         addAssessmentToContext(this, { id: '267845' });
 
         // when
-        await renderChallengeStatement(this);
+        const screen = await renderChallengeStatement(this);
 
         // then
-        assert.dom('.challenge-statement__action-link').exists();
-        assert.strictEqual(find('.challenge-statement__action-link').href, 'http://challenge.file.url/');
+        const downloadLink = await screen.getByRole('link', { name: 'Télécharger' });
+        assert.dom(downloadLink).hasAttribute('href', 'http://challenge.file.url');
+        assert.dom(downloadLink).doesNotHaveAttribute('target');
       });
     });
 
@@ -723,6 +724,39 @@ module('Integration | Component | ChallengeStatement', function (hooks) {
         await renderChallengeStatement(this);
         // then
         assert.dom('.challenge-statement__action-help').exists();
+      });
+
+      test("should display one link button with default attachment's url", async function (assert) {
+        // given
+        addChallengeToContext(this, challenge);
+        addAssessmentToContext(this, { id: '267845' });
+
+        // when
+        const screen = await renderChallengeStatement(this);
+
+        // then
+        const downloadLink = await screen.getByRole('link', { name: 'Télécharger' });
+        assert.dom(downloadLink).hasAttribute('href', 'http://file.1.docx');
+        assert.dom(downloadLink).doesNotHaveAttribute('target');
+      });
+
+      test("should update link button href with checked attachment's url", async function (assert) {
+        // given
+        addChallengeToContext(this, challenge);
+        addAssessmentToContext(this, { id: '267845' });
+
+        // when
+        const screen = await renderChallengeStatement(this);
+        const radio = await screen.getByRole('radio', { name: 'fichier .odt' });
+        radio.click();
+
+        // wait for DOM update
+        await new Promise((res) => setTimeout(res, 0));
+
+        // then
+        const downloadLink = await screen.getByRole('link', { name: 'Télécharger' });
+        assert.dom(downloadLink).hasAttribute('href', 'file.2.odt');
+        assert.dom(downloadLink).doesNotHaveAttribute('target');
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Au clic pour télécharger un document au niveau d’une épreuve, un deuxième onglet s’ouvre lorsqu’on est sur iPad / iPhone avec une pop-in de demande de confirmation de téléchargement. 

Une fois la validation donnée, la même épreuve s’affiche dans le nouvel onglet.

Il y a un petit historique sur le sujet. Pour le téléchargement, l'ouverture dans un nouvel onglet n'était pas souhaité. Il avait été ajouté pour éviter de perdre le contexte de l'épreuve car certains fichiers n'étaient pas téléchargés mais ouverts dans le navigateur. Cela était dû [au manquement d'un header `Content-Disposition` sur les fichiers à télécharger](https://github.com/1024pix/pix/pull/1605#issuecomment-654175891).

Tous les fichiers ont maintenant le bon header.

## :robot: Proposition
Ouvrir les téléchargements dans le même onglet que l'épreuve ✨.

## :rainbow: Remarques
Un peu plus d'historique : 
1. tentative de suppression : https://github.com/1024pix/pix/pull/1575
2. rollback car dans certains cas de figures le téléchargement ne se lance pas et donc l'utilisateur sort "de pix" : https://github.com/1024pix/pix/pull/1605

## :100: Pour tester
Il y a 2 cas de figures : 
- un seul fichier à télécharger https://app-pr9853.review.pix.fr/challenges/challenge101iA098OgLcGw/preview
- plusieurs fichiers à télécharger https://app-pr9853.review.pix.fr/challenges/recXMLEokPmm3RT6O/preview

Sur iPad/iPhone on ne doit plus avoir de second onglet ouvert. Testé que c'est la même chose sur ordinateur également (non régression) :) 

Le bug est constatable en intégration sur : 
- un seul fichier à télécharger https://app.integration.pix.fr/challenges/challenge101iA098OgLcGw/preview
- plusieurs fichiers à télécharger https://app.integration.pix.fr/challenges/recXMLEokPmm3RT6O/preview