### PR TITLE
[BUGFIX] Corriger l'affichage de la durée d'une certification dans pix-admin  (PIX-14153)

### DIFF
--- a/admin/app/components/certifications/certification/details-v3.gjs
+++ b/admin/app/components/certifications/certification/details-v3.gjs
@@ -8,7 +8,6 @@ import { action } from '@ember/object';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import dayjsDuration from 'ember-dayjs/helpers/dayjs-duration';
 import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
 import { t } from 'ember-intl';
 import { lt } from 'ember-truth-helpers';
@@ -238,7 +237,7 @@ export default class DetailsV3 extends Component {
                 </:tooltip>
               </PixTooltip>
               {{#if (lt @details.duration this.twentyFourHoursInMs)}}
-                <PixTag @color={{this.durationTagColor}}>{{dayjsDuration @details.duration "H[h]mm"}}</PixTag>
+                <PixTag @color={{this.durationTagColor}}>{{dayjsFormat @details.duration "HH[h]mm"}}</PixTag>
               {{else}}
                 <PixTag @color={{this.durationTagColor}}> > 24h</PixTag>
               {{/if}}


### PR DESCRIPTION
## :unicorn: Problème: 
l’information sur le temps de certification devrait s’afficher (en vert si dans le temps imparti pour la certif, en rouge si au delà du temps imparti), mais à la place on voit [object Object]

![image](https://github.com/user-attachments/assets/12eabbf1-1f45-41ca-be9f-45f958cb8429)


## :robot: Proposition
réparer l'affichage


## :100: Pour tester
- Passer/finaliser/publier une certification v3
- Dans pix admin, verifier que l'affichage est sous la bonne forme

<img width="792" alt="Capture d’écran 2024-09-05 à 14 56 16" src="https://github.com/user-attachments/assets/dff38b3c-1ca5-4e94-b026-a3122afc97e9">

