### PR TITLE
[TECH] Utiliser des PixInput pour les champs de recherche des tables de l'administration

### DIFF
--- a/admin/app/components/certification-centers/list-items.gjs
+++ b/admin/app/components/certification-centers/list-items.gjs
@@ -1,3 +1,4 @@
+import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import { fn } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
@@ -21,39 +22,20 @@ export default class CertificationCenterListItems extends Component {
           </tr>
           <tr>
             <td class="table__column table__column--id">
-              <input
-                id="id"
-                type="text"
-                value={{this.searchedId}}
-                oninput={{fn @triggerFiltering "id"}}
-                class="table-admin-input"
-              />
+              <PixInput id="id" type="text" value={{this.searchedId}} oninput={{fn @triggerFiltering "id"}} />
             </td>
             <td>
-              <input
-                id="name"
-                type="text"
-                value={{this.searchedName}}
-                oninput={{fn @triggerFiltering "name"}}
-                class="table-admin-input"
-              />
+              <PixInput id="name" type="text" value={{this.searchedName}} oninput={{fn @triggerFiltering "name"}} />
             </td>
             <td>
-              <input
-                id="type"
-                type="text"
-                value={{this.searchedType}}
-                oninput={{fn @triggerFiltering "type"}}
-                class="table-admin-input"
-              />
+              <PixInput id="type" type="text" value={{this.searchedType}} oninput={{fn @triggerFiltering "type"}} />
             </td>
             <td>
-              <input
+              <PixInput
                 id="externalId"
                 type="text"
                 value={{this.searchedExternalId}}
                 oninput={{fn @triggerFiltering "externalId"}}
-                class="table-admin-input"
               />
             </td>
           </tr>

--- a/admin/app/components/organizations/list-items.gjs
+++ b/admin/app/components/organizations/list-items.gjs
@@ -1,4 +1,5 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import { fn } from '@ember/helper';
@@ -55,39 +56,20 @@ export default class ActionsOnUsersRoleInOrganization extends Component {
             </tr>
             <tr>
               <td class="table__column table__column--id">
-                <input
-                  id="id"
-                  type="text"
-                  value={{this.searchedId}}
-                  oninput={{fn @triggerFiltering "id"}}
-                  class="table-admin-input form-control"
-                />
+                <PixInput id="id" type="text" value={{this.searchedId}} oninput={{fn @triggerFiltering "id"}} />
               </td>
               <td>
-                <input
-                  id="name"
-                  type="text"
-                  value={{this.searchedName}}
-                  oninput={{fn @triggerFiltering "name"}}
-                  class="table-admin-input form-control"
-                />
+                <PixInput id="name" type="text" value={{this.searchedName}} oninput={{fn @triggerFiltering "name"}} />
               </td>
               <td>
-                <input
-                  id="type"
-                  type="text"
-                  value={{this.searchedType}}
-                  oninput={{fn @triggerFiltering "type"}}
-                  class="table-admin-input form-control"
-                />
+                <PixInput id="type" type="text" value={{this.searchedType}} oninput={{fn @triggerFiltering "type"}} />
               </td>
               <td>
-                <input
+                <PixInput
                   id="externalId"
                   type="text"
                   value={{this.searchedExternalId}}
                   oninput={{fn @triggerFiltering "externalId"}}
-                  class="table-admin-input form-control"
                 />
               </td>
               {{#if @showDetachColumn}}

--- a/admin/app/components/organizations/team-section.gjs
+++ b/admin/app/components/organizations/team-section.gjs
@@ -1,3 +1,4 @@
+import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import { fn } from '@ember/helper';
@@ -43,33 +44,30 @@ export default class OrganizationTeamSection extends Component {
               <tr>
                 <td class="table__column"></td>
                 <td class="table__column table__column--wide">
-                  <input
+                  <PixInput
                     id="firstName"
                     type="text"
                     aria-label="Rechercher par prénom"
                     value={{this.searchedFirstName}}
                     oninput={{fn @triggerFiltering "firstName"}}
-                    class="table-admin-input form-control"
                   />
                 </td>
                 <td class="table__column table__column--wide">
-                  <input
+                  <PixInput
                     id="lastName"
                     type="text"
                     aria-label="Rechercher par nom"
                     value={{this.searchedLastName}}
                     oninput={{fn @triggerFiltering "lastName"}}
-                    class="table-admin-input form-control"
                   />
                 </td>
                 <td class="table__column table__column--wide">
-                  <input
+                  <PixInput
                     id="email"
                     type="text"
                     aria-label="Rechercher par adresse e-mail"
                     value={{this.searchedEmail}}
                     oninput={{fn @triggerFiltering "email"}}
-                    class="table-admin-input form-control"
                   />
                 </td>
                 <td class="table__column">

--- a/admin/app/components/sessions/list-items.gjs
+++ b/admin/app/components/sessions/list-items.gjs
@@ -1,3 +1,4 @@
+import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import { fn } from '@ember/helper';
@@ -106,30 +107,27 @@ export default class ListItems extends Component {
           </tr>
           <tr>
             <td class="table__column table__column--id">
-              <input
+              <PixInput
                 aria-label="Filtrer les sessions avec un id"
                 type="text"
                 value={{this.searchedId}}
                 oninput={{fn @triggerFiltering "id"}}
-                class="table-admin-input"
               />
             </td>
             <td>
-              <input
+              <PixInput
                 aria-label="Filtrer les sessions avec le nom d'un centre de certification"
                 type="text"
                 value={{this.searchedCertificationCenterName}}
                 oninput={{fn @triggerFiltering "certificationCenterName"}}
-                class="table-admin-input"
               />
             </td>
             <td>
-              <input
+              <PixInput
                 aria-label="Filtrer les sessions avec un identifiant externe"
                 type="text"
                 value={{this.searchedCertificationCenterExternalId}}
                 oninput={{fn @triggerFiltering "certificationCenterExternalId"}}
-                class="table-admin-input"
               />
             </td>
             <td>

--- a/admin/app/components/target-profiles/list-summary-items.gjs
+++ b/admin/app/components/target-profiles/list-summary-items.gjs
@@ -1,3 +1,4 @@
+import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import { fn } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
@@ -13,6 +14,7 @@ export default class TargetProfileListSummaryItems extends Component {
     <div class="content-text content-text--small">
       <div class="table-admin">
         <table>
+
           <thead>
             <tr>
               <th class="table__column table__column--id" id="target-profile-id">ID</th>
@@ -22,20 +24,18 @@ export default class TargetProfileListSummaryItems extends Component {
             </tr>
             <tr>
               <td class="table__column table__column--id">
-                <input
+                <PixInput
                   type="text"
                   value={{this.searchedId}}
                   oninput={{fn @triggerFiltering "id"}}
-                  class="table-admin-input"
                   aria-label="Filtrer les profils cible par un id"
                 />
               </td>
               <td>
-                <input
+                <PixInput
                   type="text"
                   value={{this.searchedName}}
                   oninput={{fn @triggerFiltering "name"}}
-                  class="table-admin-input"
                   aria-label="Filtrer les profils cible par un nom"
                 />
               </td>

--- a/admin/app/components/trainings/list-summary-items.gjs
+++ b/admin/app/components/trainings/list-summary-items.gjs
@@ -1,3 +1,4 @@
+import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import { fn } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
@@ -26,20 +27,18 @@ export default class TrainingListSummaryItems extends Component {
             {{#if @triggerFiltering}}
               <tr>
                 <td class="table__column table__column--id">
-                  <input
+                  <PixInput
                     type="text"
                     value={{this.searchedId}}
                     oninput={{fn @triggerFiltering "id"}}
-                    class="table-admin-input"
                     aria-label="Filtrer les contenus formatifs par un id"
                   />
                 </td>
                 <td>
-                  <input
+                  <PixInput
                     type="text"
                     value={{this.searchedTitle}}
                     oninput={{fn @triggerFiltering "title"}}
-                    class="table-admin-input"
                     aria-label="Filtrer les contenus formatifs par un titre"
                   />
                 </td>


### PR DESCRIPTION
## :unicorn: Problème
Pour uniformiser l'interface nous souhaitons utiliser notre design system. Certains elements de l'administration pourraient beneficier de l'utilisation du design system.

## :robot: Proposition
Utiliser le component PixInput dans les champs de recherche des tableaux de l'administration.

## :100: Pour tester
- Test green
- Mirer les champs de recherche et s'ébaudir