### PR TITLE
[TECH] Remplit la colonne `reconciledAt` pour les anciennes certifications 

### DIFF
--- a/api/db/migrations/20240924091540_add-reconciliation-date-to-former-candidates.js
+++ b/api/db/migrations/20240924091540_add-reconciliation-date-to-former-candidates.js
@@ -1,0 +1,47 @@
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
+
+const TABLE_NAME = 'certification-candidates';
+
+const up = async function (knex) {
+  let numberOfBatchProcessed = 0;
+  const CHUNK_SIZE = 250000;
+  const BATCH_LIMIT = 40; // around 7 millions lines in prod, 40*250000 = 1 billion so it covers the actual volume
+
+  let hasNext = false;
+  do {
+    const updates = await knex.raw(
+      `
+update "certification-candidates"
+set "reconciledAt" = "subquery"."reconciledAt"
+from (select
+  "certification-candidates"."id" as "id",
+  "certification-courses"."createdAt" as "reconciledAt"
+  from "certification-candidates"
+  left join "certification-courses" on "certification-courses"."userId" = "certification-candidates"."userId"
+  and "certification-courses"."sessionId" = "certification-candidates"."sessionId"
+  where "certification-candidates"."userId" is not null
+  and "certification-candidates"."reconciledAt" is null
+  limit ?) as "subquery"
+ where "certification-candidates"."id" = "subquery"."id"
+ returning "certification-candidates"."id", "certification-candidates"."reconciledAt";`,
+      [CHUNK_SIZE],
+    );
+
+    hasNext = updates.rowCount === CHUNK_SIZE;
+    ++numberOfBatchProcessed;
+    logger.info(
+      `${TABLE_NAME}: Batch number ${numberOfBatchProcessed} : ${updates.rowCount} items updated. hasNext = ${hasNext}`,
+    );
+  } while (hasNext && numberOfBatchProcessed <= BATCH_LIMIT);
+};
+
+const down = async function () {
+  // do nothing in the down as we cannot know what rows were impacted
+  return;
+};
+
+// We INSERT in batch of CHUNK_SIZE, hence not needing a transaction for this migration
+// @see: https://knexjs.org/guide/migrations.html#migration-api
+const config = { transaction: false };
+
+export { config, down, up };


### PR DESCRIPTION
## :unicorn: Problème

Maintenant que l’on enregistre et utilise la date de reconciliation, il y a un rattrapage à faire sur les données précédentes.

## :robot: Proposition

Ajout d'une migration.

Si le userId est rempli dans certification-candidates, alors cette migration remplit la colonne `reconciledAt` de certification-candidates qui ont créé un certification-course (`certification-courses.createdAt is not null`)

## :rainbow: Remarques

Cette migration est faite via un `knex.raw()` parce qu'on a perdu pas mal de temps à se battre sur les bindings knex.

## :100: Pour tester

Lancer la migration sur les seeds et vérifier via la requête suivante que :

- Seuls les `certification-candidates` ayant un `userId` et un `sessionId` non nuls aient une  date `reconciledAt`  non nulle.
- La date `reconciledAt` correspond au `createdAt` du certification-course du candidat

```SQL
select 
cc.id,
cc."userId",
cc."sessionId",
cc."reconciledAt",
cco."createdAt"
from "certification-candidates" cc
left join "certification-courses" cco on cc."userId" = cco."userId"
and cco."sessionId" = cc."sessionId";
```

Le résultat devrait être équivalent à : 

<img width="729" alt="Capture d’écran 2024-09-25 à 15 16 50" src="https://github.com/user-attachments/assets/07622c9c-a729-440c-99ce-ccd0cb9785b8">
