### PR TITLE
[TECH] Migrer la route POST /api/certification-center-invitations/{id}/accept vers src/team (PIX-14138)

### DIFF
--- a/api/lib/application/certification-center-invitations/certification-center-invitation-controller.js
+++ b/api/lib/application/certification-center-invitations/certification-center-invitation-controller.js
@@ -2,21 +2,6 @@ import { requestResponseUtils } from '../../../src/shared/infrastructure/utils/r
 import { certificationCenterInvitationSerializer } from '../../../src/team/infrastructure/serializers/jsonapi/certification-center-invitation-serializer.js';
 import { usecases } from '../../domain/usecases/index.js';
 
-const acceptCertificationCenterInvitation = async function (request, h) {
-  const certificationCenterInvitationId = request.params.id;
-  const { code, email: rawEmail } = request.deserializedPayload;
-  const localeFromCookie = request.state?.locale;
-  const email = rawEmail.trim().toLowerCase();
-
-  await usecases.acceptCertificationCenterInvitation({
-    certificationCenterInvitationId,
-    code,
-    email,
-    localeFromCookie,
-  });
-  return h.response({}).code(204);
-};
-
 const getCertificationCenterInvitation = async function (request) {
   const certificationCenterInvitationId = request.params.id;
   const certificationCenterInvitationCode = request.query.code;
@@ -41,7 +26,6 @@ const resendCertificationCenterInvitation = async function (request, h) {
 };
 
 const certificationCenterInvitationController = {
-  acceptCertificationCenterInvitation,
   getCertificationCenterInvitation,
   resendCertificationCenterInvitation,
 };

--- a/api/lib/application/certification-center-invitations/index.js
+++ b/api/lib/application/certification-center-invitations/index.js
@@ -7,30 +7,6 @@ import { certificationCenterInvitationController } from './certification-center-
 const register = async function (server) {
   server.route([
     {
-      method: 'POST',
-      path: '/api/certification-center-invitations/{id}/accept',
-      config: {
-        auth: false,
-        handler: certificationCenterInvitationController.acceptCertificationCenterInvitation,
-        validate: {
-          params: Joi.object({
-            id: identifiersType.certificationCenterInvitationId,
-          }),
-          payload: Joi.object({
-            data: {
-              id: Joi.string().required(),
-              type: Joi.string().required(),
-              attributes: {
-                code: Joi.string().required(),
-                email: Joi.string().email().required(),
-              },
-            },
-          }),
-        },
-        tags: ['api'],
-      },
-    },
-    {
       method: 'GET',
       path: '/api/certification-center-invitations/{id}',
       config: {

--- a/api/lib/application/certification-center-memberships/certification-center-membership-controller.js
+++ b/api/lib/application/certification-center-memberships/certification-center-membership-controller.js
@@ -1,7 +1,7 @@
 import { BadRequestError, ForbiddenError } from '../../../src/shared/application/http-errors.js';
 import * as requestResponseUtils from '../../../src/shared/infrastructure/utils/request-response-utils.js';
+import { certificationCenterMembershipRepository } from '../../../src/team/infrastructure/repositories/certification-center-membership.repository.js';
 import { usecases } from '../../domain/usecases/index.js';
-import { getCertificationCenterId } from '../../infrastructure/repositories/certification-center-membership-repository.js';
 import * as certificationCenterMembershipSerializer from '../../infrastructure/serializers/jsonapi/certification-center-membership-serializer.js';
 
 const disableFromPixAdmin = async function (request, h, dependencies = { requestResponseUtils }) {
@@ -64,8 +64,10 @@ const updateFromPixCertif = async function (
   );
   const currentUserId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
 
-  const foundCertificationCenterId = await getCertificationCenterId(certificationCenterMembershipId);
-  if (foundCertificationCenterId != certificationCenterId) {
+  const foundCertificationCenterId = await certificationCenterMembershipRepository.getCertificationCenterId(
+    certificationCenterMembershipId,
+  );
+  if (foundCertificationCenterId !== certificationCenterId) {
     throw new ForbiddenError('Wrong certification center');
   }
 

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -105,6 +105,7 @@ import * as certificationCenterInvitationService from '../../../src/team/domain/
 import { organizationInvitationService } from '../../../src/team/domain/services/organization-invitation.service.js';
 import * as certificationCenterInvitationRepository from '../../../src/team/infrastructure/repositories/certification-center-invitation-repository.js';
 import { certificationCenterInvitedUserRepository } from '../../../src/team/infrastructure/repositories/certification-center-invited-user.repository.js';
+import { certificationCenterMembershipRepository } from '../../../src/team/infrastructure/repositories/certification-center-membership.repository.js';
 import { organizationInvitationRepository } from '../../../src/team/infrastructure/repositories/organization-invitation.repository.js';
 import { userOrgaSettingsRepository } from '../../../src/team/infrastructure/repositories/user-orga-settings-repository.js';
 import * as certificationChallengesService from '../../domain/services/certification-challenges-service.js';
@@ -123,7 +124,6 @@ import { campaignParticipationResultRepository } from '../../infrastructure/repo
 import * as campaignRepository from '../../infrastructure/repositories/campaign-repository.js';
 import * as certifiableProfileForLearningContentRepository from '../../infrastructure/repositories/certifiable-profile-for-learning-content-repository.js';
 import * as certificationCenterForAdminRepository from '../../infrastructure/repositories/certification-center-for-admin-repository.js';
-import * as certificationCenterMembershipRepository from '../../infrastructure/repositories/certification-center-membership-repository.js';
 import * as certificationPointOfContactRepository from '../../infrastructure/repositories/certification-point-of-contact-repository.js';
 import * as certificationRepository from '../../infrastructure/repositories/certification-repository.js';
 import * as complementaryCertificationCourseResultRepository from '../../infrastructure/repositories/complementary-certification-course-result-repository.js';

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -104,6 +104,7 @@ import { importNamedExportsFromDirectory } from '../../../src/shared/infrastruct
 import * as certificationCenterInvitationService from '../../../src/team/domain/services/certification-center-invitation-service.js';
 import { organizationInvitationService } from '../../../src/team/domain/services/organization-invitation.service.js';
 import * as certificationCenterInvitationRepository from '../../../src/team/infrastructure/repositories/certification-center-invitation-repository.js';
+import { certificationCenterInvitedUserRepository } from '../../../src/team/infrastructure/repositories/certification-center-invited-user.repository.js';
 import { organizationInvitationRepository } from '../../../src/team/infrastructure/repositories/organization-invitation.repository.js';
 import { userOrgaSettingsRepository } from '../../../src/team/infrastructure/repositories/user-orga-settings-repository.js';
 import * as certificationChallengesService from '../../domain/services/certification-challenges-service.js';
@@ -122,7 +123,6 @@ import { campaignParticipationResultRepository } from '../../infrastructure/repo
 import * as campaignRepository from '../../infrastructure/repositories/campaign-repository.js';
 import * as certifiableProfileForLearningContentRepository from '../../infrastructure/repositories/certifiable-profile-for-learning-content-repository.js';
 import * as certificationCenterForAdminRepository from '../../infrastructure/repositories/certification-center-for-admin-repository.js';
-import * as certificationCenterInvitedUserRepository from '../../infrastructure/repositories/certification-center-invited-user-repository.js';
 import * as certificationCenterMembershipRepository from '../../infrastructure/repositories/certification-center-membership-repository.js';
 import * as certificationPointOfContactRepository from '../../infrastructure/repositories/certification-point-of-contact-repository.js';
 import * as certificationRepository from '../../infrastructure/repositories/certification-repository.js';

--- a/api/src/shared/application/usecases/check-user-is-admin-of-certification-center-with-certification-center-invitation-id.js
+++ b/api/src/shared/application/usecases/check-user-is-admin-of-certification-center-with-certification-center-invitation-id.js
@@ -1,5 +1,5 @@
-import * as certificationCenterMembershipRepository from '../../../../lib/infrastructure/repositories/certification-center-membership-repository.js';
 import * as certificationCenterInvitationRepository from '../../../team/infrastructure/repositories/certification-center-invitation-repository.js';
+import { certificationCenterMembershipRepository } from '../../../team/infrastructure/repositories/certification-center-membership.repository.js';
 
 async function execute({
   certificationCenterInvitationId,

--- a/api/src/shared/application/usecases/check-user-is-admin-of-certification-center-with-certification-center-membership-id.js
+++ b/api/src/shared/application/usecases/check-user-is-admin-of-certification-center-with-certification-center-membership-id.js
@@ -1,4 +1,4 @@
-import * as certificationCenterMembershipRepository from '../../../../lib/infrastructure/repositories/certification-center-membership-repository.js';
+import { certificationCenterMembershipRepository } from '../../../team/infrastructure/repositories/certification-center-membership.repository.js';
 
 async function execute({
   certificationCenterMembershipId,

--- a/api/src/shared/application/usecases/checkUserIsAdminOfCertificationCenter.js
+++ b/api/src/shared/application/usecases/checkUserIsAdminOfCertificationCenter.js
@@ -1,4 +1,4 @@
-import * as certificationCenterMembershipRepository from '../../../../lib/infrastructure/repositories/certification-center-membership-repository.js';
+import { certificationCenterMembershipRepository } from '../../../team/infrastructure/repositories/certification-center-membership.repository.js';
 
 const execute = async function (
   userId,

--- a/api/src/shared/application/usecases/checkUserIsMemberOfCertificationCenter.js
+++ b/api/src/shared/application/usecases/checkUserIsMemberOfCertificationCenter.js
@@ -1,4 +1,4 @@
-import * as certificationCenterMembershipRepository from '../../../../lib/infrastructure/repositories/certification-center-membership-repository.js';
+import { certificationCenterMembershipRepository } from '../../../team/infrastructure/repositories/certification-center-membership.repository.js';
 
 const execute = async function (
   userId,

--- a/api/src/team/application/certification-center-invitation/certification-center-invitation.controller.js
+++ b/api/src/team/application/certification-center-invitation/certification-center-invitation.controller.js
@@ -3,6 +3,27 @@ import { usecases } from '../../domain/usecases/index.js';
 import { certificationCenterInvitationSerializer } from '../../infrastructure/serializers/jsonapi/certification-center-invitation-serializer.js';
 
 /**
+ * @callback acceptCertificationCenterInvitatio
+ * @param request
+ * @param h
+ * @returns {Promise<void>}
+ */
+const acceptCertificationCenterInvitation = async function (request, h) {
+  const certificationCenterInvitationId = request.params.id;
+  const { code, email: rawEmail } = request.deserializedPayload;
+  const localeFromCookie = request.state?.locale;
+  const email = rawEmail.trim().toLowerCase();
+
+  await usecases.acceptCertificationCenterInvitation({
+    certificationCenterInvitationId,
+    code,
+    email,
+    localeFromCookie,
+  });
+  return h.response({}).code(204);
+};
+
+/**
  * @callback sendInvitations
  * @param request
  * @param h
@@ -34,6 +55,7 @@ const findPendingInvitations = async function (request, h) {
 };
 
 export const certificationCenterInvitationController = {
+  acceptCertificationCenterInvitation,
   cancelCertificationCenterInvitation,
   findPendingInvitations,
   sendInvitations,

--- a/api/src/team/application/certification-center-invitation/certification-center-invitation.route.js
+++ b/api/src/team/application/certification-center-invitation/certification-center-invitation.route.js
@@ -59,6 +59,30 @@ export const certificationCenterInvitationRoutes = [
     },
   },
   {
+    method: 'POST',
+    path: '/api/certification-center-invitations/{id}/accept',
+    config: {
+      auth: false,
+      handler: (request, h) => certificationCenterInvitationController.acceptCertificationCenterInvitation(request, h),
+      validate: {
+        params: Joi.object({
+          id: identifiersType.certificationCenterInvitationId,
+        }),
+        payload: Joi.object({
+          data: {
+            id: Joi.string().required(),
+            type: Joi.string().required(),
+            attributes: {
+              code: Joi.string().required(),
+              email: Joi.string().email().required(),
+            },
+          },
+        }),
+      },
+      tags: ['api'],
+    },
+  },
+  {
     method: 'DELETE',
     path: '/api/certification-center-invitations/{certificationCenterInvitationId}',
     config: {

--- a/api/src/team/domain/usecases/accept-certification-center-invitation.usecase.js
+++ b/api/src/team/domain/usecases/accept-certification-center-invitation.usecase.js
@@ -1,4 +1,4 @@
-import { AlreadyExistingMembershipError } from '../../../src/shared/domain/errors.js';
+import { AlreadyExistingMembershipError } from '../../../shared/domain/errors.js';
 
 const acceptCertificationCenterInvitation = async function ({
   certificationCenterInvitationId,

--- a/api/src/team/domain/usecases/index.js
+++ b/api/src/team/domain/usecases/index.js
@@ -2,7 +2,6 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import * as mailService from '../../../../lib/domain/services/mail-service.js';
-import * as certificationCenterMembershipRepository from '../../../../lib/infrastructure/repositories/certification-center-membership-repository.js';
 import * as membershipRepository from '../../../../lib/infrastructure/repositories/membership-repository.js';
 import * as sharedMembershipRepository from '../../../../src/shared/infrastructure/repositories/membership-repository.js';
 import * as organizationRepository from '../../../../src/shared/infrastructure/repositories/organization-repository.js';
@@ -13,6 +12,7 @@ import { adminMemberRepository } from '../../../shared/infrastructure/repositori
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as certificationCenterInvitationRepository from '../../infrastructure/repositories/certification-center-invitation-repository.js';
+import { certificationCenterMembershipRepository } from '../../infrastructure/repositories/certification-center-membership.repository.js';
 import { organizationInvitationRepository } from '../../infrastructure/repositories/organization-invitation.repository.js';
 import { organizationInvitedUserRepository } from '../../infrastructure/repositories/organization-invited-user.repository.js';
 import { prescriberRepository } from '../../infrastructure/repositories/prescriber-repository.js';

--- a/api/src/team/domain/usecases/index.js
+++ b/api/src/team/domain/usecases/index.js
@@ -12,6 +12,7 @@ import { adminMemberRepository } from '../../../shared/infrastructure/repositori
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as certificationCenterInvitationRepository from '../../infrastructure/repositories/certification-center-invitation-repository.js';
+import { certificationCenterInvitedUserRepository } from '../../infrastructure/repositories/certification-center-invited-user.repository.js';
 import { certificationCenterMembershipRepository } from '../../infrastructure/repositories/certification-center-membership.repository.js';
 import { organizationInvitationRepository } from '../../infrastructure/repositories/organization-invitation.repository.js';
 import { organizationInvitedUserRepository } from '../../infrastructure/repositories/organization-invited-user.repository.js';
@@ -25,6 +26,7 @@ const path = dirname(fileURLToPath(import.meta.url));
 const dependencies = {
   adminMemberRepository,
   certificationCenterMembershipRepository,
+  certificationCenterInvitedUserRepository,
   certificationCenterRepository,
   certificationCenterInvitationRepository,
   prescriberRepository,

--- a/api/src/team/infrastructure/repositories/certification-center-invited-user.repository.js
+++ b/api/src/team/infrastructure/repositories/certification-center-invited-user.repository.js
@@ -1,6 +1,6 @@
-import { knex } from '../../../db/knex-database-connection.js';
-import { NotFoundError } from '../../../src/shared/domain/errors.js';
-import { CertificationCenterInvitedUser } from '../../../src/shared/domain/models/CertificationCenterInvitedUser.js';
+import { knex } from '../../../../db/knex-database-connection.js';
+import { NotFoundError } from '../../../shared/domain/errors.js';
+import { CertificationCenterInvitedUser } from '../../../shared/domain/models/CertificationCenterInvitedUser.js';
 
 const get = async function ({ certificationCenterInvitationId, email }) {
   const invitation = await knex('certification-center-invitations')
@@ -36,4 +36,5 @@ const save = async function (certificationCenterInvitedUser) {
     .where({ id: certificationCenterInvitedUser.invitation.id });
 };
 
-export { get, save };
+const certificationCenterInvitedUserRepository = { get, save };
+export { certificationCenterInvitedUserRepository };

--- a/api/src/team/infrastructure/repositories/certification-center-membership.repository.js
+++ b/api/src/team/infrastructure/repositories/certification-center-membership.repository.js
@@ -1,19 +1,19 @@
 import _ from 'lodash';
 
-import { knex } from '../../../db/knex-database-connection.js';
-import { User } from '../../../src/identity-access-management/domain/models/User.js';
+import { knex } from '../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
+import { User } from '../../../identity-access-management/domain/models/User.js';
 import {
   AlreadyExistingMembershipError,
   CertificationCenterMembershipCreationError,
   CertificationCenterMembershipDisableError,
   NotFoundError,
-} from '../../../src/shared/domain/errors.js';
-import { CertificationCenter } from '../../../src/shared/domain/models/CertificationCenter.js';
-import { CertificationCenterMembership } from '../../../src/shared/domain/models/CertificationCenterMembership.js';
-import { BookshelfCertificationCenterMembership } from '../../../src/shared/infrastructure/orm-models/CertificationCenterMembership.js';
-import * as bookshelfToDomainConverter from '../../../src/shared/infrastructure/utils/bookshelf-to-domain-converter.js';
-import * as knexUtils from '../../../src/shared/infrastructure/utils/knex-utils.js';
-import { DomainTransaction } from '../DomainTransaction.js';
+} from '../../../shared/domain/errors.js';
+import { CertificationCenter } from '../../../shared/domain/models/CertificationCenter.js';
+import { CertificationCenterMembership } from '../../../shared/domain/models/CertificationCenterMembership.js';
+import { BookshelfCertificationCenterMembership } from '../../../shared/infrastructure/orm-models/CertificationCenterMembership.js';
+import * as bookshelfToDomainConverter from '../../../shared/infrastructure/utils/bookshelf-to-domain-converter.js';
+import * as knexUtils from '../../../shared/infrastructure/utils/knex-utils.js';
 
 const CERTIFICATION_CENTER_MEMBERSHIP_TABLE_NAME = 'certification-center-memberships';
 
@@ -314,7 +314,7 @@ async function findActiveAdminsByCertificationCenterId(certificationCenterId) {
   return certificationCenterMemberships.map(_toDomain);
 }
 
-export {
+const certificationCenterMembershipRepository = {
   countActiveMembersForCertificationCenter,
   create,
   disableById,
@@ -333,3 +333,5 @@ export {
   update,
   updateRefererStatusByUserIdAndCertificationCenterId,
 };
+
+export { certificationCenterMembershipRepository };

--- a/api/tests/acceptance/application/certification-center-invitations/index_test.js
+++ b/api/tests/acceptance/application/certification-center-invitations/index_test.js
@@ -17,56 +17,6 @@ describe('Acceptance | API | Certification center invitations', function () {
   });
 
   context('global routes', function () {
-    describe('POST /api/certification-center-invitations/{id}/accept', function () {
-      it('it should return an HTTP code 204', async function () {
-        // given
-        databaseBuilder.factory.buildUser({ id: 293, email: 'user@example.net' });
-        const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
-        const certificationCenterInvitation = databaseBuilder.factory.buildCertificationCenterInvitation({
-          id: 123,
-          code: 'AZERT123',
-          certificationCenterId: certificationCenter.id,
-          status: CertificationCenterInvitation.StatusType.PENDING,
-        });
-
-        await databaseBuilder.commit();
-
-        // when
-        const result = await server.inject({
-          headers: {
-            authorization: false,
-          },
-          method: 'POST',
-          url: `/api/certification-center-invitations/${certificationCenterInvitation.id}/accept`,
-          payload: {
-            data: {
-              id: '123_AZERT123',
-              type: 'certification-center-invitations-responses',
-              attributes: {
-                code: 'AZERT123',
-                email: 'user@example.net',
-              },
-            },
-          },
-        });
-
-        // then
-        expect(result.statusCode).to.equal(204);
-
-        const membership = await knex('certification-center-memberships')
-          .select('userId')
-          .where({ certificationCenterId: certificationCenter.id })
-          .first();
-        const invitation = await knex('certification-center-invitations')
-          .select('status')
-          .where({ certificationCenterId: certificationCenter.id })
-          .first();
-
-        expect(membership.userId).to.equal(293);
-        expect(invitation.status).to.equal(CertificationCenterInvitation.StatusType.ACCEPTED);
-      });
-    });
-
     describe('GET /api/certification-center-invitations/{id}', function () {
       it('should return the certification-center invitation and 200 status code', async function () {
         // given

--- a/api/tests/identity-access-management/integration/domain/usecases/anonymize-user.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/anonymize-user.usecase.test.js
@@ -1,5 +1,5 @@
 import { anonymizeUser } from '../../../../../lib/domain/usecases/anonymize-user.js';
-import * as certificationCenterMembershipRepository from '../../../../../lib/infrastructure/repositories/certification-center-membership-repository.js';
+import { certificationCenterMembershipRepository } from '../../../../../src/team/infrastructure/repositories/certification-center-membership.repository.js';
 import { userAnonymizedEventLoggingJobRepository } from '../../../../../lib/infrastructure/repositories/jobs/user-anonymized-event-logging-job-repository.js';
 import * as membershipRepository from '../../../../../lib/infrastructure/repositories/membership-repository.js';
 import * as organizationLearnerRepository from '../../../../../lib/infrastructure/repositories/organization-learner-repository.js';

--- a/api/tests/identity-access-management/integration/domain/usecases/anonymize-user.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/anonymize-user.usecase.test.js
@@ -1,5 +1,4 @@
 import { anonymizeUser } from '../../../../../lib/domain/usecases/anonymize-user.js';
-import { certificationCenterMembershipRepository } from '../../../../../src/team/infrastructure/repositories/certification-center-membership.repository.js';
 import { userAnonymizedEventLoggingJobRepository } from '../../../../../lib/infrastructure/repositories/jobs/user-anonymized-event-logging-job-repository.js';
 import * as membershipRepository from '../../../../../lib/infrastructure/repositories/membership-repository.js';
 import * as organizationLearnerRepository from '../../../../../lib/infrastructure/repositories/organization-learner-repository.js';
@@ -14,6 +13,7 @@ import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransa
 import { UserNotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { adminMemberRepository } from '../../../../../src/shared/infrastructure/repositories/admin-member.repository.js';
 import * as userLoginRepository from '../../../../../src/shared/infrastructure/repositories/user-login-repository.js';
+import { certificationCenterMembershipRepository } from '../../../../../src/team/infrastructure/repositories/certification-center-membership.repository.js';
 import { catchErr, databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Identity Access Management | Domain | UseCase | anonymize-user', function () {

--- a/api/tests/integration/domain/usecases/create-certification-center-membership-by-email_test.js
+++ b/api/tests/integration/domain/usecases/create-certification-center-membership-by-email_test.js
@@ -1,8 +1,8 @@
 import { createCertificationCenterMembershipByEmail } from '../../../../lib/domain/usecases/create-certification-center-membership-by-email.js';
-import * as certificationCenterMembershipRepository from '../../../../lib/infrastructure/repositories/certification-center-membership-repository.js';
 import * as userRepository from '../../../../src/identity-access-management/infrastructure/repositories/user.repository.js';
 import { AlreadyExistingEntityError, UserNotFoundError } from '../../../../src/shared/domain/errors.js';
 import { CertificationCenterMembership } from '../../../../src/shared/domain/models/CertificationCenterMembership.js';
+import { certificationCenterMembershipRepository } from '../../../../src/team/infrastructure/repositories/certification-center-membership.repository.js';
 import { catchErr, databaseBuilder, expect, knex } from '../../../test-helper.js';
 
 describe('Integration | UseCases | create-certification-center-membership-by-email', function () {

--- a/api/tests/integration/domain/usecases/find-certification-center-memberships-by-certification-center_test.js
+++ b/api/tests/integration/domain/usecases/find-certification-center-memberships-by-certification-center_test.js
@@ -1,6 +1,6 @@
 import { usecases } from '../../../../lib/domain/usecases/index.js';
-import * as certificationCenterMembershipRepository from '../../../../lib/infrastructure/repositories/certification-center-membership-repository.js';
 import { CertificationCenterMembership } from '../../../../src/shared/domain/models/CertificationCenterMembership.js';
+import { certificationCenterMembershipRepository } from '../../../../src/team/infrastructure/repositories/certification-center-membership.repository.js';
 import { databaseBuilder, expect } from '../../../test-helper.js';
 
 const { findCertificationCenterMembershipsByCertificationCenter } = usecases;

--- a/api/tests/team/integration/domain/usecases/create-certification-center-membership-for-sco-organization-admin-member.usecase.test.js
+++ b/api/tests/team/integration/domain/usecases/create-certification-center-membership-for-sco-organization-admin-member.usecase.test.js
@@ -1,9 +1,9 @@
-import * as certificationCenterMembershipRepository from '../../../../../lib/infrastructure/repositories/certification-center-membership-repository.js';
 import * as membershipRepository from '../../../../../lib/infrastructure/repositories/membership-repository.js';
 import * as certificationCenterRepository from '../../../../../src/certification/shared/infrastructure/repositories/certification-center-repository.js';
 import { CERTIFICATION_CENTER_MEMBERSHIP_ROLES } from '../../../../../src/shared/domain/models/CertificationCenterMembership.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
 import { createCertificationCenterMembershipForScoOrganizationAdminMember } from '../../../../../src/team/domain/usecases/create-certification-center-membership-for-sco-organization-admin-member.usecase.js';
+import { certificationCenterMembershipRepository } from '../../../../../src/team/infrastructure/repositories/certification-center-membership.repository.js';
 import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
 
 describe('Integration | Team | Domain | UseCase | create-certification-center-membership-for-sco-organization-member', function () {

--- a/api/tests/team/integration/infrastructure/repositories/certification-center-invited-user.repository.test.js
+++ b/api/tests/team/integration/infrastructure/repositories/certification-center-invited-user.repository.test.js
@@ -1,16 +1,16 @@
 import lodash from 'lodash';
 
-import * as certificationCenterInvitedUserRepository from '../../../../lib/infrastructure/repositories/certification-center-invited-user-repository.js';
-import { NotFoundError } from '../../../../src/shared/domain/errors.js';
-import { CertificationCenterInvitedUser } from '../../../../src/shared/domain/models/CertificationCenterInvitedUser.js';
-import { CertificationCenterInvitation } from '../../../../src/team/domain/models/CertificationCenterInvitation.js';
-import { catchErr, databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { CertificationCenterInvitedUser } from '../../../../../src/shared/domain/models/CertificationCenterInvitedUser.js';
+import { CertificationCenterInvitation } from '../../../../../src/team/domain/models/CertificationCenterInvitation.js';
+import { certificationCenterInvitedUserRepository } from '../../../../../src/team/infrastructure/repositories/certification-center-invited-user.repository.js';
+import { catchErr, databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
 
 const { omit } = lodash;
 
-describe('Integration | Repository | CertificationCenterInvitedUserRepository', function () {
+describe('Integration | Team | Infrastructure | Repositories | CertificationCenterInvitedUserRepository', function () {
   describe('#get', function () {
-    it('should return the invitation of the invited user', async function () {
+    it('returns the invitation of the invited user', async function () {
       // given
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({ id: 123 }).id;
       const user = databaseBuilder.factory.buildUser({ email: 'user@example.net' });
@@ -58,7 +58,7 @@ describe('Integration | Repository | CertificationCenterInvitedUserRepository', 
     });
 
     context('when there are no invitation with the certificationCenterInvitationId', function () {
-      it('should throw an error', async function () {
+      it('throws an error', async function () {
         // given
         const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({ id: 123 }).id;
         databaseBuilder.factory.buildCertificationCenterInvitation({
@@ -82,7 +82,7 @@ describe('Integration | Repository | CertificationCenterInvitedUserRepository', 
     });
 
     context('when there are no user with the given email', function () {
-      it('should throw an error', async function () {
+      it('throws an error', async function () {
         // given
         const certificationCenterInvitationId = databaseBuilder.factory.buildCertificationCenterInvitation({
           id: 123,
@@ -107,7 +107,7 @@ describe('Integration | Repository | CertificationCenterInvitedUserRepository', 
   describe('#save', function () {
     let clock;
 
-    it('should create membership', async function () {
+    it('creates membership', async function () {
       // given
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({ id: 123 }).id;
       const user = databaseBuilder.factory.buildUser({ id: 6789, email: 'user@example.net' });
@@ -136,7 +136,7 @@ describe('Integration | Repository | CertificationCenterInvitedUserRepository', 
       expect(membershipCreated.certificationCenterId).to.equal(certificationCenterId);
     });
 
-    it('should mark certification center invitation as accepted', async function () {
+    it('marks certification center invitation as accepted', async function () {
       // given
       const now = new Date('2021-05-27');
       clock = sinon.useFakeTimers({ now, toFake: ['Date'] });

--- a/api/tests/team/integration/infrastructure/repositories/certification-center-membership.repository.test.js
+++ b/api/tests/team/integration/infrastructure/repositories/certification-center-membership.repository.test.js
@@ -1,22 +1,22 @@
 import lodash from 'lodash';
 const { omit, pick } = lodash;
 
-import * as certificationCenterMembershipRepository from '../../../../lib/infrastructure/repositories/certification-center-membership-repository.js';
-import { User } from '../../../../src/identity-access-management/domain/models/User.js';
+import { User } from '../../../../../src/identity-access-management/domain/models/User.js';
 import {
   AlreadyExistingMembershipError,
   CertificationCenterMembershipDisableError,
   NotFoundError,
-} from '../../../../src/shared/domain/errors.js';
-import { CertificationCenter } from '../../../../src/shared/domain/models/CertificationCenter.js';
+} from '../../../../../src/shared/domain/errors.js';
+import { CertificationCenter } from '../../../../../src/shared/domain/models/CertificationCenter.js';
 import {
   CERTIFICATION_CENTER_MEMBERSHIP_ROLES,
   CertificationCenterMembership,
-} from '../../../../src/shared/domain/models/CertificationCenterMembership.js';
-import { BookshelfCertificationCenterMembership } from '../../../../src/shared/infrastructure/orm-models/CertificationCenterMembership.js';
-import { catchErr, databaseBuilder, domainBuilder, expect, knex, sinon } from '../../../test-helper.js';
+} from '../../../../../src/shared/domain/models/CertificationCenterMembership.js';
+import { BookshelfCertificationCenterMembership } from '../../../../../src/shared/infrastructure/orm-models/CertificationCenterMembership.js';
+import { certificationCenterMembershipRepository } from '../../../../../src/team/infrastructure/repositories/certification-center-membership.repository.js';
+import { catchErr, databaseBuilder, domainBuilder, expect, knex, sinon } from '../../../../test-helper.js';
 
-describe('Integration | Repository | Certification Center Membership', function () {
+describe('Integration | Team | Infrastructure | Repository | Certification Center Membership', function () {
   describe('#countActiveMembersForCertificationCenter', function () {
     it('returns the number of members', async function () {
       // given
@@ -146,7 +146,7 @@ describe('Integration | Repository | Certification Center Membership', function 
       );
     });
 
-    it('should return the certification center membership', async function () {
+    it('returns the certification center membership', async function () {
       // when
       const createdCertificationCenterMembership = await certificationCenterMembershipRepository.save({
         userId,
@@ -158,7 +158,7 @@ describe('Integration | Repository | Certification Center Membership', function 
     });
 
     context('when there is already a disabled membership for the same user and certification center', function () {
-      it('should add a new membership in database', async function () {
+      it('adds a new membership in database', async function () {
         // given
         databaseBuilder.factory.buildMembership({ userId, certificationCenterId, disabledAt: new Date() });
         await databaseBuilder.commit();
@@ -181,7 +181,7 @@ describe('Integration | Repository | Certification Center Membership', function 
         await databaseBuilder.commit();
       });
 
-      it('should throw an error when a membership already exist for user + certificationCenter', async function () {
+      it('throws an error when a membership already exist for user + certificationCenter', async function () {
         // when
         const error = await catchErr(certificationCenterMembershipRepository.save)({ userId, certificationCenterId });
 
@@ -210,7 +210,7 @@ describe('Integration | Repository | Certification Center Membership', function 
       await databaseBuilder.commit();
     });
 
-    it('should return certification center membership associated to the user', async function () {
+    it('returns certification center membership associated to the user', async function () {
       // when
       const certificationCenterMemberships = await certificationCenterMembershipRepository.findByUserId(userAsked.id);
 
@@ -228,7 +228,7 @@ describe('Integration | Repository | Certification Center Membership', function 
     });
 
     context('when the certification center membership is disabled', function () {
-      it('should return an empty array', async function () {
+      it('returns an empty array', async function () {
         // given
         const userId = databaseBuilder.factory.buildUser().id;
         const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
@@ -248,7 +248,7 @@ describe('Integration | Repository | Certification Center Membership', function 
     });
 
     context('when an user has a disabled membership and a not disabled one', function () {
-      it('should return the not disabled membership', async function () {
+      it('returns the not disabled membership', async function () {
         // given
         const userId = databaseBuilder.factory.buildUser().id;
         const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
@@ -320,7 +320,7 @@ describe('Integration | Repository | Certification Center Membership', function 
   });
 
   describe('#findActiveByCertificationCenterIdSortedByRole', function () {
-    it('should return certification center membership associated to the certification center', async function () {
+    it('returns certification center membership associated to the certification center', async function () {
       // given
       const now = new Date('2021-01-02');
       const clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
@@ -414,7 +414,7 @@ describe('Integration | Repository | Certification Center Membership', function 
       expect(foundCertificationCenterMemberships[3].user.lastName).to.equal('Zoldick');
     });
 
-    it('should only return active (not disabled) certification center memberships', async function () {
+    it('returns only active (not disabled) certification center memberships', async function () {
       // given
       const now = new Date();
       const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
@@ -563,7 +563,7 @@ describe('Integration | Repository | Certification Center Membership', function 
   });
 
   describe('#isMemberOfCertificationCenter', function () {
-    it('should return false if user has no membership in given certification center', async function () {
+    it('returns false if user has no membership in given certification center', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
@@ -586,7 +586,7 @@ describe('Integration | Repository | Certification Center Membership', function 
       expect(isMemberOfCertificationCenter).to.be.false;
     });
 
-    it('should return false if user has a disabled membership in given certification center', async function () {
+    it('returns false if user has a disabled membership in given certification center', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
@@ -609,7 +609,7 @@ describe('Integration | Repository | Certification Center Membership', function 
       expect(isMemberOfCertificationCenter).to.be.false;
     });
 
-    it('should return true if user has a not disabled membership in given certification center', async function () {
+    it('returns true if user has a not disabled membership in given certification center', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
@@ -646,7 +646,7 @@ describe('Integration | Repository | Certification Center Membership', function 
     });
 
     context('When certification center membership exist', function () {
-      it('should return the disabled membership', async function () {
+      it('returns the disabled membership', async function () {
         // given
         const certificationCenterMembershipId = 7;
         const userId = databaseBuilder.factory.buildUser().id;
@@ -675,7 +675,7 @@ describe('Integration | Repository | Certification Center Membership', function 
     });
 
     context('When certification center membership does not exist', function () {
-      it('should throw CertificationCenterMembershipDisableError', async function () {
+      it('throws CertificationCenterMembershipDisableError', async function () {
         // given
         const id = 7;
         const wrongId = id + 1;
@@ -701,7 +701,7 @@ describe('Integration | Repository | Certification Center Membership', function 
   });
 
   describe('#updateRefererStatusByUserIdAndCertificationCenterId', function () {
-    it('should update isReferer on certification center membership', async function () {
+    it('updates isReferer on certification center membership', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
@@ -735,7 +735,7 @@ describe('Integration | Repository | Certification Center Membership', function 
 
   describe('#getRefererByCertificationCenterId', function () {
     context('when there is a referer', function () {
-      it('should return the referer certification center membership', async function () {
+      it('returns the referer certification center membership', async function () {
         // given
         const user = databaseBuilder.factory.buildUser({ locale: 'fr-FR' });
         const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
@@ -788,7 +788,7 @@ describe('Integration | Repository | Certification Center Membership', function 
     });
 
     context('when there is no referer', function () {
-      it('should return null', async function () {
+      it('returns null', async function () {
         // given
         const userId = databaseBuilder.factory.buildUser().id;
         const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;

--- a/api/tests/team/unit/application/certification-center-invitation/certification-center-invitation.controller.test.js
+++ b/api/tests/team/unit/application/certification-center-invitation/certification-center-invitation.controller.test.js
@@ -1,0 +1,38 @@
+import { certificationCenterInvitationController } from '../../../../../src/team/application/certification-center-invitation/certification-center-invitation.controller.js';
+import { usecases } from '../../../../../src/team/domain/usecases/index.js';
+import { expect, hFake, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Team | Application | Controller | Certification-center-invitation', function () {
+  describe('#acceptCertificationCenterInvitation', function () {
+    it('accepts invitation with certificationCenterInvitationId, email and code', async function () {
+      // given
+      const code = 'ABCDEFGH01';
+      const notValidEmail = '   RANDOM@email.com   ';
+      const certificationCenterInvitationId = '1234';
+      const request = {
+        params: { id: certificationCenterInvitationId },
+        deserializedPayload: {
+          code,
+          email: notValidEmail,
+        },
+      };
+
+      sinon.stub(usecases, 'acceptCertificationCenterInvitation').resolves();
+
+      // when
+      const response = await certificationCenterInvitationController.acceptCertificationCenterInvitation(
+        request,
+        hFake,
+      );
+
+      // then
+      expect(usecases.acceptCertificationCenterInvitation).to.have.been.calledWithExactly({
+        certificationCenterInvitationId,
+        code,
+        email: notValidEmail.trim().toLowerCase(),
+        localeFromCookie: undefined,
+      });
+      expect(response.statusCode).to.equal(204);
+    });
+  });
+});

--- a/api/tests/team/unit/domain/usecases/accept-certification-center-invitation.usecase.test.js
+++ b/api/tests/team/unit/domain/usecases/accept-certification-center-invitation.usecase.test.js
@@ -1,11 +1,11 @@
-import { acceptCertificationCenterInvitation } from '../../../../lib/domain/usecases/accept-certification-center-invitation.js';
-import { AlreadyExistingMembershipError } from '../../../../src/shared/domain/errors.js';
-import { CertificationCenterInvitedUser } from '../../../../src/shared/domain/models/CertificationCenterInvitedUser.js';
-import { CertificationCenterInvitation } from '../../../../src/team/domain/models/CertificationCenterInvitation.js';
-import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';
+import { AlreadyExistingMembershipError } from '../../../../../src/shared/domain/errors.js';
+import { CertificationCenterInvitedUser } from '../../../../../src/shared/domain/models/CertificationCenterInvitedUser.js';
+import { CertificationCenterInvitation } from '../../../../../src/team/domain/models/CertificationCenterInvitation.js';
+import { acceptCertificationCenterInvitation } from '../../../../../src/team/domain/usecases/accept-certification-center-invitation.usecase.js';
+import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
-describe('Unit | Domain | UseCases | accept-certification-center-invitation', function () {
-  it('should throw an error if user is already member of the certification center', async function () {
+describe('Unit | Team | Domain | UseCase | accept-certification-center-invitation', function () {
+  it('throws an error if user is already member of the certification center', async function () {
     const {
       certificationCenterInvitedUserRepository,
       certificationCenterMembershipRepository,

--- a/api/tests/unit/application/certification-center-invitations/certification-center-invitation-controller_test.js
+++ b/api/tests/unit/application/certification-center-invitations/certification-center-invitation-controller_test.js
@@ -5,39 +5,6 @@ import { certificationCenterInvitationSerializer } from '../../../../src/team/in
 import { domainBuilder, expect, hFake, sinon } from '../../../test-helper.js';
 
 describe('Unit | Application | Certification-center-Invitations | Certification-center-invitation-controller', function () {
-  describe('#acceptCertificationCenterInvitation', function () {
-    it('should accept invitation with certificationCenterInvitationId, email and code', async function () {
-      // given
-      const code = 'ABCDEFGH01';
-      const notValidEmail = '   RANDOM@email.com   ';
-      const certificationCenterInvitationId = '1234';
-      const request = {
-        params: { id: certificationCenterInvitationId },
-        deserializedPayload: {
-          code,
-          email: notValidEmail,
-        },
-      };
-
-      sinon.stub(usecases, 'acceptCertificationCenterInvitation').resolves();
-
-      // when
-      const response = await certificationCenterInvitationController.acceptCertificationCenterInvitation(
-        request,
-        hFake,
-      );
-
-      // then
-      expect(usecases.acceptCertificationCenterInvitation).to.have.been.calledWithExactly({
-        certificationCenterInvitationId,
-        code,
-        email: notValidEmail.trim().toLowerCase(),
-        localeFromCookie: undefined,
-      });
-      expect(response.statusCode).to.equal(204);
-    });
-  });
-
   describe('#resendCertificationCenterInvitation', function () {
     it('calls the resend certification center invitation usecase and returns an certification center invitation', async function () {
       // given


### PR DESCRIPTION
## :unicorn: Problème
La route POST /api/certification-center-invitations/{id}/accept est toujours dans lib

## :robot: Proposition
Migrer cette route dans src/team
## :rainbow: Remarques
ras

## :100: Pour tester
(en local)
- activer la variable DEBUG="pix:mailer:email"
- se connecter sur pix certif avec par exemple le compte certif-pro@example.net
- dans équipe, puis inviter, mettre une adresse email
- récupérer les informations de l'email dans l'api et aller sur l'url de redirection en adaptant le nom de domaine
- vérifier dans la console du navigateur que la route POST /api/certification-center-invitations/{id}/accept a été appelée avec succès
