### PR TITLE
[FEATURE] Améliorer le formulaire d'entrée en certification sur Pix App (PIX-13948).

### DIFF
--- a/mon-pix/app/components/certification-joiner.hbs
+++ b/mon-pix/app/components/certification-joiner.hbs
@@ -5,7 +5,8 @@
     <div class="certification-joiner__row">
       <PixInput
         @id="certificationJoinerSessionId"
-        class={{if this.sessionIdIsNotANumberError "certification-joiner__input--invalid"}}
+        @errorMessage={{this.sessionIdIsNotANumberMessage}}
+        @validationStatus={{this.sessionIdStatus}}
         pattern={{this.SESSION_ID_VALIDATION_PATTERN}}
         title={{t "pages.certification-joiner.form.fields-validation.session-number-error"}}
         type="text"
@@ -18,7 +19,6 @@
       >
         <:label>{{t "pages.certification-joiner.form.fields.session-number"}}</:label>
       </PixInput>
-      <p class="certification-joiner__validation-error">{{this.sessionIdIsNotANumberError}}</p>
     </div>
     <div class="certification-joiner__row">
       <PixInput @id="certificationJoinerFirstName" type="text" {{on "change" this.setFirstName}}>

--- a/mon-pix/app/components/certification-joiner.hbs
+++ b/mon-pix/app/components/certification-joiner.hbs
@@ -2,35 +2,30 @@
 <section class="certification-joiner">
   <h1 class="certification-joiner__title">{{t "pages.certification-joiner.first-title"}}</h1>
   <form autocomplete="off" {{on "submit" this.attemptNext}}>
-    <div class="certification-joiner__row">
-      <PixInput
-        @id="certificationJoinerSessionId"
-        @errorMessage={{this.sessionIdIsNotANumberMessage}}
-        @validationStatus={{this.sessionIdStatus}}
-        pattern={{this.SESSION_ID_VALIDATION_PATTERN}}
-        title={{t "pages.certification-joiner.form.fields-validation.session-number-error"}}
-        type="text"
-        size="6"
-        {{on "input" this.checkSessionIdIsValid}}
-        {{on "change" this.setSessionId}}
-        inputmode="decimal"
-        required="true"
-        @subLabel={{t "pages.certification-joiner.form.fields.session-number-information"}}
-      >
-        <:label>{{t "pages.certification-joiner.form.fields.session-number"}}</:label>
-      </PixInput>
-    </div>
-    <div class="certification-joiner__row">
-      <PixInput @id="certificationJoinerFirstName" type="text" {{on "change" this.setFirstName}}>
-        <:label>{{t "pages.certification-joiner.form.fields.first-name"}}</:label>
-      </PixInput>
-    </div>
-    <div class="certification-joiner__row">
-      <PixInput type="text" {{on "change" this.setLastName}} @id="certificationJoinerLastName">
-        <:label>{{t "pages.certification-joiner.form.fields.birth-name"}}</:label>
-      </PixInput>
-    </div>
-    <div class="certification-joiner__row">
+    <p class="certification-joiner__mandatory">{{t "common.form.mandatory-all-fields"}}</p>
+
+    <PixInput
+      @id="certificationJoinerSessionId"
+      @errorMessage={{this.sessionIdIsNotANumberMessage}}
+      @validationStatus={{this.sessionIdStatus}}
+      pattern={{this.SESSION_ID_VALIDATION_PATTERN}}
+      title={{t "pages.certification-joiner.form.fields-validation.session-number-error"}}
+      size="6"
+      {{on "input" this.checkSessionIdIsValid}}
+      {{on "change" this.setSessionId}}
+      inputmode="decimal"
+      required="true"
+      @subLabel={{t "pages.certification-joiner.form.fields.session-number-information"}}
+    >
+      <:label>{{t "pages.certification-joiner.form.fields.session-number"}}</:label>
+    </PixInput>
+    <PixInput @id="certificationJoinerFirstName" required="true" {{on "change" this.setFirstName}}>
+      <:label>{{t "pages.certification-joiner.form.fields.first-name"}}</:label>
+    </PixInput>
+    <PixInput @id="certificationJoinerLastName" required="true" {{on "change" this.setLastName}}>
+      <:label>{{t "pages.certification-joiner.form.fields.birth-name"}}</:label>
+    </PixInput>
+    <div>
       <PixLabel class="certification-joiner__label" for="certificationJoinerDayOfBirth">{{t
           "pages.certification-joiner.form.fields.birth-date"
         }}</PixLabel>
