### PR TITLE
[FEATURE] Ajout d'une modale d'édition de candidat pour les ajustements d'a11y en certif (PIX-13683).

### DIFF
--- a/api/src/certification/enrolment/application/certification-candidate-controller.js
+++ b/api/src/certification/enrolment/application/certification-candidate-controller.js
@@ -32,6 +32,21 @@ const deleteCandidate = async function (request, h) {
   return h.response().code(204);
 };
 
+const updateEnrolledCandidate = async function (request, h, dependencies = { enrolledCandidateSerializer }) {
+  const candidateId = request.params.certificationCandidateId;
+  const enrolledCandidateData = request.payload.data.attributes;
+  const editedCandidate = dependencies.enrolledCandidateSerializer.deserialize({
+    candidateId,
+    candidateData: enrolledCandidateData,
+  });
+
+  await usecases.updateEnrolledCandidate({
+    editedCandidate,
+  });
+
+  return h.response().code(204);
+};
+
 const validateCertificationInstructions = async function (
   request,
   h,
@@ -42,7 +57,7 @@ const validateCertificationInstructions = async function (
   await usecases.candidateHasSeenCertificationInstructions({
     certificationCandidateId,
   });
-  const enrolledCandidate = await enrolledCandidateRepository.get(certificationCandidateId);
+  const enrolledCandidate = await enrolledCandidateRepository.get({ id: certificationCandidateId });
 
   return dependencies.certificationCandidateSerializer.serialize(enrolledCandidate);
 };
@@ -52,5 +67,6 @@ const certificationCandidateController = {
   getEnrolledCandidates,
   deleteCandidate,
   validateCertificationInstructions,
+  updateEnrolledCandidate,
 };
 export { certificationCandidateController };

--- a/api/src/certification/enrolment/application/certification-candidate-route.js
+++ b/api/src/certification/enrolment/application/certification-candidate-route.js
@@ -140,6 +140,37 @@ const register = async function (server) {
         ],
       },
     },
+    {
+      method: 'PATCH',
+      path: '/api/sessions/{id}/certification-candidates/{certificationCandidateId}',
+      config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.sessionId,
+            certificationCandidateId: identifiersType.certificationCandidateId,
+          }),
+          payload: Joi.object({
+            data: {
+              attributes: {
+                'accessibility-adjustment-needed': Joi.boolean().required(),
+              },
+            },
+          }),
+        },
+        pre: [
+          {
+            method: authorization.verifySessionAuthorization,
+            assign: 'authorizationCheck',
+          },
+        ],
+        handler: certificationCandidateController.updateEnrolledCandidate,
+        tags: ['api', 'sessions', 'certification-candidates'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs authentifiés',
+          "Elle permet de modifier les informations d'un candidat",
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/src/certification/enrolment/application/session-controller.js
+++ b/api/src/certification/enrolment/application/session-controller.js
@@ -56,7 +56,7 @@ const createCandidateParticipation = async function (request, h) {
     normalizeStringFnc: normalize,
   });
 
-  const candidate = await enrolledCandidateRepository.get(candidateId);
+  const candidate = await enrolledCandidateRepository.get({ id: candidateId });
   const serialized = await enrolledCandidateSerializer.serializeForParticipation(candidate);
   return linkAlreadyDone ? serialized : h.response(serialized).created();
 };

--- a/api/src/certification/enrolment/domain/models/Candidate.js
+++ b/api/src/certification/enrolment/domain/models/Candidate.js
@@ -29,6 +29,7 @@ export class Candidate {
     prepaymentCode,
     hasSeenCertificationInstructions = false,
     subscriptions = [],
+    accessibilityAdjustmentNeeded,
   } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -53,6 +54,7 @@ export class Candidate {
     this.prepaymentCode = prepaymentCode;
     this.hasSeenCertificationInstructions = hasSeenCertificationInstructions;
     this.subscriptions = subscriptions;
+    this.accessibilityAdjustmentNeeded = accessibilityAdjustmentNeeded;
   }
 
   isLinkedToAUser() {

--- a/api/src/certification/enrolment/domain/models/Candidate.js
+++ b/api/src/certification/enrolment/domain/models/Candidate.js
@@ -69,6 +69,10 @@ export class Candidate {
     this.userId = userId;
   }
 
+  updateAccessibilityAdjustmentNeededStatus(newAdjustmentStatus) {
+    this.accessibilityAdjustmentNeeded = newAdjustmentStatus;
+  }
+
   validateCertificationInstructions() {
     this.hasSeenCertificationInstructions = true;
   }

--- a/api/src/certification/enrolment/domain/models/EditedCandidate.js
+++ b/api/src/certification/enrolment/domain/models/EditedCandidate.js
@@ -1,0 +1,13 @@
+export class EditedCandidate {
+  constructor({ id, accessibilityAdjustmentNeeded = false }) {
+    this.id = id;
+    this.accessibilityAdjustmentNeeded = accessibilityAdjustmentNeeded;
+    this.#validate();
+  }
+
+  #validate() {
+    if (!this.id) {
+      throw new Error('id is required');
+    }
+  }
+}

--- a/api/src/certification/enrolment/domain/read-models/EnrolledCandidate.js
+++ b/api/src/certification/enrolment/domain/read-models/EnrolledCandidate.js
@@ -61,6 +61,10 @@ export class EnrolledCandidate {
     this.accessibilityAdjustmentNeeded = accessibilityAdjustmentNeeded;
   }
 
+  isLinkedToAUser() {
+    return !_.isNil(this.userId);
+  }
+
   findComplementarySubscriptionInfo() {
     return this.subscriptions.find((sub) => sub.type === SUBSCRIPTION_TYPES.COMPLEMENTARY);
   }

--- a/api/src/certification/enrolment/domain/usecases/update-enrolled-candidate.js
+++ b/api/src/certification/enrolment/domain/usecases/update-enrolled-candidate.js
@@ -1,20 +1,19 @@
 /**
- * @typedef {import('./index.js').EnrolledCandidateRepository} EnrolledCandidateRepository
+ * @typedef {import('./index.js').CandidateRepository} CandidateRepository
  */
 
 import {
   CandidateAlreadyLinkedToUserError,
   CertificationCandidateNotFoundError,
 } from '../../../../shared/domain/errors.js';
-import { Candidate } from '../models/Candidate.js';
 
 /**
  * @param {Object} params
  * @param {EditedCandidate} params.editedCandidate
- * @param {EnrolledCandidateRepository} params.enrolledCandidateRepository
+ * @param {CandidateRepository} params.candidateRepository
  */
