### PR TITLE
[TECH] Migrer la route User Has Seen New Dashboard (PIX-14451).

### DIFF
--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -449,31 +449,6 @@ const register = async function (server) {
     },
     {
       method: 'PATCH',
-      path: '/api/users/{id}/has-seen-new-dashboard-info',
-      config: {
-        pre: [
-          {
-            method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
-            assign: 'requestedUserIsAuthenticatedUser',
-          },
-        ],
-        validate: {
-          params: Joi.object({
-            id: identifiersType.userId,
-          }),
-        },
-        handler: userController.rememberUserHasSeenNewDashboardInfo,
-        notes: [
-          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
-            "- Sauvegarde le fait que l'utilisateur ait vu le message sur le nouveau dashboard" +
-            '- L’id demandé doit correspondre à celui de l’utilisateur authentifié',
-          "- Le contenu de la requête n'est pas pris en compte.",
-        ],
-        tags: ['api', 'user'],
-      },
-    },
-    {
-      method: 'PATCH',
       path: '/api/users/{id}/has-seen-challenge-tooltip/{challengeType}',
       config: {
         pre: [

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -44,13 +44,6 @@ const rememberUserHasSeenAssessmentInstructions = async function (request, h, de
   return dependencies.userSerializer.serialize(updatedUser);
 };
 
-const rememberUserHasSeenNewDashboardInfo = async function (request, h, dependencies = { userSerializer }) {
-  const authenticatedUserId = request.auth.credentials.userId;
-
-  const updatedUser = await usecases.rememberUserHasSeenNewDashboardInfo({ userId: authenticatedUserId });
-  return dependencies.userSerializer.serialize(updatedUser);
-};
-
 const rememberUserHasSeenChallengeTooltip = async function (request, h, dependencies = { userSerializer }) {
   const authenticatedUserId = request.auth.credentials.userId;
   const challengeType = request.params.challengeType;
@@ -269,7 +262,6 @@ const userController = {
   reassignAuthenticationMethods,
   rememberUserHasSeenAssessmentInstructions,
   rememberUserHasSeenChallengeTooltip,
-  rememberUserHasSeenNewDashboardInfo,
   removeAuthenticationMethod,
   resetScorecard,
   updateUserDetailsForAdministration,

--- a/api/src/evaluation/application/users/index.js
+++ b/api/src/evaluation/application/users/index.js
@@ -31,6 +31,31 @@ const register = async function (server) {
         tags: ['api', 'user'],
       },
     },
+    {
+      method: 'PATCH',
+      path: '/api/users/{id}/has-seen-new-dashboard-info',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
+            assign: 'requestedUserIsAuthenticatedUser',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+        },
+        handler: userController.rememberUserHasSeenNewDashboardInfo,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            "- Sauvegarde le fait que l'utilisateur ait vu le message sur le nouveau dashboard" +
+            '- L’id demandé doit correspondre à celui de l’utilisateur authentifié',
+          "- Le contenu de la requête n'est pas pris en compte.",
+        ],
+        tags: ['api', 'user'],
+      },
+    },
   ]);
 };
 

--- a/api/src/evaluation/application/users/user-controller.js
+++ b/api/src/evaluation/application/users/user-controller.js
@@ -1,3 +1,4 @@
+import { usecases as libUsecases } from '../../../../lib/domain/usecases/index.js';
 import * as userSerializer from '../../../shared/infrastructure/serializers/jsonapi/user-serializer.js';
 import { evaluationUsecases as usecases } from '../../domain/usecases/index.js';
 
@@ -8,6 +9,13 @@ const rememberUserHasSeenLevelSevenInfo = async function (request, h, dependenci
   return dependencies.userSerializer.serialize(updatedUser);
 };
 
-const userController = { rememberUserHasSeenLevelSevenInfo };
+const rememberUserHasSeenNewDashboardInfo = async function (request, h, dependencies = { userSerializer }) {
+  const authenticatedUserId = request.auth.credentials.userId;
+
+  const updatedUser = await libUsecases.rememberUserHasSeenNewDashboardInfo({ userId: authenticatedUserId });
+  return dependencies.userSerializer.serialize(updatedUser);
+};
+
+const userController = { rememberUserHasSeenLevelSevenInfo, rememberUserHasSeenNewDashboardInfo };
 
 export { userController };

