### PR TITLE
[TECH] Revue de la gestion des erreurs du domaine Modulix (PIX-14043)

### DIFF
--- a/api/src/devcomp/domain/models/Grain.js
+++ b/api/src/devcomp/domain/models/Grain.js
@@ -1,5 +1,5 @@
-import { DomainError } from '../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.js';
+import { ModuleInstantiationError } from '../errors.js';
 
 class Grain {
   constructor({ id, title, type, components }) {
@@ -15,7 +15,7 @@ class Grain {
 
   #assertComponentsIsDefinedAndAnArray(components) {
     if (components !== undefined && !Array.isArray(components)) {
-      throw new DomainError(`Grain components should be a list of components`);
+      throw new ModuleInstantiationError(`Grain components should be a list of components`);
     }
   }
 }

--- a/api/src/devcomp/domain/models/QrocmSolutions.js
+++ b/api/src/devcomp/domain/models/QrocmSolutions.js
@@ -1,5 +1,5 @@
-import { DomainError } from '../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.js';
+import { ModuleInstantiationError } from '../errors.js';
 
 class QrocmSolutions {
   constructor(proposals) {
@@ -15,10 +15,10 @@ class QrocmSolutions {
           'The tolerances are required for each QROCM proposal in QROCM solutions',
         );
         if (!Array.isArray(proposal.solutions)) {
-          throw new DomainError('Each proposal in QROCM solutions should have a list of solutions');
+          throw new ModuleInstantiationError('Each proposal in QROCM solutions should have a list of solutions');
         }
         if (!Array.isArray(proposal.tolerances)) {
-          throw new DomainError('A QROCM solution should have a list of tolerances');
+          throw new ModuleInstantiationError('A QROCM solution should have a list of tolerances');
         }
       });
 

--- a/api/src/devcomp/domain/models/component/ComponentStepper.js
+++ b/api/src/devcomp/domain/models/component/ComponentStepper.js
@@ -1,5 +1,5 @@
-import { DomainError } from '../../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { ModuleInstantiationError } from '../../errors.js';
 
 class ComponentStepper {
   constructor({ steps }) {
@@ -12,7 +12,7 @@ class ComponentStepper {
 
   #assertStepsAreAnArray(steps) {
     if (!Array.isArray(steps)) {
-      throw new DomainError('Steps should be an array');
+      throw new ModuleInstantiationError('Steps should be an array');
     }
   }
 }

--- a/api/src/devcomp/domain/models/component/Step.js
+++ b/api/src/devcomp/domain/models/component/Step.js
@@ -1,5 +1,5 @@
-import { DomainError } from '../../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { ModuleInstantiationError } from '../../errors.js';
 
 class Step {
   constructor({ elements }) {
@@ -11,10 +11,10 @@ class Step {
 
   #assertElementsNotEmpty(elements) {
     if (!Array.isArray(elements)) {
-      throw new DomainError('step.elements should be an array');
+      throw new ModuleInstantiationError('step.elements should be an array');
     }
     if (elements.length === 0) {
-      throw new DomainError('A step should contain at least one element');
+      throw new ModuleInstantiationError('A step should contain at least one element');
     }
   }
 }

--- a/api/src/devcomp/domain/models/element/Download.js
+++ b/api/src/devcomp/domain/models/element/Download.js
@@ -1,5 +1,5 @@
-import { DomainError } from '../../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { ModuleInstantiationError } from '../../errors.js';
 import { Element } from './Element.js';
 
 class Download extends Element {
@@ -19,12 +19,12 @@ class Download extends Element {
 
   #assertFilesIsAnArray(files) {
     if (!Array.isArray(files)) {
-      throw new DomainError('The Download files should be a list');
+      throw new ModuleInstantiationError('The Download files should be a list');
     }
   }
 
   #assertFilesAreNotEmpty(files) {
-    if (files.length === 0) throw new DomainError('The files are required for a Download');
+    if (files.length === 0) throw new ModuleInstantiationError('The files are required for a Download');
   }
 }
 

--- a/api/src/devcomp/domain/models/element/Image.js
+++ b/api/src/devcomp/domain/models/element/Image.js
@@ -7,7 +7,7 @@ class Image extends Element {
 
     assertNotNullOrUndefined(url, 'The URL is required for an image');
     assertNotNullOrUndefined(alt, 'The alt text is required for an image');
-    assertNotNullOrUndefined(alternativeText, 'The alternative instruction is required for an image');
+    assertNotNullOrUndefined(alternativeText, 'The alternative text is required for an image');
 
     this.url = url;
     this.alt = alt;

--- a/api/src/devcomp/domain/models/element/QCM.js
+++ b/api/src/devcomp/domain/models/element/QCM.js
@@ -1,5 +1,5 @@
-import { DomainError } from '../../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { ModuleInstantiationError } from '../../errors.js';
 import { Element } from './Element.js';
 
 class QCM extends Element {
@@ -18,13 +18,13 @@ class QCM extends Element {
 
   #assertProposalsAreNotEmpty(proposals) {
     if (proposals.length === 0) {
-      throw new DomainError('The proposals are required for a QCM');
+      throw new ModuleInstantiationError('The proposals are required for a QCM');
     }
   }
 
   #assertProposalsIsAnArray(proposals) {
     if (!Array.isArray(proposals)) {
-      throw new DomainError('The proposals should be in a list');
+      throw new ModuleInstantiationError('The proposals should be in a list');
     }
   }
 }

--- a/api/src/devcomp/domain/models/element/QCU-for-answer-verification.js
+++ b/api/src/devcomp/domain/models/element/QCU-for-answer-verification.js
@@ -1,8 +1,8 @@
 import Joi from 'joi';
 
-import { DomainError } from '../../../../shared/domain/errors.js';
 import { EntityValidationError } from '../../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { ModuleInstantiationError } from '../../errors.js';
 import { Feedbacks } from '../Feedbacks.js';
 import { QcuCorrectionResponse } from '../QcuCorrectionResponse.js';
 import { ValidatorQCU } from '../validator/ValidatorQCU.js';
@@ -32,7 +32,7 @@ class QCUForAnswerVerification extends QCU {
   #assertSolutionIsAnExistingProposal(solution, proposals) {
     const isSolutionAnExistingProposal = proposals.find(({ id: proposalId }) => proposalId === solution);
     if (!isSolutionAnExistingProposal) {
-      throw new DomainError('The QCU solution id is not an existing proposal id');
+      throw new ModuleInstantiationError('The QCU solution id is not an existing proposal id');
     }
   }
 

--- a/api/src/devcomp/domain/models/element/QCU.js
+++ b/api/src/devcomp/domain/models/element/QCU.js
@@ -1,5 +1,5 @@
-import { DomainError } from '../../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { ModuleInstantiationError } from '../../errors.js';
 import { Element } from './Element.js';
 
 class QCU extends Element {
@@ -18,13 +18,13 @@ class QCU extends Element {
 
   #assertProposalsAreNotEmpty(proposals) {
     if (proposals.length === 0) {
-      throw new DomainError('The proposals are required for a QCU');
+      throw new ModuleInstantiationError('The proposals are required for a QCU');
     }
   }
 
   #assertProposalsIsAnArray(proposals) {
     if (!Array.isArray(proposals)) {
-      throw new DomainError('The QCU proposals should be a list');
+      throw new ModuleInstantiationError('The QCU proposals should be a list');
     }
   }
 }

--- a/api/src/devcomp/domain/models/element/QROCM.js
+++ b/api/src/devcomp/domain/models/element/QROCM.js
@@ -1,5 +1,5 @@
-import { DomainError } from '../../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { ModuleInstantiationError } from '../../errors.js';
 import { Element } from './Element.js';
 
 class QROCM extends Element {
@@ -19,13 +19,13 @@ class QROCM extends Element {
 
   #assertProposalsAreNotEmpty(proposals) {
     if (proposals.length === 0) {
-      throw new DomainError('Les propositions sont obligatoires pour un QROCM');
+      throw new ModuleInstantiationError('Les propositions sont obligatoires pour un QROCM');
     }
   }
 
   #assertProposalsIsAnArray(proposals) {
     if (!Array.isArray(proposals)) {
-      throw new DomainError('Les propositions doivent apparaître dans une liste');
+      throw new ModuleInstantiationError('Les propositions doivent apparaître dans une liste');
     }
   }
 }

