### PR TITLE
[TECH] Remplacer l'usage de `memberAction` par un appel à des adapters (PIX-14093)

### DIFF
--- a/mon-pix/app/adapters/passage.js
+++ b/mon-pix/app/adapters/passage.js
@@ -1,3 +1,8 @@
 import ApplicationAdapter from './application';
 
-export default class Passage extends ApplicationAdapter {}
+export default class Passage extends ApplicationAdapter {
+  async terminate({ passageId }) {
+    const url = `${this.host}/${this.namespace}/passages/${passageId}/terminate`;
+    await this.ajax(url, 'POST');
+  }
+}

--- a/mon-pix/app/components/module/grain.gjs
+++ b/mon-pix/app/components/module/grain.gjs
@@ -147,8 +147,8 @@ export default class ModuleGrain extends Component {
   }
 
   @action
-  onModuleTerminate() {
-    this.args.onModuleTerminate({ grainId: this.args.grain.id });
+  async onModuleTerminate() {
+    await this.args.onModuleTerminate({ grainId: this.args.grain.id });
   }
 
   <template>

--- a/mon-pix/app/components/module/passage.js
+++ b/mon-pix/app/components/module/passage.js
@@ -96,8 +96,9 @@ export default class ModulePassage extends Component {
   }
 
   @action
-  onModuleTerminate({ grainId }) {
-    this.args.passage.terminate();
+  async onModuleTerminate({ grainId }) {
+    const adapter = this.store.adapterFor('passage');
+    await adapter.terminate({ passageId: this.args.passage.id });
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',

--- a/mon-pix/app/models/passage.js
+++ b/mon-pix/app/models/passage.js
@@ -1,4 +1,3 @@
-import { memberAction } from '@1024pix/ember-api-actions';
 import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class Passage extends Model {
@@ -14,9 +13,4 @@ export default class Passage extends Model {
   hasAnswerAlreadyBeenVerified(element) {
     return this.elementAnswers.some((answer) => answer.elementId === element.id);
   }
-
-  terminate = memberAction({
-    path: 'terminate',
-    type: 'post',
-  });
 }

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-passage-test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-passage-test.js
@@ -1,5 +1,5 @@
 import { clickByName, visit } from '@1024pix/ember-testing-library';
-import { currentURL } from '@ember/test-helpers';
+import { currentURL, waitUntil } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -105,10 +105,14 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
           },
         ],
       });
-      server.create('module', {
+      const module = server.create('module', {
         id: 'bien-ecrire-son-adresse-mail',
         title: 'Bien écrire son adresse mail',
         grains: [grain1],
+      });
+      server.create('passage', {
+        id: '122',
+        moduleId: module.id,
       });
 
       // when
@@ -121,6 +125,10 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
       await clickByName('Terminer');
 
       // then
+      await waitUntil(() => {
+        return screen.queryByRole('heading', { name: 'Bravo ! Module terminé', level: 1 });
+      });
+
       assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/recap');
     });
   });

--- a/mon-pix/tests/acceptance/module/retake_completed_module-test.js
+++ b/mon-pix/tests/acceptance/module/retake_completed_module-test.js
@@ -1,5 +1,5 @@
 import { visit } from '@1024pix/ember-testing-library';
-import { click } from '@ember/test-helpers';
+import { click, waitUntil } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -78,6 +78,10 @@ module('Acceptance | Module | Routes | retakeCompletedModule', function (hooks) 
 
     const terminateButton = screen.getByRole('button', { name: 'Terminer' });
     await click(terminateButton);
+
+    await waitUntil(() => {
+      return screen.queryByRole('heading', { name: 'Bravo ! Module terminé', level: 1 });
+    });
 
     const backToDetailsButton = screen.getByRole('link', { name: 'Revenir aux détails du module' });
     await click(backToDetailsButton);

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -2,6 +2,7 @@ import { clickByName, render } from '@1024pix/ember-testing-library';
 // eslint-disable-next-line no-restricted-imports
 import { find, findAll } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
+import ApplicationAdapter from 'mon-pix/adapters/application';
 import ModulePassage from 'mon-pix/components/module/passage';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -905,6 +906,10 @@ module('Integration | Component | Module | Passage', function (hooks) {
   module('When click on terminate button', function () {
     test('should push an event', async function (assert) {
       // given
+      class PassageAdapterStub extends ApplicationAdapter {
+        terminate = sinon.stub().resolves();
+      }
+      this.owner.register('adapter:passage', PassageAdapterStub);
       const router = this.owner.lookup('service:router');
       router.transitionTo = sinon.stub();
       const metrics = this.owner.lookup('service:metrics');

--- a/mon-pix/tests/unit/adapters/passage-test.js
+++ b/mon-pix/tests/unit/adapters/passage-test.js
@@ -1,0 +1,25 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Adapter | Module | Passage', function (hooks) {
+  setupTest(hooks);
+
+  module('#terminate', function () {
+    test('should trigger an ajax call with the right url and method', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const passage = store.createRecord('passage', { id: '123' });
+      const adapter = this.owner.lookup('adapter:passage');
+      sinon.stub(adapter, 'ajax').resolves();
+      const expectedUrl = `http://localhost:3000/api/passages/${passage.id}/terminate`;
+
+      // when
+      await adapter.terminate({ passageId: passage.id });
+
+      // then
+      sinon.assert.calledWith(adapter.ajax, expectedUrl, 'POST');
+      assert.ok(true);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Suite à [la PR](https://github.com/1024pix/pix/pull/9900) pour retirer les `memberAction` de Pix Admin, nous avons constaté que nous utilisions encore `memberAction` dans Modulix.

## :robot: Proposition
Retirer la `memberAction` du modèle `Passage.terminate` et la remplacer par une méthode de l'_adapter_ `Passage`.

## :rainbow: Remarques
Des tests transverses ont pété suite à la _refacto_. Il s'agissait de ceux qui nécessitaient de cliquer sur le bouton "Terminer" et qui donc faisaient appel à la nouvelle méthode `Passage.terminate` introduite par cette PR.
Il a fallut rajouter un _timeout_ de 100ms pour que la vue ait le temps de se rafraîchir et que les _asserts_ puissent être validés.

## :100: Pour tester
CI 🍏 

### Non régression technique :

1. Se rendre sur le module [bien écrire son adresse mail](https://app-pr10043.review.pix.fr/modules/bien-ecrire-son-adresse-mail)
2. Ouvrir le panneau de réseau du navigateur
3. Passer l'ensemble des grains
3. Cliquer sur le bouton "Terminer"
5. Constater dans le panneau de réseau que la route `/passages/{passageId}/terminate` a été bien appelé avec la méthode `POST` et le bon id de `passage`.

### Non régression fonctionnelle :

1. Se rendre sur le module [bien écrire son adresse mail](https://app-pr10043.review.pix.fr/modules/bien-ecrire-son-adresse-mail)
2. Passer l'ensemble des grains
3. Cliquer sur le bouton "Terminer"
4. Constater que nous arrivons bien sur l'écran de récap
