### PR TITLE
[FEATURE] Transforme le paragraphe de description du module en `div` (PIX-14011)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -4,7 +4,7 @@
   "title": "Didacticiel Modulix",
   "details": {
     "image": "https://images.pix.fr/modulix/placeholder-details.svg",
-    "description": "Découvrez avec ce didacticiel comment fonctionne Modulix !",
+    "description": "<p>Découvrez avec ce didacticiel comment fonctionne Modulix !</p>",
     "duration": 5,
     "level": "Débutant",
     "tabletSupport": "inconvenient",

--- a/mon-pix/app/components/module/details.gjs
+++ b/mon-pix/app/components/module/details.gjs
@@ -68,6 +68,7 @@ export default class ModulixDetails extends Component {
 
   <template>
     {{pageTitle @module.title}}
+
     <main id="main" class="module-details" role="main">
       <div class="module-details__image">
         <img alt="" class="module-details-image__illustration" src={{@module.details.image}} height="150" />
@@ -77,7 +78,7 @@ export default class ModulixDetails extends Component {
         <div class="module-details-content__layout">
           <h1 class="module-details-content-layout__title">{{@module.title}}</h1>
 
-          <p class="module-details-content-layout__description">{{htmlUnsafe @module.details.description}}</p>
+          <div class="module-details-content-layout__description">{{htmlUnsafe @module.details.description}}</div>
 
           <div class="module-details-content-layout__link">
             {{#if this.shouldDisplaySmallScreenModal}}

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-details-test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-details-test.js
@@ -20,7 +20,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleDetails', function (
         grains: [],
         details: {
           image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
-          description: 'Description',
+          description: '<p>Description</p>',
           duration: 'duration',
           level: 'level',
           objectives: ['Objectif #1'],
@@ -48,7 +48,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleDetails', function (
         grains: [grain],
         details: {
           image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
-          description: 'Description',
+          description: '<p>Description</p>',
           duration: 'duration',
           level: 'level',
           objectives: ['Objectif #1'],

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-recap-test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-recap-test.js
@@ -30,7 +30,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleRecap', function (ho
         grains: [grain],
         details: {
           image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
-          description: 'Description',
+          description: '<p>Description</p>',
           duration: 'duration',
           level: 'level',
           objectives: ['Objectif #1'],

--- a/mon-pix/tests/integration/components/module/details-test.gjs
+++ b/mon-pix/tests/integration/components/module/details-test.gjs
@@ -13,9 +13,10 @@ module('Integration | Component | Module | Details', function (hooks) {
   test('should display the details of a given module', async function (assert) {
     // given
     const store = this.owner.lookup('service:store');
+    const descriptionContent = 'description';
     const details = {
       image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
-      description: 'description',
+      description: `<p>${descriptionContent}</p>`,
       duration: 12,
       level: 'Débutant',
       objectives: ['Objectif 1'],
@@ -28,7 +29,7 @@ module('Integration | Component | Module | Details', function (hooks) {
     // then
     assert.ok(screen.getByRole('heading', { name: module.title, level: 1 }));
     assert.ok(screen.getByRole('presentation').hasAttribute('src', module.details.image));
-    assert.ok(screen.getByText(module.details.description));
+    assert.ok(screen.getByText(descriptionContent));
     assert.ok(screen.getByText(`${module.details.duration} min`));
     assert.ok(screen.getByText(module.details.level));
     assert.ok(screen.getByText(module.details.objectives[0]));
@@ -257,7 +258,7 @@ function prepareDetailsComponentContext(tabletSupport, breakpoint = 'desktop') {
 
   const details = {
     image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
-    description: 'description',
+    description: '<p>Description</p>',
     duration: 12,
     level: 'Débutant',
     objectives: ['Objectif 1'],

--- a/mon-pix/tests/integration/components/module/recap-test.js
+++ b/mon-pix/tests/integration/components/module/recap-test.js
@@ -12,7 +12,7 @@ module('Integration | Component | Module | Recap', function (hooks) {
     const store = this.owner.lookup('service:store');
     const details = {
       image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
-      description: 'description',
+      description: '<p>Description</p>',
       duration: 12,
       level: 'Débutant',
       objectives: ['Objectif 1'],
@@ -32,7 +32,7 @@ module('Integration | Component | Module | Recap', function (hooks) {
     const store = this.owner.lookup('service:store');
     const details = {
       image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
-      description: 'description',
+      description: '<p>Description</p>',
       duration: 12,
       level: 'Débutant',
       objectives: ['Objectif 1'],


### PR DESCRIPTION
## :unicorn: Problème
On permet d’utiliser de l’HTML dans la description des modules (page de détails), mais pour le moment ce contenu est placé dans un `p` limitant quelques peu les usages.

## :robot: Proposition
Permettre de compléter plusieurs paragraphes dans cette description et donc transformer la `p` en `div`.

## :rainbow: Remarques
RAS

## :100: Pour tester
Constater en RA que la page de détails n'a pas changée :
- https://app-pr9971.review.pix.fr/modules/didacticiel-modulix
- https://app-pr9971.review.pix.fr/modules/bien-ecrire-son-adresse-mail