--- a/api/src/devcomp/domain/models/module/Details.js
+++ b/api/src/devcomp/domain/models/module/Details.js
@@ -1,5 +1,5 @@
-import { DomainError } from '../../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { ModuleInstantiationError } from '../../errors.js';
 
 class Details {
   constructor({ image, description, duration, level, tabletSupport, objectives }) {
@@ -22,13 +22,13 @@ class Details {
 
   #assertObjectivesIsAnArray(objectives) {
     if (!Array.isArray(objectives)) {
-      throw new DomainError('The module details should contain a list of objectives');
+      throw new ModuleInstantiationError('The module details should contain a list of objectives');
     }
   }
 
   #assertObjectivesHasMinimumLength(objectives) {
     if (objectives.length < 1) {
-      throw new DomainError('The module details should contain at least one objective');
+      throw new ModuleInstantiationError('The module details should contain at least one objective');
     }
   }
 }

--- a/api/src/devcomp/domain/models/module/Module.js
+++ b/api/src/devcomp/domain/models/module/Module.js
@@ -1,5 +1,5 @@
-import { DomainError } from '../../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { ModuleInstantiationError } from '../../errors.js';
 
 class Module {
   constructor({ id, slug, title, grains, details, transitionTexts = [] }) {
@@ -24,13 +24,15 @@ class Module {
       ({ grainId }) => !!grains.find(({ id }) => grainId === id),
     );
     if (!isTransitionTextsLinkedToGrain) {
-      throw new DomainError('All the transition texts should be linked to a grain contained in the module.');
+      throw new ModuleInstantiationError(
+        'All the transition texts should be linked to a grain contained in the module.',
+      );
     }
   }
 
   #assertGrainsIsAnArray(grains) {
     if (!Array.isArray(grains)) {
-      throw new DomainError('A module should have a list of grains');
+      throw new ModuleInstantiationError('A module should have a list of grains');
     }
   }
 }

