### PR TITLE
[TECH] Ajouter une configuration de retry pour les jobs d'import (PIX-14023)

### DIFF
--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-organization-learners-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-organization-learners-job-repository.js
@@ -1,4 +1,8 @@
-import { JobExpireIn, JobRepository } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import {
+  JobExpireIn,
+  JobRepository,
+  JobRetry,
+} from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { ImportOrganizationLearnersJob } from '../../../domain/models/ImportOrganizationLearnersJob.js';
 
 class ImportOrganizationLearnersJobRepository extends JobRepository {
@@ -6,6 +10,7 @@ class ImportOrganizationLearnersJobRepository extends JobRepository {
     super({
       name: ImportOrganizationLearnersJob.name,
       expireIn: JobExpireIn.HIGH,
+      retry: JobRetry.STANDARD_RETRY,
     });
   }
 }

--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/validate-organization-learners-import-file-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/validate-organization-learners-import-file-job-repository.js
@@ -10,7 +10,7 @@ class ValidateOrganizationImportFileJobRepository extends JobRepository {
     super({
       name: ValidateOrganizationImportFileJob.name,
       expireIn: JobExpireIn.HIGH,
-      retry: JobRetry.NO_RETRY,
+      retry: JobRetry.STANDARD_RETRY,
     });
   }
 }

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-organization-learners-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-organization-learners-job-repository_test.js
@@ -1,6 +1,9 @@
 import { ImportOrganizationLearnersJob } from '../../../../../../../src/prescription/learner-management/domain/models/ImportOrganizationLearnersJob.js';
 import { importOrganizationLearnersJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/import-organization-learners-job-repository.js';
-import { JobExpireIn } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import {
+  JobExpireIn,
+  JobRetry,
+} from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Integration | Prescription | Infrastructure | Repository | Jobs | importOrganizationLearnersJobRepository', function () {
@@ -14,9 +17,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | impo
       // then
       await expect(ImportOrganizationLearnersJob.name).to.have.have.been.performed.withJob({
         expirein: JobExpireIn.HIGH,
-        retrylimit: 0,
-        retrydelay: 0,
-        retrybackoff: false,
+        retrylimit: JobRetry.STANDARD_RETRY.retryLimit,
+        retrydelay: JobRetry.STANDARD_RETRY.retryDelay,
+        retrybackoff: JobRetry.STANDARD_RETRY.retryBackoff,
         data: { organizationImportId: 4123132 },
       });
     });

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-organization-learners-import-file-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-organization-learners-import-file-job-repository_test.js
@@ -1,6 +1,9 @@
 import { ValidateOrganizationImportFileJob } from '../../../../../../../src/prescription/learner-management/domain/models/ValidateOrganizationImportFileJob.js';
 import { validateOrganizationImportFileJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/validate-organization-learners-import-file-job-repository.js';
-import { JobExpireIn } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import {
+  JobExpireIn,
+  JobRetry,
+} from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Integration | Prescription | Infrastructure | Repository | Jobs | validateOrganizationImportFileJobRepository', function () {
@@ -14,9 +17,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | vali
       // then
       await expect(ValidateOrganizationImportFileJob.name).to.have.been.performed.withJob({
         expirein: JobExpireIn.HIGH,
-        retrylimit: 0,
-        retrydelay: 0,
-        retrybackoff: false,
+        retrylimit: JobRetry.STANDARD_RETRY.retryLimit,
+        retrydelay: JobRetry.STANDARD_RETRY.retryDelay,
+        retrybackoff: JobRetry.STANDARD_RETRY.retryBackoff,
         data: { organizationImportId: 4123132 },
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Les jobs de validation et/ou d’import en BDD peuvent crash pour des temps d’excution dépassant les 30mn. On à pas encore investigué ni trouvé la cause de ces timeouts, mais actuellement la solution consiste en relancer les jobs dans ces états a la main. 

## :robot: Proposition
On va donc pour ceux ci, rajouter dans la configuration le standard retry, afin qu’ils se relancent tout seul pour essayer de se terminer. 

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- Hm
- C'est de la config ?
- 🐈‍⬛ 