### PR TITLE
[FEATURE] Accompagner l'utilisateur mobile si son expérience risque d'être dégradée (PIX-13746) (PIX-13909)

### DIFF
--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module.js
@@ -23,7 +23,7 @@ const moduleDetailsSchema = Joi.object({
   duration: Joi.number().integer().min(0).max(120).required(),
   level: Joi.string().valid('Débutant', 'Intermédiaire', 'Avancé', 'Expert').required(),
   objectives: Joi.array().items(htmlNotAllowedSchema).min(1).required(),
-  tabletSupport: Joi.string().valid('obstructed', 'inconvenient', 'comfortable').required(),
+  tabletSupport: Joi.string().valid('comfortable', 'inconvenient', 'obstructed').required(),
 });
 
 const elementSchema = Joi.alternatives().conditional('.type', {

--- a/mon-pix/app/breakpoints.js
+++ b/mon-pix/app/breakpoints.js
@@ -1,5 +1,5 @@
 export default {
-  mobile: '(max-width: 767px)',
-  tablet: '(min-width: 768px)',
-  desktop: '(min-width: 980px)',
+  mobile: '(max-width: 768px)',
+  tablet: '(min-width: 769px)',
+  desktop: '(min-width: 992px)',
 };

--- a/mon-pix/app/components/common/responsive-ul-wide-wrap.gjs
+++ b/mon-pix/app/components/common/responsive-ul-wide-wrap.gjs
@@ -1,0 +1,5 @@
+<template>
+  <ul class="responsive-list-wide-wrap">
+    {{yield}}
+  </ul>
+</template>

--- a/mon-pix/app/components/module/details.gjs
+++ b/mon-pix/app/components/module/details.gjs
@@ -7,6 +7,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import { pageTitle } from 'ember-page-title';
+import ResponsiveListWideWrap from 'mon-pix/components/common/responsive-ul-wide-wrap';
 import Objectives from 'mon-pix/components/module/objectives';
 
 export default class ModulixDetails extends Component {
@@ -102,8 +103,8 @@ export default class ModulixDetails extends Component {
               </:content>
               <:footer>
                 <div class="module-details-content-layout-small-screen-modal__footer">
-                  <ul class="module-details-content-layout-small-screen-modal-footer__actions">
-                    <li class="module-details-content-layout-small-screen-modal-footer-actions__item">
+                  <ResponsiveListWideWrap>
+                    <li>
                       <PixButton
                         class="module-details-content-layout-small-screen-modal-footer-actions-item__button"
                         @variant="secondary"
@@ -112,7 +113,7 @@ export default class ModulixDetails extends Component {
                         {{t "pages.modulix.details.smallScreenModal.cancel"}}
                       </PixButton>
                     </li>
-                    <li class="module-details-content-layout-small-screen-modal-footer-actions__item">
+                    <li>
                       <PixButton
                         class="module-details-content-layout-small-screen-modal-footer-actions-item__button"
                         @triggerAction={{this.onModuleStartUsingSmallScreen}}
@@ -120,7 +121,7 @@ export default class ModulixDetails extends Component {
                         {{t "pages.modulix.details.smallScreenModal.startModule"}}
                       </PixButton>
                     </li>
-                  </ul>
+                  </ResponsiveListWideWrap>
                 </div>
               </:footer>
             </PixModal>

--- a/mon-pix/app/components/module/details.gjs
+++ b/mon-pix/app/components/module/details.gjs
@@ -101,18 +101,27 @@ export default class ModulixDetails extends Component {
                 </p>
               </:content>
               <:footer>
-                <ul class="module-details-content-layout-small-screen-modal__footer">
-                  <li>
-                    <PixButton @variant="secondary" @triggerAction={{this.onSmallScreenModalClose}}>
-                      {{t "pages.modulix.details.smallScreenModal.cancel"}}
-                    </PixButton>
-                  </li>
-                  <li>
-                    <PixButton @triggerAction={{this.onModuleStartUsingSmallScreen}}>
-                      {{t "pages.modulix.details.smallScreenModal.startModule"}}
-                    </PixButton>
-                  </li>
-                </ul>
+                <div class="module-details-content-layout-small-screen-modal__footer">
+                  <ul class="module-details-content-layout-small-screen-modal-footer__actions">
+                    <li class="module-details-content-layout-small-screen-modal-footer-actions__item">
+                      <PixButton
+                        class="module-details-content-layout-small-screen-modal-footer-actions-item__button"
+                        @variant="secondary"
+                        @triggerAction={{this.onSmallScreenModalClose}}
+                      >
+                        {{t "pages.modulix.details.smallScreenModal.cancel"}}
+                      </PixButton>
+                    </li>
+                    <li class="module-details-content-layout-small-screen-modal-footer-actions__item">
+                      <PixButton
+                        class="module-details-content-layout-small-screen-modal-footer-actions-item__button"
+                        @triggerAction={{this.onModuleStartUsingSmallScreen}}
+                      >
+                        {{t "pages.modulix.details.smallScreenModal.startModule"}}
+                      </PixButton>
+                    </li>
+                  </ul>
+                </div>
               </:footer>
             </PixModal>
           {{/if}}

--- a/mon-pix/app/components/module/details.gjs
+++ b/mon-pix/app/components/module/details.gjs
@@ -1,9 +1,10 @@
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import { on } from '@ember/modifier';
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import { pageTitle } from 'ember-page-title';
 import Objectives from 'mon-pix/components/module/objectives';
@@ -11,6 +12,13 @@ import Objectives from 'mon-pix/components/module/objectives';
 export default class ModulixDetails extends Component {
   @service router;
   @service metrics;
+  @service media;
+
+  @tracked isSmallScreenModalOpen = false;
+
+  get shouldDisplaySmallScreenModal() {
+    return this.args.module.details.tabletSupport !== 'comfortable' && !this.media.isDesktop;
+  }
 
   @action
   onModuleStart() {
@@ -18,9 +26,42 @@ export default class ModulixDetails extends Component {
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Détails du module : ${this.args.module.id}`,
-      'pix-event-name': `Click sur le bouton Commencer`,
+      'pix-event-name': `Click sur le bouton Commencer un passage`,
     });
-    this.router.transitionTo('module.passage');
+    this.router.transitionTo('module.passage', this.args.module.id);
+  }
+
+  @action
+  onModuleStartUsingSmallScreen() {
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Modulix',
+      'pix-event-action': `Détails du module : ${this.args.module.id}`,
+      'pix-event-name': `Click sur le bouton Commencer un passage en petit écran`,
+    });
+    this.router.transitionTo('module.passage', this.args.module.id);
+  }
+
+  @action
+  onSmallScreenModalOpen() {
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Modulix',
+      'pix-event-action': `Détails du module : ${this.args.module.id}`,
+      'pix-event-name': `Ouvre la modale d'alerte de largeur d'écran`,
+    });
+    this.isSmallScreenModalOpen = true;
+  }
+
+  @action
+  onSmallScreenModalClose() {
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Modulix',
+      'pix-event-action': `Détails du module : ${this.args.module.id}`,
+      'pix-event-name': `Ferme la modale d'alerte de largeur d'écran`,
+    });
+    this.isSmallScreenModalOpen = false;
   }
 
   <template>
@@ -37,10 +78,44 @@ export default class ModulixDetails extends Component {
           <p class="module-details-content-layout__description">{{@module.details.description}}</p>
 
           <div class="module-details-content-layout__link">
-            <PixButtonLink @href="#" {{on "click" this.onModuleStart}} @model={{@module.id}} @size="large">{{t
-                "pages.modulix.details.startModule"
-              }}</PixButtonLink>
+            {{#if this.shouldDisplaySmallScreenModal}}
+              <PixButton @triggerAction={{this.onSmallScreenModalOpen}} @size="large">
+                {{t "pages.modulix.details.startModule"}}
+              </PixButton>
+            {{else}}
+              <PixButton @triggerAction={{this.onModuleStart}} @size="large">
+                {{t "pages.modulix.details.startModule"}}
+              </PixButton>
+            {{/if}}
           </div>
+
+          {{#if this.shouldDisplaySmallScreenModal}}
+            <PixModal
+              @title={{t "pages.modulix.details.smallScreenModal.title"}}
+              @showModal={{this.isSmallScreenModalOpen}}
+              @onCloseButtonClick={{this.onSmallScreenModalClose}}
+            >
+              <:content>
+                <p class="module-details-content-layout-small-screen-modal__title">
+                  {{t "pages.modulix.details.smallScreenModal.description"}}
+                </p>
+              </:content>
+              <:footer>
+                <ul class="module-details-content-layout-small-screen-modal__footer">
+                  <li>
+                    <PixButton @variant="secondary" @triggerAction={{this.onSmallScreenModalClose}}>
+                      {{t "pages.modulix.details.smallScreenModal.cancel"}}
+                    </PixButton>
+                  </li>
+                  <li>
+                    <PixButton @triggerAction={{this.onModuleStartUsingSmallScreen}}>
+                      {{t "pages.modulix.details.smallScreenModal.startModule"}}
+                    </PixButton>
+                  </li>
+                </ul>
+              </:footer>
+            </PixModal>
+          {{/if}}
         </div>
       </div>
 

--- a/mon-pix/app/components/module/element/download.gjs
+++ b/mon-pix/app/components/module/element/download.gjs
@@ -4,6 +4,7 @@ import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import { t } from 'ember-intl';
+import ResponsiveListWideWrap from 'mon-pix/components/common/responsive-ul-wide-wrap';
 
 import ModuleElement from './module-element';
 
@@ -19,25 +20,27 @@ export default class ModulixDownload extends ModuleElement {
       <p class="element-download__description">
         {{t "pages.modulix.download.description"}}
       </p>
-      <ul class="element-download__links-container">
-        {{#each @download.files as |file|}}
-          <li class="element-download__link">
-            <div class="element-download-link__format" aria-hidden="true">{{t
-                "pages.modulix.download.format"
-                format=file.format
-              }}</div>
-            <PixButtonLink
-              class="element-download-link__button"
-              @href="{{file.url}}"
-              aria-label="{{t 'pages.modulix.download.label' format=file.format}}"
-              download
-              {{on "click" (fn this.onDownload file.format)}}
-            >
-              {{t "pages.modulix.download.button"}}
-            </PixButtonLink>
-          </li>
-        {{/each}}
-      </ul>
+      <div class="element-download__links-container">
+        <ResponsiveListWideWrap>
+          {{#each @download.files as |file|}}
+            <li class="element-download__link">
+              <div class="element-download-link__format" aria-hidden="true">{{t
+                  "pages.modulix.download.format"
+                  format=file.format
+                }}</div>
+              <PixButtonLink
+                class="element-download-link__button"
+                @href="{{file.url}}"
+                aria-label="{{t 'pages.modulix.download.label' format=file.format}}"
+                download
+                {{on "click" (fn this.onDownload file.format)}}
+              >
+                {{t "pages.modulix.download.button"}}
+              </PixButtonLink>
+            </li>
+          {{/each}}
+        </ResponsiveListWideWrap>
+      </div>
       <a
         class="element-download__documentation-link link"
         href="{{t 'pages.modulix.download.documentationLinkHref'}}"

--- a/mon-pix/app/controllers/module-preview.js
+++ b/mon-pix/app/controllers/module-preview.js
@@ -15,6 +15,7 @@ export default class ModulePreviewController extends Controller {
     "description": "Découvrez la page de prévisualisation pour contribuer à Modulix !",
     "duration": 5,
     "level": "Débutant",
+    "tabletSupport": "comfortable",
     "objectives": [
       "Prévisualiser un Module",
       "Contribuer au contenu d'un Module"

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -45,6 +45,7 @@
 
 /* we need this to be before competence-card-default because of a mix
 of an adaptative/mobile-first approach — refactoring is welcome here */
+@import 'components/common/responsive-list-wide-wrap';
 @import 'components/competence-card-mobile';
 @import 'components/competence-card-default';
 @import 'components/competence-card/list';

--- a/mon-pix/app/styles/components/common/_responsive-list-wide-wrap.scss
+++ b/mon-pix/app/styles/components/common/_responsive-list-wide-wrap.scss
@@ -1,0 +1,10 @@
+.responsive-list-wide-wrap {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: var(--pix-spacing-2x);
+
+  > * {
+    flex: 1;
+    min-width: fit-content;
+  }
+}

--- a/mon-pix/app/styles/components/module/_details.scss
+++ b/mon-pix/app/styles/components/module/_details.scss
@@ -121,21 +121,6 @@
   }
 }
 
-.module-details-content-layout-small-screen-modal-footer {
-  &__actions {
-    display: inline-flex;
-    flex-wrap: wrap;
-    gap: var(--pix-spacing-4x);
-  }
-}
-
-.module-details-content-layout-small-screen-modal-footer-actions {
-  &__item {
-    flex: 1;
-    min-width: fit-content;
-  }
-}
-
 .module-details-content-layout-small-screen-modal-footer-actions-item {
   &__button {
     width: 100%;

--- a/mon-pix/app/styles/components/module/_details.scss
+++ b/mon-pix/app/styles/components/module/_details.scss
@@ -116,11 +116,28 @@
 
 .module-details-content-layout-small-screen-modal {
   &__footer {
-    display: flex;
-    flex-direction: row;
-    gap: var(--pix-spacing-4x);
-    align-items: center;
-    justify-content: right;
     margin-bottom: var(--pix-spacing-4x);
+    text-align: right;
+  }
+}
+
+.module-details-content-layout-small-screen-modal-footer {
+  &__actions {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: var(--pix-spacing-4x);
+  }
+}
+
+.module-details-content-layout-small-screen-modal-footer-actions {
+  &__item {
+    flex: 1;
+    min-width: fit-content;
+  }
+}
+
+.module-details-content-layout-small-screen-modal-footer-actions-item {
+  &__button {
+    width: 100%;
   }
 }

--- a/mon-pix/app/styles/components/module/_details.scss
+++ b/mon-pix/app/styles/components/module/_details.scss
@@ -113,3 +113,14 @@
     }
   }
 }
+
+.module-details-content-layout-small-screen-modal {
+  &__footer {
+    display: flex;
+    flex-direction: row;
+    gap: var(--pix-spacing-4x);
+    align-items: center;
+    justify-content: right;
+    margin-bottom: var(--pix-spacing-4x);
+  }
+}

--- a/mon-pix/app/styles/components/module/_download.scss
+++ b/mon-pix/app/styles/components/module/_download.scss
@@ -11,13 +11,15 @@
   }
 
   &__links-container {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    display: inline-flex;
+    flex-wrap: wrap;
     gap: var(--pix-spacing-2x);
     margin: var(--pix-spacing-3x) 0;
   }
 
   &__link {
+    flex: 1;
+    min-width: fit-content;
     padding: var(--pix-spacing-6x) var(--pix-spacing-4x);
     text-align: center;
     background: var(--pix-neutral-0);
@@ -28,6 +30,7 @@
   &__documentation-link {
     @extend %pix-body-m;
 
+    display: block;
     color: var(--pix-info-700);
   }
 }

--- a/mon-pix/app/styles/components/module/_download.scss
+++ b/mon-pix/app/styles/components/module/_download.scss
@@ -11,15 +11,10 @@
   }
 
   &__links-container {
-    display: inline-flex;
-    flex-wrap: wrap;
-    gap: var(--pix-spacing-2x);
     margin: var(--pix-spacing-3x) 0;
   }
 
   &__link {
-    flex: 1;
-    min-width: fit-content;
     padding: var(--pix-spacing-6x) var(--pix-spacing-4x);
     text-align: center;
     background: var(--pix-neutral-0);

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-details-test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-details-test.js
@@ -32,7 +32,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleDetails', function (
 
       // then
       assert
-        .dom(screen.getByRole('link', { name: this.intl.t('pages.modulix.details.startModule') }))
+        .dom(screen.getByRole('button', { name: this.intl.t('pages.modulix.details.startModule') }))
         .exists({ count: 1 });
     });
 
@@ -57,7 +57,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleDetails', function (
 
       // when
       const screen = await visit('/modules/bien-ecrire-son-adresse-mail/details');
-      await click(screen.getByRole('link', { name: this.intl.t('pages.modulix.details.startModule') }));
+      await click(screen.getByRole('button', { name: this.intl.t('pages.modulix.details.startModule') }));
 
       // then
       assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/passage');

--- a/mon-pix/tests/acceptance/module/retake_completed_module-test.js
+++ b/mon-pix/tests/acceptance/module/retake_completed_module-test.js
@@ -53,6 +53,7 @@ module('Acceptance | Module | Routes | retakeCompletedModule', function (hooks) 
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
+      details: { tabletSupport: 'comfortable' },
       grains: [grain1, grain2],
     });
 
@@ -81,7 +82,7 @@ module('Acceptance | Module | Routes | retakeCompletedModule', function (hooks) 
     const backToDetailsButton = screen.getByRole('link', { name: 'Revenir aux détails du module' });
     await click(backToDetailsButton);
 
-    const startModuleButton = screen.getByRole('link', { name: 'Commencer le module' });
+    const startModuleButton = screen.getByRole('button', { name: 'Commencer le module' });
     await click(startModuleButton);
 
     // then

--- a/mon-pix/tests/acceptance/module/visit-module-recap-page-test.js
+++ b/mon-pix/tests/acceptance/module/visit-module-recap-page-test.js
@@ -15,6 +15,7 @@ module('Acceptance | Module | Routes | recap', function (hooks) {
     // given
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
+      details: { tabletSupport: 'comfortable' },
     });
 
     // when

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1353,6 +1353,12 @@
         "explanationTitle": "What is a module?",
         "level": "Level",
         "objectives": "Objectives",
+        "smallScreenModal": {
+          "title": "You seem to be using a small screen",
+          "cancel": "Return to details",
+          "description": "Some of the activities in this module may be difficult to perform on a small screen. For the best experience, we recommend that you use a computer.",
+          "startModule": "Start"
+        },
         "startModule": "Start module"
       },
       "download": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1353,6 +1353,12 @@
         "explanationTitle": "¿Qué es un módulo?",
         "level": "Nivel",
         "objectives": "Objetivos",
+        "smallScreenModal": {
+          "title": "Parece que estás usando una pantalla pequeña",
+          "description": "Algunas de las actividades de este módulo pueden resultar difíciles de realizar en una pantalla pequeña. Para disfrutar de la mejor experiencia, le recomendamos que utilice un ordenador.",
+          "startModule": "Inicio",
+          "cancel": "Volver a los detalles"
+        },
         "startModule": "Iniciar el módulo"
       },
       "download": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1353,6 +1353,12 @@
         "explanationTitle": "C'est quoi un module ?",
         "level": "Niveau",
         "objectives": "Objectifs",
+        "smallScreenModal": {
+          "title": "Vous semblez utiliser un petit écran",
+          "cancel": "Revenir aux détails",
+          "description": "Certaines activités de ce module peuvent être difficiles à réaliser sur un petit écran. Pour une expérience optimale, nous vous recommandons d'utiliser un ordinateur.",
+          "startModule": "Commencer"
+        },
         "startModule": "Commencer le module"
       },
       "download": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1353,6 +1353,12 @@
         "explanationTitle": "Wat is een module?",
         "level": "Niveau",
         "objectives": "Doelstellingen",
+        "smallScreenModal": {
+          "title": "Je lijkt een klein scherm te gebruiken",
+          "description": "Sommige activiteiten in deze module zijn mogelijk moeilijk uit te voeren op een klein scherm. Voor de beste ervaring raden we je aan een computer te gebruiken.",
+          "startModule": "Start",
+          "cancel": "Terug naar details"
+        },
         "startModule": "De module starten"
       },
       "download": {


### PR DESCRIPTION
## :unicorn: Problème
En tant qu’utilisateur je souhaite pouvoir être informé si mon expérience sur mon module de formation va être dégradée afin de pouvoir changer de device si besoin.

## :robot: Proposition
Dans les modules concernés, afficher une modale au lancement pour prévenir que l'expérience pourra ne pas être optimale.

Techniquement, on affiche la modale uniquement si la propriété `tabletSupport` du module n'est pas `comfortable` et en dessous du breakpoint tablette.

Les événements de tracking ont été mis à jour ainsi : 
- "Click sur le bouton Commencer" devient "Click sur le bouton Commencer un passage"
- En petit écran sur les modules concernés : 
  * Nouvel événement "Ouvre la modale d'alerte de largeur d'écran"
  * Nouvel événement "Ferme la modale d'alerte de largeur d'écran" peu importe la manière de fermer
  * Nouvel événement "Click sur le bouton Commencer un passage en petit écran"

On en profite pour réaligner les breakpoints utilisés en JS avec [le code de Pix UI](https://github.com/1024pix/pix-ui/blob/dev/addon/styles/pix-design-tokens/_breakpoints.scss#L5-L7).

On s'est rendu compte que les boutons dans les modales n'étaient pas wrappés en mobile, on a profité d'une technique de @Jeyffrey pour mettre en commun ce comportement dans un composant `ResponsiveUlWideWrap`. On le réutilise également sur les éléments `Download`.

## :rainbow: Remarques
On a utilisé la librairie `ember-responsive` pour pouvoir tester automatiquement les 2 usages.

## :100: Pour tester
Sur un module concerné, par exemple sur [bien-ecrire-son-adresse-mail](https://app-pr9893.review.pix.fr/modules/bien-ecrire-son-adresse-mail/details) :
- La page de détails ne doit pas avoir changé, en "mobile/tablette" ou "desktop".

Sur un module concerné, par exemple [le didacticiel](https://app-pr9893.review.pix.fr/modules/didacticiel-modulix/details) :
- En résolution "mobile/tablette", la nouvelle modale doit s'afficher.
- En résolution "desktop", on accède au module comme avant.
- Vérifier aussi que les boutons de l'élément "Download" reste accessible que ce soit en mobile/tablette ou desktop.