### PR TITLE
[BUGFIX] Passer la bonne information en paramètre de la Pagination sur PixAdmin (Pix-14499)

### DIFF
--- a/admin/app/routes/authenticated/organizations/get/campaigns.js
+++ b/admin/app/routes/authenticated/organizations/get/campaigns.js
@@ -24,4 +24,11 @@ export default class OrganizationCampaignsRoute extends Route {
       organizationId,
     };
   }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.pageNumber = 1;
+      controller.pageSize = 10;
+    }
+  }
 }

--- a/admin/tests/unit/routes/authenticated/organizations/get/campaigns-test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/get/campaigns-test.js
@@ -1,0 +1,44 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Route | authenticated/organization/get/campaigns', function (hooks) {
+  setupTest(hooks);
+  let route;
+
+  hooks.beforeEach(function () {
+    route = this.owner.lookup('route:authenticated/organizations/get/campaigns');
+  });
+
+  module('#resetController', function (hooks) {
+    let controller;
+
+    hooks.beforeEach(function () {
+      controller = {
+        pageNumber: 'somePageNumber',
+        pageSize: 'somePageSize',
+      };
+    });
+
+    module('when route is exiting', function () {
+      test('it should reset controller', function (assert) {
+        // when
+        route.resetController(controller, true);
+
+        // then
+        assert.strictEqual(controller.pageNumber, 1);
+        assert.strictEqual(controller.pageSize, 10);
+      });
+    });
+
+    module('when route is not exiting', function () {
+      test('it should not reset controller', function (assert) {
+        // when
+        route.resetController(controller, false);
+
+        // then
+        assert.strictEqual(controller.pageNumber, 'somePageNumber');
+        assert.strictEqual(controller.pageSize, 'somePageSize');
+      });
+    });
+  });
+});

--- a/api/src/prescription/campaign/application/campaign-administration-route.js
+++ b/api/src/prescription/campaign/application/campaign-administration-route.js
@@ -2,7 +2,7 @@ import Joi from 'joi';
 
 import { PayloadTooLargeError, sendJsonApiError } from '../../../shared/application/http-errors.js';
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
-import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { identifiersType, queriesType } from '../../../shared/domain/types/identifiers-type.js';
 import { campaignAdministrationController } from './campaign-adminstration-controller.js';
 const TWENTY_MEGABYTES = 1048576 * 20;
 
@@ -281,6 +281,9 @@ const register = async function (server) {
         validate: {
           params: Joi.object({
             organizationId: identifiersType.organizationId,
+          }),
+          query: Joi.object({
+            page: queriesType.paginationType,
           }),
         },
         handler: campaignAdministrationController.findPaginatedCampaignManagements,

--- a/api/src/shared/domain/types/identifiers-type.js
+++ b/api/src/shared/domain/types/identifiers-type.js
@@ -20,6 +20,13 @@ function _assignValueToExport(array, implementationType) {
   });
 }
 
+const queriesType = {
+  paginationType: Joi.object({
+    number: Joi.number().integer().empty('').allow(null).optional(),
+    size: Joi.number().integer().empty('').allow(null).optional(),
+  }).default({}),
+};
+
 const typesPositiveInteger32bits = [
   'adminMemberId',
   'answerId',
@@ -73,4 +80,4 @@ paramsToExport.positiveInteger32bits = {
   max: postgreSQLSequenceEnd,
 };
 
-export { paramsToExport as identifiersType, queryToExport as optionalIdentifiersType };
+export { paramsToExport as identifiersType, queryToExport as optionalIdentifiersType, queriesType };

--- a/api/tests/prescription/campaign/unit/application/campaign-administration-route_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-administration-route_test.js
@@ -411,4 +411,90 @@ describe('Unit | Application | Router | campaign-administration-router ', functi
       ]);
     });
   });
