### PR TITLE
[BUGFIX] Utiliser la même icône de suppression dans Pix-Certif (PIX-14086).

### DIFF
--- a/certif/app/components/issue-report-modal/issue-reports-modal.hbs
+++ b/certif/app/components/issue-report-modal/issue-reports-modal.hbs
@@ -16,14 +16,14 @@
               {{#if (eq @version 3)}}
                 {{#unless issueReport.isInChallengeIssue}}
                   <PixIconButton
-                    @icon="trash"
+                    @icon="trash-alt"
                     aria-label={{t "pages.session-finalization.issue-reports-modal.actions.delete-reporting"}}
                     @triggerAction={{fn this.handleClickOnDeleteButton issueReport}}
                   />
                 {{/unless}}
               {{else}}
                 <PixIconButton
-                  @icon="trash"
+                  @icon="trash-alt"
                   aria-label={{t "pages.session-finalization.issue-reports-modal.actions.delete-reporting"}}
                   @triggerAction={{fn this.handleClickOnDeleteButton issueReport}}
                 />

--- a/certif/app/components/team/invitations-list-item.hbs
+++ b/certif/app/components/team/invitations-list-item.hbs
@@ -25,7 +25,7 @@
         <:triggerElement>
           <PixIconButton
             @ariaLabel={{t "pages.team-invitations.actions.cancel-invitation"}}
-            @icon="trash-can"
+            @icon="trash-alt"
             @triggerAction={{fn @onCancelInvitationButtonClicked @invitation}}
             @withBackground={{true}}
           />

--- a/certif/config/icons.js
+++ b/certif/config/icons.js
@@ -18,7 +18,6 @@ module.exports = function () {
       'redo',
       'sign-out-alt',
       'trash-alt',
-      'trash-can',
       'up-right-from-square',
       'user',
       'users',


### PR DESCRIPTION
## :unicorn: Problème

Lors de l'ajout/suppression de signalements lors de la finalisation d'une session, nous pouvons remarquer l'absence d'icone de suppression des signalements déjà présents.

<img width="632" alt="Capture d’écran 2024-08-30 à 15 25 51" src="https://github.com/user-attachments/assets/273062f3-40ab-4292-8a3a-ef2816090316">

En survolant la zone où l'icône devrait être, on peut se rendre compte que la suppression est effective mais que seule l'icône manque.

<img width="631" alt="Capture d’écran 2024-08-30 à 15 26 00" src="https://github.com/user-attachments/assets/d262d17f-0959-475b-b4e3-41e5bc23abeb">

## :robot: Proposition

Remplacer l'icône `trash` non présente dans le fichier d'icônes de l'application par une déjà existante.

## :rainbow: Remarques

Nous remplaçons et supprimons l'icône `trash-can` de l'application par `trash-alt` qui est l'icône la plus utilisée de l'application.

## :100: Pour tester

Se connecter à Pix-certif avec `certif-pro@example.net`
Créer une session de certification et ajouter un candidat
Réaliser la session (ex: `certif-success@example.net`)
Lors de la finalisation de session, ajouter un ou plusieurs signalements et vérifier que l'icône est présente.
