### PR TITLE
[FEATURE] Afficher des feedback spécifiques aux QCU (PIX-14202) (PIX-13405)

### DIFF
--- a/api/src/devcomp/domain/models/QcuProposal.js
+++ b/api/src/devcomp/domain/models/QcuProposal.js
@@ -1,12 +1,15 @@
 import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.js';
 
 class QcuProposal {
-  constructor({ id, content }) {
+  constructor({ id, content, feedback }) {
     assertNotNullOrUndefined(id, 'The id is required for a QCU proposal.');
     assertNotNullOrUndefined(content, 'The content is required for a QCU proposal.');
 
     this.id = id;
     this.content = content;
+    if (feedback) {
+      this.feedback = feedback;
+    }
   }
 }
 

--- a/api/src/devcomp/domain/models/element/QCU-for-answer-verification.js
+++ b/api/src/devcomp/domain/models/element/QCU-for-answer-verification.js
@@ -46,7 +46,7 @@ class QCUForAnswerVerification extends QCU {
 
     return new QcuCorrectionResponse({
       status: validation.result,
-      feedback: validation.result.isOK() ? this.feedbacks.valid : this.feedbacks.invalid,
+      feedback: this.#getFeedback(validation),
       solution: this.solution.value,
     });
   }
@@ -62,6 +62,22 @@ class QCUForAnswerVerification extends QCU {
     if (error) {
       throw EntityValidationError.fromJoiErrors(error.details);
     }
+  }
+
+  #getSpecificFeedbackByProposalId(proposalId) {
+    const proposalFound = this.proposals.find((proposal) => proposal.id === proposalId);
+    if (proposalFound) {
+      return proposalFound.feedback;
+    }
+  }
+
+  #getFeedback(validation) {
+    const specificFeedback = this.#getSpecificFeedbackByProposalId(this.userResponse);
+    if (specificFeedback) {
+      return specificFeedback;
+    }
+
+    return validation.result.isOK() ? this.feedbacks.valid : this.feedbacks.invalid;
   }
 }
 

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -110,21 +110,20 @@
             "proposals": [
               {
                 "id": "1",
-                "content": "Des recettes de lasagne"
+                "content": "Des recettes de lasagne",
+                "feedback": "<span class=\"feedback__state\">Incorrect.</span><p>Erreur, ce ne sont pas des lasagnes</p>"
               },
               {
                 "id": "2",
-                "content": "Des recettes de paté en croute"
+                "content": "Des recettes de pâté en croûte",
+                "feedback": "<span class=\"feedback__state\">Incorrect.</span><p>Non, ce ne sont pas des recettes de pâté en croûte</p>"
               },
               {
                 "id": "3",
-                "content": "Des recettes végétariennes"
+                "content": "Des recettes végétariennes",
+                "feedback": "<span class=\"feedback__state\">Correct&#8239;!</span><p>Bonne réponse ! Ce sont bien des recettes végétariennes</p>"
               }
             ],
-            "feedbacks": {
-              "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p> L'image contient bien une recherche de recettes végétariennes.</p>",
-              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Avez-vous téléchargé l'image jointe&nbsp;?</p>"
-            },
             "solution": "3"
           }
         }

--- a/api/src/devcomp/infrastructure/factories/element-for-verification-factory.js
+++ b/api/src/devcomp/infrastructure/factories/element-for-verification-factory.js
@@ -47,6 +47,7 @@ export class ElementForVerificationFactory {
         return new QcuProposal({
           id: proposal.id,
           content: proposal.content,
+          feedback: proposal.feedback,
         });
       }),
       feedbacks: element.feedbacks,

--- a/api/tests/devcomp/unit/domain/models/QcuProposal_test.js
+++ b/api/tests/devcomp/unit/domain/models/QcuProposal_test.js
@@ -8,14 +8,16 @@ describe('Unit | Devcomp | Domain | Models | QcuProposal', function () {
       // given
       const id = '1';
       const content = 'vrai';
+      const feedback = 'Correct !';
 
       // when
-      const proposal = new QcuProposal({ id, content });
+      const proposal = new QcuProposal({ id, content, feedback });
 
       // then
       expect(proposal).not.to.be.undefined;
       expect(proposal.id).to.equal(id);
       expect(proposal.content).to.equal(content);
+      expect(proposal.feedback).to.equal(feedback);
     });
   });
 

