### PR TITLE
[FEATURE] Mise à jour de la clé de traduction NL de la bannière d'infos (PIX-14091)

### DIFF
--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -61,7 +61,8 @@
       "message": "'<strong>'Certificaten:'</strong>' Vergeet niet om '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'de sessies af te ronden in Pix Certif'</a>' en de certificaten hier te downloaden via het tabblad \"Certificaten\" voor de start van het schooljaar {year}."
     },
     "import": {
-      "message": "De beheerder kan certificeringsresultaten downloaden en de studentendatabase '<'a href=\"/import-participants\" class=\"{linkClasses}\"'>'importeren'</a>' om terug-naar-school campagnes per niveau te maken. <'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'Meer info'</a>'"
+      "message": "De beheerder kan certificeringsresultaten downloaden en de studentendatabase '<'a href=\"/import-participants\" class=\"{linkClasses}\"'>'importeren'</a>' om terug-naar-school campagnes per niveau te maken. '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'Meer info'</a>'"
+      
     },
     "language-availability": {
       "message": "Jouw taal is nog niet beschikbaar op Pix Orga. Voor jouw gemak wordt de applicatie in het Engels weergegeven. Het Pix-team werkt eraan om jouw taal toe te voegen."


### PR DESCRIPTION
## :unicorn: Problème
La bannière d'infos SCO  ne s'affiche pas correctement en NL 
![image (20)](https://github.com/user-attachments/assets/5836d4a6-f2cf-4429-b46f-699132a141c4)

## :robot: Proposition
Il manque une simple quote dans la clé de trad 

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- se connecter sur pixorga en NL, sur une orga SCO 
- voir si la bannière n'est plus toute cassée 
- 🫰 