### PR TITLE
[FEATURE] Ajouter des titres explicites aux éléments de tableaux lors de l'export du schema Modulix (PIX-14544)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
@@ -10,7 +10,7 @@ export function convertJoiToJsonSchema(joiSchema) {
   return convertFromType(joiSchema.describe());
 }
 
-function convertFromType(joiDescribedSchema) {
+function convertFromType(joiDescribedSchema, key = '') {
   switch (joiDescribedSchema.type) {
     case 'boolean':
       return convertBoolean();
@@ -19,7 +19,7 @@ function convertFromType(joiDescribedSchema) {
     case 'number':
       return convertNumber(joiDescribedSchema);
     case 'array':
-      return convertArray(joiDescribedSchema);
+      return convertArray(joiDescribedSchema, key);
     case 'object':
       return convertObject(joiDescribedSchema);
     case 'alternatives':
@@ -125,7 +125,7 @@ function convertNumber(joiNumberDescribedSchema) {
   return jsonSchema;
 }
 
-function convertArray(joiArrayDescribedSchema) {
+function convertArray(joiArrayDescribedSchema, key = '') {
   const jsonSchema = { type: 'array' };
   const rules = joiArrayDescribedSchema.rules;
 
@@ -142,8 +142,13 @@ function convertArray(joiArrayDescribedSchema) {
   if (joiArrayDescribedSchema.items) {
     jsonSchema.items = {};
 
+    const itemTitle = key.endsWith('s') ? key.slice(0, -1) : key;
+
     for (const item of joiArrayDescribedSchema.items) {
       jsonSchema.items = convertFromType(item);
+      if (itemTitle) {
+        jsonSchema.items.title = itemTitle;
+      }
     }
   }
 
@@ -158,7 +163,7 @@ function convertObject(joiObjectDescribedSchema) {
     const required = [];
 
     for (const [key, value] of Object.entries(joiObjectDescribedSchema.keys)) {
-      properties[key] = convertFromType(value);
+      properties[key] = convertFromType(value, key);
 
       if (hasFlag(value?.flags, 'presence', 'required')) {
         required.push(key);

--- a/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
@@ -279,15 +279,15 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
 
     it('should convert Joi.object with nested Joi.array to nested JSON Schema', function () {
       const joiSchema = Joi.object({
-        addresses: Joi.array().items(Joi.string()),
+        proposals: Joi.array().items(Joi.string()),
       });
       const jsonSchema = convertJoiToJsonSchema(joiSchema);
       expect(jsonSchema).to.deep.equal({
         type: 'object',
         properties: {
-          addresses: {
+          proposals: {
             type: 'array',
-            items: { type: 'string' },
+            items: { title: 'proposal', type: 'string' },
           },
         },
         additionalProperties: false,


### PR DESCRIPTION
## :unicorn: Problème

Lorsque le schema modulix est exporté, les éléments d'un tableau ne sont pas nommés. En conséquence, dans Modulix editor, les éléments se nomment tous "item" ce qui peut rendre l'utilisation des ces éléments difficiles.

<img width="465" alt="Capture d’écran 2024-09-27 à 14 04 09" src="https://github.com/user-attachments/assets/f28cf45b-8376-44c2-a44c-c83cab74950f">

## :robot: Proposition

Utiliser la clé de la propriété qui porte le tableau pour définir le titre des éléments en retirant le "s" final. Par exemple, pour les éléments du tableau "proposals", on utilisera le titre "proposal".

<img width="627" alt="Capture d’écran 2024-09-27 à 12 11 57" src="https://github.com/user-attachments/assets/5f67e548-6eb7-4a9e-b521-836e3822a861">

## :rainbow: Remarques

- Il n'y a rien dans la doc qui décrivent explicitement comment modifier le titre d'un élément de tableau, mais on peut voir [dans le code de json-editor](https://github.com/json-editor/json-editor/blob/fca21fcc246f6846d55ffcf24b746eef642f422f/src/editors/array.js#L169) que "item" est une valeur par défaut qui peut être surchargée.
- [Modulix Editor](https://1024pix.github.io/modulix-editor/) a été mis à avec un schema généré par le code de cette PR.

## :100: Pour tester

1. Générer le schema modulix.

```shell
node ./api/scripts/modulix/convert-joi-schema-to-json-schema.js
```

2. Constater que les schema de type `array` ont tous une propriété `items.title`.