### PR TITLE
[TECH] Mettre les clés de traduction sur les boutons d'actions  (PIX-13970)

### DIFF
--- a/admin/app/components/actions-on-users-role-in-organization.gjs
+++ b/admin/app/components/actions-on-users-role-in-organization.gjs
@@ -18,8 +18,8 @@ export default class ActionsOnUsersRoleInOrganization extends Component {
 
   get organizationRoles() {
     return [
-      { value: 'ADMIN', label: 'Administrateur' },
-      { value: 'MEMBER', label: 'Membre' },
+      { value: 'ADMIN', label: this.intl.t('common.roles.admin') },
+      { value: 'MEMBER', label: this.intl.t('common.roles.member') },
     ];
   }
 

--- a/admin/app/components/actions-on-users-role-in-organization.gjs
+++ b/admin/app/components/actions-on-users-role-in-organization.gjs
@@ -135,7 +135,7 @@ export default class ActionsOnUsersRoleInOrganization extends Component {
             @triggerAction={{this.toggleDisplayConfirm}}
             @iconBefore="trash"
           >
-            Désactiver
+            {{t "common.actions.deactivate"}}
           </PixButton>
         </div>
 

--- a/admin/app/components/actions-on-users-role-in-organization.gjs
+++ b/admin/app/components/actions-on-users-role-in-organization.gjs
@@ -6,6 +6,7 @@ import { service } from '@ember/service';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 
 export default class ActionsOnUsersRoleInOrganization extends Component {
   @service notifications;
@@ -107,7 +108,7 @@ export default class ActionsOnUsersRoleInOrganization extends Component {
                 @size="small"
                 @variant="secondary"
                 @triggerAction={{this.cancelUpdateRoleOfMember}}
-                aria-label="Annuler"
+                aria-label={{t "common.actions.cancel"}}
                 class="member-item-actions__button--icon"
               >
                 <FaIcon @icon="xmark" />
@@ -150,7 +151,7 @@ export default class ActionsOnUsersRoleInOrganization extends Component {
           </:content>
           <:footer>
             <PixButton @variant="secondary" @triggerAction={{this.toggleDisplayConfirm}}>
-              Annuler
+              {{t "common.actions.cancel"}}
             </PixButton>
             <PixButton @triggerAction={{this.disableOrganizationMembership}}>Confirmer</PixButton>
           </:footer>

--- a/admin/app/components/actions-on-users-role-in-organization.gjs
+++ b/admin/app/components/actions-on-users-role-in-organization.gjs
@@ -11,6 +11,7 @@ import { t } from 'ember-intl';
 export default class ActionsOnUsersRoleInOrganization extends Component {
   @service notifications;
   @service accessControl;
+  @service intl;
 
   @tracked isEditionMode = false;
   @tracked selectedNewRole = null;

--- a/admin/app/components/actions-on-users-role-in-organization.gjs
+++ b/admin/app/components/actions-on-users-role-in-organization.gjs
@@ -102,7 +102,7 @@ export default class ActionsOnUsersRoleInOrganization extends Component {
                 @triggerAction={{this.updateRoleOfMember}}
                 class="member-item-actions__button member-item-actions__button--save"
               >
-                Enregistrer
+                {{t "common.actions.save"}}
               </PixButton>
               <PixButton
                 @size="small"

--- a/admin/app/components/administration/common/learning-content.gjs
+++ b/admin/app/components/administration/common/learning-content.gjs
@@ -9,6 +9,7 @@ import AdministrationBlockLayout from '../block-layout';
 export default class LearningContent extends Component {
   @service notifications;
   @service store;
+  @service intl;
 
   @action
   async refreshLearningContent() {
@@ -16,7 +17,8 @@ export default class LearningContent extends Component {
       await this.store.adapterFor('learning-content-cache').refreshCacheEntries();
       this.notifications.success('La demande de rechargement du cache a bien été prise en compte.');
     } catch (err) {
-      this.notifications.error('Une erreur est survenue.');
+      const genericErrorMessage = this.intl.t('common.notifications.generic-error');
+      this.notifications.error(genericErrorMessage);
     }
   }
 

--- a/admin/app/components/autonomous-courses/create-autonomous-course-form.gjs
+++ b/admin/app/components/autonomous-courses/create-autonomous-course-form.gjs
@@ -69,7 +69,10 @@ export default class CreateAutonomousCourseForm extends Component {
         {{t "common.forms.mandatory-fields" htmlSafe=true}}
       </p>
       <section class="admin-form__content admin-form__content--with-counters">
-        <Card class="admin-form__card" @title="Informations techniques">
+        <Card
+          class="admin-form__card"
+          @title={{t "pages.autonomous-course.creation-form-fields.technical-informations.title"}}
+        >
           <PixInput
             class="form-field"
             @id="autonomousCourseName"
@@ -77,55 +80,65 @@ export default class CreateAutonomousCourseForm extends Component {
             @requiredLabel={{t "common.forms.mandatory"}}
             {{on "change" (fn this.updateAutonomousCourseValue "internalTitle")}}
           >
-            <:label>Nom interne :</:label>
+            <:label>{{t "pages.autonomous-course.creation-form-fields.technical-informations.label"}} :</:label>
           </PixInput>
           <PixFilterableAndSearchableSelect
-            @placeholder="Choisir un profil cible"
+            @placeholder={{t "pages.autonomous-course.creation-form-fields.target-profile.placeholder"}}
             @options={{this.targetProfileListOptions}}
             @hideDefaultOption={{true}}
             @onChange={{this.selectTargetProfile}}
             @categoriesPlaceholder="Filtres"
             @value={{@autonomousCourse.targetProfileId}}
-            @requiredLabel="Champ obligatoire"
+            @requiredLabel={{t "common.forms.mandatory"}}
             @errorMessage={{if
               @errors.autonomousCourse
               (t "api-error-messages.campaign-creation.target-profile-required")
             }}
             @isSearchable={{true}}
-            @searchLabel="Recherchez un profil cible"
-            @subLabel="Le profil cible doit être en accès simplifié et relié à l’organisation &quot;Organisation pour les parcours autonomes&quot;"
+            @searchLabel={{t "pages.autonomous-course.creation-form-fields.target-profile.search-label"}}
+            @subLabel={{t "pages.autonomous-course.creation-form-fields.target-profile.sub-label"}}
             required={{true}}
           >
-            <:label>Quel profil cible voulez-vous associer à ce parcours autonome ?</:label>
-            <:categoriesLabel>Sélectionner une ou plusieurs catégories de profils cibles</:categoriesLabel>
+            <:label>{{t "pages.autonomous-course.creation-form-fields.target-profile.label"}}</:label>
+            <:categoriesLabel>{{t
+                "pages.autonomous-course.creation-form-fields.target-profile.category-label"
+              }}</:categoriesLabel>
           </PixFilterableAndSearchableSelect>
         </Card>
-        <Card class="admin-form__card" @title="Informations pour les utilisateurs">
+        <Card
+          class="admin-form__card"
+          @title={{t "pages.autonomous-course.creation-form-fields.user-information.title"}}
+        >
           <PixInput
             @id="nom-public"
             class="form-field"
-            placeholder="Exemple : Le super nom de mon parcours autonome"
+            placeholder={{t "pages.autonomous-course.creation-form-fields.user-information.public-name.placeholder"}}
             required={{true}}
-            @requiredLabel="Champ obligatoire"
+            @requiredLabel={{t "common.forms.mandatory"}}
             maxlength="50"
-            @subLabel="Le nom du parcours autonome sera affiché sur la page de démarrage du candidat."
+            @subLabel={{t "pages.autonomous-course.creation-form-fields.user-information.public-name.sub-label"}}
             {{on "change" (fn this.updateAutonomousCourseValue "publicTitle")}}
           >
-            <:label>Nom public <small>(50 caractères maximum)</small> :</:label>
+            <:label>{{t
+                "pages.autonomous-course.creation-form-fields.user-information.public-name.label"
+                htmlSafe=true
+              }}
+              :</:label>
           </PixInput>
           <PixTextarea
             @id="text-page-accueil"
             class="form-field"
             @maxlength="5000"
-            placeholder="Exemple : description, objectifs..."
+            placeholder={{t "pages.autonomous-course.creation-form-fields.user-information.homepage.placeholder"}}
             {{on "change" (fn this.updateAutonomousCourseValue "customLandingPageText")}}
           >
-            <:label>Texte de la page d'accueil :</:label>
+            <:label>{{t "pages.autonomous-course.creation-form-fields.user-information.homepage.label"}} :</:label>
           </PixTextarea>
         </Card>
       </section>
       <section class="admin-form__actions">
-        <PixButton @variant="secondary" @size="large" @triggerAction={{@onCancel}}>Annuler
+        <PixButton @variant="secondary" @size="large" @triggerAction={{@onCancel}}>
+          {{t "common.actions.cancel"}}
         </PixButton>
         <PixButton
           @variant="success"
@@ -134,7 +147,7 @@ export default class CreateAutonomousCourseForm extends Component {
           @isLoading={{this.submitting}}
           @triggerAction={{this.noop}}
         >
-          Créer le parcours autonome
+          {{t "pages.autonomous-course.creation-form-fields.create-autonomous-course"}}
         </PixButton>
       </section>
     </form>

--- a/admin/app/components/autonomous-courses/create-autonomous-course-form.gjs
+++ b/admin/app/components/autonomous-courses/create-autonomous-course-form.gjs
@@ -66,9 +66,7 @@ export default class CreateAutonomousCourseForm extends Component {
   <template>
     <form class="admin-form" {{on "submit" this.onSubmit}}>
       <p class="admin-form__mandatory-text">
-        Les champs marqués de
-        <span class="mandatory-mark">*</span>
-        sont obligatoires.
+        {{t "common.forms.mandatory-fields" htmlSafe=true}}
       </p>
       <section class="admin-form__content admin-form__content--with-counters">
         <Card class="admin-form__card" @title="Informations techniques">
@@ -76,7 +74,7 @@ export default class CreateAutonomousCourseForm extends Component {
             class="form-field"
             @id="autonomousCourseName"
             required="true"
-            @requiredLabel="Champ obligatoire"
+            @requiredLabel={{t "common.forms.mandatory"}}
             {{on "change" (fn this.updateAutonomousCourseValue "internalTitle")}}
           >
             <:label>Nom interne :</:label>

--- a/admin/app/components/autonomous-courses/details.gjs
+++ b/admin/app/components/autonomous-courses/details.gjs
@@ -2,6 +2,7 @@ import PixButton from '@1024pix/pix-ui/components/pix-button';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 
 import UpdateAutonomousCourseForm from './update-autonomous-course-form';
 import ViewAutonomousCourse from './view-autonomous-course';
@@ -41,7 +42,7 @@ export default class Details extends Component {
         <ViewAutonomousCourse @autonomousCourse={{@autonomousCourse}} />
         <div class="form-actions">
           <PixButton @variant="secondary" @size="small" @triggerAction={{this.toggleEditMode}}>
-            Modifier
+            {{t "common.actions.edit"}}
           </PixButton>
         </div>
       {{/if}}

--- a/admin/app/components/autonomous-courses/update-autonomous-course-form.gjs
+++ b/admin/app/components/autonomous-courses/update-autonomous-course-form.gjs
@@ -64,7 +64,7 @@ export default class UpdateAutonomousCourseForm extends Component {
       </PixTextarea>
       <div class="form-actions">
         <PixButton type="reset" @variant="secondary" @size="small" @triggerAction={{@cancel}}>
-          Annuler
+          {{t "common.actions.cancel"}}
         </PixButton>
         <PixButton @variant="success" @size="small" type="submit" @triggerAction={{this.noop}}>
           Sauvegarder les modifications

--- a/admin/app/components/autonomous-courses/update-autonomous-course-form.gjs
+++ b/admin/app/components/autonomous-courses/update-autonomous-course-form.gjs
@@ -5,6 +5,7 @@ import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
+import { t } from 'ember-intl';
 
 export default class UpdateAutonomousCourseForm extends Component {
   constructor() {
@@ -27,15 +28,13 @@ export default class UpdateAutonomousCourseForm extends Component {
   <template>
     <form class="form update-autonomous-course" {{on "submit" this.onSubmit}}>
       <span class="form__instructions">
-        Les champs marqués de
-        <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-        sont obligatoires.
+        {{t "common.forms.mandatory-fields" htmlSafe=true}}
       </span>
       <PixInput
         class="form-field"
         @id="autonomousCourseName"
         required={{true}}
-        @requiredLabel="Champ obligatoire"
+        @requiredLabel={{t "common.forms.mandatory"}}
         @value={{@autonomousCourse.internalTitle}}
         {{on "change" (fn this.updateAutonomousCourseValue "internalTitle")}}
       >
@@ -48,7 +47,7 @@ export default class UpdateAutonomousCourseForm extends Component {
         required={{true}}
         maxlength="50"
         @value={{@autonomousCourse.publicTitle}}
-        @requiredLabel="Champ obligatoire"
+        @requiredLabel={{t "common.forms.mandatory"}}
         @subLabel="Le nom du parcours autonome sera affiché sur la page de démarrage du candidat."
         {{on "change" (fn this.updateAutonomousCourseValue "publicTitle")}}
       >

--- a/admin/app/components/badges/badge.gjs
+++ b/admin/app/components/badges/badge.gjs
@@ -11,6 +11,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import pick from 'ember-composable-helpers/helpers/pick';
 import toggle from 'ember-composable-helpers/helpers/toggle';
+import { t } from 'ember-intl';
 import set from 'ember-set-helper/helpers/set';
 import { not } from 'ember-truth-helpers';
 
@@ -231,7 +232,9 @@ export default class Badge extends Component {
                 class="badge-data__action"
                 @size="small"
                 @triggerAction={{this.toggleEditMode}}
-              >Modifier</PixButton>
+              >
+                {{t "common.actions.edit"}}
+              </PixButton>
             </div>
           {{/if}}
         </div>

--- a/admin/app/components/badges/badge.gjs
+++ b/admin/app/components/badges/badge.gjs
@@ -204,7 +204,7 @@ export default class Badge extends Component {
                     {{t "common.actions.cancel"}}
                   </PixButton>
                   <PixButton @type="submit" @size="small" @variant="success" data-testid="save-badge-edit">
-                    Enregistrer
+                    {{t "common.actions.save"}}
                   </PixButton>
                 </div>
               </form>

--- a/admin/app/components/badges/badge.gjs
+++ b/admin/app/components/badges/badge.gjs
@@ -200,7 +200,9 @@ export default class Badge extends Component {
                   ><:label>Lacunes</:label></PixCheckbox>
                 </div>
                 <div class="badge-edit-form__actions">
-                  <PixButton @size="small" @variant="secondary" @triggerAction={{this.cancel}}>Annuler</PixButton>
+                  <PixButton @size="small" @variant="secondary" @triggerAction={{this.cancel}}>
+                    {{t "common.actions.cancel"}}
+                  </PixButton>
                   <PixButton @type="submit" @size="small" @variant="success" data-testid="save-badge-edit">
                     Enregistrer
                   </PixButton>

--- a/admin/app/components/badges/campaign-criterion.gjs
+++ b/admin/app/components/badges/campaign-criterion.gjs
@@ -6,6 +6,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 import { not } from 'ember-truth-helpers';
 
 export default class CampaignCriterion extends Component {
@@ -99,7 +100,7 @@ export default class CampaignCriterion extends Component {
         </:content>
         <:footer>
           <PixButton @triggerAction={{this.toggleEditModal}} @size="small" @variant="secondary">
-            Annuler
+            {{t "common.actions.cancel"}}
           </PixButton>
           <PixButton @triggerAction={{this.updateThreshold}} @size="small">
             Enregistrer

--- a/admin/app/components/badges/campaign-criterion.gjs
+++ b/admin/app/components/badges/campaign-criterion.gjs
@@ -103,7 +103,7 @@ export default class CampaignCriterion extends Component {
             {{t "common.actions.cancel"}}
           </PixButton>
           <PixButton @triggerAction={{this.updateThreshold}} @size="small">
-            Enregistrer
+            {{t "common.actions.save"}}
           </PixButton>
         </:footer>
       </PixModal>

--- a/admin/app/components/campaigns/details.gjs
+++ b/admin/app/components/campaigns/details.gjs
@@ -11,6 +11,13 @@ import SafeMarkdownToHtml from '../safe-markdown-to-html';
 
 export default class Details extends Component {
   @service accessControl;
+  @service intl;
+
+  displayBooleanState = (bool) => {
+    const yes = this.intl.t('common.words.yes');
+    const no = this.intl.t('common.words.no');
+    return bool ? yes : no;
+  };
 
   <template>
     <section class="page-section">
@@ -71,8 +78,10 @@ export default class Details extends Component {
         {{#if @campaign.customResultPageButtonUrl}}
           <li>URL du bouton de la page de fin de parcours : {{@campaign.customResultPageButtonUrl}}</li>
         {{/if}}
-        <li>Envoi multiple : {{if @campaign.multipleSendings "Oui" "Non"}}</li>
-        <li>Pour les novices (isForAbsoluteNovice): {{if @campaign.isForAbsoluteNovice "Oui" "Non"}}</li>
+        <li>Envoi multiple : {{this.displayBooleanState @campaign.multipleSendings}}</li>
+        <li>Pour les novices (isForAbsoluteNovice):
+          {{this.displayBooleanState @campaign.isForAbsoluteNovice}}
+        </li>
       </ul>
 
       {{#if this.accessControl.hasAccessToOrganizationActionsScope}}

--- a/admin/app/components/campaigns/details.gjs
+++ b/admin/app/components/campaigns/details.gjs
@@ -4,6 +4,7 @@ import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
+import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
 
 import SafeMarkdownToHtml from '../safe-markdown-to-html';
@@ -76,7 +77,9 @@ export default class Details extends Component {
 
       {{#if this.accessControl.hasAccessToOrganizationActionsScope}}
         <br />
-        <PixButton @triggerAction={{@toggleEditMode}} @variant="secondary" @size="small">Modifier</PixButton>
+        <PixButton @triggerAction={{@toggleEditMode}} @variant="secondary" @size="small">
+          {{t "common.actions.edit"}}
+        </PixButton>
       {{/if}}
 
     </section>

--- a/admin/app/components/campaigns/participation-row.gjs
+++ b/admin/app/components/campaigns/participation-row.gjs
@@ -109,7 +109,7 @@ export default class ParticipationRow extends Component {
                   @size="small"
                   @variant="secondary"
                   @triggerAction={{this.cancelUpdateParticipantExternalId}}
-                  aria-label="Annuler"
+                  aria-label={{t "common.actions.cancel"}}
                   class="participation-item-actions__button--icon"
                 >
                   <FaIcon @icon="xmark" />

--- a/admin/app/components/campaigns/participation-row.gjs
+++ b/admin/app/components/campaigns/participation-row.gjs
@@ -103,7 +103,7 @@ export default class ParticipationRow extends Component {
                   @triggerAction={{this.updateParticipantExternalId}}
                   class="participation-item-actions__button participation-item-actions__button--save"
                 >
-                  Enregistrer
+                  {{t "common.actions.save"}}
                 </PixButton>
                 <PixButton
                   @size="small"

--- a/admin/app/components/campaigns/participation-row.gjs
+++ b/admin/app/components/campaigns/participation-row.gjs
@@ -7,6 +7,7 @@ import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
+import { t } from 'ember-intl';
 
 export default class ParticipationRow extends Component {
   @service notifications;
@@ -121,7 +122,7 @@ export default class ParticipationRow extends Component {
                 class="participation-item-actions__button"
                 @iconBefore="pen-to-square"
               >
-                Modifier
+                {{t "common.actions.edit"}}
               </PixButton>
             {{/if}}
           </div>

--- a/admin/app/components/campaigns/update.gjs
+++ b/admin/app/components/campaigns/update.gjs
@@ -276,7 +276,9 @@ export default class Update extends Component {
         </div>
 
         <div class="admin-form__actions">
-          <PixButton @triggerAction={{@onExit}} @variant="secondary" @size="small">Annuler</PixButton>
+          <PixButton @triggerAction={{@onExit}} @variant="secondary" @size="small">
+            {{t "common.actions.cancel"}}
+          </PixButton>
           <PixButton @type="submit" @variant="success" @size="small">
             Enregistrer
           </PixButton>

--- a/admin/app/components/campaigns/update.gjs
+++ b/admin/app/components/campaigns/update.gjs
@@ -18,6 +18,7 @@ export default class Update extends Component {
   @service notifications;
   @service accessControl;
   @service store;
+  @service intl;
 
   @tracked displayIsForAbsoluteNoviceWarning;
 
@@ -121,14 +122,16 @@ export default class Update extends Component {
     } catch (errorResponse) {
       campaign.rollbackAttributes();
       const errors = errorResponse.errors;
+      const genericErrorMessage = this.intl.t('common.notifications.generic-error');
+
       if (!errors) {
-        return this.notifications.error('Une erreur est survenue.');
+        return this.notifications.error(genericErrorMessage);
       }
       return errorResponse.errors.forEach((error) => {
         if (error.status === '422') {
           return this.notifications.error(error.detail);
         }
-        return this.notifications.error('Une erreur est survenue.');
+        return this.notifications.error(genericErrorMessage);
       });
     }
   }

--- a/admin/app/components/campaigns/update.gjs
+++ b/admin/app/components/campaigns/update.gjs
@@ -246,7 +246,7 @@ export default class Update extends Component {
                   {{on "change" (fn this.updateFormValue "isForAbsoluteNovice")}}
                   checked={{this.form.isForAbsoluteNovice}}
                 >
-                  <:label>Oui</:label>
+                  <:label>{{t "common.words.yes"}}</:label>
                 </PixRadioButton>
 
                 <PixRadioButton
@@ -255,7 +255,9 @@ export default class Update extends Component {
                   {{on "change" (fn this.updateFormValue "isForAbsoluteNovice")}}
                   checked={{not this.form.isForAbsoluteNovice}}
                 >
-                  <:label>Non</:label>
+                  <:label>
+                    {{t "common.words.no"}}
+                  </:label>
                 </PixRadioButton>
               </:content>
             </PixFieldset>

--- a/admin/app/components/campaigns/update.gjs
+++ b/admin/app/components/campaigns/update.gjs
@@ -10,6 +10,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 import { not } from 'ember-truth-helpers';
 import PixFieldset from 'pix-admin/components/ui/pix-fieldset';
 
@@ -145,16 +146,14 @@ export default class Update extends Component {
       <h1>{{@campaign.name}}</h1>
 
       <p class="admin-form__mandatory-text">
-        Les champs marqués de
-        <span class="mandatory-mark">*</span>
-        sont obligatoires.
+        {{t "common.forms.mandatory-fields" htmlSafe=true}}
       </p>
 
       <form class="admin-form" {{on "submit" this.update}}>
         <div class="admin-form__content">
           <PixInput
             @id="name"
-            @requiredLabel="Champ obligatoire"
+            @requiredLabel={{t "common.forms.mandatory"}}
             @errorMessage={{this.nameError.message}}
             @validationStatus={{this.nameError.state}}
             @value={{this.form.name}}

--- a/admin/app/components/campaigns/update.gjs
+++ b/admin/app/components/campaigns/update.gjs
@@ -280,7 +280,7 @@ export default class Update extends Component {
             {{t "common.actions.cancel"}}
           </PixButton>
           <PixButton @type="submit" @variant="success" @size="small">
-            Enregistrer
+            {{t "common.actions.save"}}
           </PixButton>
         </div>
       </form>

--- a/admin/app/components/certification-centers/creation-form.gjs
+++ b/admin/app/components/certification-centers/creation-form.gjs
@@ -152,7 +152,9 @@ export default class CertificationCenterForm extends Component {
           </PixButton>
         </li>
         <li>
-          <PixButton @type="submit" @size="small">Ajouter</PixButton>
+          <PixButton @type="submit" @size="small">
+            {{t "common.actions.add"}}
+          </PixButton>
         </li>
       </ul>
     </form>

--- a/admin/app/components/certification-centers/creation-form.gjs
+++ b/admin/app/components/certification-centers/creation-form.gjs
@@ -147,7 +147,9 @@ export default class CertificationCenterForm extends Component {
 
       <ul class="form-actions">
         <li>
-          <PixButton @size="small" @variant="secondary" @triggerAction={{@onCancel}}>Annuler</PixButton>
+          <PixButton @size="small" @variant="secondary" @triggerAction={{@onCancel}}>
+            {{t "common.actions.cancel"}}
+          </PixButton>
         </li>
         <li>
           <PixButton @type="submit" @size="small">Ajouter</PixButton>

--- a/admin/app/components/certification-centers/information-edit.gjs
+++ b/admin/app/components/certification-centers/information-edit.gjs
@@ -206,7 +206,7 @@ export default class InformationEdit extends Component {
 
       <div class="certification-center-information__action-buttons">
         <PixButton @size="small" @variant="secondary" @triggerAction={{@toggleEditMode}}>
-          Annuler
+          {{t "common.actions.cancel"}}
         </PixButton>
         <PixButton
           @type="submit"

--- a/admin/app/components/certification-centers/information-edit.gjs
+++ b/admin/app/components/certification-centers/information-edit.gjs
@@ -213,7 +213,9 @@ export default class InformationEdit extends Component {
           @size="small"
           @variant="primary"
           @triggerAction={{this.updateCertificationCenter}}
-        >Enregistrer</PixButton>
+        >
+          {{t "common.actions.save"}}
+        </PixButton>
       </div>
     </form>
   </template>

--- a/admin/app/components/certification-centers/information-edit.gjs
+++ b/admin/app/components/certification-centers/information-edit.gjs
@@ -208,12 +208,7 @@ export default class InformationEdit extends Component {
         <PixButton @size="small" @variant="secondary" @triggerAction={{@toggleEditMode}}>
           {{t "common.actions.cancel"}}
         </PixButton>
-        <PixButton
-          @type="submit"
-          @size="small"
-          @variant="primary"
-          @triggerAction={{this.updateCertificationCenter}}
-        >
+        <PixButton @type="submit" @size="small" @variant="primary" @triggerAction={{this.updateCertificationCenter}}>
           {{t "common.actions.save"}}
         </PixButton>
       </div>

--- a/admin/app/components/certification-centers/information-view.gjs
+++ b/admin/app/components/certification-centers/information-view.gjs
@@ -116,7 +116,7 @@ export default class InformationView extends Component {
     <ul class="certification-center-information-display__action-buttons">
       <li>
         <PixButton @size="small" @triggerAction={{@toggleEditMode}}>
-          Modifier
+          {{t "common.actions.edit"}}
         </PixButton>
       </li>
       <li>

--- a/admin/app/components/certifications/candidate-edit-modal.hbs
+++ b/admin/app/components/certifications/candidate-edit-modal.hbs
@@ -147,7 +147,7 @@ https://guides.emberjs.com/release/components/template-lifecycle-dom-and-modifie
 
   <:footer>
     <PixButton @size="small" @variant="secondary" @triggerAction={{this.onCancelButtonsClicked}}>
-      Annuler
+      {{t "common.actions.cancel"}}
     </PixButton>
     <PixButton form="candidate-edit-form" @size="small" @type="submit">
       Enregistrer

--- a/admin/app/components/certifications/candidate-edit-modal.hbs
+++ b/admin/app/components/certifications/candidate-edit-modal.hbs
@@ -150,7 +150,7 @@ https://guides.emberjs.com/release/components/template-lifecycle-dom-and-modifie
       {{t "common.actions.cancel"}}
     </PixButton>
     <PixButton form="candidate-edit-form" @size="small" @type="submit">
-      Enregistrer
+      {{t "common.actions.save"}}
     </PixButton>
   </:footer>
 </PixModal>

--- a/admin/app/components/certifications/certification/comments.gjs
+++ b/admin/app/components/certifications/certification/comments.gjs
@@ -77,7 +77,7 @@ export default class Comments extends Component {
             </li>
             <li>
               <PixButton @size="small" @triggerAction={{this.saveJuryComment}}>
-                Enregistrer
+                {{t "common.actions.save"}}
               </PixButton>
             </li>
           </ul>

--- a/admin/app/components/certifications/certification/comments.gjs
+++ b/admin/app/components/certifications/certification/comments.gjs
@@ -5,6 +5,7 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import pick from 'ember-composable-helpers/helpers/pick';
+import { t } from 'ember-intl';
 import set from 'ember-set-helper/helpers/set';
 
 import CertificationInfoField from '../info-field';
@@ -71,7 +72,7 @@ export default class Comments extends Component {
           <ul class="certification-information-comments">
             <li>
               <PixButton @size="small" @variant="secondary" @triggerAction={{this.cancelJuryCommentEdition}}>
-                Annuler
+                {{t "common.actions.cancel"}}
               </PixButton>
             </li>
             <li>

--- a/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.gjs
+++ b/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.gjs
@@ -5,6 +5,7 @@ import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 
 import focus from '../../../modifiers/focus';
 
@@ -60,7 +61,7 @@ export default class CertificationIssueReportModal extends Component {
           class="pix-button--background-transparent-light"
           {{on "click" @toggleResolveModal}}
         >
-          Annuler
+          {{t "common.actions.cancel"}}
         </PixButton>
         <PixButton @size="small" @triggerAction={{this.resolve}}>{{this.actionName}}</PixButton>
       </:footer>

--- a/admin/app/components/complementary-certifications/attach-badges/index.gjs
+++ b/admin/app/components/complementary-certifications/attach-badges/index.gjs
@@ -7,6 +7,7 @@ import { service } from '@ember/service';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 import Card from 'pix-admin/components/card';
 
 import LinkToCurrentTargetProfile from '../common/link-to-current-target-profile';
@@ -192,7 +193,7 @@ export default class AttachBadges extends Component {
             Rattacher le profil cible
           </PixButton>
           <PixButton @size="large" @variant="secondary" @triggerAction={{this.onCancel}}>
-            Annuler
+            {{t "common.actions.cancel"}}
           </PixButton>
         </div>
       </form>

--- a/admin/app/components/confirm-popup.gjs
+++ b/admin/app/components/confirm-popup.gjs
@@ -1,14 +1,17 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class ConfirmPopup extends Component {
+  @service() intl;
+
   get title() {
     return this.args.title || 'Merci de confirmer';
   }
 
   get closeTitle() {
-    return this.args.closeTitle || 'Annuler';
+    return this.args.closeTitle || this.intl.t('common.actions.cancel');
   }
 
   get submitTitle() {

--- a/admin/app/components/organizations/archiving-confirmation-modal.gjs
+++ b/admin/app/components/organizations/archiving-confirmation-modal.gjs
@@ -1,6 +1,7 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import { on } from '@ember/modifier';
+import { t } from 'ember-intl';
 
 <template>
   <PixModal
@@ -28,11 +29,9 @@ import { on } from '@ember/modifier';
     </:content>
 
     <:footer>
-      <PixButton
-        @size="small"
-        @variant="secondary"
-        @triggerAction={{@toggleArchivingConfirmationModal}}
-      >Annuler</PixButton>
+      <PixButton @size="small" @variant="secondary" @triggerAction={{@toggleArchivingConfirmationModal}}>
+        {{t "common.actions.cancel"}}
+      </PixButton>
       <PixButton @type="submit" @size="small" {{on "click" @archiveOrganization}}>
         Confirmer
       </PixButton>

--- a/admin/app/components/organizations/creation-form.gjs
+++ b/admin/app/components/organizations/creation-form.gjs
@@ -105,7 +105,9 @@ export default class OrganizationCreationForm extends Component {
         <PixButton @size="small" @variant="secondary" @triggerAction={{@onCancel}}>
           {{t "common.actions.cancel"}}
         </PixButton>
-        <PixButton @type="submit" @size="small" @variant="success">Ajouter</PixButton>
+        <PixButton @type="submit" @size="small" @variant="success">
+          {{t "common.actions.add"}}
+        </PixButton>
       </section>
     </form>
   </template>

--- a/admin/app/components/organizations/creation-form.gjs
+++ b/admin/app/components/organizations/creation-form.gjs
@@ -4,6 +4,7 @@ import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
+import { t } from 'ember-intl';
 
 import Card from '../card';
 
@@ -101,7 +102,9 @@ export default class OrganizationCreationForm extends Component {
       </section>
 
       <section class="admin-form__actions">
-        <PixButton @size="small" @variant="secondary" @triggerAction={{@onCancel}}>Annuler</PixButton>
+        <PixButton @size="small" @variant="secondary" @triggerAction={{@onCancel}}>
+          {{t "common.actions.cancel"}}
+        </PixButton>
         <PixButton @type="submit" @size="small" @variant="success">Ajouter</PixButton>
       </section>
     </form>

--- a/admin/app/components/organizations/information-section-edit.gjs
+++ b/admin/app/components/organizations/information-section-edit.gjs
@@ -8,6 +8,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 
 export default class OrganizationInformationSectionEditionMode extends Component {
   @service accessControl;
@@ -117,9 +118,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
       <form class="form" {{on "submit" this.updateOrganization}}>
 
         <span class="form__instructions">
-          Les champs marqués de
-          <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-          sont obligatoires.
+          {{t "common.forms.mandatory-fields" htmlSafe=true}}
         </span>
 
         <div class="form-field">

--- a/admin/app/components/organizations/information-section-edit.gjs
+++ b/admin/app/components/organizations/information-section-edit.gjs
@@ -256,7 +256,9 @@ export default class OrganizationInformationSectionEditionMode extends Component
           <PixButton @size="small" @variant="secondary" @triggerAction={{this.closeAndResetForm}}>
             {{t "common.actions.cancel"}}
           </PixButton>
-          <PixButton @type="submit" @size="small" @variant="success">Enregistrer</PixButton>
+          <PixButton @type="submit" @size="small" @variant="success">
+            {{t "common.actions.save"}}
+          </PixButton>
         </div>
       </form>
     </div>

--- a/admin/app/components/organizations/information-section-edit.gjs
+++ b/admin/app/components/organizations/information-section-edit.gjs
@@ -253,7 +253,9 @@ export default class OrganizationInformationSectionEditionMode extends Component
           </PixCheckbox>
         </div>
         <div class="form-actions">
-          <PixButton @size="small" @variant="secondary" @triggerAction={{this.closeAndResetForm}}>Annuler</PixButton>
+          <PixButton @size="small" @variant="secondary" @triggerAction={{this.closeAndResetForm}}>
+            {{t "common.actions.cancel"}}
+          </PixButton>
           <PixButton @type="submit" @size="small" @variant="success">Enregistrer</PixButton>
         </div>
       </form>

--- a/admin/app/components/organizations/information-section-view.gjs
+++ b/admin/app/components/organizations/information-section-view.gjs
@@ -177,7 +177,7 @@ export default class OrganizationInformationSection extends Component {
           {{#if this.accessControl.hasAccessToOrganizationActionsScope}}
             <div class="form-actions">
               <PixButton @variant="secondary" @size="small" @triggerAction={{@toggleEditMode}}>
-                Modifier
+                {{t "common.actions.edit"}}
               </PixButton>
               {{#unless @organization.isArchived}}
                 <PixButton @variant="error" @size="small" @triggerAction={{@toggleArchivingConfirmationModal}}>

--- a/admin/app/components/organizations/information-section-view.gjs
+++ b/admin/app/components/organizations/information-section-view.gjs
@@ -12,6 +12,7 @@ import ENV from 'pix-admin/config/environment';
 export default class OrganizationInformationSection extends Component {
   @service oidcIdentityProviders;
   @service accessControl;
+  @service intl;
   @tracked tags;
   @tracked hasOrganizationChildren;
 
@@ -51,6 +52,12 @@ export default class OrganizationInformationSection extends Component {
     const urlDashboardPrefix = ENV.APP.ORGANIZATION_DASHBOARD_URL;
     return urlDashboardPrefix && urlDashboardPrefix + this.args.organization.id;
   }
+
+  displayBooleanState = (bool) => {
+    const yes = this.intl.t('common.words.yes');
+    const no = this.intl.t('common.words.no');
+    return bool ? yes : no;
+  };
 
   <template>
     <div class="organization__data">
@@ -150,18 +157,26 @@ export default class OrganizationInformationSection extends Component {
                 Non spécifié
               {{/if}}
             </li>
-            <li>Affichage du Net Promoter Score : {{if @organization.showNPS "Oui" "Non"}}</li>
+            <li>Affichage du Net Promoter Score :
+              {{this.displayBooleanState @organization.showNPS}}
+            </li>
           </ul>
           <h3 class="page-section__title page-section__title--sub">Fonctionnalités disponibles : </h3>
           <ul class="organization-information-section__details__list">
-            <li>Affichage des acquis dans l'export de résultats : {{if @organization.showSkills "Oui" "Non"}}</li>
+            <li>Affichage des acquis dans l'export de résultats :
+              {{this.displayBooleanState @organization.showSkills}}
+            </li>
             {{#if this.isManagingStudentAvailable}}
-              <li>Gestion d’élèves/étudiants : {{if @organization.isManagingStudents "Oui" "Non"}}</li>
+              <li>Gestion d’élèves/étudiants :
+                {{this.displayBooleanState @organization.isManagingStudents}}
+              </li>
             {{/if}}
             <li>Activer l'envoi multiple sur les campagnes d'évaluation :
-              {{if @organization.isMultipleSendingAssessmentEnabled "Oui" "Non"}}</li>
+              {{this.displayBooleanState @organization.isMultipleSendingAssessmentEnabled}}
+            </li>
             <li>Activer la page Places sur PixOrga :
-              {{if @organization.isPlacesManagementEnabled "Oui" "Non"}}</li>
+              {{this.displayBooleanState @organization.isPlacesManagementEnabled}}
+            </li>
             {{#if @organization.code}}
               <br />
               <li>Code : {{@organization.code}}</li>

--- a/admin/app/components/organizations/invitations-action.gjs
+++ b/admin/app/components/organizations/invitations-action.gjs
@@ -4,10 +4,12 @@ import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 export default class OrganizationInvitationsAction extends Component {
+  @service intl;
   @tracked organizationInvitationLang = this.languagesOptions[0].value;
   @tracked organizationInvitationRole = this.rolesOptions[0].value;
 

--- a/admin/app/components/organizations/invitations-action.gjs
+++ b/admin/app/components/organizations/invitations-action.gjs
@@ -31,7 +31,7 @@ export default class OrganizationInvitationsAction extends Component {
   get rolesOptions() {
     return [
       {
-        label: 'Automatique',
+        label: this.intl.t('common.roles.auto'),
         value: 'NULL',
       },
       {

--- a/admin/app/components/organizations/list-items.gjs
+++ b/admin/app/components/organizations/list-items.gjs
@@ -7,6 +7,7 @@ import { LinkTo } from '@ember/routing';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 import { not } from 'ember-truth-helpers';
 
 export default class ActionsOnUsersRoleInOrganization extends Component {
@@ -148,7 +149,7 @@ export default class ActionsOnUsersRoleInOrganization extends Component {
       </:content>
       <:footer>
         <PixButton @variant="secondary" @triggerAction={{this.closeModal}}>
-          Annuler
+          {{t "common.actions.cancel"}}
         </PixButton>
         <PixButton
           @variant="error"

--- a/admin/app/components/organizations/places-lot-creation-form.gjs
+++ b/admin/app/components/organizations/places-lot-creation-form.gjs
@@ -9,6 +9,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import dayjs from 'dayjs';
 import pick from 'ember-composable-helpers/helpers/pick';
+import { t } from 'ember-intl';
 import set from 'ember-set-helper/helpers/set';
 import get from 'lodash/get';
 
@@ -69,9 +70,7 @@ export default class PlacesLotCreationForm extends Component {
       <div class="places__add-form">
         <form class="form" {{on "submit" this.onSubmit}}>
           <span class="form__instructions">
-            Les champs marqués de
-            <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-            sont obligatoires.
+            {{t "common.forms.mandatory-fields" htmlSafe=true}}
           </span>
           <div class="form-field">
             <PixInput

--- a/admin/app/components/organizations/places-lot-creation-form.gjs
+++ b/admin/app/components/organizations/places-lot-creation-form.gjs
@@ -148,7 +148,9 @@ export default class PlacesLotCreationForm extends Component {
               @variant="secondary"
               @size="small"
               @route="authenticated.organizations.get.places"
-            >Annuler</PixButtonLink>
+            >
+              {{t "common.actions.cancel"}}
+            </PixButtonLink>
             <PixButton @type="submit" @size="small" @variant="success">Ajouter</PixButton>
           </div>
         </form>

--- a/admin/app/components/organizations/places-lot-creation-form.gjs
+++ b/admin/app/components/organizations/places-lot-creation-form.gjs
@@ -151,7 +151,9 @@ export default class PlacesLotCreationForm extends Component {
             >
               {{t "common.actions.cancel"}}
             </PixButtonLink>
-            <PixButton @type="submit" @size="small" @variant="success">Ajouter</PixButton>
+            <PixButton @type="submit" @size="small" @variant="success">
+              {{t "common.actions.add"}}
+            </PixButton>
           </div>
         </form>
       </div>

--- a/admin/app/components/organizations/target-profiles-section.gjs
+++ b/admin/app/components/organizations/target-profiles-section.gjs
@@ -9,6 +9,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import pick from 'ember-composable-helpers/helpers/pick';
+import { t } from 'ember-intl';
 import set from 'ember-set-helper/helpers/set';
 import { not } from 'ember-truth-helpers';
 import uniq from 'lodash/uniq';
@@ -212,7 +213,7 @@ export default class OrganizationTargetProfilesSectionComponent extends Componen
       </:content>
       <:footer>
         <PixButton @variant="secondary" @triggerAction={{this.closeModal}}>
-          Annuler
+          {{t "common.actions.cancel"}}
         </PixButton>
         <PixButton
           @variant="error"

--- a/admin/app/components/organizations/target-profiles-section.gjs
+++ b/admin/app/components/organizations/target-profiles-section.gjs
@@ -141,7 +141,9 @@ export default class OrganizationTargetProfilesSectionComponent extends Componen
               placeholder="1, 2"
               {{on "input" (pick "target.value" (set this "targetProfilesToAttach"))}}
             />
-            <PixButton @type="submit" @size="small" @isDisabled={{this.isDisabled}}>Valider</PixButton>
+            <PixButton @type="submit" @size="small" @isDisabled={{this.isDisabled}}>
+              {{t "common.actions.validate"}}
+            </PixButton>
           </form>
         </div>
       </section>

--- a/admin/app/components/organizations/target-profiles-section.gjs
+++ b/admin/app/components/organizations/target-profiles-section.gjs
@@ -23,6 +23,7 @@ export default class OrganizationTargetProfilesSectionComponent extends Componen
   @service notifications;
   @service router;
   @service store;
+  @service intl;
 
   get isDisabled() {
     return this.targetProfilesToAttach === '';
@@ -110,14 +111,16 @@ export default class OrganizationTargetProfilesSectionComponent extends Componen
   }
 
   _handleResponseError({ errors }) {
+    const genericErrorMessage = this.intl.t('common.notifications.generic-error');
+
     if (!errors) {
-      return this.notifications.error('Une erreur est survenue.');
+      return this.notifications.error(genericErrorMessage);
     }
     errors.forEach((error) => {
       if (['404', '412'].includes(error.status)) {
         return this.notifications.error(error.detail);
       }
-      return this.notifications.error('Une erreur est survenue.');
+      return this.notifications.error(genericErrorMessage);
     });
   }
 

--- a/admin/app/components/organizations/team-actions-section.gjs
+++ b/admin/app/components/organizations/team-actions-section.gjs
@@ -22,7 +22,7 @@ import { on } from '@ember/modifier';
             class="organization-team-section__button"
             aria-label="Ajouter un membre"
           >
-            Valider
+            {{t "common.actions.validate"}}
           </PixButton>
         </div>
       </form>

--- a/admin/app/components/organizations/team-actions-section.gjs
+++ b/admin/app/components/organizations/team-actions-section.gjs
@@ -1,6 +1,7 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import { on } from '@ember/modifier';
+import { t } from 'ember-intl';
 
 <template>
   <section class="page-section organization-team-section">

--- a/admin/app/components/organizations/team-section.gjs
+++ b/admin/app/components/organizations/team-section.gjs
@@ -3,6 +3,7 @@ import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import { fn } from '@ember/helper';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { t } from 'ember-intl';
 
 import MemberItem from './member-item';
 

--- a/admin/app/components/organizations/team-section.gjs
+++ b/admin/app/components/organizations/team-section.gjs
@@ -8,14 +8,15 @@ import MemberItem from './member-item';
 
 export default class OrganizationTeamSection extends Component {
   @service accessControl;
+  @service intl;
 
   searchedFirstName = this.args.firstName;
   searchedLastName = this.args.lastName;
   searchedEmail = this.args.email;
 
   options = [
-    { value: 'ADMIN', label: 'Administrateur' },
-    { value: 'MEMBER', label: 'Membre' },
+    { value: 'ADMIN', label: this.intl.t('common.roles.admin') },
+    { value: 'MEMBER', label: this.intl.t('common.roles.member') },
   ];
 
   <template>
@@ -91,7 +92,7 @@ export default class OrganizationTeamSection extends Component {
             {{#if @organizationMemberships}}
               <tbody>
                 {{#each @organizationMemberships as |organizationMembership|}}
-                  <tr aria-label="Membre">
+                  <tr aria-label={{t "common.roles.member"}}>
                     <MemberItem @organizationMembership={{organizationMembership}} />
                   </tr>
                 {{/each}}

--- a/admin/app/components/sessions/jury-comment.gjs
+++ b/admin/app/components/sessions/jury-comment.gjs
@@ -6,6 +6,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
+import { t } from 'ember-intl';
 import noop from 'lodash/noop';
 
 import ConfirmPopup from '../confirm-popup';
@@ -120,7 +121,7 @@ export default class JuryComment extends Component {
         {{#if this.accessControl.hasAccessToCertificationActionsScope}}
           <div class="jury-comment__actions">
             <PixButton @triggerAction={{this.enterEditingMode}} @size="small">
-              Modifier
+              {{t "common.actions.edit"}}
             </PixButton>
             <PixButton @triggerAction={{this.openDeletionConfirmationModal}} @size="small" @variant="secondary">
               Supprimer

--- a/admin/app/components/sessions/jury-comment.gjs
+++ b/admin/app/components/sessions/jury-comment.gjs
@@ -102,7 +102,7 @@ export default class JuryComment extends Component {
             <div class="jury-comment__actions">
               {{#if this.commentExists}}
                 <PixButton @triggerAction={{this.exitEditingMode}} @variant="secondary" @size="small">
-                  Annuler
+                  {{t "common.actions.cancel"}}
                 </PixButton>
               {{/if}}
               <PixButton @type="submit" @size="small">

--- a/admin/app/components/sessions/jury-comment.gjs
+++ b/admin/app/components/sessions/jury-comment.gjs
@@ -106,7 +106,7 @@ export default class JuryComment extends Component {
                 </PixButton>
               {{/if}}
               <PixButton @type="submit" @size="small">
-                Enregistrer
+                {{t "common.actions.save"}}
               </PixButton>
             </div>
           </form>

--- a/admin/app/components/smart-random-simulator/current-challenge.gjs
+++ b/admin/app/components/smart-random-simulator/current-challenge.gjs
@@ -1,51 +1,60 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import Component from '@glimmer/component';
 
 import Card from '../card';
 
-<template>
-  <Card class="admin-form__card current-challenge" @title="Épreuve en cours: {{this.currentChallenge.skill.name}}">
-    <ul>
-      <li>Nom de l'acquis testé : <span class="current-challenge__name">{{@challenge.skill.name}}</span></li>
+export default class CurrentChallenge extends Component {
+  displayBooleanState = (bool) => {
+    const yes = this.intl.t('common.words.yes');
+    const no = this.intl.t('common.words.no');
+    return bool ? yes : no;
+  };
 
-      <li>Épreuve avec temps imparti ?
-        <PixTag @color="{{if @challenge.timer 'tertiary' 'neutral'}}">
-          {{if @challenge.timer "Oui" "Non"}}
-        </PixTag>
-      </li>
+  <template>
+    <Card class="admin-form__card current-challenge" @title="Épreuve en cours: {{this.currentChallenge.skill.name}}">
+      <ul>
+        <li>Nom de l'acquis testé : <span class="current-challenge__name">{{@challenge.skill.name}}</span></li>
 
-      <li class="current-challenge__details">Épreuve focus ?
-        <PixTag @color="{{if @challenge.focused 'tertiary' 'neutral'}}">
-          {{if @challenge.focused "Oui" "Non"}}
-        </PixTag>
-      </li>
-
-      <li class="current-challenge__details">Type de challenge :
-        {{@challenge.type}}
-      </li>
-
-      {{#if @challenge.instruction}}
-        <li class="current-challenge__instruction">
-          {{@challenge.instruction}}
+        <li>Épreuve avec temps imparti ?
+          <PixTag @color="{{if @challenge.timer 'tertiary' 'neutral'}}">
+            {{this.displayBooleanState @challenge.timer}}
+          </PixTag>
         </li>
-      {{/if}}
 
-    </ul>
+        <li class="current-challenge__details">Épreuve focus ?
+          <PixTag @color="{{if @challenge.focused 'tertiary' 'neutral'}}">
+            {{this.displayBooleanState @challenge.focused}}
+          </PixTag>
+        </li>
 
-    <div class="current-challenge__actions">
+        <li class="current-challenge__details">Type de challenge :
+          {{@challenge.type}}
+        </li>
 
-      <PixButton @variant="error" @triggerAction={{@failCurrentChallenge}}>
-        Rater l'épreuve
-      </PixButton>
+        {{#if @challenge.instruction}}
+          <li class="current-challenge__instruction">
+            {{@challenge.instruction}}
+          </li>
+        {{/if}}
 
-      <PixButton @variant="success" @triggerAction={{@succeedCurrentChallenge}}>
-        Réussir l'épreuve
-      </PixButton>
+      </ul>
 
-      <PixButton @variant="secondary" @triggerAction={{@reset}}>
-        Redémarrer la simulation
-      </PixButton>
+      <div class="current-challenge__actions">
 
-    </div>
-  </Card>
-</template>
+        <PixButton @variant="error" @triggerAction={{@failCurrentChallenge}}>
+          Rater l'épreuve
+        </PixButton>
+
+        <PixButton @variant="success" @triggerAction={{@succeedCurrentChallenge}}>
+          Réussir l'épreuve
+        </PixButton>
+
+        <PixButton @variant="secondary" @triggerAction={{@reset}}>
+          Redémarrer la simulation
+        </PixButton>
+
+      </div>
+    </Card>
+  </template>
+}

--- a/admin/app/components/smart-random-simulator/previous-challenges.gjs
+++ b/admin/app/components/smart-random-simulator/previous-challenges.gjs
@@ -3,6 +3,12 @@ import Component from '@glimmer/component';
 import Card from '../card';
 
 export default class PreviousChallenges extends Component {
+  displayBooleanState = (bool) => {
+    const yes = this.intl.t('common.words.yes');
+    const no = this.intl.t('common.words.no');
+    return bool ? yes : no;
+  };
+
   incrementIndex(index) {
     return index + 1;
   }
@@ -15,8 +21,12 @@ export default class PreviousChallenges extends Component {
             <div class="previous-challenges__result {{challenge.result}}">
               <p class="previous-challenges__result__count">Épreuve {{this.incrementIndex index}}</p>
               <h2>{{challenge.skill.name}}</h2>
-              <p class="previous-challenges__result__focused">Focus : {{if challenge.focused "Oui" "Non"}}</p>
-              <p class="previous-challenges__result__timed">Temps imparti: {{if challenge.timer "Oui" "Non"}}</p>
+              <p class="previous-challenges__result__focused">Focus :
+                {{this.displayBooleanState challenge.focused}}
+              </p>
+              <p class="previous-challenges__result__timed">Temps imparti:
+                {{this.displayBooleanState challenge.timer}}
+              </p>
             </div>
           {{/each}}
         </div>

--- a/admin/app/components/stages/update-stage.gjs
+++ b/admin/app/components/stages/update-stage.gjs
@@ -186,7 +186,8 @@ export default class UpdateStage extends Component {
             </:label></PixTextarea>
         </div>
         <div class="form-actions">
-          <PixButton @variant="secondary" @size="small" @triggerAction={{@toggleEditMode}}>Annuler
+          <PixButton @variant="secondary" @size="small" @triggerAction={{@toggleEditMode}}>
+            {{t "common.actions.cancel"}}
           </PixButton>
           <PixButton @variant="success" @size="small" @type="submit">
             Enregistrer

--- a/admin/app/components/stages/update-stage.gjs
+++ b/admin/app/components/stages/update-stage.gjs
@@ -7,6 +7,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import pick from 'ember-composable-helpers/helpers/pick';
+import { t } from 'ember-intl';
 import set from 'ember-set-helper/helpers/set';
 import isInteger from 'lodash/isInteger';
 
@@ -132,7 +133,7 @@ export default class UpdateStage extends Component {
               @id="threshold-or-level"
               @errorMessage="Le seuil est invalide"
               @validationStatus={{this.thresholdStatus}}
-              @requiredLabel="Champ obligatoire"
+              @requiredLabel={{t "common.forms.mandatory"}}
               type="number"
               readonly={{this.isThresholdOrLevelDisabled}}
               @value={{this.threshold}}
@@ -148,7 +149,7 @@ export default class UpdateStage extends Component {
             @id="title"
             @errorMessage="Le titre est vide"
             @validationStatus={{this.titleStatus}}
-            @requiredLabel="Champ obligatoire"
+            @requiredLabel={{t "common.forms.mandatory"}}
             @value={{this.title}}
             type="text"
             {{on "focusout" this.checkTitleValidity}}

--- a/admin/app/components/stages/update-stage.gjs
+++ b/admin/app/components/stages/update-stage.gjs
@@ -190,7 +190,7 @@ export default class UpdateStage extends Component {
             {{t "common.actions.cancel"}}
           </PixButton>
           <PixButton @variant="success" @size="small" @type="submit">
-            Enregistrer
+            {{t "common.actions.save"}}
           </PixButton>
         </div>
       </form>

--- a/admin/app/components/stages/view-stage.gjs
+++ b/admin/app/components/stages/view-stage.gjs
@@ -1,4 +1,5 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { t } from 'ember-intl';
 
 <template>
   <section class="page-section">
@@ -29,7 +30,7 @@ import PixButton from '@1024pix/pix-ui/components/pix-button';
     </div>
     <br />
     <PixButton @size="small" @variant="secondary" @triggerAction={{@toggleEditMode}}>
-      Modifier
+      {{t "common.actions.edit"}}
     </PixButton>
   </section>
 </template>

--- a/admin/app/components/target-profiles/badge-form.gjs
+++ b/admin/app/components/target-profiles/badge-form.gjs
@@ -8,6 +8,7 @@ import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { t } from 'ember-intl';
 
 import Card from '../card';
 import Criteria from './badge-form/criteria';
@@ -98,7 +99,7 @@ export default class BadgeForm extends Component {
             <PixInput
               @id="title"
               @value={{this.badge.title}}
-              @requiredLabel="Champ obligatoire"
+              @requiredLabel={{t "common.forms.mandatory"}}
               {{on "change" (fn this.updateFormValue "title")}}
             >
               <:label>Nom du résultat thématique :</:label>
@@ -118,7 +119,7 @@ export default class BadgeForm extends Component {
             <PixInput
               @id="image-name"
               @value={{this.imageName}}
-              @requiredLabel="Champ obligatoire"
+              @requiredLabel={{t "common.forms.mandatory"}}
               placeholder="exemple: clea_num.svg"
               {{on "change" (fn this.updateFormValue "imageName")}}
             >
@@ -129,7 +130,7 @@ export default class BadgeForm extends Component {
             <PixInput
               @id="alt-message"
               @value={{this.badge.altMessage}}
-              @requiredLabel="Champ obligatoire"
+              @requiredLabel={{t "common.forms.mandatory"}}
               {{on "change" (fn this.updateFormValue "altMessage")}}
             >
               <:label>Texte alternatif pour l'image :</:label>
@@ -150,7 +151,7 @@ export default class BadgeForm extends Component {
               @id="badge-key"
               maxlength="255"
               @value={{this.badge.key}}
-              @requiredLabel="Champ obligatoire"
+              @requiredLabel={{t "common.forms.mandatory"}}
               {{on "change" (fn this.updateFormValue "key")}}
             >
               <:label>Clé (texte unique , vérifier qu'il n'existe pas) :</:label>

--- a/admin/app/components/target-profiles/badge-form.gjs
+++ b/admin/app/components/target-profiles/badge-form.gjs
@@ -178,7 +178,7 @@ export default class BadgeForm extends Component {
       </section>
       <section class="admin-form__actions">
         <PixButtonLink @variant="secondary" @route="authenticated.target-profiles.target-profile.insights">
-          Annuler
+          {{t "common.actions.cancel"}}
         </PixButtonLink>
         <PixButton @variant="success" @type="submit">
           Enregistrer le RT

--- a/admin/app/components/target-profiles/badge-form/campaign-criterion.gjs
+++ b/admin/app/components/target-profiles/badge-form/campaign-criterion.gjs
@@ -1,5 +1,6 @@
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import { on } from '@ember/modifier';
+import { t } from 'ember-intl';
 
 <template>
   <section class="badge-form-criterion">
@@ -12,7 +13,7 @@ import { on } from '@ember/modifier';
       type="number"
       min="0"
       max="100"
-      @requiredLabel="Champ obligatoire"
+      @requiredLabel={{t "common.forms.mandatory"}}
       {{on "change" @onThresholdChange}}
     >
       <:label>Taux de réussite requis :</:label>

--- a/admin/app/components/target-profiles/badge-form/capped-tubes-criterion.gjs
+++ b/admin/app/components/target-profiles/badge-form/capped-tubes-criterion.gjs
@@ -5,6 +5,7 @@ import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 
 import Areas from '../../common/tubes-selection/areas';
 
@@ -99,7 +100,7 @@ export default class CappedTubesCriterion extends Component {
           type="number"
           min="1"
           max="100"
-          @requiredLabel="Champ obligatoire"
+          @requiredLabel={{t "common.forms.mandatory"}}
           {{on "change" @onThresholdChange}}
         >
           <:label>Taux de réussite requis :</:label>

--- a/admin/app/components/target-profiles/edit-target-profile-form.gjs
+++ b/admin/app/components/target-profiles/edit-target-profile-form.gjs
@@ -66,16 +66,14 @@ export default class CreateTargetProfileForm extends Component {
   <template>
     <form class="admin-form">
       <p class="admin-form__mandatory-text">
-        Les champs marqués de
-        <span class="mandatory-mark">*</span>
-        sont obligatoires.
+        {{t "common.forms.mandatory-fields" htmlSafe=true}}
       </p>
       <section class="admin-form__content admin-form__content--with-counters">
         <Card class="admin-form__card" @title="Information sur le profil cible">
           <PixInput
             @id="targetProfileName"
             required={{true}}
-            @requiredLabel="Champ obligatoire"
+            @requiredLabel={{t "common.forms.mandatory"}}
             aria-required={{true}}
             @value={{@targetProfile.name}}
             {{on "change" (fn this.handleInputValue "name")}}
@@ -90,7 +88,7 @@ export default class CreateTargetProfileForm extends Component {
             @placeholder="-"
             @hideDefaultOption={{true}}
             required={{true}}
-            @requiredLabel="Champ obligatoire"
+            @requiredLabel={{t "common.forms.mandatory"}}
             aria-required={{true}}
           >
             <:label>Catégorie :</:label>
@@ -102,7 +100,7 @@ export default class CreateTargetProfileForm extends Component {
               type="number"
               @errorMessage=""
               required={{true}}
-              @requiredLabel="Champ obligatoire"
+              @requiredLabel={{t "common.forms.mandatory"}}
               aria-required={{true}}
               placeholder="7777"
               value={{@targetProfile.ownerOrganizationId}}

--- a/admin/app/components/target-profiles/edit-target-profile-form.gjs
+++ b/admin/app/components/target-profiles/edit-target-profile-form.gjs
@@ -174,7 +174,7 @@ export default class CreateTargetProfileForm extends Component {
       </section>
       <section class="admin-form__actions">
         <PixButton @variant="secondary" @size="large" @triggerAction={{@onCancel}}>
-          Annuler
+          {{t "common.actions.cancel"}}
         </PixButton>
         <PixButton
           @variant="success"

--- a/admin/app/components/target-profiles/organizations.gjs
+++ b/admin/app/components/target-profiles/organizations.gjs
@@ -16,6 +16,7 @@ export default class Organizations extends Component {
   @service notifications;
   @service router;
   @service currentUser;
+  @service intl;
 
   @tracked organizationsToAttach = '';
   @tracked existingTargetProfile = '';
@@ -89,14 +90,16 @@ export default class Organizations extends Component {
   }
 
   _handleResponseError({ errors }) {
+    const genericErrorMessage = this.intl.t('common.notifications.generic-error');
+
     if (!errors) {
-      return this.notifications.error('Une erreur est survenue.');
+      return this.notifications.error(genericErrorMessage);
     }
     errors.forEach((error) => {
       if (['404', '412'].includes(error.status)) {
         return this.notifications.error(error.detail);
       }
-      return this.notifications.error('Une erreur est survenue.');
+      return this.notifications.error(genericErrorMessage);
     });
   }
 

--- a/admin/app/components/target-profiles/organizations.gjs
+++ b/admin/app/components/target-profiles/organizations.gjs
@@ -128,7 +128,7 @@ export default class Organizations extends Component {
               aria-label="Valider le rattachement"
               @isDisabled={{this.isDisabledAttachOrganizations}}
             >
-              Valider
+              {{t "common.actions.validate"}}
             </PixButton>
           </div>
         </form>
@@ -152,7 +152,7 @@ export default class Organizations extends Component {
               aria-label="Valider le rattachement à partir de ce profil cible"
               @isDisabled={{this.isDisabledAttachOrganizationsFromExistingTargetProfile}}
             >
-              Valider
+              {{t "common.actions.validate"}}
             </PixButton>
           </div>
         </form>

--- a/admin/app/components/target-profiles/organizations.gjs
+++ b/admin/app/components/target-profiles/organizations.gjs
@@ -6,6 +6,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import pick from 'ember-composable-helpers/helpers/pick';
+import { t } from 'ember-intl';
 import set from 'ember-set-helper/helpers/set';
 import uniq from 'lodash/uniq';
 

--- a/admin/app/components/target-profiles/pdf-parameters-modal.gjs
+++ b/admin/app/components/target-profiles/pdf-parameters-modal.gjs
@@ -5,6 +5,7 @@ import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 
 export default class PdfParametersModal extends Component {
   @tracked language = null;
@@ -58,7 +59,7 @@ export default class PdfParametersModal extends Component {
           class="pix-button--background-transparent-light"
           {{on "click" @onCloseButtonClicked}}
         >
-          Annuler
+          {{t "common.actions.cancel"}}
         </PixButton>
         <PixButton @size="small" @triggerAction={{this.submit}}>Télécharger</PixButton>
       </:footer>

--- a/admin/app/components/target-profiles/stages.gjs
+++ b/admin/app/components/target-profiles/stages.gjs
@@ -284,7 +284,7 @@ export default class Stages extends Component {
               {{t "common.actions.cancel"}}
             </PixButton>
             <PixButton type="submit" @variant="success" @triggerAction={{this.createStages}}>
-              Enregistrer
+              {{t "common.actions.save"}}
             </PixButton>
           </div>
         {{/if}}

--- a/admin/app/components/target-profiles/stages.gjs
+++ b/admin/app/components/target-profiles/stages.gjs
@@ -7,6 +7,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 import difference from 'lodash/difference';
 
 import NewStage from './stages/new-stage';
@@ -280,7 +281,7 @@ export default class Stages extends Component {
         {{#if this.hasNewStage}}
           <div class="stages-actions form-actions">
             <PixButton @variant="secondary" @triggerAction={{this.cancelStagesCreation}}>
-              Annuler
+              {{t "common.actions.cancel"}}
             </PixButton>
             <PixButton type="submit" @variant="success" @triggerAction={{this.createStages}}>
               Enregistrer

--- a/admin/app/components/target-profiles/stages.gjs
+++ b/admin/app/components/target-profiles/stages.gjs
@@ -18,6 +18,7 @@ const THRESHOLD_COLUMN_NAME = 'Seuil';
 
 export default class Stages extends Component {
   @service store;
+  @service intl;
   @service notifications;
 
   @tracked
@@ -156,7 +157,8 @@ export default class Stages extends Component {
         });
       this.notifications.success('Palier(s) ajouté(s) avec succès.');
     } catch (e) {
-      this.notifications.error(e.errors?.[0]?.detail ?? 'Une erreur est survenue.');
+      const genericErrorMessage = this.intl.t('common.notifications.generic-error');
+      this.notifications.error(e.errors?.[0]?.detail ?? genericErrorMessage);
     }
   }
 

--- a/admin/app/components/target-profiles/stages/new-stage.gjs
+++ b/admin/app/components/target-profiles/stages/new-stage.gjs
@@ -6,6 +6,7 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import isInteger from 'lodash/isInteger';
+import { t } from 'ember-intl';
 
 import StageLevelSelect from '../../stages/stage-level-select';
 
@@ -90,7 +91,7 @@ export default class NewStage extends Component {
                 @id={{concat "threshold-" @index}}
                 @errorMessage="Le seuil est invalide"
                 @validationStatus={{this.thresholdStatus}}
-                @requiredLabel="Champ obligatoire"
+                @requiredLabel={{t "common.forms.mandatory"}}
                 type="number"
                 @value={{this.threshold}}
                 readonly={{@stage.isZeroStage}}
@@ -110,7 +111,7 @@ export default class NewStage extends Component {
           @errorMessage="Le titre est vide"
           @validationStatus={{this.titleStatus}}
           @value={{this.title}}
-          @requiredLabel="Champ obligatoire"
+          @requiredLabel={{t "common.forms.mandatory"}}
           @screenReaderOnly={{true}}
           {{on "focusout" this.checkTitleValidity}}
         >
@@ -122,7 +123,7 @@ export default class NewStage extends Component {
           @id={{concat "message-" @index}}
           @errorMessage="Le message est vide"
           @validationStatus={{this.messageStatus}}
-          @requiredLabel="Champ obligatoire"
+          @requiredLabel={{t "common.forms.mandatory"}}
           @screenReaderOnly={{true}}
           @value={{this.message}}
           {{on "focusout" this.checkMessageValidity}}

--- a/admin/app/components/target-profiles/stages/new-stage.gjs
+++ b/admin/app/components/target-profiles/stages/new-stage.gjs
@@ -5,8 +5,8 @@ import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import isInteger from 'lodash/isInteger';
 import { t } from 'ember-intl';
+import isInteger from 'lodash/isInteger';
 
 import StageLevelSelect from '../../stages/stage-level-select';
 

--- a/admin/app/components/target-profiles/stages/stage.gjs
+++ b/admin/app/components/target-profiles/stages/stage.gjs
@@ -92,7 +92,7 @@ export default class Stage extends Component {
                 {{t "common.actions.cancel"}}
               </PixButton>
               <PixButton @variant="error" @triggerAction={{fn @deleteStage @stage}}>
-                Valider
+                {{t "common.actions.validate"}}
               </PixButton>
             </:footer>
           </PixModal>

--- a/admin/app/components/target-profiles/stages/stage.gjs
+++ b/admin/app/components/target-profiles/stages/stage.gjs
@@ -5,6 +5,7 @@ import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 
 import TickOrCross from '../../common/tick-or-cross';
 
@@ -88,7 +89,7 @@ export default class Stage extends Component {
             </:content>
             <:footer>
               <PixButton @variant="secondary" @triggerAction={{this.toggleModal}}>
-                Annuler
+                {{t "common.actions.cancel"}}
               </PixButton>
               <PixButton @variant="error" @triggerAction={{fn @deleteStage @stage}}>
                 Valider

--- a/admin/app/components/target-profiles/target-profile.gjs
+++ b/admin/app/components/target-profiles/target-profile.gjs
@@ -24,7 +24,6 @@ export default class TargetProfile extends Component {
 
   @service fileSaver;
   @service session;
-  @service intl;
 
   @tracked showCopyModal = false;
   @tracked displayConfirm = false;
@@ -55,7 +54,11 @@ export default class TargetProfile extends Component {
     return Boolean(this.args.model.hasLinkedAutonomousCourse);
   }
 
-  displayBooleanState = (bool) => (bool ? 'Oui' : 'Non');
+  displayBooleanState = (bool) => {
+    const yes = this.intl.t('common.words.yes');
+    const no = this.intl.t('common.words.no');
+    return bool ? yes : no;
+  };
 
   @action
   toggleDisplayConfirm() {

--- a/admin/app/components/target-profiles/target-profile.gjs
+++ b/admin/app/components/target-profiles/target-profile.gjs
@@ -229,7 +229,7 @@ export default class TargetProfile extends Component {
             @size="small"
             @variant="secondary"
           >
-            Modifier
+            {{t "common.actions.edit"}}
           </PixButtonLink>
           <div class="target-profile__actions-separator"></div>
 

--- a/admin/app/components/target-profiles/target-profile.gjs
+++ b/admin/app/components/target-profiles/target-profile.gjs
@@ -20,6 +20,7 @@ import PdfParametersModal from './pdf-parameters-modal';
 export default class TargetProfile extends Component {
   @service notifications;
   @service router;
+  @service intl;
 
   @service fileSaver;
   @service session;
@@ -92,7 +93,8 @@ export default class TargetProfile extends Component {
 
       this.notifications.success('Ce profil cible a bien été marqué comme accès simplifié.');
     } catch (responseError) {
-      this.notifications.error('Une erreur est survenue.');
+      const genericErrorMessage = this.intl.t('common.notifications.generic-error');
+      this.notifications.error(genericErrorMessage);
     }
   }
 

--- a/admin/app/components/team/add-member.gjs
+++ b/admin/app/components/team/add-member.gjs
@@ -113,7 +113,7 @@ export default class AddMember extends Component {
           aria-label="Donner accès à un agent Pix"
           @triggerAction={{this.inviteMember}}
         >
-          Valider
+          {{t "common.actions.validate"}}
         </PixButton>
       </section>
     </form>

--- a/admin/app/components/team/add-member.gjs
+++ b/admin/app/components/team/add-member.gjs
@@ -6,6 +6,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 
 import isEmailValid from '../../utils/email-validator';
 
@@ -89,7 +90,7 @@ export default class AddMember extends Component {
         <section class="add-member-to-team-form__input">
           <PixInput
             @id="email"
-            @requiredLabel="Champ obligatoire"
+            @requiredLabel={{t "common.forms.mandatory"}}
             @errorMessage={{this.inviteErrorRaised}}
             @validationStatus={{this.validationStatus}}
             value={{this.email}}

--- a/admin/app/components/team/list.gjs
+++ b/admin/app/components/team/list.gjs
@@ -5,6 +5,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 import { or } from 'ember-truth-helpers';
 
 import ConfirmPopup from '../confirm-popup';
@@ -140,7 +141,8 @@ export default class List extends Component {
                         @triggerAction={{fn this.toggleEditionModeForThisMember member}}
                         @iconBefore="pen-to-square"
                       >
-                        Modifier</PixButton>
+                        {{t "common.actions.edit"}}
+                      </PixButton>
                     {{/if}}
                     <PixButton
                       class="admin-member-item-actions__button"

--- a/admin/app/components/team/list.gjs
+++ b/admin/app/components/team/list.gjs
@@ -151,7 +151,7 @@ export default class List extends Component {
                       @triggerAction={{fn this.displayDeactivateConfirmationPopup member}}
                       @iconBefore="trash"
                     >
-                      Désactiver
+                      {{t "common.actions.deactivate"}}
                     </PixButton>
 
                   </div>

--- a/admin/app/components/team/list.gjs
+++ b/admin/app/components/team/list.gjs
@@ -132,7 +132,7 @@ export default class List extends Component {
                         aria-label="Valider la modification de rôle"
                         @triggerAction={{fn this.updateMemberRole member}}
                       >
-                        Valider
+                        {{t "common.actions.validate"}}
                       </PixButton>
                     {{else}}
                       <PixButton

--- a/admin/app/components/trainings/create-or-update-training-form.gjs
+++ b/admin/app/components/trainings/create-or-update-training-form.gjs
@@ -8,6 +8,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 import set from 'lodash/set';
 
 import { optionsLocaleList, optionsTypeList } from '../../models/training';
@@ -212,7 +213,7 @@ export default class CreateOrUpdateTrainingForm extends Component {
       </section>
       <section class="admin-form__actions">
         <PixButton @variant="secondary" @size="large" @triggerAction={{@onCancel}}>
-          Annuler
+          {{t "common.actions.cancel"}}
         </PixButton>
         <PixButton @variant="success" @size="large" @type="submit" @isLoading={{this.submitting}}>
           {{if @model "Modifier" "Créer"}}

--- a/admin/app/components/users/user-detail-personal-information/add-authentication-method-modal.gjs
+++ b/admin/app/components/users/user-detail-personal-information/add-authentication-method-modal.gjs
@@ -2,6 +2,7 @@ import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import { on } from '@ember/modifier';
+import { t } from 'ember-intl';
 
 <template>
   <PixModal
@@ -17,7 +18,7 @@ import { on } from '@ember/modifier';
           @validationStatus={{if @showAlreadyExistingEmailError "error" "default"}}
           @errorMessage="Cette adresse e-mail est déjà utilisée"
           type="email"
-          @requiredLabel="Champ obligatoire"
+          @requiredLabel={{t "common.forms.mandatory"}}
         >
           <:label>Nouvelle adresse e-mail</:label>
         </PixInput>

--- a/admin/app/components/users/user-detail-personal-information/add-authentication-method-modal.gjs
+++ b/admin/app/components/users/user-detail-personal-information/add-authentication-method-modal.gjs
@@ -27,7 +27,7 @@ import { t } from 'ember-intl';
 
     <:footer>
       <PixButton @size="small" @variant="secondary" @triggerAction={{@toggleAddAuthenticationMethodModal}}>
-        Annuler
+        {{t "common.actions.cancel"}}
       </PixButton>
       <PixButton form="add-authentication-method-modal" @size="small" @type="submit">
         Enregistrer l'adresse e-mail

--- a/admin/app/components/users/user-detail-personal-information/reassign-gar-authentication-method-modal.gjs
+++ b/admin/app/components/users/user-detail-personal-information/reassign-gar-authentication-method-modal.gjs
@@ -2,6 +2,7 @@ import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import { on } from '@ember/modifier';
+import { t } from 'ember-intl';
 
 <template>
   <PixModal
@@ -25,11 +26,9 @@ import { on } from '@ember/modifier';
     </:content>
 
     <:footer>
-      <PixButton
-        @size="small"
-        @variant="secondary"
-        @triggerAction={{@toggleReassignGarAuthenticationMethodModal}}
-      >Annuler</PixButton>
+      <PixButton @size="small" @variant="secondary" @triggerAction={{@toggleReassignGarAuthenticationMethodModal}}>
+        {{t "common.actions.cancel"}}
+      </PixButton>
       <PixButton @type="submit" @size="small" {{on "click" @submitReassignGarAuthenticationMethod}}>
         Valider le déplacement
       </PixButton>

--- a/admin/app/components/users/user-detail-personal-information/reassign-oidc-authentication-method-modal.gjs
+++ b/admin/app/components/users/user-detail-personal-information/reassign-oidc-authentication-method-modal.gjs
@@ -3,6 +3,7 @@ import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
+import { t } from 'ember-intl';
 
 <template>
   <PixModal
@@ -31,7 +32,9 @@ import { on } from '@ember/modifier';
         @size="small"
         @variant="secondary"
         @triggerAction={{fn @toggleReassignOidcAuthenticationMethodModal null}}
-      >Annuler</PixButton>
+      >
+        {{t "common.actions.cancel"}}
+      </PixButton>
       <PixButton
         @type="submit"
         @size="small"

--- a/admin/app/components/users/user-overview.gjs
+++ b/admin/app/components/users/user-overview.gjs
@@ -191,9 +191,7 @@ export default class UserOverview extends Component {
         {{#if this.isEditionMode}}
           <form class="form" {{on "submit" this.updateUserDetails}}>
             <span class="form__instructions">
-              Les champs marqués de
-              <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-              sont obligatoires.
+              {{t "common.forms.mandatory-fields" htmlSafe=true}}
             </span>
             <div class="form-field">
               <PixInput

--- a/admin/app/components/users/user-overview.gjs
+++ b/admin/app/components/users/user-overview.gjs
@@ -267,7 +267,7 @@ export default class UserOverview extends Component {
             </div>
             <div class="form-actions">
               <PixButton @size="small" @variant="secondary" @triggerAction={{this.cancelEdit}}>Annuler</PixButton>
-              <PixButton @type="submit" @size="small" @variant="success">Modifier</PixButton>
+              <PixButton @type="submit" @size="small" @variant="success">{{t "common.actions.edit"}}</PixButton>
             </div>
           </form>
         {{else}}
@@ -383,7 +383,7 @@ export default class UserOverview extends Component {
                 @triggerAction={{this.changeEditionMode}}
                 @isDisabled={{@user.hasBeenAnonymised}}
               >
-                Modifier
+                {{t "common.actions.edit"}}
               </PixButton>
 
               <PixTooltip @position="bottom" @hide={{not @user.isPixAgent}} @isInline="{{true}}">

--- a/admin/app/components/users/user-overview.gjs
+++ b/admin/app/components/users/user-overview.gjs
@@ -266,7 +266,9 @@ export default class UserOverview extends Component {
               </PixSelect>
             </div>
             <div class="form-actions">
-              <PixButton @size="small" @variant="secondary" @triggerAction={{this.cancelEdit}}>Annuler</PixButton>
+              <PixButton @size="small" @variant="secondary" @triggerAction={{this.cancelEdit}}>
+                {{t "common.actions.cancel"}}
+              </PixButton>
               <PixButton @type="submit" @size="small" @variant="success">{{t "common.actions.edit"}}</PixButton>
             </div>
           </form>

--- a/admin/tests/acceptance/authenticated/autonomous-courses/autonomous-courses-test.js
+++ b/admin/tests/acceptance/authenticated/autonomous-courses/autonomous-courses-test.js
@@ -125,8 +125,8 @@ module('Acceptance | Autonomous courses', function (hooks) {
       test('it displays the update form when requested', async function (assert) {
         // when
         const screen = await visit('/autonomous-courses/1');
-
         const button = screen.getByText('Modifier');
+
         await click(button);
 
         // then

--- a/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
@@ -5,9 +5,12 @@ import { setupApplicationTest } from 'ember-qunit';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 import { module, test } from 'qunit';
 
+import setupIntl from '../../../helpers/setup-intl';
+
 module('Acceptance | Organizations | Create', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks);
 
   hooks.beforeEach(async function () {
     await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);

--- a/admin/tests/integration/components/actions-on-users-role-in-organization-test.gjs
+++ b/admin/tests/integration/components/actions-on-users-role-in-organization-test.gjs
@@ -1,13 +1,14 @@
 import { clickByName, render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
-import { setupRenderingTest } from 'ember-qunit';
 import ActionsOnUsersRoleInOrganization from 'pix-admin/components/actions-on-users-role-in-organization';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+
 module('Integration | Component | actions-on-users-role-in-organization', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   module('when user has access to organization actions scope', function () {
     test('it should be possible to modify user role', async function (assert) {

--- a/admin/tests/integration/components/autonomous-courses/create-autonomous-course-form-test.gjs
+++ b/admin/tests/integration/components/autonomous-courses/create-autonomous-course-form-test.gjs
@@ -1,15 +1,13 @@
 import { clickByName, render } from '@1024pix/ember-testing-library';
 import { triggerEvent } from '@ember/test-helpers';
-import { setupRenderingTest } from 'ember-qunit';
 import CreateAutonomousCourseForm from 'pix-admin/components/autonomous-courses/create-autonomous-course-form';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-import setupIntl from '../../../helpers/setup-intl';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | AutonomousCourses::CreateAutonomousCourseForm', function (hooks) {
-  setupRenderingTest(hooks);
-  setupIntl(hooks);
+  setupIntlRenderingTest(hooks);
 
   const autonomousCourse = {};
   const targetProfiles = [];
@@ -30,7 +28,6 @@ module('Integration | Component | AutonomousCourses::CreateAutonomousCourseForm'
     );
 
     // then
-    assert.dom(screen.getByText(/Les champs marqués de * sont obligatoires./)).exists();
     assert.dom(screen.getByText(/Informations techniques/)).exists();
     assert.dom(screen.getByText(/Nom interne/)).exists();
     assert.dom(screen.getByText(/Quel profil cible voulez-vous associer à ce parcours autonome ?/)).exists();

--- a/admin/tests/integration/components/autonomous-courses/details-test.gjs
+++ b/admin/tests/integration/components/autonomous-courses/details-test.gjs
@@ -1,12 +1,13 @@
 import { fillByLabel, render } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
-import { setupRenderingTest } from 'ember-qunit';
 import Details from 'pix-admin/components/autonomous-courses/details';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | AutonomousCourses::Details', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   let screen;
 

--- a/admin/tests/integration/components/badges/badge-test.gjs
+++ b/admin/tests/integration/components/badges/badge-test.gjs
@@ -1,10 +1,11 @@
 import { render } from '@1024pix/ember-testing-library';
-import { setupRenderingTest } from 'ember-qunit';
 import Badge from 'pix-admin/components/badges/badge';
 import { module, test } from 'qunit';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | badges/badge', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('should render all details about the badge', async function (assert) {
     // given

--- a/admin/tests/integration/components/badges/campaign-criterion-test.gjs
+++ b/admin/tests/integration/components/badges/campaign-criterion-test.gjs
@@ -1,13 +1,14 @@
 import { clickByName, fillByLabel, fireEvent, render, within } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
-import { setupRenderingTest } from 'ember-qunit';
 import CampaignCriterion from 'pix-admin/components/badges/campaign-criterion';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | Badges::CampaignCriterion', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('should display a CampaignParticipation criterion', async function (assert) {
     // given

--- a/admin/tests/integration/components/campaigns/details-test.gjs
+++ b/admin/tests/integration/components/campaigns/details-test.gjs
@@ -1,12 +1,13 @@
 import { clickByName, render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
-import { setupRenderingTest } from 'ember-qunit';
 import Details from 'pix-admin/components/campaigns/details';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | Campaigns | details', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   const toggleEditMode = sinon.stub();
 

--- a/admin/tests/integration/components/campaigns/participation-row-test.gjs
+++ b/admin/tests/integration/components/campaigns/participation-row-test.gjs
@@ -1,13 +1,14 @@
 import { clickByName, fillByLabel, render } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
-import { setupRenderingTest } from 'ember-qunit';
 import ParticipationRow from 'pix-admin/components/campaigns/participation-row';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | Campaigns | participation-row', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   module('Display information', function (hooks) {
     hooks.beforeEach(async function () {

--- a/admin/tests/integration/components/campaigns/participations-section-test.gjs
+++ b/admin/tests/integration/components/campaigns/participations-section-test.gjs
@@ -1,12 +1,13 @@
 import { render } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
-import { setupRenderingTest } from 'ember-qunit';
 import ParticipationsSection from 'pix-admin/components/campaigns/participations-section';
 import { module, test } from 'qunit';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | Campaigns | participations-section', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   hooks.beforeEach(async function () {
     // given

--- a/admin/tests/integration/components/campaigns/update-test.gjs
+++ b/admin/tests/integration/components/campaigns/update-test.gjs
@@ -2,7 +2,6 @@ import { clickByName, fillByLabel, render } from '@1024pix/ember-testing-library
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import Update from 'pix-admin/components/campaigns/update';
-import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 

--- a/admin/tests/integration/components/campaigns/update-test.gjs
+++ b/admin/tests/integration/components/campaigns/update-test.gjs
@@ -1,13 +1,15 @@
 import { clickByName, fillByLabel, render } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
-import { setupRenderingTest } from 'ember-qunit';
 import Update from 'pix-admin/components/campaigns/update';
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | Campaigns | Update', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   hooks.beforeEach(function () {
     class AccessControlStub extends Service {

--- a/admin/tests/integration/components/certifications/candidate-edit-modal-test.gjs
+++ b/admin/tests/integration/components/certifications/candidate-edit-modal-test.gjs
@@ -3,12 +3,13 @@ import EmberObject from '@ember/object';
 import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setFlatpickrDate } from 'ember-flatpickr/test-support/helpers';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | certifications/candidate-edit-modal', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   let store;
 

--- a/admin/tests/integration/components/certifications/issue-report-test.gjs
+++ b/admin/tests/integration/components/certifications/issue-report-test.gjs
@@ -1,12 +1,13 @@
 import { render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
-import { setupRenderingTest } from 'ember-qunit';
 import IssueReport from 'pix-admin/components/certifications/issue-report';
 import { certificationIssueReportSubcategories } from 'pix-admin/models/certification-issue-report';
 import { module, test } from 'qunit';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | certifications/issue-report', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('it should display issue details', async function (assert) {
     // Given

--- a/admin/tests/integration/components/certifications/issue-reports/resolve-issue-report-modal-test.gjs
+++ b/admin/tests/integration/components/certifications/issue-reports/resolve-issue-report-modal-test.gjs
@@ -1,11 +1,12 @@
 import { clickByName, fillByLabel, render } from '@1024pix/ember-testing-library';
-import { setupRenderingTest } from 'ember-qunit';
 import ResolveIssueReportModal from 'pix-admin/components/certifications/issue-reports/resolve-issue-report-modal';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | certifications/issue-reports/resolve-issue-report-modal', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   module('when the issue is not resolved', function () {
     test('it should display a report resolution title', async function (assert) {

--- a/admin/tests/integration/components/confirm-popup-test.gjs
+++ b/admin/tests/integration/components/confirm-popup-test.gjs
@@ -1,11 +1,12 @@
 import { clickByName, render } from '@1024pix/ember-testing-library';
-import { setupRenderingTest } from 'ember-qunit';
 import ConfirmPopup from 'pix-admin/components/confirm-popup';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+
 module('Integration | Component | confirm-popup', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('should display confirm', async function (assert) {
     // given & when

--- a/admin/tests/integration/components/organizations/creation-form-test.gjs
+++ b/admin/tests/integration/components/organizations/creation-form-test.gjs
@@ -1,11 +1,12 @@
 import { fillByLabel, render } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
-import { setupRenderingTest } from 'ember-qunit';
 import CreationForm from 'pix-admin/components/organizations/creation-form';
 import { module, test } from 'qunit';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | organizations/creation-form', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
   const onSubmit = () => {};
   const onCancel = () => {};
 

--- a/admin/tests/integration/components/organizations/information-section-edit-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-edit-test.gjs
@@ -1,12 +1,13 @@
 import { fillByLabel, render } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
-import { setupRenderingTest } from 'ember-qunit';
 import InformationSectionEdit from 'pix-admin/components/organizations/information-section-edit';
 import { module, test } from 'qunit';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | organizations/information-section-edit', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   module('organization validation', function (hooks) {
     hooks.beforeEach(function () {

--- a/admin/tests/integration/components/organizations/information-section-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-test.gjs
@@ -2,12 +2,13 @@ import { clickByName, fillByLabel, render } from '@1024pix/ember-testing-library
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
-import { setupRenderingTest } from 'ember-qunit';
 import InformationSection from 'pix-admin/components/organizations/information-section';
 import { module, test } from 'qunit';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | organizations/information-section', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   module('when editing organization', function (hooks) {
     hooks.beforeEach(function () {

--- a/admin/tests/integration/components/organizations/invitations-action-test.gjs
+++ b/admin/tests/integration/components/organizations/invitations-action-test.gjs
@@ -1,12 +1,13 @@
 import { clickByText } from '@1024pix/ember-testing-library';
 import { render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'ember-qunit';
 import InvitationsAction from 'pix-admin/components/organizations/invitations-action';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | organization-invitations-action', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('it should create organization invitation with default language and default role value', async function (assert) {
     // given

--- a/admin/tests/integration/components/organizations/list-items-test.gjs
+++ b/admin/tests/integration/components/organizations/list-items-test.gjs
@@ -1,12 +1,13 @@
 import { render } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
-import { setupRenderingTest } from 'ember-qunit';
 import ListItems from 'pix-admin/components/organizations/list-items';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | ListItems', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
   let currentUser;
 
   hooks.beforeEach(function () {

--- a/admin/tests/integration/components/organizations/places-lot-creation-form-test.gjs
+++ b/admin/tests/integration/components/organizations/places-lot-creation-form-test.gjs
@@ -1,12 +1,13 @@
 import { clickByName, fillByLabel, render } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
-import { setupRenderingTest } from 'ember-qunit';
 import PlacesLotCreationForm from 'pix-admin/components/organizations/places-lot-creation-form';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | organizations/places-lot-creation-form', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('Should send add organization places set request to API', async function (assert) {
     // given

--- a/admin/tests/integration/components/organizations/places-test.gjs
+++ b/admin/tests/integration/components/organizations/places-test.gjs
@@ -1,10 +1,11 @@
 import { clickByText, render } from '@1024pix/ember-testing-library';
-import { setupRenderingTest } from 'ember-qunit';
 import Places from 'pix-admin/components/organizations/places';
 import { module, test } from 'qunit';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | Organizations | Places', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   let store;
   let currentUser;

--- a/admin/tests/integration/components/organizations/places/delete-modal-test.gjs
+++ b/admin/tests/integration/components/organizations/places/delete-modal-test.gjs
@@ -1,12 +1,13 @@
 import { clickByText, render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
-import { setupRenderingTest } from 'ember-qunit';
 import DeleteModal from 'pix-admin/components/organizations/places/delete-modal';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | Organizations | Places | Delete-modal', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   const places = {
     count: 7777,

--- a/admin/tests/integration/components/organizations/target-profiles-section-test.gjs
+++ b/admin/tests/integration/components/organizations/target-profiles-section-test.gjs
@@ -2,13 +2,14 @@ import { clickByName, fillByLabel, render, within } from '@1024pix/ember-testing
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
-import { setupRenderingTest } from 'ember-qunit';
 import TargetProfilesSection from 'pix-admin/components/organizations/target-profiles-section';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | organizations/target-profiles-section', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   let store;
 

--- a/admin/tests/integration/components/organizations/team-section-test.gjs
+++ b/admin/tests/integration/components/organizations/team-section-test.gjs
@@ -1,12 +1,13 @@
 import { render } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
-import { setupRenderingTest } from 'ember-qunit';
 import TeamSection from 'pix-admin/components/organizations/team-section';
 import { module, test } from 'qunit';
 
-module('Integration | Component | organization-team-section', function (hooks) {
-  setupRenderingTest(hooks);
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | organizations | team-section', function (hooks) {
+  setupIntlRenderingTest(hooks);
 
   test('it should display a list of members', async function (assert) {
     // given

--- a/admin/tests/integration/components/routes/authenticated/organizations/list-items-test.gjs
+++ b/admin/tests/integration/components/routes/authenticated/organizations/list-items-test.gjs
@@ -1,10 +1,11 @@
 import { render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'ember-qunit';
 import ListItems from 'pix-admin/components/organizations/list-items';
 import { module, test } from 'qunit';
 
+import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | routes/authenticated/organizations | list-items', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   hooks.beforeEach(async function () {
     const currentUser = this.owner.lookup('service:currentUser');

--- a/admin/tests/integration/components/routes/authenticated/target-profiles/target-profile/insights-test.gjs
+++ b/admin/tests/integration/components/routes/authenticated/target-profiles/target-profile/insights-test.gjs
@@ -1,10 +1,11 @@
 import { render } from '@1024pix/ember-testing-library';
-import { setupRenderingTest } from 'ember-qunit';
 import Insights from 'pix-admin/components/target-profiles/insights';
 import { module, test } from 'qunit';
 
+import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | routes/authenticated/target-profiles/target-profile | Insights', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   module('section rendering', function () {
     const targetProfile = {

--- a/admin/tests/integration/components/routes/authenticated/to-be-published-sessions/list-items-test.gjs
+++ b/admin/tests/integration/components/routes/authenticated/to-be-published-sessions/list-items-test.gjs
@@ -1,12 +1,13 @@
 import { clickByName, render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
-import { setupRenderingTest } from 'ember-qunit';
 import ListItems from 'pix-admin/components/to-be-published-sessions/list-items';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | routes/authenticated/to-be-published-sessions | list-items', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('it should display to be published sessions list', async function (assert) {
     // given

--- a/admin/tests/integration/components/sessions/jury-comment-test.gjs
+++ b/admin/tests/integration/components/sessions/jury-comment-test.gjs
@@ -1,13 +1,14 @@
 import { clickByName, fillByLabel, render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import dayjs from 'dayjs';
-import { setupRenderingTest } from 'ember-qunit';
 import JuryComment from 'pix-admin/components/sessions/jury-comment';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | JuryComment', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   module('when there is no comment', function () {
     module('when current user is not allowed to comment', function () {

--- a/admin/tests/integration/components/stages/stage-test.gjs
+++ b/admin/tests/integration/components/stages/stage-test.gjs
@@ -1,12 +1,13 @@
 import { render } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
-import { setupRenderingTest } from 'ember-qunit';
 import Stage from 'pix-admin/components/stages/stage';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | Stage', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
   let component;
   const toggleEditMode = sinon.stub();
 

--- a/admin/tests/integration/components/target-profiles/badge-form-test.gjs
+++ b/admin/tests/integration/components/target-profiles/badge-form-test.gjs
@@ -1,13 +1,14 @@
 import { render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import { click, fillIn } from '@ember/test-helpers';
-import { setupRenderingTest } from 'ember-qunit';
 import BadgeForm from 'pix-admin/components/target-profiles/badge-form';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | BadgeForm', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   const targetProfile = {
     areas: [

--- a/admin/tests/integration/components/target-profiles/badges-test.gjs
+++ b/admin/tests/integration/components/target-profiles/badges-test.gjs
@@ -1,13 +1,14 @@
 import { clickByName, render } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
 import { find } from '@ember/test-helpers';
-import { setupRenderingTest } from 'ember-qunit';
 import Badges from 'pix-admin/components/target-profiles/badges';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | TargetProfiles::Badges', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('it should display the items', async function (assert) {
     // given

--- a/admin/tests/integration/components/target-profiles/organizations-test.gjs
+++ b/admin/tests/integration/components/target-profiles/organizations-test.gjs
@@ -1,11 +1,12 @@
 import { clickByName, fillByLabel, render } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
-import { setupRenderingTest } from 'ember-qunit';
 import Organizations from 'pix-admin/components/target-profiles/organizations';
 import { module, test } from 'qunit';
 
-module('Integration | Component | Organizations', function (hooks) {
-  setupRenderingTest(hooks);
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | target-profiles | Organizations', function (hooks) {
+  setupIntlRenderingTest(hooks);
 
   const triggerFiltering = () => {};
   const goToOrganizationPage = () => {};

--- a/admin/tests/integration/components/target-profiles/stages-test.gjs
+++ b/admin/tests/integration/components/target-profiles/stages-test.gjs
@@ -1,11 +1,12 @@
 import { render } from '@1024pix/ember-testing-library';
 import { click, find } from '@ember/test-helpers';
-import { setupRenderingTest } from 'ember-qunit';
 import Stages from 'pix-admin/components/target-profiles/stages';
 import { module, test } from 'qunit';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | Stages', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
   let store;
 
   hooks.beforeEach(function () {

--- a/admin/tests/integration/components/team-actions-section-test.gjs
+++ b/admin/tests/integration/components/team-actions-section-test.gjs
@@ -1,12 +1,13 @@
 import { clickByName, fillByLabel } from '@1024pix/ember-testing-library';
 import { render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'ember-qunit';
 import TeamActionsSection from 'pix-admin/components/organizations/team-actions-section';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+
 module('Integration | Component | organization-team-actions-section', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('it should call addOrganizationMembership method', async function (assert) {
     // given

--- a/admin/tests/integration/components/team/list-test.gjs
+++ b/admin/tests/integration/components/team/list-test.gjs
@@ -1,12 +1,13 @@
 import { clickByName, render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
-import { setupRenderingTest } from 'ember-qunit';
 import List from 'pix-admin/components/team/list';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | team | list', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   module('with members', function () {
     test('should display the list of members', async function (assert) {

--- a/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
+++ b/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
@@ -1,13 +1,14 @@
 import { clickByName, render } from '@1024pix/ember-testing-library';
 import { triggerEvent } from '@ember/test-helpers';
-import { setupRenderingTest } from 'ember-qunit';
 import CreateOrUpdateTrainingForm from 'pix-admin/components/trainings/create-or-update-training-form';
 import { localeCategories, typeCategories } from 'pix-admin/models/training';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-module('Integration | Component | CreateOrUpdateTrainingForm', function (hooks) {
-  setupRenderingTest(hooks);
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | trainings | CreateOrUpdateTrainingForm', function (hooks) {
+  setupIntlRenderingTest(hooks);
 
   const onSubmit = sinon.stub();
   const onCancel = sinon.stub();

--- a/admin/tests/integration/components/users/campaign-participations-test.gjs
+++ b/admin/tests/integration/components/users/campaign-participations-test.gjs
@@ -1,13 +1,14 @@
 import { clickByName, render } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
-import { setupRenderingTest } from 'ember-qunit';
 import CampaignParticipations from 'pix-admin/components/users/campaign-participations';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | users | campaign-participation', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   module('When the admin member does not have access to users actions scope', function (hooks) {
     class AccessControlStub extends Service {

--- a/admin/tests/unit/components/organizations/target-profiles-section-test.js
+++ b/admin/tests/unit/components/organizations/target-profiles-section-test.js
@@ -1,4 +1,5 @@
 import Service from '@ember/service';
+import { setupIntl } from 'ember-intl/test-support';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -7,6 +8,7 @@ import createComponent from '../../../helpers/create-glimmer-component';
 
 module('Unit | Component | organizations/target-profiles-section', function (hooks) {
   setupTest(hooks);
+  setupIntl(hooks, 'fr');
 
   module('#attachTargetProfiles', function (hooks) {
     let event;

--- a/admin/tests/unit/components/target-profiles/organizations-test.js
+++ b/admin/tests/unit/components/target-profiles/organizations-test.js
@@ -1,3 +1,4 @@
+import { setupIntl } from 'ember-intl/test-support';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -6,6 +7,7 @@ import createComponent from '../../../helpers/create-glimmer-component';
 
 module('Unit | Component | Target Profiles | Organizations', function (hooks) {
   setupTest(hooks);
+  setupIntl(hooks, 'fr');
 
   module('#attachOrganizations', function (hooks) {
     let event;

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -5,6 +5,7 @@
       "cancel": "Cancel",
       "close": "Close",
       "deactivate": "Deactivate",
+      "edit": "Edit",
       "save": "Save",
       "validate": "Validate"
     },
@@ -329,20 +330,15 @@
           "title": "Informations techniques"
         },
         "user-information": {
+          "homepage": {
+            "label": "Texte de la page d'accueil",
+            "placeholder": "Exemple : description, objectifs..."
+          },
           "public-name": {
             "label": "Nom public <small>(50 caractères maximum)</small>",
             "placeholder": "Exemple : Le super nom de mon parcours autonome",
             "sub-label": "Le nom du parcours autonome sera affiché sur la page de démarrage du candidat."
           },
-          "homepage": {
-            "label": "Texte de la page d'accueil",
-            "placeholder": "Exemple : description, objectifs..."
-          },
-          "category-label": "",
-          "label": "",
-          "placeholder": "",
-          "search-label": "",
-          "sub-label": "",
           "title": "Informations pour les utilisateurs"
         }
       }

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -19,6 +19,7 @@
     },
     "forms": {
       "loading": "Loading...",
+      "mandatory": "Champ obligatoire",
       "mandatory-fields": "The fields marked '<abbr title=\"required\" class=\"mandatory-mark\">'*'</abbr>' are required"
     },
     "notifications": {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -326,10 +326,11 @@
           "sub-label": "Le profil cible doit être en accès simplifié et relié à l’organisation \"Organisation pour les parcours autonomes\""
         },
         "technical-informations": {
-          "label": "Nom interne",
-          "title": "Informations techniques"
+          "title": "Informations techniques",
+          "label": "Nom interne"
         },
         "user-information": {
+          "title": "Informations pour les utilisateurs",
           "homepage": {
             "label": "Texte de la page d'accueil",
             "placeholder": "Exemple : description, objectifs..."
@@ -338,8 +339,7 @@
             "label": "Nom public <small>(50 caractères maximum)</small>",
             "placeholder": "Exemple : Le super nom de mon parcours autonome",
             "sub-label": "Le nom du parcours autonome sera affiché sur la page de démarrage du candidat."
-          },
-          "title": "Informations pour les utilisateurs"
+          }
         }
       }
     },

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -314,6 +314,39 @@
         }
       }
     },
+    "autonomous-course": {
+      "creation-form-fields": {
+        "create-autonomous-course": "Créer le parcours autonome",
+        "target-profile": {
+          "category-label": "Sélectionner une ou plusieurs catégories de profils cibles",
+          "label": "Quel profil cible voulez-vous associer à ce parcours autonome ?",
+          "placeholder": "Choisir un profil cible",
+          "search-label": "Recherchez un profil cible",
+          "sub-label": "Le profil cible doit être en accès simplifié et relié à l’organisation \"Organisation pour les parcours autonomes\""
+        },
+        "technical-informations": {
+          "label": "Nom interne",
+          "title": "Informations techniques"
+        },
+        "user-information": {
+          "public-name": {
+            "label": "Nom public <small>(50 caractères maximum)</small>",
+            "placeholder": "Exemple : Le super nom de mon parcours autonome",
+            "sub-label": "Le nom du parcours autonome sera affiché sur la page de démarrage du candidat."
+          },
+          "homepage": {
+            "label": "Texte de la page d'accueil",
+            "placeholder": "Exemple : description, objectifs..."
+          },
+          "category-label": "",
+          "label": "",
+          "placeholder": "",
+          "search-label": "",
+          "sub-label": "",
+          "title": "Informations pour les utilisateurs"
+        }
+      }
+    },
     "certification-centers": {
       "information-view": {
         "habilitations": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -19,6 +19,7 @@
     },
     "forms": {
       "loading": "Chargement...",
+      "mandatory": "Champ obligatoire",
       "mandatory-fields": "Les champs marqués de '<abbr title=\"obligatoire\" class=\"mandatory-mark\">'*'</abbr>' sont obligatoires"
     },
     "notifications": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -5,6 +5,7 @@
       "cancel": "Annuler",
       "close": "Fermer",
       "deactivate": "Désactiver",
+      "edit": "Modifier",
       "save": "Enregistrer",
       "validate": "Valider"
     },
@@ -339,20 +340,15 @@
           "title": "Informations techniques"
         },
         "user-information": {
+          "homepage": {
+            "label": "Texte de la page d'accueil",
+            "placeholder": "Exemple : description, objectifs..."
+          },
           "public-name": {
             "label": "Nom public <small>(50 caractères maximum)</small>",
             "placeholder": "Exemple : Le super nom de mon parcours autonome",
             "sub-label": "Le nom du parcours autonome sera affiché sur la page de démarrage du candidat."
           },
-          "homepage": {
-            "label": "Texte de la page d'accueil",
-            "placeholder": "Exemple : description, objectifs..."
-          },
-          "category-label": "",
-          "label": "",
-          "placeholder": "",
-          "search-label": "",
-          "sub-label": "",
           "title": "Informations pour les utilisateurs"
         }
       }

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -324,6 +324,39 @@
         }
       }
     },
+    "autonomous-course": {
+      "creation-form-fields": {
+        "create-autonomous-course": "Créer le parcours autonome",
+        "target-profile": {
+            "category-label": "Sélectionner une ou plusieurs catégories de profils cibles",
+            "label": "Quel profil cible voulez-vous associer à ce parcours autonome ?",
+            "placeholder": "Choisir un profil cible",
+            "search-label": "Recherchez un profil cible",
+            "sub-label": "Le profil cible doit être en accès simplifié et relié à l’organisation \"Organisation pour les parcours autonomes\""
+        },
+        "technical-informations": {
+          "label": "Nom interne",
+          "title": "Informations techniques"
+        },
+        "user-information": {
+          "public-name": {
+            "label": "Nom public <small>(50 caractères maximum)</small>",
+            "placeholder": "Exemple : Le super nom de mon parcours autonome",
+            "sub-label": "Le nom du parcours autonome sera affiché sur la page de démarrage du candidat."
+          },
+          "homepage": {
+            "label": "Texte de la page d'accueil",
+            "placeholder": "Exemple : description, objectifs..."
+          },
+          "category-label": "",
+          "label": "",
+          "placeholder": "",
+          "search-label": "",
+          "sub-label": "",
+          "title": "Informations pour les utilisateurs"
+        }
+      }
+    },
     "certification-centers": {
       "information-view": {
         "habilitations": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -329,17 +329,18 @@
       "creation-form-fields": {
         "create-autonomous-course": "Créer le parcours autonome",
         "target-profile": {
-            "category-label": "Sélectionner une ou plusieurs catégories de profils cibles",
-            "label": "Quel profil cible voulez-vous associer à ce parcours autonome ?",
-            "placeholder": "Choisir un profil cible",
-            "search-label": "Recherchez un profil cible",
-            "sub-label": "Le profil cible doit être en accès simplifié et relié à l’organisation \"Organisation pour les parcours autonomes\""
+          "category-label": "Sélectionner une ou plusieurs catégories de profils cibles",
+          "label": "Quel profil cible voulez-vous associer à ce parcours autonome ?",
+          "placeholder": "Choisir un profil cible",
+          "search-label": "Recherchez un profil cible",
+          "sub-label": "Le profil cible doit être en accès simplifié et relié à l’organisation \"Organisation pour les parcours autonomes\""
         },
         "technical-informations": {
-          "label": "Nom interne",
-          "title": "Informations techniques"
+          "title": "Informations techniques",
+          "label": "Nom interne"
         },
         "user-information": {
+          "title": "Informations pour les utilisateurs",
           "homepage": {
             "label": "Texte de la page d'accueil",
             "placeholder": "Exemple : description, objectifs..."
@@ -348,8 +349,7 @@
             "label": "Nom public <small>(50 caractères maximum)</small>",
             "placeholder": "Exemple : Le super nom de mon parcours autonome",
             "sub-label": "Le nom du parcours autonome sera affiché sur la page de démarrage du candidat."
-          },
-          "title": "Informations pour les utilisateurs"
+          }
         }
       }
     },


### PR DESCRIPTION
## :unicorn: Problème
Administration contient à la fois du texte en dur et des clés de traduction.

## :robot: Proposition
Mettre les clés de traduction au lieu du texte en dur pour les boutons d'actions (annuler, valider etc)

## :rainbow: Remarques
Il n’est pas prévu de passer Pix-Admin en international. Cependant, les clés de traduction doivent quand même être mises pour : 
- garder une cohérence dans le code et dans les tests au sein des applis
- simplifier le travail des forks Pix

## :100: Pour tester
Tests (surtout acceptance) au vert 🟢
