### PR TITLE
[TECH] Remonter les organisations ayant des lots de places illimités pour data (PIX-14247)

### DIFF
--- a/api/src/prescription/organization-place/domain/read-models/PlacesLot.js
+++ b/api/src/prescription/organization-place/domain/read-models/PlacesLot.js
@@ -23,7 +23,7 @@ export class PlacesLot {
   #deletedAt;
   constructor(params = {}) {
     validateEntity(validationSchema, params);
-    this.count = params.count === null ? 0 : params.count;
+    this.count = params.count;
     this.organizationId = params.organizationId;
     this.#activationDate = params.activationDate;
     this.#expirationDate = params.expirationDate;

--- a/api/src/prescription/organization-place/domain/read-models/PlacesLot.js
+++ b/api/src/prescription/organization-place/domain/read-models/PlacesLot.js
@@ -31,7 +31,7 @@ export class PlacesLot {
   }
 
   get isActive() {
-    return this.status == statuses.ACTIVE && !this.#deletedAt;
+    return this.status === statuses.ACTIVE && !this.#deletedAt;
   }
 
   get activationDate() {

--- a/api/src/shared/infrastructure/repositories/organization-repository.js
+++ b/api/src/shared/infrastructure/repositories/organization-repository.js
@@ -189,7 +189,6 @@ const getOrganizationsWithPlaces = async function () {
   const organizations = await knexConn('organizations')
     .select('organizations.id', 'name', 'type')
     .innerJoin('organization-places', 'organizations.id', 'organization-places.organizationId')
-    .whereNotNull('organization-places.count')
     .whereNull('archivedAt')
     .distinct();
 

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -1138,22 +1138,22 @@ describe('Integration | Repository | Organization', function () {
       expect(organizationsWithPlaces.length).to.equal(1);
     });
 
-    it('should not return organization with null place count', async function () {
+    it('should return organization instead if they have unlimited places', async function () {
       // given
       const superAdminUserId = databaseBuilder.factory.buildUser().id;
 
-      const firstOrganization = databaseBuilder.factory.buildOrganization({
+      const organizationId = databaseBuilder.factory.buildOrganization({
         type: 'SCO',
-        name: 'Organization of the dark side',
+        name: 'Organization du sud de la France avec le plus beau stade de France',
         archivedAt: null,
         isArchived: false,
-      });
+      }).id;
 
       databaseBuilder.factory.buildOrganizationPlace({
         count: null,
-        organizationId: firstOrganization.id,
-        activationDate: new Date(),
-        expirationDate: new Date(),
+        organizationId,
+        activationDate: new Date('2024-01-01'),
+        expirationDate: new Date('2025-12-31'),
         createdBy: superAdminUserId,
         createdAt: new Date(),
         deletedAt: null,
@@ -1166,7 +1166,7 @@ describe('Integration | Repository | Organization', function () {
       const organizationsWithPlaces = await organizationRepository.getOrganizationsWithPlaces();
 
       // then
-      expect(organizationsWithPlaces.length).to.equal(0);
+      expect(organizationsWithPlaces.length).to.equal(1);
     });
   });
 });

--- a/api/tests/prescription/organization-place/integration/domain/usecases/get-data-organizations-places-statistics_test.js
+++ b/api/tests/prescription/organization-place/integration/domain/usecases/get-data-organizations-places-statistics_test.js
@@ -36,7 +36,7 @@ describe('Integration | UseCases | get-data-organizations-places-statistics', fu
     });
     const secondOrganization = databaseBuilder.factory.buildOrganization({ id: 2, name: 'Pole Emploi', type: 'PRO' });
     databaseBuilder.factory.buildOrganizationPlace({
-      count: 5,
+      count: null,
       organizationId: secondOrganization.id,
       activationDate: new Date('2021-04-01'),
       expirationDate: new Date('2021-05-15'),
@@ -60,7 +60,7 @@ describe('Integration | UseCases | get-data-organizations-places-statistics', fu
 
     expect(dataOrganizationsPlacesStatistics[1].organizationId).to.equal(secondOrganization.id);
     expect(dataOrganizationsPlacesStatistics[1].organizationActivePlacesLotCount).to.equal(1);
-    expect(dataOrganizationsPlacesStatistics[1].organizationPlacesCount).to.equal(5);
+    expect(dataOrganizationsPlacesStatistics[1].organizationPlacesCount).to.equal(null);
     expect(dataOrganizationsPlacesStatistics[1].organizationName).to.equal('Pole Emploi');
     expect(dataOrganizationsPlacesStatistics[1].organizationType).to.equal('PRO');
     expect(dataOrganizationsPlacesStatistics[1].organizationOccupiedPlacesCount).to.equal(0);

--- a/api/tests/prescription/organization-place/unit/domain/read-models/PlacesLot_test.js
+++ b/api/tests/prescription/organization-place/unit/domain/read-models/PlacesLot_test.js
@@ -14,17 +14,6 @@ describe('Unit | Domain | ReadModels | PlacesLot', function () {
   });
 
   describe('#count', function () {
-    it('should return 0 if count is null', function () {
-      const placeLot = new PlacesLot({
-        count: null,
-        activationDate: new Date(),
-        expirationDate: new Date(),
-        deletedAt: null,
-      });
-
-      expect(placeLot.count).to.equal(0);
-    });
-
     it('should return count', function () {
       const placeLot = new PlacesLot({
         count: 10,


### PR DESCRIPTION
## :unicorn: Problème
Suite à cette PR : https://github.com/1024pix/pix/pull/10086
La validation des places `null` n'existe plus. On peut donc retirer la clause `whereNull` que nous avions ajoutés exclusivement pour respecter le model `PlaceStatistics`.


## :robot: Proposition
Retirer la clause `whereNull` et les tests associés. On peut également modifier le cast de `if null = 0` dans le model `PlaceLot`
Les données que le endpoint va renvoyer a l'équipe data sera maintenant complètement identiques a celle précédente en ajoutant simplement nos règles métiers. Mais les organisations ayant des places illimités pourront de nouveau être remontée

## :rainbow: Remarques
Petit BSR au passage pour l'ajout d'une stricte égalitée qui était passée sous les radars : 🛰️

## :100: Pour tester

- Rien de spécial mis a part les tests au verts
- On pourra vérifier une fois en integ si les données remontées a data contiennent effectivement les organisations illimitées
- 🐈‍⬛ 