--- a/api/src/evaluation/application/users/user-controller.js
+++ b/api/src/evaluation/application/users/user-controller.js
@@ -1,4 +1,3 @@
-import { usecases as libUsecases } from '../../../../lib/domain/usecases/index.js';
 import * as userSerializer from '../../../shared/infrastructure/serializers/jsonapi/user-serializer.js';
 import { evaluationUsecases as usecases } from '../../domain/usecases/index.js';
 
@@ -12,7 +11,7 @@ const rememberUserHasSeenLevelSevenInfo = async function (request, h, dependenci
 const rememberUserHasSeenNewDashboardInfo = async function (request, h, dependencies = { userSerializer }) {
   const authenticatedUserId = request.auth.credentials.userId;
 
-  const updatedUser = await libUsecases.rememberUserHasSeenNewDashboardInfo({ userId: authenticatedUserId });
+  const updatedUser = await usecases.rememberUserHasSeenNewDashboardInfo({ userId: authenticatedUserId });
   return dependencies.userSerializer.serialize(updatedUser);
 };
 

--- a/api/src/evaluation/domain/usecases/remember-user-has-seen-level-seven-info.js
+++ b/api/src/evaluation/domain/usecases/remember-user-has-seen-level-seven-info.js
@@ -1,5 +1,5 @@
 const rememberUserHasSeenLevelSevenInfo = function ({ userId, userRepository }) {
-  return userRepository.update({ userId });
+  return userRepository.updateMarkLevelSevenInfoAsSeen({ userId });
 };
 
 export { rememberUserHasSeenLevelSevenInfo };

--- a/api/src/evaluation/domain/usecases/remember-user-has-seen-new-dashboard-info.js
+++ b/api/src/evaluation/domain/usecases/remember-user-has-seen-new-dashboard-info.js
@@ -1,5 +1,5 @@
 const rememberUserHasSeenNewDashboardInfo = function ({ userId, userRepository }) {
-  return userRepository.updateHasSeenNewDashboardInfoToTrue(userId);
+  return userRepository.updateHasSeenNewDashboardInfo({ userId });
 };
 
 export { rememberUserHasSeenNewDashboardInfo };

--- a/api/src/evaluation/infrastructure/repositories/user-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/user-repository.js
@@ -7,8 +7,8 @@
  * @param {Object} params
  * @param {UserApi} params.userApi
  */
-const update = async function ({ userId, userApi }) {
+const updateMarkLevelSevenInfoAsSeen = async function ({ userId, userApi }) {
   return userApi.markLevelSevenInfoAsSeen({ userId });
 };
 
-export { update };
+export { updateMarkLevelSevenInfoAsSeen };

--- a/api/src/evaluation/infrastructure/repositories/user-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/user-repository.js
@@ -15,9 +15,10 @@ const updateMarkLevelSevenInfoAsSeen = async function ({ userId, userApi }) {
  * @function
  * @param {Object} params
  * @param {UserApi} params.userApi
+ * @param {number} params.userId
  */
 const updateHasSeenNewDashboardInfo = async function ({ userId, userApi }) {
-  return userApi.updateHasSeenNewDashboardInfo({ userId });
+  return userApi.markNewDashboardInfoAsSeen({ userId });
 };
 
 export { updateHasSeenNewDashboardInfo, updateMarkLevelSevenInfoAsSeen };

--- a/api/src/evaluation/infrastructure/repositories/user-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/user-repository.js
@@ -11,4 +11,13 @@ const updateMarkLevelSevenInfoAsSeen = async function ({ userId, userApi }) {
   return userApi.markLevelSevenInfoAsSeen({ userId });
 };
 
-export { updateMarkLevelSevenInfoAsSeen };
+/**
+ * @function
+ * @param {Object} params
+ * @param {UserApi} params.userApi
+ */
+const updateHasSeenNewDashboardInfo = async function ({ userId, userApi }) {
+  return userApi.updateHasSeenNewDashboardInfo({ userId });
+};
+
+export { updateHasSeenNewDashboardInfo, updateMarkLevelSevenInfoAsSeen };

--- a/api/src/identity-access-management/application/api/users-api.js
+++ b/api/src/identity-access-management/application/api/users-api.js
@@ -6,3 +6,7 @@ import { usecases } from '../../domain/usecases/index.js';
 export const markLevelSevenInfoAsSeen = async ({ userId }) => {
   return usecases.rememberUserHasSeenLevelSevenInformation({ userId });
 };
+
+export const updateHasSeenNewDashboardInfo = async ({ userId }) => {
+  return usecases.updateUserHasSeenNewDashboardInfo({ userId });
+};

--- a/api/src/identity-access-management/application/api/users-api.js
+++ b/api/src/identity-access-management/application/api/users-api.js
@@ -7,6 +7,6 @@ export const markLevelSevenInfoAsSeen = async ({ userId }) => {
   return usecases.rememberUserHasSeenLevelSevenInformation({ userId });
 };
 
-export const updateHasSeenNewDashboardInfo = async ({ userId }) => {
-  return usecases.updateUserHasSeenNewDashboardInfo({ userId });
+export const markNewDashboardInfoAsSeen = async ({ userId }) => {
+  return usecases.markUserHasSeenNewDashboardInfo({ userId });
 };

--- a/api/src/identity-access-management/domain/usecases/mark-user-has-seen-new-dashboard-info.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/mark-user-has-seen-new-dashboard-info.usecase.js
@@ -1,0 +1,14 @@
+/**
+ * @typedef {import ('../../domain/usecases/index.js').UserRepository} UserRepository
+ */
+
+/**
+ * @param {Object} params
+ * @param {number} params.userId
+ * @param {UserRepository} params.userRepository
+ */
+const markUserHasSeenNewDashboardInfo = function ({ userId, userRepository }) {
+  return userRepository.updateHasSeenNewDashboardInfoToTrue(userId);
+};
+
+export { markUserHasSeenNewDashboardInfo };

--- a/api/tests/evaluation/acceptance/application/users/remember-user-has-seen-new-dashboard-info_test.js
+++ b/api/tests/evaluation/acceptance/application/users/remember-user-has-seen-new-dashboard-info_test.js
@@ -3,7 +3,7 @@ import {
   databaseBuilder,
   expect,
   generateValidRequestAuthorizationHeader,
-} from '../../../test-helper.js';
+} from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | users-controller-has-seen-new-dashboard-info', function () {
   let server;

--- a/api/tests/evaluation/unit/application/users/user-controller_test.js
+++ b/api/tests/evaluation/unit/application/users/user-controller_test.js
@@ -1,3 +1,4 @@
+import { usecases as libUsecases } from '../../../../../lib/domain/usecases/index.js';
 import { userController } from '../../../../../src/evaluation/application/users/user-controller.js';
 import { evaluationUsecases } from '../../../../../src/evaluation/domain/usecases/index.js';
 import { expect, hFake, sinon } from '../../../../test-helper.js';
@@ -29,6 +30,33 @@ describe('Unit | Controller | user-controller', function () {
 
       // then
       expect(response).to.be.equal(userInformationSerialized);
+    });
+  });
+
+  describe('#rememberUserHasSeenNewDashboardInfo', function () {
+    it('should remember user has seen new dashboard info', async function () {
+      // given
+      const userId = 1;
+      const userSerializer = {
+        serialize: sinon.stub(),
+      };
+      sinon.stub(libUsecases, 'rememberUserHasSeenNewDashboardInfo');
+
+      libUsecases.rememberUserHasSeenNewDashboardInfo.withArgs({ userId }).resolves({});
+      userSerializer.serialize.withArgs({}).returns('ok');
+
+      // when
+      const response = await userController.rememberUserHasSeenNewDashboardInfo(
+        {
+          auth: { credentials: { userId } },
+          params: { id: userId },
+        },
+        hFake,
+        { userSerializer },
+      );
+
+      // then
+      expect(response).to.be.equal('ok');
     });
   });
 });

