### PR TITLE
[FEATURE] Remettre dans leur état initial les participations ayant eu leurs campaignId supprimé (PIX-14054)

### DIFF
--- a/api/scripts/prod/re-assign-campaign-participations-with-campaign.js
+++ b/api/scripts/prod/re-assign-campaign-participations-with-campaign.js
@@ -1,0 +1,58 @@
+import { readFile } from 'node:fs/promises';
+import * as url from 'node:url';
+
+import { disconnect, knex } from '../../db/knex-database-connection.js';
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
+
+const modulePath = url.fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === modulePath;
+
+export const fillCampaignIdInPartipations = async (object) => {
+  const totalCampaignParticipations = Object.keys(object).length;
+  logger.info(`${totalCampaignParticipations} campaign participations vont être mises a jour`);
+  const trx = await knex.transaction();
+  try {
+    let i = 0;
+    for (const key in object) {
+      const campaignId = object[key];
+      const campaignParticipationId = key;
+      await trx('campaign-participations')
+        .update({ campaignId })
+        .where({ id: campaignParticipationId })
+        .whereNull('campaignId');
+      i++;
+      logger.info(`Mise a jour de la participation ${i}/${totalCampaignParticipations}`);
+    }
+    trx.commit();
+    logger.info(`Toutes les campaign-participations ont bien été mises à jour ✅`);
+  } catch (error) {
+    trx.rollback();
+    logger.info("Aucune participation n'a été mise a jour, une erreur est survenue");
+    logger.info(error);
+  }
+};
+
+async function main() {
+  const filePath = process.argv[2];
+  logger.info(
+    `Début du script pour remettre les campaignId dans les campaign-participations contenues dans le fichier '${filePath}'`,
+  );
+  const jsonFile = await readFile(filePath);
+
+  const parsedFile = JSON.parse(jsonFile);
+
+  await fillCampaignIdInPartipations(parsedFile);
+}
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      console.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+    }
+  }
+})();

--- a/api/tests/integration/scripts/prod/re-assign-campaign-participations-with-campaign_test.js
+++ b/api/tests/integration/scripts/prod/re-assign-campaign-participations-with-campaign_test.js
@@ -1,0 +1,96 @@
+import { fillCampaignIdInPartipations } from '../../../../scripts/prod/re-assign-campaign-participations-with-campaign.js';
+import { databaseBuilder, expect, knex } from '../../../test-helper.js';
+
+describe('Script | Prod | Re Assign Campaign Participations With Campaign', function () {
+  describe('#fillCampaignIdInPartipations', function () {
+    it('fill campaignId for given campaignParticipations and campaignId couple informations', async function () {
+      const firstCampaignParticipationWithEmptyCampaignId = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: null,
+      });
+      const secondCampaignParticipationWithEmptyCampaignId = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: null,
+      });
+      const firstCampaign = databaseBuilder.factory.buildCampaign();
+      const secondCampaign = databaseBuilder.factory.buildCampaign();
+      await databaseBuilder.commit();
+
+      /*
+      Le format dans le fichier json qu'on utilisera pour mettre a jour les campaign-participations avec les bons campaignId sera :
+      {
+        "campaignParticipationId" : campaignId
+      }
+      on le reproduit ici sous forme d'objet JS
+      */
+      const datasToUpdate = {
+        [firstCampaignParticipationWithEmptyCampaignId.id]: firstCampaign.id,
+        [secondCampaignParticipationWithEmptyCampaignId.id]: secondCampaign.id,
+      };
+
+      await fillCampaignIdInPartipations(datasToUpdate);
+
+      const participationResults = await knex('campaign-participations').whereIn('id', [
+        firstCampaignParticipationWithEmptyCampaignId.id,
+        secondCampaignParticipationWithEmptyCampaignId.id,
+      ]);
+
+      const firstParticipationUpdated = participationResults.find(
+        (cp) => cp.id === firstCampaignParticipationWithEmptyCampaignId.id,
+      );
+      const secondParticipationUpdated = participationResults.find(
+        (cp) => cp.id === secondCampaignParticipationWithEmptyCampaignId.id,
+      );
+
+      expect(firstParticipationUpdated.campaignId).to.equal(firstCampaign.id);
+      expect(secondParticipationUpdated.campaignId).to.equal(secondCampaign.id);
+    });
+
+    it('not fill campaignId for others campaignParticipations', async function () {
+      const campaignParticipationWithEmptyCampaignId = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: null,
+      });
+      const campaignId = databaseBuilder.factory.buildCampaign().id;
+      const campaignParticipationWithCampaignId = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+      });
+      const otherCampaignId = databaseBuilder.factory.buildCampaign().id;
+      await databaseBuilder.commit();
+
+      const datasToUpdate = {
+        [campaignParticipationWithEmptyCampaignId.id]: otherCampaignId,
+      };
+
+      await fillCampaignIdInPartipations(datasToUpdate);
+
+      const participationResultNotUpdated = await knex('campaign-participations')
+        .where({
+          id: campaignParticipationWithCampaignId.id,
+        })
+        .first();
+
+      expect(participationResultNotUpdated.campaignId).to.equal(campaignId);
+    });
+
+    it('not update campaignId, if campaignParticipation already have campaignId filled', async function () {
+      const campaignId = databaseBuilder.factory.buildCampaign().id;
+      const campaignParticipationWithCampaignId = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+      });
+      const otherCampaignId = databaseBuilder.factory.buildCampaign().id;
+      await databaseBuilder.commit();
+
+      const datasToUpdate = {
+        [campaignParticipationWithCampaignId.id]: otherCampaignId,
+      };
+
+      await fillCampaignIdInPartipations(datasToUpdate);
+
+      const participationResult = await knex('campaign-participations')
+        .where({
+          id: campaignParticipationWithCampaignId.id,
+        })
+        .first();
+
+      expect(participationResult.campaignId).to.equal(campaignId);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Suite à la mise en production de la fonctionnalité de suppression des campagnes, nous avons constaté que le campaignId avait été supprimé sur les campaign-participations supprimées. 

Nous avons pu récupérer les données pour un certains nombre de campaign-participations

## :robot: Proposition
Faire un script qui depuis un fichier json, va réinsérer les campaignId correspondant aux campaign-participations impactées.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- Faire une participation a une campagne
- Supprimer en BDD la campaignId pour la participation précedemment crée. (mettre `NULL`)
- Créer un fichier json formaté comme dans cet exemple : 
```json
{
 "campaignParticipationId": "campaignId"
}
```
- Lancer le script via cette commande : 
```bash
node api/scripts/prod/re-assign-campaign-participations-with-campaign.js pathDuFichierJson.json
```
- Vérifier en BDD que la ligne de la campaign-participation a bien eu son campaignId de rempli
- 🐈‍⬛ 