### PR TITLE
[BUGFIX] renomme les clés de traduction dans les fichier nl / en sur la table des lots de places (PIX-14452)

### DIFF
--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1157,9 +1157,9 @@
           "caption": "Table listing your organisation's seat purchases. For each purchase, it shows: the number of tickets, the activation date, the expiry date and the status (active, coming soon or expired). It is ordered according to the status of the purchases and their expiry date.",
           "empty-state": "No seats yet!",
           "headers": {
-            "activationDate": "Activation date",
+            "activation-date": "Activation date",
             "count": "Seats count",
-            "expirationDate": "Expiration date",
+            "expiration-date": "Expiration date",
             "status": "Status"
           }
         }

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1178,11 +1178,11 @@
         "table": {
           "title": "Seats purchase history",
           "caption": "Table listing your organisation's seat purchases. For each purchase, it shows: the number of tickets, the activation date, the expiry date and the status (active, coming soon or expired). It is ordered according to the status of the purchases and their expiry date.",
-          "empty-state":"No seats yet!",
+          "empty-state": "No seats yet!",
           "headers": {
             "count": "Seats count",
-            "activationDate": "Activation date",
-            "expirationDate": "Expiration date",
+            "activation-date": "Activation date",
+            "expiration-date": "Expiration date",
             "status": "Status"
           }
         },


### PR DESCRIPTION
## :unicorn: Problème
Certaines de clés de trad sont mal nommées, ce qui fait qu'on ne les trouve pas :/

## :robot: Proposition
on renomme les clefs

## :rainbow: Remarques
RAS

## :100: Pour tester
- afficher la pages des lots de places (orga PRO_NOT_MANAGING) en EN / NL et constater qu'il ne manque pas de clés

