### PR TITLE
[TECH] Amender l'ADR sur le EventDispatcher.

### DIFF
--- a/docs/adr/0010-propager-domain-events-via-event-dispatcher.md
+++ b/docs/adr/0010-propager-domain-events-via-event-dispatcher.md
@@ -6,9 +6,10 @@ Cet ADR étend l'ADR [#8](./0008-découplage-fonctionnel-via-evenements.md)
 
 ## État
 
-Amendé par [0023-précision-sur-les-transactions-et-les-événements-métier.md][0023].
+Obsolète : l’`EventDispatcher` est déprécié.
 
-[0023]: ./0023-précision-sur-les-transactions-et-les-événements-métier.md
+Remplacé par [0025-précision-sur-les-transactions-et-les-événements-métier.md][0025].
+[0025]: ./0025-précision-sur-les-transactions-et-les-événements-métier.md
 
 ## Contexte
 

--- a/docs/adr/0025-precisions-sur-les-transactions-et-les-evenements-metier.md
+++ b/docs/adr/0025-precisions-sur-les-transactions-et-les-evenements-metier.md
@@ -2,7 +2,7 @@
 
 ## État
 
-Amende [0009-transaction-metier.md][0009] et [0010-propager-domain-events-via-event-dispatcher.md][0010].
+Remplace [0009-transaction-metier.md][0009] et [0010-propager-domain-events-via-event-dispatcher.md][0010].
 
 [0009]: ./0009-transaction-metier.md
 [0010]: ./0010-propager-domain-events-via-event-dispatcher.md


### PR DESCRIPTION
## :unicorn: Problème

Suite aux Tech Days 2024, l'EventDispatcher maison est deprecie, en faveur d'autres alternatives existantes (usecases dans le meme context, API internes en synchrone, PGBoss en asynchrone).
Il convient de ne plus creer de nouveaux usages (le temps de supprimer complementement le reste a faire)

## :robot: Proposition

Amender l'ADR cible pour deprecier l'usage.

## :rainbow: Remarques

## :100: Pour tester
RAS
