### PR TITLE
[TECH] Ajout d'un mécanisme de regroupement des jobs (PIX-13954)

### DIFF
--- a/api/src/shared/application/jobs/job-controller.js
+++ b/api/src/shared/application/jobs/job-controller.js
@@ -1,10 +1,34 @@
+import Joi from 'joi';
+
+import { EntityValidationError } from '../../domain/errors.js';
+
+export const JobGroup = {
+  DEFAULT: 'default',
+};
+
 export class JobController {
   constructor(jobName, jobGroup = JobGroup.DEFAULT) {
     this.jobName = jobName;
-    this.jobGroup = jobGroup || 'default';
+    this.jobGroup = jobGroup;
+
+    this.#validate();
   }
 
   isJobEnabled() {
     return true;
+  }
+
+  #schema = Joi.object({
+    jobName: Joi.string().required(),
+    jobGroup: Joi.string()
+      .required()
+      .valid(...Object.values(JobGroup)),
+  });
+
+  #validate() {
+    const { error } = this.#schema.validate(this, { allowUnknown: true });
+    if (error) {
+      throw EntityValidationError.fromJoiErrors(error.details);
+    }
   }
 }

--- a/api/src/shared/application/jobs/job-controller.js
+++ b/api/src/shared/application/jobs/job-controller.js
@@ -1,6 +1,7 @@
 export class JobController {
-  constructor(jobName) {
+  constructor(jobName, jobGroup = JobGroup.DEFAULT) {
     this.jobName = jobName;
+    this.jobGroup = jobGroup || 'default';
   }
 
   isJobEnabled() {

--- a/api/src/shared/infrastructure/jobs/JobQueue.js
+++ b/api/src/shared/infrastructure/jobs/JobQueue.js
@@ -9,7 +9,7 @@ class JobQueue {
     this.pgBoss = pgBoss;
   }
 
-  registerJob(name, handlerClass, dependencies) {
+  register(name, handlerClass, dependencies) {
     this.pgBoss.work(name, { teamSize, teamConcurrency }, async (job) => {
       const jobHandler = new handlerClass({ ...dependencies, logger });
       const monitoredJobHandler = new MonitoredJobHandler(jobHandler, logger);

--- a/api/tests/shared/integration/infrastructure/jobs/JobQueue_test.js
+++ b/api/tests/shared/integration/infrastructure/jobs/JobQueue_test.js
@@ -27,7 +27,7 @@ describe('Integration | Infrastructure | Jobs | JobQueue', function () {
         }
       };
 
-      jobQueue.registerJob(name, handler);
+      jobQueue.register(name, handler);
     });
 
     return promise;

--- a/api/tests/shared/unit/application/jobs/job-controller_test.js
+++ b/api/tests/shared/unit/application/jobs/job-controller_test.js
@@ -1,0 +1,42 @@
+import { JobController, JobGroup } from '../../../../../src/shared/application/jobs/job-controller.js';
+import { EntityValidationError } from '../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../test-helper.js';
+
+describe('Unit | Shared | Application | Jobs | JobController', function () {
+  it('should require a job name', async function () {
+    // given
+    const jobName = null;
+
+    // when
+    const error = catchErrSync((jobName) => new JobController(jobName))(jobName);
+
+    // then
+    expect(error).to.be.instanceOf(EntityValidationError);
+  });
+
+  it('should require a valid job group', async function () {
+    // given
+    const jobGroup = 'is-invalid-group';
+
+    // when
+    const error = catchErrSync((jobGroup) => new JobController('jobName', jobGroup))(jobGroup);
+
+    // then
+    expect(error).to.be.instanceOf(EntityValidationError);
+  });
+
+  it('should create a JobController', async function () {
+    // given
+    const jobName = 'jobName';
+    const jobGroup = JobGroup.DEFAULT;
+
+    // when
+    const controller = new JobController(jobName);
+
+    // then
+    expect(controller).to.be.instanceOf(JobController).and.to.deep.equal({
+      jobName,
+      jobGroup,
+    });
+  });
+});

--- a/api/tests/unit/worker_test.js
+++ b/api/tests/unit/worker_test.js
@@ -2,33 +2,37 @@ import { UserAnonymizedEventLoggingJob } from '../../src/identity-access-managem
 import { ValidateOrganizationLearnersImportFileJobController } from '../../src/prescription/learner-management/application/jobs/validate-organization-learners-import-file-job-controller.js';
 import { ValidateOrganizationImportFileJob } from '../../src/prescription/learner-management/domain/models/ValidateOrganizationImportFileJob.js';
 import { UserAnonymizedEventLoggingJobController } from '../../src/shared/application/jobs/audit-log/user-anonymized-event-logging-job-controller.js';
+import { JobGroup } from '../../src/shared/application/jobs/job-controller.js';
 import { config } from '../../src/shared/config.js';
 import { registerJobs } from '../../worker.js';
-import { expect, sinon } from '../test-helper.js';
+import { catchErr, expect, sinon } from '../test-helper.js';
 
 describe('#registerJobs', function () {
-  let startPgBossStub, createJobQueueStub, scheduleCpfJobsStub, jobQueueStub;
+  let startPgBossStub, createJobQueuesStub, scheduleCpfJobsStub, jobQueueStub;
 
   beforeEach(function () {
     const pgBossStub = { schedule: sinon.stub() };
-    jobQueueStub = { registerJob: sinon.stub() };
+    jobQueueStub = { register: sinon.stub() };
     startPgBossStub = sinon.stub();
     startPgBossStub.resolves(pgBossStub);
-    createJobQueueStub = sinon.stub();
-    createJobQueueStub.withArgs(pgBossStub).returns(jobQueueStub);
+    createJobQueuesStub = sinon.stub();
+    createJobQueuesStub.withArgs(pgBossStub).returns(jobQueueStub);
     scheduleCpfJobsStub = sinon.stub();
   });
 
   it('should register UserAnonymizedEventLoggingJob', async function () {
     // when
     await registerJobs({
-      startPgBoss: startPgBossStub,
-      createJobQueue: createJobQueueStub,
-      scheduleCpfJobs: scheduleCpfJobsStub,
+      jobGroup: JobGroup.DEFAULT,
+      dependencies: {
+        startPgBoss: startPgBossStub,
+        createJobQueues: createJobQueuesStub,
+        scheduleCpfJobs: scheduleCpfJobsStub,
+      },
     });
 
     // then
-    expect(jobQueueStub.registerJob).to.have.been.calledWithExactly(
+    expect(jobQueueStub.register).to.have.been.calledWithExactly(
       UserAnonymizedEventLoggingJob.name,
       UserAnonymizedEventLoggingJobController,
     );
@@ -40,13 +44,16 @@ describe('#registerJobs', function () {
 
     // when
     await registerJobs({
-      startPgBoss: startPgBossStub,
-      createJobQueue: createJobQueueStub,
-      scheduleCpfJobs: scheduleCpfJobsStub,
+      jobGroup: JobGroup.DEFAULT,
+      dependencies: {
+        startPgBoss: startPgBossStub,
+        createJobQueues: createJobQueuesStub,
+        scheduleCpfJobs: scheduleCpfJobsStub,
+      },
     });
 
     // then
-    expect(jobQueueStub.registerJob).to.have.been.calledWithExactly(
+    expect(jobQueueStub.register).to.have.been.calledWithExactly(
       ValidateOrganizationImportFileJob.name,
       ValidateOrganizationLearnersImportFileJobController,
     );
@@ -58,15 +65,33 @@ describe('#registerJobs', function () {
 
     // when
     await registerJobs({
-      startPgBoss: startPgBossStub,
-      createJobQueue: createJobQueueStub,
-      scheduleCpfJobs: scheduleCpfJobsStub,
+      jobGroup: JobGroup.DEFAULT,
+      dependencies: {
+        startPgBoss: startPgBossStub,
+        createJobQueues: createJobQueuesStub,
+        scheduleCpfJobs: scheduleCpfJobsStub,
+      },
     });
 
     // then
-    expect(jobQueueStub.registerJob).to.not.have.been.calledWithExactly(
+    expect(jobQueueStub.register).to.not.have.been.calledWithExactly(
       ValidateOrganizationImportFileJob.name,
       ValidateOrganizationLearnersImportFileJobController,
     );
+  });
+
+  it('should throws an error when group is invalid', async function () {
+    // given
+    const error = await catchErr(registerJobs)({
+      dependencies: {
+        startPgBoss: startPgBossStub,
+        createJobQueues: createJobQueuesStub,
+        scheduleCpfJobs: scheduleCpfJobsStub,
+      },
+    });
+
+    // then
+    expect(error).to.be.instanceOf(Error);
+    expect(error.message).to.equal(`Job group invalid, allowed Job groups are [${Object.values(JobGroup)}]`);
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Il est impossible actuellement de lancer plusieurs worker avec un seul fichier, il faut tout dupliquer, ce qui est légèrement dommage

## :robot: Proposition
Avec un seul worker.js il est possible de lancer plusieurs  dans différent containeur

**Usage**
```js
# depuis la commande node
node worker.js default

# depuis la commande npm
npm run start:job -- default
```


## :rainbow: Remarques
Une validation permet de ne pas lancer de jobGroup inexistant

## :100: Pour tester
Vérifier que les 13 job actuel sont bien enregistrer sur le worker `default`
