### PR TITLE
[BUGFIX] Corriger la clé de traduction

### DIFF
--- a/orga/app/components/mission/result-table.gjs
+++ b/orga/app/components/mission/result-table.gjs
@@ -8,7 +8,7 @@ import PaginationControl from '../table/pagination-control';
     <div class="panel">
       <table class="table content-text content-text--small participation-list__table">
         <caption class="screen-reader-only">{{t
-            "pages.missions.mission.table.activities.caption"
+            "pages.missions.mission.table.result.caption"
             missionName=@mission.name
           }}</caption>
         <thead>
@@ -22,7 +22,7 @@ import PaginationControl from '../table/pagination-control';
         <tbody>
 
           {{#each @missionLearners as |missionLearner|}}
-            <tr aria-label={{t "pages.missions.mission.tabs.activities.aria-label"}}>
+            <tr aria-label={{t "pages.missions.mission.tabs.result.aria-label"}}>
               <td>
                 {{missionLearner.firstName}}
               </td>
@@ -41,7 +41,7 @@ import PaginationControl from '../table/pagination-control';
     <PaginationControl @pagination={{@missionLearners.meta}} />
   {{else}}
     <div class="table__empty content-text">
-      {{t "pages.missions.mission.table.activities.no-data"}}
+      {{t "pages.missions.mission.table.result.no-data"}}
     </div>
   {{/if}}
 </template>

--- a/orga/app/templates/authenticated/missions/mission/results.hbs
+++ b/orga/app/templates/authenticated/missions/mission/results.hbs
@@ -1,8 +1,8 @@
 <PixFilterBanner
   @title={{t "common.filters.title"}}
   class="participant-filter-banner hide-on-mobile"
-  aria-label={{t "pages.missions.mission.table.results.filters.aria-label"}}
-  @details={{t "pages.missions.mission.table.results.filters.learners-count" count=this.learnersCount}}
+  aria-label={{t "pages.missions.mission.table.result.filters.aria-label"}}
+  @details={{t "pages.missions.mission.table.result.filters.learners-count" count=this.learnersCount}}
   @clearFiltersLabel={{t "common.filters.actions.clear"}}
   @onClearFilters={{this.onResetFilter}}
   @isClearFilterButtonDisabled={{this.isClearFiltersButtonDisabled}}

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -918,7 +918,7 @@
             },
             "no-data": "There is not any participants"
           },
-          "results": {
+          "result": {
             "aria-label": "Student",
             "caption": "List of students with their result for the mission {missionName}",
             "filters": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -845,7 +845,7 @@
                 "started": "Bezig"
               }
             },
-            "results": {
+            "result": {
               "aria-label": "Student",
               "caption": "Tabel van studenten met de resultaten van hun deelname aan de opdracht {missionName}",
               "filters": {


### PR DESCRIPTION
## :unicorn: Problème
On a ajouté une traduction mais ensuite on a changé la clé. On a oublié de répercuter les changements à certain endroits
![Capture d’écran 2024-09-05 à 10 06 01](https://github.com/user-attachments/assets/5301db75-6bf8-4826-b38f-c8f494f7feb0)


## :robot: Proposition
Appeler la bonne clé de traduction

## :rainbow: Remarques
RAS

## :100: Pour tester
- Pour chaque langue (prendre orga.org):
- Se connecter à pix orga et sélectionner une mission.
- Aller sur l'onglet 'Résultat' et voir qu'on a bien les bonne traductions