### PR TITLE
[FEATURE] affiche la date de naissance et la classe pour les prescrits venant d'un import à format (Pix-13984)

### DIFF
--- a/api/src/prescription/learner-management/domain/read-models/OrganizationLearnerForAdmin.js
+++ b/api/src/prescription/learner-management/domain/read-models/OrganizationLearnerForAdmin.js
@@ -2,6 +2,7 @@ import JoiDate from '@joi/date';
 import BaseJoi from 'joi';
 const Joi = BaseJoi.extend(JoiDate);
 import { validateEntity } from '../../../../shared/domain/validators/entity-validator.js';
+import { IMPORT_KEY_FIELD } from '../constants.js';
 
 const validationSchema = Joi.object({
   id: Joi.number().integer().required(),
@@ -16,6 +17,11 @@ const validationSchema = Joi.object({
   updatedAt: Joi.date().required(),
   isDisabled: Joi.boolean().required(),
   canBeDissociated: Joi.boolean().required(),
+  additionalInformations: Joi.object().allow(null),
+  additionalColumns: Joi.array().items({
+    name: Joi.string().required(),
+    key: Joi.string().required(),
+  }),
 });
 
 class OrganizationLearnerForAdmin {
@@ -32,6 +38,8 @@ class OrganizationLearnerForAdmin {
     updatedAt,
     isDisabled,
     organizationIsManagingStudents,
+    additionalInformations = {},
+    additionalColumns = [],
   }) {
     this.id = id;
     this.firstName = firstName;
@@ -45,8 +53,19 @@ class OrganizationLearnerForAdmin {
     this.updatedAt = updatedAt;
     this.isDisabled = isDisabled;
     this.canBeDissociated = organizationIsManagingStudents;
-
     validateEntity(validationSchema, this);
+    this.updateDivisionAndBirthdate({ additionalInformations, additionalColumns });
+  }
+
+  updateDivisionAndBirthdate({ additionalInformations, additionalColumns }) {
+    const dateOfBirthColumn = additionalColumns.find((column) => column.name === IMPORT_KEY_FIELD.COMMON_BIRTHDATE);
+    if (dateOfBirthColumn) {
+      this.birthdate = additionalInformations[dateOfBirthColumn.key];
+    }
+    const divisionColumn = additionalColumns.find((column) => column.name === IMPORT_KEY_FIELD.COMMON_DIVISION);
+    if (divisionColumn) {
+      this.division = additionalInformations[divisionColumn.key];
+    }
   }
 }
 

--- a/api/src/prescription/learner-management/domain/read-models/OrganizationLearnerForAdmin.js
+++ b/api/src/prescription/learner-management/domain/read-models/OrganizationLearnerForAdmin.js
@@ -7,7 +7,7 @@ const validationSchema = Joi.object({
   id: Joi.number().integer().required(),
   firstName: Joi.string().required(),
   lastName: Joi.string().required(),
-  birthdate: Joi.date().required().allow(null),
+  birthdate: Joi.string().required().allow(null),
   division: Joi.string().required().allow(null),
   group: Joi.string().required().allow(null),
   organizationId: Joi.number().integer().required(),

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
@@ -1151,8 +1151,14 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
             organizationId: secondOrganizationInDB.id,
           });
           const importFeature = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.LEARNER_IMPORT);
+          const otherFeature = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.PLACES_MANAGEMENT);
+
           databaseBuilder.factory.buildOrganizationFeature({
             featureId: importFeature.id,
+            organizationId: secondOrganizationInDB.id,
+          });
+          databaseBuilder.factory.buildOrganizationFeature({
+            featureId: otherFeature.id,
             organizationId: secondOrganizationInDB.id,
           });
 

