### PR TITLE
[BUGFIX] Correction de l'alignement des titres dans les cartes mission (Pix-14420)

### DIFF
--- a/junior/app/styles/components/mission-card/card.scss
+++ b/junior/app/styles/components/mission-card/card.scss
@@ -85,6 +85,7 @@
       margin-top: var(--pix-spacing-2x);
 
       .mission-name {
+        min-height: 62px;
         margin-bottom: var(--pix-spacing-3x);
         font-weight: 800;
         font-size: 22.38px;


### PR DESCRIPTION
Avant:
![image](https://github.com/user-attachments/assets/617eafa5-15ea-43c6-a33e-8988224fbb2c)


Après:
![image](https://github.com/user-attachments/assets/e4f03fd1-a300-448b-84b3-989833ef0588)
