### PR TITLE
[BUGFIX] Supprimer l'initialisation en lang fr par défaut de l'application (PIX-14387)

### DIFF
--- a/admin/app/index.html
+++ b/admin/app/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html>
 <head>
   <meta charset="utf-8">
   <meta content="IE=edge" http-equiv="X-UA-Compatible">

--- a/certif/app/index.html
+++ b/certif/app/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html>
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/mon-pix/app/index.html
+++ b/mon-pix/app/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html>
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -18,17 +18,6 @@ export default class ApplicationRoute extends Route {
   async beforeModel(transition) {
     this.metrics.initialize();
     await this.session.setup();
-    /*
-    Ce code permet de définir une locale par défaut différente de celle d'ember-intl.
-
-    Ember-intl utilise "en-us" comme locale par défaut.
-
-    Si aucun fichier de traduction n'existe dans le dossier spécifié dans la configuration d'ember-intl,
-    on obtient une URL de ce type : "/?lang=Missing%20translation%20%22current-lang%22%20for%20locale%20%22en-us%22".
-
-    Pour régler ce problème, il faut définir une locale ayant un fichier dans le dossier de traduction.
-     */
-    this.intl.setLocale('fr');
 
     await this.featureToggles.load().catch();
 

--- a/mon-pix/tests/unit/routes/application-test.js
+++ b/mon-pix/tests/unit/routes/application-test.js
@@ -60,20 +60,6 @@ module('Unit | Route | application', function (hooks) {
       assert.ok(true);
     });
 
-    test('should set "fr" locale as default', async function (assert) {
-      // given
-      const route = this.owner.lookup('route:application');
-      route.set('featureToggles', featureTogglesServiceStub);
-      route.set('session', sessionServiceStub);
-      route.set('oidcIdentityProviders', oidcIdentityProvidersStub);
-
-      // when
-      await route.beforeModel();
-
-      // then
-      assert.strictEqual(this.intl.primaryLocale, 'fr');
-    });
-
     test('should get feature toogles', async function (assert) {
       // given
       const route = this.owner.lookup('route:application');

--- a/orga/app/index.html
+++ b/orga/app/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html>
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
## :unicorn: Problème
Les outils de traduction automatiques ne reconnaissent pas bien la langue de nos applications.

Ce qui peut amener, sur des navigateurs ayant activé le fait de toujours proposer de traduire la page, à des comportements étranges comme le fait de proposer de traduire une page, qui est déjà en anglais, en anglais 🤔 

Car on initialise le doctype HTML avec une "lang=fr", qu'on change ensuite en fonction de la locale de l'utilisateur.

<img width="1677" alt="Capture d’écran 2024-09-20 à 09 10 01" src="https://github.com/user-attachments/assets/09142f65-9dbd-477c-977b-265eead044bd">

## :robot: Proposition

Enlever la langue "fr" par défault dans l'index.html des Pix Apps. Cette langue est initialisée par `ember-intl` lors du premier chargement du site.

## :rainbow: Remarques
- L'outil de traduction automatique ne reconnaît pas la langue de la page alors que c'est bien initialisée dans la balise sur Firefox. C'est peut être car le module est actuellement en beta.
- Ce changement a aussi été fait sur les autres applications sauf Pix Junior pour standardiser ça.  Pour Pix Junior, c'est parce qu'il n'y a pas de notion de locale pour le moment


## :100: Pour tester
> :warning: Les tests ci-dessous nécessitent d'abord de changer la langue de votre navigateur en anglais

### Reproduire le comportement
- Se connecter sur app.pix.org
- Changer la langue du compte en anglais en cliquant, sur le profil en haut à droite -> Mon Compte -> Langue.
- Revenir sur la page d'accueil.
- Rafraîchir la page.
- Afficher l'outil de traduction automatique (dans firefox => icône menu en haut à droite => Translate Page).
- Constater que l'outil indique que la langue de la page initiale en français alors que c'est en anglais.
- Traduire la page en anglais
- Constater que le contenu de la page change suite à ça.
- Afficher le code source de la page en faisant un clic droit puis en sélectionnant l'option en question.
- Vérifier la présence de la `lang=fr` dans la balise html.

### Test du correctif
- Se connecter à la RA de Pix App .org avec un compte ayant une langue en anglais (c'est fait pour allorga@example.net en RA). 
- Dans le cas où il n'y en a pas, il suffit de prendre un compte (ex: admin-orga@example.net) et changer la langue en cliquant, après connexion, sur le profil en haut à droite -> Mon Compte -> Langue.
- Afficher l'outil de traduction automatique.
- Constater que l'outil n'affiche plus français comme langue pour la page initiale.
- Afficher le code source de la page.
- Vérifier qu'il n'y a plus `lang=fr` dans la balise html.
- Faire le même test sur les autres apps 