### PR TITLE
[TECH] Ajout de OpenFeature et PixEnvVarProvider

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -86,6 +86,7 @@
         "@babel/plugin-syntax-import-attributes": "^7.24.1",
         "@eslint/compat": "^1.0.1",
         "@ls-lint/ls-lint": "^2.0.0",
+        "@openfeature/server-sdk": "^1.15.1",
         "chai": "^5.0.0",
         "chai-as-promised": "^8.0.0",
         "chai-sorted": "^0.2.0",
@@ -2525,6 +2526,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/@openfeature/core": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-Cd5eeAouAYaj1RMgVq4gfasoAc4TSkN4fuhloZ3yCQA2t74IdVMAT0iadq1Seqy+G7PZoN2jy706ei9HT55PIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@openfeature/server-sdk": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.15.1.tgz",
+      "integrity": "sha512-PaJETh/fr4N8BVQlgb5vBH8VdN25VhxaVvL0s4Wv3kAUC+MXi7B9hEVM1GUlI9CrjxRExlbAAYtLY7kzjE7SXg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@openfeature/core": "1.4.0"
       }
     },
     "node_modules/@pdf-lib/fontkit": {

--- a/api/package.json
+++ b/api/package.json
@@ -92,6 +92,7 @@
     "@babel/plugin-syntax-import-attributes": "^7.24.1",
     "@eslint/compat": "^1.0.1",
     "@ls-lint/ls-lint": "^2.0.0",
+    "@openfeature/server-sdk": "^1.15.1",
     "chai": "^5.0.0",
     "chai-as-promised": "^8.0.0",
     "chai-sorted": "^0.2.0",

--- a/api/src/shared/infrastructure/feature-toggles/index.js
+++ b/api/src/shared/infrastructure/feature-toggles/index.js
@@ -1,0 +1,9 @@
+import { OpenFeature } from '@openfeature/server-sdk';
+
+import { PixEnvVarProvider } from './pix-env-var-provider.js';
+
+await OpenFeature.setProviderAndWait(new PixEnvVarProvider());
+
+const featureToggles = OpenFeature.getClient();
+
+export { featureToggles };

--- a/api/src/shared/infrastructure/feature-toggles/pix-env-var-provider.js
+++ b/api/src/shared/infrastructure/feature-toggles/pix-env-var-provider.js
@@ -1,0 +1,30 @@
+import { StandardResolutionReasons } from '@openfeature/server-sdk';
+
+import { config } from '../../config.js';
+
+export class PixEnvVarProvider {
+  metadata = {
+    name: 'Pix environment variable feature toggles',
+  };
+
+  runsOn = 'server';
+
+  async resolveBooleanEvaluation(flagKey) {
+    return {
+      value: config.featureToggles[flagKey] ?? false,
+      reason: StandardResolutionReasons.STATIC,
+    };
+  }
+
+  async resolveStringEvaluation(_flagKey) {
+    return null;
+  }
+
+  async resolveNumberEvaluation(_flagKey) {
+    return null;
+  }
+
+  async resolveObjectEvaluation(_flagKey) {
+    return null;
+  }
+}

--- a/api/tests/shared/integration/infrastructure/feature-toggles/feature-toggles_test.js
+++ b/api/tests/shared/integration/infrastructure/feature-toggles/feature-toggles_test.js
@@ -1,0 +1,34 @@
+import { config } from '../../../../../src/shared/config.js';
+import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('FeatureToggles', function () {
+  context('#getBooleanValue', function () {
+    it('get boolean value when flagKey exists', async function () {
+      sinon.stub(config, 'featureToggles').value({ testTrueBooleanValue: true, testFalseBooleanValue: false });
+
+      const enabledFeature = await featureToggles.getBooleanValue('testTrueBooleanValue');
+      const disabledFeature = await featureToggles.getBooleanValue('testFalseBooleanValue');
+
+      expect(enabledFeature).to.equal(true);
+      expect(disabledFeature).to.equal(false);
+    });
+
+    it('get false value when flagKey does not exist', async function () {
+      sinon.stub(config, 'featureToggles').value({ existingKey: true });
+
+      const nonExistingFeature = await featureToggles.getBooleanValue('nonExistingKey');
+
+      expect(nonExistingFeature).to.equal(false);
+    });
+  });
+
+  context('#getStringValue', function () {
+    it('is not implemented', async function () {
+      sinon.stub(config, 'featureToggles').value({ stringValue: 'hello' });
+
+      const notImplemented = await featureToggles.getStringValue('stringValue');
+      expect(notImplemented).to.be.undefined;
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Notre actuelle utilisation de feature toggles (FT) n'est pas standard et assez basique.

Le but est aussi de préparer et améliorer notre système de feature toggle dans le futur.

## :robot: Proposition

Voir s'il est possible d'utiliser le standard "[OpenFeature](https://openfeature.dev/)" avec notre backend de feature toggle existant (variable d'environnement).

> [OpenFeature](https://openfeature.dev/) is an open specification that provides a vendor-agnostic, community-driven API for feature flagging that works with your favorite feature flag management tool or in-house solution.

> [!NOTE]
> Il s'agit uniquement de l'implémentation OpenFeature avec le système actuel de FT Pix.
> Dans de futurs tech times, nous pourrons voir:
> - comment l'appliquer au code existant,
> - comment faire des tests avec les feature toggles,
> - comment les documenter,
> - comment gérer les FT côté client,
> - enfin voir comment changer du provider...

**Une petite vidéo en français sur OpenFeature pour en savoir plus:**

[![OpenFeature : Vers La normalisation du feature flags (Morgan Blanloeil)](https://img.youtube.com/vi/W1E0qyH1vKY/0.jpg)](https://www.youtube.com/watch?v=W1E0qyH1vKY)

## :100: Pour tester

Pas d'intégration dans le code actuel pour le moment, seul les tests d'intégration liés à l'implémentation proposée doivent passer.