--- a/api/tests/evaluation/unit/application/users/user-controller_test.js
+++ b/api/tests/evaluation/unit/application/users/user-controller_test.js
@@ -1,4 +1,3 @@
-import { usecases as libUsecases } from '../../../../../lib/domain/usecases/index.js';
 import { userController } from '../../../../../src/evaluation/application/users/user-controller.js';
 import { evaluationUsecases } from '../../../../../src/evaluation/domain/usecases/index.js';
 import { expect, hFake, sinon } from '../../../../test-helper.js';
@@ -40,9 +39,9 @@ describe('Unit | Controller | user-controller', function () {
       const userSerializer = {
         serialize: sinon.stub(),
       };
-      sinon.stub(libUsecases, 'rememberUserHasSeenNewDashboardInfo');
+      sinon.stub(evaluationUsecases, 'rememberUserHasSeenNewDashboardInfo');
 
-      libUsecases.rememberUserHasSeenNewDashboardInfo.withArgs({ userId }).resolves({});
+      evaluationUsecases.rememberUserHasSeenNewDashboardInfo.withArgs({ userId }).resolves({});
       userSerializer.serialize.withArgs({}).returns('ok');
 
       // when

--- a/api/tests/evaluation/unit/domain/usecases/remember-user-has-seen-level-seven-info_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/remember-user-has-seen-level-seven-info_test.js
@@ -4,9 +4,9 @@ import { expect, sinon } from '../../../../test-helper.js';
 describe('Unit | UseCase | remember-user-has-seen-level-seven-info', function () {
   it('should return user information', async function () {
     // given
-    const userRepository = { update: sinon.stub() };
+    const userRepository = { updateMarkLevelSevenInfoAsSeen: sinon.stub() };
     const userId = 1;
-    userRepository.update.withArgs({ userId }).resolves();
+    userRepository.updateMarkLevelSevenInfoAsSeen.withArgs({ userId }).resolves();
 
     // when
     await rememberUserHasSeenLevelSevenInfo({
@@ -15,6 +15,6 @@ describe('Unit | UseCase | remember-user-has-seen-level-seven-info', function ()
     });
 
     // then
-    expect(userRepository.update).to.have.been.calledOnce;
+    expect(userRepository.updateMarkLevelSevenInfoAsSeen).to.have.been.calledOnce;
   });
 });

--- a/api/tests/identity-access-management/integration/application/api/users-api_test.js
+++ b/api/tests/identity-access-management/integration/application/api/users-api_test.js
@@ -15,4 +15,18 @@ describe('Integration | Application | users-api', function () {
       expect(actualUser.hasSeenLevelSevenInfo).to.be.true;
     });
   });
+
+  describe('#markNewDashboardInfoAsSeen', function () {
+    it('should return user information', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser({ hasSeenNewDashboardInfo: false }).id;
+      await databaseBuilder.commit();
+
+      // when
+      const actualUser = await userApi.markNewDashboardInfoAsSeen({ userId });
+
+      // then
+      expect(actualUser.hasSeenNewDashboardInfo).to.be.true;
+    });
+  });
 });

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -122,32 +122,6 @@ describe('Unit | Controller | user-controller', function () {
     });
   });
 
