### PR TITLE
[FEATURE] Limiter le TTL des refresh token par app (PIX-13912)

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -662,6 +662,30 @@ ACCESS_TOKEN_LIFESPAN=20m
 # default: '7d'
 REFRESH_TOKEN_LIFESPAN=7d
 
+# Refresh token lifespan for mon-pix scope
+# presence: optional
+# type: String
+# default: '7d'
+# REFRESH_TOKEN_LIFESPAN_MON_PIX=7d
+
+# Refresh token lifespan for pix-orga scope
+# presence: optional
+# type: String
+# default: '7d'
+# REFRESH_TOKEN_LIFESPAN_PIX_ORGA=7d
+
+# Refresh token lifespan for pix-certif scope
+# presence: optional
+# type: String
+# default: '7d'
+# REFRESH_TOKEN_LIFESPAN_PIX_CERTIF=7d
+
+# Refresh token lifespan for pix-admin scope
+# presence: optional
+# type: String
+# default: '7d'
+# REFRESH_TOKEN_LIFESPAN_PIX_ADMIN=7d
+
 # Saml access token lifespan
 # presence: optional
 # type: String

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -101,6 +101,12 @@ const configuration = (function () {
       secret: process.env.AUTH_SECRET,
       accessTokenLifespanMs: ms(process.env.ACCESS_TOKEN_LIFESPAN || '20m'),
       refreshTokenLifespanMs: ms(process.env.REFRESH_TOKEN_LIFESPAN || '7d'),
+      refreshTokenLifespanMsByScope: {
+        'mon-pix': ms(process.env.REFRESH_TOKEN_LIFESPAN_MON_PIX || '7d'),
+        'pix-orga': ms(process.env.REFRESH_TOKEN_LIFESPAN_PIX_ORGA || '7d'),
+        'pix-certif': ms(process.env.REFRESH_TOKEN_LIFESPAN_PIX_CERTIF || '7d'),
+        'pix-admin': ms(process.env.REFRESH_TOKEN_LIFESPAN_PIX_ADMIN || '7d'),
+      },
       tokenForCampaignResultLifespan: process.env.CAMPAIGN_RESULT_ACCESS_TOKEN_LIFESPAN || '1h',
       tokenForStudentReconciliationLifespan: '1h',
       passwordResetTokenLifespan: '1h',


### PR DESCRIPTION
## :unicorn: Problème

Les refresh tokens désormais valables par scope (1 scope par application). Mais tous les  refresh tokens ont nécessairement le même temps d'expiration.

On souhaite avoir un TTL de refresh tokens différent par application. Par exemple entre Pix APP et Pix Orga/Certif et Pix Admin

## :robot: Proposition

Permettre de définir un TTL de refresh token spécifique par scope. S'il n'est pas défini pour un scope, prendre la valeur par défaut actuelle.

Pour définir les TTL par scope, les variables d'environnement suivantes pourront être utilisées:
- `REFRESH_TOKEN_LIFESPAN_MON_PIX=7d`
- `REFRESH_TOKEN_LIFESPAN_PIX_ORGA=7d`
- `REFRESH_TOKEN_LIFESPAN_PIX_CERTIF=7d`
- `REFRESH_TOKEN_LIFESPAN_PIX_ADMIN=7d`

> [!NOTE]\
> Le `refresh-token-service` sera retravaillé (refactoring) dans un ticket suivant pour extraire les parties "repository" / "modèle" qui sont actuellement mélangées dans le service.

## :100: Pour tester

1. Mettre les variables d'environnement:
```
REFRESH_TOKEN_LIFESPAN_MON_PIX=30s
REFRESH_TOKEN_LIFESPAN_PIX_ORGA=30s
REFRESH_TOKEN_LIFESPAN_PIX_CERTIF=30s
REFRESH_TOKEN_LIFESPAN_PIX_ADMIN=30s
```
2. Se connecter sur chacune de ces applications
3. Le plus efficace pour vérifier le TTL du refresh token est vérifier directement dans Redis (en utilisant `redis-cli`

- Se connecter via `redis-cli` ([installer si besoin](https://redis.io/docs/latest/operate/oss_and_stack/install/install-redis/))
```sh
redis-cli
```
- Voir les TTL des 2 valeurs stockées dans Redis à partir de la clé, et vérifier que le ttl diminue avec le temps :
```shell
TTL temporary-storage:refresh-tokens:100014:pix-orga:f74c68ac-6025-42ef-bf88-db66016418f6
29

TTL temporary-storage:user-refresh-tokens:100014
3599
```

> [!NOTE]
> La clé est de la forme `temporary-storage:refresh-tokens:<refresh-token-complet>`, le refresh token peut être récupérer dans le local storage.
