### PR TITLE
[TECH] Ajouter le `deletedBy` en condition de la vue des organisation learners actif (PIX-14071)

### DIFF
--- a/api/db/migrations/20240829124253_add-deleted-by-clause-on-view-active-organization-learners.js
+++ b/api/db/migrations/20240829124253_add-deleted-by-clause-on-view-active-organization-learners.js
@@ -1,0 +1,16 @@
+const VIEW_NAME = 'view-active-organization-learners';
+const REFERENCE_TABLE_NAME = 'organization-learners';
+
+const up = async function (knex) {
+  await knex.schema.createViewOrReplace(VIEW_NAME, function (view) {
+    view.as(knex(REFERENCE_TABLE_NAME).whereNull('deletedAt').whereNull('deletedBy'));
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.createViewOrReplace(VIEW_NAME, function (view) {
+    view.as(knex(REFERENCE_TABLE_NAME).whereNull('deletedAt'));
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## :unicorn: Problème
Après investigations sur des perfs de la table `organization-learners` l'équipe @1024pix/team-acces s'est rendu compte que la vue `view-active-organization-learners` ne filtre que via le `deletedAt IS NULL` Ce qui n'est pas optimal car les requetes de lecture sur la table de reference n'utilisent pas l'index `one_active_organization_learner`

## :robot: Proposition
L'équipe Accès s'est occupé de rajouter un nouvel index pour leur besoin sur la table `organization-learners` ce qui rends facultatif l'ajout du filtre par `deletedBy` également, mais pour des raisons de cohérence et d'alignement dans notre code, nous avons décidé de rajouter cette condition

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

- Via CLI Scalingo pgsql : 
- Faire la commande : 

```sql
SELECT * FROM INFORMATION_SCHEMA.VIEWS WHERE "table_name" = 'view-active-organization-learners';
```

- Et vérifier la condition 
```sql 

WHERE 'deletedAt' IS NULL AND 'deletedBy' IS NULL
```
- (Il est également possible de faire un tour sur PixOrga, supprimer un learner, et vérifier qu'il n'apparait pas)

- 🐈‍⬛ 