### PR TITLE
[FEATURE] Ajouter le champ `tabletSupport` dans les métadonnées d'un modue (PIX-13908)

### DIFF
--- a/api/src/devcomp/domain/models/module/Details.js
+++ b/api/src/devcomp/domain/models/module/Details.js
@@ -1,11 +1,12 @@
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 
 class Details {
-  constructor({ image, description, duration, level, objectives }) {
+  constructor({ image, description, duration, level, tabletSupport, objectives }) {
     assertNotNullOrUndefined(image, 'The image is required for module details');
     assertNotNullOrUndefined(description, 'The description is required for module details');
     assertNotNullOrUndefined(duration, 'The duration is required for module details');
     assertNotNullOrUndefined(level, 'The level is required for module details');
+    assertNotNullOrUndefined(tabletSupport, 'The tabletSupport is required for module details');
     assertNotNullOrUndefined(objectives, 'The objectives are required for module details');
     this.#assertObjectivesIsAnArray(objectives);
     this.#assertObjectivesHasMinimumLength(objectives);
@@ -14,6 +15,7 @@ class Details {
     this.description = description;
     this.duration = duration;
     this.level = level;
+    this.tabletSupport = tabletSupport;
     this.objectives = objectives;
   }
 

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
@@ -7,6 +7,7 @@
     "description": "Découvrez dans ce module ce qu'est une adresse IP publique et les informations et les traces numériques qu'elle porte.",
     "duration": 10,
     "level": "Intermédiaire",
+    "tabletSupport": "comfortable",
     "objectives": [
       "Connaître les traces numériques portées par l'adresse IP publique",
       "Localiser une adresse IP publique",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -7,6 +7,7 @@
     "description": "Bien écrire son adresse mail est important. Dans ce module, vous allez apprendre à écrire correctement une adresse e-mail pour mieux communiquer et éviter les erreurs courantes.",
     "duration": 12,
     "level": "Débutant",
+    "tabletSupport": "comfortable",
     "objectives": [
       "Connaître les différentes parties d’une adresse mail et les identifier sur des exemples",
       "Comprendre les fonctions de chaque partie d’une adresse mail",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-parle-francais.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-parle-francais.json
@@ -7,6 +7,7 @@
     "description": "Les Large Language Model (LLM) sont des systèmes d'intelligence artificielle générative. Ils donnent l'impression de parler toutes les langues mais, du fait de leurs biais, leurs productions sont parfois stéréotypées ou discriminantes. Dans ce module, vous allez découvrir les origines de ces biais et interroger directement des LLM pour les repérer !",
     "duration": 10,
     "level": "Avancé",
+    "tabletSupport": "inconvenient",
     "objectives": [
       "Connaître les origines des biais des LLM",
       "Générer et analyser des résultats biaisés de LLM",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -7,6 +7,7 @@
     "description": "Découvrez avec ce didacticiel comment fonctionne Modulix !",
     "duration": 5,
     "level": "Débutant",
+    "tabletSupport": "inconvenient",
     "objectives": ["Naviguer dans Modulix", "Découvrir les leçons et les activités"]
   },
   "transitionTexts": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
@@ -7,6 +7,7 @@
     "description": "Sur internet, de nombreuses informations circulent. Certaines sont vraies, d'autres sont fausses. Dans ce module, vous allez découvrir une méthode pour analyser l'information et aiguiser votre esprit critique !",
     "duration": 15,
     "level": "Intermédiaire",
+    "tabletSupport": "comfortable",
     "objectives": [
       "Connaître une méthode de vérification d'informations",
       "Repérer une fausse information sur internet",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
@@ -7,6 +7,7 @@
     "description": "Aujourd'hui, on utilise des mots de passe pour tout : son téléphone, son adresse mail, ses réseaux sociaux. Dans ce module, vous allez découvrir pourquoi et comment créer des mots de passe solides.",
     "duration": 12,
     "level": "Débutant",
+    "tabletSupport": "comfortable",
     "objectives": [
       "Comprendre l'intérêt d'avoir des mots de passe solides",
       "Connaître les principaux risques liés aux mots de passe",
@@ -69,9 +70,7 @@
                 "placeholder": "",
                 "ariaLabel": "Mot de passe",
                 "defaultValue": "",
-                "tolerances": [
-                  "t1"
-                ],
+                "tolerances": ["t1"],
                 "solutions": [
                   "123456",
                   "123456789",
@@ -168,9 +167,7 @@
                 "placeholder": "",
                 "ariaLabel": "Mot de passe d'Austin",
                 "defaultValue": "",
-                "tolerances": [
-                  "t1"
-                ],
+                "tolerances": ["t1"],
                 "solutions": [
                   "Bill15111984",
                   "15111984Bill",
@@ -458,10 +455,7 @@
               "valid": "<span class=\"feedback__state\">Correct.</span><p> Un mot de passe long est plus solide. Se servir d'une phrase permet de mieux s'en souvenir. </p>",
               "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Un mot de passe long est plus solide. Se servir d'une phrase permet de mieux s'en souvenir.</p>"
             },
-            "solutions": [
-              "1",
-              "4"
-            ]
+            "solutions": ["1", "4"]
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
@@ -7,6 +7,7 @@
     "description": "Pour savoir ce qu'on peut brancher ou non à un ordinateur, il faut bien connaître les principaux ports de connexion !",
     "duration": 10,
     "level": "Débutant",
+    "tabletSupport": "comfortable",
     "objectives": [
       "Reconnaître les ports de connexion essentiels d’un ordinateur",
       "Connaître la fonction de chaque port de connexion"

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
@@ -7,6 +7,7 @@
     "description": "Wikipédia est un site très connu, que vous avez sans doute déjà utilisé. Dans ce module, vous trouverez des explications sur les principes de Wikipédia. Vous découvrirez aussi des méthodes pour l'utiliser.",
     "duration": 10,
     "level": "Intermédiaire",
+    "tabletSupport": "comfortable",
     "objectives": [
       "Comprendre les principes fondateurs de Wikipédia",
       "Connaître certaines caractéristiques et fonctionnalités de Wikipédia",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
@@ -7,6 +7,7 @@
     "description": "Sur internet et les réseaux sociaux, il est parfois difficile de savoir si une information est vraie ou fausse. Dans ce module, vous allez découvrir pourquoi il est important de s’intéresser à la source d’une information pour démêler le vrai du faux.",
     "duration": 10,
     "level": "Débutant",
+    "tabletSupport": "comfortable",
     "objectives": [
       "Rechercher la source d’une information",
       "Connaître les différents types de sources d’information",

--- a/api/tests/devcomp/acceptance/scripts/get-answerable-elements_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-answerable-elements_test.js
@@ -15,6 +15,7 @@ describe('Acceptance | Script | Get Answerable Elements as CSV', function () {
         description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',
         duration: 5,
         level: 'Débutant',
+        tabletSupport: 'comfortable',
         objectives: ['Naviguer dans Modulix', 'Découvrir les leçons et les activités'],
       },
       transitionTexts: [

--- a/api/tests/devcomp/acceptance/scripts/get-elements_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-elements_test.js
@@ -12,6 +12,7 @@ describe('Acceptance | Script | Get Elements as CSV', function () {
         description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',
         duration: 5,
         level: 'Débutant',
+        tabletSupport: 'comfortable',
         objectives: ['Naviguer dans Modulix', 'Découvrir les leçons et les activités'],
       },
       transitionTexts: [

--- a/api/tests/devcomp/acceptance/scripts/get-modules_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-modules_test.js
@@ -14,6 +14,7 @@ describe('Acceptance | Script | Get Modules as CSV', function () {
           description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',
           duration: 5,
           level: 'Débutant',
+          tabletSupport: 'comfortable',
           objectives: ['Naviguer dans Modulix', 'Découvrir les leçons et les activités'],
         },
         transitionTexts: [

--- a/api/tests/devcomp/acceptance/scripts/get-proposals_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-proposals_test.js
@@ -13,6 +13,7 @@ describe('Acceptance | Script | Get Proposals as CSV', function () {
         description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',
         duration: 5,
         level: 'Débutant',
+        tabletSupport: 'comfortable',
         objectives: ['Naviguer dans Modulix', 'Découvrir les leçons et les activités'],
       },
       transitionTexts: [

--- a/api/tests/devcomp/integration/repositories/element-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/element-repository_test.js
@@ -44,6 +44,7 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
           description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',
           duration: 5,
           level: 'Débutant',
+          tabletSupport: 'comfortable',
           objectives: ['Naviguer dans Modulix', 'Découvrir les leçons et les activités'],
         },
         grains: [
@@ -132,6 +133,7 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
           description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',
           duration: 5,
           level: 'Débutant',
+          tabletSupport: 'comfortable',
           objectives: ['Naviguer dans Modulix', 'Découvrir les leçons et les activités'],
         },
         grains: [
@@ -264,6 +266,7 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
           description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',
           duration: 5,
           level: 'Débutant',
+          tabletSupport: 'comfortable',
           objectives: ['Naviguer dans Modulix', 'Découvrir les leçons et les activités'],
         },
         grains: [

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -54,6 +54,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
             'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
           duration: 12,
           level: 'Débutant',
+          tabletSupport: 'comfortable',
           objectives: [
             'Écrire une adresse mail correctement, en évitant les erreurs courantes',
             'Connaître les parties d’une adresse mail et les identifier sur des exemples',

--- a/api/tests/devcomp/unit/domain/models/module/Details_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/Details_test.js
@@ -9,16 +9,18 @@ describe('Unit | Devcomp | Domain | Models | Module | Details', function () {
       const description = 'Description';
       const duration = 12;
       const level = 'Débutant';
+      const tabletSupport = 'comfortable';
       const objectives = ['MissionInformation #1'];
 
       // when
-      const details = new Details({ image, description, duration, level, objectives });
+      const details = new Details({ image, description, duration, level, tabletSupport, objectives });
 
       // then
       expect(details.image).to.equal(image);
       expect(details.description).to.equal(description);
       expect(details.duration).to.equal(duration);
       expect(details.level).to.equal(level);
+      expect(details.tabletSupport).to.equal(tabletSupport);
       expect(details.objectives).to.equal(objectives);
     });
 
@@ -52,6 +54,21 @@ describe('Unit | Devcomp | Domain | Models | Module | Details', function () {
       });
     });
 
+    describe('if the details do not have a tabletSupport', function () {
+      it('should throw an error', function () {
+        expect(
+          () =>
+            new Details({
+              image: 'https://image.com',
+              description: 'description',
+              duration: 12,
+              level: 'level',
+              objectives: ['objective1'],
+            }),
+        ).to.throw('The tabletSupport is required for module details');
+      });
+    });
+
     describe('if the details do not have objectives', function () {
       it('should throw an error', function () {
         expect(
@@ -61,6 +78,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Details', function () {
               description: 'description',
               duration: 12,
               level: 'level',
+              tabletSupport: 'comfortable',
             }),
         ).to.throw('The objectives are required for module details');
       });
@@ -75,6 +93,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Details', function () {
               description: 'description',
               duration: 12,
               level: 'level',
+              tabletSupport: 'comfortable',
               objectives: ' not-a-list',
             }),
         ).to.throw('The module details should contain a list of objectives');
@@ -90,6 +109,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Details', function () {
               description: 'description',
               duration: 12,
               level: 'level',
+              tabletSupport: 'comfortable',
               objectives: [],
             }),
         ).to.throw('The module details should contain at least one objective');

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -217,6 +217,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
           description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',
           duration: 5,
           level: 'Débutant',
+          tabletSupport: 'comfortable',
           objectives: ['Naviguer dans Modulix', 'Découvrir les leçons et les activités'],
         },
         grains: [
@@ -255,6 +256,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
         description: '<strong>Découvrez avec ce didacticiel</strong> comment fonctionne Modulix !',
         duration: 5,
         level: 'Débutant',
+        tabletSupport: 'comfortable',
         objectives: ['Naviguer dans Modulix', 'Découvrir les leçons et les activités'],
       };
 
@@ -275,6 +277,28 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
         description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',
         duration: 5,
         level: 'Débutant',
+        tabletSupport: 'comfortable',
+        objectives: ['<span>Naviguer dans Modulix<span>', 'Découvrir les leçons et les activités'],
+      };
+
+      try {
+        await moduleDetailsSchema.validateAsync(invalidModuleDetails, { abortEarly: false });
+        throw new Error('Joi validation should have thrown');
+      } catch (joiError) {
+        expect(joiError.message).to.deep.equal(
+          '"objectives[0]" failed custom validation because HTML is not allowed in this field',
+        );
+      }
+    });
+
+    it('should throw  custom error for details.objectives fields', async function () {
+      // given
+      const invalidModuleDetails = {
+        image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+        description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',
+        duration: 5,
+        level: 'Débutant',
+        tabletSupport: 'comfortable',
         objectives: ['<span>Naviguer dans Modulix<span>', 'Découvrir les leçons et les activités'],
       };
 

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module.js
@@ -23,6 +23,7 @@ const moduleDetailsSchema = Joi.object({
   duration: Joi.number().integer().min(0).max(120).required(),
   level: Joi.string().valid('Débutant', 'Intermédiaire', 'Avancé', 'Expert').required(),
   objectives: Joi.array().items(htmlNotAllowedSchema).min(1).required(),
+  tabletSupport: Joi.string().valid('obstructed', 'inconvenient', 'comfortable').required(),
 });
 
 const elementSchema = Joi.alternatives().conditional('.type', {

--- a/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
@@ -31,6 +31,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             description: 'Description',
             duration: 5,
             level: 'Débutant',
+            tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
           transitionTexts: [
@@ -80,6 +81,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
               description: 'Description',
               duration: 5,
               level: 'Débutant',
+              tabletSupport: 'comfortable',
               objectives: ['Objective 1'],
             },
             grains: [
@@ -127,6 +129,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
               description: 'Description',
               duration: 5,
               level: 'Débutant',
+              tabletSupport: 'comfortable',
               objectives: ['Objective 1'],
             },
             grains: [
@@ -174,6 +177,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
               description: 'Description',
               duration: 5,
               level: 'Débutant',
+              tabletSupport: 'comfortable',
               objectives: ['Objective 1'],
             },
             grains: [
@@ -228,6 +232,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           description: 'Description',
           duration: 5,
           level: 'Débutant',
+          tabletSupport: 'comfortable',
           objectives: ['Objective 1'],
         },
         grains: [
@@ -274,6 +279,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           description: 'Description',
           duration: 5,
           level: 'Débutant',
+          tabletSupport: 'comfortable',
           objectives: ['Objective 1'],
         },
         transitionTexts: [
@@ -330,6 +336,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             description: 'Description',
             duration: 5,
             level: 'Débutant',
+            tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
           grains: [
@@ -371,6 +378,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             description: 'Description',
             duration: 5,
             level: 'Débutant',
+            tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
           grains: [
@@ -410,6 +418,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             description: 'Description',
             duration: 5,
             level: 'Débutant',
+            tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
           grains: [
@@ -463,6 +472,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             description: 'Description',
             duration: 5,
             level: 'Débutant',
+            tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
           grains: [
@@ -502,6 +512,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             description: 'Description',
             duration: 5,
             level: 'Débutant',
+            tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
           grains: [
@@ -544,6 +555,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             description: 'Description',
             duration: 5,
             level: 'Débutant',
+            tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
           grains: [
@@ -600,6 +612,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             description: 'Description',
             duration: 5,
             level: 'Débutant',
+            tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
           grains: [
@@ -666,6 +679,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             description: 'Description',
             duration: 5,
             level: 'Débutant',
+            tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
           grains: [
@@ -750,6 +764,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             description: 'Description',
             duration: 5,
             level: 'Débutant',
+            tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
           grains: [
@@ -799,6 +814,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             description: 'Description',
             duration: 5,
             level: 'Débutant',
+            tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
           grains: [
@@ -846,6 +862,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             description: 'Description',
             duration: 5,
             level: 'Débutant',
+            tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
           grains: [
@@ -897,6 +914,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             description: 'Description',
             duration: 5,
             level: 'Débutant',
+            tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
           grains: [
@@ -944,6 +962,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             description: 'Description',
             duration: 5,
             level: 'Débutant',
+            tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
           grains: [
@@ -995,6 +1014,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             description: 'Description',
             duration: 5,
             level: 'Débutant',
+            tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
           grains: [
@@ -1058,6 +1078,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             description: 'Description',
             duration: 5,
             level: 'Débutant',
+            tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
           grains: [
@@ -1133,6 +1154,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             description: 'Description',
             duration: 5,
             level: 'Débutant',
+            tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
           grains: [
@@ -1219,6 +1241,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             description: 'Description',
             duration: 5,
             level: 'Débutant',
+            tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
           grains: [
@@ -1272,6 +1295,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             description: 'Description',
             duration: 5,
             level: 'Débutant',
+            tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
           grains: [
@@ -1327,6 +1351,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             description: 'Description',
             duration: 5,
             level: 'Débutant',
+            tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
           grains: [
@@ -1374,6 +1399,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           description: 'Description',
           duration: 5,
           level: 'Débutant',
+          tabletSupport: 'comfortable',
           objectives: ['Objective 1'],
         },
         grains: [
@@ -1424,6 +1450,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           description: 'Description',
           duration: 5,
           level: 'Débutant',
+          tabletSupport: 'comfortable',
           objectives: ['Objective 1'],
         },
         grains: [


### PR DESCRIPTION
## :robot: Proposition
On souhaite personnaliser l'expérience dans certains modules pas très bien adaptés à l'usage mobile/tablette.

On propose d'ajouter un champ `tabletSupport` qui peut prendre 3 valeurs : 
- `obstructed` : un des contenus du module n'est pas adapté à l'usage tablette ou mobile.
- `inconvenient`: les contenus du module n'ont pas particulièrement été conçu pour l'usage tablette ou mobile, mais rien n'est bloquant.
- `comfortable` : le module est conçu pour usage mobile et tablette.

## :rainbow: Remarques
Côté éval, on peut choisir si l'épreuve est responsive "mobile", "tablette", les deux ou aucun. Ici on choisit de ne pas aller si finement pour le moment, car le traitement sera le même qu'on soit en mobile ou tablette.

## :100: Pour tester
Vérifier au requêtage d'un module en RA qu'on récupère la nouvelle information `tabletSupport` à l'intérieur de l'objet `details`.
