### PR TITLE
[BUGFIX] Empêcher d'appeler la route de récupération d'une campagne par son code SANS code (PIX-14090)

### DIFF
--- a/api/src/prescription/campaign/application/campaign-detail-controller.js
+++ b/api/src/prescription/campaign/application/campaign-detail-controller.js
@@ -1,6 +1,5 @@
 import stream from 'node:stream';
 
-import { MissingQueryParamError } from '../../../shared/application/http-errors.js';
 import { tokenService } from '../../../shared/domain/services/token-service.js';
 import { escapeFileName } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
@@ -18,10 +17,9 @@ const getByCode = async function (
     campaignToJoinSerializer,
   },
 ) {
-  const filters = request.query.filter;
-  await _validateFilters(filters);
+  const { code } = request.query.filter;
 
-  const campaignToJoin = await usecases.getCampaignByCode({ code: filters.code });
+  const campaignToJoin = await usecases.getCampaignByCode({ code });
   return dependencies.campaignToJoinSerializer.serialize(campaignToJoin);
 };
 
@@ -136,12 +134,6 @@ const findParticipantsActivity = async function (
 
   return dependencies.campaignParticipantsActivitySerializer.serialize(paginatedParticipations);
 };
-
-function _validateFilters(filters) {
-  if (typeof filters.code === 'undefined') {
-    throw new MissingQueryParamError('filter.code');
-  }
-}
 
 const campaignDetailController = {
   getByCode,

--- a/api/src/prescription/campaign/application/campaign-detail-route.js
+++ b/api/src/prescription/campaign/application/campaign-detail-route.js
@@ -15,6 +15,13 @@ const register = async function (server) {
       config: {
         auth: false,
         handler: campaignDetailController.getByCode,
+        validate: {
+          query: Joi.object({
+            filter: Joi.object({
+              code: Joi.string().required(),
+            }).required(),
+          }),
+        },
         notes: ['- Récupération de la campagne dont le code est spécifié dans les filtres de la requête'],
         tags: ['api', 'campaign'],
       },


### PR DESCRIPTION
## :unicorn: Problème
Des petites 500 arrivent par ci par là sur la route de récupération d'une campagne par son code. il semblerait que cette route soit appelé sans passer la query filter "code" ce qui engendre ces erreurs

## :robot: Proposition
Mettre une vérification sur la route rendant obligatoire le query filter / code . retourner une 400 si ce n'est pas le cas

## :rainbow: Remarques
Suppression d'une validation dans le controller qui de facto ne sert plus.

## :100: Pour tester
Faire un curl sur cette route sans  le ?code=My_Code et vérifier que l'on a bien une 400