### PR TITLE
[FEATURE] Déconnecter l'utilisateur s'il utilise un refresh token avec un scope incorrect (PIX-14237)

### DIFF
--- a/admin/app/authenticators/oauth2.js
+++ b/admin/app/authenticators/oauth2.js
@@ -5,4 +5,9 @@ export default class Oauth2 extends OAuth2PasswordGrant {
   serverTokenEndpoint = `${ENV.APP.API_HOST}/api/token`;
   serverTokenRevocationEndpoint = `${ENV.APP.API_HOST}/api/revoke`;
   sendClientIdAsQueryParam = true;
+  refreshAccessTokensWithScope = true;
+
+  restore(data) {
+    return super.restore({ ...data, scope: ENV.APP.AUTHENTICATION.SCOPE });
+  }
 }

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -60,7 +60,7 @@
         "ember-qunit": "^8.0.0",
         "ember-resolver": "^12.0.0",
         "ember-set-helper": "^3.0.1",
-        "ember-simple-auth": "^6.0.0",
+        "ember-simple-auth": "^6.1.0",
         "ember-source": "^5.8.0",
         "ember-template-imports": "^4.1.1",
         "ember-template-lint": "^6.0.0",
@@ -28321,10 +28321,11 @@
       }
     },
     "node_modules/ember-simple-auth": {
-      "version": "6.0.0",
+      "version": "6.1.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@babel/eslint-parser": "^7.24.7",
         "@ember/test-waiters": "^3",
         "@embroider/addon-shim": "^1.0.0",
         "@embroider/macros": "^1.0.0",

--- a/admin/package.json
+++ b/admin/package.json
@@ -92,7 +92,7 @@
     "ember-qunit": "^8.0.0",
     "ember-resolver": "^12.0.0",
     "ember-set-helper": "^3.0.1",
-    "ember-simple-auth": "^6.0.0",
+    "ember-simple-auth": "^6.1.0",
     "ember-source": "^5.8.0",
     "ember-template-imports": "^4.1.1",
     "ember-template-lint": "^6.0.0",

--- a/api/src/identity-access-management/application/token/token.controller.js
+++ b/api/src/identity-access-management/application/token/token.controller.js
@@ -32,9 +32,7 @@ const createToken = async function (request, h, dependencies = { tokenService })
   if (grantType === 'refresh_token') {
     refreshToken = request.payload.refresh_token;
 
-    // TODO: we should pass the scope when ember-simple-auth will pass it
-    // see https://github.com/mainmatter/ember-simple-auth/pull/2813 for further details
-    const tokensInfo = await usecases.createAccessTokenFromRefreshToken({ refreshToken });
+    const tokensInfo = await usecases.createAccessTokenFromRefreshToken({ refreshToken, scope });
 
     accessToken = tokensInfo.accessToken;
     expirationDelaySeconds = tokensInfo.expirationDelaySeconds;

--- a/api/tests/identity-access-management/acceptance/application/token.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/token.route.test.js
@@ -143,6 +143,43 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
         expect(result.user_id).to.equal(userId);
         expect(result.refresh_token).to.exist;
       });
