### PR TITLE
[TECH] Utiliser ember intl pour les tableaux de l'administration

### DIFF
--- a/admin/app/components/autonomous-courses/list-items.gjs
+++ b/admin/app/components/autonomous-courses/list-items.gjs
@@ -1,5 +1,6 @@
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import { LinkTo } from '@ember/routing';
+import { t } from 'ember-intl';
 
 import formatDate from '../../helpers/format-date';
 
@@ -7,13 +8,17 @@ import formatDate from '../../helpers/format-date';
   <div class="content-text content-text--small">
     <div class="table-admin">
       <table>
-        <caption class="screen-reader-only">Liste des parcours autonomes</caption>
+        <caption class="screen-reader-only">{{t "components.autonomous-courses.list-items.table-caption"}}</caption>
         <thead>
           <tr>
-            <th scope="col" class="table__column table__column--id">Id</th>
-            <th scope="col">Nom</th>
-            <th scope="col" class="table__column table__medium">Date de création</th>
-            <th scope="col" class="table__column table__medium">Statut</th>
+            <th scope="col" id="autonomous-course-id" class="table__column--id">
+              {{t "components.autonomous-courses.list-items.table-headers.autonomous-course-id"}}</th>
+            <th scope="col" id="autonomous-course-name">
+              {{t "components.autonomous-courses.list-items.table-headers.autonomous-course-name"}}</th>
+            <th scope="col" id="autonomous-course-creation-date" class="table__column--medium">
+              {{t "components.autonomous-courses.list-items.table-headers.autonomous-course-creation-date"}}</th>
+            <th scope="col" id="autonomous-course-status" class="table__column--medium">
+              {{t "components.autonomous-courses.list-items.table-headers.autonomous-course-status"}}</th>
           </tr>
         </thead>
 
