### PR TITLE
[FEATURE] Bloquer l'utilisateur si on ne détecte pas l'extension et qu'il se trouve sur l'écran de démarrage (PIX-14501)

### DIFF
--- a/mon-pix/app/components/certification-starter.js
+++ b/mon-pix/app/components/certification-starter.js
@@ -3,7 +3,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
-export default class CertificationJoiner extends Component {
+export default class CertificationStarter extends Component {
   @service store;
   @service router;
   @service currentUser;

--- a/mon-pix/app/components/certifications/start.gjs
+++ b/mon-pix/app/components/certifications/start.gjs
@@ -1,0 +1,25 @@
+import PixBackgroundHeader from '@1024pix/pix-ui/components/pix-background-header';
+import PixBlock from '@1024pix/pix-ui/components/pix-block';
+
+import CertificationStarter from '../certification-starter';
+import CompanionBlocker from '../companion/blocker';
+import Footer from '../footer';
+import NavbarHeader from '../navbar-header';
+
+<template>
+  <CompanionBlocker>
+    <header role="banner">
+      <NavbarHeader />
+    </header>
+
+    <main class="main" role="main">
+      <PixBackgroundHeader id="main">
+        <PixBlock @shadow="heavy" class="certification-start-page__block">
+          <CertificationStarter @certificationCandidateSubscription={{@certificationCandidateSubscription}} />
+        </PixBlock>
+      </PixBackgroundHeader>
+    </main>
+
+    <Footer />
+  </CompanionBlocker>
+</template>

--- a/mon-pix/app/components/companion/blocker.gjs
+++ b/mon-pix/app/components/companion/blocker.gjs
@@ -2,6 +2,7 @@
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
+import ENV from 'mon-pix/config/environment';
 
 import ShieldIcon from './shield-icon';
 
@@ -10,18 +11,20 @@ export default class CompanionBlocker extends Component {
 
   constructor(...args) {
     super(...args);
-    this.pixCompanion.startCheckingExtensionIsEnabled();
+    if (ENV.APP.FT_IS_PIX_COMPANION_MANDATORY) this.pixCompanion.startCheckingExtensionIsEnabled();
   }
 
   willDestroy(...args) {
     super.willDestroy(...args);
-    this.pixCompanion.stopCheckingExtensionIsEnabled();
+    if (ENV.APP.FT_IS_PIX_COMPANION_MANDATORY) this.pixCompanion.stopCheckingExtensionIsEnabled();
+  }
+
+  get isBlocked() {
+    return ENV.APP.FT_IS_PIX_COMPANION_MANDATORY && !this.pixCompanion.isExtensionEnabled;
   }
 
   <template>
-    {{#if this.pixCompanion.isExtensionEnabled}}
-      {{yield}}
-    {{else}}
+    {{#if this.isBlocked}}
       <section class="companion-blocker">
         <ShieldIcon />
         <h1>
@@ -30,6 +33,8 @@ export default class CompanionBlocker extends Component {
         <p>{{t "common.companion.not-detected.description"}}</p>
         {{!-- <PixButtonLink @href="https://pix.fr" target="_blank">{{t "common.companion.not-detected.link"}}</PixButtonLink> --}}
       </section>
+    {{else}}
+      {{yield}}
     {{/if}}
   </template>
 }

--- a/mon-pix/app/templates/authenticated/certifications/start.hbs
+++ b/mon-pix/app/templates/authenticated/certifications/start.hbs
@@ -1,17 +1,3 @@
 {{page-title (t "pages.certification-start.title")}}
 
-<Companion::Blocker>
-  <header role="banner">
-    <NavbarHeader />
-  </header>
-
-  <main class="main" role="main">
-    <PixBackgroundHeader id="main">
-      <PixBlock @shadow="heavy" class="certification-start-page__block">
-        <CertificationStarter @certificationCandidateSubscription={{@model}} />
-      </PixBlock>
-    </PixBackgroundHeader>
-  </main>
-
-  <Footer />
-</Companion::Blocker>
+<Certifications::Start @certificationCandidateSubscription={{@model}} />

--- a/mon-pix/app/templates/authenticated/certifications/start.hbs
+++ b/mon-pix/app/templates/authenticated/certifications/start.hbs
@@ -1,15 +1,17 @@
 {{page-title (t "pages.certification-start.title")}}
 
-<header role="banner">
-  <NavbarHeader />
-</header>
+<Companion::Blocker>
+  <header role="banner">
+    <NavbarHeader />
+  </header>
 
-<main class="main" role="main">
-  <PixBackgroundHeader id="main">
-    <PixBlock @shadow="heavy" class="certification-start-page__block">
-      <CertificationStarter @certificationCandidateSubscription={{@model}} />
-    </PixBlock>
-  </PixBackgroundHeader>
-</main>
+  <main class="main" role="main">
+    <PixBackgroundHeader id="main">
+      <PixBlock @shadow="heavy" class="certification-start-page__block">
+        <CertificationStarter @certificationCandidateSubscription={{@model}} />
+      </PixBlock>
+    </PixBackgroundHeader>
+  </main>
 
-<Footer />
+  <Footer />
+</Companion::Blocker>

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -43,6 +43,7 @@ module.exports = function (environment) {
       // when it is created
       API_HOST: process.env.API_HOST || '',
       FT_FOCUS_CHALLENGE_ENABLED: _isFeatureEnabled(process.env.FT_FOCUS_CHALLENGE_ENABLED) || false,
+      FT_IS_PIX_COMPANION_MANDATORY: _isFeatureEnabled(process.env.FT_IS_PIX_COMPANION_MANDATORY) || false,
       isTimerCountdownEnabled: true,
       LOAD_EXTERNAL_SCRIPT: true,
       NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS: 5,

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -172,6 +172,7 @@ module.exports = function (environment) {
     ENV.APP.isTimerCountdownEnabled = false;
     ENV.APP.LOAD_EXTERNAL_SCRIPT = false;
     ENV.APP.FT_FOCUS_CHALLENGE_ENABLED = true;
+    ENV.APP.FT_IS_PIX_COMPANION_MANDATORY = true;
     ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID = 999;
     ENV.metrics.enabled = false;
   }

--- a/mon-pix/tests/integration/components/certifications/start-test.gjs
+++ b/mon-pix/tests/integration/components/certifications/start-test.gjs
@@ -1,0 +1,70 @@
+import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import { t } from 'ember-intl/test-support';
+import CertificationsStart from 'mon-pix/components/certifications/start';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Certifications | start', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it displays certification starter page when extension is enabled', async function (assert) {
+    // given
+    const startCheckingExtensionIsEnabledStub = sinon.stub();
+    const stopCheckingExtensionIsEnabledStub = sinon.stub();
+
+    class PixCompanionStub extends Service {
+      startCheckingExtensionIsEnabled = startCheckingExtensionIsEnabledStub;
+      stopCheckingExtensionIsEnabled = stopCheckingExtensionIsEnabledStub;
+      isExtensionEnabled = true;
+    }
+
+    this.owner.register('service:pix-companion', PixCompanionStub);
+
+    const certificationCandidateSubscription = {};
+
+    // when
+    const screen = await render(
+      <template>
+        <CertificationsStart @certificationCandidateSubscription={{certificationCandidateSubscription}} />
+      </template>,
+    );
+
+    // then
+    assert.dom(screen.queryByRole('heading', { level: 2, name: t('pages.certification-start.first-title') })).exists();
+  });
+
+  test('it displays companion blocker page when extension is disabled', async function (assert) {
+    // given
+    const startCheckingExtensionIsEnabledStub = sinon.stub();
+    const stopCheckingExtensionIsEnabledStub = sinon.stub();
+
+    class PixCompanionStub extends Service {
+      startCheckingExtensionIsEnabled = startCheckingExtensionIsEnabledStub;
+      stopCheckingExtensionIsEnabled = stopCheckingExtensionIsEnabledStub;
+      isExtensionEnabled = false;
+    }
+
+    this.owner.register('service:pix-companion', PixCompanionStub);
+
+    const certificationCandidateSubscription = {};
+
+    // when
+    const screen = await render(
+      <template>
+        <CertificationsStart @certificationCandidateSubscription={{certificationCandidateSubscription}} />
+      </template>,
+    );
+
+    // then
+    assert
+      .dom(screen.queryByRole('heading', { level: 2, name: t('pages.certification-start.first-title') }))
+      .doesNotExist();
+
+    assert
+      .dom(screen.queryByRole('heading', { level: 1, name: 'L’extension Pix Companion n’est pas détectée' }))
+      .exists();
+  });
+});

--- a/mon-pix/tests/integration/components/companion/blocker-test.gjs
+++ b/mon-pix/tests/integration/components/companion/blocker-test.gjs
@@ -2,6 +2,7 @@ import { render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import { t } from 'ember-intl/test-support';
 import CompanionBlocker from 'mon-pix/components/companion/blocker';
+import ENV from 'mon-pix/config/environment';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -12,9 +13,12 @@ module('Integration | Component | Companion | blocker', function (hooks) {
 
   test('it display children elements when extension is detected', async function (assert) {
     // given
+    const startCheckingExtensionIsEnabledStub = sinon.stub();
+    const stopCheckingExtensionIsEnabledStub = sinon.stub();
+
     class PixCompanionStub extends Service {
-      startCheckingExtensionIsEnabled = sinon.stub();
-      stopCheckingExtensionIsEnabled = sinon.stub();
+      startCheckingExtensionIsEnabled = startCheckingExtensionIsEnabledStub;
+      stopCheckingExtensionIsEnabled = stopCheckingExtensionIsEnabledStub;
       isExtensionEnabled = true;
     }
 
@@ -30,23 +34,35 @@ module('Integration | Component | Companion | blocker', function (hooks) {
     );
 
     // then
+    sinon.assert.calledOnce(startCheckingExtensionIsEnabledStub);
     assert.dom(screen.queryByRole('heading', { level: 1, name: title })).exists();
   });
 
-  test('it display blocking page when extension is NOT detected', async function (assert) {
+  test('it displays blocking page when extension is NOT detected', async function (assert) {
     // given
+    const startCheckingExtensionIsEnabledStub = sinon.stub();
+    const stopCheckingExtensionIsEnabledStub = sinon.stub();
+
     class PixCompanionStub extends Service {
-      startCheckingExtensionIsEnabled = sinon.stub();
-      stopCheckingExtensionIsEnabled = sinon.stub();
+      startCheckingExtensionIsEnabled = startCheckingExtensionIsEnabledStub;
+      stopCheckingExtensionIsEnabled = stopCheckingExtensionIsEnabledStub;
       isExtensionEnabled = false;
     }
 
     this.owner.register('service:pix-companion', PixCompanionStub);
 
+    const title = 'Companion activé';
+
     // when
-    const screen = await render(<template><CompanionBlocker /></template>);
+    const screen = await render(
+      <template>
+        <CompanionBlocker><h1>{{title}}</h1></CompanionBlocker>
+      </template>,
+    );
 
     // then
+    sinon.assert.calledOnce(startCheckingExtensionIsEnabledStub);
+
     assert.dom(screen.queryByRole('heading', { level: 1, name: 'Companion activé' })).doesNotExist();
 
     assert
@@ -56,5 +72,41 @@ module('Integration | Component | Companion | blocker', function (hooks) {
     assert.dom(screen.queryByText(t('common.companion.not-detected.description'))).exists();
 
     // assert.dom(screen.queryByRole('link', { name: t('common.companion.not-detected.link') })).exists();
+  });
+
+  module('FT_IS_PIX_COMPANION_MANDATORY feature toggle', function (hooks) {
+    const ORIGINAL_FT_IS_PIX_COMPANION_MANDATORY = ENV.APP.FT_IS_PIX_COMPANION_MANDATORY;
+
+    hooks.afterEach(() => {
+      ENV.APP.FT_IS_PIX_COMPANION_MANDATORY = ORIGINAL_FT_IS_PIX_COMPANION_MANDATORY;
+    });
+
+    test('when FT is false should always display children content', async function (assert) {
+      // given
+      ENV.APP.FT_IS_PIX_COMPANION_MANDATORY = false;
+
+      const startCheckingExtensionIsEnabledStub = sinon.stub();
+      const stopCheckingExtensionIsEnabledStub = sinon.stub();
+
+      class PixCompanionStub extends Service {
+        startCheckingExtensionIsEnabled = startCheckingExtensionIsEnabledStub;
+        stopCheckingExtensionIsEnabled = stopCheckingExtensionIsEnabledStub;
+        isExtensionEnabled = false;
+      }
+
+      this.owner.register('service:pix-companion', PixCompanionStub);
+
+      const title = 'Companion activé';
+
+      // when
+      const screen = await render(
+        <template>
+          <CompanionBlocker><h1>{{title}}</h1></CompanionBlocker>
+        </template>,
+      );
+
+      sinon.assert.notCalled(startCheckingExtensionIsEnabledStub);
+      assert.dom(screen.queryByRole('heading', { level: 1, name: title })).exists();
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Lorsque le candidat accède à l'écran de démarrage une session de certification, on ne peut pas savoir si l'extension Pix Companion est présente et activée ou non.

## :robot: Proposition
- Bloquer l'utilisateur si on ne détecte pas l'extension et qu'il se trouve / accède à l'écran de démarrage de la certification.
- Mettre en place un feature toggle pour que cette solution ne soit active uniquement en recette d’ici début novembre.

## :rainbow: Remarques
N/A

## :100: Pour tester
Le feature toggle est actif sur la RA, se rendre sur la page de démarrage de certif et vérifier que le blocage est bien effectif.
:warning: Sur Chrome le déblocage nécessite un rafraîchissement de la page (et un repassage par la réconciliation).