### PR TITLE
[BUGFIX] Encapsule les erreurs venant du client S3 et les log (PIX-14109)

### DIFF
--- a/api/src/prescription/learner-management/application/jobs/validate-organization-learners-import-file-job-controller.js
+++ b/api/src/prescription/learner-management/application/jobs/validate-organization-learners-import-file-job-controller.js
@@ -1,11 +1,16 @@
 import { JobController } from '../../../../shared/application/jobs/job-controller.js';
 import { config } from '../../../../shared/config.js';
+import { DomainError } from '../../../../shared/domain/errors.js';
+import { logger as l } from '../../../../shared/infrastructure/utils/logger.js';
 import { ValidateOrganizationImportFileJob } from '../../domain/models/ValidateOrganizationImportFileJob.js';
 import { usecases } from '../../domain/usecases/index.js';
 
 class ValidateOrganizationLearnersImportFileJobController extends JobController {
-  constructor() {
+  #logger;
+
+  constructor({ logger = l } = {}) {
     super(ValidateOrganizationImportFileJob.name);
+    this.#logger = logger;
   }
 
   get isJobEnabled() {
@@ -14,8 +19,14 @@ class ValidateOrganizationLearnersImportFileJobController extends JobController 
 
   async handle({ data }) {
     const { organizationImportId } = data;
-
-    await usecases.validateSiecleXmlFile({ organizationImportId });
+    try {
+      await usecases.validateSiecleXmlFile({ organizationImportId });
+    } catch (err) {
+      if (!(err instanceof DomainError)) {
+        throw err;
+      }
+      this.#logger.error(err);
+    }
   }
 }
 

--- a/api/src/prescription/learner-management/domain/usecases/add-or-update-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/add-or-update-organization-learners.js
@@ -14,7 +14,6 @@ async function addOrUpdateOrganizationLearners({
   organizationImportRepository,
   importStorage,
   chunkSize = ORGANIZATION_LEARNER_CHUNK_SIZE,
-  logErrorWithCorrelationIds,
 }) {
   const errors = [];
   const organizationImport = await organizationImportRepository.get(organizationImportId);
@@ -66,11 +65,8 @@ async function addOrUpdateOrganizationLearners({
       await organizationImportRepository.save(organizationImport);
       loggerForImport("IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Aprés le save de l'organizationImport");
 
-      try {
-        await importStorage.deleteFile({ filename: organizationImport.filename });
-      } catch (e) {
-        logErrorWithCorrelationIds(e);
-      }
+      await importStorage.deleteFile({ filename: organizationImport.filename });
+
       loggerForImport('IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Fin du usecase');
     }
   });

--- a/api/src/prescription/learner-management/domain/usecases/validate-siecle-xml-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/validate-siecle-xml-file.js
@@ -57,10 +57,7 @@ const validateSiecleXmlFile = async function ({
 
       await importStorage.deleteFile({ filename: organizationImport.filename });
 
-      const isKnownError = error instanceof AggregateImportError || error instanceof SiecleXmlImportError;
-      if (!isKnownError) {
-        throw error;
-      }
+      throw error;
     } finally {
       organizationImport.validate({ errors });
       await organizationImportRepository.save(organizationImport);

--- a/api/tests/prescription/learner-management/unit/domain/usecases/add-or-update-organization-learners_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/add-or-update-organization-learners_test.js
@@ -14,7 +14,6 @@ describe('Unit | UseCase | add-or-update-organization-learners', function () {
   let parserStub;
   let streamerSymbol;
   let organizationImportStub;
-  let logErrorWithCorrelationIdsStub;
 
   beforeEach(function () {
     organizationId = Symbol('organizationId');
@@ -55,8 +54,6 @@ describe('Unit | UseCase | add-or-update-organization-learners', function () {
       addOrUpdateOrganizationOfOrganizationLearners: sinon.stub(),
       disableAllOrganizationLearnersInOrganization: sinon.stub().resolves(),
     };
-
-    logErrorWithCorrelationIdsStub = sinon.stub();
   });
 
   it('should save learners', async function () {
@@ -109,22 +106,5 @@ describe('Unit | UseCase | add-or-update-organization-learners', function () {
     expect(organizationLearnerRepositoryStub.disableAllOrganizationLearnersInOrganization).to.have.been.not.called;
     expect(organizationImportStub.process).to.have.been.called;
     expect(organizationImportRepositoryStub.save).to.have.been.called;
-  });
-
-  it('should call log method if file deletion on s3 fails', async function () {
-    const deletionError = new Error('deletion error');
-    importStorageStub.readFile.rejects();
-    importStorageStub.deleteFile.rejects(deletionError);
-
-    await catchErr(addOrUpdateOrganizationLearners)({
-      organizationImportId,
-      importStorage: importStorageStub,
-      organizationImportRepository: organizationImportRepositoryStub,
-      organizationLearnerRepository: organizationLearnerRepositoryStub,
-      chunkSize: 2,
-      logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub,
-    });
-
-    expect(logErrorWithCorrelationIdsStub).to.have.been.calledWith(deletionError);
   });
 });

--- a/api/tests/prescription/learner-management/unit/domain/usecases/validate-siecle-xml-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/validate-siecle-xml-file_test.js
@@ -146,7 +146,7 @@ describe('Unit | UseCase | validate-siecle-xml-file', function () {
       it('should save parsing errors', async function () {
         const parsingErrors = [new Error('parsing'), new Error('parsing2')];
         parserStub.parse.rejects(new AggregateImportError(parsingErrors));
-        await validateSiecleXmlFile({
+        const error = await catchErr(validateSiecleXmlFile)({
           organizationImportId,
           organizationImportRepository: organizationImportRepositoryStub,
           organizationRepository: organizationRepositoryStub,
@@ -156,22 +156,26 @@ describe('Unit | UseCase | validate-siecle-xml-file', function () {
         expect(importStorageStub.deleteFile).to.have.been.calledWithExactly({
           filename: organizationImportStub.filename,
         });
+        expect(error).to.be.instanceof(AggregateImportError);
         expect(organizationImportStub.validate).to.have.been.calledWith({ errors: parsingErrors });
         expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(organizationImportStub);
       });
 
       it('should save empty learner error', async function () {
         parserStub.parse.resolves([]);
-        await validateSiecleXmlFile({
+
+        const error = await catchErr(validateSiecleXmlFile)({
           organizationImportId,
           organizationImportRepository: organizationImportRepositoryStub,
           organizationRepository: organizationRepositoryStub,
           importStorage: importStorageStub,
           importOrganizationLearnersJobRepository: importOrganizationLearnersJobRepositoryStub,
         });
+
         expect(importStorageStub.deleteFile).to.have.been.calledWithExactly({
           filename: organizationImportStub.filename,
         });
+        expect(error).to.be.instanceof(SiecleXmlImportError);
         expect(organizationImportStub.validate.getCall(0).args[0].errors[0] instanceof SiecleXmlImportError).to.equal(
           true,
         );


### PR DESCRIPTION
## :unicorn: Problème
Les erreurs venant de S3 contiennent des références circulaires. Ce qui fait qu'on arrive pas à les enregistrer dans la table organization-imports. 

## :robot: Proposition
Dans cette PR, on vient encapsuler les erreurs S3 et on les log. Cela permet de bien les enregistrer en DB.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- Couper le job de validation d'import
- Lancer un import
- Supprimer le fichier dans S3
- Ré-activer la validation
- Constater qu'on log bien l'erreur S3 et qu'on la sauvegarde en DB
