### PR TITLE
[FEATURE] Améliorer l'affichage des erreurs dans l'import en masse sur Pix Certif (PIX-10155).

### DIFF
--- a/certif/app/components/import/step-two-section.hbs
+++ b/certif/app/components/import/step-two-section.hbs
@@ -43,6 +43,11 @@
             nonBlockingErrorReportsCount=this.nonBlockingErrorReportsCount
           }}
           @iconTitle="plus"
+          @tagContent={{t
+            "pages.sessions.import.step-two.non-blocking-errors.tag-information"
+            nonBlockingErrorReportsCount=this.nonBlockingErrorReportsCount
+          }}
+          @tagColor="secondary"
           class="collapsible-header collapsible-header--non-blocking"
         >
           <ul class="collapsible-header__list">
@@ -72,6 +77,11 @@
             blockingErrorReportsCount=this.blockingErrorReportsCount
           }}
           @iconTitle="plus"
+          @tagContent={{t
+            "pages.sessions.import.step-two.blocking-errors.tag-information"
+            blockingErrorReportsCount=this.blockingErrorReportsCount
+          }}
+          @tagColor="error"
           class="collapsible-header collapsible-header--blocking"
         >
           <ul class="collapsible-header__list">

--- a/certif/app/components/import/step-two-section.hbs
+++ b/certif/app/components/import/step-two-section.hbs
@@ -28,6 +28,41 @@
         </p>
       </li>
     </ul>
