### PR TITLE
[BUGFIX] Corriger la couleur du descriptif des parcours thématiques autonomes (PIX-14032)

### DIFF
--- a/mon-pix/app/styles/components/autonomous-course/_landing-page-start-block.scss
+++ b/mon-pix/app/styles/components/autonomous-course/_landing-page-start-block.scss
@@ -23,7 +23,7 @@
   @extend %pix-body-l;
 
   margin-top: 1rem;
-  color: var(--pix-neutral-100);
+  color: var(--pix-neutral-500);
 }
 
 .autonomous-course-landing-page-start-block__launcher {


### PR DESCRIPTION
## :unicorn: Problème
Lors de la migration des couleurs, la couleur de descriptif a sauté pour un gris trop clair.

![image(25)](https://github.com/user-attachments/assets/4c4e18ac-585d-4a37-89ae-dd15c5a4d1cd)

## :robot: Proposition
Le corriger.

## :rainbow: Remarques
RAS

## :100: Pour tester
Sur la page d'accès à un parcours thématique autonome, vérifier que la couleur de descriptif est rétablie : 
- https://app-pr9962.review.pix.fr/campagnes/AUTOCOURS5/presentation
