### PR TITLE
[BUGFIX] Ne pas retourner de 500 dans le cas d'un filtre sur la certificabilité mal défini (PIX-14300)

### DIFF
--- a/api/src/prescription/organization-learner/application/learner-list-route.js
+++ b/api/src/prescription/organization-learner/application/learner-list-route.js
@@ -3,6 +3,7 @@ import BaseJoi from 'joi';
 const Joi = BaseJoi.extend(JoiDate);
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { filterType } from '../../shared/domain/types/identifiers-type.js';
 import { learnerListController } from './learner-list-controller.js';
 
 const register = async function (server) {
@@ -28,7 +29,7 @@ const register = async function (server) {
             filter: Joi.object({
               extra: Joi.object().default({}),
               fullName: Joi.string().empty(''),
-              certificability: [Joi.string(), Joi.array().items(Joi.string())],
+              certificability: [filterType.certificability, Joi.array().items(filterType.certificability)],
             }).default({}),
             sort: Joi.object({
               participationCount: Joi.string().empty(''),

--- a/api/src/prescription/organization-learner/application/sco-learner-list-route.js
+++ b/api/src/prescription/organization-learner/application/sco-learner-list-route.js
@@ -3,6 +3,7 @@ import BaseJoi from 'joi';
 const Joi = BaseJoi.extend(JoiDate);
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { filterType } from '../../shared/domain/types/identifiers-type.js';
 import { scoLearnerListController } from './sco-learner-list-controller.js';
 
 const register = async function (server) {
@@ -30,7 +31,7 @@ const register = async function (server) {
               divisions: [Joi.string(), Joi.array().items(Joi.string())],
               connectionTypes: [Joi.string(), Joi.array().items(Joi.string())],
               search: Joi.string().empty(''),
-              certificability: [Joi.string(), Joi.array().items(Joi.string())],
+              certificability: [filterType.certificability, Joi.array().items(filterType.certificability)],
             }).default({}),
             sort: {
               participationCount: Joi.string().empty(''),

--- a/api/src/prescription/organization-learner/application/sup-learner-list-route.js
+++ b/api/src/prescription/organization-learner/application/sup-learner-list-route.js
@@ -3,6 +3,7 @@ import BaseJoi from 'joi';
 const Joi = BaseJoi.extend(JoiDate);
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { filterType } from '../../shared/domain/types/identifiers-type.js';
 import { supLearnerListController } from './sup-learner-list-controller.js';
 
 const register = async function (server) {
@@ -27,7 +28,7 @@ const register = async function (server) {
               number: Joi.number().integer().empty(''),
             }),
             filter: Joi.object({
-              certificability: [Joi.string(), Joi.array().items(Joi.string())],
+              certificability: [filterType.certificability, Joi.array().items(filterType.certificability)],
               groups: [Joi.string(), Joi.array().items(Joi.string())],
               search: Joi.string().empty(''),
               studentNumber: Joi.string().empty(''),

--- a/api/src/prescription/shared/application/helpers.js
+++ b/api/src/prescription/shared/application/helpers.js
@@ -9,7 +9,10 @@ function mapCertificabilityByLabel(certificabilityFilter) {
   if (!Array.isArray(certificabilityFilter)) {
     result = [certificabilityFilter];
   }
-  return result.map((value) => certificabilityByLabel[value]);
+
+  return result
+    .filter((value) => certificabilityByLabel[value] !== undefined)
+    .map((value) => certificabilityByLabel[value]);
 }
 
 export { certificabilityByLabel, mapCertificabilityByLabel };

--- a/api/src/prescription/shared/domain/types/identifiers-type.js
+++ b/api/src/prescription/shared/domain/types/identifiers-type.js
@@ -1,0 +1,9 @@
+import Joi from 'joi';
+
+import { certificabilityByLabel } from '../../application/helpers.js';
+
+const filterType = {
+  certificability: Joi.string().valid(...Object.keys(certificabilityByLabel)),
+};
+
+export { filterType };

--- a/api/tests/prescription/organization-learner/integration/application/learner-list-route_test.js
+++ b/api/tests/prescription/organization-learner/integration/application/learner-list-route_test.js
@@ -51,5 +51,38 @@ describe('Integration | Application | Routes | Learner List', function () {
 
       expect(response.statusCode).to.equal(400);
     });
+
+    describe('certificability filter', function () {
+      it('should throw an error on single invalid parameter', async function () {
+        // given
+        const method = 'GET';
+        const url = '/api/organizations/1/participants?filter[certificability]=blabla';
+
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request(method, url);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+      it('should throw an error on multiple parameter with invalid param', async function () {
+        // given
+        const method = 'GET';
+        const url =
+          '/api/organizations/1/participants?filter[certificability][]=eligible&filter[certificability][]=blabla';
+
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request(method, url);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
   });
 });

--- a/api/tests/prescription/organization-learner/integration/application/sco-learner-list-route_test.js
+++ b/api/tests/prescription/organization-learner/integration/application/sco-learner-list-route_test.js
@@ -58,6 +58,39 @@ describe('Integration | Application | Routes | Sco Learner List', function () {
         expect(response.statusCode).to.equal(400);
       });
 
+      describe('certificability filter', function () {
+        it('should throw an error on single invalid parameter', async function () {
+          // given
+          const method = 'GET';
+          const url = '/api/organizations/1/sco-participants?filter[certificability]=blabla';
+
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          // when
+          const response = await httpTestServer.request(method, url);
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+
+        it('should throw an error on multiple parameter with invalid param', async function () {
+          // given
+          const method = 'GET';
+          const url =
+            '/api/organizations/1/sco-participants?filter[certificability][]=eligible&filter[certificability][]=blabla';
+
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          // when
+          const response = await httpTestServer.request(method, url);
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+      });
+
       it('should throw an error when id is invalid', async function () {
         // given
         const method = 'GET';

--- a/api/tests/prescription/organization-learner/integration/application/sup-learner-list-route_test.js
+++ b/api/tests/prescription/organization-learner/integration/application/sup-learner-list-route_test.js
@@ -44,6 +44,39 @@ describe('Integration | Application | Routes | Sup Learner List', function () {
         expect(response.statusCode).to.equal(400);
       });
 
+      describe('certificability filter', function () {
+        it('should throw an error on single invalid parameter', async function () {
+          // given
+          const method = 'GET';
+          const url = '/api/organizations/1/sup-participants?filter[certificability]=blabla';
+
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          // when
+          const response = await httpTestServer.request(method, url);
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+
+        it('should throw an error on multiple parameter with invalid param', async function () {
+          // given
+          const method = 'GET';
+          const url =
+            '/api/organizations/1/sup-participants?filter[certificability][]=eligible&filter[certificability][]=blabla';
+
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          // when
+          const response = await httpTestServer.request(method, url);
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+      });
+
       it('should throw an error when page number is invalid', async function () {
         // given
         const method = 'GET';

--- a/api/tests/prescription/shared/unit/application/helpers_test.js
+++ b/api/tests/prescription/shared/unit/application/helpers_test.js
@@ -2,6 +2,17 @@ import { mapCertificabilityByLabel } from '../../../../../src/prescription/share
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Application | helpers', function () {
+  it('return empty while certificabilityFilter unexisting', async function () {
+    // given
+    const certificabilityFilter = 'toto';
+
+    // when
+    const result = mapCertificabilityByLabel(certificabilityFilter);
+
+    // then
+    expect(result).to.deep.equal([]);
+  });
+
   it('map the certificability eligible value', async function () {
     // given
     const certificabilityFilter = 'eligible';

--- a/orga/app/helpers/certificability-types.js
+++ b/orga/app/helpers/certificability-types.js
@@ -1,0 +1,14 @@
+export const CERTIFICABILITY_TYPES = {
+  eligible: {
+    value: 'eligible',
+    translate: 'pages.sco-organization-participants.table.column.is-certifiable.eligible',
+  },
+  'non-eligible': {
+    value: 'non-eligible',
+    translate: 'pages.sco-organization-participants.table.column.is-certifiable.non-eligible',
+  },
+  'not-available': {
+    value: 'not-available',
+    translate: 'pages.sco-organization-participants.table.column.is-certifiable.not-available',
+  },
+};

--- a/orga/app/routes/authenticated/organization-participants/list.js
+++ b/orga/app/routes/authenticated/organization-participants/list.js
@@ -3,7 +3,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 import extraFilters from '../../../utils/extra-filter-serializer.js';
-
+import paramsValidator from '../../../utils/params-validator.js';
 export default class ListRoute extends Route {
   queryParams = {
     pageNumber: { refreshModel: true },
@@ -20,6 +20,8 @@ export default class ListRoute extends Route {
   @service store;
 
   async model(params) {
+    paramsValidator.validateCertificabilityParams(params);
+
     return this.store.query('organization-participant', {
       filter: {
         organizationId: this.currentUser.organization.id,

--- a/orga/app/routes/authenticated/sco-organization-participants/list.js
+++ b/orga/app/routes/authenticated/sco-organization-participants/list.js
@@ -3,6 +3,8 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import RSVP from 'rsvp';
 
+import paramsValidator from '../../../utils/params-validator';
+
 export default class ListRoute extends Route {
   queryParams = {
     search: { refreshModel: true },
@@ -20,6 +22,8 @@ export default class ListRoute extends Route {
   @service store;
 
   async model(params) {
+    paramsValidator.validateCertificabilityParams(params);
+
     const organizationId = this.currentUser.organization.id;
     return RSVP.hash({
       importDetail: this.currentUser.canAccessImportPage

--- a/orga/app/routes/authenticated/sup-organization-participants/list.js
+++ b/orga/app/routes/authenticated/sup-organization-participants/list.js
@@ -3,6 +3,7 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import RSVP from 'rsvp';
 
+import paramsValidator from '../../../utils/params-validator';
 export default class ListRoute extends Route {
   queryParams = {
     search: { refreshModel: true },
@@ -19,6 +20,8 @@ export default class ListRoute extends Route {
   @service store;
 
   async model(params) {
+    paramsValidator.validateCertificabilityParams(params);
+
     const organizationId = this.currentUser.organization.id;
     return RSVP.hash({
       importDetail: this.currentUser.canAccessImportPage

--- a/orga/app/utils/params-validator.js
+++ b/orga/app/utils/params-validator.js
@@ -1,0 +1,16 @@
+import { CERTIFICABILITY_TYPES } from '../helpers/certificability-types';
+
+export function validateCertificabilityParams(params) {
+  if (params.certificability) {
+    const certifibilityParams = !Array.isArray(params.certificability)
+      ? [params.certificability]
+      : params.certificability;
+    const certificability = certifibilityParams.filter((certificabilityValue) =>
+      Object.keys(CERTIFICABILITY_TYPES).includes(certificabilityValue),
+    );
+
+    params.certificability = certificability;
+  }
+}
+
+export default { validateCertificabilityParams };

--- a/orga/tests/unit/routes/authenticated/organization-participants/list-test.js
+++ b/orga/tests/unit/routes/authenticated/organization-participants/list-test.js
@@ -1,5 +1,6 @@
 import { setupTest } from 'ember-qunit';
 import extraFilterSerializer from 'pix-orga/utils/extra-filter-serializer.js';
+import paramsValidator from 'pix-orga/utils/params-validator.js';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -9,7 +10,7 @@ module('Unit | Route | authenticated/organization-participants/list', function (
   let store;
   const organizationParticipantSymbol = Symbol('organization-participant');
   const fullNameSymbol = Symbol('fullName');
-  const certificabilitySymbol = Symbol('certificability');
+  const certificabilitySymbol = [Symbol('certificability')];
   const extraFiltersSymbol = Symbol('extraFilters');
   const decodedExtraFiltersSymbol = Symbol('decodedExtraFilters');
   const encodedExtraFiltersSymbol = Symbol('encodedExtraFilters');
@@ -40,6 +41,7 @@ module('Unit | Route | authenticated/organization-participants/list', function (
       .stub(extraFilterSerializer, 'decodeExtraFilters')
       .withArgs(extraFiltersSymbol)
       .returns(decodedExtraFiltersSymbol);
+    sinon.stub(paramsValidator, 'validateCertificabilityParams').withArgs(params).returns(params);
 
     sinon
       .stub(store, 'query')

--- a/orga/tests/unit/routes/authenticated/sco-organization-participants/list-test.js
+++ b/orga/tests/unit/routes/authenticated/sco-organization-participants/list-test.js
@@ -1,7 +1,7 @@
 import { setupTest } from 'ember-qunit';
+import paramsValidator from 'pix-orga/utils/params-validator.js';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
-
 module('Unit | Route | authenticated/sco-organization-participants/list', function (hooks) {
   setupTest(hooks);
   let route;
@@ -11,7 +11,7 @@ module('Unit | Route | authenticated/sco-organization-participants/list', functi
   const searchSymbol = Symbol('search');
   const divisionsSymbol = Symbol('divisions');
   const connectionTypesSymbol = Symbol('connectionTypes');
-  const certificabilitySymbol = Symbol('certificability');
+  const certificabilitySymbol = [Symbol('certificability')];
   const pageNumberSymbol = Symbol('pageNumber');
   const pageSizeSymbol = Symbol('pageSize');
   const participationCountOrderSymbol = Symbol('participationCountOrder');
@@ -29,11 +29,15 @@ module('Unit | Route | authenticated/sco-organization-participants/list', functi
     divisionSort: divisionSortSymbol,
   };
 
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
   hooks.beforeEach(function () {
     route = this.owner.lookup('route:authenticated/sco-organization-participants/list');
     store = this.owner.lookup('service:store');
     route.currentUser = { organization: { id: Symbol('organization-id') } };
-
+    sinon.stub(paramsValidator, 'validateCertificabilityParams').withArgs(params).returns(params);
     sinon
       .stub(store, 'query')
       .withArgs('sco-organization-participant', {

--- a/orga/tests/unit/routes/authenticated/sup-organization-participants/list-test.js
+++ b/orga/tests/unit/routes/authenticated/sup-organization-participants/list-test.js
@@ -1,7 +1,7 @@
 import { setupTest } from 'ember-qunit';
+import paramsValidator from 'pix-orga/utils/params-validator.js';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
-
 module('Unit | Route | authenticated/sup-organization-participants/list', function (hooks) {
   setupTest(hooks);
   let route;
@@ -11,7 +11,7 @@ module('Unit | Route | authenticated/sup-organization-participants/list', functi
   const searchSymbol = Symbol('search');
   const studentNumberSymbol = Symbol('studentNumber');
   const groupsSymbol = Symbol('groups');
-  const certificabilitySymbol = Symbol('certificability');
+  const certificabilitySymbol = [Symbol('certificability')];
   const pageNumberSymbol = Symbol('pageNumber');
   const pageSizeSymbol = Symbol('pageSize');
   const participationCountSymbol = Symbol('participationCountOrder');
@@ -27,6 +27,10 @@ module('Unit | Route | authenticated/sup-organization-participants/list', functi
     lastnameSort: lastnameSortSymbol,
   };
 
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
   hooks.beforeEach(function () {
     route = this.owner.lookup('route:authenticated/sup-organization-participants/list');
     store = this.owner.lookup('service:store');
@@ -37,7 +41,7 @@ module('Unit | Route | authenticated/sup-organization-participants/list', functi
         organizationId: route.currentUser.organization.id,
       })
       .resolves(importDetailSymbol);
-
+    sinon.stub(paramsValidator, 'validateCertificabilityParams').withArgs(params).returns(params);
     sinon
       .stub(store, 'query')
       .withArgs('sup-organization-participant', {

--- a/orga/tests/unit/utils/params-validator-test.js
+++ b/orga/tests/unit/utils/params-validator-test.js
@@ -1,0 +1,48 @@
+import { setupTest } from 'ember-qunit';
+import paramsValidator from 'pix-orga/utils/params-validator';
+import { module, test } from 'qunit';
+
+module('Unit | Utils | params-validator', function (hooks) {
+  setupTest(hooks);
+  module('encodeExtraFilters', () => {
+    test('it remove invalid params from string', function (assert) {
+      const params = {
+        certificability: 'serge',
+      };
+
+      paramsValidator.validateCertificabilityParams(params);
+
+      assert.deepEqual(params.certificability, []);
+    });
+
+    test('it remove invalid params from array', function (assert) {
+      const params = {
+        certificability: ['serge'],
+      };
+
+      paramsValidator.validateCertificabilityParams(params);
+
+      assert.deepEqual(params.certificability, []);
+    });
+
+    test('it keep valid status from array', function (assert) {
+      const params = {
+        certificability: ['eligible', 'non-eligible', 'not-available'],
+      };
+
+      paramsValidator.validateCertificabilityParams(params);
+
+      assert.deepEqual(params.certificability, ['eligible', 'non-eligible', 'not-available']);
+    });
+
+    test('it keep valid status from string', function (assert) {
+      const params = {
+        certificability: 'eligible',
+      };
+
+      paramsValidator.validateCertificabilityParams(params);
+
+      assert.deepEqual(params.certificability, ['eligible']);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Une 500 est remontée lorsque l'on bidouille l'url et que l'on met n'importe quoi dans le filtre certificabilité.

## :robot: Proposition
Ne pas retourner `undefined` dans le filtre dans le cas ou le mapping n'existe pas.

## :rainbow: Remarques
Cela corrigera toutes les pages utilisant le filtre `certificabilité`.

On pourrait ajouter une vérification JOI en amont sur la route pour filtrer les codes qui ne sont pas acceptés. mais dans ce cas là. il faudrait le faire aussi pour les sort asc/desc etc.... ? 

## :100: Pour tester
Se connecter en RA et vérifier qu'avec une url de ce type tout passe 

```
sco-participants?filter%5Bsearch%5D=&filter%5Bdivisions%5D=%5B%5D&filter%5BconnectionTypes%5D=%5B%5D&filter%5Bcertificability%5D=%5B%5D&page%5Bnumber%5D=&page%5Bsize%5D=50&sort%5BparticipationCount%5D=&sort%5BlastnameSort%5D=asc&sort%5BdivisionSort%5D=
```