### PR TITLE
[TECH] Retirer le retry sur les Job d'état de participation (PIX-13979)

### DIFF
--- a/api/src/prescription/campaign-participation/infrastructure/repositories/jobs/participation-completed-job-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/jobs/participation-completed-job-repository.js
@@ -5,7 +5,7 @@ class ParticipationCompletedJobRepository extends JobRepository {
   constructor() {
     super({
       name: ParticipationCompletedJob.name,
-      retry: JobRetry.STANDARD_RETRY,
+      retry: JobRetry.NO_RETRY,
     });
   }
 }

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/jobs/participation-shared-job-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/jobs/participation-shared-job-repository.js
@@ -5,7 +5,7 @@ class ParticipationSharedJobRepository extends JobRepository {
   constructor() {
     super({
       name: ParticipationSharedJob.name,
-      retry: JobRetry.STANDARD_RETRY,
+      retry: JobRetry.NO_RETRY,
     });
   }
 }

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/jobs/participation-started-job-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/jobs/participation-started-job-repository.js
@@ -5,7 +5,7 @@ class ParticipationStartedJobRepository extends JobRepository {
   constructor() {
     super({
       name: ParticipationStartedJob.name,
-      retry: JobRetry.STANDARD_RETRY,
+      retry: JobRetry.NO_RETRY,
     });
   }
 }

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/jobs/participation-completed-job-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/jobs/participation-completed-job-repository_test.js
@@ -13,9 +13,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | part
 
       // then
       await expect(ParticipationCompletedJob.name).to.have.been.performed.withJob({
-        retrylimit: 10,
-        retrydelay: 30,
-        retrybackoff: true,
+        retrylimit: 0,
+        retrydelay: 0,
+        retrybackoff: false,
         data,
       });
     });

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/jobs/participation-shared-job-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/jobs/participation-shared-job-repository_test.js
@@ -12,9 +12,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | part
 
       await expect(ParticipationSharedJob.name).to.have.been.performed.withJob({
         name: ParticipationSharedJob.name,
-        retrylimit: 10,
-        retrydelay: 30,
-        retrybackoff: true,
+        retrylimit: 0,
+        retrydelay: 0,
+        retrybackoff: false,
         data: { campaignParticipationId: 2 },
       });
     });

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/jobs/participation-started-job-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/jobs/participation-started-job-repository_test.js
@@ -14,9 +14,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | part
 
       // then
       await expect(ParticipationStartedJob.name).to.have.been.performed.withJob({
-        retrylimit: 10,
-        retrydelay: 30,
-        retrybackoff: true,
+        retrylimit: 0,
+        retrydelay: 0,
+        retrybackoff: false,
         data: {
           campaignParticipationId: 777,
         },


### PR DESCRIPTION
## :unicorn: Problème
On a été un peu vite en besogne
## :robot: Proposition
Afin d'être sûr de ne pas générer de souci lors de l'insertion d'un Job d'état de participation, nous repassons le retry des jobs à 0 .

## :rainbow: Remarques
Lorsque nous aurons désactiver définitivement l'envoi des résultats. nous pourrons remettre du try et éviter de l'intervention manuel à nos captains

## :100: Pour tester
Vérifier que les Job Started / Completed / Shared Participation on bien un retry a 0