### PR TITLE
[BUGFIX]  Ajout d'espace dans le bouton de la page de fin de mission (Pix-14165)

### DIFF
--- a/junior/app/styles/pages/identified/missions/mission.scss
+++ b/junior/app/styles/pages/identified/missions/mission.scss
@@ -23,6 +23,10 @@
       font-size: 18px;
       border-radius: 100px;
 
+      &__icon {
+        margin-left: 10px;
+      }
+
       @include device-is('tablet') {
         margin: 32px 60px 0 auto;
       }


### PR DESCRIPTION
## :unicorn: Problème
La flèche est collée au texte dans le bouton de page de fin de mission.

## :robot: Proposition
Ajout d'un espace entre le texte et la flèche dans le bouton de la page de fin de mission.

## :100: Pour tester
Finir une mission et afficher la page de fin. Le bouton est bien plus joli.