### PR TITLE
[BUGFIX] Ne pas proposer d'épreuves inaccessibles à un candidat de certification nécessitant un test aménagé (PIX-14517).

### DIFF
--- a/api/src/certification/evaluation/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/certification-candidate-repository.js
@@ -5,7 +5,13 @@ import { Candidate } from '../../../enrolment/domain/models/Candidate.js';
 const findByAssessmentId = async function ({ assessmentId }) {
   const result = await knex('certification-candidates')
     .select('certification-candidates.*')
-    .join('certification-courses', 'certification-courses.userId', 'certification-candidates.userId')
+    .join('certification-courses', function () {
+      this.on('certification-courses.userId', '=', 'certification-candidates.userId').andOn(
+        'certification-courses.sessionId',
+        '=',
+        'certification-candidates.sessionId',
+      );
+    })
     .join('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
     .where('assessments.id', assessmentId)
     .first();


### PR DESCRIPTION
## :unicorn: Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Bien qu'un candidat de certification soit identifié comme ayant besoin d'un test aménagé, il peut arriver que des épreuves non accessibles lui soit proposé.
Après anlayse, lors de la recherche d'un `certification-candidates` pour un `assessment` donné, on ne restreint pas les résultats à une seule session aussi la requête peut retourner plusieurs `certification-candidates` pour lesquelles l'aménagement n'avait pas été identifié.

## :robot: Proposition

Ajouter la jointure sur le `sessionId` dans le `certificationCandidateRepository` du contexte d'évaluation.

## :rainbow: Remarques

RAS

## :100: Pour tester
Passer un test de certification avec un candidat identifié comme ayant besoin d'un test aménagé.
- [ ] les épreuves proposées doivent être accessibles
- [ ] dans les logs de la review app, vérifier la présence d'un log de debug de la forme :
```
pix:certif:v3:get-next-challenge Candidate needs accessibility adjustment, possible challenges have been filtered (629 out of 1678 selected)
```

Passer un test de certification avec un candidat non-identifié comme ayant besoin d'un test aménagé.
- [ ] les épreuves proposées peuvent être non accessibles
- [ ] dans les logs de la review app, vérifier la présence d'un log de debug de la forme :
```
pix:certif:v3:get-next-challenge Candidate does need any adjustment, all 1678 have been selected
```