### PR TITLE
[FEATURE] Permettre de modifier une configuration d'import sans migration (PIX-14151)

### DIFF
--- a/$
+++ b/$
@@ -1,0 +1,38 @@
+pick 6c9c4a1aef feat(api): add repository to update several learner import format
+f eb09d5c8c7 repo
+pick 05556165cb feat(api): add model to validate organization learner import format
+pick edf3ee8205 feat(api): add usecase to update import format from data
+f a3239aa8e8 chore?(api): add jsdoc on usecase
+f 63f043c8e3 usecase
+pick 9e16f75277 feat(api): use usecase on script
+
+# Rebase 97a949cca8..eb09d5c8c7 onto 97a949cca8 (7 commands)
+#
+# Commands:
+# p, pick <commit> = use commit
+# r, reword <commit> = use commit, but edit the commit message
+# e, edit <commit> = use commit, but stop for amending
+# s, squash <commit> = use commit, but meld into previous commit
+# f, fixup [-C | -c] <commit> = like "squash" but keep only the previous
+#                    commit's log message, unless -C is used, in which case
+#                    keep only this commit's message; -c is same as -C but
+#                    opens the editor
+# x, exec <command> = run command (the rest of the line) using shell
+# b, break = stop here (continue rebase later with 'git rebase --continue')
+# d, drop <commit> = remove commit
+# l, label <label> = label current HEAD with a name
+# t, reset <label> = reset HEAD to a label
+# m, merge [-C <commit> | -c <commit>] <label> [# <oneline>]
+#         create a merge commit using the original merge commit's
+#         message (or the oneline, if no original merge commit was
+#         specified); use -c <commit> to reword the commit message
+# u, update-ref <ref> = track a placeholder for the <ref> to be updated
+#                       to this position in the new commits. The <ref> is
+#                       updated at the end of the rebase
+#
+# These lines can be re-ordered; they are executed from top to bottom.
+#
+# If you remove a line here THAT COMMIT WILL BE LOST.
+#
+# However, if you remove everything, the rebase will be aborted.
+#

--- a/api/scripts/organization-import-format/update-organization-import-format.js
+++ b/api/scripts/organization-import-format/update-organization-import-format.js
@@ -1,0 +1,52 @@
+import { readFile } from 'node:fs/promises';
+import * as url from 'node:url';
+
+import { disconnect } from '../../db/knex-database-connection.js';
+import { usecases } from '../../src/prescription/learner-management/domain/usecases/index.js';
+import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
+
+// Usage: node scripts/organization-import-format/update-organization-import-format.js path/data.json
+// data.json
+// [{
+//   "name": 'FORMAT_NAME',
+//   "config": {
+//      "new_config": "awesome",
+//    },
+//   "fileType": "csv",
+// }]
+
+const modulePath = url.fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === modulePath;
+
+async function main() {
+  console.log('Starting update import format configuration');
+
+  const filePath = process.argv[2];
+
+  console.log('Reading json data file... ');
+  const jsonFile = await readFile(filePath);
+  const rawImportFormats = JSON.parse(jsonFile);
+  console.log(`Import Format to update : ${rawImportFormats.length}`);
+
+  try {
+    await DomainTransaction.execute(async () => {
+      await usecases.updateOrganizationLearnerImportFormats({ rawImportFormats });
+    });
+    console.log('ok');
+  } catch (error) {
+    console.log(error);
+  }
+}
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      console.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+    }
+  }
+})();

