### PR TITLE
[TECH] Supprimer l'ancienne route de génération d'identifiants et mots de passe en masse (PIX-14498)

### DIFF
--- a/api/lib/application/sco-organization-learners/index.js
+++ b/api/lib/application/sco-organization-learners/index.js
@@ -212,45 +212,8 @@ const register = async function (server) {
           },
         },
         notes: [
-          "- Réinitialise, avec un mot de passe à usage unique, les mots de passe des élèves dont les identifiants sont passés en paramètre et qui ont un identifiant comme méthode d'authentification\n" +
-            "- La demande de modification du mot de passe doit être effectuée par un membre de l'organisation à laquelle appartiennent les élèves.",
-        ],
-        tags: ['api', 'sco-organization-learners'],
-      },
-    },
-    {
-      method: 'POST',
-      path: '/api/sco-organization-learners/password-reset',
-      config: {
-        pre: [
-          {
-            method: securityPreHandlers.checkUserBelongsToScoOrganizationAndManagesStudents,
-            assign: 'belongsToScoOrganizationAndManageStudents',
-          },
-        ],
-        handler: scoOrganizationLearnerController.batchGenerateOrganizationLearnersUsernameWithTemporaryPassword,
-        validate: {
-          options: {
-            allowUnknown: true,
-          },
-          payload: Joi.object({
-            data: {
-              attributes: {
-                'organization-id': identifiersType.campaignId,
-                'organization-learners-id': Joi.array().items(identifiersType.organizationLearnerId),
-              },
-            },
-          }),
-          failAction: (request, h) => {
-            return sendJsonApiError(
-              new BadRequestError('The server could not understand the request due to invalid syntax.'),
-              h,
-            );
-          },
-        },
-        notes: [
-          "- Réinitialise, avec un mot de passe à usage unique, les mots de passe des élèves dont les identifiants sont passés en paramètre et qui ont un identifiant comme méthode d'authentification\n" +
-            "- La demande de modification du mot de passe doit être effectuée par un membre de l'organisation à laquelle appartiennent les élèves.",
+          '- Génère les identifiants et les mots de passe à usage unique des élèves dont les identifiants sont passés en paramètre dans un fichier CSV\n' +
+            "- La demande de génération doit être effectuée par un membre de l'organisation à laquelle appartiennent les élèves.",
         ],
         tags: ['api', 'sco-organization-learners'],
       },


### PR DESCRIPTION
## :unicorn: Problème
Actuellement l’API de génération d’identifiants et mots de passe est disponible sur 2 routes différentes
- `/api/sco-organization-learners/password-reset`
- `api/sco-organization-learners/batch-username-password-generate`

Ceci afin que les modifications effectuées sur la PR https://github.com/1024pix/pix/pull/10096 soient rétrocompatibles avec les utilisateurs de Pix Orga connectées sur une ancienne version de l’API Pix.

## :robot: Proposition
Supprimer la route `/api/sco-organization-learners/password-reset`

## :rainbow: Remarques
La description de l'api a été aussi améliorée sur cette PR

## :100: Pour tester
### Test de non régression
- Se connecter à la RA de Pix Orga avec le compte `allorga@example.net`
- Sélectionner, en cliquant sur le profil en haut à droite, l'organisation `Collège House of The Dragon`
- Aller dans l'onglet Elèves
- Sélectionner / Cocher les élèves Mikasa, Eliza, Edward, Hermione et Bob
- Vérifier que le bouton `Réinitialiser les mots de passe des élèves sélectionnés` dans la barre en bas s'affiche bien.
- Cliquer sur le bouton
- Vérifier que la modale s'affiche bien avec le fait que 2 élèves auront leur mot de passe réinitialisé.
- Ouvrir la console navigateur
- Cliquer sur Confirmer
- Vérifier que l'appel `/api/sco-organization-learners/batch-username-password-generate` renvoie bien une 200.
- Vérifier, dans le contenu du fichier CSV, qu'on retrouve bien les informations de Eliza et Bob
