### PR TITLE
[TECH] Migrer la route /api/admin/organizations/{id}/memberships dans src (PIX-14172)

### DIFF
--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -174,47 +174,6 @@ const register = async function (server) {
     },
     {
       method: 'GET',
-      path: '/api/admin/organizations/{id}/memberships',
-      config: {
-        pre: [
-          {
-            method: (request, h) =>
-              securityPreHandlers.hasAtLeastOneAccessOf([
-                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-                securityPreHandlers.checkAdminMemberHasRoleCertif,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-                securityPreHandlers.checkAdminMemberHasRoleMetier,
-              ])(request, h),
-            assign: 'belongsToOrganization',
-          },
-        ],
-        validate: {
-          params: Joi.object({
-            id: identifiersType.organizationId,
-          }),
-          query: Joi.object({
-            filter: Joi.object({
-              firstName: Joi.string().empty('').allow(null).optional(),
-              lastName: Joi.string().empty('').allow(null).optional(),
-              email: Joi.string().empty('').allow(null).optional(),
-              organizationRole: Joi.string().empty('').allow(null).optional(),
-            }).default({}),
-            page: Joi.object({
-              number: Joi.number().integer().empty('').allow(null).optional(),
-              size: Joi.number().integer().empty('').allow(null).optional(),
-            }).default({}),
-          }),
-        },
-        handler: organizationController.findPaginatedFilteredMembershipsForAdmin,
-        tags: ['api', 'organizations'],
-        notes: [
-          'Cette route est restreinte aux utilisateurs de Pix Admin',
-          'Elle retourne les rôles des membres rattachés à l’organisation de manière paginée.',
-        ],
-      },
-    },
-    {
-      method: 'GET',
       path: '/api/admin/organizations/{organizationId}/children',
       config: {
         pre: [

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -1,12 +1,10 @@
 import * as organizationSerializer from '../../../src/organizational-entities/infrastructure/serializers/jsonapi/organization-serializer.js';
 import { organizationForAdminSerializer } from '../../../src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js';
 import * as csvSerializer from '../../../src/shared/infrastructure/serializers/csv/csv-serializer.js';
-import * as membershipSerializer from '../../../src/shared/infrastructure/serializers/jsonapi/membership.serializer.js';
 import {
   extractLocaleFromRequest,
   extractUserIdFromRequest,
 } from '../../../src/shared/infrastructure/utils/request-response-utils.js';
-import { usecases as teamUsecases } from '../../../src/team/domain/usecases/index.js';
 import { organizationInvitationSerializer } from '../../../src/team/infrastructure/serializers/jsonapi/organization-invitation.serializer.js';
 import { usecases } from '../../domain/usecases/index.js';
 import * as organizationMemberIdentitySerializer from '../../infrastructure/serializers/jsonapi/organization-member-identity-serializer.js';
@@ -40,18 +38,6 @@ const findPaginatedFilteredOrganizations = async function (request, h, dependenc
     page: options.page,
   });
   return dependencies.organizationSerializer.serialize(organizations, pagination);
-};
-
-const findPaginatedFilteredMembershipsForAdmin = async function (request) {
-  const organizationId = request.params.id;
-  const options = request.query;
-
-  const { models: memberships, pagination } = await teamUsecases.findPaginatedFilteredOrganizationMemberships({
-    organizationId,
-    filter: options.filter,
-    page: options.page,
-  });
-  return membershipSerializer.serializeForAdmin(memberships, pagination);
 };
 
 const getOrganizationMemberIdentities = async function (
@@ -107,7 +93,6 @@ const organizationController = {
   create,
   createInBatch,
   findChildrenOrganizationsForAdmin,
-  findPaginatedFilteredMembershipsForAdmin,
   findPaginatedFilteredOrganizations,
   findTargetProfileSummariesForAdmin,
   getOrganizationMemberIdentities,

--- a/api/src/team/application/membership/membership.admin.controller.js
+++ b/api/src/team/application/membership/membership.admin.controller.js
@@ -1,0 +1,20 @@
+import * as membershipSerializer from '../../../shared/infrastructure/serializers/jsonapi/membership.serializer.js';
+import { usecases } from '../../domain/usecases/index.js';
+
+const findPaginatedFilteredMembershipsForAdmin = async function (request) {
+  const organizationId = request.params.id;
+  const options = request.query;
+
+  const { models: memberships, pagination } = await usecases.findPaginatedFilteredOrganizationMemberships({
+    organizationId,
+    filter: options.filter,
+    page: options.page,
+  });
+  return membershipSerializer.serializeForAdmin(memberships, pagination);
+};
+
+const membershipAdminController = {
+  findPaginatedFilteredMembershipsForAdmin,
+};
+
+export { membershipAdminController };

--- a/api/src/team/application/membership/membership.admin.route.js
+++ b/api/src/team/application/membership/membership.admin.route.js
@@ -1,8 +1,8 @@
 import Joi from 'joi';
 
-import { organizationController } from '../../../../lib/application/organizations/organization-controller.js';
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { membershipAdminController } from './membership.admin.controller.js';
 import { membershipController } from './membership.controller.js';
 
 export const membershipAdminRoutes = [
@@ -103,7 +103,7 @@ export const membershipAdminRoutes = [
           }).default({}),
         }),
       },
