### PR TITLE
[TECH] Surcharger les propriétés teamConcurrency et teamSize (PIX-13964)

### DIFF
--- a/api/src/prescription/learner-management/application/jobs/import-organization-learners-job-controller.js
+++ b/api/src/prescription/learner-management/application/jobs/import-organization-learners-job-controller.js
@@ -8,7 +8,7 @@ class ImportOrganizationLearnersJobController extends JobController {
     super(ImportOrganizationLearnersJob.name);
   }
 
-  isJobEnabled() {
+  get isJobEnabled() {
     return config.pgBoss.importFileJobEnabled;
   }
 

--- a/api/src/prescription/learner-management/application/jobs/validate-organization-learners-import-file-job-controller.js
+++ b/api/src/prescription/learner-management/application/jobs/validate-organization-learners-import-file-job-controller.js
@@ -8,7 +8,7 @@ class ValidateOrganizationLearnersImportFileJobController extends JobController 
     super(ValidateOrganizationImportFileJob.name);
   }
 
-  isJobEnabled() {
+  get isJobEnabled() {
     return config.pgBoss.validationFileJobEnabled;
   }
 

--- a/api/src/shared/application/jobs/job-controller.js
+++ b/api/src/shared/application/jobs/job-controller.js
@@ -14,7 +14,7 @@ export class JobController {
     this.#validate();
   }
 
-  isJobEnabled() {
+  get isJobEnabled() {
     return true;
   }
 

--- a/api/src/shared/application/jobs/job-controller.js
+++ b/api/src/shared/application/jobs/job-controller.js
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 
+import { config } from '../../config.js';
 import { EntityValidationError } from '../../domain/errors.js';
 
 export const JobGroup = {
@@ -16,6 +17,14 @@ export class JobController {
 
   get isJobEnabled() {
     return true;
+  }
+
+  get teamSize() {
+    return config.pgBoss.teamSize;
+  }
+
+  get teamConcurrency() {
+    return config.pgBoss.teamConcurrency;
   }
 
   #schema = Joi.object({

--- a/api/src/shared/infrastructure/jobs/JobQueue.js
+++ b/api/src/shared/infrastructure/jobs/JobQueue.js
@@ -1,17 +1,16 @@
-import { config } from '../../config.js';
 import { logger } from '../utils/logger.js';
 import { MonitoredJobHandler } from './monitoring/MonitoredJobHandler.js';
 import { MonitoringJobExecutionTimeHandler } from './monitoring/MonitoringJobExecutionTimeHandler.js';
-const { teamSize, teamConcurrency } = config.pgBoss;
 
 class JobQueue {
   constructor(pgBoss) {
     this.pgBoss = pgBoss;
   }
 
-  register(name, handlerClass, dependencies) {
+  register(name, handlerClass) {
+    const jobHandler = new handlerClass();
+    const { teamConcurrency, teamSize } = jobHandler;
     this.pgBoss.work(name, { teamSize, teamConcurrency }, async (job) => {
-      const jobHandler = new handlerClass({ ...dependencies, logger });
       const monitoredJobHandler = new MonitoredJobHandler(jobHandler, logger);
       return monitoredJobHandler.handle(job.data, name);
     });

--- a/api/tests/prescription/learner-management/unit/application/jobs/import-organization-learners-job-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/jobs/import-organization-learners-job-controller_test.js
@@ -13,7 +13,7 @@ describe('Unit | Prescription | Application | Jobs | importOrganizationLearnersJ
       const handler = new ImportOrganizationLearnersJobController();
 
       // then
-      expect(handler.isJobEnabled()).to.be.true;
+      expect(handler.isJobEnabled).to.be.true;
     });
 
     it('return false when job is disabled', function () {
@@ -24,7 +24,7 @@ describe('Unit | Prescription | Application | Jobs | importOrganizationLearnersJ
       const handler = new ImportOrganizationLearnersJobController();
 
       //then
-      expect(handler.isJobEnabled()).to.be.false;
+      expect(handler.isJobEnabled).to.be.false;
     });
   });
 

--- a/api/tests/prescription/learner-management/unit/application/jobs/validate-organization-learners-import-file-job-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/jobs/validate-organization-learners-import-file-job-controller_test.js
@@ -13,7 +13,7 @@ describe('Unit | Prescription | Application | Jobs | validateOrganizationLearner
       const handler = new ValidateOrganizationLearnersImportFileJobController();
 
       // then
-      expect(handler.isJobEnabled()).to.be.true;
+      expect(handler.isJobEnabled).to.be.true;
     });
 
     it('return false when job is disabled', function () {
@@ -24,7 +24,7 @@ describe('Unit | Prescription | Application | Jobs | validateOrganizationLearner
       const handler = new ValidateOrganizationLearnersImportFileJobController();
 
       //then
-      expect(handler.isJobEnabled()).to.be.false;
+      expect(handler.isJobEnabled).to.be.false;
     });
   });
 

--- a/api/tests/shared/integration/infrastructure/jobs/JobQueue_test.js
+++ b/api/tests/shared/integration/infrastructure/jobs/JobQueue_test.js
@@ -17,6 +17,14 @@ describe('Integration | Infrastructure | Jobs | JobQueue', function () {
 
     const promise = new Promise((resolve, reject) => {
       const handler = class {
+        get teamConcurrency() {
+          return 1;
+        }
+
+        get teamSize() {
+          return 2;
+        }
+
         handle(params) {
           try {
             expect(params).to.deep.equal(expectedParams);

--- a/api/worker.js
+++ b/api/worker.js
@@ -93,7 +93,7 @@ export async function registerJobs({ jobGroup, dependencies = { startPgBoss, cre
 
     if (!isJobInWebProcess && job.jobGroup !== jobGroup) continue;
 
-    if (job.isJobEnabled()) {
+    if (job.isJobEnabled) {
       logger.info(`Job "${job.jobName}" registered from module "${moduleName}."`);
       jobQueues.register(job.jobName, ModuleClass);
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, il n’est pas possible de surcharger les paramètres teamSize et teamConcurrency d’un worker PgBoss. Cela fait, qu’on ne peut pas instancier des workers avec des configurations différentes.

## :robot: Proposition
Ajouter des getters pour ces 2 propriétés dans JobController.

## :rainbow: Remarques
RAS

## :100: Pour tester
La CI est au vert ✅ 
