### PR TITLE
[FEATURE] Ajout de données l'audit logger pour le changement d'email (PIX-14362)

### DIFF
--- a/audit-logger/src/db/migrations/20240916143835_add-email-changed-action.ts
+++ b/audit-logger/src/db/migrations/20240916143835_add-email-changed-action.ts
@@ -1,0 +1,19 @@
+import type { Knex } from 'knex';
+
+const TABLE_NAME = 'audit-log';
+const CONSTRAINT_NAME = 'audit-log_action_check';
+const COLUMN_NAME = 'action';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`ALTER TABLE "${TABLE_NAME}" DROP CONSTRAINT "${CONSTRAINT_NAME}"`);
+  await knex.raw(
+    `ALTER TABLE "${TABLE_NAME}" ADD CONSTRAINT "${CONSTRAINT_NAME}" CHECK ( "${COLUMN_NAME}" IN ('ANONYMIZATION', 'ANONYMIZATION_GAR', 'EMAIL_CHANGED') )`,
+  );
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`ALTER TABLE "${TABLE_NAME}" DROP CONSTRAINT "${CONSTRAINT_NAME}"`);
+  await knex.raw(
+    `ALTER TABLE "${TABLE_NAME}" ADD CONSTRAINT "${CONSTRAINT_NAME}" CHECK ( "${COLUMN_NAME}" IN ('ANONYMIZATION', 'ANONYMIZATION_GAR') )`,
+  );
+}

--- a/audit-logger/src/db/migrations/20240916143940_add-pix-app-client.ts
+++ b/audit-logger/src/db/migrations/20240916143940_add-pix-app-client.ts
@@ -1,0 +1,19 @@
+import type { Knex } from 'knex';
+
+const TABLE_NAME = 'audit-log';
+const CONSTRAINT_NAME = 'audit-log_client_check';
+const COLUMN_NAME = 'client';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`ALTER TABLE "${TABLE_NAME}" DROP CONSTRAINT "${CONSTRAINT_NAME}"`);
+  await knex.raw(
+    `ALTER TABLE "${TABLE_NAME}" ADD CONSTRAINT "${CONSTRAINT_NAME}" CHECK ( "${COLUMN_NAME}" IN ('PIX_ADMIN', 'PIX_APP') )`,
+  );
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`ALTER TABLE "${TABLE_NAME}" DROP CONSTRAINT "${CONSTRAINT_NAME}"`);
+  await knex.raw(
+    `ALTER TABLE "${TABLE_NAME}" ADD CONSTRAINT "${CONSTRAINT_NAME}" CHECK ( "${COLUMN_NAME}" = 'PIX_ADMIN' )`,
+  );
+}

--- a/audit-logger/src/db/migrations/20240916144100_add-user-role.ts
+++ b/audit-logger/src/db/migrations/20240916144100_add-user-role.ts
@@ -1,0 +1,19 @@
+import type { Knex } from 'knex';
+
+const TABLE_NAME = 'audit-log';
+const CONSTRAINT_NAME = 'audit-log_role_check';
+const COLUMN_NAME = 'role';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`ALTER TABLE "${TABLE_NAME}" DROP CONSTRAINT "${CONSTRAINT_NAME}"`);
+  await knex.raw(
+    `ALTER TABLE "${TABLE_NAME}" ADD CONSTRAINT "${CONSTRAINT_NAME}" CHECK ( "${COLUMN_NAME}" IN ('SUPER_ADMIN', 'SUPPORT', 'USER') )`,
+  );
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`ALTER TABLE "${TABLE_NAME}" DROP CONSTRAINT "${CONSTRAINT_NAME}"`);
+  await knex.raw(
+    `ALTER TABLE "${TABLE_NAME}" ADD CONSTRAINT "${CONSTRAINT_NAME}" CHECK ( "${COLUMN_NAME}" IN ('SUPER_ADMIN', 'SUPPORT') )`,
+  );
+}

--- a/audit-logger/src/db/migrations/20240916144632_add-data-column.ts
+++ b/audit-logger/src/db/migrations/20240916144632_add-data-column.ts
@@ -1,0 +1,16 @@
+import type { Knex } from 'knex';
+
+const TABLE_NAME = 'audit-log';
+const COLUMN_NAME = 'data';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.jsonb(COLUMN_NAME).defaultTo(null);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+}

--- a/audit-logger/src/lib/controllers/create-audit-log.controller.ts
+++ b/audit-logger/src/lib/controllers/create-audit-log.controller.ts
@@ -51,6 +51,7 @@ export const CREATE_AUDIT_LOG_ROUTE: ServerRoute = {
             client: Joi.string()
               .valid(...AuditLogClientTypes)
               .required(),
+            data: Joi.object().optional(),
           }),
         )
         .single(),

