### PR TITLE
[FEATURE] Changer le format de date en NL sur la page de réconciliation (PIX-13985)

### DIFF
--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1353,6 +1353,12 @@
         "explanationTitle": "¿Qué es un módulo?",
         "level": "Nivel",
         "objectives": "Objetivos",
+        "smallScreenModal": {
+          "cancel": "Volver a los detalles",
+          "description": "Algunas de las actividades de este módulo pueden resultar difíciles de realizar en una pantalla pequeña. Para disfrutar de la mejor experiencia, le recomendamos que utilice un ordenador.",
+          "startModule": "Empezar",
+          "title": "Parece que estás usando una pantalla pequeña"
+        },
         "startModule": "Iniciar el módulo"
       },
       "download": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1356,7 +1356,7 @@
         "smallScreenModal": {
           "cancel": "Volver a los detalles",
           "description": "Algunas de las actividades de este módulo pueden resultar difíciles de realizar en una pantalla pequeña. Para disfrutar de la mejor experiencia, le recomendamos que utilice un ordenador.",
-          "startModule": "Empezar",
+          "startModule": "Inicio",
           "title": "Parece que estás usando una pantalla pequeña"
         },
         "startModule": "Iniciar el módulo"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1353,12 +1353,6 @@
         "explanationTitle": "¿Qué es un módulo?",
         "level": "Nivel",
         "objectives": "Objetivos",
-        "smallScreenModal": {
-          "title": "Parece que estás usando una pantalla pequeña",
-          "description": "Algunas de las actividades de este módulo pueden resultar difíciles de realizar en una pantalla pequeña. Para disfrutar de la mejor experiencia, le recomendamos que utilice un ordenador.",
-          "startModule": "Inicio",
-          "cancel": "Volver a los detalles"
-        },
         "startModule": "Iniciar el módulo"
       },
       "download": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -116,7 +116,7 @@
     "invited": {
       "reconciliation": {
         "error-message": {
-          "date-field": "Gebruik het formaat dd/mm/jjjj bij het invoeren van het veld {fieldName}",
+          "date-field": "Gebruik het formaat dd-mm-jjjj bij het invoeren van het veld {fieldName}",
           "invalid-reconciliation-error": "Controleer je gegevens ({fields}) of neem contact op met een docent.",
           "mandatory-field": "Dit veld is verplicht"
         },
@@ -125,7 +125,7 @@
           "firstname": "Voornaam",
           "lastname": "Achternaam",
           "sub-label": {
-            "date": "In (dd/mm/jjjj) formaat, bijvoorbeeld : {dateFormat}"
+            "date": "In (dd-mm-jjjj) formaat, bijvoorbeeld : {dateFormat}"
           }
         },
         "title": "Sluit je aan bij de organisatie { organizationName }"
@@ -1263,7 +1263,7 @@
               "label": "Geboortedag",
               "placeholder": "JJ"
             },
-            "label": "Geboortedatum (dd/mm/jjjj)",
+            "label": "Geboortedatum (dd-mm-jjjj)",
             "month": {
               "error": "Je geboortemaand is niet geldig.",
               "label": "Maand van geboorte",
@@ -1353,12 +1353,6 @@
         "explanationTitle": "Wat is een module?",
         "level": "Niveau",
         "objectives": "Doelstellingen",
-        "smallScreenModal": {
-          "title": "Je lijkt een klein scherm te gebruiken",
-          "description": "Sommige activiteiten in deze module zijn mogelijk moeilijk uit te voeren op een klein scherm. Voor de beste ervaring raden we je aan een computer te gebruiken.",
-          "startModule": "Start",
-          "cancel": "Terug naar details"
-        },
         "startModule": "De module starten"
       },
       "download": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1353,6 +1353,12 @@
         "explanationTitle": "Wat is een module?",
         "level": "Niveau",
         "objectives": "Doelstellingen",
+        "smallScreenModal": {
+          "cancel": "Terug naar details",
+          "description": "Sommige activiteiten in deze module zijn mogelijk moeilijk uit te voeren op een klein scherm. Voor de beste ervaring raden we je aan een computer te gebruiken.",
+          "startModule": "Start",
+          "title": "Je lijkt een klein scherm te gebruiken"
+        },
         "startModule": "De module starten"
       },
       "download": {


### PR DESCRIPTION
Il y avait une incohérence dans les formats de date sur la page de réconciliation SCO-FWB : 
![image (18)](https://github.com/user-attachments/assets/09e16136-4a30-467f-b1f5-3f689f9dbb21)

En NL on doit avoir la date au format suivant : dd-mm-jjjj