### PR TITLE
[FEATURE] Réorganiser la page Administration en créant 2 nouveaux onglets et déplacer les fonctionnalités

### DIFF
--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -143,6 +143,8 @@ Router.map(function () {
     this.route('administration', function () {
       this.route('common');
       this.route('certification');
+      this.route('deployment');
+      this.route('access');
     });
 
     this.route('tools');

--- a/admin/app/templates/authenticated/administration.hbs
+++ b/admin/app/templates/authenticated/administration.hbs
@@ -18,6 +18,14 @@
         {{t "pages.administration.navigation.certification.label"}}
       </LinkTo>
 
+      <LinkTo @route="authenticated.administration.deployment" class="navbar-item">
+        {{t "pages.administration.navigation.deployment.label"}}
+      </LinkTo>
+
+      <LinkTo @route="authenticated.administration.access" class="navbar-item">
+        {{t "pages.administration.navigation.access.label"}}
+      </LinkTo>
+
     </nav>
 
     {{outlet}}

--- a/admin/app/templates/authenticated/administration/access.hbs
+++ b/admin/app/templates/authenticated/administration/access.hbs
@@ -1,0 +1,3 @@
+<Administration::OidcProvidersImport />
+
+<Administration::AnonymizeGarImport />

--- a/admin/app/templates/authenticated/administration/common.hbs
+++ b/admin/app/templates/authenticated/administration/common.hbs
@@ -1,13 +1,5 @@
 <Administration::LearningContent />
 
-<Tools::NewTag />
-
-<Administration::OrganizationTagsImport />
-
-<Administration::OrganizationsImport />
-
-<Administration::UpdateOrganizationsInBatch />
-
 <Administration::AddOrganizationFeaturesInBatch />
 
 <Administration::CampaignsImport />
@@ -15,7 +7,3 @@
 <Administration::SwapCampaignCodes />
 
 <Administration::UpdateCampaignCode />
-
-<Administration::OidcProvidersImport />
-
-<Administration::AnonymizeGarImport />

--- a/admin/app/templates/authenticated/administration/deployment.hbs
+++ b/admin/app/templates/authenticated/administration/deployment.hbs
@@ -1,0 +1,7 @@
+<Tools::NewTag />
+
+<Administration::OrganizationTagsImport />
+
+<Administration::OrganizationsImport />
+
+<Administration::UpdateOrganizationsInBatch />

--- a/admin/tests/acceptance/administration-test.js
+++ b/admin/tests/acceptance/administration-test.js
@@ -14,7 +14,7 @@ module('Acceptance | administration | common ', function (hooks) {
   });
 
   module('Access', function () {
-    test('Administration page should be accessible from /administration/common', async function (assert) {
+    test('Administration page is accessible from /administration/common', async function (assert) {
       // given & when
       await visit('/administration');
 
@@ -22,7 +22,7 @@ module('Acceptance | administration | common ', function (hooks) {
       assert.strictEqual(currentURL(), '/administration/common');
     });
 
-    test('it should set administration menubar item active', async function (assert) {
+    test('it sets administration menubar item active', async function (assert) {
       // when
       const screen = await visit(`/administration`);
 
@@ -32,7 +32,7 @@ module('Acceptance | administration | common ', function (hooks) {
   });
 
   module('Rendering', function () {
-    test('Should display "Learning content" information', async function (assert) {
+    test('displays "Learning content" information', async function (assert) {
       // given & when
       const screen = await visit('/administration/common');
 
@@ -54,7 +54,7 @@ module('Acceptance | administration | common ', function (hooks) {
   });
 
   module('Refresh cache content', function () {
-    test('it request the cache refresh', async function (assert) {
+    test('it requests the cache refresh', async function (assert) {
       // given
       const screen = await visit('/administration/common');
 
@@ -67,7 +67,7 @@ module('Acceptance | administration | common ', function (hooks) {
   });
 
   module('Create release and refresh cache content', function () {
-    test('it request the release creation and refresh cache', async function (assert) {
+    test('it requests the release creation and refresh cache', async function (assert) {
       // given
       const screen = await visit('/administration/common');
 
@@ -85,20 +85,7 @@ module('Acceptance | administration | common ', function (hooks) {
     });
   });
 
-  test('it should be possible to create a new tag', async function (assert) {
-    // given
-    const screen = await visit('/administration/common');
-
-    // when
-    await fillByLabel('Nom du tag', 'Mon super tag');
-    await clickByName('Créer le tag');
-
-    // then
-    assert.dom(screen.getByText('Le tag a bien été créé !')).exists();
-    assert.dom(screen.getByRole('textbox', { name: 'Nom du tag' })).hasNoValue();
-  });
-
-  test('should display a navigation with tabs', async function (assert) {
+  test('displays a navigation with tabs', async function (assert) {
     // given
     // when
     const screen = await visit('/administration/common');
@@ -107,10 +94,12 @@ module('Acceptance | administration | common ', function (hooks) {
     assert.dom(screen.getByRole('navigation', { name: 'Navigation de la section administration' })).exists();
     assert.dom(screen.getByRole('link', { name: 'Commun' })).exists();
     assert.dom(screen.getByRole('link', { name: 'Certification' })).exists();
+    assert.dom(screen.getByRole('link', { name: 'Accès' })).exists();
+    assert.dom(screen.getByRole('link', { name: 'Déploiement' })).exists();
   });
 
   module('when certification tab is clicked', function () {
-    test('should display certification sections', async function (assert) {
+    test('displays certification sections', async function (assert) {
       // given
       const screen = await visit('/administration/common');
 
@@ -125,11 +114,41 @@ module('Acceptance | administration | common ', function (hooks) {
       assert.dom(screen.getByRole('heading', { name: 'Simulateur de scoring', level: 2 })).exists();
     });
   });
+  module('when access tab is clicked', function () {
+    test('displays Access sections', async function (assert) {
+      // given
+      const screen = await visit('/administration/common');
+
+      // when
+      await click(screen.getByRole('link', { name: 'Accès' }));
+
+      // then
+      assert.dom(screen.getByRole('heading', { name: 'Import d’OIDC Providers', level: 2 })).exists();
+      assert.dom(screen.getByRole('heading', { name: 'Anonymiser les données du GAR', level: 2 })).exists();
+    });
+  });
+  module('when deployment tab is clicked', function () {
+    test('displays Deployment sections', async function (assert) {
+      // given
+      const screen = await visit('/administration/common');
+
+      // when
+      await click(screen.getByRole('link', { name: 'Déploiement' }));
+
+      // then
+      assert.dom(screen.getByRole('heading', { name: 'Créer un nouveau tag', level: 2 })).exists();
+      assert
+        .dom(screen.getByRole('heading', { name: 'Ajout de tags en masse sur des organisations', level: 2 }))
+        .exists();
+      assert.dom(screen.getByRole('heading', { name: "Création d'organisations en masse", level: 2 })).exists();
+      assert.dom(screen.getByRole('heading', { name: 'Modification des organisations en masse', level: 2 })).exists();
+    });
+  });
 
   module('certification tab', function () {
     module('scoring simulator', function () {
       module('when a capacity is given', function () {
-        test('should display a score and competence levels list', async function (assert) {
+        test('displays a score and competence levels list', async function (assert) {
           // given
           const screen = await visit('/administration/common');
           await click(screen.getByRole('link', { name: 'Certification' }));
@@ -156,7 +175,7 @@ module('Acceptance | administration | common ', function (hooks) {
       });
 
       module('when a score is given', function () {
-        test('should display a competence and competence levels list', async function (assert) {
+        test('displays a competence and competence levels list', async function (assert) {
           // given
           const screen = await visit('/administration/common');
           await click(screen.getByRole('link', { name: 'Certification' }));
@@ -180,6 +199,21 @@ module('Acceptance | administration | common ', function (hooks) {
           assert.dom(within(rows[1]).getByRole('cell', { name: '3' })).exists();
         });
       });
+    });
+  });
+  module('deployment tab', function () {
+    test('it is possible to create a new tag', async function (assert) {
+      // given
+      const screen = await visit('/administration/common');
+      await click(screen.getByRole('link', { name: 'Déploiement' }));
+
+      // when
+      await fillByLabel('Nom du tag', 'Mon super tag');
+      await clickByName('Créer le tag');
+
+      // then
+      assert.dom(screen.getByText('Le tag a bien été créé !')).exists();
+      assert.dom(screen.getByRole('textbox', { name: 'Nom du tag' })).hasNoValue();
     });
   });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -295,12 +295,18 @@
         }
       },
       "navigation": {
+        "access": {
+          "label": "Access"
+        },
         "aria-label": "Administration section navigation",
         "certification": {
           "label": "Certification"
         },
         "common": {
           "label": "Common"
+        },
+        "deployment": {
+          "label": "Deployment"
         }
       }
     },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -305,12 +305,18 @@
         }
       },
       "navigation": {
+        "access": {
+          "label": "Accès"
+        },
         "aria-label": "Navigation de la section administration",
         "certification": {
           "label": "Certification"
         },
         "common": {
           "label": "Commun"
+        },
+        "deployment": {
+          "label": "Déploiement"
         }
       }
     },


### PR DESCRIPTION
## :unicorn: Problème
Certaines fonctionnalités proposées sur la page Administration de Pix Admin, présentes sous l'onglet "Commun", devraient être rangées dans des catégories plus explicites.

## :robot: Proposition
Créer deux onglets "Accès" et "Déploiement" à côté des onglets "Commun" et "Certification"
Déplacer dans l'onglet "Déploiement" les fonctionnalités suivantes : 

- Créer un nouveau tag
- Ajout de tags en masse sur des organisations
- Création d'organisations en masse
- Modification des organisations en masse

Déplacer dans l'onglet "Accès" les fonctionnalités suivantes : 

- Import d’OIDC Providers
- Anonymiser les données du GAR

## :rainbow: Remarques
RAS

## :100: Pour tester
- Se connecter sur Pix Admin avec le compte superadmin@example.net
- Aller dans la partie "Administration"
- Constater la présence des onglets "Accès" et "Déploiement", avec les fonctionnalités listées ci-dessus.
- Tests de non régression : tester chacune des fonctionnalités.
     - pour l'ajout de tags en masse : voir https://github.com/1024pix/pix/pull/9609 pour le fichier .csv
     - pour la création et la modification en masse d'organisations : https://github.com/1024pix/pix/pull/8397 pour le fichier .csv
     - pour l'import d'un OIDC Provider : voir https://github.com/1024pix/pix/pull/9275 pour le fichier csv
     - pour l'anonymisation des données du GAR : voir https://github.com/1024pix/pix/pull/9363 pour le fichier csv et la procédure
