### PR TITLE
[FEATURE] Mettre à jour la bannière de certification sur PixOrga (PIX-13969)

### DIFF
--- a/orga/app/components/banner/information.gjs
+++ b/orga/app/components/banner/information.gjs
@@ -52,7 +52,7 @@ const NewYearBanner = <template>
 </template>;
 
 const CertificationBanner = <template>
-  <PixBanner @type="information">
+  <PixBanner @type="warning">
     {{t
       "banners.certification.message"
       documentationLink="https://view.genial.ly/62cd67b161c1e3001759e818?idSlide=0f1b3413-7fef-4c97-b890-675c5bafbe93"

--- a/orga/app/components/banner/information.gjs
+++ b/orga/app/components/banner/information.gjs
@@ -55,7 +55,7 @@ const CertificationBanner = <template>
   <PixBanner @type="warning">
     {{t
       "banners.certification.message"
-      documentationLink="https://view.genial.ly/62cd67b161c1e3001759e818?idSlide=0f1b3413-7fef-4c97-b890-675c5bafbe93"
+      documentationLink="https://cloud.pix.fr/s/DEarDXyxFxM78ps"
       linkClasses="link link--banner link--bold link--underlined"
       htmlSafe=true
       year=@year

--- a/orga/tests/integration/components/banner/information_test.gjs
+++ b/orga/tests/integration/components/banner/information_test.gjs
@@ -126,10 +126,7 @@ module('Integration | Component | Banner::Information', function (hooks) {
           const link = screen.getByRole('link', { name: 'finaliser les sessions dans Pix Certif' });
 
           // then
-          assert.strictEqual(
-            link.href,
-            'https://view.genial.ly/62cd67b161c1e3001759e818?idSlide=0f1b3413-7fef-4c97-b890-675c5bafbe93',
-          );
+          assert.strictEqual(link.href, 'https://cloud.pix.fr/s/DEarDXyxFxM78ps');
         });
       });
 


### PR DESCRIPTION
## :unicorn: Problème
La bannière de certification n'est pas suffisament visible

## :robot: Proposition
Changer la banniere en type warning, modifier le lien pour permettre d'ajouter plus de documentation

## :rainbow: Remarques
Il restera à modifier les variable d'environnement pour prendre en compte le bon mois sur les RA / Recette / Production

## :100: Pour tester
Vérifier que la bannière s'affiche bien quand on est dans le mois selectionné avec le bon lien