--- a/api/tests/prescription/learner-management/unit/domain/read-models/OrganizationLearnerForAdmin_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/read-models/OrganizationLearnerForAdmin_test.js
@@ -11,7 +11,7 @@ describe('Unit | Domain | Read-models | OrganizationLearnerForAdmin', function (
         id: 1,
         firstName: 'John',
         lastName: 'Doe',
-        birthdate: new Date('2000-10-15'),
+        birthdate: '2000-10-15',
         division: '3A',
         group: 'L1',
         organizationId: 1,
@@ -60,9 +60,7 @@ describe('Unit | Domain | Read-models | OrganizationLearnerForAdmin', function (
 
     it('should throw an ObjectValidationError when birthdate is not valid', function () {
       // when
-      expect(() => new OrganizationLearnerForAdmin({ ...validArguments, birthdate: 'not_valid' })).to.throw(
-        ObjectValidationError,
-      );
+
       expect(() => new OrganizationLearnerForAdmin({ ...validArguments, birthdate: undefined })).to.throw(
         ObjectValidationError,
       );
@@ -70,7 +68,7 @@ describe('Unit | Domain | Read-models | OrganizationLearnerForAdmin', function (
 
     it('should not throw an ObjectValidationError when birthdate is null', function () {
       // when
-      expect(() => new OrganizationLearnerForAdmin({ ...validArguments, birthdate: 'null' })).to.throw(
+      expect(() => new OrganizationLearnerForAdmin({ ...validArguments, birthdate: null })).not.to.throw(
         ObjectValidationError,
       );
     });

--- a/api/tests/prescription/learner-management/unit/domain/read-models/OrganizationLearnerForAdmin_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/read-models/OrganizationLearnerForAdmin_test.js
@@ -1,3 +1,4 @@
+import { IMPORT_KEY_FIELD } from '../../../../../../src/prescription/learner-management/domain/constants.js';
 import { OrganizationLearnerForAdmin } from '../../../../../../src/prescription/learner-management/domain/read-models/OrganizationLearnerForAdmin.js';
 import { ObjectValidationError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
@@ -26,6 +27,25 @@ describe('Unit | Domain | Read-models | OrganizationLearnerForAdmin', function (
     it('should successfully instantiate object when passing all valid arguments', function () {
       // when
       expect(() => new OrganizationLearnerForAdmin(validArguments)).not.to.throw(ObjectValidationError);
+    });
+
+    it('should overide birthdate and division if additionalColumns and additionalInfos are given', function () {
+      const learner = new OrganizationLearnerForAdmin({
+        ...validArguments,
+        additionalColumns: [
+          {
+            name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE,
+            key: 'dateofbirth',
+          },
+          { name: IMPORT_KEY_FIELD.COMMON_DIVISION, key: 'groupe' },
+        ],
+        additionalInformations: {
+          groupe: 'CP',
+          dateofbirth: '2020-02-01',
+        },
+      });
+      expect(learner.division).to.equal('CP');
+      expect(learner.birthdate).to.deep.equal('2020-02-01');
     });
 
     it('should throw an ObjectValidationError when id is not valid', function () {


### PR DESCRIPTION
## :unicorn: Problème
Certaines orgas ont l’import SCO FWB activé et peuvent importer leurs élèves dans PixOrga avec des données supplémentaires : date de naissance, classe, ... Pourtant ces champs ne remontent pas dans admin, ce qui rend plus complexe la tâche du support

## :robot: Proposition
Afficher ces informations dans la table

## :rainbow: Remarques
Le premier commit corrige un bug que j'avais introduit sans le savoir... 
La suite, c'est pas joli joli mais c'est temporaire. 
On réfléchi à tagger ces champs-là pour pouvoir facilement les afficher

## :100: Pour tester

- Faire un import dans l'orga PRO_MANAGING
- Participer à la campagne PROGENCOL et se réconcilier avec Annie Bal (01/05/2000)

- Aller dans admin, et rechercher l'utilisateur Annie Bal
- Cliquer sur l'utilisateur trouvé
- Voir la date de naissance et la classe dans la liste des prescrits.