### PR TITLE
[BUGFIX] Changer la couleur pour corriger le contraste sur la page de code candidat sur Pix App (PIX-14123).

### DIFF
--- a/mon-pix/app/styles/components/_certification-starter.scss
+++ b/mon-pix/app/styles/components/_certification-starter.scss
@@ -93,7 +93,7 @@
 
       &__non-eligible-item,
       &__non-eligible-icon {
-        color: var(--pix-neutral-100);
+        color: var(--pix-neutral-500);
       }
     }
 


### PR DESCRIPTION
## :unicorn: Problème
<img width="904" alt="Capture d’écran 2024-09-03 à 11 19 54" src="https://github.com/user-attachments/assets/9028eca8-7d90-4a6c-8bd3-bbaa7d647aff">


## :robot: Proposition
Corriger la couleur pour corriger le soucis de contraste

## :rainbow: Remarques
Introduit lors de la mise à jour des couleurs de Pix UI

## :100: Pour tester
Se connecter sur Pix App avec
Remplir le formulaire pour entrer en certification
Dans la page de code candidat, constater que le contraste est good ✅ 
