### PR TITLE
[FEATURE] Supprimer le support des anciens messages d’embed (PIX-14118)

### DIFF
--- a/mon-pix/app/components/challenge-embed-simulator.js
+++ b/mon-pix/app/components/challenge-embed-simulator.js
@@ -57,15 +57,8 @@ export default class ChallengeEmbedSimulator extends Component {
           thisComponent.isSimulatorRebootable = false;
         }
       }
-      if (isReadyMessage(data) && thisComponent.isSimulatorLaunched) {
-        thisComponent.launchSimulator();
-      }
       if (isHeightMessage(data)) {
         thisComponent.embedHeight = data.height;
-      }
-      if (isAutoLaunchMessage(data)) {
-        thisComponent.launchSimulator();
-        thisComponent.isSimulatorRebootable = false;
       }
     };
 
@@ -112,15 +105,6 @@ export default class ChallengeEmbedSimulator extends Component {
 }
 
 /**
- * Checks if event is a "ready" message.
- * @param {unknown} data
- * @returns {boolean}
- */
-function isReadyMessage(data) {
-  return isMessageType(data, 'ready');
-}
-
-/**
  * Checks if event is an "init" message.
  * @param {unknown} data
  * @returns {data is {
@@ -139,15 +123,6 @@ function isInitMessage(data) {
  */
 function isHeightMessage(data) {
   return isMessageType(data, 'height');
-}
-
-/**
- * Checks if event is a "auto-launch" message.
- * @param {unknown} data
- * @returns {boolean}
- */
-function isAutoLaunchMessage(data) {
-  return isMessageType(data, 'auto-launch');
 }
 
 function isMessageType(data, type) {

--- a/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
+++ b/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
@@ -114,21 +114,6 @@ module('Integration | Component | Challenge Embed Simulator', function (hooks) {
       });
     });
 
-    module('when embed auto launches', function () {
-      test('should not display launch button and reboot button', async function (assert) {
-        const event = new MessageEvent('message', {
-          data: { from: 'pix', type: 'auto-launch' },
-          origin: 'https://epreuves.pix.fr',
-        });
-        window.dispatchEvent(event);
-
-        await new Promise((resolve) => setTimeout(resolve, 0));
-
-        assert.dom(screen.queryByText(t('pages.challenge.embed-simulator.actions.launch'))).doesNotExist();
-        assert.dom(screen.queryByText(t('pages.challenge.embed-simulator.actions.reset'))).doesNotExist();
-      });
-    });
-
     module('when embed initializes', function () {
       module('and does not ask for autoLaunch', () => {
         test('should display launch button', async function (assert) {


### PR DESCRIPTION
## :unicorn: Problème

Les embeds n’utilisent plus les message "ready" et "autoLaunch", mais PixApp les supportent encore.

## :robot: Proposition

Supprimer le support de ces anciens messages.

## :rainbow: Remarques

N/A

## :100: Pour tester

Vérifier le fonctionnement des épreuves concernées, [voir slack](https://1024pix.slack.com/archives/C02DKQECJUX/p1726735664848039).