### PR TITLE
[BUGFIX] Mise à jour du lien de téléchargement de PV d'incident (PIX-14406).

### DIFF
--- a/certif/app/components/session-details/index.gjs
+++ b/certif/app/components/session-details/index.gjs
@@ -56,7 +56,7 @@ export default class SessionDetails extends Component {
   }
 
   get urlToDownloadSessionIssueReportSheet() {
-    if (this.args.model.session.version === 3) {
+    if (this.args.model.sessionManagement.version === 3) {
       return this.url.urlToDownloadSessionV3IssueReportSheet;
     }
     return this.url.urlToDownloadSessionIssueReportSheet;

--- a/certif/app/models/session-enrolment.js
+++ b/certif/app/models/session-enrolment.js
@@ -18,7 +18,6 @@ export default class Session extends Model {
   @attr('string') status;
   @attr('string') supervisorPassword;
   @attr() certificationCenterId;
-  @attr('number') version;
 
   get urlToDownloadAttendanceSheet() {
     return `${ENV.APP.API_HOST}/api/sessions/${this.id}/attendance-sheet`;

--- a/certif/tests/acceptance/session-details-test.js
+++ b/certif/tests/acceptance/session-details-test.js
@@ -126,26 +126,47 @@ module('Acceptance | Session Details', function (hooks) {
 
         assert.dom(screen.getByRole('heading', { name: 'Date', level: 2 })).exists();
         assert.dom(screen.getByText('14:00')).exists();
-
-        assert
-          .dom(screen.getByRole('link', { name: "Télécharger le PV d'incident" }))
-          .hasAttribute('href', 'https://cloud.pix.fr/s/B76yA8ip9Radej9/download');
         assert.dom(screen.getByRole('button', { name: 'Télécharger le kit surveillant' })).exists();
       });
 
-      test('it should show issue report sheet download button', async function (assert) {
-        // given
-        const sessionWithCandidates = server.create('session-enrolment');
-        server.createList('certification-candidate', 3, { isLinked: true, sessionId: 1234321 });
-        server.create('session-management', {
-          id: sessionWithCandidates.id,
+      module('when session is V2', function () {
+        test('it should show the V2 issue report sheet download button', async function (assert) {
+          // given
+          const sessionWithCandidates = server.create('session-enrolment');
+          server.createList('certification-candidate', 3, { isLinked: true, sessionId: 1234321 });
+          server.create('session-management', {
+            id: sessionWithCandidates.id,
+            version: 2,
+          });
+
+          // when
+          const screen = await visit(`/sessions/${sessionWithCandidates.id}`);
+
+          // then
+          assert
+            .dom(screen.getByRole('link', { name: "Télécharger le PV d'incident" }))
+            .hasAttribute('href', 'https://cloud.pix.fr/s/B76yA8ip9Radej9/download');
         });
+      });
 
-        // when
-        const screen = await visit(`/sessions/${sessionWithCandidates.id}`);
+      module('when session is V3', function () {
+        test('it should show the V3 issue report sheet download button', async function (assert) {
+          // given
+          const sessionWithCandidates = server.create('session-enrolment');
+          server.createList('certification-candidate', 3, { isLinked: true, sessionId: 1234321 });
+          server.create('session-management', {
+            id: sessionWithCandidates.id,
+            version: 3,
+          });
 
-        // then
-        assert.dom(screen.getByRole('link', { name: "Télécharger le PV d'incident" })).exists();
+          // when
+          const screen = await visit(`/sessions/${sessionWithCandidates.id}`);
+
+          // then
+          assert
+            .dom(screen.getByRole('link', { name: "Télécharger le PV d'incident" }))
+            .hasAttribute('href', 'https://cloud.pix.fr/s/wJc6N3sZNZRC4MZ/download');
+        });
       });
 
       test('it should show attendance sheet download button when there is one or more candidate', async function (assert) {


### PR DESCRIPTION
## :unicorn: Problème

Le PV d'incident pour les CDC pilote V3 n'est plus le bon

## :robot: Proposition

Mettre à jour le lien

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

 • Dans Pix Certif, ouvrir la page de détails d’une session V3 Pilot
• Cliquer sur “PV d’incident” pour le télécharger
• Le fichier est celui correspondant à la V3

 • Dans Pix Certif, ouvrir la page de détails d’une session V2 
• Cliquer sur “PV d’incident” pour le télécharger
• Le fichier est celui correspondant à la V2




PIX CERTIF: https://certif-pr10138.review.pix.fr/
