### PR TITLE
[BUGFIX] La liste déroulante pour choisir la méthode facturation entre deux inscriptions de candidats n'est pas réinitialisée sur PixCertif (PIX-14178)

### DIFF
--- a/certif/app/components/new-candidate-modal/index.gjs
+++ b/certif/app/components/new-candidate-modal/index.gjs
@@ -111,8 +111,7 @@ export default class NewCandidateModal extends Component {
 
   closeModal = () => {
     this.args.closeModal();
-    document.getElementById('new-candidate-form').reset();
-    this.selectedBillingMode = undefined;
+    this._resetForm();
   };
 
   selectBirthGeoCodeOption = (option) => {
@@ -219,6 +218,7 @@ export default class NewCandidateModal extends Component {
     document.getElementById('new-candidate-form').reset();
     this.selectedCountryInseeCode = FRANCE_INSEE_CODE;
     this.selectedBirthGeoCodeOption = INSEE_CODE_OPTION;
+    this.selectedBillingMode = undefined;
   }
 
   <template>


### PR DESCRIPTION
## :unicorn: Problème
Bug :
- Aller sur PixCertif, centre de certification non SCO/managing students
- Ajouter un candidat à une session via la modale
- Essayer d'ajouter un autre candidat via la modale et NE PAS toucher la dropdown de facturation
On constate :
1. Que la dropdown est restée à la valeur du candidat d'avant
2. Que quand on interagit pas avec la modale la sauvegarde n'est pas possible

https://github.com/user-attachments/assets/756d5c8b-c9fa-43ee-b4e0-2df9147fa7e1

## :robot: Proposition
3 événements provoquent le reset du formulaire et des variables de formulaire du composant :
- on clique à côté de la modale (fermeture)
- on clique sur "Annuler"
- on valide l'enregistrement d'un candidat
A ce jour, la manière de réinitialiser le formulaire dans le code n'était pas harmonisée pour ces trois cas.
Désormais les 3 appellent la méthode privée _resetForm() laquelle procède au reset du form et à la réinitialisation des variables du formulaire (code insee géographie et billing mode)

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->



## :100: Pour tester
Essayer de reproduire le bug sans succès !
https://github.com/user-attachments/assets/ec0ae07d-625f-43af-ba50-461d559216b2
