### PR TITLE
[BUGFIX] supprime la validation du model PlaceStatistics (Pix-14195)

### DIFF
--- a/api/src/prescription/organization-place/domain/read-models/PlaceStatistics.js
+++ b/api/src/prescription/organization-place/domain/read-models/PlaceStatistics.js
@@ -1,7 +1,5 @@
 import _ from 'lodash';
 
-import { OrganizationCantGetPlacesStatisticsError } from '../../../../prescription/organization-place/domain/errors.js';
-
 export class PlaceStatistics {
   #placesLots;
   #placeRepartition;
@@ -10,14 +8,8 @@ export class PlaceStatistics {
     this.id = `${organizationId}_place_statistics`;
     this.#placesLots = placesLots;
     this.#placeRepartition = placeRepartition;
-    this.#validate();
   }
 
-  #validate() {
-    if (this.#placesLots.every((placesLot) => placesLot.count === 0) && this.#placesLots.length > 0) {
-      throw new OrganizationCantGetPlacesStatisticsError();
-    }
-  }
   static buildFrom({ placesLots, placeRepartition, organizationId } = {}) {
     return new PlaceStatistics({ placesLots, placeRepartition, organizationId });
   }

--- a/api/tests/prescription/organization-place/acceptance/application/get-organization-places-statistics_test.js
+++ b/api/tests/prescription/organization-place/acceptance/application/get-organization-places-statistics_test.js
@@ -49,44 +49,5 @@ describe('Acceptance | Route | Get Organizations Places Statistics', function ()
       expect(response.statusCode).to.equal(200);
       expect(response.result.data.type).to.equal('organization-place-statistics');
     });
-
-    it('should return 412 http code if organisation have unlimited places', async function () {
-      // given
-      const server = await createServer();
-
-      const { userId, organizationId } = databaseBuilder.factory.buildMembership({
-        organizationRole: Membership.roles.ADMIN,
-      });
-      const placesManagementFeatureId = databaseBuilder.factory.buildFeature({
-        key: ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key,
-      }).id;
-      databaseBuilder.factory.buildOrganizationFeature({
-        organizationId,
-        featureId: placesManagementFeatureId,
-      });
-      databaseBuilder.factory.buildOrganizationPlace({
-        organizationId,
-        count: null,
-        activationDate: new Date('2023-01-01'),
-        expirationDate: new Date('2023-12-12'),
-        category: categories.T0,
-        createdBy: userId,
-      });
-      await databaseBuilder.commit();
-
-      const options = {
-        method: 'GET',
-        url: `/api/organizations/${organizationId}/place-statistics`,
-        headers: {
-          authorization: generateValidRequestAuthorizationHeader(userId),
-        },
-      };
-
-      // when
-      const response = await server.inject(options);
-
-      // then
-      expect(response.statusCode).to.equal(412);
-    });
   });
 });

--- a/api/tests/prescription/organization-place/integration/infrastructure/repositories/organization-places-lot-repository_test.js
+++ b/api/tests/prescription/organization-place/integration/infrastructure/repositories/organization-places-lot-repository_test.js
@@ -227,7 +227,7 @@ describe('Integration | Repository | Organization Places Lot', function () {
       expect(places[0]).to.be.instanceOf(PlacesLot);
     });
 
-    it('should return empty array if there is no places', async function () {
+    it('should return empty array if there is no placelots', async function () {
       await databaseBuilder.commit();
 
       const places = await organizationPlacesLotRepository.findAllByOrganizationId(organizationId);
@@ -235,7 +235,7 @@ describe('Integration | Repository | Organization Places Lot', function () {
       expect(places).to.be.empty;
     });
 
-    it('should return places if there are places for given organizationId', async function () {
+    it('should return placelots if there are places for given organizationId', async function () {
       databaseBuilder.factory.buildOrganizationPlace({
         organizationId,
         count: 7,

--- a/api/tests/prescription/organization-place/unit/domain/read-models/PlaceStatistics_test.js
+++ b/api/tests/prescription/organization-place/unit/domain/read-models/PlaceStatistics_test.js
@@ -1,7 +1,6 @@
-import { OrganizationCantGetPlacesStatisticsError } from '../../../../../../src/prescription/organization-place/domain/errors.js';
 import { PlacesLot } from '../../../../../../src/prescription/organization-place/domain/read-models/PlacesLot.js';
 import { PlaceStatistics } from '../../../../../../src/prescription/organization-place/domain/read-models/PlaceStatistics.js';
-import { catchErr, expect, sinon } from '../../../../../test-helper.js';
+import { expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | Domain | ReadModels | PlaceStatistics', function () {
   let clock;
@@ -156,39 +155,6 @@ describe('Unit | Domain | ReadModels | PlaceStatistics', function () {
       });
 
       expect(statistics.available).to.equal(0);
-    });
-  });
-
-  describe('#validate', function () {
-    it('should throw an error if all places count are null', async function () {
-      const error = await catchErr(() => {
-        new PlaceStatistics({
-          placesLots: [
-            new PlacesLot({
-              count: null,
-              expirationDate: new Date('2021-05-02'),
-              activationDate: new Date('2021-04-01'),
-              deletedAt: null,
-            }),
-            new PlacesLot({
-              count: null,
-              expirationDate: new Date('2021-03-02'),
-              activationDate: new Date('2021-02-01'),
-              deletedAt: new Date('2021-01-01'),
-            }),
-            new PlacesLot({
-              count: null,
-              expirationDate: new Date('2022-04-02'),
-              activationDate: new Date('2022-04-01'),
-              deletedAt: null,
-            }),
-          ],
-          placeRepartition: { totalUnRegisteredParticipant: 0, totalRegisteredParticipant: 0 },
-        });
-      })();
-
-      expect(error).to.be.an.instanceof(OrganizationCantGetPlacesStatisticsError);
-      expect(error.message).to.equal("L'organisation ne peut pas avoir de statistiques sur ses lots de places.");
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Le modèle `PlaceStatistics` a une méthode validate qui lance un erreur si tout les lots de place n'ont pas de count (cela veut dire qu'on ne peut pas calculer les statistiques de places). Cela est problématique car cela empêche les utilisateurs de se connecter dans le cas ou l'organisation tombe dans ce cas.

## :robot: Proposition
On supprime la méthode `validate` du modèle. Cela permet de débloquer l'utilisateur. Le cas d'un lot de place sans un nombre de place n'est pas censé arrivé, dans ce cas, il faudrait plutôt supprimé la fonctionnalité de gestion de place. 

## :rainbow: Remarques
Le fait de supprimer la validation rend visible le compteur de place à zéro 
![image](https://github.com/user-attachments/assets/fb7b612c-a8ab-43ac-a951-943f08105cfd) ce qui permettra de faire remonter l'info aux partenariat si cela n'est pas bon (cas de place illimité ou oubli du nombre de place) 

## :100: Pour tester
**sur admin** 
- créer une orga
- ajouter la feature des places à l'orga
- créer un lot de place pour l'orga sans définir de nombre de place
- ajouter admin-orga@example.net dans l'équipe

**sur orga**
- se connecter avec admin-orga@example.net
- aller sur l'orga créée
- voir le bandeau de place avec le compteur à zéro
