### PR TITLE
[TECH] :recycle: Déplace un model dans son context

### DIFF
--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -10,6 +10,7 @@ import { ArchivedCampaignError, DeletedCampaignError } from '../../prescription/
 import { CampaignParticipationDeletedError } from '../../prescription/campaign-participation/domain/errors.js';
 import { AggregateImportError, SiecleXmlImportError } from '../../prescription/learner-management/domain/errors.js';
 import { OrganizationCantGetPlacesStatisticsError } from '../../prescription/organization-place/domain/errors.js';
+import { AlreadyAcceptedOrCancelledInvitationError } from '../../team/domain/errors.js';
 import * as DomainErrors from '../domain/errors.js';
 import {
   AutonomousCourseRequiresATargetProfileWithSimplifiedAccessError,
@@ -345,7 +346,7 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.AlreadyExistingInvitationError) {
     return new HttpErrors.PreconditionFailedError(error.message);
   }
-  if (error instanceof DomainErrors.AlreadyAcceptedOrCancelledInvitationError) {
+  if (error instanceof AlreadyAcceptedOrCancelledInvitationError) {
     return new HttpErrors.ConflictError(error.message);
   }
   if (error instanceof DomainErrors.AlreadyExistingCampaignParticipationError) {

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -649,12 +649,6 @@ class AlreadyExistingInvitationError extends DomainError {
   }
 }
 
-class AlreadyAcceptedOrCancelledInvitationError extends DomainError {
-  constructor(message = "L'invitation a déjà été acceptée ou annulée.") {
-    super(message);
-  }
-}
-
 class AlreadyRatedAssessmentError extends DomainError {
   constructor(message = 'Cette évaluation a déjà été évaluée.') {
     super(message);
@@ -1083,7 +1077,6 @@ export {
   AccountRecoveryDemandExpired,
   AccountRecoveryUserAlreadyConfirmEmail,
   AcquiredBadgeForbiddenDeletionError,
-  AlreadyAcceptedOrCancelledInvitationError,
   AlreadyExistingCampaignParticipationError,
   AlreadyExistingEntityError,
   AlreadyExistingInvitationError,

--- a/api/src/shared/domain/models/OrganizationInvitedUser.js
+++ b/api/src/shared/domain/models/OrganizationInvitedUser.js
@@ -1,5 +1,6 @@
+import { AlreadyAcceptedOrCancelledInvitationError } from '../../../team/domain/errors.js';
 import { OrganizationInvitation } from '../../../team/domain/models/OrganizationInvitation.js';
-import { AlreadyAcceptedOrCancelledInvitationError, AlreadyExistingMembershipError, NotFoundError } from '../errors.js';
+import { AlreadyExistingMembershipError, NotFoundError } from '../errors.js';
 import { roles } from './Membership.js';
 
 class OrganizationInvitedUser {

--- a/api/src/shared/domain/models/index.js
+++ b/api/src/shared/domain/models/index.js
@@ -63,7 +63,6 @@ import { CertifiableBadgeAcquisition } from './CertifiableBadgeAcquisition.js';
 import { CertifiableProfileForLearningContent } from './CertifiableProfileForLearningContent.js';
 import { CertificationCandidate } from './CertificationCandidate.js';
 import { CertificationCenter } from './CertificationCenter.js';
-import { CertificationCenterInvitedUser } from './CertificationCenterInvitedUser.js';
 import { CertificationCenterMembership } from './CertificationCenterMembership.js';
 import { CertificationChallenge } from './CertificationChallenge.js';
 import { CertificationChallengeWithType } from './CertificationChallengeWithType.js';
@@ -151,7 +150,6 @@ export {
   CertificationCandidate,
   CertificationCandidateForSupervising,
   CertificationCenter,
-  CertificationCenterInvitedUser,
   CertificationCenterMembership,
   CertificationChallenge,
   CertificationChallengeWithType,

--- a/api/src/team/domain/errors.js
+++ b/api/src/team/domain/errors.js
@@ -1,5 +1,11 @@
 import { DomainError } from '../../shared/domain/errors.js';
 
+class AlreadyAcceptedOrCancelledInvitationError extends DomainError {
+  constructor(message = "L'invitation a déjà été acceptée ou annulée.") {
+    super(message);
+  }
+}
+
 class AlreadyExistingAdminMemberError extends DomainError {
   constructor(message = 'Cet agent a déjà accès') {
     super(message);
@@ -33,6 +39,7 @@ class OrganizationArchivedError extends DomainError {
 }
 
 export {
+  AlreadyAcceptedOrCancelledInvitationError,
   AlreadyExistingAdminMemberError,
   MembershipNotFound,
   OrganizationArchivedError,

--- a/api/src/team/domain/models/CertificationCenterInvitedUser.js
+++ b/api/src/team/domain/models/CertificationCenterInvitedUser.js
@@ -1,5 +1,6 @@
+import { NotFoundError } from '../../../shared/domain/errors.js';
 import { CertificationCenterInvitation } from '../../../team/domain/models/CertificationCenterInvitation.js';
-import { AlreadyAcceptedOrCancelledInvitationError, NotFoundError } from '../errors.js';
+import { AlreadyAcceptedOrCancelledInvitationError } from '../errors.js';
 
 class CertificationCenterInvitedUser {
   constructor({ userId, invitation, status, role } = {}) {

--- a/api/src/team/domain/models/OrganizationInvitedUser.js
+++ b/api/src/team/domain/models/OrganizationInvitedUser.js
@@ -1,10 +1,7 @@
-import {
-  AlreadyAcceptedOrCancelledInvitationError,
-  AlreadyExistingMembershipError,
-  NotFoundError,
-} from '../../../shared/domain/errors.js';
+import { AlreadyExistingMembershipError, NotFoundError } from '../../../shared/domain/errors.js';
 import { roles } from '../../../shared/domain/models/Membership.js';
 import { OrganizationInvitation } from '../../../team/domain/models/OrganizationInvitation.js';
+import { AlreadyAcceptedOrCancelledInvitationError } from '../errors.js';
 
 class OrganizationInvitedUser {
   constructor({ userId, invitation, currentRole, organizationHasMemberships, currentMembershipId, status } = {}) {

--- a/api/src/team/infrastructure/repositories/certification-center-invited-user.repository.js
+++ b/api/src/team/infrastructure/repositories/certification-center-invited-user.repository.js
@@ -1,6 +1,6 @@
 import { knex } from '../../../../db/knex-database-connection.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
-import { CertificationCenterInvitedUser } from '../../../shared/domain/models/CertificationCenterInvitedUser.js';
+import { CertificationCenterInvitedUser } from '../../domain/models/CertificationCenterInvitedUser.js';
 
 const get = async function ({ certificationCenterInvitationId, email }) {
   const invitation = await knex('certification-center-invitations')

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -7,6 +7,7 @@ import {
 } from '../../../src/identity-access-management/domain/errors.js';
 import { CampaignParticipationDeletedError } from '../../../src/prescription/campaign-participation/domain/errors.js';
 import * as DomainErrors from '../../../src/shared/domain/errors.js';
+import { AlreadyAcceptedOrCancelledInvitationError } from '../../../src/team/domain/errors.js';
 import { expect, HttpTestServer, sinon } from '../../test-helper.js';
 
 describe('Integration | API | Controller Error', function () {
@@ -259,7 +260,7 @@ describe('Integration | API | Controller Error', function () {
     });
 
     it('responds Conflict when an AlreadyAcceptedOrCancelledInvitationError occurs', async function () {
-      routeHandler.throws(new DomainErrors.AlreadyAcceptedOrCancelledInvitationError());
+      routeHandler.throws(new AlreadyAcceptedOrCancelledInvitationError());
       const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(CONFLICT_ERROR);

--- a/api/tests/team/integration/infrastructure/repositories/certification-center-invited-user.repository.test.js
+++ b/api/tests/team/integration/infrastructure/repositories/certification-center-invited-user.repository.test.js
@@ -1,8 +1,8 @@
 import lodash from 'lodash';
 
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
-import { CertificationCenterInvitedUser } from '../../../../../src/shared/domain/models/CertificationCenterInvitedUser.js';
 import { CertificationCenterInvitation } from '../../../../../src/team/domain/models/CertificationCenterInvitation.js';
+import { CertificationCenterInvitedUser } from '../../../../../src/team/domain/models/CertificationCenterInvitedUser.js';
 import { certificationCenterInvitedUserRepository } from '../../../../../src/team/infrastructure/repositories/certification-center-invited-user.repository.js';
 import { catchErr, databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
 

--- a/api/tests/team/unit/domain/models/CertificationCenterInvitedUser_test.js
+++ b/api/tests/team/unit/domain/models/CertificationCenterInvitedUser_test.js
@@ -1,7 +1,8 @@
-import { AlreadyAcceptedOrCancelledInvitationError, NotFoundError } from '../../../../src/shared/domain/errors.js';
-import { CertificationCenterInvitedUser } from '../../../../src/shared/domain/models/CertificationCenterInvitedUser.js';
-import { CertificationCenterInvitation } from '../../../../src/team/domain/models/CertificationCenterInvitation.js';
-import { catchErr, domainBuilder, expect } from '../../../test-helper.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { AlreadyAcceptedOrCancelledInvitationError } from '../../../../../src/team/domain/errors.js';
+import { CertificationCenterInvitation } from '../../../../../src/team/domain/models/CertificationCenterInvitation.js';
+import { CertificationCenterInvitedUser } from '../../../../../src/team/domain/models/CertificationCenterInvitedUser.js';
+import { catchErr, domainBuilder, expect } from '../../../../test-helper.js';
 
 describe('Unit | Domain | Models | CertificationCenterInvitedUser', function () {
   describe('#acceptInvitation', function () {

--- a/api/tests/team/unit/domain/models/OrganizationInvitedUser.test.js
+++ b/api/tests/team/unit/domain/models/OrganizationInvitedUser.test.js
@@ -1,9 +1,6 @@
-import {
-  AlreadyAcceptedOrCancelledInvitationError,
-  AlreadyExistingMembershipError,
-  NotFoundError,
-} from '../../../../../src/shared/domain/errors.js';
+import { AlreadyExistingMembershipError, NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { OrganizationInvitedUser } from '../../../../../src/shared/domain/models/OrganizationInvitedUser.js';
+import { AlreadyAcceptedOrCancelledInvitationError } from '../../../../../src/team/domain/errors.js';
 import { catchErr, domainBuilder, expect } from '../../../../test-helper.js';
 
 describe('Unit | Team | Domain | Model | OrganizationInvitedUser', function () {

--- a/api/tests/team/unit/domain/usecases/accept-certification-center-invitation.usecase.test.js
+++ b/api/tests/team/unit/domain/usecases/accept-certification-center-invitation.usecase.test.js
@@ -1,6 +1,6 @@
 import { AlreadyExistingMembershipError } from '../../../../../src/shared/domain/errors.js';
-import { CertificationCenterInvitedUser } from '../../../../../src/shared/domain/models/CertificationCenterInvitedUser.js';
 import { CertificationCenterInvitation } from '../../../../../src/team/domain/models/CertificationCenterInvitation.js';
+import { CertificationCenterInvitedUser } from '../../../../../src/team/domain/models/CertificationCenterInvitedUser.js';
 import { acceptCertificationCenterInvitation } from '../../../../../src/team/domain/usecases/accept-certification-center-invitation.usecase.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.js';
 

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -246,10 +246,6 @@ describe('Unit | Domain | Errors', function () {
     expect(errors.OrganizationLearnerCannotBeDissociatedError).to.exist;
   });
 
-  it('should export an AlreadyAcceptedOrCancelledInvitationError', function () {
-    expect(errors.AlreadyAcceptedOrCancelledInvitationError).to.exist;
-  });
-
   it('should export an MissingAttributesError', function () {
     expect(errors.MissingAttributesError).to.exist;
   });


### PR DESCRIPTION
## :unicorn: Problème

La migration du répertoire `lib/domain/models/` dans `src/shared/domain/models/` a emporté des fichiers qui ne sont utilisés que dans un seul domaine. 

Ici nous traitons du cas `CerticiationCenterInvitedUser`.

## :robot: Proposition

Déplacer le modèle `CertificationCenterInvitedUser` dans le domaine qui l'utilise `team`

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
