### PR TITLE
[BUGFIX] Vérifier si l'utilisateur est membre de l'orga pour accéder aux stats de places (PIX-14083)

### DIFF
--- a/api/src/prescription/organization-place/application/organization-place-route.js
+++ b/api/src/prescription/organization-place/application/organization-place-route.js
@@ -128,8 +128,8 @@ const register = async (server) => {
             assign: 'checkOrganizationHasPlacesFeature',
           },
           {
-            method: securityPreHandlers.checkUserIsAdminInOrganization,
-            assign: 'checkUserIsOrganizationsAdmin',
+            method: securityPreHandlers.checkUserBelongsToOrganization,
+            assign: 'checkUserBelongsToOrganization',
           },
         ],
         validate: {

--- a/api/tests/prescription/organization-place/unit/application/organization-place-route_test.js
+++ b/api/tests/prescription/organization-place/unit/application/organization-place-route_test.js
@@ -35,7 +35,7 @@ describe('Unit | Router | organization-place-route', function () {
     sinon.stub(usecases, 'findOrganizationPlacesLot');
     sinon.stub(organizationPlaceController, 'createOrganizationPlacesLot');
     sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin');
-    sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization');
+    sinon.stub(securityPreHandlers, 'checkUserBelongsToOrganization');
     sinon.stub(organizationPlaceController, 'getOrganizationPlacesStatistics');
     httpTestServer = new HttpTestServer();
     httpTestServer.setupAuthentication();
@@ -166,14 +166,14 @@ describe('Unit | Router | organization-place-route', function () {
   });
 
   describe('GET /api/organizations/{id}/places-statistics', function () {
-    it('should return HTTP code 200 when organization has the right feature activated and user is admin of the orga', async function () {
+    it('should return HTTP code 200 when organization has the right feature activated and user belong to the orga', async function () {
       // given
       const method = 'GET';
       const url = '/api/organizations/1/place-statistics';
       const payload = {};
 
       checkOrganizationHasPlacesFeature.resolves(true);
-      securityPreHandlers.checkUserIsAdminInOrganization.resolves(true);
+      securityPreHandlers.checkUserBelongsToOrganization.resolves(true);
 
       organizationPlaceController.getOrganizationPlacesStatistics.callsFake((_, h) => h.response('ok').code(200));
 
@@ -187,13 +187,13 @@ describe('Unit | Router | organization-place-route', function () {
       expect(response.statusCode).to.equal(200);
     });
 
-    it('should return HTTP code 403 if user is not admin of the organization', async function () {
+    it('should return HTTP code 403 if user do not belong of the organization', async function () {
       // given
       const method = 'GET';
       const url = '/api/organizations/1/place-statistics';
       const payload = {};
 
-      securityPreHandlers.checkUserIsAdminInOrganization.callsFake(respondWithError);
+      securityPreHandlers.checkUserBelongsToOrganization.callsFake(respondWithError);
       checkOrganizationHasPlacesFeature.resolves(true);
 
       // when
@@ -211,7 +211,7 @@ describe('Unit | Router | organization-place-route', function () {
       const url = '/api/organizations/1/place-statistics';
       const payload = {};
 
-      securityPreHandlers.checkUserIsAdminInOrganization.resolves(true);
+      securityPreHandlers.checkUserBelongsToOrganization.resolves(true);
       checkOrganizationHasPlacesFeature.callsFake(respondWithError);
 
       // when


### PR DESCRIPTION
## :unicorn: Problème
Le fait de ne laisser accès qu'aux admin de l'orga loque toute l'appli pour tous les membres d'orga avec des places

## :robot: Proposition
Donner l'accès à tous les membres

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- se connecter en tant que membre sur Pix Orga et voir que l'appli est accessible
