### PR TITLE
[FEATURE] Enregistrer comme correcte une réponse focused out si le candidat a un besoin d'aménagement (PIX-14242).

### DIFF
--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -153,14 +153,16 @@ const correctAnswerThenUpdateAssessment = async function ({
 
   const challenge = await challengeRepository.get(answer.challengeId);
 
-  const onGoingCertificationChallengeLiveAlert =
-    await certificationChallengeLiveAlertRepository.getOngoingByChallengeIdAndAssessmentId({
-      challengeId: challenge.id,
-      assessmentId: assessment.id,
-    });
+  if (assessment.isCertification()) {
+    const onGoingCertificationChallengeLiveAlert =
+      await certificationChallengeLiveAlertRepository.getOngoingByChallengeIdAndAssessmentId({
+        challengeId: challenge.id,
+        assessmentId: assessment.id,
+      });
 
-  if (onGoingCertificationChallengeLiveAlert) {
-    throw new ForbiddenAccess('An alert has been set.');
+    if (onGoingCertificationChallengeLiveAlert) {
+      throw new ForbiddenAccess('An alert has been set.');
+    }
   }
 
   const correctedAnswer = evaluateAnswer({ challenge, answer, assessment, examiner });

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -10,6 +10,7 @@ import * as centerRepository from '../../../src/certification/enrolment/infrastr
 import * as certificationCandidateRepository from '../../../src/certification/enrolment/infrastructure/repositories/certification-candidate-repository.js';
 import * as certificationCpfCityRepository from '../../../src/certification/enrolment/infrastructure/repositories/certification-cpf-city-repository.js';
 import * as sessionEnrolmentRepository from '../../../src/certification/enrolment/infrastructure/repositories/session-repository.js';
+import * as certificationEvaluationCandidateRepository from '../../../src/certification/evaluation/infrastructure/repositories/certification-candidate-repository.js';
 import * as flashAlgorithmService from '../../../src/certification/flash-certification/domain/services/algorithm-methods/flash.js';
 import * as certificationOfficerRepository from '../../../src/certification/session-management/infrastructure/repositories/certification-officer-repository.js';
 import * as finalizedSessionRepository from '../../../src/certification/session-management/infrastructure/repositories/finalized-session-repository.js';
@@ -175,6 +176,7 @@ function requirePoleEmploiNotifier() {
  * @typedef {certificationBadgesService} CertificationBadgesService
  * @typedef {certificationCenterRepository} CertificationCenterRepository
  * @typedef {certificationRepository} CertificationRepository
+ * @typedef {certificationEvaluationCandidateRepository} CertificationEvaluationCandidateRepository
  * @typedef {complementaryCertificationRepository} ComplementaryCertificationRepository
  * @typedef {complementaryCertificationCourseRepository} ComplementaryCertificationCourseRepository
  * @typedef {finalizedSessionRepository} FinalizedSessionRepository
@@ -225,6 +227,7 @@ const dependencies = {
   certificationAssessmentRepository,
   certificationBadgesService,
   certificationCandidateRepository,
+  certificationEvaluationCandidateRepository,
   certificationCenterForAdminRepository,
   certificationCenterInvitationRepository,
   certificationCenterInvitationService,

--- a/api/src/certification/evaluation/domain/models/Candidate.js
+++ b/api/src/certification/evaluation/domain/models/Candidate.js
@@ -1,0 +1,5 @@
+export class Candidate {
+  constructor({ accessibilityAdjustmentNeeded } = {}) {
+    this.accessibilityAdjustmentNeeded = accessibilityAdjustmentNeeded;
+  }
+}

--- a/api/src/certification/evaluation/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/certification-candidate-repository.js
@@ -1,6 +1,6 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { CertificationCandidateNotFoundError } from '../../../../shared/domain/errors.js';
-import { Candidate } from '../../../enrolment/domain/models/Candidate.js';
+import { Candidate } from '../../domain/models/Candidate.js';
 
 const findByAssessmentId = async function ({ assessmentId }) {
   const result = await knex('certification-candidates')

--- a/api/src/shared/domain/models/Examiner.js
+++ b/api/src/shared/domain/models/Examiner.js
@@ -10,7 +10,14 @@ class Examiner {
     this.validator = validator;
   }
 
-  evaluate({ answer, challengeFormat, isFocusedChallenge, isCertificationEvaluation, hasLastQuestionBeenFocusedOut }) {
+  evaluate({
+    answer,
+    challengeFormat,
+    isFocusedChallenge,
+    isCertificationEvaluation,
+    hasLastQuestionBeenFocusedOut,
+    certificationCandidate,
+  }) {
     const correctedAnswer = new Answer(answer);
 
     if (answer.value === Answer.FAKE_VALUE_FOR_SKIPPED_QUESTIONS) {
@@ -68,7 +75,9 @@ class Examiner {
     }
 
     if (isCorrectAnswer && isFocusedChallenge && answer.isFocusedOut && isCertificationEvaluation) {
-      correctedAnswer.result = AnswerStatus.FOCUSEDOUT;
+      correctedAnswer.result = certificationCandidate?.accessibilityAdjustmentNeeded
+        ? AnswerStatus.OK
+        : AnswerStatus.FOCUSEDOUT;
       correctedAnswer.isFocusedOut = true;
     }
 

--- a/api/tests/certification/evaluation/acceptance/answer-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/answer-route_test.js
@@ -1,0 +1,169 @@
+import {
+  createServer,
+  databaseBuilder,
+  expect,
+  generateValidRequestAuthorizationHeader,
+  knex,
+  mockLearningContent,
+} from '../../../test-helper.js';
+
+describe('Certification | Evaluation | Acceptance | answer-route', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('POST /api/answers', function () {
+    context('when challenge is focused out and answer is correct', function () {
+      context('when the candidate needs an accessibility adjustment', function () {
+        it('should save the answer as correct', async function () {
+          // given
+          const { competenceId, challengeId } = _buildLearningContent();
+          const { assessmentId, userId } = await _setupTestData(databaseBuilder, {
+            competenceId,
+            doesCandidateNeedAccessibilityAdjustment: true,
+          });
+          const options = _setupRequestOptions({ userId, challengeId, assessmentId });
+
+          // when
+          await server.inject(options);
+
+          // then
+          const [answer] = await knex('answers');
+          expect(answer.result).to.equal('ok');
+          expect(answer.isFocusedOut).to.equal(true);
+        });
+      });
+
+      context('when the candidate does not need an accessibility adjustment', function () {
+        it('should save the answer as focused out', async function () {
+          // given
+          const { competenceId, challengeId } = _buildLearningContent();
+          const { assessmentId, userId } = await _setupTestData(databaseBuilder, {
+            competenceId,
+            doesCandidateNeedAccessibilityAdjustment: false,
+          });
+          const options = _setupRequestOptions({ userId, challengeId, assessmentId });
+
+          // when
+          await server.inject(options);
+
+          // then
+          const [answer] = await knex('answers');
+          expect(answer.result).to.equal('focusedOut');
+          expect(answer.isFocusedOut).to.equal(true);
+        });
+      });
+    });
+  });
+});
+
+async function _setupTestData(databaseBuilder, { competenceId, doesCandidateNeedAccessibilityAdjustment }) {
+  const userId = databaseBuilder.factory.buildUser().id;
+
+  const session = databaseBuilder.factory.buildSession({});
+
+  databaseBuilder.factory.buildCertificationCandidate({
+    sessionId: session.id,
+    userId,
+    accessibilityAdjustmentNeeded: doesCandidateNeedAccessibilityAdjustment,
+  });
+
+  const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+    userId,
+    sessionId: session.id,
+  });
+
+  const assessment = databaseBuilder.factory.buildAssessment({
+    type: 'CERTIFICATION',
+    userId,
+    competenceId: competenceId,
+    certificationCourseId: certificationCourse.id,
+  });
+
+  await databaseBuilder.commit();
+
+  return { assessmentId: assessment.id, userId };
+}
+
+function _setupRequestOptions({ userId, challengeId, assessmentId }) {
+  return {
+    method: 'POST',
+    url: '/api/answers',
+    headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+    payload: {
+      data: {
+        type: 'answers',
+        attributes: {
+          value: 'correct',
+          'focused-out': true,
+        },
+        relationships: {
+          assessment: {
+            data: {
+              type: 'assessments',
+              id: assessmentId,
+            },
+          },
+          challenge: {
+            data: {
+              type: 'challenges',
+              id: challengeId,
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+function _buildLearningContent() {
+  const challengeId = 'a_challenge_id';
+  const competenceId = 'recCompetence';
+
+  const learningContent = {
+    areas: [{ id: 'recArea1', competenceIds: ['recCompetence'] }],
+    competences: [
+      {
+        id: 'recCompetence',
+        areaId: 'recArea1',
+        skillIds: ['recSkill1'],
+        origin: 'Pix',
+        name_i18n: {
+          fr: 'Nom de la competence FR',
+          en: 'Nom de la competence EN',
+        },
+        statue: 'active',
+      },
+    ],
+    skills: [
+      {
+        id: 'recSkill1',
+        name: '@recArea1_Competence1_Tube1_Skill1',
+        status: 'actif',
+        competenceId: competenceId,
+        pixValue: '5',
+      },
+    ],
+    challenges: [
+      {
+        id: challengeId,
+        competenceId: competenceId,
+        skillId: 'recSkill1',
+        status: 'validé',
+        solution: 'correct',
+        proposals: '${a}',
+        locales: ['fr-fr'],
+        type: 'QROC',
+        focusable: true,
+      },
+    ],
+  };
+  mockLearningContent(learningContent);
+
+  return {
+    competenceId,
+    challengeId,
+  };
+}

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/certification-candidate-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/certification-candidate-repository_test.js
@@ -36,9 +36,8 @@ describe('Integration | Repository | certification candidate', function () {
 
         // then
         expect(result).to.deep.equal(
-          domainBuilder.certification.enrolment.buildCandidate({
+          domainBuilder.certification.evaluation.buildEvaluationCandidate({
             ...candidate,
-            subscriptions: [],
           }),
         );
       });
@@ -124,9 +123,8 @@ describe('Integration | Repository | certification candidate', function () {
 
           // then
           expect(result).to.deep.equal(
-            domainBuilder.certification.enrolment.buildCandidate({
+            domainBuilder.certification.evaluation.buildEvaluationCandidate({
               ...candidate,
-              subscriptions: [],
             }),
           );
         });

--- a/api/tests/shared/unit/domain/models/Examiner_test.js
+++ b/api/tests/shared/unit/domain/models/Examiner_test.js
@@ -96,42 +96,46 @@ describe('Unit | Domain | Models | Examiner', function () {
           isFocusedChallenge = true;
         });
 
-        it('should return an answer with FOCUSEDOUT as result when the assessment is a certification, and the correct resultDetails', function () {
-          // given
-          const expectedAnswer = new Answer(uncorrectedAnswer);
-          expectedAnswer.result = AnswerStatus.FOCUSEDOUT;
-          expectedAnswer.resultDetails = validation.resultDetails;
+        context('when the assessment is a certification', function () {
+          it('should return an answer with FOCUSEDOUT as result and the correct resultDetails', function () {
+            // given
+            const expectedAnswer = new Answer(uncorrectedAnswer);
+            expectedAnswer.result = AnswerStatus.FOCUSEDOUT;
+            expectedAnswer.resultDetails = validation.resultDetails;
 
-          // when
-          correctedAnswer = examiner.evaluate({
-            answer: uncorrectedAnswer,
-            challengeFormat,
-            isFocusedChallenge,
-            isCertificationEvaluation: true,
+            // when
+            correctedAnswer = examiner.evaluate({
+              answer: uncorrectedAnswer,
+              challengeFormat,
+              isFocusedChallenge,
+              isCertificationEvaluation: true,
+            });
+
+            // then
+            expect(correctedAnswer).to.be.an.instanceOf(Answer);
+            expect(correctedAnswer).to.deep.equal(expectedAnswer);
           });
-
-          // then
-          expect(correctedAnswer).to.be.an.instanceOf(Answer);
-          expect(correctedAnswer).to.deep.equal(expectedAnswer);
         });
 
-        it('should return an answer with OK as result when the assessment is not a certification, and the correct resultDetails', function () {
-          // given
-          const expectedAnswer = new Answer(uncorrectedAnswer);
-          expectedAnswer.result = AnswerStatus.OK;
-          expectedAnswer.resultDetails = validation.resultDetails;
+        context('when the assessment is not a certification', function () {
+          it('should return an answer with OK as result, and the correct resultDetails', function () {
+            // given
+            const expectedAnswer = new Answer(uncorrectedAnswer);
+            expectedAnswer.result = AnswerStatus.OK;
+            expectedAnswer.resultDetails = validation.resultDetails;
 
-          // when
-          correctedAnswer = examiner.evaluate({
-            answer: uncorrectedAnswer,
-            challengeFormat,
-            isFocusedChallenge,
-            isCertificationEvaluation: false,
+            // when
+            correctedAnswer = examiner.evaluate({
+              answer: uncorrectedAnswer,
+              challengeFormat,
+              isFocusedChallenge,
+              isCertificationEvaluation: false,
+            });
+
+            // then
+            expect(correctedAnswer).to.be.an.instanceOf(Answer);
+            expect(correctedAnswer).to.deep.equal(expectedAnswer);
           });
-
-          // then
-          expect(correctedAnswer).to.be.an.instanceOf(Answer);
-          expect(correctedAnswer).to.deep.equal(expectedAnswer);
         });
 
         it('should call validator.assess with answer to assess validity of answer', function () {

--- a/api/tests/shared/unit/domain/models/Examiner_test.js
+++ b/api/tests/shared/unit/domain/models/Examiner_test.js
@@ -91,35 +91,64 @@ describe('Unit | Domain | Models | Examiner', function () {
       });
 
       context('and is a focused challenge', function () {
-        beforeEach(function () {
-          // given
-          isFocusedChallenge = true;
-        });
-
         context('when the assessment is a certification', function () {
-          it('should return an answer with FOCUSEDOUT as result and the correct resultDetails', function () {
-            // given
-            const expectedAnswer = new Answer(uncorrectedAnswer);
-            expectedAnswer.result = AnswerStatus.FOCUSEDOUT;
-            expectedAnswer.resultDetails = validation.resultDetails;
+          context('when the candidate needs an accessibility adjustment', function () {
+            it('should return an answer with OK as result, and the correct resultDetails', function () {
+              // given
+              const isFocusedChallenge = true;
+              const certificationCandidate = domainBuilder.certification.evaluation.buildEvaluationCandidate({
+                accessibilityAdjustmentNeeded: true,
+              });
+              const expectedAnswer = new Answer(uncorrectedAnswer);
+              expectedAnswer.result = AnswerStatus.OK;
+              expectedAnswer.resultDetails = validation.resultDetails;
 
-            // when
-            correctedAnswer = examiner.evaluate({
-              answer: uncorrectedAnswer,
-              challengeFormat,
-              isFocusedChallenge,
-              isCertificationEvaluation: true,
+              // when
+              correctedAnswer = examiner.evaluate({
+                answer: uncorrectedAnswer,
+                challengeFormat,
+                isFocusedChallenge,
+                isCertificationEvaluation: true,
+                certificationCandidate,
+              });
+
+              // then
+              expect(correctedAnswer).to.be.an.instanceOf(Answer);
+              expect(correctedAnswer).to.deep.equal(expectedAnswer);
             });
+          });
 
-            // then
-            expect(correctedAnswer).to.be.an.instanceOf(Answer);
-            expect(correctedAnswer).to.deep.equal(expectedAnswer);
+          context('when the candidate does not need an accessibility adjustment', function () {
+            it('should return an answer with FOCUSEDOUT as a result, and the correct resultDetails', function () {
+              // given
+              const isFocusedChallenge = true;
+              const certificationCandidate = domainBuilder.certification.evaluation.buildEvaluationCandidate({
+                accessibilityAdjustmentNeeded: false,
+              });
+              const expectedAnswer = new Answer(uncorrectedAnswer);
+              expectedAnswer.result = AnswerStatus.FOCUSEDOUT;
+              expectedAnswer.resultDetails = validation.resultDetails;
+
+              // when
+              correctedAnswer = examiner.evaluate({
+                answer: uncorrectedAnswer,
+                challengeFormat,
+                isFocusedChallenge,
+                isCertificationEvaluation: true,
+                certificationCandidate,
+              });
+
+              // then
+              expect(correctedAnswer).to.be.an.instanceOf(Answer);
+              expect(correctedAnswer).to.deep.equal(expectedAnswer);
+            });
           });
         });
 
         context('when the assessment is not a certification', function () {
           it('should return an answer with OK as result, and the correct resultDetails', function () {
             // given
+            const isFocusedChallenge = true;
             const expectedAnswer = new Answer(uncorrectedAnswer);
             expectedAnswer.result = AnswerStatus.OK;
             expectedAnswer.resultDetails = validation.resultDetails;
@@ -139,6 +168,9 @@ describe('Unit | Domain | Models | Examiner', function () {
         });
 
         it('should call validator.assess with answer to assess validity of answer', function () {
+          // given
+          const isFocusedChallenge = true;
+
           // when
           examiner.evaluate({
             answer: uncorrectedAnswer,

--- a/api/tests/tooling/domain-builder/factory/certification/evaluation/build-candidate.js
+++ b/api/tests/tooling/domain-builder/factory/certification/evaluation/build-candidate.js
@@ -1,0 +1,9 @@
+import { Candidate } from '../../../../../../src/certification/evaluation/domain/models/Candidate.js';
+
+const buildEvaluationCandidate = function ({ accessibilityAdjustmentNeeded } = {}) {
+  return new Candidate({
+    accessibilityAdjustmentNeeded,
+  });
+};
+
+export { buildEvaluationCandidate };

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -187,6 +187,7 @@ import {
 import { buildUserEnrolment } from './certification/enrolment/build-user.js';
 import { buildUserCertificationEligibility } from './certification/enrolment/build-user-certification-eligibility.js';
 import { buildV3CertificationEligibility } from './certification/enrolment/build-v3-certification-eligibility.js';
+import { buildEvaluationCandidate } from './certification/evaluation/build-candidate.js';
 import { buildFlashAssessmentAlgorithm } from './certification/flash-certification/build-flash-assessment-algorithm.js';
 import { buildAssessmentResult as buildCertificationScoringAssessmentResult } from './certification/scoring/build-assessment-result.js';
 import { buildCertificationAssessmentHistory } from './certification/scoring/build-certification-assessment-history.js';
@@ -233,6 +234,9 @@ const certification = {
     buildV3CertificationEligibility,
     buildPixCertification,
     buildComplementaryCertificationBadge: buildComplementaryCertificationBadgeForEnrolment,
+  },
+  evaluation: {
+    buildEvaluationCandidate,
   },
   sessionManagement: {
     buildCertificationSessionComplementaryCertification,

--- a/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
+++ b/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
@@ -35,6 +35,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
     scorecardService,
     knowledgeElementRepository,
     certificationChallengeLiveAlertRepository,
+    certificationEvaluationCandidateRepository,
     flashAlgorithmService,
     algorithmDataFetcherService;
   const competenceEvaluationRepository = {};
@@ -56,6 +57,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
     scorecardService = { computeScorecard: sinon.stub() };
     knowledgeElementRepository = { findUniqByUserIdAndAssessmentId: sinon.stub() };
     certificationChallengeLiveAlertRepository = { getOngoingByChallengeIdAndAssessmentId: sinon.stub() };
+    certificationEvaluationCandidateRepository = { findByAssessmentId: sinon.stub() };
     flashAlgorithmService = { getCapacityAndErrorRate: sinon.stub() };
     algorithmDataFetcherService = { fetchForFlashLevelEstimation: sinon.stub() };
     dateUtils = {
@@ -86,6 +88,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
       knowledgeElementRepository,
       flashAssessmentResultRepository,
       certificationChallengeLiveAlertRepository,
+      certificationEvaluationCandidateRepository,
       scorecardService,
       flashAlgorithmService,
       algorithmDataFetcherService,
@@ -718,6 +721,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
       let savedAnswer;
       let solution;
       let validator;
+      let candidate;
 
       beforeEach(function () {
         // given
@@ -731,6 +735,9 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         solution = domainBuilder.buildSolution({ id: answer.challengeId, value: correctAnswerValue });
         validator = domainBuilder.buildValidator.ofTypeQCU({ solution });
         challenge = domainBuilder.buildChallenge({ id: answer.challengeId, validator });
+        candidate = domainBuilder.certification.evaluation.buildEvaluationCandidate({
+          accessibilityAdjustmentNeeded: true,
+        });
 
         completedAnswer = domainBuilder.buildAnswer(answer);
         completedAnswer.timeSpent = 0;
@@ -749,6 +756,9 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         assessmentRepository.get.resolves(assessment);
         challengeRepository.get.resolves(challenge);
         answerRepository.saveWithKnowledgeElements.resolves(savedAnswer);
+        certificationEvaluationCandidateRepository.findByAssessmentId
+          .withArgs({ assessmentId: assessment.id })
+          .resolves(candidate);
       });
 
       it('should call the answer repository to save the answer', async function () {
@@ -929,65 +939,143 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
   context('when the challenge is focused in certification', function () {
     let answer;
     let assessment;
+    let candidate;
 
-    beforeEach(function () {
-      // Given
-      answer = domainBuilder.buildAnswer({});
-      const nonFocusedChallenge = domainBuilder.buildChallenge({
-        id: answer.challengeId,
-        validator,
-        focused: true,
+    context('when the candidate does not need an accessibility adjustment', function () {
+      beforeEach(function () {
+        // Given
+        answer = domainBuilder.buildAnswer({});
+        candidate = domainBuilder.certification.evaluation.buildEvaluationCandidate({
+          accessibilityAdjustmentNeeded: false,
+        });
+        const nonFocusedChallenge = domainBuilder.buildChallenge({
+          id: answer.challengeId,
+          validator,
+          focused: true,
+        });
+        challengeRepository.get.resolves(nonFocusedChallenge);
+        assessment = domainBuilder.buildAssessment({
+          userId,
+          lastQuestionDate: new Date('2021-03-11T11:00:00Z'),
+          type: Assessment.types.CERTIFICATION,
+        });
+        assessmentRepository.get.resolves(assessment);
+        certificationEvaluationCandidateRepository.findByAssessmentId
+          .withArgs({ assessmentId: assessment.id })
+          .resolves(candidate);
       });
-      challengeRepository.get.resolves(nonFocusedChallenge);
-      assessment = domainBuilder.buildAssessment({
-        userId,
-        lastQuestionDate: new Date('2021-03-11T11:00:00Z'),
-        type: Assessment.types.CERTIFICATION,
+
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      [
+        {
+          isFocusedOut: true,
+          lastQuestionState: 'focusedout',
+          expected: { result: ANSWER_STATUS_FOCUSEDOUT, isFocusedOut: true },
+        },
+        {
+          isFocusedOut: false,
+          lastQuestionState: 'asked',
+          expected: { result: ANSWER_STATUS_OK, isFocusedOut: false },
+        },
+        {
+          isFocusedOut: false,
+          lastQuestionState: 'focusedout',
+          expected: { result: ANSWER_STATUS_FOCUSEDOUT, isFocusedOut: true },
+        },
+        {
+          isFocusedOut: true,
+          lastQuestionState: 'asked',
+          expected: { result: ANSWER_STATUS_FOCUSEDOUT, isFocusedOut: true },
+        },
+      ].forEach(({ isFocusedOut, lastQuestionState, expected }) => {
+        context(`when answer.isFocusedOut=${isFocusedOut} and lastQuestionState=${lastQuestionState}`, function () {
+          it(`should return result=${expected.result.status} and isFocusedOut=${expected.isFocusedOut}`, async function () {
+            // Given
+            answer.isFocusedOut = isFocusedOut;
+            assessment.lastQuestionState = lastQuestionState;
+            answerRepository.saveWithKnowledgeElements = (_) => _;
+
+            // When
+            const correctedAnswer = await correctAnswerThenUpdateAssessment({
+              answer: answer,
+              userId,
+              locale,
+              ...dependencies,
+            });
+
+            // Then
+            expect(correctedAnswer).to.deep.contain(expected);
+          });
+        });
       });
-      assessmentRepository.get.resolves(assessment);
     });
 
-    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    [
-      {
-        isFocusedOut: true,
-        lastQuestionState: 'focusedout',
-        expected: { result: ANSWER_STATUS_FOCUSEDOUT, isFocusedOut: true },
-      },
-      {
-        isFocusedOut: false,
-        lastQuestionState: 'asked',
-        expected: { result: ANSWER_STATUS_OK, isFocusedOut: false },
-      },
-      {
-        isFocusedOut: false,
-        lastQuestionState: 'focusedout',
-        expected: { result: ANSWER_STATUS_FOCUSEDOUT, isFocusedOut: true },
-      },
-      {
-        isFocusedOut: true,
-        lastQuestionState: 'asked',
-        expected: { result: ANSWER_STATUS_FOCUSEDOUT, isFocusedOut: true },
-      },
-    ].forEach(({ isFocusedOut, lastQuestionState, expected }) => {
-      context(`when answer.isFocusedOut=${isFocusedOut} and lastQuestionState=${lastQuestionState}`, function () {
-        it(`should return result=${expected.result.status} and isFocusedOut=${expected.isFocusedOut}`, async function () {
-          // Given
-          answer.isFocusedOut = isFocusedOut;
-          assessment.lastQuestionState = lastQuestionState;
-          answerRepository.saveWithKnowledgeElements = (_) => _;
+    context('when the candidate needs an accessibility adjustment', function () {
+      beforeEach(function () {
+        // Given
+        answer = domainBuilder.buildAnswer({});
+        candidate = domainBuilder.certification.evaluation.buildEvaluationCandidate({
+          accessibilityAdjustmentNeeded: true,
+        });
+        const nonFocusedChallenge = domainBuilder.buildChallenge({
+          id: answer.challengeId,
+          validator,
+          focused: true,
+        });
+        challengeRepository.get.resolves(nonFocusedChallenge);
+        assessment = domainBuilder.buildAssessment({
+          userId,
+          lastQuestionDate: new Date('2021-03-11T11:00:00Z'),
+          type: Assessment.types.CERTIFICATION,
+        });
+        assessmentRepository.get.resolves(assessment);
+        certificationEvaluationCandidateRepository.findByAssessmentId
+          .withArgs({ assessmentId: assessment.id })
+          .resolves(candidate);
+      });
 
-          // When
-          const correctedAnswer = await correctAnswerThenUpdateAssessment({
-            answer: answer,
-            userId,
-            locale,
-            ...dependencies,
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      [
+        {
+          isFocusedOut: true,
+          lastQuestionState: 'focusedout',
+          expected: { result: ANSWER_STATUS_OK, isFocusedOut: true },
+        },
+        {
+          isFocusedOut: false,
+          lastQuestionState: 'asked',
+          expected: { result: ANSWER_STATUS_OK, isFocusedOut: false },
+        },
+        {
+          isFocusedOut: false,
+          lastQuestionState: 'focusedout',
+          expected: { result: ANSWER_STATUS_OK, isFocusedOut: true },
+        },
+        {
+          isFocusedOut: true,
+          lastQuestionState: 'asked',
+          expected: { result: ANSWER_STATUS_OK, isFocusedOut: true },
+        },
+      ].forEach(({ isFocusedOut, lastQuestionState, expected }) => {
+        context(`when answer.isFocusedOut=${isFocusedOut} and lastQuestionState=${lastQuestionState}`, function () {
+          it(`should return result=${expected.result.status} and isFocusedOut=${expected.isFocusedOut}`, async function () {
+            // Given
+            answer.isFocusedOut = isFocusedOut;
+            assessment.lastQuestionState = lastQuestionState;
+            answerRepository.saveWithKnowledgeElements = (_) => _;
+
+            // When
+            const correctedAnswer = await correctAnswerThenUpdateAssessment({
+              answer: answer,
+              userId,
+              locale,
+              ...dependencies,
+            });
+
+            // Then
+            expect(correctedAnswer).to.deep.contain(expected);
           });
-
-          // Then
-          expect(correctedAnswer).to.deep.contain(expected);
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème

Un centre de certification a maintenant la possibilité de renseigner le besoin d’un test aménagé pour l’accessibilité d’un candidat inscrit en session.

Les questions focus ne sont, par défaut, pas accessibles. 
En effet, si un candidat en situation de handicap utilise un outil de type lecteur d'écran ou clavier virtuel pour réaliser son test, il sera considéré comme “focus out” sur une question focus.

## :robot: Proposition

Pour un candidat ayant été taggué comme nécessitant un aménagement d’accessibilité : 

- considérer comme OK une question focus bien répondue, même s’il a perdu le focus
- pour le moment, le message de warning en cas de défocus reste (wording à revoir ultérieurement)

## :rainbow: Remarques

On ne migre pas le usecase (bien trop conséquent dans le cadre de cette PR) et on y injecte un repository provenant de src.
Nous pourrions églament dupliquer la méthode du repository en question mais cela ne ferait qu'ajouter de la maintenance supplémentaire.

## :100: Pour tester

- Connectez-vous sur Pix-certif avec `certifv3@example.net`
- Choisissez un centre qui permet l'ajout d'ajustements d'accessibilité aux candidats
- Créez une session
- Ajoutez un candidat
- Modifiez-le en lui ajoutant un besoin d'ajustement
- Réaliser la session de certification en essayant de répondre de façon correcte, erronnée et en passant les questions focus (en défocusant les questions). Faites ce que vous voulez pour les autres questions
- Finalisez la session
- Sur pix-admin, avec `superadmin@example.net`, allez dans les détails de la certification et vérifiez que les réponses aux questions correspondent à ce que vous avez répondu malgré les défocus. 