### PR TITLE
[TECH] Retirer le tag deprecated de la route d'inscription de candidat.

### DIFF
--- a/api/src/certification/enrolment/application/certification-candidate-route.js
+++ b/api/src/certification/enrolment/application/certification-candidate-route.js
@@ -63,7 +63,7 @@ const register = async function (server) {
           },
         ],
         handler: certificationCandidateController.addCandidate,
-        tags: ['api', 'sessions', 'certification-candidates', 'deprecated'],
+        tags: ['api', 'sessions', 'certification-candidates'],
         notes: [
           'Cette route est restreinte aux utilisateurs authentifiés',
           'Elle ajoute un candidat de certification à la session.',


### PR DESCRIPTION
## :unicorn: Problème
Nous avions dupliqué cette route pour les besoins partenaires, mais ceci étant réglé nous avons supprimé cette duplication. Or il reste toujours le tag deprecated sur la route.

## :robot: Proposition
Retirer le tag

## :100: Pour tester
RAS
