### PR TITLE
[BUGFIX] Corriger un test flaky dans 'Integration | Component | Team::MembersListItem' (PIX-14084)

### DIFF
--- a/orga/tests/helpers/wait-for.js
+++ b/orga/tests/helpers/wait-for.js
@@ -1,0 +1,28 @@
+import { getScreen } from '@1024pix/ember-testing-library';
+import { waitUntil } from '@ember/test-helpers';
+
+export async function waitForDialogClose() {
+  const screen = await getScreen();
+
+  await waitUntil(() => {
+    try {
+      screen.getByRole('dialog');
+      return false;
+    } catch {
+      return true;
+    }
+  });
+}
+
+export async function waitForDialog() {
+  const screen = await getScreen();
+
+  await waitUntil(() => {
+    try {
+      screen.getByRole('dialog');
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}

--- a/orga/tests/integration/components/team/members-list-item-test.js
+++ b/orga/tests/integration/components/team/members-list-item-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import { waitForDialogClose } from '../../../helpers/wait-for';
 
 module('Integration | Component | Team::MembersListItem', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -299,7 +300,7 @@ module('Integration | Component | Team::MembersListItem', function (hooks) {
         // then
         sinon.assert.calledWith(removeMembershipStub, memberMembership);
 
-        await waitForElementToBeRemoved(() => screen.queryByRole('dialog'));
+        await waitForDialogClose();
 
         assert
           .dom(


### PR DESCRIPTION
## :unicorn: Problème

Le test d'intégration de Pix Orga suivant plante avec le message d'erreur ci-dessous : 

'Integration | Component | Team::MembersListItem'

'when current user is an administrator'

'When remove member button is clicked'

'should call removeMembership and close modal by clicking on remove button'

> The element(s) given to waitForElementToBeRemoved are already removed. waitForElementToBeRemoved requires that the element(s) exist(s) before waiting for removal.

## :robot: Proposition

Remplacer l'utilisation problématique de `waitForElementToBeRemoved` par `waitForDialogClose`.

En effet `waitForElementToBeRemoved` nécessite que l'élément attendu existe préalablement à sa disparition, alors que  `waitForDialogClose` attend uniquement que la modale soit fermée. `waitForDialogClose` est donc plus résistant quant à la présence ou non d'éléments juste avant de l'exécution de la fonction, c'est à dire reformulé et plus généralement quel que soit l'environnement dans lequel on se trouve.

## :rainbow: Remarques

La fonction `waitForDialogClose` provient d'un helper déjà présent dans tous les autres projets Front, on ne fait donc que le copier dans Pix Orga.

## :100: Pour tester

* Vérifier que la CI passe.
* Suivre les Insights dans CircleCI pour vérifier que ce test descend et n'apparait plus dans les *Most Failed Tests*
