### PR TITLE
[TECH] Optimiser les requêtes sur organization-learners (PIX-14068)

### DIFF
--- a/api/db/migrations/20240829094054_create-index-organization-learners-user-id-organization-id.js
+++ b/api/db/migrations/20240829094054_create-index-organization-learners-user-id-organization-id.js
@@ -1,0 +1,18 @@
+const TABLE_NAME = 'organization-learners';
+const INDEX_NAME = 'organization_learners_userid_organizationid_index';
+const USER_ID_COLUMN = 'userId';
+const ORGANIZATION_ID_COLUMN = 'organizationId';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.index([USER_ID_COLUMN, ORGANIZATION_ID_COLUMN], INDEX_NAME);
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropIndex([USER_ID_COLUMN, ORGANIZATION_ID_COLUMN], INDEX_NAME);
+  });
+};
+
+export { down, up };

--- a/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -216,12 +216,14 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       const firstOrganizationLearner = databaseBuilder.factory.buildOrganizationLearner({
         organizationId: organization_1.id,
         division: '3A',
+        lastName: 'last-name-1',
         updatedAt: new Date(),
       });
       const secondOrganizationLearner = databaseBuilder.factory.buildOrganizationLearner({
         organizationId: organization_1.id,
         userId: user.id,
         division: '3A',
+        lastName: 'last-name-2',
         updatedAt: new Date(),
       });
       databaseBuilder.factory.buildOrganizationLearner({ organizationId: organization_2.id });


### PR DESCRIPTION
## :unicorn: Problème

Lors de l’exécution du script de backfill de l’anonymisation, le traitement prenait plus de 2s par utilisateur.
Après analyse, cela correspond à la méthode `organizationLearnerRepository.dissociateAllStudentsByUserId()` et plus particulièrement sur cette requête.

```sql
update "organization-learners" 
set "userId" = $1, "certifiableAt" = $2, "isCertifiable" = $3, "updatedAt" = $4 
from "organizations" 
where "organization-learners"."userId"= $5 
and "organization-learners"."organizationId" = "organizations".id 
and "organizations"."isManagingStudents" = $6
```

De plus, l’anonymisation se fait également sur Pix Admin et prend plus de 2 secondes à cause de cette requête.

## :robot: Proposition

**Analyse**

Après un analyse plus poussée, nous nous sommes rendu compte:
- Que la requête utilise un index pas performant sur la table `organization-learners` (index uniquement sur `organization_id`: `organization_learners_organizationid_nationalapprenticeid_uniqu`
- Que la majorité du Top 10 des requêtes les plus longues portaient sur la vue `view-active-organization-learners` qui est elle-même basée sur la table `organization-learners`

Ces requêtes réalisent des `seq_scan` ou utilise un index non performant pour ces requêtes qui filtre quasiment à chaque fois sur `userId` et `organizationId`

Nous avons tester sur `pix-datawarehouse` l’ajout d’un index sur `userId` et `organizationId`)

**Résultat:** les requêtes de lecture et écriture utilisent bien cet index et améliore le plan d’exécution de la majorité des requêtes. 🎉

**Changement**

Créer l’index:

```sql
CREATE INDEX "organization_learners_userid_organizationid_index" 
ON "organization-learners" ("userId", "organizationId")
```


## :rainbow: Remarques

> [!NOTE]
> Le test de création d'index sur `pix-datawarehouse-api` a montré qu'il prenait moins d'une minute, donc aucun souci pour la mise en production

> [!NOTE]
> Un test de `organization-learners-repository` a été corrigé, car l'index change l'ordre des ids retournée, et le test testait l'ordre mais les JDD d'entrée étaient mal configuré (Tous les JDD avaient les même valeurs sur les attributs du `order by`) 

## :100: Pour tester

Vérifier que l’index a bien été ajouté sur la table `organization-learners`:
- `npm run db:migrate`
- verifier l'index sur la table `organization-learners`
- `npm run db:rollback:latest`

On peut vraiment vérifier le gain de performance uniquement en production (dû a volume de donnée trop bas des autres environnement)