### PR TITLE
[FEATURE] Ajouter un lien vers Modulix Editor dans la page de preview des modules (PIX-14095)

### DIFF
--- a/mon-pix/app/components/module/preview.gjs
+++ b/mon-pix/app/components/module/preview.gjs
@@ -1,3 +1,4 @@
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
@@ -152,6 +153,15 @@ export default class ModulixPreview extends Component {
       </aside>
 
       <main class="module-preview__form">
+        <PixButtonLink
+          @variant="tertiary"
+          @href="https://1024pix.github.io/modulix-editor/"
+          @size="small"
+          target="_blank"
+        >
+          {{! template-lint-disable "no-bare-strings" }}
+          Modulix Editor
+        </PixButtonLink>
         <PixTextarea
           class="module-preview-form__textarea"
           @id="module"

--- a/mon-pix/tests/integration/components/module/preview_test.gjs
+++ b/mon-pix/tests/integration/components/module/preview_test.gjs
@@ -1,0 +1,23 @@
+import { render } from '@1024pix/ember-testing-library';
+import ModulixPreview from 'mon-pix/components/module/preview';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Module | Preview', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('should display a link to Modulix Editor', async function (assert) {
+    // given
+    const expectedUrl = 'https://1024pix.github.io/modulix-editor/';
+    const linkName = 'Modulix Editor';
+
+    //  when
+    const screen = await render(<template><ModulixPreview /></template>);
+
+    // then
+    const linkToModulixEditor = screen.getByRole('link', { name: linkName });
+    assert.dom(linkToModulixEditor).exists();
+    assert.strictEqual(linkToModulixEditor.href, expectedUrl);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Lors de la prévisualisation des modules, nous aimerions pouvoir nous rendre facilement vers le nouvel outil **Modulix Editor**.

## :robot: Proposition
Dans la page de prévisualisation, ajouter un lien vers **Modulix Editor** en haut à droite.

## :rainbow: Remarques
J'ai pris le parti de ne pas rajouter de clé de traduction pour le lien "Modulix Editor" étant donné que le nom donné à l'outil est en anglais. À challenger 👌 

Le rendu n'est pas super actuellement, à discuter en équipe (voir ci-dessous)
![image](https://github.com/user-attachments/assets/4a169c21-7670-47a1-b5f4-2b68f2014eb7)


## :100: Pour tester

1. Se rendre sur [la page de preview](https://app-pr10027.review.pix.fr/modules/preview)
2. Constater que le lien vers Modulix Editor est bien présent à la bonne place
3. Constater qu'il mène bien vers l'URL "https://1024pix.github.io/modulix-editor/" dans un nouvel onglet.
