### PR TITLE
[BUGFIX] Corriger l'affichage des listes à puces dans les indices (PIX-9987)

### DIFF
--- a/mon-pix/app/styles/components/_tutorial-panel.scss
+++ b/mon-pix/app/styles/components/_tutorial-panel.scss
@@ -50,6 +50,14 @@
   font-size: 1.125rem;
   font-family: $font-open-sans;
 
+  ul,
+  ol {
+    margin: var(--pix-spacing-1x) 0;
+    padding: revert;
+    list-style: revert;
+  }
+
+
   & p {
     padding: 12px 12px 0;
   }


### PR DESCRIPTION
## :unicorn: Problème
Réponses & Tutos > Pour réussir la prochaine fois : liste à puces KO (indice)

![Capture d’écran 2024-09-13 à 11 47 04](https://github.com/user-attachments/assets/46075101-c0cc-4c91-8711-0256718984b3)

## :robot: Proposition
Modifier CSS pour surcharger le reset de PIX-UI sur les listes à puce dans un indice.

## :rainbow: Remarques
Pour reproduire le cas en local, nous sommes passés par l'inspecteur de navigateur et une modification HTML en ajoutant des puces à un indice. Le résultat était celui attendu.

## :100: Pour tester
En Recette: aller sur Réponses & Tutos de ce lien : https://app.recette.pix.fr/assessments/100126912/results
