### PR TITLE
[TECH] Prendre en compte la date de réconciliation dans les cas qui vérifie la réconciliation (PIX-14515).

### DIFF
--- a/api/src/certification/enrolment/application/services/register-candidate-participation-service.js
+++ b/api/src/certification/enrolment/application/services/register-candidate-participation-service.js
@@ -32,7 +32,7 @@ export const registerCandidateParticipation = async ({
     normalizeStringFnc,
   });
 
-  if (candidate.isLinkedToAUser()) {
+  if (candidate.isReconciled()) {
     return candidate;
   }
 

--- a/api/src/certification/enrolment/application/usecases/check-user-is-candidate.js
+++ b/api/src/certification/enrolment/application/usecases/check-user-is-candidate.js
@@ -2,7 +2,7 @@ import * as candidateRepository from '../../infrastructure/repositories/candidat
 
 const execute = async ({ userId, certificationCandidateId, dependencies = { candidateRepository } }) => {
   const candidate = await dependencies.candidateRepository.get({ certificationCandidateId });
-  return candidate?.isLinkedTo(userId);
+  return candidate?.isReconciledTo(userId);
 };
 
 export { execute };

--- a/api/src/certification/enrolment/domain/models/Candidate.js
+++ b/api/src/certification/enrolment/domain/models/Candidate.js
@@ -59,10 +59,24 @@ export class Candidate {
     this.reconciledAt = reconciledAt;
   }
 
+  isReconciled() {
+    return !!this.userId && !!this.reconciledAt;
+  }
+
+  isReconciledTo(userId) {
+    return this.isReconciled() && this.userId === userId;
+  }
+
+  /**
+   * @deprecated please use isReconciled function
+   */
   isLinkedToAUser() {
     return !_.isNil(this.userId);
   }
 
+  /**
+   * @deprecated please use isReconciledTo function
+   */
   isLinkedTo(userId) {
     return this.userId === userId;
   }

--- a/api/src/certification/enrolment/domain/models/Candidate.js
+++ b/api/src/certification/enrolment/domain/models/Candidate.js
@@ -67,13 +67,6 @@ export class Candidate {
     return this.isReconciled() && this.userId === userId;
   }
 
-  /**
-   * @deprecated please use isReconciledTo function
-   */
-  isLinkedTo(userId) {
-    return this.userId === userId;
-  }
-
   reconcile(userId) {
     this.userId = userId;
     this.reconciledAt = new Date();

--- a/api/src/certification/enrolment/domain/models/Candidate.js
+++ b/api/src/certification/enrolment/domain/models/Candidate.js
@@ -68,13 +68,6 @@ export class Candidate {
   }
 
   /**
-   * @deprecated please use isReconciled function
-   */
-  isLinkedToAUser() {
-    return !_.isNil(this.userId);
-  }
-
-  /**
    * @deprecated please use isReconciledTo function
    */
   isLinkedTo(userId) {

--- a/api/src/certification/enrolment/domain/models/SessionEnrolment.js
+++ b/api/src/certification/enrolment/domain/models/SessionEnrolment.js
@@ -1,3 +1,6 @@
+/**
+ * @typedef {import('./Candidate.js').Candidate} Candidate
+ */
 import _ from 'lodash';
 
 import { CERTIFICATION_CENTER_TYPES } from '../../../../shared/domain/constants.js';
@@ -66,12 +69,21 @@ class SessionEnrolment {
     return matchingCandidates.length > 0;
   }
 
-  hasLinkedCandidate({ candidates }) {
-    return candidates.some((candidate) => candidate.isLinkedToAUser());
+  /**
+   * @param {Object} params
+   * @param {Array<Candidate>} params.candidates
+   */
+  hasReconciledCandidate({ candidates }) {
+    return candidates.some((candidate) => candidate.isReconciled());
   }
 
-  hasLinkedCandidateTo({ candidates, userId }) {
-    return candidates.some((candidate) => candidate.isLinkedTo(userId));
+  /**
+   * @param {Object} params
+   * @param {Array<Candidate>} params.candidates
+   * @param {number} params.user
+   */
+  hasReconciledCandidateTo({ candidates, userId }) {
+    return candidates.some((candidate) => candidate.isReconciledTo(userId));
   }
 
   updateInfo(sessionData) {

--- a/api/src/certification/enrolment/domain/read-models/EnrolledCandidate.js
+++ b/api/src/certification/enrolment/domain/read-models/EnrolledCandidate.js
@@ -66,10 +66,6 @@ export class EnrolledCandidate {
     this.accessibilityAdjustmentNeeded = accessibilityAdjustmentNeeded;
   }
 
-  isLinkedToAUser() {
-    return !_.isNil(this.userId);
-  }
-
   findComplementarySubscriptionInfo() {
     return this.subscriptions.find((sub) => sub.type === SUBSCRIPTION_TYPES.COMPLEMENTARY);
   }

--- a/api/src/certification/enrolment/domain/usecases/delete-unlinked-certification-candidate.js
+++ b/api/src/certification/enrolment/domain/usecases/delete-unlinked-certification-candidate.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('./index.js').CandidateRepository} candidateRepository
+ * @typedef {import('./index.js').CandidateRepository} CandidateRepository
  */
 
 import { NotFoundError } from '../../../../shared/domain/errors.js';
@@ -16,7 +16,7 @@ const deleteUnlinkedCertificationCandidate = async function ({ candidateId, cand
     throw new NotFoundError();
   }
 
-  if (!candidate.isLinkedToAUser()) {
+  if (!candidate.isReconciled()) {
     return candidateRepository.remove({ id: candidateId });
   }
 

--- a/api/src/certification/enrolment/domain/usecases/import-certification-candidates-from-candidates-import-sheet.js
+++ b/api/src/certification/enrolment/domain/usecases/import-certification-candidates-from-candidates-import-sheet.js
@@ -1,6 +1,16 @@
+/**
+ * @typedef {import('./index.js').CandidateRepository} CandidateRepository
+ * @typedef {import('./index.js').SessionRepository} SessionRepository
+ */
+
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { CandidateAlreadyLinkedToUserError } from '../../../../shared/domain/errors.js';
 
+/**
+ * @param {Object} params
+ * @param {CandidateRepository} params.candidateRepository
+ * @param {SessionRepository} params.sessionRepository
+ */
 const importCertificationCandidatesFromCandidatesImportSheet = async function ({
   sessionId,
   odsBuffer,
@@ -17,7 +27,7 @@ const importCertificationCandidatesFromCandidatesImportSheet = async function ({
   const candidatesInSession = await candidateRepository.findBySessionId({ sessionId });
   const session = await sessionRepository.get({ id: sessionId });
 
-  if (session.hasLinkedCandidate({ candidates: candidatesInSession })) {
+  if (session.hasReconciledCandidate({ candidates: candidatesInSession })) {
     throw new CandidateAlreadyLinkedToUserError('At least one candidate is already linked to a user');
   }
 

--- a/api/src/certification/enrolment/domain/usecases/update-enrolled-candidate.js
+++ b/api/src/certification/enrolment/domain/usecases/update-enrolled-candidate.js
@@ -19,7 +19,7 @@ const updateEnrolledCandidate = async function ({ editedCandidate, candidateRepo
     throw new CertificationCandidateNotFoundError();
   }
 
-  if (foundCandidate.isLinkedToAUser()) {
+  if (foundCandidate.isReconciled()) {
     throw new CandidateAlreadyLinkedToUserError();
   }
 

--- a/api/src/certification/enrolment/domain/usecases/verify-candidate-identity.js
+++ b/api/src/certification/enrolment/domain/usecases/verify-candidate-identity.js
@@ -18,6 +18,11 @@ import { CertificationCourse } from '../../../shared/domain/models/Certification
 import { CertificationVersion } from '../../../shared/domain/models/CertificationVersion.js';
 
 /**
+ * @param {Object} params
+ * @param {CandidateRepository} params.candidateRepository
+ * @param {CenterRepository} params.centerRepository
+ * @param {SessionRepository} params.sessionRepository
+ * @param {UserRepository} params.userRepository
  * @returns {Promise<Candidate>}
  */
 export const verifyCandidateIdentity = async ({
@@ -61,7 +66,7 @@ export const verifyCandidateIdentity = async ({
     throw new UnexpectedUserAccountError({});
   }
 
-  if (session.hasLinkedCandidateTo({ candidates: candidatesInSession, userId })) {
+  if (session.hasReconciledCandidateTo({ candidates: candidatesInSession, userId })) {
     throw new UserAlreadyLinkedToCandidateInSessionError(
       'The user is already linked to a candidate with different personal info in the given session',
     );

--- a/api/src/certification/enrolment/domain/usecases/verify-candidate-identity.js
+++ b/api/src/certification/enrolment/domain/usecases/verify-candidate-identity.js
@@ -54,8 +54,8 @@ export const verifyCandidateIdentity = async ({
     normalizeStringFnc,
   });
 
-  if (candidate.isLinkedToAUser()) {
-    if (candidate.isLinkedTo(userId)) {
+  if (candidate.isReconciled()) {
+    if (candidate.isReconciledTo(userId)) {
       return candidate;
     }
     throw new UnexpectedUserAccountError({});

--- a/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
@@ -25,7 +25,7 @@ export async function get({ certificationCandidateId }) {
  * @param {Object} params
  * @param {number} params.sessionId
  *
- * @return [Candidate]
+ * @return {Array<Candidate>}
  */
 export async function findBySessionId({ sessionId }) {
   const candidatesData = await buildBaseReadQuery(knex)

--- a/api/tests/certification/enrolment/unit/application/validator/checkUserIsCandidate_test.js
+++ b/api/tests/certification/enrolment/unit/application/validator/checkUserIsCandidate_test.js
@@ -14,6 +14,7 @@ describe('Unit | Application | Validator | checkUserIsCandidateUseCase', functio
       candidateRepositoryStub.get.withArgs({ certificationCandidateId }).resolves(
         domainBuilder.certification.enrolment.buildCandidate({
           userId,
+          reconciledAt: new Date('2024-09-25'),
         }),
       );
 

--- a/api/tests/certification/enrolment/unit/domain/models/Candidate_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/Candidate_test.js
@@ -1102,6 +1102,47 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
     });
   });
 
+  context('isReconciled', function () {
+    it('should return false when candidate is not reconciled', function () {
+      // given
+      const notReconciledCandidates = [
+        domainBuilder.certification.enrolment.buildCandidate({
+          userId: null,
+          reconciledAt: null,
+        }),
+        domainBuilder.certification.enrolment.buildCandidate({
+          userId: 123,
+          reconciledAt: null,
+        }),
+        domainBuilder.certification.enrolment.buildCandidate({
+          userId: null,
+          reconciledAt: new Date(),
+        }),
+      ];
+
+      notReconciledCandidates.forEach((candidate) => {
+        // when
+        const isReconciled = candidate.isReconciled();
+        // then
+        expect(isReconciled).to.be.false;
+      });
+    });
+
+    it('should return true when candidate is reconciled', function () {
+      // given
+      const candidate = domainBuilder.certification.enrolment.buildCandidate({
+        userId: 123,
+        reconciledAt: new Date(),
+      });
+
+      // when
+      const isReconciled = candidate.isReconciled();
+
+      // then
+      expect(isReconciled).to.be.true;
+    });
+  });
+
   context('isLinkedToAUser', function () {
     it('should return false when candidate is not linked', function () {
       // given
@@ -1127,6 +1168,63 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
 
       // then
       expect(isLinked).to.be.true;
+    });
+  });
+
+  context('isReconciledTo', function () {
+    it('should return true when candidate is reconciled to given userId', function () {
+      // given
+      const userId = 123;
+      const candidate = domainBuilder.certification.enrolment.buildCandidate({
+        userId,
+        reconciledAt: new Date(),
+      });
+
+      // when
+      const isReconciledTo = candidate.isReconciledTo(userId);
+
+      // then
+      expect(isReconciledTo).to.be.true;
+    });
+
+    it('should return false when candidate is not linked to given userId', function () {
+      // given
+      const userId = 123;
+      const notReconciledToUser123 = [
+        domainBuilder.certification.enrolment.buildCandidate({
+          userId: 456,
+          reconciledAt: new Date(),
+        }),
+        domainBuilder.certification.enrolment.buildCandidate({
+          userId,
+          reconciledAt: null,
+        }),
+        domainBuilder.certification.enrolment.buildCandidate({
+          userId: null,
+          reconciledAt: new Date(),
+        }),
+      ];
+
+      notReconciledToUser123.forEach((candidate) => {
+        // when
+        const isReconciledTo = candidate.isReconciledTo(userId);
+        // then
+        expect(isReconciledTo).to.be.false;
+      });
+    });
+
+    it('should return false when candidate is not linked to anyone', function () {
+      // given
+      const userId = 123;
+      const candidate = domainBuilder.certification.enrolment.buildCandidate({
+        userId: null,
+      });
+
+      // when
+      const isLinkedTo = candidate.isLinkedTo(userId);
+
+      // then
+      expect(isLinkedTo).to.be.false;
     });
   });
 

--- a/api/tests/certification/enrolment/unit/domain/models/Candidate_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/Candidate_test.js
@@ -1185,7 +1185,7 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
       });
     });
 
-    it('should return false when candidate is not linked to anyone', function () {
+    it('should return false when candidate is not reconciled to anyone', function () {
       // given
       const userId = 123;
       const candidate = domainBuilder.certification.enrolment.buildCandidate({
@@ -1193,54 +1193,10 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
       });
 
       // when
-      const isLinkedTo = candidate.isLinkedTo(userId);
+      const isReconciledTo = candidate.isReconciledTo(userId);
 
       // then
-      expect(isLinkedTo).to.be.false;
-    });
-  });
-
-  context('isLinkedTo', function () {
-    it('should return true when candidate is linked to given userId', function () {
-      // given
-      const userId = 123;
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
-        userId,
-      });
-
-      // when
-      const isLinkedTo = candidate.isLinkedTo(userId);
-
-      // then
-      expect(isLinkedTo).to.be.true;
-    });
-
-    it('should return false when candidate is not linked to given userId', function () {
-      // given
-      const userId = 123;
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
-        userId: 456,
-      });
-
-      // when
-      const isLinkedTo = candidate.isLinkedTo(userId);
-
-      // then
-      expect(isLinkedTo).to.be.false;
-    });
-
-    it('should return false when candidate is not linked to anyone', function () {
-      // given
-      const userId = 123;
-      const candidate = domainBuilder.certification.enrolment.buildCandidate({
-        userId: null,
-      });
-
-      // when
-      const isLinkedTo = candidate.isLinkedTo(userId);
-
-      // then
-      expect(isLinkedTo).to.be.false;
+      expect(isReconciledTo).to.be.false;
     });
   });
 

--- a/api/tests/certification/enrolment/unit/domain/models/Candidate_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/Candidate_test.js
@@ -1143,34 +1143,6 @@ describe('Certification | Enrolment | Unit | Domain | Models | Candidate', funct
     });
   });
 
-  context('isLinkedToAUser', function () {
-    it('should return false when candidate is not linked', function () {
-      // given
-      const unlinkedCandidate = domainBuilder.certification.enrolment.buildCandidate({
-        userId: null,
-      });
-
-      // when
-      const isLinked = unlinkedCandidate.isLinkedToAUser();
-
-      // then
-      expect(isLinked).to.be.false;
-    });
-
-    it('should return true when candidate is linked', function () {
-      // given
-      const unlinkedCandidate = domainBuilder.certification.enrolment.buildCandidate({
-        userId: 123,
-      });
-
-      // when
-      const isLinked = unlinkedCandidate.isLinkedToAUser();
-
-      // then
-      expect(isLinked).to.be.true;
-    });
-  });
-
   context('isReconciledTo', function () {
     it('should return true when candidate is reconciled to given userId', function () {
       // given

--- a/api/tests/certification/enrolment/unit/domain/models/SessionEnrolment_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/SessionEnrolment_test.js
@@ -363,8 +363,8 @@ describe('Unit | Certification | Enrolment | Domain | Models | SessionEnrolment'
     });
   });
 
-  context('#hasLinkedCandidateTo', function () {
-    it('should return true when at least one candidate is linked to given user', function () {
+  context('#hasReconciledCandidateTo', function () {
+    it('should return true when at least one candidate is reconciled to given user', function () {
       // given
       const userId = 123;
       const session = domainBuilder.certification.enrolment.buildSession();
@@ -374,23 +374,25 @@ describe('Unit | Certification | Enrolment | Domain | Models | SessionEnrolment'
         }),
         domainBuilder.certification.enrolment.buildCandidate({
           userId: 123,
+          reconciledAt: new Date('2024-09-25'),
         }),
         domainBuilder.certification.enrolment.buildCandidate({
           userId: 456,
+          reconciledAt: new Date('2024-09-25'),
         }),
       ];
 
       // when
-      const hasLinkedCandidateTo = session.hasLinkedCandidateTo({
+      const hasReconciledCandidateTo = session.hasReconciledCandidateTo({
         candidates,
         userId,
       });
 
       // then
-      expect(hasLinkedCandidateTo).to.be.true;
+      expect(hasReconciledCandidateTo).to.be.true;
     });
 
-    it('should return false when no candidate is linked to user', function () {
+    it('should return false when no candidate is reconciled to user', function () {
       // given
       const userId = 123;
       const session = domainBuilder.certification.enrolment.buildSession();
@@ -404,13 +406,13 @@ describe('Unit | Certification | Enrolment | Domain | Models | SessionEnrolment'
       ];
 
       // when
-      const hasLinkedCandidateTo = session.hasLinkedCandidateTo({
+      const hasReconciledCandidateTo = session.hasReconciledCandidateTo({
         candidates,
         userId,
       });
 
       // then
-      expect(hasLinkedCandidateTo).to.be.false;
+      expect(hasReconciledCandidateTo).to.be.false;
     });
   });
 

--- a/api/tests/certification/enrolment/unit/domain/models/SessionEnrolment_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/SessionEnrolment_test.js
@@ -318,7 +318,7 @@ describe('Unit | Certification | Enrolment | Domain | Models | SessionEnrolment'
     });
   });
 
-  context('#hasLinkedCandidate', function () {
+  context('#hasReconciledCandidate', function () {
     it('should return true when at least one candidate is linked', function () {
       // given
       const session = domainBuilder.certification.enrolment.buildSession();
@@ -328,16 +328,17 @@ describe('Unit | Certification | Enrolment | Domain | Models | SessionEnrolment'
         }),
         domainBuilder.certification.enrolment.buildCandidate({
           userId: 123,
+          reconciledAt: new Date('2024-09-25'),
         }),
       ];
 
       // when
-      const hasLinkedCandidate = session.hasLinkedCandidate({
+      const hasReconciledCandidate = session.hasReconciledCandidate({
         candidates,
       });
 
       // then
-      expect(hasLinkedCandidate).to.be.true;
+      expect(hasReconciledCandidate).to.be.true;
     });
 
     it('should return false when no candidate is linked', function () {
@@ -353,12 +354,12 @@ describe('Unit | Certification | Enrolment | Domain | Models | SessionEnrolment'
       ];
 
       // when
-      const hasLinkedCandidate = session.hasLinkedCandidate({
+      const hasReconciledCandidate = session.hasReconciledCandidate({
         candidates,
       });
 
       // then
-      expect(hasLinkedCandidate).to.be.false;
+      expect(hasReconciledCandidate).to.be.false;
     });
   });
 

--- a/api/tests/certification/enrolment/unit/domain/services/register-candidate-participation-service_test.js
+++ b/api/tests/certification/enrolment/unit/domain/services/register-candidate-participation-service_test.js
@@ -23,9 +23,10 @@ describe('Unit | Application | Service | register-candidate-participation', func
   context('when the candidate is already link to a user', function () {
     it('should not link the candidate to the given user', async function () {
       // given
-      const alreadyLinkedCandidate = domainBuilder.certification.enrolment.buildEnrolledCandidate({
+      const alreadyLinkedCandidate = domainBuilder.certification.enrolment.buildCandidate({
         ...candidateData,
         userId,
+        reconciledAt: new Date('2024-09-25'),
       });
       sinon.stub(usecases, 'verifyCandidateIdentity').returns(alreadyLinkedCandidate);
 
@@ -52,7 +53,7 @@ describe('Unit | Application | Service | register-candidate-participation', func
   context('when the candidate is not yet linked to a user', function () {
     it('should link the candidate to the given user', async function () {
       // given
-      const unlinkedCandidate = domainBuilder.certification.enrolment.buildEnrolledCandidate({
+      const unlinkedCandidate = domainBuilder.certification.enrolment.buildCandidate({
         ...candidateData,
         userId: null,
       });

--- a/api/tests/certification/enrolment/unit/domain/services/register-candidate-participation-service_test.js
+++ b/api/tests/certification/enrolment/unit/domain/services/register-candidate-participation-service_test.js
@@ -56,6 +56,7 @@ describe('Unit | Application | Service | register-candidate-participation', func
       const unlinkedCandidate = domainBuilder.certification.enrolment.buildCandidate({
         ...candidateData,
         userId: null,
+        reconciledAt: null,
       });
       sinon.stub(usecases, 'verifyCandidateIdentity').returns(unlinkedCandidate);
 

--- a/api/tests/certification/enrolment/unit/domain/usecases/import-certification-candidates-from-candidates-import-sheet_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/import-certification-candidates-from-candidates-import-sheet_test.js
@@ -50,7 +50,9 @@ describe('Unit | UseCase | import-certification-candidates-from-attendance-sheet
 
         candidateRepository.findBySessionId
           .withArgs({ sessionId })
-          .resolves([domainBuilder.certification.enrolment.buildCandidate({ userId: 123 })]);
+          .resolves([
+            domainBuilder.certification.enrolment.buildCandidate({ userId: 123, reconciledAt: new Date('2024-09-25') }),
+          ]);
         sessionRepository.get.withArgs({ id: sessionId }).resolves(session);
 
         // when

--- a/api/tests/certification/enrolment/unit/domain/usecases/update-enrolled-candidate_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/update-enrolled-candidate_test.js
@@ -65,13 +65,14 @@ describe('Unit | UseCase | update-enrolled-candidate', function () {
     });
   });
 
-  context('when the candidate is linked to a user', function () {
+  context('when the candidate is reconciled', function () {
     it('should call update method with correct data', async function () {
       // given
       const foundCandidate = domainBuilder.certification.enrolment.buildCandidate({
         id: editedCandidate.id,
         accessibilityAdjustmentNeeded: false,
         userId: 123,
+        reconciledAt: new Date('2024-09-25'),
       });
       candidateRepository.get.withArgs({ certificationCandidateId: editedCandidate.id }).resolves(foundCandidate);
 

--- a/api/tests/certification/enrolment/unit/domain/usecases/verify-candidate-identity_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/verify-candidate-identity_test.js
@@ -221,7 +221,7 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | verify-candidate
   });
 
   context('when there are one matching candidate in session with provided personal info', function () {
-    context('when matching candidate is already linked to another user', function () {
+    context('when matching candidate is already reconciled to another user', function () {
       it('should throw a UnexpectedUserAccountError', async function () {
         // given
         userRepository.get.withArgs({ id: userId }).resolves(
@@ -248,6 +248,7 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | verify-candidate
           firstName,
           lastName,
           userId: userId + 10,
+          reconciledAt: new Date('2024-09-25'),
           birthdate,
           subscriptions: [domainBuilder.certification.enrolment.buildCoreSubscription()],
         });
@@ -272,8 +273,8 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | verify-candidate
       });
     });
 
-    context('when matching candidate is already linked given user', function () {
-      it('should return a succes indicating no linkage done', async function () {
+    context('when matching candidate is already reconciled to given user', function () {
+      it('should return a succes indicating no reconciliation done', async function () {
         // given
         userRepository.get.withArgs({ id: userId }).resolves(
           domainBuilder.certification.enrolment.buildUser({
@@ -299,6 +300,7 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | verify-candidate
           firstName,
           lastName,
           userId,
+          reconciledAt: new Date('2024-09-25'),
           birthdate,
           subscriptions: [domainBuilder.certification.enrolment.buildCoreSubscription()],
         });

--- a/api/tests/certification/enrolment/unit/domain/usecases/verify-candidate-identity_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/verify-candidate-identity_test.js
@@ -325,7 +325,7 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | verify-candidate
       });
     });
 
-    context('when user is already linked to another matching candidate within the same session', function () {
+    context('when user is already reconciled to another matching candidate within the same session', function () {
       it('should throw a UserAlreadyLinkedToCandidateInSessionError', async function () {
         // given
         userRepository.get.withArgs({ id: userId }).resolves(
@@ -352,6 +352,7 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | verify-candidate
           firstName: 'Louis',
           lastName: 'Michel',
           userId,
+          reconciledAt: new Date('2024-09-25'),
           birthdate: '2005-05-01',
           subscriptions: [domainBuilder.certification.enrolment.buildCoreSubscription()],
         });
@@ -380,7 +381,7 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | verify-candidate
       });
     });
 
-    context('when linkage is non-existent on all sides', function () {
+    context('when reconciliation is non-existent on all sides', function () {
       context('when it is a session sco / is managing students', function () {
         context('when matching candidate is not related to a reconcilied learner', function () {
           it('should throw a MatchingReconciledStudentNotFoundError', async function () {

--- a/api/tests/certification/session-management/unit/domain/usecases/delete-unlinked-certification-candidate_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/delete-unlinked-certification-candidate_test.js
@@ -51,11 +51,13 @@ describe('Unit | UseCase | delete-unlinked-certification-candidate', function ()
     });
   });
 
-  context('When the certification candidate is linked to a user ', function () {
+  context('When the certification candidate is reconciled', function () {
     beforeEach(function () {
       candidateRepository.get
         .withArgs({ certificationCandidateId: candidateId })
-        .resolves(domainBuilder.certification.enrolment.buildCandidate({ userId: 123 }));
+        .resolves(
+          domainBuilder.certification.enrolment.buildCandidate({ userId: 123, reconciledAt: new Date('2024-09-25') }),
+        );
     });
 
     it('should throw a forbidden deletion error', async function () {

--- a/api/tests/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -208,7 +208,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
       });
     });
 
-    context('When the external user is already linked to another account', function () {
+    context('When the external user is already reconciled to another account', function () {
       context('without samlId authentication method', function () {
         it('throws an OrganizationLearnerAlreadyLinkedToUserError', async function () {
           // given


### PR DESCRIPTION
## :unicorn: Problème

Maintenant que l’on a une date de reconciliation, cela devient un discriminant, car 

- Avant : on pouvait etre reconcilier sans avoir de certification-course, on avait pas besoin de figer dans le temps le “placement“ a l’entree en session
- Desormais : on fige le placement, le candidat peut faire autant de reset ou autre qu’il souhaite, c’est la date de reconcialiation qui permet de savoir son placement au moment de son entree en session

Il faut donc que la reconcialiation depende aussi de la presence d’une date de reconcialiation afin de remplacer l’ancienne version ou on attendait un certif-course (donc + tard dans le processus)

On ne doit plus permettre d’avoir un candidat juge comme “reconcilie“ sans date de reconcialiation, cela est devenu un non-sens technique

## :robot: Proposition

Le code de reconcialiation doit evaluer si il y a une date de reconcialiation

- si oui : RAS
- si non, il faut refaire la reconciliation, on ne doit plus permettre de novueaux cas (ou meme une entree en session d’un ancien cas) ou on a un candidat reconcilie sans date

## :rainbow: Remarques

## :100: Pour tester

Plusieurs cas a tester 
* Reussir un import de session en masse
  * Tester en particulier le cas d'erreur ou on essaye d'ajouter un candidat deja present
* Tester une reconciliation, pas d'erreur 
* Tester un affichage des instructions de certif en V3, pas d'erreur 

