### PR TITLE
[TECH] Création d'un service de calcul d'éligibilité aux certifications pour un utilisateur - Partie 1 (Eligibilité PIX uniquement) (PIX-14077)

### DIFF
--- a/api/lib/domain/usecases/get-user-certification-eligibility.js
+++ b/api/lib/domain/usecases/get-user-certification-eligibility.js
@@ -30,20 +30,21 @@ import { CertificationEligibility } from '../../../src/shared/domain/read-models
  * @param {CertificationBadgesService} params.certificationBadgesService
  * @param {ComplementaryCertificationCourseRepository} params.complementaryCertificationCourseRepository
  * @param {TargetProfileHistoryRepository} params.targetProfileHistoryRepository
- * @param {PlacementProfileService} params.placementProfileService
+ * @param {UserEligibilityService} params.userEligibilityService
  *
  * @returns {CertificationEligibility}
  */
 const getUserCertificationEligibility = async function ({
   userId,
   limitDate = new Date(),
-  placementProfileService,
+  userEligibilityService,
   certificationBadgesService,
   complementaryCertificationCourseRepository,
   targetProfileHistoryRepository,
 }) {
-  const placementProfile = await placementProfileService.getPlacementProfile({ userId, limitDate });
-  const pixCertificationEligible = placementProfile.isCertifiable();
+  const userEligibilityList = await userEligibilityService.getUserEligibilityList({ userId, limitDate });
+  const coreEligibility = userEligibilityList.coreEligibilityV2;
+  const pixCertificationEligible = coreEligibility.isCertifiable;
 
   if (!pixCertificationEligible) {
     return CertificationEligibility.notCertifiable({ userId });

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 import * as complementaryCertificationCourseRepository from '../../../src/certification/complementary-certification/infrastructure/repositories/complementary-certification-course-repository.js';
 import * as complementaryCertificationRepository from '../../../src/certification/complementary-certification/infrastructure/repositories/complementary-certification-repository.js';
 import * as targetProfileHistoryRepository from '../../../src/certification/complementary-certification/infrastructure/repositories/target-profile-history-repository.js';
+import { services as certificationEnrolmentServices } from '../../../src/certification/enrolment/domain/services/index.js';
 import * as sessionCodeService from '../../../src/certification/enrolment/domain/services/session-code-service.js';
 import { getCenterForAdmin } from '../../../src/certification/enrolment/domain/usecases/get-center-for-admin.js';
 import * as centerRepository from '../../../src/certification/enrolment/infrastructure/repositories/center-repository.js';
@@ -189,6 +190,7 @@ function requirePoleEmploiNotifier() {
  * @typedef {complementaryCertificationHabilitationRepository} ComplementaryCertificationHabilitationRepository
  * @typedef {dataProtectionOfficerRepository} DataProtectionOfficerRepository
  * @typedef {userAnonymizedEventLoggingJobRepository} UserAnonymizedEventLoggingJobRepository
+ * @typedef {userEligibilityService} UserEligibilityService
  */
 
 const dependencies = {
@@ -348,6 +350,7 @@ const dependencies = {
   badgeCriteriaRepository,
   sharedSessionRepository,
   improvementService,
+  userEligibilityService: certificationEnrolmentServices.userEligibilityService,
 };
 
 const path = dirname(fileURLToPath(import.meta.url));

--- a/api/src/certification/enrolment/domain/models/UserEligibilityCalculator.js
+++ b/api/src/certification/enrolment/domain/models/UserEligibilityCalculator.js
@@ -1,0 +1,68 @@
+import _ from 'lodash';
+
+import {
+  MINIMUM_CERTIFIABLE_COMPETENCES_FOR_CERTIFIABILITY,
+  MINIMUM_COMPETENCE_LEVEL_FOR_CERTIFIABILITY,
+  PIX_COUNT_BY_LEVEL,
+} from '../../../../shared/domain/constants.js';
+import { UserCoreEligibility, UserEligibilityList } from './UserEligibilityList.js';
+
+export const LABEL_FOR_CORE = 'CORE';
+
+export class UserEligibilityCalculator {
+  #eligibilities;
+  #eligibilitiesV2;
+  #hasBeenCalculated;
+
+  constructor({ userId, date, eligibilities, eligibilitiesV2 }) {
+    this.userId = userId;
+    this.date = date;
+    this.#eligibilities = eligibilities ?? [];
+    this.#eligibilitiesV2 = eligibilitiesV2 ?? [];
+    this.#hasBeenCalculated = false;
+  }
+
+  computeCoreEligibility({ allKnowledgeElements, coreCompetences }) {
+    this.#hasBeenCalculated = true;
+    const knowledgeElementsGroupedByCompetence = _.groupBy(allKnowledgeElements, 'competenceId');
+    let countAtLeastLevelOneCompetences = 0;
+    for (const competence of coreCompetences) {
+      const knowledgeElementsForCompetence = knowledgeElementsGroupedByCompetence[competence.id];
+      const totalEarnedPix = _.sumBy(knowledgeElementsForCompetence, 'earnedPix');
+      const level = Math.floor(totalEarnedPix / PIX_COUNT_BY_LEVEL);
+      if (level >= MINIMUM_COMPETENCE_LEVEL_FOR_CERTIFIABILITY) {
+        ++countAtLeastLevelOneCompetences;
+      }
+      if (countAtLeastLevelOneCompetences >= MINIMUM_CERTIFIABLE_COMPETENCES_FOR_CERTIFIABILITY) {
+        break;
+      }
+    }
+
+    const isCertifiable = countAtLeastLevelOneCompetences >= MINIMUM_CERTIFIABLE_COMPETENCES_FOR_CERTIFIABILITY;
+    this.#eligibilities.push(buildCoreEligibility({ isCertifiable }));
+    this.#eligibilitiesV2.push(buildCoreEligibility({ isCertifiable }));
+  }
+
+  buildUserEligibilityList() {
+    if (!this.#hasBeenCalculated) throw new Error('Cannot produce final UserEligibilityList before computing them.');
+    return new UserEligibilityList({
+      userId: this.userId,
+      date: this.date,
+      eligibilities: this.#eligibilities,
+      eligibilitiesV2: this.#eligibilitiesV2,
+    });
+  }
+
+  toDTO() {
+    return {
+      userId: this.userId,
+      date: this.date,
+      eligibilities: this.#eligibilities.map((eligibility) => eligibility.toDTO()),
+      eligibilitiesV2: this.#eligibilitiesV2.map((eligibilityV2) => eligibilityV2.toDTO()),
+    };
+  }
+}
+
+function buildCoreEligibility({ isCertifiable }) {
+  return new UserCoreEligibility({ isCertifiable });
+}

--- a/api/src/certification/enrolment/domain/models/UserEligibilityList.js
+++ b/api/src/certification/enrolment/domain/models/UserEligibilityList.js
@@ -13,6 +13,10 @@ export class UserEligibilityList {
     this.#eligibilitiesV2 = eligibilitiesV2;
   }
 
+  get coreEligibilityV2() {
+    return this.#eligibilitiesV2.find((eligibility) => eligibility.isCore) ?? null;
+  }
+
   toDTO() {
     return {
       userId: this.#userId,
@@ -29,6 +33,14 @@ export class UserCoreEligibility {
 
   constructor({ isCertifiable }) {
     this.#isCertifiable = isCertifiable;
+  }
+
+  get isCore() {
+    return true;
+  }
+
+  get isCertifiable() {
+    return this.#isCertifiable;
   }
 
   toDTO() {

--- a/api/src/certification/enrolment/domain/models/UserEligibilityList.js
+++ b/api/src/certification/enrolment/domain/models/UserEligibilityList.js
@@ -1,0 +1,40 @@
+import { LABEL_FOR_CORE } from './UserEligibilityCalculator.js';
+
+export class UserEligibilityList {
+  #userId;
+  #date;
+  #eligibilities;
+  #eligibilitiesV2;
+
+  constructor({ userId, date, eligibilities, eligibilitiesV2 }) {
+    this.#userId = userId;
+    this.#date = date;
+    this.#eligibilities = eligibilities;
+    this.#eligibilitiesV2 = eligibilitiesV2;
+  }
+
+  toDTO() {
+    return {
+      userId: this.#userId,
+      date: this.#date,
+      eligibilities: this.#eligibilities.map((eligibility) => eligibility.toDTO()),
+      eligibilitiesV2: this.#eligibilitiesV2.map((eligibilityV2) => eligibilityV2.toDTO()),
+    };
+  }
+}
+
+export class UserCoreEligibility {
+  #certification = LABEL_FOR_CORE;
+  #isCertifiable;
+
+  constructor({ isCertifiable }) {
+    this.#isCertifiable = isCertifiable;
+  }
+
+  toDTO() {
+    return {
+      certification: this.#certification,
+      isCertifiable: this.#isCertifiable,
+    };
+  }
+}

--- a/api/src/certification/enrolment/domain/services/index.js
+++ b/api/src/certification/enrolment/domain/services/index.js
@@ -1,0 +1,18 @@
+import * as knowledgeElementRepository from '../../../../../lib/infrastructure/repositories/knowledge-element-repository.js';
+import * as competenceRepository from '../../../../shared/infrastructure/repositories/competence-repository.js';
+import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
+import { enrolmentRepositories } from '../../infrastructure/repositories/index.js';
+import * as userEligibilityService from '../services/user-eligibility-service.js';
+
+const dependencies = {
+  ...enrolmentRepositories,
+  competenceRepository,
+  knowledgeElementRepository,
+};
+
+const servicesWithoutInjectedDependencies = {
+  userEligibilityService: userEligibilityService,
+};
+
+const services = injectDependencies(servicesWithoutInjectedDependencies, dependencies);
+export { services };

--- a/api/src/certification/enrolment/domain/services/user-eligibility-service.js
+++ b/api/src/certification/enrolment/domain/services/user-eligibility-service.js
@@ -1,0 +1,19 @@
+import { UserEligibilityCalculator } from '../models/UserEligibilityCalculator.js';
+
+async function getUserEligibilityList({
+  userId,
+  limitDate = new Date(),
+  knowledgeElementRepository,
+  competenceRepository,
+}) {
+  const userEligibilityCalculator = new UserEligibilityCalculator({ userId, date: limitDate });
+  const allKnowledgeElements = await knowledgeElementRepository.findUniqByUserId({
+    userId: userId,
+    limitDate,
+  });
+  const coreCompetences = await competenceRepository.listPixCompetencesOnly();
+  userEligibilityCalculator.computeCoreEligibility({ allKnowledgeElements, coreCompetences });
+  return userEligibilityCalculator.buildUserEligibilityList();
+}
+
+export { getUserEligibilityList };

--- a/api/tests/certification/enrolment/integration/domain/services/user-eligibility-service_test.js
+++ b/api/tests/certification/enrolment/integration/domain/services/user-eligibility-service_test.js
@@ -1,0 +1,133 @@
+import dayjs from 'dayjs';
+
+import { LABEL_FOR_CORE } from '../../../../../../src/certification/enrolment/domain/models/UserEligibilityCalculator.js';
+import { UserEligibilityList } from '../../../../../../src/certification/enrolment/domain/models/UserEligibilityList.js';
+import { services } from '../../../../../../src/certification/enrolment/domain/services/index.js';
+import { PIX_ORIGIN } from '../../../../../../src/shared/domain/constants.js';
+import { databaseBuilder, expect, mockLearningContent } from '../../../../../test-helper.js';
+import * as learningContentBuilder from '../../../../../tooling/learning-content-builder/index.js';
+
+describe('Certification | Enrolment | Integration | Domain | Services | UserEligibilityService', function () {
+  let userEligibilityService;
+
+  beforeEach(function () {
+    userEligibilityService = services.userEligibilityService;
+  });
+
+  describe('#getUserEligibilityList', function () {
+    let userId = 123;
+    let someDate;
+
+    beforeEach(function () {
+      someDate = new Date('2020-01-01');
+      userId = databaseBuilder.factory.buildUser().id;
+      _mockLearningContent();
+      _makeUserCoreCertifiable({ userId, refDate: someDate });
+      return databaseBuilder.commit();
+    });
+
+    it('should compute and return user eligibility list (core certifiable)', async function () {
+      // when
+      const userEligibilityList = await userEligibilityService.getUserEligibilityList({
+        userId,
+        limitDate: someDate,
+      });
+
+      // then
+      expect(userEligibilityList).to.be.instanceOf(UserEligibilityList);
+      expect(userEligibilityList.toDTO()).to.deep.equal({
+        userId,
+        date: someDate,
+        eligibilities: [{ certification: LABEL_FOR_CORE, isCertifiable: true }],
+        eligibilitiesV2: [{ certification: LABEL_FOR_CORE, isCertifiable: true }],
+      });
+    });
+  });
+});
+
+function _mockLearningContent() {
+  mockLearningContent({
+    competences: [
+      learningContentBuilder.buildCompetence({
+        id: 'competenceA',
+        origin: PIX_ORIGIN,
+      }),
+      learningContentBuilder.buildCompetence({
+        id: 'competenceB',
+        origin: PIX_ORIGIN,
+      }),
+      learningContentBuilder.buildCompetence({
+        id: 'competenceC',
+        origin: PIX_ORIGIN,
+      }),
+      learningContentBuilder.buildCompetence({
+        id: 'competenceD',
+        origin: PIX_ORIGIN,
+      }),
+      learningContentBuilder.buildCompetence({
+        id: 'competenceE',
+        origin: PIX_ORIGIN,
+      }),
+    ],
+  });
+}
+
+function _makeUserCoreCertifiable({ userId, refDate }) {
+  const oneDayBefore = dayjs(refDate).subtract(1, 'day').toDate();
+  databaseBuilder.factory.buildKnowledgeElement({
+    userId,
+    competenceId: 'competenceA',
+    skillId: 'skill1_competenceA',
+    earnedPix: 4,
+    createdAt: oneDayBefore,
+  });
+  databaseBuilder.factory.buildKnowledgeElement({
+    userId,
+    competenceId: 'competenceA',
+    skillId: 'skill2_competenceA',
+    earnedPix: 5,
+    createdAt: oneDayBefore,
+  });
+  databaseBuilder.factory.buildKnowledgeElement({
+    userId,
+    competenceId: 'competenceB',
+    skillId: 'skill1_competenceB',
+    earnedPix: 10,
+    createdAt: oneDayBefore,
+  });
+  databaseBuilder.factory.buildKnowledgeElement({
+    userId,
+    competenceId: 'competenceC',
+    skillId: 'skill1_competenceC',
+    earnedPix: 20,
+    createdAt: oneDayBefore,
+  });
+  databaseBuilder.factory.buildKnowledgeElement({
+    userId,
+    competenceId: 'competenceD',
+    skillId: 'skill1_competenceD',
+    earnedPix: 2,
+    createdAt: oneDayBefore,
+  });
+  databaseBuilder.factory.buildKnowledgeElement({
+    userId,
+    competenceId: 'competenceD',
+    skillId: 'skill2_competenceD',
+    earnedPix: 2,
+    createdAt: oneDayBefore,
+  });
+  databaseBuilder.factory.buildKnowledgeElement({
+    userId,
+    competenceId: 'competenceD',
+    skillId: 'skill3_competenceD',
+    earnedPix: 4,
+    createdAt: oneDayBefore,
+  });
+  databaseBuilder.factory.buildKnowledgeElement({
+    userId,
+    competenceId: 'competenceE',
+    skillId: 'skill1_competenceE',
+    earnedPix: 10,
+    createdAt: oneDayBefore,
+  });
+}

--- a/api/tests/certification/enrolment/unit/domain/models/UserEligibilityCalculator_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/UserEligibilityCalculator_test.js
@@ -1,0 +1,234 @@
+import { LABEL_FOR_CORE } from '../../../../../../src/certification/enrolment/domain/models/UserEligibilityCalculator.js';
+import { UserEligibilityList } from '../../../../../../src/certification/enrolment/domain/models/UserEligibilityList.js';
+import { catchErrSync, domainBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Unit | Certification | Enrolment | Domain | Models | UserEligibilityCalculator', function () {
+  context('#computeCoreEligibility', function () {
+    let coreCompetences;
+    let allKnowledgeElements;
+    beforeEach(function () {
+      coreCompetences = [];
+      coreCompetences.push(domainBuilder.buildCompetence({ id: 'compA' }));
+      coreCompetences.push(domainBuilder.buildCompetence({ id: 'compB' }));
+      coreCompetences.push(domainBuilder.buildCompetence({ id: 'compC' }));
+      coreCompetences.push(domainBuilder.buildCompetence({ id: 'compD' }));
+      coreCompetences.push(domainBuilder.buildCompetence({ id: 'compE' }));
+      allKnowledgeElements = [];
+      // competence A is certificable
+      allKnowledgeElements.push(
+        domainBuilder.buildKnowledgeElement({
+          competenceId: 'compA',
+          earnedPix: 2,
+        }),
+      );
+      allKnowledgeElements.push(
+        domainBuilder.buildKnowledgeElement({
+          competenceId: 'compA',
+          earnedPix: 3,
+        }),
+      );
+      allKnowledgeElements.push(
+        domainBuilder.buildKnowledgeElement({
+          competenceId: 'compA',
+          earnedPix: 4,
+        }),
+      );
+      // competence B is certificable
+      allKnowledgeElements.push(
+        domainBuilder.buildKnowledgeElement({
+          competenceId: 'compB',
+          earnedPix: 12,
+        }),
+      );
+      // competence C is certificable
+      allKnowledgeElements.push(
+        domainBuilder.buildKnowledgeElement({
+          competenceId: 'compC',
+          earnedPix: 7,
+        }),
+      );
+      allKnowledgeElements.push(
+        domainBuilder.buildKnowledgeElement({
+          competenceId: 'compC',
+          earnedPix: 1,
+        }),
+      );
+      // competence D is certificable
+      allKnowledgeElements.push(
+        domainBuilder.buildKnowledgeElement({
+          competenceId: 'compD',
+          earnedPix: 25,
+        }),
+      );
+    });
+
+    context('for V2 AND V3 (same requirements)', function () {
+      it('should compute core certificable as true when user is level 1 at 5 competences at least', function () {
+        // given
+        const someDate = new Date('2021-10-29');
+        allKnowledgeElements.push(
+          domainBuilder.buildKnowledgeElement({
+            competenceId: 'compE',
+            earnedPix: 2,
+          }),
+        );
+        allKnowledgeElements.push(
+          domainBuilder.buildKnowledgeElement({
+            competenceId: 'compE',
+            earnedPix: 2,
+          }),
+        );
+        allKnowledgeElements.push(
+          domainBuilder.buildKnowledgeElement({
+            competenceId: 'compE',
+            earnedPix: 2,
+          }),
+        );
+        allKnowledgeElements.push(
+          domainBuilder.buildKnowledgeElement({
+            competenceId: 'compE',
+            earnedPix: 2,
+          }),
+        );
+        const userEligibilityCalculator = domainBuilder.certification.enrolment.buildUserEligibilityCalculator({
+          userId: 123,
+          date: someDate,
+          eligibilities: [],
+          eligibilitiesV2: [],
+        });
+
+        // when
+        userEligibilityCalculator.computeCoreEligibility({ allKnowledgeElements, coreCompetences });
+
+        // then
+        expect(userEligibilityCalculator.toDTO()).to.deep.equal({
+          userId: 123,
+          date: someDate,
+          eligibilities: [{ certification: LABEL_FOR_CORE, isCertifiable: true }],
+          eligibilitiesV2: [{ certification: LABEL_FOR_CORE, isCertifiable: true }],
+        });
+      });
+
+      it('should compute core certificable as false when user is level 1 on less than 5 competences', function () {
+        // given
+        const someDate = new Date('2021-10-29');
+        // competence E
+        allKnowledgeElements.push(
+          domainBuilder.buildKnowledgeElement({
+            competenceId: 'compE',
+            earnedPix: 2,
+          }),
+        );
+        const userEligibilityCalculator = domainBuilder.certification.enrolment.buildUserEligibilityCalculator({
+          userId: 123,
+          date: someDate,
+          eligibilities: [],
+          eligibilitiesV2: [],
+        });
+
+        // when
+        userEligibilityCalculator.computeCoreEligibility({ allKnowledgeElements, coreCompetences });
+
+        // then
+        expect(userEligibilityCalculator.toDTO()).to.deep.equal({
+          userId: 123,
+          date: someDate,
+          eligibilities: [{ certification: LABEL_FOR_CORE, isCertifiable: false }],
+          eligibilitiesV2: [{ certification: LABEL_FOR_CORE, isCertifiable: false }],
+        });
+      });
+
+      it('should compute core certifiable as false when user is level 1 on less than 5 competences (no KE in one competence)', function () {
+        // given
+        const someDate = new Date('2021-10-29');
+        const userEligibilityCalculator = domainBuilder.certification.enrolment.buildUserEligibilityCalculator({
+          userId: 123,
+          date: someDate,
+          eligibilities: [],
+          eligibilitiesV2: [],
+        });
+
+        // when
+        userEligibilityCalculator.computeCoreEligibility({ allKnowledgeElements, coreCompetences });
+
+        // then
+        expect(userEligibilityCalculator.toDTO()).to.deep.equal({
+          userId: 123,
+          date: someDate,
+          eligibilities: [{ certification: LABEL_FOR_CORE, isCertifiable: false }],
+          eligibilitiesV2: [{ certification: LABEL_FOR_CORE, isCertifiable: false }],
+        });
+      });
+    });
+  });
+
+  context('#buildUserEligibilityList', function () {
+    context('when computing is not done', function () {
+      it('should throw an Error stating that computing is not done', function () {
+        // given
+        const someDate = new Date('2020-01-01');
+        const userEligibilityCalculator = domainBuilder.certification.enrolment.buildUserEligibilityCalculator({
+          userId: 123,
+          date: someDate,
+          eligibilities: [],
+          eligibilitiesV2: [],
+        });
+
+        // when
+        const error = catchErrSync(userEligibilityCalculator.buildUserEligibilityList, userEligibilityCalculator)();
+
+        // then
+        expect(error).to.be.instanceof(Error);
+        expect(error.message).to.equal('Cannot produce final UserEligibilityList before computing them.');
+      });
+
+      it('should return a UserEligibilityList because computing is done', function () {
+        // given
+        const someDate = new Date('2020-01-01');
+        const userEligibilityCalculator = domainBuilder.certification.enrolment.buildUserEligibilityCalculator({
+          userId: 123,
+          date: someDate,
+          eligibilities: [],
+          eligibilitiesV2: [],
+        });
+        userEligibilityCalculator.computeCoreEligibility({ allKnowledgeElements: [], coreCompetences: [] });
+
+        // when
+        const userEligibilityList = userEligibilityCalculator.buildUserEligibilityList();
+
+        // then
+        expect(userEligibilityList).to.be.instanceOf(UserEligibilityList);
+        expect(userEligibilityList.toDTO()).to.deep.equal({
+          userId: 123,
+          date: someDate,
+          eligibilities: [{ certification: LABEL_FOR_CORE, isCertifiable: false }],
+          eligibilitiesV2: [{ certification: LABEL_FOR_CORE, isCertifiable: false }],
+        });
+      });
+    });
+  });
+
+  context('#toDTO', function () {
+    it('should return model as DTO', function () {
+      // given
+      const someDate = new Date('2020-01-01');
+      const userEligibilityCalculator = domainBuilder.certification.enrolment.buildUserEligibilityCalculator({
+        userId: 123,
+        date: someDate,
+        eligibilities: [domainBuilder.certification.enrolment.buildUserCoreEligibility({ isCertifiable: true })],
+        eligibilitiesV2: [domainBuilder.certification.enrolment.buildUserCoreEligibility({ isCertifiable: true })],
+      });
+
+      // when
+      const DTO = userEligibilityCalculator.toDTO();
+
+      // then
+      expect(DTO).to.deep.equal({
+        userId: 123,
+        date: someDate,
+        eligibilities: [{ certification: LABEL_FOR_CORE, isCertifiable: true }],
+        eligibilitiesV2: [{ certification: LABEL_FOR_CORE, isCertifiable: true }],
+      });
+    });
+  });
+});

--- a/api/tests/certification/enrolment/unit/domain/models/UserEligibilityList_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/UserEligibilityList_test.js
@@ -1,0 +1,47 @@
+import { LABEL_FOR_CORE } from '../../../../../../src/certification/enrolment/domain/models/UserEligibilityCalculator.js';
+import { domainBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Unit | Certification | Enrolment | Domain | Models | UserEligibilityList and UserEligibilities classes', function () {
+  describe('UserEligibilityList', function () {
+    context('#toDTO', function () {
+      it('should return model as DTO', function () {
+        // given
+        const someDate = new Date('2020-01-01');
+        const userEligibilityList = domainBuilder.certification.enrolment.buildUserEligibilityList({
+          userId: 123,
+          date: someDate,
+          eligibilities: [domainBuilder.certification.enrolment.buildUserCoreEligibility({ isCertifiable: true })],
+          eligibilitiesV2: [domainBuilder.certification.enrolment.buildUserCoreEligibility({ isCertifiable: true })],
+        });
+
+        // when
+        const DTO = userEligibilityList.toDTO();
+
+        // then
+        expect(DTO).to.deep.equal({
+          userId: 123,
+          date: someDate,
+          eligibilities: [{ certification: LABEL_FOR_CORE, isCertifiable: true }],
+          eligibilitiesV2: [{ certification: LABEL_FOR_CORE, isCertifiable: true }],
+        });
+      });
+    });
+  });
+
+  describe('UserCoreEligibility', function () {
+    context('#toDTO', function () {
+      it('should return model as DTO', function () {
+        // given
+        const coreUserEligibility = domainBuilder.certification.enrolment.buildUserCoreEligibility({
+          isCertifiable: true,
+        });
+
+        // when
+        const DTO = coreUserEligibility.toDTO();
+
+        // then
+        expect(DTO).to.deep.equal({ certification: LABEL_FOR_CORE, isCertifiable: true });
+      });
+    });
+  });
+});

--- a/api/tests/certification/enrolment/unit/domain/models/UserEligibilityList_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/UserEligibilityList_test.js
@@ -3,6 +3,37 @@ import { domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Certification | Enrolment | Domain | Models | UserEligibilityList and UserEligibilities classes', function () {
   describe('UserEligibilityList', function () {
+    context('#get coreEligibilityV2', function () {
+      it('should return core eligibility v2 if any', function () {
+        // given
+        const userEligibilityList = domainBuilder.certification.enrolment.buildUserEligibilityList({
+          eligibilities: [domainBuilder.certification.enrolment.buildUserCoreEligibility({ isCertifiable: false })],
+          eligibilitiesV2: [domainBuilder.certification.enrolment.buildUserCoreEligibility({ isCertifiable: true })],
+        });
+
+        // when
+        const coreEligibilityV2 = userEligibilityList.coreEligibilityV2;
+
+        // then
+        expect(coreEligibilityV2.toDTO()).to.deep.equal({
+          certification: LABEL_FOR_CORE,
+          isCertifiable: true,
+        });
+      });
+      it('should return null if none', function () {
+        // given
+        const userEligibilityList = domainBuilder.certification.enrolment.buildUserEligibilityList({
+          eligibilities: [domainBuilder.certification.enrolment.buildUserCoreEligibility({ isCertifiable: false })],
+          eligibilitiesV2: [],
+        });
+
+        // when
+        const coreEligibilityV2 = userEligibilityList.coreEligibilityV2;
+
+        // then
+        expect(coreEligibilityV2).to.be.null;
+      });
+    });
     context('#toDTO', function () {
       it('should return model as DTO', function () {
         // given
@@ -29,6 +60,42 @@ describe('Unit | Certification | Enrolment | Domain | Models | UserEligibilityLi
   });
 
   describe('UserCoreEligibility', function () {
+    context('#get isCore', function () {
+      it('should return true', function () {
+        // given
+        const coreEligibility = domainBuilder.certification.enrolment.buildUserCoreEligibility();
+
+        // when
+        const isCore = coreEligibility.isCore;
+
+        // then
+        expect(isCore).to.be.true;
+      });
+    });
+    context('#get isCertifiable', function () {
+      it('should return true when is certifiable', function () {
+        // given
+        const coreEligibility = domainBuilder.certification.enrolment.buildUserCoreEligibility({ isCertifiable: true });
+
+        // when
+        const isCertifiable = coreEligibility.isCertifiable;
+
+        // then
+        expect(isCertifiable).to.be.true;
+      });
+      it('should return false when is not certifiable', function () {
+        // given
+        const coreEligibility = domainBuilder.certification.enrolment.buildUserCoreEligibility({
+          isCertifiable: false,
+        });
+
+        // when
+        const isCertifiable = coreEligibility.isCertifiable;
+
+        // then
+        expect(isCertifiable).to.be.false;
+      });
+    });
     context('#toDTO', function () {
       it('should return model as DTO', function () {
         // given

--- a/api/tests/certification/enrolment/unit/domain/services/user-eligibility-service_test.js
+++ b/api/tests/certification/enrolment/unit/domain/services/user-eligibility-service_test.js
@@ -1,0 +1,53 @@
+import { LABEL_FOR_CORE } from '../../../../../../src/certification/enrolment/domain/models/UserEligibilityCalculator.js';
+import { UserEligibilityList } from '../../../../../../src/certification/enrolment/domain/models/UserEligibilityList.js';
+import * as userEligibilityService from '../../../../../../src/certification/enrolment/domain/services/user-eligibility-service.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+
+describe('Certification | Enrolment | Unit | Domain | Services | UserEligibilityService', function () {
+  describe('#getUserEligibilityList', function () {
+    const userId = 123;
+    let knowledgeElementRepository;
+    let competenceRepository;
+    let dependencies;
+    let someDate;
+
+    beforeEach(function () {
+      someDate = new Date('1990-01-04');
+      knowledgeElementRepository = {
+        findUniqByUserId: sinon.stub(),
+      };
+      competenceRepository = {
+        listPixCompetencesOnly: sinon.stub(),
+      };
+      dependencies = {
+        userId,
+        limitDate: someDate,
+        knowledgeElementRepository,
+        competenceRepository,
+      };
+    });
+
+    it('should compute and return user eligibility list', async function () {
+      // given
+      knowledgeElementRepository.findUniqByUserId.resolves([]);
+      competenceRepository.listPixCompetencesOnly.resolves([]);
+
+      // when
+      const userEligibilityList = await userEligibilityService.getUserEligibilityList(dependencies);
+
+      // then
+      expect(userEligibilityList).to.be.instanceOf(UserEligibilityList);
+      expect(userEligibilityList.toDTO()).to.deep.equal({
+        userId: 123,
+        date: someDate,
+        eligibilities: [{ certification: LABEL_FOR_CORE, isCertifiable: false }],
+        eligibilitiesV2: [{ certification: LABEL_FOR_CORE, isCertifiable: false }],
+      });
+      expect(knowledgeElementRepository.findUniqByUserId).to.have.been.calledWith({
+        userId,
+        limitDate: someDate,
+      });
+      expect(competenceRepository.listPixCompetencesOnly).to.have.been.calledOnce;
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/certification/enrolment/build-user-core-eligibility.js
+++ b/api/tests/tooling/domain-builder/factory/certification/enrolment/build-user-core-eligibility.js
@@ -1,0 +1,7 @@
+import { UserCoreEligibility } from '../../../../../../src/certification/enrolment/domain/models/UserEligibilityList.js';
+
+const buildUserCoreEligibility = function ({ isCertifiable = true } = {}) {
+  return new UserCoreEligibility({ isCertifiable });
+};
+
+export { buildUserCoreEligibility };

--- a/api/tests/tooling/domain-builder/factory/certification/enrolment/build-user-eligibility-calculator.js
+++ b/api/tests/tooling/domain-builder/factory/certification/enrolment/build-user-eligibility-calculator.js
@@ -1,0 +1,17 @@
+import { UserEligibilityCalculator } from '../../../../../../src/certification/enrolment/domain/models/UserEligibilityCalculator.js';
+
+const buildUserEligibilityCalculator = function ({
+  userId = 123,
+  date = new Date('1990-01-04'),
+  eligibilities = [],
+  eligibilitiesV2 = [],
+} = {}) {
+  return new UserEligibilityCalculator({
+    userId,
+    date,
+    eligibilities,
+    eligibilitiesV2,
+  });
+};
+
+export { buildUserEligibilityCalculator };

--- a/api/tests/tooling/domain-builder/factory/certification/enrolment/build-user-eligibility-list.js
+++ b/api/tests/tooling/domain-builder/factory/certification/enrolment/build-user-eligibility-list.js
@@ -1,0 +1,17 @@
+import { UserEligibilityList } from '../../../../../../src/certification/enrolment/domain/models/UserEligibilityList.js';
+
+const buildUserEligibilityList = function ({
+  userId = 123,
+  date = new Date('1990-01-04'),
+  eligibilities = [],
+  eligibilitiesV2 = [],
+} = {}) {
+  return new UserEligibilityList({
+    userId,
+    date,
+    eligibilities,
+    eligibilitiesV2,
+  });
+};
+
+export { buildUserEligibilityList };

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -181,6 +181,9 @@ import {
   buildSubscription,
 } from './certification/enrolment/build-subscription.js';
 import { buildUserEnrolment } from './certification/enrolment/build-user.js';
+import { buildUserCoreEligibility } from './certification/enrolment/build-user-core-eligibility.js';
+import { buildUserEligibilityCalculator } from './certification/enrolment/build-user-eligibility-calculator.js';
+import { buildUserEligibilityList } from './certification/enrolment/build-user-eligibility-list.js';
 import { buildFlashAssessmentAlgorithm } from './certification/flash-certification/build-flash-assessment-algorithm.js';
 import { buildAssessmentResult as buildCertificationScoringAssessmentResult } from './certification/scoring/build-assessment-result.js';
 import { buildCertificationAssessmentHistory } from './certification/scoring/build-certification-assessment-history.js';
@@ -217,6 +220,9 @@ const certification = {
     buildComplementarySubscription,
     buildSubscription,
     buildUser: buildUserEnrolment,
+    buildUserEligibilityCalculator,
+    buildUserEligibilityList,
+    buildUserCoreEligibility,
   },
   sessionManagement: {
     buildCertificationSessionComplementaryCertification,

--- a/api/tests/tooling/learning-content-builder/build-competence.js
+++ b/api/tests/tooling/learning-content-builder/build-competence.js
@@ -1,0 +1,29 @@
+const buildCompetence = function ({
+  id = 'competenceId',
+  index = 'competenceIndex',
+  origin = 'competenceOrigin',
+  name_i18n = {
+    fr: 'name_fr',
+    en: 'name_eng',
+  },
+  description_i18n = {
+    fr: 'description_fr',
+    en: 'description_eng',
+  },
+  skillIds = ['someSkillId'],
+  thematicIds = ['someThematicId'],
+  areaId = 'parentAreaId',
+} = {}) {
+  return {
+    id,
+    index,
+    origin,
+    name_i18n,
+    description_i18n,
+    skillIds,
+    thematicIds,
+    areaId,
+  };
+};
+
+export { buildCompetence };

--- a/api/tests/tooling/learning-content-builder/index.js
+++ b/api/tests/tooling/learning-content-builder/index.js
@@ -1,8 +1,9 @@
 import { buildArea } from './build-area.js';
 import { buildChallenge } from './build-challenge.js';
+import { buildCompetence } from './build-competence.js';
 import { buildLearningContent } from './build-learning-content.js';
 import { buildMission } from './build-mission.js';
 import { buildSkill } from './build-skill.js';
 import { buildTube } from './build-tube.js';
 
-export { buildArea, buildChallenge, buildLearningContent, buildMission, buildSkill, buildTube };
+export { buildArea, buildChallenge, buildCompetence, buildLearningContent, buildMission, buildSkill, buildTube };

--- a/api/tests/unit/domain/usecases/get-user-certification-eligibility_test.js
+++ b/api/tests/unit/domain/usecases/get-user-certification-eligibility_test.js
@@ -4,7 +4,7 @@ import { domainBuilder, expect, sinon } from '../../../test-helper.js';
 
 describe('Unit | UseCase | get-user-certification-eligibility', function () {
   let clock,
-    placementProfileService,
+    userEligibilityService,
     certificationBadgesService,
     complementaryCertificationCourseRepository,
     targetProfileHistoryRepository;
@@ -22,8 +22,8 @@ describe('Unit | UseCase | get-user-certification-eligibility', function () {
     certificationBadgesService = {
       findLatestBadgeAcquisitions: sinon.stub(),
     };
-    placementProfileService = {
-      getPlacementProfile: sinon.stub(),
+    userEligibilityService = {
+      getUserEligibilityList: sinon.stub(),
     };
   });
 
@@ -34,14 +34,19 @@ describe('Unit | UseCase | get-user-certification-eligibility', function () {
   context('when pix certification is not eligible', function () {
     it('should return the user certification eligibility without eligible complementary certifications', async function () {
       // given
-      const placementProfile = { isCertifiable: () => false };
-      placementProfileService.getPlacementProfile.withArgs({ userId: 2, limitDate: now }).resolves(placementProfile);
+      userEligibilityService.getUserEligibilityList.withArgs({ userId: 2, limitDate: now }).resolves(
+        domainBuilder.certification.enrolment.buildUserEligibilityList({
+          userId: 2,
+          date: now,
+          eligibilitiesV2: [domainBuilder.certification.enrolment.buildUserCoreEligibility({ isCertifiable: false })],
+        }),
+      );
       certificationBadgesService.findLatestBadgeAcquisitions.throws(new Error('I should not be called'));
 
       // when
       const certificationEligibility = await getUserCertificationEligibility({
         userId: 2,
-        placementProfileService,
+        userEligibilityService,
         certificationBadgesService,
         targetProfileHistoryRepository,
       });
@@ -55,333 +60,155 @@ describe('Unit | UseCase | get-user-certification-eligibility', function () {
     });
   });
 
-  context(`when badge is not acquired`, function () {
-    it('should return the user certification eligibility without eligible badge', async function () {
-      // given
-      const placementProfile = { isCertifiable: () => true };
-      placementProfileService.getPlacementProfile.withArgs({ userId: 2, limitDate: now }).resolves(placementProfile);
-      certificationBadgesService.findLatestBadgeAcquisitions.resolves([]);
-      complementaryCertificationCourseRepository.findByUserId.resolves([]);
-
-      // when
-      const certificationEligibility = await getUserCertificationEligibility({
-        userId: 2,
-        placementProfileService,
-        certificationBadgesService,
-        complementaryCertificationCourseRepository,
-        targetProfileHistoryRepository,
-      });
-
-      // then
-      expect(certificationEligibility.complementaryCertifications).to.be.empty;
+  context('when pix certification is eligible', function () {
+    beforeEach(function () {
+      userEligibilityService.getUserEligibilityList.withArgs({ userId: 2, limitDate: now }).resolves(
+        domainBuilder.certification.enrolment.buildUserEligibilityList({
+          userId: 2,
+          date: now,
+          eligibilitiesV2: [domainBuilder.certification.enrolment.buildUserCoreEligibility({ isCertifiable: true })],
+        }),
+      );
     });
-  });
 
-  context('when badge is acquired', function () {
-    context('when the complementary certification is not acquired', function () {
-      it('should return the user certification eligibility with the acquired badge information', async function () {
+    context(`when badge is not acquired`, function () {
+      it('should return the user certification eligibility without eligible badge', async function () {
         // given
-        const placementProfile = { isCertifiable: () => true };
-        placementProfileService.getPlacementProfile.withArgs({ userId: 2, limitDate: now }).resolves(placementProfile);
-        const badgeAcquisition = _getOutdatedBadgeAcquisition({ complementaryCertificationBadgeId: 34 });
-        const detachedTargetProfileHistory = domainBuilder.buildTargetProfileHistoryForAdmin({
-          badges: [
-            domainBuilder.buildComplementaryCertificationBadgeForAdmin({
-              id: 3,
-              complementaryCertificationBadgeId: 34,
-            }),
-          ],
-          attachedAt: new Date('2021-01-01'),
-          detachedAt: new Date('2022-01-01'),
-        });
-        const attachedTargetProfileHistory = domainBuilder.buildTargetProfileHistoryForAdmin({
-          detachedAt: null,
-          attachedAt: new Date('2024-01-01'),
-          badges: [
-            domainBuilder.buildComplementaryCertificationBadgeForAdmin({
-              id: 3,
-              complementaryCertificationBadgeId: 35,
-            }),
-          ],
-        });
-        certificationBadgesService.findLatestBadgeAcquisitions.resolves([badgeAcquisition]);
-        targetProfileHistoryRepository.getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId
-          .withArgs({ complementaryCertificationId: 1 })
-          .resolves([attachedTargetProfileHistory]);
-
-        targetProfileHistoryRepository.getDetachedTargetProfilesHistoryByComplementaryCertificationId
-          .withArgs({ complementaryCertificationId: 1 })
-          .resolves([detachedTargetProfileHistory]);
-
-        complementaryCertificationCourseRepository.findByUserId.resolves([
-          domainBuilder.buildComplementaryCertificationCourseWithResults({
-            id: 1,
-            hasExternalJury: false,
-            complementaryCertificationBadgeId: 34,
-            results: [
-              {
-                id: 3,
-                acquired: false,
-                source: 'PIX',
-              },
-            ],
-          }),
-        ]);
+        certificationBadgesService.findLatestBadgeAcquisitions.resolves([]);
+        complementaryCertificationCourseRepository.findByUserId.resolves([]);
 
         // when
         const certificationEligibility = await getUserCertificationEligibility({
           userId: 2,
-          placementProfileService,
+          userEligibilityService,
           certificationBadgesService,
           complementaryCertificationCourseRepository,
           targetProfileHistoryRepository,
         });
 
         // then
-        expect(certificationEligibility.complementaryCertifications).to.deep.equal([
-          {
-            label: 'BADGE_LABEL',
-            imageUrl: 'http://www.image-url.com',
-            isOutdated: true,
-            isAcquiredExpectedLevel: false,
-          },
-        ]);
+        expect(certificationEligibility.complementaryCertifications).to.be.empty;
       });
     });
 
-    context('when the complementary certification is acquired', function () {
-      it('should return the user certification eligibility with an acquired badge', async function () {
-        // given
-        const placementProfile = { isCertifiable: () => true };
-        placementProfileService.getPlacementProfile.withArgs({ userId: 2, limitDate: now }).resolves(placementProfile);
-        const badgeAcquisition = _getBadgeAcquisition({ complementaryCertificationBadgeId: 34 });
-        certificationBadgesService.findLatestBadgeAcquisitions.resolves([badgeAcquisition]);
-
-        complementaryCertificationCourseRepository.findByUserId.resolves([
-          domainBuilder.buildComplementaryCertificationCourseWithResults({
-            id: 1,
-            hasExternalJury: false,
-            complementaryCertificationBadgeId: 34,
-            results: [
-              {
+    context('when badge is acquired', function () {
+      context('when the complementary certification is not acquired', function () {
+        it('should return the user certification eligibility with the acquired badge information', async function () {
+          // given
+          const badgeAcquisition = _getOutdatedBadgeAcquisition({ complementaryCertificationBadgeId: 34 });
+          const detachedTargetProfileHistory = domainBuilder.buildTargetProfileHistoryForAdmin({
+            badges: [
+              domainBuilder.buildComplementaryCertificationBadgeForAdmin({
                 id: 3,
-                acquired: true,
-                source: 'PIX',
                 complementaryCertificationBadgeId: 34,
-              },
+              }),
             ],
-          }),
-        ]);
+            attachedAt: new Date('2021-01-01'),
+            detachedAt: new Date('2022-01-01'),
+          });
+          const attachedTargetProfileHistory = domainBuilder.buildTargetProfileHistoryForAdmin({
+            detachedAt: null,
+            attachedAt: new Date('2024-01-01'),
+            badges: [
+              domainBuilder.buildComplementaryCertificationBadgeForAdmin({
+                id: 3,
+                complementaryCertificationBadgeId: 35,
+              }),
+            ],
+          });
+          certificationBadgesService.findLatestBadgeAcquisitions.resolves([badgeAcquisition]);
+          targetProfileHistoryRepository.getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId
+            .withArgs({ complementaryCertificationId: 1 })
+            .resolves([attachedTargetProfileHistory]);
 
-        // when
-        const certificationEligibility = await getUserCertificationEligibility({
-          userId: 2,
-          placementProfileService,
-          certificationBadgesService,
-          complementaryCertificationCourseRepository,
-          targetProfileHistoryRepository,
-        });
+          targetProfileHistoryRepository.getDetachedTargetProfilesHistoryByComplementaryCertificationId
+            .withArgs({ complementaryCertificationId: 1 })
+            .resolves([detachedTargetProfileHistory]);
 
-        // then
-        expect(certificationEligibility.complementaryCertifications).to.deep.equal([
-          {
-            label: 'BADGE_LABEL',
-            imageUrl: 'http://www.image-url.com',
-            isOutdated: false,
-            isAcquiredExpectedLevel: true,
-          },
-        ]);
-      });
-
-      context('when the complementary certification badge has been deprecated', function () {
-        context('when the acquired complementary certification badge is lower level', function () {
-          context('when there is only one new version', function () {
-            it('should return the user certification eligibility with complementary certification', async function () {
-              // given
-              const detachedTargetProfileHistory = domainBuilder.buildTargetProfileHistoryForAdmin({
-                badges: [
-                  domainBuilder.buildComplementaryCertificationBadgeForAdmin({
-                    id: 3,
-                    complementaryCertificationBadgeId: 34,
-                  }),
-                ],
-                attachedAt: new Date('2021-01-01'),
-                detachedAt: new Date('2022-01-01'),
-              });
-              const attachedTargetProfileHistory = domainBuilder.buildTargetProfileHistoryForAdmin({
-                detachedAt: null,
-                attachedAt: new Date('2024-01-01'),
-                badges: [
-                  domainBuilder.buildComplementaryCertificationBadgeForAdmin({
-                    id: 3,
-                    complementaryCertificationBadgeId: 35,
-                  }),
-                  domainBuilder.buildComplementaryCertificationBadgeForAdmin({
-                    id: 3,
-                    complementaryCertificationBadgeId: 36,
-                  }),
-                ],
-              });
-              targetProfileHistoryRepository.getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId
-                .withArgs({ complementaryCertificationId: 1 })
-                .resolves([attachedTargetProfileHistory]);
-
-              targetProfileHistoryRepository.getDetachedTargetProfilesHistoryByComplementaryCertificationId
-                .withArgs({ complementaryCertificationId: 1 })
-                .resolves([detachedTargetProfileHistory]);
-
-              const placementProfile = { isCertifiable: () => true };
-              placementProfileService.getPlacementProfile
-                .withArgs({ userId: 2, limitDate: now })
-                .resolves(placementProfile);
-              const badgeAcquisition = _getOutdatedBadgeAcquisition({ complementaryCertificationBadgeId: 34 });
-              certificationBadgesService.findLatestBadgeAcquisitions.resolves([badgeAcquisition]);
-
-              complementaryCertificationCourseRepository.findByUserId.resolves([
-                domainBuilder.buildComplementaryCertificationCourseWithResults({
-                  id: 1,
-                  hasExternalJury: false,
-                  complementaryCertificationBadgeId: 36,
-                  results: [
-                    {
-                      id: 3,
-                      acquired: true,
-                      source: 'PIX',
-                      complementaryCertificationBadgeId: 35,
-                    },
-                  ],
-                }),
-              ]);
-
-              // when
-              const certificationEligibility = await getUserCertificationEligibility({
-                userId: 2,
-                placementProfileService,
-                certificationBadgesService,
-                complementaryCertificationCourseRepository,
-                targetProfileHistoryRepository,
-              });
-
-              // then
-              expect(certificationEligibility.complementaryCertifications).to.deep.equal([
+          complementaryCertificationCourseRepository.findByUserId.resolves([
+            domainBuilder.buildComplementaryCertificationCourseWithResults({
+              id: 1,
+              hasExternalJury: false,
+              complementaryCertificationBadgeId: 34,
+              results: [
                 {
-                  label: 'BADGE_LABEL',
-                  imageUrl: 'http://www.image-url.com',
-                  isOutdated: true,
-                  isAcquiredExpectedLevel: false,
+                  id: 3,
+                  acquired: false,
+                  source: 'PIX',
                 },
-              ]);
-            });
+              ],
+            }),
+          ]);
+
+          // when
+          const certificationEligibility = await getUserCertificationEligibility({
+            userId: 2,
+            userEligibilityService,
+            certificationBadgesService,
+            complementaryCertificationCourseRepository,
+            targetProfileHistoryRepository,
           });
 
-          context('when there is more than one new version', function () {
-            context('if FT_ENABLE_PIX_PLUS_LOWER_LEVEL is enabled', function () {
-              it('should return the user certification eligibility without complementary certification', async function () {
-                // given
-                sinon.stub(config.featureToggles, 'isPixPlusLowerLeverEnabled').value(true);
+          // then
+          expect(certificationEligibility.complementaryCertifications).to.deep.equal([
+            {
+              label: 'BADGE_LABEL',
+              imageUrl: 'http://www.image-url.com',
+              isOutdated: true,
+              isAcquiredExpectedLevel: false,
+            },
+          ]);
+        });
+      });
 
-                const detachedTargetProfileHistory1 = domainBuilder.buildTargetProfileHistoryForAdmin({
-                  badges: [
-                    domainBuilder.buildComplementaryCertificationBadgeForAdmin({
-                      id: 3,
-                      complementaryCertificationBadgeId: 32,
-                    }),
-                    domainBuilder.buildComplementaryCertificationBadgeForAdmin({
-                      id: 3,
-                      complementaryCertificationBadgeId: 33,
-                    }),
-                  ],
-                  attachedAt: new Date('2020-01-01'),
-                  detachedAt: new Date('2021-01-01'),
-                });
-                const detachedTargetProfileHistory2 = domainBuilder.buildTargetProfileHistoryForAdmin({
-                  badges: [
-                    domainBuilder.buildComplementaryCertificationBadgeForAdmin({
-                      id: 3,
-                      complementaryCertificationBadgeId: 34,
-                    }),
-                  ],
-                  attachedAt: new Date('2021-01-01'),
-                  detachedAt: new Date('2022-01-01'),
-                });
-                const attachedTargetProfileHistory = domainBuilder.buildTargetProfileHistoryForAdmin({
-                  detachedAt: null,
-                  attachedAt: new Date('2024-01-01'),
-                  badges: [
-                    domainBuilder.buildComplementaryCertificationBadgeForAdmin({
-                      id: 3,
-                      complementaryCertificationBadgeId: 35,
-                    }),
-                  ],
-                });
+      context('when the complementary certification is acquired', function () {
+        it('should return the user certification eligibility with an acquired badge', async function () {
+          // given
+          const badgeAcquisition = _getBadgeAcquisition({ complementaryCertificationBadgeId: 34 });
+          certificationBadgesService.findLatestBadgeAcquisitions.resolves([badgeAcquisition]);
 
-                targetProfileHistoryRepository.getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId
-                  .withArgs({ complementaryCertificationId: 1 })
-                  .resolves([attachedTargetProfileHistory]);
+          complementaryCertificationCourseRepository.findByUserId.resolves([
+            domainBuilder.buildComplementaryCertificationCourseWithResults({
+              id: 1,
+              hasExternalJury: false,
+              complementaryCertificationBadgeId: 34,
+              results: [
+                {
+                  id: 3,
+                  acquired: true,
+                  source: 'PIX',
+                  complementaryCertificationBadgeId: 34,
+                },
+              ],
+            }),
+          ]);
 
-                targetProfileHistoryRepository.getDetachedTargetProfilesHistoryByComplementaryCertificationId
-                  .withArgs({ complementaryCertificationId: 1 })
-                  .resolves([detachedTargetProfileHistory2, detachedTargetProfileHistory1]);
+          // when
+          const certificationEligibility = await getUserCertificationEligibility({
+            userId: 2,
+            userEligibilityService,
+            certificationBadgesService,
+            complementaryCertificationCourseRepository,
+            targetProfileHistoryRepository,
+          });
 
-                const placementProfile = { isCertifiable: () => true };
-                placementProfileService.getPlacementProfile
-                  .withArgs({ userId: 2, limitDate: now })
-                  .resolves(placementProfile);
+          // then
+          expect(certificationEligibility.complementaryCertifications).to.deep.equal([
+            {
+              label: 'BADGE_LABEL',
+              imageUrl: 'http://www.image-url.com',
+              isOutdated: false,
+              isAcquiredExpectedLevel: true,
+            },
+          ]);
+        });
 
-                const badgeAcquisition = _getOutdatedBadgeAcquisition({ complementaryCertificationBadgeId: 33 });
-
-                certificationBadgesService.findLatestBadgeAcquisitions.resolves([badgeAcquisition]);
-
-                complementaryCertificationCourseRepository.findByUserId.resolves([
-                  domainBuilder.buildComplementaryCertificationCourseWithResults({
-                    id: 1,
-                    hasExternalJury: false,
-                    complementaryCertificationBadgeId: 33,
-                    results: [
-                      {
-                        id: 3,
-                        acquired: true,
-                        source: 'PIX',
-                        complementaryCertificationBadgeId: 32,
-                      },
-                    ],
-                  }),
-                ]);
-
-                // when
-                const certificationEligibility = await getUserCertificationEligibility({
-                  userId: 2,
-                  placementProfileService,
-                  certificationBadgesService,
-                  complementaryCertificationCourseRepository,
-                  targetProfileHistoryRepository,
-                });
-
-                // then
-                expect(certificationEligibility.complementaryCertifications).to.deep.equal([]);
-              });
-            });
-
-            context('if FT_ENABLE_PIX_PLUS_LOWER_LEVEL is not enabled', function () {
+        context('when the complementary certification badge has been deprecated', function () {
+          context('when the acquired complementary certification badge is lower level', function () {
+            context('when there is only one new version', function () {
               it('should return the user certification eligibility with complementary certification', async function () {
                 // given
-                sinon.stub(config.featureToggles, 'isPixPlusLowerLeverEnabled').value(false);
-
-                const detachedTargetProfileHistory1 = domainBuilder.buildTargetProfileHistoryForAdmin({
-                  badges: [
-                    domainBuilder.buildComplementaryCertificationBadgeForAdmin({
-                      id: 3,
-                      complementaryCertificationBadgeId: 32,
-                    }),
-                    domainBuilder.buildComplementaryCertificationBadgeForAdmin({
-                      id: 3,
-                      complementaryCertificationBadgeId: 33,
-                    }),
-                  ],
-                  attachedAt: new Date('2020-01-01'),
-                  detachedAt: new Date('2021-01-01'),
-                });
-                const detachedTargetProfileHistory2 = domainBuilder.buildTargetProfileHistoryForAdmin({
+                const detachedTargetProfileHistory = domainBuilder.buildTargetProfileHistoryForAdmin({
                   badges: [
                     domainBuilder.buildComplementaryCertificationBadgeForAdmin({
                       id: 3,
@@ -399,37 +226,34 @@ describe('Unit | UseCase | get-user-certification-eligibility', function () {
                       id: 3,
                       complementaryCertificationBadgeId: 35,
                     }),
+                    domainBuilder.buildComplementaryCertificationBadgeForAdmin({
+                      id: 3,
+                      complementaryCertificationBadgeId: 36,
+                    }),
                   ],
                 });
-
                 targetProfileHistoryRepository.getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId
                   .withArgs({ complementaryCertificationId: 1 })
                   .resolves([attachedTargetProfileHistory]);
 
                 targetProfileHistoryRepository.getDetachedTargetProfilesHistoryByComplementaryCertificationId
                   .withArgs({ complementaryCertificationId: 1 })
-                  .resolves([detachedTargetProfileHistory2, detachedTargetProfileHistory1]);
+                  .resolves([detachedTargetProfileHistory]);
 
-                const placementProfile = { isCertifiable: () => true };
-                placementProfileService.getPlacementProfile
-                  .withArgs({ userId: 2, limitDate: now })
-                  .resolves(placementProfile);
-
-                const badgeAcquisition = _getOutdatedBadgeAcquisition({ complementaryCertificationBadgeId: 33 });
-
+                const badgeAcquisition = _getOutdatedBadgeAcquisition({ complementaryCertificationBadgeId: 34 });
                 certificationBadgesService.findLatestBadgeAcquisitions.resolves([badgeAcquisition]);
 
                 complementaryCertificationCourseRepository.findByUserId.resolves([
                   domainBuilder.buildComplementaryCertificationCourseWithResults({
                     id: 1,
                     hasExternalJury: false,
-                    complementaryCertificationBadgeId: 33,
+                    complementaryCertificationBadgeId: 36,
                     results: [
                       {
                         id: 3,
                         acquired: true,
                         source: 'PIX',
-                        complementaryCertificationBadgeId: 32,
+                        complementaryCertificationBadgeId: 35,
                       },
                     ],
                   }),
@@ -438,7 +262,7 @@ describe('Unit | UseCase | get-user-certification-eligibility', function () {
                 // when
                 const certificationEligibility = await getUserCertificationEligibility({
                   userId: 2,
-                  placementProfileService,
+                  userEligibilityService,
                   certificationBadgesService,
                   complementaryCertificationCourseRepository,
                   targetProfileHistoryRepository,
@@ -455,210 +279,372 @@ describe('Unit | UseCase | get-user-certification-eligibility', function () {
                 ]);
               });
             });
+
+            context('when there is more than one new version', function () {
+              context('if FT_ENABLE_PIX_PLUS_LOWER_LEVEL is enabled', function () {
+                it('should return the user certification eligibility without complementary certification', async function () {
+                  // given
+                  sinon.stub(config.featureToggles, 'isPixPlusLowerLeverEnabled').value(true);
+
+                  const detachedTargetProfileHistory1 = domainBuilder.buildTargetProfileHistoryForAdmin({
+                    badges: [
+                      domainBuilder.buildComplementaryCertificationBadgeForAdmin({
+                        id: 3,
+                        complementaryCertificationBadgeId: 32,
+                      }),
+                      domainBuilder.buildComplementaryCertificationBadgeForAdmin({
+                        id: 3,
+                        complementaryCertificationBadgeId: 33,
+                      }),
+                    ],
+                    attachedAt: new Date('2020-01-01'),
+                    detachedAt: new Date('2021-01-01'),
+                  });
+                  const detachedTargetProfileHistory2 = domainBuilder.buildTargetProfileHistoryForAdmin({
+                    badges: [
+                      domainBuilder.buildComplementaryCertificationBadgeForAdmin({
+                        id: 3,
+                        complementaryCertificationBadgeId: 34,
+                      }),
+                    ],
+                    attachedAt: new Date('2021-01-01'),
+                    detachedAt: new Date('2022-01-01'),
+                  });
+                  const attachedTargetProfileHistory = domainBuilder.buildTargetProfileHistoryForAdmin({
+                    detachedAt: null,
+                    attachedAt: new Date('2024-01-01'),
+                    badges: [
+                      domainBuilder.buildComplementaryCertificationBadgeForAdmin({
+                        id: 3,
+                        complementaryCertificationBadgeId: 35,
+                      }),
+                    ],
+                  });
+
+                  targetProfileHistoryRepository.getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId
+                    .withArgs({ complementaryCertificationId: 1 })
+                    .resolves([attachedTargetProfileHistory]);
+
+                  targetProfileHistoryRepository.getDetachedTargetProfilesHistoryByComplementaryCertificationId
+                    .withArgs({ complementaryCertificationId: 1 })
+                    .resolves([detachedTargetProfileHistory2, detachedTargetProfileHistory1]);
+
+                  const badgeAcquisition = _getOutdatedBadgeAcquisition({ complementaryCertificationBadgeId: 33 });
+
+                  certificationBadgesService.findLatestBadgeAcquisitions.resolves([badgeAcquisition]);
+
+                  complementaryCertificationCourseRepository.findByUserId.resolves([
+                    domainBuilder.buildComplementaryCertificationCourseWithResults({
+                      id: 1,
+                      hasExternalJury: false,
+                      complementaryCertificationBadgeId: 33,
+                      results: [
+                        {
+                          id: 3,
+                          acquired: true,
+                          source: 'PIX',
+                          complementaryCertificationBadgeId: 32,
+                        },
+                      ],
+                    }),
+                  ]);
+
+                  // when
+                  const certificationEligibility = await getUserCertificationEligibility({
+                    userId: 2,
+                    userEligibilityService,
+                    certificationBadgesService,
+                    complementaryCertificationCourseRepository,
+                    targetProfileHistoryRepository,
+                  });
+
+                  // then
+                  expect(certificationEligibility.complementaryCertifications).to.deep.equal([]);
+                });
+              });
+
+              context('if FT_ENABLE_PIX_PLUS_LOWER_LEVEL is not enabled', function () {
+                it('should return the user certification eligibility with complementary certification', async function () {
+                  // given
+                  sinon.stub(config.featureToggles, 'isPixPlusLowerLeverEnabled').value(false);
+
+                  const detachedTargetProfileHistory1 = domainBuilder.buildTargetProfileHistoryForAdmin({
+                    badges: [
+                      domainBuilder.buildComplementaryCertificationBadgeForAdmin({
+                        id: 3,
+                        complementaryCertificationBadgeId: 32,
+                      }),
+                      domainBuilder.buildComplementaryCertificationBadgeForAdmin({
+                        id: 3,
+                        complementaryCertificationBadgeId: 33,
+                      }),
+                    ],
+                    attachedAt: new Date('2020-01-01'),
+                    detachedAt: new Date('2021-01-01'),
+                  });
+                  const detachedTargetProfileHistory2 = domainBuilder.buildTargetProfileHistoryForAdmin({
+                    badges: [
+                      domainBuilder.buildComplementaryCertificationBadgeForAdmin({
+                        id: 3,
+                        complementaryCertificationBadgeId: 34,
+                      }),
+                    ],
+                    attachedAt: new Date('2021-01-01'),
+                    detachedAt: new Date('2022-01-01'),
+                  });
+                  const attachedTargetProfileHistory = domainBuilder.buildTargetProfileHistoryForAdmin({
+                    detachedAt: null,
+                    attachedAt: new Date('2024-01-01'),
+                    badges: [
+                      domainBuilder.buildComplementaryCertificationBadgeForAdmin({
+                        id: 3,
+                        complementaryCertificationBadgeId: 35,
+                      }),
+                    ],
+                  });
+
+                  targetProfileHistoryRepository.getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId
+                    .withArgs({ complementaryCertificationId: 1 })
+                    .resolves([attachedTargetProfileHistory]);
+
+                  targetProfileHistoryRepository.getDetachedTargetProfilesHistoryByComplementaryCertificationId
+                    .withArgs({ complementaryCertificationId: 1 })
+                    .resolves([detachedTargetProfileHistory2, detachedTargetProfileHistory1]);
+
+                  const badgeAcquisition = _getOutdatedBadgeAcquisition({ complementaryCertificationBadgeId: 33 });
+
+                  certificationBadgesService.findLatestBadgeAcquisitions.resolves([badgeAcquisition]);
+
+                  complementaryCertificationCourseRepository.findByUserId.resolves([
+                    domainBuilder.buildComplementaryCertificationCourseWithResults({
+                      id: 1,
+                      hasExternalJury: false,
+                      complementaryCertificationBadgeId: 33,
+                      results: [
+                        {
+                          id: 3,
+                          acquired: true,
+                          source: 'PIX',
+                          complementaryCertificationBadgeId: 32,
+                        },
+                      ],
+                    }),
+                  ]);
+
+                  // when
+                  const certificationEligibility = await getUserCertificationEligibility({
+                    userId: 2,
+                    userEligibilityService,
+                    certificationBadgesService,
+                    complementaryCertificationCourseRepository,
+                    targetProfileHistoryRepository,
+                  });
+
+                  // then
+                  expect(certificationEligibility.complementaryCertifications).to.deep.equal([
+                    {
+                      label: 'BADGE_LABEL',
+                      imageUrl: 'http://www.image-url.com',
+                      isOutdated: true,
+                      isAcquiredExpectedLevel: false,
+                    },
+                  ]);
+                });
+              });
+            });
           });
-        });
 
-        context('when the acquired complementary certification badge is current level', function () {
-          it('should return the user certification eligibility without complementary certification', async function () {
-            // given
-            const attachedTargetProfileHistory = domainBuilder.buildTargetProfileHistoryForAdmin({
-              detachedAt: null,
-              attachedAt: new Date('2024-01-01'),
-              badges: [
-                domainBuilder.buildComplementaryCertificationBadgeForAdmin({
-                  id: 3,
-                  complementaryCertificationBadgeId: 35,
-                }),
-              ],
-            });
-
-            const detachedTargetProfileHistory = domainBuilder.buildTargetProfileHistoryForAdmin({
-              detachedAt: null,
-              attachedAt: new Date('2024-01-01'),
-              badges: [
-                domainBuilder.buildComplementaryCertificationBadgeForAdmin({
-                  id: 3,
-                  complementaryCertificationBadgeId: 34,
-                }),
-              ],
-            });
-
-            targetProfileHistoryRepository.getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId
-              .withArgs({ complementaryCertificationId: 1 })
-              .resolves([attachedTargetProfileHistory]);
-
-            targetProfileHistoryRepository.getDetachedTargetProfilesHistoryByComplementaryCertificationId
-              .withArgs({ complementaryCertificationId: 1 })
-              .resolves([detachedTargetProfileHistory]);
-
-            const placementProfile = { isCertifiable: () => true };
-            placementProfileService.getPlacementProfile
-              .withArgs({ userId: 2, limitDate: now })
-              .resolves(placementProfile);
-
-            const badgeAcquisition = _getOutdatedBadgeAcquisition({ complementaryCertificationBadgeId: 35 });
-
-            certificationBadgesService.findLatestBadgeAcquisitions.resolves([badgeAcquisition]);
-
-            complementaryCertificationCourseRepository.findByUserId.resolves([
-              domainBuilder.buildComplementaryCertificationCourseWithResults({
-                id: 1,
-                hasExternalJury: false,
-                complementaryCertificationBadgeId: 35,
-                results: [
-                  {
+          context('when the acquired complementary certification badge is current level', function () {
+            it('should return the user certification eligibility without complementary certification', async function () {
+              // given
+              const attachedTargetProfileHistory = domainBuilder.buildTargetProfileHistoryForAdmin({
+                detachedAt: null,
+                attachedAt: new Date('2024-01-01'),
+                badges: [
+                  domainBuilder.buildComplementaryCertificationBadgeForAdmin({
                     id: 3,
-                    acquired: true,
-                    source: 'PIX',
                     complementaryCertificationBadgeId: 35,
-                  },
+                  }),
                 ],
-              }),
-            ]);
+              });
 
-            // when
-            const certificationEligibility = await getUserCertificationEligibility({
-              userId: 2,
-              placementProfileService,
-              certificationBadgesService,
-              complementaryCertificationCourseRepository,
-              targetProfileHistoryRepository,
+              const detachedTargetProfileHistory = domainBuilder.buildTargetProfileHistoryForAdmin({
+                detachedAt: null,
+                attachedAt: new Date('2024-01-01'),
+                badges: [
+                  domainBuilder.buildComplementaryCertificationBadgeForAdmin({
+                    id: 3,
+                    complementaryCertificationBadgeId: 34,
+                  }),
+                ],
+              });
+
+              targetProfileHistoryRepository.getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId
+                .withArgs({ complementaryCertificationId: 1 })
+                .resolves([attachedTargetProfileHistory]);
+
+              targetProfileHistoryRepository.getDetachedTargetProfilesHistoryByComplementaryCertificationId
+                .withArgs({ complementaryCertificationId: 1 })
+                .resolves([detachedTargetProfileHistory]);
+
+              const badgeAcquisition = _getOutdatedBadgeAcquisition({ complementaryCertificationBadgeId: 35 });
+
+              certificationBadgesService.findLatestBadgeAcquisitions.resolves([badgeAcquisition]);
+
+              complementaryCertificationCourseRepository.findByUserId.resolves([
+                domainBuilder.buildComplementaryCertificationCourseWithResults({
+                  id: 1,
+                  hasExternalJury: false,
+                  complementaryCertificationBadgeId: 35,
+                  results: [
+                    {
+                      id: 3,
+                      acquired: true,
+                      source: 'PIX',
+                      complementaryCertificationBadgeId: 35,
+                    },
+                  ],
+                }),
+              ]);
+
+              // when
+              const certificationEligibility = await getUserCertificationEligibility({
+                userId: 2,
+                userEligibilityService,
+                certificationBadgesService,
+                complementaryCertificationCourseRepository,
+                targetProfileHistoryRepository,
+              });
+
+              // then
+              expect(certificationEligibility.complementaryCertifications).to.deep.equal([]);
             });
-
-            // then
-            expect(certificationEligibility.complementaryCertifications).to.deep.equal([]);
           });
         });
       });
-    });
 
-    context('when the complementary certification has not been taken', function () {
-      it('should return the user certification eligibility with the acquired badge information', async function () {
-        // given
-        const attachedTargetProfileHistory = domainBuilder.buildTargetProfileHistoryForAdmin({
-          detachedAt: null,
-          attachedAt: new Date('2024-01-01'),
-          badges: [
-            domainBuilder.buildComplementaryCertificationBadgeForAdmin({
-              id: 3,
-              complementaryCertificationBadgeId: 35,
-            }),
-          ],
-        });
-
-        targetProfileHistoryRepository.getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId
-          .withArgs({ complementaryCertificationId: 1 })
-          .resolves([attachedTargetProfileHistory]);
-
-        targetProfileHistoryRepository.getDetachedTargetProfilesHistoryByComplementaryCertificationId
-          .withArgs({ complementaryCertificationId: 1 })
-          .resolves([]);
-        const placementProfile = { isCertifiable: () => true };
-        placementProfileService.getPlacementProfile.withArgs({ userId: 2, limitDate: now }).resolves(placementProfile);
-        const badgeAcquisition = _getBadgeAcquisition({});
-        certificationBadgesService.findLatestBadgeAcquisitions.resolves([badgeAcquisition]);
-
-        complementaryCertificationCourseRepository.findByUserId.resolves([
-          domainBuilder.buildComplementaryCertificationCourseWithResults({
-            id: 1,
-            hasExternalJury: false,
-            complementaryCertificationBadgeId: 2,
-            results: [],
-          }),
-        ]);
-
-        // when
-        const certificationEligibility = await getUserCertificationEligibility({
-          userId: 2,
-          placementProfileService,
-          certificationBadgesService,
-          complementaryCertificationCourseRepository,
-          targetProfileHistoryRepository,
-        });
-
-        // then
-        expect(certificationEligibility.complementaryCertifications).to.deep.equal([
-          {
-            label: 'BADGE_LABEL',
-            imageUrl: 'http://www.image-url.com',
-            isOutdated: false,
-            isAcquiredExpectedLevel: false,
-          },
-        ]);
-      });
-    });
-
-    context('when the complementary certification has an external', function () {
-      context('when the pix jury is acquired', function () {
-        context('when the external jury is not acquired', function () {
-          it('should return the user certification eligibility with acquired badge', async function () {
-            // given
-            const attachedTargetProfileHistory = domainBuilder.buildTargetProfileHistoryForAdmin({
-              detachedAt: null,
-              attachedAt: new Date('2024-01-01'),
-              badges: [
-                domainBuilder.buildComplementaryCertificationBadgeForAdmin({
-                  id: 3,
-                  complementaryCertificationBadgeId: 35,
-                }),
-              ],
-            });
-
-            targetProfileHistoryRepository.getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId
-              .withArgs({ complementaryCertificationId: 1 })
-              .resolves([attachedTargetProfileHistory]);
-
-            targetProfileHistoryRepository.getDetachedTargetProfilesHistoryByComplementaryCertificationId
-              .withArgs({ complementaryCertificationId: 1 })
-              .resolves([]);
-
-            const placementProfile = { isCertifiable: () => true };
-            placementProfileService.getPlacementProfile
-              .withArgs({ userId: 2, limitDate: now })
-              .resolves(placementProfile);
-            const badgeAcquisition = _getBadgeAcquisition({ complementaryCertificationBadgeId: 33 });
-            certificationBadgesService.findLatestBadgeAcquisitions.resolves([badgeAcquisition]);
-
-            complementaryCertificationCourseRepository.findByUserId.resolves([
-              domainBuilder.buildComplementaryCertificationCourseWithResults({
-                id: 1,
-                hasExternalJury: true,
-                complementaryCertificationBadgeId: 33,
-                results: [
-                  {
-                    id: 3,
-                    acquired: true,
-                    source: 'PIX',
-                    complementaryCertificationBadgeId: 33,
-                  },
-                  {
-                    id: 4,
-                    acquired: false,
-                    source: 'EXTERNAL',
-                    complementaryCertificationBadgeId: 33,
-                  },
-                ],
+      context('when the complementary certification has not been taken', function () {
+        it('should return the user certification eligibility with the acquired badge information', async function () {
+          // given
+          const attachedTargetProfileHistory = domainBuilder.buildTargetProfileHistoryForAdmin({
+            detachedAt: null,
+            attachedAt: new Date('2024-01-01'),
+            badges: [
+              domainBuilder.buildComplementaryCertificationBadgeForAdmin({
+                id: 3,
+                complementaryCertificationBadgeId: 35,
               }),
-            ]);
+            ],
+          });
 
-            // when
-            const certificationEligibility = await getUserCertificationEligibility({
-              userId: 2,
-              placementProfileService,
-              certificationBadgesService,
-              complementaryCertificationCourseRepository,
-              targetProfileHistoryRepository,
+          targetProfileHistoryRepository.getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId
+            .withArgs({ complementaryCertificationId: 1 })
+            .resolves([attachedTargetProfileHistory]);
+
+          targetProfileHistoryRepository.getDetachedTargetProfilesHistoryByComplementaryCertificationId
+            .withArgs({ complementaryCertificationId: 1 })
+            .resolves([]);
+          const badgeAcquisition = _getBadgeAcquisition({});
+          certificationBadgesService.findLatestBadgeAcquisitions.resolves([badgeAcquisition]);
+
+          complementaryCertificationCourseRepository.findByUserId.resolves([
+            domainBuilder.buildComplementaryCertificationCourseWithResults({
+              id: 1,
+              hasExternalJury: false,
+              complementaryCertificationBadgeId: 2,
+              results: [],
+            }),
+          ]);
+
+          // when
+          const certificationEligibility = await getUserCertificationEligibility({
+            userId: 2,
+            userEligibilityService,
+            certificationBadgesService,
+            complementaryCertificationCourseRepository,
+            targetProfileHistoryRepository,
+          });
+
+          // then
+          expect(certificationEligibility.complementaryCertifications).to.deep.equal([
+            {
+              label: 'BADGE_LABEL',
+              imageUrl: 'http://www.image-url.com',
+              isOutdated: false,
+              isAcquiredExpectedLevel: false,
+            },
+          ]);
+        });
+      });
+
+      context('when the complementary certification has an external', function () {
+        context('when the pix jury is acquired', function () {
+          context('when the external jury is not acquired', function () {
+            it('should return the user certification eligibility with acquired badge', async function () {
+              // given
+              const attachedTargetProfileHistory = domainBuilder.buildTargetProfileHistoryForAdmin({
+                detachedAt: null,
+                attachedAt: new Date('2024-01-01'),
+                badges: [
+                  domainBuilder.buildComplementaryCertificationBadgeForAdmin({
+                    id: 3,
+                    complementaryCertificationBadgeId: 35,
+                  }),
+                ],
+              });
+
+              targetProfileHistoryRepository.getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId
+                .withArgs({ complementaryCertificationId: 1 })
+                .resolves([attachedTargetProfileHistory]);
+
+              targetProfileHistoryRepository.getDetachedTargetProfilesHistoryByComplementaryCertificationId
+                .withArgs({ complementaryCertificationId: 1 })
+                .resolves([]);
+
+              const badgeAcquisition = _getBadgeAcquisition({ complementaryCertificationBadgeId: 33 });
+              certificationBadgesService.findLatestBadgeAcquisitions.resolves([badgeAcquisition]);
+
+              complementaryCertificationCourseRepository.findByUserId.resolves([
+                domainBuilder.buildComplementaryCertificationCourseWithResults({
+                  id: 1,
+                  hasExternalJury: true,
+                  complementaryCertificationBadgeId: 33,
+                  results: [
+                    {
+                      id: 3,
+                      acquired: true,
+                      source: 'PIX',
+                      complementaryCertificationBadgeId: 33,
+                    },
+                    {
+                      id: 4,
+                      acquired: false,
+                      source: 'EXTERNAL',
+                      complementaryCertificationBadgeId: 33,
+                    },
+                  ],
+                }),
+              ]);
+
+              // when
+              const certificationEligibility = await getUserCertificationEligibility({
+                userId: 2,
+                userEligibilityService,
+                certificationBadgesService,
+                complementaryCertificationCourseRepository,
+                targetProfileHistoryRepository,
+              });
+
+              // then
+              expect(certificationEligibility.complementaryCertifications).to.deep.equals([
+                {
+                  label: 'BADGE_LABEL',
+                  imageUrl: 'http://www.image-url.com',
+                  isOutdated: false,
+                  isAcquiredExpectedLevel: true,
+                },
+              ]);
             });
-
-            // then
-            expect(certificationEligibility.complementaryCertifications).to.deep.equals([
-              {
-                label: 'BADGE_LABEL',
-                imageUrl: 'http://www.image-url.com',
-                isOutdated: false,
-                isAcquiredExpectedLevel: true,
-              },
-            ]);
           });
         });
       });


### PR DESCRIPTION
https://1024pix.atlassian.net/wiki/spaces/DC/pages/4517068828/Persistance+des+ligibilit+s+d+un+utilisateur
## :unicorn: Problème
Eviter de calculer la certificabilité N fois d'un utilisateur alors que sa certificabilité n'a pas changé.

## :robot: Proposition
Ecrire un service qui calcule la certificabilité d'un utilisateur. Le service va gérer la persistance / mise à jour de la certificabilité de l'utilisateur.
Ca fait beaucoup de code, j'avais fait une PR de presque 4000 lignes je n'avais pas trop envie de vous l'imposer en revue en l'état.
J'ai donc décidé de couper en 3 parties avec à chaque fois utilisation de la nouveauté dans le usecase de calcul du bandeau d'éligibilités.
Propositions en 3 parties :
- Calcul eligibilité PIX + usage dans le usecase (pas de persistance, re-calcul systématique)
- Calcul éligibilités complémentaires + usage dans le usecase (pas de persistance, re-calcul systématique)
- Mise en place du mécanisme de persistance et de mise à jour

## :rainbow: Remarques
Je ne fais pas le déplacement du usecase de bandeau dans le bon bounded context, ce sera une partie 4 qui sera assez courte !
Aussi le nombre de lignes monte vite, mais c'est BEAUCOUP de tests !

## :100: Pour tester
Tester la non régression sur le bandeau de l'onglet "Certification" de mon pix


- Tester que le bandeau affiche "Non certifiable"
- Tester que le bandeau affiche "Vous êtes certifiable" pour certif-success@example.net
- Tester que le bandeau affiche l'éligibilité à une complémentaire (user-1-7403@example.net éligible cléA)
- Histoire de tester, tester que le bandeau affiche la perte de l'éligibilité suite à un versionning : 
Parcours : user-1-7403@example.net, lui retirer sa certification cléA (complementary-certification-course-results), faire le versioning du profil cible (dupliquer le PC et le rattacher), et constater que le bandeau de la perte de l'éligibilité suite à un versionning s'affiche
