### PR TITLE
[TECH] Uniformiser le nom de la propriété des participations aux campagnes dans l'API interne (PIX-14239).

### DIFF
--- a/api/db/seeds/data/team-prescription/build-quests.js
+++ b/api/db/seeds/data/team-prescription/build-quests.js
@@ -25,13 +25,13 @@ async function createAttestationQuest(databasebuilder) {
       comparison: 'one-of',
     },
     {
-      type: 'organization-learner',
+      type: 'organizationLearner',
       data: {
         MEFCode: '10010012110',
       },
     },
     {
-      type: 'campaign-participation',
+      type: 'campaignParticipations',
       data: {
         targetProfileIds: [TARGET_PROFILE_BADGES_STAGES_ID],
       },

--- a/api/src/prescription/API.md
+++ b/api/src/prescription/API.md
@@ -5,6 +5,8 @@
 <dd></dd>
 <dt><a href="#module_OrganizationLearnerApi">OrganizationLearnerApi</a></dt>
 <dd></dd>
+<dt><a href="#module_OrganizationLearnerWithParticipationsApi">OrganizationLearnerWithParticipationsApi</a></dt>
+<dd></dd>
 <dt><a href="#module_TargetProfileApi">TargetProfileApi</a></dt>
 <dd></dd>
 </dl>
@@ -257,6 +259,84 @@ Si le params 'filter' est présent, les organization-learners seront filtrés
 | --- | --- |
 | organizationLearners | <code>Array.&lt;OrganizationLearner&gt;</code> | 
 | pagination | <code>Pagination</code> \| <code>undefined</code> | 
+
+<a name="module_OrganizationLearnerWithParticipationsApi"></a>
+
+## OrganizationLearnerWithParticipationsApi
+
+* [OrganizationLearnerWithParticipationsApi](#module_OrganizationLearnerWithParticipationsApi)
+    * [~find(payload)](#module_OrganizationLearnerWithParticipationsApi..find) ⇒ <code>Promise.&lt;Array.&lt;OrganizationLearnerWithParticipations&gt;&gt;</code>
+    * [~FindPayload](#module_OrganizationLearnerWithParticipationsApi..FindPayload) : <code>object</code>
+    * [~OrganizationLearner](#module_OrganizationLearnerWithParticipationsApi..OrganizationLearner) : <code>object</code>
+    * [~Organization](#module_OrganizationLearnerWithParticipationsApi..Organization) : <code>object</code>
+    * [~CampaignParticipation](#module_OrganizationLearnerWithParticipationsApi..CampaignParticipation) : <code>object</code>
+    * [~OrganizationLearnerWithParticipations](#module_OrganizationLearnerWithParticipationsApi..OrganizationLearnerWithParticipations) : <code>object</code>
+
+<a name="module_OrganizationLearnerWithParticipationsApi..find"></a>
+
+### OrganizationLearnerWithParticipationsApi~find(payload) ⇒ <code>Promise.&lt;Array.&lt;OrganizationLearnerWithParticipations&gt;&gt;</code>
+Récupère les organizations-learners avec leurs participations à partir d'une liste d'ids d'utilisateurs
+
+**Kind**: inner method of [<code>OrganizationLearnerWithParticipationsApi</code>](#module_OrganizationLearnerWithParticipationsApi)  
+
+| Param | Type |
+| --- | --- |
+| payload | <code>FindPayload</code> | 
+
+<a name="module_OrganizationLearnerWithParticipationsApi..FindPayload"></a>
+
+### OrganizationLearnerWithParticipationsApi~FindPayload : <code>object</code>
+**Kind**: inner typedef of [<code>OrganizationLearnerWithParticipationsApi</code>](#module_OrganizationLearnerWithParticipationsApi)  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| userIds | <code>Array.&lt;number&gt;</code> | 
+
+<a name="module_OrganizationLearnerWithParticipationsApi..OrganizationLearner"></a>
+
+### OrganizationLearnerWithParticipationsApi~OrganizationLearner : <code>object</code>
+**Kind**: inner typedef of [<code>OrganizationLearnerWithParticipationsApi</code>](#module_OrganizationLearnerWithParticipationsApi)  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| id | <code>number</code> | 
+| MEFCode | <code>string</code> | 
+
+<a name="module_OrganizationLearnerWithParticipationsApi..Organization"></a>
+
+### OrganizationLearnerWithParticipationsApi~Organization : <code>object</code>
+**Kind**: inner typedef of [<code>OrganizationLearnerWithParticipationsApi</code>](#module_OrganizationLearnerWithParticipationsApi)  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| isManagingStudents | <code>boolean</code> | 
+| tags | <code>Array.&lt;string&gt;</code> | 
+| type | <code>string</code> | 
+
+<a name="module_OrganizationLearnerWithParticipationsApi..CampaignParticipation"></a>
+
+### OrganizationLearnerWithParticipationsApi~CampaignParticipation : <code>object</code>
+**Kind**: inner typedef of [<code>OrganizationLearnerWithParticipationsApi</code>](#module_OrganizationLearnerWithParticipationsApi)  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| targetProfileId | <code>number</code> | 
+
+<a name="module_OrganizationLearnerWithParticipationsApi..OrganizationLearnerWithParticipations"></a>
+
+### OrganizationLearnerWithParticipationsApi~OrganizationLearnerWithParticipations : <code>object</code>
+**Kind**: inner typedef of [<code>OrganizationLearnerWithParticipationsApi</code>](#module_OrganizationLearnerWithParticipationsApi)  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| organizationLearner | <code>OrganizationLearner</code> | 
+| organization | <code>Organization</code> | 
+| campaignParticipations | <code>Array.&lt;CampaignParticipation&gt;</code> | 
 
 <a name="module_TargetProfileApi"></a>
 

--- a/api/src/prescription/organization-learner/application/api/organization-learners-with-participations-api.js
+++ b/api/src/prescription/organization-learner/application/api/organization-learners-with-participations-api.js
@@ -27,7 +27,7 @@ import { OrganizationLearnerWithParticipations } from './read-models/Organizatio
  */
 
 /**
- * @typedef Participations
+ * @typedef CampaignParticipation
  * @type {object}
  * @property {number} targetProfileId
  */
@@ -37,7 +37,7 @@ import { OrganizationLearnerWithParticipations } from './read-models/Organizatio
  * @type {object}
  * @property {OrganizationLearner} organizationLearner
  * @property {Organization} organization
- * @property {Array<Participations>} participations
+ * @property {Array<CampaignParticipation>} campaignParticipations
  */
 
 /**
@@ -54,11 +54,11 @@ export async function find({ userIds }) {
   });
 
   return organizationLearnersWithParticipations.map(
-    ({ organizationLearner, organization, participations, tagNames }) => {
+    ({ organizationLearner, organization, campaignParticipations, tagNames }) => {
       return new OrganizationLearnerWithParticipations({
         organizationLearner,
         organization,
-        participations,
+        campaignParticipations,
         tagNames,
       });
     },

--- a/api/src/prescription/organization-learner/application/api/read-models/OrganizationLearnerWithParticipations.js
+++ b/api/src/prescription/organization-learner/application/api/read-models/OrganizationLearnerWithParticipations.js
@@ -1,5 +1,5 @@
 export class OrganizationLearnerWithParticipations {
-  constructor({ organizationLearner, organization, participations, tagNames }) {
+  constructor({ organizationLearner, organization, campaignParticipations, tagNames }) {
     this.organizationLearner = {
       id: organizationLearner.id,
       MEFCode: organizationLearner.MEFCode,
@@ -9,6 +9,6 @@ export class OrganizationLearnerWithParticipations {
       tags: tagNames,
       type: organization.type,
     };
-    this.participations = participations.map(({ targetProfileId }) => ({ targetProfileId }));
+    this.campaignParticipations = campaignParticipations.map(({ targetProfileId }) => ({ targetProfileId }));
   }
 }

--- a/api/tests/prescription/organization-learner/unit/application/api/models/OrganizationLearnerWithParticipations_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/api/models/OrganizationLearnerWithParticipations_test.js
@@ -16,12 +16,16 @@ describe('Unit | Application| API | Models | OrganizationLearnerWithParticipatio
     const organizationLearnerWithParticipations = new OrganizationLearnerWithParticipations({
       organizationLearner,
       organization,
-      participations: participationsList,
+      campaignParticipations: participationsList,
       tagNames,
     });
 
     // then
-    expect(organizationLearnerWithParticipations).to.have.keys('organizationLearner', 'organization', 'participations');
+    expect(organizationLearnerWithParticipations).to.have.keys(
+      'organizationLearner',
+      'organization',
+      'campaignParticipations',
+    );
     expect(organizationLearnerWithParticipations.organizationLearner).to.deep.equal({
       id: organizationLearner.id,
       MEFCode: organizationLearner.MEFCode,
@@ -31,7 +35,7 @@ describe('Unit | Application| API | Models | OrganizationLearnerWithParticipatio
       tags: tagNames,
       type: organization.type,
     });
-    expect(organizationLearnerWithParticipations.participations).to.deep.have.members([
+    expect(organizationLearnerWithParticipations.campaignParticipations).to.deep.have.members([
       { targetProfileId: participationsList[0].targetProfileId },
       { targetProfileId: participationsList[1].targetProfileId },
     ]);

--- a/api/tests/prescription/organization-learner/unit/application/api/organization-learners-with-participations-api_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/api/organization-learners-with-participations-api_test.js
@@ -13,7 +13,7 @@ describe('Unit | API | Organization Learner With Participations', function () {
       const organizationLearner1 = domainBuilder.buildOrganizationLearner();
       const organization2 = domainBuilder.buildOrganization();
       const organizationLearner2 = domainBuilder.buildOrganizationLearner();
-      const participations = [
+      const campaignParticipations = [
         domainBuilder.buildCampaignParticipationOverview(),
         domainBuilder.buildCampaignParticipationOverview(),
       ];
@@ -21,8 +21,8 @@ describe('Unit | API | Organization Learner With Participations', function () {
 
       const useCaseStub = sinon.stub(usecases, 'findOrganizationLearnersWithParticipations');
       useCaseStub.withArgs({ userIds }).resolves([
-        { organizationLearner: organizationLearner1, organization: organization1, participations, tagNames },
-        { organizationLearner: organizationLearner2, organization: organization2, participations, tagNames },
+        { organizationLearner: organizationLearner1, organization: organization1, campaignParticipations, tagNames },
+        { organizationLearner: organizationLearner2, organization: organization2, campaignParticipations, tagNames },
       ]);
 
       // when
@@ -45,7 +45,7 @@ describe('Unit | API | Organization Learner With Participations', function () {
             tags: tagNames,
             type: organization1.type,
           },
-          participations: participations.map(({ targetProfileId }) => ({ targetProfileId })),
+          campaignParticipations: campaignParticipations.map(({ targetProfileId }) => ({ targetProfileId })),
         },
         {
           organizationLearner: {
@@ -57,7 +57,7 @@ describe('Unit | API | Organization Learner With Participations', function () {
             tags: tagNames,
             type: organization2.type,
           },
-          participations: participations.map(({ targetProfileId }) => ({ targetProfileId })),
+          campaignParticipations: campaignParticipations.map(({ targetProfileId }) => ({ targetProfileId })),
         },
       ]);
     });


### PR DESCRIPTION
## :robot: Proposition
On souhaite uniformiser les propriétés des conditions d'éligibilité dans l'API interne destinée aux attestations. On remplace donc la propriété participation par campaignParticipations.

## :100: Pour tester
