### PR TITLE
[BUGFIX] Enlever les organisations archivees des resultats LSU LSL (PIX-14103).

### DIFF
--- a/api/src/certification/results/infrastructure/repositories/certification-livret-scolaire-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certification-livret-scolaire-repository.js
@@ -30,6 +30,11 @@ const getCertificatesByOrganizationUAI = async function (uai) {
       'view-active-organization-learners.userId',
       'certification-courses.userId',
     )
+    .innerJoin('organizations', (builder) => {
+      return builder
+        .on('view-active-organization-learners.organizationId', '=', 'organizations.id')
+        .andOnNull('organizations.archivedAt');
+    })
     .innerJoin('sessions', 'sessions.id', 'certification-courses.sessionId')
     .innerJoin(
       'certification-courses-last-assessment-results',
@@ -54,12 +59,7 @@ const getCertificatesByOrganizationUAI = async function (uai) {
 
     .where({ 'certification-courses.isCancelled': false })
     .where({ 'view-active-organization-learners.isDisabled': false })
-    .where(
-      'view-active-organization-learners.organizationId',
-      '=',
-      knex.select('id').from('organizations').whereRaw('LOWER("externalId") = LOWER(?)', uai),
-    )
-
+    .whereRaw('LOWER("organizations"."externalId") = LOWER(?)', uai)
     .groupBy(
       'view-active-organization-learners.id',
       'view-active-organization-learners.firstName',


### PR DESCRIPTION
## :unicorn: Problème
On a eu un cas d’echec (HTTP 500) sur la recuperation d’un livret scolaire en production. La raison est que la requete SQL ne filtre pas les orgas archivees, ce qui fait qu’un orga SCO peut remonter deux fois dans la requete SQL, ce qui est pas OK (un seul resultat par UAI possible)

## :robot: Proposition

* Si une orga est archivee, alors elle ne doit pas remonter dans les resultats.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

* Avoir deux organisations SCO avec le meme UAI, mais l'une des deux organisations doit etre archivee
* Faire un appel sur l'API `/api/organizations/{uai}/certifications`
* Pas d'erreur 500