@@ -21,10 +26,10 @@ import formatDate from '../../helpers/format-date';
           <tbody>
             {{#each @items as |autonomousCourseListItem|}}
               <tr>
-                <td>
+                <td headers="autonomous-course-id">
                   {{autonomousCourseListItem.id}}
                 </td>
-                <td>
+                <td headers="autonomous-course-name">
                   <LinkTo
                     @route="authenticated.autonomous-courses.autonomous-course"
                     @model={{autonomousCourseListItem.id}}
@@ -32,17 +37,17 @@ import formatDate from '../../helpers/format-date';
                     {{autonomousCourseListItem.name}}
                   </LinkTo>
                 </td>
-                <td>
+                <td headers="autonomous-course-creation-date">
                   {{formatDate autonomousCourseListItem.createdAt}}
                 </td>
-                <td>
+                <td headers="autonomous-course-status">
                   {{#if autonomousCourseListItem.archivedAt}}
                     <PixTag @color="grey-light">
-                      Archivé
+                      {{t "common.words.archived"}}
                     </PixTag>
                   {{else}}
                     <PixTag @color="green-light">
-                      Actif
+                      {{t "common.words.active"}}
                     </PixTag>
                   {{/if}}
                 </td>
@@ -53,7 +58,7 @@ import formatDate from '../../helpers/format-date';
       </table>
 
       {{#unless @items}}
-        <div class="table__empty">Aucun résultat</div>
+        <div class="table__empty">{{t "common.tables.no-result"}}</div>
       {{/unless}}
     </div>
   </div>

--- a/admin/app/components/complementary-certifications/list.gjs
+++ b/admin/app/components/complementary-certifications/list.gjs
@@ -1,5 +1,6 @@
 import { LinkTo } from '@ember/routing';
 import Component from '@glimmer/component';
+import { t } from 'ember-intl';
 
 export default class List extends Component {
   get sortedComplementaryCertifications() {
@@ -10,18 +11,28 @@ export default class List extends Component {
     <div class="content-text content-text--small">
       <div class="table-admin">
         <table>
+          <caption class="screen-reader-only">
+            {{t "components.complementary-certifications.list.table-caption"}}
+          </caption>
           <thead>
             <tr>
-              <th class="table__column--id">ID</th>
-              <th>Nom</th>
+              <th scope="col" id="complementary-certification-id" class="table__column--id">{{t
+                  "components.complementary-certifications.list.table-headers.id"
+                }}</th>
+              <th scope="col" id="complementary-certification-name">{{t
+                  "components.complementary-certifications.list.table-headers.name"
+                }}</th>
             </tr>
           </thead>
 
           <tbody>
             {{#each this.sortedComplementaryCertifications as |complementaryCertification|}}
               <tr>
-                <td class="table__column--id">{{complementaryCertification.id}}</td>
-                <td>
+                <td
+                  headers="complementary-certification-id"
+                  class="table__column--id"
+                >{{complementaryCertification.id}}</td>
+                <td headers="complementary-certification-name">
                   <LinkTo
                     @route="authenticated.complementary-certifications.complementary-certification"
                     @model={{complementaryCertification.id}}

--- a/admin/app/components/sessions/list-items.gjs
+++ b/admin/app/components/sessions/list-items.gjs
@@ -6,6 +6,7 @@ import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 import map from 'lodash/map';
 import { statusToDisplayName } from 'pix-admin/models/session';
 
@@ -93,22 +94,39 @@ export default class ListItems extends Component {
   <template>
     <div class="content-text content-text--small table-admin__wrapper session-list">
       <table class="table-admin table-admin__auto-width">
+        <caption class="screen-reader-only">
+          {{t "components.sessions.list-items.table-caption"}}
+        </caption>
         <thead>
           <tr>
-            <th class="table__column table__column--id" id="session-id">ID</th>
-            <th id="certification-center-name">Centre de certification</th>
-            <th id="session-external-id">Identifiant externe</th>
-            <th id="certification-center-category">Catégorie</th>
-            <th id="session-date">Date de session</th>
-            <th id="session-status">Statut</th>
-            <th id="session-finalization-date">Date de finalisation</th>
-            <th id="session-publication-date">Date de publication</th>
-            <th id="session-version">Version de la session</th>
+            <th scope="col" id="session-id" class="table__column table__column--id">{{t
+                "components.sessions.list-items.table-headers.session-id"
+              }}</th>
+            <th scope="col" id="certification-center-name">{{t
+                "components.sessions.list-items.table-headers.certification-center-name"
+              }}</th>
+            <th scope="col" id="session-external-id">{{t
+                "components.sessions.list-items.table-headers.session-external-id"
+              }}</th>
+            <th scope="col" id="certification-center-category">{{t
+                "components.sessions.list-items.table-headers.certification-center-category"
+              }}</th>
+            <th scope="col" id="session-date">{{t "components.sessions.list-items.table-headers.session-date"}}</th>
+            <th scope="col" id="session-status">{{t "components.sessions.list-items.table-headers.session-status"}}</th>
+            <th scope="col" id="session-finalization-date">{{t
+                "components.sessions.list-items.table-headers.session-finalization-date"
+              }}</th>
+            <th scope="col" id="session-publication-date">{{t
+                "components.sessions.list-items.table-headers.session-publication-date"
+              }}</th>
+            <th scope="col" id="session-version">{{t
+                "components.sessions.list-items.table-headers.session-version"
+              }}</th>
           </tr>
           <tr>
             <td class="table__column table__column--id">
               <PixInput
-                aria-label="Filtrer les sessions avec un id"
+                aria-label="{{t 'components.sessions.list-items.labels.filter-by-session-id'}}"
                 type="text"
                 value={{this.searchedId}}
                 oninput={{fn @triggerFiltering "id"}}
@@ -116,7 +134,7 @@ export default class ListItems extends Component {
             </td>
             <td>
               <PixInput
-                aria-label="Filtrer les sessions avec le nom d'un centre de certification"
+                aria-label="{{t 'components.sessions.list-items.labels.filter-by-certification-center'}}"
                 type="text"
                 value={{this.searchedCertificationCenterName}}
                 oninput={{fn @triggerFiltering "certificationCenterName"}}
@@ -124,7 +142,7 @@ export default class ListItems extends Component {
             </td>
             <td>
               <PixInput
-                aria-label="Filtrer les sessions avec un identifiant externe"
+                aria-label="{{t 'components.sessions.list-items.labels.filter-by-external-id'}}"
                 type="text"
                 value={{this.searchedCertificationCenterExternalId}}
                 oninput={{fn @triggerFiltering "certificationCenterExternalId"}}
@@ -138,7 +156,7 @@ export default class ListItems extends Component {
                 @onChange={{this.selectCertificationCenterType}}
                 @value={{@certificationCenterType}}
               >
-                <:label>Filtrer les sessions en sélectionnant un type de centre de certification</:label>
+                <:label>{{t "components.sessions.list-items.labels.filter-by-certification-center-type"}}</:label>
               </PixSelect>
             </td>
             <td></td>
@@ -150,7 +168,7 @@ export default class ListItems extends Component {
                 @onChange={{this.selectSessionStatus}}
                 @value={{@status}}
               >
-                <:label>Filtrer les sessions en sélectionnant un statut</:label>
+                <:label>{{t "components.sessions.list-items.labels.filter-by-status"}}</:label>
               </PixSelect>
             </td>
             <td></td>
@@ -163,7 +181,7 @@ export default class ListItems extends Component {
                 @onChange={{this.selectSessionVersion}}
                 @value={{@version}}
               >
-                <:label>Filtrer les sessions par leur version</:label>
+                <:label>{{t "components.sessions.list-items.labels.filter-by-version"}}</:label>
               </PixSelect>
             </td>
           </tr>
@@ -199,7 +217,7 @@ export default class ListItems extends Component {
       </table>
 
       {{#unless @sessions}}
-        <div class="table__empty">Aucun résultat</div>
+        <div class="table__empty">{{t "common.tables.no-result"}}</div>
       {{/unless}}
     </div>
 

--- a/admin/app/components/target-profiles/list-summary-items.gjs
+++ b/admin/app/components/target-profiles/list-summary-items.gjs
@@ -3,6 +3,7 @@ import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import { fn } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
 import Component from '@glimmer/component';
+import { t } from 'ember-intl';
 
 import formatDate from '../../helpers/format-date';
 
@@ -14,16 +15,26 @@ export default class TargetProfileListSummaryItems extends Component {
     <div class="content-text content-text--small">
       <div class="table-admin">
         <table>
-
+          <caption class="screen-reader-only">
+            {{t "components.target-profiles.list-summary-items.table-caption"}}
+          </caption>
           <thead>
             <tr>
-              <th class="table__column table__column--id" id="target-profile-id">ID</th>
-              <th id="target-profile-name">Nom</th>
-              <th class="col-date">Date de création</th>
-              <th class="col-status" id="target-profile-status">Statut</th>
+              <th scope="col" id="target-profile-id" class="table__column--id">{{t
+                  "components.target-profiles.list-summary-items.table-headers.target-profile-id"
+                }}</th>
+              <th scope="col" id="target-profile-name">{{t
+                  "components.target-profiles.list-summary-items.table-headers.target-profile-name"
+                }}</th>
+              <th scope="col" id="target-profile-creation-date" class="table__column--medium">{{t
+                  "components.target-profiles.list-summary-items.table-headers.target-profile-creation-date"
+                }}</th>
+              <th scope="col" id="target-profile-status" class="table__column--medium">{{t
+                  "components.target-profiles.list-summary-items.table-headers.target-profile-status"
+                }}</th>
             </tr>
             <tr>
-              <td class="table__column table__column--id">
+              <td class="table__column--id">
                 <PixInput
                   type="text"
                   value={{this.searchedId}}
@@ -48,15 +59,15 @@ export default class TargetProfileListSummaryItems extends Component {
             <tbody>
               {{#each @summaries as |summary|}}
                 <tr aria-label="Profil cible">
-                  <td headers="target-profile-id" class="table__column table__column--id">{{summary.id}}</td>
+                  <td headers="target-profile-id" class="table__column--id">{{summary.id}}</td>
                   <td headers="target-profile-name">
                     <LinkTo @route="authenticated.target-profiles.target-profile" @model={{summary.id}}>
                       {{summary.name}}
                     </LinkTo>
                   </td>
-                  <td class="table__column">{{formatDate summary.createdAt}}</td>
-                  <td headers="target-profile-status" class="target-profile-table-column__status">
-                    {{if summary.outdated "Obsolète" "Actif"}}
+                  <td headers="target-profile-creation-date" class="table__column">{{formatDate summary.createdAt}}</td>
+                  <td headers="target-profile-status">
+                    {{if summary.outdated (t "common.words.obsolete") (t "common.words.active")}}
                   </td>
                 </tr>
               {{/each}}
@@ -65,7 +76,7 @@ export default class TargetProfileListSummaryItems extends Component {
         </table>
 
         {{#unless @summaries}}
-          <div class="table__empty">Aucun résultat</div>
+          <div class="table__empty">{{t "common.tables.no-result"}}</div>
         {{/unless}}
       </div>
     </div>

--- a/admin/app/components/team/list.gjs
+++ b/admin/app/components/team/list.gjs
@@ -92,23 +92,34 @@ export default class List extends Component {
   <template>
     <div class="content-text content-text--small">
       <table aria-label="Liste des membres" class="table-admin">
+        <caption class="screen-reader-only">{{t "components.team.list.table-caption"}}</caption>
         <thead>
           <tr>
-            <th>Prénom</th>
-            <th>Nom</th>
-            <th>Adresse e-mail</th>
-            <th>Rôle</th>
-            <th>Actions</th>
+            <th scope="col" id="team-member-first-name">
+              {{t "components.team.list.table-headers.team-member-first-name"}}
+            </th>
+            <th scope="col" id="team-member-last-name">
+              {{t "components.team.list.table-headers.team-member-last-name"}}
+            </th>
+            <th scope="col" id="team-member-email">
+              {{t "components.team.list.table-headers.team-member-email"}}
+            </th>
+            <th scope="col" id="team-member-role">
+              {{t "components.team.list.table-headers.team-member-role"}}
+            </th>
+            <th scope="col" id="team-member-actions">
+              {{t "components.team.list.table-headers.team-member-actions"}}
+            </th>
           </tr>
         </thead>
         {{#if @members}}
           <tbody>
             {{#each @members as |member|}}
               <tr aria-label={{concat member.firstName " " member.lastName}}>
-                <td>{{member.firstName}}</td>
-                <td>{{member.lastName}}</td>
-                <td>{{member.email}}</td>
-                <td>
+                <td headers="team-member-first-name">{{member.firstName}}</td>
+                <td headers="team-member-last-name">{{member.lastName}}</td>
+                <td headers="team-member-email">{{member.email}}</td>
+                <td headers="team-member-role">
                   {{#if member.isInEditionMode}}
                     <PixSelect
                       @onChange={{fn this.setAdminRoleSelection member}}
@@ -117,19 +128,21 @@ export default class List extends Component {
                       @screenReaderOnly={{true}}
                       @hideDefaultOption={{true}}
                     >
-                      <:label>Sélectionner un rôle</:label>
+                      <:label>
+                        {{t "components.team.list.labels.select-role"}}
+                      </:label>
                       <:default as |role|>{{role.label}}</:default>
                     </PixSelect>
                   {{else}}
                     {{member.role}}
                   {{/if}}
                 </td>
-                <td>
+                <td headers="team-member-actions">
                   <div class="admin-member-item-actions">
                     {{#if member.isInEditionMode}}
                       <PixButton
                         class="admin-member-item-actions__button"
-                        aria-label="Valider la modification de rôle"
+                        aria-label="{{t 'components.team.list.labels.confirm-role-modification'}}"
                         @triggerAction={{fn this.updateMemberRole member}}
                       >
                         {{t "common.actions.validate"}}
@@ -137,7 +150,11 @@ export default class List extends Component {
                     {{else}}
                       <PixButton
                         class="admin-member-item-actions__button"
-                        aria-label={{concat "Modifier le rôle de l'agent " member.firstName " " member.lastName}}
+                        aria-label={{t
+                          "components.team.list.labels.change-member-role"
+                          firstName=member.firstName
+                          lastName=member.lastName
+                        }}
                         @triggerAction={{fn this.toggleEditionModeForThisMember member}}
                         @iconBefore="pen-to-square"
                       >
@@ -147,13 +164,16 @@ export default class List extends Component {
                     <PixButton
                       class="admin-member-item-actions__button"
                       @variant="error"
-                      aria-label={{concat "Désactiver l'agent " member.firstName " " member.lastName}}
+                      aria-label={{t
+                        "components.team.list.labels.deactivate-member"
+                        firstName=member.firstName
+                        lastName=member.lastName
+                      }}
                       @triggerAction={{fn this.displayDeactivateConfirmationPopup member}}
                       @iconBefore="trash"
                     >
                       {{t "common.actions.deactivate"}}
                     </PixButton>
-
                   </div>
                 </td>
               </tr>
@@ -162,14 +182,14 @@ export default class List extends Component {
         {{/if}}
       </table>
       {{#unless @members}}
-        <div class="table__empty">Aucun résultat</div>
+        <div class="table__empty">{{t "common.tables.no-result"}}</div>
       {{/unless}}
     </div>
 
     <ConfirmPopup
       @message={{this.confirmPopUpMessage}}
-      @title="Désactivation d'un agent Pix"
-      @submitTitle="Confirmer"
+      @title={{t "components.team.list.labels.deactivate-confirmation"}}
+      @submitTitle={{t "common.actions.confirm"}}
       @confirm={{fn this.deactivateAdminMember this.adminMemberToDeactivate}}
       @cancel={{this.toggleDisplayConfirm}}
       @show={{this.displayConfirm}}

--- a/admin/app/components/trainings/list-summary-items.gjs
+++ b/admin/app/components/trainings/list-summary-items.gjs
@@ -3,6 +3,7 @@ import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import { fn } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
 import Component from '@glimmer/component';
+import { t } from 'ember-intl';
 
 import StateTag from './state-tag';
 
@@ -14,15 +15,27 @@ export default class TrainingListSummaryItems extends Component {
     <div class="content-text content-text--small">
       <div class="table-admin">
         <table>
-          <caption class="screen-reader-only">Liste des contenus formatifs</caption>
+          <caption class="screen-reader-only">{{t "components.trainings.list-summary-items.table-caption"}}</caption>
           <thead>
             <tr>
-              <th class="table__column table__column--id" id="training-id" scope="col">ID</th>
-              <th id="training-titre" scope="col">Titre</th>
-              <th id="training-prerequisite-threshold" scope="col" class="col-status">Prérequis</th>
-              <th id="training-goal-threshold" scope="col" class="col-status">Objectif à ne pas dépasser</th>
-              <th id="training-target-profile-count" scope="col" class="col-status">Profils cibles associés</th>
-              <th id="training-state" scope="col" class="col-status">État</th>
+              <th id="training-id" scope="col" class="table__column--id">{{t
+                  "components.trainings.list-summary-items.table-headers.training-id"
+                }}</th>
+              <th id="training-title" scope="col">{{t
+                  "components.trainings.list-summary-items.table-headers.training-title"
+                }}</th>
+              <th id="training-prerequisite-threshold" scope="col" class="table__column--medium">{{t
+                  "components.trainings.list-summary-items.table-headers.training-prerequisite-threshold"
+                }}</th>
+              <th id="training-goal-threshold" scope="col" class="table__column--medium">{{t
+                  "components.trainings.list-summary-items.table-headers.training-goal-threshold"
+                }}</th>
+              <th id="training-target-profile-count" scope="col" class="table__column--medium">{{t
+                  "components.trainings.list-summary-items.table-headers.training-target-profile-count"
+                }}</th>
+              <th id="training-state" scope="col" class="table__column--medium">{{t
+                  "components.trainings.list-summary-items.table-headers.training-state"
+                }}</th>
             </tr>
             {{#if @triggerFiltering}}
               <tr>
@@ -31,7 +44,7 @@ export default class TrainingListSummaryItems extends Component {
                     type="text"
                     value={{this.searchedId}}
                     oninput={{fn @triggerFiltering "id"}}
-                    aria-label="Filtrer les contenus formatifs par un id"
+                    aria-label={{t "components.trainings.list-summary-items.labels.filter-by-id"}}
                   />
                 </td>
                 <td>
@@ -39,7 +52,7 @@ export default class TrainingListSummaryItems extends Component {
                     type="text"
                     value={{this.searchedTitle}}
                     oninput={{fn @triggerFiltering "title"}}
-                    aria-label="Filtrer les contenus formatifs par un titre"
+                    aria-label={{t "components.trainings.list-summary-items.labels.filter-by-title"}}
                   />
                 </td>
                 <td></td>
@@ -79,7 +92,7 @@ export default class TrainingListSummaryItems extends Component {
         </table>
 
         {{#unless @summaries}}
-          <div class="table__empty">Aucun résultat</div>
+          <div class="table__empty">{{t "common.tables.no-result"}}</div>
         {{/unless}}
       </div>
     </div>

--- a/admin/app/components/users/list-items.gjs
+++ b/admin/app/components/users/list-items.gjs
@@ -1,16 +1,20 @@
 import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import { LinkTo } from '@ember/routing';
+import { t } from 'ember-intl';
 
 <template>
   <div class="content-text content-text--small">
     <table class="table-admin">
+      <caption class="screen-reader-only">{{t "components.users.list-items.table-caption"}}</caption>
       <thead>
         <tr>
-          <th class="table__column table__column--id">ID</th>
-          <th>Prénom</th>
-          <th>Nom</th>
-          <th>Adresse e-mail</th>
-          <th>Identifiant</th>
+          <th scope="col" id="user-id" class="table__column--id">{{t
+              "components.users.list-items.table-headers.user-id"
+            }}</th>
+          <th scope="col" id="user-firstname">{{t "components.users.list-items.table-headers.user-firstname"}}</th>
+          <th scope="col" id="user-lastname">{{t "components.users.list-items.table-headers.user-lastname"}}</th>
+          <th scope="col" id="user-email">{{t "components.users.list-items.table-headers.user-email"}}</th>
+          <th scope="col" id="user-username">{{t "components.users.list-items.table-headers.user-username"}}</th>
         </tr>
       </thead>
 
@@ -18,15 +22,15 @@ import { LinkTo } from '@ember/routing';
         <tbody>
           {{#each @users as |user|}}
             <tr aria-label="Informations de l'utilisateur {{user.firstName}} {{user.lastName}}">
-              <td class="table__column table__column--id">
+              <td headers="user-id" class="table__column table__column--id">
                 <LinkTo @route="authenticated.users.get" @model={{user.id}}>
                   {{user.id}}
                 </LinkTo>
               </td>
-              <td>{{user.firstName}}</td>
-              <td>{{user.lastName}}</td>
-              <td>{{user.email}}</td>
-              <td>{{user.username}}</td>
+              <td headers="user-firstname">{{user.firstName}}</td>
+              <td headers="user-lastname">{{user.lastName}}</td>
+              <td headers="user-email">{{user.email}}</td>
+              <td headers="user-username">{{user.username}}</td>
             </tr>
           {{/each}}
         </tbody>
@@ -34,7 +38,7 @@ import { LinkTo } from '@ember/routing';
     </table>
 
     {{#unless @users}}
-      <div class="table__empty">Aucun résultat</div>
+      <div class="table__empty">{{t "common.tables.no-result"}}</div>
     {{/unless}}
   </div>
 

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -85,7 +85,6 @@
 @import 'components/target-profiles/badges';
 @import 'components/target-profiles/details';
 @import 'components/target-profiles/insights';
-@import 'components/target-profiles/list-items';
 @import 'components/target-profiles/organizations';
 @import 'components/target-profiles/pdf-modal';
 @import 'components/target-profiles/stage-form';

--- a/admin/app/styles/components/target-profiles/list-items.scss
+++ b/admin/app/styles/components/target-profiles/list-items.scss
@@ -1,7 +1,0 @@
-/* stylelint-disable selector-class-pattern */
-.target-profile-table-column__status {
-
-  p {
-    display: inline;
-  }
-}

--- a/admin/tests/acceptance/authenticated/complementary-certifications/list-test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/list-test.js
@@ -1,13 +1,17 @@
 import { visit } from '@1024pix/ember-testing-library';
 import { click, currentURL } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 import { module, test } from 'qunit';
 
+import setupIntl from '../../../helpers/setup-intl';
+
 module('Acceptance | Complementary certifications | list ', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks);
 
   module('When admin member is not logged in', function () {
     test('it should not be accessible by an unauthenticated user', async function (assert) {
@@ -48,10 +52,14 @@ module('Acceptance | Complementary certifications | list ', function (hooks) {
       const screen = await visit('/complementary-certifications/list');
 
       // then
-      assert.dom(screen.getByText('ID')).exists({ count: 1 });
+      assert
+        .dom(screen.getByText(t('components.complementary-certifications.list.table-headers.id')))
+        .exists({ count: 1 });
       assert.dom(screen.getByText('1')).exists({ count: 1 });
 
-      assert.dom(screen.getByText('Nom')).exists({ count: 1 });
+      assert
+        .dom(screen.getByText(t('components.complementary-certifications.list.table-headers.name')))
+        .exists({ count: 1 });
       assert.dom(screen.getByText('TOINE')).exists({ count: 1 });
     });
 

--- a/admin/tests/acceptance/authenticated/team/list-test.js
+++ b/admin/tests/acceptance/authenticated/team/list-test.js
@@ -5,9 +5,12 @@ import { setupApplicationTest } from 'ember-qunit';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 import { module, test } from 'qunit';
 
+import setupIntl from '../../../helpers/setup-intl';
+
 module('Acceptance | Team | List', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks);
 
   module('When user is not logged in', function () {
     test('it should not be accessible by an unauthenticated user', async function (assert) {
@@ -66,7 +69,7 @@ module('Acceptance | Team | List', function (hooks) {
       await click(screen.getByRole('button', { name: 'Sélectionner un rôle' }));
       await screen.findByRole('listbox');
       await click(screen.getByRole('option', { name: 'CERTIF' }));
-      await clickByName('Valider la modification de rôle');
+      await clickByName('Valider la modification du rôle');
 
       // then
       assert.dom(screen.getByText("L'agent Anne Estésie a désormais le rôle CERTIF")).exists();
@@ -98,7 +101,6 @@ module('Acceptance | Team | List', function (hooks) {
       await clickByName("Désactiver l'agent Anne Estésie");
 
       await screen.findByRole('dialog');
-
       await clickByName('Confirmer');
 
       // then
@@ -145,7 +147,7 @@ module('Acceptance | Team | List', function (hooks) {
       await click(screen.getByRole('button', { name: 'Sélectionner un rôle' }));
       await screen.findByRole('listbox');
       await click(screen.getByRole('option', { name: 'CERTIF' }));
-      await clickByName('Valider la modification de rôle');
+      await clickByName('Valider la modification du rôle');
 
       // then
       assert.dom(screen.getByText('Erreur lors de la mise à jour du rôle de cet agent Pix.')).exists();

--- a/admin/tests/acceptance/authenticated/trainings/list-test.js
+++ b/admin/tests/acceptance/authenticated/trainings/list-test.js
@@ -5,9 +5,13 @@ import { setupApplicationTest } from 'ember-qunit';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 import { module, test } from 'qunit';
 
+import setupIntl from '../../../helpers/setup-intl';
+
 module('Acceptance | Trainings | List', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+
+  setupIntl(hooks);
 
   module('When admin member is not logged in', function () {
     test('it should not be accessible by an unauthenticated user', async function (assert) {

--- a/admin/tests/integration/components/autonomous-courses/list-items-test.gjs
+++ b/admin/tests/integration/components/autonomous-courses/list-items-test.gjs
@@ -3,8 +3,11 @@ import { setupRenderingTest } from 'ember-qunit';
 import ListItems from 'pix-admin/components/autonomous-courses/list-items';
 import { module, test } from 'qunit';
 
+import setupIntl from '../../../helpers/setup-intl';
+
 module('Integration | Component | AutonomousCourses::ListItems', function (hooks) {
   setupRenderingTest(hooks);
+  setupIntl(hooks);
 
   test('it should display a autonomous courses list', async function (assert) {
     // given

--- a/admin/tests/integration/components/routes/authenticated/sessions/list-items-test.gjs
+++ b/admin/tests/integration/components/routes/authenticated/sessions/list-items-test.gjs
@@ -5,8 +5,11 @@ import ListItems from 'pix-admin/components/sessions/list-items';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntl from '../../../../../helpers/setup-intl';
+
 module('Integration | Component | routes/authenticated/sessions | list-items', function (hooks) {
   setupRenderingTest(hooks);
+  setupIntl(hooks);
 
   const triggerFiltering = () => {};
 

--- a/admin/tests/integration/components/routes/authenticated/target-profiles/list-items-test.gjs
+++ b/admin/tests/integration/components/routes/authenticated/target-profiles/list-items-test.gjs
@@ -3,8 +3,11 @@ import { setupRenderingTest } from 'ember-qunit';
 import ListSummaryItems from 'pix-admin/components/target-profiles/list-summary-items';
 import { module, test } from 'qunit';
 
+import setupIntl from '../../../../../helpers/setup-intl';
+
 module('Integration | Component | routes/authenticated/target-profiles | list-items', function (hooks) {
   setupRenderingTest(hooks);
+  setupIntl(hooks);
 
   const triggerFiltering = function () {};
   const goToTargetProfilePage = function () {};
@@ -18,7 +21,7 @@ module('Integration | Component | routes/authenticated/target-profiles | list-it
     );
 
     // then
-    assert.dom(screen.getByText('ID')).exists();
+    assert.dom(screen.getByText('Id')).exists();
     assert.dom(screen.getByText('Nom')).exists();
     assert.dom(screen.getByText('Statut')).exists();
   });

--- a/admin/tests/integration/components/routes/authenticated/trainings/list-items-test.gjs
+++ b/admin/tests/integration/components/routes/authenticated/trainings/list-items-test.gjs
@@ -3,8 +3,11 @@ import { setupRenderingTest } from 'ember-qunit';
 import ListSummaryItems from 'pix-admin/components/trainings/list-summary-items';
 import { module, test } from 'qunit';
 
+import setupIntl from '../../../../../helpers/setup-intl';
+
 module('Integration | Component | routes/authenticated/trainings | list-items', function (hooks) {
   setupRenderingTest(hooks);
+  setupIntl(hooks);
 
   const noop = () => {};
 

--- a/admin/tests/integration/components/routes/authenticated/users/list-items-test.gjs
+++ b/admin/tests/integration/components/routes/authenticated/users/list-items-test.gjs
@@ -3,8 +3,11 @@ import { setupRenderingTest } from 'ember-qunit';
 import ListItems from 'pix-admin/components/users/list-items';
 import { module, test } from 'qunit';
 
+import setupIntl from '../../../../../helpers/setup-intl';
+
 module('Integration | Component | routes/authenticated/users | list-items', function (hooks) {
   setupRenderingTest(hooks);
+  setupIntl(hooks);
 
   const triggerFiltering = () => {};
 

--- a/admin/tests/integration/components/target-profiles/list-summary-items-test.gjs
+++ b/admin/tests/integration/components/target-profiles/list-summary-items-test.gjs
@@ -2,8 +2,11 @@ import { render } from '@1024pix/ember-testing-library';
 import { setupRenderingTest } from 'ember-qunit';
 import ListSummaryItems from 'pix-admin/components/target-profiles/list-summary-items';
 import { module, test } from 'qunit';
+
+import setupIntl from '../../../helpers/setup-intl';
 module('Integration | Component | TargetProfiles::ListSummaryItems', function (hooks) {
   setupRenderingTest(hooks);
+  setupIntl(hooks);
 
   const triggerFiltering = () => {};
 

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -7,7 +7,8 @@
       "deactivate": "Désactiver",
       "edit": "Modifier",
       "save": "Enregistrer",
-      "validate": "Valider"
+      "validate": "Valider",
+      "confirm": "Confirmer"
     },
     "api-error-messages": {
       "bad-request-error": "Les données que vous avez soumises ne sont pas au bon format.",
@@ -31,8 +32,14 @@
       "auto": "Automatique",
       "member": "Membre"
     },
+    "tables": {
+      "no-result": "Aucun résultat"
+    },
     "words": {
+      "active": "Actif",
+      "archived": "Archivé",
       "no": "Non",
+      "obsolete": "Obsolète",
       "yes": "Oui"
     }
   },
@@ -143,6 +150,17 @@
         "upload-button": "Importer un fichier CSV"
       }
     },
+    "autonomous-courses": {
+      "list-items": {
+        "table-caption": "Liste des parcours autonomes",
+        "table-headers": {
+          "autonomous-course-creation-date": "Date de création",
+          "autonomous-course-id": "Id",
+          "autonomous-course-name": "Nom",
+          "autonomous-course-status": "Statut"
+        }
+      }
+    },
     "badges": {
       "api-error-messages": {
         "key-already-exists": "La clé de badge {badgeKey} est déjà utilisée"
@@ -169,6 +187,13 @@
       }
     },
     "complementary-certifications": {
+      "list" : {
+        "table-caption": "Liste des certifications complémentaires",
+        "table-headers": {
+          "id": "Id",
+          "name": "Nom"
+        }
+      },
       "target-profiles": {
         "badges-list": {
           "title": "Badges certifiés du profil cible actuel",
@@ -212,6 +237,57 @@
         "parent-organization": "Organisation mère"
       }
     },
+    "sessions": {
+      "list-items": {
+        "table-caption": "Liste des sessions",
+        "labels": {
+          "filter-by-certification-center": "Filtrer les sessions avec le nom d'un centre de certification",
+          "filter-by-certification-center-type": "Filtrer les sessions en sélectionnant un type de centre de certification",
+          "filter-by-external-id": "Filtrer les sessions avec un identifiant externe",
+          "filter-by-session-id": "Filtrer les sessions avec un id",
+          "filter-by-status": "Filtrer les sessions en sélectionnant un statut",
+          "filter-by-version": "Filtrer les sessions par leur version"
+        },
+        "table-headers": {
+          "certification-center-category": "Catégorie",
+          "certification-center-name": "Centre de certification",
+          "session-date": "Date de session",
+          "session-external-id": "Identifiant externe",
+          "session-finalization-date": "Date de finalisation",
+          "session-id": "Id",
+          "session-publication-date": "Date de publication",
+          "session-status": "Statut",
+          "session-version": "Version de la session"
+        }
+      }
+    },
+    "target-profiles": {
+      "list-summary-items": {
+        "table-caption" : "Liste des profils cibles",
+        "table-headers": {
+          "target-profile-creation-date": "Date de création",
+          "target-profile-id": "Id",
+          "target-profile-name": "Nom",
+          "target-profile-status": "Statut"
+        }
+      }
+    },
+    "trainings": {
+      "list-summary-items": {
+        "labels": {
+          "filter-by-id": "Filtrer les contenus formatifs par un id",
+          "filter-by-title": "Filtrer les contenus formatifs par un titre"
+        },
+        "table-headers": {
+          "training-goal-threshold": "Objectif à ne pas dépasser",
+          "training-id": "ID",
+          "training-prerequisite-threshold": "Prérequis",
+          "training-state": "État",
+          "training-target-profile-count": "Profils cibles associés",
+          "training-title": "Titre"
+        }
+      }
+    },
     "users": {
       "certification-centers": {
         "memberships": {
@@ -240,6 +316,16 @@
           }
         }
       },
+      "list-items": {
+        "table-caption": "Liste des utilisateurs",
+        "table-headers": {
+          "user-email": "Adresse e-mail",
+          "user-firstname": "Prénom",
+          "user-id": "Id",
+          "user-lastname": "Nom",
+          "user-username": "Identifiant"
+        }
+      },
       "user-detail-personal-information": {
         "actions": {
           "copy-email": "Copier l’adresse e-mail",
@@ -249,6 +335,25 @@
           "should-change-password-status": "Mot de passe temporaire :"
         },
         "copied": "Copié !"
+      }
+    },
+    "team": {
+      "list": {
+        "table-caption" : "Liste des membres de l'équipe",
+        "table-headers": {
+          "team-member-first-name" : "Prénom",
+          "team-member-last-name" : "Nom",
+          "team-member-email" :  "Adresse e-mail",
+          "team-member-role" : "Rôle",
+          "team-member-actions" :  "Actions"
+        },
+        "labels": {
+          "select-role": "Sélectionner un rôle",
+          "confirm-role-modification": "Valider la modification du rôle",
+          "change-member-role": "Modifier le rôle de l'agent {firstName} {lastName}",
+          "deactivate-member": "Désactiver l'agent {firstName} {lastName}",
+          "deactivate-confirmation": "Désactivation d'un agent Pix"
+        }
       }
     }
   },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -4,11 +4,11 @@
       "add": "Ajouter",
       "cancel": "Annuler",
       "close": "Fermer",
+      "confirm": "Confirmer",
       "deactivate": "Désactiver",
       "edit": "Modifier",
       "save": "Enregistrer",
-      "validate": "Valider",
-      "confirm": "Confirmer"
+      "validate": "Valider"
     },
     "api-error-messages": {
       "bad-request-error": "Les données que vous avez soumises ne sont pas au bon format.",
@@ -187,7 +187,7 @@
       }
     },
     "complementary-certifications": {
-      "list" : {
+      "list": {
         "table-caption": "Liste des certifications complémentaires",
         "table-headers": {
           "id": "Id",
@@ -239,7 +239,6 @@
     },
     "sessions": {
       "list-items": {
-        "table-caption": "Liste des sessions",
         "labels": {
           "filter-by-certification-center": "Filtrer les sessions avec le nom d'un centre de certification",
           "filter-by-certification-center-type": "Filtrer les sessions en sélectionnant un type de centre de certification",
@@ -248,6 +247,7 @@
           "filter-by-status": "Filtrer les sessions en sélectionnant un statut",
           "filter-by-version": "Filtrer les sessions par leur version"
         },
+        "table-caption": "Liste des sessions",
         "table-headers": {
           "certification-center-category": "Catégorie",
           "certification-center-name": "Centre de certification",
@@ -263,12 +263,31 @@
     },
     "target-profiles": {
       "list-summary-items": {
-        "table-caption" : "Liste des profils cibles",
+        "table-caption": "Liste des profils cibles",
         "table-headers": {
           "target-profile-creation-date": "Date de création",
           "target-profile-id": "Id",
           "target-profile-name": "Nom",
           "target-profile-status": "Statut"
+        }
+      }
+    },
+    "team": {
+      "list": {
+        "labels": {
+          "change-member-role": "Modifier le rôle de l'agent {firstName} {lastName}",
+          "confirm-role-modification": "Valider la modification du rôle",
+          "deactivate-confirmation": "Désactivation d'un agent Pix",
+          "deactivate-member": "Désactiver l'agent {firstName} {lastName}",
+          "select-role": "Sélectionner un rôle"
+        },
+        "table-caption": "Liste des membres de l'équipe",
+        "table-headers": {
+          "team-member-actions": "Actions",
+          "team-member-email": "Adresse e-mail",
+          "team-member-first-name": "Prénom",
+          "team-member-last-name": "Nom",
+          "team-member-role": "Rôle"
         }
       }
     },
@@ -335,25 +354,6 @@
           "should-change-password-status": "Mot de passe temporaire :"
         },
         "copied": "Copié !"
-      }
-    },
-    "team": {
-      "list": {
-        "table-caption" : "Liste des membres de l'équipe",
-        "table-headers": {
-          "team-member-first-name" : "Prénom",
-          "team-member-last-name" : "Nom",
-          "team-member-email" :  "Adresse e-mail",
-          "team-member-role" : "Rôle",
-          "team-member-actions" :  "Actions"
-        },
-        "labels": {
-          "select-role": "Sélectionner un rôle",
-          "confirm-role-modification": "Valider la modification du rôle",
-          "change-member-role": "Modifier le rôle de l'agent {firstName} {lastName}",
-          "deactivate-member": "Désactiver l'agent {firstName} {lastName}",
-          "deactivate-confirmation": "Désactivation d'un agent Pix"
-        }
       }
     }
   },
@@ -728,3 +728,4 @@
     }
   }
 }
+


### PR DESCRIPTION
## :unicorn: Problème
L'interface d'administration n'utilise pas ember intl pour afficher les messages sur l'interface. Cela nous limitera par la suite si nous souhaitons traduire l'interface ou utiliser un outil tiers pour gerer les messages a l'ecran.

## :robot: Proposition
Cette PR a  pour but d'imposer l'utilisation de ember intl sur les pages listant les ressources dans l'administration.

## :100: Pour tester
テストはグリーンでなければなりません
Accede a las diferentes tablas de recursos y comprueba que las cadenas de caracteres siguen mostrándose correctamente.

## :rainbow: Remarques
J'ai egalement ajoute des captions et des proprietes headers la ou il n'y en avait pas.