### PR TITLE
[TECH] Améliorer les performances pour la récupération des stats de places de toutes les organisations via un endpoint (PIX-13983)

### DIFF
--- a/api/src/prescription/organization-place/domain/read-models/PlacesLot.js
+++ b/api/src/prescription/organization-place/domain/read-models/PlacesLot.js
@@ -5,6 +5,7 @@ import { validateEntity } from '../../../../shared/domain/validators/entity-vali
 
 const validationSchema = Joi.object({
   count: Joi.number().required().allow(null),
+  organizationId: Joi.number(),
   activationDate: Joi.date().required(),
   expirationDate: Joi.date().required().allow(null),
   deletedAt: Joi.date().required().allow(null),
@@ -17,6 +18,7 @@ export class PlacesLot {
   constructor(params = {}) {
     validateEntity(validationSchema, params);
     this.count = params.count === null ? 0 : params.count;
+    this.organizationId = params.organizationId;
     this.#activationDate = params.activationDate;
     this.#expirationDate = params.expirationDate;
     this.#deletedAt = params.deletedAt;

--- a/api/src/prescription/organization-place/infrastructure/repositories/organization-places-lot-repository.js
+++ b/api/src/prescription/organization-place/infrastructure/repositories/organization-places-lot-repository.js
@@ -36,6 +36,16 @@ const findAllByOrganizationId = async function (organizationId) {
     .where({ organizationId });
   return placesLots.map((e) => new PlacesLot(e));
 };
+
+const findAllByOrganizationIds = async function (organizationIds) {
+  const knexConn = DomainTransaction.getConnection();
+  const placesLots = await knexConn('organization-places')
+    .select('count', 'organizationId', 'activationDate', 'expirationDate', 'deletedAt')
+    .whereIn('organizationId', organizationIds);
+
+  return placesLots.map((e) => new PlacesLot(e));
+};
+
 const get = async function (id) {
   const result = await knex('organization-places')
     .select(
@@ -74,4 +84,4 @@ const remove = async function ({ id, deletedBy }) {
   }
 };
 
-export { create, findAllByOrganizationId, findByOrganizationId, get, remove };
+export { create, findAllByOrganizationId, findAllByOrganizationIds, findByOrganizationId, get, remove };

--- a/api/tests/prescription/organization-place/integration/domain/usecases/get-data-organizations-places-statistics_test.js
+++ b/api/tests/prescription/organization-place/integration/domain/usecases/get-data-organizations-places-statistics_test.js
@@ -1,5 +1,6 @@
+import * as organizationLearnerRepository from '../../../../../../lib/infrastructure/repositories/organization-learner-repository.js';
 import { getDataOrganizationsPlacesStatistics } from '../../../../../../src/prescription/organization-place/domain/usecases/get-data-organizations-places-statistics.js';
-import { usecases as organizationPlacesUsecases } from '../../../../../../src/prescription/organization-place/domain/usecases/index.js';
+import * as organizationPlacesLotRepository from '../../../../../../src/prescription/organization-place/infrastructure/repositories/organization-places-lot-repository.js';
 import * as organizationRepository from '../../../../../../src/shared/infrastructure/repositories/organization-repository.js';
 import { databaseBuilder, expect, sinon } from '../../../../../test-helper.js';
 
@@ -44,8 +45,9 @@ describe('Integration | UseCases | get-data-organizations-places-statistics', fu
 
     // when
     const dataOrganizationsPlacesStatistics = await getDataOrganizationsPlacesStatistics({
-      getOrganizationPlacesStatistics: organizationPlacesUsecases.getOrganizationPlacesStatistics,
       organizationRepository,
+      organizationPlacesLotRepository,
+      organizationLearnerRepository,
     });
 
     // then

--- a/api/tests/prescription/organization-place/integration/infrastructure/repositories/organization-places-lot-repository_test.js
+++ b/api/tests/prescription/organization-place/integration/infrastructure/repositories/organization-places-lot-repository_test.js
@@ -266,6 +266,67 @@ describe('Integration | Repository | Organization Places Lot', function () {
     });
   });
 
+  describe('#findAllByOrganizationIds', function () {
+    let firstOrganizationId;
+    let secondOrganizationId;
+
+    beforeEach(async function () {
+      firstOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      secondOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      await databaseBuilder.commit();
+    });
+
+    it('should return empty array if there is no placesLot', async function () {
+      const organizationIds = [firstOrganizationId, secondOrganizationId];
+
+      const places = await organizationPlacesLotRepository.findAllByOrganizationIds(organizationIds);
+
+      expect(places).to.be.empty;
+    });
+
+    it('should return places if there are places for given organizationIds', async function () {
+      databaseBuilder.factory.buildOrganizationPlace({
+        organizationId: firstOrganizationId,
+        count: 7,
+      });
+      databaseBuilder.factory.buildOrganizationPlace({
+        organizationId: secondOrganizationId,
+        count: 3,
+      });
+      await databaseBuilder.commit();
+      const organizationIds = [firstOrganizationId, secondOrganizationId];
+
+      const places = await organizationPlacesLotRepository.findAllByOrganizationIds(organizationIds);
+
+      expect(places.length).to.equal(2);
+      expect(places[0]).to.be.an.instanceOf(PlacesLot);
+      expect(places[1]).to.be.an.instanceOf(PlacesLot);
+
+      const firstOrganizationIdPlaces = places.find((place) => place.organizationId === firstOrganizationId);
+      expect(firstOrganizationIdPlaces.count).to.equal(7);
+
+      const secondOrganizationIdPlaces = places.find((place) => place.organizationId === secondOrganizationId);
+      expect(secondOrganizationIdPlaces.count).to.equal(3);
+    });
+
+    it('should not return places for others organization than given', async function () {
+      databaseBuilder.factory.buildOrganizationPlace({
+        organizationId: firstOrganizationId,
+        count: 7,
+      });
+      databaseBuilder.factory.buildOrganizationPlace({
+        organizationId: secondOrganizationId,
+        count: 3,
+      });
+      await databaseBuilder.commit();
+      const organizationIds = [firstOrganizationId];
+
+      const places = await organizationPlacesLotRepository.findAllByOrganizationIds(organizationIds);
+      expect(places.length).to.equal(1);
+      expect(places[0].organizationId).to.equal(firstOrganizationId);
+    });
+  });
+
   describe('#create', function () {
     it('should create the given lot of places', async function () {
       // given


### PR DESCRIPTION
## :unicorn: Problème
Suite à cette PR : 

- https://github.com/1024pix/pix/pull/9691

Nous avons constaté que, pour notre POC, l'utilisation de mécanismes et méthodes existantes n'était pas du tout optimisée au niveau des performances. Lorsque ce endpoint était appelé pour faire la récupération des stats, il pouvait mettre plus de 60 sec à envoyer sa réponse, ce qui provoquait la fermeture de la connexion côté client et donc des erreurs des deux côtés.

## :robot: Proposition
Créer des méthodes de repository spécifique a ce cas d'usage afin de réduire considérablement le nombre de requêtes faites a la BDD. 

## :rainbow: Remarques
J'ai ajouté l'information de l'organisationId au niveau du model PlaceLots en optionnel car dans notre cas nous en avons besoin pour recouper les infos avec la bonne orga alors que dans d'autres usages plus classiques il n'est pas nécessaire. 
Dans le cas où ce code règle notre souci de performance, on pourra possiblement faire un refacto pour sortir cet organisationId de ce model et plutôt formatter les données depuis le repository (comme c'est le cas pour la répartition des places)

## :100: Pour tester
Mis à part les tests au vert, il n'est pas possible de tester l'amélioration des performances tant que ce ne sera pas avec les véritables données, le volume et le trafic de la production
