### PR TITLE
[BUGFIX] Ajout d'un prehandler sur le endpoint place-statistics

### DIFF
--- a/api/src/prescription/organization-place/application/organization-place-route.js
+++ b/api/src/prescription/organization-place/application/organization-place-route.js
@@ -127,6 +127,10 @@ const register = async (server) => {
             method: securityPreHandlers.makeCheckOrganizationHasFeature(ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key),
             assign: 'checkOrganizationHasPlacesFeature',
           },
+          {
+            method: securityPreHandlers.checkUserIsAdminInOrganization,
+            assign: 'checkUserIsOrganizationsAdmin',
+          },
         ],
         validate: {
           params: Joi.object({

--- a/api/tests/prescription/organization-place/unit/application/organization-place-route_test.js
+++ b/api/tests/prescription/organization-place/unit/application/organization-place-route_test.js
@@ -35,6 +35,7 @@ describe('Unit | Router | organization-place-route', function () {
     sinon.stub(usecases, 'findOrganizationPlacesLot');
     sinon.stub(organizationPlaceController, 'createOrganizationPlacesLot');
     sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin');
+    sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization');
     sinon.stub(organizationPlaceController, 'getOrganizationPlacesStatistics');
     httpTestServer = new HttpTestServer();
     httpTestServer.setupAuthentication();
@@ -165,13 +166,14 @@ describe('Unit | Router | organization-place-route', function () {
   });
 
   describe('GET /api/organizations/{id}/places-statistics', function () {
-    it('should return HTTP code 200 when organization has the right feature activated', async function () {
+    it('should return HTTP code 200 when organization has the right feature activated and user is admin of the orga', async function () {
       // given
       const method = 'GET';
       const url = '/api/organizations/1/place-statistics';
       const payload = {};
 
       checkOrganizationHasPlacesFeature.resolves(true);
+      securityPreHandlers.checkUserIsAdminInOrganization.resolves(true);
 
       organizationPlaceController.getOrganizationPlacesStatistics.callsFake((_, h) => h.response('ok').code(200));
 
@@ -185,12 +187,31 @@ describe('Unit | Router | organization-place-route', function () {
       expect(response.statusCode).to.equal(200);
     });
 
+    it('should return HTTP code 403 if user is not admin of the organization', async function () {
+      // given
+      const method = 'GET';
+      const url = '/api/organizations/1/place-statistics';
+      const payload = {};
+
+      securityPreHandlers.checkUserIsAdminInOrganization.callsFake(respondWithError);
+      checkOrganizationHasPlacesFeature.resolves(true);
+
+      // when
+      const response = await httpTestServer.request(method, url, payload, null, {
+        authorization: generateValidRequestAuthorizationHeader(),
+      });
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+
     it('should return HTTP code 403 if organization doesnt have the right feature activated', async function () {
       // given
       const method = 'GET';
       const url = '/api/organizations/1/place-statistics';
       const payload = {};
 
+      securityPreHandlers.checkUserIsAdminInOrganization.resolves(true);
       checkOrganizationHasPlacesFeature.callsFake(respondWithError);
 
       // when


### PR DESCRIPTION
## :unicorn: Problème
Nous ne vérifions pas au niveau de l'API si la personne fesant la requête faisait bien partie de l'organisation dont elle réclamait les données

## :robot: Proposition
Ajouter un prehendler pour couvrir ce cas en cas de curl

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- essayer de taper directement sur l'api pour demander les places-statistics d'une autre orga que la tienne => voir que ça retourne une 403
