### PR TITLE
[FEATURE] Créer un composant local pour la sélection des OidcProvider (PIX-14134).

### DIFF
--- a/mon-pix/app/components/authentication/oidc-provider-selector.gjs
+++ b/mon-pix/app/components/authentication/oidc-provider-selector.gjs
@@ -3,6 +3,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 
 export default class OidcProviderSelector extends Component {
   @service oidcIdentityProviders;
@@ -29,19 +30,19 @@ export default class OidcProviderSelector extends Component {
 
   <template>
     <PixSelect
-      @id="oidc-provider-selector"
-      @value={{this.selectedProvider}}
-      @options={{this.providerOptions}}
-      @onChange={{this.onProviderChange}}
       @hideDefaultOption="true"
+      @id="oidc-provider-selector"
       @isSearchable="true"
-      @placeholder="Sélectionner un organisme"
-      @searchLabel="Recherche par mot clé"
-      @searchPlaceholder="Recherche par mot clé"
+      @onChange={{this.onProviderChange}}
+      @options={{this.providerOptions}}
+      @placeholder={{t "components.authentication.oidc-provider-selector.placeholder"}}
+      @searchLabel={{t "components.authentication.oidc-provider-selector.searchLabel"}}
+      @searchPlaceholder={{t "components.authentication.oidc-provider-selector.searchLabel"}}
+      @value={{this.selectedProvider}}
       class="oidc-provider-selector"
       ...attributes
     >
-      <:label>Rechercher une organisation</:label>
+      <:label>{{t "components.authentication.oidc-provider-selector.label"}}</:label>
     </PixSelect>
   </template>
 }

--- a/mon-pix/app/components/authentication/oidc-provider-selector.gjs
+++ b/mon-pix/app/components/authentication/oidc-provider-selector.gjs
@@ -1,0 +1,47 @@
+import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class OidcProviderSelector extends Component {
+  @service oidcIdentityProviders;
+
+  @tracked selectedProvider;
+
+  get providerOptions() {
+    const options = this.oidcIdentityProviders.list.map((provider) => ({
+      label: provider.organizationName,
+      value: provider.id,
+    }));
+
+    return options.sort((option1, option2) => option1.label.localeCompare(option2.label));
+  }
+
+  @action
+  onProviderChange(value) {
+    this.selectedProvider = value;
+
+    if (this.args.onProviderChange) {
+      this.args.onProviderChange(this.selectedProvider);
+    }
+  }
+
+  <template>
+    <PixSelect
+      @id="oidc-provider-selector"
+      @value={{this.selectedProvider}}
+      @options={{this.providerOptions}}
+      @onChange={{this.onProviderChange}}
+      @hideDefaultOption="true"
+      @isSearchable="true"
+      @placeholder="Sélectionner un organisme"
+      @searchLabel="Recherche par mot clé"
+      @searchPlaceholder="Recherche par mot clé"
+      class="oidc-provider-selector"
+      ...attributes
+    >
+      <:label>Rechercher une organisation</:label>
+    </PixSelect>
+  </template>
+}

--- a/mon-pix/app/components/authentication/oidc-provider-selector.scss
+++ b/mon-pix/app/components/authentication/oidc-provider-selector.scss
@@ -1,0 +1,65 @@
+.oidc-provider-selector {
+  .pix-select-button {
+    padding: var(--pix-spacing-3x);
+    border-color: var(--pix-neutral-500);
+
+    .pix-select-button__text {
+      color: var(--pix-neutral-500);
+    }
+  }
+
+  .pix-select__search {
+    flex-direction: row-reverse;
+    margin: var(--pix-spacing-3x) var(--pix-spacing-2x);
+    padding: 0;
+    background: var(--pix-neutral-0);
+    border: 1px solid var(--pix-neutral-100);
+    border-radius: var(--pix-spacing-2x);
+
+    input {
+      margin: 0;
+      padding: var(--pix-spacing-2x) var(--pix-spacing-4x);
+      border-radius: var(--pix-spacing-2x);
+
+      &:hover, &:focus {
+        background: var(--pix-neutral-0);
+      }
+
+      &::placeholder {
+        color: var(--pix-neutral-500);
+      }
+    }
+
+    svg {
+      margin-right: var(--pix-spacing-4x);
+      color: var(--pix-neutral-500);
+    }
+  }
+
+  .pix-select__dropdown {
+    max-height: 488px;
+    background-color : var(--pix-neutral-20);
+  }
+
+  .pix-select-options-category__option {
+    padding: var(--pix-spacing-3x) var(--pix-spacing-2x);
+
+    &:first-child {
+      display: none;
+    }
+
+    &:hover, &:focus {
+      background: var(--pix-primary-100);
+    }
+
+    &:nth-child(even) {
+      background: var(--pix-neutral-0);
+
+      &:hover, &:focus {
+        background: var(--pix-primary-100);
+      }
+    }
+  }
+}
+
+

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -135,6 +135,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 /* Styles for colocated components */
 @import 'authentication-layout';
 @import 'authentication/signin-form';
+@import 'authentication/oidc-provider-selector';
 
 /* pages */
 @import 'pages/assessment-results';

--- a/mon-pix/tests/integration/components/authentication/oidc-provider-selector-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/oidc-provider-selector-test.gjs
@@ -1,0 +1,90 @@
+import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import { click } from '@ember/test-helpers';
+import OidcProviderSelector from 'mon-pix/components/authentication/oidc-provider-selector';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Authentication | oidc-provider-selector', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it displays an Oidc Provider selector with correct labels', async function (assert) {
+    //given
+    class OidcProvidersServiceStub extends Service {
+      get list() {
+        return [
+          { id: '1', organizationName: 'ConnectEtMoi' },
+          { id: '2', organizationName: 'StarConnect' },
+        ];
+      }
+    }
+    this.owner.register('service:oidcIdentityProviders', OidcProvidersServiceStub);
+
+    //when
+    const screen = await render(<template><OidcProviderSelector /></template>);
+    await click(screen.getByRole('button', { name: 'Rechercher une organisation' }));
+    await screen.findByRole('listbox');
+
+    //then
+    assert.dom(screen.getAllByText('Sélectionner un organisme')[0]).exists();
+    assert.dom(screen.getByText('Recherche par mot clé')).exists();
+    assert.dom(screen.getByText('Rechercher une organisation')).exists();
+    assert.dom(screen.getByText('ConnectEtMoi')).isVisible();
+  });
+
+  test('it displays a sorted list of oidc providers', async function (assert) {
+    // given
+    class OidcProvidersServiceStub extends Service {
+      get list() {
+        return [
+          { id: '1', organizationName: 'Third' },
+          { id: '2', organizationName: 'Second' },
+          { id: '3', organizationName: 'First' },
+        ];
+      }
+    }
+    this.owner.register('service:oidcIdentityProviders', OidcProvidersServiceStub);
+
+    // when
+    const screen = await render(<template><OidcProviderSelector /></template>);
+    await click(screen.getByRole('button', { name: 'Rechercher une organisation' }));
+    await screen.findByRole('listbox');
+
+    // then
+    const options = await screen.findAllByRole('option');
+    const optionsLabels = options.map((option) => option.innerText);
+
+    assert.deepEqual(optionsLabels, ['First', 'Second', 'Third']);
+  });
+
+  module('when user selects a provider', function () {
+    test('it triggers the onProviderChange property', async function (assert) {
+      // given
+      class OidcProvidersServiceStub extends Service {
+        get list() {
+          return [
+            { id: '1', organizationName: 'ConnectEtMoi' },
+            { id: '2', organizationName: 'StarConnect' },
+          ];
+        }
+      }
+      this.owner.register('service:oidcIdentityProviders', OidcProvidersServiceStub);
+
+      const onProviderChangeStub = sinon.stub();
+
+      // when
+      const screen = await render(
+        <template><OidcProviderSelector @onProviderChange={{onProviderChangeStub}} /></template>,
+      );
+      await click(screen.getByRole('button', { name: 'Rechercher une organisation' }));
+      await screen.findByRole('listbox');
+
+      await click(screen.getByRole('option', { name: 'ConnectEtMoi' }));
+
+      // then
+      assert.ok(onProviderChangeStub.calledWith('1'));
+    });
+  });
+});

