### PR TITLE
[TECH] Remplacer les erreurs génériques par des `DomainError` dans le contexte Modulix (PIX-14015)

### DIFF
--- a/api/src/devcomp/domain/models/Grain.js
+++ b/api/src/devcomp/domain/models/Grain.js
@@ -1,3 +1,4 @@
+import { DomainError } from '../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.js';
 
 class Grain {
@@ -14,7 +15,7 @@ class Grain {
 
   #assertComponentsIsDefinedAndAnArray(components) {
     if (components !== undefined && !Array.isArray(components)) {
-      throw new Error(`Grain components should be a list of components`);
+      throw new DomainError(`Grain components should be a list of components`);
     }
   }
 }

--- a/api/src/devcomp/domain/models/QrocmSolutions.js
+++ b/api/src/devcomp/domain/models/QrocmSolutions.js
@@ -1,3 +1,4 @@
+import { DomainError } from '../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.js';
 
 class QrocmSolutions {
@@ -14,10 +15,10 @@ class QrocmSolutions {
           'The tolerances are required for each QROCM proposal in QROCM solutions',
         );
         if (!Array.isArray(proposal.solutions)) {
-          throw new Error('Each proposal in QROCM solutions should have a list of solutions');
+          throw new DomainError('Each proposal in QROCM solutions should have a list of solutions');
         }
         if (!Array.isArray(proposal.tolerances)) {
-          throw new Error('A QROCM solution should have a list of tolerances');
+          throw new DomainError('A QROCM solution should have a list of tolerances');
         }
       });
 

--- a/api/src/devcomp/domain/models/component/ComponentStepper.js
+++ b/api/src/devcomp/domain/models/component/ComponentStepper.js
@@ -1,3 +1,4 @@
+import { DomainError } from '../../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 
 class ComponentStepper {
@@ -11,7 +12,7 @@ class ComponentStepper {
 
   #assertStepsAreAnArray(steps) {
     if (!Array.isArray(steps)) {
-      throw new Error('Steps should be an array');
+      throw new DomainError('Steps should be an array');
     }
   }
 }

--- a/api/src/devcomp/domain/models/component/Step.js
+++ b/api/src/devcomp/domain/models/component/Step.js
@@ -1,3 +1,4 @@
+import { DomainError } from '../../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 
 class Step {
@@ -10,10 +11,10 @@ class Step {
 
   #assertElementsNotEmpty(elements) {
     if (!Array.isArray(elements)) {
-      throw new Error('step.elements should be an array');
+      throw new DomainError('step.elements should be an array');
     }
     if (elements.length === 0) {
-      throw new Error('A step should contain at least one element');
+      throw new DomainError('A step should contain at least one element');
     }
   }
 }

--- a/api/src/devcomp/domain/models/element/Download.js
+++ b/api/src/devcomp/domain/models/element/Download.js
@@ -1,3 +1,4 @@
+import { DomainError } from '../../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 import { Element } from './Element.js';
 
@@ -18,12 +19,12 @@ class Download extends Element {
 
   #assertFilesIsAnArray(files) {
     if (!Array.isArray(files)) {
-      throw new Error('The Download files should be a list');
+      throw new DomainError('The Download files should be a list');
     }
   }
 
   #assertFilesAreNotEmpty(files) {
-    if (files.length === 0) throw new Error('The files are required for a Download');
+    if (files.length === 0) throw new DomainError('The files are required for a Download');
   }
 }
 

--- a/api/src/devcomp/domain/models/element/QCM.js
+++ b/api/src/devcomp/domain/models/element/QCM.js
@@ -1,3 +1,4 @@
+import { DomainError } from '../../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 import { Element } from './Element.js';
 
@@ -17,13 +18,13 @@ class QCM extends Element {
 
   #assertProposalsAreNotEmpty(proposals) {
     if (proposals.length === 0) {
-      throw new Error('The proposals are required for a QCM');
+      throw new DomainError('The proposals are required for a QCM');
     }
   }
 
   #assertProposalsIsAnArray(proposals) {
     if (!Array.isArray(proposals)) {
-      throw new Error('The proposals should be in a list');
+      throw new DomainError('The proposals should be in a list');
     }
   }
 }

--- a/api/src/devcomp/domain/models/element/QCU-for-answer-verification.js
+++ b/api/src/devcomp/domain/models/element/QCU-for-answer-verification.js
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 
+import { DomainError } from '../../../../shared/domain/errors.js';
 import { EntityValidationError } from '../../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 import { Feedbacks } from '../Feedbacks.js';
@@ -31,7 +32,7 @@ class QCUForAnswerVerification extends QCU {
   #assertSolutionIsAnExistingProposal(solution, proposals) {
     const isSolutionAnExistingProposal = proposals.find(({ id: proposalId }) => proposalId === solution);
     if (!isSolutionAnExistingProposal) {
-      throw new Error('The QCU solution id is not an existing proposal id');
+      throw new DomainError('The QCU solution id is not an existing proposal id');
     }
   }
 

--- a/api/src/devcomp/domain/models/element/QCU.js
+++ b/api/src/devcomp/domain/models/element/QCU.js
@@ -1,3 +1,4 @@
+import { DomainError } from '../../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 import { Element } from './Element.js';
 
@@ -17,13 +18,13 @@ class QCU extends Element {
 
   #assertProposalsAreNotEmpty(proposals) {
     if (proposals.length === 0) {
-      throw new Error('The proposals are required for a QCU');
+      throw new DomainError('The proposals are required for a QCU');
     }
   }
 
   #assertProposalsIsAnArray(proposals) {
     if (!Array.isArray(proposals)) {
-      throw new Error('The QCU proposals should be a list');
+      throw new DomainError('The QCU proposals should be a list');
     }
   }
 }

--- a/api/src/devcomp/domain/models/element/QROCM.js
+++ b/api/src/devcomp/domain/models/element/QROCM.js
@@ -1,3 +1,4 @@
+import { DomainError } from '../../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 import { Element } from './Element.js';
 
@@ -18,13 +19,13 @@ class QROCM extends Element {
 
   #assertProposalsAreNotEmpty(proposals) {
     if (proposals.length === 0) {
-      throw new Error('Les propositions sont obligatoires pour un QROCM');
+      throw new DomainError('Les propositions sont obligatoires pour un QROCM');
     }
   }
 
   #assertProposalsIsAnArray(proposals) {
     if (!Array.isArray(proposals)) {
-      throw new Error('Les propositions doivent apparaître dans une liste');
+      throw new DomainError('Les propositions doivent apparaître dans une liste');
     }
   }
 }

--- a/api/src/devcomp/domain/models/module/Details.js
+++ b/api/src/devcomp/domain/models/module/Details.js
@@ -1,3 +1,4 @@
+import { DomainError } from '../../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 
 class Details {
@@ -21,13 +22,13 @@ class Details {
 
   #assertObjectivesIsAnArray(objectives) {
     if (!Array.isArray(objectives)) {
-      throw new Error('The module details should contain a list of objectives');
+      throw new DomainError('The module details should contain a list of objectives');
     }
   }
 
   #assertObjectivesHasMinimumLength(objectives) {
     if (objectives.length < 1) {
-      throw new Error('The module details should contain at least one objective');
+      throw new DomainError('The module details should contain at least one objective');
     }
   }
 }

--- a/api/src/devcomp/domain/models/module/Module.js
+++ b/api/src/devcomp/domain/models/module/Module.js
@@ -1,3 +1,4 @@
+import { DomainError } from '../../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 
 class Module {
@@ -23,13 +24,13 @@ class Module {
       ({ grainId }) => !!grains.find(({ id }) => grainId === id),
     );
     if (!isTransitionTextsLinkedToGrain) {
-      throw new Error('All the transition texts should be linked to a grain contained in the module.');
+      throw new DomainError('All the transition texts should be linked to a grain contained in the module.');
     }
   }
 
   #assertGrainsIsAnArray(grains) {
     if (!Array.isArray(grains)) {
-      throw new Error('A module should have a list of grains');
+      throw new DomainError('A module should have a list of grains');
     }
   }
 }

--- a/api/src/shared/domain/models/asserts.js
+++ b/api/src/shared/domain/models/asserts.js
@@ -1,6 +1,8 @@
+import { DomainError } from '../errors.js';
+
 export function assertNotNullOrUndefined(value, errorMessage = 'Ne doit pas être null ou undefined') {
   if (value === null || value === undefined) {
-    throw new Error(errorMessage);
+    throw new DomainError(errorMessage);
   }
 }
 

--- a/api/tests/devcomp/integration/domain/models/Module_test.js
+++ b/api/tests/devcomp/integration/domain/models/Module_test.js
@@ -1,7 +1,8 @@
 import { Text } from '../../../../../src/devcomp/domain/models/element/Text.js';
 import { Grain } from '../../../../../src/devcomp/domain/models/Grain.js';
 import { Module } from '../../../../../src/devcomp/domain/models/module/Module.js';