--- a/api/tests/devcomp/integration/application/modules/index_test.js
+++ b/api/tests/devcomp/integration/application/modules/index_test.js
@@ -1,0 +1,52 @@
+import { modulesController } from '../../../../../src/devcomp/application/modules/controller.js';
+import * as moduleUnderTest from '../../../../../src/devcomp/application/modules/index.js';
+import { ElementInstantiationError, ModuleInstantiationError } from '../../../../../src/devcomp/domain/errors.js';
+import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
+
+describe('Integration | Devcomp | Application | Module | Router | modules-router', function () {
+  describe('GET /api/modules/{slug}', function () {
+    describe('when controller throws a ModuleInstantiationError', function () {
+      it('should return an HTTP 502 error', async function () {
+        // given
+        sinon.stub(modulesController, 'getBySlug').throws(new ModuleInstantiationError());
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+        const invalidPayload = {
+          data: {
+            attributes: {
+              'module-id': 'not existing id',
+            },
+          },
+        };
+
+        // when
+        const response = await httpTestServer.request('GET', '/api/modules/module', invalidPayload);
+
+        // then
+        expect(response.statusCode).to.equal(502);
+      });
+    });
+
+    describe('when controller throws an ElementInstantiationError', function () {
+      it('should return an HTTP 502 error', async function () {
+        // given
+        sinon.stub(modulesController, 'getBySlug').throws(new ElementInstantiationError());
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+        const invalidPayload = {
+          data: {
+            attributes: {
+              'module-id': 'not existing id',
+            },
+          },
+        };
+
+        // when
+        const response = await httpTestServer.request('GET', '/api/modules/module', invalidPayload);
+
+        // then
+        expect(response.statusCode).to.equal(502);
+      });
+    });
+  });
+});

