### PR TITLE
[FEATURE] Suppression du check de certificabilité à la création de la certification (PIX-14206).

### DIFF
--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -21,7 +21,6 @@ import {
   CandidateNotAuthorizedToResumeCertificationTestError,
   NotFoundError,
   UnexpectedUserAccountError,
-  UserNotAuthorizedToCertifyError,
 } from '../../../src/shared/domain/errors.js';
 import { Assessment } from '../../../src/shared/domain/models/Assessment.js';
 import { DomainTransaction } from '../../infrastructure/DomainTransaction.js';
@@ -195,10 +194,6 @@ async function _startNewCertification({
     limitDate: new Date(),
     version,
   });
-
-  if (!placementProfile.isCertifiable()) {
-    throw new UserNotAuthorizedToCertifyError();
-  }
 
   const certificationCenter = await certificationCenterRepository.getBySessionId({ sessionId });
 


### PR DESCRIPTION
## :unicorn: Problème

La vérification de la certificabilité d'un candidat est désormais faite plus tôt, lors de la réconciliation entre l’utilisateur et le candidat.
Il devient donc inutile de le faire une seconde fois.

## :robot: Proposition

On supprime ce petit bout de code

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

- Créer une session de certification
- Utiliser le compte d'un candidat certifiable
- Vérifier qu'il puisse accéder au test