--- a/api/tests/devcomp/unit/domain/models/element/QCU-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCU-for-answer-verification_test.js
@@ -68,88 +68,296 @@ describe('Unit | Devcomp | Domain | Models | Element | QcuForAnswerVerification'
   });
 
   describe('#assess', function () {
-    it('should return a QcuCorrectionResponse for a valid answer', function () {
-      // given
-      const stubedIsOk = sinon.stub().returns(true);
-      const assessResult = { result: { isOK: stubedIsOk } };
-      const qcuSolution = Symbol('correctSolution');
-      const userResponse = qcuSolution;
+    describe('when we have only global feedback for proposals', function () {
+      it('should return a QcuCorrectionResponse for a valid answer', function () {
+        // given
+        const stubedIsOk = sinon.stub().returns(true);
+        const assessResult = { result: { isOK: stubedIsOk } };
+        const qcuSolution = Symbol('correctSolution');
+        const userResponse = qcuSolution;
 
-      const validator = {
-        assess: sinon.stub(),
-      };
-      const qcu = new QCUForAnswerVerification({
-        id: 'qcu-id',
-        instruction: '',
-        proposals: [{ id: qcuSolution }],
-        feedbacks: { valid: 'OK', invalid: 'KO' },
-        solution: qcuSolution,
-        validator,
+        const validator = {
+          assess: sinon.stub(),
+        };
+        const qcu = new QCUForAnswerVerification({
+          id: 'qcu-id',
+          instruction: '',
+          proposals: [{ id: qcuSolution }],
+          feedbacks: { valid: 'OK', invalid: 'KO' },
+          solution: qcuSolution,
+          validator,
+        });
+        qcu.userResponse = userResponse;
+
+        validator.assess
+          .withArgs({
+            answer: {
+              value: userResponse,
+            },
+          })
+          .returns(assessResult);
+
+        const expectedCorrection = {
+          status: assessResult.result,
+          feedback: qcu.feedbacks.valid,
+          solution: qcuSolution,
+        };
+
+        // when
+        const correction = qcu.assess();
+
+        // then
+        expect(correction).to.deep.equal(expectedCorrection);
+        expect(correction).to.deepEqualInstance(new QcuCorrectionResponse(expectedCorrection));
       });
-      qcu.userResponse = userResponse;
 
-      validator.assess
-        .withArgs({
-          answer: {
-            value: userResponse,
-          },
-        })
-        .returns(assessResult);
+      it('should return a QcuCorrectionResponse for a invalid answer', function () {
+        // given
+        const stubedIsOk = sinon.stub().returns(false);
+        const assessResult = { result: { isOK: stubedIsOk } };
+        const qcuSolution = Symbol('correctSolution');
+        const userResponse = 'wrongAnswer';
 
-      const expectedCorrection = {
-        status: assessResult.result,
-        feedback: qcu.feedbacks.valid,
-        solution: qcuSolution,
-      };
+        const validator = {
+          assess: sinon.stub(),
+        };
+        const qcu = new QCUForAnswerVerification({
+          id: 'qcu-id',
+          instruction: '',
+          proposals: [{ id: qcuSolution }],
+          feedbacks: { valid: 'OK', invalid: 'KO' },
+          solution: qcuSolution,
+          validator,
+        });
+        qcu.userResponse = userResponse;
 
-      // when
-      const correction = qcu.assess();
+        validator.assess
+          .withArgs({
+            answer: {
+              value: userResponse,
+            },
+          })
+          .returns(assessResult);
 
-      // then
-      expect(correction).to.deep.equal(expectedCorrection);
-      expect(correction).to.deepEqualInstance(new QcuCorrectionResponse(expectedCorrection));
+        const expectedCorrection = {
+          status: assessResult.result,
+          feedback: qcu.feedbacks.invalid,
+          solution: qcuSolution,
+        };
+
+        // when
+        const correction = qcu.assess();
+
+        // then
+        expect(correction).to.deep.equal(expectedCorrection);
+        expect(correction).to.deepEqualInstance(new QcuCorrectionResponse(expectedCorrection));
+      });
     });
 
-    it('should return a QcuCorrectionResponse for a invalid answer', function () {
-      // given
-      const stubedIsOk = sinon.stub().returns(false);
-      const assessResult = { result: { isOK: stubedIsOk } };
-      const qcuSolution = Symbol('correctSolution');
-      const userResponse = 'wrongAnswer';
+    describe('when there are specific feedbacks for proposals', function () {
+      it('should return a QcuCorrectionResponse for a valid answer', function () {
+        // given
+        const stubedIsOk = sinon.stub().returns(true);
+        const assessResult = { result: { isOK: stubedIsOk } };
+        const qcuSolution = Symbol('correctSolution');
+        const userResponse = qcuSolution;
 
-      const validator = {
-        assess: sinon.stub(),
-      };
-      const qcu = new QCUForAnswerVerification({
-        id: 'qcu-id',
-        instruction: '',
-        proposals: [{ id: qcuSolution }],
-        feedbacks: { valid: 'OK', invalid: 'KO' },
-        solution: qcuSolution,
-        validator,
+        const validator = {
+          assess: sinon.stub(),
+        };
+        const qcu = new QCUForAnswerVerification({
+          id: 'qcu-id',
+          instruction: '',
+          proposals: [
+            {
+              id: qcuSolution,
+              feedback: 'Answer 1 is correct',
+            },
+            {
+              id: 'wrongSolution',
+              feedback: 'Answer 2 is wrong',
+            },
+          ],
+          solution: qcuSolution,
+          validator,
+        });
+        qcu.userResponse = userResponse;
+
+        validator.assess
+          .withArgs({
+            answer: {
+              value: userResponse,
+            },
+          })
+          .returns(assessResult);
+
+        const expectedCorrection = {
+          status: assessResult.result,
+          feedback: qcu.proposals[0].feedback,
+          solution: qcuSolution,
+        };
+
+        // when
+        const correction = qcu.assess();
+
+        // then
+        expect(correction).to.deep.equal(expectedCorrection);
+        expect(correction).to.deepEqualInstance(new QcuCorrectionResponse(expectedCorrection));
       });
-      qcu.userResponse = userResponse;
 
-      validator.assess
-        .withArgs({
-          answer: {
-            value: userResponse,
-          },
-        })
-        .returns(assessResult);
+      it('should return a QcuCorrectionResponse for a invalid answer', function () {
+        // given
+        const stubedIsOk = sinon.stub().returns(false);
+        const assessResult = { result: { isOK: stubedIsOk } };
+        const qcuSolution = Symbol('correctSolution');
+        const userResponse = 'wrongAnswer';
 
-      const expectedCorrection = {
-        status: assessResult.result,
-        feedback: qcu.feedbacks.invalid,
-        solution: qcuSolution,
-      };
+        const validator = {
+          assess: sinon.stub(),
+        };
+        const qcu = new QCUForAnswerVerification({
+          id: 'qcu-id',
+          instruction: '',
+          proposals: [
+            {
+              id: qcuSolution,
+              feedback: 'Answer 1 is correct',
+            },
+            {
+              id: 'wrongAnswer',
+              feedback: 'Answer 2 is wrong',
+            },
+          ],
+          solution: qcuSolution,
+          validator,
+        });
+        qcu.userResponse = userResponse;
 
-      // when
-      const correction = qcu.assess();
+        validator.assess
+          .withArgs({
+            answer: {
+              value: userResponse,
+            },
+          })
+          .returns(assessResult);
 
-      // then
-      expect(correction).to.deep.equal(expectedCorrection);
-      expect(correction).to.deepEqualInstance(new QcuCorrectionResponse(expectedCorrection));
+        const expectedCorrection = {
+          status: assessResult.result,
+          feedback: qcu.proposals[1].feedback,
+          solution: qcuSolution,
+        };
+
+        // when
+        const correction = qcu.assess();
+
+        // then
+        expect(correction).to.deep.equal(expectedCorrection);
+        expect(correction).to.deepEqualInstance(new QcuCorrectionResponse(expectedCorrection));
+      });
+    });
+
+    describe('when there are both specific feedbacks and global feedbacks for proposals', function () {
+      it('should return a QcuCorrectionResponse for a valid answer', function () {
+        // given
+        const stubedIsOk = sinon.stub().returns(true);
+        const assessResult = { result: { isOK: stubedIsOk } };
+        const qcuSolution = Symbol('correctSolution');
+        const userResponse = qcuSolution;
+
+        const validator = {
+          assess: sinon.stub(),
+        };
+        const qcu = new QCUForAnswerVerification({
+          id: 'qcu-id',
+          instruction: '',
+          proposals: [
+            {
+              id: qcuSolution,
+              feedback: 'Answer 1 is correct',
+            },
+            {
+              id: 'wrongSolution',
+              feedback: 'Answer 2 is wrong',
+            },
+          ],
+          feedbacks: { valid: 'OK', invalid: 'KO' },
+          solution: qcuSolution,
+          validator,
+        });
+        qcu.userResponse = userResponse;
+
+        validator.assess
+          .withArgs({
+            answer: {
+              value: userResponse,
+            },
+          })
+          .returns(assessResult);
+
+        const expectedCorrection = {
+          status: assessResult.result,
+          feedback: qcu.proposals[0].feedback,
+          solution: qcuSolution,
+        };
+
+        // when
+        const correction = qcu.assess();
+
+        // then
+        expect(correction).to.deep.equal(expectedCorrection);
+        expect(correction).to.deepEqualInstance(new QcuCorrectionResponse(expectedCorrection));
+      });
+
+      it('should return a QcuCorrectionResponse for a invalid answer', function () {
+        // given
+        const stubedIsOk = sinon.stub().returns(false);
+        const assessResult = { result: { isOK: stubedIsOk } };
+        const qcuSolution = Symbol('correctSolution');
+        const userResponse = 'wrongAnswer';
+
+        const validator = {
+          assess: sinon.stub(),
+        };
+        const qcu = new QCUForAnswerVerification({
+          id: 'qcu-id',
+          instruction: '',
+          proposals: [
+            {
+              id: qcuSolution,
+              feedback: 'Answer 1 is correct',
+            },
+            {
+              id: 'wrongAnswer',
+              feedback: 'Answer 2 is wrong',
+            },
+          ],
+          feedbacks: { valid: 'OK', invalid: 'KO' },
+          solution: qcuSolution,
+          validator,
+        });
+        qcu.userResponse = userResponse;
+
+        validator.assess
+          .withArgs({
+            answer: {
+              value: userResponse,
+            },
+          })
+          .returns(assessResult);
+
+        const expectedCorrection = {
+          status: assessResult.result,
+          feedback: qcu.proposals[1].feedback,
+          solution: qcuSolution,
+        };
+
+        // when
+        const correction = qcu.assess();
+
+        // then
+        expect(correction).to.deep.equal(expectedCorrection);
+        expect(correction).to.deepEqualInstance(new QcuCorrectionResponse(expectedCorrection));
+      });
     });
   });
 

--- a/api/tests/devcomp/unit/domain/models/element/QCU-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCU-for-answer-verification_test.js
@@ -107,7 +107,6 @@ describe('Unit | Devcomp | Domain | Models | Element | QcuForAnswerVerification'
         const correction = qcu.assess();
 
         // then
-        expect(correction).to.deep.equal(expectedCorrection);
         expect(correction).to.deepEqualInstance(new QcuCorrectionResponse(expectedCorrection));
       });
 
@@ -149,7 +148,6 @@ describe('Unit | Devcomp | Domain | Models | Element | QcuForAnswerVerification'
         const correction = qcu.assess();
 
         // then
-        expect(correction).to.deep.equal(expectedCorrection);
         expect(correction).to.deepEqualInstance(new QcuCorrectionResponse(expectedCorrection));
       });
     });
@@ -201,7 +199,6 @@ describe('Unit | Devcomp | Domain | Models | Element | QcuForAnswerVerification'
         const correction = qcu.assess();
 
         // then
-        expect(correction).to.deep.equal(expectedCorrection);
         expect(correction).to.deepEqualInstance(new QcuCorrectionResponse(expectedCorrection));
       });
 
@@ -251,7 +248,6 @@ describe('Unit | Devcomp | Domain | Models | Element | QcuForAnswerVerification'
         const correction = qcu.assess();
 
         // then
-        expect(correction).to.deep.equal(expectedCorrection);
         expect(correction).to.deepEqualInstance(new QcuCorrectionResponse(expectedCorrection));
       });
     });
