### PR TITLE
[FEATURE] Rendre la création de sessions en masse fonctionnel avec la compatibilité coeur/complémentaire (PIX-13654)

### DIFF
--- a/api/src/certification/enrolment/application/session-mass-import-controller.js
+++ b/api/src/certification/enrolment/application/session-mass-import-controller.js
@@ -28,6 +28,7 @@ const validateSessions = async function (request, h, dependencies = { csvHelpers
     parsedCsvData,
     hasBillingMode: center.hasBillingMode,
     certificationCenterHabilitations: center.habilitations,
+    isCoreComplementaryCompatibilityEnabled: center.isCoreComplementaryCompatibilityEnabled,
   });
 
   const sessionMassImportReport = await usecases.validateSessions({

--- a/api/src/certification/enrolment/domain/services/sessions-import-validation-service.js
+++ b/api/src/certification/enrolment/domain/services/sessions-import-validation-service.js
@@ -1,9 +1,11 @@
 import dayjs from 'dayjs';
+import _ from 'lodash';
 
 import * as mailCheck from '../../../../shared/mail/infrastructure/services/mail-check.js';
 import { SUBSCRIPTION_TYPES } from '../../../shared/domain/constants.js';
 import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../shared/domain/constants/certification-candidates-errors.js';
 import { CERTIFICATION_SESSIONS_ERRORS } from '../../../shared/domain/constants/sessions-errors.js';
+import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
 //  should be injected
 import * as certificationCpfService from '../../../shared/domain/services/certification-cpf-service.js';
 import * as sessionValidator from '../../../shared/domain/validators/session-validator.js';
@@ -123,7 +125,16 @@ const getValidatedSubscriptionsForMassImport = async function ({
   subscriptionLabels,
   line,
   complementaryCertificationRepository,
+  isCoreComplementaryCompatibilityEnabled,
 }) {
+  if (!isCoreComplementaryCompatibilityEnabled) {
+    return _getValidatedSubscriptionsForMassImport_old({
+      subscriptionLabels,
+      line,
+      complementaryCertificationRepository,
+    });
+  }
+  const subscriptions = [];
   const certificationCandidateComplementaryErrors = [];
 
   if (subscriptionLabels.length === 0) {
@@ -133,44 +144,38 @@ const getValidatedSubscriptionsForMassImport = async function ({
       codes: [CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_NO_SUBSCRIPTION.code],
     });
 
-    return { certificationCandidateComplementaryErrors, subscriptions: [] };
+    return { certificationCandidateComplementaryErrors, subscriptions };
   }
 
-  if (!subscriptionLabels.find((label) => label === SUBSCRIPTION_TYPES.CORE)) {
-    _addToErrorList({
-      errorList: certificationCandidateComplementaryErrors,
-      line,
-      codes: [CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_COMPLEMENTARY_WITHOUT_CORE.code],
-    });
-
-    return { certificationCandidateComplementaryErrors, subscriptions: [] };
-  }
-
-  if (_hasMoreThanOneComplementaryCertificationSubscriptions(subscriptionLabels)) {
+  if (subscriptionLabels.length > 1) {
     _addToErrorList({
       errorList: certificationCandidateComplementaryErrors,
       line,
       codes: [CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION.code],
     });
 
-    return { certificationCandidateComplementaryErrors, subscriptions: [] };
+    return { certificationCandidateComplementaryErrors, subscriptions };
   }
 
-  const subscriptions = [];
-  for (const subscriptionLabel of subscriptionLabels) {
-    if (subscriptionLabel === SUBSCRIPTION_TYPES.CORE) {
+  const allComplementaryCertifications = await complementaryCertificationRepository.findAll();
+  const complementaryCertificationsByLabel = _.keyBy(allComplementaryCertifications, 'label');
+  const cleaComplementaryCertification = allComplementaryCertifications.find(
+    (complementaryCertification) => complementaryCertification.key === ComplementaryCertificationKeys.CLEA,
+  );
+  const subscriptionLabel = subscriptionLabels[0];
+  if (subscriptionLabel === SUBSCRIPTION_TYPES.CORE) {
+    subscriptions.push(Subscription.buildCore({ certificationCandidateId: null }));
+  } else {
+    const complementaryCertification = complementaryCertificationsByLabel[subscriptionLabel];
+    if (complementaryCertification.id === cleaComplementaryCertification.id) {
       subscriptions.push(Subscription.buildCore({ certificationCandidateId: null }));
-    } else {
-      const complementaryCertification = await complementaryCertificationRepository.getByLabel({
-        label: subscriptionLabel,
-      });
-      subscriptions.push(
-        Subscription.buildComplementary({
-          certificationCandidateId: null,
-          complementaryCertificationId: complementaryCertification.id,
-        }),
-      );
     }
+    subscriptions.push(
+      Subscription.buildComplementary({
+        certificationCandidateId: null,
+        complementaryCertificationId: complementaryCertification.id,
+      }),
+    );
   }
 
   return { certificationCandidateComplementaryErrors, subscriptions };
@@ -306,4 +311,61 @@ async function _validateEmail({ email, mailCheck, errorCode, certificationCandid
       });
     }
   }
+}
+
+async function _getValidatedSubscriptionsForMassImport_old({
+  subscriptionLabels,
+  line,
+  complementaryCertificationRepository,
+}) {
+  const certificationCandidateComplementaryErrors = [];
+
+  if (subscriptionLabels.length === 0) {
+    _addToErrorList({
+      errorList: certificationCandidateComplementaryErrors,
+      line,
+      codes: [CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_NO_SUBSCRIPTION.code],
+    });
+
+    return { certificationCandidateComplementaryErrors, subscriptions: [] };
+  }
+
+  if (!subscriptionLabels.find((label) => label === SUBSCRIPTION_TYPES.CORE)) {
+    _addToErrorList({
+      errorList: certificationCandidateComplementaryErrors,
+      line,
+      codes: [CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_COMPLEMENTARY_WITHOUT_CORE.code],
+    });
+
+    return { certificationCandidateComplementaryErrors, subscriptions: [] };
+  }
+
+  if (_hasMoreThanOneComplementaryCertificationSubscriptions(subscriptionLabels)) {
+    _addToErrorList({
+      errorList: certificationCandidateComplementaryErrors,
+      line,
+      codes: [CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION.code],
+    });
+
+    return { certificationCandidateComplementaryErrors, subscriptions: [] };
+  }
+
+  const subscriptions = [];
+  for (const subscriptionLabel of subscriptionLabels) {
+    if (subscriptionLabel === SUBSCRIPTION_TYPES.CORE) {
+      subscriptions.push(Subscription.buildCore({ certificationCandidateId: null }));
+    } else {
+      const complementaryCertification = await complementaryCertificationRepository.getByLabel({
+        label: subscriptionLabel,
+      });
+      subscriptions.push(
+        Subscription.buildComplementary({
+          certificationCandidateId: null,
+          complementaryCertificationId: complementaryCertification.id,
+        }),
+      );
+    }
+  }
+
+  return { certificationCandidateComplementaryErrors, subscriptions };
 }

--- a/api/src/certification/enrolment/domain/services/sessions-import-validation-service.js
+++ b/api/src/certification/enrolment/domain/services/sessions-import-validation-service.js
@@ -181,7 +181,7 @@ const getValidatedSubscriptionsForMassImport = async function ({
   return { certificationCandidateComplementaryErrors, subscriptions };
 };
 
-const getValidatedCandidateBirthInformation = async function ({
+const getValidatedCandidateInformation = async function ({
   candidate,
   isSco,
   line,
@@ -203,7 +203,10 @@ const getValidatedCandidateBirthInformation = async function ({
     }
   }
 
-  const errorCodes = candidate.validateForMassSessionImport(isSco);
+  let errorCodes = candidate.validateForMassSessionImport(isSco);
+
+  errorCodes = errorCodes?.filter((errorCode) => !errorCode.includes('subscriptions'));
+
   _addToErrorList({ errorList: certificationCandidateErrors, line, codes: errorCodes });
 
   const cpfBirthInformation = await dependencies.certificationCpfService.getBirthInformation({
@@ -261,7 +264,7 @@ const validateCandidateEmails = async function ({ candidate, line, dependencies 
 
 export {
   getUniqueCandidates,
-  getValidatedCandidateBirthInformation,
+  getValidatedCandidateInformation,
   getValidatedSubscriptionsForMassImport,
   validateCandidateEmails,
   validateSession,

--- a/api/src/certification/enrolment/domain/usecases/validate-sessions.js
+++ b/api/src/certification/enrolment/domain/usecases/validate-sessions.js
@@ -150,15 +150,14 @@ async function _createValidCertificationCandidates({
       createdAt: null,
     });
 
-    const candidateBirthInformationValidation =
-      await sessionsImportValidationService.getValidatedCandidateBirthInformation({
-        candidate,
-        isSco,
-        isSessionsMassImport: true,
-        line: candidateDTO.line,
-        certificationCpfCountryRepository,
-        certificationCpfCityRepository,
-      });
+    const candidateBirthInformationValidation = await sessionsImportValidationService.getValidatedCandidateInformation({
+      candidate,
+      isSco,
+      isSessionsMassImport: true,
+      line: candidateDTO.line,
+      certificationCpfCountryRepository,
+      certificationCpfCityRepository,
+    });
 
     certificationCandidateErrors.push(...candidateBirthInformationValidation.certificationCandidateErrors);
 

--- a/api/src/certification/enrolment/domain/usecases/validate-sessions.js
+++ b/api/src/certification/enrolment/domain/usecases/validate-sessions.js
@@ -10,7 +10,6 @@ import { SessionMassImportReport } from '../models/SessionMassImportReport.js';
 
 /**
  * @param {Object} params
- * @param {deps["certificationCenterRepository"]} params.certificationCenterRepository
  * @param {deps["sessionRepository"]} params.sessionRepository
  * @param {deps["certificationCpfCountryRepository"]} params.certificationCpfCountryRepository
  * @param {deps["certificationCpfCityRepository"]} params.certificationCpfCityRepository
@@ -80,6 +79,7 @@ const validateSessions = async function ({
         complementaryCertificationRepository,
         translate,
         sessionsImportValidationService,
+        isCoreComplementaryCompatibilityEnabled: center.isCoreComplementaryCompatibilityEnabled,
       });
 
       session.certificationCandidates = validatedCandidates;
@@ -113,6 +113,7 @@ async function _createValidCertificationCandidates({
   complementaryCertificationRepository,
   translate,
   sessionsImportValidationService,
+  isCoreComplementaryCompatibilityEnabled,
 }) {
   const { uniqueCandidates, duplicateCandidateErrors } =
     sessionsImportValidationService.getUniqueCandidates(candidatesDTO);
@@ -133,6 +134,7 @@ async function _createValidCertificationCandidates({
         subscriptionLabels: candidateDTO.subscriptionLabels,
         line: candidateDTO.line,
         complementaryCertificationRepository,
+        isCoreComplementaryCompatibilityEnabled,
       });
 
     certificationCandidateErrors.push(...certificationCandidateComplementaryErrors);

--- a/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
@@ -35,7 +35,12 @@ function _csvSerializeValue(data) {
   }
 }
 
-function deserializeForSessionsImport({ parsedCsvData, hasBillingMode, certificationCenterHabilitations }) {
+function deserializeForSessionsImport({
+  parsedCsvData,
+  hasBillingMode,
+  certificationCenterHabilitations,
+  isCoreComplementaryCompatibilityEnabled,
+}) {
   const sessions = [];
   const expectedHeadersKeys = Object.keys(headers);
 
@@ -91,7 +96,7 @@ function deserializeForSessionsImport({ parsedCsvData, hasBillingMode, certifica
     }
 
     if (_hasCandidateInformation(data)) {
-      currentParsedSession.candidates.push(_createCandidate(data));
+      currentParsedSession.candidates.push(_createCandidate(data, isCoreComplementaryCompatibilityEnabled));
     }
   });
 
@@ -391,24 +396,37 @@ function _createSession({ sessionId, address, room, date, time, examiner, descri
   };
 }
 
-function _createCandidate({
-  lastName,
-  firstName,
-  birthdate,
-  birthINSEECode,
-  birthPostalCode,
-  birthCity,
-  birthCountry,
-  resultRecipientEmail,
-  email,
-  externalId,
-  extraTimePercentage,
-  billingMode,
-  prepaymentCode,
-  sex,
-  complementarySubscriptionLabels,
-  line,
-}) {
+function _createCandidate(
+  {
+    lastName,
+    firstName,
+    birthdate,
+    birthINSEECode,
+    birthPostalCode,
+    birthCity,
+    birthCountry,
+    resultRecipientEmail,
+    email,
+    externalId,
+    extraTimePercentage,
+    billingMode,
+    prepaymentCode,
+    sex,
+    complementarySubscriptionLabels,
+    line,
+  },
+  isCoreComplementaryCompatibilityEnabled,
+) {
+  const subscriptionLabels = [];
+  if (!isCoreComplementaryCompatibilityEnabled) {
+    subscriptionLabels.push(...[SUBSCRIPTION_TYPES.CORE, ...complementarySubscriptionLabels]);
+  } else {
+    if (complementarySubscriptionLabels.length > 0) {
+      subscriptionLabels.push(...complementarySubscriptionLabels);
+    } else {
+      subscriptionLabels.push(SUBSCRIPTION_TYPES.CORE);
+    }
+  }
   return {
     lastName,
     firstName,
@@ -424,7 +442,7 @@ function _createCandidate({
     billingMode,
     prepaymentCode,
     sex,
-    subscriptionLabels: [SUBSCRIPTION_TYPES.CORE, ...complementarySubscriptionLabels],
+    subscriptionLabels,
     line,
   };
 }

--- a/api/tests/certification/enrolment/unit/domain/services/sessions-import-validation-service_test.js
+++ b/api/tests/certification/enrolment/unit/domain/services/sessions-import-validation-service_test.js
@@ -3,6 +3,7 @@ import lodash from 'lodash';
 import * as sessionsImportValidationService from '../../../../../../src/certification/enrolment/domain/services/sessions-import-validation-service.js';
 import { SUBSCRIPTION_TYPES } from '../../../../../../src/certification/shared/domain/constants.js';
 import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../../../../src/certification/shared/domain/constants/certification-candidates-errors.js';
+import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { CpfBirthInformationValidation } from '../../../../../../src/certification/shared/domain/services/certification-cpf-service.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
@@ -455,146 +456,346 @@ describe('Unit | Service | sessions import validation Service', function () {
   });
 
   describe('#getValidatedSubscriptionsForMassImport', function () {
-    context('when there are no subscriptions at all', function () {
-      it('should return an error accordingly and no subscriptions models', async function () {
-        // given
-        const subscriptionLabels = [];
-        const line = 12;
-
-        // when
-        const { certificationCandidateComplementaryErrors, subscriptions } =
-          await sessionsImportValidationService.getValidatedSubscriptionsForMassImport({
-            subscriptionLabels,
-            line,
-            complementaryCertificationRepository: {},
-          });
-
-        // then
-        expect(certificationCandidateComplementaryErrors).to.deep.equal([
-          {
-            code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_NO_SUBSCRIPTION.code,
-            line,
-            isBlocking: true,
-          },
-        ]);
-        expect(subscriptions).to.be.empty;
+    let isCoreComplementaryCompatibilityEnabled;
+    context('isCoreComplementaryCompatibilityEnabled false', function () {
+      beforeEach(function () {
+        isCoreComplementaryCompatibilityEnabled = false;
       });
-    });
-    context('when there is a complementary subscription without core', function () {
-      it('should return an error accordingly and no subscriptions models', async function () {
-        // given
-        const subscriptionLabels = ['MaComplémentaire'];
-        const line = 12;
-        const complementaryCertificationRepository = {
-          getByLabel: sinon
-            .stub()
+      context('when there are no subscriptions at all', function () {
+        it('should return an error accordingly and no subscriptions models', async function () {
+          // given
+          const subscriptionLabels = [];
+          const line = 12;
+
+          // when
+          const { certificationCandidateComplementaryErrors, subscriptions } =
+            await sessionsImportValidationService.getValidatedSubscriptionsForMassImport({
+              subscriptionLabels,
+              line,
+              complementaryCertificationRepository: {},
+              isCoreComplementaryCompatibilityEnabled,
+            });
+
+          // then
+          expect(certificationCandidateComplementaryErrors).to.deep.equal([
+            {
+              code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_NO_SUBSCRIPTION.code,
+              line,
+              isBlocking: true,
+            },
+          ]);
+          expect(subscriptions).to.be.empty;
+        });
+      });
+      context('when there is a complementary subscription without core', function () {
+        it('should return an error accordingly and no subscriptions models', async function () {
+          // given
+          const subscriptionLabels = ['MaComplémentaire'];
+          const line = 12;
+          const complementaryCertificationRepository = {
+            getByLabel: sinon
+              .stub()
+              .withArgs({ label: 'MaComplémentaire' })
+              .resolves({ id: 3, key: 'SOME_KEY', label: 'MaComplémentaire' }),
+          };
+
+          // when
+          const { certificationCandidateComplementaryErrors, subscriptions } =
+            await sessionsImportValidationService.getValidatedSubscriptionsForMassImport({
+              subscriptionLabels,
+              line,
+              complementaryCertificationRepository,
+              isCoreComplementaryCompatibilityEnabled,
+            });
+
+          // then
+          expect(certificationCandidateComplementaryErrors).to.deep.equal([
+            {
+              code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_COMPLEMENTARY_WITHOUT_CORE.code,
+              line,
+              isBlocking: true,
+            },
+          ]);
+          expect(subscriptions).to.be.empty;
+        });
+      });
+      context('when there are many complementary subscriptions', function () {
+        it('should return an error accordingly and no subscriptions models', async function () {
+          // given
+          const subscriptionLabels = ['MaComplémentaire1', 'MaComplémentaire2', SUBSCRIPTION_TYPES.CORE];
+          const line = 12;
+          const complementaryCertificationRepository = {
+            getByLabel: sinon.stub(),
+          };
+          complementaryCertificationRepository.getByLabel
+            .withArgs({ label: 'MaComplémentaire1' })
+            .resolves({ id: 3, key: 'SOME_KEY1', label: 'MaComplémentaire1' });
+          complementaryCertificationRepository.getByLabel
+            .withArgs({ label: 'MaComplémentaire2' })
+            .resolves({ id: 4, key: 'SOME_KEY2', label: 'MaComplémentaire2' });
+
+          // when
+          const { certificationCandidateComplementaryErrors, subscriptions } =
+            await sessionsImportValidationService.getValidatedSubscriptionsForMassImport({
+              subscriptionLabels,
+              line,
+              complementaryCertificationRepository,
+              isCoreComplementaryCompatibilityEnabled,
+            });
+
+          // then
+          expect(certificationCandidateComplementaryErrors).to.deep.equal([
+            {
+              code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION.code,
+              line,
+              isBlocking: true,
+            },
+          ]);
+          expect(subscriptions).to.be.empty;
+        });
+      });
+      context('when there is only a core subscription', function () {
+        it('should return no error and a core subscription', async function () {
+          // given
+          const subscriptionLabels = [SUBSCRIPTION_TYPES.CORE];
+          const line = 12;
+
+          // when
+          const { certificationCandidateComplementaryErrors, subscriptions } =
+            await sessionsImportValidationService.getValidatedSubscriptionsForMassImport({
+              subscriptionLabels,
+              line,
+              complementaryCertificationRepository: {},
+              isCoreComplementaryCompatibilityEnabled,
+            });
+
+          // then
+          expect(certificationCandidateComplementaryErrors).to.be.empty;
+          expect(subscriptions).to.deepEqualArray([
+            domainBuilder.buildCoreSubscription({ certificationCandidateId: null }),
+          ]);
+        });
+      });
+      context('when there are a core and a complementary subscriptions', function () {
+        it('should return no error and the right subscriptions', async function () {
+          // given
+          const subscriptionLabels = [SUBSCRIPTION_TYPES.CORE, 'MaComplémentaire'];
+          const line = 12;
+          const complementaryCertificationRepository = {
+            getByLabel: sinon.stub(),
+          };
+          complementaryCertificationRepository.getByLabel
             .withArgs({ label: 'MaComplémentaire' })
-            .resolves({ id: 3, key: 'SOME_KEY', label: 'MaComplémentaire' }),
-        };
+            .resolves({ id: 3, key: 'SOME_KEY', label: 'MaComplémentaire' });
 
-        // when
-        const { certificationCandidateComplementaryErrors, subscriptions } =
-          await sessionsImportValidationService.getValidatedSubscriptionsForMassImport({
-            subscriptionLabels,
-            line,
-            complementaryCertificationRepository,
-          });
+          // when
+          const { certificationCandidateComplementaryErrors, subscriptions } =
+            await sessionsImportValidationService.getValidatedSubscriptionsForMassImport({
+              subscriptionLabels,
+              line,
+              complementaryCertificationRepository,
+              isCoreComplementaryCompatibilityEnabled,
+            });
 
-        // then
-        expect(certificationCandidateComplementaryErrors).to.deep.equal([
-          {
-            code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_COMPLEMENTARY_WITHOUT_CORE.code,
-            line,
-            isBlocking: true,
-          },
-        ]);
-        expect(subscriptions).to.be.empty;
+          // then
+          expect(certificationCandidateComplementaryErrors).to.be.empty;
+          expect(subscriptions).to.deepEqualArray([
+            domainBuilder.buildCoreSubscription({ certificationCandidateId: null }),
+            domainBuilder.buildComplementarySubscription({
+              certificationCandidateId: null,
+              complementaryCertificationId: 3,
+            }),
+          ]);
+        });
       });
     });
-    context('when there are many complementary subscriptions', function () {
-      it('should return an error accordingly and no subscriptions models', async function () {
-        // given
-        const subscriptionLabels = ['MaComplémentaire1', 'MaComplémentaire2', SUBSCRIPTION_TYPES.CORE];
-        const line = 12;
-        const complementaryCertificationRepository = {
-          getByLabel: sinon.stub(),
-        };
-        complementaryCertificationRepository.getByLabel
-          .withArgs({ label: 'MaComplémentaire1' })
-          .resolves({ id: 3, key: 'SOME_KEY1', label: 'MaComplémentaire1' });
-        complementaryCertificationRepository.getByLabel
-          .withArgs({ label: 'MaComplémentaire2' })
-          .resolves({ id: 4, key: 'SOME_KEY2', label: 'MaComplémentaire2' });
 
-        // when
-        const { certificationCandidateComplementaryErrors, subscriptions } =
-          await sessionsImportValidationService.getValidatedSubscriptionsForMassImport({
-            subscriptionLabels,
-            line,
-            complementaryCertificationRepository,
-          });
+    context('isCoreComplementaryCompatibilityEnabled true', function () {
+      const notCleaComplementaryCertificationId = 111,
+        notCleaComplementaryCertificationLabel = 'PAS CLEA';
+      const cleaComplementaryCertificationId = 222,
+        cleaComplementaryCertificationLabel = 'CLEA';
+      const reallyNotCleaComplementaryCertificationId = 333,
+        reallyNotCleaComplementaryCertificationLabel = 'VRAIMENT PAS CLEA';
+      let complementaryCertificationRepository;
 
-        // then
-        expect(certificationCandidateComplementaryErrors).to.deep.equal([
-          {
-            code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION.code,
-            line,
-            isBlocking: true,
-          },
-        ]);
-        expect(subscriptions).to.be.empty;
-      });
-    });
-    context('when there is only a core subscription', function () {
-      it('should return no error and a core subscription', async function () {
-        // given
-        const subscriptionLabels = [SUBSCRIPTION_TYPES.CORE];
-        const line = 12;
-
-        // when
-        const { certificationCandidateComplementaryErrors, subscriptions } =
-          await sessionsImportValidationService.getValidatedSubscriptionsForMassImport({
-            subscriptionLabels,
-            line,
-            complementaryCertificationRepository: {},
-          });
-
-        // then
-        expect(certificationCandidateComplementaryErrors).to.be.empty;
-        expect(subscriptions).to.deepEqualArray([
-          domainBuilder.buildCoreSubscription({ certificationCandidateId: null }),
-        ]);
-      });
-    });
-    context('when there are a core and a complementary subscriptions', function () {
-      it('should return no error and the right subscriptions', async function () {
-        // given
-        const subscriptionLabels = [SUBSCRIPTION_TYPES.CORE, 'MaComplémentaire'];
-        const line = 12;
-        const complementaryCertificationRepository = {
-          getByLabel: sinon.stub(),
-        };
-        complementaryCertificationRepository.getByLabel
-          .withArgs({ label: 'MaComplémentaire' })
-          .resolves({ id: 3, key: 'SOME_KEY', label: 'MaComplémentaire' });
-
-        // when
-        const { certificationCandidateComplementaryErrors, subscriptions } =
-          await sessionsImportValidationService.getValidatedSubscriptionsForMassImport({
-            subscriptionLabels,
-            line,
-            complementaryCertificationRepository,
-          });
-
-        // then
-        expect(certificationCandidateComplementaryErrors).to.be.empty;
-        expect(subscriptions).to.deepEqualArray([
-          domainBuilder.buildCoreSubscription({ certificationCandidateId: null }),
-          domainBuilder.buildComplementarySubscription({
-            certificationCandidateId: null,
-            complementaryCertificationId: 3,
+      beforeEach(function () {
+        isCoreComplementaryCompatibilityEnabled = true;
+        const complementaryCertifications = [
+          domainBuilder.buildComplementaryCertification({
+            id: notCleaComplementaryCertificationId,
+            label: notCleaComplementaryCertificationLabel,
+            key: 'someKey',
           }),
-        ]);
+          domainBuilder.buildComplementaryCertification({
+            id: cleaComplementaryCertificationId,
+            label: cleaComplementaryCertificationLabel,
+            key: ComplementaryCertificationKeys.CLEA,
+          }),
+          domainBuilder.buildComplementaryCertification({
+            id: reallyNotCleaComplementaryCertificationId,
+            label: reallyNotCleaComplementaryCertificationLabel,
+            key: 'someOtherKey',
+          }),
+        ];
+        complementaryCertificationRepository = {
+          findAll: sinon.stub().resolves(complementaryCertifications),
+        };
+      });
+
+      context('success cases', function () {
+        it('should return valid core subscription when only core submitted', async function () {
+          // given
+          const subscriptionLabels = [SUBSCRIPTION_TYPES.CORE];
+          const line = 12;
+
+          // when
+          const { certificationCandidateComplementaryErrors, subscriptions } =
+            await sessionsImportValidationService.getValidatedSubscriptionsForMassImport({
+              subscriptionLabels,
+              line,
+              complementaryCertificationRepository,
+              isCoreComplementaryCompatibilityEnabled,
+            });
+
+          // then
+          expect(certificationCandidateComplementaryErrors).to.be.empty;
+          expect(subscriptions).to.deepEqualArray([
+            domainBuilder.buildCoreSubscription({ certificationCandidateId: null }),
+          ]);
+        });
+
+        it('should return valid core/clea subscriptions when clea submitted', async function () {
+          // given
+          const subscriptionLabels = [cleaComplementaryCertificationLabel];
+          const line = 12;
+
+          // when
+          const { certificationCandidateComplementaryErrors, subscriptions } =
+            await sessionsImportValidationService.getValidatedSubscriptionsForMassImport({
+              subscriptionLabels,
+              line,
+              complementaryCertificationRepository,
+              isCoreComplementaryCompatibilityEnabled,
+            });
+
+          // then
+          expect(certificationCandidateComplementaryErrors).to.be.empty;
+          expect(subscriptions).to.deepEqualArray([
+            domainBuilder.buildCoreSubscription({ certificationCandidateId: null }),
+            domainBuilder.buildComplementarySubscription({
+              certificationCandidateId: null,
+              complementaryCertificationId: cleaComplementaryCertificationId,
+            }),
+          ]);
+        });
+
+        it('should return valid complementary subscription when only complementary not clea submitted', async function () {
+          // given
+          const subscriptionLabels = [notCleaComplementaryCertificationLabel];
+          const line = 12;
+
+          // when
+          const { certificationCandidateComplementaryErrors, subscriptions } =
+            await sessionsImportValidationService.getValidatedSubscriptionsForMassImport({
+              subscriptionLabels,
+              line,
+              complementaryCertificationRepository,
+              isCoreComplementaryCompatibilityEnabled,
+            });
+
+          // then
+          expect(certificationCandidateComplementaryErrors).to.be.empty;
+          expect(subscriptions).to.deepEqualArray([
+            domainBuilder.buildComplementarySubscription({
+              certificationCandidateId: null,
+              complementaryCertificationId: notCleaComplementaryCertificationId,
+            }),
+          ]);
+        });
+      });
+
+      context('ko cases', function () {
+        it('should return an error when there are no subscription at all', async function () {
+          // given
+          const subscriptionLabels = [];
+          const line = 12;
+
+          // when
+          const { certificationCandidateComplementaryErrors, subscriptions } =
+            await sessionsImportValidationService.getValidatedSubscriptionsForMassImport({
+              subscriptionLabels,
+              line,
+              complementaryCertificationRepository,
+              isCoreComplementaryCompatibilityEnabled,
+            });
+
+          // then
+          expect(certificationCandidateComplementaryErrors).to.deep.equal([
+            {
+              code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_NO_SUBSCRIPTION.code,
+              line,
+              isBlocking: true,
+            },
+          ]);
+          expect(subscriptions).to.be.empty;
+        });
+
+        it('should return an error when there are two complementary (neither clea)', async function () {
+          // given
+          const subscriptionLabels = [
+            notCleaComplementaryCertificationLabel,
+            reallyNotCleaComplementaryCertificationLabel,
+          ];
+          const line = 12;
+
+          // when
+          const { certificationCandidateComplementaryErrors, subscriptions } =
+            await sessionsImportValidationService.getValidatedSubscriptionsForMassImport({
+              subscriptionLabels,
+              line,
+              complementaryCertificationRepository,
+              isCoreComplementaryCompatibilityEnabled,
+            });
+
+          // then
+          expect(certificationCandidateComplementaryErrors).to.deep.equal([
+            {
+              code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION.code,
+              line,
+              isBlocking: true,
+            },
+          ]);
+          expect(subscriptions).to.be.empty;
+        });
+
+        it('should return an error when there are two complementary (one clea)', async function () {
+          // given
+          const subscriptionLabels = [
+            cleaComplementaryCertificationLabel,
+            reallyNotCleaComplementaryCertificationLabel,
+          ];
+          const line = 12;
+
+          // when
+          const { certificationCandidateComplementaryErrors, subscriptions } =
+            await sessionsImportValidationService.getValidatedSubscriptionsForMassImport({
+              subscriptionLabels,
+              line,
+              complementaryCertificationRepository,
+              isCoreComplementaryCompatibilityEnabled,
+            });
+
+          // then
+          expect(certificationCandidateComplementaryErrors).to.deep.equal([
+            {
+              code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION.code,
+              line,
+              isBlocking: true,
+            },
+          ]);
+          expect(subscriptions).to.be.empty;
+        });
       });
     });
   });

--- a/api/tests/certification/enrolment/unit/domain/usecases/validate-sessions_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/validate-sessions_test.js
@@ -53,7 +53,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
 
     sessionsImportValidationService = {
       getValidatedSubscriptionsForMassImport: sinon.stub(),
-      getValidatedCandidateBirthInformation: sinon.stub(),
+      getValidatedCandidateInformation: sinon.stub(),
       validateSession: sinon.stub(),
       getUniqueCandidates: sinon.stub(),
       validateCandidateEmails: sinon.stub(),
@@ -149,7 +149,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
         subscriptions: [domainBuilder.buildCoreSubscription({ certificationCandidateId: null })],
       });
 
-      sessionsImportValidationService.getValidatedCandidateBirthInformation.resolves({
+      sessionsImportValidationService.getValidatedCandidateInformation.resolves({
         certificationCandidateErrors: [],
         cpfBirthInformation,
       });
@@ -270,7 +270,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
         cpfBirthInformationValidation2.success({ ...candidate2 });
         const cpfBirthInformationValidation3 = new CpfBirthInformationValidation();
         cpfBirthInformationValidation3.success({ ...candidate3 });
-        sessionsImportValidationService.getValidatedCandidateBirthInformation
+        sessionsImportValidationService.getValidatedCandidateInformation
           .onFirstCall()
           .resolves({ certificationCandidateErrors: [], cpfBirthInformation: cpfBirthInformationValidation1 })
           .onSecondCall()
@@ -359,7 +359,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
       sessionsImportValidationService.validateSession.resolves([
         { code: 'Veuillez indiquer un nom de site.', isBlocking: true },
       ]);
-      sessionsImportValidationService.getValidatedCandidateBirthInformation.resolves({
+      sessionsImportValidationService.getValidatedCandidateInformation.resolves({
         certificationCandidateErrors: [],
         cpfBirthInformation: {},
       });
@@ -394,7 +394,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           subscriptions: [domainBuilder.buildCoreSubscription({ certificationCandidateId: null })],
         });
         sessionsImportValidationService.validateSession.resolves(['Veuillez indiquer un nom de site.']);
-        sessionsImportValidationService.getValidatedCandidateBirthInformation.resolves({
+        sessionsImportValidationService.getValidatedCandidateInformation.resolves({
           certificationCandidateErrors: ['lastName required'],
         });
 
@@ -458,7 +458,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           complementaryCertification: [domainBuilder.buildCoreSubscription({ certificationCandidateId: null })],
         });
         sessionsImportValidationService.validateSession.resolves([]);
-        sessionsImportValidationService.getValidatedCandidateBirthInformation.resolves({
+        sessionsImportValidationService.getValidatedCandidateInformation.resolves({
           certificationCandidateErrors: [],
           cpfBirthInformation: {},
         });
@@ -525,7 +525,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           subscriptions: [domainBuilder.buildCoreSubscription({ certificationCandidateId: null })],
         });
         sessionsImportValidationService.validateSession.resolves([]);
-        sessionsImportValidationService.getValidatedCandidateBirthInformation.resolves({
+        sessionsImportValidationService.getValidatedCandidateInformation.resolves({
           certificationCandidateErrors: [],
           cpfBirthInformation: {},
         });

--- a/api/tests/shared/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -526,225 +526,462 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
       });
 
       describe('when there is different session information on consecutive lines', function () {
-        it('should return a full session object per line', function () {
-          // given
-          const parsedCsvData = [
-            _lineWithSessionAndCandidate({ sessionNumber: 1, candidateNumber: 1 }),
-            _lineWithSessionAndCandidate({ sessionNumber: 2, candidateNumber: 1 }),
-            _lineWithSessionAndCandidate({ sessionNumber: 1, candidateNumber: 2 }),
-          ];
+        context('isCoreComplementaryCompatibilityEnabled OFF', function () {
+          it('should return a full session object per line', function () {
+            // given
+            const parsedCsvData = [
+              _lineWithSessionAndCandidate({ sessionNumber: 1, candidateNumber: 1 }),
+              _lineWithSessionAndCandidate({ sessionNumber: 2, candidateNumber: 1 }),
+              _lineWithSessionAndCandidate({ sessionNumber: 1, candidateNumber: 2 }),
+            ];
 
-          const expectedResult = [
-            {
-              sessionId: undefined,
-              address: 'Site 1',
-              room: 'Salle 1',
-              date: '2023-05-12',
-              time: '01:00',
-              examiner: 'Paul',
-              description: '',
-              candidates: [
-                {
-                  lastName: 'Candidat 1',
-                  firstName: 'Candidat 1',
-                  birthdate: '1981-03-01',
-                  sex: 'M',
-                  birthINSEECode: '75015',
-                  birthPostalCode: '',
-                  birthCity: '',
-                  birthCountry: 'France',
-                  resultRecipientEmail: 'robindahood@email.fr',
-                  email: '',
-                  externalId: '',
-                  extraTimePercentage: null,
-                  billingMode: 'Prépayée',
-                  prepaymentCode: '43',
-                  subscriptionLabels: [SUBSCRIPTION_TYPES.CORE],
-                  line: 2,
-                },
-                {
-                  lastName: 'Candidat 2',
-                  firstName: 'Candidat 2',
-                  birthdate: '1981-03-01',
-                  sex: 'M',
-                  birthINSEECode: '75015',
-                  birthPostalCode: '',
-                  birthCity: '',
-                  birthCountry: 'France',
-                  resultRecipientEmail: 'robindahood@email.fr',
-                  email: '',
-                  externalId: '',
-                  extraTimePercentage: null,
-                  billingMode: 'Prépayée',
-                  prepaymentCode: '43',
-                  subscriptionLabels: [SUBSCRIPTION_TYPES.CORE],
-                  line: 4,
-                },
-              ],
-              line: 2,
-            },
-            {
-              sessionId: undefined,
-              address: 'Site 2',
-              room: 'Salle 2',
-              date: '2023-05-12',
-              time: '01:00',
-              examiner: 'Paul',
-              description: '',
-              candidates: [
-                {
-                  lastName: 'Candidat 1',
-                  firstName: 'Candidat 1',
-                  birthdate: '1981-03-01',
-                  sex: 'M',
-                  birthINSEECode: '75015',
-                  birthPostalCode: '',
-                  birthCity: '',
-                  birthCountry: 'France',
-                  resultRecipientEmail: 'robindahood@email.fr',
-                  email: '',
-                  externalId: '',
-                  extraTimePercentage: null,
-                  billingMode: 'Prépayée',
-                  prepaymentCode: '43',
-                  subscriptionLabels: [SUBSCRIPTION_TYPES.CORE],
-                  line: 3,
-                },
-              ],
-              line: 3,
-            },
-          ];
+            const expectedResult = [
+              {
+                sessionId: undefined,
+                address: 'Site 1',
+                room: 'Salle 1',
+                date: '2023-05-12',
+                time: '01:00',
+                examiner: 'Paul',
+                description: '',
+                candidates: [
+                  {
+                    lastName: 'Candidat 1',
+                    firstName: 'Candidat 1',
+                    birthdate: '1981-03-01',
+                    sex: 'M',
+                    birthINSEECode: '75015',
+                    birthPostalCode: '',
+                    birthCity: '',
+                    birthCountry: 'France',
+                    resultRecipientEmail: 'robindahood@email.fr',
+                    email: '',
+                    externalId: '',
+                    extraTimePercentage: null,
+                    billingMode: 'Prépayée',
+                    prepaymentCode: '43',
+                    subscriptionLabels: [SUBSCRIPTION_TYPES.CORE],
+                    line: 2,
+                  },
+                  {
+                    lastName: 'Candidat 2',
+                    firstName: 'Candidat 2',
+                    birthdate: '1981-03-01',
+                    sex: 'M',
+                    birthINSEECode: '75015',
+                    birthPostalCode: '',
+                    birthCity: '',
+                    birthCountry: 'France',
+                    resultRecipientEmail: 'robindahood@email.fr',
+                    email: '',
+                    externalId: '',
+                    extraTimePercentage: null,
+                    billingMode: 'Prépayée',
+                    prepaymentCode: '43',
+                    subscriptionLabels: [SUBSCRIPTION_TYPES.CORE],
+                    line: 4,
+                  },
+                ],
+                line: 2,
+              },
+              {
+                sessionId: undefined,
+                address: 'Site 2',
+                room: 'Salle 2',
+                date: '2023-05-12',
+                time: '01:00',
+                examiner: 'Paul',
+                description: '',
+                candidates: [
+                  {
+                    lastName: 'Candidat 1',
+                    firstName: 'Candidat 1',
+                    birthdate: '1981-03-01',
+                    sex: 'M',
+                    birthINSEECode: '75015',
+                    birthPostalCode: '',
+                    birthCity: '',
+                    birthCountry: 'France',
+                    resultRecipientEmail: 'robindahood@email.fr',
+                    email: '',
+                    externalId: '',
+                    extraTimePercentage: null,
+                    billingMode: 'Prépayée',
+                    prepaymentCode: '43',
+                    subscriptionLabels: [SUBSCRIPTION_TYPES.CORE],
+                    line: 3,
+                  },
+                ],
+                line: 3,
+              },
+            ];
 
-          // when
-          const result = csvSerializer.deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true });
+            // when
+            const result = csvSerializer.deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true });
 
-          // then
-          expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
+            // then
+            expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
+          });
+        });
+        context('isCoreComplementaryCompatibilityEnabled ON', function () {
+          it('should return a full session object per line', function () {
+            // given
+            const isCoreComplementaryCompatibilityEnabled = true;
+            const parsedCsvData = [
+              _lineWithSessionAndCandidate({ sessionNumber: 1, candidateNumber: 1 }),
+              _lineWithSessionAndCandidate({ sessionNumber: 2, candidateNumber: 1 }),
+              _lineWithSessionAndCandidate({ sessionNumber: 1, candidateNumber: 2 }),
+            ];
+
+            const expectedResult = [
+              {
+                sessionId: undefined,
+                address: 'Site 1',
+                room: 'Salle 1',
+                date: '2023-05-12',
+                time: '01:00',
+                examiner: 'Paul',
+                description: '',
+                candidates: [
+                  {
+                    lastName: 'Candidat 1',
+                    firstName: 'Candidat 1',
+                    birthdate: '1981-03-01',
+                    sex: 'M',
+                    birthINSEECode: '75015',
+                    birthPostalCode: '',
+                    birthCity: '',
+                    birthCountry: 'France',
+                    resultRecipientEmail: 'robindahood@email.fr',
+                    email: '',
+                    externalId: '',
+                    extraTimePercentage: null,
+                    billingMode: 'Prépayée',
+                    prepaymentCode: '43',
+                    subscriptionLabels: [SUBSCRIPTION_TYPES.CORE],
+                    line: 2,
+                  },
+                  {
+                    lastName: 'Candidat 2',
+                    firstName: 'Candidat 2',
+                    birthdate: '1981-03-01',
+                    sex: 'M',
+                    birthINSEECode: '75015',
+                    birthPostalCode: '',
+                    birthCity: '',
+                    birthCountry: 'France',
+                    resultRecipientEmail: 'robindahood@email.fr',
+                    email: '',
+                    externalId: '',
+                    extraTimePercentage: null,
+                    billingMode: 'Prépayée',
+                    prepaymentCode: '43',
+                    subscriptionLabels: [SUBSCRIPTION_TYPES.CORE],
+                    line: 4,
+                  },
+                ],
+                line: 2,
+              },
+              {
+                sessionId: undefined,
+                address: 'Site 2',
+                room: 'Salle 2',
+                date: '2023-05-12',
+                time: '01:00',
+                examiner: 'Paul',
+                description: '',
+                candidates: [
+                  {
+                    lastName: 'Candidat 1',
+                    firstName: 'Candidat 1',
+                    birthdate: '1981-03-01',
+                    sex: 'M',
+                    birthINSEECode: '75015',
+                    birthPostalCode: '',
+                    birthCity: '',
+                    birthCountry: 'France',
+                    resultRecipientEmail: 'robindahood@email.fr',
+                    email: '',
+                    externalId: '',
+                    extraTimePercentage: null,
+                    billingMode: 'Prépayée',
+                    prepaymentCode: '43',
+                    subscriptionLabels: [SUBSCRIPTION_TYPES.CORE],
+                    line: 3,
+                  },
+                ],
+                line: 3,
+              },
+            ];
+
+            // when
+            const result = csvSerializer.deserializeForSessionsImport({
+              parsedCsvData,
+              hasBillingMode: true,
+              isCoreComplementaryCompatibilityEnabled,
+            });
+
+            // then
+            expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
+          });
         });
       });
     });
 
     describe('when there is a sessionId', function () {
       context('when there is certification candidate information', function () {
-        it('should return data', function () {
-          // given
-          const parsedCsvData = [
-            _lineWithSessionIdAndCandidate({
-              sessionId: 1,
-              candidateNumber: 1,
-            }),
-            _lineWithSessionIdAndCandidate({
-              sessionId: 1,
-              candidateNumber: 2,
-            }),
-          ];
+        context('isCoreComplementaryCompatibilityEnabled OFF', function () {
+          it('should return data', function () {
+            // given
+            const parsedCsvData = [
+              _lineWithSessionIdAndCandidate({
+                sessionId: 1,
+                candidateNumber: 1,
+              }),
+              _lineWithSessionIdAndCandidate({
+                sessionId: 1,
+                candidateNumber: 2,
+              }),
+            ];
 
-          const expectedResult = [
-            {
-              sessionId: 1,
-              examiner: '',
-              line: 2,
-              candidates: [
-                {
-                  lastName: 'Candidat 1',
-                  firstName: 'Candidat 1',
-                  birthdate: '1981-03-01',
-                  birthINSEECode: '75015',
-                  birthPostalCode: '',
-                  billingMode: 'Prépayée',
-                  birthCity: '',
-                  birthCountry: 'France',
-                  email: '',
-                  externalId: '',
-                  extraTimePercentage: null,
-                  prepaymentCode: '43',
-                  resultRecipientEmail: 'robindahood@email.fr',
-                  sex: 'M',
-                  subscriptionLabels: [SUBSCRIPTION_TYPES.CORE],
-                  line: 2,
-                },
-                {
-                  lastName: 'Candidat 2',
-                  firstName: 'Candidat 2',
-                  birthdate: '1981-03-01',
-                  birthINSEECode: '75015',
-                  birthPostalCode: '',
-                  billingMode: 'Prépayée',
-                  birthCity: '',
-                  birthCountry: 'France',
-                  email: '',
-                  externalId: '',
-                  extraTimePercentage: null,
-                  prepaymentCode: '43',
-                  resultRecipientEmail: 'robindahood@email.fr',
-                  sex: 'M',
-                  subscriptionLabels: [SUBSCRIPTION_TYPES.CORE],
-                  line: 3,
-                },
-              ],
-            },
-          ];
+            const expectedResult = [
+              {
+                sessionId: 1,
+                examiner: '',
+                line: 2,
+                candidates: [
+                  {
+                    lastName: 'Candidat 1',
+                    firstName: 'Candidat 1',
+                    birthdate: '1981-03-01',
+                    birthINSEECode: '75015',
+                    birthPostalCode: '',
+                    billingMode: 'Prépayée',
+                    birthCity: '',
+                    birthCountry: 'France',
+                    email: '',
+                    externalId: '',
+                    extraTimePercentage: null,
+                    prepaymentCode: '43',
+                    resultRecipientEmail: 'robindahood@email.fr',
+                    sex: 'M',
+                    subscriptionLabels: [SUBSCRIPTION_TYPES.CORE],
+                    line: 2,
+                  },
+                  {
+                    lastName: 'Candidat 2',
+                    firstName: 'Candidat 2',
+                    birthdate: '1981-03-01',
+                    birthINSEECode: '75015',
+                    birthPostalCode: '',
+                    billingMode: 'Prépayée',
+                    birthCity: '',
+                    birthCountry: 'France',
+                    email: '',
+                    externalId: '',
+                    extraTimePercentage: null,
+                    prepaymentCode: '43',
+                    resultRecipientEmail: 'robindahood@email.fr',
+                    sex: 'M',
+                    subscriptionLabels: [SUBSCRIPTION_TYPES.CORE],
+                    line: 3,
+                  },
+                ],
+              },
+            ];
 
-          // when
-          const result = csvSerializer
-            .deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true })
-            .map((session) => _.omit(session, 'uniqueKey'));
+            // when
+            const result = csvSerializer
+              .deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true })
+              .map((session) => _.omit(session, 'uniqueKey'));
 
-          // then
-          expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
+            // then
+            expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
+          });
+        });
+        context('isCoreComplementaryCompatibilityEnabled ON', function () {
+          it('should return data', function () {
+            // given
+            const isCoreComplementaryCompatibilityEnabled = true;
+            const parsedCsvData = [
+              _lineWithSessionIdAndCandidate({
+                sessionId: 1,
+                candidateNumber: 1,
+              }),
+              _lineWithSessionIdAndCandidate({
+                sessionId: 1,
+                candidateNumber: 2,
+              }),
+            ];
+
+            const expectedResult = [
+              {
+                sessionId: 1,
+                examiner: '',
+                line: 2,
+                candidates: [
+                  {
+                    lastName: 'Candidat 1',
+                    firstName: 'Candidat 1',
+                    birthdate: '1981-03-01',
+                    birthINSEECode: '75015',
+                    birthPostalCode: '',
+                    billingMode: 'Prépayée',
+                    birthCity: '',
+                    birthCountry: 'France',
+                    email: '',
+                    externalId: '',
+                    extraTimePercentage: null,
+                    prepaymentCode: '43',
+                    resultRecipientEmail: 'robindahood@email.fr',
+                    sex: 'M',
+                    subscriptionLabels: [SUBSCRIPTION_TYPES.CORE],
+                    line: 2,
+                  },
+                  {
+                    lastName: 'Candidat 2',
+                    firstName: 'Candidat 2',
+                    birthdate: '1981-03-01',
+                    birthINSEECode: '75015',
+                    birthPostalCode: '',
+                    billingMode: 'Prépayée',
+                    birthCity: '',
+                    birthCountry: 'France',
+                    email: '',
+                    externalId: '',
+                    extraTimePercentage: null,
+                    prepaymentCode: '43',
+                    resultRecipientEmail: 'robindahood@email.fr',
+                    sex: 'M',
+                    subscriptionLabels: [SUBSCRIPTION_TYPES.CORE],
+                    line: 3,
+                  },
+                ],
+              },
+            ];
+
+            // when
+            const result = csvSerializer
+              .deserializeForSessionsImport({
+                parsedCsvData,
+                hasBillingMode: true,
+                isCoreComplementaryCompatibilityEnabled,
+              })
+              .map((session) => _.omit(session, 'uniqueKey'));
+
+            // then
+            expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
+          });
         });
       });
     });
 
     describe('when there is no session information', function () {
       context('when there is a previous session line in csv', function () {
-        it('should return a full session object with previous session information and current candidate information if any', function () {
-          // given
-          const parsedCsvData = [
-            _lineWithSessionAndNoCandidate({ sessionNumber: 1 }),
-            _lineWithCandidateAndNoSession(),
-          ];
+        context('isCoreComplementaryCompatibilityEnabled OFF', function () {
+          it('should return a full session object with previous session information and current candidate information if any', function () {
+            // given
+            const parsedCsvData = [
+              _lineWithSessionAndNoCandidate({ sessionNumber: 1 }),
+              _lineWithCandidateAndNoSession(),
+            ];
 
-          const expectedResult = [
-            {
-              sessionId: undefined,
-              address: 'Site 1',
-              room: 'Salle 1',
-              date: '2023-05-12',
-              time: '01:00',
-              examiner: 'Paul',
-              description: '',
-              line: 2,
-              candidates: [
-                {
-                  lastName: 'Pennyworth',
-                  firstName: 'Alfred',
-                  birthdate: '1951-03-02',
-                  sex: 'M',
-                  birthINSEECode: '75015',
-                  birthPostalCode: '',
-                  birthCity: '',
-                  birthCountry: 'France',
-                  resultRecipientEmail: 'alfredOfficial@email.fr',
-                  email: '',
-                  externalId: '',
-                  extraTimePercentage: null,
-                  billingMode: 'Prépayée',
-                  prepaymentCode: '43',
-                  subscriptionLabels: [SUBSCRIPTION_TYPES.CORE],
-                  line: 3,
-                },
-              ],
-            },
-          ];
+            const expectedResult = [
+              {
+                sessionId: undefined,
+                address: 'Site 1',
+                room: 'Salle 1',
+                date: '2023-05-12',
+                time: '01:00',
+                examiner: 'Paul',
+                description: '',
+                line: 2,
+                candidates: [
+                  {
+                    lastName: 'Pennyworth',
+                    firstName: 'Alfred',
+                    birthdate: '1951-03-02',
+                    sex: 'M',
+                    birthINSEECode: '75015',
+                    birthPostalCode: '',
+                    birthCity: '',
+                    birthCountry: 'France',
+                    resultRecipientEmail: 'alfredOfficial@email.fr',
+                    email: '',
+                    externalId: '',
+                    extraTimePercentage: null,
+                    billingMode: 'Prépayée',
+                    prepaymentCode: '43',
+                    subscriptionLabels: [SUBSCRIPTION_TYPES.CORE],
+                    line: 3,
+                  },
+                ],
+              },
+            ];
 
-          // when
-          const result = csvSerializer
-            .deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true })
-            .map((session) => _.omit(session, 'uniqueKey'));
+            // when
+            const result = csvSerializer
+              .deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true })
+              .map((session) => _.omit(session, 'uniqueKey'));
 
-          // then
-          expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
+            // then
+            expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
+          });
+        });
+        context('isCoreComplementaryCompatibilityEnabled ON', function () {
+          it('should return a full session object with previous session information and current candidate information if any', function () {
+            // given
+            const isCoreComplementaryCompatibilityEnabled = true;
+            const parsedCsvData = [
+              _lineWithSessionAndNoCandidate({ sessionNumber: 1 }),
+              _lineWithCandidateAndNoSession(),
+            ];
+
+            const expectedResult = [
+              {
+                sessionId: undefined,
+                address: 'Site 1',
+                room: 'Salle 1',
+                date: '2023-05-12',
+                time: '01:00',
+                examiner: 'Paul',
+                description: '',
+                line: 2,
+                candidates: [
+                  {
+                    lastName: 'Pennyworth',
+                    firstName: 'Alfred',
+                    birthdate: '1951-03-02',
+                    sex: 'M',
+                    birthINSEECode: '75015',
+                    birthPostalCode: '',
+                    birthCity: '',
+                    birthCountry: 'France',
+                    resultRecipientEmail: 'alfredOfficial@email.fr',
+                    email: '',
+                    externalId: '',
+                    extraTimePercentage: null,
+                    billingMode: 'Prépayée',
+                    prepaymentCode: '43',
+                    subscriptionLabels: [SUBSCRIPTION_TYPES.CORE],
+                    line: 3,
+                  },
+                ],
+              },
+            ];
+
+            // when
+            const result = csvSerializer
+              .deserializeForSessionsImport({
+                parsedCsvData,
+                hasBillingMode: true,
+                isCoreComplementaryCompatibilityEnabled,
+              })
+              .map((session) => _.omit(session, 'uniqueKey'));
+
+            // then
+            expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
+          });
         });
       });
     });
@@ -803,56 +1040,117 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
         });
       });
 
-      it('should return a session object with candidate information per csv line', function () {
-        // given
-        const parsedCsvData = [
-          lineWithSessionAndCandidateWithComplementaryCertificationSubscription({
-            sessionNumber: 1,
-            candidateNumber: 1,
-            shouldSubscribeToComplementaryCertification: 'oui',
-          }),
-        ];
+      context('isCoreComplementaryCompatibilityEnabled OFF', function () {
+        it('should return a session object with candidate information per csv line', function () {
+          // given
+          const parsedCsvData = [
+            lineWithSessionAndCandidateWithComplementaryCertificationSubscription({
+              sessionNumber: 1,
+              candidateNumber: 1,
+              shouldSubscribeToComplementaryCertification: 'oui',
+            }),
+          ];
 
-        const expectedResult = [
-          {
-            sessionId: undefined,
-            address: 'Site 1',
-            room: 'Salle 1',
-            date: '2023-05-12',
-            time: '01:00',
-            examiner: 'Paul',
-            description: '',
-            line: 2,
-            candidates: [
-              {
-                lastName: 'Candidat 1',
-                firstName: 'Candidat 1',
-                birthdate: '1981-03-01',
-                birthINSEECode: '75015',
-                birthPostalCode: '',
-                billingMode: 'Prépayée',
-                birthCity: '',
-                birthCountry: 'France',
-                email: '',
-                externalId: '',
-                extraTimePercentage: null,
-                prepaymentCode: '43',
-                resultRecipientEmail: 'robindahood@email.fr',
-                sex: 'M',
-                subscriptionLabels: [SUBSCRIPTION_TYPES.CORE, 'Pix certif complementaire'],
-                line: 2,
-              },
-            ],
-          },
-        ];
+          const expectedResult = [
+            {
+              sessionId: undefined,
+              address: 'Site 1',
+              room: 'Salle 1',
+              date: '2023-05-12',
+              time: '01:00',
+              examiner: 'Paul',
+              description: '',
+              line: 2,
+              candidates: [
+                {
+                  lastName: 'Candidat 1',
+                  firstName: 'Candidat 1',
+                  birthdate: '1981-03-01',
+                  birthINSEECode: '75015',
+                  birthPostalCode: '',
+                  billingMode: 'Prépayée',
+                  birthCity: '',
+                  birthCountry: 'France',
+                  email: '',
+                  externalId: '',
+                  extraTimePercentage: null,
+                  prepaymentCode: '43',
+                  resultRecipientEmail: 'robindahood@email.fr',
+                  sex: 'M',
+                  subscriptionLabels: [SUBSCRIPTION_TYPES.CORE, 'Pix certif complementaire'],
+                  line: 2,
+                },
+              ],
+            },
+          ];
 
-        // when
-        const result = csvSerializer
-          .deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true })
-          .map((session) => _.omit(session, 'uniqueKey'));
+          // when
+          const result = csvSerializer
+            .deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true })
+            .map((session) => _.omit(session, 'uniqueKey'));
 
-        // then
-        expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
+          // then
+          expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
+        });
+      });
+
+      context('isCoreComplementaryCompatibilityEnabled ON', function () {
+        it('should return a session object with candidate information per csv line', function () {
+          // given
+          const isCoreComplementaryCompatibilityEnabled = true;
+          const parsedCsvData = [
+            lineWithSessionAndCandidateWithComplementaryCertificationSubscription({
+              sessionNumber: 1,
+              candidateNumber: 1,
+              shouldSubscribeToComplementaryCertification: 'oui',
+            }),
+          ];
+
+          const expectedResult = [
+            {
+              sessionId: undefined,
+              address: 'Site 1',
+              room: 'Salle 1',
+              date: '2023-05-12',
+              time: '01:00',
+              examiner: 'Paul',
+              description: '',
+              line: 2,
+              candidates: [
+                {
+                  lastName: 'Candidat 1',
+                  firstName: 'Candidat 1',
+                  birthdate: '1981-03-01',
+                  birthINSEECode: '75015',
+                  birthPostalCode: '',
+                  billingMode: 'Prépayée',
+                  birthCity: '',
+                  birthCountry: 'France',
+                  email: '',
+                  externalId: '',
+                  extraTimePercentage: null,
+                  prepaymentCode: '43',
+                  resultRecipientEmail: 'robindahood@email.fr',
+                  sex: 'M',
+                  subscriptionLabels: ['Pix certif complementaire'],
+                  line: 2,
+                },
+              ],
+            },
+          ];
+
+          // when
+          const result = csvSerializer
+            .deserializeForSessionsImport({
+              parsedCsvData,
+              hasBillingMode: true,
+              isCoreComplementaryCompatibilityEnabled,
+            })
+            .map((session) => _.omit(session, 'uniqueKey'));
+
+          // then
+          expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
+        });
       });
 
       describe('when some mandatory candidate fields are missing', function () {


### PR DESCRIPTION
## :unicorn: Problème
L'import en masse ne permet pas de valider les nouvelles règles concernant la souscription en certif selon les nouvelles règles de compatibilité coeur/complémentaire

## :robot: Proposition
Rendre compatible pour les centres isV3Pilot & complementaryCertifAlone

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
Tester l'import en masse pour deux centres, un avec isV3Pilot & complementaryCertifAlone et l'autre pas.

La grande différence entre les deux est que, pour l'un l'inscription en certif complémentaire ne génère qu'une subscription dans la complémentaire, alors que l'autre inscrit aussi en certification pix. 
Tester aussi l'exception cléa, qui en tous les cas doit inscrire en certification pix et en cléa
