### PR TITLE
[FEATURE] Tenir compte de la condition sur l'obligation d'avoir une certification pix délivrée et validée avec un score minimum requis dans le bandeau V3 (PIX-14236)

### DIFF
--- a/api/src/certification/enrolment/domain/models/ComplementaryCertificationBadge.js
+++ b/api/src/certification/enrolment/domain/models/ComplementaryCertificationBadge.js
@@ -1,6 +1,7 @@
 export class ComplementaryCertificationBadge {
-  constructor({ id, requiredPixScore }) {
+  constructor({ id, requiredPixScore, offsetVersion }) {
     this.id = id;
     this.requiredPixScore = requiredPixScore;
+    this.offsetVersion = offsetVersion;
   }
 }

--- a/api/src/certification/enrolment/domain/models/ComplementaryCertificationBadge.js
+++ b/api/src/certification/enrolment/domain/models/ComplementaryCertificationBadge.js
@@ -1,7 +1,8 @@
 export class ComplementaryCertificationBadge {
-  constructor({ id, requiredPixScore, offsetVersion }) {
+  constructor({ id, requiredPixScore, offsetVersion, currentAttachedComplementaryCertificationBadgeId }) {
     this.id = id;
     this.requiredPixScore = requiredPixScore;
     this.offsetVersion = offsetVersion;
+    this.currentAttachedComplementaryCertificationBadgeId = currentAttachedComplementaryCertificationBadgeId;
   }
 }

--- a/api/src/certification/enrolment/domain/models/ComplementaryCertificationBadge.js
+++ b/api/src/certification/enrolment/domain/models/ComplementaryCertificationBadge.js
@@ -1,0 +1,6 @@
+export class ComplementaryCertificationBadge {
+  constructor({ id, requiredPixScore }) {
+    this.id = id;
+    this.requiredPixScore = requiredPixScore;
+  }
+}

--- a/api/src/certification/enrolment/domain/models/PixCertification.js
+++ b/api/src/certification/enrolment/domain/models/PixCertification.js
@@ -1,0 +1,8 @@
+export class PixCertification {
+  constructor({ pixScore, status, isCancelled, isRejectedForFraud }) {
+    this.pixScore = pixScore;
+    this.status = status;
+    this.isCancelled = isCancelled;
+    this.isRejectedForFraud = isRejectedForFraud;
+  }
+}

--- a/api/src/certification/enrolment/domain/usecases/get-user-certification-eligibility.js
+++ b/api/src/certification/enrolment/domain/usecases/get-user-certification-eligibility.js
@@ -1,3 +1,4 @@
+import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
 import { CertificationEligibility, UserCertificationEligibility } from '../read-models/UserCertificationEligibility.js';
 
 const getUserCertificationEligibility = async function ({
@@ -19,6 +20,7 @@ const getUserCertificationEligibility = async function ({
     userId,
   });
   for (const acquiredBadge of userAcquiredBadges) {
+    const isClea = acquiredBadge.complementaryCertificationKey === ComplementaryCertificationKeys.CLEA;
     const isAcquiredExpectedLevel = _hasAcquiredComplementaryCertificationForExpectedLevel(
       complementaryCertificationAcquiredByUser,
       acquiredBadge,
@@ -27,8 +29,12 @@ const getUserCertificationEligibility = async function ({
     const badgeIsNotOutdated = acquiredBadge.offsetVersion === 0;
     const badgeIsOutdatedByOneVersionAndUserHasNoComplementaryCertificationForIt =
       acquiredBadge.offsetVersion === 1 && !isAcquiredExpectedLevel;
+    const areOtherEligibilityConditionsFulfilled = isClea ? isCertifiable : true;
 
-    if (badgeIsNotOutdated || badgeIsOutdatedByOneVersionAndUserHasNoComplementaryCertificationForIt) {
+    if (
+      (badgeIsNotOutdated || badgeIsOutdatedByOneVersionAndUserHasNoComplementaryCertificationForIt) &&
+      areOtherEligibilityConditionsFulfilled
+    ) {
       certificationEligibilities.push(
         new CertificationEligibility({
           label: acquiredBadge.complementaryCertificationBadgeLabel,

--- a/api/src/certification/enrolment/infrastructure/repositories/complementary-certification-badge-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/complementary-certification-badge-repository.js
@@ -1,0 +1,14 @@
+import { knex } from '../../../../../db/knex-database-connection.js';
+import { ComplementaryCertificationBadge } from '../../domain/models/ComplementaryCertificationBadge.js';
+
+export async function findAll() {
+  const results = await knex('complementary-certification-badges').select('id', 'minimumEarnedPix').orderBy('id');
+  return results.map(_toDomain);
+}
+
+function _toDomain(data) {
+  return new ComplementaryCertificationBadge({
+    id: data.id,
+    requiredPixScore: data.minimumEarnedPix,
+  });
+}

--- a/api/src/certification/enrolment/infrastructure/repositories/complementary-certification-badge-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/complementary-certification-badge-repository.js
@@ -9,6 +9,9 @@ export async function findAll() {
       knex.raw(
         '(rank() over (partition by "complementaryCertificationId", "level" ORDER BY "detachedAt" DESC NULLS FIRST)) - 1 as "offsetVersion"',
       ),
+      knex.raw(
+        ' (first_value("id") over (partition by "complementaryCertificationId", "level" ORDER BY "detachedAt" DESC NULLS FIRST)) as "currentAttachedComplementaryCertificationBadgeId"',
+      ),
     )
 
     .orderBy('id');
@@ -20,5 +23,6 @@ function _toDomain(data) {
     id: data.id,
     requiredPixScore: data.minimumEarnedPix,
     offsetVersion: data.offsetVersion,
+    currentAttachedComplementaryCertificationBadgeId: data.currentAttachedComplementaryCertificationBadgeId,
   });
 }

--- a/api/src/certification/enrolment/infrastructure/repositories/complementary-certification-badge-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/complementary-certification-badge-repository.js
@@ -2,7 +2,16 @@ import { knex } from '../../../../../db/knex-database-connection.js';
 import { ComplementaryCertificationBadge } from '../../domain/models/ComplementaryCertificationBadge.js';
 
 export async function findAll() {
-  const results = await knex('complementary-certification-badges').select('id', 'minimumEarnedPix').orderBy('id');
+  const results = await knex('complementary-certification-badges')
+    .select(
+      'id',
+      'minimumEarnedPix',
+      knex.raw(
+        '(rank() over (partition by "complementaryCertificationId", "level" ORDER BY "detachedAt" DESC NULLS FIRST)) - 1 as "offsetVersion"',
+      ),
+    )
+
+    .orderBy('id');
   return results.map(_toDomain);
 }
 
@@ -10,5 +19,6 @@ function _toDomain(data) {
   return new ComplementaryCertificationBadge({
     id: data.id,
     requiredPixScore: data.minimumEarnedPix,
+    offsetVersion: data.offsetVersion,
   });
 }

--- a/api/src/certification/enrolment/infrastructure/repositories/index.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/index.js
@@ -9,6 +9,7 @@ import * as centerRepository from './center-repository.js';
 import * as certificationCandidateRepository from './certification-candidate-repository.js';
 import * as certificationCpfCityRepository from './certification-cpf-city-repository.js';
 import * as certificationCpfCountryRepository from './certification-cpf-country-repository.js';
+import * as complementaryCertificationBadgeRepository from './complementary-certification-badge-repository.js';
 import * as complementaryCertificationCourseRepository from './complementary-certification-course-repository.js';
 import * as complementaryCertificationRepository from './complementary-certification-repository.js';
 import * as countryRepository from './country-repository.js';
@@ -40,6 +41,7 @@ import * as userRepository from './user-repository.js';
  * @typedef {targetProfileHistoryRepository} TargetProfileHistoryRepository
  * @typedef {complementaryCertificationCourseRepository} ComplementaryCertificationCourseRepository
  * @typedef {pixCertificationRepository} PixCertificationRepository
+ * @typedef {complementaryCertificationBadgeRepository} ComplementaryCertificationBadgeRepository
  */
 const repositoriesWithoutInjectedDependencies = {
   candidateRepository,
@@ -60,6 +62,7 @@ const repositoriesWithoutInjectedDependencies = {
   targetProfileHistoryRepository,
   complementaryCertificationCourseRepository,
   pixCertificationRepository,
+  complementaryCertificationBadgeRepository,
 };
 
 /**

--- a/api/src/certification/enrolment/infrastructure/repositories/index.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/index.js
@@ -13,6 +13,7 @@ import * as complementaryCertificationCourseRepository from './complementary-cer
 import * as complementaryCertificationRepository from './complementary-certification-repository.js';
 import * as countryRepository from './country-repository.js';
 import * as enrolledCandidateRepository from './enrolled-candidate-repository.js';
+import * as pixCertificationRepository from './pix-certification-repository.js';
 import * as scoCertificationCandidateRepository from './sco-certification-candidate-repository.js';
 import * as sessionForAttendanceSheetRepository from './session-for-attendance-sheet-repository.js';
 import * as sessionRepository from './session-repository.js';
@@ -38,6 +39,7 @@ import * as userRepository from './user-repository.js';
  * @typedef {userRepository} UserRepository
  * @typedef {targetProfileHistoryRepository} TargetProfileHistoryRepository
  * @typedef {complementaryCertificationCourseRepository} ComplementaryCertificationCourseRepository
+ * @typedef {pixCertificationRepository} PixCertificationRepository
  */
 const repositoriesWithoutInjectedDependencies = {
   candidateRepository,
@@ -57,6 +59,7 @@ const repositoriesWithoutInjectedDependencies = {
   userRepository,
   targetProfileHistoryRepository,
   complementaryCertificationCourseRepository,
+  pixCertificationRepository,
 };
 
 /**

--- a/api/src/certification/enrolment/infrastructure/repositories/pix-certification-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/pix-certification-repository.js
@@ -1,0 +1,30 @@
+import { knex } from '../../../../../db/knex-database-connection.js';
+import { PixCertification } from '../../domain/models/PixCertification.js';
+
+export async function findByUserId({ userId }) {
+  const results = await knex('certification-courses')
+    .select(
+      'certification-courses.isRejectedForFraud',
+      'certification-courses.isCancelled',
+      'assessment-results.pixScore',
+      'assessment-results.status',
+    )
+    .join(
+      'certification-courses-last-assessment-results',
+      'certification-courses-last-assessment-results.certificationCourseId',
+      'certification-courses.id',
+    )
+    .join(
+      'assessment-results',
+      'assessment-results.id',
+      'certification-courses-last-assessment-results.lastAssessmentResultId',
+    )
+    .where({ userId })
+    .andWhere({ isPublished: true });
+
+  return _toDomain(results);
+}
+
+function _toDomain(results) {
+  return results.map((result) => new PixCertification(result));
+}

--- a/api/src/shared/domain/models/CertifiableBadgeAcquisition.js
+++ b/api/src/shared/domain/models/CertifiableBadgeAcquisition.js
@@ -9,7 +9,6 @@ class CertifiableBadgeAcquisition {
     complementaryCertificationBadgeImageUrl,
     complementaryCertificationBadgeLabel,
     isOutdated,
-    offsetVersion,
   }) {
     this.badgeId = badgeId;
     this.badgeKey = badgeKey;
@@ -20,7 +19,6 @@ class CertifiableBadgeAcquisition {
     this.complementaryCertificationBadgeImageUrl = complementaryCertificationBadgeImageUrl;
     this.complementaryCertificationBadgeLabel = complementaryCertificationBadgeLabel;
     this.isOutdated = isOutdated;
-    this.offsetVersion = offsetVersion;
   }
 }
 

--- a/api/tests/certification/enrolment/acceptance/application/user-route_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/user-route_test.js
@@ -1,4 +1,5 @@
 import { config } from '../../../../../src/shared/config.js';
+import { AssessmentResult } from '../../../../../src/shared/domain/models/index.js';
 import {
   createServer,
   databaseBuilder,
@@ -221,6 +222,20 @@ describe('Certification | Enrolment | Acceptance | user routes', function () {
       badgeId: cleaBadgeId,
       complementaryCertificationId,
       label: 'PARTNER_LABEL',
+      minimumEarnedPix: 120,
+    });
+
+    const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+      userId: user.id,
+      isPublished: true,
+    }).id;
+    const lastAssessmentResultId = databaseBuilder.factory.buildAssessmentResult({
+      pixScore: 999,
+      status: AssessmentResult.status.VALIDATED,
+    }).id;
+    databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+      certificationCourseId,
+      lastAssessmentResultId,
     });
 
     options = {

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/complementary-certification-badge-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/complementary-certification-badge-repository_test.js
@@ -1,0 +1,58 @@
+import * as complementaryCertificationBadgeRepository from '../../../../../../src/certification/enrolment/infrastructure/repositories/complementary-certification-badge-repository.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+
+describe('Certification | Enrolment | Integration | Repository | ComplementaryCertificationBadge', function () {
+  describe('#findAll', function () {
+    it('should return all complementarycertificationbadge models from DB', async function () {
+      // given
+      const complementaryCertificationId1 = databaseBuilder.factory.buildComplementaryCertification({ key: 'key1' }).id;
+      databaseBuilder.factory.buildComplementaryCertificationBadge({
+        id: 1,
+        minimumEarnedPix: 150,
+        complementaryCertificationId: complementaryCertificationId1,
+      });
+      const complementaryCertificationId2 = databaseBuilder.factory.buildComplementaryCertification({ key: 'key2' }).id;
+      databaseBuilder.factory.buildComplementaryCertificationBadge({
+        id: 3,
+        minimumEarnedPix: 350,
+        complementaryCertificationId: complementaryCertificationId2,
+      });
+      const complementaryCertificationId3 = databaseBuilder.factory.buildComplementaryCertification({ key: 'key3' }).id;
+      databaseBuilder.factory.buildComplementaryCertificationBadge({
+        id: 2,
+        minimumEarnedPix: 0,
+        complementaryCertificationId: complementaryCertificationId3,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const actualComplementaryCertificationBadges = await complementaryCertificationBadgeRepository.findAll();
+
+      // then
+      const expectedResult = [
+        domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
+          id: 1,
+          requiredPixScore: 150,
+        }),
+        domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
+          id: 2,
+          requiredPixScore: 0,
+        }),
+        domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
+          id: 3,
+          requiredPixScore: 350,
+        }),
+      ];
+      expect(actualComplementaryCertificationBadges).to.have.deep.members(expectedResult);
+    });
+
+    it('should return empty array when there are none', async function () {
+      // when
+      const actualComplementaryCertificationBadges = await complementaryCertificationBadgeRepository.findAll();
+
+      // then
+      expect(actualComplementaryCertificationBadges).to.deepEqualArray([]);
+    });
+  });
+});

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/complementary-certification-badge-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/complementary-certification-badge-repository_test.js
@@ -11,6 +11,12 @@ describe('Certification | Enrolment | Integration | Repository | ComplementaryCe
         id: 1,
         minimumEarnedPix: 150,
         complementaryCertificationId: complementaryCertificationId1,
+        detachedAt: '2020-01-01',
+      });
+      databaseBuilder.factory.buildComplementaryCertificationBadge({
+        id: 4,
+        minimumEarnedPix: 150,
+        complementaryCertificationId: complementaryCertificationId1,
       });
       const complementaryCertificationId2 = databaseBuilder.factory.buildComplementaryCertification({ key: 'key2' }).id;
       databaseBuilder.factory.buildComplementaryCertificationBadge({
@@ -34,14 +40,22 @@ describe('Certification | Enrolment | Integration | Repository | ComplementaryCe
         domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
           id: 1,
           requiredPixScore: 150,
+          offsetVersion: 1,
+        }),
+        domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
+          id: 4,
+          requiredPixScore: 150,
+          offsetVersion: 0,
         }),
         domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
           id: 2,
           requiredPixScore: 0,
+          offsetVersion: 0,
         }),
         domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
           id: 3,
           requiredPixScore: 350,
+          offsetVersion: 0,
         }),
       ];
       expect(actualComplementaryCertificationBadges).to.have.deep.members(expectedResult);

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/complementary-certification-badge-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/complementary-certification-badge-repository_test.js
@@ -41,21 +41,25 @@ describe('Certification | Enrolment | Integration | Repository | ComplementaryCe
           id: 1,
           requiredPixScore: 150,
           offsetVersion: 1,
-        }),
-        domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
-          id: 4,
-          requiredPixScore: 150,
-          offsetVersion: 0,
+          currentAttachedComplementaryCertificationBadgeId: 4,
         }),
         domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
           id: 2,
           requiredPixScore: 0,
           offsetVersion: 0,
+          currentAttachedComplementaryCertificationBadgeId: 2,
         }),
         domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
           id: 3,
           requiredPixScore: 350,
           offsetVersion: 0,
+          currentAttachedComplementaryCertificationBadgeId: 3,
+        }),
+        domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
+          id: 4,
+          requiredPixScore: 150,
+          offsetVersion: 0,
+          currentAttachedComplementaryCertificationBadgeId: 4,
         }),
       ];
       expect(actualComplementaryCertificationBadges).to.have.deep.members(expectedResult);

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/pix-certification-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/pix-certification-repository_test.js
@@ -1,0 +1,86 @@
+import * as pixCertificationRepository from '../../../../../../src/certification/enrolment/infrastructure/repositories/pix-certification-repository.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+
+describe('Certification | Enrolment | Integration | Repository | PixCertification', function () {
+  describe('#findByUserId', function () {
+    context('when a user has no certification', function () {
+      it('should return an empty array', async function () {
+        // when
+        const actualPixCertifications = await pixCertificationRepository.findByUserId({ userId: 99999999 });
+
+        // then
+        expect(actualPixCertifications).to.deepEqualArray([]);
+      });
+    });
+
+    context('when a user has certifications', function () {
+      it("should return all published user's certifications", async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const firstPublishedSessionId = databaseBuilder.factory.buildSession().id;
+        const secondPublishedSessionId = databaseBuilder.factory.buildSession().id;
+        const unpublishedSessionId = databaseBuilder.factory.buildSession().id;
+        _buildCertificationForSession({ userId, sessionId: firstPublishedSessionId, isPublished: true, pixScore: 400 });
+        _buildCertificationForSession({
+          userId,
+          sessionId: secondPublishedSessionId,
+          isPublished: true,
+          pixScore: 500,
+        });
+        _buildCertificationForSession({ userId, sessionId: unpublishedSessionId, isPublished: false });
+        await databaseBuilder.commit();
+
+        // when
+        const actualPixCertifications = await pixCertificationRepository.findByUserId({ userId });
+
+        // then
+        const expectedResult = [
+          domainBuilder.certification.enrolment.buildPixCertification({
+            pixScore: 400,
+            status: 'validated',
+            isCancelled: false,
+            isRejectedForFraud: false,
+          }),
+          domainBuilder.certification.enrolment.buildPixCertification({
+            pixScore: 500,
+            status: 'validated',
+            isCancelled: false,
+            isRejectedForFraud: false,
+          }),
+        ];
+        expect(actualPixCertifications).to.have.deep.members(expectedResult);
+      });
+    });
+  });
+});
+
+function _buildCertificationForSession({ userId, sessionId, isPublished, pixScore = 200 }) {
+  const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+    sessionId,
+    userId,
+    isPublished,
+  }).id;
+
+  const assessmentId = databaseBuilder.factory.buildAssessment({
+    certificationCourseId,
+    userId,
+  }).id;
+
+  databaseBuilder.factory.buildAssessmentResult({
+    assessmentId,
+    certificationCourseId,
+    pixScore: 100,
+  });
+
+  const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({
+    assessmentId,
+    certificationCourseId,
+    pixScore,
+  }).id;
+
+  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+    certificationCourseId,
+    lastAssessmentResultId: assessmentResultId,
+  });
+}

--- a/api/tests/certification/enrolment/unit/domain/usecases/get-user-certification-eligibility_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/get-user-certification-eligibility_test.js
@@ -117,15 +117,23 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
       context('CLEA', function () {
         beforeEach(function () {
           complementaryCertificationKey = ComplementaryCertificationKeys.CLEA;
-          complementaryCertificationBadgeRepository.findAll.resolves([
-            domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
-              id: complementaryCertificationBadgeId,
-              requiredPixScore,
-            }),
-          ]);
         });
         context('when acquired badge is outdated', function () {
           const isOutdated = true;
+          beforeEach(function () {
+            complementaryCertificationBadgeRepository.findAll.resolves([
+              domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
+                id: '1234',
+                requiredPixScore,
+                offsetVersion: 0,
+              }),
+              domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
+                id: complementaryCertificationBadgeId,
+                requiredPixScore,
+                offsetVersion: 1,
+              }),
+            ]);
+          });
           context('when user is certifiable', function () {
             const isCertifiable = true;
             beforeEach(function () {
@@ -164,7 +172,6 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
                       complementaryCertificationBadgeImageUrl: 'monImageUrl',
                       complementaryCertificationBadgeLabel: 'monLabel',
                       isOutdated,
-                      offsetVersion: 1,
                     }),
                   ]);
 
@@ -187,7 +194,25 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
               });
 
               context('when badge is outdated by more than one version', function () {
-                const offsetVersion = 2;
+                beforeEach(function () {
+                  complementaryCertificationBadgeRepository.findAll.resolves([
+                    domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
+                      id: '1234',
+                      requiredPixScore,
+                      offsetVersion: 0,
+                    }),
+                    domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
+                      id: '5678',
+                      requiredPixScore,
+                      offsetVersion: 1,
+                    }),
+                    domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
+                      id: complementaryCertificationBadgeId,
+                      requiredPixScore,
+                      offsetVersion: 2,
+                    }),
+                  ]);
+                });
                 it('should not be added in the eligibilities of the model', async function () {
                   // given
                   certificationBadgesService.findLatestBadgeAcquisitions
@@ -202,7 +227,6 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
                         complementaryCertificationBadgeImageUrl: 'monImageUrl',
                         complementaryCertificationBadgeLabel: 'monLabel',
                         isOutdated,
-                        offsetVersion,
                       }),
                     ]);
 
@@ -393,7 +417,15 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
         });
         context('when acquired badge is not outdated', function () {
           const isOutdated = false;
-          const offsetVersion = 0;
+          beforeEach(function () {
+            complementaryCertificationBadgeRepository.findAll.resolves([
+              domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
+                id: complementaryCertificationBadgeId,
+                requiredPixScore,
+                offsetVersion: 0,
+              }),
+            ]);
+          });
           context('when user is certifiable', function () {
             const isCertifiable = true;
             beforeEach(function () {
@@ -432,7 +464,6 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
                       complementaryCertificationBadgeImageUrl: 'monImageUrl',
                       complementaryCertificationBadgeLabel: 'monLabel',
                       isOutdated,
-                      offsetVersion,
                     }),
                   ]);
 
@@ -474,7 +505,6 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
                       complementaryCertificationBadgeImageUrl: 'monImageUrl',
                       complementaryCertificationBadgeLabel: 'monLabel',
                       isOutdated,
-                      offsetVersion,
                     }),
                   ]);
 
@@ -538,7 +568,6 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
                       complementaryCertificationBadgeImageUrl: 'monImageUrl',
                       complementaryCertificationBadgeLabel: 'monLabel',
                       isOutdated,
-                      offsetVersion,
                     }),
                   ]);
 
@@ -587,7 +616,6 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
                       complementaryCertificationBadgeImageUrl: 'monImageUrl',
                       complementaryCertificationBadgeLabel: 'monLabel',
                       isOutdated,
-                      offsetVersion,
                     }),
                   ]);
 
@@ -621,13 +649,13 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
             domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
               id: complementaryCertificationBadgeId,
               requiredPixScore,
+              offsetVersion: 0,
             }),
           ]);
         });
 
         context('when user has no pix certification', function () {
           const isOutdated = false;
-          const offsetVersion = 0;
           beforeEach(function () {
             pixCertificationRepository.findByUserId.withArgs({ userId }).resolves([]);
           });
@@ -645,7 +673,6 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
                   complementaryCertificationBadgeImageUrl: 'monImageUrl',
                   complementaryCertificationBadgeLabel: 'monLabel',
                   isOutdated,
-                  offsetVersion,
                 }),
               ]);
 
@@ -664,7 +691,6 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
           'when user has a validated certification that is not cancelled not rejected and without the required pixscore',
           function () {
             const isOutdated = false;
-            const offsetVersion = 0;
             beforeEach(function () {
               pixCertificationRepository.findByUserId.withArgs({ userId }).resolves([
                 domainBuilder.certification.enrolment.buildPixCertification({
@@ -689,7 +715,6 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
                     complementaryCertificationBadgeImageUrl: 'monImageUrl',
                     complementaryCertificationBadgeLabel: 'monLabel',
                     isOutdated,
-                    offsetVersion,
                   }),
                 ]);
 
@@ -709,7 +734,6 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
           'when user has a validated and cancelled certification that is not rejected for fraud and with the required pixscore',
           function () {
             const isOutdated = false;
-            const offsetVersion = 0;
             beforeEach(function () {
               pixCertificationRepository.findByUserId.withArgs({ userId }).resolves([
                 domainBuilder.certification.enrolment.buildPixCertification({
@@ -734,7 +758,6 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
                     complementaryCertificationBadgeImageUrl: 'monImageUrl',
                     complementaryCertificationBadgeLabel: 'monLabel',
                     isOutdated,
-                    offsetVersion,
                   }),
                 ]);
 
@@ -754,7 +777,6 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
           'when user has not cancelled but rejected for fraud validated pix certification with the required pix score',
           function () {
             const isOutdated = false;
-            const offsetVersion = 0;
             beforeEach(function () {
               pixCertificationRepository.findByUserId.withArgs({ userId }).resolves([
                 domainBuilder.certification.enrolment.buildPixCertification({
@@ -779,7 +801,6 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
                     complementaryCertificationBadgeImageUrl: 'monImageUrl',
                     complementaryCertificationBadgeLabel: 'monLabel',
                     isOutdated,
-                    offsetVersion,
                   }),
                 ]);
 
@@ -797,7 +818,6 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
         );
         context('when user has not cancelled not rejected for fraud but not validated pix certification', function () {
           const isOutdated = false;
-          const offsetVersion = 0;
           beforeEach(function () {
             pixCertificationRepository.findByUserId.withArgs({ userId }).resolves([
               domainBuilder.certification.enrolment.buildPixCertification({
@@ -822,7 +842,6 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
                   complementaryCertificationBadgeImageUrl: 'monImageUrl',
                   complementaryCertificationBadgeLabel: 'monLabel',
                   isOutdated,
-                  offsetVersion,
                 }),
               ]);
 
@@ -850,7 +869,6 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
           });
           context('when acquired badge is not outdated', function () {
             const isOutdated = false;
-            const offsetVersion = 0;
             context('when user has an acquired certification for this badge', function () {
               it('returns a UserCertificationEligibility model with the outdated eligibility inside', async function () {
                 // given
@@ -878,7 +896,6 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
                       complementaryCertificationBadgeImageUrl: 'monImageUrl',
                       complementaryCertificationBadgeLabel: 'monLabel',
                       isOutdated,
-                      offsetVersion,
                     }),
                   ]);
 
@@ -920,7 +937,6 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
                       complementaryCertificationBadgeImageUrl: 'monImageUrl',
                       complementaryCertificationBadgeLabel: 'monLabel',
                       isOutdated,
-                      offsetVersion,
                     }),
                   ]);
 
@@ -947,10 +963,22 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
           });
           context('when acquired badge is outdated by one version', function () {
             const isOutdated = true;
-            const offsetVersion = 1;
             context('when user has an acquired certification for this badge', function () {
               it('should not be added in the eligibilities of the model', async function () {
                 // given
+                complementaryCertificationBadgeRepository.findAll.resolves([
+                  domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
+                    id: '1234',
+                    requiredPixScore,
+                    offsetVersion: 0,
+                  }),
+                  domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
+                    id: complementaryCertificationBadgeId,
+                    requiredPixScore,
+                    offsetVersion: 1,
+                  }),
+                ]);
+
                 complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([
                   domainBuilder.certification.enrolment.buildComplementaryCertificationCourseWithResults({
                     complementaryCertificationBadgeId,
@@ -975,7 +1003,6 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
                       complementaryCertificationBadgeImageUrl: 'monImageUrl',
                       complementaryCertificationBadgeLabel: 'monLabel',
                       isOutdated,
-                      offsetVersion,
                     }),
                   ]);
 
@@ -1010,7 +1037,6 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
                       complementaryCertificationBadgeImageUrl: 'monImageUrl',
                       complementaryCertificationBadgeLabel: 'monLabel',
                       isOutdated,
-                      offsetVersion,
                     }),
                   ]);
 
@@ -1037,9 +1063,26 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
           });
           context('when acquired badge is outdated by more than one version', function () {
             const isOutdated = true;
-            const offsetVersion = 2;
             it('should not be added in the eligibilities of the model', async function () {
               // given
+              complementaryCertificationBadgeRepository.findAll.resolves([
+                domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
+                  id: '1234',
+                  requiredPixScore,
+                  offsetVersion: 0,
+                }),
+                domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
+                  id: '5678',
+                  requiredPixScore,
+                  offsetVersion: 1,
+                }),
+                domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
+                  id: complementaryCertificationBadgeId,
+                  requiredPixScore,
+                  offsetVersion: 2,
+                }),
+              ]);
+
               complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([
                 domainBuilder.certification.enrolment.buildComplementaryCertificationCourseWithResults({
                   complementaryCertificationBadgeId,
@@ -1064,7 +1107,6 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
                     complementaryCertificationBadgeImageUrl: 'monImageUrl',
                     complementaryCertificationBadgeLabel: 'monLabel',
                     isOutdated,
-                    offsetVersion,
                   }),
                 ]);
 

--- a/api/tests/integration/infrastructure/repositories/certifiable-badge-acquisition-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certifiable-badge-acquisition-repository_test.js
@@ -49,7 +49,6 @@ describe('Integration | Repository | Certifiable Badge Acquisition', function ()
           complementaryCertificationBadgeLabel: complementaryCertificationBadge.label,
           complementaryCertificationBadgeImageUrl: complementaryCertificationBadge.imageUrl,
           isOutdated: false,
-          offsetVersion: 0,
         });
         expect(certifiableBadgesAcquiredByUser).to.deepEqualArray([expectedCertifiableBadgeAcquisition]);
       });
@@ -92,7 +91,6 @@ describe('Integration | Repository | Certifiable Badge Acquisition', function ()
             complementaryCertificationBadgeLabel: complementaryCertificationBadge.label,
             complementaryCertificationBadgeImageUrl: complementaryCertificationBadge.imageUrl,
             isOutdated: false,
-            offsetVersion: 0,
           });
           expect(certifiableBadgesAcquiredByUser).to.deepEqualArray([expectedCertifiableBadgeAcquisition]);
         });
@@ -152,7 +150,6 @@ describe('Integration | Repository | Certifiable Badge Acquisition', function ()
           complementaryCertificationBadgeLabel: complementaryCertificationBadge.label,
           complementaryCertificationBadgeImageUrl: complementaryCertificationBadge.imageUrl,
           isOutdated: false,
-          offsetVersion: 0,
         });
         expect(certifiableBadgesAcquiredByUser).to.deepEqualArray([expectedCertifiableBadgeAcquisition]);
       });
@@ -306,7 +303,6 @@ describe('Integration | Repository | Certifiable Badge Acquisition', function ()
             expect(certifiableBadgesAcquiredByUser.length).to.equal(1);
             expect(certifiableBadgesAcquiredByUser[0].badgeKey).to.equal('level-2');
             expect(certifiableBadgesAcquiredByUser[0].isOutdated).to.equal(true);
-            expect(certifiableBadgesAcquiredByUser[0].offsetVersion).to.equal(2);
           });
         });
 
@@ -365,7 +361,6 @@ describe('Integration | Repository | Certifiable Badge Acquisition', function ()
             expect(certifiableBadgesAcquiredByUser.length).to.equal(1);
             expect(certifiableBadgesAcquiredByUser[0].badgeKey).to.equal('level-2');
             expect(certifiableBadgesAcquiredByUser[0].isOutdated).to.equal(false);
-            expect(certifiableBadgesAcquiredByUser[0].offsetVersion).to.equal(0);
           });
         });
       });

--- a/api/tests/tooling/domain-builder/factory/build-certifiable-badge-acquisition.js
+++ b/api/tests/tooling/domain-builder/factory/build-certifiable-badge-acquisition.js
@@ -10,7 +10,6 @@ const buildCertifiableBadgeAcquisition = function ({
   complementaryCertificationBadgeImageUrl = 'image/droit.svg',
   complementaryCertificationBadgeLabel = 'Pix+ droit avance',
   isOutdated = false,
-  offsetVersion = 0,
 } = {}) {
   return new CertifiableBadgeAcquisition({
     badgeId,
@@ -22,7 +21,6 @@ const buildCertifiableBadgeAcquisition = function ({
     complementaryCertificationBadgeImageUrl,
     complementaryCertificationBadgeLabel,
     isOutdated,
-    offsetVersion,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/certification/enrolment/build-complementary-certification-badge.js
+++ b/api/tests/tooling/domain-builder/factory/certification/enrolment/build-complementary-certification-badge.js
@@ -1,0 +1,10 @@
+import { ComplementaryCertificationBadge } from '../../../../../../src/certification/enrolment/domain/models/ComplementaryCertificationBadge.js';
+
+const buildComplementaryCertificationBadge = function ({ id = 123, requiredPixScore = 100 } = {}) {
+  return new ComplementaryCertificationBadge({
+    id,
+    requiredPixScore,
+  });
+};
+
+export { buildComplementaryCertificationBadge };

--- a/api/tests/tooling/domain-builder/factory/certification/enrolment/build-complementary-certification-badge.js
+++ b/api/tests/tooling/domain-builder/factory/certification/enrolment/build-complementary-certification-badge.js
@@ -1,10 +1,16 @@
 import { ComplementaryCertificationBadge } from '../../../../../../src/certification/enrolment/domain/models/ComplementaryCertificationBadge.js';
 
-const buildComplementaryCertificationBadge = function ({ id = 123, requiredPixScore = 100, offsetVersion = 0 } = {}) {
+const buildComplementaryCertificationBadge = function ({
+  id = 123,
+  requiredPixScore = 100,
+  offsetVersion = 0,
+  currentAttachedComplementaryCertificationBadgeId = 123,
+} = {}) {
   return new ComplementaryCertificationBadge({
     id,
     requiredPixScore,
     offsetVersion,
+    currentAttachedComplementaryCertificationBadgeId,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/certification/enrolment/build-complementary-certification-badge.js
+++ b/api/tests/tooling/domain-builder/factory/certification/enrolment/build-complementary-certification-badge.js
@@ -1,9 +1,10 @@
 import { ComplementaryCertificationBadge } from '../../../../../../src/certification/enrolment/domain/models/ComplementaryCertificationBadge.js';
 
-const buildComplementaryCertificationBadge = function ({ id = 123, requiredPixScore = 100 } = {}) {
+const buildComplementaryCertificationBadge = function ({ id = 123, requiredPixScore = 100, offsetVersion = 0 } = {}) {
   return new ComplementaryCertificationBadge({
     id,
     requiredPixScore,
+    offsetVersion,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/certification/enrolment/build-pix-certification.js
+++ b/api/tests/tooling/domain-builder/factory/certification/enrolment/build-pix-certification.js
@@ -1,0 +1,18 @@
+import { PixCertification } from '../../../../../../src/certification/enrolment/domain/models/PixCertification.js';
+import { AssessmentResult } from '../../../../../../src/shared/domain/models/index.js';
+
+const buildPixCertification = function ({
+  pixScore = 123,
+  status = AssessmentResult.status.VALIDATED,
+  isCancelled = false,
+  isRejectedForFraud = false,
+} = {}) {
+  return new PixCertification({
+    pixScore,
+    status,
+    isCancelled,
+    isRejectedForFraud,
+  });
+};
+
+export { buildPixCertification };

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -173,6 +173,7 @@ import { buildValidator } from './build-validator.js';
 import { buildCenterPilotFeatures } from './certification/configuration/build-center-pilot-features.js';
 import { buildCandidate } from './certification/enrolment/build-candidate.js';
 import { buildCertificationEligibilityEnrolment } from './certification/enrolment/build-certification-eligibility.js';
+import { buildComplementaryCertificationBadge as buildComplementaryCertificationBadgeForEnrolment } from './certification/enrolment/build-complementary-certification-badge.js';
 import { buildComplementaryCertificationCourseWithResultsEnrolment } from './certification/enrolment/build-complementary-certification-course-with-results.js';
 import { buildEditedCandidate } from './certification/enrolment/build-edited-candidate.js';
 import { buildEnrolledCandidate } from './certification/enrolment/build-enrolled-candidate.js';
@@ -231,6 +232,7 @@ const certification = {
     buildUserCertificationEligibility,
     buildV3CertificationEligibility,
     buildPixCertification,
+    buildComplementaryCertificationBadge: buildComplementaryCertificationBadgeForEnrolment,
   },
   sessionManagement: {
     buildCertificationSessionComplementaryCertification,

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -176,6 +176,7 @@ import { buildCertificationEligibilityEnrolment } from './certification/enrolmen
 import { buildComplementaryCertificationCourseWithResultsEnrolment } from './certification/enrolment/build-complementary-certification-course-with-results.js';
 import { buildEditedCandidate } from './certification/enrolment/build-edited-candidate.js';
 import { buildEnrolledCandidate } from './certification/enrolment/build-enrolled-candidate.js';
+import { buildPixCertification } from './certification/enrolment/build-pix-certification.js';
 import { buildSessionEnrolment } from './certification/enrolment/build-session.js';
 import {
   buildComplementarySubscription,
@@ -229,6 +230,7 @@ const certification = {
     buildComplementaryCertificationCourseWithResults: buildComplementaryCertificationCourseWithResultsEnrolment,
     buildUserCertificationEligibility,
     buildV3CertificationEligibility,
+    buildPixCertification,
   },
   sessionManagement: {
     buildCertificationSessionComplementaryCertification,


### PR DESCRIPTION
## :unicorn: Problème
Avec la V3 et la séparation PIx PIx+, il faut adapter le bandeau avec les nouvelles conditions d'éligibilité.

## :robot: Proposition
Ajouter la condition liée à l'obtention d'une certif pix avec un score minimum (selon la complémentaire)

## :rainbow: Remarques
TODO ✅  : en cas de
- complementary-certification-badges Pix+Edu avancé (exemple hein) avec un minimumEarnedPix de 120
- demain on détache et on rattache avec le meme sauf que le minimumEarnedPix de 130
- pour afficher le bandeau spécial (repasser votre campagne) il faut vérifier en fait que ma certif a au moins 130 points maintenant et pas 120 !!!



TLDR:
Déplacer l'attribut "offsetVersion" qu'on a ajouté dans le modèle CertifiableBadgeAcquisition vers le nouveau modèle COmplementaryCertificationBadge ✅ 

 + ajouter dans ce modèle la notion de badgeEquivalentMaisDeLaBonneVErsion ✅ 

## :100: Pour tester

- Cas pas certifiable ✅ 
- Cas certifiable ✅ 

-  Cas CLEA : ✅ 
    - Cas pas périmé et je suis certifiable : info dans le bandeau 
    - cas périmé une version et je suis toujours certifiable  : info spéciale bandeau
    - cas périmée + d'une versions et certifiable : rien dans le bandeau

- Cas des badges pas périmés : ✅
  - Cas "j'ai pas de certif pix du tout" -> rien dans le bandeau 
  - Cas "j'ai une certif pix avec pas assez de point" -> rien dans le bandeau 
  - Cas "j'ai une certif pix avec assez de points -> Dans le bandeau 
  - Cas "j'ai une certif pix avec assez de points ET j'ai déjà une certification complémentaire pour ce niveau" -> Dans le bandeau 

- Cas des badges périmés :  ✅ 
  - Périmé une version :
    - j'ai une certif avec assez de points mais je n'ai pas validé la certif complémentaire dessus -> mot spécial va repasser ta campagne 
    - j'ai une certif avec assez de points ET j'ai une certif complémentaire dessus -> rien dans le bandeau :
  -  Périmé de plusieurs versions :
      - j'ai une certif avec assez de points mais je n'ai pas validé la certif complémentaire dessus -> rien dans le bandeau  
      - j'ai une certif avec assez de points ET j'ai une certif complémentaire dessus -> rien dans le bandeau
    