### PR TITLE
[TECH] Remplacer le `request_id` d'Hapi par celui de Scalingo

### DIFF
--- a/api/src/shared/infrastructure/monitoring-tools.js
+++ b/api/src/shared/infrastructure/monitoring-tools.js
@@ -21,7 +21,8 @@ function getCorrelationContext() {
   const request = get(context, 'request');
   return {
     user_id: extractUserIdFromRequest(request),
-    request_id: get(request, 'info.id', '-'),
+    request_id: get(request, 'headers.x-request-id', '-'),
+    id: get(request, 'info.id', '-'),
   };
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Nous avons aujourd'hui des loggers qui sont capables de fournir l'identifiant de l'utilisateur effectuant la requête ainsi qu'un identifiant de requête lorsqu'ils sont disponibles. Cet identifiant de requête est généré par Hapi et prend la forme: `a unique request identifier (using the format '{now}:{server.info.id}:{5 digits counter}')`. Cependant, il existe aussi un `request_id` plus intéressant afin de suivre les logs liés à une même requête http, celui fourni par le router de Scalingo à chaque requête passant par lui.   

## :robot: Proposition
- Remplacer le `request_id` par celui de Scalingo

## :rainbow: Remarques
On conserve néanmoins l'ancien `request_id` dans l'attribut `id` pour les bouts de code qui ne sont pas exécutés suite à une requête http comme les scripts ou pg-boss.  

## :100: Pour tester

Testé avec l'ajout suivant:
![Screenshot from 2024-08-30 11-15-20](https://github.com/user-attachments/assets/e185ccd8-249a-47f8-9dab-6af80c8e4f5b)

Résultats:

2024-08-30 10:57:19.040113539 +0200 CEST [web-1] {"level":30,"time":1725008239039,"pid":22,"hostname":"pix-api-review-pr10001-web-1","user_id":"-","request_id":"**6fa49065-4292-43ae-a0be-de1d90597c23**","id":"1725008239037:pix-api-review-pr10001-web-1:22:m0ggzqnv:10002","msg":"Test request_id"}

2024-08-30 10:57:19.042778205 +0200 CEST [web-1] {"level":30,"time":1725008239041,"pid":22,"hostname":"pix-api-review-pr10001-web-1","queryParams":{"id":"0"},"req":{"id":"1725008239037:pix-api-review-pr10001-web-1:22:m0ggzqnv:10002","method":"get","url":"/api/feature-toggles","query":{"id":"0"},"params":{},"headers":{"host":"pix-api-review-pr10001.osc-fr1.scalingo.io","x-forwarded-proto":"https","x-real-ip":"171.33.105.206","x-forwarded-port":"443","x-forwarded-for":"91.175.244.194, 91.175.244.194, 171.33.105.206","connection":"close","x-forwarded-host":"app-pr10001.review.pix.fr","pix-application":"api","user-agent":"Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0","accept":"application/vnd.api+json","accept-language":"fr-fr","accept-encoding":"gzip, deflate, br, zstd","referer":"https://app-pr10001.review.pix.fr/connexion","x-app-version":"4f2a04e3703e824b50587dfc23b550f586ee8882","sec-fetch-dest":"empty","sec-fetch-mode":"cors","sec-fetch-site":"same-origin","priority":"u=4","cookie":"locale=fr-FR; cookiename=cookievalue","x-request-id":"**6fa49065-4292-43ae-a0be-de1d90597c23**","x-request-start":"t=1725008239.037"},"remoteAddress":"10.0.0.231","remotePort":45618,"version":"4f2a04e3703e824b50587dfc23b550f586ee8882","clientVersion":"4f2a04e3703e824b50587dfc23b550f586ee8882","clientVersionMismatched":false,"user_id":"-","route":"/api/feature-toggles"},"res":{"statusCode":200,"headers":{"content-type":"application/json; charset=utf-8","vary":"origin","access-control-expose-headers":"WWW-Authenticate,Server-Authorization","cache-control":"no-cache","content-length":475,"accept-ranges":"bytes"}},"responseTime":4,"msg":"request completed"}