### PR TITLE
[FEATURE] : Traduction du message d'avertissement

### DIFF
--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1468,7 +1468,7 @@
         "multiple-invitations": "Er is een uitnodiging gestuurd naar de vermelde e-mailadressen."
       },
       "title": "Een lid uitnodigen",
-      "warning":"Les membres que vous ajoutez ci-dessous auront accès aux résultats des participants et à l’analyse des campagnes. Veuillez vous assurer que les personnes invitées sont des membres de votre organisation."
+      "warning":"De leden die je hieronder toevoegt, krijgen toegang tot deelnemersresultaten en campagneanalyses. Zorg ervoor dat de mensen die u uitnodigt lid zijn van uw organisatie."
     },
     "terms-of-service": {
       "accept": "Ik accepteer de gebruiksvoorwaarden",


### PR DESCRIPTION
## :unicorn: Problème

Dans la page d'invitation des membres sur Pix Orga en NL, on affiche par défaut un message d'avertissement. Ce message n'était pas traduit en NL.

Le message en question : Les membres que vous ajoutez ci-dessous auront accès aux résultats des participants et à l’analyse des campagnes. Veuillez vous assurer que les personnes invitées sont des membres de votre organisation.


## :robot: Proposition
Traduire en NL

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
* Aller sur Pix Orga en NL
* Aller dans Equipes
* Aller dans Inviter un membre
* Vérifier que le bandeau jaune affichant le message d'avertissement est bien traduit en NL