+
+      context('when the scope is different from the refresh token one', function () {
+        it('returns a 401 (unauthorized)', async function () {
+          // given
+          const { result: accessTokenResult } = await server.inject({
+            method: 'POST',
+            url: '/api/token',
+            headers: {
+              'content-type': 'application/x-www-form-urlencoded',
+            },
+            payload: querystring.stringify({
+              grant_type: 'password',
+              username: userEmailAddress,
+              password: userPassword,
+              scope: 'pix-app',
+            }),
+          });
+
+          // when
+          const differentScope = 'pix-admin';
+          const response = await server.inject({
+            method: 'POST',
+            url: '/api/token',
+            headers: {
+              'content-type': 'application/x-www-form-urlencoded',
+            },
+            payload: querystring.stringify({
+              grant_type: 'refresh_token',
+              refresh_token: accessTokenResult.refresh_token,
+              scope: differentScope,
+            }),
+          });
+
+          // then
+          expect(response.statusCode).to.equal(401);
+        });
+      });
     });
 
     context('when scope is admin', function () {

--- a/api/tests/identity-access-management/unit/application/token.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/token.controller.test.js
@@ -100,7 +100,7 @@ describe('Unit | Identity Access Management | Application | Controller | Token',
 
         sinon
           .stub(usecases, 'createAccessTokenFromRefreshToken')
-          .withArgs({ refreshToken })
+          .withArgs({ refreshToken, scope })
           .resolves({ accessToken, expirationDelaySeconds });
 
         const tokenServiceStub = { extractUserId: sinon.stub() };

--- a/certif/app/authenticators/oauth2.js
+++ b/certif/app/authenticators/oauth2.js
@@ -5,4 +5,9 @@ export default class OAuth2 extends OAuth2PasswordGrant {
   serverTokenEndpoint = `${ENV.APP.API_HOST}/api/token`;
   serverTokenRevocationEndpoint = `${ENV.APP.API_HOST}/api/revoke`;
   sendClientIdAsQueryParam = true;
+  refreshAccessTokensWithScope = true;
+
+  restore(data) {
+    return super.restore({ ...data, scope: ENV.APP.AUTHENTICATION.SCOPE });
+  }
 }

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -65,7 +65,7 @@
         "ember-page-title": "^8.0.0",
         "ember-qunit": "^8.1.0",
         "ember-resolver": "^12.0.0",
-        "ember-simple-auth": "^6.0.0",
+        "ember-simple-auth": "^6.1.0",
         "ember-source": "^5.8.0",
         "ember-template-imports": "^4.1.1",
         "ember-template-lint": "^6.0.0",
@@ -1658,10 +1658,11 @@
       }
     },
     "node_modules/@babel/eslint-parser": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.24.6.tgz",
-      "integrity": "sha512-Q1BfQX42zXHx732PLW0w4+Y3wJjoZKEMaatFUEAmQ7Z+jCXxinzeqX9bvv2Q8xNPes/H6F0I23oGkcgjaItmLw==",
+      "version": "7.25.1",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.25.1.tgz",
+      "integrity": "sha512-Y956ghgTT4j7rKesabkh5WeqgSFZVFwaPR0IWFm7KFHFmmJ4afbG49SmfW4S+GyRPx0Dy5jxEWA5t0rpxfElWg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
         "eslint-visitor-keys": "^2.1.0",
@@ -32121,11 +32122,13 @@
       }
     },
     "node_modules/ember-simple-auth": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-6.0.0.tgz",
-      "integrity": "sha512-9SzSFApxZ74CD4UxIeTV+poIPeXcRLXWM60cMvC1SwTYjoc/p9DeQF0pVm6m1XV6uA3kPUzEsEn4/GeHc2YX1w==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-6.1.0.tgz",
+      "integrity": "sha512-LhOl7TrOKlqb+0a/5STOoTSncDNuPELuFZ9+1SLduVX7DtdQr8VOEAmB8UaOnG0clJ9Bj6E3SczhXGjqd718Lw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
+        "@babel/eslint-parser": "^7.24.7",
         "@ember/test-waiters": "^3",
         "@embroider/addon-shim": "^1.0.0",
         "@embroider/macros": "^1.0.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -105,7 +105,7 @@
     "ember-page-title": "^8.0.0",
     "ember-qunit": "^8.1.0",
     "ember-resolver": "^12.0.0",
-    "ember-simple-auth": "^6.0.0",
+    "ember-simple-auth": "^6.1.0",
     "ember-source": "^5.8.0",
     "ember-template-imports": "^4.1.1",
     "ember-template-lint": "^6.0.0",

--- a/high-level-tests/e2e/cypress/support/commands.js
+++ b/high-level-tests/e2e/cypress/support/commands.js
@@ -2,11 +2,12 @@ const jsonwebtoken = require('jsonwebtoken');
 const { addCompareSnapshotCommand } = require('cypress-visual-regression/dist/command');
 require('@testing-library/cypress/add-commands');
 
-function getLoginBody(username, password) {
+function getLoginBody(username, password, scope) {
   return {
     username,
     password,
     grant_type: 'password',
+    scope,
   };
 }
 
@@ -20,6 +21,7 @@ function setEmberSimpleAuthSession(response) {
         access_token: response.body.access_token,
         user_id: response.body.user_id,
         refresh_token: response.body.refresh_token,
+        scope: response.body.scope,
         expires_in: 1000,
       },
     })
@@ -32,7 +34,7 @@ Cypress.Commands.add('login', (username, password) => {
     url: `${Cypress.env('API_URL')}/api/token`,
     method: 'POST',
     form: true,
-    body: getLoginBody(username, password),
+    body: getLoginBody(username, password, 'mon-pix'),
   }).then(setEmberSimpleAuthSession);
   cy.wait(['@getCurrentUser']);
 });
