### PR TITLE
[BUGFIX] Ne pas afficher un indice lorsque la traduction n'est pas dispo (PIX-14227)

### DIFF
--- a/api/lib/infrastructure/repositories/correction-repository.js
+++ b/api/lib/infrastructure/repositories/correction-repository.js
@@ -4,7 +4,6 @@ import { Answer } from '../../../src/evaluation/domain/models/Answer.js';
 import { Challenge } from '../../../src/shared/domain/models/Challenge.js';
 import { Correction } from '../../../src/shared/domain/models/Correction.js';
 import { Hint } from '../../../src/shared/domain/models/Hint.js';
-import { getTranslatedKey } from '../../../src/shared/domain/services/get-translated-text.js';
 import {
   challengeDatasource,
   skillDatasource,
@@ -74,9 +73,16 @@ function _hasValidatedHint(skillDataObject) {
 }
 
 function _convertSkillToHint({ skill, locale }) {
+  const matches = locale.match(/^([a-z]{2,3})-?[a-z]{0,3}$/);
+  const language = matches?.[1];
+  const translation = skill.hint_i18n?.[language];
+  if (!translation) {
+    return null;
+  }
+
   return new Hint({
     skillName: skill.name,
-    value: getTranslatedKey(skill.hint_i18n, locale),
+    value: translation,
   });
 }
 

--- a/api/tests/unit/infrastructure/repositories/correction-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/correction-repository_test.js
@@ -223,6 +223,114 @@ describe('Unit | Repository | correction-repository', function () {
           expect(correction.answersEvaluation).to.equal(answersEvaluation);
         });
       });
+
+      context('when hint is not available for the provided locale', function () {
+        context('but there is a fallback available (ex: fr available for locale fr-fr)', function () {
+          it('should return fallback hint', async function () {
+            // given
+            const userId = 1;
+            const providedLocale = 'fr-fr';
+            const challengeId = 'recTuto1';
+            const challengeId3 = 'recTuto3';
+            challengeDataObject = ChallengeLearningContentDataObjectFixture({
+              skillId: 'recIdSkill003',
+            });
+            challengeDatasource.get.resolves(challengeDataObject);
+            const getCorrectionStub = sinon.stub();
+            tutorialRepository.findByRecordIdsForCurrentUser
+              .withArgs({ ids: [challengeId], userId, locale: providedLocale })
+              .resolves(expectedTutorials);
+            tutorialRepository.findByRecordIdsForCurrentUser
+              .withArgs({ ids: [challengeId3], userId, locale: providedLocale })
+              .resolves(expectedLearningMoreTutorials);
+
+            // when
+            const result = await correctionRepository.getByChallengeId({
+              challengeId,
+              userId,
+              locale: providedLocale,
+              tutorialRepository,
+              fromDatasourceObject,
+              getCorrection: getCorrectionStub,
+            });
+
+            // then
+            expectedHint = domainBuilder.buildHint({
+              skillName: '@web1',
+              value: 'Peut-on géo-localiser un lapin sur la banquise ?',
+            });
+            expect(result.hint).to.deep.equal(expectedHint);
+          });
+        });
+
+        context('when there is no fallback available ', function () {
+          it('should return null value as hint', async function () {
+            // given
+            const userId = 1;
+            const locale = 'jp';
+            const challengeId = 'recTuto1';
+            const challengeId3 = 'recTuto3';
+            challengeDataObject = ChallengeLearningContentDataObjectFixture({
+              skillId: 'recIdSkill003',
+            });
+            challengeDatasource.get.resolves(challengeDataObject);
+            const getCorrectionStub = sinon.stub();
+            tutorialRepository.findByRecordIdsForCurrentUser
+              .withArgs({ ids: [challengeId], userId, locale })
+              .resolves(expectedTutorials);
+            tutorialRepository.findByRecordIdsForCurrentUser
+              .withArgs({ ids: [challengeId3], userId, locale })
+              .resolves(expectedLearningMoreTutorials);
+
+            // when
+            const result = await correctionRepository.getByChallengeId({
+              challengeId,
+              userId,
+              locale,
+              tutorialRepository,
+              fromDatasourceObject,
+              getCorrection: getCorrectionStub,
+            });
+
+            // then
+            expect(result.hint).to.be.null;
+          });
+        });
+
+        context('when provided locale is invalid ', function () {
+          it('should return null value as hint', async function () {
+            // given
+            const userId = 1;
+            const providedLocale = 'frop-fr';
+            const challengeId = 'recTuto1';
+            const challengeId3 = 'recTuto3';
+            challengeDataObject = ChallengeLearningContentDataObjectFixture({
+              skillId: 'recIdSkill003',
+            });
+            challengeDatasource.get.resolves(challengeDataObject);
+            const getCorrectionStub = sinon.stub();
+            tutorialRepository.findByRecordIdsForCurrentUser
+              .withArgs({ ids: [challengeId], userId, locale: providedLocale })
+              .resolves(expectedTutorials);
+            tutorialRepository.findByRecordIdsForCurrentUser
+              .withArgs({ ids: [challengeId3], userId, locale: providedLocale })
+              .resolves(expectedLearningMoreTutorials);
+
+            // when
+            const result = await correctionRepository.getByChallengeId({
+              challengeId,
+              userId,
+              locale: providedLocale,
+              tutorialRepository,
+              fromDatasourceObject,
+              getCorrection: getCorrectionStub,
+            });
+
+            // then
+            expect(result.hint).to.be.null;
+          });
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Dans l'écran intermédiaire sur les épreuves, on affiche des indices

![image](https://github.com/user-attachments/assets/087017f4-af26-4170-a746-108e5c2ea419)

Quand un indice n'est traduit alors il est affiché en français

## :robot: Proposition

Il faudrait que l’indice ne s’affiche pas
Pour avoir un cas de test dans la RA, nous avons modifié les données en cache Redis d'un challenge, en supprimant son indice en anglais et en conservant l'indice français.

## :rainbow: Remarques

RAS

## :100: Pour tester

1. Vérifier pour une épreuve en anglais que l'indice n'apparaît pas 
 - Utiliser ce lien : https://app-pr10123.review.pix.org/challenges/challenge1fN33vc9h3siMv/preview?lang=en 
 - Répondre à la question et ouvrir le Tutoriel pour afficher les indices
 - Constater qu'il n'y a pas d'indice
 
2. Vérifier pour une épreuve en français que l'indice apparaît
- Utiliser ce lien : https://app-pr10123.review.pix.fr/assessments/168358/challenges/0?challengeId=challenge1fN33vc9h3siMv
 - Répondre à la question et ouvrir le Tutoriel pour afficher les indices
 - Constater qu'il y a un indice !