### PR TITLE
[FEATURE] Le script d'anonymisation ne necessite pas d'admin pour anonymiser (PIX-13798)

### DIFF
--- a/api/src/identity-access-management/scripts/backfill-anonymized-users.js
+++ b/api/src/identity-access-management/scripts/backfill-anonymized-users.js
@@ -32,7 +32,7 @@ export async function backfillAnonymizedUsers() {
   let current = 1;
   for (const anonymizedUserId of anonymizedUserIds) {
     logger.info(`Backfill anonymized user ${current++}/${anonymizedUserIds.length}: "${anonymizedUserId}"`);
-    await withTransaction(usecases.anonymizeUser)({ userId: anonymizedUserId });
+    await withTransaction(usecases.anonymizeUser)({ userId: anonymizedUserId, preventAuditLogging: true });
   }
 
   logger.info(`Anonymized users backfill finished.`);

--- a/api/tests/identity-access-management/acceptance/scripts/backfill-anonymized-users.script.test.js
+++ b/api/tests/identity-access-management/acceptance/scripts/backfill-anonymized-users.script.test.js
@@ -29,4 +29,25 @@ describe('Acceptance | Identity Access Management | Scripts | backfill-anonymize
     expect(notAnonymizedUser.firstName).to.be.equal('Jack');
     expect(notAnonymizedUser.hasBeenAnonymised).to.be.false;
   });
+
+  context('when the anonymized user has been anonymized without hasBeenAnonymisedBy set', function () {
+    it('backfills the anonymized user', async function () {
+      // given
+      const legacyAnonymizedUser = databaseBuilder.factory.buildUser({
+        firstName: 'Jane',
+        hasBeenAnonymised: true,
+        hasBeenAnonymisedBy: null,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      await backfillAnonymizedUsers();
+
+      // then
+      const anonymizedUser = await knex('users').where({ id: legacyAnonymizedUser.id }).first();
+      expect(anonymizedUser.firstName).to.be.equal('(anonymised)');
+      expect(anonymizedUser.hasBeenAnonymised).to.be.true;
+      expect(anonymizedUser.hasBeenAnonymisedBy).to.be.null;
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème

Quand nous avons exécuté le script en recette, celui-ci s'est arrêté car beaucoup d'utilisateurs déjà anonymisés n'ont pas de valeur dans le champ `hasBeenAnonymisedBy`.

## :robot: Proposition

Rendre cette information non-obligatoire (au niveau du use case), elle reste obligatoire au niveau du contrôleur (quand exécuté depuis PixAdmin).

## :rainbow: Remarques

- Une propriété `preventAuditLogging` a été ajoutée sur le use-case pour ne pas exécuter l'audit logger depuis le script.

## :100: Pour tester

- Avoir des utilisateurs déjà anonymisés en base de données dont au moins un avec `hasBeenAnonymisedBy` null.

- Exécuter le script:
```sh
# en local
node src/identity-access-management/scripts/backfill-anonymized-users.js

# sur la RA
scalingo --region osc-fr1 -a pix-api-review-pr9876 run node src/identity-access-management/scripts/backfill-anonymized-users.js
```

- Vérifier que le script est bien passé sur tous les utilisateurs déjà anonymisés en appliquant les nouvelles règles (par exemple: email passé à `null` au lieu de `email_{userID}@example.net`)

