### PR TITLE
[FEATURE] Utiliser le scope dans les refresh tokens (PIX-13911)

### DIFF
--- a/api/src/identity-access-management/application/token/token.controller.js
+++ b/api/src/identity-access-management/application/token/token.controller.js
@@ -26,37 +26,41 @@ const createToken = async function (request, h, dependencies = { tokenService })
   let accessToken, refreshToken;
   let expirationDelaySeconds;
 
-  if (request.payload.grant_type === 'refresh_token') {
+  const grantType = request.payload.grant_type;
+  const scope = request.payload.scope;
+
+  if (grantType === 'refresh_token') {
     refreshToken = request.payload.refresh_token;
-    const accessTokenAndExpirationDelaySeconds = await usecases.createAccessTokenFromRefreshToken({ refreshToken });
-    accessToken = accessTokenAndExpirationDelaySeconds.accessToken;
-    expirationDelaySeconds = accessTokenAndExpirationDelaySeconds.expirationDelaySeconds;
-  } else if (request.payload.grant_type === 'password') {
+
+    // TODO: we should pass the scope when ember-simple-auth will pass it
+    const tokensInfo = await usecases.createAccessTokenFromRefreshToken({ refreshToken });
+
+    accessToken = tokensInfo.accessToken;
+    expirationDelaySeconds = tokensInfo.expirationDelaySeconds;
+  } else if (grantType === 'password') {
     const { username, password, scope } = request.payload;
     const localeFromCookie = request.state?.locale;
-
     const source = 'pix';
-    const tokensAndExpirationDelaySeconds = await usecases.authenticateUser({
-      username,
-      password,
-      scope,
-      source,
-      localeFromCookie,
-    });
-    accessToken = tokensAndExpirationDelaySeconds.accessToken;
-    refreshToken = tokensAndExpirationDelaySeconds.refreshToken;
-    expirationDelaySeconds = tokensAndExpirationDelaySeconds.expirationDelaySeconds;
+
+    const tokensInfo = await usecases.authenticateUser({ username, password, scope, source, localeFromCookie });
+
+    accessToken = tokensInfo.accessToken;
+    refreshToken = tokensInfo.refreshToken;
+    expirationDelaySeconds = tokensInfo.expirationDelaySeconds;
   } else {
     throw new BadRequestError('Invalid grant type');
   }
 
+  const userId = dependencies.tokenService.extractUserId(accessToken);
+
   return h
     .response({
       token_type: 'bearer',
+      user_id: userId,
       access_token: accessToken,
-      user_id: dependencies.tokenService.extractUserId(accessToken),
       refresh_token: refreshToken,
       expires_in: expirationDelaySeconds,
+      scope,
     })
     .code(200)
     .header('Content-Type', 'application/json;charset=UTF-8')

--- a/api/src/identity-access-management/application/token/token.controller.js
+++ b/api/src/identity-access-management/application/token/token.controller.js
@@ -33,6 +33,7 @@ const createToken = async function (request, h, dependencies = { tokenService })
     refreshToken = request.payload.refresh_token;
 
     // TODO: we should pass the scope when ember-simple-auth will pass it
+    // see https://github.com/mainmatter/ember-simple-auth/pull/2813 for further details
     const tokensInfo = await usecases.createAccessTokenFromRefreshToken({ refreshToken });
 
     accessToken = tokensInfo.accessToken;

--- a/api/src/identity-access-management/domain/models/User.js
+++ b/api/src/identity-access-management/domain/models/User.js
@@ -96,7 +96,15 @@ class User {
       (authenticationMethod) => authenticationMethod.identityProvider === NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
     );
 
-    return pixAuthenticationMethod ? pixAuthenticationMethod.authenticationComplement.shouldChangePassword : null;
+    return pixAuthenticationMethod ? pixAuthenticationMethod.authenticationComplement?.shouldChangePassword : null;
+  }
+
+  get passwordHash() {
+    const pixAuthenticationMethod = this.authenticationMethods.find(
+      (authenticationMethod) => authenticationMethod.identityProvider === NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
+    );
+
+    return pixAuthenticationMethod ? pixAuthenticationMethod.authenticationComplement?.password : null;
   }
 
   get shouldSeeDataProtectionPolicyInformationBanner() {

--- a/api/src/identity-access-management/domain/services/pix-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/pix-authentication-service.js
@@ -18,7 +18,6 @@ async function getUserByUsernameAndPassword({
   dependencies = { userLoginRepository, cryptoService },
 }) {
   const foundUser = await userRepository.getByUsernameOrEmailWithRolesAndPassword(username);
-  const passwordHash = foundUser.authenticationMethods[0].authenticationComplement.password;
 
   let userLogin = await dependencies.userLoginRepository.findByUserId(foundUser.id);
   if (!userLogin) {
@@ -26,10 +25,8 @@ async function getUserByUsernameAndPassword({
   }
 
   try {
-    await dependencies.cryptoService.checkPassword({
-      password,
-      passwordHash,
-    });
+    const passwordHash = foundUser.passwordHash;
+    await dependencies.cryptoService.checkPassword({ password, passwordHash });
   } catch (error) {
     if (error instanceof PasswordNotMatching) {
       userLogin.incrementFailureCount();

--- a/api/src/identity-access-management/domain/services/refresh-token-service.js
+++ b/api/src/identity-access-management/domain/services/refresh-token-service.js
@@ -12,7 +12,7 @@ const REFRESH_TOKEN_EXPIRATION_DELAY_ADDITION_SECONDS = 60 * 60; // 1 hour
 
 /**
  * @param refreshToken
- * @returns {Promise<{userId: string, source: string}>}
+ * @returns {Promise<{userId: string, source: string, scope: string}>}
  */
 async function findByRefreshToken(refreshToken) {
   return refreshTokenTemporaryStorage.get(refreshToken);

--- a/api/src/identity-access-management/domain/usecases/authenticate-user.js
+++ b/api/src/identity-access-management/domain/usecases/authenticate-user.js
@@ -1,7 +1,3 @@
-import lodash from 'lodash';
-
-const { get } = lodash;
-
 import { PIX_ADMIN, PIX_ORGA } from '../../../authorization/domain/constants.js';
 import { ForbiddenAccess, LocaleFormatError, LocaleNotSupportedError } from '../../../shared/domain/errors.js';
 import { MissingOrInvalidCredentialsError, UserShouldChangePasswordError } from '../errors.js';
@@ -39,13 +35,7 @@ const authenticateUser = async function ({
       userRepository,
     });
 
-    // TODO: étrange ?
-    const shouldChangePassword = get(
-      foundUser,
-      'authenticationMethods[0].authenticationComplement.shouldChangePassword',
-    );
-
-    if (shouldChangePassword) {
+    if (foundUser.shouldChangePassword) {
       const passwordResetToken = tokenService.createPasswordResetToken(foundUser.id);
       throw new UserShouldChangePasswordError(undefined, passwordResetToken);
     }

--- a/api/src/identity-access-management/domain/usecases/authenticate-user.js
+++ b/api/src/identity-access-management/domain/usecases/authenticate-user.js
@@ -39,6 +39,7 @@ const authenticateUser = async function ({
       userRepository,
     });
 
+    // TODO: étrange ?
     const shouldChangePassword = get(
       foundUser,
       'authenticationMethods[0].authenticationComplement.shouldChangePassword',
@@ -50,9 +51,14 @@ const authenticateUser = async function ({
     }
 
     await _checkUserAccessScope(scope, foundUser, adminMemberRepository);
-    const refreshToken = await refreshTokenService.createRefreshTokenFromUserId({ userId: foundUser.id, source });
+    const refreshToken = await refreshTokenService.createRefreshTokenFromUserId({
+      userId: foundUser.id,
+      source,
+      scope,
+    });
     const { accessToken, expirationDelaySeconds } = await refreshTokenService.createAccessTokenFromRefreshToken({
       refreshToken,
+      scope,
     });
 
     foundUser.setLocaleIfNotAlreadySet(localeFromCookie);

--- a/api/src/identity-access-management/domain/usecases/create-access-token-from-refresh-token.js
+++ b/api/src/identity-access-management/domain/usecases/create-access-token-from-refresh-token.js
@@ -1,5 +1,5 @@
-const createAccessTokenFromRefreshToken = async function ({ refreshToken, refreshTokenService }) {
-  return refreshTokenService.createAccessTokenFromRefreshToken({ refreshToken });
+const createAccessTokenFromRefreshToken = async function ({ refreshToken, scope, refreshTokenService }) {
+  return refreshTokenService.createAccessTokenFromRefreshToken({ refreshToken, scope });
 };
 
 export { createAccessTokenFromRefreshToken };

--- a/api/tests/identity-access-management/acceptance/application/token.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/token.route.test.js
@@ -117,7 +117,7 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
             grant_type: 'password',
             username: userEmailAddress,
             password: userPassword,
-            scope: 'pix',
+            scope: 'pix-orga',
           }),
         });
 
@@ -131,6 +131,7 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
           payload: querystring.stringify({
             grant_type: 'refresh_token',
             refresh_token: accessTokenResult.refresh_token,
+            scope: 'pix-orga',
           }),
         });
 

--- a/api/tests/identity-access-management/unit/application/token.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/token.controller.test.js
@@ -27,8 +27,8 @@ describe('Unit | Identity Access Management | Application | Controller | Token',
   });
 
   describe('#createToken', function () {
+    const userId = 1;
     const accessToken = 'jwt.access.token';
-    const USER_ID = 1;
     const username = 'user@email.com';
     const password = 'user_password';
     const scope = 'pix-orga';
@@ -37,59 +37,14 @@ describe('Unit | Identity Access Management | Application | Controller | Token',
     /**
      * @see https://www.oauth.com/oauth2-servers/access-tokens/access-token-response/
      */
-    it('returns an OAuth 2 token response (even if we do not really implement OAuth 2 authorization protocol)', async function () {
-      // given
-      const expirationDelaySeconds = 6666;
-      const refreshToken = 'refresh.token';
-      const request = {
-        headers: {
-          'content-type': 'application/x-www-form-urlencoded',
-        },
-        payload: {
-          grant_type: 'password',
-          username,
-          password,
-          scope,
-        },
-      };
-
-      sinon.stub(usecases, 'authenticateUser').resolves({ accessToken, refreshToken, expirationDelaySeconds });
-
-      const tokenServiceStub = { extractUserId: sinon.stub() };
-      tokenServiceStub.extractUserId.withArgs(accessToken).returns(USER_ID);
-
-      const dependencies = { tokenService: tokenServiceStub };
-
-      // when
-      const response = await tokenController.createToken(request, hFake, dependencies);
-
-      // then
-      const expectedResponseResult = {
-        token_type: 'bearer',
-        access_token: accessToken,
-        user_id: USER_ID,
-        refresh_token: refreshToken,
-        expires_in: expirationDelaySeconds,
-      };
-      expect(response.source).to.deep.equal(expectedResponseResult);
-      expect(response.statusCode).to.equal(200);
-      expect(response.headers).to.deep.equal({
-        'Content-Type': 'application/json;charset=UTF-8',
-        'Cache-Control': 'no-store',
-        Pragma: 'no-cache',
-      });
-    });
-
-    context('when there is a locale cookie', function () {
-      it('retrieves the value from the cookie and pass it as an argument to the use case', async function () {
+    context('when the user authenticates (grant_type: password)', function () {
+      it('returns an OAuth 2 token response (even if we do not really implement OAuth 2 authorization protocol)', async function () {
         // given
-        const expirationDelaySeconds = 777;
-        const refreshToken = 'cookie.refresh.token';
+        const expirationDelaySeconds = 6666;
+        const refreshToken = 'refresh.token';
         const localeFromCookie = 'fr-FR';
         const request = {
-          headers: {
-            'content-type': 'application/x-www-form-urlencoded',
-          },
+          headers: { 'content-type': 'application/x-www-form-urlencoded' },
           payload: {
             grant_type: 'password',
             username,
@@ -100,22 +55,77 @@ describe('Unit | Identity Access Management | Application | Controller | Token',
             locale: localeFromCookie,
           },
         };
-        sinon.stub(usecases, 'authenticateUser').resolves({ accessToken, refreshToken, expirationDelaySeconds });
+
+        sinon
+          .stub(usecases, 'authenticateUser')
+          .withArgs({ username, password, scope, source, localeFromCookie })
+          .resolves({ accessToken, refreshToken, expirationDelaySeconds });
+
         const tokenServiceStub = { extractUserId: sinon.stub() };
-        tokenServiceStub.extractUserId.withArgs(accessToken).returns(USER_ID);
+        tokenServiceStub.extractUserId.withArgs(accessToken).returns(userId);
 
         const dependencies = { tokenService: tokenServiceStub };
 
         // when
-        await tokenController.createToken(request, hFake, dependencies);
+        const response = await tokenController.createToken(request, hFake, dependencies);
 
         // then
-        expect(usecases.authenticateUser).to.have.been.calledWithExactly({
-          username,
-          password,
+        const expectedResponseResult = {
+          token_type: 'bearer',
+          access_token: accessToken,
+          user_id: userId,
+          refresh_token: refreshToken,
+          expires_in: expirationDelaySeconds,
           scope,
-          source,
-          localeFromCookie,
+        };
+        expect(response.source).to.deep.equal(expectedResponseResult);
+        expect(response.statusCode).to.equal(200);
+        expect(response.headers).to.deep.equal({
+          'Content-Type': 'application/json;charset=UTF-8',
+          'Cache-Control': 'no-store',
+          Pragma: 'no-cache',
+        });
+      });
+    });
+
+    context('when the user refresh its token (grant_type: refresh_token)', function () {
+      it('returns an OAuth 2 token response', async function () {
+        // given
+        const expirationDelaySeconds = 6666;
+        const refreshToken = 'refresh.token';
+        const request = {
+          headers: { 'content-type': 'application/x-www-form-urlencoded' },
+          payload: { grant_type: 'refresh_token', refresh_token: refreshToken, scope },
+        };
+
+        sinon
+          .stub(usecases, 'createAccessTokenFromRefreshToken')
+          .withArgs({ refreshToken })
+          .resolves({ accessToken, expirationDelaySeconds });
+
+        const tokenServiceStub = { extractUserId: sinon.stub() };
+        tokenServiceStub.extractUserId.withArgs(accessToken).returns(userId);
+
+        const dependencies = { tokenService: tokenServiceStub };
+
+        // when
+        const response = await tokenController.createToken(request, hFake, dependencies);
+
+        // then
+        const expectedResponseResult = {
+          token_type: 'bearer',
+          access_token: accessToken,
+          user_id: userId,
+          refresh_token: refreshToken,
+          expires_in: expirationDelaySeconds,
+          scope,
+        };
+        expect(response.source).to.deep.equal(expectedResponseResult);
+        expect(response.statusCode).to.equal(200);
+        expect(response.headers).to.deep.equal({
+          'Content-Type': 'application/json;charset=UTF-8',
+          'Cache-Control': 'no-store',
+          Pragma: 'no-cache',
         });
       });
     });

--- a/api/tests/identity-access-management/unit/domain/models/User.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/User.test.js
@@ -428,6 +428,43 @@ describe('Unit | Identity Access Management | Domain | Model | User', function (
     });
   });
 
+  describe('#passwordHash', function () {
+    context('when there is a Pix authentication method', function () {
+      it('returns the password hash', function () {
+        // given
+        const hashedPassword = 'xxx';
+        const pixAuthenticationMethod =
+          domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({ hashedPassword });
+
+        // when
+        const user = new User({
+          id: 1,
+          authenticationMethods: [pixAuthenticationMethod],
+        });
+
+        // then
+        expect(user.passwordHash).to.equal(hashedPassword);
+      });
+    });
+
+    context('when there is no Pix authentication method', function () {
+      it('returns null', function () {
+        // given
+        const poleEmploiAuthenticationMethod =
+          domainBuilder.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider();
+
+        // when
+        const user = new User({
+          id: 1,
+          authenticationMethods: [poleEmploiAuthenticationMethod],
+        });
+
+        // then
+        expect(user.passwordHash).to.be.null;
+      });
+    });
+  });
+
   describe('#shouldSeeDataProtectionPolicyInformationBanner', function () {
     context('when user has not seen data protection policy but data protection date is not setted', function () {
       it('should return false', function () {

--- a/api/tests/identity-access-management/unit/domain/usecases/authenticate-user_test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/authenticate-user_test.js
@@ -148,13 +148,10 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
         const expirationDelaySeconds = '';
 
         refreshTokenService.createRefreshTokenFromUserId
-          .withArgs({
-            userId: user.id,
-            source,
-          })
+          .withArgs({ userId: user.id, source, scope })
           .returns(refreshToken);
         refreshTokenService.createAccessTokenFromRefreshToken
-          .withArgs({ refreshToken })
+          .withArgs({ refreshToken, scope })
           .resolves({ accessToken, expirationDelaySeconds });
 
         // when
@@ -196,13 +193,10 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
 
           pixAuthenticationService.getUserByUsernameAndPassword.resolves(user);
           refreshTokenService.createRefreshTokenFromUserId
-            .withArgs({
-              userId: user.id,
-              source,
-            })
+            .withArgs({ userId: user.id, source, scope })
             .returns(refreshToken);
           refreshTokenService.createAccessTokenFromRefreshToken
-            .withArgs({ refreshToken })
+            .withArgs({ refreshToken, scope })
             .resolves({ accessToken, expirationDelaySeconds });
 
           // when
@@ -233,18 +227,14 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
     const accessToken = 'jwt.access.token';
     const refreshToken = 'jwt.refresh.token';
     const source = 'pix';
+    const scope = 'mon-pix';
     const expirationDelaySeconds = 1;
     const user = domainBuilder.buildUser({ email: userEmail });
 
     pixAuthenticationService.getUserByUsernameAndPassword.resolves(user);
-    refreshTokenService.createRefreshTokenFromUserId
-      .withArgs({
-        userId: user.id,
-        source,
-      })
-      .returns(refreshToken);
+    refreshTokenService.createRefreshTokenFromUserId.withArgs({ userId: user.id, source, scope }).returns(refreshToken);
     refreshTokenService.createAccessTokenFromRefreshToken
-      .withArgs({ refreshToken })
+      .withArgs({ refreshToken, scope })
       .resolves({ accessToken, expirationDelaySeconds });
 
     // when
@@ -252,6 +242,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
       username: userEmail,
       password,
       source,
+      scope,
       pixAuthenticationService,
       refreshTokenService,
       userRepository,
@@ -271,6 +262,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
     // given
     const accessToken = 'jwt.access.token';
     const source = 'pix';
+    const scope = 'mon-pix';
     const expirationDelaySeconds = 1;
     const user = domainBuilder.buildUser({ email: userEmail });
 
@@ -282,6 +274,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
       username: userEmail,
       password,
       source,
+      scope,
       pixAuthenticationService,
       refreshTokenService,
       userRepository,
@@ -398,6 +391,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
           // given
           const accessToken = 'jwt.access.token';
           const source = 'pix';
+          const scope = 'mon-pix';
           const expirationDelaySeconds = 1;
           const user = domainBuilder.buildUser({ email: userEmail, locale: null });
           const setLocaleIfNotAlreadySetStub = sinon.stub(user, 'setLocaleIfNotAlreadySet');
@@ -410,6 +404,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
             username: userEmail,
             password,
             source,
+            scope,
             localeFromCookie: 'localeFromCookie',
             pixAuthenticationService,
             refreshTokenService,
@@ -427,6 +422,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
           // given
           const accessToken = 'jwt.access.token';
           const source = 'pix';
+          const scope = 'mon-pix';
           const expirationDelaySeconds = 1;
           const user = domainBuilder.buildUser({ email: userEmail, locale: undefined });
 
@@ -438,6 +434,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
             username: userEmail,
             password,
             source,
+            scope,
             localeFromCookie: undefined,
             pixAuthenticationService,
             refreshTokenService,

--- a/api/tests/identity-access-management/unit/domain/usecases/create-access-token-from-refresh-token_test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/create-access-token-from-refresh-token_test.js
@@ -9,13 +9,14 @@ describe('Unit | Identity Access Management | Domain | UseCases | create-access-
       const expirationDelaySeconds = 1;
 
       const refreshToken = 'valid refresh token';
+      const scope = 'mon-pix';
       const refreshTokenService = { createAccessTokenFromRefreshToken: sinon.stub() };
       refreshTokenService.createAccessTokenFromRefreshToken
-        .withArgs({ refreshToken })
+        .withArgs({ refreshToken, scope })
         .returns({ accessToken, expirationDelaySeconds });
 
       // when
-      const createdAccessToken = await createAccessTokenFromRefreshToken({ refreshToken, refreshTokenService });
+      const createdAccessToken = await createAccessTokenFromRefreshToken({ refreshToken, scope, refreshTokenService });
 
       // then
       expect(createdAccessToken).to.deep.equal({ accessToken, expirationDelaySeconds });


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, les refresh token sont réutilisables entre les différentes applications pour renouveler des access tokens. On ne peut pas avoir de durée (TTL) des refresh token différents par application.

## :robot: Proposition

Utiliser le scope pour restreindre les refresh token par application.

Dans une autre PR, nous pourrons définir des durées de vie différentes des refresh token par application.

> [!IMPORTANT]
> Pour le moment le `scope` est envoyé uniquement dans la requête d'authentification. Il n'est jamais passé dans la requête de refresh token. De plus, la requête de refresh de token ne peut pas être modifiée ou surchargée dans `ember-simple-auth` sans recoder toute la logique de refresh de token dans l'authenticator. Nous avons créé une PR sur `ember-simple-auth` pour corriger ce problème.

> [!NOTE]
> 2 petits refactoring on été inclus afin d'utiliser le modèle User pour récupérer les informations `shouldChangePassword` et `passwordHash`. Ces informations n'étaient pas correctement récupérées, elles prenaient toujours la première méthode d'authentication (sans distinction du provider `PIX`).

## :100: Pour tester

Pour chaque application (Pix App, Pix Admin, Pix Certif, Pix Orga)

1. Se connecter à l'application

> Dans le local storage, vérifier que le refresh token généré contient le scope:
> `<user_id>:<scope>:<uuid>`

2. Dans le local storage, modifier l'expiration de l'access token (`expires_at`) en mettant un timestamp dans le passé, par exemple `1725372008161`

> L'access token doit changer dans le local storage.