--- a/api/src/prescription/learner-management/domain/models/OrganizationLearnerImportFormat.js
+++ b/api/src/prescription/learner-management/domain/models/OrganizationLearnerImportFormat.js
@@ -1,8 +1,33 @@
+import Joi from 'joi';
+
+import { EntityValidationError } from '../../../../shared/domain/errors.js';
+
+const organizationLearnerImportFormatSchame = Joi.object({
+  name: Joi.string().required(),
+  config: Joi.object().required(),
+  fileType: Joi.string().valid('csv', 'xml'),
+});
 class OrganizationLearnerImportFormat {
+  /**
+   * @param data
+   * @param {string} data.name
+   * @param {string} data.fileType
+   * @param {Object} data.config
+   */
   constructor({ name, fileType, config } = {}) {
     this.name = name;
     this.fileType = fileType;
     this.config = config;
+
+    this.#validate();
+  }
+
+  #validate() {
+    const { error } = organizationLearnerImportFormatSchame.validate(this, { abortEarly: false });
+
+    if (error) {
+      throw EntityValidationError.fromJoiErrors(error.details);
+    }
   }
 
   #sortObject = (columnA, columnB) => columnA.position - columnB.position;

--- a/api/src/prescription/learner-management/domain/usecases/index.js
+++ b/api/src/prescription/learner-management/domain/usecases/index.js
@@ -1,7 +1,6 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { eventBus } from '../../../../../lib/domain/events/index.js';
 import * as userReconciliationService from '../../../../../lib/domain/services/user-reconciliation-service.js';
 import * as campaignRepository from '../../../../../lib/infrastructure/repositories/campaign-repository.js';
 import * as membershipRepository from '../../../../../lib/infrastructure/repositories/membership-repository.js';
@@ -20,6 +19,21 @@ import * as organizationLearnerRepository from '../../infrastructure/repositorie
 import * as supOrganizationLearnerRepository from '../../infrastructure/repositories/sup-organization-learner-repository.js';
 import { importStorage } from '../../infrastructure/storage/import-storage.js';
 
+/**
+ * @typedef {import ('../../../../../lib/infrastructure/repositories/campaign-repository.js')} CampaignRepository
+ * @typedef {import ('../../infrastructure/repositories/organization-feature-repository.js')} CampaignParticipationRepository
+ * @typedef {import ('../../infrastructure/storage/import-storage.js')} ImportStorage
+ * @typedef {import ('../../../../../lib/infrastructure/repositories/membership-repository.js')} MembershipRepository
+ * @typedef {import ('../../infrastructure/repositories/organization-learner-repository.js')} OrganizationLearnerRepository
+ * @typedef {import ('../../infrastructure/repositories/organization-learner-import-format-repository.js')} OrganizationLearnerImportFormatRepository
+ * @typedef {import ('../../../../shared/infrastructure/repositories/organization-repository.js')} OrganizationRepository
+ * @typedef {import ('../../infrastructure/repositories/organization-import-repository.js')} OrganizationImportRepository
+ * @typedef {import ('../../infrastructure/repositories/sup-organization-learner-repository.js')} SupOrganizationLearnerRepository
+ * @typedef {import ('../../../../organizational-entities/application/api/organization-features-api.js')} OrganizationFeatureApi
+ * @typedef {import ('../../../../../src/shared/infrastructure/utils/logger.js')} logger
+ * @typedef {import ('../../../../../lib/domain/services/user-reconciliation-service.js')} UserReconciliationService
+ * @typedef {import ('../../infrastructure/repositories/organization-feature-repository.js')} OrganizationFeatureRepository
+ */
 const dependencies = {
   campaignRepository,
   campaignParticipationRepository,
@@ -33,7 +47,6 @@ const dependencies = {
   organizationImportRepository,
   supOrganizationLearnerRepository,
   organizationFeatureApi,
-  eventBus,
   logger,
   userReconciliationService,
   organizationFeatureRepository: repositories.organizationFeatureRepository,
@@ -52,6 +65,33 @@ const usecasesWithoutInjectedDependencies = {
   })),
 };
 
