### PR TITLE
[TECH] :recycle: Déplacement du modèle `UserDetailsForAdmin` dans le bon context

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/user-details-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-details-for-admin-serializer.js
@@ -2,7 +2,7 @@ import jsonapiSerializer from 'jsonapi-serializer';
 
 const { Serializer } = jsonapiSerializer;
 
-import { UserDetailsForAdmin } from '../../../../src/shared/domain/models/UserDetailsForAdmin.js';
+import { UserDetailsForAdmin } from '../../../../src/identity-access-management/domain/models/UserDetailsForAdmin.js';
 
 const serialize = function (usersDetailsForAdmin) {
   return new Serializer('user', {

--- a/api/src/identity-access-management/domain/models/UserDetailsForAdmin.js
+++ b/api/src/identity-access-management/domain/models/UserDetailsForAdmin.js
@@ -1,4 +1,4 @@
-import * as localeService from '../services/locale-service.js';
+import * as localeService from '../../../shared/domain/services/locale-service.js';
 
 class UserDetailsForAdmin {
   constructor(

--- a/api/src/identity-access-management/infrastructure/repositories/user.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user.repository.js
@@ -14,12 +14,12 @@ import {
 import { CertificationCenter } from '../../../shared/domain/models/CertificationCenter.js';
 import { CertificationCenterMembership } from '../../../shared/domain/models/CertificationCenterMembership.js';
 import { Membership } from '../../../shared/domain/models/Membership.js';
-import { UserDetailsForAdmin } from '../../../shared/domain/models/UserDetailsForAdmin.js';
 import { fetchPage, isUniqConstraintViolated } from '../../../shared/infrastructure/utils/knex-utils.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../domain/constants/identity-providers.js';
 import * as OidcIdentityProviders from '../../domain/constants/oidc-identity-providers.js';
 import { AuthenticationMethod } from '../../domain/models/AuthenticationMethod.js';
 import { User } from '../../domain/models/User.js';
+import { UserDetailsForAdmin } from '../../domain/models/UserDetailsForAdmin.js';
 import { UserLogin } from '../../domain/models/UserLogin.js';
 
 const getByEmail = async function (email) {

--- a/api/src/shared/domain/models/index.js
+++ b/api/src/shared/domain/models/index.js
@@ -109,7 +109,6 @@ import { TargetProfileForAdmin } from './TargetProfileForAdmin.js';
 import { Thematic } from './Thematic.js';
 import { Tube } from './Tube.js';
 import { UserCompetence } from './UserCompetence.js';
-import { UserDetailsForAdmin } from './UserDetailsForAdmin.js';
 import { UserOrgaSettings } from './UserOrgaSettings.js';
 import { UserSavedTutorialWithTutorial } from './UserSavedTutorialWithTutorial.js';
 import { Validation } from './Validation.js';
@@ -227,7 +226,6 @@ export {
   TutorialEvaluation,
   User,
   UserCompetence,
-  UserDetailsForAdmin,
   UserLogin,
   UserOrgaSettings,
   UserSavedTutorial,

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
@@ -4,6 +4,7 @@ import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTrans
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../../src/identity-access-management/domain/constants/identity-providers.js';
 import * as OidcIdentityProviders from '../../../../../src/identity-access-management/domain/constants/oidc-identity-providers.js';
 import { User } from '../../../../../src/identity-access-management/domain/models/User.js';
+import { UserDetailsForAdmin } from '../../../../../src/identity-access-management/domain/models/UserDetailsForAdmin.js';
 import * as userRepository from '../../../../../src/identity-access-management/infrastructure/repositories/user.repository.js';
 import { Organization } from '../../../../../src/organizational-entities/domain/models/Organization.js';
 import { IMPORT_KEY_FIELD } from '../../../../../src/prescription/learner-management/domain/constants.js';
@@ -18,7 +19,6 @@ import {
 import { CertificationCenter } from '../../../../../src/shared/domain/models/CertificationCenter.js';
 import { CertificationCenterMembership } from '../../../../../src/shared/domain/models/CertificationCenterMembership.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
-import { UserDetailsForAdmin } from '../../../../../src/shared/domain/models/UserDetailsForAdmin.js';
 import { catchErr, databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
 
 const expectedUserDetailsForAdminAttributes = [

--- a/api/tests/identity-access-management/unit/domain/models/UserDetailsForAdmin_test.js
+++ b/api/tests/identity-access-management/unit/domain/models/UserDetailsForAdmin_test.js
@@ -1,5 +1,5 @@
-import { UserDetailsForAdmin } from '../../../../src/shared/domain/models/UserDetailsForAdmin.js';
-import { expect, sinon } from '../../../test-helper.js';
+import { UserDetailsForAdmin } from '../../../../../src/identity-access-management/domain/models/UserDetailsForAdmin.js';
+import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Domain | Models | UserDetailsForAdmin', function () {
   let localeService;

--- a/api/tests/integration/domain/usecases/update-user-details-for-administration_test.js
+++ b/api/tests/integration/domain/usecases/update-user-details-for-administration_test.js
@@ -1,7 +1,7 @@
 import { updateUserDetailsForAdministration } from '../../../../lib/domain/usecases/update-user-details-for-administration.js';
+import { UserDetailsForAdmin } from '../../../../src/identity-access-management/domain/models/UserDetailsForAdmin.js';
 import * as userRepository from '../../../../src/identity-access-management/infrastructure/repositories/user.repository.js';
 import { AlreadyRegisteredEmailError, AlreadyRegisteredUsernameError } from '../../../../src/shared/domain/errors.js';
-import { UserDetailsForAdmin } from '../../../../src/shared/domain/models/UserDetailsForAdmin.js';
 import { catchErr, databaseBuilder, expect } from '../../../test-helper.js';
 
 describe('Integration | UseCases | updateUserDetailsForAdministration', function () {

--- a/api/tests/tooling/domain-builder/factory/build-user-details-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-user-details-for-admin.js
@@ -1,4 +1,4 @@
-import { UserDetailsForAdmin } from '../../../../src/shared/domain/models/UserDetailsForAdmin.js';
+import { UserDetailsForAdmin } from '../../../../src/identity-access-management/domain/models/UserDetailsForAdmin.js';
 
 const buildUserDetailsForAdmin = function ({
   id = 123,


### PR DESCRIPTION
## :unicorn: Problème

Lors du déplacement du répertoire `domain/models` dans le contexte partagé `src/shared/domain/models`, nous avons embarqué des fichiers qui devraient être dans des contextes spécifiques.

## :robot: Proposition

Déplacer le modèle `UserDetailsForAdmin` dans son contexte

## :rainbow: Remarques


## :100: Pour tester

