### PR TITLE
[BUGFIX] Empêche le job d'import d'échouer lorsqu'il y a une erreur du domain (PIX-14108).

### DIFF
--- a/api/src/prescription/learner-management/application/jobs/import-organization-learners-job-controller.js
+++ b/api/src/prescription/learner-management/application/jobs/import-organization-learners-job-controller.js
@@ -1,11 +1,16 @@
 import { JobController } from '../../../../shared/application/jobs/job-controller.js';
 import { config } from '../../../../shared/config.js';
+import { DomainError } from '../../../../shared/domain/errors.js';
+import { logger as l } from '../../../../shared/infrastructure/utils/logger.js';
 import { ImportOrganizationLearnersJob } from '../../domain/models/ImportOrganizationLearnersJob.js';
 import { usecases } from '../../domain/usecases/index.js';
 
 class ImportOrganizationLearnersJobController extends JobController {
-  constructor() {
+  #logger;
+
+  constructor({ logger = l } = {}) {
     super(ImportOrganizationLearnersJob.name);
+    this.#logger = logger;
   }
 
   get isJobEnabled() {
@@ -15,7 +20,14 @@ class ImportOrganizationLearnersJobController extends JobController {
   async handle({ data }) {
     const { organizationImportId } = data;
 
-    return usecases.addOrUpdateOrganizationLearners({ organizationImportId });
+    try {
+      return await usecases.addOrUpdateOrganizationLearners({ organizationImportId });
+    } catch (err) {
+      if (!(err instanceof DomainError)) {
+        throw err;
+      }
+      this.#logger.error(err);
+    }
   }
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Le job de traitement de l'import SIECLE échoue lorsqu'une erreur du domain se produit. Cela a pour conséquence de déclencher les 10 retry configuré sur le job. 

## :robot: Proposition
Dans le controller du job, on catch l'erreur et on vérifie si elle vient du domain et si c'est le cas on ne fait rien.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
🤷 
