### PR TITLE
[TECH] Ajouter les infos de corrélation à chaque log via le logger

### DIFF
--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -19,7 +19,7 @@ const seed = async function (knex) {
   const seedsContext = process.env.SEEDS_CONTEXT ? process.env.SEEDS_CONTEXT.split('|') : [];
 
   const hasToSeed = _buildContextToSeed(seedsContext);
-  logger.info({ seedsContext }, 'Seeds Context');
+  logger.info({ seedsContext, msg: 'Seeds Context' });
 
   const databaseBuilder = new DatabaseBuilder({ knex });
 

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -21,7 +21,6 @@ import * as flashAlgorithmConfigurationRepository from '../../../src/certificati
 import * as authenticationMethodRepository from '../../../src/identity-access-management/infrastructure/repositories/authentication-method.repository.js';
 import * as userRepository from '../../../src/identity-access-management/infrastructure/repositories/user.repository.js';
 import { config } from '../../../src/shared/config.js';
-import { monitoringTools as MonitoringTools } from '../../../src/shared/infrastructure/monitoring-tools.js';
 import * as answerRepository from '../../../src/shared/infrastructure/repositories/answer-repository.js';
 import * as assessmentRepository from '../../../src/shared/infrastructure/repositories/assessment-repository.js';
 import * as assessmentResultRepository from '../../../src/shared/infrastructure/repositories/assessment-result-repository.js';
@@ -105,7 +104,7 @@ const handlersToBeInjected = {
 };
 
 function buildEventDispatcher(handlersStubs) {
-  const eventDispatcher = new EventDispatcher(new EventDispatcherLogger(MonitoringTools, config, performance));
+  const eventDispatcher = new EventDispatcher(new EventDispatcherLogger(logger, config, performance));
 
   const handlersNames = _.map(handlersToBeInjected, (handler) => handler.name);
 

--- a/api/lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js
+++ b/api/lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js
@@ -10,7 +10,7 @@ import {
 } from '../../../src/shared/domain/errors.js';
 import { Organization, OrganizationForAdmin, OrganizationTag } from '../../../src/shared/domain/models/index.js';
 import * as codeGenerator from '../../../src/shared/domain/services/code-generator.js';
-import { monitoringTools } from '../../../src/shared/infrastructure/monitoring-tools.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import { PromiseUtils } from '../../../src/shared/infrastructure/utils/promise-utils.js';
 import { CONCURRENCY_HEAVY_OPERATIONS } from '../../infrastructure/constants.js';
 import { DomainTransaction } from '../../infrastructure/DomainTransaction.js';
@@ -293,7 +293,6 @@ async function _sendInvitationEmails({
 
 function _monitorError(message, { data, error, event } = {}) {
   const monitoringData = {
-    message,
     context: 'create-organizations-with-tags-and-target-profiles',
     event,
     team: 'acces',
@@ -307,5 +306,5 @@ function _monitorError(message, { data, error, event } = {}) {
     monitoringData.error = { name: error.constructor.name };
   }
 
-  monitoringTools.logErrorWithCorrelationIds(monitoringData);
+  logger.error(monitoringData, message);
 }

--- a/api/lib/infrastructure/events/EventDispatcherLogger.js
+++ b/api/lib/infrastructure/events/EventDispatcherLogger.js
@@ -1,16 +1,18 @@
 class EventDispatcherLogger {
-  constructor(monitoringTools, settings, performance) {
-    this._monitoringTools = monitoringTools;
+  constructor(logger, settings, performance) {
+    this._logger = logger;
     this._settings = settings;
     this._performance = performance;
   }
 
   onEventDispatchStarted(event, eventHandlerName) {
     if (this._settings?.logging?.enableLogStartingEventDispatch) {
-      this._monitoringTools.logInfoWithCorrelationIds({
-        ...buildLogBody({ event, eventHandlerName }),
-        message: 'EventDispatcher : Event dispatch started',
-      });
+      this._logger.info(
+        {
+          ...buildLogBody({ event, eventHandlerName }),
+        },
+        'EventDispatcher : Event dispatch started',
+      );
     }
     return {
       startedAt: this._performance.now(),
@@ -19,19 +21,23 @@ class EventDispatcherLogger {
 
   onEventDispatchSuccess(event, eventHandlerName, loggingContext) {
     if (this._settings?.logging?.enableLogEndingEventDispatch) {
-      this._monitoringTools.logInfoWithCorrelationIds({
-        ...buildLogBody({ event, eventHandlerName, duration: this._duration(loggingContext) }),
-        message: 'EventDispatcher : Event dispatched successfully',
-      });
+      this._logger.info(
+        {
+          ...buildLogBody({ event, eventHandlerName, duration: this._duration(loggingContext) }),
+        },
+        'EventDispatcher : Event dispatched successfully',
+      );
     }
   }
 
   onEventDispatchFailure(event, eventHandlerName, error) {
     if (this._settings?.logging?.enableLogEndingEventDispatch) {
-      this._monitoringTools.logInfoWithCorrelationIds({
-        ...buildLogBody({ event, eventHandlerName, error }),
-        message: 'EventDispatcher : An error occurred while dispatching the event',
-      });
+      this._logger.info(
+        {
+          ...buildLogBody({ event, eventHandlerName, error }),
+        },
+        'EventDispatcher : An error occurred while dispatching the event',
+      );
     }
   }
 

--- a/api/lib/infrastructure/events/EventDispatcherLogger.js
+++ b/api/lib/infrastructure/events/EventDispatcherLogger.js
@@ -7,12 +7,10 @@ class EventDispatcherLogger {
 
   onEventDispatchStarted(event, eventHandlerName) {
     if (this._settings?.logging?.enableLogStartingEventDispatch) {
-      this._logger.info(
-        {
-          ...buildLogBody({ event, eventHandlerName }),
-        },
-        'EventDispatcher : Event dispatch started',
-      );
+      this._logger.info({
+        ...buildLogBody({ event, eventHandlerName }),
+        msg: 'EventDispatcher : Event dispatch started',
+      });
     }
     return {
       startedAt: this._performance.now(),
@@ -21,23 +19,19 @@ class EventDispatcherLogger {
 
   onEventDispatchSuccess(event, eventHandlerName, loggingContext) {
     if (this._settings?.logging?.enableLogEndingEventDispatch) {
-      this._logger.info(
-        {
-          ...buildLogBody({ event, eventHandlerName, duration: this._duration(loggingContext) }),
-        },
-        'EventDispatcher : Event dispatched successfully',
-      );
+      this._logger.info({
+        ...buildLogBody({ event, eventHandlerName, duration: this._duration(loggingContext) }),
+        msg: 'EventDispatcher : Event dispatched successfully',
+      });
     }
   }
 
   onEventDispatchFailure(event, eventHandlerName, error) {
     if (this._settings?.logging?.enableLogEndingEventDispatch) {
-      this._logger.info(
-        {
-          ...buildLogBody({ event, eventHandlerName, error }),
-        },
-        'EventDispatcher : An error occurred while dispatching the event',
-      );
+      this._logger.info({
+        ...buildLogBody({ event, eventHandlerName, error }),
+        msg: 'EventDispatcher : An error occurred while dispatching the event',
+      });
     }
   }
 

--- a/api/lib/infrastructure/events/EventHandlerDependenciesBuilder.js
+++ b/api/lib/infrastructure/events/EventHandlerDependenciesBuilder.js
@@ -1,15 +1,15 @@
-import { monitoringTools } from '../../../src/shared/infrastructure/monitoring-tools.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 
 function build(classToInstanciate) {
   const dependencies = _buildDependencies();
 
   const instance = new classToInstanciate(dependencies);
-  return new EventErrorHandler(instance, monitoringTools);
+  return new EventErrorHandler(instance, logger);
 }
 
 function _buildDependencies() {
   return {
-    monitoringTools,
+    logger,
   };
 }
 
@@ -34,25 +34,21 @@ class EventErrorHandler {
   }
 
   logHandlerStarting(event) {
-    this.logger.logInfoWithCorrelationIds({
-      message: {
-        event,
-        handlerName: this.handler.name,
-        type: 'EVENT_LOG',
-        info: 'EventBus : Event dispatched',
-      },
+    this.logger.info({
+      event,
+      handlerName: this.handler.name,
+      type: 'EVENT_LOG',
+      info: 'EventBus : Event dispatched',
     });
   }
 
   logHandlerFailed(event, error) {
-    this.logger.logErrorWithCorrelationIds({
-      message: {
-        event,
-        handlerName: this.handler.name,
-        error: error?.message ? error.message + ' (see dedicated log for more information)' : undefined,
-        type: 'EVENT_LOG_ERROR',
-        info: 'EventBus : Event Handling Error',
-      },
+    this.logger.error({
+      event,
+      handlerName: this.handler.name,
+      error: error?.message ? error.message + ' (see dedicated log for more information)' : undefined,
+      type: 'EVENT_LOG_ERROR',
+      info: 'EventBus : Event Handling Error',
     });
   }
 }

--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -1,10 +1,8 @@
 import perf_hooks from 'node:perf_hooks';
 
 import axios from 'axios';
-
 const { performance } = perf_hooks;
-
-import { monitoringTools } from '../../../src/shared/infrastructure/monitoring-tools.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 
 class HttpResponse {
   constructor({ code, data, isSuccessful }) {
@@ -27,10 +25,12 @@ const httpAgent = {
       }
       const httpResponse = await axios.post(url, payload, config);
       responseTime = performance.now() - startTime;
-      monitoringTools.logInfoWithCorrelationIds({
-        metrics: { responseTime },
-        message: `End POST request to ${url} success: ${httpResponse.status}`,
-      });
+      logger.info(
+        {
+          metrics: { responseTime },
+        },
+        `End POST request to ${url} success: ${httpResponse.status}`,
+      );
 
       return new HttpResponse({
         code: httpResponse.status,
@@ -52,10 +52,12 @@ const httpAgent = {
 
       const message = `End POST request to ${url} error: ${code || ''} ${JSON.stringify(data)}`;
 
-      monitoringTools.logErrorWithCorrelationIds({
-        metrics: { responseTime },
+      logger.error(
+        {
+          metrics: { responseTime },
+        },
         message,
-      });
+      );
 
       return new HttpResponse({
         code,
@@ -77,10 +79,12 @@ const httpAgent = {
       }
       const httpResponse = await axios.get(url, config);
       responseTime = performance.now() - startTime;
-      monitoringTools.logInfoWithCorrelationIds({
-        metrics: { responseTime },
-        message: `End GET request to ${url} success: ${httpResponse.status}`,
-      });
+      logger.info(
+        {
+          metrics: { responseTime },
+        },
+        `End GET request to ${url} success: ${httpResponse.status}`,
+      );
 
       return new HttpResponse({
         code: httpResponse.status,
@@ -102,10 +106,12 @@ const httpAgent = {
         data = null;
       }
 
-      monitoringTools.logErrorWithCorrelationIds({
-        metrics: { responseTime },
-        message: `End GET request to ${url} error: ${code || ''} ${JSON.stringify(data)}`,
-      });
+      logger.error(
+        {
+          metrics: { responseTime },
+        },
+        `End GET request to ${url} error: ${code || ''} ${JSON.stringify(data)}`,
+      );
 
       return new HttpResponse({
         code,

--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -52,12 +52,10 @@ const httpAgent = {
 
       const message = `End POST request to ${url} error: ${code || ''} ${JSON.stringify(data)}`;
 
-      logger.error(
-        {
-          metrics: { responseTime },
-        },
-        message,
-      );
+      logger.error({
+        metrics: { responseTime },
+        msg: message,
+      });
 
       return new HttpResponse({
         code,
@@ -106,12 +104,10 @@ const httpAgent = {
         data = null;
       }
 
-      logger.error(
-        {
-          metrics: { responseTime },
-        },
-        `End GET request to ${url} error: ${code || ''} ${JSON.stringify(data)}`,
-      );
+      logger.error({
+        metrics: { responseTime },
+        msg: `End GET request to ${url} error: ${code || ''} ${JSON.stringify(data)}`,
+      });
 
       return new HttpResponse({
         code,

--- a/api/scripts/prod/target-profile-migrations/migrate-stages-to-level.js
+++ b/api/scripts/prod/target-profile-migrations/migrate-stages-to-level.js
@@ -206,7 +206,7 @@ async function _writeReport(migrations) {
 async function main() {
   const startTime = performance.now();
   const dryRun = process.env.DRY_RUN !== 'false';
-  logger.info({ dryRun }, `Script ${modulePath} has started`);
+  logger.info({ dryRun, msg: `Script ${modulePath} has started` });
   const inputFile = resolve(process.cwd(), process.argv[2]);
   await migrateStagesToLevel(inputFile, dryRun);
   const endTime = performance.now();

--- a/api/scripts/prod/target-profile-migrations/revert-stages-to-threshold.js
+++ b/api/scripts/prod/target-profile-migrations/revert-stages-to-threshold.js
@@ -40,7 +40,7 @@ async function _computeReverts(inputFile, sample) {
 
   if (sample) {
     targetProfileIds = fp.sampleSize(10, targetProfileIds);
-    logger.info({ targetProfileIds }, `Using sample target profiles`);
+    logger.info({ targetProfileIds, msg: `Using sample target profiles` });
   }
 
   const targetProfiles = await Promise.all(targetProfileIds.map((id) => targetProfileForAdminRepository.get({ id })));
@@ -118,7 +118,7 @@ async function main() {
   const dryRun = process.env.DRY_RUN !== 'false';
   const sample = process.env.SAMPLE === 'true';
   if (!dryRun && sample) throw new Error('SAMPLE=true is not allowed when DRY_RUN=false');
-  logger.info({ dryRun, sample }, `Script ${modulePath} has started`);
+  logger.info({ dryRun, sample, msg: `Script ${modulePath} has started` });
   const inputFile = resolve(process.cwd(), process.argv[2]);
   await revertStagesToThreshold(inputFile, dryRun, sample);
   const endTime = performance.now();

--- a/api/src/certification/complementary-certification/domain/usecases/send-target-profile-notifications.js
+++ b/api/src/certification/complementary-certification/domain/usecases/send-target-profile-notifications.js
@@ -27,7 +27,7 @@ async function sendTargetProfileNotifications({
         if (result.hasFailed()) {
           logger.error({
             event: EVENT_NAME,
-            message: `Failed to send email to notify organisation user "${email}" of ${complementaryCertificationName}'s target profile change`,
+            msg: `Failed to send email to notify organisation user "${email}" of ${complementaryCertificationName}'s target profile change`,
           });
 
           return;
@@ -39,7 +39,7 @@ async function sendTargetProfileNotifications({
 
     logger.info({
       event: EVENT_NAME,
-      message: `${sucessCounter} email(s) sent to notify organisation users of ${complementaryCertificationName}'s target profile change`,
+      msg: `${sucessCounter} email(s) sent to notify organisation users of ${complementaryCertificationName}'s target profile change`,
     });
   }
 }

--- a/api/src/certification/shared/infrastructure/repositories/certification-challenge-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-challenge-repository.js
@@ -27,21 +27,17 @@ const save = async function ({ certificationChallenge }) {
     .insert(certificationChallengeToSave)
     .returning('*')
     .on('query', function (data) {
-      logger.info(
-        {
-          event: 'save-certification-challenge',
-        },
-        `A certification challenge will be inserted with transaction ${data.__knexTxId}`,
-      );
+      logger.info({
+        event: 'save-certification-challenge',
+        msg: `A certification challenge will be inserted with transaction ${data.__knexTxId}`,
+      });
     })
     .on('query-error', function (data) {
-      logger.error(
-        {
-          event: 'save-certification-challenge',
-          data: _(data).pick(['code', 'constraint', 'detail']),
-        },
-        `A certification challenge could not be inserted`,
-      );
+      logger.error({
+        event: 'save-certification-challenge',
+        data: _(data).pick(['code', 'constraint', 'detail']),
+        msg: `A certification challenge could not be inserted`,
+      });
     });
 
   return new CertificationChallenge(savedCertificationChallenge);

--- a/api/src/certification/shared/infrastructure/repositories/certification-challenge-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-challenge-repository.js
@@ -1,13 +1,9 @@
 import _ from 'lodash';
 
 import { knex } from '../../../../../db/knex-database-connection.js';
-import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';
-import {
-  logErrorWithCorrelationIds,
-  logInfoWithCorrelationIds,
-} from '../../../../../src/shared/infrastructure/monitoring-tools.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { AssessmentEndedError } from '../../../../shared/domain/errors.js';
-import { CertificationChallenge } from '../../../../shared/domain/models/CertificationChallenge.js';
+import { CertificationChallenge } from '../../../../shared/domain/models/index.js';
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 
 const logContext = {
@@ -31,17 +27,21 @@ const save = async function ({ certificationChallenge }) {
     .insert(certificationChallengeToSave)
     .returning('*')
     .on('query', function (data) {
-      logInfoWithCorrelationIds({
-        event: 'save-certification-challenge',
-        message: `A certification challenge will be inserted with transaction ${data.__knexTxId}`,
-      });
+      logger.info(
+        {
+          event: 'save-certification-challenge',
+        },
+        `A certification challenge will be inserted with transaction ${data.__knexTxId}`,
+      );
     })
     .on('query-error', function (data) {
-      logErrorWithCorrelationIds({
-        event: 'save-certification-challenge',
-        message: `A certification challenge could not be inserted`,
-        data: _(data).pick(['code', 'constraint', 'detail']),
-      });
+      logger.error(
+        {
+          event: 'save-certification-challenge',
+          data: _(data).pick(['code', 'constraint', 'detail']),
+        },
+        `A certification challenge could not be inserted`,
+      );
     });
 
   return new CertificationChallenge(savedCertificationChallenge);

--- a/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
@@ -1,14 +1,11 @@
 import _ from 'lodash';
 
 import { knex } from '../../../../../db/knex-database-connection.js';
-import {
-  logErrorWithCorrelationIds,
-  logInfoWithCorrelationIds,
-} from '../../../../../src/shared/infrastructure/monitoring-tools.js';
 import { config } from '../../../../shared/config.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { Assessment } from '../../../../shared/domain/models/index.js';
+import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 import { ComplementaryCertificationCourse } from '../../../session-management/domain/models/ComplementaryCertificationCourse.js';
 import { CertificationCourse } from '../../domain/models/CertificationCourse.js';
 import { CertificationIssueReport } from '../../domain/models/CertificationIssueReport.js';
@@ -22,17 +19,21 @@ async function save({ certificationCourse }) {
     .insert(certificationCourseToSaveDTO)
     .returning('id')
     .on('query', function (data) {
-      logInfoWithCorrelationIds({
-        event: 'save-certification-course',
-        message: `A certification course will be inserted with transaction ${data.__knexTxId}`,
-      });
+      logger.info(
+        {
+          event: 'save-certification-course',
+        },
+        `A certification course will be inserted with transaction ${data.__knexTxId}`,
+      );
     })
     .on('query-error', function (data) {
-      logErrorWithCorrelationIds({
-        event: 'save-certification-course',
-        message: `A certification course could not be inserted`,
-        data: _(data).pick(['code', 'constraint', 'detail']),
-      });
+      logger.error(
+        {
+          event: 'save-certification-course',
+          data: _(data).pick(['code', 'constraint', 'detail']),
+        },
+        `A certification course could not be inserted`,
+      );
     });
 
   const complementaryCertificationCourses = certificationCourse

--- a/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
@@ -19,12 +19,10 @@ async function save({ certificationCourse }) {
     .insert(certificationCourseToSaveDTO)
     .returning('id')
     .on('query', function (data) {
-      logger.info(
-        {
-          event: 'save-certification-course',
-        },
-        `A certification course will be inserted with transaction ${data.__knexTxId}`,
-      );
+      logger.info({
+        event: 'save-certification-course',
+        msg: `A certification course will be inserted with transaction ${data.__knexTxId}`,
+      });
     })
     .on('query-error', function (data) {
       logger.error(

--- a/api/src/devcomp/infrastructure/factories/element-for-verification-factory.js
+++ b/api/src/devcomp/infrastructure/factories/element-for-verification-factory.js
@@ -23,13 +23,13 @@ export class ElementForVerificationFactory {
           }
           logger.warn({
             event: 'embed_without_required_completion_is_not_handled_for_verification',
-            message: `Embed without required completion is not handled: ${elementData.id}`,
+            msg: `Embed without required completion is not handled: ${elementData.id}`,
           });
           return undefined;
         default:
           logger.warn({
             event: 'module_element_type_not_handled_for_verification',
-            message: `Element type not handled for verification: ${elementData.type}`,
+            msg: `Element type not handled for verification: ${elementData.type}`,
           });
           return undefined;
       }

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -68,7 +68,7 @@ export class ModuleFactory {
                   default:
                     logger.warn({
                       event: 'module_component_type_unknown',
-                      message: `Component inconnu: ${component.type}`,
+                      msg: `Component inconnu: ${component.type}`,
                     });
                     return undefined;
                 }
@@ -105,7 +105,7 @@ export class ModuleFactory {
       default:
         logger.warn({
           event: 'module_element_type_unknown',
-          message: `Element inconnu: ${element.type}`,
+          msg: `Element inconnu: ${element.type}`,
         });
         return undefined;
     }

--- a/api/src/devcomp/infrastructure/repositories/training-trigger-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/training-trigger-repository.js
@@ -97,7 +97,7 @@ async function _toDomain({ trainingTrigger, triggerTubes }) {
   if (notFoundTubeIds.length > 0) {
     logger.warn({
       event: 'training_trigger_tubes_not_found',
-      message: `Les sujets ${notFoundTubeIds.join(', ')} du déclencheur ${
+      msg: `Les sujets ${notFoundTubeIds.join(', ')} du déclencheur ${
         trainingTrigger.id
       } n'existent pas dans le référentiel.`,
       notFoundTubeIds,

--- a/api/src/identity-access-management/application/saml/saml.controller.js
+++ b/api/src/identity-access-management/application/saml/saml.controller.js
@@ -17,7 +17,7 @@ const assert = async function (request, h) {
   try {
     userAttributes = await saml.parsePostResponse(request.payload);
   } catch (e) {
-    logger.error({ e }, 'SAML: Error while parsing post response');
+    logger.error({ e, msg: 'SAML: Error while parsing post response' });
     return h.response(e.toString()).code(400);
   }
 
@@ -30,7 +30,7 @@ const assert = async function (request, h) {
 
     return h.redirect(redirectionUrl);
   } catch (e) {
-    logger.error({ e }, 'SAML: Error while get external authentication redirection url');
+    logger.error({ e, msg: 'SAML: Error while get external authentication redirection url' });
     return h.response(e.toString()).code(500);
   }
 };

--- a/api/src/identity-access-management/domain/services/oidc-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/oidc-authentication-service.js
@@ -10,7 +10,6 @@ import { OIDC_ERRORS } from '../../../shared/domain/constants.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { OidcError, OidcMissingFieldsError } from '../../../shared/domain/errors.js';
 import { AuthenticationMethod, AuthenticationSessionContent } from '../../../shared/domain/models/index.js';
-import { monitoringTools } from '../../../shared/infrastructure/monitoring-tools.js';
 import { temporaryStorage } from '../../../shared/infrastructure/temporary-storage/index.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { DEFAULT_CLAIM_MAPPING } from '../constants/oidc-identity-providers.js';
@@ -306,7 +305,6 @@ export class OidcAuthenticationService {
 
 function _monitorOidcError(message, { data, error, event }) {
   const monitoringData = {
-    message,
     context: 'oidc',
     data,
     event,
@@ -319,5 +317,5 @@ function _monitorOidcError(message, { data, error, event }) {
     error.response && Object.assign(monitoringData.error, { response: error.response });
   }
 
-  monitoringTools.logErrorWithCorrelationIds(monitoringData);
+  logger.error(monitoringData, message);
 }

--- a/api/src/identity-access-management/domain/services/oidc-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/oidc-authentication-service.js
@@ -309,6 +309,7 @@ function _monitorOidcError(message, { data, error, event }) {
     data,
     event,
     team: 'acces',
+    msg: message,
   };
 
   if (error) {
@@ -317,5 +318,5 @@ function _monitorOidcError(message, { data, error, event }) {
     error.response && Object.assign(monitoringData.error, { response: error.response });
   }
 
-  logger.error(monitoringData, message);
+  logger.error(monitoringData);
 }

--- a/api/src/identity-access-management/domain/usecases/validate-user-account-email.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/validate-user-account-email.usecase.js
@@ -33,14 +33,12 @@ export const validateUserAccountEmail = async ({
     await userRepository.update(user.mapToDatabaseDto());
     await emailValidationDemandRepository.remove(token);
   } catch (error) {
-    logger.error(
-      {
-        context: 'email-validation',
-        data: { token },
-        team: 'acces',
-      },
-      error.message,
-    );
+    logger.error({
+      context: 'email-validation',
+      data: { token },
+      team: 'acces',
+      msg: error.message,
+    });
   }
 
   return _getRedirectionUrl(redirectUrl);

--- a/api/src/identity-access-management/domain/usecases/validate-user-account-email.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/validate-user-account-email.usecase.js
@@ -1,5 +1,5 @@
 import { config } from '../../../shared/config.js';
-import { monitoringTools } from '../../../shared/infrastructure/monitoring-tools.js';
+import { logger } from '../../../shared/infrastructure/utils/logger.js';
 
 /**
  * @param {{
@@ -33,12 +33,14 @@ export const validateUserAccountEmail = async ({
     await userRepository.update(user.mapToDatabaseDto());
     await emailValidationDemandRepository.remove(token);
   } catch (error) {
-    monitoringTools.logErrorWithCorrelationIds({
-      message: error.message,
-      context: 'email-validation',
-      data: { token },
-      team: 'acces',
-    });
+    logger.error(
+      {
+        context: 'email-validation',
+        data: { token },
+        team: 'acces',
+      },
+      error.message,
+    );
   }
 
   return _getRedirectionUrl(redirectUrl);

--- a/api/src/prescription/learner-management/application/sco-organization-management-controller.js
+++ b/api/src/prescription/learner-management/application/sco-organization-management-controller.js
@@ -1,17 +1,13 @@
 import fs from 'node:fs/promises';
 
-import { FileValidationError } from '../../../../src/shared/domain/errors.js';
-import { logErrorWithCorrelationIds } from '../../../../src/shared/infrastructure/monitoring-tools.js';
+import { FileValidationError } from '../../../shared/domain/errors.js';
+import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { usecases } from '../domain/usecases/index.js';
 import { OrganizationLearnerParser } from '../infrastructure/serializers/csv/organization-learner-parser.js';
 
 const INVALID_FILE_EXTENSION_ERROR = 'INVALID_FILE_EXTENSION';
 
-const importOrganizationLearnersFromSIECLE = async function (
-  request,
-  h,
-  dependencies = { logErrorWithCorrelationIds },
-) {
+const importOrganizationLearnersFromSIECLE = async function (request, h, dependencies = { logger }) {
   const authenticatedUserId = request.auth.credentials.userId;
   const organizationId = request.params.id;
   const userId = request.auth.credentials.userId;
@@ -51,7 +47,7 @@ const importOrganizationLearnersFromSIECLE = async function (
     try {
       await fs.unlink(request.payload.path);
     } catch (err) {
-      dependencies.logErrorWithCorrelationIds(err);
+      dependencies.logger.error(err);
     }
   }
 

--- a/api/src/prescription/learner-management/application/sup-organization-management-controller.js
+++ b/api/src/prescription/learner-management/application/sup-organization-management-controller.js
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 
-import { logErrorWithCorrelationIds } from '../../../../src/shared/infrastructure/monitoring-tools.js';
+import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
 import { tokenService } from '../../../shared/domain/services/token-service.js';
 import { usecases } from '../domain/usecases/index.js';
 import { SupOrganizationLearnerParser } from '../infrastructure/serializers/csv/sup-organization-learner-parser.js';
@@ -9,7 +9,7 @@ const importSupOrganizationLearners = async function (
   request,
   h,
   dependencies = {
-    logErrorWithCorrelationIds,
+    logger,
     unlink: fs.unlink,
   },
 ) {
@@ -37,7 +37,7 @@ const importSupOrganizationLearners = async function (
     try {
       dependencies.unlink(request.payload.path);
     } catch (err) {
-      dependencies.logErrorWithCorrelationIds(err);
+      dependencies.logger.error(err);
     }
   }
 
@@ -48,7 +48,7 @@ const replaceSupOrganizationLearners = async function (
   request,
   h,
   dependencies = {
-    logErrorWithCorrelationIds,
+    logger,
     unlink: fs.unlink,
   },
 ) {
@@ -78,7 +78,7 @@ const replaceSupOrganizationLearners = async function (
     try {
       dependencies.unlink(request.payload.path);
     } catch (err) {
-      dependencies.logErrorWithCorrelationIds(err);
+      dependencies.logger.error(err);
     }
   }
 

--- a/api/src/prescription/learner-management/domain/usecases/index.js
+++ b/api/src/prescription/learner-management/domain/usecases/index.js
@@ -5,7 +5,7 @@ import { eventBus } from '../../../../../lib/domain/events/index.js';
 import * as userReconciliationService from '../../../../../lib/domain/services/user-reconciliation-service.js';
 import * as campaignRepository from '../../../../../lib/infrastructure/repositories/campaign-repository.js';
 import * as membershipRepository from '../../../../../lib/infrastructure/repositories/membership-repository.js';
-import { logErrorWithCorrelationIds } from '../../../../../src/shared/infrastructure/monitoring-tools.js';
+import { logger } from '../../../../../src/shared/infrastructure/utils/logger.js';
 import * as organizationFeatureApi from '../../../../organizational-entities/application/api/organization-features-api.js';
 import * as organizationRepository from '../../../../shared/infrastructure/repositories/organization-repository.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
@@ -34,7 +34,7 @@ const dependencies = {
   supOrganizationLearnerRepository,
   organizationFeatureApi,
   eventBus,
-  logErrorWithCorrelationIds,
+  logger,
   userReconciliationService,
   organizationFeatureRepository: repositories.organizationFeatureRepository,
 };

--- a/api/src/prescription/learner-management/domain/usecases/upload-siecle-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/upload-siecle-file.js
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 
-import { logErrorWithCorrelationIds } from '../../../../../src/shared/infrastructure/monitoring-tools.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 import { detectEncoding } from '../../infrastructure/utils/xml/detect-encoding.js';
 import * as zip from '../../infrastructure/utils/xml/zip.js';
 import { OrganizationImport } from '../models/OrganizationImport.js';
@@ -18,7 +18,7 @@ const uploadSiecleFile = async function ({
     unzip: zip.unzip,
     detectEncoding,
   },
-  dependencies = { logErrorWithCorrelationIds },
+  dependencies = { logger },
 }) {
   await DomainTransaction.execute(async () => {
     let organizationImport = OrganizationImport.create({ organizationId, createdBy: userId });
@@ -38,7 +38,7 @@ const uploadSiecleFile = async function ({
         try {
           await fs.rm(directory, { recursive: true });
         } catch (rmError) {
-          dependencies.logErrorWithCorrelationIds(rmError);
+          dependencies.logger.error(rmError);
         }
       }
       await validateOrganizationImportFileJobRepository.performAsync(

--- a/api/src/prescription/learner-management/infrastructure/storage/import-storage.js
+++ b/api/src/prescription/learner-management/infrastructure/storage/import-storage.js
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { logErrorWithCorrelationIds } from '../../../../../src/shared/infrastructure/monitoring-tools.js';
 import { config } from '../../../../shared/config.js';
 import { DomainError, FileValidationError } from '../../../../shared/domain/errors.js';
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
@@ -38,7 +37,7 @@ class ImportStorage {
         throw error;
       });
     } catch (error) {
-      logErrorWithCorrelationIds(error);
+      logger.error(error);
       throw new FileValidationError('INVALID_FILE');
     }
     try {

--- a/api/src/prescription/learner-management/infrastructure/utils/xml/detect-encoding.js
+++ b/api/src/prescription/learner-management/infrastructure/utils/xml/detect-encoding.js
@@ -4,7 +4,7 @@ import * as fs from 'node:fs/promises';
 import xmlBufferTostring from 'xml-buffer-tostring';
 
 import { FileValidationError } from '../../../../../shared/domain/errors.js';
-import { logErrorWithCorrelationIds } from '../../../../../shared/infrastructure/monitoring-tools.js';
+import { logger } from '../../../../../shared/infrastructure/utils/logger.js';
 
 const { xmlEncoding } = xmlBufferTostring;
 const { Buffer } = buffer;
@@ -28,7 +28,7 @@ async function readFirstLine(path) {
     await file.read(buffer, 0, 128, 0);
     file.close();
   } catch (err) {
-    logErrorWithCorrelationIds(err);
+    logger.error(err);
     throw new FileValidationError(ERRORS.INVALID_FILE);
   }
 

--- a/api/src/prescription/learner-management/infrastructure/utils/xml/siecle-file-streamer.js
+++ b/api/src/prescription/learner-management/infrastructure/utils/xml/siecle-file-streamer.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import sax from 'sax';
 
 import { FileValidationError } from '../../../../../shared/domain/errors.js';
-import { logErrorWithCorrelationIds } from '../../../../../shared/infrastructure/monitoring-tools.js';
+import { logger } from '../../../../../shared/infrastructure/utils/logger.js';
 import { SiecleXmlImportError } from '../../../domain/errors.js';
 
 /*
@@ -18,7 +18,7 @@ const ERRORS = {
 };
 
 class SiecleFileStreamer {
-  static async create(readableStream, encoding = 'utf-8', logError = logErrorWithCorrelationIds) {
+  static async create(readableStream, encoding = 'utf-8', logError = logger.error) {
     const stream = new SiecleFileStreamer(readableStream, encoding, logError);
     return stream;
   }
@@ -68,7 +68,7 @@ function _getDecodingStream(encoding) {
   try {
     return iconv.decodeStream(encoding);
   } catch (err) {
-    logErrorWithCorrelationIds(err);
+    logger.error(err);
     throw new SiecleXmlImportError(ERRORS.ENCODING_NOT_SUPPORTED);
   }
 }

--- a/api/src/prescription/learner-management/infrastructure/utils/xml/zip.js
+++ b/api/src/prescription/learner-management/infrastructure/utils/xml/zip.js
@@ -10,7 +10,7 @@ import { fileTypeFromFile } from 'file-type';
 import StreamZip from 'node-stream-zip';
 
 import { FileValidationError } from '../../../../../shared/domain/errors.js';
-import { logErrorWithCorrelationIds } from '../../../../../shared/infrastructure/monitoring-tools.js';
+import { logger } from '../../../../../shared/infrastructure/utils/logger.js';
 
 const VALID_FILE_NAME_REGEX = /^([^.][^/]*\/)*[^./][^/]*\.xml$/;
 const ZIP = 'application/zip';
@@ -57,7 +57,7 @@ async function _getFileToExtractName(zipStream) {
   const validFiles = fileNames.filter((name) => VALID_FILE_NAME_REGEX.test(name));
   if (validFiles.length != 1) {
     zipStream.close();
-    logErrorWithCorrelationIds({ ERROR: ERRORS.INVALID_FILE, entries });
+    logger.error({ ERROR: ERRORS.INVALID_FILE, entries });
     throw new FileValidationError(ERRORS.INVALID_FILE);
   }
   return validFiles[0];

--- a/api/src/shared/infrastructure/caches/DistributedCache.js
+++ b/api/src/shared/infrastructure/caches/DistributedCache.js
@@ -21,10 +21,10 @@ class DistributedCache extends Cache {
   clientSubscriberCallback(_channel, rawMessage) {
     const message = JSON.parse(rawMessage);
     if (message.type === 'flushAll') {
-      logger.info({ event: 'cache-event' }, 'Flushing the local cache');
+      logger.info({ event: 'cache-event', msg: 'Flushing the local cache' });
       return this._underlyingCache.flushAll();
     } else if (message.type === 'patch') {
-      logger.info({ event: 'cache-event' }, 'Patching the local cache');
+      logger.info({ event: 'cache-event', msg: 'Patching the local cache' });
       this._underlyingCache.patch(message.cacheKey, message.patch);
     }
   }

--- a/api/src/shared/infrastructure/caches/RedisCache.js
+++ b/api/src/shared/infrastructure/caches/RedisCache.js
@@ -39,11 +39,11 @@ class RedisCache extends Cache {
   async _manageValueNotFoundInCache(key, generator) {
     const keyToLock = REDIS_LOCK_PREFIX + key;
     const retrieveAndSetValue = async () => {
-      logger.info({ key }, 'Executing generator for Redis key');
+      logger.info({ key, msg: 'Executing generator for Redis key' });
       const value = await generator();
       return this.set(key, value);
     };
-    const unlockErrorHandler = (err) => logger.error({ key }, 'Error while trying to unlock Redis key', err);
+    const unlockErrorHandler = (err) => logger.error({ key, msg: 'Error while trying to unlock Redis key', err });
 
     try {
       const locker = this._client.lockDisposer(keyToLock, config.caching.redisCacheKeyLockTTL, unlockErrorHandler);
@@ -55,7 +55,7 @@ class RedisCache extends Cache {
         await new Promise((resolve) => setTimeout(resolve, config.caching.redisCacheLockedWaitBeforeRetry));
         return this.get(key, generator);
       }
-      logger.error({ err }, 'Error while trying to update value in Redis cache');
+      logger.error({ err, msg: 'Error while trying to update value in Redis cache' });
       throw err;
     }
   }
@@ -63,7 +63,7 @@ class RedisCache extends Cache {
   async set(key, object) {
     const objectAsString = JSON.stringify(object);
 
-    logger.info({ key, length: objectAsString.length }, 'Setting Redis key');
+    logger.info({ key, length: objectAsString.length, msg: 'Setting Redis key' });
 
     await this._client.set(key, objectAsString);
     await this._client.del(`${key}:${PATCHES_KEY}`);

--- a/api/src/shared/infrastructure/jobs/monitoring/MonitoredJobHandler.js
+++ b/api/src/shared/infrastructure/jobs/monitoring/MonitoredJobHandler.js
@@ -21,7 +21,7 @@ class MonitoredJobHandler {
       data,
       handlerName: jobName,
       type: 'JOB_LOG',
-      message: 'Job Started',
+      msg: 'Job Started',
       jobId,
     });
   }
@@ -32,7 +32,7 @@ class MonitoredJobHandler {
       handlerName: jobName,
       error: error?.message ? error.message + ' (see dedicated log for more information)' : undefined,
       type: 'JOB_LOG_ERROR',
-      message: 'Job failed',
+      msg: 'Job failed',
       jobId,
     });
   }

--- a/api/src/shared/infrastructure/monitoring-tools.js
+++ b/api/src/shared/infrastructure/monitoring-tools.js
@@ -3,10 +3,9 @@ import lodash from 'lodash';
 
 import { config } from '../config.js';
 
-const { get, set, update, omit } = lodash;
+const { get, set, update } = lodash;
 import async_hooks from 'node:async_hooks';
 
-import { logger } from './utils/logger.js';
 import * as requestResponseUtils from './utils/request-response-utils.js';
 
 const { AsyncLocalStorage } = async_hooks;
@@ -24,46 +23,6 @@ function getCorrelationContext() {
     request_id: get(request, 'headers.x-request-id', '-'),
     id: get(request, 'info.id', '-'),
   };
-}
-
-function logInfoWithCorrelationIds(data) {
-  const context = getCorrelationContext();
-  logger.info(
-    {
-      ...context,
-      ...omit(data, 'message'),
-    },
-    get(data, 'message', '-'),
-  );
-}
-
-/**
- * In order to be displayed properly in Datadog,
- * the parameter "data" should contain
- * - a required property message as string
- * - all other properties you need to pass to Datadog
- *
- * @example
- * const data = {
- *   message: 'Error message',
- *   context: 'My Context',
- *   data: { more: 'data', if: 'needed' },
- *   event: 'Event which trigger this error',
- *   team: 'My Team',
- * };
- * monitoringTools.logErrorWithCorrelationIds(data);
- *
- * @param {object} data
- */
-function logErrorWithCorrelationIds(data) {
-  const context = getCorrelationContext();
-  logger.error(
-    {
-      ...context,
-      ...omit(data, 'message'),
-    },
-    get(data, 'message', '-'),
-  );
 }
 
 function extractUserIdFromRequest(request) {
@@ -116,21 +75,19 @@ const monitoringTools = {
   getInContext,
   incrementInContext,
   installHapiHook,
-  logErrorWithCorrelationIds,
-  logInfoWithCorrelationIds,
   setInContext,
   asyncLocalStorage,
+  getCorrelationContext,
 };
 
 export {
   asyncLocalStorage,
   extractUserIdFromRequest,
   getContext,
+  getCorrelationContext,
   getInContext,
   incrementInContext,
   installHapiHook,
-  logErrorWithCorrelationIds,
-  logInfoWithCorrelationIds,
   monitoringTools,
   setInContext,
 };

--- a/api/src/shared/infrastructure/monitoring-tools.js
+++ b/api/src/shared/infrastructure/monitoring-tools.js
@@ -94,18 +94,6 @@ function getContext() {
   return asyncLocalStorage.getStore();
 }
 
-function pushInContext(path, value) {
-  const store = asyncLocalStorage.getStore();
-  if (!store) return;
-  let array = get(store, path);
-  if (!array) {
-    array = [value];
-    set(store, path, array);
-  } else {
-    array.push(value);
-  }
-}
-
 function installHapiHook() {
   if (!config.hapi.enableRequestMonitoring) return;
 
@@ -130,7 +118,6 @@ const monitoringTools = {
   installHapiHook,
   logErrorWithCorrelationIds,
   logInfoWithCorrelationIds,
-  pushInContext,
   setInContext,
   asyncLocalStorage,
 };
@@ -145,6 +132,5 @@ export {
   logErrorWithCorrelationIds,
   logInfoWithCorrelationIds,
   monitoringTools,
-  pushInContext,
   setInContext,
 };

--- a/api/src/shared/infrastructure/utils/RedisClient.js
+++ b/api/src/shared/infrastructure/utils/RedisClient.js
@@ -11,9 +11,9 @@ class RedisClient {
 
     this._client = new Redis(redisUrl);
 
-    this._client.on('connect', () => logger.info({ redisClient: this._clientName }, 'Connected to server'));
-    this._client.on('end', () => logger.info({ redisClient: this._clientName }, 'Disconnected from server'));
-    this._client.on('error', (err) => logger.warn({ redisClient: this._clientName, err }, 'Error encountered'));
+    this._client.on('connect', () => logger.info({ redisClient: this._clientName, msg: 'Connected to server' }));
+    this._client.on('end', () => logger.info({ redisClient: this._clientName, msg: 'Disconnected from server' }));
+    this._client.on('error', (err) => logger.warn({ redisClient: this._clientName, err, msg: 'Error encountered' }));
 
     this._clientWithLock = new Redlock(
       [this._client],
@@ -46,13 +46,13 @@ class RedisClient {
 
   subscribe(channel) {
     this._client.subscribe(channel, () =>
-      logger.info({ redisClient: this._clientName }, `Subscribed to channel '${channel}'`),
+      logger.info({ redisClient: this._clientName, msg: `Subscribed to channel '${channel}'` }),
     );
   }
 
   publish(channel, message) {
     this._client.publish(channel, message, () =>
-      logger.info({ redisClient: this._clientName }, `Published on channel '${channel}'`),
+      logger.info({ redisClient: this._clientName, msg: `Published on channel '${channel}'` }),
     );
   }
 
@@ -67,7 +67,7 @@ class RedisClient {
       if (e.message === 'Connection is closed.') {
         return;
       }
-      logger.warn({ redisClient: this._clientName, err: e }, 'Error encountered while quitting');
+      logger.warn({ redisClient: this._clientName, err: e, msg: 'Error encountered while quitting' });
     }
   }
 }

--- a/api/src/shared/infrastructure/utils/logger.js
+++ b/api/src/shared/infrastructure/utils/logger.js
@@ -35,6 +35,7 @@ if (logging.logForHumans) {
  *   data: { more: 'data', if: 'needed' },
  *   event: 'Event which trigger this error',
  *   team: 'My Team',
+ *   msg: 'My message related to the log',
  * };
  */
 const logger = pino(
@@ -45,12 +46,8 @@ const logger = pino(
     mixin() {
       return getCorrelationContext();
     },
-    mixinMergeStrategy(originalMessage, correlationContext) {
-      return {
-        ...correlationContext,
-        ...originalMessage,
-        message: undefined,
-      };
+    mixinMergeStrategy(mergeObject, mixinObject) {
+      return Object.assign(Object.create(mergeObject), mixinObject);
     },
   },
   prettyPrint,

--- a/api/src/shared/infrastructure/utils/logger.js
+++ b/api/src/shared/infrastructure/utils/logger.js
@@ -2,6 +2,7 @@ import pino from 'pino';
 import pretty from 'pino-pretty';
 
 import { config } from '../../config.js';
+import { getCorrelationContext } from '../monitoring-tools.js';
 
 const { logging } = config;
 
@@ -16,11 +17,41 @@ if (logging.logForHumans) {
   });
 }
 
+/**
+ * Pino Logger - How to use :
+ * logger.<anyLoggingMethod>([mergingObject], [message])
+ * with
+ *  - mergingObject <Object>: an object optionally supplied. Each enumerable key and value of the mergingObject is copied into the JSON log line.
+ *  - message <String>: a string which will be merged into the JSON log line under the "msg" key.
+ * NOTE: The [message] parameter takes precedence over the [mergingObject].
+ * That is, if a [mergingObject] contains a "msg" property, and a [message] parameter is supplied in addition,
+ * the "msg" property in the output log will be the value of the [message] parameter not the value of the "msg" property on the [mergingObject]
+
+ * Interoperability with Datadog
+ * In order to be displayed properly in Datadog, the [mergingObject] can contain the following keys
+ * @example
+ * {
+ *   context: 'My Context',
+ *   data: { more: 'data', if: 'needed' },
+ *   event: 'Event which trigger this error',
+ *   team: 'My Team',
+ * };
+ */
 const logger = pino(
   {
     level: logging.logLevel,
     redact: ['req.headers.authorization'],
     enabled: logging.enabled,
+    mixin() {
+      return getCorrelationContext();
+    },
+    mixinMergeStrategy(originalMessage, correlationContext) {
+      return {
+        ...correlationContext,
+        ...originalMessage,
+        message: undefined,
+      };
+    },
   },
   prettyPrint,
 );

--- a/api/src/shared/mail/infrastructure/services/mailer.js
+++ b/api/src/shared/mail/infrastructure/services/mailer.js
@@ -37,14 +37,14 @@ class Mailer {
     try {
       await this.dependencies.mailCheck.checkDomainIsValid(options.to);
     } catch (err) {
-      logger.warn({ err }, `Email is not valid '${options.to}'`);
+      logger.warn({ err, msg: `Email is not valid '${options.to}'` });
       return EmailingAttempt.failure(options.to, EmailingAttempt.errorCode.INVALID_DOMAIN);
     }
 
     try {
       await this._provider.sendEmail(options);
     } catch (err) {
-      logger.warn({ err }, `Could not send email to '${options.to}'`);
+      logger.warn({ err, msg: `Could not send email to '${options.to}'` });
 
       if (err instanceof MailingProviderInvalidEmailError) {
         return EmailingAttempt.failure(options.to, EmailingAttempt.errorCode.INVALID_EMAIL, err.message);

--- a/api/tests/devcomp/integration/infrastructure/repositories/training-trigger-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/training-trigger-repository_test.js
@@ -469,7 +469,7 @@ describe('Integration | Repository | training-trigger-repository', function () {
         // then
         expect(logger.warn).to.have.been.calledWithExactly({
           event: 'training_trigger_tubes_not_found',
-          message: `Les sujets notExistTubeId du déclencheur ${trainingTrigger.id} n'existent pas dans le référentiel.`,
+          msg: `Les sujets notExistTubeId du déclencheur ${trainingTrigger.id} n'existent pas dans le référentiel.`,
           notFoundTubeIds: ['notExistTubeId'],
           trainingTriggerId: trainingTrigger.id,
         });

--- a/api/tests/devcomp/unit/infrastructure/factories/element-for-verification-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/element-for-verification-factory_test.js
@@ -58,7 +58,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | ElementForVerification',
           // then
           expect(logger.warn).to.have.been.calledWithExactly({
             event: 'module_element_type_not_handled_for_verification',
-            message: `Element type not handled for verification: unknown`,
+            msg: `Element type not handled for verification: unknown`,
           });
         });
       });
@@ -110,7 +110,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | ElementForVerification',
           // then
           expect(logger.warn).to.have.been.calledWithExactly({
             event: 'embed_without_required_completion_is_not_handled_for_verification',
-            message: `Embed without required completion is not handled: ${elementData.id}`,
+            msg: `Embed without required completion is not handled: ${elementData.id}`,
           });
         });
       });

--- a/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
@@ -113,7 +113,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           // then
           expect(logger.warn).to.have.been.calledWithExactly({
             event: 'module_component_type_unknown',
-            message: 'Component inconnu: unknown',
+            msg: 'Component inconnu: unknown',
           });
         });
       });
@@ -161,7 +161,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           // then
           expect(logger.warn).to.have.been.calledWithExactly({
             event: 'module_element_type_unknown',
-            message: 'Element inconnu: unknown',
+            msg: 'Element inconnu: unknown',
           });
         });
       });

--- a/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service_test.js
+++ b/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service_test.js
@@ -12,14 +12,14 @@ import {
   AuthenticationSessionContent,
   UserToCreate,
 } from '../../../../../src/shared/domain/models/index.js';
-import { monitoringTools } from '../../../../../src/shared/infrastructure/monitoring-tools.js';
+import { logger } from '../../../../../src/shared/infrastructure/utils/logger.js';
 import { catchErr, catchErrSync, expect, sinon } from '../../../../test-helper.js';
 
 const uuidV4Regex = /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i;
 
 describe('Unit | Domain | Services | oidc-authentication-service', function () {
   beforeEach(function () {
-    sinon.stub(monitoringTools, 'logErrorWithCorrelationIds');
+    sinon.stub(logger, 'error');
   });
 
   describe('constructor', function () {
@@ -263,14 +263,16 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         // then
         expect(error).to.be.instanceOf(OidcError);
         expect(error.message).to.be.equal('Fails to generate endSessionUrl');
-        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWithExactly({
-          context: 'oidc',
-          data: { organizationName: 'Oidc Example' },
-          error: { name: errorThrown.name },
-          event: 'get-redirect-logout-url',
-          message: errorThrown.message,
-          team: 'acces',
-        });
+        expect(logger.error).to.have.been.calledWithExactly(
+          {
+            context: 'oidc',
+            data: { organizationName: 'Oidc Example' },
+            error: { name: errorThrown.name },
+            event: 'get-redirect-logout-url',
+            team: 'acces',
+          },
+          errorThrown.message,
+        );
       });
     });
   });
@@ -369,25 +371,27 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         // then
         expect(error).to.be.instanceOf(OidcError);
         expect(error.message).to.be.equal('Fails to get tokens');
-        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWithExactly({
-          context: 'oidc',
-          data: {
-            code,
-            state,
-            iss,
-            nonce,
-            organizationName: 'Oidc Example',
-            sessionState,
+        expect(logger.error).to.have.been.calledWithExactly(
+          {
+            context: 'oidc',
+            data: {
+              code,
+              state,
+              iss,
+              nonce,
+              organizationName: 'Oidc Example',
+              sessionState,
+            },
+            error: {
+              name: errorThrown.name,
+              errorUri: '/oauth2/token',
+              response: 'api call response here',
+            },
+            event: 'exchange-code-for-tokens',
+            team: 'acces',
           },
-          error: {
-            name: errorThrown.name,
-            errorUri: '/oauth2/token',
-            response: 'api call response here',
-          },
-          event: 'exchange-code-for-tokens',
-          message: errorThrown.message,
-          team: 'acces',
-        });
+          errorThrown.message,
+        );
       });
     });
   });
@@ -457,14 +461,16 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         // then
         expect(error).to.be.instanceOf(OidcError);
         expect(error.message).to.be.equal('Fails to generate authorization url');
-        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWithExactly({
-          context: 'oidc',
-          data: { organizationName: 'Oidc Example' },
-          error: { name: errorThrown.name },
-          event: 'generate-authorization-url',
-          message: errorThrown.message,
-          team: 'acces',
-        });
+        expect(logger.error).to.have.been.calledWithExactly(
+          {
+            context: 'oidc',
+            data: { organizationName: 'Oidc Example' },
+            error: { name: errorThrown.name },
+            event: 'generate-authorization-url',
+            team: 'acces',
+          },
+          errorThrown.message,
+        );
       });
     });
   });
@@ -626,14 +632,16 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         // then
         expect(error).to.be.instanceOf(OidcError);
         expect(error.message).to.be.equal('Fails to get user info');
-        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWithExactly({
-          message: errorThrown.message,
-          context: 'oidc',
-          data: { organizationName: 'Oidc Example' },
-          error: { name: errorThrown.name },
-          event: 'get-user-info-from-endpoint',
-          team: 'acces',
-        });
+        expect(logger.error).to.have.been.calledWithExactly(
+          {
+            context: 'oidc',
+            data: { organizationName: 'Oidc Example' },
+            error: { name: errorThrown.name },
+            event: 'get-user-info-from-endpoint',
+            team: 'acces',
+          },
+          errorThrown.message,
+        );
       });
     });
 
@@ -679,20 +687,22 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         expect(error).to.be.instanceOf(OidcMissingFieldsError);
         expect(error.message).to.be.equal(errorMessage);
         expect(error.code).to.be.equal(OIDC_ERRORS.USER_INFO.missingFields.code);
-        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWithExactly({
-          context: 'oidc',
-          data: {
-            missingFields: 'family_name',
-            userInfo: {
-              sub: 'sub-id',
-              given_name: 'givenName',
-              family_name: undefined,
+        expect(logger.error).to.have.been.calledWithExactly(
+          {
+            context: 'oidc',
+            data: {
+              missingFields: 'family_name',
+              userInfo: {
+                sub: 'sub-id',
+                given_name: 'givenName',
+                family_name: undefined,
+              },
             },
+            event: 'find-missing-required-claims',
+            team: 'acces',
           },
-          event: 'find-missing-required-claims',
-          message: errorMessage,
-          team: 'acces',
-        });
+          errorMessage,
+        );
       });
     });
 
@@ -740,21 +750,23 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         expect(error).to.be.instanceOf(OidcMissingFieldsError);
         expect(error.message).to.be.equal(errorMessage);
         expect(error.code).to.be.equal(OIDC_ERRORS.USER_INFO.missingFields.code);
-        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWithExactly({
-          context: 'oidc',
-          data: {
-            missingFields: 'population',
-            userInfo: {
-              sub: 'sub-id',
-              given_name: 'givenName',
-              family_name: 'familyName',
-              population: '',
+        expect(logger.error).to.have.been.calledWithExactly(
+          {
+            context: 'oidc',
+            data: {
+              missingFields: 'population',
+              userInfo: {
+                sub: 'sub-id',
+                given_name: 'givenName',
+                family_name: 'familyName',
+                population: '',
+              },
             },
+            event: 'find-missing-required-claims',
+            team: 'acces',
           },
-          event: 'find-missing-required-claims',
-          message: errorMessage,
-          team: 'acces',
-        });
+          errorMessage,
+        );
       });
     });
   });

--- a/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service_test.js
+++ b/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service_test.js
@@ -263,16 +263,14 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         // then
         expect(error).to.be.instanceOf(OidcError);
         expect(error.message).to.be.equal('Fails to generate endSessionUrl');
-        expect(logger.error).to.have.been.calledWithExactly(
-          {
-            context: 'oidc',
-            data: { organizationName: 'Oidc Example' },
-            error: { name: errorThrown.name },
-            event: 'get-redirect-logout-url',
-            team: 'acces',
-          },
-          errorThrown.message,
-        );
+        expect(logger.error).to.have.been.calledWithExactly({
+          context: 'oidc',
+          data: { organizationName: 'Oidc Example' },
+          error: { name: errorThrown.name },
+          event: 'get-redirect-logout-url',
+          team: 'acces',
+          msg: errorThrown.message,
+        });
       });
     });
   });
@@ -371,27 +369,25 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         // then
         expect(error).to.be.instanceOf(OidcError);
         expect(error.message).to.be.equal('Fails to get tokens');
-        expect(logger.error).to.have.been.calledWithExactly(
-          {
-            context: 'oidc',
-            data: {
-              code,
-              state,
-              iss,
-              nonce,
-              organizationName: 'Oidc Example',
-              sessionState,
-            },
-            error: {
-              name: errorThrown.name,
-              errorUri: '/oauth2/token',
-              response: 'api call response here',
-            },
-            event: 'exchange-code-for-tokens',
-            team: 'acces',
+        expect(logger.error).to.have.been.calledWithExactly({
+          context: 'oidc',
+          data: {
+            code,
+            state,
+            iss,
+            nonce,
+            organizationName: 'Oidc Example',
+            sessionState,
           },
-          errorThrown.message,
-        );
+          error: {
+            name: errorThrown.name,
+            errorUri: '/oauth2/token',
+            response: 'api call response here',
+          },
+          event: 'exchange-code-for-tokens',
+          team: 'acces',
+          msg: errorThrown.message,
+        });
       });
     });
   });
@@ -461,16 +457,14 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         // then
         expect(error).to.be.instanceOf(OidcError);
         expect(error.message).to.be.equal('Fails to generate authorization url');
-        expect(logger.error).to.have.been.calledWithExactly(
-          {
-            context: 'oidc',
-            data: { organizationName: 'Oidc Example' },
-            error: { name: errorThrown.name },
-            event: 'generate-authorization-url',
-            team: 'acces',
-          },
-          errorThrown.message,
-        );
+        expect(logger.error).to.have.been.calledWithExactly({
+          context: 'oidc',
+          data: { organizationName: 'Oidc Example' },
+          error: { name: errorThrown.name },
+          event: 'generate-authorization-url',
+          team: 'acces',
+          msg: errorThrown.message,
+        });
       });
     });
   });
@@ -632,16 +626,14 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         // then
         expect(error).to.be.instanceOf(OidcError);
         expect(error.message).to.be.equal('Fails to get user info');
-        expect(logger.error).to.have.been.calledWithExactly(
-          {
-            context: 'oidc',
-            data: { organizationName: 'Oidc Example' },
-            error: { name: errorThrown.name },
-            event: 'get-user-info-from-endpoint',
-            team: 'acces',
-          },
-          errorThrown.message,
-        );
+        expect(logger.error).to.have.been.calledWithExactly({
+          context: 'oidc',
+          data: { organizationName: 'Oidc Example' },
+          error: { name: errorThrown.name },
+          event: 'get-user-info-from-endpoint',
+          team: 'acces',
+          msg: errorThrown.message,
+        });
       });
     });
 
@@ -687,22 +679,20 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         expect(error).to.be.instanceOf(OidcMissingFieldsError);
         expect(error.message).to.be.equal(errorMessage);
         expect(error.code).to.be.equal(OIDC_ERRORS.USER_INFO.missingFields.code);
-        expect(logger.error).to.have.been.calledWithExactly(
-          {
-            context: 'oidc',
-            data: {
-              missingFields: 'family_name',
-              userInfo: {
-                sub: 'sub-id',
-                given_name: 'givenName',
-                family_name: undefined,
-              },
+        expect(logger.error).to.have.been.calledWithExactly({
+          context: 'oidc',
+          data: {
+            missingFields: 'family_name',
+            userInfo: {
+              sub: 'sub-id',
+              given_name: 'givenName',
+              family_name: undefined,
             },
-            event: 'find-missing-required-claims',
-            team: 'acces',
           },
-          errorMessage,
-        );
+          event: 'find-missing-required-claims',
+          team: 'acces',
+          msg: errorMessage,
+        });
       });
     });
 
