### PR TITLE
[BUGFIX] Consigne : retour ligne pour les très long mots (PIX-13836)

### DIFF
--- a/mon-pix/app/styles/components/_challenge-statement.scss
+++ b/mon-pix/app/styles/components/_challenge-statement.scss
@@ -60,7 +60,8 @@
     color: var(--pix-neutral-800);
 
     p {
-      overflow-wrap: break-word;
+      overflow-wrap: break-word; // keep break-word as fallback for older browsers
+      overflow-wrap: anywhere;
     }
 
     strong {


### PR DESCRIPTION
## :unicorn: Problème

Lorsqu’il y a un très long mot dans la consigne, celui "dépasse" :

![image](https://github.com/user-attachments/assets/0cf74824-56f0-4181-b7f6-93f102385310)

## :robot: Proposition

Autoriser un retour ligne en milieu de mots si cela est nécessaire.

## :rainbow: Remarques

On garde l’ancienne règle CSS en [fallback](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Supporting_Older_Browsers#creating_fallbacks_in_css) car la valeur `anywhere` de `overflow-wrap` [est encore relativement récente](https://caniuse.com/mdn-css_properties_overflow-wrap_anywhere).

## :100: Pour tester

Faire une prévisualisuation de l’épreuve `challenge1UT6j3vgSZOata` en nl sur [App (.org)](https://app-pr10000.review.pix.org/).