### PR TITLE
[FEATURE] Support du message d’initialisation d’embed (PIX-14116)

### DIFF
--- a/mon-pix/app/components/challenge-embed-simulator.js
+++ b/mon-pix/app/components/challenge-embed-simulator.js
@@ -91,7 +91,6 @@ export default class ChallengeEmbedSimulator extends Component {
         iframe.src = tmpSrc;
       } else {
         // Second onload: when we re-assign the iframe's src to its original value
-        iframe.contentWindow.postMessage('reload', '*');
         iframe.focus();
         iframe.removeEventListener('load', loadListener);
       }

--- a/mon-pix/app/components/challenge-embed-simulator.js
+++ b/mon-pix/app/components/challenge-embed-simulator.js
@@ -49,9 +49,16 @@ export default class ChallengeEmbedSimulator extends Component {
 
     thisComponent._embedMessageListener = ({ origin, data }) => {
       if (!isEmbedAllowedOrigin(origin)) return;
+      if (isInitMessage(data)) {
+        if (data.autoLaunch || thisComponent.isSimulatorLaunched) {
+          thisComponent.launchSimulator();
+        }
+        if (!data.rebootable) {
+          thisComponent.isSimulatorRebootable = false;
+        }
+      }
       if (isReadyMessage(data) && thisComponent.isSimulatorLaunched) {
-        iframe.contentWindow.postMessage('launch', '*');
-        iframe.focus();
+        thisComponent.launchSimulator();
       }
       if (isHeightMessage(data)) {
         thisComponent.embedHeight = data.height;
@@ -112,6 +119,18 @@ export default class ChallengeEmbedSimulator extends Component {
  */
 function isReadyMessage(data) {
   return isMessageType(data, 'ready');
+}
+
+/**
+ * Checks if event is an "init" message.
+ * @param {unknown} data
+ * @returns {data is {
+ *   autoLaunch: boolean
+ *   rebootable: boolean
+ * }}
+ */
+function isInitMessage(data) {
+  return isMessageType(data, 'init');
 }
 
 /**

--- a/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
+++ b/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
@@ -128,5 +128,63 @@ module('Integration | Component | Challenge Embed Simulator', function (hooks) {
         assert.dom(screen.queryByText(t('pages.challenge.embed-simulator.actions.reset'))).doesNotExist();
       });
     });
+
+    module('when embed initializes', function () {
+      module('and does not ask for autoLaunch', () => {
+        test('should display launch button', async function (assert) {
+          const event = new MessageEvent('message', {
+            data: { from: 'pix', type: 'init', autoLaunch: false, rebootable: true },
+            origin: 'https://epreuves.pix.fr',
+          });
+          window.dispatchEvent(event);
+
+          await new Promise((resolve) => setTimeout(resolve, 0));
+
+          assert.dom(screen.queryByText(t('pages.challenge.embed-simulator.actions.launch'))).exists();
+        });
+      });
+
+      module('and asks for autoLaunch', () => {
+        test('should not display launch button', async function (assert) {
+          const event = new MessageEvent('message', {
+            data: { from: 'pix', type: 'init', autoLaunch: true, rebootable: true },
+            origin: 'https://epreuves.pix.fr',
+          });
+          window.dispatchEvent(event);
+
+          await new Promise((resolve) => setTimeout(resolve, 0));
+
+          assert.dom(screen.queryByText(t('pages.challenge.embed-simulator.actions.launch'))).doesNotExist();
+        });
+      });
+
+      module('and is rebootable', () => {
+        test('should display reboot button', async function (assert) {
+          const event = new MessageEvent('message', {
+            data: { from: 'pix', type: 'init', autoLaunch: false, rebootable: true },
+            origin: 'https://epreuves.pix.fr',
+          });
+          window.dispatchEvent(event);
+
+          await new Promise((resolve) => setTimeout(resolve, 0));
+
+          assert.dom(screen.queryByText(t('pages.challenge.embed-simulator.actions.reset'))).exists();
+        });
+      });
+
+      module('and is not rebootable', () => {
+        test('should not display reboot button', async function (assert) {
+          const event = new MessageEvent('message', {
+            data: { from: 'pix', type: 'init', autoLaunch: false, rebootable: false },
+            origin: 'https://epreuves.pix.fr',
+          });
+          window.dispatchEvent(event);
+
+          await new Promise((resolve) => setTimeout(resolve, 0));
+
+          assert.dom(screen.queryByText(t('pages.challenge.embed-simulator.actions.reset'))).doesNotExist();
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Le message de lancement automatique d’embed ne permet pas de décorréler l’affichage des boutons de lancement et de réinialisation.

## :robot: Proposition
Supporter un message d’initialisation d’embed.

Ce message d’initialisation est voué à remplacer principalement le message de “lancement automatique”, en apportant plus de souplesse.

Le message de lancement automatique fait disparaître le bouton de lancement et le bouton de réinitialisation, le message d’initialisation doit permettre à l’embed de faire disparaître l’un ou l’autre ou les deux.

## :rainbow: Remarques
Dans un souci de cohérence, on souhaite également remplacer le message “ready” par le message d’initialisation.

Le message “ready” est utile pour redéclencher le lancement de l’embed après une réinitialisation, il peut donc être remplacer par un message d’initialisation, sans lancement automatique et avec réinialisation possible.

## :100: Pour tester

Vérifier pour les différents embeds que la version de prod (colonne Ancien), et la version de la RA 1024pix/pix-epreuves#1872 (colonne Nouveau), ont bien toutes les deux les comportements attendus (décrits dans la colonne Test).

