### PR TITLE
[FEATURE] Ajout d'une bulle info lors de la selection des classes (pix-13987)

### DIFF
--- a/junior/app/templates/school/divisions.hbs
+++ b/junior/app/templates/school/divisions.hbs
@@ -4,9 +4,21 @@
 </RobotDialog>
 <div class="list">
   {{#each @model.divisions as |division|}}
-    <LinkTo @route="school.students" @query={{hash division=division}} class="divisions__item">
-      <p class="item__title">{{division}}</p>
+    <LinkTo @route="school.students" @query={{hash division=division}}>
+      <PixTooltip @isInline={{true}}>
+        <:triggerElement>
+          <div class="divisions__item">
+            <p class="item__title">{{division}}</p>
+
+          </div>
+        </:triggerElement>
+
+        <:tooltip>
+          {{division}}
+        </:tooltip>
+      </PixTooltip>
     </LinkTo>
+
   {{/each}}
 </div>
 <Footer />

--- a/junior/tests/acceptance/school-divisions-test.js
+++ b/junior/tests/acceptance/school-divisions-test.js
@@ -1,0 +1,33 @@
+import { visit } from '@1024pix/ember-testing-library';
+import { module, test } from 'qunit';
+
+import { setupApplicationTest } from '../../tests/helpers';
+
+module('Acceptance | School | divisions', function (hooks) {
+  setupApplicationTest(hooks);
+  hooks.afterEach(async function () {
+    localStorage.clear();
+  });
+
+  test('should display all existant divisions', async function (assert) {
+    // given
+    const longClassName = 'CM2-B 3 3 3 3 adzaz azd adazdzad dzad d';
+    this.server.create('school', {
+      organizationLearners: [
+        {
+          id: 1,
+          division: longClassName,
+          firstName: 'Sara',
+          displayName: 'Sara A.',
+          organizationId: 9000,
+        },
+        { id: 2, division: 'CM2 A', firstName: 'Mickey', displayName: 'Mickey', organizationId: 9000 },
+      ],
+    });
+    // when
+    const screen = await visit('/schools/MINIPIXOU');
+    const htmlElementsWithLongName = screen.queryAllByText(longClassName);
+
+    assert.strictEqual(htmlElementsWithLongName.length, 2);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Lorsque les noms des classe sont long, on applique un effet ellipsis. Mais le problème est que l'on n'a pas de moyen de voir le nom en entier

## :robot: Proposition
Ajouter une bulle info pour voir le nom en entier

## :rainbow: Remarques
RAS

## :100: Pour tester
- Se connecter à la RA Junior.
- Rentrer le code "MINIPIXOU"
- Passer la sourie sur une classe et observer l'apparition d'une bulle info !

![image](https://github.com/user-attachments/assets/1a7c0ebe-64bc-4d0f-8353-a99f3360297d)