### PR TITLE
[BUGFIX] Empêche les jobs de validation d'échouer pour des erreurs métiers (PIX-13956)

### DIFF
--- a/api/src/prescription/learner-management/domain/usecases/validate-siecle-xml-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/validate-siecle-xml-file.js
@@ -19,7 +19,6 @@ const validateSiecleXmlFile = async function ({
   organizationRepository,
   organizationImportRepository,
   importStorage,
-  logErrorWithCorrelationIds,
   importOrganizationLearnersJobRepository,
 }) {
   await DomainTransaction.execute(async () => {
@@ -55,12 +54,13 @@ const validateSiecleXmlFile = async function ({
       } else {
         errors.push(error);
       }
-      try {
-        await importStorage.deleteFile({ filename: organizationImport.filename });
-      } catch (e) {
-        logErrorWithCorrelationIds(e);
+
+      await importStorage.deleteFile({ filename: organizationImport.filename });
+
+      const isKnownError = error instanceof AggregateImportError || error instanceof SiecleXmlImportError;
+      if (!isKnownError) {
+        throw error;
       }
-      throw error;
     } finally {
       organizationImport.validate({ errors });
       await organizationImportRepository.save(organizationImport);


### PR DESCRIPTION
## :unicorn: Problème

Depuis la PR https://github.com/1024pix/pix/pull/9816, on se retrouve avec des jobs failed quand la validation d'un fichier a échoué pour des raisons légitimes. Cela engendre du bruit pour la @1024pix/team-captains qui se retrouve à investiguer des  alertes qui n'ont pas lieu d'être.

## :robot: Proposition
Dans cette PR, on se propose de ne faire échouer le job de validation que si une erreur non connue a eu lieu ou si on a pas pu supprimer le fichier d'import du stockage.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- Essayer d'importer un fichier non valide et constater en DB que le job est marqué comme completed.
