### PR TITLE
[FEATURE] Optimiser le script d'anonymisation (PIX-14044)

### DIFF
--- a/api/src/identity-access-management/infrastructure/repositories/anonymized-user.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/anonymized-user.repository.js
@@ -1,8 +1,8 @@
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 
-async function findIds() {
+async function findLegacyAnonymizedIds() {
   const knexConn = DomainTransaction.getConnection();
-  return knexConn('users').where({ hasBeenAnonymised: true }).pluck('id');
+  return knexConn('users').where({ hasBeenAnonymised: true }).whereNot({ lastName: '(anonymised)' }).pluck('id');
 }
 
-export const anonymizedUserRepository = { findIds };
+export const anonymizedUserRepository = { findLegacyAnonymizedIds };

--- a/api/src/identity-access-management/scripts/backfill-anonymized-users.js
+++ b/api/src/identity-access-management/scripts/backfill-anonymized-users.js
@@ -25,7 +25,7 @@ if (isLaunchedFromCommandLine) {
 }
 
 export async function backfillAnonymizedUsers() {
-  const anonymizedUserIds = await anonymizedUserRepository.findIds();
+  const anonymizedUserIds = await anonymizedUserRepository.findLegacyAnonymizedIds();
 
   logger.info(`Total anonymized users to backfill: ${anonymizedUserIds.length}`);
 

--- a/api/src/shared/domain/models/AdminMember.js
+++ b/api/src/shared/domain/models/AdminMember.js
@@ -28,7 +28,7 @@ class AdminMember {
         userId: Joi.number().optional(),
         firstName: Joi.string().optional(),
         lastName: Joi.string().optional(),
-        email: Joi.string().email().optional(),
+        email: Joi.string().email().optional().allow(null),
         role: Joi.string().valid(ROLES.SUPER_ADMIN, ROLES.SUPPORT, ROLES.METIER, ROLES.CERTIF).required(),
         createdAt: Joi.date().allow(null).optional(),
         updatedAt: Joi.date().allow(null).optional(),

--- a/api/tests/identity-access-management/acceptance/scripts/backfill-anonymized-users.script.test.js
+++ b/api/tests/identity-access-management/acceptance/scripts/backfill-anonymized-users.script.test.js
@@ -14,6 +14,11 @@ describe('Acceptance | Identity Access Management | Scripts | backfill-anonymize
       firstName: 'Jack',
       hasBeenAnonymised: false,
     });
+    databaseBuilder.factory.buildUser({
+      lastName: '(anonymized)',
+      hasBeenAnonymised: true,
+      hasBeenAnonymisedBy: admin.id,
+    });
     await databaseBuilder.commit();
 
     // when

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/anonymized-user.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/anonymized-user.repository.test.js
@@ -2,15 +2,16 @@ import { anonymizedUserRepository } from '../../../../../src/identity-access-man
 import { databaseBuilder, expect } from '../../../../test-helper.js';
 
 describe('Integration | Identity Access Management | Infrastructure | Repository | Anonymized User', function () {
-  describe('#findIds', function () {
-    it('returns anonymized user ids', async function () {
+  describe('#findLegacyAnonymizedIds', function () {
+    it('returns legacy anonymized user ids', async function () {
       // given
       databaseBuilder.factory.buildUser();
       const anonymizedUser = databaseBuilder.factory.buildUser({ hasBeenAnonymised: true });
+      databaseBuilder.factory.buildUser({ hasBeenAnonymised: true, lastName: '(anonymised)' });
       await databaseBuilder.commit();
 
       // when
-      const anonymizedUserIds = await anonymizedUserRepository.findIds();
+      const anonymizedUserIds = await anonymizedUserRepository.findLegacyAnonymizedIds();
 
       // then
       expect(anonymizedUserIds).to.be.deep.equal([anonymizedUser.id]);

--- a/api/tests/shared/unit/domain/models/AdminMember_test.js
+++ b/api/tests/shared/unit/domain/models/AdminMember_test.js
@@ -54,6 +54,20 @@ describe('Unit | Shared | Domain | Models | AdminMember', function () {
       });
     });
 
+    describe('when email is null', function () {
+      it('should successfully instantiate object', function () {
+        // when
+        expect(
+          () =>
+            new AdminMember({
+              id: 1,
+              email: null,
+              role: ROLES.SUPER_ADMIN,
+            }),
+        ).not.to.throw(ObjectValidationError);
+      });
+    });
+
     describe('when the given role is undefined or null', function () {
       it('should throw an ObjectValidationError', function () {
         // when


### PR DESCRIPTION
## :unicorn: Problème

Lors de l'exécution du script de reprise des utilisateurs anonymisés en production, nous nous sommes rendu compte qu'il prenait beaucoup de temps à s'exécuter (contrairement à l'environnement de recette).
> En production, 16000 utilisateurs, déjà anonymisés éligibles au script. (800 en recette)

De plus, une erreur à stopper l'exécution du script.

## :robot: Proposition

Lors de la première exécution, environs 14000 utilisateurs ont eu le backfill de l'anonymisation d'appliqués avant l'erreur qui a stoppé le script.

1. Corriger l'erreur `Erreur : ValidationError: "email" must be a string` causée par la validation d'email dans le modèle `AdminMember`, car cet admin était lui-même déjà anonymisé (plus d'email)
2. Faire en sorte d'avoir de ne pas traiter l'ensemble des utilisateurs déjà backfill à l'exécution du script, pour ne traiter que les 1634 utilisateurs restants. Pour cela nous pouvons vérifier que le `lastName` contient `(anonymised)`

## :rainbow: Remarques

Il a été vu que la requête effectuée par `organizationLearnerRepository.dissociateAllStudentsByUserId()` était celle qui prenait le plus temps (environ 2 secondes) et qui ralenti fortement le script. Nous allons traité cette optimisation dans un autre ticket afin de vérifier avec Prescription l'optimisation idéale à effectuer.

## :100: Pour tester

Avoir des utilisateurs déjà anonymisés en base de données dont:
- au moins un complètement anonymisé via l'interface Admin
- au moins un partiellement anonymisé par un admin qui est lui-même déjà anonymisé.

- Exécuter le script:
```sh
# en local
node src/identity-access-management/scripts/backfill-anonymized-users.js

# sur la RA
scalingo --region osc-fr1 -a pix-api-review-pr9876 run node src/identity-access-management/scripts/backfill-anonymized-users.js
```

- Vérifier que le script est bien passé sur tous les utilisateurs déjà anonymisés en appliquant les nouvelles règles (par exemple: email passé à `null` au lieu de `email_{userID}@example.net`)