--- a/mon-pix/tests/integration/components/authentication/oidc-provider-selector-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/oidc-provider-selector-test.gjs
@@ -1,11 +1,18 @@
 import { render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
 import OidcProviderSelector from 'mon-pix/components/authentication/oidc-provider-selector';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+const I18N_KEYS = {
+  selectLabel: 'components.authentication.oidc-provider-selector.label',
+  selectPlaceholder: 'components.authentication.oidc-provider-selector.placeholder',
+  searchLabel: 'components.authentication.oidc-provider-selector.searchLabel',
+};
 
 module('Integration | Component | Authentication | oidc-provider-selector', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -24,13 +31,12 @@ module('Integration | Component | Authentication | oidc-provider-selector', func
 
     //when
     const screen = await render(<template><OidcProviderSelector /></template>);
-    await click(screen.getByRole('button', { name: 'Rechercher une organisation' }));
+    await click(screen.getByRole('button', { name: t(I18N_KEYS.selectLabel) }));
     await screen.findByRole('listbox');
 
     //then
-    assert.dom(screen.getAllByText('Sélectionner un organisme')[0]).exists();
-    assert.dom(screen.getByText('Recherche par mot clé')).exists();
-    assert.dom(screen.getByText('Rechercher une organisation')).exists();
+    assert.dom(screen.getAllByText(t(I18N_KEYS.selectPlaceholder))[0]).exists();
+    assert.dom(screen.getByText(t(I18N_KEYS.searchLabel))).exists();
     assert.dom(screen.getByText('ConnectEtMoi')).isVisible();
   });
 
@@ -49,7 +55,7 @@ module('Integration | Component | Authentication | oidc-provider-selector', func
 
     // when
     const screen = await render(<template><OidcProviderSelector /></template>);
-    await click(screen.getByRole('button', { name: 'Rechercher une organisation' }));
+    await click(screen.getByRole('button', { name: t(I18N_KEYS.selectLabel) }));
     await screen.findByRole('listbox');
 
     // then
@@ -78,7 +84,7 @@ module('Integration | Component | Authentication | oidc-provider-selector', func
       const screen = await render(
         <template><OidcProviderSelector @onProviderChange={{onProviderChangeStub}} /></template>,
       );
-      await click(screen.getByRole('button', { name: 'Rechercher une organisation' }));
+      await click(screen.getByRole('button', { name: t(I18N_KEYS.selectLabel) }));
       await screen.findByRole('listbox');
 
       await click(screen.getByRole('option', { name: 'ConnectEtMoi' }));

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -120,6 +120,13 @@
     }
   },
   "components": {
+    "authentication": {
+      "oidc-provider-selector": {
+        "label": "Search for an organization",
+        "placeholder": "Select an organization",
+        "searchLabel": "Keyword search"
+      }
+    },
     "invited": {
       "reconciliation": {
         "title": "Join organization { organizationName }",
@@ -1360,7 +1367,7 @@
           }
         },
         "flashcards": {
-          "seeAnswer" : "See the answer",
+          "seeAnswer": "See the answer",
           "seeAgain": "Review the question",
           "nextCard": "Next"
         },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -113,6 +113,13 @@
     }
   },
   "components": {
+    "authentication": {
+      "oidc-provider-selector": {
+        "label": "Search for an organization",
+        "placeholder": "Select an organization",
+        "searchLabel": "Keyword search"
+      }
+    },
     "invited": {
       "reconciliation": {
         "error-message": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -120,6 +120,13 @@
     }
   },
   "components": {
+    "authentication": {
+      "oidc-provider-selector": {
+        "label": "Rechercher une organisation",
+        "placeholder": "Sélectionner un organisme",
+        "searchLabel": "Recherche par mots-clés"
+      }
+    },
     "invited": {
       "reconciliation": {
         "title": "Rejoignez l'organisation { organizationName }",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -113,6 +113,13 @@
     }
   },
   "components": {
+    "authentication": {
+      "oidc-provider-selector": {
+        "label": "Search for an organization",
+        "placeholder": "Select an organization",
+        "searchLabel": "Keyword search"
+      }
+    },
     "invited": {
       "reconciliation": {
         "error-message": {


### PR DESCRIPTION
## :robot: Proposition
Créer un composant OidcProviderSelect dans Pix App.

On pourra s’aider du composant PixSelect avec la propriété @isSearchable. Démo ici : https://ui.pix.fr/?path=/story/form-select--with-search 

- Afficher le label Rechercher une organisation (wording à avoir par langue)
- Afficher un placeholder Sélectionner un organisme dans le select (aussi avoir le wording)
- Passer un tableau d’objet [{name, value, image}]
- La partie “Image” (logo des organisations) ne sera pas réalisée dans ce ticket
- Triés par ordre alphabétique par rapport au nom
- Fond gris à mettre suivant tout les 2 éléments affichés

## :rainbow: Remarques

Le composant a été affiché dans le page `/connexion` afin d'être testable dans le cadre de la review, il sera supprimé avant le merge.

> [!IMPORTANT]
> Le style du composant `PixSelect` a été surchargé au mieux pour coller au design.
> Pour aller, au plus proche, il sera nécessaire de modifier le composant du design système directement et appliquer le style voulu.

## :100: Pour tester
- Aller sur la page de connexion de Pix App
- S'assurer que le design du select est bien respecter
- Tester que le changement de langue fonctionne sur le select également