@@ -750,23 +740,21 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         expect(error).to.be.instanceOf(OidcMissingFieldsError);
         expect(error.message).to.be.equal(errorMessage);
         expect(error.code).to.be.equal(OIDC_ERRORS.USER_INFO.missingFields.code);
-        expect(logger.error).to.have.been.calledWithExactly(
-          {
-            context: 'oidc',
-            data: {
-              missingFields: 'population',
-              userInfo: {
-                sub: 'sub-id',
-                given_name: 'givenName',
-                family_name: 'familyName',
-                population: '',
-              },
+        expect(logger.error).to.have.been.calledWithExactly({
+          context: 'oidc',
+          data: {
+            missingFields: 'population',
+            userInfo: {
+              sub: 'sub-id',
+              given_name: 'givenName',
+              family_name: 'familyName',
+              population: '',
             },
-            event: 'find-missing-required-claims',
-            team: 'acces',
           },
-          errorMessage,
-        );
+          event: 'find-missing-required-claims',
+          team: 'acces',
+          msg: errorMessage,
+        });
       });
     });
   });

--- a/api/tests/identity-access-management/unit/domain/usecases/validate-user-account-email.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/validate-user-account-email.usecase.test.js
@@ -1,5 +1,5 @@
 import { validateUserAccountEmail } from '../../../../../src/identity-access-management/domain/usecases/validate-user-account-email.usecase.js';
