### PR TITLE
[BUGFIX] Fixer le problème de contraste dans l'écran de fin de test sur Pix App (PIX-13951).

### DIFF
--- a/mon-pix/app/styles/components/certifications/certification-ender.scss
+++ b/mon-pix/app/styles/components/certifications/certification-ender.scss
@@ -56,7 +56,7 @@
 
       &__content {
         margin-left: 16px;
-        color: var(--pix-neutral-100);
+        color: var(--pix-neutral-500);
         font-size: 14px;
         line-height: 20px;
       }
@@ -75,7 +75,7 @@
     display: block;
     width: 272px;
     margin: auto;
-    color: var(--pix-neutral-100);
+    color: var(--pix-neutral-500);
     font-size: 0.875rem;
     font-family: $font-roboto;
     line-height: 22px;


### PR DESCRIPTION
## :unicorn: Problème
Suite à la mise à jour des couleurs sur Pix App, l'écran de fin de test affiche des phrases avec un contraste très faible avec le fond.

<img width="1432" alt="Capture d’écran 2024-08-21 à 11 25 01" src="https://github.com/user-attachments/assets/806e547a-d375-4264-b8b8-f00d8d67846f">


## :robot: Proposition
Mettre la bonne couleur.

## :100: Pour tester

- Se connecter avec certif-success@example.net
- passer une certification jusqu'au bout pour atterrir sur l'écran de fin de test
- S'assurer que le contraste est bon sur l'ensemble de la page.

<img width="1080" alt="Capture d’écran 2024-08-23 à 12 17 50" src="https://github.com/user-attachments/assets/07c8efcf-c7b4-44fe-97f6-d1667eb2c7da">