-const updateEnrolledCandidate = async function ({ editedCandidate, enrolledCandidateRepository }) {
-  const foundCandidate = await enrolledCandidateRepository.get({ id: editedCandidate.id });
+const updateEnrolledCandidate = async function ({ editedCandidate, candidateRepository }) {
+  const foundCandidate = await candidateRepository.get({ certificationCandidateId: editedCandidate.id });
 
   if (!foundCandidate) {
     throw new CertificationCandidateNotFoundError();
@@ -24,12 +23,9 @@ const updateEnrolledCandidate = async function ({ editedCandidate, enrolledCandi
     throw new CandidateAlreadyLinkedToUserError();
   }
 
-  const candidate = new Candidate({
-    ...foundCandidate,
-    accessibilityAdjustmentNeeded: editedCandidate.accessibilityAdjustmentNeeded,
-  });
+  foundCandidate.updateAccessibilityAdjustmentNeededStatus(editedCandidate.accessibilityAdjustmentNeeded);
 
-  return enrolledCandidateRepository.update({ candidate });
+  return candidateRepository.update(foundCandidate);
 };
 
 export { updateEnrolledCandidate };

--- a/api/src/certification/enrolment/domain/usecases/update-enrolled-candidate.js
+++ b/api/src/certification/enrolment/domain/usecases/update-enrolled-candidate.js
@@ -1,0 +1,28 @@
+/**
+ * @typedef {import('./index.js').EnrolledCandidateRepository} EnrolledCandidateRepository
+ */
+
+import { CertificationCandidateNotFoundError } from '../../../../shared/domain/errors.js';
+import { Candidate } from '../models/Candidate.js';
+
+/**
+ * @param {Object} params
+ * @param {EditedCandidate} params.editedCandidate
+ * @param {EnrolledCandidateRepository} params.enrolledCandidateRepository
+ */
+const updateEnrolledCandidate = async function ({ editedCandidate, enrolledCandidateRepository }) {
+  const foundedCandidate = await enrolledCandidateRepository.get({ id: editedCandidate.id });
+
+  if (!foundedCandidate) {
+    throw new CertificationCandidateNotFoundError();
+  }
+
+  const candidate = new Candidate({
+    ...foundedCandidate,
+    accessibilityAdjustmentNeeded: editedCandidate.accessibilityAdjustmentNeeded,
+  });
+
+  return enrolledCandidateRepository.update({ candidate });
+};
+
+export { updateEnrolledCandidate };

--- a/api/src/certification/enrolment/domain/usecases/update-enrolled-candidate.js
+++ b/api/src/certification/enrolment/domain/usecases/update-enrolled-candidate.js
@@ -2,7 +2,10 @@
  * @typedef {import('./index.js').EnrolledCandidateRepository} EnrolledCandidateRepository
  */
 
-import { CertificationCandidateNotFoundError } from '../../../../shared/domain/errors.js';
+import {
+  CandidateAlreadyLinkedToUserError,
+  CertificationCandidateNotFoundError,
+} from '../../../../shared/domain/errors.js';
 import { Candidate } from '../models/Candidate.js';
 
 /**
@@ -15,6 +18,10 @@ const updateEnrolledCandidate = async function ({ editedCandidate, enrolledCandi
 
   if (!foundedCandidate) {
     throw new CertificationCandidateNotFoundError();
+  }
+
+  if (foundedCandidate.isLinkedToAUser()) {
+    throw new CandidateAlreadyLinkedToUserError();
   }
 
   const candidate = new Candidate({

--- a/api/src/certification/enrolment/domain/usecases/update-enrolled-candidate.js
+++ b/api/src/certification/enrolment/domain/usecases/update-enrolled-candidate.js
@@ -14,18 +14,18 @@ import { Candidate } from '../models/Candidate.js';
  * @param {EnrolledCandidateRepository} params.enrolledCandidateRepository
  */
 const updateEnrolledCandidate = async function ({ editedCandidate, enrolledCandidateRepository }) {
-  const foundedCandidate = await enrolledCandidateRepository.get({ id: editedCandidate.id });
+  const foundCandidate = await enrolledCandidateRepository.get({ id: editedCandidate.id });
 
-  if (!foundedCandidate) {
+  if (!foundCandidate) {
     throw new CertificationCandidateNotFoundError();
   }
 
-  if (foundedCandidate.isLinkedToAUser()) {
+  if (foundCandidate.isLinkedToAUser()) {
     throw new CandidateAlreadyLinkedToUserError();
   }
 
   const candidate = new Candidate({
-    ...foundedCandidate,
+    ...foundCandidate,
     accessibilityAdjustmentNeeded: editedCandidate.accessibilityAdjustmentNeeded,
   });
 

--- a/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
@@ -189,6 +189,7 @@ function adaptModelToDb(candidate) {
     billingMode: candidate.billingMode,
     prepaymentCode: candidate.prepaymentCode,
     hasSeenCertificationInstructions: candidate.hasSeenCertificationInstructions,
+    accessibilityAdjustmentNeeded: candidate.accessibilityAdjustmentNeeded,
   };
 }
 

--- a/api/src/certification/enrolment/infrastructure/repositories/enrolled-candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/enrolled-candidate-repository.js
@@ -8,7 +8,7 @@ export async function findBySessionId({ sessionId }) {
   return candidatesData.map(toDomain).sort(sortAlphabeticallyByLastNameThenFirstName);
 }
 
-export async function get(id) {
+export async function get({ id }) {
   const candidateData = await buildBaseReadQuery(knex).where({ 'certification-candidates.id': id }).first();
 
   if (!candidateData) return null;

--- a/api/src/certification/enrolment/infrastructure/serializers/enrolled-candidate-serializer.js
+++ b/api/src/certification/enrolment/infrastructure/serializers/enrolled-candidate-serializer.js
@@ -1,5 +1,14 @@
 import { Serializer } from 'jsonapi-serializer';
 
+import { EditedCandidate } from '../../domain/models/EditedCandidate.js';
+
+const deserialize = function ({ candidateId, candidateData }) {
+  return new EditedCandidate({
+    id: candidateId,
+    accessibilityAdjustmentNeeded: candidateData['accessibility-adjustment-needed'],
+  });
+};
+
 const serialize = function (enrolledCandidates) {
   return new Serializer('certification-candidate', {
     transform: function (enrolledCandidate) {
@@ -50,4 +59,4 @@ const serializeForParticipation = function (enrolledCandidate) {
   }).serialize(enrolledCandidate);
 };
 
-export { serialize, serializeForParticipation };
+export { deserialize, serialize, serializeForParticipation };

--- a/api/tests/certification/enrolment/acceptance/application/certification-candidate-route_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/certification-candidate-route_test.js
@@ -6,6 +6,7 @@ import {
   databaseBuilder,
   expect,
   generateValidRequestAuthorizationHeader,
+  knex,
 } from '../../../../test-helper.js';
 
 const { ROLES } = PIX_ADMIN;
@@ -145,6 +146,7 @@ describe('Acceptance | Controller | Session | certification-candidate-route', fu
         sessionId,
         userId: null,
         billingMode: CertificationCandidate.BILLING_MODES.PREPAID,
+        accessibilityAdjustmentNeeded: false,
       }).id;
       const cleaComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
         id: 10000006,
@@ -180,6 +182,11 @@ describe('Acceptance | Controller | Session | certification-candidate-route', fu
       const response = await server.inject(options);
 
       // then
+      const [{ accessibilityAdjustmentNeeded: candidateAccessibilityAdjustmentNeededExpected }] = await knex
+        .select('accessibilityAdjustmentNeeded')
+        .from('certification-candidates')
+        .where({ id: candidateId });
+      expect(candidateAccessibilityAdjustmentNeededExpected).to.equal(true);
       expect(response.statusCode).to.equal(204);
     });
   });

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
@@ -58,7 +58,7 @@ describe('Integration | Certification | Session | Repository | Candidate', funct
 
   describe('#findBySessionId', function () {
     context('when there are candidates', function () {
-      it('should return the candidate', async function () {
+      it('should return the candidates', async function () {
         // given
         const sessionId = databaseBuilder.factory.buildSession().id;
         databaseBuilder.factory.buildComplementaryCertification({

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/enrolled-candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/enrolled-candidate-repository_test.js
@@ -266,7 +266,7 @@ describe('Certification | Enrolment | Integration | Repository | EnrolledCandida
 
     it('should return null when candidate not found', async function () {
       // when
-      const actualEnrolledCandidate = await enrolledCandidateRepository.get(999999);
+      const actualEnrolledCandidate = await enrolledCandidateRepository.get({ id: 999999 });
 
       // then
       expect(actualEnrolledCandidate).to.be.null;
@@ -274,7 +274,7 @@ describe('Certification | Enrolment | Integration | Repository | EnrolledCandida
 
     it('should return the candidate when found', async function () {
       // when
-      const actualEnrolledCandidate = await enrolledCandidateRepository.get(michelId);
+      const actualEnrolledCandidate = await enrolledCandidateRepository.get({ id: michelId });
 
       // then
       expect(actualEnrolledCandidate).to.deepEqualInstance(
@@ -306,7 +306,7 @@ describe('Certification | Enrolment | Integration | Repository | EnrolledCandida
       await databaseBuilder.commit();
 
       // when
-      const actualEnrolledCandidate = await enrolledCandidateRepository.get(michelId);
+      const actualEnrolledCandidate = await enrolledCandidateRepository.get({ id: michelId });
 
       // then
       expect(actualEnrolledCandidate).to.deepEqualInstance(

--- a/api/tests/certification/enrolment/unit/application/certification-candidate-controller_test.js
+++ b/api/tests/certification/enrolment/unit/application/certification-candidate-controller_test.js
@@ -1,4 +1,5 @@
 import { certificationCandidateController } from '../../../../../src/certification/enrolment/application/certification-candidate-controller.js';
+import { EditedCandidate } from '../../../../../src/certification/enrolment/domain/models/EditedCandidate.js';
 import { usecases } from '../../../../../src/certification/enrolment/domain/usecases/index.js';
 import { normalize } from '../../../../../src/shared/infrastructure/utils/string-utils.js';
 import { expect, hFake, sinon } from '../../../../test-helper.js';
@@ -98,6 +99,38 @@ describe('Unit | Controller | certification-candidate-controller', function () {
 
       // then
       expect(response).to.deep.equal(enrolledCandidatesJsonAPI);
+    });
+  });
+
+  describe('#updateEnrolledCandidate', function () {
+    it('should call the usecase with correct data and return 204 NoContent', async function () {
+      // given
+      sinon.stub(usecases, 'updateEnrolledCandidate');
+      usecases.updateEnrolledCandidate.resolves();
+      const request = {
+        params: {
+          certificationCandidateId: 123,
+        },
+        payload: {
+          data: {
+            attributes: {
+              'accessibility-adjustment-needed': true,
+            },
+          },
+        },
+      };
+
+      // when
+      const response = await certificationCandidateController.updateEnrolledCandidate(request, hFake);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+      expect(usecases.updateEnrolledCandidate).to.have.been.calledWithExactly({
+        editedCandidate: new EditedCandidate({
+          id: 123,
+          accessibilityAdjustmentNeeded: request.payload.data.attributes['accessibility-adjustment-needed'],
+        }),
+      });
     });
   });
 });

--- a/api/tests/certification/enrolment/unit/application/certification-candidate-route_test.js
+++ b/api/tests/certification/enrolment/unit/application/certification-candidate-route_test.js
@@ -214,6 +214,120 @@ describe('Unit | Application | Sessions | Routes', function () {
     });
   });
 
+  describe('PATCH /api/sessions/{id}/certification-candidates/{certificationCandidateId}', function () {
+    const method = 'PATCH';
+
+    it('should return 204', async function () {
+      // given
+      sinon.stub(authorization, 'verifySessionAuthorization').returns(null);
+      sinon
+        .stub(certificationCandidateController, 'updateEnrolledCandidate')
+        .callsFake((_, h) => h.response().code(204));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const id = 123;
+      const certificationCandidateId = 456;
+      const url = `/api/sessions/${id}/certification-candidates/${certificationCandidateId}`;
+      const payload = {
+        data: {
+          attributes: {
+            'accessibility-adjustment-needed': true,
+          },
+        },
+      };
+
+      // when
+      const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+    });
+
+    context('when the user is not authorized on the session', function () {
+      it('should return 404', async function () {
+        // given
+        sinon.stub(authorization, 'verifySessionAuthorization').throws(new NotFoundError());
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const id = 123;
+        const certificationCandidateId = 456;
+        const url = `/api/sessions/${id}/certification-candidates/${certificationCandidateId}`;
+        const payload = {
+          data: {
+            attributes: {
+              'accessibility-adjustment-needed': true,
+            },
+          },
+        };
+
+        // when
+        const response = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(response.statusCode).to.equal(404);
+      });
+    });
+
+    context('when id params is not a number', function () {
+      it('should return 400', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const id = 'wrongType';
+        const certificationCandidateId = 456;
+        const url = `/api/sessions/${id}/certification-candidates/${certificationCandidateId}`;
+
+        // when
+        const response = await httpTestServer.request(method, url);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+
+    context('when certificationCandidateId params is not a number', function () {
+      it('should return 400', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const id = 123;
+        const certificationCandidateId = 'wrongType';
+        const url = `/api/sessions/${id}/certification-candidates/${certificationCandidateId}`;
+
+        // when
+        const response = await httpTestServer.request(method, url);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+
+    context('when the payload is incorrect', function () {
+      it('should return 400', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const id = 123;
+        const certificationCandidateId = 456;
+        const url = `/api/sessions/${id}/certification-candidates/${certificationCandidateId}`;
+        const payload = {
+          accessibilityAdjustmentNeeded: 'wrongType',
+        };
+
+        // when
+        const response = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+  });
+
   describe('id validation', function () {
     // eslint-disable-next-line mocha/no-setup-in-describe
     [

--- a/api/tests/certification/enrolment/unit/domain/usecases/update-enrolled-candidate_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/update-enrolled-candidate_test.js
@@ -25,12 +25,12 @@ describe('Unit | UseCase | update-enrolled-candidate', function () {
   context('when the  candidate is found and not linked to a user', function () {
     it('should call update method with correct data', async function () {
       // given
-      const foundedCandidate = domainBuilder.certification.enrolment.buildEnrolledCandidate({
+      const foundCandidate = domainBuilder.certification.enrolment.buildEnrolledCandidate({
         userId: null,
         accessibilityAdjustmentNeeded: false,
         createdAt,
       });
-      enrolledCandidateRepository.get.withArgs({ id: editedCandidate.id }).resolves(foundedCandidate);
+      enrolledCandidateRepository.get.withArgs({ id: editedCandidate.id }).resolves(foundCandidate);
       enrolledCandidateRepository.update.resolves();
 
       // when
@@ -41,7 +41,7 @@ describe('Unit | UseCase | update-enrolled-candidate', function () {
 
       // then
       const candidate = domainBuilder.certification.enrolment.buildCandidate({
-        ...foundedCandidate,
+        ...foundCandidate,
         accessibilityAdjustmentNeeded: editedCandidate.accessibilityAdjustmentNeeded,
       });
 
@@ -70,12 +70,12 @@ describe('Unit | UseCase | update-enrolled-candidate', function () {
   context('when the candidate is linked to a user', function () {
     it('should call update method with correct data', async function () {
       // given
-      const foundedCandidate = domainBuilder.certification.enrolment.buildEnrolledCandidate({
+      const foundCandidate = domainBuilder.certification.enrolment.buildEnrolledCandidate({
         id: editedCandidate.id,
         accessibilityAdjustmentNeeded: false,
         userId: 123,
       });
-      enrolledCandidateRepository.get.withArgs({ id: editedCandidate.id }).resolves(foundedCandidate);
+      enrolledCandidateRepository.get.withArgs({ id: editedCandidate.id }).resolves(foundCandidate);
 
       // when
       const error = await catchErr(updateEnrolledCandidate)({

--- a/api/tests/certification/enrolment/unit/domain/usecases/update-enrolled-candidate_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/update-enrolled-candidate_test.js
@@ -1,0 +1,66 @@
+import { updateEnrolledCandidate } from '../../../../../../src/certification/enrolment/domain/usecases/update-enrolled-candidate.js';
+import { CertificationCandidateNotFoundError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | UseCase | update-enrolled-candidate', function () {
+  let enrolledCandidateRepository;
+  let editedCandidate;
+  let createdAt;
+
+  beforeEach(function () {
+    enrolledCandidateRepository = {
+      get: sinon.stub(),
+      update: sinon.stub(),
+    };
+    createdAt = new Date();
+    editedCandidate = domainBuilder.certification.enrolment.buildEditedCandidate({
+      id: 123,
+      accessibilityAdjustmentNeeded: true,
+    });
+  });
+
+  context('when the candidate is found', function () {
+    it('should call update method with correct data', async function () {
+      // given
+      const foundedCandidate = domainBuilder.certification.enrolment.buildEnrolledCandidate({
+        id: editedCandidate.id,
+        accessibilityAdjustmentNeeded: false,
+        createdAt,
+      });
+      enrolledCandidateRepository.get.withArgs({ id: editedCandidate.id }).resolves(foundedCandidate);
+      enrolledCandidateRepository.update.resolves();
+
+      // when
+      await updateEnrolledCandidate({
+        editedCandidate,
+        enrolledCandidateRepository,
+      });
+
+      // then
+      const candidate = domainBuilder.certification.enrolment.buildCandidate({
+        ...foundedCandidate,
+        accessibilityAdjustmentNeeded: editedCandidate.accessibilityAdjustmentNeeded,
+      });
+
+      expect(enrolledCandidateRepository.update).to.have.been.calledOnceWithExactly({
+        candidate,
+      });
+    });
+  });
+
+  context('when the candidate is not found', function () {
+    it('should throw a CertificationCandidateNotFoundError', async function () {
+      // given
+      enrolledCandidateRepository.get.withArgs({ id: 123 }).resolves(null);
+
+      // when
+      const error = await catchErr(updateEnrolledCandidate)({
+        editedCandidate,
+        enrolledCandidateRepository,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(CertificationCandidateNotFoundError);
+    });
+  });
+});

--- a/api/tests/certification/enrolment/unit/domain/usecases/update-enrolled-candidate_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/update-enrolled-candidate_test.js
@@ -6,12 +6,12 @@ import {
 import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | update-enrolled-candidate', function () {
-  let enrolledCandidateRepository;
+  let candidateRepository;
   let editedCandidate;
   let createdAt;
 
   beforeEach(function () {
-    enrolledCandidateRepository = {
+    candidateRepository = {
       get: sinon.stub(),
       update: sinon.stub(),
     };
@@ -25,18 +25,18 @@ describe('Unit | UseCase | update-enrolled-candidate', function () {
   context('when the  candidate is found and not linked to a user', function () {
     it('should call update method with correct data', async function () {
       // given
-      const foundCandidate = domainBuilder.certification.enrolment.buildEnrolledCandidate({
+      const foundCandidate = domainBuilder.certification.enrolment.buildCandidate({
         userId: null,
         accessibilityAdjustmentNeeded: false,
         createdAt,
       });
-      enrolledCandidateRepository.get.withArgs({ id: editedCandidate.id }).resolves(foundCandidate);
-      enrolledCandidateRepository.update.resolves();
+      candidateRepository.get.withArgs({ certificationCandidateId: editedCandidate.id }).resolves(foundCandidate);
+      candidateRepository.update.resolves();
 
       // when
       await updateEnrolledCandidate({
         editedCandidate,
-        enrolledCandidateRepository,
+        candidateRepository,
       });
 
       // then
@@ -45,21 +45,19 @@ describe('Unit | UseCase | update-enrolled-candidate', function () {
         accessibilityAdjustmentNeeded: editedCandidate.accessibilityAdjustmentNeeded,
       });
 
-      expect(enrolledCandidateRepository.update).to.have.been.calledOnceWithExactly({
-        candidate,
-      });
+      expect(candidateRepository.update).to.have.been.calledOnceWithExactly(candidate);
     });
   });
 
   context('when the candidate is not found', function () {
     it('should throw a CertificationCandidateNotFoundError', async function () {
       // given
-      enrolledCandidateRepository.get.withArgs({ id: 123 }).resolves(null);
+      candidateRepository.get.withArgs({ id: 123 }).resolves(null);
 
       // when
       const error = await catchErr(updateEnrolledCandidate)({
         editedCandidate,
-        enrolledCandidateRepository,
+        candidateRepository,
       });
 
       // then
@@ -70,17 +68,17 @@ describe('Unit | UseCase | update-enrolled-candidate', function () {
   context('when the candidate is linked to a user', function () {
     it('should call update method with correct data', async function () {
       // given
-      const foundCandidate = domainBuilder.certification.enrolment.buildEnrolledCandidate({
+      const foundCandidate = domainBuilder.certification.enrolment.buildCandidate({
         id: editedCandidate.id,
         accessibilityAdjustmentNeeded: false,
         userId: 123,
       });
-      enrolledCandidateRepository.get.withArgs({ id: editedCandidate.id }).resolves(foundCandidate);
+      candidateRepository.get.withArgs({ certificationCandidateId: editedCandidate.id }).resolves(foundCandidate);
 
       // when
       const error = await catchErr(updateEnrolledCandidate)({
         editedCandidate,
-        enrolledCandidateRepository,
+        candidateRepository,
       });
 
       // then

--- a/api/tests/tooling/domain-builder/factory/certification/enrolment/build-candidate.js
+++ b/api/tests/tooling/domain-builder/factory/certification/enrolment/build-candidate.js
@@ -24,6 +24,7 @@ const buildCandidate = function ({
   prepaymentCode = null,
   hasSeenCertificationInstructions = false,
   subscriptions = [],
+  accessibilityAdjustmentNeeded,
 } = {}) {
   return new Candidate({
     id,
@@ -49,6 +50,7 @@ const buildCandidate = function ({
     prepaymentCode,
     hasSeenCertificationInstructions,
     subscriptions,
+    accessibilityAdjustmentNeeded,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/certification/enrolment/build-edited-candidate.js
+++ b/api/tests/tooling/domain-builder/factory/certification/enrolment/build-edited-candidate.js
@@ -1,0 +1,10 @@
+import { EditedCandidate } from '../../../../../../src/certification/enrolment/domain/models/EditedCandidate.js';
+
+const buildEditedCandidate = function ({ id = 123, accessibilityAdjustmentNeeded = false } = {}) {
+  return new EditedCandidate({
+    id,
+    accessibilityAdjustmentNeeded,
+  });
+};
+
+export { buildEditedCandidate };

--- a/api/tests/tooling/domain-builder/factory/certification/enrolment/build-enrolled-candidate.js
+++ b/api/tests/tooling/domain-builder/factory/certification/enrolment/build-enrolled-candidate.js
@@ -18,7 +18,7 @@ const buildEnrolledCandidate = function ({
   externalId = 'externalId',
   userId = 789,
   sessionId = 456,
-  organizationLearnerId,
+  organizationLearnerId = null,
   billingMode = null,
   prepaymentCode = null,
   subscriptions = [],

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -173,6 +173,7 @@ import { buildV3CertificationCourseDetailsForAdministration } from './build-v3-c
 import { buildValidation } from './build-validation.js';
 import { buildValidator } from './build-validator.js';
 import { buildCandidate } from './certification/enrolment/build-candidate.js';
+import { buildEditedCandidate } from './certification/enrolment/build-edited-candidate.js';
 import { buildEnrolledCandidate } from './certification/enrolment/build-enrolled-candidate.js';
 import { buildSessionEnrolment } from './certification/enrolment/build-session.js';
 import {
@@ -215,6 +216,7 @@ const certification = {
     buildCandidate,
     buildCoreSubscription,
     buildComplementarySubscription,
+    buildEditedCandidate,
     buildSubscription,
     buildUser: buildUserEnrolment,
   },

--- a/certif/app/adapters/certification-candidate.js
+++ b/certif/app/adapters/certification-candidate.js
@@ -52,4 +52,18 @@ export default class CertificationCandidateAdapter extends ApplicationAdapter {
 
     return super.createRecord(...arguments);
   }
+
+  updateRecord({ candidate, sessionId }) {
+    const certificationCandidateId = candidate.id;
+    const payload = {
+      data: {
+        attributes: {
+          'accessibility-adjustment-needed': candidate.accessibilityAdjustmentNeeded,
+        },
+      },
+    };
+    const url = `${this.host}/${this.namespace}/sessions/${sessionId}/certification-candidates/${certificationCandidateId}`;
+
+    return this.ajax(url, 'PATCH', { data: payload });
+  }
 }

--- a/certif/app/components/edit-candidate-modal/index.gjs
+++ b/certif/app/components/edit-candidate-modal/index.gjs
@@ -1,0 +1,63 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
+import PixInput from '@1024pix/pix-ui/components/pix-input';
+import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+
+export default class EditCandidateModal extends Component {
+  closeModal = () => {
+    this.args.candidate.rollbackAttributes();
+    this.args.closeModal();
+  };
+
+  <template>
+    <PixModal
+      @title={{t 'pages.sessions.detail.candidates.edit-modal.title'}}
+      class='edit-candidate-modal'
+      @showModal={{@showModal}}
+      @onCloseButtonClick={{this.closeModal}}
+    >
+      <:content>
+        <form id='edit-candidate-form' class='edit-candidate-modal__form'>
+          <div class='edit-candidate-modal-form__disabled-fields'>
+            <PixInput @id='last-name' autocomplete='off' disabled='true' value={{@candidate.lastName}}>
+              <:label>{{t 'common.labels.candidate.birth-name'}}</:label>
+            </PixInput>
+            <PixInput @id='first-name' autocomplete='off' disabled='true' value={{@candidate.firstName}}>
+              <:label>{{t 'common.labels.candidate.firstname'}}</:label>
+            </PixInput>
+          </div>
+
+          <fieldset class='edit-candidate-modal-form__accessibility-adjustment'>
+            <legend class='edit-candidate-modal-form-accessibility-adjustment__legend'>{{t
+                'pages.sessions.detail.candidates.edit-modal.accessibility-adjustment.title'
+              }}</legend>
+            <span id='adjustment-details'>{{t
+                'pages.sessions.detail.candidates.edit-modal.accessibility-adjustment.details'
+              }}</span>
+            <PixCheckbox
+              aria-describedby='adjustment-details'
+              @checked={{@candidate.accessibilityAdjustmentNeeded}}
+              {{on 'change' (fn @updateCandidateDataFromValue @candidate 'accessibilityAdjustmentNeeded')}}
+            >
+              <:label>
+                {{t 'pages.sessions.detail.candidates.edit-modal.accessibility-adjustment.label'}}
+              </:label>
+            </PixCheckbox>
+          </fieldset>
+        </form>
+      </:content>
+      <:footer>
+        <PixButton @triggerAction={{this.closeModal}} @variant='secondary' @isBorderVisible='true'>
+          {{t 'common.actions.cancel'}}
+        </PixButton>
+        <PixButton @type='submit' form='edit-candidate-form'>
+          {{t 'common.actions.update'}}
+        </PixButton>
+      </:footer>
+    </PixModal>
+  </template>
+}

--- a/certif/app/components/edit-candidate-modal/index.gjs
+++ b/certif/app/components/edit-candidate-modal/index.gjs
@@ -21,7 +21,7 @@ export default class EditCandidateModal extends Component {
       @onCloseButtonClick={{this.closeModal}}
     >
       <:content>
-        <form id='edit-candidate-form' class='edit-candidate-modal__form'>
+        <form id='edit-candidate-form' class='edit-candidate-modal__form' {{on 'submit' @updateCandidate}}>
           <div class='edit-candidate-modal-form__disabled-fields'>
             <PixInput @id='last-name' autocomplete='off' disabled='true' value={{@candidate.lastName}}>
               <:label>{{t 'common.labels.candidate.birth-name'}}</:label>

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -226,3 +226,10 @@
   @updateCandidateDataFromValue={{this.updateCertificationCandidateInStagingFieldFromValue}}
   @shouldDisplayPaymentOptions={{@shouldDisplayPaymentOptions}}
 />
+
+<EditCandidateModal
+  @showModal={{this.shouldDisplayEditCertificationCandidateModal}}
+  @closeModal={{this.closeEditCandidateModal}}
+  @candidate={{this.certificationCandidateInEditModal}}
+  @updateCandidateDataFromValue={{this.updateEditCandidateInStagingFieldFromValue}}
+/>

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -232,4 +232,5 @@
   @closeModal={{this.closeEditCandidateModal}}
   @candidate={{this.certificationCandidateInEditModal}}
   @updateCandidateDataFromValue={{this.updateEditCandidateInStagingFieldFromValue}}
+  @updateCandidate={{this.updateCandidate}}
 />

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -132,6 +132,37 @@
                       </button>
                     </div>
                   {{/unless}}
+                  {{#if this.shouldDisplayAccessibilityAdjustmentNeededFeature}}
+                    <div class="certification-candidates-actions__edit">
+                      {{#if candidate.isLinked}}
+                        <PixTooltip @position="left" @isInline={{true}} @id="tooltip-edit-student-button">
+                          <:triggerElement>
+                            <PixIconButton
+                              @icon="pen-to-square"
+                              class="certification-candidates-actions__edit-button--disabled"
+                              aria-label="{{t
+                                'pages.sessions.detail.candidates.list.actions.edit.extra-information'
+                              }} {{candidate.firstName}} {{candidate.lastName}}"
+                              aria-disabled="true"
+                              aria-describedby="tooltip-edit-student-button"
+                              @withBackground={{true}}
+                            />
+                          </:triggerElement>
+                          <:tooltip>{{t "pages.sessions.detail.candidates.list.actions.edit.tooltip"}}</:tooltip>
+                        </PixTooltip>
+                      {{else}}
+                        <PixIconButton
+                          @icon="pen-to-square"
+                          {{on "click" (fn this.openEditCertificationCandidateDetailsModal candidate)}}
+                          aria-label="{{t
+                            'pages.sessions.detail.candidates.list.actions.edit.extra-information'
+                          }} {{candidate.firstName}} {{candidate.lastName}}"
+                          class="certification-candidates-actions__edit-button"
+                          @withBackground={{true}}
+                        />
+                      {{/if}}
+                    </div>
+                  {{/if}}
                   <div class="certification-candidates-actions__delete">
                     {{#if candidate.isLinked}}
                       <PixTooltip @position="left" @isInline={{true}} @id="tooltip-delete-student-button">

--- a/certif/app/components/enrolled-candidates.js
+++ b/certif/app/components/enrolled-candidates.js
@@ -19,6 +19,7 @@ export default class EnrolledCandidates extends Component {
   @tracked shouldDisplayCertificationCandidateModal = false;
   @tracked shouldDisplayEditCertificationCandidateModal = false;
   @tracked certificationCandidateInDetailsModal = null;
+  @tracked certificationCandidateInEditModal = null;
   @tracked showNewCandidateModal = false;
 
   get shouldDisplayAccessibilityAdjustmentNeededFeature() {
@@ -102,6 +103,11 @@ export default class EnrolledCandidates extends Component {
   }
 
   @action
+  updateEditCandidateInStagingFieldFromValue(candidateInStaging, field, event) {
+    candidateInStaging.set(field, event.target.checked);
+  }
+
+  @action
   updateCertificationCandidateInStagingBirthdate(candidateInStaging, value) {
     candidateInStaging.set('birthdate', value);
   }
@@ -142,7 +148,7 @@ export default class EnrolledCandidates extends Component {
   @action
   openEditCertificationCandidateDetailsModal(candidate) {
     this.shouldDisplayEditCertificationCandidateModal = true;
-    this.certificationCandidateInDetailsModal = candidate;
+    this.certificationCandidateInEditModal = candidate;
   }
 
   @action
@@ -160,6 +166,11 @@ export default class EnrolledCandidates extends Component {
   @action
   closeNewCandidateModal() {
     this.showNewCandidateModal = false;
+  }
+
+  @action
+  closeEditCandidateModal() {
+    this.shouldDisplayEditCertificationCandidateModal = false;
   }
 
   _createCertificationCandidateRecord(certificationCandidateData) {

--- a/certif/app/components/enrolled-candidates.js
+++ b/certif/app/components/enrolled-candidates.js
@@ -108,6 +108,21 @@ export default class EnrolledCandidates extends Component {
   }
 
   @action
+  async updateCandidate(event) {
+    event.preventDefault();
+    try {
+      const adapter = this.store.adapterFor('certification-candidate');
+      await adapter.updateRecord({ candidate: this.certificationCandidateInEditModal, sessionId: this.args.sessionId });
+      this.notifications.success(this.intl.t('pages.sessions.detail.candidates.edit-modal.notifications.success'));
+      this.closeEditCandidateModal();
+    } catch (e) {
+      this.notifications.error(this.intl.t('pages.sessions.detail.candidates.edit-modal.notifications.error'));
+    } finally {
+      this.args.reloadCertificationCandidate();
+    }
+  }
+
+  @action
   updateCertificationCandidateInStagingBirthdate(candidateInStaging, value) {
     candidateInStaging.set('birthdate', value);
   }

--- a/certif/app/components/enrolled-candidates.js
+++ b/certif/app/components/enrolled-candidates.js
@@ -17,6 +17,7 @@ export default class EnrolledCandidates extends Component {
   @tracked candidatesInStaging = [];
   @tracked newCandidate = {};
   @tracked shouldDisplayCertificationCandidateModal = false;
+  @tracked shouldDisplayEditCertificationCandidateModal = false;
   @tracked certificationCandidateInDetailsModal = null;
   @tracked showNewCandidateModal = false;
 
@@ -135,6 +136,12 @@ export default class EnrolledCandidates extends Component {
   @action
   openCertificationCandidateDetailsModal(candidate) {
     this.shouldDisplayCertificationCandidateModal = true;
+    this.certificationCandidateInDetailsModal = candidate;
+  }
+
+  @action
+  openEditCertificationCandidateDetailsModal(candidate) {
+    this.shouldDisplayEditCertificationCandidateModal = true;
     this.certificationCandidateInDetailsModal = candidate;
   }
 

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -33,6 +33,7 @@ $navbar-height: 60px;
 @import 'components/add-issue-report-modal';
 @import 'components/certification-candidate-details-modal/index';
 @import 'components/certification-candidate-details-modal/row';
+@import 'components/edit-candidate-modal';
 @import 'components/issue-report-modal';
 @import 'components/layout/footer';
 @import 'components/login-form';

--- a/certif/app/styles/components/edit-candidate-modal.scss
+++ b/certif/app/styles/components/edit-candidate-modal.scss
@@ -1,0 +1,25 @@
+.edit-candidate-modal__form {
+  display: flex;
+  flex-flow: column wrap;
+  gap: var(--pix-spacing-4x);
+}
+
+.edit-candidate-modal-form {
+  &__disabled-fields {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 10px;
+  }
+
+  &__accessibility-adjustment {
+    display: flex;
+    flex-flow: column wrap;
+    gap: var(--pix-spacing-1x);
+  }
+}
+
+.edit-candidate-modal-form-accessibility-adjustment__legend {
+  color: var(--pix-neutral-900);
+  font-weight: var(--pix-font-medium);
+  font-size: 1rem;
+}

--- a/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
@@ -184,12 +184,13 @@
   align-items: center;
   justify-content: flex-end;
   padding-right: 16px;
+  gap: var(--pix-spacing-2x);
 
   &__display-details {
     margin-right: 16px;
   }
 
-  &__delete {
+  &__delete, &__edit {
 
     display: flex;
     justify-content: center;

--- a/certif/config/icons.js
+++ b/certif/config/icons.js
@@ -12,6 +12,7 @@ module.exports = function () {
       'file-download',
       'info',
       'link',
+      'pen-to-square',
       'plus-circle',
       'power-off',
       'redo',

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -114,6 +114,10 @@ function routes() {
     });
   });
 
+  this.patch('/sessions/:id/certification-candidates/:candidateId', function () {
+    return new Response(204);
+  });
+
   this.post('/certification-reports/:id/certification-issue-reports', function (schema, request) {
     const certificationCourseId = request.params.id;
     const requestBody = JSON.parse(request.requestBody);

--- a/certif/tests/acceptance/session-details-certification-candidates-test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates-test.js
@@ -206,6 +206,8 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
               certificationCenterId: allowedCertificationCenterAccess.id,
             });
             server.create('certification-candidate', {
+              firstName: 'John',
+              lastName: 'Doe',
               sessionId: session.id,
               accessibilityAdjustedCertificationNeeded: true,
             });
@@ -217,13 +219,26 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
 
           test('should display accessibility adjusted certification needed information', async function (assert) {
             // given
-
-            // when
             const screen = await visit(`/sessions/${session.id}/candidats`);
 
             // then
             assert.dom(screen.getByRole('columnheader', { name: 'Accessibilité' })).exists();
             assert.dom(screen.getByRole('cell', { name: 'Oui' })).exists();
+          });
+
+          test('should be possible to update candidate information', async function (assert) {
+            // given
+            const screen = await visit(`/sessions/${session.id}/candidats`);
+            assert.dom(screen.getByRole('columnheader', { name: 'Accessibilité' })).exists();
+            assert.dom(screen.getByRole('cell', { name: 'Oui' })).exists();
+
+            // when
+            await click(screen.getByRole('button', { name: 'Editer le candidat John Doe' }));
+            await click(screen.getByText("Le candidat a besoin d'un aménagement"));
+            await click(screen.getByText('Modifier'));
+
+            // then
+            assert.dom(screen.queryByRole('cell', { name: 'Oui' })).doesNotExist();
           });
         },
       );

--- a/certif/tests/integration/components/edit-candidate-modal/index-test.gjs
+++ b/certif/tests/integration/components/edit-candidate-modal/index-test.gjs
@@ -19,6 +19,7 @@ module('Integration | Component | edit-candidate-modal', function (hooks) {
 
     const closeModalStub = sinon.stub();
     const updateCandidateDataFromValueStub = sinon.stub();
+    const updateCandidateStub = sinon.stub();
 
     // when
     const screen = await render(
@@ -28,6 +29,7 @@ module('Integration | Component | edit-candidate-modal', function (hooks) {
           @closeModal={{closeModalStub}}
           @candidate={{candidate}}
           @updateCandidateDataFromValue={{updateCandidateDataFromValueStub}}
+          @updateCandidate={{updateCandidateStub}}
         />
       </template>,
     );

--- a/certif/tests/integration/components/edit-candidate-modal/index-test.gjs
+++ b/certif/tests/integration/components/edit-candidate-modal/index-test.gjs
@@ -1,0 +1,55 @@
+import { render } from '@1024pix/ember-testing-library';
+import EditCandidateModal from 'pix-certif/components/edit-candidate-modal';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | edit-candidate-modal', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it shows form', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const candidate = store.createRecord('certification-candidate', {
+      firstName: 'Jean',
+      lastName: 'De la fontaine',
+      accessibilityAdjustmentNeeded: false,
+    });
+
+    const closeModalStub = sinon.stub();
+    const updateCandidateDataFromValueStub = sinon.stub();
+
+    // when
+    const screen = await render(
+      <template>
+        <EditCandidateModal
+          @showModal={{true}}
+          @closeModal={{closeModalStub}}
+          @candidate={{candidate}}
+          @updateCandidateDataFromValue={{updateCandidateDataFromValueStub}}
+        />
+      </template>,
+    );
+
+    // then
+    const lastNameInput = screen.getByRole('textbox', { name: 'Nom de naissance' });
+    const firstNameInput = screen.getByRole('textbox', { name: 'Prénom' });
+
+    assert.dom(lastNameInput).hasValue('De la fontaine');
+    assert.dom(lastNameInput).hasAttribute('disabled');
+    assert.dom(firstNameInput).hasValue('Jean');
+    assert.dom(firstNameInput).hasAttribute('disabled');
+    assert
+      .dom(
+        screen.getByRole('checkbox', {
+          name: "Le candidat a besoin d'un aménagement",
+          description: "L'aménagement consiste à retirer les questions non accessibles",
+          checked: false,
+        }),
+      )
+      .exists();
+    assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
+    assert.dom(screen.getByRole('button', { name: 'Modifier' })).exists();
+  });
+});

--- a/certif/tests/integration/components/enrolled-candidates-test.js
+++ b/certif/tests/integration/components/enrolled-candidates-test.js
@@ -12,7 +12,9 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   const DELETE_BUTTON_SELECTOR = 'certification-candidates-actions__delete-button';
+  const EDIT_BUTTON_SELECTOR = 'certification-candidates-actions__edit-button';
   const DELETE_BUTTON_DISABLED_SELECTOR = `${DELETE_BUTTON_SELECTOR}--disabled`;
+  const EDIT_BUTTON_DISABLED_SELECTOR = `${EDIT_BUTTON_SELECTOR}--disabled`;
 
   let store;
 
@@ -153,6 +155,59 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
         this.owner.register('service:feature-toggles', FeatureTogglesStub);
       });
 
+      test('it display candidates with an edit button', async function (assert) {
+        // given
+        const certificationCandidates = [
+          _buildCertificationCandidate({
+            id: 1,
+            firstName: 'Riri',
+            lastName: 'Duck',
+            isLinked: false,
+            subscriptions: [],
+          }),
+          _buildCertificationCandidate({
+            id: 2,
+            firstName: 'Fifi',
+            lastName: 'Duck',
+            isLinked: true,
+            subscriptions: [],
+          }),
+          _buildCertificationCandidate({
+            id: 3,
+            firstName: 'Loulou',
+            lastName: 'Duck',
+            isLinked: false,
+            subscriptions: [],
+          }),
+        ].map((candidateData) => store.createRecord('certification-candidate', candidateData));
+        const countries = store.createRecord('country', { name: 'CANADA', code: 99401 });
+
+        this.set('countries', [countries]);
+        this.set('certificationCandidates', certificationCandidates);
+
+        // when
+        const screen = await renderScreen(hbs`<EnrolledCandidates
+  @sessionId='1'
+  @certificationCandidates={{this.certificationCandidates}}
+  @countries={{this.countries}}
+/>`);
+
+        // then
+
+        // then
+        assert.dom(screen.getByRole('button', { name: 'Editer le candidat Riri Duck' })).hasClass(EDIT_BUTTON_SELECTOR);
+        assert
+          .dom(screen.getByRole('button', { name: 'Editer le candidat Fifi Duck' }))
+          .hasClass(EDIT_BUTTON_DISABLED_SELECTOR);
+        assert
+          .dom(screen.getByRole('button', { name: 'Editer le candidat Loulou Duck' }))
+          .hasClass(EDIT_BUTTON_SELECTOR);
+        assert.strictEqual(
+          screen.getAllByText("Ce candidat a déjà rejoint la session. Vous ne pouvez pas l'éditer.").length,
+          1,
+        );
+      });
+
       module('when candidate needs accessibility adjusted certification', function () {
         test('should display candidate needs accessibility adjusted certification', async function (assert) {
           // given
@@ -244,6 +299,41 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
         // then
         assert.dom(screen.queryByRole('columnheader', { name: 'Accessibilité' })).doesNotExist();
         assert.dom(screen.queryByRole('cell', { name: 'Oui' })).doesNotExist();
+      });
+
+      test('it does not display candidates with an edit button', async function (assert) {
+        // given
+        const certificationCandidates = [
+          _buildCertificationCandidate({
+            id: 1,
+            firstName: 'Riri',
+            lastName: 'Duck',
+            isLinked: false,
+            subscriptions: [],
+          }),
+          _buildCertificationCandidate({
+            id: 2,
+            firstName: 'Fifi',
+            lastName: 'Duck',
+            isLinked: true,
+            subscriptions: [],
+          }),
+        ].map((candidateData) => store.createRecord('certification-candidate', candidateData));
+        const countries = store.createRecord('country', { name: 'CANADA', code: 99401 });
+
+        this.set('countries', [countries]);
+        this.set('certificationCandidates', certificationCandidates);
+
+        // when
+        const screen = await renderScreen(hbs`<EnrolledCandidates
+  @sessionId='1'
+  @certificationCandidates={{this.certificationCandidates}}
+  @countries={{this.countries}}
+/>`);
+
+        // then
+        assert.dom(screen.queryByRole('button', { name: 'Editer le candidat Riri Duck' })).doesNotExist();
+        assert.dom(screen.queryByRole('button', { name: 'Editer le candidat Fifi Duck' })).doesNotExist();
       });
     });
   });

--- a/certif/tests/unit/adapters/certification-candidate-test.js
+++ b/certif/tests/unit/adapters/certification-candidate-test.js
@@ -1,6 +1,6 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import { resolve } from 'rsvp';
+import sinon from 'sinon';
 
 module('Unit | Adapters | certification-candidate', function (hooks) {
   setupTest(hooks);
@@ -11,8 +11,7 @@ module('Unit | Adapters | certification-candidate', function (hooks) {
 
   hooks.beforeEach(function () {
     adapter = this.owner.lookup('adapter:certification-candidate');
-    const ajaxStub = () => resolve();
-    adapter.ajax = ajaxStub;
+    adapter.ajax = sinon.stub();
   });
 
   module('#urlForQuery', function () {
@@ -64,6 +63,30 @@ module('Unit | Adapters | certification-candidate', function (hooks) {
 
       // then
       assert.true(url.endsWith(`/sessions/${sessionId}/certification-candidates/${certificationCandidateId}`));
+    });
+  });
+
+  module('#updateRecord', function () {
+    test('should build create url from certification-candidate id', async function (assert) {
+      // given
+      const candidate = { id: 1, accessibilityAdjustmentNeeded: true };
+      const sessionId = 2;
+      const payload = {
+        data: {
+          attributes: {
+            'accessibility-adjustment-needed': candidate.accessibilityAdjustmentNeeded,
+          },
+        },
+      };
+
+      // when
+      await adapter.updateRecord({ candidate, sessionId });
+
+      // then
+      const expectedUrl = 'http://localhost:3000/api/sessions/2/certification-candidates/1';
+
+      sinon.assert.calledWithExactly(adapter.ajax, expectedUrl, 'PATCH', { data: payload });
+      assert.ok(true);
     });
   });
 });

--- a/certif/tests/unit/components/enrolled-candidates-test.js
+++ b/certif/tests/unit/components/enrolled-candidates-test.js
@@ -38,6 +38,77 @@ module('Unit | Component | enrolled-candidates', function (hooks) {
     });
   });
 
+  module('#updateCandidate', function () {
+    module('when update succeeds', function () {
+      test('should update the candidate with appropriate edited parameters', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const adapter = store.adapterFor('certification-candidate');
+        adapter.updateRecord = sinon.stub();
+        adapter.updateRecord.resolves();
+
+        const notifications = this.owner.lookup('service:notifications');
+        notifications.success = sinon.stub();
+
+        const sessionId = 'sessionId';
+        const candidate = _buildCandidate({}, { destroyRecord: sinon.stub() });
+        component.args = {
+          sessionId,
+          reloadCertificationCandidate: sinon.stub(),
+        };
+        component.certificationCandidateInEditModal = candidate;
+
+        const event = {
+          preventDefault: sinon.stub(),
+        };
+
+        // when
+        await component.updateCandidate(event);
+
+        // then
+        sinon.assert.calledOnce(notifications.success);
+        sinon.assert.calledWithExactly(adapter.updateRecord, {
+          candidate: component.certificationCandidateInEditModal,
+          sessionId,
+        });
+        assert.ok(true);
+      });
+    });
+
+    module('when update fails', function () {
+      test('should display an error message', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+
+        const adapter = store.adapterFor('certification-candidate');
+        adapter.updateRecord = sinon.stub();
+        adapter.updateRecord.throws();
+
+        const notifications = this.owner.lookup('service:notifications');
+        notifications.error = sinon.stub();
+
+        const sessionId = 'sessionId';
+        const candidate = _buildCandidate({}, { destroyRecord: sinon.stub() });
+        component.args = {
+          sessionId,
+          reloadCertificationCandidate: sinon.stub(),
+        };
+        component.certificationCandidateInEditModal = candidate;
+
+        const event = {
+          preventDefault: sinon.stub(),
+        };
+
+        // when
+        await component.updateCandidate(event);
+
+        // then
+        sinon.assert.calledOnce(notifications.error);
+        assert.ok(true);
+      });
+    });
+  });
+
   module('#openCertificationCandidateDetailsModal', function () {
     test('should open the candidate details modal', async function (assert) {
       // given

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -585,15 +585,15 @@
               "title": "Digital accessibility adjustment",
               "details": "The adjustment involves removing questions that are not accessible",
               "label": "Candidate needs an adjustment"
+            },
+            "notifications": {
+              "error": "A problem occurred while trying to edit the candidate. Please try again later.",
+              "success": "Canditate's information has been successfully updated."
             }
           },
           "list": {
             "title": "Candidates' list",
             "actions": {
-              "edit": {
-                "extra-information": "Edit the candidate",
-                "tooltip": "This candidate has already joined the session, you can’t edit them."
-              },
               "delete": {
                 "extra-information": "Delete the candidate",
                 "tooltip": "This candidate has already joined the session, you can’t delete them."
@@ -601,6 +601,10 @@
               "details": {
                 "extra-information": "See the candidate’s details",
                 "label": "See details"
+              },
+              "edit": {
+                "extra-information": "Edit the candidate",
+                "tooltip": "This candidate has already joined the session, you can’t edit them."
               },
               "inscription": {
                 "label": "Enrol a candidate"

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -582,6 +582,10 @@
           "list": {
             "title": "Candidates' list",
             "actions": {
+              "edit": {
+                "extra-information": "Edit the candidate",
+                "tooltip": "This candidate has already joined the session, you can’t edit them."
+              },
               "delete": {
                 "extra-information": "Delete the candidate",
                 "tooltip": "This candidate has already joined the session, you can’t delete them."

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -579,6 +579,14 @@
               "close-extra-information": "Close candidate's detail window modal"
             }
           },
+          "edit-modal": {
+            "title": "Edit candidate's details",
+            "accessibility-adjustment": {
+              "title": "Digital accessibility adjustment",
+              "details": "The adjustment involves removing questions that are not accessible",
+              "label": "Candidate needs an adjustment"
+            }
+          },
           "list": {
             "title": "Candidates' list",
             "actions": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -582,6 +582,10 @@
           "list": {
             "title": "Liste des candidats",
             "actions": {
+              "edit": {
+                "extra-information": "Editer le candidat",
+                "tooltip": "Ce candidat a déjà rejoint la session. Vous ne pouvez pas l'éditer."
+              },
               "delete": {
                 "extra-information": "Supprimer le candidat",
                 "tooltip": "Ce candidat a déjà rejoint la session. Vous ne pouvez pas le supprimer."

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -585,15 +585,15 @@
               "title": "Aménagement d'accessibilité numérique",
               "details": "L'aménagement consiste à retirer les questions non accessibles",
               "label": "Le candidat a besoin d'un aménagement"
+            },
+            "notifications": {
+              "error": "Un problème est survenu pendant la mise à jour du candidat. Merci de réessayer ultérieurement.",
+              "success": "Données mises à jour avec succès."
             }
           },
           "list": {
             "title": "Liste des candidats",
             "actions": {
-              "edit": {
-                "extra-information": "Editer le candidat",
-                "tooltip": "Ce candidat a déjà rejoint la session. Vous ne pouvez pas l'éditer."
-              },
               "delete": {
                 "extra-information": "Supprimer le candidat",
                 "tooltip": "Ce candidat a déjà rejoint la session. Vous ne pouvez pas le supprimer."
@@ -601,6 +601,10 @@
               "details": {
                 "extra-information": "Voir le détail du candidat",
                 "label": "Voir le détail"
+              },
+              "edit": {
+                "extra-information": "Editer le candidat",
+                "tooltip": "Ce candidat a déjà rejoint la session. Vous ne pouvez pas l'éditer."
               },
               "inscription": {
                 "label": "Inscrire un candidat"

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -579,6 +579,14 @@
               "close-extra-information": "Fermer la fenêtre de détail du candidat"
             }
           },
+          "edit-modal": {
+            "title": "Modifier les informations d'un candidat",
+            "accessibility-adjustment": {
+              "title": "Aménagement d'accessibilité numérique",
+              "details": "L'aménagement consiste à retirer les questions non accessibles",
+              "label": "Le candidat a besoin d'un aménagement"
+            }
+          },
           "list": {
             "title": "Liste des candidats",
             "actions": {


### PR DESCRIPTION
## :unicorn: Problème

Un centre de certification doit pouvoir déclarer un besoin d’aménagement pour un candidat.

Si pour les centres de certification de type SUP, PRO et ScoIsNOTManagingStudent il est possible de déclarer un besoin de test aménagé à l’inscription d’un candidat, ce n’est pas possible pour le ScoIsManagingStudent qui sélectionne les candidats à inscrire depuis une liste de candidats pré-importée dans Pix Orga.

## :robot: Proposition

![image](https://github.com/user-attachments/assets/438cfb53-3893-4ca7-8e11-b8ad7d4d4f65)

Dans un premier temps, dans le cadre de la v0 et pour toucher TOUS les types de centre de certification, permettre de déclarer le besoin d’un test accessible depuis une modale de modification d’un candidat.

- ajouter une icône de modification depuis la liste des candidats dans Pix Certif
- cliquer sur cette icône affiche une modale “Modifier les informations d’un candidat”
- affichage des champs suivants : 
- Nom de naissance (:warning: et non “Nom de famille” comme sur la maquette)
- Prénom

:warning: contrairement à ce qui est indiqué sur la maquette, ne PAS afficher le champ “Temps majoré” pour le moment (sera fait plus tard)

- Aménagement d’accessibilité numérique
- champ modifiable uniquement jusqu'à ce que le candidat entre en session (= jusqu'à la réconciliation)
- cliquer sur “Modifier” permet de déclarer un besoin de test aménagé pour le candidat concerné

## :rainbow: Remarques

## :100: Pour tester

- Se connecter sur pix-certif avec `certifv3@example.net`
- Choisir le centre pilote Pix/Pix+
- Créer une session
- Ajouter un candidat
- Editer le candidat via la modale en modifiant son statut d'aménagement d'a11y
- Vérifier que le statut a bient été changé dans la liste de candidats
