### PR TITLE
[TECH] Retirer les logs de débug de l'import SIECLE (PIX-14529)

### DIFF
--- a/api/src/prescription/learner-management/domain/usecases/add-or-update-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/add-or-update-organization-learners.js
@@ -4,7 +4,6 @@ import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTrans
 import { ORGANIZATION_LEARNER_CHUNK_SIZE } from '../../../../shared/infrastructure/constants.js';
 import { SiecleParser } from '../../infrastructure/serializers/xml/siecle-parser.js';
 import { SiecleFileStreamer } from '../../infrastructure/utils/xml/siecle-file-streamer.js';
-import { loggerForImport } from '../../utils/loggerForImport.js';
 
 const { chunk } = lodash;
 
@@ -20,32 +19,23 @@ async function addOrUpdateOrganizationLearners({
   const organizationImport = await organizationImportRepository.get(organizationImportId);
 
   return DomainTransaction.execute(async () => {
-    loggerForImport('IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Debut du usecase');
     try {
       const readableStream = await importStorage.readFile({ filename: organizationImport.filename });
-      loggerForImport('IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Apres readableStream');
 
       const siecleFileStreamer = await SiecleFileStreamer.create(readableStream, organizationImport.encoding);
-      loggerForImport('IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Apres le siecleFileStreamer');
 
       const parser = SiecleParser.create(siecleFileStreamer);
-      loggerForImport('IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Aprés le parser');
 
       const organizationLearnerData = await parser.parse();
-      loggerForImport('IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Recuperation des OL datas');
 
       const organizationLearnersChunks = chunk(organizationLearnerData, chunkSize);
 
       const nationalStudentIdData = organizationLearnerData.map((learner) => learner.nationalStudentId);
-      loggerForImport('IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Recuperation des nationalStudentId');
 
       await organizationLearnerRepository.disableAllOrganizationLearnersInOrganization({
         organizationId: organizationImport.organizationId,
         nationalStudentIds: nationalStudentIdData,
       });
-      loggerForImport(
-        'IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Aprés la methode disableAllOrganizationLearnersInOrganization',
-      );
 
       for (const chunk of organizationLearnersChunks) {
         await organizationLearnerRepository.addOrUpdateOrganizationOfOrganizationLearners(
@@ -53,25 +43,17 @@ async function addOrUpdateOrganizationLearners({
           organizationImport.organizationId,
         );
       }
-      loggerForImport(
-        'IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Aprés la methode addOrUpdateOrganizationOfOrganizationLearners',
-      );
     } catch (error) {
       errors.push(error);
       throw error;
     } finally {
-      loggerForImport('IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Debut du finally');
-
       organizationImport.process({ errors });
       await organizationImportRepository.save(organizationImport);
-      loggerForImport("IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Aprés le save de l'organizationImport");
       try {
         await importStorage.deleteFile({ filename: organizationImport.filename });
       } catch (error) {
         logger.error(error);
       }
-
-      loggerForImport('IMPORT_LOG -> <<addOrUpdateOrganizationLearners>> Fin du usecase');
     }
   });
 }

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
@@ -11,7 +11,6 @@ import { OrganizationLearner } from '../../../../shared/domain/models/index.js';
 import { ApplicationTransaction } from '../../../shared/infrastructure/ApplicationTransaction.js';
 import { CommonOrganizationLearner } from '../../domain/models/CommonOrganizationLearner.js';
 import { OrganizationLearnerForAdmin } from '../../domain/read-models/OrganizationLearnerForAdmin.js';
-import { loggerForImport } from '../../utils/loggerForImport.js';
 
 const dissociateUserFromOrganizationLearner = async function (organizationLearnerId) {
   const knexConn = DomainTransaction.getConnection();
@@ -65,19 +64,14 @@ const removeByIds = function ({ organizationLearnerIds, userId }) {
 };
 
 const disableAllOrganizationLearnersInOrganization = async function ({ organizationId, nationalStudentIds }) {
-  loggerForImport('IMPORT_LOG -> <<disableAllOrganizationLearnersInOrganization>> Debut de la méthode');
-
   const knexConn = DomainTransaction.getConnection();
   await knexConn('organization-learners')
     .where({ organizationId, isDisabled: false })
     .whereNotIn('nationalStudentId', nationalStudentIds)
     .update({ isDisabled: true, updatedAt: knexConn.raw('CURRENT_TIMESTAMP') });
-  loggerForImport('IMPORT_LOG -> <<disableAllOrganizationLearnersInOrganization>> Fin de la méthode');
 };
 
 const addOrUpdateOrganizationOfOrganizationLearners = async function (organizationLearnerDatas, organizationId) {
-  loggerForImport('IMPORT_LOG -> <<addOrUpdateOrganizationOfOrganizationLearners>> Debut de la methode');
-
   const knexConn = DomainTransaction.getConnection();
   const organizationLearnersFromFile = organizationLearnerDatas.map(
     (organizationLearnerData) =>
@@ -87,34 +81,26 @@ const addOrUpdateOrganizationOfOrganizationLearners = async function (organizati
       }),
   );
   const existingOrganizationLearners = await organizationLearnerRepository.findByOrganizationId({ organizationId });
-  loggerForImport(
-    'IMPORT_LOG -> <<addOrUpdateOrganizationOfOrganizationLearners>> Apres la recuperation des learners existants',
-  );
+
   const reconciledOrganizationLearnersToImport = await organizationLearnerRepository._reconcileOrganizationLearners(
     organizationLearnersFromFile,
     existingOrganizationLearners,
   );
-  loggerForImport(
-    'IMPORT_LOG -> <<addOrUpdateOrganizationOfOrganizationLearners>> Apres la recuperation des reconciledOrganizationLearnersToImport',
-  );
+
   try {
     const organizationLearnersToSave = reconciledOrganizationLearnersToImport.map((organizationLearner) => ({
       ..._.omit(organizationLearner, ['id', 'createdAt', 'isCertifiable', 'certifiableAt']),
       updatedAt: knexConn.raw('CURRENT_TIMESTAMP'),
       isDisabled: false,
     }));
-    loggerForImport(
-      'IMPORT_LOG -> <<addOrUpdateOrganizationOfOrganizationLearners>> Apres la recuperation des organizationLearnersToSave',
-    );
+
     await knexConn('organization-learners')
       .insert(organizationLearnersToSave)
       .onConflict(['organizationId', 'nationalStudentId'])
       .merge();
-    loggerForImport('IMPORT_LOG -> <<addOrUpdateOrganizationOfOrganizationLearners>> Apres linsertion en bdd');
   } catch (err) {
     throw new OrganizationLearnersCouldNotBeSavedError();
   }
-  loggerForImport('IMPORT_LOG -> <<addOrUpdateOrganizationOfOrganizationLearners>> Fin de la méthode');
 };
 
 const saveCommonOrganizationLearners = function (learners) {

--- a/api/src/prescription/learner-management/utils/loggerForImport.js
+++ b/api/src/prescription/learner-management/utils/loggerForImport.js
@@ -1,8 +1,0 @@
-import { config } from '../../../shared/config.js';
-import { logger } from '../../../shared/infrastructure/utils/logger.js';
-
-export const loggerForImport = (message) => {
-  if (config.import.logEnabled) {
-    logger.info(message);
-  }
-};

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -61,7 +61,6 @@ const configuration = (function () {
           forcePathStyle: true,
         },
       },
-      logEnabled: toBoolean(process.env.DEBUG_IMPORT_LOG),
     },
     account: {
       passwordValidationPattern: '^(?=.*\\p{Lu})(?=.*\\p{Ll})(?=.*\\d).{8,}$',


### PR DESCRIPTION
## :unicorn: Problème
Nous avions ajouté des logs pour nous aider à débugger l'import SIECLE.
Voir cette PR : https://github.com/1024pix/pix/pull/9989

## :robot: Proposition
Retirer tout ce qui a été fait dans la PR précédente.

## :rainbow: Remarques
La variable d'env DEBUG_IMPORT_LOG a été supprimée de la production par les Captains.

## :100: Pour tester
- ajouter sur la RA la variable d'env ci-dessus à true
- redémarrer le container
- faire un import SIECLE
- vérifier sur Scalingo qu'il n'y a plus de logs
