### PR TITLE
[TECH] Changer le system de Redis lock et supprimer Bluebird.

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -28,7 +28,6 @@
         "@xmldom/xmldom": "^0.7.5",
         "axios": "^1.0.0",
         "bcrypt": "^5.0.1",
-        "bluebird": "^3.7.2",
         "bookshelf": "^1.2.0",
         "bookshelf-validate": "^2.0.3",
         "cron-parser": "^4.9.0",

--- a/api/package.json
+++ b/api/package.json
@@ -34,7 +34,6 @@
     "@xmldom/xmldom": "^0.7.5",
     "axios": "^1.0.0",
     "bcrypt": "^5.0.1",
-    "bluebird": "^3.7.2",
     "bookshelf": "^1.2.0",
     "bookshelf-validate": "^2.0.3",
     "cron-parser": "^4.9.0",

--- a/api/src/shared/infrastructure/utils/RedisClient.js
+++ b/api/src/shared/infrastructure/utils/RedisClient.js
@@ -34,7 +34,7 @@ class RedisClient {
     this.keys = this._wrapWithPrefix(this._client.keys).bind(this._client);
     this.ping = this._client.ping.bind(this._client);
     this.flushall = this._client.flushall.bind(this._client);
-    this.lockDisposer = this._clientWithLock.disposer.bind(this._clientWithLock);
+    this.lock = this._clientWithLock.lock.bind(this._clientWithLock);
   }
 
   _wrapWithPrefix(fn) {


### PR DESCRIPTION
## :unicorn: Problème

La classe `RedisClient` est le dernier endroit où nous utilisons encore la dépendance `bluebird`. 
Elle est utilisée pour release les verrous `Redlock` via la fonction `bluebird.using`. 

> [Bluebird](https://github.com/petkaantonov/bluebird) est une librairie d’utilitaire autour des promesses, qui a été utilisée à Pix côté API principalement pour palier au manque de fonctionnalités autour des promesses natives NodeJS d’il y a quelques années. Mais les promesses natives NodeJS ont énormément évoluées depuis ce qui rend en partie l’utilisation de Bluebird obsolète. De plus la librairie n’est plus maintenue, sa dernière release v3.7.2 date du 28/11/2019.

## :robot: Proposition

La documentation Redlock propose 3 façons d'utiliser la librairie et de release les locks:
- [Usage (Promise Style)](https://github.com/mike-marcacci/node-redlock/tree/v4?tab=readme-ov-file#usage-promise-style)
- [Usage (Disposer Style)](https://github.com/mike-marcacci/node-redlock/tree/v4?tab=readme-ov-file#usage-disposer-style)
- [Usage (Callback Style)](https://github.com/mike-marcacci/node-redlock/tree/v4?tab=readme-ov-file#usage-callback-style)

Dans cette PR, nous passons **du "Disposer style" au "Promise style"** et ainsi on peut se débarrasser de la dépendance avec bluebird.

> [!NOTE]
> Un partie des tests de `RedisCache_test.js` ont été refactorés pour utiliser `async..await`

## :100: Pour tester

Faire différentes campagnes afin d'accéder au cache LCMS.