-  describe('#rememberUserHasSeenNewDashboardInfo', function () {
-    let request;
-    const userId = 1;
-
-    beforeEach(function () {
-      request = {
-        auth: { credentials: { userId } },
-        params: { id: userId },
-      };
-
-      sinon.stub(usecases, 'rememberUserHasSeenNewDashboardInfo');
-    });
-
-    it('should remember user has seen new dashboard info', async function () {
-      // given
-      usecases.rememberUserHasSeenNewDashboardInfo.withArgs({ userId }).resolves({});
-      userSerializer.serialize.withArgs({}).returns('ok');
-
-      // when
-      const response = await userController.rememberUserHasSeenNewDashboardInfo(request, hFake, { userSerializer });
-
-      // then
-      expect(response).to.be.equal('ok');
-    });
-  });
-
   describe('#rememberUserHasSeenChallengeTooltip', function () {
     let request;
     const userId = 1;


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la migration lib>src, on cherche à migrer la route permettant de mettre à jour la donnée qui marque qu'un utilisateur a vu la nouvelle version du dashboard. 

## :robot: Proposition
Migrer cette route vers le scope Evaluation, celle-ci s'appuiera sur une API interne pour aller modifier la donnée se trouvant dans le scope Identity Access Management. 

## :100: Pour tester

1. Se connecter sur Pix App (pour la première fois)
2. Cliquer sur la croix dans la section "Bonjour XXX, découvrez..."

Au moment du clique, l'appel au endpoint `PATCH /api/users/{id}/has-seen-new-dashboard-info` est réalisé

![image](https://github.com/user-attachments/assets/d0b0a6dd-206b-4752-ac26-f569f7c205f1)

![image](https://github.com/user-attachments/assets/5cbe45d8-9194-4390-9270-153715530701)
