### PR TITLE
[BUGFIX] Améliorer la lisibilité de la solution d'un input de QROC(M) (PIX-14045).

### DIFF
--- a/mon-pix/app/components/solution-panel/qroc-solution-panel.gjs
+++ b/mon-pix/app/components/solution-panel/qroc-solution-panel.gjs
@@ -98,14 +98,10 @@ export default class QrocSolutionPanel extends Component {
               </div>
             {{else}}
               <div class="correction-qroc-box-answer {{this.inputClass}}">
-                <PixInput
-                  class="correction-qroc-box-answer--input"
-                  @id="correction-qroc-box-answer"
-                  size="{{this.answerToDisplay.length}}"
-                  @value="{{this.answerToDisplay}}"
-                  @ariaLabel={{this.inputAriaLabel}}
-                  disabled
-                />
+                <span id="correction-qroc-box-answer" class="correction-qroc-box-answer--input">
+                  <span class="sr-only">{{this.inputAriaLabel}}</span>
+                  {{this.answerToDisplay}}
+                </span>
               </div>
             {{/if}}
           </div>

--- a/mon-pix/app/components/solution-panel/qrocm-dep-solution-panel.hbs
+++ b/mon-pix/app/components/solution-panel/qrocm-dep-solution-panel.hbs
@@ -45,14 +45,10 @@
           </div>
         {{else}}
           <div class="correction-qrocm__answer correction-qrocm__answer--input {{block.inputClass}}">
-            <PixInput
-              class="correction-qrocm-answer__input"
-              @value="{{block.answer}}"
-              size="{{block.answer.length}}"
-              @id="{{block.input}}"
-              aria-label={{block.ariaLabel}}
-              disabled
-            />
+            <span id={{block.input}} class="correction-qrocm-answer__input correction-qroc-box-answer--input">
+              <span class="sr-only">{{block.ariaLabel}}</span>
+              {{block.answer}}
+            </span>
             {{#if block.solution}}
               <p class="correction-qrocm__solution">
                 <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>

--- a/mon-pix/app/components/solution-panel/qrocm-ind-solution-panel.hbs
+++ b/mon-pix/app/components/solution-panel/qrocm-ind-solution-panel.hbs
@@ -52,14 +52,10 @@
           {{/if}}
         {{else}}
           <div class="correction-qrocm__answer correction-qrocm__answer--input {{block.inputClass}}">
-            <PixInput
-              class="correction-qrocm-answer__input"
-              @value="{{block.answer}}"
-              size="{{block.answer.length}}"
-              @id="{{block.input}}"
-              aria-label={{block.ariaLabel}}
-              disabled
-            />
+            <span id={{block.input}} class="correction-qrocm-answer__input correction-qroc-box-answer--input">
+              <span class="sr-only">{{block.ariaLabel}}</span>
+              {{block.answer}}
+            </span>
             {{#if block.emptyOrWrongAnswer}}
               <p class="correction-qrocm__solution">
                 <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>

--- a/mon-pix/app/styles/components/_qroc-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qroc-solution-panel.scss
@@ -16,13 +16,22 @@
   }
 
   &--input {
-    width: auto;
+    display: inline-block;
     max-width: 100%;
+    padding: var(--pix-spacing-2x) var(--pix-spacing-3x);
+    overflow: hidden;
+    color: var(--pix-neutral-500);
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    vertical-align: top;
+    background-color: var(--pix-neutral-20);
+    border: 1px solid var(--pix-neutral-100);
+    border-radius: var(--pix-spacing-1x);
   }
 
   &--correct {
     textarea,
-    input,
+    .correction-qroc-box-answer--input,
     [disabled] {
       color: var(--pix-success-700);
       font-weight: var(--pix-font-bold);
@@ -31,14 +40,15 @@
 
   &--wrong {
     textarea,
-    input {
+    .correction-qroc-box-answer--input {
       text-decoration: line-through;
     }
   }
 
-  &--aband, &--timeout {
+  &--aband,
+  &--timeout {
     textarea,
-    input {
+    .correction-qroc-box-answer--input {
       color: var(--pix-neutral-800);
       font-style: italic;
     }

--- a/mon-pix/app/styles/components/_qrocm-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qrocm-solution-panel.scss
@@ -12,7 +12,7 @@
   &--input {
     display: inline-block;
     padding: var(--pix-spacing-1x) var(--pix-spacing-1x) var(--pix-spacing-1x) 0;
-    vertical-align: 0;
+    vertical-align: middle;
 
     &:not(:last-child) {
       padding-left: 0;

--- a/mon-pix/tests/acceptance/challenge-item-qroc-test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qroc-test.js
@@ -5,6 +5,9 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
+const BAD_ANSWER_ARIA_TEXT = 'La réponse donnée est fausse';
+const cleanString = (string) => string.trim().replace(/\s+/g, ' ');
+
 module('Acceptance | Displaying a QROC challenge', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
@@ -208,7 +211,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
         const badAnswerFromUserResultInput = find('.correction-qroc-box-answer--input');
         assert.strictEqual(goodAnswer.textContent.trim(), 'Mangue');
         assert.ok(badAnswerFromUserResultContainer.className.includes('correction-qroc-box-answer--wrong'));
-        assert.strictEqual(badAnswerFromUserResultInput.value, 'Banane');
+        assert.strictEqual(cleanString(badAnswerFromUserResultInput.textContent), `${BAD_ANSWER_ARIA_TEXT} Banane`);
         assert.ok(find('.tutorial-panel__hint-container').textContent.includes(correction.hint));
 
         const tutorialToSuccess = findAll('.tutorial-panel__tutorials-container .tutorial-card')[0];
@@ -485,7 +488,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
 
         assert.strictEqual(goodAnswer.textContent.trim(), 'Mangue');
         assert.ok(badAnswerFromUserResultContainer.className.includes('correction-qroc-box-answer--wrong'));
-        assert.strictEqual(badAnswerFromUserResultInput.value, 'Banane');
+        assert.strictEqual(cleanString(badAnswerFromUserResultInput.textContent), `${BAD_ANSWER_ARIA_TEXT} Banane`);
         assert.ok(find('.tutorial-panel__hint-container').textContent.includes(correction.hint));
 
         const tutorialToSuccess = findAll('.tutorial-panel__tutorials-container .tutorial-card')[0];

--- a/mon-pix/tests/acceptance/challenge-item-qrocm-test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qrocm-test.js
@@ -7,6 +7,9 @@ import { module, test } from 'qunit';
 
 import setupIntl from '../helpers/setup-intl';
 
+const BAD_ANSWER_ARIA_TEXT = 'La réponse donnée est fausse';
+const cleanString = (string) => string.trim().replace(/\s+/g, ' ');
+
 module('Acceptance | Displaying a QROCM challenge', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
@@ -283,8 +286,8 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
       const badAnswersFromUserResult = findAll('.correction-qrocm-answer__input');
 
       assert.strictEqual(goodAnswers.textContent.trim(), 'Versailles-Chantiers');
-      assert.strictEqual(badAnswersFromUserResult[0].value, 'Republique');
-      assert.strictEqual(badAnswersFromUserResult[1].value, 'Chatelet');
+      assert.strictEqual(cleanString(badAnswersFromUserResult[0].textContent), `${BAD_ANSWER_ARIA_TEXT} Republique`);
+      assert.strictEqual(cleanString(badAnswersFromUserResult[1].textContent), `${BAD_ANSWER_ARIA_TEXT} Chatelet`);
 
       assert.ok(find('.tutorial-panel__hint-container').textContent.includes(correctionDep.hint));
 
@@ -312,8 +315,12 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
 
       assert.strictEqual(goodAnswers[0].textContent.trim(), 'Le petit prince');
       assert.strictEqual(goodAnswers[1].textContent.trim(), 'Saint-Exupéry');
-      assert.strictEqual(badAnswersFromUserResult[0].value, 'Le rouge et le noir');
-      assert.strictEqual(badAnswersFromUserResult[1].value, 'Stendhal');
+
+      assert.strictEqual(
+        cleanString(badAnswersFromUserResult[0].textContent),
+        `${BAD_ANSWER_ARIA_TEXT} Le rouge et le noir`,
+      );
+      assert.strictEqual(cleanString(badAnswersFromUserResult[1].textContent), `${BAD_ANSWER_ARIA_TEXT} Stendhal`);
 
       assert.ok(find('.tutorial-panel__hint-container').textContent.includes(correctionDep.hint));
 
@@ -340,7 +347,7 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
       const badAnswersFromUserResult = findAll('.correction-qrocm-answer__input');
 
       assert.strictEqual(goodAnswers[0].textContent.trim(), 'mango');
-      assert.strictEqual(badAnswersFromUserResult[0].value, 'potato');
+      assert.strictEqual(cleanString(badAnswersFromUserResult[0].textContent), `${BAD_ANSWER_ARIA_TEXT} potato`);
 
       assert.ok(find('.tutorial-panel__hint-container').textContent.includes(correctionIndSelect.hint));
 

--- a/mon-pix/tests/integration/components/solution-panel/qroc-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/solution-panel/qroc-solution-panel-test.js
@@ -65,11 +65,7 @@ module('Integration | Component | QROC solution panel', function (hooks) {
       // then
       assert.dom('textarea.correction-qroc-box-answer--paragraph').doesNotExist();
       assert.dom('textarea.correction-qroc-box-answer--sentence').doesNotExist();
-      assert.dom('input.correction-qroc-box-answer--input').hasAttribute('disabled');
-      assert.strictEqual(
-        find('input.correction-qroc-box-answer--input').getAttribute('size'),
-        answer.value.length.toString(),
-      );
+      assert.dom('.correction-qroc-box-answer--input').exists();
     });
   });
 
@@ -166,7 +162,10 @@ module('Integration | Component | QROC solution panel', function (hooks) {
           const answerBlock = find(data.input);
 
           assert.ok(answerBlock);
-          assert.strictEqual(answerBlock.value, EMPTY_DEFAULT_MESSAGE);
+
+          const answerContent = answerBlock.value || answerBlock.innerText;
+          assert.ok(answerContent.includes(EMPTY_DEFAULT_MESSAGE));
+
           assert.dom('.correction-qroc-box-answer--aband').exists();
         });
       });
@@ -198,7 +197,10 @@ module('Integration | Component | QROC solution panel', function (hooks) {
           const answerBlock = find(data.input);
 
           assert.ok(answerBlock);
-          assert.strictEqual(answerBlock.value, 'Temps dépassé');
+
+          const answerContent = answerBlock.value || answerBlock.innerText;
+          assert.ok(answerContent.includes('Temps dépassé'));
+
           assert.dom('.correction-qroc-box-answer--timeout').exists();
         });
       });

--- a/mon-pix/tests/integration/components/solution-panel/qrocm-dep-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/solution-panel/qrocm-dep-solution-panel-test.js
@@ -8,7 +8,7 @@ import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 const ANSWER = '.correction-qrocm__answer';
-const INPUT = 'input.correction-qrocm-answer__input';
+const INPUT = '.correction-qrocm-answer__input';
 const PARAGRAPH = 'textarea.correction-qrocm-answer__input-paragraph';
 const SENTENCE = 'input.correction-qrocm-answer__input-sentence';
 const SOLUTION_BLOCK = '.comparison-window-solution';
@@ -122,7 +122,10 @@ module('Integration | Component | QROCm dep solution panel', function (hooks) {
             const firstAnswerInputContainer = findAll(ANSWER)[0];
             const firstAnswerInput = findAll(input)[0];
             assert.ok(firstAnswerInput);
-            assert.strictEqual(firstAnswerInput.value, EMPTY_DEFAULT_MESSAGE);
+
+            const answerContent = firstAnswerInput.value || firstAnswerInput.innerText;
+            assert.ok(answerContent.includes(EMPTY_DEFAULT_MESSAGE));
+
             assert.true(firstAnswerInputContainer.classList.contains('correction-qroc-box-answer--aband'));
           });
         });
@@ -241,10 +244,8 @@ module('Integration | Component | QROCm dep solution panel', function (hooks) {
       // Then
       assert.dom(PARAGRAPH).doesNotExist();
       assert.dom(SENTENCE).doesNotExist();
-      assert.strictEqual(find(INPUT).tagName, 'INPUT');
-      assert.strictEqual(find(INPUT).getAttribute('size'), '12');
-      assert.strictEqual(find(INPUT).getAttribute('aria-label'), 'La réponse donnée est valide');
-      assert.true(find(INPUT).hasAttribute('disabled'));
+      assert.dom(INPUT).exists();
+      assert.ok(find(INPUT).innerText.includes('La réponse donnée est valide'));
     });
   });
 });

--- a/mon-pix/tests/integration/components/solution-panel/qrocm-ind-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/solution-panel/qrocm-ind-solution-panel-test.js
@@ -8,7 +8,7 @@ import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 const ANSWER = '.correction-qrocm__answer';
-const INPUT = 'input.correction-qrocm-answer__input';
+const INPUT = '.correction-qrocm-answer__input';
 const PARAGRAPH = 'textarea.correction-qrocm-answer__input-paragraph';
 const SENTENCE = 'input.correction-qrocm-answer__input-sentence';
 const SOLUTION_BLOCK = '.correction-qrocm__solution';
@@ -103,7 +103,10 @@ module('Integration | Component | QROCm ind solution panel', function (hooks) {
           const answerInput = findAll(data.input)[0];
 
           assert.ok(answerInput);
-          assert.strictEqual(answerInput.value, EMPTY_DEFAULT_MESSAGE);
+
+          const answerContent = answerInput.value || answerInput.innerText;
+          assert.ok(answerContent.includes(EMPTY_DEFAULT_MESSAGE));
+
           assert.true(answerInputContainer.classList.contains('correction-qroc-box-answer--aband'));
         });
       });
