### PR TITLE
[FEATURE] Retourner un élément de type Flashcards dans l'API (PIX-14305)

### DIFF
--- a/api/src/devcomp/domain/models/element/flashcards/Card.js
+++ b/api/src/devcomp/domain/models/element/flashcards/Card.js
@@ -1,0 +1,9 @@
+class Card {
+  constructor({ id, recto, verso }) {
+    this.id = id;
+    this.recto = recto;
+    this.verso = verso;
+  }
+}
+
+export { Card };

--- a/api/src/devcomp/domain/models/element/flashcards/Flashcards.js
+++ b/api/src/devcomp/domain/models/element/flashcards/Flashcards.js
@@ -1,0 +1,8 @@
+import { Element } from '../Element.js';
+
+class Flashcards extends Element {
+  constructor({ id }) {
+    super({ id, type: 'flashcards' });
+  }
+}
+export { Flashcards };

--- a/api/src/devcomp/domain/models/element/flashcards/Flashcards.js
+++ b/api/src/devcomp/domain/models/element/flashcards/Flashcards.js
@@ -1,8 +1,13 @@
 import { Element } from '../Element.js';
 
 class Flashcards extends Element {
-  constructor({ id }) {
+  constructor({ id, title, instruction, introImage, cards }) {
     super({ id, type: 'flashcards' });
+
+    this.title = title;
+    this.instruction = instruction;
+    this.introImage = introImage;
+    this.cards = cards;
   }
 }
 export { Flashcards };

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -45,6 +45,35 @@
         {
           "type": "element",
           "element": {
+            "id": "47823e8f-a4af-44d6-96f7-5b6fc7bc6b51",
+            "type": "flashcards",
+            "title": "Introduction à l'adresse e-mail",
+            "instruction": "<p>...</p>",
+            "introImage": {
+              "url": "https://example.org/image.jpeg"
+            },
+            "cards": [
+              {
+                "id": "e1de6394-ff88-4de3-8834-a40057a50ff4",
+                "recto": {
+                  "image": {
+                    "url": "https://example.org/image.jpeg"
+                  },
+                  "text": "A quoi sert l'arobase dans mon adresse email ?"
+                },
+                "verso": {
+                  "image": {
+                    "url": "https://example.org/image.jpeg"
+                  },
+                  "text": "Parce que c'est joli"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "element",
+          "element": {
             "id": "84726001-1665-457d-8f13-4a74dc4768ea",
             "type": "text",
             "content": "<h3>On commence avec les leçons.<br>Les leçons sont des textes, des images ou des vidéos. Les leçons sont là pour vous expliquer des concepts ou des méthodes.</h3>"

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -9,6 +9,7 @@ import { ComponentStepper } from '../../domain/models/component/ComponentStepper
 import { Step } from '../../domain/models/component/Step.js';
 import { Download } from '../../domain/models/element/Download.js';
 import { Embed } from '../../domain/models/element/Embed.js';
+import { Flashcards } from '../../domain/models/element/flashcards/Flashcards.js';
 import { Image } from '../../domain/models/element/Image.js';
 import { QCM } from '../../domain/models/element/QCM.js';
 import { QCU } from '../../domain/models/element/QCU.js';
@@ -102,6 +103,8 @@ export class ModuleFactory {
         return ModuleFactory.#buildQCU(element);
       case 'qrocm':
         return ModuleFactory.#buildQROCM(element);
+      case 'flashcards':
+        return ModuleFactory.#buildFlashcards(element);
       default:
         logger.warn({
           event: 'module_element_type_unknown',
@@ -210,5 +213,9 @@ export class ModuleFactory {
         }
       }),
     });
+  }
+
+  static #buildFlashcards(element) {
+    return new Flashcards({ id: element.id });
   }
 }

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -9,6 +9,7 @@ import { ComponentStepper } from '../../domain/models/component/ComponentStepper
 import { Step } from '../../domain/models/component/Step.js';
 import { Download } from '../../domain/models/element/Download.js';
 import { Embed } from '../../domain/models/element/Embed.js';
+import { Card } from '../../domain/models/element/flashcards/Card.js';
 import { Flashcards } from '../../domain/models/element/flashcards/Flashcards.js';
 import { Image } from '../../domain/models/element/Image.js';
 import { QCM } from '../../domain/models/element/QCM.js';
@@ -216,6 +217,19 @@ export class ModuleFactory {
   }
 
   static #buildFlashcards(element) {
-    return new Flashcards({ id: element.id });
+    return new Flashcards({
+      id: element.id,
+      title: element.title,
+      instruction: element.instruction,
+      introImage: element.introImage,
+      cards: element.cards.map(
+        (card) =>
+          new Card({
+            id: card.id,
+            recto: card.recto,
+            verso: card.verso,
+          }),
+      ),
+    });
   }
 }

--- a/api/tests/devcomp/shared/validateFlashcards.js
+++ b/api/tests/devcomp/shared/validateFlashcards.js
@@ -1,0 +1,23 @@
+import { Card } from '../../../src/devcomp/domain/models/element/flashcards/Card.js';
+import { Flashcards } from '../../../src/devcomp/domain/models/element/flashcards/Flashcards.js';
+import { expect } from '../../test-helper.js';
+
+function validateFlashcards(flashcards, expectedFlashcards) {
+  expect(flashcards).to.be.an.instanceOf(Flashcards);
+  expect(flashcards.id).to.equal(expectedFlashcards.id);
+  expect(flashcards.title).to.equal(expectedFlashcards.title);
+  expect(flashcards.instruction).to.equal(expectedFlashcards.instruction);
+  expect(flashcards.introImage.url).to.equal(expectedFlashcards.introImage.url);
+  validateCard(flashcards.cards[0], expectedFlashcards.cards[0]);
+}
+
+function validateCard(card, expectedCard) {
+  expect(card).to.be.instanceOf(Card);
+  expect(card.id).deep.equal(expectedCard.id);
+  expect(card.recto.image.url).deep.equal(expectedCard.recto.image.url);
+  expect(card.recto.text).deep.equal(expectedCard.recto.text);
+  expect(card.verso.image.url).deep.equal(expectedCard.verso.image.url);
+  expect(card.verso.text).deep.equal(expectedCard.verso.text);
+}
+
+export { validateCard, validateFlashcards };

--- a/api/tests/devcomp/unit/domain/models/element/flashcards/Card_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/flashcards/Card_test.js
@@ -1,5 +1,5 @@
 import { Card } from '../../../../../../../src/devcomp/domain/models/element/flashcards/Card.js';
-import { expect } from '../../../../../../test-helper.js';
+import { validateCard } from '../../../../../shared/validateFlashcards.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | Flashcards | Card', function () {
   describe('#constructor', function () {
@@ -25,11 +25,7 @@ describe('Unit | Devcomp | Domain | Models | Element | Flashcards | Card', funct
       const card = new Card(attributes);
 
       // then
-      expect(card.id).deep.equal(attributes.id);
-      expect(card.recto.image.url).deep.equal(attributes.recto.image.url);
-      expect(card.recto.text).deep.equal(attributes.recto.text);
-      expect(card.verso.image.url).deep.equal(attributes.verso.image.url);
-      expect(card.verso.text).deep.equal(attributes.verso.text);
+      validateCard(card, attributes);
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/element/flashcards/Card_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/flashcards/Card_test.js
@@ -1,0 +1,35 @@
+import { Card } from '../../../../../../../src/devcomp/domain/models/element/flashcards/Card.js';
+import { expect } from '../../../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | Element | Flashcards | Card', function () {
+  describe('#constructor', function () {
+    it('should create a card and keep attributes', function () {
+      // given
+      const attributes = {
+        id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+        recto: {
+          image: {
+            url: 'https://example.org/image.jpeg',
+          },
+          text: "A quoi sert l'arobase dans mon adresse email ?",
+        },
+        verso: {
+          image: {
+            url: 'https://example.org/image.jpeg',
+          },
+          text: "Parce que c'est joli",
+        },
+      };
+
+      // when
+      const card = new Card(attributes);
+
+      // then
+      expect(card.id).deep.equal(attributes.id);
+      expect(card.recto.image.url).deep.equal(attributes.recto.image.url);
+      expect(card.recto.text).deep.equal(attributes.recto.text);
+      expect(card.verso.image.url).deep.equal(attributes.verso.image.url);
+      expect(card.verso.text).deep.equal(attributes.verso.text);
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/models/element/flashcards/Flashcards_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/flashcards/Flashcards_test.js
@@ -1,14 +1,35 @@
+import { Card } from '../../../../../../../src/devcomp/domain/models/element/flashcards/Card.js';
 import { Flashcards } from '../../../../../../../src/devcomp/domain/models/element/flashcards/Flashcards.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | Flashcards | Flashcards', function () {
   describe('#constructor', function () {
     it('should create a Flashcards element and keep attributes', function () {
+      // given
+      const attributes = {
+        id: 'id',
+        title: 'title',
+        instruction: 'instruction',
+        introImage: Symbol('introImage'),
+        cards: [
+          new Card({
+            id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+            recto: Symbol('recto'),
+            verso: Symbol('verso'),
+          }),
+        ],
+      };
+
       // when
-      const flashcards = new Flashcards({ id: 'id' });
+      const flashcards = new Flashcards(attributes);
 
       // then
-      expect(flashcards.id).to.equal('id');
+      expect(flashcards.id).to.equal(attributes.id);
+      expect(flashcards.type).to.equal('flashcards');
+      expect(flashcards.title).to.equal(attributes.title);
+      expect(flashcards.instruction).to.equal(attributes.instruction);
+      expect(flashcards.introImage).to.equal(attributes.introImage);
+      expect(flashcards.cards[0]).to.be.instanceof(Card);
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/element/flashcards/Flashcards_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/flashcards/Flashcards_test.js
@@ -1,6 +1,6 @@
 import { Card } from '../../../../../../../src/devcomp/domain/models/element/flashcards/Card.js';
 import { Flashcards } from '../../../../../../../src/devcomp/domain/models/element/flashcards/Flashcards.js';
-import { expect } from '../../../../../../test-helper.js';
+import { validateFlashcards } from '../../../../../shared/validateFlashcards.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | Flashcards | Flashcards', function () {
   describe('#constructor', function () {
@@ -10,12 +10,18 @@ describe('Unit | Devcomp | Domain | Models | Element | Flashcards | Flashcards',
         id: 'id',
         title: 'title',
         instruction: 'instruction',
-        introImage: Symbol('introImage'),
+        introImage: {
+          url: 'https://...',
+        },
         cards: [
           new Card({
             id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-            recto: Symbol('recto'),
-            verso: Symbol('verso'),
+            recto: { image: { url: 'https://...' } },
+            verso: {
+              image: {
+                url: 'https://...',
+              },
+            },
           }),
         ],
       };
@@ -24,12 +30,7 @@ describe('Unit | Devcomp | Domain | Models | Element | Flashcards | Flashcards',
       const flashcards = new Flashcards(attributes);
 
       // then
-      expect(flashcards.id).to.equal(attributes.id);
-      expect(flashcards.type).to.equal('flashcards');
-      expect(flashcards.title).to.equal(attributes.title);
-      expect(flashcards.instruction).to.equal(attributes.instruction);
-      expect(flashcards.introImage).to.equal(attributes.introImage);
-      expect(flashcards.cards[0]).to.be.instanceof(Card);
+      validateFlashcards(flashcards, attributes);
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/element/flashcards/Flashcards_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/flashcards/Flashcards_test.js
@@ -1,0 +1,14 @@
+import { Flashcards } from '../../../../../../../src/devcomp/domain/models/element/flashcards/Flashcards.js';
+import { expect } from '../../../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | Element | Flashcards | Flashcards', function () {
+  describe('#constructor', function () {
+    it('should create a Flashcards element and keep attributes', function () {
+      // when
+      const flashcards = new Flashcards({ id: 'id' });
+
+      // then
+      expect(flashcards.id).to.equal('id');
+    });
+  });
+});

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/flashcards-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/flashcards-schema.js
@@ -1,0 +1,27 @@
+import Joi from 'joi';
+
+import { htmlNotAllowedSchema, htmlSchema, uuidSchema } from '../utils.js';
+
+const image = Joi.object({
+  url: Joi.string().uri().required(),
+});
+
+const cardSide = Joi.object({
+  image,
+  text: htmlNotAllowedSchema.required(),
+});
+
+const flashcardsElementSchema = Joi.object({
+  id: uuidSchema,
+  type: Joi.string().valid('flashcards').required(),
+  title: htmlNotAllowedSchema.required(),
+  instruction: htmlSchema.optional(),
+  introImage: image,
+  cards: Joi.array().items({
+    id: uuidSchema,
+    recto: cardSide,
+    verso: cardSide,
+  }),
+}).required();
+
+export { flashcardsElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
@@ -2,6 +2,7 @@ import Joi from 'joi';
 
 import { downloadElementSchema } from './element/download-schema.js';
 import { embedElementSchema } from './element/embed-schema.js';
+import { flashcardsElementSchema } from './element/flashcards-schema.js';
 import { imageElementSchema } from './element/image-schema.js';
 import { qcmElementSchema } from './element/qcm-schema.js';
 import { qcuElementSchema } from './element/qcu-schema.js';
@@ -29,6 +30,7 @@ const elementSchema = Joi.alternatives().conditional('.type', {
   switch: [
     { is: 'download', then: downloadElementSchema },
     { is: 'embed', then: embedElementSchema },
+    { is: 'flashcards', then: flashcardsElementSchema },
     { is: 'image', then: imageElementSchema },
     { is: 'qcu', then: qcuElementSchema },
     { is: 'qcm', then: qcmElementSchema },

--- a/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
@@ -3,6 +3,7 @@ import { ComponentStepper } from '../../../../../src/devcomp/domain/models/compo
 import { Step } from '../../../../../src/devcomp/domain/models/component/Step.js';
 import { Download } from '../../../../../src/devcomp/domain/models/element/Download.js';
 import { Embed } from '../../../../../src/devcomp/domain/models/element/Embed.js';
+import { Flashcards } from '../../../../../src/devcomp/domain/models/element/flashcards/Flashcards.js';
 import { Image } from '../../../../../src/devcomp/domain/models/element/Image.js';
 import { QCM } from '../../../../../src/devcomp/domain/models/element/QCM.js';
 import { QCU } from '../../../../../src/devcomp/domain/models/element/QCU.js';
@@ -797,6 +798,67 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         // then
         expect(module.grains[0].components[0].element).to.be.an.instanceOf(QROCM);
       });
+
+      it('should instantiate a Module with a ComponentElement which contains a Flashcard Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            tabletSupport: 'comfortable',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              components: [
+                {
+                  type: 'element',
+                  element: {
+                    id: '71de6394-ff88-4de3-8834-a40057a50ff4',
+                    type: 'flashcards',
+                    title: "Introduction à l'adresse e-mail",
+                    instruction: '<p>...</p>',
+                    introImage: {
+                      url: 'https://example.org/image.jpeg',
+                    },
+                    cards: [
+                      {
+                        id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+                        recto: {
+                          image: {
+                            url: 'https://example.org/image.jpeg',
+                          },
+                          text: "A quoi sert l'arobase dans mon adresse email ?",
+                        },
+                        verso: {
+                          image: {
+                            url: 'https://example.org/image.jpeg',
+                          },
+                          text: "Parce que c'est joli",
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = ModuleFactory.build(moduleData);
+
+        // then
+        expect(module.grains[0].components[0].element).to.be.an.instanceOf(Flashcards);
+      });
     });
 
     describe('With ComponentStepper', function () {
@@ -1324,6 +1386,73 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         expect(module.grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
         expect(module.grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
         expect(module.grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(QROCM);
+      });
+
+      it('should instantiate a Module with a ComponentElement which contains a Flashcard Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            tabletSupport: 'comfortable',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              components: [
+                {
+                  type: 'stepper',
+                  steps: [
+                    {
+                      elements: [
+                        {
+                          id: '71de6394-ff88-4de3-8834-a40057a50ff4',
+                          type: 'flashcards',
+                          title: "Introduction à l'adresse e-mail",
+                          instruction: '<p>...</p>',
+                          introImage: {
+                            url: 'https://example.org/image.jpeg',
+                          },
+                          cards: [
+                            {
+                              id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+                              recto: {
+                                image: {
+                                  url: 'https://example.org/image.jpeg',
+                                },
+                                text: "A quoi sert l'arobase dans mon adresse email ?",
+                              },
+                              verso: {
+                                image: {
+                                  url: 'https://example.org/image.jpeg',
+                                },
+                                text: "Parce que c'est joli",
+                              },
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = ModuleFactory.build(moduleData);
+
+        // then
+        expect(module.grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Flashcards);
       });
 
       it('should filter out unknown element type', function () {

--- a/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
@@ -3,7 +3,6 @@ import { ComponentStepper } from '../../../../../src/devcomp/domain/models/compo
 import { Step } from '../../../../../src/devcomp/domain/models/component/Step.js';
 import { Download } from '../../../../../src/devcomp/domain/models/element/Download.js';
 import { Embed } from '../../../../../src/devcomp/domain/models/element/Embed.js';
-import { Flashcards } from '../../../../../src/devcomp/domain/models/element/flashcards/Flashcards.js';
 import { Image } from '../../../../../src/devcomp/domain/models/element/Image.js';
 import { QCM } from '../../../../../src/devcomp/domain/models/element/QCM.js';
 import { QCU } from '../../../../../src/devcomp/domain/models/element/QCU.js';
@@ -17,6 +16,7 @@ import { TransitionText } from '../../../../../src/devcomp/domain/models/Transit
 import { ModuleFactory } from '../../../../../src/devcomp/infrastructure/factories/module-factory.js';
 import { logger } from '../../../../../src/shared/infrastructure/utils/logger.js';
 import { catchErrSync, expect, sinon } from '../../../../test-helper.js';
+import { validateFlashcards } from '../../../shared/validateFlashcards.js';
 
 describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
   describe('#toDomain', function () {
@@ -857,7 +857,9 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        expect(module.grains[0].components[0].element).to.be.an.instanceOf(Flashcards);
+        const flashcards = module.grains[0].components[0].element;
+        const expectedFlashcards = moduleData.grains[0].components[0].element;
+        validateFlashcards(flashcards, expectedFlashcards);
       });
     });
 
@@ -1452,7 +1454,9 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        expect(module.grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Flashcards);
+        const flashcards = module.grains[0].components[0].steps[0].elements[0];
+        const expectedFlashcards = moduleData.grains[0].components[0].steps[0].elements[0];
+        validateFlashcards(flashcards, expectedFlashcards);
       });
 
       it('should filter out unknown element type', function () {

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -6,6 +6,8 @@ import { ComponentElement } from '../../../../../../src/devcomp/domain/models/co
 import { ComponentStepper } from '../../../../../../src/devcomp/domain/models/component/ComponentStepper.js';
 import { Download } from '../../../../../../src/devcomp/domain/models/element/Download.js';
 import { Embed } from '../../../../../../src/devcomp/domain/models/element/Embed.js';
+import { Card } from '../../../../../../src/devcomp/domain/models/element/flashcards/Card.js';
+import { Flashcards } from '../../../../../../src/devcomp/domain/models/element/flashcards/Flashcards.js';
 import { Image } from '../../../../../../src/devcomp/domain/models/element/Image.js';
 import { QCM } from '../../../../../../src/devcomp/domain/models/element/QCM.js';
 import { QCU } from '../../../../../../src/devcomp/domain/models/element/QCU.js';
@@ -245,6 +247,27 @@ function getComponents() {
         id: '6',
       }),
     }),
+    new ComponentElement({
+      element: new Flashcards({
+        id: '7',
+        title: 'title',
+        instruction: 'instruction',
+        introImage: {
+          url: 'https://...',
+        },
+        cards: [
+          new Card({
+            id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+            recto: { image: { url: 'https://...' } },
+            verso: {
+              image: {
+                url: 'https://...',
+              },
+            },
+          }),
+        ],
+      }),
+    }),
   ];
 }
 
@@ -408,6 +431,30 @@ function getAttributesComponents() {
         id: '6',
         isAnswerable: false,
         type: 'separator',
+      },
+    },
+    {
+      type: 'element',
+      element: {
+        id: '7',
+        isAnswerable: false,
+        title: 'title',
+        instruction: 'instruction',
+        introImage: {
+          url: 'https://...',
+        },
+        type: 'flashcards',
+        cards: [
+          {
+            id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+            recto: { image: { url: 'https://...' } },
+            verso: {
+              image: {
+                url: 'https://...',
+              },
+            },
+          },
+        ],
       },
     },
   ];


### PR DESCRIPTION
## :unicorn: Problème

L'élément Flashcards n'existe pas dans l'API Modulix.

## :robot: Proposition

- Ajouter un premier élément Flashcards dans le didactiel
- Faire en sorte qu’il soit retourné par l’API

```json
{
    "id": "71de6394-ff88-4de3-8834-a40057a50ff4",
    "type": "flashcards",
    "title": "Introduction à l'adresse e-mail",
    "instruction": "<p>...</p>"
    "introImage": {"url": "https://…"},
    "cards": [
        {
            "id": "e1de6394-ff88-4de3-8834-a40057a50ff4",
            "recto": {
                "image": {"url": "https://…"},
                "text": "A quoi sert l'arobase dans mon adresse email ?"
            },
            "verso": {
                "image": {"url": "https://…"},
                "text": "Parce que c'est joli"
            },
                
        },
    ]
}
```

## :rainbow: Remarques

### Le soucis avec les tests de `ModuleFactory` + notre proposition pour les rendre + solides

La manière dont tests de `ModuleFactory` ont été implémentés ne nous semblent pas pertinents. Et nous en avons eu encore l'illustration via cette PR.
Le but de notre _factory_ est de prendre en charge l'instanciation de nos modèles. Elle est utilisée par notre _repository_ pour retourner de la donnée métier à notre _usecase_.
Dans les faits, les tests de cette _factory_ vérifient que pour un référentiel donné, elle renvoi bien des instances de classes métier. Les tests ne vérifient pas si ces classes sont correctement instanciées, si elles ont les bons champs à l'instant T.
Pourquoi pensons-nous que les tests de notre factory ne sont pas cohérents ?
Si par exemple un modèle existant change (ajout d'une variable d'instance par exemple), nous pourrions très bien modifier l'implémentation de la _factory_ sans casser ses tests. D'un point de vue TDD, nous pourrions tout aussi bien modifier le test avant de modifier l'implémentation, le résultat serait le même : les tests de casseraient pas.
Pour nous, c'est le signe que ces tests ne nous protègent pas suffisamment d'une erreur humaine ou d'un changement de besoin métier.
Nous proposons donc que ces tests puissent vérifier chaque champ de chaque instance retournée. Mais c'est déjà ce que nous faisons dans les tests unitaires de chaque modèle.
Alors, dans le cadre de cette PR, nous avons implémenté la fonction `validateFlashcards` qui se charge de cette vérification. Et nous l'avons mis dans un nouveau répertoire `./tests/devcomp/shared`. Enfin, nous utilisons cette fonction à la fois dans les tests du modèle `Flashcards` et dans ceux de la _factory_.

### Validations du référentiel via _Joi_ vs via nos modèles

C'est un sujet déjà abordé avec @yannbertrand 
Le référentiel Modulix est déjà grandement validé via _Joi_ lors de la contribution. La librairie nous permet de remonter des erreurs lorsqu'il manque des champs requis, lorsque les différents objets n'ont pas le bon format, voire même intègre des règles _custom_ plus complexes (cf. les règles `Joi.custom` du `grainSchema`). Cela permet donc de pousser en prod seulement les modules qui répondent aux attendus métier de l'équipe contenu.
Mais il y a aussi des règles de validation dans les modèles (cf. l'usage constant de la fonction `assertNotNullOrUndefined`) qui, pour la plupart, sont redondantes avec le travail de _Joi_. Mais nous avions fait ce choix à l'époque afin d'avoir de nous assurer que nos modèles métiers respectent les règles qui les régissent.

Le sujet est donc de savoir si:

- On continue de doubler les vérifications. Et si oui, qui fait quoi ?
- On ne vérifie que dans Joi
- On ne vérifie que dans le modèle

Pourquoi se poser cette question ?
Dans les faits, bien que le référentiel Modulix se trouve dans le repo, nous le considérons comme une source externe, de la même manière que le référentiel servi par _Pix Editor_. D'ailleurs petit à petit, nous externalisons le process de contribution avec l'ajout de l'outil _Modulix Editor_ et la page de preview dans _Mon Pix_.
En qualité de source de données externe, l'intégrité de notre référentiel se doit d'être validé en amont, d'où l'ensemble des tests faits avec _Joi_.
Dans ce contexte, notre domaine devrait pouvoir faire confiance au référentiel et ainsi, notre `ModuleFactory` ne devrait livrer que des _read-models_. En terme DDD, ces modèles n'ont pas de cycle de vie, ce ne seraient que des _value object_ basiques, de bêtes _pojo_.
Si nous décidions de gérer la validation seulement via _Joi_, nous pourrions non seulement atteindre cette vision mais aussi simplifier notre code en arrêtant de coder la responsabilité de validation dans mille endroits différents.

Dans cette PR, nous avons pris le parti de suivre cette voie pour le modèle `Flashcards`. La validation se fait donc entièrement côté _Joi_ mais pas du tout dans le modèle.

## :100: Pour tester

1. Accéder à https://app-pr10131.review.pix.fr/api/modules/didacticiel-modulix
2. Constater que l'élément Flashcards apparait dans la réponse JSON