+/**
+ * @typedef PrescriptionLearnerManagementUsecases
+ * @property {saveOrganizationLearnersFile} saveOrganizationLearnersFile
+ * @property {sendOrganizationLearnersFile} sendOrganizationLearnersFile
+ * @property {validateOrganizationLearnersFile} validateOrganizationLearnersFile
+ * @property {addOrUpdateOrganizationLearners} addOrUpdateOrganizationLearners
+ * @property {deleteOrganizationLearners} deleteOrganizationLearners
+ * @property {dissociateUserFromOrganizationLearner} dissociateUserFromOrganizationLearner
+ * @property {getOrganizationImportStatus} getOrganizationImportStatus
+ * @property {getOrganizationLearnersCsvTemplate} getOrganizationLearnersCsvTemplate
+ * @property {handlePayloadTooLargeError} handlePayloadTooLargeError
+ * @property {importOrganizationLearnersFromSIECLECSVFormat} importOrganizationLearnersFromSIECLECSVFormat
+ * @property {importSupOrganizationLearners} importSupOrganizationLearners
+ * @property {reconcileCommonOrganizationLearner} reconcileCommonOrganizationLearner
+ * @property {reconcileScoOrganizationLearnerAutomatically} reconcileScoOrganizationLearnerAutomatically
+ * @property {replaceSupOrganizationLearners} replaceSupOrganizationLearners
+ * @property {updateOrganizationLearnerImportFormats} updateOrganizationLearnerImportFormats
+ * @property {updateStudentNumber} updateStudentNumber
+ * @property {uploadCsvFile} uploadCsvFile
+ * @property {uploadSiecleFile} uploadSiecleFile
+ * @property {validateCsvFile} validateCsvFile
+ * @property {validateSiecleXmlFile} validateSiecleXmlFile
+ */
+
+/**
+ * @type {PrescriptionLearnerManagementUsecases}
+ */
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
 
 export { usecases };

--- a/api/src/prescription/learner-management/domain/usecases/update-organization-learner-import-formats.js
+++ b/api/src/prescription/learner-management/domain/usecases/update-organization-learner-import-formats.js
@@ -1,0 +1,31 @@
+import { EntityValidationError } from '../../../../shared/domain/errors.js';
+import { OrganizationLearnerImportFormat } from '../models/OrganizationLearnerImportFormat.js';
+
+/**
+ * @param {Object} params
+ * @param {Object} params.importFormats
+ * @param {OrganizationImportFormat} params.organizationLearnerImportFormatRepository
+ * @returns {Promise<void>}
+ */
+const updateOrganizationLearnerImportFormats = async function ({
+  rawImportFormats,
+  organizationLearnerImportFormatRepository,
+}) {
+  const errors = [];
+  const organizationLearnerImportFormats = rawImportFormats.flatMap((rawImportFormat) => {
+    try {
+      return new OrganizationLearnerImportFormat(rawImportFormat);
+    } catch (error) {
+      errors.push(error);
+      return null;
+    }
+  });
+
+  if (errors.length > 0) {
+    throw EntityValidationError.fromMultipleEntityValidationErrors(errors);
+  }
+
+  return organizationLearnerImportFormatRepository.updateAllByName({ organizationLearnerImportFormats });
+};
+
+export { updateOrganizationLearnerImportFormats };

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-import-format-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-import-format-repository.js
@@ -1,4 +1,5 @@
 import { ORGANIZATION_FEATURE } from '../../../../shared/domain/constants.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { ApplicationTransaction } from '../../../shared/infrastructure/ApplicationTransaction.js';
 import { OrganizationLearnerImportFormat } from '../../domain/models/OrganizationLearnerImportFormat.js';
 
@@ -31,4 +32,21 @@ const get = async function (organizationId) {
   return _toDomain(result);
 };
 
-export { get };
+/**
+ * @type {function}
+ * @param {Object} params
+ * @param {Array|Object} params.organizationImports
+ * @return {Promise<void>}
+ */
+const updateAllByName = async function ({ organizationLearnerImportFormats }) {
+  const knexConn = DomainTransaction.getConnection();
+  const updatedAt = new Date();
+
+  for (const organizationLearnerImport of organizationLearnerImportFormats) {
+    await knexConn('organization-learner-import-formats')
+      .where({ name: organizationLearnerImport.name })
+      .update({ fileType: organizationLearnerImport.fileType, config: organizationLearnerImport.config, updatedAt });
+  }
+};
+
+export { get, updateAllByName };