-import { monitoringTools } from '../../../../../src/shared/infrastructure/monitoring-tools.js';
+import { logger } from '../../../../../src/shared/infrastructure/utils/logger.js';
 import { domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Domain | UseCase | validate-user-account-email', function () {
@@ -22,7 +22,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | validate-user-a
     now = new Date('2024-06-26');
     clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
 
-    sinon.stub(monitoringTools, 'logErrorWithCorrelationIds');
+    sinon.stub(logger, 'error');
   });
 
   afterEach(function () {
@@ -132,12 +132,14 @@ describe('Unit | Identity Access Management | Domain | UseCase | validate-user-a
       });
 
       // then
-      expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith({
-        message: 'error',
-        context: 'email-validation',
-        data: { token },
-        team: 'acces',
-      });
+      expect(logger.error).to.have.been.calledWith(
+        {
+          context: 'email-validation',
+          data: { token },
+          team: 'acces',
+        },
+        'error',
+      );
       expect(redirectionUrl).to.equal(defaultRedirectionUrl);
     });
   });

--- a/api/tests/identity-access-management/unit/domain/usecases/validate-user-account-email.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/validate-user-account-email.usecase.test.js
@@ -132,14 +132,12 @@ describe('Unit | Identity Access Management | Domain | UseCase | validate-user-a
       });
 
       // then