-      handler: organizationController.findPaginatedFilteredMembershipsForAdmin,
+      handler: membershipAdminController.findPaginatedFilteredMembershipsForAdmin,
       tags: ['api', 'organizations'],
       notes: [
         'Cette route est restreinte aux utilisateurs de Pix Admin',

--- a/api/src/team/application/membership/membership.admin.route.js
+++ b/api/src/team/application/membership/membership.admin.route.js
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 
+import { organizationController } from '../../../../lib/application/organizations/organization-controller.js';
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { membershipController } from './membership.controller.js';
@@ -67,6 +68,47 @@ export const membershipAdminRoutes = [
         },
       },
       tags: ['api', 'memberships'],
+    },
+  },
+  {
+    method: 'GET',
+    path: '/api/admin/organizations/{id}/memberships',
+    config: {
+      pre: [
+        {
+          method: (request, h) =>
+            securityPreHandlers.hasAtLeastOneAccessOf([
+              securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+              securityPreHandlers.checkAdminMemberHasRoleCertif,
+              securityPreHandlers.checkAdminMemberHasRoleSupport,
+              securityPreHandlers.checkAdminMemberHasRoleMetier,
+            ])(request, h),
+          assign: 'belongsToOrganization',
+        },
+      ],
+      validate: {
+        params: Joi.object({
+          id: identifiersType.organizationId,
+        }),
+        query: Joi.object({
+          filter: Joi.object({
+            firstName: Joi.string().empty('').allow(null).optional(),
+            lastName: Joi.string().empty('').allow(null).optional(),
+            email: Joi.string().empty('').allow(null).optional(),
+            organizationRole: Joi.string().empty('').allow(null).optional(),
+          }).default({}),
+          page: Joi.object({
+            number: Joi.number().integer().empty('').allow(null).optional(),
+            size: Joi.number().integer().empty('').allow(null).optional(),
+          }).default({}),
+        }),
+      },
+      handler: organizationController.findPaginatedFilteredMembershipsForAdmin,
+      tags: ['api', 'organizations'],
+      notes: [
+        'Cette route est restreinte aux utilisateurs de Pix Admin',
+        'Elle retourne les rôles des membres rattachés à l’organisation de manière paginée.',
+      ],
     },
   },
 ];

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -523,67 +523,6 @@ describe('Acceptance | Application | organization-controller', function () {
     });
   });
 
