### PR TITLE
[TECH] Ajouter le participation id sur le log des jobs des état de participation (PIX-14106)

### DIFF
--- a/api/lib/domain/usecases/send-shared-participation-results-to-pole-emploi.js
+++ b/api/lib/domain/usecases/send-shared-participation-results-to-pole-emploi.js
@@ -1,5 +1,5 @@
 import { PoleEmploiSending } from '../../../src/shared/domain/models/PoleEmploiSending.js';
-import * as monitoringTools from '../../../src/shared/infrastructure/monitoring-tools.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import { PoleEmploiPayload } from '../../infrastructure/externals/pole-emploi/PoleEmploiPayload.js';
 import * as httpErrorsHelper from '../../infrastructure/http/errors-helper.js';
 import { httpAgent } from '../../infrastructure/http/http-agent.js';
@@ -20,7 +20,7 @@ const sendSharedParticipationResultsToPoleEmploi = async ({
   notifierDependencies = {
     httpAgent,
     httpErrorsHelper,
-    monitoringTools,
+    logger,
   },
 }) => {
   const participation = await campaignParticipationRepository.get(campaignParticipationId);

--- a/api/src/prescription/campaign-participation/application/jobs/participation-completed-job-controller.js
+++ b/api/src/prescription/campaign-participation/application/jobs/participation-completed-job-controller.js
@@ -6,7 +6,7 @@ import * as campaignParticipationRepository from '../../../../../lib/infrastruct
 import * as campaignRepository from '../../../../../lib/infrastructure/repositories/campaign-repository.js';
 import * as poleEmploiSendingRepository from '../../../../../lib/infrastructure/repositories/pole-emploi-sending-repository.js';
 import * as targetProfileRepository from '../../../../../lib/infrastructure/repositories/target-profile-repository.js';
-import { monitoringTools } from '../../../../../src/shared/infrastructure/monitoring-tools.js';
+import { logger } from '../../../../../src/shared/infrastructure/utils/logger.js';
 import { assessmentRepository } from '../../../../certification/session-management/infrastructure/repositories/index.js';
 import * as authenticationMethodRepository from '../../../../identity-access-management/infrastructure/repositories/authentication-method.repository.js';
 import * as userRepository from '../../../../identity-access-management/infrastructure/repositories/user.repository.js';
@@ -36,8 +36,9 @@ export class ParticipationCompletedJobController extends JobController {
       targetProfileRepository,
       userRepository,
       poleEmploiNotifier,
+      logger,
       httpAgent,
-      monitoringTools,
+      httpErrorsHelper,
     },
   }) {
     const { campaignParticipationId } = data;
@@ -63,8 +64,8 @@ export class ParticipationCompletedJobController extends JobController {
       const response = await dependencies.poleEmploiNotifier.notify(user.id, payload, {
         authenticationMethodRepository: dependencies.authenticationMethodRepository,
         httpAgent: dependencies.httpAgent,
-        httpErrorsHelper,
-        monitoringTools: dependencies.monitoringTools,
+        httpErrorsHelper: dependencies.httpErrorsHelper,
+        logger: dependencies.logger,
       });
 
       const poleEmploiSending = PoleEmploiSending.buildForParticipationFinished({

--- a/api/src/prescription/campaign-participation/application/jobs/participation-started-job-controller.js
+++ b/api/src/prescription/campaign-participation/application/jobs/participation-started-job-controller.js
@@ -9,8 +9,8 @@ import * as authenticationMethodRepository from '../../../../identity-access-man
 import * as userRepository from '../../../../identity-access-management/infrastructure/repositories/user.repository.js';
 import { JobController } from '../../../../shared/application/jobs/job-controller.js';
 import { PoleEmploiSending } from '../../../../shared/domain/models/index.js';
-import { monitoringTools } from '../../../../shared/infrastructure/monitoring-tools.js';
 import * as organizationRepository from '../../../../shared/infrastructure/repositories/organization-repository.js';
+import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 import { ParticipationStartedJob } from '../../domain/models/ParticipationStartedJob.js';
 import * as campaignParticipationRepository from '../../infrastructure/repositories/campaign-participation-repository.js';
 
@@ -36,7 +36,7 @@ export class ParticipationStartedJobController extends JobController {
       poleEmploiNotifier,
       httpAgent,
       httpErrorsHelper,
-      monitoringTools,
+      logger,
     },
   }) {
     const { campaignParticipationId } = data;
@@ -60,7 +60,7 @@ export class ParticipationStartedJobController extends JobController {
         authenticationMethodRepository: dependencies.authenticationMethodRepository,
         httpAgent: dependencies.httpAgent,
         httpErrorsHelper: dependencies.httpErrorsHelper,
-        monitoringTools: dependencies.monitoringTools,
+        logger: dependencies.logger,
       });
 
       const poleEmploiSending = PoleEmploiSending.buildForParticipationStarted({

--- a/api/tests/integration/domain/usecases/send-shared-participation-results-to-pole-emploi_test.js
+++ b/api/tests/integration/domain/usecases/send-shared-participation-results-to-pole-emploi_test.js
@@ -11,11 +11,11 @@ import {
 
 describe('Integration | Domain | UseCases | send-shared-participation-results-to-pole-emploi', function () {
   let campaignParticipationId, userId, responseCode;
-  let httpAgentStub, httpErrorsHelperStub, monitoringToolsStub;
+  let httpAgentStub, httpErrorsHelperStub, loggerStub;
 
   beforeEach(async function () {
     httpAgentStub = { post: sinon.stub() };
-    monitoringToolsStub = { logErrorWithCorrelationIds: sinon.stub(), logInfoWithCorrelationIds: sinon.stub() };
+    loggerStub = { info: sinon.stub(), error: sinon.stub() };
     httpErrorsHelperStub = { serializeHttpErrorResponse: sinon.stub() };
     responseCode = Symbol('responseCode');
 
@@ -53,7 +53,7 @@ describe('Integration | Domain | UseCases | send-shared-participation-results-to
       notifierDependencies: {
         httpAgent: httpAgentStub,
         httpErrorsHelper: httpErrorsHelperStub,
-        monitoringTools: monitoringToolsStub,
+        logger: loggerStub,
       },
     });
 

--- a/api/tests/prescription/campaign-participation/integration/application/jobs/participation-completed-job-controller_test.js
+++ b/api/tests/prescription/campaign-participation/integration/application/jobs/participation-completed-job-controller_test.js
@@ -17,10 +17,13 @@ import {
 } from '../../../../../test-helper.js';
 
 describe('Integration | Prescription | Application | Jobs | ParticipationCompletedJobController', function () {
-  let campaignParticipationId, userId, data, poleEmploiNotifier, responseCode;
+  let campaignParticipationId, userId, data, poleEmploiNotifier, responseCode, logger, httpAgent, httpErrorsHelper;
 
   describe('#handle', function () {
     beforeEach(async function () {
+      logger = sinon.stub();
+      httpAgent = sinon.stub();
+      httpErrorsHelper = sinon.stub();
       responseCode = Symbol('responseCode');
       poleEmploiNotifier = { notify: sinon.stub().resolves({ isSuccessful: true, code: responseCode }) };
 
@@ -57,6 +60,9 @@ describe('Integration | Prescription | Application | Jobs | ParticipationComplet
           targetProfileRepository,
           userRepository,
           poleEmploiNotifier,
+          httpErrorsHelper,
+          logger,
+          httpAgent,
         },
       });
 

--- a/api/tests/prescription/campaign-participation/integration/application/jobs/participation-started-job-controller_test.js
+++ b/api/tests/prescription/campaign-participation/integration/application/jobs/participation-started-job-controller_test.js
@@ -1,5 +1,3 @@
-import * as httpErrorsHelper from '../../../../../../lib/infrastructure/http/errors-helper.js';
-import { httpAgent } from '../../../../../../lib/infrastructure/http/http-agent.js';
 import * as campaignParticipationRepository from '../../../../../../lib/infrastructure/repositories/campaign-participation-repository.js';
 import * as campaignRepository from '../../../../../../lib/infrastructure/repositories/campaign-repository.js';
 import * as poleEmploiSendingRepository from '../../../../../../lib/infrastructure/repositories/pole-emploi-sending-repository.js';
@@ -7,7 +5,6 @@ import * as targetProfileRepository from '../../../../../../lib/infrastructure/r
 import * as userRepository from '../../../../../../src/identity-access-management/infrastructure/repositories/user.repository.js';
 import { ParticipationStartedJobController } from '../../../../../../src/prescription/campaign-participation/application/jobs/participation-started-job-controller.js';
 import { ParticipationStartedJob } from '../../../../../../src/prescription/campaign-participation/domain/models/ParticipationStartedJob.js';
-import { monitoringTools } from '../../../../../../src/shared/infrastructure/monitoring-tools.js';
 import * as assessmentRepository from '../../../../../../src/shared/infrastructure/repositories/assessment-repository.js';
 import * as organizationRepository from '../../../../../../src/shared/infrastructure/repositories/organization-repository.js';
 import {
@@ -20,10 +17,13 @@ import {
 } from '../../../../../test-helper.js';
 
 describe('Integration | Application | pole-emploi-participation-started-job-controller', function () {
-  let campaignParticipationId, userId, poleEmploiNotifier, responseCode, data;
+  let campaignParticipationId, userId, poleEmploiNotifier, responseCode, data, logger, httpAgent, httpErrorsHelper;
 
   describe('#handle', function () {
     beforeEach(async function () {
+      logger = sinon.stub();
+      httpAgent = sinon.stub();
+      httpErrorsHelper = sinon.stub();
       responseCode = Symbol('responseCode');
       poleEmploiNotifier = { notify: sinon.stub().resolves({ isSuccessful: true, code: responseCode }) };
 
@@ -61,7 +61,7 @@ describe('Integration | Application | pole-emploi-participation-started-job-cont
           userRepository,
           poleEmploiNotifier,
           httpErrorsHelper,
-          monitoringTools,
+          logger,
           httpAgent,
         },
       });

--- a/api/tests/prescription/campaign-participation/unit/application/jobs/participation-completed-job-controller_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/jobs/participation-completed-job-controller_test.js
@@ -1,5 +1,4 @@
 import { PoleEmploiPayload } from '../../../../../../lib/infrastructure/externals/pole-emploi/PoleEmploiPayload.js';
-import * as httpErrorsHelper from '../../../../../../lib/infrastructure/http/errors-helper.js';
 import { ParticipationCompletedJobController } from '../../../../../../src/prescription/campaign-participation/application/jobs/participation-completed-job-controller.js';
 import { ParticipationCompletedJob } from '../../../../../../src/prescription/campaign-participation/domain/models/ParticipationCompletedJob.js';
 import { PoleEmploiSending } from '../../../../../../src/shared/domain/models/PoleEmploiSending.js';
@@ -10,6 +9,7 @@ describe('Unit | Prescription | Application | Jobs | ParticipationCompletedJobCo
     let data, dependencies, expectedResults;
     let campaignId, userId, organizationId, assessmentId;
     let campaignParticipationCompletedJobController;
+    let httpAgent, logger, httpErrorsHelper;
     let assessmentRepository,
       campaignRepository,
       campaignParticipationRepository,
@@ -18,9 +18,7 @@ describe('Unit | Prescription | Application | Jobs | ParticipationCompletedJobCo
       userRepository,
       poleEmploiNotifier,
       poleEmploiSendingRepository,
-      authenticationMethodRepository,
-      httpAgent,
-      monitoringTools;
+      authenticationMethodRepository;
 
     beforeEach(function () {
       campaignId = Symbol('campaignId');
@@ -29,7 +27,8 @@ describe('Unit | Prescription | Application | Jobs | ParticipationCompletedJobCo
       assessmentId = Symbol('assessmentId');
 
       httpAgent = sinon.stub();
-      monitoringTools = sinon.stub();
+      logger = sinon.stub();
+      httpErrorsHelper = sinon.stub();
       assessmentRepository = { get: sinon.stub() };
       campaignRepository = { get: sinon.stub() };
       campaignParticipationRepository = { get: sinon.stub() };
@@ -54,8 +53,9 @@ describe('Unit | Prescription | Application | Jobs | ParticipationCompletedJobCo
         poleEmploiNotifier,
         poleEmploiSendingRepository,
         authenticationMethodRepository,
+        httpErrorsHelper,
         httpAgent,
-        monitoringTools,
+        logger,
       };
 
       expectedResults = new PoleEmploiPayload({
@@ -131,9 +131,9 @@ describe('Unit | Prescription | Application | Jobs | ParticipationCompletedJobCo
         poleEmploiNotifier.notify
           .withArgs(userId, expectedResults, {
             authenticationMethodRepository,
-            httpAgent,
             httpErrorsHelper,
-            monitoringTools,
+            httpAgent,
+            logger,
           })
           .resolves(expectedResponse);
         const poleEmploiSending = Symbol('Pole emploi sending');

--- a/api/tests/prescription/campaign-participation/unit/application/jobs/participation-started-job-controller_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/jobs/participation-started-job-controller_test.js
@@ -8,7 +8,7 @@ describe('Unit | Application | Controller | Jobs | participation-started-control
   let data, dependencies, expectedResults;
   let httpAgent,
     httpErrorsHelper,
-    monitoringTools,
+    logger,
     campaignRepository,
     campaignParticipationRepository,
     organizationRepository,
@@ -32,7 +32,7 @@ describe('Unit | Application | Controller | Jobs | participation-started-control
     poleEmploiSendingRepository = { create: sinon.stub() };
 
     httpAgent = Symbol('httpAgent');
-    monitoringTools = Symbol('monitoringTools');
+    logger = Symbol('logger');
     httpErrorsHelper = Symbol('httpErrorsHelper');
 
     dependencies = {
@@ -45,7 +45,7 @@ describe('Unit | Application | Controller | Jobs | participation-started-control
       userRepository,
       poleEmploiNotifier,
       httpAgent,
-      monitoringTools,
+      logger,
       httpErrorsHelper,
     };
 
@@ -139,7 +139,7 @@ describe('Unit | Application | Controller | Jobs | participation-started-control
             authenticationMethodRepository,
             httpAgent,
             httpErrorsHelper,
-            monitoringTools,
+            logger,
           })
           .resolves(expectedResponse);
         const poleEmploiSending = Symbol('Pole emploi sending');

--- a/api/tests/unit/domain/usecases/send-shared-participation-results-to-pole-emploi_test.js
+++ b/api/tests/unit/domain/usecases/send-shared-participation-results-to-pole-emploi_test.js
@@ -1,9 +1,6 @@
 import { sendSharedParticipationResultsToPoleEmploi } from '../../../../lib/domain/usecases/send-shared-participation-results-to-pole-emploi.js';
 import { PoleEmploiPayload } from '../../../../lib/infrastructure/externals/pole-emploi/PoleEmploiPayload.js';
-import * as httpErrorsHelper from '../../../../lib/infrastructure/http/errors-helper.js';
-import { httpAgent } from '../../../../lib/infrastructure/http/http-agent.js';
 import { PoleEmploiSending } from '../../../../src/shared/domain/models/PoleEmploiSending.js';
-import * as monitoringTools from '../../../../src/shared/infrastructure/monitoring-tools.js';
 import { domainBuilder, expect, sinon } from '../../../test-helper.js';
 
 describe('Unit | Domain | UseCase | send-shared-participation-results-to-pole-emploi', function () {
@@ -18,10 +15,14 @@ describe('Unit | Domain | UseCase | send-shared-participation-results-to-pole-em
     userRepository,
     poleEmploiNotifier,
     poleEmploiSendingRepository;
+  let httpAgent, httpErrorsHelper, logger;
   let campaignId, campaignParticipationId, userId, organizationId, badges, badgeAcquiredIds;
   let authenticationMethodRepository;
 
   beforeEach(function () {
+    httpAgent = Symbol('httpAgent');
+    logger = Symbol('logger');
+    httpErrorsHelper = Symbol('httpErrorsHelper');
     badgeRepository = { findByCampaignId: sinon.stub() };
     badgeAcquisitionRepository = { getAcquiredBadgeIds: sinon.stub() };
     campaignRepository = { get: sinon.stub() };
@@ -49,6 +50,11 @@ describe('Unit | Domain | UseCase | send-shared-participation-results-to-pole-em
       targetProfileRepository,
       userRepository,
       poleEmploiNotifier,
+      notifierDependencies: {
+        httpAgent,
+        logger,
+        httpErrorsHelper,
+      },
     };
 
     expectedResults = new PoleEmploiPayload({
@@ -193,8 +199,8 @@ describe('Unit | Domain | UseCase | send-shared-participation-results-to-pole-em
         .withArgs(userId, expectedResults, {
           authenticationMethodRepository,
           httpAgent,
+          logger,
           httpErrorsHelper,
-          monitoringTools,
         })
         .resolves(expectedResponse);
       const poleEmploiSending = Symbol('Pole emploi sending');


### PR DESCRIPTION
## :unicorn: Problème
En passant par des job asynchrone, nous n'avons plus le userId dans les log sur l'envoi de données, ce qui peut être compliqué pour retrouver le job en erreur.

## :robot: Proposition
Ajouter la campaignParticipationId dans le log afin d'ajouter une finesse dans le log inséré

## :rainbow: Remarques
Peut être plus tard le remplacer par le job id quand on aura mis au propre les controller / usecase etc.... 

## :100: Pour tester
Faire une campagne PE en local. et vérifier que le log contient bien le campaignParticipationId