### PR TITLE
[BUGFIX] Utiliser les styles par défaut du navigateur sur les liens hypertexte des contenus Modulix (PIX-13989)

### DIFF
--- a/mon-pix/app/styles/components/module/_passage.scss
+++ b/mon-pix/app/styles/components/module/_passage.scss
@@ -10,6 +10,7 @@
     }
   }
 
+  /** Revert Pix UI styles for Modulix */
   h3,
   h4,
   p {
@@ -19,6 +20,11 @@
   h3,
   h4 {
     font-weight: var(--pix-font-medium);
+  }
+
+  a:not([class]) {
+    color: revert;
+    text-decoration: revert;
   }
 
   ul:not([class]),
@@ -95,4 +101,3 @@
     justify-content: center;
   }
 }
-


### PR DESCRIPTION
## :unicorn: Problème
Dans Modulix, si les contenus contiennent des liens hypertextes, ils ne sont pas mis en avant. C'est dû au [reset.css de Pix UI](https://github.com/1024pix/pix-ui/blob/dev/addon/styles/normalize-reset/_reset.scss#L23-L24) qu'on étend.

## :robot: Proposition
Rajouter dans le reset de styles de Modulix le revert des styles par défaut des liens sur leur couleur et le fait qu'ils soient soulignés.

Pour éviter des conflits avec les composants Pix UI qui utilisent ce style, on précise que ces styles ne s'appliquent que sur les balises `a` sans classe associée.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier sur les modules qui contiennent des liens, qu'ils sont bien différenciés visuellement du reste du contenu. Par exemple : 
- https://app-pr9953.review.pix.fr/modules/adresse-ip-publique-et-vous/passage
- https://app-pr9953.review.pix.fr/modules/chatgpt-parle-francais/passage
- https://app-pr9953.review.pix.fr/modules/didacticiel-modulix/passage
- https://app-pr9953.review.pix.fr/modules/distinguer-vrai-faux-sur-internet/passage
- https://app-pr9953.review.pix.fr/modules/principes-fondateurs-wikipedia/passage

Les liens de l'interface Modulix ne doivent pas avoir changé de tête : élément "Download", liens dans la page de récap.