--- a/audit-logger/src/lib/domain/models/audit-log.ts
+++ b/audit-logger/src/lib/domain/models/audit-log.ts
@@ -8,9 +8,10 @@ export class AuditLog {
   targetUserId: string;
   client: AuditLogClient;
   role: AuditLogRole;
+  data?: Record<string, unknown> | null;
   createdAt?: Date;
 
-  constructor({ id, occurredAt, action, userId, targetUserId, client, role, createdAt }: AuditLog) {
+  constructor({ id, occurredAt, action, userId, targetUserId, client, role, data, createdAt }: AuditLog) {
     this.id = id;
     this.occurredAt = occurredAt;
     this.action = action;
@@ -18,6 +19,7 @@ export class AuditLog {
     this.targetUserId = targetUserId;
     this.client = client;
     this.role = role;
+    this.data = data;
     this.createdAt = createdAt;
   }
 }

--- a/audit-logger/src/lib/domain/models/models.definition.ts
+++ b/audit-logger/src/lib/domain/models/models.definition.ts
@@ -1,6 +1,8 @@
-export const AuditLogActionTypes = ['ANONYMIZATION', 'ANONYMIZATION_GAR'] as const;
+export const AuditLogActionTypes = ['ANONYMIZATION', 'ANONYMIZATION_GAR', 'EMAIL_CHANGED'] as const;
 export type AuditLogAction = (typeof AuditLogActionTypes)[number];
-export const AuditLogClientTypes = ['PIX_ADMIN'] as const;
+
+export const AuditLogClientTypes = ['PIX_ADMIN', 'PIX_APP'] as const;
 export type AuditLogClient = (typeof AuditLogClientTypes)[number];
-export const AuditLogRoleTypes = ['SUPER_ADMIN', 'SUPPORT'] as const;
+
+export const AuditLogRoleTypes = ['SUPER_ADMIN', 'SUPPORT', 'USER'] as const;
 export type AuditLogRole = (typeof AuditLogRoleTypes)[number];

--- a/audit-logger/tests/acceptance/controllers/create-audit-log.controller.test.ts
+++ b/audit-logger/tests/acceptance/controllers/create-audit-log.controller.test.ts
@@ -80,6 +80,7 @@ describe('Acceptance | Controllers | CreateAuditLogController', () => {
             occurredAt: '2024-06-25T16:09:05.761Z',
             role: 'SUPER_ADMIN',
             client: 'PIX_ADMIN',
+            data: { hello: 'world' },
           },
         ];
 

--- a/audit-logger/tests/integration/infrastructure/repositories/audit-log-postgres.repository.test.ts
+++ b/audit-logger/tests/integration/infrastructure/repositories/audit-log-postgres.repository.test.ts
@@ -39,9 +39,32 @@ describe('Integration | Infrastructure | Repositories | AuditLogPostgresReposito
         targetUserId: '2',
         client: 'PIX_ADMIN',
         role: 'SUPER_ADMIN',
+        data: null,
         createdAt: result.createdAt,
       });
       expect(result).toEqual(expectedResult);
+    });
+  });
+
+  describe('when data is specified', () => {
+    test('creates new audit log', async () => {
+      // given
+      const auditLog = new AuditLog({
+        occurredAt: new Date(),
+        action: 'ANONYMIZATION',
+        userId: '1',
+        targetUserId: '2',
+        client: 'PIX_ADMIN',
+        role: 'SUPER_ADMIN',
+        data: { hello: 'world' },
+      });
+
+      // when
+      await auditLogPostgresRepository.create(auditLog);
+
+      // then
+      const result = await knex('audit-log').first();
+      expect(result.data).toEqual({ hello: 'world' });
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Pour journaliser les changement d’adresse email, nous avons besoin de stocker des informations supplémentaires.

## :robot: Proposition

Ajouter les valeurs suivantes pour les champs:
```
client = PIX_APP
action = EMAIL_CHANGED
role = USER
```

Ajouter une colonne `data` de type `jsonb` et `nullable`.

Exemple d’utilisation:
```js
data = { oldEmail, newEmail }
```

## :100: Pour tester

1. Réaliser la validation de la migration de la DB : 
   1. Exécuter la commande `npm run db:migrate` en local
   2. Vérifier que la table `audit-log` a bien été modifiée : 
      * avec la mise à jour des contraintes sur `client`, `action` et `role` qui possèdent les nouvelles valeurs
      * avec l'ajout d'une colonne `data`
   3.  Exécuter la commande `npm run db:rollback:latest` et vérifier que les contraintes sur `client`, `action` et `role` de la table `audit-log` ne contiennent plus les nouvelles valeurs et que la table `audit-log` ne contient plus la nouvelle colonne `data`
2. Vérifier qu'il n'y a pas de régression sur l'AuditLogger : 
   * Via Pix Admin, réaliser l'anonymisation d'un utilisateur.
   * Vérifier, dans la base de données audit-log, que l'anonymisation a bien été logguée.
3. Constater qu'on peut bien envoyer à l'AuditLogger la nouvelle action `EMAIL_CHANGED` : 

```shell
curl \
-X POST \
-H 'Content-Type: application/json' \
-u pix-api:pixApiClientSecretTest \
--data '{"targetUserId": "123456", "userId": "123456", "action": "EMAIL_CHANGED", "occurredAt": "2024-09-18", "role": "USER", "client": "PIX_APP", "data": {"oldEmail": "someone@example.net", "newEmail": "someone@example.org"}}' \
http://localhost:3001/api/audit-logs
```

---

Pour tester en local les envois à l'AuditLogger il y a des actions à réaliser au préalable :

1. Faire un build de l'Audit Logger pour que le code TypeScript génère du JavaScript à jour :

```shell
cd api/audit-logger/
npm run build
```

2. Démarrer l'Audit Logger

```shell
cd api/audit-logger/
npm start
```

3. Lancer les jobs

```shell
cd api/
npm run start:job
```

---