-      expect(logger.error).to.have.been.calledWith(
-        {
-          context: 'email-validation',
-          data: { token },
-          team: 'acces',
-        },
-        'error',
-      );
+      expect(logger.error).to.have.been.calledWith({
+        context: 'email-validation',
+        data: { token },
+        team: 'acces',
+        msg: 'error',
+      });
       expect(redirectionUrl).to.equal(defaultRedirectionUrl);
     });
   });

--- a/api/tests/integration/infrastructure/event-dispatcher-logger_test.js
+++ b/api/tests/integration/infrastructure/event-dispatcher-logger_test.js
@@ -17,18 +17,16 @@ describe('Integration | Infrastructure | EventHandlerLogger', function () {
       eventDispatcherLogger.onEventDispatchStarted(event, eventHandlerName);
 
       // then
-      expect(logger.info).to.have.been.calledWithExactly(
-        {
-          metrics: {
-            event_name: 'TestEvent',
-            event_content: event,
-            event_handler_name: "the event handler's name",
-            event_error: undefined,
-            event_handling_duration: undefined,
-          },
+      expect(logger.info).to.have.been.calledWithExactly({
+        metrics: {
+          event_name: 'TestEvent',
+          event_content: event,
+          event_handler_name: "the event handler's name",
+          event_error: undefined,
+          event_handling_duration: undefined,
         },
-        'EventDispatcher : Event dispatch started',
-      );
+        msg: 'EventDispatcher : Event dispatch started',
+      });
     });
   });
 
