### PR TITLE
[TECH] Sauvegarder l'état de l'import dans tous les cas (PIX-14200)

### DIFF
--- a/api/src/prescription/learner-management/domain/usecases/add-or-update-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/add-or-update-organization-learners.js
@@ -13,6 +13,7 @@ async function addOrUpdateOrganizationLearners({
   organizationLearnerRepository,
   organizationImportRepository,
   importStorage,
+  logger,
   chunkSize = ORGANIZATION_LEARNER_CHUNK_SIZE,
 }) {
   const errors = [];
@@ -64,8 +65,11 @@ async function addOrUpdateOrganizationLearners({
       organizationImport.process({ errors });
       await organizationImportRepository.save(organizationImport);
       loggerForImport("IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Aprés le save de l'organizationImport");
-
-      await importStorage.deleteFile({ filename: organizationImport.filename });
+      try {
+        await importStorage.deleteFile({ filename: organizationImport.filename });
+      } catch (error) {
+        logger.error(error);
+      }
 
       loggerForImport('IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Fin du usecase');
     }

--- a/api/src/prescription/learner-management/domain/usecases/index.js
+++ b/api/src/prescription/learner-management/domain/usecases/index.js
@@ -5,6 +5,7 @@ import * as userReconciliationService from '../../../../../lib/domain/services/u
 import * as campaignRepository from '../../../../../lib/infrastructure/repositories/campaign-repository.js';
 import * as membershipRepository from '../../../../../lib/infrastructure/repositories/membership-repository.js';
 import { logErrorWithCorrelationIds } from '../../../../../src/shared/infrastructure/monitoring-tools.js';
+import { logger } from '../../../../../src/shared/infrastructure/utils/logger.js';
 import * as organizationFeatureApi from '../../../../organizational-entities/application/api/organization-features-api.js';
 import * as organizationRepository from '../../../../shared/infrastructure/repositories/organization-repository.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
@@ -50,6 +51,7 @@ const dependencies = {
   logErrorWithCorrelationIds,
   userReconciliationService,
   organizationFeatureRepository: repositories.organizationFeatureRepository,
+  logger,
 };
 
 const path = dirname(fileURLToPath(import.meta.url));

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-import-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-import-repository.js
@@ -1,7 +1,6 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { ApplicationTransaction } from '../../../shared/infrastructure/ApplicationTransaction.js';
-import { IMPORT_STATUSES } from '../../domain/constants.js';
 import { OrganizationImport } from '../../domain/models/OrganizationImport.js';
 import { OrganizationImportDetail } from '../../domain/read-models/OrganizationImportDetail.js';
 
@@ -50,18 +49,13 @@ function _stringifyErrors(errors) {
 }
 
 const save = async function (organizationImport) {
-  let knexConn = DomainTransaction.getConnection();
-
   const attributes = { ...organizationImport, errors: _stringifyErrors(organizationImport.errors) };
-  if (attributes.errors || attributes.status === IMPORT_STATUSES.UPLOADING) {
-    // if there is errors, we don't want to use the given transaction
-    knexConn = knex;
-  }
+
   if (organizationImport.id) {
-    const updatedRows = await knexConn('organization-imports').update(attributes).where({ id: organizationImport.id });
+    const updatedRows = await knex('organization-imports').update(attributes).where({ id: organizationImport.id });
     if (updatedRows === 0) throw new Error();
   } else {
-    await knexConn('organization-imports').insert(attributes);
+    await knex('organization-imports').insert(attributes);
   }
 };
 

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-import-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-import-repository_test.js
@@ -2,7 +2,7 @@ import { IMPORT_STATUSES } from '../../../../../../src/prescription/learner-mana
 import { OrganizationImport } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationImport.js';
 import * as organizationImportRepository from '../../../../../../src/prescription/learner-management/infrastructure/repositories/organization-import-repository.js';
 import { ApplicationTransaction } from '../../../../../../src/prescription/shared/infrastructure/ApplicationTransaction.js';
-import { DomainTransaction, withTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
+import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { catchErr, databaseBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Integration | Repository | Organization Learner Management | Organization Import', function () {
@@ -64,45 +64,6 @@ describe('Integration | Repository | Organization Learner Management | Organizat
       const error = await catchErr(organizationImportRepository.save)(organizationImport);
 
       expect(error).to.be.ok;
-    });
-
-    it('should use domainTransaction', async function () {
-      const organizationId = databaseBuilder.factory.buildOrganization().id;
-      const userId = databaseBuilder.factory.buildUser().id;
-      await databaseBuilder.commit();
-
-      const organizationImport = OrganizationImport.create({ organizationId, createdBy: userId });
-      organizationImport.upload({ filename: 'test.csv', encoding: 'utf8' });
-      try {
-        await DomainTransaction.execute(async (domainTransaction) => {
-          await organizationImportRepository.save(organizationImport, domainTransaction);
-          throw new Error();
-        });
-        // eslint-disable-next-line no-empty
-      } catch (e) {}
-
-      const savedImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
-      expect(savedImport).to.be.null;
-    });
-
-    it('should use ApplicationTransaction', async function () {
-      const organizationId = databaseBuilder.factory.buildOrganization().id;
-      const userId = databaseBuilder.factory.buildUser().id;
-      await databaseBuilder.commit();
-
-      const organizationImport = OrganizationImport.create({ organizationId, createdBy: userId });
-      organizationImport.upload({ filename: 'test.csv', encoding: 'utf8' });
-
-      try {
-        await withTransaction(async () => {
-          await organizationImportRepository.save(organizationImport);
-          throw new Error();
-        })();
-        // eslint-disable-next-line no-empty
-      } catch (e) {}
-
-      const savedImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
-      expect(savedImport).to.be.null;
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Au début du dev de la feature d'import siècle asynchrone, on a implémenté la sauvegarde de l'état de l'import. Au fur-et-à-mesure de l'amélioration de ce système on a commencé à catch les erreurs classiques et attendues, et on a fait en sorte que le moins d'edge-case puissent arriver.
Cependant, nous avons gardé la transaction dans la sauvegarde de l'état de l'import dans certains cas. Nous avons eu un soucis la semaine passée ou la suppression du fichier du s3 en fin d'import a fail. Ce qui a fait rollback tout l'import ainsi que l'inscription de son état. Alors que concrètement : Côté utilisateur -> L'import aurait du être finalisé, car il n'a pas besoin d'être impacté si le problème de suppression de son fichier apparaît.

## :robot: Proposition
Try Catch si une erreur de deleteFile se produit, et y ajouter un logger afin d'en informer les captains. Mais laisser la suite se dérouler sans soucis dans ce cas de figure, car l'import n'a pas de lien direct à ce moment avec le fichier distant.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

- Désactiver la variable d'eniromment `PGBOSS_VALIDATION_FILE_JOB_ENABLED` à `false` 
- Faire un import OK
- En local ( restart le conteneur s3 ), en RA supprimer dans le S3 pix-dev-import (j'ai plus le nom en tête) ?
- Activer la variable d'eniromment `PGBOSS_VALIDATION_FILE_JOB_ENABLED` à `true` 
- Vérifier que le log apparait bien
- Mais que l'import s'est tout de même bien déroulé
- Est ce faisable ? A vous de le décider 😏
- 🐈‍⬛ 
