### PR TITLE
[BUGFIX] Améliorer la lisibilité de la solution d'un input de QROC(M) (PIX-14045).

### DIFF
--- a/mon-pix/app/components/solution-panel/qroc-solution-panel.gjs
+++ b/mon-pix/app/components/solution-panel/qroc-solution-panel.gjs
@@ -5,6 +5,8 @@ import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
 
+import inc from '../../helpers/inc';
+
 const classByResultValue = {
   ok: 'correction-qroc-box-answer--correct',
   ko: 'correction-qroc-box-answer--wrong',
@@ -98,14 +100,16 @@ export default class QrocSolutionPanel extends Component {
               </div>
             {{else}}
               <div class="correction-qroc-box-answer {{this.inputClass}}">
-                <PixInput
-                  class="correction-qroc-box-answer--input"
-                  @id="correction-qroc-box-answer"
-                  size="{{this.answerToDisplay.length}}"
-                  @value="{{this.answerToDisplay}}"
-                  @ariaLabel={{this.inputAriaLabel}}
-                  disabled
-                />
+                {{#if this.answerToDisplay.length}}
+                  <PixInput
+                    class="correction-qroc-box-answer--input"
+                    @id="correction-qroc-box-answer"
+                    size="{{inc this.answerToDisplay.length}}"
+                    @value="{{this.answerToDisplay}}"
+                    @ariaLabel={{this.inputAriaLabel}}
+                    disabled
+                  />
+                {{/if}}
               </div>
             {{/if}}
           </div>

--- a/mon-pix/app/components/solution-panel/qrocm-dep-solution-panel.hbs
+++ b/mon-pix/app/components/solution-panel/qrocm-dep-solution-panel.hbs
@@ -45,14 +45,16 @@
           </div>
         {{else}}
           <div class="correction-qrocm__answer correction-qrocm__answer--input {{block.inputClass}}">
-            <PixInput
-              class="correction-qrocm-answer__input"
-              @value="{{block.answer}}"
-              size="{{block.answer.length}}"
-              @id="{{block.input}}"
-              aria-label={{block.ariaLabel}}
-              disabled
-            />
+            {{#if block.answer.length}}
+              <PixInput
+                class="correction-qrocm-answer__input"
+                @value="{{block.answer}}"
+                size={{inc block.answer.length}}
+                @id="{{block.input}}"
+                aria-label={{block.ariaLabel}}
+                disabled
+              />
+            {{/if}}
             {{#if block.solution}}
               <p class="correction-qrocm__solution">
                 <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>

--- a/mon-pix/app/components/solution-panel/qrocm-ind-solution-panel.hbs
+++ b/mon-pix/app/components/solution-panel/qrocm-ind-solution-panel.hbs
@@ -52,14 +52,16 @@
           {{/if}}
         {{else}}
           <div class="correction-qrocm__answer correction-qrocm__answer--input {{block.inputClass}}">
-            <PixInput
-              class="correction-qrocm-answer__input"
-              @value="{{block.answer}}"
-              size="{{block.answer.length}}"
-              @id="{{block.input}}"
-              aria-label={{block.ariaLabel}}
-              disabled
-            />
+            {{#if block.answer.length}}
+              <PixInput
+                class="correction-qrocm-answer__input"
+                @value="{{block.answer}}"
+                size={{inc block.answer.length}}
+                @id="{{block.input}}"
+                aria-label={{block.ariaLabel}}
+                disabled
+              />
+            {{/if}}
             {{#if block.emptyOrWrongAnswer}}
               <p class="correction-qrocm__solution">
                 <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>

--- a/mon-pix/tests/integration/components/solution-panel/qroc-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/solution-panel/qroc-solution-panel-test.js
@@ -68,7 +68,7 @@ module('Integration | Component | QROC solution panel', function (hooks) {
       assert.dom('input.correction-qroc-box-answer--input').hasAttribute('disabled');
       assert.strictEqual(
         find('input.correction-qroc-box-answer--input').getAttribute('size'),
-        answer.value.length.toString(),
+        String(answer.value.length + 1),
       );
     });
   });

--- a/mon-pix/tests/integration/components/solution-panel/qrocm-dep-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/solution-panel/qrocm-dep-solution-panel-test.js
@@ -242,7 +242,7 @@ module('Integration | Component | QROCm dep solution panel', function (hooks) {
       assert.dom(PARAGRAPH).doesNotExist();
       assert.dom(SENTENCE).doesNotExist();
       assert.strictEqual(find(INPUT).tagName, 'INPUT');
-      assert.strictEqual(find(INPUT).getAttribute('size'), '12');
+      assert.strictEqual(find(INPUT).getAttribute('size'), '13');
       assert.strictEqual(find(INPUT).getAttribute('aria-label'), 'La réponse donnée est valide');
       assert.true(find(INPUT).hasAttribute('disabled'));
     });

--- a/mon-pix/tests/integration/components/solution-panel/qrocm-ind-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/solution-panel/qrocm-ind-solution-panel-test.js
@@ -170,7 +170,7 @@ module('Integration | Component | QROCm ind solution panel', function (hooks) {
       assert.dom(PARAGRAPH).doesNotExist();
       assert.strictEqual(find(INPUT).tagName, 'INPUT');
       assert.strictEqual(find(INPUT).value, EMPTY_DEFAULT_MESSAGE);
-      assert.strictEqual(find(INPUT).getAttribute('size'), EMPTY_DEFAULT_MESSAGE.length.toString());
+      assert.strictEqual(find(INPUT).getAttribute('size'), String(EMPTY_DEFAULT_MESSAGE.length + 1));
       assert.strictEqual(find(INPUT).getAttribute('aria-label'), 'Question passée');
       assert.true(find(INPUT).hasAttribute('disabled'));
     });


### PR DESCRIPTION
## :unicorn: Problème

Pour des épreuves QROC, sur l'écran de réponse, le champ de réponse est coupé quand la réponse a été rentrée en majuscules pas l'utilisateur.

On ne la revoit donc pas en entier, mais on peut scroller dans l'encadré pour le faire.

## :robot: Proposition

Augmenter de 1 la `size` de l'input grâce au helper `inc`.

## :rainbow: Remarques

Ce n'est pas optimal, mais ça fait l'affaire avant une possible refacto globale.

## :100: Pour tester

Répondre avec des réponses justes et fausses, en majuscule, à ces épreuves :
- QROC :
  - [/challenges/recYB0FRW3A6T59M/preview](https://app-pr9984.review.pix.fr/challenges/recYB0FRW3A6T59M/preview)
  - [/challenges/recTl3Xm1qHqDr2ZP/preview](https://app-pr9984.review.pix.fr/challenges/recTl3Xm1qHqDr2ZP/preview)
  - [/challenges/challenge1z8iBJajkAQr0c/preview](https://app-pr9984.review.pix.fr/challenges/challenge1z8iBJajkAQr0c/preview)
- QROCM dep : [/challenges/recLxoiSI8BkzF91o/preview](https://app-pr9984.review.pix.fr/challenges/recLxoiSI8BkzF91o/preview)
- QROCM ind : [/challenges/recfvhcGd1TMNA44p/preview](https://app-pr9984.review.pix.fr/challenges/recfvhcGd1TMNA44p/preview)