+
+    {{#if (gt this.blockingErrorReportsCount 0)}}
+      <span class="import-page-section__information">
+        {{t "pages.sessions.import.step-two.blocking-errors.information"}}
+      </span>
+      <div>
+        <PixCollapsible
+          @titleIcon="circle-exclamation"
+          @title={{t
+            "pages.sessions.import.step-two.blocking-errors.title"
+            blockingErrorReportsCount=this.blockingErrorReportsCount
+          }}
+          @iconTitle="plus"
+          @tagContent={{t
+            "pages.sessions.import.step-two.blocking-errors.tag-information"
+            blockingErrorReportsCount=this.blockingErrorReportsCount
+          }}
+          @tagColor="error"
+          class="collapsible-header collapsible-header--blocking"
+        >
+          <ul class="collapsible-header__list">
+            {{#each this.translatedBlockingErrorReport as |report|}}
+              <li>
+                <PixMessage @type="error">
+                  {{t "pages.sessions.import.step-two.blocking-errors.line"}}
+                  {{report.line}}
+                  :
+                  {{report.message}}
+                </PixMessage>
+              </li>
+            {{/each}}
+          </ul>
+        </PixCollapsible>
+      </div>
+    {{/if}}
     {{#if (gt this.nonBlockingErrorReportsCount 0)}}
       <span class="import-page-section__information">
         {{t
@@ -55,40 +90,6 @@
               <li>
                 <PixMessage @type="warning">
                   {{t "pages.sessions.import.step-two.non-blocking-errors.line"}}
-                  {{report.line}}
-                  :
-                  {{report.message}}
-                </PixMessage>
-              </li>
-            {{/each}}
-          </ul>
-        </PixCollapsible>
-      </div>
-    {{/if}}
-    {{#if (gt this.blockingErrorReportsCount 0)}}
-      <span class="import-page-section__information">
-        {{t "pages.sessions.import.step-two.blocking-errors.information"}}
-      </span>
-      <div>
-        <PixCollapsible
-          @titleIcon="circle-exclamation"
-          @title={{t
-            "pages.sessions.import.step-two.blocking-errors.title"
-            blockingErrorReportsCount=this.blockingErrorReportsCount
-          }}
-          @iconTitle="plus"
-          @tagContent={{t
-            "pages.sessions.import.step-two.blocking-errors.tag-information"
-            blockingErrorReportsCount=this.blockingErrorReportsCount
-          }}
-          @tagColor="error"
-          class="collapsible-header collapsible-header--blocking"
-        >
-          <ul class="collapsible-header__list">
-            {{#each this.translatedBlockingErrorReport as |report|}}
-              <li>
-                <PixMessage @type="error">
-                  {{t "pages.sessions.import.step-two.blocking-errors.line"}}
                   {{report.line}}
                   :
                   {{report.message}}

--- a/certif/tests/acceptance/routes/authenticated/sessions/import-test.js
+++ b/certif/tests/acceptance/routes/authenticated/sessions/import-test.js
@@ -277,7 +277,7 @@ module('Acceptance | Routes | Authenticated | Sessions | import', function (hook
                 await settled();
 
                 // then
-                assert.dom(screen.getByText('1 point d’attention non bloquant')).exists();
+                assert.dom(screen.getByRole('button', { name: 'Point d’attention non bloquant 1 erreur' })).exists();
                 assert.dom(screen.getByRole('heading', { name: 'Importer à nouveau' })).exists();
 
                 //given
@@ -306,7 +306,7 @@ module('Acceptance | Routes | Authenticated | Sessions | import', function (hook
 
                 // then
                 await screen.findByRole('heading', { name: 'Récapitulatif' });
-                assert.dom(screen.getByText('2 points d’attention non bloquants')).exists();
+                assert.dom(screen.getByRole('button', { name: 'Points d’attention non bloquants 2 erreurs' })).exists();
               });
             });
 

--- a/certif/tests/integration/components/sessions-import/step-two-section-test.js
+++ b/certif/tests/integration/components/sessions-import/step-two-section-test.js
@@ -174,7 +174,7 @@ module('Integration | Component | Import::StepTwoSection', function (hooks) {
           hbs`<Import::StepTwoSection @errorReports={{this.errorReports}} @validateSessions={{this.validateSessions}} />`,
         );
 
-        await click(getByRole('button', { name: '1 erreur bloquante' }));
+        await click(getByRole('button', { name: 'Erreur bloquante 1 erreur' }));
 
         // then
         assert.dom(getByText(`Ligne 5 : ${expectedMessage}`)).exists();
@@ -221,7 +221,11 @@ module('Integration | Component | Import::StepTwoSection', function (hooks) {
           hbs`<Import::StepTwoSection @errorReports={{this.errorReports}} @validateSessions={{this.validateSessions}} />`,
         );
 
-        await click(getByRole('button', { name: '1 point d’attention non bloquant' }));
+        await click(
+          getByRole('button', {
+            name: 'Point d’attention non bloquant 1 erreur',
+          }),
+        );
 
         // then
         assert.dom(getByText(`Ligne 5 : ${expectedMessage}`)).exists();

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -733,7 +733,7 @@
             }
           },
           "blocking-errors": {
-            "title": "{blockingErrorReportsCount} {blockingErrorReportsCount, plural,one {erreur bloquante} other {erreurs bloquantes}}",
+            "title": "{blockingErrorReportsCount, plural,one {Erreur bloquante} other {Erreurs bloquantes}}",
             "errors": {
               "CANDIDATE_BILLING_MODE_NOT_VALID": "Donnée du champ \"Tarification part Pix\" invalide (formats acceptés \"Gratuite\", \"Payante\" ou \"Prépayée\")",
               "CANDIDATE_BILLING_MODE_REQUIRED": "Champ obligatoire \"Tarification part Pix\" manquant",
@@ -779,17 +779,19 @@
               "SESSION_WITH_DATE_AND_TIME_ALREADY_EXISTS": "Une session a déjà été créée avec ces informations. Pour ajouter des candidats à une session, indiquer uniquement le numéro de session sans les informations de session"
             },
             "information": "Veuillez corriger toutes les erreurs bloquantes avant de re-importer le fichier .csv :",
-            "line": "Line"
+            "line": "Line",
+            "tag-information": "{blockingErrorReportsCount} {blockingErrorReportsCount, plural,one {erreur} other {erreurs}}"
           },
           "candidates-count": "{candidatesCount} {candidatesCount, plural,one {candidate} other {candidates}}",
           "non-blocking-errors": {
-            "title": "{nonBlockingErrorReportsCount} {nonBlockingErrorReportsCount, plural,one {Point d’attention non bloquant} other {Points d’attention non bloquants}}",
+            "title": "{nonBlockingErrorReportsCount, plural,one {Point d’attention non bloquant} other {Points d’attention non bloquants}}",
             "errors": {
               "DUPLICATE_CANDIDATE_IN_SESSION": "Le candidat inscrit plusieurs fois à la même session, une seule inscription sera prise en compte.",
               "EMPTY_SESSION": "La session ne contient pas de candidat"
             },
             "information": "Nous avons détecté {nonBlockingErrorReportsCount, plural,one {un point d’attention non bloquant} other {des points d’attention non bloquants}} lors de l’import, consultez-{nonBlockingErrorReportsCount, plural,one {le} other {les}} avant de procéder à la création ou l’édition de vos sessions :",
-            "line": "Line"
+            "line": "Line",
+            "tag-information": "{nonBlockingErrorReportsCount} {nonBlockingErrorReportsCount, plural,one {erreur} other {erreurs}}"
           },
           "sessions-and-empty-sessions-count": "{sessionsCount} {sessionsCount, plural,one {session} other {sessions}} including {sessionsWithoutCandidatesCount} {sessionsWithoutCandidatesCount, plural,one {session} other {sessions}} without candidates"
         },

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -733,7 +733,7 @@
             }
           },
           "blocking-errors": {
-            "title": "{blockingErrorReportsCount} {blockingErrorReportsCount, plural,one {erreur bloquante} other {erreurs bloquantes}}",
+            "title": "{blockingErrorReportsCount, plural,one {Erreur bloquante} other {Erreurs bloquantes}}",
             "errors": {
               "CANDIDATE_BILLING_MODE_NOT_VALID": "Donnée du champ \"Tarification part Pix\" invalide (formats acceptés \"Gratuite\", \"Payante\" ou \"Prépayée\")",
               "CANDIDATE_BILLING_MODE_REQUIRED": "Champ obligatoire \"Tarification part Pix\" manquant",
@@ -779,17 +779,19 @@
               "SESSION_WITH_DATE_AND_TIME_ALREADY_EXISTS": "Une session a déjà été créée avec ces informations. Pour ajouter des candidats à une session, indiquer uniquement le numéro de session sans les informations de session"
             },
             "information": "Veuillez corriger toutes les erreurs bloquantes avant de re-importer le fichier .csv :",
-            "line": "Ligne"
+            "line": "Ligne",
+            "tag-information": "{blockingErrorReportsCount} {blockingErrorReportsCount, plural,one {erreur} other {erreurs}}"
           },
           "candidates-count": "{candidatesCount} {candidatesCount, plural,one {candidat} other {candidats}}",
           "non-blocking-errors": {
-            "title": "{nonBlockingErrorReportsCount} {nonBlockingErrorReportsCount, plural,one {point d’attention non bloquant} other {points d’attention non bloquants}}",
+            "title": "{nonBlockingErrorReportsCount, plural,one {Point d’attention non bloquant} other {Points d’attention non bloquants}}",
             "errors": {
               "DUPLICATE_CANDIDATE_IN_SESSION": "Le candidat est inscrit plusieurs fois à la même session, une seule inscription sera prise en compte.",
               "EMPTY_SESSION": "La session ne contient pas de candidat"
             },
             "information": "Nous avons détecté {nonBlockingErrorReportsCount, plural,one {un point d’attention non bloquant} other {des points d’attention non bloquants}} lors de l’import, consultez-{nonBlockingErrorReportsCount, plural,one {le} other {les}} avant de procéder à la création ou l’édition de vos sessions :",
-            "line": "Ligne"
+            "line": "Ligne",
+            "tag-information": "{nonBlockingErrorReportsCount} {nonBlockingErrorReportsCount, plural,one {erreur} other {erreurs}}"
           },
           "sessions-and-empty-sessions-count": "{sessionsCount} {sessionsCount, plural,one {session} other {sessions}} dont {sessionsWithoutCandidatesCount} {sessionsWithoutCandidatesCount, plural,one {session} other {sessions}} sans candidat"
         },


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix Certif, le nombre d’erreurs à traiter dans l'import en masse des sessions n’est pas très visible pour l’utilisateur.

<img width="1235" alt="Capture d’écran 2023-12-08 à 17 58 09" src="https://github.com/user-attachments/assets/9c0cbb77-afb2-48df-9e35-536b74f2dae0">

## :robot: Proposition
Utiliser le tag dans le pix Collapsible et mettre les erreurs bloquantes devant les erreur non bloquantes

## :100: Pour tester

- Se connecter sur Pix Certif avec certif-pro
- Créer plusieurs sessions pour accéder à l'import en masse
- Créer un CSV avec des erreurs bloquantes et non bloquantes
```
Numéro de session préexistante;* Nom du site;* Nom de la salle;* Date de début (format: JJ/MM/AAAA);* Heure de début (heure locale format: HH:MM);* Surveillant(s);Observations (optionnel);* Nom de naissance;* Prénom;* Date de naissance (format: JJ/MM/AAAA);* Sexe (M ou F);Code INSEE de la commune de naissance;Code postal de la commune de naissance;Nom de la commune de naissance;* Pays de naissance;E-mail du destinataire des résultats (formateur, enseignant…);E-mail de convocation;Identifiant externe;Temps majoré ? (exemple format: 33%);* Tarification part Pix (Gratuite, Prépayée ou Payante);Code de prépaiement (si Tarification part Pix Prépayée);CléA Numérique ('oui' ou laisser vide);Pix+ Édu 2nd degré ('oui' ou laisser vide);Pix+ Édu 1er degré ('oui' ou laisser vide);Pix+ Droit ('oui' ou laisser vide)
;;Pix;01/01/2024;12:00;Surveillant A;;;;;;;;;;;;;;;;;;;
```
<img width="1504" alt="Capture d’écran 2024-08-27 à 12 13 08" src="https://github.com/user-attachments/assets/33c2c5b5-0cac-4e33-8cd8-64bb391a7679">