@@ -66,18 +64,16 @@ describe('Integration | Infrastructure | EventHandlerLogger', function () {
       eventDispatcherLogger.onEventDispatchSuccess(event, eventHandlerName);
 
       // then
-      expect(logger.info).to.have.been.calledWithExactly(
-        {
-          metrics: {
-            event_name: 'TestEvent',
-            event_content: event,
-            event_handler_name: "the event handler's name",
-            event_error: undefined,
-            event_handling_duration: undefined,
-          },
+      expect(logger.info).to.have.been.calledWithExactly({
+        metrics: {
+          event_name: 'TestEvent',
+          event_content: event,
+          event_handler_name: "the event handler's name",
+          event_error: undefined,
+          event_handling_duration: undefined,
         },
-        'EventDispatcher : Event dispatched successfully',
-      );
+        msg: 'EventDispatcher : Event dispatched successfully',
+      });
     });
 
     it('logs an event dispatch failure as info', function () {
@@ -95,18 +91,16 @@ describe('Integration | Infrastructure | EventHandlerLogger', function () {
       eventDispatcherLogger.onEventDispatchFailure(event, eventHandlerName, anError);
 
       // then
-      expect(logger.info).to.have.been.calledWithExactly(
-        {
-          metrics: {
-            event_name: 'TestEvent',
-            event_content: event,
-            event_handler_name: "the event handler's name",
-            event_error: 'an error (see dedicated log for more information)',
-            event_handling_duration: undefined,
-          },
+      expect(logger.info).to.have.been.calledWithExactly({
+        metrics: {
+          event_name: 'TestEvent',
+          event_content: event,
+          event_handler_name: "the event handler's name",
+          event_error: 'an error (see dedicated log for more information)',
+          event_handling_duration: undefined,
         },
-        'EventDispatcher : An error occurred while dispatching the event',
-      );
+        msg: 'EventDispatcher : An error occurred while dispatching the event',
+      });
     });
   });
 
@@ -165,18 +159,16 @@ describe('Integration | Infrastructure | EventHandlerLogger', function () {
       eventDispatcherLogger.onEventDispatchSuccess(event, eventHandlerName, context);
 
       // then
-      expect(logger.info).to.have.been.calledWithExactly(
-        {
-          metrics: {
-            event_name: 'TestEvent',
-            event_content: event,
-            event_handler_name: "the event handler's name",
-            event_error: undefined,
-            event_handling_duration: 4,
-          },
+      expect(logger.info).to.have.been.calledWithExactly({
+        metrics: {
+          event_name: 'TestEvent',
+          event_content: event,
+          event_handler_name: "the event handler's name",
+          event_error: undefined,
+          event_handling_duration: 4,
         },
-        'EventDispatcher : Event dispatched successfully',
-      );
+        msg: 'EventDispatcher : Event dispatched successfully',
+      });
     });
   });
 });

