### PR TITLE
[TECH] Remplit la colonne `reconciledAt` pour les anciennes certifications (PIX-14403).

### DIFF
--- a/api/db/migrations/20240924091540_add-reconciliation-date-to-former-candidates.js
+++ b/api/db/migrations/20240924091540_add-reconciliation-date-to-former-candidates.js
@@ -1,0 +1,45 @@
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
+
+const TABLE_NAME = 'certification-candidates';
+
+const up = async function (knex) {
+  let numberOfBatchProcessed = 0;
+  const CHUNK_SIZE = 250000;
+
+  let hasNext = false;
+  do {
+    const updates = await knex.raw(
+      `
+update "certification-candidates"
+set "reconciledAt" = "subquery"."reconciledAt"
+from (select
+  "certification-candidates"."id" as "id",
+  "certification-courses"."createdAt" as "reconciledAt"
+  from "certification-candidates"
+  left join "certification-courses" on "certification-courses"."userId" = "certification-candidates"."userId"
+  and "certification-courses"."sessionId" = "certification-candidates"."sessionId"
+  where "certification-candidates"."userId" is not null
+  and "certification-candidates"."reconciledAt" is null
+  limit ?) as "subquery"
+ where "certification-candidates"."id" = "subquery"."id"
+ returning "certification-candidates"."id", "certification-candidates"."reconciledAt";`,
+      [CHUNK_SIZE],
+    );
+
+    hasNext = updates.rowCount === CHUNK_SIZE;
+    ++numberOfBatchProcessed;
+    logger.info(
+      `${TABLE_NAME}: Batch number ${numberOfBatchProcessed} : ${updates.rowCount} items updated. hasNext = ${hasNext}`,
+    );
+  } while (hasNext);
+};
+
+const down = async function (knex) {
+  return knex(TABLE_NAME).update('reconciledAt', null);
+};
+
+// We UPDATE in batch of CHUNK_SIZE, hence not needing a transaction for this migration
+// @see: https://knexjs.org/guide/migrations.html#migration-api
+const config = { transaction: false };
+
+export { config, down, up };


### PR DESCRIPTION
## :unicorn: Problème

Maintenant que l’on enregistre et utilise la date de reconciliation, il y a un rattrapage à faire sur les données précédentes.

## :robot: Proposition

Ajout d'une migration.

Si le userId est rempli dans certification-candidates, alors cette migration remplit la colonne `reconciledAt` de certification-candidates qui ont créé un certification-course (`certification-courses.createdAt is not null`)

## :rainbow: Remarques

Cette migration est faite via un `knex.raw()` parce qu'on a perdu pas mal de temps à se battre sur les bindings knex.

> [!WARNING]  
> Une fonction down a été ajoutée car les seeds étant joués après les migrations, il nous faut pouvoir rollback cette migration et la rejouer afin d'éxecuter la requête sur les données inscrites à posteriori des migrations initiales.

## :100: Pour tester

Lancer la migration sur les seeds et vérifier via la requête suivante que :

- Seuls les `certification-candidates` ayant un `userId` et un `sessionId` non nuls aient une  date `reconciledAt`  non nulle.
- La date `reconciledAt` correspond au `createdAt` du certification-course du candidat

```SQL
select 
cc.id,
cc."userId",
cc."sessionId",
cc."reconciledAt",
cco."createdAt"
from "certification-candidates" cc
left join "certification-courses" cco on cc."userId" = cco."userId"
and cco."sessionId" = cc."sessionId";
```

Le résultat devrait être équivalent à : 

<img width="729" alt="Capture d’écran 2024-09-25 à 15 16 50" src="https://github.com/user-attachments/assets/07622c9c-a729-440c-99ce-ccd0cb9785b8">