@@ -43,7 +45,7 @@ Cypress.Commands.add('loginOrga', (username, password) => {
     url: `${Cypress.env('API_URL')}/api/token`,
     method: 'POST',
     form: true,
-    body: getLoginBody(username, password),
+    body: getLoginBody(username, password, 'pix-orga'),
   }).then(setEmberSimpleAuthSession);
   cy.wait(['@getCurrentUser']);
 });
@@ -54,7 +56,7 @@ Cypress.Commands.add('loginAdmin', (username, password) => {
     url: `${Cypress.env('API_URL')}/api/token`,
     method: 'POST',
     form: true,
-    body: getLoginBody(username, password),
+    body: getLoginBody(username, password, 'pix-admin'),
   }).then((response) => {
     window.localStorage.setItem(
       'ember_simple_auth-session',
@@ -63,6 +65,7 @@ Cypress.Commands.add('loginAdmin', (username, password) => {
           authenticator: 'authenticator:oauth2',
           token_type: 'bearer',
           access_token: response.body.access_token,
+          scope: response.body.scope,
           user_id: 2,
         },
       })

--- a/mon-pix/app/authenticators/oauth2.js
+++ b/mon-pix/app/authenticators/oauth2.js
@@ -6,6 +6,7 @@ import RSVP from 'rsvp';
 export default class OAuth2 extends OAuth2PasswordGrant {
   serverTokenEndpoint = `${ENV.APP.API_HOST}/api/token`;
   serverTokenRevocationEndpoint = `${ENV.APP.API_HOST}/api/revoke`;
+  refreshAccessTokensWithScope = true;
 
   authenticate({ login, password, scope, token }) {
     if (token) {
@@ -18,9 +19,14 @@ export default class OAuth2 extends OAuth2PasswordGrant {
         access_token: token,
         user_id,
         source,
+        scope,
       });
     }
 
     return super.authenticate(login, password, scope);
+  }
+
+  restore(data) {
+    return super.restore({ ...data, scope: ENV.APP.AUTHENTICATION.SCOPE });
   }
 }

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -68,7 +68,7 @@
         "ember-qunit": "^8.0.0",
         "ember-resolver": "^11.0.0",
         "ember-responsive": "^5.0.0",
-        "ember-simple-auth": "^6.0.0",
+        "ember-simple-auth": "^6.1.0",
         "ember-source": "^5.9.0",
         "ember-template-imports": "^4.1.1",
         "ember-template-lint": "^5.13.0",
@@ -31202,12 +31202,13 @@
       }
     },
     "node_modules/ember-simple-auth": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-6.0.0.tgz",
-      "integrity": "sha512-9SzSFApxZ74CD4UxIeTV+poIPeXcRLXWM60cMvC1SwTYjoc/p9DeQF0pVm6m1XV6uA3kPUzEsEn4/GeHc2YX1w==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-6.1.0.tgz",
+      "integrity": "sha512-LhOl7TrOKlqb+0a/5STOoTSncDNuPELuFZ9+1SLduVX7DtdQr8VOEAmB8UaOnG0clJ9Bj6E3SczhXGjqd718Lw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@babel/eslint-parser": "^7.24.7",
         "@ember/test-waiters": "^3",
         "@embroider/addon-shim": "^1.0.0",
         "@embroider/macros": "^1.0.0",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -99,7 +99,7 @@
     "ember-qunit": "^8.0.0",
     "ember-resolver": "^11.0.0",
     "ember-responsive": "^5.0.0",
-    "ember-simple-auth": "^6.0.0",
+    "ember-simple-auth": "^6.1.0",
     "ember-source": "^5.9.0",
     "ember-template-imports": "^4.1.1",
     "ember-template-lint": "^5.13.0",

--- a/orga/app/authenticators/oauth2.js
+++ b/orga/app/authenticators/oauth2.js
@@ -5,4 +5,9 @@ export default class Oauth2 extends OAuth2PasswordGrant {
   serverTokenEndpoint = `${ENV.APP.API_HOST}/api/token`;
   serverTokenRevocationEndpoint = `${ENV.APP.API_HOST}/api/revoke`;
   sendClientIdAsQueryParam = true;
+  refreshAccessTokensWithScope = true;
+
+  restore(data) {
+    return super.restore({ ...data, scope: ENV.APP.AUTHENTICATION.SCOPE });
+  }
 }

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -59,7 +59,7 @@
         "ember-page-title": "^8.0.0",
         "ember-qunit": "^8.0.0",
         "ember-resolver": "^12.0.0",
