### PR TITLE
[TECH] Ajouter la propriété name aux jobs d'import de fichier Siècle

### DIFF
--- a/api/src/prescription/learner-management/infrastructure/jobs/ImportOrganizationLearnersJobHandler.js
+++ b/api/src/prescription/learner-management/infrastructure/jobs/ImportOrganizationLearnersJobHandler.js
@@ -1,10 +1,15 @@
 import { usecases } from '../../domain/usecases/index.js';
+import { ImportOrganizationLearnersJob } from './ImportOrganizationLearnersJob.js';
 
 class ImportOrganizationLearnersJobHandler {
   async handle(event) {
     const { organizationImportId } = event;
 
     return usecases.addOrUpdateOrganizationLearners({ organizationImportId });
+  }
+
+  get name() {
+    return ImportOrganizationLearnersJob.name;
   }
 }
 

--- a/api/src/prescription/learner-management/infrastructure/jobs/ValidateOrganizationImportFileJobHandler.js
+++ b/api/src/prescription/learner-management/infrastructure/jobs/ValidateOrganizationImportFileJobHandler.js
@@ -1,10 +1,15 @@
 import { usecases } from '../../domain/usecases/index.js';
+import { ValidateOrganizationImportFileJob } from './ValidateOrganizationImportFileJob.js';
 
 class ValidateOrganizationImportFileJobHandler {
   async handle(event) {
     const { organizationImportId } = event;
 
     await usecases.validateSiecleXmlFile({ organizationImportId });
+  }
+
+  get name() {
+    return ValidateOrganizationImportFileJob.name;
   }
 }
 

--- a/api/tests/prescription/learner-management/unit/infrastructure/jobs/ImportOrganizationLearnersJobHandler_test.js
+++ b/api/tests/prescription/learner-management/unit/infrastructure/jobs/ImportOrganizationLearnersJobHandler_test.js
@@ -1,4 +1,5 @@
 import { usecases } from '../../../../../../src/prescription/learner-management/domain/usecases/index.js';
+import { ImportOrganizationLearnersJob } from '../../../../../../src/prescription/learner-management/infrastructure/jobs/ImportOrganizationLearnersJob.js';
 import { ImportOrganizationLearnersJobHandler } from '../../../../../../src/prescription/learner-management/infrastructure/jobs/ImportOrganizationLearnersJobHandler.js';
 import { expect, sinon } from '../../../../../test-helper.js';
 
@@ -13,6 +14,14 @@ describe('Unit | Handler | ImportOrganizationLearnersJobHandler', function () {
 
     expect(usecases.addOrUpdateOrganizationLearners).to.have.been.calledWithExactly({
       organizationImportId: event.organizationImportId,
+    });
+  });
+
+  describe('#name', function () {
+    it('should return the name of the job', function () {
+      const handler = new ImportOrganizationLearnersJobHandler();
+
+      expect(handler.name).to.equal(ImportOrganizationLearnersJob.name);
     });
   });
 });

--- a/api/tests/prescription/learner-management/unit/infrastructure/jobs/ValidateOrganizationImportFileJobHandler_test.js
+++ b/api/tests/prescription/learner-management/unit/infrastructure/jobs/ValidateOrganizationImportFileJobHandler_test.js
@@ -1,4 +1,5 @@
 import { usecases } from '../../../../../../src/prescription/learner-management/domain/usecases/index.js';
+import { ValidateOrganizationImportFileJob } from '../../../../../../src/prescription/learner-management/infrastructure/jobs/ValidateOrganizationImportFileJob.js';
 import { ValidateOrganizationImportFileJobHandler } from '../../../../../../src/prescription/learner-management/infrastructure/jobs/ValidateOrganizationImportFileJobHandler.js';
 import { expect, sinon } from '../../../../../test-helper.js';
 
@@ -13,6 +14,14 @@ describe('Unit | Handler | ValidateOrganizationImportFileJobHandler', function (
 
     expect(usecases.validateSiecleXmlFile).to.have.been.calledWithExactly({
       organizationImportId: event.organizationImportId,
+    });
+  });
+
+  describe('#name', function () {
+    it('should return the name of the job', function () {
+      const handler = new ValidateOrganizationImportFileJobHandler();
+
+      expect(handler.name).to.equal(ValidateOrganizationImportFileJob.name);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Certains monitors Datadog se basent sur la propriété `name` du job handler., notamment celui informant de l'échec d'un job. Cependant, les handler `ImportOrganizationLearnersJobHandler` et `ValidateOrganizationImportFileJobHandler` ne possèdent pas cette propriété. 

## :robot: Proposition
Ajouter un getter `name` aux job handler `ImportOrganizationLearnersJobHandler` et `ValidateOrganizationImportFileJobHandler`.

## :100: Pour tester
Les tests n'échouent pas.