-  describe('GET /api/admin/organizations/{id}/memberships', function () {
-    it('should return the matching membership as JSON API', async function () {
-      // given
-      const userSuperAdmin = databaseBuilder.factory.buildUser.withRole();
-      const organization = databaseBuilder.factory.buildOrganization();
-      const user = databaseBuilder.factory.buildUser();
-      const membershipId = databaseBuilder.factory.buildMembership({
-        userId: user.id,
-        organizationId: organization.id,
-      }).id;
-
-      await databaseBuilder.commit();
-
-      // when
-      const response = await server.inject({
-        method: 'GET',
-        url: `/api/admin/organizations/${organization.id}/memberships?filter[email]=&filter[firstName]=&filter[lastName]=&filter[organizationRole]=`,
-        headers: { authorization: generateValidRequestAuthorizationHeader(userSuperAdmin.id) },
-      });
-
-      // then
-      expect(response.statusCode).to.equal(200);
-      expect(response.result).to.deep.equal({
-        data: [
-          {
-            attributes: {
-              'organization-role': 'MEMBER',
-            },
-            id: membershipId.toString(),
-            relationships: {
-              user: {
-                data: {
-                  id: user.id.toString(),
-                  type: 'users',
-                },
-              },
-            },
-            type: 'organization-memberships',
-          },
-        ],
-        included: [
-          {
-            attributes: {
-              email: user.email,
-              'first-name': user.firstName,
-              'last-name': user.lastName,
-            },
-            id: user.id.toString(),
-            type: 'users',
-          },
-        ],
-        meta: {
-          page: 1,
-          pageCount: 1,
-          pageSize: 10,
-          rowCount: 1,
-        },
-      });
-    });
-  });
-
   describe('GET /api/organizations/{id}/member-identities', function () {
     it('should return the members identities as JSON API', async function () {
       // given

--- a/api/tests/team/acceptance/application/membership/membership.admin.route.test.js
+++ b/api/tests/team/acceptance/application/membership/membership.admin.route.test.js
@@ -8,7 +8,7 @@ import {
   generateValidRequestAuthorizationHeader,
 } from '../../../../test-helper.js';
 
-describe('Acceptance | Controller | membership-controller', function () {
+describe('Acceptance | Team | Admin | Route | membership', function () {
   let server;
 
   beforeEach(async function () {
@@ -232,6 +232,67 @@ describe('Acceptance | Controller | membership-controller', function () {
         expect(response.statusCode).to.equal(400);
         const firstError = response.result.errors[0];
         expect(firstError.detail).to.equal('"id" must be a number');
+      });
+    });
+  });
+
+  describe('GET /api/admin/organizations/{id}/memberships', function () {
+    it('returns the matching membership as JSON API', async function () {
+      // given
+      const userSuperAdmin = databaseBuilder.factory.buildUser.withRole();
+      const organization = databaseBuilder.factory.buildOrganization();
+      const user = databaseBuilder.factory.buildUser();
+      const membershipId = databaseBuilder.factory.buildMembership({
+        userId: user.id,
+        organizationId: organization.id,
+      }).id;
+
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject({
+        method: 'GET',
+        url: `/api/admin/organizations/${organization.id}/memberships?filter[email]=&filter[firstName]=&filter[lastName]=&filter[organizationRole]=`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userSuperAdmin.id) },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result).to.deep.equal({
+        data: [
+          {
+            attributes: {
+              'organization-role': 'MEMBER',
+            },
+            id: membershipId.toString(),
+            relationships: {
+              user: {
+                data: {
+                  id: user.id.toString(),
+                  type: 'users',
+                },
+              },
+            },
+            type: 'organization-memberships',
+          },
+        ],
+        included: [
+          {
+            attributes: {
+              email: user.email,
+              'first-name': user.firstName,
+              'last-name': user.lastName,
+            },
+            id: user.id.toString(),
+            type: 'users',
+          },
+        ],
+        meta: {
+          page: 1,
+          pageCount: 1,
+          pageSize: 10,
+          rowCount: 1,
+        },
       });
     });
   });

--- a/api/tests/team/acceptance/application/membership/membership.admin.route.test.js
+++ b/api/tests/team/acceptance/application/membership/membership.admin.route.test.js
@@ -56,7 +56,7 @@ describe('Acceptance | Team | Admin | Route | membership', function () {
     });
 
     context('Success cases', function () {
-      it('should return the created membership', async function () {
+      it('returns the created membership', async function () {
         // when
         const response = await server.inject(options);
 
@@ -81,7 +81,7 @@ describe('Acceptance | Team | Admin | Route | membership', function () {
       });
 
       context('When a membership is disabled', function () {
-        it('should be able to recreate it', async function () {
+        it('recreates it', async function () {
           // given
           databaseBuilder.factory.buildMembership({ userId, organizationId, disabledAt: new Date() });
           await databaseBuilder.commit();
@@ -95,7 +95,7 @@ describe('Acceptance | Team | Admin | Route | membership', function () {
       });
 
       context('When a membership is not disabled', function () {
-        it('should not be able to recreate it', async function () {
+        it('does not recreate it', async function () {
           // given
           databaseBuilder.factory.buildMembership({ userId, organizationId });
           await databaseBuilder.commit();
@@ -166,7 +166,7 @@ describe('Acceptance | Team | Admin | Route | membership', function () {
     });
 
     context('Success cases', function () {
-      it('should return the updated membership and add certification center membership', async function () {
+      it('returns the updated membership and add certification center membership', async function () {
         // given
         const expectedMembership = {
           data: {
@@ -202,7 +202,7 @@ describe('Acceptance | Team | Admin | Route | membership', function () {
     });
 
     context('Error cases', function () {
-      it('should respond with a 403 if user is not admin of membership organization', async function () {
+      it('responds with a 403 if user is not admin of membership organization', async function () {
         // given
         const notAdminUserId = databaseBuilder.factory.buildUser().id;
         databaseBuilder.factory.buildMembership({
@@ -221,7 +221,7 @@ describe('Acceptance | Team | Admin | Route | membership', function () {
         expect(response.statusCode).to.equal(403);
       });
 
-      it('should respond with a 400 if membership does not exist', async function () {
+      it('responds with a 400 if membership does not exist', async function () {
         // given
         options.url = '/api/memberships/NOT_NUMERIC';
 


### PR DESCRIPTION
## :unicorn: Problème
Le code de la route  /api/admin/organizations/{id}/memberships était toujours dans le lib

## :robot: Proposition
Le migrer dans src/team

## :rainbow: Remarques
Il faut que la PR https://github.com/1024pix/pix/pull/10053 soit mergée avant celle là !

## :100: Pour tester
- Se connecter à la RA de Pix Admin avec par exemple un compte superadmin.
- Cliquer sur l'onglet Organisation dans le menu à gauche
- Ouvrir la console navigateur puis l'onglet Network
- Cliquer sur l'id d'une organisation ayant des membres pour afficher sa page de détail (ex: College House of the dragon)
- Vérifier que l'appel /api/admin/organizations/{id}/memberships renvoie bien une 200
- Vérifier que la liste des membres s'affiche bien sur la page
