### PR TITLE
[FEATURE] Passer le nom de l'application (le scope) à l'authentification de manière standardisée (PIX-13910)

### DIFF
--- a/admin/app/components/login-form.gjs
+++ b/admin/app/components/login-form.gjs
@@ -32,7 +32,7 @@ export default class LoginForm extends Component {
     event.preventDefault();
     const identification = this.email ? this.email.trim() : '';
     const password = this.password;
-    const scope = 'pix-admin';
+    const scope = ENV.APP.AUTHENTICATION.SCOPE;
     try {
       await this.session.authenticate('authenticator:oauth2', identification, password, scope);
     } catch (responseError) {

--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -82,6 +82,9 @@ module.exports = function (environment) {
         minValue: 6,
       }),
       APP_VERSION: process.env.SOURCE_VERSION || 'development',
+      AUTHENTICATION: {
+        SCOPE: 'pix-admin',
+      },
     },
 
     'ember-cli-notifications': {

--- a/certif/app/authenticators/oauth2.js
+++ b/certif/app/authenticators/oauth2.js
@@ -1,7 +1,7 @@
 import OAuth2PasswordGrant from 'ember-simple-auth/authenticators/oauth2-password-grant';
 import ENV from 'pix-certif/config/environment';
 
-export default class OAuth2Authenticator extends OAuth2PasswordGrant {
+export default class OAuth2 extends OAuth2PasswordGrant {
   serverTokenEndpoint = `${ENV.APP.API_HOST}/api/token`;
   serverTokenRevocationEndpoint = `${ENV.APP.API_HOST}/api/revoke`;
   sendClientIdAsQueryParam = true;

--- a/certif/app/components/auth/register-form.js
+++ b/certif/app/components/auth/register-form.js
@@ -4,6 +4,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
+import ENV from 'pix-certif/config/environment.js';
 
 import isEmailValid from '../../utils/email-validator';
 import isPasswordValid from '../../utils/password-validator';
@@ -205,7 +206,7 @@ export default class RegisterForm extends Component {
   }
 
   _authenticate(email, password) {
-    const scope = 'pix-certif';
+    const scope = ENV.APP.AUTHENTICATION.SCOPE;
     return this.session.authenticate('authenticator:oauth2', email, password, scope);
   }
 }

--- a/certif/app/components/auth/toggable-login-form.js
+++ b/certif/app/components/auth/toggable-login-form.js
@@ -4,6 +4,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
+import ENV from 'pix-certif/config/environment.js';
 
 import isEmailValid from '../../utils/email-validator';
 
@@ -98,7 +99,7 @@ export default class ToggableLoginForm extends Component {
   }
 
   async _authenticate(password, email) {
-    const scope = 'pix-certif';
+    const scope = ENV.APP.AUTHENTICATION.SCOPE;
 
     try {
       await this.session.authenticate('authenticator:oauth2', email, password, scope);

--- a/certif/app/components/login/index.gjs
+++ b/certif/app/components/login/index.gjs
@@ -37,7 +37,7 @@ export default class Login extends Component {
     event.preventDefault();
     const email = this.email ? this.email.trim() : '';
     const password = this.password;
-    const scope = 'pix-certif';
+    const scope = ENV.APP.AUTHENTICATION.SCOPE;
     try {
       await this.session.authenticate('authenticator:oauth2', email, password, scope);
     } catch (responseError) {

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -92,6 +92,9 @@ module.exports = function (environment) {
       sessionSupervisingPollingRate: process.env.SESSION_SUPERVISING_POLLING_RATE ?? 5000,
       COOKIE_LOCALE_LIFESPAN_IN_SECONDS: 31536000, // 1 year in seconds
       APP_VERSION: process.env.SOURCE_VERSION || 'development',
+      AUTHENTICATION: {
+        SCOPE: 'pix-certif',
+      },
     },
 
     matomo: {},

--- a/mon-pix/app/authenticators/oauth2.js
+++ b/mon-pix/app/authenticators/oauth2.js
@@ -3,9 +3,9 @@ import ENV from 'mon-pix/config/environment';
 import { decodeToken } from 'mon-pix/helpers/jwt';
 import RSVP from 'rsvp';
 
-export default OAuth2PasswordGrant.extend({
-  serverTokenEndpoint: `${ENV.APP.API_HOST}/api/token`,
-  serverTokenRevocationEndpoint: `${ENV.APP.API_HOST}/api/revoke`,
+export default class OAuth2 extends OAuth2PasswordGrant {
+  serverTokenEndpoint = `${ENV.APP.API_HOST}/api/token`;
+  serverTokenRevocationEndpoint = `${ENV.APP.API_HOST}/api/revoke`;
 
   authenticate({ login, password, scope, token }) {
     if (token) {
@@ -21,6 +21,6 @@ export default OAuth2PasswordGrant.extend({
       });
     }
 
-    return this._super(login, password, scope);
-  },
-});
+    return super.authenticate(login, password, scope);
+  }
+}

--- a/mon-pix/app/components/routes/login-form.js
+++ b/mon-pix/app/components/routes/login-form.js
@@ -42,7 +42,8 @@ export default class LoginForm extends Component {
 
   async _authenticatePixUser(password, login) {
     try {
-      await this.session.authenticate('authenticator:oauth2', { login, password, scope: 'mon-pix' });
+      const scope = ENV.APP.AUTHENTICATION.SCOPE;
+      await this.session.authenticate('authenticator:oauth2', { login, password, scope });
     } catch (response) {
       const shouldChangePassword = get(response, 'responseJSON.errors[0].title') === 'PasswordShouldChange';
       if (shouldChangePassword) {

--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -340,7 +340,7 @@ export default class RegisterForm extends Component {
   }
 
   _authenticate(login, password) {
-    const scope = 'mon-pix';
+    const scope = ENV.APP.AUTHENTICATION.SCOPE;
     return this.session.authenticate('authenticator:oauth2', { login, password, scope });
   }
 

--- a/mon-pix/app/components/update-expired-password-form.js
+++ b/mon-pix/app/components/update-expired-password-form.js
@@ -10,7 +10,6 @@ import ENV from 'mon-pix/config/environment';
 
 import isPasswordValid from '../utils/password-validator';
 
-const SCOPE_MON_PIX = 'mon-pix';
 const ERROR_PASSWORD_MESSAGE = 'pages.update-expired-password.fields.error';
 const AUTHENTICATED_SOURCE_FROM_GAR = ENV.APP.AUTHENTICATED_SOURCE_FROM_GAR;
 
@@ -90,11 +89,8 @@ export default class UpdateExpiredPasswordForm extends Component {
 
   async _authenticateWithUpdatedPassword({ login, password }) {
     try {
-      await this.session.authenticate('authenticator:oauth2', {
-        login,
-        password,
-        scope: SCOPE_MON_PIX,
-      });
+      const scope = ENV.APP.AUTHENTICATION.SCOPE;
+      await this.session.authenticate('authenticator:oauth2', { login, password, scope });
       this.session.set('data.externalUser', null);
       this.session.set('data.expectedUserId', null);
     } catch (errorResponse) {

--- a/mon-pix/app/controllers/account-recovery/update-sco-record.js
+++ b/mon-pix/app/controllers/account-recovery/update-sco-record.js
@@ -2,6 +2,7 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import ENV from 'mon-pix/config/environment';
 
 export default class UpdateScoRecordController extends Controller {
   @service intl;
@@ -31,7 +32,7 @@ export default class UpdateScoRecordController extends Controller {
       await this.session.authenticate('authenticator:oauth2', {
         login: this.model.email,
         password,
-        scope: 'mon-pix',
+        scope: ENV.APP.AUTHENTICATION.SCOPE,
       });
     } catch (err) {
       this._handleError(err);

--- a/mon-pix/app/services/session.js
+++ b/mon-pix/app/services/session.js
@@ -1,6 +1,7 @@
 import { service } from '@ember/service';
 import SessionService from 'ember-simple-auth/services/session';
 import get from 'lodash/get';
+import ENV from 'mon-pix/config/environment';
 import { FRENCH_FRANCE_LOCALE, FRENCH_INTERNATIONAL_LOCALE } from 'mon-pix/services/locale';
 
 const FRANCE_TLD = 'fr';
@@ -20,8 +21,8 @@ export default class CurrentSessionService extends SessionService {
   async authenticateUser(login, password) {
     await this._removeExternalUserContext();
 
-    const scope = 'mon-pix';
     const trimedLogin = login ? login.trim() : '';
+    const scope = ENV.APP.AUTHENTICATION.SCOPE;
     return this.authenticate('authenticator:oauth2', { login: trimedLogin, password, scope });
   }
 

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -101,6 +101,9 @@ module.exports = function (environment) {
       COOKIE_LOCALE_LIFESPAN_IN_SECONDS: 31536000, // 1 year in seconds
       AUTONOMOUS_COURSES_ORGANIZATION_ID: parseInt(process.env.AUTONOMOUS_COURSES_ORGANIZATION_ID, 10),
       APP_VERSION: process.env.SOURCE_VERSION || 'development',
+      AUTHENTICATION: {
+        SCOPE: 'mon-pix',
+      },
     },
 
     fontawesome: {

--- a/orga/app/components/auth/login-form.js
+++ b/orga/app/components/auth/login-form.js
@@ -102,7 +102,7 @@ export default class LoginForm extends Component {
   }
 
   async _authenticate(password, email) {
-    const scope = 'pix-orga';
+    const scope = ENV.APP.AUTHENTICATION.SCOPE;
 
     this.errorMessage = null;
     try {

--- a/orga/app/components/auth/register-form.js
+++ b/orga/app/components/auth/register-form.js
@@ -3,6 +3,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import isEmpty from 'lodash/isEmpty';
+import ENV from 'pix-orga/config/environment';
 
 import isEmailValid from '../../utils/email-validator';
 import isPasswordValid from '../../utils/password-validator';
@@ -213,7 +214,7 @@ export default class RegisterForm extends Component {
   }
 
   _authenticate(email, password) {
-    const scope = 'pix-orga';
+    const scope = ENV.APP.AUTHENTICATION.SCOPE;
     return this.session.authenticate('authenticator:oauth2', email, password, scope);
   }
 }

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -96,6 +96,9 @@ module.exports = function (environment) {
       APP_VERSION: process.env.SOURCE_VERSION || 'development',
       SURVEY_LINK: process.env.SURVEY_ORGA_LINK || null,
       SURVEY_BANNER_ENABLED: _isFeatureEnabled(process.env.SURVEY_ORGA_BANNER_ENABLED),
+      AUTHENTICATION: {
+        SCOPE: 'pix-orga',
+      },
     },
 
     fontawesome: {


### PR DESCRIPTION
## :unicorn: Problème

Nous voulons pouvoir identifier l'application d'origine lorsque l'utilisateur s'authentifie ou renouvelle son authentification (via le endpoint `/api/token`)

## :robot: Proposition

Pour chaque application, **le nom de l'application est déjà envoyé** 😁 dans la variable OAuth2 `scope` de l'appel sur `/api/token` avec comme valeurs respectives:
- `mon-pix`
- `pix-admin`
- `pix-certif`
- `pix-orga`

Cette PR ne fait donc qu'un refactoring pour globaliser le nom de ces scopes pour chaque application dans une variable globale: `ENV.APP.AUTHENTICATION.SCOPE` plutôt que de l'avoir en "dur" à chaque fois qu'elle est nécessaire.

## :100: Pour tester

- Se connecter sur Pix app et voir la propriété `scope=mon-pix` sur le payload de `/api/token`
- Se connecter sur Pix admin et voir la propriété `scope=pix-admin` sur le payload de `/api/token`
- Se connecter sur Pix certif et voir la propriété `scope=pix-certif` sur le payload de `/api/token`
- Se connecter sur Pix orga et voir la propriété `scope=pix-orga` sur le payload de `/api/token`
