### PR TITLE
[BUGFIX] Un candidat inscrit en certification dans une session, dont le centre est isV3Pilot et complementaryAlone mais sans habilitations, est en échec (PIX-13950)

### DIFF
--- a/certif/app/components/enrolled-candidates.js
+++ b/certif/app/components/enrolled-candidates.js
@@ -158,7 +158,10 @@ export default class EnrolledCandidates extends Component {
   _createCertificationCandidateRecord(certificationCandidateData) {
     const subscriptions = certificationCandidateData.subscriptions;
     delete certificationCandidateData.subscriptions;
-    if (!this.currentUser.currentAllowedCertificationCenterAccess.isCoreComplementaryCompatibilityEnabled) {
+    if (
+      !this.currentUser.currentAllowedCertificationCenterAccess.isCoreComplementaryCompatibilityEnabled ||
+      subscriptions.length === 0
+    ) {
       subscriptions.push({
         type: SUBSCRIPTION_TYPES.CORE,
         complementaryCertificationId: null,

--- a/certif/app/components/new-candidate-modal/index.gjs
+++ b/certif/app/components/new-candidate-modal/index.gjs
@@ -172,12 +172,7 @@ export default class NewCandidateModal extends Component {
         });
       }
     } else {
-      this.args.candidateData.subscriptions = [
-        {
-          type: SUBSCRIPTION_TYPES.CORE,
-          complementaryCertificationId: null,
-        },
-      ];
+      this.args.candidateData.subscriptions = [];
     }
   };
 

--- a/certif/tests/acceptance/session-add-candidate-test.js
+++ b/certif/tests/acceptance/session-add-candidate-test.js
@@ -122,6 +122,29 @@ module('Acceptance | Session Add Candidate', function (hooks) {
       assert.dom(screen.getByRole('cell', { name: 'Certification Pix' })).exists();
     });
 
+    test('it should add a candidate without any complementary subscription when center has no habilitations', async function (assert) {
+      // given
+      allowedCertificationCenterAccess.update({ habilitations: [] });
+      const screen = await visit(`/sessions/${sessionId}/candidats`);
+
+      // when
+      await click(screen.getByRole('button', { name: 'Inscrire un candidat' }));
+      await fillIn(screen.getByLabelText('* Nom de naissance'), 'Quatorze');
+      await fillIn(screen.getByLabelText('* Prénom'), 'Louis');
+      await click(screen.getByLabelText('Homme'));
+      await fillIn(screen.getByLabelText('* Date de naissance'), '01/01/2000');
+      await click(screen.getByLabelText('* Pays de naissance'));
+      await click(screen.getByText('Portugal'));
+      await fillIn(screen.getByLabelText('* Commune de naissance'), 'Paris');
+      await click(screen.getByRole('button', { name: 'Inscrire le candidat' }));
+
+      // then
+      assert.dom(screen.getByRole('cell', { name: 'Quatorze' })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'Louis' })).exists();
+      assert.dom(screen.getByRole('cell', { name: '01/01/2000' })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'Certification Pix' })).exists();
+    });
+
     test('it should add a candidate with a CleA dual subscription', async function (assert) {
       // given
       const screen = await visit(`/sessions/${sessionId}/candidats`);


### PR DESCRIPTION
## :unicorn: Problème
Bug :
Avec un centre de certif isV3Pilot et complementaryAlone mais sans habilitations
Essayer d'ajouter un candidat à une session de certification.
Ca plante car il n'a aucune subscription

## :robot: Proposition
La subscription CORE était mise lorsqu'on clique sur le choix "Certification Pix" de la modale. Or, quand le centre n'a pas d'habilitations, les radio buttons de choix n'apparaissent car l'inscription est forcément à Certification Pix.
Du coup, au moment de save, je regarde si aucune subscription n'est indiquée, alors je mets une CORE

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
Essayer de reproduire le bug (sans succès j'espère) + non rég sur l'inscription 
