### PR TITLE
[BUGFIX] Jeter une erreur si le candidat n'existe pas lors de la suppression de ce dernier sur Pix Certif (PIX-13961).

### DIFF
--- a/api/src/certification/enrolment/domain/usecases/delete-unlinked-certification-candidate.js
+++ b/api/src/certification/enrolment/domain/usecases/delete-unlinked-certification-candidate.js
@@ -2,6 +2,7 @@
  * @typedef {import('./index.js').CandidateRepository} candidateRepository
  */
 
+import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { CertificationCandidateForbiddenDeletionError } from '../errors.js';
 
 /**
@@ -10,6 +11,10 @@ import { CertificationCandidateForbiddenDeletionError } from '../errors.js';
  */
 const deleteUnlinkedCertificationCandidate = async function ({ candidateId, candidateRepository }) {
   const candidate = await candidateRepository.get({ certificationCandidateId: candidateId });
+
+  if (!candidate) {
+    throw new NotFoundError();
+  }
 
   if (!candidate.isLinkedToAUser()) {
     return candidateRepository.remove({ id: candidateId });

--- a/api/tests/certification/session-management/unit/domain/usecases/delete-unlinked-certification-candidate_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/delete-unlinked-certification-candidate_test.js
@@ -1,5 +1,6 @@
 import { CertificationCandidateForbiddenDeletionError } from '../../../../../../src/certification/enrolment/domain/errors.js';
 import { deleteUnlinkedCertificationCandidate } from '../../../../../../src/certification/enrolment/domain/usecases/delete-unlinked-certification-candidate.js';
+import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | delete-unlinked-certification-candidate', function () {
@@ -31,6 +32,22 @@ describe('Unit | UseCase | delete-unlinked-certification-candidate', function ()
 
       // then
       expect(res).to.deep.equal(true);
+    });
+  });
+
+  context('When the certification candidate does not exist', function () {
+    it('should throw an error', async function () {
+      // given
+      candidateRepository.get.withArgs({ certificationCandidateId: candidateId }).resolves(null);
+
+      // when
+      const error = await catchErr(deleteUnlinkedCertificationCandidate)({
+        candidateId,
+        candidateRepository,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Pour peu que l'utilisateur fasse un double clique lors de la suppression du candidat, une 500 apparaît car on ne gère pas le fait que la bdd ne retrouve plus le candidat, car il vient fraîchement d'être supprimé.


https://github.com/user-attachments/assets/cb293af6-b868-467c-9b49-6fe6f9075d97

## :robot: Proposition
Jeter une erreur appropriée.

## :100: Pour tester
(Mettre le réseau en lent pour faire l'action du double clique sur la suppression)

- Sur Pix Certif, choisir une session, aller voir ses candidats et en supprimer un dans la liste.
- S'assurer qu'on jette une 404 plutôt qu'une 500

<img width="781" alt="Capture d’écran 2024-08-22 à 12 22 22" src="https://github.com/user-attachments/assets/2d4f5592-727c-4a36-bcb6-d40ac2e39bbf">


L'idéal serait d'avoir un loader pour éviter les multiples clics. (composant pix ui)