### PR TITLE
[FEATURE] Ajouter un avertissement dans la page d'invitation des membres (PIX-12917)

### DIFF
--- a/orga/app/styles/pages/authenticated/team/new.scss
+++ b/orga/app/styles/pages/authenticated/team/new.scss
@@ -4,8 +4,13 @@
   &__form {
     margin-top: var(--pix-spacing-8x);
   }
+
+  &__warning-banner {
+    margin-bottom: var(--pix-spacing-8x);
+  }
 }
 
 .invite-form__email-field {
   min-height: 70px;
 }
+

--- a/orga/app/templates/authenticated/team/new.hbs
+++ b/orga/app/templates/authenticated/team/new.hbs
@@ -5,6 +5,7 @@
   <h1 class="page__title page-title">
     {{t "pages.team-new.title"}}
   </h1>
+  <PixBanner @type="warning" class="new-team-page__warning-banner">{{t "pages.team-new.warning"}}</PixBanner>
 
   <p class="paragraph">
     {{t "pages.team-new.email-requirement"}}<br />

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1484,7 +1484,8 @@
       "success": {
         "invitation": "An invitation has been sent to the email address {email}.",
         "multiple-invitations": "An invitation has been sent to the listed email addresses."
-      }
+      },
+      "warning": "The members you add below will have access to participant results and campaign analysis. Please ensure that the people you invite are members of your organisation."
     },
     "team-new-item": {
       "input-label": "Email address(es)",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1493,7 +1493,8 @@
       "success": {
         "invitation": "Une invitation a bien été envoyée à l’adresse e-mail {email}.",
         "multiple-invitations": "Une invitation a bien été envoyée aux adresses e-mails listées."
-      }
+      },
+      "warning": "Les membres que vous ajoutez ci-dessous auront accès aux résultats des participants et à l’analyse des campagnes. Veuillez vous assurer que les personnes invitées sont des membres de votre organisation."
     },
     "team-new-item": {
       "input-label": "Adresse(s) e-mail",


### PR DESCRIPTION
## :unicorn: Problème
Certaines organisations invitent par erreur des participants pour être des membres de l’organisation à travers le module d’invitation. Il manque des informations sur l’impact sur la page “Inviter un membre”

## :robot: Proposition
Sur la page “Inviter un membre”, ajouter un bandeau d’avertissement sous le titre “Inviter un membre”
Composant à utiliser : https://ui.pix.fr/?path=/story/notification-banner--warning 

Texte dans le composant : 

FR : Les membres que vous ajoutez ci-dessous auront accès aux résultats des participants et à l’analyse des campagnes. Veuillez vous assurer que les personnes invitées sont des membres de votre organisation.
EN : The members you add below will have access to participant results and campaign analysis. Please ensure that the people you invite are members of your organisation.

## :rainbow: Remarques
L'espagnol et le néerlandais doivent être gérés par Phrase

## :100: Pour tester
- Se connecter à PixOrga avec un profil d'administrateur d'une organisation (par exemple allorga@example.net)
- Dans l'onglet "Equipe", cliquer sur "Inviter un membre"
- Vérifier la présence d'une bannière d'avertissement avec le texte "Les membres que vous ajoutez ci-dessous auront accès aux résultats des participants et à l’analyse des campagnes. Veuillez vous assurer que les personnes invitées sont des membres de votre organisation.".