--- a/api/tests/devcomp/integration/domain/models/Module_test.js
+++ b/api/tests/devcomp/integration/domain/models/Module_test.js
@@ -1,7 +1,7 @@
+import { ModuleInstantiationError } from '../../../../../src/devcomp/domain/errors.js';
 import { Text } from '../../../../../src/devcomp/domain/models/element/Text.js';
 import { Grain } from '../../../../../src/devcomp/domain/models/Grain.js';
 import { Module } from '../../../../../src/devcomp/domain/models/module/Module.js';
-import { DomainError } from '../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../test-helper.js';
 
 describe('Integration | Devcomp | Domain | Models | Module', function () {
@@ -33,7 +33,7 @@ describe('Integration | Devcomp | Domain | Models | Module', function () {
       const error = catchErrSync(() => new Module({ id, slug, title, grains, transitionTexts, details }))();
 
       // then
-      expect(error).to.be.instanceOf(DomainError);
+      expect(error).to.be.instanceOf(ModuleInstantiationError);
       expect(error.message).to.equal('All the transition texts should be linked to a grain contained in the module.');
     });
   });

--- a/api/tests/devcomp/unit/domain/models/Grain_test.js
+++ b/api/tests/devcomp/unit/domain/models/Grain_test.js
@@ -1,3 +1,4 @@
+import { ModuleInstantiationError } from '../../../../../src/devcomp/domain/errors.js';
 import { Grain } from '../../../../../src/devcomp/domain/models/Grain.js';
 import { DomainError } from '../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../test-helper.js';
@@ -56,7 +57,7 @@ describe('Unit | Devcomp | Domain | Models | Grain', function () {
           )();
 
           // then
-          expect(error).to.be.instanceOf(DomainError);
+          expect(error).to.be.instanceOf(ModuleInstantiationError);
           expect(error.message).to.equal('Grain components should be a list of components');
         });
       });

--- a/api/tests/devcomp/unit/domain/models/QrocmSolutions_test.js
+++ b/api/tests/devcomp/unit/domain/models/QrocmSolutions_test.js
@@ -1,3 +1,4 @@
+import { ModuleInstantiationError } from '../../../../../src/devcomp/domain/errors.js';
 import { QrocmSolutions } from '../../../../../src/devcomp/domain/models/QrocmSolutions.js';
 import { DomainError } from '../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../test-helper.js';
@@ -133,7 +134,7 @@ describe('Unit | Devcomp | Domain | Models | QrocmSolutions', function () {
         )();
 
         // then
-        expect(error).to.be.instanceOf(DomainError);
+        expect(error).to.be.instanceOf(ModuleInstantiationError);
         expect(error.message).to.equal('Each proposal in QROCM solutions should have a list of solutions');
       });
     });
@@ -160,7 +161,7 @@ describe('Unit | Devcomp | Domain | Models | QrocmSolutions', function () {
         )();
 
         // then
-        expect(error).to.be.instanceOf(DomainError);
+        expect(error).to.be.instanceOf(ModuleInstantiationError);
         expect(error.message).to.equal('A QROCM solution should have a list of tolerances');
       });
     });

--- a/api/tests/devcomp/unit/domain/models/component/ComponentStepper_test.js
+++ b/api/tests/devcomp/unit/domain/models/component/ComponentStepper_test.js
@@ -1,3 +1,4 @@
+import { ModuleInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
 import { ComponentStepper } from '../../../../../../src/devcomp/domain/models/component/ComponentStepper.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
@@ -35,7 +36,7 @@ describe('Unit | Devcomp | Domain | Models | Component | ComponentStepper', func
       const error = catchErrSync(() => new ComponentStepper({ steps: 'steps' }))();
 
       // then
-      expect(error).to.be.instanceOf(DomainError);
+      expect(error).to.be.instanceOf(ModuleInstantiationError);
       expect(error.message).to.equal('Steps should be an array');
     });
   });