--- a/api/tests/prescription/learner-management/integration/domain/usecases/update-organization-import-learner-import-format_test.js
+++ b/api/tests/prescription/learner-management/integration/domain/usecases/update-organization-import-learner-import-format_test.js
@@ -1,0 +1,65 @@
+import { usecases } from '../../../../../../src/prescription/learner-management/domain/usecases/index.js';
+import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErr, databaseBuilder, expect, knex } from '../../../../../test-helper.js';
+
+describe('Integration | Organizational Entities | Domain | UseCase | update-organization-learner-import-formats', function () {
+  beforeEach(function () {
+    databaseBuilder.factory.buildOrganizationLearnerImportFormat({
+      name: 'FIRST_FORMAT',
+      fileType: 'xml',
+      config: { basic_config: 'first_format' },
+    });
+
+    databaseBuilder.factory.buildOrganizationLearnerImportFormat({
+      name: 'SECOND_FORMAT',
+      fileType: 'csv',
+      config: { basic_config: 'second_format' },
+    });
+
+    return databaseBuilder.commit();
+  });
+
+  describe('success case', function () {
+    it('update organization learner import format given parameter', async function () {
+      // given && when
+      await usecases.updateOrganizationLearnerImportFormats({
+        rawImportFormats: [{ name: 'FIRST_FORMAT', fileType: 'csv', config: { new_config: 'awesome' } }],
+      });
+
+      // then
+      const importFormat = await knex('organization-learner-import-formats').where({ name: 'FIRST_FORMAT' }).first();
+
+      expect(importFormat.fileType).to.be.equal('csv');
+      expect(importFormat.config).to.be.deep.equal({ new_config: 'awesome' });
+    });
+  });
+
+  describe('error case', function () {
+    it('should not update organization learner import format when error occured', async function () {
+      // given && when
+      const error = await catchErr(usecases.updateOrganizationLearnerImportFormats)({
+        rawImportFormats: [
+          { name: 'FIRST_FORMAT', fileType: 'csv', config: 'toto' },
+          { name: 'SECOND_FORMAT', fileType: 'unsupportedFileType', config: { new_config: 'not_bad' } },
+        ],
+      });
+
+      // then
+      const firstImportFormat = await knex('organization-learner-import-formats')
+        .where({ name: 'FIRST_FORMAT' })
+        .first();
+
+      expect(firstImportFormat.fileType).to.be.equal('xml');
+      expect(firstImportFormat.config).to.be.deep.equal({ basic_config: 'first_format' });
+
+      const secondImportFormat = await knex('organization-learner-import-formats')
+        .where({ name: 'SECOND_FORMAT' })
+        .first();
+
+      expect(secondImportFormat.fileType).to.be.equal('csv');
+      expect(secondImportFormat.config).to.be.deep.equal({ basic_config: 'second_format' });
+
+      expect(error).to.be.instanceOf(EntityValidationError);
+    });
+  });
+});

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-import-format-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-import-format-repository_test.js
@@ -1,7 +1,7 @@
 import { OrganizationLearnerImportFormat } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationLearnerImportFormat.js';
 import * as organizationLearnerImportFormatRepository from '../../../../../../src/prescription/learner-management/infrastructure/repositories/organization-learner-import-format-repository.js';
 import { ORGANIZATION_FEATURE } from '../../../../../../src/shared/domain/constants.js';
