### PR TITLE
[FEATURE] Gérer l'affichage conditionnel de l'onglet Formations (PIX-13986).

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/skill-review/evaluation-results-tabs/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/skill-review/evaluation-results-tabs/index.gjs
@@ -15,33 +15,51 @@ export default class EvaluationResultsTabs extends Component {
     return this.showRewardsTab ? 0 : 1;
   }
 
-  <template>
-    <Tabs
-      class="evaluation-results-tabs"
-      @ariaLabel={{t "pages.skill-review.tabs.aria-label"}}
-      @initialTabIndex={{this.initialTabIndex}}
-    >
-      <:tabs as |Tab|>
-        {{#if this.showRewardsTab}}
-          <Tab @index={{0}}>{{t "pages.skill-review.tabs.rewards.tab-label"}}</Tab>
-        {{/if}}
-        <Tab @index={{1}}>{{t "pages.skill-review.tabs.results-details.tab-label"}}</Tab>
-        <Tab @index={{2}}>{{t "pages.skill-review.tabs.trainings.tab-label"}}</Tab>
-      </:tabs>
+  get showTrainingsTab() {
+    return this.args.trainings.length > 0;
+  }
 
-      <:panels as |Panel|>
-        {{#if this.showRewardsTab}}
-          <Panel @index={{0}}>
-            <Rewards @badges={{@badges}} />
+  get showTabs() {
+    return this.showRewardsTab || this.showTrainingsTab;
+  }
+
+  <template>
+    {{#if this.showTabs}}
+      <Tabs
+        class="evaluation-results-tabs"
+        @ariaLabel={{t "pages.skill-review.tabs.aria-label"}}
+        @initialTabIndex={{this.initialTabIndex}}
+      >
+        <:tabs as |Tab|>
+          {{#if this.showRewardsTab}}
+            <Tab @index={{0}}>{{t "pages.skill-review.tabs.rewards.tab-label"}}</Tab>
+          {{/if}}
+          <Tab @index={{1}}>{{t "pages.skill-review.tabs.results-details.tab-label"}}</Tab>
+          {{#if this.showTrainingsTab}}
+            <Tab @index={{2}}>{{t "pages.skill-review.tabs.trainings.tab-label"}}</Tab>
+          {{/if}}
+        </:tabs>
+
+        <:panels as |Panel|>
+          {{#if this.showRewardsTab}}
+            <Panel @index={{0}}>
+              <Rewards @badges={{@badges}} />
+            </Panel>
+          {{/if}}
+          <Panel @index={{1}}>
+            <ResultsDetails />
           </Panel>
-        {{/if}}
-        <Panel @index={{1}}>
-          <ResultsDetails />
-        </Panel>
-        <Panel @index={{2}}>
-          <Trainings />
-        </Panel>
-      </:panels>
-    </Tabs>
+          {{#if this.showTrainingsTab}}
+            <Panel @index={{2}}>
+              <Trainings />
+            </Panel>
+          {{/if}}
+        </:panels>
+      </Tabs>
+    {{else}}
+      <section class="evaluation-results-tabs">
+        <ResultsDetails />
+      </section>
+    {{/if}}
   </template>
 }

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results.gjs
@@ -14,6 +14,9 @@ import EvaluationResultsTabs from '../../../campaigns/assessment/skill-review/ev
         {{t "common.actions.quit"}}
       </LinkTo>
     </header>
-    <EvaluationResultsTabs @badges={{@model.campaignParticipationResult.campaignParticipationBadges}} />
+    <EvaluationResultsTabs
+      @badges={{@model.campaignParticipationResult.campaignParticipationBadges}}
+      @trainings={{@model.trainings}}
+    />
   </div>
 </template>

--- a/mon-pix/tests/acceptance/campaigns/campaign-skill-review-test.js
+++ b/mon-pix/tests/acceptance/campaigns/campaign-skill-review-test.js
@@ -70,7 +70,9 @@ module('Acceptance | Campaigns | Skill Review', function (hooks) {
 
           // then
           assert.ok(screen.getByText(campaign.title));
-          assert.dom(screen.getByRole('tablist')).exists();
+          assert
+            .dom(screen.getByRole('heading', { name: this.intl.t('pages.skill-review.tabs.results-details.title') }))
+            .isVisible();
         });
       });
 

--- a/mon-pix/tests/integration/components/campaigns/assessment/skill-review/evaluation-results-tabs-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/skill-review/evaluation-results-tabs-test.js
@@ -8,18 +8,25 @@ module('Integration | Components | Campaigns | Assessment | Skill Review | Evalu
   setupIntlRenderingTest(hooks);
 
   module('when there are rewards and trainings', function (hooks) {
-    hooks.beforeEach(function () {
+    let screen;
+
+    hooks.beforeEach(async function () {
+      // given
       const store = this.owner.lookup('service:store');
+
       const acquiredBadge = store.createRecord('badge', { isAcquired: true });
       this.set('badges', [acquiredBadge]);
+
+      const training = store.createRecord('training');
+      this.set('trainings', [training]);
+
+      // when
+      screen = await render(
+        hbs`<Campaigns::Assessment::SkillReview::EvaluationResultsTabs @badges={{this.badges}} @trainings={{this.trainings}} />`,
+      );
     });
 
     test('it should display a tablist with three tabs', async function (assert) {
-      // when
-      const screen = await render(
-        hbs`<Campaigns::Assessment::SkillReview::EvaluationResultsTabs @badges={{this.badges}} />`,
-      );
-
       // then
       assert.dom(screen.getByRole('tablist', { name: this.intl.t('pages.skill-review.tabs.aria-label') })).exists();
       assert.strictEqual(screen.getAllByRole('tab').length, 3);
@@ -29,11 +36,6 @@ module('Integration | Components | Campaigns | Assessment | Skill Review | Evalu
     });
 
     test('it should display the rewards tab first', async function (assert) {
-      // when
-      const screen = await render(
-        hbs`<Campaigns::Assessment::SkillReview::EvaluationResultsTabs @badges={{this.badges}} />`,
-      );
-
       // then
       assert
         .dom(screen.getByRole('heading', { name: this.intl.t('pages.skill-review.tabs.rewards.title') }))
@@ -41,16 +43,47 @@ module('Integration | Components | Campaigns | Assessment | Skill Review | Evalu
     });
   });
 
-  module('when there are no rewards', function () {
-    test('it should not display the rewards tab', async function (assert) {
+  module('when there are rewards but no trainings', function () {
+    test('it should not display the trainings tab', async function (assert) {
       // given
-      this.set('badges', []);
+      const store = this.owner.lookup('service:store');
+      const acquiredBadge = store.createRecord('badge', { isAcquired: true });
+      this.set('badges', [acquiredBadge]);
+      this.set('trainings', []);
 
       // when
       const screen = await render(
-        hbs`<Campaigns::Assessment::SkillReview::EvaluationResultsTabs @badges={{this.badges}} />`,
+        hbs`<Campaigns::Assessment::SkillReview::EvaluationResultsTabs @badges={{this.badges}} @trainings={{this.trainings}} />`,
       );
 
+      // then
+      assert.dom(screen.getByRole('tablist', { name: this.intl.t('pages.skill-review.tabs.aria-label') })).exists();
+      assert.strictEqual(screen.getAllByRole('tab').length, 2);
+      assert.dom(screen.getByRole('tab', { name: this.intl.t('pages.skill-review.tabs.rewards.tab-label') }));
+      assert.dom(screen.getByRole('tab', { name: this.intl.t('pages.skill-review.tabs.results-details.tab-label') }));
+      assert.notOk(screen.queryByRole('tab', { name: this.intl.t('pages.skill-review.tabs.trainings.tab-label') }));
+    });
+  });
+
+  module('when there are no rewards but trainings', function (hooks) {
+    let screen;
+
+    hooks.beforeEach(async function () {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      this.set('badges', []);
+
+      const training = store.createRecord('training');
+      this.set('trainings', [training]);
+
+      // when
+      screen = await render(
+        hbs`<Campaigns::Assessment::SkillReview::EvaluationResultsTabs @badges={{this.badges}} @trainings={{this.trainings}} />`,
+      );
+    });
+
+    test('it should not display the rewards tab', async function (assert) {
       // then
       assert.dom(screen.getByRole('tablist', { name: this.intl.t('pages.skill-review.tabs.aria-label') })).exists();
       assert.strictEqual(screen.getAllByRole('tab').length, 2);
@@ -60,18 +93,26 @@ module('Integration | Components | Campaigns | Assessment | Skill Review | Evalu
     });
 
     test('it should display the results details tab first', async function (assert) {
-      // given
-      this.set('badges', []);
-
-      // when
-      const screen = await render(
-        hbs`<Campaigns::Assessment::SkillReview::EvaluationResultsTabs @badges={{this.badges}} />`,
-      );
-
       // then
       assert
         .dom(screen.getByRole('heading', { name: this.intl.t('pages.skill-review.tabs.results-details.title') }))
         .isVisible();
+    });
+  });
+
+  module('when there are no rewards and no trainings', function () {
+    test('it should not display the tabs component', async function (assert) {
+      // given
+      this.set('badges', []);
+      this.set('trainings', []);
+
+      // when
+      const screen = await render(
+        hbs`<Campaigns::Assessment::SkillReview::EvaluationResultsTabs @badges={{this.badges}} @trainings={{this.trainings}} />`,
+      );
+
+      // then
+      assert.notOk(screen.queryByRole('tablist', { name: this.intl.t('pages.skill-review.tabs.aria-label') }));
     });
   });
 });

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/evaluation-results-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/evaluation-results-test.js
@@ -7,9 +7,7 @@ import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering'
 module('Integration | Components | Routes | Campaigns | Assessment | Evaluation Results', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  let screen;
-
-  hooks.beforeEach(async function () {
+  test('it should display a header', async function (assert) {
     // given
     const store = this.owner.lookup('service:store');
 
@@ -20,19 +18,36 @@ module('Integration | Components | Routes | Campaigns | Assessment | Evaluation 
     this.set('model', {
       campaign,
       campaignParticipationResult: { campaignParticipationBadges: [] },
+      trainings: [],
     });
 
     // when
-    screen = await render(hbs`<Routes::Campaigns::Assessment::EvaluationResults @model={{this.model}} />`);
-  });
+    const screen = await render(hbs`<Routes::Campaigns::Assessment::EvaluationResults @model={{this.model}} />`);
 
-  test('it should display a header', async function (assert) {
     // then
     assert.dom(screen.getByRole('heading', { name: 'Campaign title' })).exists();
   });
 
-  test('it should display a tablist', async function (assert) {
-    // then
-    assert.dom(screen.getByRole('tablist', { name: this.intl.t('pages.skill-review.tabs.aria-label') })).exists();
+  module('when the campaign has trainings or badges', function () {
+    test('it should display a tablist', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const campaign = store.createRecord('campaign', {
+        title: 'Campaign title',
+      });
+
+      this.set('model', {
+        campaign,
+        campaignParticipationResult: { campaignParticipationBadges: [] },
+        trainings: [Symbol('training')],
+      });
+
+      // when
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::EvaluationResults @model={{this.model}} />`);
+
+      // then
+      assert.dom(screen.getByRole('tablist', { name: this.intl.t('pages.skill-review.tabs.aria-label') })).exists();
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

L'affichage actuel de l'onglet Formations de la nouvelle page de fin de parcours ne répond pas à ces besoins :

- ETQ utilisateur, si le profil cible de ma campagne n’est pas relié à des contenus formatifs, je ne vois pas l’onglet Formations.

- ETQ utilisateur, sur un profil cible qui est relié à des contenus formatifs, si je n’ai pas rempli les conditions d’au moins 1 contenu formatif, alors je ne vois pas l’onglet Formations.

## :robot: Proposition

Afficher l'onglet Formations uniquement si une formation est disponible.

## :rainbow: Remarques

Dans le cas où les onglets Récompenses et Formations ne sont pas affichés : alors il n'est pas nécessaire d'afficher le composant onglets.

## :100: Pour tester

**Affichage de l'onglet :**

- Se connecter sur PixApp avec l'utilisateur `learneremail1003_30@example.net` (mot de passe habituel)
- Aller à la page de fin de parcours `campagnes/EDUSIMPLE/evaluation/resultats`
- Constater que l'onglet Formations est bien présent

**Onglet non affiché :**

- Se connecter sur PixApp avec l'utilisateur `eval-campaign-with-badges@example.net` (mot de passe habituel)
- Aller à la page de fin de parcours `/campagnes/EVALBADGE/evaluation/resultats`
- Constater que l'onglet n'est pas affiché

**Composant Onglets complètement caché :** 

- Se connecter sur PixApp avec l'utilisateur `eval-campaign-with-stages@example.net` (mot de passe habituel)
- Aller à la page de fin de parcours `/campagnes/EVALSTAG3/evaluation/resultats`
- Constater qu'aucun onglet n'est affiché mais qu'on voit bien le détail des résultats