### PR TITLE
[TECH] Ajouter un legacyName afin de pouvoir renommer un Job (PIX-13982)

### DIFF
--- a/api/src/prescription/campaign-participation/application/jobs/participation-completed-job-controller.js
+++ b/api/src/prescription/campaign-participation/application/jobs/participation-completed-job-controller.js
@@ -20,6 +20,10 @@ export class ParticipationCompletedJobController extends JobController {
     super(ParticipationCompletedJob.name);
   }
 
+  get legacyName() {
+    return 'PoleEmploiParticipationCompletedJob';
+  }
+
   async handle(
     campaignParticipationCompletedJob,
     dependencies = {

--- a/api/src/prescription/campaign-participation/application/jobs/participation-shared-job-controller.js
+++ b/api/src/prescription/campaign-participation/application/jobs/participation-shared-job-controller.js
@@ -7,6 +7,10 @@ export class ParticipationSharedJobController extends JobController {
     super(ParticipationSharedJob.name);
   }
 
+  get legacyName() {
+    return 'SendSharedParticipationResultsToPoleEmploiJob';
+  }
+
   async handle(participationSharedJobController) {
     const { campaignParticipationId } = participationSharedJobController;
 

--- a/api/src/prescription/campaign-participation/application/jobs/participation-started-job-controller.js
+++ b/api/src/prescription/campaign-participation/application/jobs/participation-started-job-controller.js
@@ -19,6 +19,10 @@ export class ParticipationStartedJobController extends JobController {
     super(ParticipationStartedJob.name);
   }
 
+  get legacyName() {
+    return 'PoleEmploiParticipationStartedJob';
+  }
+
   async handle(
     data,
     dependencies = {

--- a/api/src/shared/application/jobs/job-controller.js
+++ b/api/src/shared/application/jobs/job-controller.js
@@ -19,6 +19,10 @@ export class JobController {
     return true;
   }
 
+  get legacyName() {
+    return null;
+  }
+
   get teamSize() {
     return config.pgBoss.teamSize;
   }

--- a/api/tests/shared/unit/application/jobs/job-controller_test.js
+++ b/api/tests/shared/unit/application/jobs/job-controller_test.js
@@ -39,4 +39,20 @@ describe('Unit | Shared | Application | Jobs | JobController', function () {
       jobGroup,
     });
   });
+
+  it('should set isJobEnabled to true by default', function () {
+    // when
+    const controller = new JobController('jobName');
+
+    // then
+    expect(controller.isJobEnabled).to.be.true;
+  });
+
+  it('should set legacyName to null by default', function () {
+    // when
+    const controller = new JobController('jobName');
+
+    // then
+    expect(controller.legacyName).to.be.null;
+  });
 });

--- a/api/tests/unit/worker_test.js
+++ b/api/tests/unit/worker_test.js
@@ -1,4 +1,5 @@
 import { UserAnonymizedEventLoggingJob } from '../../src/identity-access-management/domain/models/UserAnonymizedEventLoggingJob.js';
+import { ParticipationSharedJobController } from '../../src/prescription/campaign-participation/application/jobs/participation-shared-job-controller.js';
 import { ValidateOrganizationLearnersImportFileJobController } from '../../src/prescription/learner-management/application/jobs/validate-organization-learners-import-file-job-controller.js';
 import { ValidateOrganizationImportFileJob } from '../../src/prescription/learner-management/domain/models/ValidateOrganizationImportFileJob.js';
 import { UserAnonymizedEventLoggingJobController } from '../../src/shared/application/jobs/audit-log/user-anonymized-event-logging-job-controller.js';
@@ -36,6 +37,22 @@ describe('#registerJobs', function () {
       UserAnonymizedEventLoggingJob.name,
       UserAnonymizedEventLoggingJobController,
     );
+  });
+
+  it('should register legacyName', async function () {
+    // when
+    await registerJobs({
+      jobGroup: JobGroup.DEFAULT,
+      dependencies: {
+        startPgBoss: startPgBossStub,
+        createJobQueues: createJobQueuesStub,
+        scheduleCpfJobs: scheduleCpfJobsStub,
+      },
+    });
+
+    const job = new ParticipationSharedJobController();
+    // then
+    expect(jobQueueStub.register).to.have.been.calledWithExactly(job.legacyName, ParticipationSharedJobController);
   });
 
   it('should register ValidateOrganizationImportFileJob when job is enabled', async function () {

--- a/api/worker.js
+++ b/api/worker.js
@@ -7,9 +7,6 @@ import { glob } from 'glob';
 import _ from 'lodash';
 import PgBoss from 'pg-boss';
 
-import { ParticipationCompletedJobController } from './src/prescription/campaign-participation/application/jobs/participation-completed-job-controller.js';
-import { ParticipationSharedJobController } from './src/prescription/campaign-participation/application/jobs/participation-shared-job-controller.js';
-import { ParticipationStartedJobController } from './src/prescription/campaign-participation/application/jobs/participation-started-job-controller.js';
 import { ScheduleComputeOrganizationLearnersCertificabilityJob } from './src/prescription/learner-management/domain/models/ScheduleComputeOrganizationLearnersCertificabilityJob.js';
 import { JobGroup } from './src/shared/application/jobs/job-controller.js';
 import { config } from './src/shared/config.js';
@@ -97,16 +94,16 @@ export async function registerJobs({ jobGroup, dependencies = { startPgBoss, cre
       logger.info(`Job "${job.jobName}" registered from module "${moduleName}."`);
       jobQueues.register(job.jobName, ModuleClass);
 
+      if (job.legacyName) {
+        logger.warn(`Temporary Job" ${job.legacyName}" registered from module "${moduleName}."`);
+        jobQueues.register(job.legacyName, ModuleClass);
+      }
+
       jobRegisteredCount++;
     } else {
       logger.warn(`Job "${job.jobName}" is disabled.`);
     }
   }
-
-  // deprecated name remove later
-  jobQueues.register('SendSharedParticipationResultsToPoleEmploiJob', ParticipationSharedJobController);
-  jobQueues.register('PoleEmploiParticipationCompletedJob', ParticipationCompletedJobController);
-  jobQueues.register('PoleEmploiParticipationStartedJob', ParticipationStartedJobController);
 
   logger.info(`${jobRegisteredCount} jobs registered for group "${jobGroup}".`);
 


### PR DESCRIPTION
## :unicorn: Problème
Si nous souhaitons renommer un job, il est possible de le faire. Mais nécessite de l'écriture dans le worker

## :robot: Proposition
Ajouter un legacyName en getter afin de pouvoir le surcharger, vérifier dans le worker la présence d'un legacyName pour register un job sous ce nom là

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier dans les log api que 3 warning sont bien écrit afin de notifié de l'enregistrement de job legacy