--- a/api/tests/devcomp/unit/domain/models/component/Step_test.js
+++ b/api/tests/devcomp/unit/domain/models/component/Step_test.js
@@ -1,3 +1,4 @@
+import { ModuleInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
 import { Step } from '../../../../../../src/devcomp/domain/models/component/Step.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
@@ -33,7 +34,7 @@ describe('Unit | Devcomp | Domain | Models | Component | Step', function () {
       const error = catchErrSync(() => new Step({ elements: 'not a list' }))();
 
       // then
-      expect(error).to.be.instanceOf(DomainError);
+      expect(error).to.be.instanceOf(ModuleInstantiationError);
       expect(error.message).to.equal('step.elements should be an array');
     });
   });
@@ -44,7 +45,7 @@ describe('Unit | Devcomp | Domain | Models | Component | Step', function () {
       const error = catchErrSync(() => new Step({ elements: [] }))();
 
       // then
-      expect(error).to.be.instanceOf(DomainError);
+      expect(error).to.be.instanceOf(ModuleInstantiationError);
       expect(error.message).to.equal('A step should contain at least one element');
     });
   });

--- a/api/tests/devcomp/unit/domain/models/element/Download_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Download_test.js
@@ -1,3 +1,4 @@
+import { ModuleInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
 import { Download } from '../../../../../../src/devcomp/domain/models/element/Download.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
@@ -37,7 +38,7 @@ describe('Unit | Devcomp | Domain | Models | Element | Download', function () {
           const error = catchErrSync(() => new Download({ id: '123' }))();
 
           // then
-          expect(error).to.be.instanceOf(DomainError);
+          expect(error).to.be.instanceOf(ModuleInstantiationError);
           expect(error.message).to.equal('The Download files should be a list');
         });
       });
@@ -48,7 +49,7 @@ describe('Unit | Devcomp | Domain | Models | Element | Download', function () {
           const error = catchErrSync(() => new Download({ id: '123', files: [] }))();
 
           // then
-          expect(error).to.be.instanceOf(DomainError);
+          expect(error).to.be.instanceOf(ModuleInstantiationError);
           expect(error.message).to.equal('The files are required for a Download');
         });
       });

--- a/api/tests/devcomp/unit/domain/models/element/Image_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Image_test.js
@@ -50,14 +50,14 @@ describe('Unit | Devcomp | Domain | Models | Element | Image', function () {
     });
   });
 
-  describe('An image without an alternative Instruction', function () {
+  describe('An image without an alternative text', function () {
     it('should throw an error', function () {
       // when
       const error = catchErrSync(() => new Image({ id: 'id', url: 'url', alt: 'alt' }))();
 
       // then
       expect(error).to.be.instanceOf(DomainError);
-      expect(error.message).to.equal('The alternative instruction is required for an image');
+      expect(error.message).to.equal('The alternative text is required for an image');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/element/QCM_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCM_test.js
@@ -1,3 +1,4 @@
+import { ModuleInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
 import { QCM } from '../../../../../../src/devcomp/domain/models/element/QCM.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
@@ -55,7 +56,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QCM', function () {
       const error = catchErrSync(() => new QCM({ id: '123', instruction: 'toto', proposals: [] }))();
 
       // then
-      expect(error).to.be.instanceOf(DomainError);
+      expect(error).to.be.instanceOf(ModuleInstantiationError);
       expect(error.message).to.equal('The proposals are required for a QCM');
     });
   });
@@ -66,7 +67,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QCM', function () {
       const error = catchErrSync(() => new QCM({ id: '123', instruction: 'toto', proposals: 'toto' }))();
 
       // then
-      expect(error).to.be.instanceOf(DomainError);
+      expect(error).to.be.instanceOf(ModuleInstantiationError);
       expect(error.message).to.equal('The proposals should be in a list');
     });
   });

--- a/api/tests/devcomp/unit/domain/models/element/QCU-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCU-for-answer-verification_test.js
@@ -1,3 +1,4 @@
+import { ModuleInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
 import { QCUForAnswerVerification } from '../../../../../../src/devcomp/domain/models/element/QCU-for-answer-verification.js';
 import { Feedbacks } from '../../../../../../src/devcomp/domain/models/Feedbacks.js';
 import { QcuCorrectionResponse } from '../../../../../../src/devcomp/domain/models/QcuCorrectionResponse.js';
@@ -60,7 +61,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QcuForAnswerVerification'
         )();
 
         // then