--- a/api/tests/integration/infrastructure/event-dispatcher-logger_test.js
+++ b/api/tests/integration/infrastructure/event-dispatcher-logger_test.js
@@ -7,26 +7,28 @@ describe('Integration | Infrastructure | EventHandlerLogger', function () {
       // given
       const event = new TestEvent('the content');
       const eventHandlerName = "the event handler's name";
-      const monitoringTools = _getMonitoringToolsMock();
+      const logger = _getLoggerMock();
       const settings = _getSettingsMock();
       const performance = _getPerformanceMock();
       settings.logging.enableLogStartingEventDispatch = true;
-      const eventDispatcherLogger = new EventDispatcherLogger(monitoringTools, settings, performance);
+      const eventDispatcherLogger = new EventDispatcherLogger(logger, settings, performance);
 
       // when
       eventDispatcherLogger.onEventDispatchStarted(event, eventHandlerName);
 
       // then
-      expect(monitoringTools.logInfoWithCorrelationIds).to.have.been.calledWithExactly({
-        metrics: {
-          event_name: 'TestEvent',
-          event_content: event,
-          event_handler_name: "the event handler's name",
-          event_error: undefined,
-          event_handling_duration: undefined,
+      expect(logger.info).to.have.been.calledWithExactly(
+        {
+          metrics: {
+            event_name: 'TestEvent',
+            event_content: event,
+            event_handler_name: "the event handler's name",
+            event_error: undefined,
+            event_handling_duration: undefined,
+          },
         },
-        message: 'EventDispatcher : Event dispatch started',
-      });
+        'EventDispatcher : Event dispatch started',
+      );
     });
   });
 
@@ -35,17 +37,17 @@ describe('Integration | Infrastructure | EventHandlerLogger', function () {
       // given
       const event = new TestEvent('the content');
       const eventHandlerName = "the event handler's name";
-      const monitoringTools = _getMonitoringToolsMock();
+      const logger = _getLoggerMock();
       const settings = _getSettingsMock();
       const performance = _getPerformanceMock();
       settings.logging.enableLogStartingEventDispatch = false;
-      const eventDispatcherLogger = new EventDispatcherLogger(monitoringTools, settings, performance);
+      const eventDispatcherLogger = new EventDispatcherLogger(logger, settings, performance);
 
       // when
       eventDispatcherLogger.onEventDispatchStarted(event, eventHandlerName);
 
       // then
-      expect(monitoringTools.logInfoWithCorrelationIds).not.to.be.called;
+      expect(logger.info).not.to.be.called;
     });
   });
 
@@ -54,53 +56,57 @@ describe('Integration | Infrastructure | EventHandlerLogger', function () {
       // given
       const event = new TestEvent('the content');
       const eventHandlerName = "the event handler's name";
-      const monitoringTools = _getMonitoringToolsMock();
+      const logger = _getLoggerMock();
       const settings = _getSettingsMock();
       const performance = _getPerformanceMock();
       settings.logging.enableLogEndingEventDispatch = true;
-      const eventDispatcherLogger = new EventDispatcherLogger(monitoringTools, settings, performance);
+      const eventDispatcherLogger = new EventDispatcherLogger(logger, settings, performance);
 
       // when
       eventDispatcherLogger.onEventDispatchSuccess(event, eventHandlerName);
 
       // then
-      expect(monitoringTools.logInfoWithCorrelationIds).to.have.been.calledWithExactly({
-        metrics: {
-          event_name: 'TestEvent',
-          event_content: event,
-          event_handler_name: "the event handler's name",
-          event_error: undefined,
-          event_handling_duration: undefined,
+      expect(logger.info).to.have.been.calledWithExactly(
+        {
+          metrics: {
+            event_name: 'TestEvent',
+            event_content: event,
+            event_handler_name: "the event handler's name",
+            event_error: undefined,
+            event_handling_duration: undefined,
+          },
         },
-        message: 'EventDispatcher : Event dispatched successfully',
-      });
+        'EventDispatcher : Event dispatched successfully',
+      );
     });
 
     it('logs an event dispatch failure as info', function () {
       // given
       const event = new TestEvent('the content');
       const eventHandlerName = "the event handler's name";
-      const monitoringTools = _getMonitoringToolsMock();
+      const logger = _getLoggerMock();
       const settings = _getSettingsMock();
       settings.logging.enableLogEndingEventDispatch = true;
       const performance = _getPerformanceMock();
-      const eventDispatcherLogger = new EventDispatcherLogger(monitoringTools, settings, performance);
+      const eventDispatcherLogger = new EventDispatcherLogger(logger, settings, performance);
       const anError = new Error('an error');
 
       // when
       eventDispatcherLogger.onEventDispatchFailure(event, eventHandlerName, anError);
 
       // then
-      expect(monitoringTools.logInfoWithCorrelationIds).to.have.been.calledWithExactly({
-        metrics: {
-          event_name: 'TestEvent',
-          event_content: event,
-          event_handler_name: "the event handler's name",
-          event_error: 'an error (see dedicated log for more information)',
-          event_handling_duration: undefined,
+      expect(logger.info).to.have.been.calledWithExactly(
+        {
+          metrics: {
+            event_name: 'TestEvent',
+            event_content: event,
+            event_handler_name: "the event handler's name",
+            event_error: 'an error (see dedicated log for more information)',
+            event_handling_duration: undefined,
+          },
         },
-        message: 'EventDispatcher : An error occurred while dispatching the event',
-      });
+        'EventDispatcher : An error occurred while dispatching the event',
+      );
     });
   });
 