-import { expect } from '../../../../test-helper.js';
+import { DomainError } from '../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../test-helper.js';
 
 describe('Integration | Devcomp | Domain | Models | Module', function () {
   describe('When a transition text is related to a missing grain', function () {
@@ -28,9 +29,12 @@ describe('Integration | Devcomp | Domain | Models | Module', function () {
       ];
       const details = Symbol('details');
 
-      expect(() => new Module({ id, slug, title, grains, transitionTexts, details })).to.throw(
-        'All the transition texts should be linked to a grain contained in the module.',
-      );
+      // when
+      const error = catchErrSync(() => new Module({ id, slug, title, grains, transitionTexts, details }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('All the transition texts should be linked to a grain contained in the module.');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/ElementAnswer_test.js
+++ b/api/tests/devcomp/unit/domain/models/ElementAnswer_test.js
@@ -1,5 +1,6 @@
 import { ElementAnswer } from '../../../../../src/devcomp/domain/models/ElementAnswer.js';
-import { expect } from '../../../../test-helper.js';
+import { DomainError } from '../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | ElementAnswer', function () {
   describe('#constructor', function () {
@@ -22,23 +23,36 @@ describe('Unit | Devcomp | Domain | Models | ElementAnswer', function () {
 
     describe('An element answer without element id', function () {
       it('should throw an error', function () {
-        expect(() => new ElementAnswer({})).to.throw('The id of the element is required for an element answer.');
+        // when
+        const error = catchErrSync(() => new ElementAnswer({}))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The id of the element is required for an element answer.');
       });
     });
 
     describe('An element answer without user response value', function () {
       it('should throw an error', function () {
-        expect(() => new ElementAnswer({ elementId: 'elementId' })).to.throw(
-          'The user response is required for an element answer.',
-        );
+        // when
+        const error = catchErrSync(() => new ElementAnswer({ elementId: 'elementId' }))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The user response is required for an element answer.');
       });
     });
 
     describe('An element answer without correction', function () {
       it('should throw an error', function () {
-        expect(() => new ElementAnswer({ elementId: 'elementId', userResponseValue: 'userResponseValue' })).to.throw(
-          'The correction is required for an element answer.',
-        );
+        // when
+        const error = catchErrSync(
+          () => new ElementAnswer({ elementId: 'elementId', userResponseValue: 'userResponseValue' }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The correction is required for an element answer.');
       });
     });
   });

--- a/api/tests/devcomp/unit/domain/models/EmbedCorrectionResponse_test.js
+++ b/api/tests/devcomp/unit/domain/models/EmbedCorrectionResponse_test.js
@@ -1,6 +1,7 @@
 import { EmbedCorrectionResponse } from '../../../../../src/devcomp/domain/models/EmbedCorrectionResponse.js';
 import { AnswerStatus } from '../../../../../src/devcomp/domain/models/validator/AnswerStatus.js';
-import { expect } from '../../../../test-helper.js';
+import { DomainError } from '../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | EmbedCorrectionResponse', function () {
   describe('#constructor', function () {
@@ -21,15 +22,25 @@ describe('Unit | Devcomp | Domain | Models | EmbedCorrectionResponse', function 
 
   describe('A QCU correction response without status', function () {
     it('should throw an error', function () {
-      expect(() => new EmbedCorrectionResponse({})).to.throw('The result is required for an embed response');
+      // when
+      const error = catchErrSync(() => new EmbedCorrectionResponse({}))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The result is required for an embed response');
     });
   });
 
   describe('A QCU correction response without proposal id', function () {
     it('should throw an error', function () {
-      expect(() => new EmbedCorrectionResponse({ status: AnswerStatus.OK, feedback: 'Bien joué !' })).to.throw(
-        'The id of the correct proposal is required for an embed response',
-      );
+      // when
+      const error = catchErrSync(
+        () => new EmbedCorrectionResponse({ status: AnswerStatus.OK, feedback: 'Bien joué !' }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The id of the correct proposal is required for an embed response');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/Feedbacks_test.js
+++ b/api/tests/devcomp/unit/domain/models/Feedbacks_test.js
@@ -1,5 +1,6 @@
 import { Feedbacks } from '../../../../../src/devcomp/domain/models/Feedbacks.js';
-import { expect } from '../../../../test-helper.js';
+import { DomainError } from '../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Feedbacks', function () {
   describe('#constructor', function () {
@@ -22,15 +23,23 @@ describe('Unit | Devcomp | Domain | Models | Feedbacks', function () {
 
   describe('An empty Feedbacks', function () {
     it('should throw an error', function () {
-      expect(() => new Feedbacks({})).to.throw('The feedback message for the field valid is required');
+      // when
+      const error = catchErrSync(() => new Feedbacks({}))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The feedback message for the field valid is required');
     });
   });
 
   describe('A Feedbacks without invalid key', function () {
     it('should throw an error', function () {
-      expect(() => new Feedbacks({ valid: 'valid' })).to.throw(
-        'The feedback message for the field invalid is required',
-      );
+      // when
+      const error = catchErrSync(() => new Feedbacks({ valid: 'valid' }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The feedback message for the field invalid is required');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/Grain_test.js
+++ b/api/tests/devcomp/unit/domain/models/Grain_test.js
@@ -1,5 +1,6 @@
 import { Grain } from '../../../../../src/devcomp/domain/models/Grain.js';
-import { expect } from '../../../../test-helper.js';
+import { DomainError } from '../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Grain', function () {
   describe('#constructor', function () {
@@ -20,13 +21,23 @@ describe('Unit | Devcomp | Domain | Models | Grain', function () {
 
     describe('if a grain does not have an id', function () {
       it('should throw an error', function () {
-        expect(() => new Grain({})).to.throw('The id is required for a grain');
+        // when
+        const error = catchErrSync(() => new Grain({}))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The id is required for a grain');
       });
     });
 
     describe('if a grain does not have a title', function () {
       it('should throw an error', function () {
-        expect(() => new Grain({ id: 1 })).to.throw('The title is required for a grain');
+        // when
+        const error = catchErrSync(() => new Grain({ id: 1 }))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The title is required for a grain');
       });
     });
 
@@ -39,14 +50,14 @@ describe('Unit | Devcomp | Domain | Models | Grain', function () {
     describe('if a grain does have components', function () {
       describe('given a wrong typed grain.components in param', function () {
         it('should throw an error', function () {
-          expect(
-            () =>
-              new Grain({
-                id: 'id_grain_1',
-                title: 'Bien écrire son adresse mail',
-                components: 'components',
-              }),
-          ).to.throw(`Grain components should be a list of components`);
+          // when
+          const error = catchErrSync(
+            () => new Grain({ id: 'id_grain_1', title: 'Bien écrire son adresse mail', components: 'components' }),
+          )();
+
+          // then
+          expect(error).to.be.instanceOf(DomainError);
+          expect(error.message).to.equal('Grain components should be a list of components');
         });
       });
     });

--- a/api/tests/devcomp/unit/domain/models/QcmCorrectionResponse_test.js
+++ b/api/tests/devcomp/unit/domain/models/QcmCorrectionResponse_test.js
@@ -1,6 +1,7 @@
 import { QcmCorrectionResponse } from '../../../../../src/devcomp/domain/models/QcmCorrectionResponse.js';
 import { AnswerStatus } from '../../../../../src/devcomp/domain/models/validator/AnswerStatus.js';
-import { expect } from '../../../../test-helper.js';
+import { DomainError } from '../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | QcmCorrectionResponse', function () {
   describe('#constructor', function () {
@@ -23,23 +24,36 @@ describe('Unit | Devcomp | Domain | Models | QcmCorrectionResponse', function ()
 
   describe('A QCM correction response without status', function () {
     it('should throw an error', function () {
-      expect(() => new QcmCorrectionResponse({})).to.throw('The result is required for a QCM answer');
+      // when
+      const error = catchErrSync(() => new QcmCorrectionResponse({}))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The result is required for a QCM answer');
     });
   });
 
   describe('A QCM correction response without feedback', function () {
     it('should throw an error', function () {
-      expect(() => new QcmCorrectionResponse({ status: AnswerStatus.OK })).to.throw(
-        'The feedback is required for a QCM answer',
-      );
+      // when
+      const error = catchErrSync(() => new QcmCorrectionResponse({ status: AnswerStatus.OK }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The feedback is required for a QCM answer');
     });
   });
 
   describe('A QCM correction response without proposal id', function () {
     it('should throw an error', function () {
-      expect(() => new QcmCorrectionResponse({ status: AnswerStatus.OK, feedback: 'Bien joué !' })).to.throw(
-        'The solutions are required for a QCM answer',
-      );
+      // when
+      const error = catchErrSync(
+        () => new QcmCorrectionResponse({ status: AnswerStatus.OK, feedback: 'Bien joué !' }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The solutions are required for a QCM answer');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/QcmProposal_test.js
+++ b/api/tests/devcomp/unit/domain/models/QcmProposal_test.js
@@ -1,5 +1,6 @@
 import { QcmProposal } from '../../../../../src/devcomp/domain/models/QcmProposal.js';
-import { expect } from '../../../../test-helper.js';
+import { DomainError } from '../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | QcmProposal', function () {
   describe('#constructor', function () {
@@ -20,13 +21,23 @@ describe('Unit | Devcomp | Domain | Models | QcmProposal', function () {
 
   describe('A QCM proposal without id', function () {
     it('should throw an error', function () {
-      expect(() => new QcmProposal({})).to.throw('The id is required for a QCM proposal');
+      // when
+      const error = catchErrSync(() => new QcmProposal({}))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The id is required for a QCM proposal');
     });
   });
 
   describe('A QCM proposal without content', function () {
     it('should throw an error', function () {
-      expect(() => new QcmProposal({ id: '1' })).to.throw('The content is required for a QCM proposal');
+      // when
+      const error = catchErrSync(() => new QcmProposal({ id: '1' }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The content is required for a QCM proposal');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/QcuCorrectionResponse_test.js
+++ b/api/tests/devcomp/unit/domain/models/QcuCorrectionResponse_test.js
@@ -1,6 +1,7 @@
 import { QcuCorrectionResponse } from '../../../../../src/devcomp/domain/models/QcuCorrectionResponse.js';
 import { AnswerStatus } from '../../../../../src/devcomp/domain/models/validator/AnswerStatus.js';
-import { expect } from '../../../../test-helper.js';
+import { DomainError } from '../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | QcuCorrectionResponse', function () {
   describe('#constructor', function () {
@@ -23,23 +24,36 @@ describe('Unit | Devcomp | Domain | Models | QcuCorrectionResponse', function ()
 
   describe('A QCU correction response without status', function () {
     it('should throw an error', function () {
-      expect(() => new QcuCorrectionResponse({})).to.throw('The result is required for a QCU response');
+      // when
+      const error = catchErrSync(() => new QcuCorrectionResponse({}))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The result is required for a QCU response');
     });
   });
 
   describe('A QCU correction response without feedback', function () {
     it('should throw an error', function () {
-      expect(() => new QcuCorrectionResponse({ status: AnswerStatus.OK })).to.throw(
-        'The feedback is required for a QCU response',
-      );
+      // when
+      const error = catchErrSync(() => new QcuCorrectionResponse({ status: AnswerStatus.OK }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The feedback is required for a QCU response');
     });
   });
 
   describe('A QCU correction response without proposal id', function () {
     it('should throw an error', function () {
-      expect(() => new QcuCorrectionResponse({ status: AnswerStatus.OK, feedback: 'Bien joué !' })).to.throw(
-        'The id of the correct proposal is required for a QCU response',
-      );
+      // when
+      const error = catchErrSync(
+        () => new QcuCorrectionResponse({ status: AnswerStatus.OK, feedback: 'Bien joué !' }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The id of the correct proposal is required for a QCU response');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/QcuProposal_test.js
+++ b/api/tests/devcomp/unit/domain/models/QcuProposal_test.js
@@ -1,5 +1,6 @@
 import { QcuProposal } from '../../../../../src/devcomp/domain/models/QcuProposal.js';
-import { expect } from '../../../../test-helper.js';
+import { DomainError } from '../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | QcuProposal', function () {
   describe('#constructor', function () {
@@ -20,13 +21,23 @@ describe('Unit | Devcomp | Domain | Models | QcuProposal', function () {
 
   describe('A QCU proposal without id', function () {
     it('should throw an error', function () {
-      expect(() => new QcuProposal({})).to.throw('The id is required for a QCU proposal.');
+      // when
+      const error = catchErrSync(() => new QcuProposal({}))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The id is required for a QCU proposal.');
     });
   });
 
   describe('A QCU proposal without content', function () {
     it('should throw an error', function () {
-      expect(() => new QcuProposal({ id: '1' })).to.throw('The content is required for a QCU proposal.');
+      // when
+      const error = catchErrSync(() => new QcuProposal({ id: '1' }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The content is required for a QCU proposal.');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/QrocmCorrectionResponse_test.js
+++ b/api/tests/devcomp/unit/domain/models/QrocmCorrectionResponse_test.js
@@ -1,6 +1,7 @@
 import { QrocmCorrectionResponse } from '../../../../../src/devcomp/domain/models/QrocmCorrectionResponse.js';
 import { AnswerStatus } from '../../../../../src/devcomp/domain/models/validator/AnswerStatus.js';
-import { expect } from '../../../../test-helper.js';
+import { DomainError } from '../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | QrocmCorrectionResponse', function () {
   describe('#constructor', function () {
@@ -23,23 +24,36 @@ describe('Unit | Devcomp | Domain | Models | QrocmCorrectionResponse', function 
 
   describe('A QROCM correction response without status', function () {
     it('should throw an error', function () {
-      expect(() => new QrocmCorrectionResponse({})).to.throw('The result is required in a QROCM correction');
+      // when
+      const error = catchErrSync(() => new QrocmCorrectionResponse({}))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The result is required in a QROCM correction');
     });
   });
 
   describe('A QROCM correction response without feedback', function () {
     it('should throw an error', function () {
-      expect(() => new QrocmCorrectionResponse({ status: AnswerStatus.OK })).to.throw(
-        'The feedback is required in a QROCM correction',
-      );
+      // when
+      const error = catchErrSync(() => new QrocmCorrectionResponse({ status: AnswerStatus.OK }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The feedback is required in a QROCM correction');
     });
   });
 
   describe('A QROCM correction response without solutions', function () {
     it('should throw an error', function () {
-      expect(() => new QrocmCorrectionResponse({ status: AnswerStatus.OK, feedback: 'Bien joué !' })).to.throw(
-        'The solution is required in a QROCM correction',
-      );
+      // when
+      const error = catchErrSync(
+        () => new QrocmCorrectionResponse({ status: AnswerStatus.OK, feedback: 'Bien joué !' }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The solution is required in a QROCM correction');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/QrocmSolutions_test.js
+++ b/api/tests/devcomp/unit/domain/models/QrocmSolutions_test.js
@@ -1,5 +1,6 @@
 import { QrocmSolutions } from '../../../../../src/devcomp/domain/models/QrocmSolutions.js';
-import { expect } from '../../../../test-helper.js';
+import { DomainError } from '../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | QrocmSolutions', function () {
   describe('#constructor', function () {
@@ -60,7 +61,8 @@ describe('Unit | Devcomp | Domain | Models | QrocmSolutions', function () {
 
     describe('A QROCM solution with missing solutions into a proposal', function () {
       it('should throw an error', function () {
-        expect(
+        // when
+        const error = catchErrSync(
           () =>
             new QrocmSolutions([
               {
@@ -75,13 +77,18 @@ describe('Unit | Devcomp | Domain | Models | QrocmSolutions', function () {
                 tolerances: ['t1', 't2'],
               },
             ]),
-        ).to.throw('The solutions are required for each QROCM proposal in QROCM solutions');
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The solutions are required for each QROCM proposal in QROCM solutions');
       });
     });
 
     describe('A QROCM solution with missing tolerances into a proposal', function () {
       it('should throw an error', function () {
-        expect(
+        // when
+        const error = catchErrSync(
           () =>
             new QrocmSolutions([
               {
@@ -96,13 +103,18 @@ describe('Unit | Devcomp | Domain | Models | QrocmSolutions', function () {
                 solutions: ['@'],
               },
             ]),
-        ).to.throw('The tolerances are required for each QROCM proposal in QROCM solutions');
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The tolerances are required for each QROCM proposal in QROCM solutions');
       });
     });
 
     describe('A QROCM solution with solutions which is not a list', function () {
       it('should throw an error', function () {
-        expect(
+        // when
+        const error = catchErrSync(
           () =>
             new QrocmSolutions([
               {
@@ -118,13 +130,18 @@ describe('Unit | Devcomp | Domain | Models | QrocmSolutions', function () {
                 solutions: '@',
               },
             ]),
-        ).to.throw('Each proposal in QROCM solutions should have a list of solutions');
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('Each proposal in QROCM solutions should have a list of solutions');
       });
     });
 
     describe('A QROCM solution with tolerances which is not a list', function () {
       it('should throw an error', function () {
-        expect(
+        // when
+        const error = catchErrSync(
           () =>
             new QrocmSolutions([
               {
@@ -140,7 +157,11 @@ describe('Unit | Devcomp | Domain | Models | QrocmSolutions', function () {
                 tolerances: 't1',
               },
             ]),
-        ).to.throw('A QROCM solution should have a list of tolerances');
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('A QROCM solution should have a list of tolerances');
       });
     });
   });

--- a/api/tests/devcomp/unit/domain/models/TransitionText_test.js
+++ b/api/tests/devcomp/unit/domain/models/TransitionText_test.js
@@ -1,5 +1,6 @@
 import { TransitionText } from '../../../../../src/devcomp/domain/models/TransitionText.js';
-import { expect } from '../../../../test-helper.js';
+import { DomainError } from '../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | TransitionText', function () {
   describe('#constructor', function () {
@@ -15,13 +16,23 @@ describe('Unit | Devcomp | Domain | Models | TransitionText', function () {
 
   describe('if a transition text does not have a content', function () {
     it('should throw an error', function () {
-      expect(() => new TransitionText({})).to.throw('The content is required for a transition text');
+      // when
+      const error = catchErrSync(() => new TransitionText({}))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The content is required for a transition text');
     });
   });
 
   describe('if a transition text does not have a grain id', function () {
     it('should throw an error', function () {
-      expect(() => new TransitionText({ content: '' })).to.throw('The grain id is required for a transition text');
+      // when
+      const error = catchErrSync(() => new TransitionText({ content: '' }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The grain id is required for a transition text');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/block/BlockInput_test.js
+++ b/api/tests/devcomp/unit/domain/models/block/BlockInput_test.js
@@ -1,5 +1,6 @@
 import { BlockInput } from '../../../../../../src/devcomp/domain/models/block/BlockInput.js';
-import { expect } from '../../../../../test-helper.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
   describe('#constructor', function () {
@@ -36,78 +37,78 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
 
   describe('If input is missing', function () {
     it('should throw an error', function () {
-      expect(() => new BlockInput({})).to.throw('The input is required for an input block');
+      // when
+      const error = catchErrSync(() => new BlockInput({}))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The input is required for an input block');
     });
   });
 
   describe('If inputType is missing', function () {
     it('should throw an error', function () {
-      expect(
-        () =>
-          new BlockInput({
-            input: 'symbole',
-          }),
-      ).to.throw('The input type is required for an input block');
+      // when
+      const error = catchErrSync(() => new BlockInput({ input: 'symbole' }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The input type is required for an input block');
     });
   });
 
   describe('If size is missing', function () {
     it('should throw an error', function () {
-      expect(
-        () =>
-          new BlockInput({
-            input: 'symbole',
-            inputType: 'text',
-          }),
-      ).to.throw('The size is required for an input block');
+      // when
+      const error = catchErrSync(() => new BlockInput({ input: 'symbole', inputType: 'text' }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The size is required for an input block');
     });
   });
 
   describe('If display is missing', function () {
     it('should throw an error', function () {
-      expect(
-        () =>
-          new BlockInput({
-            input: 'symbole',
-            inputType: 'text',
-            size: 1,
-          }),
-      ).to.throw('The display is required for an input block');
+      // when
+      const error = catchErrSync(() => new BlockInput({ input: 'symbole', inputType: 'text', size: 1 }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The display is required for an input block');
     });
   });
 
   describe('If placeholder is missing', function () {
     it('should throw an error', function () {
-      expect(
-        () =>
-          new BlockInput({
-            input: 'symbole',
-            inputType: 'text',
-            size: 1,
-            display: 'inline',
-          }),
-      ).to.throw('The placeholder is required for an input block');
+      // when
+      const error = catchErrSync(
+        () => new BlockInput({ input: 'symbole', inputType: 'text', size: 1, display: 'inline' }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The placeholder is required for an input block');
     });
   });
 
   describe('If ariaLabel is missing', function () {
     it('should throw an error', function () {
-      expect(
-        () =>
-          new BlockInput({
-            input: 'symbole',
-            inputType: 'text',
-            size: 1,
-            display: 'inline',
-            placeholder: '',
-          }),
-      ).to.throw('The aria Label is required for an input block');
+      // when
+      const error = catchErrSync(
+        () => new BlockInput({ input: 'symbole', inputType: 'text', size: 1, display: 'inline', placeholder: '' }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The aria Label is required for an input block');
     });
   });
 
   describe('If defaultValue is missing', function () {
     it('should throw an error', function () {
-      expect(
+      // when
+      const error = catchErrSync(
         () =>
           new BlockInput({
             input: 'symbole',
@@ -117,13 +118,18 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
             placeholder: '',
             ariaLabel: 'Réponse 1',
           }),
-      ).to.throw('The default value is required for an input block');
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The default value is required for an input block');
     });
   });
 
   describe('If tolerances are missing', function () {
     it('should throw an error', function () {
-      expect(
+      // when
+      const error = catchErrSync(
         () =>
           new BlockInput({
             input: 'symbole',
@@ -134,13 +140,18 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
             ariaLabel: 'Réponse 1',
             defaultValue: '',
           }),
-      ).to.throw('The tolerances are required for an input block');
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The tolerances are required for an input block');
     });
   });
 
   describe('If solutions are missing', function () {
     it('should throw an error', function () {
-      expect(
+      // when
+      const error = catchErrSync(
         () =>
           new BlockInput({
             input: 'symbole',
@@ -152,7 +163,11 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
             defaultValue: '',
             tolerances: ['t1'],
           }),
-      ).to.throw('The solutions are required for an input block');
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The solutions are required for an input block');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/block/BlockSelectOption_test.js
+++ b/api/tests/devcomp/unit/domain/models/block/BlockSelectOption_test.js
@@ -1,5 +1,6 @@
 import { BlockSelectOption } from '../../../../../../src/devcomp/domain/models/block/BlockSelectOption.js';
-import { expect } from '../../../../../test-helper.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Block | BlockSelectOption', function () {
   describe('#constructor', function () {
@@ -15,13 +16,23 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockSelectOption', functio
 
   describe('If id is missing', function () {
     it('should throw an error', function () {
-      expect(() => new BlockSelectOption({})).to.throw('The id is required for a select block option');
+      // when
+      const error = catchErrSync(() => new BlockSelectOption({}))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The id is required for a select block option');
     });
   });
 
   describe('If content is missing', function () {
     it('should throw an error', function () {
-      expect(() => new BlockSelectOption({ id: '1' })).to.throw('The content is required for a select block option');
+      // when
+      const error = catchErrSync(() => new BlockSelectOption({ id: '1' }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The content is required for a select block option');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/block/BlockSelect_test.js
+++ b/api/tests/devcomp/unit/domain/models/block/BlockSelect_test.js
@@ -1,5 +1,6 @@
 import { BlockSelect } from '../../../../../../src/devcomp/domain/models/block/BlockSelect.js';
-import { expect } from '../../../../../test-helper.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Block | BlockSelect', function () {
   describe('#constructor', function () {
@@ -34,49 +35,54 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockSelect', function () {
 
   describe('If input is missing', function () {
     it('should throw an error', function () {
-      expect(() => new BlockSelect({})).to.throw('The input is required for a select block');
+      // when
+      const error = catchErrSync(() => new BlockSelect({}))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The input is required for a select block');
     });
   });
 
   describe('If display is missing', function () {
     it('should throw an error', function () {
-      expect(
-        () =>
-          new BlockSelect({
-            input: 'symbole',
-          }),
-      ).to.throw('The display is required for a select block');
+      // when
+      const error = catchErrSync(() => new BlockSelect({ input: 'symbole' }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The display is required for a select block');
     });
   });
 
   describe('If placeholder is missing', function () {
     it('should throw an error', function () {
-      expect(
-        () =>
-          new BlockSelect({
-            input: 'symbole',
-            display: 'inline',
-          }),
-      ).to.throw('The placeholder is required for a select block');
+      // when
+      const error = catchErrSync(() => new BlockSelect({ input: 'symbole', display: 'inline' }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The placeholder is required for a select block');
     });
   });
 
   describe('If ariaLabel is missing', function () {
     it('should throw an error', function () {
-      expect(
-        () =>
-          new BlockSelect({
-            input: 'symbole',
-            display: 'inline',
-            placeholder: 'a placeholder',
-          }),
-      ).to.throw('The aria Label is required for a select block');
+      // when
+      const error = catchErrSync(
+        () => new BlockSelect({ input: 'symbole', display: 'inline', placeholder: 'a placeholder' }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The aria Label is required for a select block');
     });
   });
 
   describe('If defaultValue is missing', function () {
     it('should throw an error', function () {
-      expect(
+      // when
+      const error = catchErrSync(
         () =>
           new BlockSelect({
             input: 'symbole',
@@ -84,13 +90,18 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockSelect', function () {
             placeholder: 'a placeholder',
             ariaLabel: 'Réponse 1',
           }),
-      ).to.throw('The default value is required for a select block');
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The default value is required for a select block');
     });
   });
 
   describe('If tolerances are missing', function () {
     it('should throw an error', function () {
-      expect(
+      // when
+      const error = catchErrSync(
         () =>
           new BlockSelect({
             input: 'symbole',
@@ -99,13 +110,18 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockSelect', function () {
             ariaLabel: 'Réponse 1',
             defaultValue: 'default',
           }),
-      ).to.throw('The tolerances are required for a select block');
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The tolerances are required for a select block');
     });
   });
 
   describe('If options are missing', function () {
     it('should throw an error', function () {
-      expect(
+      // when
+      const error = catchErrSync(
         () =>
           new BlockSelect({
             input: 'symbole',
@@ -115,13 +131,18 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockSelect', function () {
             defaultValue: 'default',
             tolerances: ['t1'],
           }),
-      ).to.throw('The options are required for a select block');
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The options are required for a select block');
     });
   });
 
   describe('If solutions are missing', function () {
     it('should throw an error', function () {
-      expect(
+      // when
+      const error = catchErrSync(
         () =>
           new BlockSelect({
             input: 'symbole',
@@ -132,7 +153,11 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockSelect', function () {
             tolerances: ['t1'],
             options: [Symbol('option')],
           }),
-      ).to.throw('The solutions are required for a select block');
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The solutions are required for a select block');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/block/BlockText_test.js
+++ b/api/tests/devcomp/unit/domain/models/block/BlockText_test.js
@@ -1,5 +1,6 @@
 import { BlockText } from '../../../../../../src/devcomp/domain/models/block/BlockText.js';
-import { expect } from '../../../../../test-helper.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Block | BlockText', function () {
   describe('#constructor', function () {
@@ -15,7 +16,12 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockText', function () {
 
   describe('If content is missing', function () {
     it('should throw an error', function () {
-      expect(() => new BlockText({})).to.throw('The content is required for a text block');
+      // when
+      const error = catchErrSync(() => new BlockText({}))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The content is required for a text block');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/component/ComponentElement_test.js
+++ b/api/tests/devcomp/unit/domain/models/component/ComponentElement_test.js
@@ -1,5 +1,6 @@
 import { ComponentElement } from '../../../../../../src/devcomp/domain/models/component/ComponentElement.js';
-import { expect } from '../../../../../test-helper.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Component | ComponentElement', function () {
   describe('#constructor', function () {
@@ -19,7 +20,12 @@ describe('Unit | Devcomp | Domain | Models | Component | ComponentElement', func
 
   describe('if a componentElement does not have an element', function () {
     it('should throw an error', function () {
-      expect(() => new ComponentElement({})).to.throw('An element is required for a componentElement');
+      // when
+      const error = catchErrSync(() => new ComponentElement({}))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('An element is required for a componentElement');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/component/ComponentStepper_test.js
+++ b/api/tests/devcomp/unit/domain/models/component/ComponentStepper_test.js
@@ -1,5 +1,6 @@
 import { ComponentStepper } from '../../../../../../src/devcomp/domain/models/component/ComponentStepper.js';
-import { expect } from '../../../../../test-helper.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Component | ComponentStepper', function () {
   describe('#constructor', function () {
@@ -19,17 +20,23 @@ describe('Unit | Devcomp | Domain | Models | Component | ComponentStepper', func
 
   describe('if a componentStepper does not have steps', function () {
     it('should throw an error', function () {
-      expect(() => new ComponentStepper({})).to.throw('Steps are required for a componentStepper');
+      // when
+      const error = catchErrSync(() => new ComponentStepper({}))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('Steps are required for a componentStepper');
     });
   });
 
   describe('when a componentStepper does not have an array of Steps', function () {
     it('should throw an error', function () {
-      // given
-      const steps = 'steps';
+      // when
+      const error = catchErrSync(() => new ComponentStepper({ steps: 'steps' }))();
 
-      // when/then
-      expect(() => new ComponentStepper({ steps })).to.throw('Steps should be an array');
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('Steps should be an array');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/component/Step_test.js
+++ b/api/tests/devcomp/unit/domain/models/component/Step_test.js
@@ -1,5 +1,6 @@
 import { Step } from '../../../../../../src/devcomp/domain/models/component/Step.js';
-import { expect } from '../../../../../test-helper.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Component | Step', function () {
   describe('#constructor', function () {
@@ -17,22 +18,34 @@ describe('Unit | Devcomp | Domain | Models | Component | Step', function () {
 
   describe('when a step does not have elements', function () {
     it('should throw an error', function () {
-      // when/then
-      expect(() => new Step({})).to.throw('A step should contain elements');
+      // when
+      const error = catchErrSync(() => new Step({}))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('A step should contain elements');
     });
   });
 
   describe('when the elements of a Step is not a list', function () {
     it('should throw an error', function () {
-      // when/then
-      expect(() => new Step({ elements: 'not a list' })).to.throw('step.elements should be an array');
+      // when
+      const error = catchErrSync(() => new Step({ elements: 'not a list' }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('step.elements should be an array');
     });
   });
 
   describe('when a step has an empty list of elements', function () {
     it('should throw an error', function () {
-      // when/then
-      expect(() => new Step({ elements: [] })).to.throw('A step should contain at least one element');
+      // when
+      const error = catchErrSync(() => new Step({ elements: [] }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('A step should contain at least one element');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/element/Download_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Download_test.js
@@ -1,5 +1,6 @@
 import { Download } from '../../../../../../src/devcomp/domain/models/element/Download.js';
-import { expect } from '../../../../../test-helper.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | Download', function () {
   describe('#constructor', function () {
@@ -21,34 +22,57 @@ describe('Unit | Devcomp | Domain | Models | Element | Download', function () {
     describe('errors', function () {
       describe('A Download without an id', function () {
         it('should throw an error', function () {
-          expect(() => new Download({})).to.throw('The id is required for an element');
+          // when
+          const error = catchErrSync(() => new Download({}))();
+
+          // then
+          expect(error).to.be.instanceOf(DomainError);
+          expect(error.message).to.equal('The id is required for an element');
         });
       });
 
       describe('A Download without files', function () {
         it('should throw an error', function () {
-          expect(() => new Download({ id: '123' })).to.throw('The Download files should be a list');
+          // when
+          const error = catchErrSync(() => new Download({ id: '123' }))();
+
+          // then
+          expect(error).to.be.instanceOf(DomainError);
+          expect(error.message).to.equal('The Download files should be a list');
         });
       });
 
       describe('A Download with an empty list of files', function () {
         it('should throw an error', function () {
-          expect(() => new Download({ id: '123', files: [] })).to.throw('The files are required for a Download');
+          // when
+          const error = catchErrSync(() => new Download({ id: '123', files: [] }))();
+
+          // then
+          expect(error).to.be.instanceOf(DomainError);
+          expect(error.message).to.equal('The files are required for a Download');
         });
       });
 
       describe('files', function () {
         describe('A file with no URL', function () {
           it('should throw an error', function () {
-            expect(() => new Download({ id: '123', files: [{}] })).to.throw('The Download files should have an URL');
+            // when
+            const error = catchErrSync(() => new Download({ id: '123', files: [{}] }))();
+
+            // then
+            expect(error).to.be.instanceOf(DomainError);
+            expect(error.message).to.equal('The Download files should have an URL');
           });
         });
 
         describe('A file with no format', function () {
           it('should throw an error', function () {
-            expect(() => new Download({ id: '123', files: [{ url: 'https://example.org' }] })).to.throw(
-              'The Download files should have a format',
-            );
+            // when
+            const error = catchErrSync(() => new Download({ id: '123', files: [{ url: 'https://example.org' }] }))();
+
+            // then
+            expect(error).to.be.instanceOf(DomainError);
+            expect(error.message).to.equal('The Download files should have a format');
           });
         });
       });

--- a/api/tests/devcomp/unit/domain/models/element/Embed-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Embed-for-answer-verification_test.js
@@ -1,7 +1,7 @@
 import { EmbedForAnswerVerification } from '../../../../../../src/devcomp/domain/models/element/Embed-for-answer-verification.js';
 import { EmbedCorrectionResponse } from '../../../../../../src/devcomp/domain/models/EmbedCorrectionResponse.js';
-import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
-import { expect, sinon } from '../../../../../test-helper.js';
+import { DomainError, EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | EmbedForAnswerVerification', function () {
   describe('#constructor', function () {
@@ -28,7 +28,8 @@ describe('Unit | Devcomp | Domain | Models | Element | EmbedForAnswerVerificatio
 
     describe('An embed For Verification without a solution', function () {
       it('should throw an error', function () {
-        expect(
+        // when
+        const error = catchErrSync(
           () =>
             new EmbedForAnswerVerification({
               id: '123',
@@ -37,7 +38,11 @@ describe('Unit | Devcomp | Domain | Models | Element | EmbedForAnswerVerificatio
               url: 'https://embed.example.net',
               instruction: 'toto',
             }),
-        ).to.throw('The solution is required for a verification embed');
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The solution is required for a verification embed');
       });
     });
   });
@@ -197,8 +202,11 @@ describe('Unit | Devcomp | Domain | Models | Element | EmbedForAnswerVerificatio
             solution: embedSolution,
           });
 
-          // when/then
-          expect(() => embed.setUserResponse(userResponse)).to.throw(EntityValidationError);
+          // when
+          const error = catchErrSync(() => embed.setUserResponse(userResponse))();
+
+          // then
+          expect(error).to.be.instanceOf(EntityValidationError);
         });
       });
     });

--- a/api/tests/devcomp/unit/domain/models/element/Embed_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Embed_test.js
@@ -1,5 +1,6 @@
 import { Embed } from '../../../../../../src/devcomp/domain/models/element/Embed.js';
-import { expect } from '../../../../../test-helper.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | Embed', function () {
   describe('#constructor', function () {
@@ -66,37 +67,58 @@ describe('Unit | Devcomp | Domain | Models | Element | Embed', function () {
     describe('errors', function () {
       describe('An embed without an id', function () {
         it('should throw an error', function () {
-          expect(() => new Embed({})).to.throw('The id is required for an element');
+          // when
+          const error = catchErrSync(() => new Embed({}))();
+
+          // then
+          expect(error).to.be.instanceOf(DomainError);
+          expect(error.message).to.equal('The id is required for an element');
         });
       });
 
       describe('An embed without the isCompletionRequired attribute', function () {
         it('should throw an error', function () {
-          expect(() => new Embed({ id: 'id' })).to.throw('The isCompletionRequired attribute is required for an embed');
+          // when
+          const error = catchErrSync(() => new Embed({ id: 'id' }))();
+
+          // then
+          expect(error).to.be.instanceOf(DomainError);
+          expect(error.message).to.equal('The isCompletionRequired attribute is required for an embed');
         });
       });
 
       describe('An embed without a title', function () {
         it('should throw an error', function () {
-          expect(() => new Embed({ id: 'id', isCompletionRequired: false })).to.throw(
-            'The title is required for an embed',
-          );
+          // when
+          const error = catchErrSync(() => new Embed({ id: 'id', isCompletionRequired: false }))();
+
+          // then
+          expect(error).to.be.instanceOf(DomainError);
+          expect(error.message).to.equal('The title is required for an embed');
         });
       });
 
       describe('An embed without an url', function () {
         it('should throw an error', function () {
-          expect(() => new Embed({ id: 'id', isCompletionRequired: false, title: 'title' })).to.throw(
-            'The url is required for an embed',
-          );
+          // when
+          const error = catchErrSync(() => new Embed({ id: 'id', isCompletionRequired: false, title: 'title' }))();
+
+          // then
+          expect(error).to.be.instanceOf(DomainError);
+          expect(error.message).to.equal('The url is required for an embed');
         });
       });
 
       describe('An embed without a height', function () {
         it('should throw an error', function () {
-          expect(
+          // when
+          const error = catchErrSync(
             () => new Embed({ id: 'id', isCompletionRequired: false, title: 'title', url: 'https://example.org' }),
-          ).to.throw('The height is required for an embed');
+          )();
+
+          // then
+          expect(error).to.be.instanceOf(DomainError);
+          expect(error.message).to.equal('The height is required for an embed');
         });
       });
     });

--- a/api/tests/devcomp/unit/domain/models/element/Image_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Image_test.js
@@ -1,5 +1,6 @@
 import { Image } from '../../../../../../src/devcomp/domain/models/element/Image.js';
-import { expect } from '../../../../../test-helper.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | Image', function () {
   describe('#constructor', function () {
@@ -18,27 +19,45 @@ describe('Unit | Devcomp | Domain | Models | Element | Image', function () {
 
   describe('An image without id', function () {
     it('should throw an error', function () {
-      expect(() => new Image({})).to.throw('The id is required for an element');
+      // when
+      const error = catchErrSync(() => new Image({}))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The id is required for an element');
     });
   });
 
   describe('An image without url', function () {
     it('should throw an error', function () {
-      expect(() => new Image({ id: 'id' })).to.throw('The URL is required for an image');
+      // when
+      const error = catchErrSync(() => new Image({ id: 'id' }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The URL is required for an image');
     });
   });
 
   describe('An image without alt', function () {
     it('should throw an error', function () {
-      expect(() => new Image({ id: 'id', url: 'url' })).to.throw('The alt text is required for an image');
+      // when
+      const error = catchErrSync(() => new Image({ id: 'id', url: 'url' }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The alt text is required for an image');
     });
   });
 
   describe('An image without an alternative Instruction', function () {
     it('should throw an error', function () {
-      expect(() => new Image({ id: 'id', url: 'url', alt: 'alt' })).to.throw(
-        'The alternative instruction is required for an image',
-      );
+      // when
+      const error = catchErrSync(() => new Image({ id: 'id', url: 'url', alt: 'alt' }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The alternative instruction is required for an image');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/element/QCM-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCM-for-answer-verification_test.js
@@ -2,8 +2,8 @@ import { QCMForAnswerVerification } from '../../../../../../src/devcomp/domain/m
 import { Feedbacks } from '../../../../../../src/devcomp/domain/models/Feedbacks.js';
 import { QcmCorrectionResponse } from '../../../../../../src/devcomp/domain/models/QcmCorrectionResponse.js';
 import { ValidatorQCM } from '../../../../../../src/devcomp/domain/models/validator/ValidatorQCM.js';
-import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
-import { expect, sinon } from '../../../../../test-helper.js';
+import { DomainError, EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | QcmForAnswerVerification', function () {
   describe('#constructor', function () {
@@ -38,14 +38,19 @@ describe('Unit | Devcomp | Domain | Models | Element | QcmForAnswerVerification'
 
     describe('A QCM For Verification without a solution', function () {
       it('should throw an error', function () {
-        expect(
+        // when
+        const error = catchErrSync(
           () =>
             new QCMForAnswerVerification({
               id: '123',
               instruction: 'toto',
               proposals: [Symbol('proposal1')],
             }),
-        ).to.throw('The solutions are required for a QCM for verification');
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The solutions are required for a QCM for verification');
       });
     });
   });
@@ -212,8 +217,12 @@ describe('Unit | Devcomp | Domain | Models | Element | QcmForAnswerVerification'
             solutions: qcmSolutions,
           });
 
-          // when/then
-          expect(() => qcm.setUserResponse(userResponse)).to.throw(EntityValidationError);
+          // when
+          const error = catchErrSync(() => qcm.setUserResponse(userResponse))();
+
+          // then
+          expect(error).to.be.instanceOf(EntityValidationError);
+          expect(error.message).to.equal("Échec de validation de l'entité.");
         });
       });
     });

--- a/api/tests/devcomp/unit/domain/models/element/QCM_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCM_test.js
@@ -1,5 +1,6 @@
 import { QCM } from '../../../../../../src/devcomp/domain/models/element/QCM.js';
-import { expect } from '../../../../../test-helper.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | QCM', function () {
   describe('#constructor', function () {
@@ -28,29 +29,45 @@ describe('Unit | Devcomp | Domain | Models | Element | QCM', function () {
 
   describe('A QCM without id', function () {
     it('should throw an error', function () {
-      expect(() => new QCM({})).to.throw('The id is required for an element');
+      // when
+      const error = catchErrSync(() => new QCM({}))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The id is required for an element');
     });
   });
 
   describe('A QCM without instruction', function () {
     it('should throw an error', function () {
-      expect(() => new QCM({ id: '123' })).to.throw('The instruction is required for a QCM');
+      // when
+      const error = catchErrSync(() => new QCM({ id: '123' }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The instruction is required for a QCM');
     });
   });
 
   describe('A QCM with an empty list of proposals', function () {
     it('should throw an error', function () {
-      expect(() => new QCM({ id: '123', instruction: 'toto', proposals: [] })).to.throw(
-        'The proposals are required for a QCM',
-      );
+      // when
+      const error = catchErrSync(() => new QCM({ id: '123', instruction: 'toto', proposals: [] }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The proposals are required for a QCM');
     });
   });
 
   describe('A QCM does not have a list of proposals', function () {
     it('should throw an error', function () {
-      expect(() => new QCM({ id: '123', instruction: 'toto', proposals: 'toto' })).to.throw(
-        'The proposals should be in a list',
-      );
+      // when
+      const error = catchErrSync(() => new QCM({ id: '123', instruction: 'toto', proposals: 'toto' }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The proposals should be in a list');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/element/QCU-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCU-for-answer-verification_test.js
@@ -1,8 +1,8 @@
 import { QCUForAnswerVerification } from '../../../../../../src/devcomp/domain/models/element/QCU-for-answer-verification.js';
 import { Feedbacks } from '../../../../../../src/devcomp/domain/models/Feedbacks.js';
 import { QcuCorrectionResponse } from '../../../../../../src/devcomp/domain/models/QcuCorrectionResponse.js';
-import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
-import { expect, sinon } from '../../../../../test-helper.js';
+import { DomainError, EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | QcuForAnswerVerification', function () {
   describe('#constructor', function () {
@@ -35,20 +35,21 @@ describe('Unit | Devcomp | Domain | Models | Element | QcuForAnswerVerification'
 
     describe('A QCU For Verification without a solution', function () {
       it('should throw an error', function () {
-        expect(
-          () =>
-            new QCUForAnswerVerification({
-              id: '123',
-              instruction: 'toto',
-              proposals: [Symbol('proposal1')],
-            }),
-        ).to.throw('The solution is required for a verification QCU');
+        // when
+        const error = catchErrSync(
+          () => new QCUForAnswerVerification({ id: '123', instruction: 'toto', proposals: [Symbol('proposal1')] }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The solution is required for a verification QCU');
       });
     });
 
     describe('A QCU For Verification with an unexisting solution', function () {
       it('should throw an error', function () {
-        expect(
+        // when
+        const error = catchErrSync(
           () =>
             new QCUForAnswerVerification({
               id: '123',
@@ -56,7 +57,11 @@ describe('Unit | Devcomp | Domain | Models | Element | QcuForAnswerVerification'
               proposals: [Symbol('proposal1')],
               solution: Symbol('unexistingProposalId'),
             }),
-        ).to.throw('The QCU solution id is not an existing proposal id');
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The QCU solution id is not an existing proposal id');
       });
     });
   });
@@ -215,8 +220,11 @@ describe('Unit | Devcomp | Domain | Models | Element | QcuForAnswerVerification'
             solution: qcuSolution,
           });
 
-          // when/then
-          expect(() => qcu.setUserResponse(userResponse)).to.throw(EntityValidationError);
+          // when
+          const error = catchErrSync(() => qcu.setUserResponse(userResponse))();
+
+          // then
+          expect(error).to.be.instanceOf(EntityValidationError);
         });
       });
     });

--- a/api/tests/devcomp/unit/domain/models/element/QCU_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCU_test.js
@@ -1,5 +1,6 @@
 import { QCU } from '../../../../../../src/devcomp/domain/models/element/QCU.js';
-import { expect } from '../../../../../test-helper.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | QCU', function () {
   describe('#constructor', function () {
@@ -28,29 +29,45 @@ describe('Unit | Devcomp | Domain | Models | Element | QCU', function () {
 
   describe('A QCU without id', function () {
     it('should throw an error', function () {
-      expect(() => new QCU({})).to.throw('The id is required for an element');
-    });
-  });
+      // when
+      const error = catchErrSync(() => new QCU({}))();
 
-  describe('A QCU without instruction', function () {
-    it('should throw an error', function () {
-      expect(() => new QCU({ id: '123' })).to.throw('The instruction is required for a QCU');
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The id is required for an element');
     });
-  });
 
-  describe('A QCU with an empty list of proposals', function () {
-    it('should throw an error', function () {
-      expect(() => new QCU({ id: '123', instruction: 'toto', proposals: [] })).to.throw(
-        'The proposals are required for a QCU',
-      );
+    describe('A QCU without instruction', function () {
+      it('should throw an error', function () {
+        // when
+        const error = catchErrSync(() => new QCU({ id: '123' }))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The instruction is required for a QCU');
+      });
     });
-  });
 
-  describe('A QCU does not have a list of proposals', function () {
-    it('should throw an error', function () {
-      expect(() => new QCU({ id: '123', instruction: 'toto', proposals: 'toto' })).to.throw(
-        'The QCU proposals should be a list',
-      );
+    describe('A QCU with an empty list of proposals', function () {
+      it('should throw an error', function () {
+        // when
+        const error = catchErrSync(() => new QCU({ id: '123', instruction: 'toto', proposals: [] }))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The proposals are required for a QCU');
+      });
+    });
+
+    describe('A QCU does not have a list of proposals', function () {
+      it('should throw an error', function () {
+        // when
+        const error = catchErrSync(() => new QCU({ id: '123', instruction: 'toto', proposals: 'toto' }))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The QCU proposals should be a list');
+      });
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/element/QROCM-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QROCM-for-answer-verification_test.js
@@ -1,7 +1,7 @@
 import { QROCMForAnswerVerification } from '../../../../../../src/devcomp/domain/models/element/QROCM-for-answer-verification.js';
 import { QrocmCorrectionResponse } from '../../../../../../src/devcomp/domain/models/QrocmCorrectionResponse.js';
-import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
-import { expect, sinon } from '../../../../../test-helper.js';
+import { DomainError, EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | QrocMForAnswerVerification', function () {
   describe('#constructor', function () {
@@ -68,7 +68,8 @@ describe('Unit | Devcomp | Domain | Models | Element | QrocMForAnswerVerificatio
 
     describe('A QROCM For Verification without feedbacks', function () {
       it('should throw an error', function () {
-        expect(
+        // when
+        const error = catchErrSync(
           () =>
             new QROCMForAnswerVerification({
               id: '123',
@@ -88,7 +89,11 @@ describe('Unit | Devcomp | Domain | Models | Element | QrocMForAnswerVerificatio
                 },
               ],
             }),
-        ).to.throw('The feedbacks are required for a verification QROCM.');
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The feedbacks are required for a verification QROCM.');
       });
     });
   });

--- a/api/tests/devcomp/unit/domain/models/element/QROCM_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QROCM_test.js
@@ -1,5 +1,6 @@
 import { QROCM } from '../../../../../../src/devcomp/domain/models/element/QROCM.js';
-import { expect } from '../../../../../test-helper.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | QROCM', function () {
   describe('#constructor', function () {
@@ -26,29 +27,45 @@ describe('Unit | Devcomp | Domain | Models | Element | QROCM', function () {
 
   describe('A QROCM without id', function () {
     it('should throw an error', function () {
-      expect(() => new QROCM({})).to.throw('The id is required for an element');
+      // when
+      const error = catchErrSync(() => new QROCM({}))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The id is required for an element');
     });
   });
 
   describe('A QROCM without instruction', function () {
     it('should throw an error', function () {
-      expect(() => new QROCM({ id: '123' })).to.throw("L'instruction est obligatoire pour un QROCM");
+      // when
+      const error = catchErrSync(() => new QROCM({ id: '123' }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal("L'instruction est obligatoire pour un QROCM");
     });
   });
 
   describe('A QROCM with an empty list of proposals', function () {
     it('should throw an error', function () {
-      expect(() => new QROCM({ id: '123', instruction: 'toto', proposals: [] })).to.throw(
-        'Les propositions sont obligatoires pour un QROCM',
-      );
+      // when
+      const error = catchErrSync(() => new QROCM({ id: '123', instruction: 'toto', proposals: [] }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('Les propositions sont obligatoires pour un QROCM');
     });
   });
 
   describe('A QROCM does not have a list of proposals', function () {
     it('should throw an error', function () {
-      expect(() => new QROCM({ id: '123', instruction: 'toto', proposals: 'toto' })).to.throw(
-        'Les propositions doivent apparaître dans une liste',
-      );
+      // when
+      const error = catchErrSync(() => new QROCM({ id: '123', instruction: 'toto', proposals: 'toto' }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('Les propositions doivent apparaître dans une liste');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/element/Text_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Text_test.js
@@ -1,5 +1,6 @@
 import { Text } from '../../../../../../src/devcomp/domain/models/element/Text.js';
-import { expect } from '../../../../../test-helper.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | Text', function () {
   describe('#constructor', function () {
@@ -16,13 +17,23 @@ describe('Unit | Devcomp | Domain | Models | Element | Text', function () {
 
   describe('A text without id', function () {
     it('should throw an error', function () {
-      expect(() => new Text({ content: 'content' })).to.throw('The id is required for an element');
+      // when
+      const error = catchErrSync(() => new Text({ content: 'content' }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The id is required for an element');
     });
   });
 
   describe('A text without content', function () {
     it('should throw an error', function () {
-      expect(() => new Text({ id: '1' })).to.throw('The content is required for a text');
+      // when
+      const error = catchErrSync(() => new Text({ id: '1' }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The content is required for a text');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/element/Video_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Video_test.js
@@ -1,5 +1,6 @@
 import { Video } from '../../../../../../src/devcomp/domain/models/element/Video.js';
-import { expect } from '../../../../../test-helper.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | Video', function () {
   describe('#constructor', function () {
@@ -27,35 +28,56 @@ describe('Unit | Devcomp | Domain | Models | Element | Video', function () {
 
   describe('An video without id', function () {
     it('should throw an error', function () {
-      expect(() => new Video({})).to.throw('The id is required for an element');
+      // when
+      const error = catchErrSync(() => new Video({}))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The id is required for an element');
     });
   });
 
   describe('An video without a title', function () {
     it('should throw an error', function () {
-      expect(() => new Video({ id: 'id' })).to.throw('The title is required for a video');
+      // when
+      const error = catchErrSync(() => new Video({ id: 'id' }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The title is required for a video');
     });
   });
 
   describe('A video without a url', function () {
     it('should throw an error', function () {
-      expect(() => new Video({ id: 'id', title: 'title' })).to.throw('The URL is required for a video');
+      // when
+      const error = catchErrSync(() => new Video({ id: 'id', title: 'title' }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The URL is required for a video');
     });
   });
 
   describe('A video without subtitles', function () {
     it('should throw an error', function () {
-      expect(() => new Video({ id: 'id', title: 'title', url: 'url' })).to.throw(
-        'The subtitles are required for a video',
-      );
+      // when
+      const error = catchErrSync(() => new Video({ id: 'id', title: 'title', url: 'url' }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The subtitles are required for a video');
     });
   });
 
   describe('A video without a transcription', function () {
     it('should throw an error', function () {
-      expect(() => new Video({ id: 'id', title: 'title', url: 'url', subtitles: 'subtitles' })).to.throw(
-        'The transcription is required for a video',
-      );
+      // when
+      const error = catchErrSync(() => new Video({ id: 'id', title: 'title', url: 'url', subtitles: 'subtitles' }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The transcription is required for a video');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/module/Details_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/Details_test.js
@@ -1,5 +1,6 @@
 import { Details } from '../../../../../../src/devcomp/domain/models/module/Details.js';
-import { expect } from '../../../../../test-helper.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Module | Details', function () {
   describe('#constructor', function () {
@@ -26,37 +27,54 @@ describe('Unit | Devcomp | Domain | Models | Module | Details', function () {
 
     describe('if the details do not have an image', function () {
       it('should throw an error', function () {
-        expect(() => new Details({})).to.throw('The image is required for module details');
+        // when
+        const error = catchErrSync(() => new Details({}))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The image is required for module details');
       });
     });
 
     describe('if the details do not have a description', function () {
       it('should throw an error', function () {
-        expect(() => new Details({ image: 'https://image.com' })).to.throw(
-          'The description is required for module details',
-        );
+        // when
+        const error = catchErrSync(() => new Details({ image: 'https://image.com' }))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The description is required for module details');
       });
     });
 
     describe('if the details do not have a duration', function () {
       it('should throw an error', function () {
-        expect(() => new Details({ image: 'https://image.com', description: 'description' })).to.throw(
-          'The duration is required for module details',
-        );
+        // when
+        const error = catchErrSync(() => new Details({ image: 'https://image.com', description: 'description' }))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The duration is required for module details');
       });
     });
 
     describe('if the details do not have a level', function () {
       it('should throw an error', function () {
-        expect(() => new Details({ image: 'https://image.com', description: 'description', duration: 12 })).to.throw(
-          'The level is required for module details',
-        );
+        // when
+        const error = catchErrSync(
+          () => new Details({ image: 'https://image.com', description: 'description', duration: 12 }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The level is required for module details');
       });
     });
 
     describe('if the details do not have a tabletSupport', function () {
       it('should throw an error', function () {
-        expect(
+        // when
+        const error = catchErrSync(
           () =>
             new Details({
               image: 'https://image.com',
@@ -65,13 +83,18 @@ describe('Unit | Devcomp | Domain | Models | Module | Details', function () {
               level: 'level',
               objectives: ['objective1'],
             }),
-        ).to.throw('The tabletSupport is required for module details');
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The tabletSupport is required for module details');
       });
     });
 
     describe('if the details do not have objectives', function () {
       it('should throw an error', function () {
-        expect(
+        // when
+        const error = catchErrSync(
           () =>
             new Details({
               image: 'https://image.com',
@@ -80,13 +103,18 @@ describe('Unit | Devcomp | Domain | Models | Module | Details', function () {
               level: 'level',
               tabletSupport: 'comfortable',
             }),
-        ).to.throw('The objectives are required for module details');
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The objectives are required for module details');
       });
     });
 
     describe('if the objectives is not a list', function () {
       it('should throw an error', function () {
-        expect(
+        // when
+        const error = catchErrSync(
           () =>
             new Details({
               image: 'https://image.com',
@@ -96,13 +124,18 @@ describe('Unit | Devcomp | Domain | Models | Module | Details', function () {
               tabletSupport: 'comfortable',
               objectives: ' not-a-list',
             }),
-        ).to.throw('The module details should contain a list of objectives');
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The module details should contain a list of objectives');
       });
     });
 
     describe(`if details has less than 1 objective`, function () {
       it('should throw an error', function () {
-        expect(
+        // when
+        const error = catchErrSync(
           () =>
             new Details({
               image: 'https://image.com',
@@ -112,7 +145,11 @@ describe('Unit | Devcomp | Domain | Models | Module | Details', function () {
               tabletSupport: 'comfortable',
               objectives: [],
             }),
-        ).to.throw('The module details should contain at least one objective');
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The module details should contain at least one objective');
       });
     });
   });

--- a/api/tests/devcomp/unit/domain/models/module/Module_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/Module_test.js
@@ -1,5 +1,6 @@
 import { Module } from '../../../../../../src/devcomp/domain/models/module/Module.js';
-import { expect } from '../../../../../test-helper.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
   describe('#constructor', function () {
@@ -26,38 +27,59 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
 
     describe('if a module does not have an id', function () {
       it('should throw an error', function () {
-        expect(() => new Module({})).to.throw('The id is required for a module');
+        // when
+        const error = catchErrSync(() => new Module({}))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The id is required for a module');
       });
     });
 
     describe('if a module does not have a title', function () {
       it('should throw an error', function () {
-        expect(() => new Module({ id: 1 })).to.throw('The title is required for a module');
+        // when
+        const error = catchErrSync(() => new Module({ id: 1 }))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The title is required for a module');
       });
     });
 
     describe('if a module does not have a slug', function () {
       it('should throw an error', function () {
-        expect(() => new Module({ id: 1, title: '' })).to.throw('The slug is required for a module');
+        // when
+        const error = catchErrSync(() => new Module({ id: 1, title: '' }))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The slug is required for a module');
       });
     });
 
     describe('if a module does not have grains', function () {
       it('should throw an error', function () {
-        expect(
+        // when
+        const error = catchErrSync(
           () =>
             new Module({
               id: 'id_module_1',
               slug: 'bien-ecrire-son-adresse-mail',
               title: 'Bien écrire son adresse mail',
             }),
-        ).to.throw('A list of grains is required for a module');
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('A list of grains is required for a module');
       });
     });
 
     describe('if a module has grains with the wrong type', function () {
       it('should throw an error', function () {
-        expect(
+        // when
+        const error = catchErrSync(
           () =>
             new Module({
               id: 'id_module_1',
@@ -65,13 +87,18 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               title: 'Bien écrire son adresse mail',
               grains: 'elements',
             }),
-        ).to.throw(`A module should have a list of grains`);
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal(`A module should have a list of grains`);
       });
     });
 
     describe('if a module does not have details', function () {
       it('should throw an error', function () {
-        expect(
+        // when
+        const error = catchErrSync(
           () =>
             new Module({
               id: 'id_module_1',
@@ -79,7 +106,11 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               title: 'Bien écrire son adresse mail',
               grains: [],
             }),
-        ).to.throw('The details are required for a module');
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The details are required for a module');
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
La majorité des erreurs lancées lors de la validation des modules Modulix utilisent la classe générique `Error`. Cela a notamment pour conséquence que le front reçoit des erreurs HTTP 502 qui ne sont pas appropriées.

## :robot: Proposition
Remplacer les erreurs génériques `Error` par des `DomainError`.

### Next steps
- [ ] Revoir le mapping des erreurs : actuellement, toute erreur jetée à l'instantiation d'un module [est transformée en `ModuleInstantiationError`](https://github.com/1024pix/pix/blob/27a264ed2f674dfa712b64069216c4d2cdc6381e/api/src/devcomp/infrastructure/factories/module-factory.js#L80) laquelle [renvoie ensuite une erreur HTTP 502](https://github.com/1024pix/pix/blob/e7b3167f00866f5132483a934aa0157f21a795a9/api/src/devcomp/application/http-error-mapper-configuration.js#L21).
- [ ] (éventuellement) Créer une nouvelle erreur spécifique à la validation des modules (`ModulixValidationError` ?)

## :rainbow: Remarques

Les tests ont été améliorés pour vérifier le type de l'erreur lancée et non plus seulement son message.

## :100: Pour tester
CI ok
