### PR TITLE
[TECH]  Ajout du tooling pour les tests des Jobs (PIX-13879)

### DIFF
--- a/api/tests/identity-access-management/integration/domain/usecases/anonymize-user.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/anonymize-user.usecase.test.js
@@ -15,7 +15,6 @@ import { ObjectValidationError, UserNotFoundError } from '../../../../../src/sha
 import { adminMemberRepository } from '../../../../../src/shared/infrastructure/repositories/admin-member.repository.js';
 import * as userLoginRepository from '../../../../../src/shared/infrastructure/repositories/user-login-repository.js';
 import { catchErr, databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
-import { jobs } from '../../../../tooling/jobs/expect-job.js';
 
 describe('Integration | Identity Access Management | Domain | UseCase | anonymize-user', function () {
   let clock;
@@ -86,9 +85,7 @@ describe('Integration | Identity Access Management | Domain | UseCase | anonymiz
     );
 
     // then
-    const userAnonymizedJobs = await jobs(UserAnonymizedEventLoggingJob.name);
-    expect(userAnonymizedJobs).to.have.length(1);
-    expect(userAnonymizedJobs[0]).to.have.deep.property('data', {
+    await expect(UserAnonymizedEventLoggingJob.name).to.have.been.performed.withJobPayload({
       client: 'PIX_ADMIN',
       role: PIX_ADMIN.ROLES.SUPER_ADMIN,
       occurredAt: now.toISOString(),
@@ -343,8 +340,7 @@ describe('Integration | Identity Access Management | Domain | UseCase | anonymiz
       const anonymizedUser = await knex('users').where({ id: user.id }).first();
       expect(anonymizedUser.hasBeenAnonymised).to.be.true;
 
-      const userAnonymizedJobs = await jobs(UserAnonymizedEventLoggingJob.name);
-      expect(userAnonymizedJobs).to.have.length(0);
+      await expect(UserAnonymizedEventLoggingJob.name).to.have.been.performed.withJobsCount(0);
     });
   });
 });

--- a/api/tests/prescription/campaign-participation/acceptance/application/learner-participation-route_test.js
+++ b/api/tests/prescription/campaign-participation/acceptance/application/learner-participation-route_test.js
@@ -13,7 +13,6 @@ import {
   learningContentBuilder,
   mockLearningContent,
 } from '../../../../test-helper.js';
-import { jobs } from '../../../../tooling/jobs/expect-job.js';
 import { buildLearningContent } from '../../../../tooling/learning-content-builder/build-learning-content.js';
 
 const { SHARED, STARTED } = CampaignParticipationStatuses;
@@ -91,13 +90,8 @@ describe('Acceptance | API | Campaign Participations', function () {
       expect(response.statusCode).to.equal(204);
       expect(result.status).to.equal(SHARED);
 
-      const participationResultCalculationJobs = await jobs(ParticipationResultCalculationJob.name);
-      expect(participationResultCalculationJobs).lengthOf(1);
-
-      const sendSharedParticipationResultsToPoleEmploiJobs = await jobs(
-        SendSharedParticipationResultsToPoleEmploiJob.name,
-      );
-      expect(sendSharedParticipationResultsToPoleEmploiJobs).lengthOf(1);
+      await expect(ParticipationResultCalculationJob.name).to.have.been.performed.withJobsCount(1);
+      await expect(SendSharedParticipationResultsToPoleEmploiJob.name).to.have.been.performed.withJobsCount(1);
     });
   });
 

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/jobs/participation-result-calculation-job-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/jobs/participation-result-calculation-job-repository_test.js
@@ -1,7 +1,6 @@
 import { ParticipationResultCalculationJob } from '../../../../../../../src/prescription/campaign-participation/domain/models/ParticipationResultCalculationJob.js';
 import { participationResultCalculationJobRepository } from '../../../../../../../src/prescription/campaign-participation/infrastructure/repositories/jobs/participation-result-calculation-job-repository.js';
 import { expect } from '../../../../../../test-helper.js';
