### PR TITLE
[TECH] Corriger un test de script flaky (PIX-14148)

### DIFF
--- a/api/scripts/prod/re-assign-campaign-participations-with-campaign.js
+++ b/api/scripts/prod/re-assign-campaign-participations-with-campaign.js
@@ -23,10 +23,10 @@ export const fillCampaignIdInPartipations = async (object) => {
       i++;
       logger.info(`Mise a jour de la participation ${i}/${totalCampaignParticipations}`);
     }
-    trx.commit();
+    await trx.commit();
     logger.info(`Toutes les campaign-participations ont bien été mises à jour ✅`);
   } catch (error) {
-    trx.rollback();
+    await trx.rollback();
     logger.info("Aucune participation n'a été mise a jour, une erreur est survenue");
     logger.info(error);
   }


### PR DESCRIPTION
## :unicorn: Problème
Le test d'integration `Script | Prod | Re Assign Campaign Participations With Campaign` est flaky

## :robot: Proposition
Corriger le test afin qu'il ne le soit plus

## :rainbow: Remarques
On utilisait les méthodes `commit()` et `rollback()` qui sont asynchronent sans attendre que la promesse soit résolue.
On se retrouvait dont a chercher des infos en base avant que la transaction ne soit commit.

## :100: Pour tester
- Tests Vert ✅ 