+
+  describe('GET /api/admin/organizations/{organizationId}/campaigns', function () {
+    describe('success case', function () {
+      beforeEach(function () {
+        sinon.stub(campaignAdministrationController, 'findPaginatedCampaignManagements').returns('ok');
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+      });
+
+      it('should return 200 when organizationId valid', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('GET', '/api/admin/organizations/12/campaigns');
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+
+      it('should return 200 when pageSize valid', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('GET', '/api/admin/organizations/12/campaigns?page[size]=12');
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+
+      it('should return 200 when pageNumber valid', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('GET', '/api/admin/organizations/12/campaigns?page[number]=12');
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+
+    describe('error case', function () {
+      it('should return 400 with an invalid organizationId', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('GET', '/api/admin/organizations/invalid/campaigns');
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+      it('should return 400 with an invalid pageSize is given', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('GET', '/api/admin/organizations/666/campaigns?page[size]=toto');
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+      it('should return 400 with an invalid page number is given', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request(
+          'GET',
+          '/api/admin/organizations/666/campaigns?page[number]=toto',
+        );
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+  });
 });

--- a/api/tests/shared/unit/domain/types/identifiers-type_test.js
+++ b/api/tests/shared/unit/domain/types/identifiers-type_test.js
@@ -1,4 +1,8 @@
-import { identifiersType, optionalIdentifiersType } from '../../../../../src/shared/domain/types/identifiers-type.js';
+import {
+  identifiersType,
+  optionalIdentifiersType,
+  queriesType,
+} from '../../../../../src/shared/domain/types/identifiers-type.js';
 import { expect } from '../../../../test-helper.js';
 const { userId, competenceId } = identifiersType;
 const { organizationId } = optionalIdentifiersType;
@@ -84,7 +88,7 @@ describe('Unit | Domain | Type | identifier-types', function () {
     });
   });
 
-  context('queryIdentifiersType', function () {
+  context('optionalIdentifiersType', function () {
     describe('#organizationId', function () {
       context('when organizationId is null', function () {
         it('should not throw', function () {
@@ -144,6 +148,106 @@ describe('Unit | Domain | Type | identifier-types', function () {
 
           // then
           expect(error.message).to.equal('"value" must be less than or equal to 2147483647');
+        });
+      });
+    });
+  });
+
+  context('queriesType', function () {
+    describe('#paginationType', function () {
+      context('when number is valid', function () {
+        it('should not reject', function () {
+          // given
+          const validNumber = 1;
+
+          // when
+          const { error } = queriesType.paginationType.validate({ number: validNumber });
+
+          // then
+          expect(error).to.be.undefined;
+        });
+
+        it('should not reject when string is number', function () {
+          // given
+          const validNumber = '18';
+
+          // when
+          const { error } = queriesType.paginationType.validate({ number: validNumber });
+
+          // then
+          expect(error).to.be.undefined;
+        });
+
+        it('should not reject when is null', async function () {
+          // given
+          const validNumber = null;
+
+          // when
+          const { error } = queriesType.paginationType.validate({ number: validNumber });
+
+          // then
+          expect(error).to.be.undefined;
+        });
+      });
+
+      context('when number is invalid', function () {
+        it('should reject when is string', async function () {
+          // given
+          const invalidNumber = 'toto';
+
+          // when
+          const { error } = queriesType.paginationType.validate({ number: invalidNumber });
+
+          // then
+          expect(error.message).to.equal('"number" must be a number');
+        });
+      });
+
+      context('when size is valid', function () {
+        it('should not reject', function () {
+          // given
+          const validNumber = 1;
+
+          // when
+          const { error } = queriesType.paginationType.validate({ size: validNumber });
+
+          // then
+          expect(error).to.be.undefined;
+        });
+
+        it('should not reject when string is number', function () {
+          // given
+          const validNumber = '18';
+
+          // when
+          const { error } = queriesType.paginationType.validate({ size: validNumber });
+
+          // then
+          expect(error).to.be.undefined;
+        });
+
+        it('should not reject when is null', async function () {
+          // given
+          const validNumber = null;
+
+          // when
+          const { error } = queriesType.paginationType.validate({ size: validNumber });
+
+          // then
+          expect(error).to.be.undefined;
+        });
+      });
+
+      context('when size is invalid', function () {
+        it('should reject when is string', async function () {
+          // given
+          const invalidNumber = 'toto';
+
+          // when
+          const { error } = queriesType.paginationType.validate({ size: invalidNumber });
+
+          // then
+          expect(error.message).to.equal('"size" must be a number');
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
On a des changements de pages ératiques sur la page des campagnes d'une organisation

## :robot: Proposition
Ajouter un validator en entrée de route qui permet de valider que ce que l'on passe est bien un nombre

## :rainbow: Remarques
ajout d'un reset controller qui remet à zéro les queryParams de la route

## :100: Pour tester
Aller sur Pixadmin => Organization => Campagne => Afficher au moins 3 page, vérifier que le clique sur la page suivante fait bien un +1 