### PR TITLE
[TECH] Supprimer les usages des key dans la configuration des imports à format (PIX-14622)

### DIFF
--- a/api/db/seeds/data/common/organization-learner-import-formats.js
+++ b/api/db/seeds/data/common/organization-learner-import-formats.js
@@ -9,25 +9,64 @@ export const organizationLearnerImportFormat = async function ({ databaseBuilder
     config: {
       acceptedEncoding: ['iso-8859-1', 'utf8'],
       unicityColumns: ['INE'],
-      validationRules: {
-        formats: [
-          { key: 1, name: 'Nom élève', type: 'string', required: true },
-          { key: 2, name: 'Prénom élève', type: 'string', required: true },
-          { key: 3, name: 'INE', type: 'string', required: true },
-          { key: 5, name: 'Niveau', type: 'string', expectedValues: ['CM1', 'CM2'], required: true },
-          { key: 6, name: 'Libellé classe', type: 'string', required: true },
-          { key: 7, name: 'Date naissance', type: 'date', format: 'YYYY-MM-DD', required: true },
-          { key: 4, name: 'Cycle', type: 'string', expectedValues: ['CYCLE III'], required: true },
-        ],
-      },
       headers: [
-        { key: 1, name: 'Nom élève', property: 'lastName', required: true },
-        { key: 2, name: 'Prénom élève', property: 'firstName', required: true },
-        { key: 3, name: 'INE', required: true },
-        { key: 4, name: 'Cycle', required: true },
-        { key: 5, name: 'Niveau', required: true },
-        { key: 6, name: 'Libellé classe', required: true },
-        { key: 7, name: 'Date naissance', required: true },
+        {
+          name: 'Nom élève',
+          required: true,
+          config: {
+            property: 'lastName',
+            validate: { type: 'string', required: true },
+          },
+        },
+        {
+          name: 'Prénom élève',
+          config: {
+            property: 'firstName',
+            validate: { type: 'string', required: true },
+          },
+          required: true,
+        },
+        {
+          name: 'INE',
+          required: true,
+          config: {
+            validate: { type: 'string', required: true },
+          },
+        },
+        {
+          name: 'Cycle',
+          required: true,
+          config: {
+            validate: {
+              type: 'string',
+              expectedValues: ['CYCLE III'],
+              required: true,
+            },
+          },
+        },
+        {
+          name: 'Niveau',
+          required: true,
+          config: {
+            validate: {
+              type: 'string',
+              expectedValues: ['CM1', 'CM2'],
+              required: true,
+            },
+          },
+        },
+        {
+          name: 'Libellé classe',
+          required: true,
+          config: {
+            validate: { type: 'string', required: true },
+          },
+        },
+        {
+          name: 'Date naissance',
+          required: true,
+          config: { validate: { type: 'date', format: 'YYYY-MM-DD', required: true } },
+        },
       ],
     },
     createdAt: new Date('2024-01-01'),
@@ -42,43 +81,60 @@ export const organizationLearnerImportFormat = async function ({ databaseBuilder
     config: {
       acceptedEncoding: ['utf8'],
       unicityColumns: ['Nom apprenant', 'Prénom apprenant', 'Date de naissance'],
-      reconciliationMappingColumns: [
-        { key: 2, fieldId: 'reconcileField2', name: IMPORT_KEY_FIELD.COMMON_FIRSTNAME, position: 2 },
-        { key: 4, fieldId: 'reconcileField3', name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE, position: 3 },
-        { key: 1, fieldId: 'reconcileField1', name: IMPORT_KEY_FIELD.COMMON_LASTNAME, position: 1 },
-      ],
-      filterableColumns: [
-        {
-          key: 3,
-          position: 1,
-          name: IMPORT_KEY_FIELD.COMMON_DIVISION,
-        },
-      ],
-      displayableColumns: [
-        {
-          key: 4,
-          position: 2,
-          name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE,
-        },
-        {
-          key: 3,
-          position: 1,
-          name: IMPORT_KEY_FIELD.COMMON_DIVISION,
-        },
-      ],
-      validationRules: {
-        formats: [
-          { key: 1, name: 'Nom apprenant', type: 'string', required: true },
-          { key: 2, name: 'Prénom apprenant', type: 'string', required: true },
-          { key: 3, name: 'Classe', type: 'string', required: true },
-          { key: 4, name: 'Date de naissance', type: 'date', format: 'YYYY-MM-DD', required: true },
-        ],
-      },
       headers: [
-        { key: 1, name: 'Nom apprenant', property: 'lastName', required: true },
-        { key: 2, name: 'Prénom apprenant', property: 'firstName', required: true },
-        { key: 3, name: 'Classe', required: true, config: { exportable: true } },
-        { key: 4, name: 'Date de naissance', required: true },
+        {
+          name: 'Nom apprenant',
+          required: true,
+          config: {
+            property: 'lastName',
+            validate: { type: 'string', required: true },
+            reconcile: { fieldId: 'reconcileField1', name: IMPORT_KEY_FIELD.COMMON_LASTNAME, position: 1 },
+          },
+        },
+        {
+          name: 'Prénom apprenant',
+          required: true,
+          config: {
+            property: 'firstName',
+            validate: { type: 'string', required: true },
+            reconcile: {
+              fieldId: 'reconcileField2',
+              name: IMPORT_KEY_FIELD.COMMON_FIRSTNAME,
+              position: 2,
+            },
+          },
+        },
+        {
+          name: 'Classe',
+          required: true,
+          config: {
+            exportable: true,
+            validate: { type: 'string', required: true },
+            displayable: {
+              position: 1,
+              name: IMPORT_KEY_FIELD.COMMON_DIVISION,
+              filterable: {
+                type: 'string',
+              },
+            },
+          },
+        },
+        {
+          name: 'Date de naissance',
+          required: true,
+          config: {
+            reconcile: {
+              fieldId: 'reconcileField3',
+              name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE,
+              position: 3,
+            },
+            validate: { type: 'date', format: 'YYYY-MM-DD', required: true },
+            displayable: {
+              position: 2,
+              name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE,
+            },
+          },
+        },
       ],
     },
     createdAt: new Date('2024-01-01'),

--- a/api/src/prescription/learner-management/domain/usecases/get-organization-learners-csv-template.js
+++ b/api/src/prescription/learner-management/domain/usecases/get-organization-learners-csv-template.js
@@ -22,7 +22,7 @@ const getOrganizationLearnersCsvTemplate = async function ({
   const importFormat = await organizationLearnerImportFormatRepository.get(organizationId);
   let columns;
   if (importFormat) {
-    columns = importFormat.headersFields;
+    columns = importFormat.headersName;
   } else {
     if (!_isSupManagingStudents(membership)) {
       throw new UserNotAuthorizedToAccessEntityError(ERROR_MESSAGE);

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
@@ -1160,23 +1160,24 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
             name: 'test',
             fileType: 'csv',
             config: {
-              displayableColumns: [
-                {
-                  key: 4,
-                  position: 2,
-                  name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE,
-                },
-                {
-                  key: 3,
-                  position: 1,
-                  name: IMPORT_KEY_FIELD.COMMON_DIVISION,
-                },
-              ],
               headers: [
-                { key: 1, name: 'Nom apprenant', property: 'lastName', required: true },
-                { key: 2, name: 'Prénom apprenant', property: 'firstName', required: true },
-                { key: 3, name: 'Classe', required: true },
-                { key: 4, name: 'Date de naissance', required: true },
+                { name: 'Nom apprenant', property: 'lastName', required: true },
+                { name: 'Prénom apprenant', property: 'firstName', required: true },
+                {
+                  name: 'Classe',
+                  required: true,
+                  config: {
+                    displayable: {
+                      position: 1,
+                      name: IMPORT_KEY_FIELD.COMMON_DIVISION,
+                    },
+                  },
+                },
+                {
+                  name: 'Date de naissance',
+                  required: true,
+                  config: { displayable: { position: 2, name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE } },
+                },
               ],
             },
           });

--- a/api/tests/prescription/learner-management/acceptance/application/organization-learners-route_test.js
+++ b/api/tests/prescription/learner-management/acceptance/application/organization-learners-route_test.js
@@ -92,10 +92,13 @@ describe('Acceptance | Prescription | learner management | Application | organiz
         config: {
           unicityColumns: ['column_firstname'],
           acceptedEncoding: ['utf-8'],
-          validationRules: { formats: [{ name: 'column_lastname', type: 'string' }] },
           headers: [
-            { name: 'column_firstname', property: 'firstName', required: true },
-            { name: 'column_lastname', property: 'lastName', required: true },
+            {
+              name: 'column_firstname',
+              config: { property: 'firstName', validate: { type: 'string' } },
+              required: true,
+            },
+            { name: 'column_lastname', config: { property: 'lastName' }, required: true },
             { name: 'hobby', required: false },
           ],
         },
@@ -153,25 +156,32 @@ describe('Acceptance | Prescription | learner management | Application | organiz
         config: {
           acceptedEncoding: ['utf8'],
           unicityColumns: ['unicity key'],
-          reconciliationMappingColumns: [
-            { key: 1, fieldId: 'reconcileField1', columnName: IMPORT_KEY_FIELD.COMMON_LASTNAME, position: 1 },
-            { key: 2, fieldId: 'reconcileField2', columnName: IMPORT_KEY_FIELD.COMMON_FIRSTNAME, position: 2 },
-          ],
-          validationRules: {
-            formats: [
-              { name: 'Nom apprenant', type: 'string', required: true },
-              { name: 'Prénom apprenant', type: 'string', required: true },
-              { name: 'unicity key', type: 'string', required: true },
-              { name: 'catégorie', type: 'string', required: true },
-              { name: 'Date de naissance', type: 'date', format: 'YYYY-MM-DD', required: true },
-            ],
-          },
           headers: [
-            { key: 1, name: 'Nom apprenant', property: 'lastName', required: true },
-            { key: 2, name: 'Prénom apprenant', property: 'firstName', required: true },
-            { key: 3, name: 'unicity key', required: true },
-            { key: 4, name: 'catégorie', required: true },
-            { key: 5, name: 'Date de naissance', required: true },
+            {
+              config: {
+                property: 'lastName',
+                validate: { type: 'string', required: true },
+                reconcile: { fieldId: 'reconcileField1', name: IMPORT_KEY_FIELD.COMMON_LASTNAME, position: 1 },
+              },
+              name: 'Nom apprenant',
+              required: true,
+            },
+            {
+              config: {
+                property: 'firstName',
+                validate: { type: 'string', required: true },
+                reconcile: { fieldId: 'reconcileField2', name: IMPORT_KEY_FIELD.COMMON_FIRSTNAME, position: 2 },
+              },
+              name: 'Prénom apprenant',
+              required: true,
+            },
+            { config: {}, name: 'unicity key', required: true },
+            { config: { validate: { type: 'string', required: true } }, name: 'catégorie', required: true },
+            {
+              config: { validate: { type: 'date', format: 'YYYY-MM-DD', required: true } },
+              name: 'Date de naissance',
+              required: true,
+            },
           ],
         },
       }).id;

--- a/api/tests/prescription/learner-management/unit/domain/models/OrganizationLearnerImportFormat_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/models/OrganizationLearnerImportFormat_test.js
@@ -14,50 +14,49 @@ describe('Unit | Models | OrganizationLearnerImportFormat', function () {
       config: {
         acceptedEncoding: ['utf8'],
         unicityColumns: ['unicity key'],
-        reconciliationMappingColumns: [
-          { key: 4, fieldId: 'reconcileField3', name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE, position: 3 },
-          { key: 1, fieldId: 'reconcileField1', name: IMPORT_KEY_FIELD.COMMON_LASTNAME, position: 1 },
-          { key: 2, fieldId: 'reconcileField2', name: IMPORT_KEY_FIELD.COMMON_FIRSTNAME, position: 2 },
-        ],
-        validationRules: {
-          formats: [
-            { key: 1, name: 'Nom apprenant', type: 'string', required: true },
-            { key: 2, name: 'Prénom apprenant', type: 'string', required: true },
-            { key: 3, name: 'catégorie', type: 'string', required: true },
-            { key: 4, name: 'Date de naissance', type: 'date', format: 'YYYY-MM-DD', required: true },
-            { key: 5, name: 'unicity key', type: 'string', required: true },
-          ],
-        },
         headers: [
-          { key: 1, name: 'Nom apprenant', property: 'lastName', required: true },
-          { key: 2, name: 'Prénom apprenant', property: 'firstName', required: true },
-          { key: 3, name: 'catégorie', required: true, config: { exportable: true } },
-          { key: 4, name: 'Date de naissance', required: true, config: { exportable: true } },
-          { key: 5, name: 'unicity key', required: true },
-        ],
-        filterableColumns: [
           {
-            key: 4,
-            position: 2,
-            name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE,
+            name: 'Nom apprenant',
+            config: {
+              validate: { type: 'string', required: true },
+              property: 'lastName',
+              reconcile: { fieldId: 'reconcileField1', name: IMPORT_KEY_FIELD.COMMON_LASTNAME, position: 1 },
+            },
+            required: true,
           },
           {
-            key: 3,
-            position: 1,
-            name: IMPORT_KEY_FIELD.COMMON_DIVISION,
-          },
-        ],
-        displayableColumns: [
-          {
-            key: 3,
-            position: 2,
-            name: IMPORT_KEY_FIELD.COMMON_DIVISION,
+            name: 'Prénom apprenant',
+            config: {
+              validate: { type: 'string', required: true },
+              property: 'firstName',
+              reconcile: { fieldId: 'reconcileField2', name: IMPORT_KEY_FIELD.COMMON_FIRSTNAME, position: 2 },
+            },
+            required: true,
           },
           {
-            key: 4,
-            position: 1,
-            name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE,
+            name: 'catégorie',
+            required: true,
+            config: {
+              displayable: {
+                position: 2,
+                name: IMPORT_KEY_FIELD.COMMON_DIVISION,
+                filterable: { type: 'string' },
+              },
+              exportable: true,
+              validate: { type: 'string', required: true },
+            },
           },
+          {
+            name: 'Date de naissance',
+            required: true,
+            config: {
+              validate: { type: 'date', format: 'YYYY-MM-DD', required: true },
+              reconcile: { fieldId: 'reconcileField3', name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE, position: 3 },
+              displayable: { position: 1, name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE, filterable: { type: 'string' } },
+              exportable: true,
+            },
+          },
+          { name: 'unicity key', required: true, validate: { type: 'string', required: true } },
         ],
       },
       createdAt: new Date('2024-01-01'),
@@ -144,14 +143,33 @@ describe('Unit | Models | OrganizationLearnerImportFormat', function () {
       const organizationLearnerImportFormat = new OrganizationLearnerImportFormat(
         organizationLearnerImportFormatPayload,
       );
-      expect(organizationLearnerImportFormat.extraColumns).to.deep.equal([
+      expect(organizationLearnerImportFormat.extraColumns).to.deep.members([
         { key: 'Date de naissance', name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE },
         { key: 'catégorie', name: IMPORT_KEY_FIELD.COMMON_DIVISION },
       ]);
     });
 
     it('should return empty when displayableColumns is not defined', function () {
-      delete organizationLearnerImportFormatPayload.config.displayableColumns;
+      organizationLearnerImportFormatPayload.config.headers = [
+        {
+          name: 'Nom apprenant',
+          config: {
+            validate: { type: 'string', required: true },
+            property: 'lastName',
+            reconcile: { fieldId: 'reconcileField1', name: IMPORT_KEY_FIELD.COMMON_LASTNAME, position: 1 },
+          },
+          required: true,
+        },
+        {
+          name: 'Prénom apprenant',
+          config: {
+            validate: { type: 'string', required: true },
+            property: 'firstName',
+            reconcile: { fieldId: 'reconcileField2', name: IMPORT_KEY_FIELD.COMMON_FIRSTNAME, position: 2 },
+          },
+          required: true,
+        },
+      ];
 
       const organizationLearnerImportFormat = new OrganizationLearnerImportFormat(
         organizationLearnerImportFormatPayload,
@@ -166,13 +184,32 @@ describe('Unit | Models | OrganizationLearnerImportFormat', function () {
         organizationLearnerImportFormatPayload,
       );
       expect(organizationLearnerImportFormat.orderedFilterableColumns).to.deep.equal([
-        { key: 3, name: IMPORT_KEY_FIELD.COMMON_DIVISION, position: 1 },
-        { key: 4, name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE, position: 2 },
+        { name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE, position: 1 },
+        { name: IMPORT_KEY_FIELD.COMMON_DIVISION, position: 2 },
       ]);
     });
 
     it('should return empty when filterableColumns is not defined', function () {
-      delete organizationLearnerImportFormatPayload.config.filterableColumns;
+      organizationLearnerImportFormatPayload.config.headers = [
+        {
+          name: 'Nom apprenant',
+          config: {
+            validate: { type: 'string', required: true },
+            property: 'lastName',
+            reconcile: { fieldId: 'reconcileField1', name: IMPORT_KEY_FIELD.COMMON_LASTNAME, position: 1 },
+          },
+          required: true,
+        },
+        {
+          name: 'Prénom apprenant',
+          config: {
+            validate: { type: 'string', required: true },
+            property: 'firstName',
+            reconcile: { fieldId: 'reconcileField2', name: IMPORT_KEY_FIELD.COMMON_FIRSTNAME, position: 2 },
+          },
+          required: true,
+        },
+      ];
 
       const organizationLearnerImportFormat = new OrganizationLearnerImportFormat(
         organizationLearnerImportFormatPayload,
@@ -187,13 +224,32 @@ describe('Unit | Models | OrganizationLearnerImportFormat', function () {
         organizationLearnerImportFormatPayload,
       );
       expect(organizationLearnerImportFormat.orderedDisplayabledColumns).to.deep.equal([
-        { key: 4, name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE, position: 1 },
-        { key: 3, name: IMPORT_KEY_FIELD.COMMON_DIVISION, position: 2 },
+        { name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE, position: 1 },
+        { name: IMPORT_KEY_FIELD.COMMON_DIVISION, position: 2 },
       ]);
     });
 
     it('should return empty when displayableColumns is not defined', function () {
-      delete organizationLearnerImportFormatPayload.config.displayableColumns;
+      organizationLearnerImportFormatPayload.config.headers = [
+        {
+          name: 'Nom apprenant',
+          config: {
+            validate: { type: 'string', required: true },
+            property: 'lastName',
+            reconcile: { fieldId: 'reconcileField1', name: IMPORT_KEY_FIELD.COMMON_LASTNAME, position: 1 },
+          },
+          required: true,
+        },
+        {
+          name: 'Prénom apprenant',
+          config: {
+            validate: { type: 'string', required: true },
+            property: 'firstName',
+            reconcile: { fieldId: 'reconcileField2', name: IMPORT_KEY_FIELD.COMMON_FIRSTNAME, position: 2 },
+          },
+          required: true,
+        },
+      ];
 
       const organizationLearnerImportFormat = new OrganizationLearnerImportFormat(
         organizationLearnerImportFormatPayload,
@@ -208,8 +264,8 @@ describe('Unit | Models | OrganizationLearnerImportFormat', function () {
         organizationLearnerImportFormatPayload,
       );
       expect(organizationLearnerImportFormat.filtersToDisplay).to.deep.equal([
-        IMPORT_KEY_FIELD.COMMON_DIVISION,
         IMPORT_KEY_FIELD.COMMON_BIRTHDATE,
+        IMPORT_KEY_FIELD.COMMON_DIVISION,
       ]);
     });
   });
@@ -226,7 +282,26 @@ describe('Unit | Models | OrganizationLearnerImportFormat', function () {
     });
 
     it('should return empty when displayableColumns is not defined', function () {
-      delete organizationLearnerImportFormatPayload.config.displayableColumns;
+      organizationLearnerImportFormatPayload.config.headers = [
+        {
+          name: 'Nom apprenant',
+          config: {
+            validate: { type: 'string', required: true },
+            property: 'lastName',
+            reconcile: { fieldId: 'reconcileField1', name: IMPORT_KEY_FIELD.COMMON_LASTNAME, position: 1 },
+          },
+          required: true,
+        },
+        {
+          name: 'Prénom apprenant',
+          config: {
+            validate: { type: 'string', required: true },
+            property: 'firstName',
+            reconcile: { fieldId: 'reconcileField2', name: IMPORT_KEY_FIELD.COMMON_FIRSTNAME, position: 2 },
+          },
+          required: true,
+        },
+      ];
 
       const organizationLearnerImportFormat = new OrganizationLearnerImportFormat(
         organizationLearnerImportFormatPayload,
@@ -241,24 +316,24 @@ describe('Unit | Models | OrganizationLearnerImportFormat', function () {
         organizationLearnerImportFormatPayload,
       );
       expect(organizationLearnerImportFormat.reconciliationFields).to.deep.equal([
-        { fieldId: 'reconcileField1', name: IMPORT_KEY_FIELD.COMMON_LASTNAME, type: 'string' },
-        { fieldId: 'reconcileField2', name: IMPORT_KEY_FIELD.COMMON_FIRSTNAME, type: 'string' },
-        { fieldId: 'reconcileField3', name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE, type: 'date' },
+        { fieldId: 'reconcileField1', name: IMPORT_KEY_FIELD.COMMON_LASTNAME, type: 'string', position: 1 },
+        { fieldId: 'reconcileField2', name: IMPORT_KEY_FIELD.COMMON_FIRSTNAME, type: 'string', position: 2 },
+        { fieldId: 'reconcileField3', name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE, type: 'date', position: 3 },
       ]);
     });
   });
 
-  describe('#headersFields', function () {
+  describe('#headersName', function () {
     it('should return headers fields', function () {
       const organizationLearnerImportFormat = new OrganizationLearnerImportFormat(
         organizationLearnerImportFormatPayload,
       );
-      expect(organizationLearnerImportFormat.headersFields).to.deep.equal([
-        { key: 1, name: 'Nom apprenant', property: 'lastName', required: true },
-        { key: 2, name: 'Prénom apprenant', property: 'firstName', required: true },
-        { key: 3, name: 'catégorie', required: true, config: { exportable: true } },
-        { key: 4, name: 'Date de naissance', required: true, config: { exportable: true } },
-        { key: 5, name: 'unicity key', required: true },
+      expect(organizationLearnerImportFormat.headersName).to.deep.equal([
+        { name: 'Nom apprenant' },
+        { name: 'Prénom apprenant' },
+        { name: 'catégorie' },
+        { name: 'Date de naissance' },
+        { name: 'unicity key' },
       ]);
     });
   });
@@ -297,7 +372,7 @@ describe('Unit | Models | OrganizationLearnerImportFormat', function () {
 
     it('should return empty when there is no exportable columns', function () {
       organizationLearnerImportFormatPayload.config.headers = [
-        { key: 1, name: 'Nom apprenant', property: 'lastName', required: true },
+        { name: 'Nom apprenant', property: 'lastName', required: true },
       ];
 
       const organizationLearnerImportFormat = new OrganizationLearnerImportFormat(


### PR DESCRIPTION
## :unicorn: Problème
l'extension de la config des imports à format nous a amené a devoir générer des key pour rester ISO avec le fonctionnement précédent.
Or il n'est pas très pertinent, peu modulable et sujet à erreur

## :robot: Proposition
Rapatrier les configuration du header ( property / validate / reconcil / exportable / filterable ...) dans un sous objet config du header afin d'y voir plus clair.
 
## :rainbow: Remarques
Pensez à faire la migration pour les imports existant via la feature sur PixAdmin qui permet de mettre à jour un model d'import à format (fichier à jour dans le JIRA en attachement)

## :100: Pour tester
Faire un import sur PRO_MANAGING
Vérifier l'affichage du filtrage / des colonnes dans PixOrga sur la page participants
Vérifier le téléchargement du template csv

Faire une réconciliation avec un apprenant.