-import { databaseBuilder, expect } from '../../../../../test-helper.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../../../test-helper.js';
 
 describe('Integration | Repository | Organization Learner Management | Organization Learner Import Format', function () {
   describe('#get', function () {
@@ -55,6 +55,112 @@ describe('Integration | Repository | Organization Learner Management | Organizat
       const result = await organizationLearnerImportFormatRepository.get(1);
 
       expect(result).to.equal(null);
+    });
+  });
+
+  describe('#updateAllByName', function () {
+    let clock;
+    const now = new Date('2022-02-02');
+    const updatedAt = new Date('2020-01-01');
+
+    afterEach(function () {
+      clock.restore();
+    });
+
+    beforeEach(async function () {
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+
+      // First format
+      databaseBuilder.factory.buildOrganizationLearnerImportFormat({
+        name: 'FIRST_FORMAT',
+        fileType: 'xml',
+        config: { basic_config: 'first_format' },
+        updatedAt,
+      });
+
+      // Second format
+      databaseBuilder.factory.buildOrganizationLearnerImportFormat({
+        name: 'SECOND_FORMAT',
+        fileType: 'xml',
+        config: { basic_config: 'second_format' },
+        updatedAt,
+      });
+
+      databaseBuilder.factory.buildOrganizationLearnerImportFormat({
+        name: 'THIRD_FORMAT',
+        fileType: 'xml',
+        config: { basic_config: 'third_format' },
+        updatedAt,
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    it('update several learner import format given', async function () {
+      // given
+      const organizationLearnerImportFormats = [
+        { name: 'FIRST_FORMAT', fileType: 'csv', config: { new_config: 'awesome' } },
+        { name: 'SECOND_FORMAT', fileType: 'csv', config: { new_config: 'not_bad' } },
+      ];
+      // when
+      await organizationLearnerImportFormatRepository.updateAllByName({ organizationLearnerImportFormats });
+
+      // then
+      const fistLearnerImportFormat = await knex('organization-learner-import-formats')
+        .where({
+          name: 'FIRST_FORMAT',
+        })
+        .first();
+
+      expect(fistLearnerImportFormat.config).to.deep.equal({ new_config: 'awesome' });
+      expect(fistLearnerImportFormat.fileType).to.equal('csv');
+
+      const secondLearnerImportFormat = await knex('organization-learner-import-formats')
+        .where({
+          name: 'SECOND_FORMAT',
+        })
+        .first();
+
+      expect(secondLearnerImportFormat.config).to.deep.equal({ new_config: 'not_bad' });
+      expect(secondLearnerImportFormat.fileType).to.equal('csv');
+    });
+
+    it('set updatedAt field to today', async function () {
+      // given
+      const organizationLearnerImportFormats = [
+        { name: 'FIRST_FORMAT', fileType: 'csv', config: { new_config: 'awesome' } },
+      ];
+      // when
+      await organizationLearnerImportFormatRepository.updateAllByName({ organizationLearnerImportFormats });
+
+      // then
+      const fistLearnerImportFormat = await knex('organization-learner-import-formats')
+        .where({
+          name: 'FIRST_FORMAT',
+        })
+        .first();
+
+      expect(fistLearnerImportFormat.updatedAt).to.deep.equal(now);
+    });
+
+    it('should not update other import format', async function () {
+      // given
+      const organizationLearnerImportFormats = [
+        { name: 'FIRST_FORMAT', fileType: 'csv', config: { new_config: 'awesome' } },
+      ];
+      // when
+      await organizationLearnerImportFormatRepository.updateAllByName({ organizationLearnerImportFormats });
+
+      // then
+      const fistLearnerImportFormat = await knex('organization-learner-import-formats')
+        .where({
+          name: 'SECOND_FORMAT',
+        })
+        .first();
+
+      expect(fistLearnerImportFormat.fileType).to.be.equal('xml');
+      expect(fistLearnerImportFormat.config).to.deep.equal({ basic_config: 'second_format' });
+      expect(fistLearnerImportFormat.updatedAt).to.deep.equal(updatedAt);
     });
   });
 });

--- a/api/tests/prescription/learner-management/unit/domain/models/OrganizationLearnerImportFormat_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/models/OrganizationLearnerImportFormat_test.js
@@ -1,5 +1,6 @@
 import { IMPORT_KEY_FIELD } from '../../../../../../src/prescription/learner-management/domain/constants.js';
 import { OrganizationLearnerImportFormat } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationLearnerImportFormat.js';
+import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Models | OrganizationLearnerImportFormat', function () {
@@ -62,6 +63,80 @@ describe('Unit | Models | OrganizationLearnerImportFormat', function () {
       createdAt: new Date('2024-01-01'),
       createdBy: 666,
     };
+  });
+
+  describe('#constructor', function () {
+    it('should initialize valid object', function () {
+      //when
+      const organizationLearnerImportFormat = new OrganizationLearnerImportFormat({
+        name: 'SAY_MY_NAME',
+        config: { basic_config: 'toto' },
+        fileType: 'csv',
+      });
+      // then
+      expect(organizationLearnerImportFormat).to.deep.equal({
+        name: 'SAY_MY_NAME',
+        config: { basic_config: 'toto' },
+        fileType: 'csv',
+      });
+    });
+
+    context('Validation Cases', function () {
+      it('returns an EntityValidator when missing fileType', function () {
+        //when
+        try {
+          new OrganizationLearnerImportFormat({
+            name: 'SAY_MY_NAME',
+            config: { basic_config: 'toto' },
+            fileType: 'incalif_file_type',
+          });
+        } catch (error) {
+          // then
+          expect(error).to.be.instanceOf(EntityValidationError);
+          expect(error.invalidAttributes[0].attribute).to.be.equal('fileType');
+        }
+      });
+
+      it('returns an EntityValidator when missing name', function () {
+        //when
+        try {
+          new OrganizationLearnerImportFormat({
+            config: { basic_config: 'toto' },
+            fileType: 'csv',
+          });
+        } catch (error) {
+          // then
+          expect(error).to.be.instanceOf(EntityValidationError);
+          expect(error.invalidAttributes[0].attribute).to.be.equal('name');
+        }
+      });
+
+      it('returns an EntityValidator when missing config', function () {
+        //when
+        try {
+          new OrganizationLearnerImportFormat({
+            name: 'SAY_MY_NAME',
+            fileType: 'csv',
+          });
+        } catch (error) {
+          // then
+          expect(error).to.be.instanceOf(EntityValidationError);
+          expect(error.invalidAttributes[0].attribute).to.be.equal('config');
+        }
+      });
+
+      it('returns multiple EntityValidator when missing multiple config', function () {
+        //when
+        try {
+          new OrganizationLearnerImportFormat({
+            fileType: 'csv',
+          });
+        } catch (error) {
+          // then
+          expect(error.invalidAttributes).to.be.lengthOf(2);
+        }
+      });
+    });
   });
 
   describe('#extraColumns', function () {


### PR DESCRIPTION
## :unicorn: Problème
Les migrations n'ont pas vocation à insérer des spécificités métier, chose qui pour le moment, le temps de faire une interface était "acceptable".
Cela pose des soucis au niveau du code open source qui contient des configurations que d'autres utilisateur n'ont aucune nécessité. 
Ce qui "pollue" l'installation au final

## :robot: Proposition
Ajouter un script qui appel un usecase permettant de mettre à jour une liste de configue par rapport à un fichier JSON.

## :rainbow: Remarques
A posteriori, on pourrait nettoyer les migrations ( sans supprimer le fichier, supprimer le contenu qui n'a pas lieu de servir )

## :100: Pour tester
Lancer le script sur la RA et vérifier que l'import GENERIC a été mis à jour

Code a insérer dans un fichier `.json`

`scalingo -a pix-api-review-pr10075 --region osc-fr1 run --file ./data.json`

`node scripts/organization-import-format/update-organization-import-format.js /tmp/uploads/data.json`

`[{"name": "GENERIC","config": { "custom_config": "not_bad" }, "fileType": "xml"}]`