### PR TITLE
[BUGFIX] Correction de l'affichage du temps de certification (PIX-14318)

### DIFF
--- a/admin/app/components/certifications/certification/details-v3.gjs
+++ b/admin/app/components/certifications/certification/details-v3.gjs
@@ -12,6 +12,7 @@ import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
 import { t } from 'ember-intl';
 import { lt } from 'ember-truth-helpers';
 
+import DayjsFormatDuration from '../../../helpers/dayjs-format-duration';
 import { AnswerStatus } from '../../../models/certification-challenges-for-administration';
 import { subcategoryToCode, subcategoryToLabel } from '../../../models/certification-issue-report';
 import { abortReasons, assessmentStates } from '../../../models/v3-certification-course-details-for-administration';
@@ -237,7 +238,7 @@ export default class DetailsV3 extends Component {
                 </:tooltip>
               </PixTooltip>
               {{#if (lt @details.duration this.twentyFourHoursInMs)}}
-                <PixTag @color={{this.durationTagColor}}>{{dayjsFormat @details.duration "HH[h]mm"}}</PixTag>
+                <PixTag @color={{this.durationTagColor}}>{{DayjsFormatDuration @details.duration "HH[h]mm"}}</PixTag>
               {{else}}
                 <PixTag @color={{this.durationTagColor}}> > 24h</PixTag>
               {{/if}}

--- a/admin/tests/integration/components/certifications/certification/details-v3-test.gjs
+++ b/admin/tests/integration/components/certifications/certification/details-v3-test.gjs
@@ -162,8 +162,20 @@ module('Integration | Component | Certifications | certification > details v3', 
 
           // then
           const endedAtLabel = t('pages.certifications.certification.details.v3.general-informations.labels.ended-at');
+          assert.dom(screen.getByLabelText(`${endedAtLabel} :`)).containsText('13/01/2023 09:05:00');
+        });
 
-          assert.dom(screen.getByText(`${endedAtLabel} :`)).exists();
+        test('should display the certification duration', async function (assert) {
+          // given
+          const model = createCertificationCourseDetailsRecord(certificationCourseDetailsRecord);
+
+          // when
+          const screen = await render(<template><DetailsV3 @details={{model}} /></template>);
+
+          // then
+          const endedAtLabel = t('pages.certifications.certification.details.v3.general-informations.labels.ended-at');
+
+          assert.dom(screen.getByLabelText(`${endedAtLabel} :`)).containsText('1h05');
         });
 
         test('should NOT display the ended by info or the abort reason', async function (assert) {
@@ -602,7 +614,8 @@ module('Integration | Component | Certifications | certification > details v3', 
 function createCertificationCourseDetailsRecord({ certificationChallengesForAdministration, store, params }) {
   return store.createRecord('v3-certification-course-details-for-administration', {
     assessmentState: 'completed',
-    completedAt: new Date(),
+    // eslint-disable-next-line no-restricted-syntax
+    completedAt: new Date('2023-01-13T09:05:00'),
     assessmentResultStatus: 'validated',
     numberOfChallenges: 15,
     certificationChallengesForAdministration,


### PR DESCRIPTION
## :unicorn: Problème
Sur la page des détails d’une certification, l’affichage de l’heure ne se fait pas correctement

![image](https://github.com/user-attachments/assets/b160aa80-b2c7-4d6e-9ee5-180e39fe20a5)

## :robot: Proposition
Fix de l'affichage

## :100: Pour tester
Vérifier que l'affichage est OK