### PR TITLE
[FEATURE] Afficher une carte question / réponse (PIX-14306)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -65,7 +65,7 @@
                   "image": {
                     "url": "https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg"
                   },
-                  "text": "Parce que c'est joli"
+                  "text": "<p>Parce que c'est joli</p>"
                 }
               }
             ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -57,13 +57,13 @@
                 "id": "e1de6394-ff88-4de3-8834-a40057a50ff4",
                 "recto": {
                   "image": {
-                    "url": "https://example.org/image.jpeg"
+                    "url": "https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg"
                   },
                   "text": "A quoi sert l'arobase dans mon adresse email ?"
                 },
                 "verso": {
                   "image": {
-                    "url": "https://example.org/image.jpeg"
+                    "url": "https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg"
                   },
                   "text": "Parce que c'est joli"
                 }

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/flashcards-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/flashcards-schema.js
@@ -6,9 +6,14 @@ const image = Joi.object({
   url: Joi.string().uri().required(),
 });
 
-const cardSide = Joi.object({
+const rectoSide = Joi.object({
   image,
   text: htmlNotAllowedSchema.required(),
+});
+
+const versoSide = Joi.object({
+  image,
+  text: htmlSchema.required(),
 });
 
 const flashcardsElementSchema = Joi.object({
@@ -19,8 +24,8 @@ const flashcardsElementSchema = Joi.object({
   introImage: image,
   cards: Joi.array().items({
     id: uuidSchema,
-    recto: cardSide,
-    verso: cardSide,
+    recto: rectoSide,
+    verso: versoSide,
   }),
 }).required();
 

--- a/mon-pix/app/components/module/element.gjs
+++ b/mon-pix/app/components/module/element.gjs
@@ -3,6 +3,7 @@ import Component from '@glimmer/component';
 import { eq } from 'ember-truth-helpers';
 import DownloadElement from 'mon-pix/components/module/element/download';
 import EmbedElement from 'mon-pix/components/module/element/embed';
+import FlashcardsElement from 'mon-pix/components/module/element/flashcards';
 import ImageElement from 'mon-pix/components/module/element/image';
 import QcmElement from 'mon-pix/components/module/element/qcm';
 import QcuElement from 'mon-pix/components/module/element/qcu';
@@ -30,6 +31,8 @@ export default class ModulixElement extends Component {
       <EmbedElement @embed={{@element}} @onAnswer={{@onElementAnswer}} />
     {{else if (eq @element.type "separator")}}
       <SeparatorElement />
+    {{else if (eq @element.type "flashcards")}}
+      <FlashcardsElement @flashcards={{@element}} />
     {{else if (eq @element.type "qcu")}}
       <QcuElement
         @element={{@element}}

--- a/mon-pix/app/components/module/element/flashcards.gjs
+++ b/mon-pix/app/components/module/element/flashcards.gjs
@@ -1,10 +1,9 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
-import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
 
 export default class ModulixFlashcards extends Component {
   @tracked
@@ -66,19 +65,12 @@ export default class ModulixFlashcards extends Component {
         </div>
       </div>
 
-      <div class="element-flashcards__footer">
-        {{#if (eq this.displayedSide "recto")}}
-          <p class="element-flashcards-footer__direction">{{t "pages.modulix.flashcards.direction"}}</p>
-          <p class="element-flashcards-footer__position">{{t
-              "pages.modulix.flashcards.position"
-            currentCardPosition=1
-            totalCards=1
-          }}</p>
-        {{/if}}
-        {{#if (eq this.displayedSide "verso")}}
-          <button type="button">{{t "pages.modulix.buttons.flashcards.nextCard"}}</button>
-        {{/if}}
-      </div>
-    </div>
+    {{#if (eq this.displayedSide "recto")}}
+      <p>{{t "pages.modulix.flashcards.direction"}}</p>
+      <p>{{t "pages.modulix.flashcards.position" currentCardPosition=1 totalCards=1}}</p>
+    {{/if}}
+    {{#if (eq this.displayedSide "verso")}}
+      <button type="button">{{t "pages.modulix.buttons.flashcards.nextCard"}}</button>
+    {{/if}}
   </template>
 }

--- a/mon-pix/app/components/module/element/flashcards.gjs
+++ b/mon-pix/app/components/module/element/flashcards.gjs
@@ -1,0 +1,16 @@
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+
+export default class ModulixFlashcards extends Component {
+  get currentCard() {
+    return this.args.flashcards.cards[0];
+  }
+
+  <template>
+    <img src={{this.currentCard.recto.image.url}} />
+    {{this.currentCard.recto.text}}
+    <button type="button">{{t "pages.modulix.buttons.flashcards.seeAnswer"}}</button>
+    <p>{{t "pages.modulix.flashcards.direction"}}</p>
+    <p>{{t "pages.modulix.flashcards.position" currentCardPosition=1 totalCards=1}}</p>
+  </template>
+}

--- a/mon-pix/app/components/module/element/flashcards.gjs
+++ b/mon-pix/app/components/module/element/flashcards.gjs
@@ -1,9 +1,10 @@
-import { on } from '@ember/modifier';
+import PixButton from '@1024pix/pix-ui/components/pix-button';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
+import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
 
 export default class ModulixFlashcards extends Component {
   @tracked
@@ -48,12 +49,7 @@ export default class ModulixFlashcards extends Component {
 
         <div class="element-flashcards-card__footer element-flashcards-card__footer--{{this.displayedSide}}">
           {{#if (eq this.displayedSide "recto")}}
-            <PixButton
-              @triggerAction={{this.flipCard}}
-              @variant="primary"
-              @size="small"
-              @iconAfter="rotate-right"
-            >
+            <PixButton @triggerAction={{this.flipCard}} @variant="primary" @size="small" @iconAfter="rotate-right">
               {{t "pages.modulix.buttons.flashcards.seeAnswer"}}
             </PixButton>
           {{/if}}
@@ -65,12 +61,19 @@ export default class ModulixFlashcards extends Component {
         </div>
       </div>
 
-    {{#if (eq this.displayedSide "recto")}}
-      <p>{{t "pages.modulix.flashcards.direction"}}</p>
-      <p>{{t "pages.modulix.flashcards.position" currentCardPosition=1 totalCards=1}}</p>
-    {{/if}}
-    {{#if (eq this.displayedSide "verso")}}
-      <button type="button">{{t "pages.modulix.buttons.flashcards.nextCard"}}</button>
-    {{/if}}
+      <div class="element-flashcards__footer">
+        {{#if (eq this.displayedSide "recto")}}
+          <p class="element-flashcards-footer__direction">{{t "pages.modulix.flashcards.direction"}}</p>
+          <p class="element-flashcards-footer__position">{{t
+              "pages.modulix.flashcards.position"
+              currentCardPosition=1
+              totalCards=1
+            }}</p>
+        {{/if}}
+        {{#if (eq this.displayedSide "verso")}}
+          <button type="button">{{t "pages.modulix.buttons.flashcards.nextCard"}}</button>
+        {{/if}}
+      </div>
+    </div>
   </template>
 }

--- a/mon-pix/app/components/module/element/flashcards.gjs
+++ b/mon-pix/app/components/module/element/flashcards.gjs
@@ -1,16 +1,84 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { action } from '@ember/object';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
+import { eq } from 'ember-truth-helpers';
+import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
 
 export default class ModulixFlashcards extends Component {
-  get currentCard() {
-    return this.args.flashcards.cards[0];
+  @tracked
+  /**
+   * Displayed side of the card on the screen
+   * @type {'recto'|'verso'}
+   */
+  displayedSide = 'recto';
+
+  /**
+   * Index of the displayed card in the deck
+   * @type {number}
+   */
+  currentCardIndex = 0;
+
+  get currentCardSide() {
+    const side = this.displayedSide;
+    return this.args.flashcards.cards[this.currentCardIndex][side];
+  }
+
+  @action
+  flipCard() {
+    this.displayedSide = this.displayedSide === 'recto' ? 'verso' : 'recto';
   }
 
   <template>
-    <img src={{this.currentCard.recto.image.url}} />
-    {{this.currentCard.recto.text}}
-    <button type="button">{{t "pages.modulix.buttons.flashcards.seeAnswer"}}</button>
-    <p>{{t "pages.modulix.flashcards.direction"}}</p>
-    <p>{{t "pages.modulix.flashcards.position" currentCardPosition=1 totalCards=1}}</p>
+    <div class="element-flashcards">
+      <div class="element-flashcards__card">
+        {{#if this.currentCardSide.image}}
+          <div class="element-flashcards-card__image">
+            <img src={{this.currentCardSide.image.url}} alt="" />
+          </div>
+        {{/if}}
+
+        <div class="element-flashcards-card__text">
+          {{#if (eq this.displayedSide "recto")}}
+            <p class="element-flashcards-card__text--recto">{{this.currentCardSide.text}}</p>
+          {{else if (eq this.displayedSide "verso")}}
+            {{htmlUnsafe this.currentCardSide.text}}
+          {{/if}}
+        </div>
+
+        <div class="element-flashcards-card__footer element-flashcards-card__footer--{{this.displayedSide}}">
+          {{#if (eq this.displayedSide "recto")}}
+            <PixButton
+              @triggerAction={{this.flipCard}}
+              @variant="primary"
+              @size="small"
+              @iconAfter="rotate-right"
+            >
+              {{t "pages.modulix.buttons.flashcards.seeAnswer"}}
+            </PixButton>
+          {{/if}}
+          {{#if (eq this.displayedSide "verso")}}
+            <PixButton @triggerAction={{this.flipCard}} @variant="tertiary" @size="small">
+              {{t "pages.modulix.buttons.flashcards.seeAgain"}}
+            </PixButton>
+          {{/if}}
+        </div>
+      </div>
+
+      <div class="element-flashcards__footer">
+        {{#if (eq this.displayedSide "recto")}}
+          <p class="element-flashcards-footer__direction">{{t "pages.modulix.flashcards.direction"}}</p>
+          <p class="element-flashcards-footer__position">{{t
+              "pages.modulix.flashcards.position"
+            currentCardPosition=1
+            totalCards=1
+          }}</p>
+        {{/if}}
+        {{#if (eq this.displayedSide "verso")}}
+          <button type="button">{{t "pages.modulix.buttons.flashcards.nextCard"}}</button>
+        {{/if}}
+      </div>
+    </div>
   </template>
 }

--- a/mon-pix/app/components/module/grain.gjs
+++ b/mon-pix/app/components/module/grain.gjs
@@ -16,7 +16,18 @@ export default class ModuleGrain extends Component {
 
   grain = this.args.grain;
 
-  static AVAILABLE_ELEMENT_TYPES = ['download', 'embed', 'image', 'qcu', 'qcm', 'qrocm', 'separator', 'text', 'video'];
+  static AVAILABLE_ELEMENT_TYPES = [
+    'download',
+    'embed',
+    'flashcards',
+    'image',
+    'qcu',
+    'qcm',
+    'qrocm',
+    'separator',
+    'text',
+    'video',
+  ];
   static AVAILABLE_GRAIN_TYPES = ['lesson', 'activity'];
 
   @tracked isStepperFinished = this.hasStepper === false;

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -70,6 +70,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @import 'components/module/stepper';
 @import 'components/module/download';
 @import 'components/module/embed';
+@import 'components/module/flashcards';
 @import 'components/module/image';
 @import 'components/module/qcu';
 @import 'components/module/qcm';

--- a/mon-pix/app/styles/components/module/_flashcards.scss
+++ b/mon-pix/app/styles/components/module/_flashcards.scss
@@ -1,0 +1,70 @@
+.element-flashcards {
+  &__card {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    max-width: 345px;
+    height: 440px;
+    margin: auto auto var(--pix-spacing-4x);
+    padding: var(--pix-spacing-6x);
+    background: var(--pix-neutral-0);
+    border: 5px solid var(--pix-neutral-100);
+    border-radius: var(--modulix-radius-l);
+    box-shadow: 0 12px 24px 0 rgb(7 20 46 / 12%);
+  }
+
+  &__footer {
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-2x);
+    align-items: center;
+    color: var(--pix-neutral-500);
+  }
+}
+
+.element-flashcards-card {
+  &__image {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    img {
+      height: auto;
+      max-height: 250px;
+      border-radius: var(--modulix-radius-s);
+    }
+  }
+
+  &__text {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--pix-neutral-900);
+    text-align: center;
+
+    &--recto {
+      font-weight: bold;
+    }
+  }
+
+  &__footer {
+    display: flex;
+    align-items: center;
+
+    &--recto {
+      flex-direction: column;
+    }
+
+    &--verso {
+      justify-content: flex-end;
+    }
+  }
+}
+
+.element-flashcards-footer {
+  &__position {
+    @extend %pix-body-m;
+
+    font-weight: 700;
+  }
+}

--- a/mon-pix/app/styles/pages/_module.scss
+++ b/mon-pix/app/styles/pages/_module.scss
@@ -3,6 +3,8 @@
 
   --modulix-max-content-width: 740px;
   --modulix-radius: 16px;
+  --modulix-radius-s: 8px;
+  --modulix-radius-l: 24px;
 
   flex-grow: 1;
   color: var(--pix-neutral-900);

--- a/mon-pix/tests/integration/components/module/element_test.gjs
+++ b/mon-pix/tests/integration/components/module/element_test.gjs
@@ -217,4 +217,41 @@ module('Integration | Component | Module | Element', function (hooks) {
     // then
     assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).exists();
   });
+
+  test('should display an element with a flashcards element', async function (assert) {
+    // given
+    const element = {
+      id: '71de6394-ff88-4de3-8834-a40057a50ff4',
+      type: 'flashcards',
+      title: "Introduction à l'adresse e-mail",
+      instruction: '<p>...</p>',
+      introImage: { url: 'https://images.pix.fr/modulix/placeholder-details.svg' },
+      cards: [
+        {
+          id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+          recto: {
+            image: {
+              url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+            },
+            text: "A quoi sert l'arobase dans mon adresse email ?",
+          },
+          verso: {
+            image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+            text: "Parce que c'est joli",
+          },
+        },
+      ],
+    };
+    const getLastCorrectionForElementStub = () => {};
+
+    // when
+    const screen = await render(
+      <template>
+        <ModulixElement @element={{element}} @getLastCorrectionForElement={{getLastCorrectionForElementStub}} />
+      </template>,
+    );
+
+    // then
+    assert.dom(screen.getByRole('button', { name: 'Voir la réponse' })).exists();
+  });
 });

--- a/mon-pix/tests/integration/components/module/flashcards_test.gjs
+++ b/mon-pix/tests/integration/components/module/flashcards_test.gjs
@@ -16,12 +16,12 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
       type: 'flashcards',
       title: "Introduction à l'adresse e-mail",
       instruction: '<p>...</p>',
-      introImage: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+      introImage: { url: 'https://images.pix.fr/modulix/placeholder-details.svg' },
       cards: [
         {
           id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
           recto: {
-            image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+            image: { url: 'https://images.pix.fr/modulix/distinguer-vrai-faux-sur-internet/tweet6.jpg' },
             text: "A quoi sert l'arobase dans mon adresse email ?",
           },
           verso: {
@@ -39,11 +39,40 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
     assert.ok(screen.getByText("A quoi sert l'arobase dans mon adresse email ?"));
     assert.strictEqual(
       screen.getByRole('presentation').getAttribute('src'),
-      'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg',
+      'https://images.pix.fr/modulix/distinguer-vrai-faux-sur-internet/tweet6.jpg',
     );
     assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.seeAnswer') })).exists();
     assert.ok(screen.getByText(t('pages.modulix.flashcards.direction')));
     assert.ok(screen.getByText(t('pages.modulix.flashcards.position', { currentCardPosition: 1, totalCards: 1 })));
+  });
+
+  test('should not display recto image if no one is provided', async function (assert) {
+    // given
+    const flashcards = {
+      id: '71de6394-ff88-4de3-8834-a40057a50ff4',
+      type: 'flashcards',
+      title: "Introduction à l'adresse e-mail",
+      instruction: '<p>...</p>',
+      introImage: { url: 'https://images.pix.fr/modulix/placeholder-details.svg' },
+      cards: [
+        {
+          id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+          recto: {
+            text: 'A quoi shttps://images.pix.fr/modulix/distinguer-vrai-faux-sur-internet/tweet6.jpg?',
+          },
+          verso: {
+            image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+            text: "Parce que c'est joli",
+          },
+        },
+      ],
+    };
+
+    // when
+    const screen = await render(<template><ModulixFlashcards @flashcards={{flashcards}} /></template>);
+
+    // then
+    assert.dom(screen.queryByRole('img')).doesNotExist();
   });
 
   test('should display the verso when click on button', async function (assert) {
@@ -53,12 +82,12 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
       type: 'flashcards',
       title: "Introduction à l'adresse e-mail",
       instruction: '<p>...</p>',
-      introImage: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+      introImage: { url: 'https://images.pix.fr/modulix/placeholder-details.svg' },
       cards: [
         {
           id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
           recto: {
-            image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+            image: { url: 'https://images.pix.fr/modulix/distinguer-vrai-faux-sur-internet/tweet6.jpg' },
             text: "A quoi sert l'arobase dans mon adresse email ?",
           },
           verso: {
@@ -78,6 +107,36 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
     assert.ok(screen.getByText("Parce que c'est joli"));
   });
 
+  test('should not display verso image if no one is provided', async function (assert) {
+    // given
+    const flashcards = {
+      id: '71de6394-ff88-4de3-8834-a40057a50ff4',
+      type: 'flashcards',
+      title: "Introduction à l'adresse e-mail",
+      instruction: '<p>...</p>',
+      introImage: { url: 'https://images.pix.fr/modulix/placeholder-details.svg' },
+      cards: [
+        {
+          id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+          recto: {
+            image: { url: 'https://images.pix.fr/modulix/distinguer-vrai-faux-sur-internet/tweet6.jpg' },
+            text: "A quoi sert l'arobase dans mon adresse email ?",
+          },
+          verso: {
+            text: "Parce que c'est joli",
+          },
+        },
+      ],
+    };
+    const screen = await render(<template><ModulixFlashcards @flashcards={{flashcards}} /></template>);
+
+    // when
+    await clickByName(t('pages.modulix.buttons.flashcards.seeAnswer'));
+
+    // then
+    assert.dom(screen.queryByRole('img')).doesNotExist();
+  });
+
   module('when we click on "Revoir la question"', function () {
     test('should go back to recto', async function (assert) {
       // given
@@ -86,12 +145,12 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
         type: 'flashcards',
         title: "Introduction à l'adresse e-mail",
         instruction: '<p>...</p>',
-        introImage: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+        introImage: { url: 'https://images.pix.fr/modulix/placeholder-details.svg' },
         cards: [
           {
             id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
             recto: {
-              image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+              image: { url: 'https://images.pix.fr/modulix/distinguer-vrai-faux-sur-internet/tweet6.jpg' },
               text: "A quoi sert l'arobase dans mon adresse email ?",
             },
             verso: {

--- a/mon-pix/tests/integration/components/module/flashcards_test.gjs
+++ b/mon-pix/tests/integration/components/module/flashcards_test.gjs
@@ -1,0 +1,48 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import ModulixFlashcards from 'mon-pix/components/module/element/flashcards';
+// eslint-disable-next-line no-restricted-imports
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Module | Flashcards', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('should display the recto of given card', async function (assert) {
+    // given
+    const flashcards = {
+      id: '71de6394-ff88-4de3-8834-a40057a50ff4',
+      type: 'flashcards',
+      title: "Introduction à l'adresse e-mail",
+      instruction: '<p>...</p>',
+      introImage: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+      cards: [
+        {
+          id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+          recto: {
+            image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+            text: "A quoi sert l'arobase dans mon adresse email ?",
+          },
+          verso: {
+            image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+            text: "Parce que c'est joli",
+          },
+        },
+      ],
+    };
+
+    // when
+    const screen = await render(<template><ModulixFlashcards @flashcards={{flashcards}} /></template>);
+
+    // then
+    assert.ok(screen.getByText("A quoi sert l'arobase dans mon adresse email ?"));
+    assert.strictEqual(
+      screen.getByRole('presentation').getAttribute('src'),
+      'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg',
+    );
+    assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.seeAnswer') })).exists();
+    assert.ok(screen.getByText(t('pages.modulix.flashcards.direction')));
+    assert.ok(screen.getByText(t('pages.modulix.flashcards.position', { currentCardPosition: 1, totalCards: 1 })));
+  });
+});

--- a/mon-pix/tests/integration/components/module/flashcards_test.gjs
+++ b/mon-pix/tests/integration/components/module/flashcards_test.gjs
@@ -1,4 +1,4 @@
-import { render } from '@1024pix/ember-testing-library';
+import { clickByName, render } from '@1024pix/ember-testing-library';
 import { t } from 'ember-intl/test-support';
 import ModulixFlashcards from 'mon-pix/components/module/element/flashcards';
 // eslint-disable-next-line no-restricted-imports
@@ -44,5 +44,71 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
     assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.seeAnswer') })).exists();
     assert.ok(screen.getByText(t('pages.modulix.flashcards.direction')));
     assert.ok(screen.getByText(t('pages.modulix.flashcards.position', { currentCardPosition: 1, totalCards: 1 })));
+  });
+
+  test('should display the verso when click on button', async function (assert) {
+    // given
+    const flashcards = {
+      id: '71de6394-ff88-4de3-8834-a40057a50ff4',
+      type: 'flashcards',
+      title: "Introduction à l'adresse e-mail",
+      instruction: '<p>...</p>',
+      introImage: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+      cards: [
+        {
+          id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+          recto: {
+            image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+            text: "A quoi sert l'arobase dans mon adresse email ?",
+          },
+          verso: {
+            image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+            text: "Parce que c'est joli",
+          },
+        },
+      ],
+    };
+    const screen = await render(<template><ModulixFlashcards @flashcards={{flashcards}} /></template>);
+
+    // when
+    await clickByName(t('pages.modulix.buttons.flashcards.seeAnswer'));
+
+    // then
+    assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.seeAgain') })).exists();
+    assert.ok(screen.getByText("Parce que c'est joli"));
+  });
+
+  module('when we click on "Revoir la question"', function () {
+    test('should go back to recto', async function (assert) {
+      // given
+      const flashcards = {
+        id: '71de6394-ff88-4de3-8834-a40057a50ff4',
+        type: 'flashcards',
+        title: "Introduction à l'adresse e-mail",
+        instruction: '<p>...</p>',
+        introImage: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+        cards: [
+          {
+            id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+            recto: {
+              image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+              text: "A quoi sert l'arobase dans mon adresse email ?",
+            },
+            verso: {
+              image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+              text: "Parce que c'est joli",
+            },
+          },
+        ],
+      };
+      const screen = await render(<template><ModulixFlashcards @flashcards={{flashcards}} /></template>);
+      await clickByName(t('pages.modulix.buttons.flashcards.seeAnswer'));
+
+      // when
+      await clickByName(t('pages.modulix.buttons.flashcards.seeAgain'));
+
+      // then
+      assert.ok(screen.getByText("A quoi sert l'arobase dans mon adresse email ?"));
+    });
   });
 });

--- a/mon-pix/tests/integration/components/module/flashcards_test.gjs
+++ b/mon-pix/tests/integration/components/module/flashcards_test.gjs
@@ -21,7 +21,9 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
         {
           id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
           recto: {
-            image: { url: 'https://images.pix.fr/modulix/distinguer-vrai-faux-sur-internet/tweet6.jpg' },
+            image: {
+              url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+            },
             text: "A quoi sert l'arobase dans mon adresse email ?",
           },
           verso: {
@@ -39,7 +41,7 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
     assert.ok(screen.getByText("A quoi sert l'arobase dans mon adresse email ?"));
     assert.strictEqual(
       screen.getByRole('presentation').getAttribute('src'),
-      'https://images.pix.fr/modulix/distinguer-vrai-faux-sur-internet/tweet6.jpg',
+      'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
     );
     assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.seeAnswer') })).exists();
     assert.ok(screen.getByText(t('pages.modulix.flashcards.direction')));
@@ -58,7 +60,7 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
         {
           id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
           recto: {
-            text: 'A quoi shttps://images.pix.fr/modulix/distinguer-vrai-faux-sur-internet/tweet6.jpg?',
+            text: "A quoi sert l'arobase dans mon adresse email ?",
           },
           verso: {
             image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
@@ -87,7 +89,9 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
         {
           id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
           recto: {
-            image: { url: 'https://images.pix.fr/modulix/distinguer-vrai-faux-sur-internet/tweet6.jpg' },
+            image: {
+              url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+            },
             text: "A quoi sert l'arobase dans mon adresse email ?",
           },
           verso: {
@@ -119,7 +123,9 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
         {
           id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
           recto: {
-            image: { url: 'https://images.pix.fr/modulix/distinguer-vrai-faux-sur-internet/tweet6.jpg' },
+            image: {
+              url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+            },
             text: "A quoi sert l'arobase dans mon adresse email ?",
           },
           verso: {
@@ -150,7 +156,9 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
           {
             id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
             recto: {
-              image: { url: 'https://images.pix.fr/modulix/distinguer-vrai-faux-sur-internet/tweet6.jpg' },
+              image: {
+                url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+              },
               text: "A quoi sert l'arobase dans mon adresse email ?",
             },
             verso: {

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -262,6 +262,47 @@ module('Integration | Component | Module | Grain', function (hooks) {
       });
     });
 
+    module('when element is of type flashcards', function () {
+      test('should display a flashcards element', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const flashCardsElement = {
+          id: '71de6394-ff88-4de3-8834-a40057a50ff4',
+          type: 'flashcards',
+          title: "Introduction à l'adresse e-mail",
+          instruction: '<p>...</p>',
+          introImage: { url: 'https://images.pix.fr/modulix/placeholder-details.svg' },
+          cards: [
+            {
+              id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+              recto: {
+                image: {
+                  url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+                },
+                text: "A quoi sert l'arobase dans mon adresse email ?",
+              },
+              verso: {
+                image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+                text: "Parce que c'est joli",
+              },
+            },
+          ],
+        };
+        const grain = store.createRecord('grain', {
+          title: 'Grain title',
+          components: [{ type: 'element', element: flashCardsElement }],
+        });
+        this.set('grain', grain);
+
+        // when
+        const screen = await render(hbs`
+          <Module::Grain @grain={{this.grain}} />`);
+
+        // then
+        assert.dom(screen.getByRole('button', { name: 'Voir la réponse' })).exists();
+      });
+    });
+
     module('when all elements are answered', function () {
       test('should not display skip button', async function (assert) {
         // given

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1352,6 +1352,9 @@
             "name": "Start"
           }
         },
+        "flashcards": {
+          "seeAnswer" : "See the answer"
+        },
         "grain": {
           "continue": "Continue",
           "skip": "Skip",
@@ -1388,6 +1391,10 @@
         "format": "{format} format ",
         "intro": "Choose the file format you would like to use.",
         "label": "Download file in {format} format"
+      },
+      "flashcards": {
+        "direction": "Look for the answer then turn the card",
+        "position": "Card {currentCardPosition}/{totalCards}"
       },
       "grain": {
         "tag": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1353,7 +1353,9 @@
           }
         },
         "flashcards": {
-          "seeAnswer" : "See the answer"
+          "seeAnswer" : "See the answer",
+          "seeAgain": "Review the question",
+          "nextCard": "Next"
         },
         "grain": {
           "continue": "Continue",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1334,6 +1334,9 @@
             "name": "Empezar"
           }
         },
+        "flashcards": {
+          "seeAnswer" : "ver la respuesta"
+        },
         "grain": {
           "continue": "Continuar",
           "skip": "Ir a",
@@ -1370,6 +1373,10 @@
         "format": "Formato {format}",
         "intro": "Elija el formato de archivo que desea utilizar.",
         "label": "Descargue el archivo en {format}"
+      },
+      "flashcards": {
+        "direction": "Encuentra la respuesta y luego gira la tarjeta.",
+        "position": "Tarjeta {currentCardPosition}/{totalCards}"
       },
       "grain": {
         "tag": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1335,7 +1335,9 @@
           }
         },
         "flashcards": {
-          "seeAnswer" : "ver la respuesta"
+          "seeAnswer" : "ver la respuesta",
+          "seeAgain": "Revisa la pregunta",
+          "nextCard": "Siguiente"
         },
         "grain": {
           "continue": "Continuar",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1352,6 +1352,9 @@
             "name": "Commencer"
           }
         },
+        "flashcards": {
+          "seeAnswer" : "Voir la réponse"
+        },
         "grain": {
           "continue": "Continuer",
           "skip": "Passer",
@@ -1388,6 +1391,10 @@
         "format": "Format {format}",
         "intro": "Choisissez le format de fichier que vous voulez utiliser.",
         "label": "Télécharger le fichier au format {format}"
+      },
+      "flashcards": {
+        "direction": "Cherchez la réponse puis tournez la carte",
+        "position": "Carte {currentCardPosition}/{totalCards}"
       },
       "grain": {
         "tag": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1353,7 +1353,9 @@
           }
         },
         "flashcards": {
-          "seeAnswer" : "Voir la réponse"
+          "seeAnswer": "Voir la réponse",
+          "seeAgain": "Revoir la question",
+          "nextCard": "Suivant"
         },
         "grain": {
           "continue": "Continuer",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1335,7 +1335,9 @@
           }
         },
         "flashcards": {
-          "seeAnswer" : "Zie het antwoord"
+          "seeAnswer" : "Zie het antwoord",
+          "seeAgain": "Bekijk de vraag",
+          "nextCard": "Volgende"
         },
         "grain": {
           "continue": "Ga verder met",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1334,6 +1334,9 @@
             "name": "Start"
           }
         },
+        "flashcards": {
+          "seeAnswer" : "Zie het antwoord"
+        },
         "grain": {
           "continue": "Ga verder met",
           "skip": "Overslaan",
@@ -1370,6 +1373,10 @@
         "format": "Formaat {format}",
         "intro": "Kies het bestandsformaat dat je wilt gebruiken.",
         "label": "Download het bestand in {format}"
+      },
+      "flashcards": {
+        "direction": "Zoek het antwoord en draai de kaart om",
+        "position": "Kaart {currentCardPosition}/{totalCards}"
       },
       "grain": {
         "tag": {


### PR DESCRIPTION
## :unicorn: Problème
Les flashcards renvoyées par l'API ne s'affichent pas dans Modulix.

## :robot: Proposition
Avec le côté recto “question”, le côté verso “réponse” et les boutons pour passer de la question à la réponse et inversement

## :rainbow: Remarques
- Icône dans le bouton "Voir la réponse" n'est pas à jour côté Pix-UI, donc l'ancienne icône a été utilisée
- La couleur du bouton "Revoir la question" n'est pas exactement la même entre la maquette et le bouton _tertiary_ de Pix UI

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
- Se rendre dans le module didacticiel : https://app-pr10164.review.pix.fr/modules/didacticiel-modulix/details
- Démarrer le module. La première leçon contient une seule flashcard.
- Vérifier le recto. Cliquer sur le bouton "Voir la réponse" et vérifier que le verso apparaît.
- Cliquer sur "Revoir la question", et vérifier que le recto se ré affiche.
