### PR TITLE
[TECH] Ajouter des logs pour aider le debug des timeouts des jobs d'import SIECLE (PIX-14055)

### DIFF
--- a/api/src/prescription/learner-management/domain/usecases/add-or-update-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/add-or-update-organization-learners.js
@@ -5,6 +5,7 @@ import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTrans
 import { ORGANIZATION_LEARNER_CHUNK_SIZE } from '../../../../shared/infrastructure/constants.js';
 import { SiecleParser } from '../../infrastructure/serializers/xml/siecle-parser.js';
 import { SiecleFileStreamer } from '../../infrastructure/utils/xml/siecle-file-streamer.js';
+import { loggerForImport } from '../../utils/loggerForImport.js';
 
 const { chunk } = lodash;
 
@@ -20,21 +21,32 @@ async function addOrUpdateOrganizationLearners({
   const organizationImport = await organizationImportRepository.get(organizationImportId);
 
   return DomainTransaction.execute(async () => {
+    loggerForImport('IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Debut du usecase');
     try {
       const readableStream = await importStorage.readFile({ filename: organizationImport.filename });
+      loggerForImport('IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Apres readableStream');
+
       const siecleFileStreamer = await SiecleFileStreamer.create(readableStream, organizationImport.encoding);
+      loggerForImport('IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Apres le siecleFileStreamer');
+
       const parser = SiecleParser.create(siecleFileStreamer);
+      loggerForImport('IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Aprés le parser');
 
       const organizationLearnerData = await parser.parse();
+      loggerForImport('IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Recuperation des OL datas');
 
       const organizationLearnersChunks = chunk(organizationLearnerData, chunkSize);
 
       const nationalStudentIdData = organizationLearnerData.map((learner) => learner.nationalStudentId);
+      loggerForImport('IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Recuperation des nationalStudentId');
 
       await organizationLearnerRepository.disableAllOrganizationLearnersInOrganization({
         organizationId: organizationImport.organizationId,
         nationalStudentIds: nationalStudentIdData,
       });
+      loggerForImport(
+        'IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Aprés la methode disableAllOrganizationLearnersInOrganization',
+      );
 
       await bluebird.mapSeries(organizationLearnersChunks, (chunk) => {
         return organizationLearnerRepository.addOrUpdateOrganizationOfOrganizationLearners(
@@ -42,17 +54,25 @@ async function addOrUpdateOrganizationLearners({
           organizationImport.organizationId,
         );
       });
+      loggerForImport(
+        'IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Aprés la methode addOrUpdateOrganizationOfOrganizationLearners',
+      );
     } catch (error) {
       errors.push(error);
       throw error;
     } finally {
+      loggerForImport('IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Debut du finally');
+
       organizationImport.process({ errors });
       await organizationImportRepository.save(organizationImport);
+      loggerForImport("IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Aprés le save de l'organizationImport");
+
       try {
         await importStorage.deleteFile({ filename: organizationImport.filename });
       } catch (e) {
         logErrorWithCorrelationIds(e);
       }
+      loggerForImport('IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Fin du usecase');
     }
   });
 }

--- a/api/src/prescription/learner-management/utils/loggerForImport.js
+++ b/api/src/prescription/learner-management/utils/loggerForImport.js
@@ -1,0 +1,8 @@
+import { config } from '../../../shared/config.js';
+import { logger } from '../../../shared/infrastructure/utils/logger.js';
+
+export const loggerForImport = (message) => {
+  if (config.import.logEnabled) {
+    logger.info(message);
+  }
+};

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -61,6 +61,7 @@ const configuration = (function () {
           forcePathStyle: true,
         },
       },
+      logEnabled: toBoolean(process.env.DEBUG_IMPORT_LOG),
     },
     account: {
       passwordValidationPattern: '^(?=.*\\p{Lu})(?=.*\\p{Ll})(?=.*\\d).{8,}$',


### PR DESCRIPTION
## :unicorn: Problème
Actuellement on a des jobs d'import SIECLE en base qui timeout au bout de 30mn, et on a aucune idée de pourquoi ... Est ce le code ? un soucis d'infra ? autre ? 

## :robot: Proposition
Ajouter des logs un peu partout dans le usecase ainsi que les 2 repositories utilisés afin de voir a quel endroit ça coince pour nous aider a comprendre et a debugger

## :rainbow: Remarques
J'ai englober la fonction de logger afin de pouvoir conditionner l'affichage des logs ou non via une variable d'env.

J'ai fait le choix de préfixer ces logs de 'IMPORT_LOG' afin de pouvoir les retrouver rapidement, ainsi que entre <<>> le nom de la méthode ou ils se trouvent afin également de nous y retrouver plus facilement.

Faut - il encore plus de logs ? si oui ou ? Je peux en ajouter sans soucis

## :100: Pour tester
- Sans ajouter la var d'env -> Faire un import SIECLE, constater l'absence de logs
- Ajouter la var d'env `DEBUG_IMPORT_LOG=true`
- Refaire un import SIECLE, constater la présence des logs sur scalingo