-        "ember-simple-auth": "^6.0.0",
+        "ember-simple-auth": "^6.1.0",
         "ember-source": "^5.9.0",
         "ember-template-imports": "^4.1.0",
         "ember-template-lint": "^6.0.0",
@@ -1846,9 +1846,9 @@
       }
     },
     "node_modules/@babel/eslint-parser": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.24.6.tgz",
-      "integrity": "sha512-Q1BfQX42zXHx732PLW0w4+Y3wJjoZKEMaatFUEAmQ7Z+jCXxinzeqX9bvv2Q8xNPes/H6F0I23oGkcgjaItmLw==",
+      "version": "7.25.1",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.25.1.tgz",
+      "integrity": "sha512-Y956ghgTT4j7rKesabkh5WeqgSFZVFwaPR0IWFm7KFHFmmJ4afbG49SmfW4S+GyRPx0Dy5jxEWA5t0rpxfElWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -33802,12 +33802,13 @@
       }
     },
     "node_modules/ember-simple-auth": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-6.0.0.tgz",
-      "integrity": "sha512-9SzSFApxZ74CD4UxIeTV+poIPeXcRLXWM60cMvC1SwTYjoc/p9DeQF0pVm6m1XV6uA3kPUzEsEn4/GeHc2YX1w==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-6.1.0.tgz",
+      "integrity": "sha512-LhOl7TrOKlqb+0a/5STOoTSncDNuPELuFZ9+1SLduVX7DtdQr8VOEAmB8UaOnG0clJ9Bj6E3SczhXGjqd718Lw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@babel/eslint-parser": "^7.24.7",
         "@ember/test-waiters": "^3",
         "@embroider/addon-shim": "^1.0.0",
         "@embroider/macros": "^1.0.0",

--- a/orga/package.json
+++ b/orga/package.json
@@ -100,7 +100,7 @@
     "ember-page-title": "^8.0.0",
     "ember-qunit": "^8.0.0",
     "ember-resolver": "^12.0.0",
-    "ember-simple-auth": "^6.0.0",
+    "ember-simple-auth": "^6.1.0",
     "ember-source": "^5.9.0",
     "ember-template-imports": "^4.1.0",
     "ember-template-lint": "^6.0.0",


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, si un refresh token n'appartient pas au scope de l'application, il est quand même accepté pour régénérer un access token.

## :robot: Proposition

Utiliser le scope pour vérifier qu'il est le même que celui du refresh token.
Pour cela, il est nécessaire de mettre à jour la librairie `ember-simple-auth` en version `6.1.0` qui inclut un correctif permettant d'envoyer le `scope` dans le endpoint de refresh.

Pour plus de détails, voir la PR https://github.com/mainmatter/ember-simple-auth/pull/2813

## :100: Pour tester

:warning: Pour réaliser ces tests, bien penser à ne pas avoir une configuration de Pix Api avec des valeurs de `REFRESH_TOKEN_LIFESPAN` trop petites, sinon vous aurez beaucoup de mal à pouvoir conclure quoi que ce soit. Aussi voici des valeurs conseillées pour ce test à mettre dans votre `.env` :
```shell
REFRESH_TOKEN_LIFESPAN_MON_PIX=7d
REFRESH_TOKEN_LIFESPAN_PIX_ORGA=7d
REFRESH_TOKEN_LIFESPAN_PIX_CERTIF=7d
REFRESH_TOKEN_LIFESPAN_PIX_ADMIN=7d
```

1. Se connecter sur Pix Admin (avec superadmin)
   -  Copier le refresh token depuis le local storage

2. Se connecter sur Pix App (avec superadmin)
   - Remplacer le refresh token par celui de Pix App dans le local storage
   - Changer le timestamp d'access token dans le local storage avec un timestamp dans le passé pour l'expirer (ex: 1726065420825)
> Vous devez être déconnecté 🎉

3. Retourner sur Pix Admin
   - Changer le timestamp d'access token dans le local storage avec un timestamp dans le passé pour l'expirer (ex: 1726065420825)
> l'access token doit être correctement renouvellé (voir s'il a changé dans le local storage)