@@ -154,7 +157,7 @@ module('Integration | Component | QROCm ind solution panel', function (hooks) {
       this.set('challenge', challenge);
     });
 
-    test(`should display a disabled input with size based on the length of the value`, async function (assert) {
+    test(`should display a span with the user answer`, async function (assert) {
       //given
       const EMPTY_DEFAULT_MESSAGE = 'Pas de réponse';
       //when
@@ -166,13 +169,10 @@ module('Integration | Component | QROCm ind solution panel', function (hooks) {
 />`,
       );
       //then
-
       assert.dom(PARAGRAPH).doesNotExist();
-      assert.strictEqual(find(INPUT).tagName, 'INPUT');
-      assert.strictEqual(find(INPUT).value, EMPTY_DEFAULT_MESSAGE);
-      assert.strictEqual(find(INPUT).getAttribute('size'), EMPTY_DEFAULT_MESSAGE.length.toString());
-      assert.strictEqual(find(INPUT).getAttribute('aria-label'), 'Question passée');
-      assert.true(find(INPUT).hasAttribute('disabled'));
+
+      const answerContent = find(INPUT).value || find(INPUT).innerText;
+      assert.ok(answerContent.includes(EMPTY_DEFAULT_MESSAGE));
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème

Pour des épreuves QROC, sur l'écran de réponse, le champ de réponse est coupé quand la réponse a été rentrée en majuscules pas l'utilisateur.

On ne la revoit donc pas en entier, mais on peut scroller dans l'encadré pour le faire.

## :robot: Proposition

Ne plus utiliser un input disabled mais un simple span pour afficher la solution.

Avantage : le span prend directement la bonne largeur, majuscules ou non.

## :rainbow: Remarques

Une ellipse a été prévu dans le cas où la réponse est trop longue.

## :100: Pour tester

Répondre avec des réponses justes et fausses à ces épreuves :
- QROC :
  - [/challenges/recYB0FRW3A6T59M/preview](https://app-pr9975.review.pix.fr/challenges/recYB0FRW3A6T59M/preview)
  - [/challenges/recTl3Xm1qHqDr2ZP/preview](https://app-pr9975.review.pix.fr/challenges/recTl3Xm1qHqDr2ZP/preview)
  - [/challenges/challenge1z8iBJajkAQr0c/preview](https://app-pr9975.review.pix.fr/challenges/challenge1z8iBJajkAQr0c/preview)
- QROCM dep : [/challenges/recLxoiSI8BkzF91o/preview](https://app-pr9975.review.pix.fr/challenges/recLxoiSI8BkzF91o/preview)
- QROCM ind : [/challenges/recfvhcGd1TMNA44p/preview](https://app-pr9975.review.pix.fr/challenges/recfvhcGd1TMNA44p/preview)
