### PR TITLE
[FEATURE] Filtre sur les résultats dans le détail d'une mission sur Pix Orga (PIX-13377)

### DIFF
--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
@@ -85,12 +85,14 @@ async function findPaginatedLearners({ organizationId, page, filter }) {
 
   if (filter) {
     const { name, ...attributesToFilter } = filter;
-    Object.entries(attributesToFilter).forEach(([name, values]) => {
-      query.andWhere(function () {
-        // eslint-disable-next-line knex/avoid-injections
-        this.whereRaw(`attributes->>'${name}' in ( ${values.map((_) => '?').join(' , ')} )`, values);
+    Object.entries(attributesToFilter)
+      .filter(([_, values]) => values !== undefined)
+      .forEach(([name, values]) => {
+        query.andWhere(function () {
+          // eslint-disable-next-line knex/avoid-injections
+          this.whereRaw(`attributes->>'${name}' in ( ${values.map((_) => '?').join(' , ')} )`, values);
+        });
       });
-    });
     if (name) {
       filterByFullName(query, name, 'firstName', 'lastName');
     }

--- a/api/src/school/application/mission-learner-controller.js
+++ b/api/src/school/application/mission-learner-controller.js
@@ -7,6 +7,10 @@ const findPaginatedMissionLearners = async function (request) {
   if (filter.divisions && !Array.isArray(filter.divisions)) {
     filter.divisions = [filter.divisions];
   }
+
+  if (filter.results && !Array.isArray(filter.results)) {
+    filter.results = [filter.results];
+  }
   const result = await usecases.findPaginatedMissionLearners({ organizationId, missionId, page, filter });
   return missionLearnerSerializer.serialize(result);
 };

--- a/api/src/school/application/mission-learner-route.js
+++ b/api/src/school/application/mission-learner-route.js
@@ -21,8 +21,8 @@ const register = async function (server) {
           }),
           query: Joi.object({
             page: {
-              number: Joi.number().integer().empty(''),
-              size: Joi.number().integer().empty(''),
+              number: Joi.number().integer().empty('').required(),
+              size: Joi.number().integer().empty('').required(),
             },
             filter: Joi.object({
               divisions: [Joi.string(), Joi.array().items(Joi.string())],

--- a/api/src/school/application/mission-learner-route.js
+++ b/api/src/school/application/mission-learner-route.js
@@ -26,6 +26,7 @@ const register = async function (server) {
             },
             filter: Joi.object({
               divisions: [Joi.string(), Joi.array().items(Joi.string())],
+              results: [Joi.string(), Joi.array().items(Joi.string())],
               name: Joi.string().empty(''),
             }).default({}),
           }),

--- a/api/src/school/application/mission-learner-route.js
+++ b/api/src/school/application/mission-learner-route.js
@@ -21,7 +21,7 @@ const register = async function (server) {
           }),
           query: Joi.object({
             page: {
-              number: Joi.number().integer().empty('').required(),
+              number: Joi.number().integer().empty(''),
               size: Joi.number().integer().empty('').required(),
             },
             filter: Joi.object({

--- a/api/src/school/domain/usecases/find-paginated-mission-learners.js
+++ b/api/src/school/domain/usecases/find-paginated-mission-learners.js
@@ -6,9 +6,8 @@ const findPaginatedMissionLearners = async function ({
   page,
   filter,
 } = {}) {
-  const { pagination, missionLearners } = await missionLearnerRepository.findPaginatedMissionLearners({
+  const { missionLearners } = await missionLearnerRepository.findMissionLearners({
     organizationId,
-    page,
     filter,
   });
 
@@ -17,7 +16,27 @@ const findPaginatedMissionLearners = async function ({
     missionLearners,
   );
 
-  return { pagination, missionLearners: missionLearnersWithStatus };
+  // faire le filtre sur le resultat
+
+  return _paginateMissionLearner(missionLearnersWithStatus, page);
 };
 
 export { findPaginatedMissionLearners };
+
+function _paginateMissionLearner(missionLearners, page) {
+  const rowCount = missionLearners.length;
+  const firstLearnerIndex = (page.number - 1) * page.size;
+  const lastLearnerIndex = page.number * page.size - 1 + page.size;
+  const missionLearnersPaginated = missionLearners.slice(firstLearnerIndex, lastLearnerIndex);
+  const pageCount = Math.ceil(missionLearners.length / page.size);
+
+  return {
+    pagination: {
+      page: page.number,
+      pageCount,
+      pageSize: page.size,
+      rowCount,
+    },
+    missionLearners: missionLearnersPaginated,
+  };
+}

--- a/api/src/school/infrastructure/repositories/mission-learner-repository.js
+++ b/api/src/school/infrastructure/repositories/mission-learner-repository.js
@@ -1,10 +1,10 @@
 import { SchoolLearner } from '../../domain/models/SchoolLearner.js';
 
-const findPaginatedMissionLearners = async function ({ organizationId, page, filter, organizationLearnerApi }) {
-  const { organizationLearners, pagination } = await organizationLearnerApi.find({ organizationId, page, filter });
+const findMissionLearners = async function ({ organizationId, filter, organizationLearnerApi }) {
+  const { organizationLearners } = await organizationLearnerApi.find({ organizationId, filter });
 
   const missionLearners = organizationLearners.map((missionLearner) => new SchoolLearner({ ...missionLearner }));
-  return { missionLearners, pagination };
+  return { missionLearners };
 };
 
-export { findPaginatedMissionLearners };
+export { findMissionLearners };

--- a/api/tests/school/integration/application/mission-learner-controller_test.js
+++ b/api/tests/school/integration/application/mission-learner-controller_test.js
@@ -4,7 +4,7 @@ import { usecases } from '../../../../src/school/domain/usecases/index.js';
 import { expect, hFake, sinon } from '../../../test-helper.js';
 
 describe('Integration | Controller | mission-learner-controller', function () {
-  describe('#findPaginatedMissionLearners', function () {
+  describe('#findMissionLearners', function () {
     it('should return missionLearners', async function () {
       const organizationId = 1;
       const missionId = 1;
@@ -37,6 +37,7 @@ describe('Integration | Controller | mission-learner-controller', function () {
             page: { size: 50, number: 1 },
             filter: {
               divisions: 'CP',
+              results: 'reached',
               name: 'Léa',
             },
           },
@@ -63,7 +64,7 @@ describe('Integration | Controller | mission-learner-controller', function () {
         organizationId,
         missionId,
         page: { size: 50, number: 1 },
-        filter: { divisions: ['CP'], name: 'Léa' },
+        filter: { divisions: ['CP'], results: ['reached'], name: 'Léa' },
       });
     });
 

--- a/api/tests/school/integration/domain/usecases/find-paginated-mission-learners_test.js
+++ b/api/tests/school/integration/domain/usecases/find-paginated-mission-learners_test.js
@@ -5,7 +5,7 @@ import { Assessment } from '../../../../../src/shared/domain/models/index.js';
 import { databaseBuilder, expect } from '../../../../test-helper.js';
 
 describe('Integration | Usecase | find-paginated-mission-learners', function () {
-  describe('#findPaginatedMissionLearners', function () {
+  describe('#findMissionLearners', function () {
     it('should return mission learners with mission progress status', async function () {
       const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO-1D' });
 
@@ -55,10 +55,8 @@ describe('Integration | Usecase | find-paginated-mission-learners', function () 
       await databaseBuilder.commit();
 
       const page = {
-        page: 1,
-        pageCount: 1,
-        pageSize: 50,
-        rowCount: 1,
+        number: 1,
+        size: 50,
       };
       const result = await usecases.findPaginatedMissionLearners({
         organizationId: organization.id,
@@ -91,7 +89,83 @@ describe('Integration | Usecase | find-paginated-mission-learners', function () 
         pagination: {
           page: 1,
           pageCount: 1,
-          pageSize: 10,
+          pageSize: 50,
+          rowCount: 3,
+        },
+      });
+    });
+
+    it('should return mission learners paginated', async function () {
+      const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO-1D' });
+
+      databaseBuilder.factory.prescription.organizationLearners.buildOndeOrganizationLearner({
+        organizationId: organization.id,
+      });
+      const organizationLearnerWithStartedAssessment =
+        databaseBuilder.factory.prescription.organizationLearners.buildOndeOrganizationLearner({
+          organizationId: organization.id,
+        });
+      const organizationLearnerWithCompletedAssessment =
+        databaseBuilder.factory.prescription.organizationLearners.buildOndeOrganizationLearner({
+          organizationId: organization.id,
+        });
+
+      const startedAssessment = databaseBuilder.factory.buildPix1dAssessment({
+        state: Assessment.states.STARTED,
+      });
+      const completedAssessment = databaseBuilder.factory.buildPix1dAssessment({
+        state: Assessment.states.COMPLETED,
+      });
+
+      const missionId = 1;
+      databaseBuilder.factory.buildMissionAssessment({
+        missionId,
+        organizationLearnerId: organizationLearnerWithStartedAssessment.id,
+        assessmentId: startedAssessment.id,
+      });
+      databaseBuilder.factory.buildMissionAssessment({
+        missionId,
+        organizationLearnerId: organizationLearnerWithCompletedAssessment.id,
+        assessmentId: completedAssessment.id,
+        result: { global: 'reached', steps: ['reached'], dare: 'not-reached' },
+      });
+      databaseBuilder.factory.buildActivity({
+        assessmentId: completedAssessment.id,
+        level: Activity.levels.VALIDATION,
+        status: Activity.status.SUCCEEDED,
+        stepIndex: 0,
+      });
+      databaseBuilder.factory.buildActivity({
+        assessmentId: completedAssessment.id,
+        level: Activity.levels.CHALLENGE,
+        status: Activity.status.SKIPPED,
+      });
+      await databaseBuilder.commit();
+
+      const page = {
+        number: 2,
+        size: 1,
+      };
+      const result = await usecases.findPaginatedMissionLearners({
+        organizationId: organization.id,
+        missionId,
+        page,
+        filter: { divisions: ['CM2A'] },
+      });
+
+      expect(result).to.deep.equal({
+        missionLearners: [
+          new MissionLearner({
+            ...organizationLearnerWithStartedAssessment,
+            division: 'CM2A',
+            missionStatus: 'started',
+            result: null,
+          }),
+        ],
+        pagination: {
+          page: 2,
+          pageCount: 3,
+          pageSize: 1,
           rowCount: 3,
         },
       });

--- a/api/tests/school/unit/application/mission-learner-route_test.js
+++ b/api/tests/school/unit/application/mission-learner-route_test.js
@@ -33,7 +33,7 @@ describe('Unit | Route | mission-learner-route', function () {
       // when
       const response = await httpTestServer.request(
         'GET',
-        `/api/organizations/4/missions/1/learners?filter[name]=Henry&filter[divisions][]=CM2-C&filter[divisions][]=CM2-B&page[number]=1&page[size]=25`,
+        `/api/organizations/4/missions/1/learners?filter[name]=Henry&filter[divisions][]=CM2-C&filter[divisions][]=CM2-B&page[number]=1&page[size]=25&filter[results][]=exceeded`,
       );
 
       // then
@@ -41,7 +41,12 @@ describe('Unit | Route | mission-learner-route', function () {
       expect(findPaginatedMissionLearnersStub).to.have.been.calledWith(
         sinon.match.has(
           'query',
-          sinon.match.has('filter', sinon.match.has('divisions', ['CM2-C', 'CM2-B']), sinon.match.has('name', 'Henry')),
+          sinon.match.has(
+            'filter',
+            sinon.match.has('divisions', ['CM2-C', 'CM2-B']),
+            sinon.match.has('results', ['exceeded']),
+            sinon.match.has('name', 'Henry'),
+          ),
           sinon.match.has('page', sinon.match.has('number', '1'), sinon.match.has('size', '25')),
         ),
       );

--- a/api/tests/school/unit/infrastructure/repositories/mission-learner-repository_test.js
+++ b/api/tests/school/unit/infrastructure/repositories/mission-learner-repository_test.js
@@ -4,7 +4,7 @@ import { OrganizationLearner } from '../../../../../src/shared/domain/models/Org
 import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Repository | organizationLearner', function () {
-  describe('#findPaginatedMissionLearners', function () {
+  describe('#findMissionLearners', function () {
     it('should return missionLearners corresponding to the organizationId', async function () {
       const organizationId = 123456;
       const rawStudent = {
@@ -29,7 +29,7 @@ describe('Unit | Repository | organizationLearner', function () {
         .withArgs({ organizationId, page: customPagination, filter: divisionFilter })
         .resolves({ organizationLearners: [new OrganizationLearner(rawStudent)], pagination: expectedPagination });
 
-      const { missionLearners, pagination } = await missionLearnersRepository.findPaginatedMissionLearners({
+      const { missionLearners, pagination } = await missionLearnersRepository.findMissionLearners({
         organizationId,
         page: customPagination,
         filter: divisionFilter,

--- a/api/tests/school/unit/infrastructure/repositories/mission-learner-repository_test.js
+++ b/api/tests/school/unit/infrastructure/repositories/mission-learner-repository_test.js
@@ -14,7 +14,6 @@ describe('Unit | Repository | organizationLearner', function () {
         division: '4ème',
         organizationId: 23456,
       };
-      const customPagination = { number: 1, size: 100 };
       const organizationLearnerApiStub = { find: sinon.stub() };
       const expectedMissionLearner = new SchoolLearner(rawStudent);
       const expectedPagination = {
@@ -26,18 +25,16 @@ describe('Unit | Repository | organizationLearner', function () {
       const divisionFilter = { divisions: ['4ème'] };
 
       organizationLearnerApiStub.find
-        .withArgs({ organizationId, page: customPagination, filter: divisionFilter })
+        .withArgs({ organizationId, filter: divisionFilter })
         .resolves({ organizationLearners: [new OrganizationLearner(rawStudent)], pagination: expectedPagination });
 
-      const { missionLearners, pagination } = await missionLearnersRepository.findMissionLearners({
+      const { missionLearners } = await missionLearnersRepository.findMissionLearners({
         organizationId,
-        page: customPagination,
         filter: divisionFilter,
         organizationLearnerApi: organizationLearnerApiStub,
       });
 
       expect(missionLearners).to.deep.equal([expectedMissionLearner]);
-      expect(pagination).to.deep.equal(expectedPagination);
     });
   });
 });

--- a/orga/app/components/mission/result-table.gjs
+++ b/orga/app/components/mission/result-table.gjs
@@ -1,7 +1,7 @@
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip.js';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
-import { t } from 'ember-intl';
+import {t} from 'ember-intl';
 
 import Header from '../table/header';
 import PaginationControl from '../table/pagination-control';
@@ -40,12 +40,12 @@ function getMissionResultColor(result) {
             <Header scope="col">{{t "pages.missions.mission.table.result.headers.division"}}</Header>
             {{#each @mission.content.steps as |step index|}}
               <Header scope="col">
-                <div class="result-header-cell">
+                <div class="mission-result-table__header-cell">
                   {{t "pages.missions.mission.table.result.headers.step" (indexNumber index)}}
 
                   <PixTooltip @id="tooltip-{{index}}" @isInline={{true}}>
                     <:triggerElement>
-                      <FaIcon @icon="circle-info" class="form__field-info-icon" aria-describedby="tooltip-{{index}}" />
+                      <FaIcon @icon="circle-info" class="mission-result-table__info-icon" aria-describedby="tooltip-{{index}}" />
                     </:triggerElement>
 
                     <:tooltip>

--- a/orga/app/components/mission/result-table.gjs
+++ b/orga/app/components/mission/result-table.gjs
@@ -1,7 +1,7 @@
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip.js';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
-import {t} from 'ember-intl';
+import { t } from 'ember-intl';
 
 import Header from '../table/header';
 import PaginationControl from '../table/pagination-control';
@@ -45,7 +45,11 @@ function getMissionResultColor(result) {
 
                   <PixTooltip @id="tooltip-{{index}}" @isInline={{true}}>
                     <:triggerElement>
-                      <FaIcon @icon="circle-info" class="mission-result-table__info-icon" aria-describedby="tooltip-{{index}}" />
+                      <FaIcon
+                        @icon="circle-info"
+                        class="mission-result-table__info-icon"
+                        aria-describedby="tooltip-{{index}}"
+                      />
                     </:triggerElement>
 
                     <:tooltip>

--- a/orga/app/controllers/authenticated/missions/mission/results.js
+++ b/orga/app/controllers/authenticated/missions/mission/results.js
@@ -7,14 +7,28 @@ const DEFAULT_PAGE_NUMBER = 1;
 
 export default class MissionResultsController extends Controller {
   @service router;
+  @service intl;
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
   @tracked pageSize = 25;
   @tracked divisions = [];
+  @tracked results = [];
+  @tracked resultOptions = [
+    { value: 'reached', label: this.translateResultOptionKey('reached') },
+    { value: 'not-reached', label: this.translateResultOptionKey('not-reached') },
+    { value: 'exceeded', label: this.translateResultOptionKey('exceeded') },
+    { value: 'partially-reached', label: this.translateResultOptionKey('partially-reached') },
+    { value: 'no-result', label: this.translateResultOptionKey('no-result') },
+  ];
   @tracked name = '';
+
+  translateResultOptionKey(key) {
+    return this.intl.t(`pages.missions.mission.table.result.filters.global-result.options.${key}`);
+  }
 
   get learnersCount() {
     return this.model.missionLearners.meta.rowCount;
   }
+
   @action
   clearFilters() {
     this.pageNumber = null;
@@ -27,6 +41,12 @@ export default class MissionResultsController extends Controller {
   }
 
   @action
+  onSelectResults(result) {
+    this.results = result;
+    this.pageNumber = null;
+  }
+
+  @action
   onFilter(inputText, value) {
     this[inputText] = value;
   }
@@ -34,6 +54,7 @@ export default class MissionResultsController extends Controller {
   @action
   onResetFilter() {
     this.divisions = [];
+    this.results = [];
     this.name = '';
   }
 

--- a/orga/app/routes/authenticated/missions/mission/results.js
+++ b/orga/app/routes/authenticated/missions/mission/results.js
@@ -10,6 +10,7 @@ export default class MissionResultsRoute extends Route {
   queryParams = {
     divisions: { refreshModel: true },
     name: { refreshModel: true },
+    results: { refreshModel: true },
     pageNumber: {
       refreshModel: true,
     },
@@ -24,6 +25,7 @@ export default class MissionResultsRoute extends Route {
       controller.pageSize = 25;
       controller.divisions = undefined;
       controller.name = undefined;
+      controller.results = undefined;
     }
   }
 
@@ -38,6 +40,7 @@ export default class MissionResultsRoute extends Route {
         filter: {
           divisions: params.divisions,
           name: params.name,
+          results: params.results,
         },
         page: {
           number: params.pageNumber,

--- a/orga/app/styles/components/mission/result-table.scss
+++ b/orga/app/styles/components/mission/result-table.scss
@@ -1,7 +1,10 @@
-.result-header-cell {
-  display: flex;
-}
+.mission-result-table {
+  &__header-cell {
+    display: flex;
+  }
 
-.form__field-info-icon {
-  margin-left: var(--pix-spacing-2x);
+  &__info-icon {
+    margin-left: var(--pix-spacing-2x);
+    color: var(--pix-neutral-500);
+  }
 }

--- a/orga/app/templates/authenticated/missions/list.hbs
+++ b/orga/app/templates/authenticated/missions/list.hbs
@@ -23,7 +23,6 @@
           <div class="mission-list-banner__copypaste-container">
             <span>{{html-unsafe (t "pages.missions.list.banner.step2.option1" pixJuniorUrl=this.juniorUrl)}}
             </span>
-
             <div class="mission-list-banner__school-code">
               Code :&nbsp;<b>{{this.schoolCode}}</b>
               <CopyPasteButton

--- a/orga/app/templates/authenticated/missions/mission/results.hbs
+++ b/orga/app/templates/authenticated/missions/mission/results.hbs
@@ -20,5 +20,16 @@
     @triggerFiltering={{this.onFilter}}
   />
 
+  <PixMultiSelect
+    @options={{this.resultOptions}}
+    @values={{this.results}}
+    @placeholder={{t "pages.missions.mission.table.result.filters.global-result.label"}}
+    @onChange={{this.onSelectResults}}
+    @isSearchable={{false}}
+    @screenReaderOnly={{true}}
+  >
+    <:label>{{t "pages.missions.mission.table.result.filters.global-result.label"}}</:label>
+    <:default as |option|>{{option.label}}</:default>
+  </PixMultiSelect>
 </PixFilterBanner>
 <Mission::ResultTable @missionLearners={{this.model.missionLearners}} @mission={{this.model.mission.mission}} />

--- a/orga/mirage/handlers/find-paginated-mission-learners.js
+++ b/orga/mirage/handlers/find-paginated-mission-learners.js
@@ -5,6 +5,7 @@ export function findPaginatedMissionLearners(schema, request) {
   const queryParams = request.queryParams;
   const divisionsFilter = queryParams['filter[divisions]'];
   const nameFilter = queryParams['filter[name]'];
+  const resultFilter = queryParams['filter[results]'];
 
   let missionLearners = schema.missionLearners.where({ organizationId });
   if (divisionsFilter) {
@@ -20,6 +21,11 @@ export function findPaginatedMissionLearners(schema, request) {
           learner.lastName.toUpperCase().includes(nameFilter.toUpperCase())) &&
         learner.organizationId === Number(organizationId)
       );
+    });
+  }
+  if (resultFilter) {
+    missionLearners = missionLearners.filter((learner) => {
+      return resultFilter.includes(learner.result.global) && learner.organizationId === Number(organizationId);
     });
   }
   const rowCount = missionLearners.length;

--- a/orga/tests/acceptance/missions-details-test.js
+++ b/orga/tests/acceptance/missions-details-test.js
@@ -163,6 +163,42 @@ module('Acceptance | Missions Detail', function (hooks) {
         assert.strictEqual(screen.getAllByRole('cell', { name: 'Charles' }).length, 2);
         assert.dom(screen.queryByRole('cell', { name: xavierHenry.firstName })).doesNotExist();
       });
+      test('Should filter on the mission assessment result', async function (assert) {
+        server.create('mission-learner', {
+          firstName: 'Charles',
+          lastName: 'Qui a réussi',
+          division: 'CM2-C',
+          status: 'completed',
+          organizationId: 1,
+          result: {
+            global: 'reached',
+          },
+        });
+        server.create('mission-learner', {
+          firstName: 'Charles',
+          lastName: 'Qui a moins réussi',
+          division: 'CM2-B',
+          status: 'completed',
+          organizationId: 1,
+          result: {
+            global: 'not-reached',
+          },
+        });
+
+        const screen = await visit('/missions/1/results');
+
+        const select = screen.getByRole('button', {
+          name: t('pages.missions.mission.table.result.filters.global-result.label'),
+        });
+        await click(select);
+        const optionSelected = await screen.findByRole('checkbox', {
+          name: t('pages.missions.mission.table.result.filters.global-result.options.reached'),
+        });
+        await click(optionSelected);
+
+        assert.strictEqual(screen.getAllByRole('cell', { name: 'Qui a réussi' }).length, 1);
+        assert.dom(screen.queryByRole('cell', { name: 'Qui a moins réussi' })).doesNotExist();
+      });
     });
   });
 });

--- a/orga/tests/acceptance/sup-organization-participant-list-test.js
+++ b/orga/tests/acceptance/sup-organization-participant-list-test.js
@@ -78,9 +78,7 @@ module('Acceptance | Sup Organization Participant List', function (hooks) {
         const screen = await visit('/etudiants');
 
         // when
-        const select = screen.getByRole('textbox', {
-          name: t('pages.sup-organization-participants.filter.certificability.label'),
-        });
+        const select = screen.getByText(t('pages.sup-organization-participants.filter.certificability.label'));
         await click(select);
         await clickByText(t('pages.sco-organization-participants.table.column.is-certifiable.eligible'));
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -938,6 +938,16 @@
             "caption": "List of students with their result for the mission {missionName}",
             "filters": {
               "aria-label": "Filter on students",
+              "global-result": {
+                "label": "Mission assessment",
+                "options": {
+                  "exceeded": "Exceeded",
+                  "no-result": "No assessment",
+                  "not-reached": "Not reached",
+                  "partially-reached": "Partially reached",
+                  "reached": "Reached"
+                }
+              },
               "learners-count": "{count, plural, =0 {No student} =1 {1 student} other {{count} students}}"
             },
             "headers": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -963,8 +963,8 @@
               "division": "Classe",
               "first-name": "Prénom",
               "last-name": "Nom",
-              "result": "Evaluation de la mission",
-              "step": "Etape {number}"
+              "result": "Évaluation de la mission",
+              "step": "Étape {number}"
             },
             "mission-dare-result": {
               "not-reached": "NA",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -946,6 +946,16 @@
             "caption": "Tableau des élèves avec le résultat de leur participation à la mission {missionName}",
             "filters": {
               "aria-label": "Filtre sur les élèves",
+              "global-result": {
+                "label": "Évaluation de la mission",
+                "options": {
+                  "exceeded": "Dépassé",
+                  "no-result": "Pas d'évaluation",
+                  "not-reached": "Non atteint",
+                  "partially-reached": "Partiellement atteint",
+                  "reached": "Atteint"
+                }
+              },
               "learners-count": "{count, plural, =0 {Aucun élève} =1 {1 élève} other {{count} élèves}}"
             },
             "headers": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -954,6 +954,16 @@
             "caption": "Tabel van studenten met de resultaten van hun deelname aan de opdracht {missionName}",
             "filters": {
               "aria-label": "Filter studenten",
+              "global-result": {
+                "options": {
+                  "exceeded": "Overtroffen",
+                  "no-result": "Geen beoordeling",
+                  "not-reached": "Niet bereikt",
+                  "partially-reached": "Gedeeltelijk bereikt",
+                  "reached": "Bereikt"
+                },
+                "label": "Évaluation de la mission"
+              },
               "learners-count": "{count, plural, =0 {Geen student} =1 {1 student} other {{count} studenten}}"
             },
             "headers": {
@@ -965,10 +975,10 @@
               "dare-challenge": "Uitdaging"
             },
             "mission-result": {
-              "exceeded": "Overtroffen (O)",
-              "not-reached": "Niet bereikt (NB)",
-              "partially-reached": "Gedeeltelijk bereikt (GB)",
-              "reached": "Bereikt (B)",
+              "exceeded": "Overtroffen",
+              "not-reached": "Niet bereikt",
+              "partially-reached": "Gedeeltelijk bereikt",
+              "reached": "Bereikt",
               "undefined": "-"
             },
             "step-result": {


### PR DESCRIPTION
## :unicorn: Problème
On ne peut pas filtrer les élèves ayant réussi/échoué une mission.

## :robot: Proposition
Ajouter un filtrer sur chacun des résultats globaux possible, ainsi que "Sans résultat".

## :100: Pour tester
Avoir une mission avec au moins un élève par résultat global pour vérifier chacune des valeurs de filtres et les combinaisons.