@@ -304,7 +300,6 @@ describe('Unit | Devcomp | Domain | Models | Element | QcuForAnswerVerification'
         const correction = qcu.assess();
 
         // then
-        expect(correction).to.deep.equal(expectedCorrection);
         expect(correction).to.deepEqualInstance(new QcuCorrectionResponse(expectedCorrection));
       });
 
@@ -355,7 +350,6 @@ describe('Unit | Devcomp | Domain | Models | Element | QcuForAnswerVerification'
         const correction = qcu.assess();
 
         // then
-        expect(correction).to.deep.equal(expectedCorrection);
         expect(correction).to.deepEqualInstance(new QcuCorrectionResponse(expectedCorrection));
       });
     });

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-schema.js
@@ -8,15 +8,35 @@ const qcuElementSchema = Joi.object({
   instruction: htmlSchema.required(),
   proposals: Joi.array()
     .items({
-      id: proposalIdSchema,
-      content: htmlSchema,
+      id: proposalIdSchema.required(),
+      content: htmlSchema.required(),
+      feedback: htmlSchema,
     })
     .required(),
   feedbacks: Joi.object({
     valid: htmlSchema,
     invalid: htmlSchema,
-  }).required(),
-  solution: proposalIdSchema,
-}).required();
+  }),
+  solution: proposalIdSchema.required(),
+}).custom((qcuElement, helpers) => {
+  const hasGlobalFeedbacks = qcuElement.feedbacks !== undefined;
+  const hasSpecificFeedbacks = qcuElement.proposals.some((proposal) => proposal.feedback !== undefined);
+  if (hasGlobalFeedbacks && hasSpecificFeedbacks) {
+    return helpers.message('Un QCU ne peut pas avoir à la fois des feedbacks spécifiques et globales');
+  }
+  if (hasSpecificFeedbacks) {
+    const someProposalsDoNotHaveSpecificFeedback = qcuElement.proposals.some(
+      (proposal) => proposal.feedback === undefined,
+    );
+    if (someProposalsDoNotHaveSpecificFeedback) {
+      return helpers.message('Dans ce QCU, au moins une proposition ne possède pas de feedback spécifique');
+    }
+  }
+  if (!hasGlobalFeedbacks && !hasSpecificFeedbacks) {
+    return helpers.message("Dans ce QCU, il n'y a ni feedbacks spécifiques, ni feedbacks globales");
+  }
+
+  return qcuElement;
+});
 
 export { qcuElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
@@ -619,10 +619,12 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
                       {
                         id: '1',
                         content: 'Vrai',
+                        feedback: 'Bonne réponse !',
                       },
                       {
                         id: '2',
                         content: 'Faux',
+                        feedback: "Faux n'est pas la bonne réponse.",
                       },
                     ],
                     feedbacks: {
@@ -1128,10 +1130,12 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
                             {
                               id: '1',
                               content: 'Vrai',
+                              feedback: 'Bonne réponse !',
                             },
                             {
                               id: '2',
                               content: 'Faux',
+                              feedback: "Faux n'est pas la bonne réponse.",
                             },
                           ],
                           feedbacks: {


### PR DESCRIPTION
## :unicorn: Problème

En tant qu’équipe Contenu je souhaite pouvoir proposer des feedbacks pour chacune des propositions de mon QCU. Mais actuellement, nous n'avons que des feedbacks globales.

## :robot: Proposition
Ajouter un feedback spécifique par proposition de QCU dans l'API.
Continuer de permettre le fonctionnement des feedbacks globales, ceci afin d'assurer la rétro-compatibilité des modules qui ne sont pas encore mis à jour.

## :rainbow: Remarques

Nous avons fait le choix de gérer au sein du modèle `QcuForAnswerVerification` l'envoi des feedbacks spécifiques ou globales. Ainsi nous n'impactons pas le front et nous assurons la rétro-compatibilité.

❓ Dans l'état actuelle, les tests du `ModuleFactory` ne fail pas quand on ajoute un champ "feedback" non obligatoire côté model de QCU. Ces tests valident seulement que la factory retourne une instance de Module et donc cela a pour conséquence de brouiller notre boucle TDD. En effet, dans notre cas précis, ajouter ou non des feedback spécifiques au QCU dans notre scénario de test ne fait pas péter le test.

🙏  Il semble OK pour l'équipe (PO, tech et métier) d'utiliser le terme "`spécifique`" pour parler de ces feedbacks.

### Règles métiers ajoutées

> Un QCU **doit** posséder **soit** des feedbacks spécifiques **soit** des feedbacks globales.

**Lors des tests de contribution, afficher une erreur si :**
- Il n'y a pas de feedback du tout
- Il y a la présence de feedbacks spécifiques **ET** globales
- Règle bonus : dans le cas où on configure des feedbacks spécifiques, afficher une erreur s'il manque un/des feedbacks spécifiques

@AnaisAllamand ces règles sont-elles à prendre en compte dans Confluence ?

## :100: Pour tester

1. Se rendre sur [le didacticiel](https://app-pr10097.review.pix.fr/modules/didacticiel-modulix/details)
2. Répondre au QCU de la première activité
3. Constater que nous recevons bien des feedbacks spécifiques pour chacune des propositions
4. Répondre aux autres QCU
5. Constater que nous recevons bien des feedbacks globales