### PR TITLE
[BUGFIX] Remettre le numéro des questions sur la page de détails des certifs V3 (PIX-14142).

### DIFF
--- a/admin/app/models/certification-challenges-for-administration.js
+++ b/admin/app/models/certification-challenges-for-administration.js
@@ -16,6 +16,7 @@ export default class CertificationChallengesForAdministration extends Model {
   @attr() competenceName;
   @attr() validatedLiveAlert;
   @attr() skillName;
+  @attr() questionNumber;
   version = 3;
 
   isOk() {


### PR DESCRIPTION
## :unicorn: Problème

Les numéros des questions n'apparait plus sur la page de `/details` des certifications V3 lors du premier chargement de la page.
Toutefois, ceux-ci sont présent en cas de retour via la navigation par onglets `Informations -> Détails`

![image](https://github.com/user-attachments/assets/45d5e87b-5488-4d40-bdf9-0e7a70a8625b)

## :robot: Proposition

Ajout de la propriété `questionNumber` dans le modèle le `certification-challenges-for-administration`  et utilisée dans le template.

## :rainbow: Remarques

Cette propriété du modèle est calculée et ajoutée à l'objet `certificationChallenge` grâce à l'appel de la fonction `assignQuestionNumberForDisplay` appelée lors de l'initialisation du controller dans la route `/details`

Je ne m'explique pas pourquoi malgré la présence de la propriété dans l'objet, celle-ci n'apparaisse pas au premier chargement 🤔 

⚠️ 🧪  J'ai trouvé un peu overkill d'ajouter un test d'acceptation pour tester uniquement l'affichage des numéros de questions. 
Car cela est déjà testé en intégration.

## :100: Pour tester

- Créer une session V3 avec `certifv3@example.net`
- Réaliser au moins quelques questions de cette session avec `certif-success@example.net`
- Finaliser la session (avec ou sans motif d'abandon en fonction de si vous avez fini le test ou non)
- Aller sur la page de détails de cette certification dans pix-admin et vérifier que les numéros de questions apparaissent bien
