### PR TITLE
[TECH] Remplacer Bluebird mapSeries par des fonctions natives

### DIFF
--- a/api/db/database-builder/database-builder.js
+++ b/api/db/database-builder/database-builder.js
@@ -1,5 +1,4 @@
 /* eslint-disable knex/avoid-injections */
-import bluebird from 'bluebird';
 import _ from 'lodash';
 
 import { databaseBuffer } from './database-buffer.js';
@@ -97,12 +96,13 @@ class DatabaseBuilder {
     }
     const dirtyTablesSequencesInfo = await this._getSequencesInfo(dirtyTables);
 
-    return bluebird.mapSeries(dirtyTablesSequencesInfo, async ({ tableName, sequenceName }) => {
+    for (const dirtyTablesSequence of dirtyTablesSequencesInfo) {
+      const { tableName, sequenceName } = dirtyTablesSequence;
       const sequenceRestartAtNumber = (await this._getTableMaxId(tableName)) + 1;
       if (sequenceRestartAtNumber !== 0) {
         await this.knex.raw(`ALTER SEQUENCE "${sequenceName}" RESTART WITH ${sequenceRestartAtNumber};`);
       }
-    });
+    }
   }
 
   async _getSequencesInfo(dirtyTables) {

--- a/api/db/migrations/20210610172018_fill_badge_partner_competence_for_critera.js
+++ b/api/db/migrations/20210610172018_fill_badge_partner_competence_for_critera.js
@@ -1,4 +1,3 @@
-import bluebird from 'bluebird';
 import _ from 'lodash';
 
 const up = async function (knex) {
@@ -16,13 +15,13 @@ const up = async function (knex) {
     return [badgeId, partnerCompetenceIds];
   });
 
-  await bluebird.mapSeries(badgesWithPartnerCompetences, async (badgeWithPartnerCompetences) => {
+  for (const badgeWithPartnerCompetences of badgesWithPartnerCompetences) {
     const badgeId = badgeWithPartnerCompetences[0];
     const partnerCompetenceIds = badgeWithPartnerCompetences[1];
     await knex('badge-criteria')
       .update({ partnerCompetenceIds, scope: 'SomePartnerCompetences' })
       .where({ badgeId, scope: 'EveryPartnerCompetence' });
-  });
+  }
 };
 
 const down = function () {

--- a/api/db/migrations/20220328102301_link-complementary-certification-course-results-to-complementary-certification-courses.js
+++ b/api/db/migrations/20220328102301_link-complementary-certification-course-results-to-complementary-certification-courses.js
@@ -5,7 +5,6 @@ const COMPLEMENTARY_CERTIFICATION_COURSE_ID_COLUMN = 'complementaryCertification
 const CERTIFICATION_COURSE_ID = 'certificationCourseId';
 import lodash from 'lodash';
 const { uniqBy } = lodash;
-import bluebird from 'bluebird';
 
 import { badges } from '../constants.js';
 const {
@@ -52,14 +51,14 @@ const up = async function (knex) {
     const complementaryCertifCourseIdForComplementaryCertifCourseResultIds =
       await _getComplementaryCertifCourseIdForComplementaryCertifCourseResultId();
 
-    return bluebird.mapSeries(
-      complementaryCertifCourseIdForComplementaryCertifCourseResultIds,
-      async ({ complementaryCertificationCourseResultId, complementaryCertificationCourseId }) => {
-        await knex(COMPLEMENTARY_CERTIFICATION_COURSE_RESULTS_TABLE)
-          .update(COMPLEMENTARY_CERTIFICATION_COURSE_ID_COLUMN, complementaryCertificationCourseId)
-          .where({ id: complementaryCertificationCourseResultId });
-      },
-    );
+    for (const complementaryCertifCourse of complementaryCertifCourseIdForComplementaryCertifCourseResultIds) {
+      const { complementaryCertificationCourseResultId, complementaryCertificationCourseId } =
+        complementaryCertifCourse;
+
+      await knex(COMPLEMENTARY_CERTIFICATION_COURSE_RESULTS_TABLE)
+        .update(COMPLEMENTARY_CERTIFICATION_COURSE_ID_COLUMN, complementaryCertificationCourseId)
+        .where({ id: complementaryCertificationCourseResultId });
+    }
   }
 
   async function _addMissingComplementaryCertificationCourses() {

--- a/api/db/migrations/20220629091212_drop-target-profile-template-table.js
+++ b/api/db/migrations/20220629091212_drop-target-profile-template-table.js
@@ -1,5 +1,3 @@
-import bluebird from 'bluebird';
-
 const TEMPLATE_TABLE_NAME = 'target-profile-templates';
 const OLD_TEMPLATE_TUBES_TABLE_NAME = 'target-profile-templates_tubes';
 const TARGET_PROFILE_TUBES_TABLE_NAME = 'target-profile_tubes';
@@ -45,12 +43,13 @@ const down = async function (knex) {
 
   const results = await knex(TARGET_PROFILE_TUBES_TABLE_NAME).distinct('targetProfileId');
 
-  await bluebird.mapSeries(results, async ({ targetProfileId }) => {
+  for (const targetProfiles of results) {
+    const { targetProfileId } = targetProfiles;
     const [{ id: targetProfileTemplateId }] = await knex(TEMPLATE_TABLE_NAME).insert({}).returning('id');
 
     await knex(TARGET_PROFILE_TABLE_NAME).update({ targetProfileTemplateId }).where({ id: targetProfileId });
     await knex(TARGET_PROFILE_TUBES_TABLE_NAME).update({ targetProfileTemplateId }).where({ targetProfileId });
-  });
+  }
 
   await knex.schema.table(TARGET_PROFILE_TUBES_TABLE_NAME, (t) => {
     t.dropNullable('targetProfileTemplateId');

--- a/api/db/migrations/20220802093742_add-imageUrl-to-complementary-certification-badges.js
+++ b/api/db/migrations/20220802093742_add-imageUrl-to-complementary-certification-badges.js
@@ -19,8 +19,6 @@ const {
   PIX_EMPLOI_CLEA_V3,
 } = badges.keys;
 
-import bluebird from 'bluebird';
-
 const up = async function (knex) {
   await knex.schema.table(TABLE_NAME, function (table) {
     table.string(COLUMN_NAME);
@@ -83,7 +81,9 @@ const up = async function (knex) {
     },
   ];
 
-  await bluebird.mapSeries(data, addImageUrlForBadgeKey);
+  for (const badgeImage of data) {
+    await addImageUrlForBadgeKey(badgeImage);
+  }
 
   await knex.schema.alterTable(TABLE_NAME, function (table) {
     table.string(COLUMN_NAME).notNullable().alter();

--- a/api/db/migrations/20220808152543_add-label-column-to-complementary-certification-badges-table.js
+++ b/api/db/migrations/20220808152543_add-label-column-to-complementary-certification-badges-table.js
@@ -20,8 +20,6 @@ const {
   PIX_EMPLOI_CLEA_V3,
 } = badges.keys;
 
-import bluebird from 'bluebird';
-
 const up = async function (knex) {
   await knex.schema.table(TABLE_NAME, function (table) {
     table.string(COLUMN_NAME);
@@ -84,7 +82,9 @@ const up = async function (knex) {
     },
   ];
 
-  await bluebird.mapSeries(data, addLabelForBadgeKey);
+  for (const badgeLabel of data) {
+    await addLabelForBadgeKey(badgeLabel);
+  }
 
   await knex.schema.alterTable(TABLE_NAME, function (table) {
     table.string(COLUMN_NAME).notNullable().alter();

--- a/api/db/migrations/20220831084146_add-complementary-certification-badges-fk-to-complementary-certification-courses.js
+++ b/api/db/migrations/20220831084146_add-complementary-certification-badges-fk-to-complementary-certification-courses.js
@@ -1,4 +1,3 @@
-import bluebird from 'bluebird';
 const TABLE_NAME = 'complementary-certification-courses';
 const COLUMN = 'complementaryCertificationBadgeId';
 
@@ -18,10 +17,11 @@ const up = async function (knex) {
     )
     .select('complementary-certification-courses.id', 'complementary-certification-course-results.partnerKey');
 
-  await bluebird.mapSeries(complementaryCertificationCourses, async function ({ id, partnerKey }) {
+  for (const complementaryCertificationCourse of complementaryCertificationCourses) {
+    const { id, partnerKey } = complementaryCertificationCourse;
     const complementaryCertificationBadgeId = complementaryCertificationBadges.find(({ key }) => key === partnerKey).id;
     await knex(TABLE_NAME).update(COLUMN, complementaryCertificationBadgeId).where({ id });
-  });
+  }
 };
 
 const down = async function (knex) {

--- a/api/db/migrations/20220920091611_add-message-columns-to-complementary-certification-badges.js
+++ b/api/db/migrations/20220920091611_add-message-columns-to-complementary-certification-badges.js
@@ -1,5 +1,3 @@
-import bluebird from 'bluebird';
-
 const TABLE_NAME = 'complementary-certification-badges';
 const MESSAGE_COLUMN_NAME = 'certificateMessage';
 const TEMP_MESSAGE_COLUMN_NAME = 'temporaryCertificateMessage';
@@ -19,14 +17,15 @@ const up = async function (knex) {
     complementaryCertificationIds,
   );
 
-  await bluebird.mapSeries(eduBadges, async ({ id, label }) => {
+  for (const eduBadge of eduBadges) {
+    const { id, label } = eduBadge;
     await knex(TABLE_NAME)
       .where({ id })
       .update({
         [MESSAGE_COLUMN_NAME]: `Vous avez obtenu la certification ${label}`,
         [TEMP_MESSAGE_COLUMN_NAME]: `Vous avez obtenu le niveau “${label}” dans le cadre du volet 1 de la certification Pix+Édu. Votre niveau final sera déterminé à l’issue du volet 2`,
       });
-  });
+  }
 };
 
 const down = function (knex) {

--- a/api/lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js
+++ b/api/lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js
@@ -1,4 +1,3 @@
-import bluebird from 'bluebird';
 import lodash from 'lodash';
 
 import { PGSQL_FOREIGN_KEY_VIOLATION_ERROR } from '../../../db/pgsql-errors.js';
@@ -274,13 +273,13 @@ async function _sendInvitationEmails({
       })
       .filter((organization) => Boolean(organization.email));
 
-    await bluebird.mapSeries(createdOrganizationsWithEmail, (organizationWithEmail) =>
-      organizationInvitationService.createProOrganizationInvitation({
+    for (const organizationWithEmail of createdOrganizationsWithEmail) {
+      await organizationInvitationService.createProOrganizationInvitation({
         organizationRepository,
         organizationInvitationRepository,
         ...organizationWithEmail,
-      }),
-    );
+      });
+    }
   } catch (error) {
     _monitorError(error.message, { error, event: 'send-organizations-invitation-emails' });
 

--- a/api/lib/domain/usecases/update-certification-center.js
+++ b/api/lib/domain/usecases/update-certification-center.js
@@ -4,8 +4,6 @@
  * @typedef {import('./index.js').ComplementaryCertificationHabilitationRepository} ComplementaryCertificationHabilitationRepository
  * @typedef {import('./index.js').DataProtectionOfficerRepository} DataProtectionOfficerRepository
  */
-import bluebird from 'bluebird';
-
 import { CenterForAdminFactory } from '../../../src/certification/enrolment/domain/models/factories/CenterForAdminFactory.js';
 import { CertificationCenterPilotFeaturesConflictError } from '../../../src/shared/domain/errors.js';
 import {
@@ -113,13 +111,13 @@ const _updateHabilitations = async ({
   await complementaryCertificationHabilitationRepository.deleteByCertificationCenterId(certificationCenterId);
 
   if (complementaryCertificationIds) {
-    await bluebird.mapSeries(complementaryCertificationIds, (complementaryCertificationId) => {
+    for (const complementaryCertificationId of complementaryCertificationIds) {
       const complementaryCertificationHabilitation = new ComplementaryCertificationHabilitation({
         complementaryCertificationId: parseInt(complementaryCertificationId),
         certificationCenterId,
       });
-      return complementaryCertificationHabilitationRepository.save(complementaryCertificationHabilitation);
-    });
+      await complementaryCertificationHabilitationRepository.save(complementaryCertificationHabilitation);
+    }
   }
 };
 

--- a/api/lib/infrastructure/events/EventBus.js
+++ b/api/lib/infrastructure/events/EventBus.js
@@ -1,5 +1,3 @@
-import bluebird from 'bluebird';
-
 class SubscriberList {
   constructor() {
     this._subscribers = new Map();
@@ -36,13 +34,13 @@ class EventBus {
   }
   async publish(event, domainTransaction) {
     const subscribersToCall = this._subscriptions.get(event);
-    await bluebird.mapSeries(subscribersToCall, async (subscriberClass) => {
+    for (const subscriberClass of subscribersToCall) {
       //La transaction knex est injecté dans le subscriber via le constructeur
       //Du coup à chaque requête il faut re-instancier le subscriber pour passer
       //une nouvelle transaction.
       const subscriber = this._dependenciesBuilder.build(subscriberClass, domainTransaction);
       await subscriber.handle(event);
-    });
+    }
   }
 }
 

--- a/api/scripts/add-or-update-certification-centers-dpo-infos.js
+++ b/api/scripts/add-or-update-certification-centers-dpo-infos.js
@@ -2,7 +2,6 @@ import 'dotenv/config';
 
 import * as url from 'node:url';
 
-import bluebird from 'bluebird';
 import _ from 'lodash';
 
 import { disconnect } from '../db/knex-database-connection.js';
@@ -48,7 +47,7 @@ async function _updateCertificationCentersDataProtectionOfficerInformation(fileP
 
   const dataProtectionOfficers = await parseCsvWithHeader(filePath, parsingOptions);
 
-  await bluebird.mapSeries(dataProtectionOfficers, async (dataProtectionOfficer) => {
+  for (const dataProtectionOfficer of dataProtectionOfficers) {
     try {
       await updateCertificationCenterDataProtectionOfficerInformation({
         dataProtectionOfficer,
@@ -57,7 +56,7 @@ async function _updateCertificationCentersDataProtectionOfficerInformation(fileP
     } catch (error) {
       errors.push({ dataProtectionOfficer, error });
     }
-  });
+  }
 
   if (errors.length === 0) {
     return;

--- a/api/scripts/certification/send-certification-result-emails.js
+++ b/api/scripts/certification/send-certification-result-emails.js
@@ -3,7 +3,6 @@ import 'dotenv/config';
 import path from 'node:path';
 import * as url from 'node:url';
 
-import bluebird from 'bluebird';
 import i18n from 'i18n';
 
 import { disconnect } from '../../db/knex-database-connection.js';
@@ -39,19 +38,19 @@ async function main() {
   const sessionIds = process.argv[2].split(',');
   let successes = 0;
 
-  await bluebird.mapSeries(sessionIds, async (sessionId) => {
+  for (const sessionId of sessionIds) {
     let session;
 
     try {
       session = await sharedSessionRepository.getWithCertificationCandidates({ id: parseInt(sessionId) });
     } catch (e) {
       logger.error({ e });
-      return;
+      continue;
     }
 
     if (!session.isPublished()) {
       logger.error(`La session ${sessionId} n'est pas publiée`);
-      return;
+      continue;
     }
 
     const publishedAt = session.publishedAt;
@@ -70,7 +69,7 @@ async function main() {
     } catch (e) {
       logger.error(e);
     }
-  });
+  }
 
   logger.info(`Nombre de session traitées: ${successes}/${sessionIds.length}`);
   logger.info('Fin du script.');

--- a/api/scripts/create-badge-criteria-for-specified-badge.js
+++ b/api/scripts/create-badge-criteria-for-specified-badge.js
@@ -1,7 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import * as url from 'node:url';
 
-import bluebird from 'bluebird';
 import Joi from 'joi';
 
 import { disconnect } from '../db/knex-database-connection.js';
@@ -71,10 +70,10 @@ async function main() {
   console.log('BadgeCriteria schema ok');
 
   console.log('Saving badge criteria... ');
-  return DomainTransaction.execute(async () => {
-    await bluebird.mapSeries(jsonFile.criteria, (badgeCriterion) => {
-      return _createBadgeCriterion({ ...badgeCriterion, badgeId: jsonFile.badgeId });
-    });
+  await DomainTransaction.execute(async () => {
+    for (const badgeCriterion of jsonFile.criteria) {
+      await _createBadgeCriterion({ ...badgeCriterion, badgeId: jsonFile.badgeId });
+    }
   });
 }
 

--- a/api/scripts/create-certification-center-memberships-from-organization-admins.js
+++ b/api/scripts/create-certification-center-memberships-from-organization-admins.js
@@ -1,10 +1,10 @@
 import * as url from 'node:url';
 
-import bluebird from 'bluebird';
 import _ from 'lodash';
 
 import { disconnect, knex } from '../db/knex-database-connection.js';
 import { Membership } from '../src/shared/domain/models/Membership.js';
+import { PromiseUtils } from '../src/shared/infrastructure/utils/promise-utils.js';
 import { parseCsvWithHeader } from './helpers/csvHelpers.js';
 
 async function getCertificationCenterIdWithMembershipsUserIdByExternalId(externalId) {
@@ -60,7 +60,7 @@ async function fetchCertificationCenterMembershipsByExternalId(externalId) {
 
 async function prepareDataForInsert(rawExternalIds) {
   const externalIds = _.uniq(_.map(rawExternalIds, 'externalId'));
-  const certificationCenterMembershipsLists = await bluebird.mapSeries(
+  const certificationCenterMembershipsLists = await PromiseUtils.mapSeries(
     externalIds,
     fetchCertificationCenterMembershipsByExternalId,
   );

--- a/api/scripts/create-users-accounts-for-contest.js
+++ b/api/scripts/create-users-accounts-for-contest.js
@@ -1,7 +1,5 @@
 import * as url from 'node:url';
 
-import bluebird from 'bluebird';
-
 import { disconnect } from '../db/knex-database-connection.js';
 import * as authenticationMethodRepository from '../src/identity-access-management/infrastructure/repositories/authentication-method.repository.js';
 import { userToCreateRepository } from '../src/identity-access-management/infrastructure/repositories/user-to-create.repository.js';
@@ -22,7 +20,8 @@ function prepareDataForInsert(rawUsers) {
 
 async function createUsers({ usersInRaw }) {
   const now = new Date();
-  await bluebird.mapSeries(usersInRaw, async (userDTO) => {
+
+  for (const userDTO of usersInRaw) {
     const userToCreate = {
       firstName: userDTO.firstName,
       lastName: userDTO.lastName,
@@ -40,7 +39,7 @@ async function createUsers({ usersInRaw }) {
       userToCreateRepository,
       authenticationMethodRepository,
     });
-  });
+  }
 }
 
 const modulePath = url.fileURLToPath(import.meta.url);

--- a/api/scripts/data-generation/generate-certif-cli.js
+++ b/api/scripts/data-generation/generate-certif-cli.js
@@ -5,7 +5,6 @@ const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 import * as dotenv from 'dotenv';
 
 dotenv.config({ path: `${__dirname}/../../.env` });
-import bluebird from 'bluebird';
 import lodash from 'lodash';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
@@ -135,12 +134,12 @@ async function _createComplementaryCertificationHabilitations(
   { complementaryCertificationIds, certificationCenterId },
   databaseBuilder,
 ) {
-  return bluebird.mapSeries(complementaryCertificationIds, async (complementaryCertificationId) => {
-    databaseBuilder.factory.buildComplementaryCertificationHabilitation({
+  for (const complementaryCertificationId of complementaryCertificationIds) {
+    await databaseBuilder.factory.buildComplementaryCertificationHabilitation({
       certificationCenterId,
       complementaryCertificationId,
     });
-  });
+  }
 }
 
 async function _createSessionAndReturnId({ certificationCenterId, databaseBuilder, userIds }) {

--- a/api/scripts/fill-campaign-participation-id-in-badge-acquisitions.js
+++ b/api/scripts/fill-campaign-participation-id-in-badge-acquisitions.js
@@ -1,7 +1,5 @@
 import * as url from 'node:url';
 
-import bluebird from 'bluebird';
-
 import { disconnect, knex } from '../db/knex-database-connection.js';
 
 async function getAllBadgeAcquistionsWithoutCampaignParticipationId() {
@@ -70,10 +68,10 @@ async function main() {
   console.log(`${badgeAcquisitionsWithoutCampaignParticipationId.length} badges without campaignParticipationId.`);
   console.log('badgeAcquisitionId;BadgeId;Possibility;ListOfCampaignParticipations');
 
-  await bluebird.mapSeries(badgeAcquisitionsWithoutCampaignParticipationId, async (badgeAcquisition) => {
+  for (const badgeAcquisition of badgeAcquisitionsWithoutCampaignParticipationId) {
     const campaignsParticipations = await getCampaignParticipationFromBadgeAcquisition(badgeAcquisition);
     await updateBadgeAcquisitionWithCampaignParticipationId(badgeAcquisition, campaignsParticipations);
-  });
+  }
 }
 
 (async () => {

--- a/api/scripts/prod/compute-badge-acquisitions.js
+++ b/api/scripts/prod/compute-badge-acquisitions.js
@@ -2,7 +2,6 @@ import 'dotenv/config';
 
 import perf_hooks from 'node:perf_hooks';
 
-import bluebird from 'bluebird';
 import _ from 'lodash';
 
 const { performance } = perf_hooks;
@@ -19,6 +18,7 @@ import * as knowledgeElementRepository from '../../lib/infrastructure/repositori
 import { CampaignParticipation } from '../../src/prescription/campaign-participation/domain/models/CampaignParticipation.js';
 import { learningContentCache as cache } from '../../src/shared/infrastructure/caches/learning-content-cache.js';
 import { logger } from '../../src/shared/infrastructure/utils/logger.js';
+import { PromiseUtils } from '../../src/shared/infrastructure/utils/promise-utils.js';
 
 const MAX_RANGE_SIZE = 100_000;
 
@@ -65,7 +65,7 @@ function normalizeRange({ idMin, idMax }) {
 
 async function computeAllBadgeAcquisitions({ idMin, idMax, dryRun }) {
   const campaignParticipations = await getCampaignParticipationsBetweenIds({ idMin, idMax });
-  const numberOfBadgeCreatedByCampaignParticipation = await bluebird.mapSeries(
+  const numberOfBadgeCreatedByCampaignParticipation = await PromiseUtils.mapSeries(
     campaignParticipations,
     async (campaignParticipation, index) => {
       logger.info(`${index}/${campaignParticipations.length}`);

--- a/api/scripts/prod/compute-participation-results.js
+++ b/api/scripts/prod/compute-participation-results.js
@@ -11,7 +11,6 @@ import { CampaignParticipationStatuses } from '../../src/prescription/shared/dom
 import { ParticipantResultsShared } from '../../src/shared/domain/models/ParticipantResultsShared.js';
 
 const { SHARED } = CampaignParticipationStatuses;
-import bluebird from 'bluebird';
 import _ from 'lodash';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
@@ -85,7 +84,7 @@ async function _computeCampaignParticipationResults(campaign) {
   const skillIds = await campaignRepository.findSkillIds({ campaignId: campaign.id });
   const computeResultsWithTargetedSkillIds = _.partial(_computeResults, skillIds, competences);
 
-  const participantsResults = await bluebird.mapSeries(
+  const participantsResults = await PromiseUtils.mapSeries(
     campaignParticipationInfosChunks,
     computeResultsWithTargetedSkillIds,
   );

--- a/api/scripts/prod/create-assessment-campaigns-for-sco.js
+++ b/api/scripts/prod/create-assessment-campaigns-for-sco.js
@@ -1,6 +1,5 @@
 import * as url from 'node:url';
 
-import bluebird from 'bluebird';
 import _ from 'lodash';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
@@ -8,6 +7,7 @@ import * as campaignUpdateValidator from '../../src/prescription/campaign/domain
 import * as campaignRepository from '../../src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js';
 import { CampaignTypes } from '../../src/prescription/shared/domain/constants.js';
 import * as codeGenerator from '../../src/shared/domain/services/code-generator.js';
+import { PromiseUtils } from '../../src/shared/infrastructure/utils/promise-utils.js';
 import { parseCsvWithHeader } from '../helpers/csvHelpers.js';
 
 function checkData(csvData) {
@@ -32,7 +32,7 @@ function checkData(csvData) {
 }
 
 async function prepareCampaigns(campaignsData) {
-  const campaigns = await bluebird.mapSeries(campaignsData, async (campaignData) => {
+  const campaigns = await PromiseUtils.mapSeries(campaignsData, async (campaignData) => {
     const organization = await getByExternalIdFetchingIdOnly(campaignData.externalId);
 
     const campaign = {

--- a/api/scripts/prod/select-category-for-target-profiles.js
+++ b/api/scripts/prod/select-category-for-target-profiles.js
@@ -1,6 +1,5 @@
 import 'dotenv/config';
 
-import bluebird from 'bluebird';
 import lodash from 'lodash';
 const { groupBy, sum, has, partition, negate } = lodash;
 
@@ -8,6 +7,7 @@ import * as url from 'node:url';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 import { categories } from '../../src/shared/domain/models/TargetProfile.js';
+import { PromiseUtils } from '../../src/shared/infrastructure/utils/promise-utils.js';
 import { parseCsvData, readCsvFile } from '../helpers/csvHelpers.js';
 
 const TARGET_PROFILE_ID_COLUMN = 'targetProfileId';
@@ -32,7 +32,7 @@ async function setCategoriesToTargetProfiles(csvData) {
   const validCategories = parsedCategories.filter(_isSupportedCategory);
   let invalidTargetProfiles = [];
 
-  const result = await bluebird.mapSeries(validCategories, function (category) {
+  const result = await PromiseUtils.mapSeries(validCategories, async function (category) {
     const targetProfiles = targetProfilesGroupedByCategory[category].map((row) => row[TARGET_PROFILE_ID_COLUMN]);
     const [validTargetProfilesIds, invalidTargetProfilesIds] = partition(targetProfiles, (targetProfileId) =>
       Number.isInteger(parseInt(targetProfileId)),

--- a/api/scripts/tooling/tooling.js
+++ b/api/scripts/tooling/tooling.js
@@ -1,4 +1,3 @@
-import bluebird from 'bluebird';
 import _ from 'lodash';
 
 import { knex } from '../../db/knex-database-connection.js';
@@ -58,10 +57,10 @@ async function makeUserCleaCertifiable({ userId, databaseBuilder }) {
 
   const skillIds = await campaignRepository.findSkillIds({ campaignId });
 
-  return bluebird.mapSeries(skillIds, async (skillId) => {
+  for (const skillId of skillIds) {
     const skill = await skillRepository.get(skillId);
-    return _addAnswerAndKnowledgeElementForSkill({ assessmentId, userId, skill, databaseBuilder });
-  });
+    await _addAnswerAndKnowledgeElementForSkill({ assessmentId, userId, skill, databaseBuilder });
+  }
 }
 
 function _createComplementeCompetenceEvaluationAssessment({ databaseBuilder, userId }) {
@@ -79,9 +78,10 @@ async function _cacheLearningContent() {
     allPixCompetences = _.filter(allCompetences, { origin: 'Pix' });
     allDroitCompetences = _.filter(allCompetences, { origin: 'Droit' });
     allEduCompetences = _.filter(allCompetences, { origin: 'Edu' });
-    await bluebird.mapSeries(allCompetences, async (competence) => {
+
+    for (const competence of allCompetences) {
       skillsByCompetenceId[competence.id] = await skillRepository.findActiveByCompetenceId(competence.id);
-    });
+    }
   }
 }
 

--- a/api/src/certification/complementary-certification/infrastructure/repositories/target-profile-history-repository.js
+++ b/api/src/certification/complementary-certification/infrastructure/repositories/target-profile-history-repository.js
@@ -1,8 +1,7 @@
-import bluebird from 'bluebird';
-
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { ComplementaryCertificationBadgeForAdmin } from '../../../../shared/domain/models/ComplementaryCertificationBadgeForAdmin.js';
 import { TargetProfileHistoryForAdmin } from '../../../../shared/domain/models/TargetProfileHistoryForAdmin.js';
+import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 
 const getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId = async function ({
   complementaryCertificationId,
@@ -21,7 +20,7 @@ const getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId = 
     .whereNull('complementary-certification-badges.detachedAt')
     .orderBy('attachedAt', 'desc');
 
-  return bluebird.mapSeries(currentTargetProfiles, async (targetProfile) => {
+  return PromiseUtils.mapSeries(currentTargetProfiles, async (targetProfile) => {
     const badges = await _getTargetProfileComplementaryCertificationBadges({ targetProfile });
     return _toDomain({ targetProfile, badges });
   });
@@ -49,7 +48,7 @@ const getDetachedTargetProfilesHistoryByComplementaryCertificationId = async fun
     )
     .orderBy('attachedAt', 'desc');
 
-  return bluebird.mapSeries(detachedTargetProfiles, async (targetProfile) => {
+  return PromiseUtils.mapSeries(detachedTargetProfiles, async (targetProfile) => {
     const badges = await _getTargetProfileComplementaryCertificationBadges({ targetProfile });
     return _toDomain({ targetProfile, badges });
   });

--- a/api/src/certification/enrolment/domain/services/certification-candidates-ods-service.js
+++ b/api/src/certification/enrolment/domain/services/certification-candidates-ods-service.js
@@ -1,7 +1,7 @@
-import bluebird from 'bluebird';
 import _ from 'lodash';
 
 import { CertificationCandidatesError } from '../../../../shared/domain/errors.js';
+import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 import * as mailCheckImplementation from '../../../../shared/mail/infrastructure/services/mail-check.js';
 import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../shared/domain/constants/certification-candidates-errors.js';
 import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
@@ -54,7 +54,8 @@ async function extractCertificationCandidatesFromCandidatesImportSheet({
   candidatesDataByLine = _filterOutEmptyCandidateData(candidatesDataByLine);
 
   const _checkForDuplication = _handleDuplicateCandidate();
-  return await bluebird.mapSeries(Object.entries(candidatesDataByLine), async ([line, candidateData]) => {
+
+  return PromiseUtils.mapSeries(Object.entries(candidatesDataByLine), async ([line, candidateData]) => {
     let { sex, birthCountry, birthINSEECode, birthPostalCode, birthCity, billingMode } = candidateData;
     const { email, resultRecipientEmail } = candidateData;
     const { hasCleaNumerique, hasPixPlusDroit, hasPixPlusEdu1erDegre, hasPixPlusEdu2ndDegre, hasPixPlusProSante } =

--- a/api/src/certification/enrolment/domain/usecases/create-sessions.js
+++ b/api/src/certification/enrolment/domain/usecases/create-sessions.js
@@ -2,8 +2,6 @@
  * @typedef {import ("./index.js").dependencies} deps
  */
 
-import bluebird from 'bluebird';
-
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { CERTIFICATION_VERSIONS } from '../../../shared/domain/models/CertificationVersion.js';
@@ -38,7 +36,7 @@ const createSessions = async function ({
   const { isV3Pilot } = await centerRepository.getById({ id: certificationCenterId });
 
   await DomainTransaction.execute(async () => {
-    return await bluebird.mapSeries(temporaryCachedSessions, async (sessionDTO) => {
+    for (const sessionDTO of temporaryCachedSessions) {
       let { id: sessionId } = sessionDTO;
       const candidates = sessionDTO.certificationCandidates;
 
@@ -60,7 +58,7 @@ const createSessions = async function ({
           candidateRepository,
         });
       }
-    });
+    }
   });
 
   await temporarySessionsStorageForMassImportService.remove({
@@ -88,11 +86,11 @@ async function _deleteExistingCandidatesInSession({ candidateRepository, session
 }
 
 async function _saveCandidates({ candidates, sessionId, candidateRepository }) {
-  await bluebird.mapSeries(candidates, async (candidateDTO) => {
+  for (const candidateDTO of candidates) {
     const candidate = new Candidate({ ...candidateDTO });
     await candidateRepository.saveInSession({
       sessionId,
       candidate,
     });
-  });
+  }
 }

--- a/api/src/certification/enrolment/domain/usecases/import-certification-candidates-from-candidates-import-sheet.js
+++ b/api/src/certification/enrolment/domain/usecases/import-certification-candidates-from-candidates-import-sheet.js
@@ -1,5 +1,3 @@
-import bluebird from 'bluebird';
-
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { CandidateAlreadyLinkedToUserError } from '../../../../shared/domain/errors.js';
 
@@ -37,12 +35,10 @@ const importCertificationCandidatesFromCandidatesImportSheet = async function ({
 
   await DomainTransaction.execute(async () => {
     await candidateRepository.deleteBySessionId({ sessionId });
-    await bluebird.mapSeries(candidates, function (candidate) {
-      return candidateRepository.saveInSession({
-        candidate,
-        sessionId,
-      });
-    });
+
+    for (const candidate of candidates) {
+      await candidateRepository.saveInSession({ candidate, sessionId });
+    }
   });
 };
 

--- a/api/src/certification/enrolment/domain/usecases/validate-sessions.js
+++ b/api/src/certification/enrolment/domain/usecases/validate-sessions.js
@@ -2,8 +2,7 @@
  * @typedef {import ("./index.js").dependencies} deps
  */
 
-import bluebird from 'bluebird';
-
+import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 import { Candidate } from '../models/Candidate.js';
 import { SessionEnrolment } from '../models/SessionEnrolment.js';
 import { SessionMassImportReport } from '../models/SessionMassImportReport.js';
@@ -41,7 +40,7 @@ const validateSessions = async function ({
   const sessionsMassImportReport = new SessionMassImportReport();
   const translate = i18n.__;
 
-  const validatedSessions = await bluebird.mapSeries(sessionsData, async (sessionDTO) => {
+  const validatedSessions = await PromiseUtils.mapSeries(sessionsData, async (sessionDTO) => {
     const { sessionId } = sessionDTO;
 
     const accessCode = sessionCodeService.getNewSessionCode();
@@ -121,7 +120,7 @@ async function _createValidCertificationCandidates({
     sessionsMassImportReport.addErrorReports(duplicateCandidateErrors);
   }
 
-  return bluebird.mapSeries(uniqueCandidates, async (candidateDTO) => {
+  return PromiseUtils.mapSeries(uniqueCandidates, async (candidateDTO) => {
     const billingMode = Candidate.parseBillingMode({
       billingMode: candidateDTO.billingMode,
       translate,

--- a/api/src/certification/results/domain/usecases/get-certification-attestations-for-session.js
+++ b/api/src/certification/results/domain/usecases/get-certification-attestations-for-session.js
@@ -1,8 +1,8 @@
-import bluebird from 'bluebird';
 import compact from 'lodash/compact.js';
 import isEmpty from 'lodash/isEmpty.js';
 
 import { NotFoundError } from '../../../../shared/domain/errors.js';
+import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 
 const getCertificationAttestationsForSession = async function ({
   sessionId,
@@ -16,7 +16,7 @@ const getCertificationAttestationsForSession = async function ({
   }
 
   const certificationAttestations = compact(
-    await bluebird.mapSeries(certificationCourses, async (certificationCourse) => {
+    await PromiseUtils.mapSeries(certificationCourses, async (certificationCourse) => {
       try {
         return await certificateRepository.getCertificationAttestation({
           certificationCourseId: certificationCourse.getId(),

--- a/api/src/certification/session-management/domain/usecases/finalize-session.js
+++ b/api/src/certification/session-management/domain/usecases/finalize-session.js
@@ -5,9 +5,6 @@
  *
  * @typedef {import('../../../session-management/domain/usecases/index.js').CertificationReportRepository} CertificationReportRepository
  */
-
-import bluebird from 'bluebird';
-
 import {
   SessionAlreadyFinalizedError,
   SessionWithAbortReasonOnCompletedCertificationCourseError,
@@ -114,18 +111,16 @@ async function _removeAbortReasonFromCompletedCertificationCourses({
     sessionId,
   });
   for (const sessionCertificationCourse of sessionCertificationCourses) {
-    await bluebird.mapSeries(
-      certificationReports,
-      async ({ certificationCourseId: abortReasonCertificationCourseId, abortReason }) => {
-        if (
-          sessionCertificationCourse.getId() === abortReasonCertificationCourseId &&
-          abortReason &&
-          sessionCertificationCourse.isCompleted()
-        ) {
-          sessionCertificationCourse.unabort();
-          await certificationCourseRepository.update({ certificationCourse: sessionCertificationCourse });
-        }
-      },
-    );
+    for (const certificationReport of certificationReports) {
+      const { certificationCourseId: abortReasonCertificationCourseId, abortReason } = certificationReport;
+      if (
+        sessionCertificationCourse.getId() === abortReasonCertificationCourseId &&
+        abortReason &&
+        sessionCertificationCourse.isCompleted()
+      ) {
+        sessionCertificationCourse.unabort();
+        await certificationCourseRepository.update({ certificationCourse: sessionCertificationCourse });
+      }
+    }
   }
 }

--- a/api/src/certification/shared/domain/services/certification-badges-service.js
+++ b/api/src/certification/shared/domain/services/certification-badges-service.js
@@ -1,12 +1,12 @@
 /**
  * @typedef {import ('../../../../../src/shared/domain/models/CertifiableBadgeAcquisition.js').CertifiableBadgeAcquisition} CertifiableBadgeAcquisition
  */
-import bluebird from 'bluebird';
 import _ from 'lodash';
 
 import * as badgeForCalculationRepository from '../../../../../lib/infrastructure/repositories/badge-for-calculation-repository.js';
 import * as certifiableBadgeAcquisitionRepository from '../../../../../lib/infrastructure/repositories/certifiable-badge-acquisition-repository.js';
 import * as knowledgeElementRepository from '../../../../../lib/infrastructure/repositories/knowledge-element-repository.js';
+import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 
 const findStillValidBadgeAcquisitions = async function ({
   userId,
@@ -50,7 +50,7 @@ const _findBadgeAcquisitions = async function ({
     limitDate,
   });
 
-  const badgeAcquisitions = await bluebird.mapSeries(
+  const badgeAcquisitions = await PromiseUtils.mapSeries(
     highestCertifiableBadgeAcquisitions,
     async (certifiableBadgeAcquisition) => {
       if (!shouldGetOutdated && certifiableBadgeAcquisition.isOutdated) {

--- a/api/src/certification/shared/domain/services/scoring-certification-service.js
+++ b/api/src/certification/shared/domain/services/scoring-certification-service.js
@@ -1,4 +1,3 @@
-import bluebird from 'bluebird';
 import _ from 'lodash';
 
 import * as scoringService from '../../../../evaluation/domain/services/scoring/scoring-service.js';
@@ -366,13 +365,13 @@ async function _saveV3Result({
     assessmentResult,
   });
 
-  await bluebird.mapSeries(certificationAssessmentScore.competenceMarks, (competenceMark) => {
+  for (const competenceMark of certificationAssessmentScore.competenceMarks) {
     const competenceMarkDomain = new CompetenceMark({
       ...competenceMark,
       assessmentResultId: newAssessmentResult.id,
     });
-    return competenceMarkRepository.save(competenceMarkDomain);
-  });
+    await competenceMarkRepository.save(competenceMarkDomain);
+  }
 }
 
 function _createV2AssessmentResult({
@@ -445,10 +444,10 @@ async function _saveV2Result({
     assessmentResult,
   });
 
-  await bluebird.mapSeries(certificationAssessmentScore.competenceMarks, (competenceMark) => {
+  for (const competenceMark of certificationAssessmentScore.competenceMarks) {
     const competenceMarkDomain = new CompetenceMark({ ...competenceMark, assessmentResultId });
-    return competenceMarkRepository.save(competenceMarkDomain);
-  });
+    await competenceMarkRepository.save(competenceMarkDomain);
+  }
 }
 
 function _shouldRejectWhenV3CertificationCandidateDidNotAnswerToEnoughQuestions({ allAnswers, certificationCourse }) {

--- a/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation-for-admin.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation-for-admin.js
@@ -1,5 +1,3 @@
-import bluebird from 'bluebird';
-
 import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
 
 const deleteCampaignParticipationForAdmin = withTransaction(async function ({
@@ -16,11 +14,11 @@ const deleteCampaignParticipationForAdmin = withTransaction(async function ({
       campaignParticipationId,
     });
 
-  await bluebird.mapSeries(campaignParticipations, async (campaignParticipation) => {
+  for (const campaignParticipation of campaignParticipations) {
     campaignParticipation.delete(userId);
     const { id, deletedAt, deletedBy } = campaignParticipation;
     await campaignParticipationRepository.remove({ id, deletedAt, deletedBy });
-  });
+  }
 });
 
 export { deleteCampaignParticipationForAdmin };

--- a/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation.js
@@ -1,5 +1,3 @@
-import bluebird from 'bluebird';
-
 const deleteCampaignParticipation = async function ({
   userId,
   campaignId,
@@ -12,11 +10,11 @@ const deleteCampaignParticipation = async function ({
       campaignParticipationId,
     });
 
-  await bluebird.mapSeries(campaignParticipations, async (campaignParticipation) => {
+  for (const campaignParticipation of campaignParticipations) {
     campaignParticipation.delete(userId);
     const { id, deletedAt, deletedBy } = campaignParticipation;
     await campaignParticipationRepository.remove({ id, deletedAt, deletedBy });
-  });
+  }
 };
 
 export { deleteCampaignParticipation };

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-analysis-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-analysis-repository.js
@@ -1,4 +1,3 @@
-import bluebird from 'bluebird';
 import _ from 'lodash';
 
 import { knex } from '../../../../../db/knex-database-connection.js';
@@ -21,13 +20,14 @@ const getCampaignAnalysis = async function (campaignId, campaignLearningContent,
     participantCount,
   });
 
-  await bluebird.mapSeries(userIdsAndSharedDatesChunks, async (userIdsAndSharedDates) => {
+  for (const userIdsAndSharedDates of userIdsAndSharedDatesChunks) {
     const knowledgeElementsByTube = await knowledgeElementRepository.findValidatedGroupedByTubesWithinCampaign(
       Object.fromEntries(userIdsAndSharedDates),
       campaignLearningContent,
     );
     campaignAnalysis.addToTubeRecommendations({ knowledgeElementsByTube });
-  });
+  }
+
   campaignAnalysis.finalize();
   return campaignAnalysis;
 };

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-assessment-participation-result-list-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-assessment-participation-result-list-repository.js
@@ -1,8 +1,7 @@
-import bluebird from 'bluebird';
-
 import { knex } from '../../../../../db/knex-database-connection.js';
 import * as stageCollectionRepository from '../../../../../lib/infrastructure/repositories/user-campaign-results/stage-collection-repository.js';
 import { fetchPage } from '../../../../shared/infrastructure/utils/knex-utils.js';
+import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 import { CampaignParticipationStatuses } from '../../../shared/domain/constants.js';
 import { CampaignAssessmentParticipationResultMinimal } from '../../domain/read-models/CampaignAssessmentParticipationResultMinimal.js';
 
@@ -155,7 +154,7 @@ function _filterByStage(queryBuilder, stageCollection, filters) {
 }
 
 async function _buildCampaignAssessmentParticipationResultList(results, stageCollection) {
-  return await bluebird.mapSeries(results, async (result) => {
+  return PromiseUtils.mapSeries(results, async (result) => {
     const badges = await getAcquiredBadges(result.campaignParticipationId);
     const participantReachedStage = stageCollection.getReachedStage(
       result.validatedSkillsCount,

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-collective-result-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-collective-result-repository.js
@@ -1,4 +1,3 @@
-import bluebird from 'bluebird';
 import _ from 'lodash';
 
 import { knex } from '../../../../../db/knex-database-connection.js';
@@ -19,7 +18,7 @@ const getCampaignCollectiveResult = async function (campaignId, campaignLearning
   const userIdsAndSharedDatesChunks = await _getChunksSharedParticipationsWithUserIdsAndDates(campaignId);
 
   let participantCount = 0;
-  await bluebird.mapSeries(userIdsAndSharedDatesChunks, async (userIdsAndSharedDates) => {
+  for (const userIdsAndSharedDates of userIdsAndSharedDatesChunks) {
     participantCount += userIdsAndSharedDates.length;
     const validatedTargetedKnowledgeElementsCountByCompetenceId =
       await knowledgeElementRepository.countValidatedByCompetencesForUsersWithinCampaign(
@@ -27,7 +26,7 @@ const getCampaignCollectiveResult = async function (campaignId, campaignLearning
         campaignLearningContent,
       );
     campaignCollectiveResult.addValidatedSkillCountToCompetences(validatedTargetedKnowledgeElementsCountByCompetenceId);
-  });
+  }
 
   campaignCollectiveResult.finalize(participantCount);
   return campaignCollectiveResult;

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
@@ -1,4 +1,3 @@
-import bluebird from 'bluebird';
 import chunk from 'lodash/chunk.js';
 import isBoolean from 'lodash/isBoolean.js';
 
@@ -8,6 +7,7 @@ import * as placementProfileService from '../../../../shared/domain/services/pla
 import * as competenceRepository from '../../../../shared/infrastructure/repositories/competence-repository.js';
 import { filterByFullName } from '../../../../shared/infrastructure/utils/filter-utils.js';
 import { fetchPage } from '../../../../shared/infrastructure/utils/knex-utils.js';
+import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 import { CampaignProfilesCollectionParticipationSummary } from '../../domain/read-models/CampaignProfilesCollectionParticipationSummary.js';
 
 async function findPaginatedByCampaignId(campaignId, page = {}, filters = {}) {
@@ -81,7 +81,7 @@ async function _makeMemoizedGetPlacementProfileForUser(results) {
 
   const sharedResults = results.filter(({ sharedAt }) => sharedAt);
 
-  const sharedResultsChunks = await bluebird.mapSeries(
+  const sharedResultsChunks = await PromiseUtils.mapSeries(
     chunk(sharedResults, constants.CHUNK_SIZE_CAMPAIGN_RESULT_PROCESSING),
     (sharedResultsChunk) => {
       const userIdsAndDates = sharedResultsChunk.map(({ userId, sharedAt }) => {

--- a/api/src/prescription/learner-management/domain/usecases/add-or-update-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/add-or-update-organization-learners.js
@@ -1,4 +1,3 @@
-import bluebird from 'bluebird';
 import lodash from 'lodash';
 
 import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';
@@ -48,12 +47,12 @@ async function addOrUpdateOrganizationLearners({
         'IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Aprés la methode disableAllOrganizationLearnersInOrganization',
       );
 
-      await bluebird.mapSeries(organizationLearnersChunks, (chunk) => {
-        return organizationLearnerRepository.addOrUpdateOrganizationOfOrganizationLearners(
+      for (const chunk of organizationLearnersChunks) {
+        await organizationLearnerRepository.addOrUpdateOrganizationOfOrganizationLearners(
           chunk,
           organizationImport.organizationId,
         );
-      });
+      }
       loggerForImport(
         'IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Aprés la methode addOrUpdateOrganizationOfOrganizationLearners',
       );

--- a/api/src/prescription/learner-management/domain/usecases/import-organization-learners-from-siecle-csv-format.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-organization-learners-from-siecle-csv-format.js
@@ -1,6 +1,5 @@
 const { chunk } = lodash;
 
-import bluebird from 'bluebird';
 import lodash from 'lodash';
 
 import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';
@@ -40,9 +39,9 @@ const importOrganizationLearnersFromSIECLECSVFormat = async function ({
         nationalStudentIds: nationalStudentIdData,
       });
 
-      await bluebird.mapSeries(organizationLearnersChunks, (chunk) => {
-        return organizationLearnerRepository.addOrUpdateOrganizationOfOrganizationLearners(chunk, organizationId);
-      });
+      for (const chunk of organizationLearnersChunks) {
+        await organizationLearnerRepository.addOrUpdateOrganizationOfOrganizationLearners(chunk, organizationId);
+      }
     } catch (error) {
       errors.push(error);
       throw error;

--- a/api/src/prescription/target-profile/infrastructure/repositories/target-profile-for-specifier-repository.js
+++ b/api/src/prescription/target-profile/infrastructure/repositories/target-profile-for-specifier-repository.js
@@ -1,12 +1,11 @@
-import bluebird from 'bluebird';
-
 import { knex } from '../../../../../db/knex-database-connection.js';
+import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 import { TargetProfileForSpecifier } from '../../domain/read-models/TargetProfileForSpecifier.js';
 
 async function availableForOrganization(organizationId) {
   const targetProfileRows = await _fetchTargetProfiles(organizationId);
 
-  return bluebird.mapSeries(targetProfileRows, _buildTargetProfileForSpecifier);
+  return PromiseUtils.mapSeries(targetProfileRows, _buildTargetProfileForSpecifier);
 }
 
 function _fetchTargetProfiles(organizationId) {

--- a/api/src/shared/domain/services/placement-profile-service.js
+++ b/api/src/shared/domain/services/placement-profile-service.js
@@ -1,4 +1,3 @@
-import bluebird from 'bluebird';
 import _ from 'lodash';
 
 import * as knowledgeElementRepository from '../../../../lib/infrastructure/repositories/knowledge-element-repository.js';
@@ -14,6 +13,7 @@ import * as assessmentRepository from '../../infrastructure/repositories/assessm
 import * as assessmentResultRepository from '../../infrastructure/repositories/assessment-result-repository.js';
 import * as competenceRepository from '../../infrastructure/repositories/competence-repository.js';
 import * as skillRepository from '../../infrastructure/repositories/skill-repository.js';
+import { PromiseUtils } from '../../infrastructure/utils/promise-utils.js';
 
 async function getPlacementProfile({
   userId,
@@ -35,7 +35,7 @@ async function getPlacementProfile({
 }
 
 async function _createUserCompetencesV1({ competences, userLastAssessments, limitDate }) {
-  return bluebird.mapSeries(competences, async (competence) => {
+  return PromiseUtils.mapSeries(competences, async (competence) => {
     const assessment = _.find(userLastAssessments, { competenceId: competence.id });
     let estimatedLevel = 0;
     let pixScore = 0;

--- a/api/src/shared/infrastructure/utils/promise-utils.js
+++ b/api/src/shared/infrastructure/utils/promise-utils.js
@@ -41,4 +41,22 @@ function map(array, mapper, { concurrency = Infinity } = {}) {
   });
 }
 
-export const PromiseUtils = { map };
+/**
+ * Asynchronously maps in series over an array of values and keeps the array order.
+ *
+ * @param {Array} array - The array of values to be mapped.
+ * @param {Function} mapper - A function that takes a value and its index, and returns a promise or value.
+ *
+ * @returns {Promise<Array>} A promise that resolves to an array of mapped results.
+ *
+ */
+async function mapSeries(array, mapper) {
+  const result = [];
+  for (const [index, item] of array.entries()) {
+    const mapped = await mapper(item, index);
+    result.push(mapped);
+  }
+  return result;
+}
+
+export const PromiseUtils = { map, mapSeries };

--- a/api/src/team/domain/usecases/create-or-update-certification-center-invitation.js
+++ b/api/src/team/domain/usecases/create-or-update-certification-center-invitation.js
@@ -1,5 +1,3 @@
-import bluebird from 'bluebird';
-
 const createOrUpdateCertificationCenterInvitation = async function ({
   certificationCenterId,
   emails,
@@ -13,15 +11,15 @@ const createOrUpdateCertificationCenterInvitation = async function ({
   const uniqueEmails = [...new Set(emails)];
   const trimmedUniqueEmails = uniqueEmails.map((email) => email.replace(/[\s\r\n]/g, ''));
 
-  return bluebird.mapSeries(trimmedUniqueEmails, (email) =>
-    certificationCenterInvitationService.createOrUpdateCertificationCenterInvitation({
+  for (const email of trimmedUniqueEmails) {
+    await certificationCenterInvitationService.createOrUpdateCertificationCenterInvitation({
       certificationCenterInvitationRepository,
     })({
       certificationCenter,
       email,
       locale,
-    }),
-  );
+    });
+  }
 };
 
 export { createOrUpdateCertificationCenterInvitation };

--- a/api/src/team/domain/usecases/create-organization-invitations.usecase.js
+++ b/api/src/team/domain/usecases/create-organization-invitations.usecase.js
@@ -1,5 +1,4 @@
-import bluebird from 'bluebird';
-
+import { PromiseUtils } from '../../../shared/infrastructure/utils/promise-utils.js';
 import { OrganizationArchivedError } from '../errors.js';
 
 const createOrganizationInvitations = async function ({
@@ -19,7 +18,7 @@ const createOrganizationInvitations = async function ({
   const trimmedEmails = emails.map((email) => email.trim());
   const uniqueEmails = [...new Set(trimmedEmails)];
 
-  return bluebird.mapSeries(uniqueEmails, (email) => {
+  return PromiseUtils.mapSeries(uniqueEmails, async (email) => {
     return organizationInvitationService.createOrUpdateOrganizationInvitation({
       organizationRepository,
       organizationInvitationRepository,

--- a/api/tests/shared/unit/infrastructure/utils/promise-utils_test.js
+++ b/api/tests/shared/unit/infrastructure/utils/promise-utils_test.js
@@ -1,72 +1,123 @@
 import { PromiseUtils } from '../../../../../src/shared/infrastructure/utils/promise-utils.js';
 import { catchErr, expect, sinon } from '../../../../test-helper.js';
 
-describe('#map', function () {
-  it('maps', async function () {
-    const arr = [1, 2, 3];
-    const callback = sinon.spy((v) => Promise.resolve(v + 1));
+describe('Promise utils', function () {
+  describe('#map', function () {
+    it('maps', async function () {
+      const arr = [1, 2, 3];
+      const callback = sinon.spy((v) => Promise.resolve(v + 1));
 
-    const result = await PromiseUtils.map(arr, callback);
+      const result = await PromiseUtils.map(arr, callback);
 
-    expect(callback).to.have.been.calledThrice;
-    expect(result).to.deep.equal([2, 3, 4]);
+      expect(callback).to.have.been.calledThrice;
+      expect(result).to.deep.equal([2, 3, 4]);
+    });
+
+    it('rejects if an error occurred', async function () {
+      const arr = [1, 2, 3];
+      const callback = sinon.spy(() => Promise.reject('boo'));
+
+      const error = await catchErr(PromiseUtils.map)(arr, callback);
+
+      expect(error).to.be.equal('boo');
+    });
+
+    describe('concurrency limit', function () {
+      let currentConcurrentExecutions;
+      let maxConcurrentExecutions;
+      let concurrentCallback;
+
+      beforeEach(function () {
+        currentConcurrentExecutions = 0;
+        maxConcurrentExecutions = 0;
+
+        concurrentCallback = async (item) => {
+          currentConcurrentExecutions++;
+          maxConcurrentExecutions = Math.max(maxConcurrentExecutions, currentConcurrentExecutions);
+          const result = await Promise.resolve(item);
+          currentConcurrentExecutions--;
+          return result;
+        };
+      });
+
+      it('respects concurrency limit', async function () {
+        const arr = [1, 2, 3, 4, 5, 6];
+        const concurrency = 2;
+
+        const result = await PromiseUtils.map(arr, concurrentCallback, { concurrency });
+
+        expect(result).to.deep.equal(arr);
+        expect(maxConcurrentExecutions).to.be.equal(concurrency);
+      });
+
+      it('handles concurrency of 1 correctly', async function () {
+        const arr = [1, 2, 3, 4, 5, 6];
+        const concurrency = 1;
+
+        const result = await PromiseUtils.map(arr, concurrentCallback, { concurrency });
+
+        expect(result).to.deep.equal(arr);
+        expect(maxConcurrentExecutions).to.be.equal(concurrency);
+      });
+
+      it('handles no concurrency limit', async function () {
+        const arr = [1, 2, 3, 4, 5, 6];
+        const concurrency = Infinity;
+
+        const result = await PromiseUtils.map(arr, concurrentCallback, { concurrency });
+
+        expect(result).to.deep.equal(arr);
+        expect(maxConcurrentExecutions).to.be.equal(arr.length);
+      });
+    });
   });
 
-  it('rejects if an error occurred', async function () {
-    const arr = [1, 2, 3];
-    const callback = sinon.spy(() => Promise.reject('boo'));
+  describe('#mapSeries', function () {
+    it('maps array values sequentially using an async mapper', async function () {
+      const array = [1, 2, 3];
+      const asyncMapper = async (item, index) => item * index;
 
-    const error = await catchErr(PromiseUtils.map)(arr, callback);
+      const result = await PromiseUtils.mapSeries(array, asyncMapper);
 
-    expect(error).to.be.equal('boo');
-  });
+      expect(result).to.deep.equal([0, 2, 6]);
+    });
 
-  describe('concurrency limit', function () {
-    let currentConcurrentExecutions;
-    let maxConcurrentExecutions;
-    let concurrentCallback;
+    it('returns an empty array when the input array is empty', async function () {
+      const array = [];
+      const asyncMapper = async (x) => x * 2;
 
-    beforeEach(function () {
-      currentConcurrentExecutions = 0;
-      maxConcurrentExecutions = 0;
+      const result = await PromiseUtils.mapSeries(array, asyncMapper);
 
-      concurrentCallback = async (item) => {
-        currentConcurrentExecutions++;
-        maxConcurrentExecutions = Math.max(maxConcurrentExecutions, currentConcurrentExecutions);
-        const result = await Promise.resolve(item);
-        currentConcurrentExecutions--;
-        return result;
+      expect(result).to.deep.equal([]);
+    });
+
+    it('throws an error if the mapper function throws', async function () {
+      const array = [1, 2, 3];
+      const asyncMapper = async (x) => {
+        if (x === 2) throw new Error('Test error');
+        return x * 2;
       };
+
+      const error = await catchErr(PromiseUtils.mapSeries)(array, asyncMapper);
+
+      expect(error).to.be.instanceof(Error);
     });
 
-    it('respects concurrency limit', async function () {
-      const arr = [1, 2, 3, 4, 5, 6];
-      const concurrency = 2;
+    it('executes the mapper function sequentially', async function () {
+      const array = [1, 2, 3];
+      const executionOrder = [];
 
-      const result = await PromiseUtils.map(arr, concurrentCallback, { concurrency });
+      const asyncMapper = async (x, index) => {
+        if (index === 1) {
+          await new Promise((resolve) => setTimeout(resolve, 1));
+        }
+        executionOrder.push(x);
+        return x * 2;
+      };
 
-      expect(result).to.deep.equal(arr);
-      expect(maxConcurrentExecutions).to.be.equal(concurrency);
-    });
+      await PromiseUtils.mapSeries(array, asyncMapper);
 
-    it('handles concurrency of 1 correctly', async function () {
-      const arr = [1, 2, 3, 4, 5, 6];
-      const concurrency = 1;
-
-      const result = await PromiseUtils.map(arr, concurrentCallback, { concurrency });
-
-      expect(result).to.deep.equal(arr);
-      expect(maxConcurrentExecutions).to.be.equal(concurrency);
-    });
-
-    it('handles no concurrency limit', async function () {
-      const arr = [1, 2, 3, 4, 5, 6];
-      const concurrency = Infinity;
-
-      const result = await PromiseUtils.map(arr, concurrentCallback, { concurrency });
-
-      expect(result).to.deep.equal(arr);
-      expect(maxConcurrentExecutions).to.be.equal(arr.length);
+      expect(executionOrder).to.deep.equal([1, 2, 3]);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

[Bluebird](https://github.com/petkaantonov/bluebird) est une librairie d’utilitaire autour des promesses, qui a été utilisée à Pix côté API principalement pour palier au manque de fonctionnalités autour des promesses natives NodeJS d’il y a quelques années.

Mais les promesses natives NodeJS ont énormément évoluées depuis ce qui rend en partie l’utilisation de Bluebird obsolète. De plus la librairie n’est plus maintenue, sa dernière release v3.7.2 date du 28/11/2019.

## :robot: Proposition

1. Dans le cas où `bluebird.mapSeries` était juste utilisé pour itérer sur une liste et exécuter une fonction asynchrone, remplacer par un simple `for..of`

2. Dans le cas où `bluebird.mapSeries` était utilisé pour mapper sur une liste avec une fonction asynchrone, remplacer par une implémentation native de `mapSeries` dans `PromiseUtils`:
```js
PromiseUtils.mapSeries(array, asynCallback)
```

## :rainbow: Remarques

Les autres PR de remplacement de Bluebird : 
* #9757
* #9764

## :100: Pour tester

- La CI doit passer
- Quelques tests fonctionnels par équipe sur les fonctionnalités importantes