### PR TITLE
[BUGFIX] Corriger l'affichage des onglets sessions V3 sur la barre de navigation de Pix Admin (PIX-14349).

### DIFF
--- a/admin/app/components/administration/nav.scss
+++ b/admin/app/components/administration/nav.scss
@@ -27,7 +27,7 @@
       }
 
       &:hover {
-        color: var(--pix-tertiary-500);
+        color: var(--pix-primary-500);
       }
 
       &.active {
@@ -35,6 +35,10 @@
         font-weight: var(--pix-font-bold);
         border-bottom: 2px solid var(--pix-primary-500);
       }
+    }
+
+    &--right{
+      margin-left:auto;
     }
   }
 }

--- a/admin/app/styles/authenticated/sessions/list.scss
+++ b/admin/app/styles/authenticated/sessions/list.scss
@@ -7,12 +7,6 @@
     margin: 20px 10px 10px;
   }
 
-  .navbar-item {
-    &--right {
-      margin-left: auto;
-    }
-  }
-
   &__self-toogle {
     display: flex;
     justify-content: flex-end;


### PR DESCRIPTION
## :unicorn: Problème
Les onglets sessions V3 étaient affichés à gauche pour les séparer des onglets V2.

<img width="1791" alt="Capture d’écran 2024-09-16 à 09 20 06" src="https://github.com/user-attachments/assets/b2c29a73-bc75-4f37-b168-8e7b32dbb715">


## :robot: Proposition
Corriger le soucis.

Un changement de couleur a été apporté sur le hover des onglets de navigation.
Le tertiary, ancienne couleur (bleu) de nos apps à été remplacé par le primary (violet) mais nos onglets  coté admin étaient encore en bleu. ça a donc été remplacé.

## :100: Pour tester

- Se connecter à Admin avec le superadmin
- Aller dans l'onglet sessions de certification
- Les onglets V3 sont de nouveau à droite
