### PR TITLE
[FEATURE] Personnaliser le message de fin de mission en fonction des résultats (Pix-13845)

### DIFF
--- a/api/db/database-builder/factory/build-mission-assessment.js
+++ b/api/db/database-builder/factory/build-mission-assessment.js
@@ -12,6 +12,7 @@ const buildMissionAssessment = function ({
   createdAt = new Date('2020-01-01'),
   state = Assessment.states.STARTED,
   lastChallengeId,
+  result = null,
 } = {}) {
   assessmentId = _.isUndefined(assessmentId)
     ? buildPix1dAssessment({ state, lastChallengeId, createdAt }).id
@@ -23,6 +24,7 @@ const buildMissionAssessment = function ({
     assessmentId,
     organizationLearnerId,
     createdAt,
+    result,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'mission-assessments',

--- a/api/db/migrations/20240830131255_add_results_column_into_mission_assessments.js
+++ b/api/db/migrations/20240830131255_add_results_column_into_mission_assessments.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'mission-assessments';
+const COLUMN_NAME = 'result';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).defaultTo(null);
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/src/school/application/assessment-controller.js
+++ b/api/src/school/application/assessment-controller.js
@@ -1,7 +1,7 @@
-import * as assessmentSerializer from '../../../src/school/infrastructure/serializers/assessment.js';
 import * as challengeSerializer from '../../shared/infrastructure/serializers/jsonapi/challenge-serializer.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as activitySerializer from '../infrastructure/serializers/activity-serializer.js';
+import * as assessmentSerializer from '../infrastructure/serializers/assessment-serializer.js';
 
 const getNextChallengeForPix1d = async function (request, h, dependencies = { challengeSerializer }) {
   const assessmentId = request.params.id;

--- a/api/src/school/domain/models/Assessment.js
+++ b/api/src/school/domain/models/Assessment.js
@@ -1,11 +1,24 @@
 import { Assessment as SharedAssessment } from '../../../shared/domain/models/Assessment.js';
 
+const results = {
+  EXCEEDED: 'exceeded',
+  REACHED: 'reached',
+  PARTIALLY_REACHED: 'partially_reached',
+  NOT_REACHED: 'not_reached',
+};
+
 class Assessment extends SharedAssessment {
   constructor({ missionId, organizationLearnerId, ...args } = {}) {
     super({ ...args });
     this.missionId = missionId;
     this.organizationLearnerId = organizationLearnerId;
+
+    if (args.result) {
+      this.result = args.result;
+    }
   }
 }
+
+Assessment.results = results;
 
 export { Assessment };

--- a/api/src/school/domain/services/update-assessment.js
+++ b/api/src/school/domain/services/update-assessment.js
@@ -1,8 +1,18 @@
 import { Activity } from '../models/Activity.js';
+import { getMissionResult } from './get-mission-result.js';
 
-export async function updateAssessment({ assessmentId, lastActivity, assessmentRepository }) {
+export async function updateAssessment({
+  assessmentId,
+  lastActivity,
+  assessmentRepository,
+  activityRepository,
+  missionAssessmentRepository,
+}) {
   const terminatedStatuses = [Activity.status.SUCCEEDED, Activity.status.SKIPPED, Activity.status.FAILED];
   if (terminatedStatuses.includes(lastActivity.status)) {
     await assessmentRepository.completeByAssessmentId(assessmentId);
+    const activities = await activityRepository.getAllByAssessmentId(assessmentId);
+    const result = await getMissionResult({ activities });
+    await missionAssessmentRepository.updateResult(assessmentId, result);
   }
 }

--- a/api/src/school/domain/usecases/handle-activity-answer.js
+++ b/api/src/school/domain/usecases/handle-activity-answer.js
@@ -46,6 +46,8 @@ const handleActivityAnswer = async function ({
       lastActivity,
       assessmentId,
       assessmentRepository,
+      activityRepository,
+      missionAssessmentRepository,
     });
 
     return correctedAnswer;

--- a/api/src/school/infrastructure/models/mission-assessment.js
+++ b/api/src/school/infrastructure/models/mission-assessment.js
@@ -1,9 +1,8 @@
-class MissionAssessment {
-  constructor({ missionId, assessmentId, organizationLearnerId } = {}) {
+export class MissionAssessment {
+  constructor({ missionId, assessmentId, organizationLearnerId, result } = {}) {
     this.assessmentId = assessmentId;
     this.missionId = missionId;
     this.organizationLearnerId = organizationLearnerId;
+    this.result = result;
   }
 }
-
-export { MissionAssessment };

--- a/api/src/school/infrastructure/repositories/mission-assessment-repository.js
+++ b/api/src/school/infrastructure/repositories/mission-assessment-repository.js
@@ -10,6 +10,11 @@ const save = async function ({ missionAssessment }) {
   await knexConn('mission-assessments').insert({ ...missionAssessment });
 };
 
+async function updateResult(assessmentId, result) {
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn('mission-assessments').update('result', result).where({ assessmentId });
+}
+
 const getByAssessmentId = async function (assessmentId) {
   const knexConn = DomainTransaction.getConnection();
   const rawAssessmentMission = await knexConn('mission-assessments')
@@ -105,4 +110,4 @@ const getMissionIdsByState = async function (organizationLearnerId) {
   return missionIdsGroupByState;
 };
 
-export { getByAssessmentId, getCurrent, getMissionIdsByState, getStatusesForLearners, save };
+export { getByAssessmentId, getCurrent, getMissionIdsByState, getStatusesForLearners, save, updateResult };

--- a/api/src/school/infrastructure/serializers/assessment-serializer.js
+++ b/api/src/school/infrastructure/serializers/assessment-serializer.js
@@ -2,7 +2,7 @@ import { Serializer } from 'jsonapi-serializer';
 
 const serialize = function (assessment) {
   return new Serializer('assessment', {
-    attributes: ['missionId', 'organizationLearnerId', 'state'],
+    attributes: ['missionId', 'organizationLearnerId', 'state', 'result'],
   }).serialize(assessment);
 };
 

--- a/api/tests/school/integration/application/assessment-controller_test.js
+++ b/api/tests/school/integration/application/assessment-controller_test.js
@@ -14,6 +14,7 @@ describe('Integration | Controller | assessment-controller', function () {
         id: assessmentId,
         organizationLearnerId,
         state: Assessment.states.STARTED,
+        result: Assessment.results.EXCEEDED,
       });
       sinon.stub(usecases, 'getAssessmentById').withArgs({ assessmentId }).resolves(createdMissionAssessment);
       const request = { params: { id: assessmentId } };
@@ -25,6 +26,7 @@ describe('Integration | Controller | assessment-controller', function () {
           'mission-id': missionId,
           'organization-learner-id': organizationLearnerId,
           state: Assessment.states.STARTED,
+          result: Assessment.results.EXCEEDED,
         },
         type: 'assessments',
       });

--- a/api/tests/school/integration/domain/usecases/get-assessment-by-id_test.js
+++ b/api/tests/school/integration/domain/usecases/get-assessment-by-id_test.js
@@ -9,7 +9,12 @@ import { databaseBuilder, expect } from '../../../../test-helper.js';
 describe('Integration | UseCase | getAssessmentById', function () {
   it('should return the missionAssessment corresponding to the assessmentId', async function () {
     const assessmentId = databaseBuilder.factory.buildPix1dAssessment().id;
-    const missionAssessment = databaseBuilder.factory.buildMissionAssessment({ assessmentId });
+    const missionAssessment = databaseBuilder.factory.buildMissionAssessment({
+      assessmentId,
+      status: Assessment.states.COMPLETED,
+      result: Assessment.results.NOT_REACHED,
+    });
+
     await databaseBuilder.commit();
 
     const result = await usecases.getAssessmentById({
@@ -23,6 +28,7 @@ describe('Integration | UseCase | getAssessmentById', function () {
       organizationLearnerId: missionAssessment.organizationLearnerId,
       missionId: missionAssessment.missionId,
       state: Assessment.states.STARTED,
+      result: Assessment.results.NOT_REACHED,
     };
 
     expect(_.pick(result, Object.keys(expectedMissionAssessment))).to.deep.equal(expectedMissionAssessment);

--- a/api/tests/school/unit/domain/services/get-mission-result-tests.js
+++ b/api/tests/school/unit/domain/services/get-mission-result-tests.js
@@ -1,9 +1,10 @@
 import { Activity } from '../../../../../src/school/domain/models/Activity.js';
 import { getMissionResult, results } from '../../../../../src/school/domain/services/get-mission-result.js';
 import { domainBuilder, expect } from '../../../../test-helper.js';
+
 const { EXCEEDED, REACHED, NOT_REACHED, PARTIALLY_REACHED } = results;
 
-describe('Unit | Domain | Pix Junior | get mission resultt', function () {
+describe('Unit | Domain | Pix Junior | get mission result', function () {
   // eslint-disable-next-line mocha/no-setup-in-describe
   [
     {

--- a/junior/app/controllers/assessment/results.js
+++ b/junior/app/controllers/assessment/results.js
@@ -2,6 +2,23 @@ import Controller from '@ember/controller';
 
 export default class Missions extends Controller {
   get validatedObjectives() {
-    return this.model.validatedObjectives?.split('\n') ?? [];
+    return this.model.mission.validatedObjectives?.split('\n') ?? [];
+  }
+
+  get resultMessage() {
+    return 'pages.missions.end-page.result.' + this.model.assessment.result;
+  }
+
+  get robotMood() {
+    switch (this.model.assessment.result) {
+      case 'exceeded':
+        return 'happy';
+      case 'reached':
+        return 'proud';
+      case 'not-reached':
+        return 'retry';
+      default:
+        return 'default';
+    }
   }
 }

--- a/junior/app/models/assessment.js
+++ b/junior/app/models/assessment.js
@@ -4,4 +4,5 @@ export default class Assessment extends Model {
   @attr('string') state;
   @attr('string') missionId;
   @attr('string') organizationLearnerId;
+  @attr('string') result;
 }

--- a/junior/app/routes/assessment/results.js
+++ b/junior/app/routes/assessment/results.js
@@ -6,7 +6,8 @@ export default class ResultRoute extends Route {
   @service store;
 
   async model() {
-    const assessment = await this.modelFor('assessment');
-    return this.store.findRecord('mission', assessment.missionId);
+    const assessment = await this.modelFor('assessment').reload();
+    const mission = await this.store.findRecord('mission', assessment.missionId);
+    return { mission, assessment };
   }
 }

--- a/junior/app/templates/assessment/results.hbs
+++ b/junior/app/templates/assessment/results.hbs
@@ -1,13 +1,14 @@
 {{page-title (t "pages.missions.end-page.title")}}
 <div class="mission-page">
-  <RobotDialog @class="happy">
+  <RobotDialog @class={{this.robotMood}}>
     <Bubble @message={{t "pages.missions.end-page.congratulations"}} @status="success" />
+    <Bubble @message={{t this.resultMessage}} @status="success" />
   </RobotDialog>
   <div class="mission-page__body">
     <MissionCard::CompletedMissionCard
       @missionLabelStatus={{t "pages.missions.list.status.completed.label"}}
-      @title={{@model.name}}
-      @areaCode={{@model.areaCode}}
+      @title={{@model.mission.name}}
+      @areaCode={{@model.mission.areaCode}}
     />
 
     <div class="mission-page__details">

--- a/junior/tests/acceptance/end-mission-test.js
+++ b/junior/tests/acceptance/end-mission-test.js
@@ -7,6 +7,7 @@ import identifyLearner from '../helpers/identify-learner';
 
 module('Acceptance | End mission', function (hooks) {
   setupApplicationTest(hooks);
+
   test('displays mission validated objectives', async function (assert) {
     // given
     const mission = this.server.create('mission');
@@ -20,6 +21,47 @@ module('Acceptance | End mission', function (hooks) {
     assert.dom(screen.getByText('Recherche sur internet')).exists();
     assert.dom(screen.getByText('validatedObjectives')).exists();
     assert.dom(screen.getByText(t('pages.missions.end-page.back-to-missions'))).exists();
+  });
+
+  test('when mission goal has been exceeded', async function (assert) {
+    const mission = this.server.create('mission');
+    const assessment = this.server.create('assessment', { missionId: mission.id, result: 'exceeded' });
+    identifyLearner(this.owner);
+    const screen = await visit(`/assessments/${assessment.id}/results`);
+    assert.dom(screen.getByText(t('pages.missions.end-page.result.exceeded'))).exists();
+  });
+
+  test('when mission goal has been reached', async function (assert) {
+    const mission = this.server.create('mission');
+    const assessment = this.server.create('assessment', {
+      missionId: mission.id,
+      result: 'reached',
+    });
+    identifyLearner(this.owner);
+    const screen = await visit(`/assessments/${assessment.id}/results`);
+    assert.dom(screen.getByText(t('pages.missions.end-page.result.reached'))).exists();
+  });
+
+  test('when mission goal has been partially reached', async function (assert) {
+    const mission = this.server.create('mission');
+    const assessment = this.server.create('assessment', {
+      missionId: mission.id,
+      result: 'partially-reached',
+    });
+    identifyLearner(this.owner);
+    const screen = await visit(`/assessments/${assessment.id}/results`);
+    assert.dom(screen.getByText(t('pages.missions.end-page.result.partially-reached'))).exists();
+  });
+
+  test('when mission goal has not been reached', async function (assert) {
+    const mission = this.server.create('mission');
+    const assessment = this.server.create('assessment', {
+      missionId: mission.id,
+      result: 'not-reached',
+    });
+    identifyLearner(this.owner);
+    const screen = await visit(`/assessments/${assessment.id}/results`);
+    assert.dom(screen.getByText(t('pages.missions.end-page.result.not-reached'))).exists();
   });
 
   test('redirect to home page after clicking on return button', async function (assert) {

--- a/junior/translations/fr.json
+++ b/junior/translations/fr.json
@@ -84,7 +84,13 @@
         "title": "Fin de mission",
         "congratulations": "Bravo ! <br> Tu as terminé ta mission !",
         "back-to-missions": "Voir d'autres missions",
-        "details-list": "Tu as pu travailler :"
+        "details-list": "Tu as pu travailler :",
+        "result": {
+          "exceeded": "Waouh, tu sembles être incollable sur ce sujet ! Tu as relevé le défi.",
+          "reached": "Bravo, tu as réussi !",
+          "partially-reached": "Il te manque quelques épreuves, reviens vite pour réessayer.",
+          "not-reached": "Cette mission semble difficile, n’hésite pas à réessayer dès que tu te sens prêt."
+        }
       }
     },
     "error": {


### PR DESCRIPTION
## :unicorn: Problème
Nous avions un message générique à la fin de la mission. Il n'était pas forcément pertinent.

## :robot: Proposition
Avoir un message en fonction du résultat de la mission.

## :rainbow: Remarques
RAS

## :100: Pour tester
- Finir une mission:
    - en ayant validé le défi 
    - en ayant raté/passé le défi
    - en ayant raté la validation du step 2
    - en ayant raté la validation du step 1