### PR TITLE
[TECH] Remplacer le logger error par juste un warn dans le cas des erreurs connues (PIX-14314)

### DIFF
--- a/api/src/prescription/learner-management/application/jobs/validate-organization-learners-import-file-job-controller.js
+++ b/api/src/prescription/learner-management/application/jobs/validate-organization-learners-import-file-job-controller.js
@@ -25,7 +25,7 @@ class ValidateOrganizationLearnersImportFileJobController extends JobController 
       if (!(err instanceof DomainError)) {
         throw err;
       }
-      this.#logger.error(err);
+      this.#logger.warn(err);
     }
   }
 }

--- a/api/tests/prescription/learner-management/unit/application/jobs/validate-organization-learners-import-file-job-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/jobs/validate-organization-learners-import-file-job-controller_test.js
@@ -49,15 +49,15 @@ describe('Unit | Prescription | Application | Jobs | validateOrganizationLearner
       sinon.stub(usecases, 'validateSiecleXmlFile').rejects(error);
 
       // given
-      const errorStub = sinon.stub();
-      const handler = new ValidateOrganizationLearnersImportFileJobController({ logger: { error: errorStub } });
+      const warnStub = sinon.stub();
+      const handler = new ValidateOrganizationLearnersImportFileJobController({ logger: { warn: warnStub } });
       const data = { organizationImportId: Symbol('organizationImportId') };
 
       // when
       await handler.handle({ data });
 
       // then
-      expect(errorStub).to.have.been.calledWithExactly(error);
+      expect(warnStub).to.have.been.calledWithExactly(error);
     });
 
     it('should throw when error is not from domain', async function () {


### PR DESCRIPTION
## :unicorn: Problème
On avait mis en place un logger.error afin d'être informé des erreurs lors de la validation des fichiers siecle. Or les 'erreurs' sont un peu trop "alarmante" pour des erreurs que l'on maitrise et qui sont ok dans le cycle de vie de l'import

## :robot: Proposition
On décide donc de remplacer par simplement un warn, afin d'alleger un peu la souffrance et la charge mentale de nos chers captains adorés 🫶 

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
Faire un import siecle avec un fichier en erreur de valdiation
Aller vérifier sur scalingo ( ou en local ) que c'est juste un warn et non plus une erreur
🐈‍⬛ 