### PR TITLE
[DOC] Corriger une erreur de frappe dans la doc. 

### DIFF
--- a/docs/adr/0055-communication-bounded-contexts.md
+++ b/docs/adr/0055-communication-bounded-contexts.md
@@ -33,7 +33,7 @@ Ce code partagé est actuellement placé dans différents dossiers nommés `shar
 Il y a plusieurs conséquences négatives à garder ce code dans un état partagé :
 
 - nécessite de la communication et du partage de connaissances qui, s'ils sont réalisés, entraînent une surcharge cognitive, et dans le cas contraire, risquent d'occasionner des anomalies ou incohérences.
-- allonge les délais de mise en oeuvre
+- allonge les délais de mise en œuvre
 - perte d'engagement sur le sujet
 - perte d'autonomie des équipes
 


### PR DESCRIPTION
## :unicorn: Problème
Dans le but de tester des modifications sur la configuration de la CI, on souhaite merger une branche depuis l'interface GitHub et non plus à l'aide du tag Ready To Merge faisant appel à Jean-Pierre. Cette modif dans la doc est un prétexte à créer une PR de test. 

## :robot: Proposition
Corriger une faute de frappe sur le mot "œuvre".
