### PR TITLE
[TECH] Ajout d'une colonne pour enregistrer la reconciliation candidat (PIX-14391).

### DIFF
--- a/api/db/database-builder/factory/build-certification-candidate.js
+++ b/api/db/database-builder/factory/build-certification-candidate.js
@@ -28,6 +28,7 @@ const buildCertificationCandidate = function ({
   prepaymentCode = null,
   hasSeenCertificationInstructions = false,
   accessibilityAdjustmentNeeded = false,
+  reconciliatedAt = null,
 } = {}) {
   sessionId = _.isUndefined(sessionId) ? buildSession().id : sessionId;
   userId = _.isUndefined(userId) ? buildUser().id : userId;
@@ -56,6 +57,7 @@ const buildCertificationCandidate = function ({
     prepaymentCode,
     hasSeenCertificationInstructions,
     accessibilityAdjustmentNeeded,
+    reconciliatedAt,
   };
 
   databaseBuffer.pushInsertable({
@@ -87,6 +89,7 @@ const buildCertificationCandidate = function ({
     prepaymentCode,
     hasSeenCertificationInstructions,
     accessibilityAdjustmentNeeded,
+    reconciliatedAt,
   };
 };
 

--- a/api/db/migrations/20240916152303_add-reconciliatedAt-on-certification-candidates-table.js
+++ b/api/db/migrations/20240916152303_add-reconciliatedAt-on-certification-candidates-table.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'certification-candidates';
+const COLUMN_NAME = 'reconciliatedAt';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dateTime(COLUMN_NAME).nullable().defaultTo(null);
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
@@ -279,6 +279,7 @@ describe('Integration | Certification | Session | Repository | Candidate', funct
             complementaryCertificationKey: 'Chose',
           },
         ],
+        reconciliatedAt: null,
       };
       databaseBuilder.factory.buildSession({ id: candidateData.sessionId });
       databaseBuilder.factory.buildComplementaryCertification({ id: 22, label: 'Quelque', key: 'Chose' });


### PR DESCRIPTION
## :unicorn: Problème
Pour l'entree en session, on veut savoir a quelle date le candidat s'est reconcilie afin de mieux savoir quel etait l'etat de son profil applicable pour sa certification (au moment de la reconciliation de son compte utilisateur avec son profil candidat).

## :robot: Proposition
* Enregistrement de la date de reconciliation

## :rainbow: Remarques
(on a peut etre un peu trop decoupe les tickets 😅 )

## :100: Pour tester

Tests au vert
