### PR TITLE
[TECH] Réparer l'envoi de résultats d'avancement de la migration dans src (PIX-14199)

### DIFF
--- a/api/scripts/arborescence-monitoring/time-series.js
+++ b/api/scripts/arborescence-monitoring/time-series.js
@@ -1,5 +1,3 @@
-import { assertNotNullOrUndefined } from '../../src/shared/domain/models/asserts.js';
-
 const MAXIMUM_NUMBER_OF_POINTS_THRESHOLD = 28;
 
 const PURGE_MIDDLE_POINT_INDEX = 10;
@@ -12,7 +10,7 @@ export class TimeSeries {
   #points;
 
   constructor(points) {
-    assertNotNullOrUndefined(points, NULL_OR_UNDEFINED_POINTS_ERROR_MESSAGE);
+    this.#assertPointsIsNotNullOrUndefined(points);
     points.sort((pointA, pointB) => new Date(pointA.x).getTime() - new Date(pointB.x).getTime());
     this.#points = points;
   }
@@ -38,6 +36,12 @@ export class TimeSeries {
       this.#purgeOnePoint();
     }
     return new TimeSeries(this.#points);
+  }
+
+  #assertPointsIsNotNullOrUndefined(points) {
+    if (points === null || points === undefined) {
+      throw new Error(NULL_OR_UNDEFINED_POINTS_ERROR_MESSAGE);
+    }
   }
 
   #purgeOnePoint() {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, l’envoi de l’avancement de la migration sur le channel slack. ne se fait plus. 
Après analyse, cela est causé par une erreur lors du lancement d’un script sur l’intégration continue : 

`Cannot find package 'dotenv' imported from /home/runner/work/pix/pix/api/src/shared/config.js`

Causé par l’import d’une assertion dans `/api/scripts/arborescence-monitoring/time-series.js` qui a été modifié récemment.

## :robot: Proposition
Supprimer l'utilisation de l'assertion. Le script devrait pouvoir se lancer sans utilisation de dépendances externes

## :rainbow: Remarques

RAS

## :100: Pour tester
- Modifier le fichier `.github/workflows/arborescence-monitoring.yaml` en mettant un `on: push` au lieu de `on: schedule...` et pousser cette modif
- Vérifier que l'envoi fonctionne bien sur le channel slack
- Enlever la modif que vous avez faite pour tester 😄 
