### PR TITLE
[TECH] Permettre l'ajout d'une configuration avec peu de retry sur les job (PIX-14169)

### DIFF
--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-organization-learners-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-organization-learners-job-repository.js
@@ -10,7 +10,7 @@ class ImportOrganizationLearnersJobRepository extends JobRepository {
     super({
       name: ImportOrganizationLearnersJob.name,
       expireIn: JobExpireIn.HIGH,
-      retry: JobRetry.STANDARD_RETRY,
+      retry: JobRetry.FEW_RETRY,
     });
   }
 }

--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/validate-organization-learners-import-file-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/validate-organization-learners-import-file-job-repository.js
@@ -10,7 +10,7 @@ class ValidateOrganizationImportFileJobRepository extends JobRepository {
     super({
       name: ValidateOrganizationImportFileJob.name,
       expireIn: JobExpireIn.HIGH,
-      retry: JobRetry.STANDARD_RETRY,
+      retry: JobRetry.FEW_RETRY,
     });
   }
 }

--- a/api/src/shared/infrastructure/repositories/jobs/job-repository.js
+++ b/api/src/shared/infrastructure/repositories/jobs/job-repository.js
@@ -100,6 +100,11 @@ export const JobRetry = Object.freeze({
     retryDelay: 0,
     retryBackoff: false,
   },
+  FEW_RETRY: {
+    retryLimit: 2,
+    retryDelay: 30,
+    retryBackoff: true,
+  },
   STANDARD_RETRY: {
     retryLimit: 10,
     retryDelay: 30,

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-organization-learners-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-organization-learners-job-repository_test.js
@@ -17,9 +17,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | impo
       // then
       await expect(ImportOrganizationLearnersJob.name).to.have.have.been.performed.withJob({
         expirein: JobExpireIn.HIGH,
-        retrylimit: JobRetry.STANDARD_RETRY.retryLimit,
-        retrydelay: JobRetry.STANDARD_RETRY.retryDelay,
-        retrybackoff: JobRetry.STANDARD_RETRY.retryBackoff,
+        retrylimit: JobRetry.FEW_RETRY.retryLimit,
+        retrydelay: JobRetry.FEW_RETRY.retryDelay,
+        retrybackoff: JobRetry.FEW_RETRY.retryBackoff,
         data: { organizationImportId: 4123132 },
       });
     });

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-organization-learners-import-file-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-organization-learners-import-file-job-repository_test.js
@@ -17,9 +17,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | vali
       // then
       await expect(ValidateOrganizationImportFileJob.name).to.have.been.performed.withJob({
         expirein: JobExpireIn.HIGH,
-        retrylimit: JobRetry.STANDARD_RETRY.retryLimit,
-        retrydelay: JobRetry.STANDARD_RETRY.retryDelay,
-        retrybackoff: JobRetry.STANDARD_RETRY.retryBackoff,
+        retrylimit: JobRetry.FEW_RETRY.retryLimit,
+        retrydelay: JobRetry.FEW_RETRY.retryDelay,
+        retrybackoff: JobRetry.FEW_RETRY.retryBackoff,
         data: { organizationImportId: 4123132 },
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Certains job on des retry a 10, qui peuvent exploser indépendament du code  ( appel tiers ou autres )

## :robot: Proposition
Ajouter une config avec peu de tentatives dans le cas où l'on fait appel à des services tiers

## :rainbow: Remarques
Plutôt que 3 j'ai mis 2 retry, pas besoin d'avoir un retry qui s'execute 1h après ( le retrybackoff étant exponentiel )

## :100: Pour tester
Ci au vert
