### PR TITLE
[BUGFIX] Régression sur la pagination des sessions côté Pix Certif (PIX-13334)

### DIFF
--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -234,6 +234,12 @@ const register = async function (server) {
           params: Joi.object({
             id: identifiersType.certificationCenterId,
           }),
+          query: Joi.object({
+            page: Joi.object({
+              number: Joi.number().integer().empty('').allow(null).optional(),
+              size: Joi.number().integer().empty('').allow(null).optional(),
+            }).default({}),
+          }),
         },
         handler: certificationCenterController.findPaginatedSessionSummaries,
         tags: ['api', 'certification-center'],


### PR DESCRIPTION
## :unicorn: Problème
La pagination sur la liste des sessions ne fonctionne plus : cliquer sur la flèche suivante renvoie à la mauvaise page.

Le problème vient des queryParams, typées en string.
Pour passer à la page suivante, on fait un `currentPage+1`. Si c'est un integer, c'est bon : 1+1 renvoie 2. Si c'est une string, c'est pas bon : '1'+1 renvoie 11...

## :robot: Proposition
La plupart des autres routes sur l'API ont une vérification Joi, et Joi va automatiquement convertir les strings en number si on lui indique que le paramètre est un number.
On va ajouter cette vérification sur la route des sessions.

## :100: Pour tester
- Connexion à certif-pro
- Ajouter plein de sessions
- Vérifier que la pagination est OK

[Un fichier csv avec 25 sessions](https://github.com/user-attachments/files/16905555/import-sessions.OK.csv)