-import { jobs } from '../../../../../../tooling/jobs/expect-job.js';
 
 describe('Integration | Repository | Jobs | ParticipationResultCalculationJobRepository', function () {
   describe('#performAsync', function () {
@@ -10,9 +9,8 @@ describe('Integration | Repository | Jobs | ParticipationResultCalculationJobRep
       await participationResultCalculationJobRepository.performAsync({ campaignParticipationId: 3 });
 
       // then
-      const results = await jobs(ParticipationResultCalculationJob.name);
-      expect(results).to.have.lengthOf(1);
-      expect(results[0]).to.deep.contains({
+      await expect(ParticipationResultCalculationJob.name).to.have.been.performed.withJob({
+        name: ParticipationResultCalculationJob.name,
         retrylimit: 10,
         retrydelay: 30,
         retrybackoff: true,

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/jobs/send-share-participation-results-to-pole-emploi-job-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/jobs/send-share-participation-results-to-pole-emploi-job-repository_test.js
@@ -1,7 +1,6 @@
 import { SendSharedParticipationResultsToPoleEmploiJob } from '../../../../../../../src/prescription/campaign-participation/domain/models/SendSharedParticipationResultsToPoleEmploiJob.js';
 import { sendSharedParticipationResultsToPoleEmploiJobRepository } from '../../../../../../../src/prescription/campaign-participation/infrastructure/repositories/jobs/send-share-participation-results-to-pole-emploi-job-repository.js';
 import { expect } from '../../../../../../test-helper.js';
-import { jobs } from '../../../../../../tooling/jobs/expect-job.js';
 
 describe('Integration | Repository | Jobs| SendSharedParticipationResultsToPoleEmploiJobRepository', function () {
   describe('#performAsync', function () {
@@ -10,9 +9,9 @@ describe('Integration | Repository | Jobs| SendSharedParticipationResultsToPoleE
       await sendSharedParticipationResultsToPoleEmploiJobRepository.performAsync({ campaignParticipationId: 2 });
 
       // then
-      const results = await jobs(SendSharedParticipationResultsToPoleEmploiJob.name);
-      expect(results).to.have.lengthOf(1);
-      expect(results[0]).to.deep.contains({
+
+      await expect(SendSharedParticipationResultsToPoleEmploiJob.name).to.have.been.performed.withJob({
+        name: SendSharedParticipationResultsToPoleEmploiJob.name,
         retrylimit: 0,
         retrydelay: 0,
         retrybackoff: false,

--- a/api/tests/shared/integration/infrastructure/jobs/JobPgBoss_test.js
+++ b/api/tests/shared/integration/infrastructure/jobs/JobPgBoss_test.js
@@ -2,7 +2,6 @@ import { EntityValidationError } from '../../../../../src/shared/domain/errors.j
 import { JobPgBoss as Job } from '../../../../../src/shared/infrastructure/jobs/JobPgBoss.js';
 import { JobPriority } from '../../../../../src/shared/infrastructure/jobs/JobPriority.js';
 import { catchErrSync, expect, knex } from '../../../../test-helper.js';
-import { jobs } from '../../../../tooling/jobs/expect-job.js';
 
 describe('Integration | Infrastructure | Jobs | JobPgBoss', function () {
   it('schedule a job and create in db with given config', async function () {
@@ -20,12 +19,8 @@ describe('Integration | Infrastructure | Jobs | JobPgBoss', function () {
     // when
     await job.schedule(expectedParams);
 
-    const result = await jobs(name)
-      .select(knex.raw(`priority, retrylimit, retrydelay, retrybackoff, data, expirein::varchar`))
-      .first();
-
-    // then
-    expect(result).to.deep.contains({
+    await expect(name).to.have.been.performed.withJob({
+      name,
       data: expectedParams,
       expirein: expireIn,
       priority,

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -25,6 +25,7 @@ import * as tokenService from '../src/shared/domain/services/token-service.js';
 import { LearningContentCache } from '../src/shared/infrastructure/caches/learning-content-cache.js';
 import * as customChaiHelpers from './tooling/chai-custom-helpers/index.js';
 import * as domainBuilder from './tooling/domain-builder/factory/index.js';
+import { jobChai } from './tooling/jobs/expect-job.js';
 import { buildLearningContent as learningContentBuilder } from './tooling/learning-content-builder/index.js';
 import { increaseCurrentTestTimeout } from './tooling/mocha-tools.js';
 import { createServerWithTestOidcProvider } from './tooling/server/hapi-server-with-test-oidc-provider.js';
@@ -41,6 +42,8 @@ chaiUse(chaiSorted);
 chaiUse(sinonChai);
 
 _.each(customChaiHelpers, chaiUse);
+
+chaiUse(jobChai(knex));
 
 const { apimRegisterApplicationsCredentials, jwtConfig } = config;
 

--- a/api/tests/tooling/jobs/expect-job.js
+++ b/api/tests/tooling/jobs/expect-job.js
@@ -1,7 +1,38 @@
-import { knex } from '../../test-helper.js';
+import { assert, Assertion } from 'chai';
 
-function jobs(jobName) {
-  return knex('pgboss.job').where({ name: jobName });
-}
+export const jobChai = (knex) => (_chai, utils) => {
+  utils.addProperty(Assertion.prototype, 'performed', function () {
+    return this;
+  });
 
-export { jobs };
+  Assertion.addMethod('withJobsCount', async function (expectedCount) {
+    const jobName = this._obj;
+    const jobs = await knex('pgboss.job').where({ name: jobName });
+    assert.strictEqual(
+      jobs.length,
+      expectedCount,
+      `expected ${jobName} to have been performed ${expectedCount} times, but it was performed ${jobs.length} times`,
+    );
+  });
+
+  Assertion.addMethod('withJob', async function (jobData) {
+    await this.withJobsCount(1);
+
+    const jobName = this._obj;
+    const jobs = await knex('pgboss.job').select(knex.raw(`*, expirein::varchar`)).where({ name: jobName });
+    assert.deepInclude(jobs[0], jobData, `Job '${jobName}' was performed with a different payload`);
+  });
+
+  Assertion.addMethod('withJobPayloads', async function (payloads) {
+    await this.withJobsCount(payloads.length);
+
+    const jobName = this._obj;
+    const jobs = await knex('pgboss.job').where({ name: jobName });
+    const actualPayloads = jobs.map((job) => job.data);
+    assert.deepEqual(actualPayloads, payloads, `Job '${jobName}' was performed with a different payload`);
+  });
+
+  Assertion.addMethod('withJobPayload', async function (payload) {
+    await this.withJobPayloads([payload]);
+  });
+};

--- a/api/tests/tooling/jobs/expect-job.test.js
+++ b/api/tests/tooling/jobs/expect-job.test.js
@@ -1,0 +1,183 @@
+import { JobPgBoss } from '../../../src/shared/infrastructure/jobs/JobPgBoss.js';
+import { catchErr, expect, knex } from '../../test-helper.js';
+
+describe('Integration | Tooling | Expect Job', function () {
+  describe('#withJobsCount', function () {
+    it('succeeds when count of executed jobs is correct', async function () {
+      // given
+      const job = new JobPgBoss({ name: 'JobTest' }, knex);
+      const job2 = new JobPgBoss({ name: 'JobTest2' }, knex);
+
+      // when
+      await job.performAsync({ foo: 'bar' });
+      await job2.performAsync({ foo: 'bar' });
+      await job2.performAsync({ foo: 'bar' });
+
+      // then
+      await expect('JobTest').to.have.been.performed.withJobsCount(1);
+      await expect('JobTest2').to.have.been.performed.withJobsCount(2);
+      await expect('JobTestOther').to.have.been.performed.withJobsCount(0);
+    });
+
+    it('fails when count of executed jobs is not correct', async function () {
+      // given
+      const job = new JobPgBoss({ name: 'JobTest' }, knex);
+
+      // when
+      await job.performAsync({ foo: 'bar' });
+
+      const expectation = () => expect('JobTest').to.have.been.performed.withJobsCount(2);
+      const error = await catchErr(expectation)();
+
+      // then
+      expect(error.message).to.equal(
+        'expected JobTest to have been performed 2 times, but it was performed 1 times: expected 1 to equal 2',
+      );
+    });
+  });
+
+  describe('#withJob', function () {
+    it('succeeds when the full job data is the same', async function () {
+      // given
+      const job = new JobPgBoss({ name: 'JobTest' }, knex);
+
+      // when
+      await job.performAsync({ foo: 'bar' });
+
+      // then
+      await expect('JobTest').to.have.been.performed.withJob({
+        name: 'JobTest',
+        data: { foo: 'bar' },
+        retrylimit: job.retryLimit,
+        retrydelay: job.retryDelay,
+        retrybackoff: job.retryBackoff,
+        expirein: job.expireIn,
+      });
+    });
+
+    it('fails when the full job data is not the same', async function () {
+      // given
+      const job = new JobPgBoss({ name: 'JobTest' }, knex);
+
+      // when
+      await job.performAsync({ foo: 'bar' });
+
+      const expectation = () => expect('JobTest').to.have.been.performed.withJob({ name: 'foo' });
+      const error = await catchErr(expectation)();
+
+      // then
+      expect(error.message).to.contains(`Job 'JobTest' was performed with a different payload`);
+    });
+
+    it('fails when multiple jobs are triggered instead of 1', async function () {
+      // given
+      const job = new JobPgBoss({ name: 'JobTest' }, knex);
+
+      // when
+      await job.performAsync({ foo: 'bar' });
+      await job.performAsync({ foo: 'bar' });
+
+      const expectation = () => expect('JobTest').to.have.been.performed.withJob({ name: 'foo' });
+      const error = await catchErr(expectation)();
+
+      // then
+      expect(error.message).to.equal(
+        'expected JobTest to have been performed 1 times, but it was performed 2 times: expected 2 to equal 1',
+      );
+    });
+  });
+
+  describe('#withJobPayloads', function () {
+    it('succeeds when the jobs payloads are correct', async function () {
+      // given
+      const job = new JobPgBoss({ name: 'JobTest' }, knex);
+
+      // when
+      await job.performAsync({ foo: 'bar' });
+      await job.performAsync({ bar: 'baz' });
+
+      // then
+      await expect('JobTest').to.have.been.performed.withJobPayloads([{ foo: 'bar' }, { bar: 'baz' }]);
+    });
+
+    it('fails when not all job payloads are correct', async function () {
+      // given
+      const job = new JobPgBoss({ name: 'JobTest' }, knex);
+
+      // when
+      await job.performAsync({ foo: 'bar' });
+      await job.performAsync({ bar: 'biz' });
+
+      const expectation = () =>
+        expect('JobTest').to.have.been.performed.withJobPayloads([{ foo: 'bar' }, { bar: 'baz' }]);
+      const error = await catchErr(expectation)();
+
+      // then
+      expect(error.message).to.contains(`Job 'JobTest' was performed with a different payload`);
+    });
+
+    it('fails when not all jobs are executed', async function () {
+      // given
+      const job = new JobPgBoss({ name: 'JobTest' }, knex);
+
+      // when
+      await job.performAsync({ foo: 'bar' });
+
+      const expectation = () =>
+        expect('JobTest').to.have.been.performed.withJobPayloads([{ foo: 'bar' }, { bar: 'baz' }]);
+      const error = await catchErr(expectation)();
+
+      // then
+      expect(error.message).to.equal(
+        'expected JobTest to have been performed 2 times, but it was performed 1 times: expected 1 to equal 2',
+      );
+    });
+  });
+
+  describe('#withJobPayload', function () {
+    it('succeeds when the job payload is correct', async function () {
+      // given
+      const job = new JobPgBoss({ name: 'JobTest' }, knex);
+      const job2 = new JobPgBoss({ name: 'JobTest2' }, knex);
+
+      // when
+      await job.performAsync({ foo: 'bar' });
+      await job2.performAsync({ bar: 'baz' });
+
+      // then
+      await expect('JobTest').to.have.been.performed.withJobPayload({ foo: 'bar' });
+      await expect('JobTest2').to.have.been.performed.withJobPayload({ bar: 'baz' });
+    });
+
+    it('fails when the job payload is not correct', async function () {
+      // given
+      const job = new JobPgBoss({ name: 'JobTest' }, knex);
+
+      // when
+      await job.performAsync({ foo: 'bar' });
+
+      const expectation = () => expect('JobTest').to.have.been.performed.withJobPayload({ boo: 'boo' });
+      const error = await catchErr(expectation)();
+
+      // then
+      expect(error.message).to.contains(`Job 'JobTest' was performed with a different payload`);
+    });
+
+    it('fails when multiple jobs are triggered instead of 1', async function () {
+      // given
+      const job = new JobPgBoss({ name: 'JobTest' }, knex);
+
+      // when
+      await job.performAsync({ foo: 'bar' });
+      await job.performAsync({ foo: 'bar' });
+
+      const expectation = () => expect('JobTest').to.have.been.performed.withJobPayload({ foo: 'bar' });
+      const error = await catchErr(expectation)();
+
+      // then
+      expect(error.message).to.equal(
+        'expected JobTest to have been performed 1 times, but it was performed 2 times: expected 2 to equal 1',
+      );
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Nous n'avons pas de tooling pour gérer les différentes assertion sur l'exécution des jobs.

## :robot: Proposition

Ajout d'assertion custom pour la gestion des jobs:

```js
// succeeds when count of executed jobs is correct
await expect('MyJobName').to.have.been.performed.withJobsCount(1);

// succeeds when the full job data is correct
await expect('MyJobName').to.have.been.performed.withJob({
  name: 'MyJobName',
  data: { foo: 'bar' },
  retrylimit: 1,
  retrydelay: 1,
  retrybackoff: 1,
  expirein: '00:10:00',
});

// succeeds when multiple jobs payloads are correct
await expect('MyJobName').to.have.been.performed.withJobPayloads([
  { foo: 'bar' },
  { bar: 'baz' },
]);

// succeeds when the job payload is correct
await expect('MyJobName').to.have.been.performed.withJobPayload({ foo: 'bar' });
```

> [!IMPORTANT]
> Le `await` est nécessaire avant le `expect`, car les fonctions d'assertion ont besoin d'interroger la base de données `pgboss`.

## :100: Pour tester

Les tests vérifiant l'exécution de jobs ont été modifiés pour utiliser ces helpers.