@@ -109,35 +115,35 @@ describe('Integration | Infrastructure | EventHandlerLogger', function () {
       // given
       const event = new TestEvent('the content');
       const eventHandlerName = "the event handler's name";
-      const monitoringTools = _getMonitoringToolsMock();
+      const logger = _getLoggerMock();
       const settings = _getSettingsMock();
       const performance = _getPerformanceMock();
       settings.logging.enableLogEndingEventDispatch = false;
-      const eventDispatcherLogger = new EventDispatcherLogger(monitoringTools, settings, performance);
+      const eventDispatcherLogger = new EventDispatcherLogger(logger, settings, performance);
 
       // when
       eventDispatcherLogger.onEventDispatchSuccess(event, eventHandlerName);
 
       // then
-      expect(monitoringTools.logInfoWithCorrelationIds).to.not.have.been.called;
+      expect(logger.info).to.not.have.been.called;
     });
 
     it('logs an event dispatch failure as info', function () {
       // given
       const event = new TestEvent('the content');
       const eventHandlerName = "the event handler's name";
-      const monitoringTools = _getMonitoringToolsMock();
+      const logger = _getLoggerMock();
       const settings = _getSettingsMock();
       const performance = _getPerformanceMock();
       settings.logging.enableLogEndingEventDispatch = false;
-      const eventDispatcherLogger = new EventDispatcherLogger(monitoringTools, settings, performance);
+      const eventDispatcherLogger = new EventDispatcherLogger(logger, settings, performance);
       const anError = new Error('an error');
 
       // when
       eventDispatcherLogger.onEventDispatchFailure(event, eventHandlerName, anError);
 
       // then
-      expect(monitoringTools.logInfoWithCorrelationIds).to.not.have.been.called;
+      expect(logger.info).to.not.have.been.called;
     });
   });
 
@@ -146,11 +152,11 @@ describe('Integration | Infrastructure | EventHandlerLogger', function () {
       // given
       const event = new TestEvent('the content');
       const eventHandlerName = "the event handler's name";
-      const monitoringTools = _getMonitoringToolsMock();
+      const logger = _getLoggerMock();
       const settings = _getSettingsMock();
       const performance = _getPerformanceMock();
       settings.logging.enableLogEndingEventDispatch = true;
-      const eventDispatcherLogger = new EventDispatcherLogger(monitoringTools, settings, performance);
+      const eventDispatcherLogger = new EventDispatcherLogger(logger, settings, performance);
       performance.now.onCall(0).returns(1);
       performance.now.onCall(1).returns(5);
 
@@ -159,16 +165,18 @@ describe('Integration | Infrastructure | EventHandlerLogger', function () {
       eventDispatcherLogger.onEventDispatchSuccess(event, eventHandlerName, context);
 
       // then
-      expect(monitoringTools.logInfoWithCorrelationIds).to.have.been.calledWithExactly({
-        metrics: {
-          event_name: 'TestEvent',
-          event_content: event,
-          event_handler_name: "the event handler's name",
-          event_error: undefined,
-          event_handling_duration: 4,
+      expect(logger.info).to.have.been.calledWithExactly(
+        {
+          metrics: {
+            event_name: 'TestEvent',
+            event_content: event,
+            event_handler_name: "the event handler's name",
+            event_error: undefined,
+            event_handling_duration: 4,
+          },
         },
-        message: 'EventDispatcher : Event dispatched successfully',
-      });
+        'EventDispatcher : Event dispatched successfully',
+      );
     });
   });
 });
@@ -179,9 +187,9 @@ class TestEvent {
   }
 }
 