@@ -45,6 +40,7 @@
           {{on "input" this.handleDayInputChange}}
           {{on "focus-in" this.handleInputFocus}}
           @screenReaderOnly="true"
+          required="true"
         >
           <:label>{{t "pages.certification-joiner.form.fields.birth-day"}}</:label>
         </PixInput>
@@ -58,6 +54,7 @@
           {{on "input" this.handleMonthInputChange}}
           {{on "focus-in" this.handleInputFocus}}
           @screenReaderOnly="true"
+          required="true"
         >
           <:label>{{t "pages.certification-joiner.form.fields.birth-month"}}</:label>
         </PixInput>
@@ -70,6 +67,7 @@
           {{on "change" this.setYearOfBirth}}
           {{on "focus-in" this.handleInputFocus}}
           @screenReaderOnly="true"
+          required="true"
         >
           <:label>{{t "pages.certification-joiner.form.fields.birth-year"}}</:label>
         </PixInput>

--- a/mon-pix/app/components/certification-joiner.js
+++ b/mon-pix/app/components/certification-joiner.js
@@ -36,7 +36,8 @@ export default class CertificationJoiner extends Component {
   @tracked errorMessage = null;
   @tracked errorDetailList = [];
   @tracked errorMessageLink = null;
-  @tracked sessionIdIsNotANumberError = null;
+  @tracked sessionIdIsNotANumberMessage = null;
+  @tracked sessionIdStatus = 'default';
   @tracked validationClassName = '';
   @tracked sessionId = null;
   @tracked firstName = null;
@@ -69,12 +70,15 @@ export default class CertificationJoiner extends Component {
   @action
   checkSessionIdIsValid(event) {
     const { value } = event.target;
+
+    this.sessionIdIsNotANumberMessage = null;
+    this.sessionIdStatus = 'default';
+
     if (value && !this._isANumber(value)) {
-      this.sessionIdIsNotANumberError = this.intl.t(
+      this.sessionIdIsNotANumberMessage = this.intl.t(
         'pages.certification-joiner.form.fields-validation.session-number-error',
       );
-    } else {
-      this.sessionIdIsNotANumberError = null;
+      this.sessionIdStatus = 'error';
     }
   }
 

--- a/mon-pix/app/styles/components/_certification-joiner.scss
+++ b/mon-pix/app/styles/components/_certification-joiner.scss
@@ -24,44 +24,6 @@
     margin: 0 auto;
   }
 
-  input {
-    width: 100%;
-    min-width: 0;
-    height: 50px;
-    padding-left: 10px;
-    border: 2px solid var(--pix-neutral-100);
-    border-radius: 4px;
-    outline-width: 1px;
-
-    &:hover {
-      box-shadow: 0 0 0 2px var(--pix-primary-500);
-    }
-
-    &:focus {
-      outline: 1px solid var(--pix-primary-500);
-      box-shadow: 0 0 0 2px var(--pix-primary-500);
-    }
-
-    &:focus-within {
-      outline: 1px solid var(--pix-primary-500);
-      box-shadow: 0 0 0 2px var(--pix-primary-500);
-    }
-
-    &.certification-joiner__input--invalid:not(:hover) {
-      outline: 1px solid var(--pix-error-500);
-      box-shadow: 0 0 0 2px var(--pix-error-500);
-    }
-
-    &.certification-joiner__input--invalid:focus {
-      outline: 1px solid var(--pix-error-500);
-      box-shadow: 0 0 0 2px var(--pix-error-500);
-    }
-  }
-
-  input::-ms-clear {
-    display: none;
-  }
-
   button {
     width: 100%;
     margin-top: 8px;
@@ -72,10 +34,6 @@
       border: 2px solid var(--pix-neutral-0);
       box-shadow: 0 0 0 2px var(--pix-primary-500);
     }
-  }
-
-  :input-placeholder {
-    color: var(--pix-neutral-100);
   }
 
   p.certification-joiner__validation-error {

--- a/mon-pix/app/styles/components/_certification-joiner.scss
+++ b/mon-pix/app/styles/components/_certification-joiner.scss
@@ -36,13 +36,6 @@
     }
   }
 
