### PR TITLE
[TECH] Essai de déclenchement de la CI via une Github Action, uniquement pour les Pull Requests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,20 @@
 
 version: 2.1
 
+parameters:
+  GHA_Actor:
+    type: string
+    default: ''
+  GHA_Action:
+    type: string
+    default: ''
+  GHA_Event:
+    type: string
+    default: ''
+  GHA_Meta:
+    type: string
+    default: ''
+
 orbs:
   browser-tools: circleci/browser-tools@1.4.8
 
@@ -93,6 +107,10 @@ executors:
 workflows:
   version: 2
   build-and-test:
+    # This workflow is set to be conditionally triggered, only when
+    # the GitHub Action is triggered.
+    # With no other workflows, normal push events will be ignored currently.
+    when: << pipeline.parameters.GHA_Action >>
     jobs:
       - checkout:
           context: Pix

--- a/.github/workflows/trigger-ci.yaml
+++ b/.github/workflows/trigger-ci.yaml
@@ -1,0 +1,19 @@
+name: Trigger CircleCI
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+  push:
+    branches: dev
+
+jobs:
+  trigger-ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger CircleCI
+        # ensure PR is not draft
+        if: '! github.event.pull_request.draft'
+        uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.0.5
+        env:
+          CCI_TOKEN: ${{ secrets.PIX_SERVICE_CIRCLE_CI_TOKEN }}


### PR DESCRIPTION
## :unicorn: Problème
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Actuellement, la CI (pipeline dans CircleCI) est déclenchée sur tous les commits de toutes les branches.
On souhaite diminuer notre consommation sans transiger sur notre pipeline de production.
Pour cela, on veut exécuter le pipeline de CI uniquement pour les commits d'une branche faisant l'objet d'une Pull Request prête à être revue (ie. non draft).
Nous avons essayé le réglage dans les paramètres de CircleCI permettant de lancer les pipelines uniquement pour les Pull Requests mais cela a permis à des branches d'être mergée sans pipeline du tout ...

## :robot: Proposition
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
CircleCI propose une [Github Action officielle](https://circleci.com/blog/trigger-circleci-pipeline-github-action/) permettant de déclencher un pipeline de CI.
On créé donc une Github Action qui s'exécute uniquement pour les PRs non draft et lance le pipeline de CI sur CircleCI.
On prend soin également d'autoriser tous les commits de la branche `dev`.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->
RAS

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
Changer l'état de la PR et constater qu'une PR draft ne déclenche pas la CI, alors qu'une PR prête pour revue la déclenche.
Mettre à jour la branche (par rebase par exemple) et constater que la CI est déclenchée également.