### PR TITLE
[TECH] Permettre la suppression de cronJob lorsque l'on change son nom (PIX-14453)

### DIFF
--- a/api/db/database-builder/factory/prescription/organization-learners/build-organization-learner.js
+++ b/api/db/database-builder/factory/prescription/organization-learners/build-organization-learner.js
@@ -16,6 +16,8 @@ const buildOrganizationLearner = function ({
   deletedBy = null,
   deletedAt = null,
   attributes = null,
+  certifiableAt = null,
+  isCertifiable = null,
 } = {}) {
   organizationId = _.isUndefined(organizationId) ? buildOrganization().id : organizationId;
   userId = _.isUndefined(userId) ? buildUser().id : userId;
@@ -32,6 +34,8 @@ const buildOrganizationLearner = function ({
     deletedBy,
     deletedAt,
     attributes,
+    certifiableAt,
+    isCertifiable,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/src/prescription/campaign-participation/application/jobs/participation-completed-job-controller.js
+++ b/api/src/prescription/campaign-participation/application/jobs/participation-completed-job-controller.js
@@ -6,10 +6,6 @@ export class ParticipationCompletedJobController extends JobController {
     super(ParticipationCompletedJob.name);
   }
 
-  get legacyName() {
-    return 'PoleEmploiParticipationCompletedJob';
-  }
-
   async handle({ data }) {
     const { campaignParticipationId } = data;
 

--- a/api/src/prescription/campaign-participation/application/jobs/participation-shared-job-controller.js
+++ b/api/src/prescription/campaign-participation/application/jobs/participation-shared-job-controller.js
@@ -7,10 +7,6 @@ export class ParticipationSharedJobController extends JobController {
     super(ParticipationSharedJob.name);
   }
 
-  get legacyName() {
-    return 'SendSharedParticipationResultsToPoleEmploiJob';
-  }
-
   async handle({ data }) {
     const { campaignParticipationId } = data;
 

--- a/api/src/prescription/campaign-participation/application/jobs/participation-started-job-controller.js
+++ b/api/src/prescription/campaign-participation/application/jobs/participation-started-job-controller.js
@@ -7,10 +7,6 @@ export class ParticipationStartedJobController extends JobController {
     super(ParticipationStartedJob.name);
   }
 
-  get legacyName() {
-    return 'PoleEmploiParticipationStartedJob';
-  }
-
   async handle({ data }) {
     const { campaignParticipationId } = data;
 

--- a/api/src/prescription/learner-management/application/jobs/schedule-compute-organization-learners-certificability-job-controller.js
+++ b/api/src/prescription/learner-management/application/jobs/schedule-compute-organization-learners-certificability-job-controller.js
@@ -11,7 +11,7 @@ import { computeCertificabilityJobRepository } from '../../../learner-management
 
 class ScheduleComputeOrganizationLearnersCertificabilityJobController extends JobScheduleController {
   constructor() {
-    super('ComputeOrganizationLearnersCertificabilityJob', {
+    super('ScheduleComputeOrganizationLearnersCertificabilityJob', {
       jobCron: config.features.scheduleComputeOrganizationLearnersCertificability.cron,
     });
   }

--- a/api/src/prescription/learner-management/application/jobs/schedule-compute-organization-learners-certificability-job-controller.js
+++ b/api/src/prescription/learner-management/application/jobs/schedule-compute-organization-learners-certificability-job-controller.js
@@ -16,6 +16,10 @@ class ScheduleComputeOrganizationLearnersCertificabilityJobController extends Jo
     });
   }
 
+  get legacyName() {
+    return 'ComputeOrganizationLearnersCertificabilityJob';
+  }
+
   async handle({
     data = {},
     dependencies = { organizationLearnerRepository, computeCertificabilityJobRepository, config, logger },

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -191,7 +191,7 @@ const configuration = (function () {
       pixCertifScoBlockedAccessDateCollege: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_COLLEGE,
       scheduleComputeOrganizationLearnersCertificability: {
         cron: process.env.SCHEDULE_COMPUTE_LEARNERS_CERTIFICABILITY_JOB_CRON || '0 21 * * *',
-        chunkSize: process.env.SCHEDULE_COMPUTE_LEARNERS_CERTIFICABILITY_CHUNK_SIZE || 50000,
+        chunkSize: process.env.SCHEDULE_COMPUTE_LEARNERS_CERTIFICABILITY_CHUNK_SIZE || 1000,
       },
       scoAccountRecoveryKeyLifetimeMinutes: process.env.SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES,
     },

--- a/api/src/shared/infrastructure/jobs/JobQueue.js
+++ b/api/src/shared/infrastructure/jobs/JobQueue.js
@@ -21,6 +21,14 @@ class JobQueue {
     });
   }
 
+  scheduleCronJob({ name, cron, data, options }) {
+    return this.pgBoss.schedule(name, cron, data, options);
+  }
+
+  unscheduleCronJob(name) {
+    return this.pgBoss.unschedule(name);
+  }
+
   async stop() {
     await this.pgBoss.stop({ graceful: false, timeout: 1000, destroy: true });
   }

--- a/api/src/shared/infrastructure/repositories/jobs/job-repository.js
+++ b/api/src/shared/infrastructure/repositories/jobs/job-repository.js
@@ -59,7 +59,11 @@ export class JobRepository {
   async #send(jobs) {
     const knexConn = DomainTransaction.getConnection();
 
-    return knexConn('pgboss.job').insert(jobs);
+    const results = await knexConn.batchInsert('pgboss.job', jobs);
+
+    const rowCount = results.reduce((total, batchResult) => total + (batchResult.rowCount || 0), 0);
+
+    return { rowCount };
   }
 
   async performAsync(...datas) {

--- a/api/tests/prescription/learner-management/integration/application/jobs/schedule-compute-organization-learners-certificability-job-controller_test.js
+++ b/api/tests/prescription/learner-management/integration/application/jobs/schedule-compute-organization-learners-certificability-job-controller_test.js
@@ -1,0 +1,62 @@
+import * as organizationLearnerRepository from '../../../../../../lib/infrastructure/repositories/organization-learner-repository.js';
+import { ScheduleComputeOrganizationLearnersCertificabilityJobController } from '../../../../../../src/prescription/learner-management/application/jobs/schedule-compute-organization-learners-certificability-job-controller.js';
+import { computeCertificabilityJobRepository } from '../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/compute-certificability-job-repository.js';
+import { ORGANIZATION_FEATURE } from '../../../../../../src/shared/domain/constants.js';
+import { databaseBuilder, expect, sinon } from '../../../../../test-helper.js';
+
+describe('Integration | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCertificabilityJobController', function () {
+  context('#handle', function () {
+    let logger;
+
+    beforeEach(async function () {
+      const organization = databaseBuilder.factory.buildOrganization();
+      const feature = databaseBuilder.factory.buildFeature({
+        key: ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key,
+      });
+      databaseBuilder.factory.buildOrganizationFeature({ featureId: feature.id, organizationId: organization.id });
+
+      databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+        organizationId: organization.id,
+        certifiabledAt: null,
+        isCertifiable: null,
+      });
+      databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+        organizationId: organization.id,
+        certifiabledAt: null,
+        isCertifiable: null,
+      });
+
+      await databaseBuilder.commit();
+      logger = {
+        info: sinon.stub(),
+      };
+    });
+
+    it('should schedule multiple ComputeCertificabilityJob', async function () {
+      // given
+      const scheduleComputeOrganizationLearnersCertificabilityJobHandler =
+        new ScheduleComputeOrganizationLearnersCertificabilityJobController();
+
+      // when
+      await scheduleComputeOrganizationLearnersCertificabilityJobHandler.handle({
+        data: { skipLoggedLastDayCheck: true, onlyNotComputed: false },
+        dependencies: {
+          logger,
+          organizationLearnerRepository,
+          computeCertificabilityJobRepository,
+          config: {
+            features: {
+              scheduleComputeOrganizationLearnersCertificability: {
+                chunkSize: 2,
+                cron: '0 21 * * *',
+              },
+            },
+          },
+        },
+      });
+      // then
+
+      await expect('ComputeCertificabilityJob').to.have.been.performed.withJobsCount(2);
+    });
+  });
+});

--- a/api/tests/shared/integration/infrastructure/jobs/JobQueue_test.js
+++ b/api/tests/shared/integration/infrastructure/jobs/JobQueue_test.js
@@ -5,39 +5,88 @@ import { JobRepository } from '../../../../../src/shared/infrastructure/reposito
 import { expect } from '../../../../test-helper.js';
 
 describe('Integration | Infrastructure | Jobs | JobQueue', function () {
-  it('executes job when a job is added to the queue', async function () {
-    const name = 'JobTest';
-    const expectedParams = { jobParam: 1 };
-    const job = new JobRepository({ name });
-    await job.performAsync(expectedParams);
-    const pgBoss = new PgBoss(process.env.TEST_DATABASE_URL);
+  let pgBoss, jobQueue;
+
+  beforeEach(async function () {
+    pgBoss = new PgBoss(process.env.TEST_DATABASE_URL);
     await pgBoss.start();
 
-    const jobQueue = new JobQueue(pgBoss);
+    jobQueue = new JobQueue(pgBoss);
+  });
 
-    const promise = new Promise((resolve, reject) => {
-      const handler = class {
-        get teamConcurrency() {
-          return 1;
-        }
+  describe('register', function () {
+    it('executes job when a job is added to the queue', async function () {
+      // given
+      const name = 'JobTest';
+      const expectedParams = { jobParam: 1 };
+      const job = new JobRepository({ name });
 
-        get teamSize() {
-          return 2;
-        }
+      // when
+      await job.performAsync(expectedParams);
 
-        handle(params) {
-          try {
-            expect(params).to.deep.contains({ data: expectedParams });
-          } catch (err) {
-            reject(err);
+      // then
+      const promise = new Promise((resolve, reject) => {
+        const handler = class {
+          get teamConcurrency() {
+            return 1;
           }
-          resolve();
-        }
-      };
 
-      jobQueue.register(name, handler);
+          get teamSize() {
+            return 2;
+          }
+
+          handle(params) {
+            try {
+              expect(params).to.deep.contains({ data: expectedParams });
+            } catch (err) {
+              reject(err);
+            }
+            resolve();
+          }
+        };
+
+        jobQueue.register(name, handler);
+      });
+
+      return promise;
+    });
+  });
+
+  describe('cronJob', function () {
+    it('save schedule job', async function () {
+      // given
+      const name = 'CronJobTest';
+
+      // when
+      await jobQueue.scheduleCronJob({
+        name,
+        cron: '*/5 * * * *',
+        data: { my_data: 'awesome_data' },
+        options: { tz: 'Europe/Paris' },
+      });
+
+      await expect(name).to.have.been.schedule.withCronJob({
+        name,
+        cron: '*/5 * * * *',
+        data: { my_data: 'awesome_data' },
+        options: { tz: 'Europe/Paris' },
+      });
     });
 
-    return promise;
+    it('remove schedule job', async function () {
+      // given
+      const name = 'CronJobTest';
+      await jobQueue.scheduleCronJob({
+        name,
+        cron: '*/5 * * * *',
+        data: { my_data: 'awesome_data' },
+        options: { tz: 'Europe/Paris' },
+      });
+
+      // when
+      await jobQueue.unscheduleCronJob(name);
+
+      await expect(name).to.have.been.schedule.withCronJobsCount(0);
+    });
   });
 });

--- a/api/tests/tooling/jobs/expect-job.js
+++ b/api/tests/tooling/jobs/expect-job.js
@@ -5,6 +5,10 @@ export const jobChai = (knex) => (_chai, utils) => {
     return this;
   });
 
+  utils.addProperty(Assertion.prototype, 'schedule', function () {
+    return this;
+  });
+
   Assertion.addMethod('withJobsCount', async function (expectedCount) {
     const jobName = this._obj;
     const jobs = await knex('pgboss.job').where({ name: jobName });
@@ -21,6 +25,27 @@ export const jobChai = (knex) => (_chai, utils) => {
     const jobName = this._obj;
     const jobs = await knex('pgboss.job').select(knex.raw(`*, expirein::varchar`)).where({ name: jobName });
     assert.deepInclude(jobs[0], jobData, `Job '${jobName}' was performed with a different payload`);
+  });
+
+  Assertion.addMethod('withCronJobsCount', async function (expectedCount) {
+    const jobName = this._obj;
+    const jobs = await knex('pgboss.schedule').where({ name: jobName });
+    assert.strictEqual(
+      jobs.length,
+      expectedCount,
+      `expected ${jobName} to have been performed ${expectedCount} times, but it was performed ${jobs.length} times`,
+    );
+  });
+
+  Assertion.addMethod('withCronJob', async function (jobData) {
+    await this.withCronJobsCount(1);
+
+    const jobName = this._obj;
+    const job = await knex('pgboss.schedule')
+      .select('name', 'cron', 'data', 'options')
+      .where({ name: jobName })
+      .first();
+    assert.deepInclude(job, jobData, `Job '${jobName}' was schedule with a different payload`);
   });
 
   Assertion.addMethod('withJobPayloads', async function (payloads) {

--- a/api/tests/unit/worker_test.js
+++ b/api/tests/unit/worker_test.js
@@ -1,4 +1,5 @@
 import { UserAnonymizedEventLoggingJob } from '../../src/identity-access-management/domain/models/UserAnonymizedEventLoggingJob.js';
+import { ScheduleComputeOrganizationLearnersCertificabilityJobController } from '../../src/prescription/learner-management/application/jobs/schedule-compute-organization-learners-certificability-job-controller.js';
 import { ValidateOrganizationLearnersImportFileJobController } from '../../src/prescription/learner-management/application/jobs/validate-organization-learners-import-file-job-controller.js';
 import { ValidateOrganizationImportFileJob } from '../../src/prescription/learner-management/domain/models/ValidateOrganizationImportFileJob.js';
 import { UserAnonymizedEventLoggingJobController } from '../../src/shared/application/jobs/audit-log/user-anonymized-event-logging-job-controller.js';
@@ -8,16 +9,19 @@ import { registerJobs } from '../../worker.js';
 import { catchErr, expect, sinon } from '../test-helper.js';
 
 describe('#registerJobs', function () {
-  let startPgBossStub, createJobQueuesStub, scheduleCpfJobsStub, jobQueueStub;
+  let startPgBossStub, createJobQueuesStub, jobQueueStub;
 
   beforeEach(function () {
-    const pgBossStub = { schedule: sinon.stub() };
-    jobQueueStub = { register: sinon.stub() };
+    const pgBossStub = Symbol('pgBoss');
+    jobQueueStub = { register: sinon.stub(), scheduleCronJob: sinon.stub(), unscheduleCronJob: sinon.stub() };
     startPgBossStub = sinon.stub();
     startPgBossStub.resolves(pgBossStub);
     createJobQueuesStub = sinon.stub();
     createJobQueuesStub.withArgs(pgBossStub).returns(jobQueueStub);
-    scheduleCpfJobsStub = sinon.stub();
+  });
+
+  afterEach(function () {
+    sinon.restore();
   });
 
   it('should register UserAnonymizedEventLoggingJob', async function () {
@@ -27,13 +31,32 @@ describe('#registerJobs', function () {
       dependencies: {
         startPgBoss: startPgBossStub,
         createJobQueues: createJobQueuesStub,
-        scheduleCpfJobs: scheduleCpfJobsStub,
       },
     });
 
     // then
     expect(jobQueueStub.register).to.have.been.calledWithExactly(
       UserAnonymizedEventLoggingJob.name,
+      UserAnonymizedEventLoggingJobController,
+    );
+  });
+
+  it('should register legacyName from UserAnonymizedEventLoggingJob', async function () {
+    // when
+    sinon
+      .stub(UserAnonymizedEventLoggingJobController.prototype, 'legacyName')
+      .get(() => 'legyNameForUserAnonymizedEventLoggingJobController');
+    await registerJobs({
+      jobGroup: JobGroup.DEFAULT,
+      dependencies: {
+        startPgBoss: startPgBossStub,
+        createJobQueues: createJobQueuesStub,
+      },
+    });
+
+    // then
+    expect(jobQueueStub.register).to.have.been.calledWithExactly(
+      'legyNameForUserAnonymizedEventLoggingJobController',
       UserAnonymizedEventLoggingJobController,
     );
   });
@@ -48,7 +71,6 @@ describe('#registerJobs', function () {
       dependencies: {
         startPgBoss: startPgBossStub,
         createJobQueues: createJobQueuesStub,
-        scheduleCpfJobs: scheduleCpfJobsStub,
       },
     });
 
@@ -69,7 +91,6 @@ describe('#registerJobs', function () {
       dependencies: {
         startPgBoss: startPgBossStub,
         createJobQueues: createJobQueuesStub,
-        scheduleCpfJobs: scheduleCpfJobsStub,
       },
     });
 
@@ -86,12 +107,55 @@ describe('#registerJobs', function () {
       dependencies: {
         startPgBoss: startPgBossStub,
         createJobQueues: createJobQueuesStub,
-        scheduleCpfJobs: scheduleCpfJobsStub,
       },
     });
 
     // then
     expect(error).to.be.instanceOf(Error);
     expect(error.message).to.equal(`Job group invalid, allowed Job groups are [${Object.values(JobGroup)}]`);
+  });
+
+  describe('cron Job', function () {
+    it('schedule ScheduleComputeOrganizationLearnersCertificabilityJob', async function () {
+      //given
+      sinon.stub(config.features.scheduleComputeOrganizationLearnersCertificability, 'cron').value('0 21 * * *');
+
+      await registerJobs({
+        jobGroup: JobGroup.DEFAULT,
+        dependencies: {
+          startPgBoss: startPgBossStub,
+          createJobQueues: createJobQueuesStub,
+        },
+      });
+
+      // then
+      expect(jobQueueStub.scheduleCronJob).to.have.been.calledWithExactly({
+        name: 'ScheduleComputeOrganizationLearnersCertificabilityJob',
+        cron: '0 21 * * *',
+        options: { tz: 'Europe/Paris' },
+      });
+    });
+
+    it('unschedule legacyName from ScheduleComputeOrganizationLearnersCertificabilityJob', async function () {
+      //given
+      sinon
+        .stub(ScheduleComputeOrganizationLearnersCertificabilityJobController.prototype, 'legacyName')
+        .get(() => 'legyNameForScheduleComputeOrganizationLearnersCertificabilityJobController');
+
+      sinon.stub(config.features.scheduleComputeOrganizationLearnersCertificability, 'cron').value('0 21 * * *');
+
+      await registerJobs({
+        jobGroup: JobGroup.DEFAULT,
+        dependencies: {
+          startPgBoss: startPgBossStub,
+          createJobQueues: createJobQueuesStub,
+        },
+      });
+
+      // then
+      expect(jobQueueStub.unscheduleCronJob).to.have.been.calledWithExactly(
+        'legyNameForScheduleComputeOrganizationLearnersCertificabilityJobController',
+      );
+    });
   });
 });

--- a/api/tests/unit/worker_test.js
+++ b/api/tests/unit/worker_test.js
@@ -1,5 +1,4 @@
 import { UserAnonymizedEventLoggingJob } from '../../src/identity-access-management/domain/models/UserAnonymizedEventLoggingJob.js';
-import { ParticipationSharedJobController } from '../../src/prescription/campaign-participation/application/jobs/participation-shared-job-controller.js';
 import { ValidateOrganizationLearnersImportFileJobController } from '../../src/prescription/learner-management/application/jobs/validate-organization-learners-import-file-job-controller.js';
 import { ValidateOrganizationImportFileJob } from '../../src/prescription/learner-management/domain/models/ValidateOrganizationImportFileJob.js';
 import { UserAnonymizedEventLoggingJobController } from '../../src/shared/application/jobs/audit-log/user-anonymized-event-logging-job-controller.js';
@@ -37,22 +36,6 @@ describe('#registerJobs', function () {
       UserAnonymizedEventLoggingJob.name,
       UserAnonymizedEventLoggingJobController,
     );
-  });
-
-  it('should register legacyName', async function () {
-    // when
-    await registerJobs({
-      jobGroup: JobGroup.DEFAULT,
-      dependencies: {
-        startPgBoss: startPgBossStub,
-        createJobQueues: createJobQueuesStub,
-        scheduleCpfJobs: scheduleCpfJobsStub,
-      },
-    });
-
-    const job = new ParticipationSharedJobController();
-    // then
-    expect(jobQueueStub.register).to.have.been.calledWithExactly(job.legacyName, ParticipationSharedJobController);
   });
 
   it('should register ValidateOrganizationImportFileJob when job is enabled', async function () {


### PR DESCRIPTION
## :unicorn: Problème
Lors des Tech Days Evenementiel, nous avons introduit un petit changement de nom dans le job de calcul de la certificabilité auto. Ce qui nous a permis de voir qu'une table pgboss.schedule enregistré les job a executé.

## :robot: Proposition
Utiliser le nom en cohérence avec le controller associé. Ajouter un legacyName dans les cronJob si l'on souhaite nettoyer un ancien nom.

Il y aura certainement un autre cas à gérer dans le cas de la suppression d'un cron job afin que celui ci soit pris en compte.
## :rainbow: Remarques
RAS

## :100: Pour tester
Ajouter l'ancien nom dans la table pgboss.schedule .

Vérifier que la table pg.boss ne contient plus l'ancien job `ComputeOrganizationLearnersCertificability` au restart du container ( sur les RA le worker est sur la même instance que l'api )