-        expect(error).to.be.instanceOf(DomainError);
+        expect(error).to.be.instanceOf(ModuleInstantiationError);
         expect(error.message).to.equal('The QCU solution id is not an existing proposal id');
       });
     });

--- a/api/tests/devcomp/unit/domain/models/element/QCU_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCU_test.js
@@ -1,3 +1,4 @@
+import { ModuleInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
 import { QCU } from '../../../../../../src/devcomp/domain/models/element/QCU.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
@@ -54,7 +55,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QCU', function () {
         const error = catchErrSync(() => new QCU({ id: '123', instruction: 'toto', proposals: [] }))();
 
         // then
-        expect(error).to.be.instanceOf(DomainError);
+        expect(error).to.be.instanceOf(ModuleInstantiationError);
         expect(error.message).to.equal('The proposals are required for a QCU');
       });
     });
@@ -65,7 +66,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QCU', function () {
         const error = catchErrSync(() => new QCU({ id: '123', instruction: 'toto', proposals: 'toto' }))();
 
         // then
-        expect(error).to.be.instanceOf(DomainError);
+        expect(error).to.be.instanceOf(ModuleInstantiationError);
         expect(error.message).to.equal('The QCU proposals should be a list');
       });
     });

--- a/api/tests/devcomp/unit/domain/models/element/QROCM_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QROCM_test.js
@@ -1,3 +1,4 @@
+import { ModuleInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
 import { QROCM } from '../../../../../../src/devcomp/domain/models/element/QROCM.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
@@ -53,7 +54,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QROCM', function () {
       const error = catchErrSync(() => new QROCM({ id: '123', instruction: 'toto', proposals: [] }))();
 
       // then
-      expect(error).to.be.instanceOf(DomainError);
+      expect(error).to.be.instanceOf(ModuleInstantiationError);
       expect(error.message).to.equal('Les propositions sont obligatoires pour un QROCM');
     });
   });
@@ -64,7 +65,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QROCM', function () {
       const error = catchErrSync(() => new QROCM({ id: '123', instruction: 'toto', proposals: 'toto' }))();
 
       // then
-      expect(error).to.be.instanceOf(DomainError);
+      expect(error).to.be.instanceOf(ModuleInstantiationError);
       expect(error.message).to.equal('Les propositions doivent apparaître dans une liste');
     });
   });

--- a/api/tests/devcomp/unit/domain/models/module/Details_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/Details_test.js
@@ -1,3 +1,4 @@
+import { ModuleInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
 import { Details } from '../../../../../../src/devcomp/domain/models/module/Details.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
@@ -127,7 +128,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Details', function () {
         )();
 
         // then
-        expect(error).to.be.instanceOf(DomainError);
+        expect(error).to.be.instanceOf(ModuleInstantiationError);
         expect(error.message).to.equal('The module details should contain a list of objectives');
       });
     });
@@ -148,7 +149,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Details', function () {
         )();
 
         // then
-        expect(error).to.be.instanceOf(DomainError);
+        expect(error).to.be.instanceOf(ModuleInstantiationError);
         expect(error.message).to.equal('The module details should contain at least one objective');
       });
     });

--- a/api/tests/devcomp/unit/domain/models/module/Module_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/Module_test.js
@@ -1,3 +1,4 @@
+import { ModuleInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
 import { Module } from '../../../../../../src/devcomp/domain/models/module/Module.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
@@ -90,7 +91,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
         )();
 
         // then
-        expect(error).to.be.instanceOf(DomainError);
+        expect(error).to.be.instanceOf(ModuleInstantiationError);
         expect(error.message).to.equal(`A module should have a list of grains`);
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Une partie de nos erreurs sont génériques et peuvent être spécialisées pour les différencier.

## :robot: Proposition
Utiliser des `ModuleInstantiationError` là où c'est pertinent.

## :rainbow: Remarques
Les `assertNotNullOrUndefined` restent génériques donc à moins de les wrapper/catcher on récupère des `DomainError`.

## :100: Pour tester
CI 🆗 