-function _getMonitoringToolsMock() {
+function _getLoggerMock() {
   return {
-    logInfoWithCorrelationIds: sinon.stub(),
+    info: sinon.stub(),
   };
 }
 

--- a/api/tests/prescription/campaign-participation/unit/application/jobs/participation-completed-job-controller_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/jobs/participation-completed-job-controller_test.js
@@ -1,7 +1,7 @@
 import { PoleEmploiPayload } from '../../../../../../lib/infrastructure/externals/pole-emploi/PoleEmploiPayload.js';
 import { ParticipationCompletedJobController } from '../../../../../../src/prescription/campaign-participation/application/jobs/participation-completed-job-controller.js';
 import { ParticipationCompletedJob } from '../../../../../../src/prescription/campaign-participation/domain/models/ParticipationCompletedJob.js';
-import { PoleEmploiSending } from '../../../../../../src/shared/domain/models/PoleEmploiSending.js';
+import { PoleEmploiSending } from '../../../../../../src/shared/domain/models/index.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | Prescription | Application | Jobs | ParticipationCompletedJobController', function () {

--- a/api/tests/prescription/campaign-participation/unit/application/jobs/participation-started-job-controller_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/jobs/participation-started-job-controller_test.js
@@ -1,7 +1,7 @@
 import { PoleEmploiPayload } from '../../../../../../lib/infrastructure/externals/pole-emploi/PoleEmploiPayload.js';
 import { ParticipationStartedJobController } from '../../../../../../src/prescription/campaign-participation/application/jobs/participation-started-job-controller.js';
 import { ParticipationStartedJob } from '../../../../../../src/prescription/campaign-participation/domain/models/ParticipationStartedJob.js';
-import { PoleEmploiSending } from '../../../../../../src/shared/domain/models/PoleEmploiSending.js';
+import { PoleEmploiSending } from '../../../../../../src/shared/domain/models/index.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | Application | Controller | Jobs | participation-started-controller', function () {

--- a/api/tests/prescription/campaign-participation/unit/application/learner-participation-controller_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/learner-participation-controller_test.js
@@ -74,13 +74,13 @@ describe('Unit | Application | Controller | Learner-Participation', function () 
         deserialize: sinon.stub(),
       };
 
-      const monitoringToolsStub = {
-        logErrorWithCorrelationIds: sinon.stub(),
+      const loggerStub = {
+        error: sinon.stub(),
       };
 
       dependencies = {
         campaignParticipationSerializer: campaignParticipationSerializerStub,
-        monitoringTools: monitoringToolsStub,
+        logger: loggerStub,
       };
 
       request = {

--- a/api/tests/prescription/learner-management/unit/application/sco-organization-management-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/sco-organization-management-controller_test.js
@@ -38,7 +38,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       ApplicationTransaction.getTransactionAsDomainTransaction.returns(domainTransaction);
 
       usecases.uploadSiecleFile.resolves();
-      dependencies = { logErrorWithCorrelationIds: sinon.stub() };
+      dependencies = { logger: { error: sinon.stub() } };
     });
 
     it('should delete uploaded file', async function () {
@@ -67,7 +67,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
 
       // then
       expect(fs.unlink).to.have.been.calledWithExactly(request.payload.path);
-      expect(dependencies.logErrorWithCorrelationIds).to.have.been.calledWith(error);
+      expect(dependencies.logger.error).to.have.been.calledWith(error);
     });
 
     it('should call usecases to import organizationLearners xml', async function () {

--- a/api/tests/prescription/learner-management/unit/application/sup-organization-management-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/sup-organization-management-controller_test.js
@@ -12,7 +12,7 @@ describe('Unit | Controller | sup-organization-management-controller', function 
   let userId;
 
   let supOrganizationLearnerWarningSerializerStub;
-  let logErrorWithCorrelationIdsStub;
+  let loggerStub;
   let unlinkStub;
 
   beforeEach(function () {
@@ -26,7 +26,9 @@ describe('Unit | Controller | sup-organization-management-controller', function 
     sinon.stub(usecases, 'importSupOrganizationLearners');
     sinon.stub(usecases, 'replaceSupOrganizationLearners');
     supOrganizationLearnerWarningSerializerStub = { serialize: sinon.stub() };
-    logErrorWithCorrelationIdsStub = sinon.stub();
+    loggerStub = {
+      error: sinon.stub(),
+    };
     unlinkStub = sinon.stub();
   });
 
@@ -55,7 +57,7 @@ describe('Unit | Controller | sup-organization-management-controller', function 
       // when
       const response = await supOrganizationManagementController.importSupOrganizationLearners(request, hFake, {
         supOrganizationLearnerWarningSerializer: supOrganizationLearnerWarningSerializerStub,
-        logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub,
+        logger: loggerStub,
         unlink: unlinkStub,
       });
 
@@ -85,7 +87,7 @@ describe('Unit | Controller | sup-organization-management-controller', function 
       // when
       await catchErr(supOrganizationManagementController.importSupOrganizationLearners)(request, hFake, {
         supOrganizationLearnerWarningSerializer: supOrganizationLearnerWarningSerializerStub,
-        logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub,
+        logger: loggerStub,
         unlink: unlinkStub,
       });
 
@@ -106,14 +108,14 @@ describe('Unit | Controller | sup-organization-management-controller', function 
 
       // when
       const response = await supOrganizationManagementController.importSupOrganizationLearners(request, hFake, {
-        logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub,
+        logger: loggerStub,
         unlink: unlinkStub,
       });
 
       // then
       expect(response.statusCode).to.be.equal(204);
 
-      expect(logErrorWithCorrelationIdsStub).to.have.been.calledWith(error);
+      expect(loggerStub.error).to.have.been.calledWith(error);
     });
   });
   context('#replaceSupOrganizationLearner', function () {
@@ -141,7 +143,7 @@ describe('Unit | Controller | sup-organization-management-controller', function 
       // when
       const response = await supOrganizationManagementController.replaceSupOrganizationLearners(request, hFake, {
         supOrganizationLearnerWarningSerializer: supOrganizationLearnerWarningSerializerStub,
-        logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub,
+        logger: loggerStub,
         unlink: unlinkStub,
       });
 
@@ -171,7 +173,7 @@ describe('Unit | Controller | sup-organization-management-controller', function 
 
       // when
       await catchErr(supOrganizationManagementController.replaceSupOrganizationLearners)(request, hFake, {
-        logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub,
+        logger: loggerStub,
         unlink: unlinkStub,
       });
 
@@ -193,14 +195,14 @@ describe('Unit | Controller | sup-organization-management-controller', function 
       // when
       const response = await supOrganizationManagementController.replaceSupOrganizationLearners(request, hFake, {
         supOrganizationLearnerWarningSerializer: supOrganizationLearnerWarningSerializerStub,
-        logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub,
+        logger: loggerStub,
         unlink: unlinkStub,
       });
 
       // then
       expect(response.statusCode).to.be.equal(204);
 
-      expect(logErrorWithCorrelationIdsStub).to.have.been.calledWith(error);
+      expect(loggerStub.error).to.have.been.calledWith(error);
     });
   });
 

--- a/api/tests/prescription/learner-management/unit/domain/usecases/upload-siecle-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/upload-siecle-file_test.js
@@ -103,7 +103,9 @@ describe('Unit | UseCase | upload-siecle-file', function () {
         siecleServiceStub.unzip.withArgs(payload.path).resolves({ directory: 'tmp', file: filepath });
         const rmError = new Error('rm');
         rmStub.rejects(rmError);
-        const logErrorWithCorrelationIdsStub = sinon.stub();
+        const loggerStub = {
+          error: sinon.stub(),
+        };
         // when
         await uploadSiecleFile({
           userId,
@@ -113,11 +115,11 @@ describe('Unit | UseCase | upload-siecle-file', function () {
           siecleService: siecleServiceStub,
           importStorage: importStorageStub,
           validateOrganizationImportFileJobRepository: validateOrganizationImportFileJobRepositoryStub,
-          dependencies: { logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub },
+          dependencies: { logger: loggerStub },
         });
 
         // then
-        expect(logErrorWithCorrelationIdsStub).to.have.been.calledWithExactly(rmError);
+        expect(loggerStub.error).to.have.been.calledWithExactly(rmError);
         expect(organizationImportSavedStub.upload).to.have.been.calledWithExactly({
           filename: s3filename,
           encoding,

--- a/api/tests/shared/unit/mail/infrastructure/services/mailer_test.js
+++ b/api/tests/shared/unit/mail/infrastructure/services/mailer_test.js
@@ -118,10 +118,10 @@ describe('Unit | Infrastructure | Mailers | mailer', function () {
           const result = await mailer.sendEmail({ to: recipient });
 
           // then
-          expect(logger.warn).to.have.been.calledWithExactly(
-            { err: expectedError },
-            "Email is not valid 'test@example.net'",
-          );
+          expect(logger.warn).to.have.been.calledWithExactly({
+            err: expectedError,
+            msg: "Email is not valid 'test@example.net'",
+          });
           expect(result).to.deep.equal(
             EmailingAttempt.failure('test@example.net', EmailingAttempt.errorCode.INVALID_DOMAIN),
           );
@@ -144,7 +144,10 @@ describe('Unit | Infrastructure | Mailers | mailer', function () {
           const result = await mailer.sendEmail({ to: recipient });
 
           // then
-          expect(logger.warn).to.have.been.calledOnceWith({ err: error }, "Could not send email to 'test@example.net'");
+          expect(logger.warn).to.have.been.calledOnceWith({
+            err: error,
+            msg: "Could not send email to 'test@example.net'",
+          });
           expect(result).to.deep.equal(EmailingAttempt.failure('test@example.net'));
         });
       });
@@ -167,10 +170,10 @@ describe('Unit | Infrastructure | Mailers | mailer', function () {
             const result = await mailer.sendEmail({ to: invalidEmailRecipient });
 
             // Then
-            expect(logger.warn).to.have.been.calledOnceWith(
-              { err: error },
-              `Could not send email to '${invalidEmailRecipient}'`,
-            );
+            expect(logger.warn).to.have.been.calledOnceWith({
+              err: error,
+              msg: `Could not send email to '${invalidEmailRecipient}'`,
+            });
             expect(result).to.deep.equal(
               EmailingAttempt.failure(
                 invalidEmailRecipient,

--- a/api/tests/unit/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
+++ b/api/tests/unit/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
@@ -6,9 +6,9 @@ import { DomainTransaction as domainTransaction } from '../../../../lib/infrastr
 import { ObjectValidationError, OrganizationTagNotFound } from '../../../../src/shared/domain/errors.js';
 import { InvalidInputDataError } from '../../../../src/shared/domain/errors.js';
 import { OrganizationForAdmin } from '../../../../src/shared/domain/models/index.js';
-import { Membership } from '../../../../src/shared/domain/models/Membership.js';
-import { OrganizationTag } from '../../../../src/shared/domain/models/OrganizationTag.js';
-import { monitoringTools } from '../../../../src/shared/infrastructure/monitoring-tools.js';
+import { Membership } from '../../../../src/shared/domain/models/index.js';
+import { OrganizationTag } from '../../../../src/shared/domain/models/index.js';
+import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';
 
 describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', function () {
@@ -61,7 +61,7 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
     };
 
     organizationInvitationService.createProOrganizationInvitation.resolves();
-    sinon.stub(monitoringTools, 'logErrorWithCorrelationIds');
+    sinon.stub(logger, 'error');
   });
 
   context('#errors', function () {
@@ -126,13 +126,15 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
         // then
         expect(error).to.be.instanceOf(OrganizationTagNotFound);
         expect(error.message).to.be.equal("Le tag TagNotFound de l'organisation organization A n'existe pas.");
-        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith({
-          message: `Le tag TagNotFound de l'organisation organization A n'existe pas.`,
-          context: 'create-organizations-with-tags-and-target-profiles',
-          error: { name: 'OrganizationTagNotFound' },
-          event: 'add-organizations-tags',
-          team: 'acces',
-        });
+        expect(logger.error).to.have.been.calledWith(
+          {
+            context: 'create-organizations-with-tags-and-target-profiles',
+            error: { name: 'OrganizationTagNotFound' },
+            event: 'add-organizations-tags',
+            team: 'acces',
+          },
+          `Le tag TagNotFound de l'organisation organization A n'existe pas.`,
+        );
       });
     });
 
@@ -173,13 +175,15 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
         // then
         expect(error).to.be.instanceOf(InvalidInputDataError);
         expect(error.message).to.be.equal('User with ID "990000" does not exist');
-        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith({
-          message: errorThrownMessage,
-          context: 'create-organizations-with-tags-and-target-profiles',
-          error: { name: 'Error' },
-          event: 'create-organizations',
-          team: 'acces',
-        });
+        expect(logger.error).to.have.been.calledWith(
+          {
+            context: 'create-organizations-with-tags-and-target-profiles',
+            error: { name: 'Error' },
+            event: 'create-organizations',
+            team: 'acces',
+          },
+          errorThrownMessage,
+        );
       });
     });
   });

--- a/api/tests/unit/domain/usecases/send-shared-participation-results-to-pole-emploi_test.js
+++ b/api/tests/unit/domain/usecases/send-shared-participation-results-to-pole-emploi_test.js
@@ -4,6 +4,7 @@ import { PoleEmploiSending } from '../../../../src/shared/domain/models/PoleEmpl
 import { domainBuilder, expect, sinon } from '../../../test-helper.js';
 
 describe('Unit | Domain | UseCase | send-shared-participation-results-to-pole-emploi', function () {
+  let httpAgent, httpErrorsHelper, logger;
   let dependencies, expectedResults;
   let campaignRepository,
     badgeRepository,
@@ -15,7 +16,6 @@ describe('Unit | Domain | UseCase | send-shared-participation-results-to-pole-em
     userRepository,
     poleEmploiNotifier,
     poleEmploiSendingRepository;
-  let httpAgent, httpErrorsHelper, logger;
   let campaignId, campaignParticipationId, userId, organizationId, badges, badgeAcquiredIds;
   let authenticationMethodRepository;
 

--- a/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
+++ b/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
@@ -17,13 +17,8 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
     let httpErrorsHelper;
     let logger;
     let payload;
-
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const originPoleEmploiSendingUrl = settings.poleEmploi.sendingUrl;
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const originPoleEmploiTokenUrl = settings.poleEmploi.tokenUrl;
+    let originPoleEmploiSendingUrl;
+    let originPoleEmploiTokenUrl;
 
     const userId = 123;
     const code = 'someCode';
@@ -39,6 +34,8 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
     const authenticationMethod = { authenticationComplement: { accessToken, expiredDate, refreshToken } };
 
     beforeEach(function () {
+      originPoleEmploiSendingUrl = settings.poleEmploi.sendingUrl;
+      originPoleEmploiTokenUrl = settings.poleEmploi.tokenUrl;
       clock = sinon.useFakeTimers({ now: Date.now(), toFake: ['Date'] });
       httpAgent = {
         post: sinon.stub(),

--- a/api/tests/unit/infrastructure/http/http-agent_test.js
+++ b/api/tests/unit/infrastructure/http/http-agent_test.js
@@ -59,9 +59,8 @@ describe('Unit | Infrastructure | http | http-agent', function () {
 
         // then
         const expected = 'End POST request to someUrl error: 400 {"a":"1","b":"2"}';
-        const { metrics } = logger.error.firstCall.args[0];
-        const message = logger.error.firstCall.args[1];
-        expect(message).to.equal(expected);
+        const { metrics, msg } = logger.error.firstCall.args[0];
+        expect(msg).to.equal(expected);
         expect(metrics.responseTime).to.be.greaterThan(0);
       });
 
@@ -167,9 +166,8 @@ describe('Unit | Infrastructure | http | http-agent', function () {
 
         // then
         const expected = 'End GET request to someUrl error: 400 {"a":"1","b":"2"}';
-        const { metrics } = logger.error.firstCall.args[0];
-        const message = logger.error.firstCall.args[1];
-        expect(message).to.equal(expected);
+        const { metrics, msg } = logger.error.firstCall.args[0];
+        expect(msg).to.equal(expected);
         expect(metrics.responseTime).to.be.greaterThan(0);
       });
 

--- a/api/tests/unit/infrastructure/http/http-agent_test.js
+++ b/api/tests/unit/infrastructure/http/http-agent_test.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 import { httpAgent } from '../../../../lib/infrastructure/http/http-agent.js';
-import { monitoringTools } from '../../../../src/shared/infrastructure/monitoring-tools.js';
+import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
 import { expect, sinon } from '../../../test-helper.js';
 
 const { post, get } = httpAgent;
@@ -40,8 +40,8 @@ describe('Unit | Infrastructure | http | http-agent', function () {
     context('when an error occurs', function () {
       it('should log the response error data and response time', async function () {
         // given
-        sinon.stub(monitoringTools, 'logErrorWithCorrelationIds');
-        monitoringTools.logErrorWithCorrelationIds.resolves();
+        sinon.stub(logger, 'error');
+        logger.error.returns();
 
         const url = 'someUrl';
         const payload = 'somePayload';
@@ -59,7 +59,8 @@ describe('Unit | Infrastructure | http | http-agent', function () {
 
         // then
         const expected = 'End POST request to someUrl error: 400 {"a":"1","b":"2"}';
-        const { message, metrics } = monitoringTools.logErrorWithCorrelationIds.firstCall.args[0];
+        const { metrics } = logger.error.firstCall.args[0];
+        const message = logger.error.firstCall.args[1];
         expect(message).to.equal(expected);
         expect(metrics.responseTime).to.be.greaterThan(0);
       });
@@ -147,8 +148,8 @@ describe('Unit | Infrastructure | http | http-agent', function () {
     context('when an error occurs', function () {
       it('should log the response error data and response time', async function () {
         // given
-        sinon.stub(monitoringTools, 'logErrorWithCorrelationIds');
-        monitoringTools.logErrorWithCorrelationIds.resolves();
+        sinon.stub(logger, 'error');
+        logger.error.returns();
 
         const url = 'someUrl';
         const payload = 'somePayload';
@@ -166,7 +167,8 @@ describe('Unit | Infrastructure | http | http-agent', function () {
 
         // then
         const expected = 'End GET request to someUrl error: 400 {"a":"1","b":"2"}';
-        const { message, metrics } = monitoringTools.logErrorWithCorrelationIds.firstCall.args[0];
+        const { metrics } = logger.error.firstCall.args[0];
+        const message = logger.error.firstCall.args[1];
         expect(message).to.equal(expected);
         expect(metrics.responseTime).to.be.greaterThan(0);
       });

--- a/api/worker.js
+++ b/api/worker.js
@@ -29,14 +29,14 @@ async function startPgBoss() {
   pgBoss.on('monitor-states', (state) => {
     logger.info({ event: 'pg-boss-state', name: 'global' }, { ...state, queues: undefined });
     _.each(state.queues, (queueState, queueName) => {
-      logger.info({ event: 'pg-boss-state', name: queueName }, queueState);
+      logger.info({ event: 'pg-boss-state', name: queueName, msg: queueState });
     });
   });
   pgBoss.on('error', (err) => {
-    logger.error({ event: 'pg-boss-error' }, err);
+    logger.error({ event: 'pg-boss-error', msg: err });
   });
   pgBoss.on('wip', (data) => {
-    logger.info({ event: 'pg-boss-wip' }, data);
+    logger.info({ event: 'pg-boss-wip', msg: data });
   });
   await pgBoss.start();
   return pgBoss;


### PR DESCRIPTION
## :unicorn: Problème
Il est bien pratique de pouvoir avoir dans datadog les informations de corrélation (request_id et user_id).
Aujourd'hui, on avait besoin d'appeler spécifiquement une méthode maison, laquelle récupérait ces infos depuis le AsyncLocalStorage et appelait le logger Pino avec ces éléments.
Idéalement, on aimerait maintenant que ce soit le cas pour tous les logs tout le temps, mais c'était pas un super design de remplacer tous les logger.error et logger.info par nos méthodes maison.

## :robot: Proposition
Il se trouve qu'il existe un moyen de configurer pino pour qu'il fasse le travail de récupération de contexte et d'ajout de données dans le log : https://github.com/pinojs/pino/blob/main/docs/api.md#mixin-function

Donc on configure en deux temps :
```js
const logger = pino(
  {
    level: logging.logLevel,
    redact: ['req.headers.authorization'],
    enabled: logging.enabled,
    // Méthode appelée avant chaque log. Permet de fournir de l'info supplémentaire pour alimenter le log
    // Ici, on récupère les infos de corrélation
    mixin() {
      return getCorrelationContext();
    },
    // Juste après, il faut définir cette méthode pour lui expliquer quoi faire avec le truc retourné de mixin()
   // Ici je reproduis le comportement qu'il y avait dans les méthodes logErrorWithCorrelationId et logInfoWithCorrelationId
   // à savoir merger les deux objets et retirer la clé "message"
    mixinMergeStrategy(originalMessage, correlationContext) {
      return {
        ...correlationContext,
        ...originalMessage,
        message: undefined,
      };
    },
  },
  prettyPrint,
);
```

## :rainbow: Remarques
J'ai gardé le même comportement qu'avant, et je suis repassée dans le code pour déplacer les paramètres "message" en deuxième argument d'appel des loggers comme le dit la doc (les méthodes `logErrorWithCorrelationId` et `logInfoWithCorrelationId` faisaient ce tour de passe-passe mais maintenant elles ne sont plus là !)

## :100: Pour tester
Tester avec du code sur dév, capturer un log d'info et un log d'error émis depuis les "vieilles méthodes".
Les reproduire sur cette branche et voir que c'est le même log

