### PR TITLE
[TECH] Ajouter un feature toggle pour les nouvelles pages d'authentification (PIX-14001)

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -774,6 +774,11 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: false
 # FT_SHOW_EXPERIMENTAL_MISSIONS=false
 
+# Display the new design of authentication pages
+# type: boolean
+# default: false
+# FT_NEW_AUTHENTICATION_DESIGN_ENABLED=false
+
 # =====
 # CPF
 # =====

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -191,19 +191,19 @@ const configuration = (function () {
     },
     featureToggles: {
       areV3InfoScreensEnabled: toBoolean(process.env.FT_ENABLE_V3_INFO_SCREENS),
+      deprecatePoleEmploiPushNotification: toBoolean(process.env.DEPRECATE_PE_PUSH_NOTIFICATION),
       isAlwaysOkValidateNextChallengeEndpointEnabled: toBoolean(
         process.env.FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT,
       ),
-      isPix1dEnabled: toBoolean(process.env.FT_PIX_1D_ENABLED),
-      isPixPlusLowerLeverEnabled: toBoolean(process.env.FT_ENABLE_PIX_PLUS_LOWER_LEVEL),
       isCertificationTokenScopeEnabled: toBoolean(process.env.FT_ENABLE_CERTIF_TOKEN_SCOPE),
-      deprecatePoleEmploiPushNotification: toBoolean(process.env.DEPRECATE_PE_PUSH_NOTIFICATION),
-      isTextToSpeechButtonEnabled: toBoolean(process.env.FT_ENABLE_TEXT_TO_SPEECH_BUTTON),
       isNeedToAdjustCertificationAccessibilityEnabled: toBoolean(
         process.env.FT_ENABLE_NEED_TO_ADJUST_CERTIFICATION_ACCESSIBILITY,
       ),
-      showNewResultPage: toBoolean(process.env.FT_SHOW_NEW_RESULT_PAGE),
+      isPix1dEnabled: toBoolean(process.env.FT_PIX_1D_ENABLED),
+      isPixPlusLowerLeverEnabled: toBoolean(process.env.FT_ENABLE_PIX_PLUS_LOWER_LEVEL),
+      isTextToSpeechButtonEnabled: toBoolean(process.env.FT_ENABLE_TEXT_TO_SPEECH_BUTTON),
       showExperimentalMissions: toBoolean(process.env.FT_SHOW_EXPERIMENTAL_MISSIONS),
+      showNewResultPage: toBoolean(process.env.FT_SHOW_NEW_RESULT_PAGE),
     },
     hapi: {
       options: {},

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -199,6 +199,7 @@ const configuration = (function () {
       isNeedToAdjustCertificationAccessibilityEnabled: toBoolean(
         process.env.FT_ENABLE_NEED_TO_ADJUST_CERTIFICATION_ACCESSIBILITY,
       ),
+      isNewAuthenticationDesignEnabled: toBoolean(process.env.FT_NEW_AUTHENTICATION_DESIGN_ENABLED),
       isPix1dEnabled: toBoolean(process.env.FT_PIX_1D_ENABLED),
       isPixPlusLowerLeverEnabled: toBoolean(process.env.FT_ENABLE_PIX_PLUS_LOWER_LEVEL),
       isTextToSpeechButtonEnabled: toBoolean(process.env.FT_ENABLE_TEXT_TO_SPEECH_BUTTON),

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -1,6 +1,6 @@
 import { createServer, expect } from '../../../../test-helper.js';
 
-describe('Acceptance | Controller | feature-toggle-controller', function () {
+describe('Acceptance | Shared | Application | Controller | feature-toggle', function () {
   let server;
 
   beforeEach(async function () {
@@ -23,11 +23,12 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
             'are-v3-info-screens-enabled': false,
             'deprecate-pole-emploi-push-notification': false,
             'is-always-ok-validate-next-challenge-endpoint-enabled': false,
+            'is-certification-token-scope-enabled': false,
+            'is-new-authentication-design-enabled': false,
             'is-pix1d-enabled': true,
             'is-pix-plus-lower-lever-enabled': false,
-            'is-certification-token-scope-enabled': false,
-            'is-text-to-speech-button-enabled': false,
             'is-need-to-adjust-certification-accessibility-enabled': false,
+            'is-text-to-speech-button-enabled': false,
             'show-new-result-page': false,
             'show-experimental-missions': false,
           },

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -2,6 +2,7 @@ import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
   @attr areV3InfoScreensEnabled;
+  @attr('boolean') isNewAuthenticationDesignEnabled;
   @attr('boolean') isTextToSpeechButtonEnabled;
   @attr('boolean') showNewResultPage;
 }

--- a/mon-pix/tests/unit/services/feature-toggles-test.js
+++ b/mon-pix/tests/unit/services/feature-toggles-test.js
@@ -10,6 +10,7 @@ module('Unit | Service | feature-toggles', function (hooks) {
   module('feature toggles are loaded', function (hooks) {
     const featureToggles = Object.create({
       isTextToSpeechButtonEnabled: false,
+      isNewAuthenticationDesignEnabled: false,
     });
 
     let storeStub;
@@ -42,6 +43,18 @@ module('Unit | Service | feature-toggles', function (hooks) {
 
       // then
       assert.false(featureToggleService.featureToggles.isTextToSpeechButtonEnabled);
+    });
+
+    test('it initializes the feature toggle isNewAuthenticationDesignEnabled to true', async function (assert) {
+      // given
+      const featureToggleService = this.owner.lookup('service:featureToggles');
+      featureToggleService.set('store', storeStub);
+
+      // when
+      await featureToggleService.load();
+
+      // then
+      assert.false(featureToggleService.featureToggles.isNewAuthenticationDesignEnabled);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Nous n'avons pas de moyen pour intervertir facilement les anciennes et nouvelles pages d'authentification que nous allons créer.

## :robot: Proposition
Ajouter un feature toggle FT_NEW_AUTHENTICATION_DESIGN_ENABLED pour ça.

## :rainbow: Remarques
RAS

## :100: Pour tester
### En local
#### Test valeur par défaut 
- Lancer les applications mon-pix et api
- Ouvrir la console navigateur => onglet Network
- Aller sur http://localhost:4200
- Vérifier que la réponse de l'appel à /api/feature-toggles contient bien un nouvel attribut `is-new-authentication-design-enabled: false`
#### Test feature toggle à true
- Ajouter, dans votre `.env` la ligne `FT_NEW_AUTHENTICATION_DESIGN_ENABLED=true`
- Vérifier, dans la réponse de l'appel à  /api/feature-toggles, que la valeur du champ `is-new-authentication-design-enabled` est maintenant à true.
#### Tester l'intégration du feature toggle à Pix App
- Dans `mon-pix/app/controllers/authentication/login.js`, ajouter un getter `isNewAuthenticationDesignEnabled` : 
```js
@service featureToggles;

 get isNewAuthenticationDesignEnabled() {
    return this.featureToggles.featureToggles.isNewAuthenticationDesignEnabled;
 }
```
- Ajouter la div suivante dans mon-pix/app/templates/authentication/login.hbs
```html
<div style="color: red; background-color: white">
      Feature toggle value isNewAuthenticationDesignEnabled
      {{this.isNewAuthenticationDesignEnabled}}
</div>
```
- Aller sur http://localhost:4200
- Vérifier qu'on affiche bien le feature toggle avec une valeur à true 😄 

### Test en RA
- Sur la RA de l'application [api](https://dashboard.scalingo.com/apps/osc-fr1/pix-api-review-pr10076/environment) de Scalingo, changer la valeur de la variable d'environnement `FT_NEW_AUTHENTICATION_DESIGN_ENABLED` à true
- Redémarrer l'application
- Ouvrir l'onglet Network de la console navigateur
- Aller sur la RA de mon-pix https://app-pr10076.review.pix.fr/
- Vérifier, dans la réponse de l'appel à  /api/feature-toggles, que la valeur du champ `is-new-authentication-design-enabled` est à true.