### PR TITLE
[TECH] Migrer la route GET api/certification-center-invitations/{id} dans src (PIX-14184)

### DIFF
--- a/api/lib/application/certification-center-invitations/certification-center-invitation-controller.js
+++ b/api/lib/application/certification-center-invitations/certification-center-invitation-controller.js
@@ -2,17 +2,6 @@ import { requestResponseUtils } from '../../../src/shared/infrastructure/utils/r
 import { certificationCenterInvitationSerializer } from '../../../src/team/infrastructure/serializers/jsonapi/certification-center-invitation-serializer.js';
 import { usecases } from '../../domain/usecases/index.js';
 
-const getCertificationCenterInvitation = async function (request) {
-  const certificationCenterInvitationId = request.params.id;
-  const certificationCenterInvitationCode = request.query.code;
-
-  const certificationCenterInvitation = await usecases.getCertificationCenterInvitation({
-    certificationCenterInvitationId,
-    certificationCenterInvitationCode,
-  });
-  return certificationCenterInvitationSerializer.serialize(certificationCenterInvitation);
-};
-
 const resendCertificationCenterInvitation = async function (request, h) {
   const certificationCenterInvitationId = request.params.certificationCenterInvitationId;
   const locale = requestResponseUtils.extractLocaleFromRequest(request);
@@ -26,7 +15,6 @@ const resendCertificationCenterInvitation = async function (request, h) {
 };
 
 const certificationCenterInvitationController = {
-  getCertificationCenterInvitation,
   resendCertificationCenterInvitation,
 };
 

--- a/api/lib/application/certification-center-invitations/index.js
+++ b/api/lib/application/certification-center-invitations/index.js
@@ -7,26 +7,6 @@ import { certificationCenterInvitationController } from './certification-center-
 const register = async function (server) {
   server.route([
     {
-      method: 'GET',
-      path: '/api/certification-center-invitations/{id}',
-      config: {
-        auth: false,
-        handler: certificationCenterInvitationController.getCertificationCenterInvitation,
-        validate: {
-          params: Joi.object({
-            id: identifiersType.certificationCenterInvitationId.required(),
-          }),
-          query: Joi.object({
-            code: Joi.string().required(),
-          }),
-        },
-        notes: [
-          "- Cette route permet de récupérer les détails d'une invitation selon un **id d'invitation** et un **code**\n",
-        ],
-        tags: ['api', 'invitations'],
-      },
-    },
-    {
       method: 'PATCH',
       path: '/api/certification-center-invitations/{certificationCenterInvitationId}',
       config: {

--- a/api/src/team/application/certification-center-invitation/certification-center-invitation.controller.js
+++ b/api/src/team/application/certification-center-invitation/certification-center-invitation.controller.js
@@ -23,6 +23,17 @@ const acceptCertificationCenterInvitation = async function (request, h) {
   return h.response({}).code(204);
 };
 
+const getCertificationCenterInvitation = async function (request) {
+  const certificationCenterInvitationId = request.params.id;
+  const certificationCenterInvitationCode = request.query.code;
+
+  const certificationCenterInvitation = await usecases.getCertificationCenterInvitation({
+    certificationCenterInvitationId,
+    certificationCenterInvitationCode,
+  });
+  return certificationCenterInvitationSerializer.serialize(certificationCenterInvitation);
+};
+
 /**
  * @callback sendInvitations
  * @param request
@@ -57,6 +68,7 @@ const findPendingInvitations = async function (request, h) {
 export const certificationCenterInvitationController = {
   acceptCertificationCenterInvitation,
   cancelCertificationCenterInvitation,
+  getCertificationCenterInvitation,
   findPendingInvitations,
   sendInvitations,
 };

--- a/api/src/team/application/certification-center-invitation/certification-center-invitation.route.js
+++ b/api/src/team/application/certification-center-invitation/certification-center-invitation.route.js
@@ -59,6 +59,26 @@ export const certificationCenterInvitationRoutes = [
     },
   },
   {
+    method: 'GET',
+    path: '/api/certification-center-invitations/{id}',
+    config: {
+      auth: false,
+      handler: certificationCenterInvitationController.getCertificationCenterInvitation,
+      validate: {
+        params: Joi.object({
+          id: identifiersType.certificationCenterInvitationId.required(),
+        }),
+        query: Joi.object({
+          code: Joi.string().required(),
+        }),
+      },
+      notes: [
+        "- Cette route permet de récupérer les détails d'une invitation selon un **id d'invitation** et un **code**\n",
+      ],
+      tags: ['api', 'invitations'],
+    },
+  },
+  {
     method: 'POST',
     path: '/api/certification-center-invitations/{id}/accept',
     config: {

--- a/api/src/team/domain/usecases/get-certification-center-invitation.usecase.js
+++ b/api/src/team/domain/usecases/get-certification-center-invitation.usecase.js
@@ -1,5 +1,12 @@
-import { AlreadyExistingInvitationError, CancelledInvitationError } from '../../../src/shared/domain/errors.js';
+import { AlreadyExistingInvitationError, CancelledInvitationError } from '../../../shared/domain/errors.js';
 
+/**
+ * @param {Object} params
+ * @param {string} params.certificationCenterInvitationId
+ * @param {string} params.certificationCenterInvitationCode
+ * @param {CertificationCenterInvitationRepository} params.certificationCenterInvitationRepository
+ * @returns {Promise<CertificationCenterInvitation>}
+ */
 const getCertificationCenterInvitation = async function ({
   certificationCenterInvitationId,
   certificationCenterInvitationCode,

--- a/api/tests/acceptance/application/certification-center-invitations/index_test.js
+++ b/api/tests/acceptance/application/certification-center-invitations/index_test.js
@@ -1,4 +1,3 @@
-import { CertificationCenterInvitation } from '../../../../src/team/domain/models/CertificationCenterInvitation.js';
 import {
   createServer,
   databaseBuilder,
@@ -17,42 +16,6 @@ describe('Acceptance | API | Certification center invitations', function () {
   });
 
   context('global routes', function () {
-    describe('GET /api/certification-center-invitations/{id}', function () {
-      it('should return the certification-center invitation and 200 status code', async function () {
-        // given
-        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
-          name: 'Centre des Pixous',
-        }).id;
-        const certificationCenterInvitationId = databaseBuilder.factory.buildCertificationCenterInvitation({
-          certificationCenterId,
-          status: CertificationCenterInvitation.StatusType.PENDING,
-          code: 'ABCDEFGH01',
-        }).id;
-
-        await databaseBuilder.commit();
-
-        // when
-        const response = await server.inject({
-          method: 'GET',
-          url: `/api/certification-center-invitations/${certificationCenterInvitationId}?code=ABCDEFGH01`,
-        });
-
-        // then
-        expect(response.statusCode).to.equal(200);
-        expect(response.result).to.deep.equal({
-          data: {
-            type: 'certification-center-invitations',
-            id: certificationCenterInvitationId.toString(),
-            attributes: {
-              'certification-center-id': certificationCenterId,
-              'certification-center-name': 'Centre des Pixous',
-              status: CertificationCenterInvitation.StatusType.PENDING,
-            },
-          },
-        });
-      });
-    });
-
     describe(`PATCH /api/certification-center-invitations/{id}`, function () {
       context('when user is admin of the certification center', function () {
         let adminUser;

--- a/api/tests/team/acceptance/application/certification-center-invitation/certification-center-invitation.route.test.js
+++ b/api/tests/team/acceptance/application/certification-center-invitation/certification-center-invitation.route.test.js
@@ -151,6 +151,42 @@ describe('Acceptance | Team | Application | Route | Certification Center Invitat
     });
   });
 
+  describe('GET /api/certification-center-invitations/{id}', function () {
+    it('returns the certification-center invitation and 200 status code', async function () {
+      // given
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
+        name: 'Centre des Pixous',
+      }).id;
+      const certificationCenterInvitationId = databaseBuilder.factory.buildCertificationCenterInvitation({
+        certificationCenterId,
+        status: CertificationCenterInvitation.StatusType.PENDING,
+        code: 'ABCDEFGH01',
+      }).id;
+
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject({
+        method: 'GET',
+        url: `/api/certification-center-invitations/${certificationCenterInvitationId}?code=ABCDEFGH01`,
+      });
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result).to.deep.equal({
+        data: {
+          type: 'certification-center-invitations',
+          id: certificationCenterInvitationId.toString(),
+          attributes: {
+            'certification-center-id': certificationCenterId,
+            'certification-center-name': 'Centre des Pixous',
+            status: CertificationCenterInvitation.StatusType.PENDING,
+          },
+        },
+      });
+    });
+  });
+
   describe('POST /api/certification-center-invitations/{id}/accept', function () {
     it('it returns an HTTP code 204', async function () {
       // given

--- a/api/tests/team/integration/domain/usecases/get-certification-center-invitation.usecase.test.js
+++ b/api/tests/team/integration/domain/usecases/get-certification-center-invitation.usecase.test.js
@@ -1,15 +1,15 @@
-import { usecases } from '../../../../lib/domain/usecases/index.js';
 import {
   AlreadyExistingInvitationError,
   CancelledInvitationError,
   NotFoundError,
-} from '../../../../src/shared/domain/errors.js';
-import { CertificationCenterInvitation } from '../../../../src/team/domain/models/CertificationCenterInvitation.js';
-import { catchErr, databaseBuilder, expect } from '../../../test-helper.js';
+} from '../../../../../src/shared/domain/errors.js';
+import { CertificationCenterInvitation } from '../../../../../src/team/domain/models/CertificationCenterInvitation.js';
+import { usecases } from '../../../../../src/team/domain/usecases/index.js';
+import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
 
-describe('Integration | API | getCertificationCenterInvitation', function () {
+describe('Integration | Team | Domain | UseCase | getCertificationCenterInvitation', function () {
   describe('when an invitation exists', function () {
-    it('should return an invitation information', async function () {
+    it('returns an invitation information', async function () {
       // given
       const certificationCenter = databaseBuilder.factory.buildCertificationCenter({ name: 'Konoha' });
 
@@ -48,7 +48,7 @@ describe('Integration | API | getCertificationCenterInvitation', function () {
   });
 
   describe('when an invitation does not exist', function () {
-    it('should throw a not found error', async function () {
+    it('throws a not found error', async function () {
       // given
       const certificationCenter = databaseBuilder.factory.buildCertificationCenter({ name: 'Konoha' });
 
@@ -74,7 +74,7 @@ describe('Integration | API | getCertificationCenterInvitation', function () {
   });
 
   describe('when an invitation is already accepted', function () {
-    it('should throw an already existing invitation error', async function () {
+    it('throws an already existing invitation error', async function () {
       // given
       const certificationCenter = databaseBuilder.factory.buildCertificationCenter({ name: 'HunterxHunter' });
 
@@ -100,7 +100,7 @@ describe('Integration | API | getCertificationCenterInvitation', function () {
   });
 
   describe('when an invitation is cancelled', function () {
-    it('should throw a cancelled invitation error', async function () {
+    it('throws a cancelled invitation error', async function () {
       // given
       const certificationCenter = databaseBuilder.factory.buildCertificationCenter({ name: 'MyHeroAcademia' });
 


### PR DESCRIPTION
## :unicorn: Problème
La route GET /api/certification-center-invitations/{id} est toujours dans lib

## :robot: Proposition
Déplacer cette route dans src

## :rainbow: Remarques
ras

## :100: Pour tester
- se connecter en tant que james-paledroits@example.net sur Pix Certif
- inviter quelqu'un dans l'onglet Equipe (si vous êtes en local : peu importe le mail mais vérifiez que la variable DEBUG="pix:mailer:email" es dans le fichier .env de votre api ; et si vous êtes en RA, choisissez une adresse mail existante et allez récupérer le lien envoyé dans ce courrier)
- adaptez si besoin le lien reçu au domaine et copiez-le dans le navigateur
- vérifiez dans la console du navigateur que la route GET /api/certification-center-invitations/XXXXXX?code=XXXXXXXXXX a été appelée avec succès