-  p.certification-joiner__validation-error {
-    margin-top: 6px;
-    margin-bottom: 0;
-    color: var(--pix-error-500);
-    font-size: 0.875rem;
-  }
-
   &__birthdate {
     display: flex;
     flex-flow: row nowrap;

--- a/mon-pix/app/styles/components/_certification-joiner.scss
+++ b/mon-pix/app/styles/components/_certification-joiner.scss
@@ -1,39 +1,27 @@
 .certification-joiner {
-  margin-top: 32px;
+  margin: var(--pix-spacing-8x) 0;
   text-rendering: optimizelegibility;
 
   &__title {
-    margin-bottom: 32px;
-    color: var(--pix-neutral-900);
-    font-size: 2rem;
-    font-family: $font-open-sans;
+    @extend %pix-title-m;
+
+    margin-bottom: var(--pix-spacing-4x);
     text-align: center;
   }
 
-  &__row {
-    position: relative;
-    display: flex;
-    flex-flow: column nowrap;
-    width: 100%;
-    margin-bottom: 24px;
+  &__mandatory {
+    @extend %pix-body-s;
+
+    color: var(--pix-neutral-800);
+    text-align: center;
   }
 
   form {
-    display: block;
-    width: 280px;
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-6x);
+    width: 300px;
     margin: 0 auto;
-  }
-
-  button {
-    width: 100%;
-    margin-top: 8px;
-    margin-bottom: 34px;
-    border: 2px solid var(--pix-neutral-0);
-
-    &:focus-within {
-      border: 2px solid var(--pix-neutral-0);
-      box-shadow: 0 0 0 2px var(--pix-primary-500);
-    }
   }
 
   &__birthdate {
@@ -52,7 +40,7 @@
   }
 
   &__label {
-    margin-bottom: 4px;
+    margin-bottom: var(--pix-spacing-2x);
   }
 
   .certification-course-page {

--- a/mon-pix/tests/integration/components/certification-joiner-test.js
+++ b/mon-pix/tests/integration/components/certification-joiner-test.js
@@ -289,6 +289,49 @@ module('Integration | Component | certification-joiner', function (hooks) {
     assert.ok(screen.getByText(this.intl.t('pages.certification-joiner.form.fields.session-number-information')));
   });
 
+  test('should have inputs mandatory', async function (assert) {
+    // given & when
+    const screen = await render(hbs`<CertificationJoiner @onStepChange={{this.onStepChange}} />`);
+
+    // then
+    assert
+      .dom(
+        screen.getByRole('textbox', {
+          name: 'Numéro de session Communiqué uniquement par le surveillant en début de session',
+        }),
+      )
+      .isRequired();
+    assert
+      .dom(screen.getByRole('textbox', { name: this.intl.t('pages.certification-joiner.form.fields.first-name') }))
+      .isRequired();
+    assert
+      .dom(screen.getByRole('textbox', { name: this.intl.t('pages.certification-joiner.form.fields.birth-name') }))
+      .isRequired();
+    assert
+      .dom(
+        screen.getByRole('spinbutton', {
+          name: `${this.intl.t('pages.certification-joiner.form.fields.birth-date')} ${this.intl.t(
+            'pages.certification-joiner.form.fields.birth-day',
+          )}`,
+        }),
+      )
+      .isRequired();
+    assert
+      .dom(
+        screen.getByRole('spinbutton', {
+          name: `${this.intl.t('pages.certification-joiner.form.fields.birth-month')}`,
+        }),
+      )
+      .isRequired();
+    assert
+      .dom(
+        screen.getByRole('spinbutton', {
+          name: `${this.intl.t('pages.certification-joiner.form.fields.birth-year')}`,
+        }),
+      )
+      .isRequired();
+  });
+
   module('when filling form', function () {
     module('should not allow filling letters in birth date', function () {
       test('day', async function (assert) {


### PR DESCRIPTION
## :unicorn: Problème
Le formulaire d'entrée en certification présente plusieurs soucis : 
- On y utilise les composants pix ui, pourtant une couche css manipule le design des champs
- Le champ session jette une erreur si on met des lettres en valeur avec l'ajout d'une classe pour passer le border en rouge et un p qui s'affiche sous le champ, mais des paramètres coté PixInput existent pour gérer visuellement le champ en erreur.
- Tous les champs sont attendus coté API pour identifier l'utilisateur, pourtant seul le champ de session est flag comme obligatoire

## :robot: Proposition
Rendre tous les champs de l'entrée en certification obligatoire et améliorer le design

## :rainbow: Remarques
Avant/ Après
<img width="600" alt="Capture d’écran 2024-08-22 à 15 16 20" src="https://github.com/user-attachments/assets/b885a3bc-f160-4002-9b6d-574e757643d8"><img width="650" alt="Capture d’écran 2024-08-22 à 15 52 24" src="https://github.com/user-attachments/assets/b715aaeb-929f-4042-b060-d2a052859735">


## :100: Pour tester

- Se connecter avec certif-success@example
- Aller dans certification
- Bidouiller les champs pour vérifier la non régression du formulaire
