### PR TITLE
[BUGFIX] Ne pas déclencher une erreur 503 quand l'email est invalide lors de l'envoi d'email transactionnel (PIX-14315)

### DIFF
--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -785,8 +785,8 @@ class DeprecatedCertificationIssueReportSubcategoryError extends DomainError {
 }
 
 class SendingEmailError extends DomainError {
-  constructor() {
-    super("Échec lors de l'envoi de l'email.");
+  constructor(emailAddress) {
+    super(`Failed to send email to "${emailAddress}" for some unknown reason.`);
     this.code = 'SENDING_EMAIL_FAILED';
   }
 }

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -793,14 +793,14 @@ class SendingEmailError extends DomainError {
 
 class SendingEmailToInvalidDomainError extends DomainError {
   constructor(emailAddress) {
-    super(`Failed to send email to ${emailAddress} because domain seems to be invalid.`);
+    super(`Failed to send email to "${emailAddress}" because domain seems to be invalid.`);
     this.code = 'INVALID_EMAIL_DOMAIN';
   }
 }
 
 class SendingEmailToInvalidEmailAddressError extends DomainError {
   constructor(emailAddress, errorMessage) {
-    super(`Failed to send email to ${emailAddress} because email address seems to be invalid.`);
+    super(`Failed to send email to "${emailAddress}" because email address seems to be invalid.`);
     this.code = 'INVALID_EMAIL_ADDRESS_FORMAT';
     this.meta = {
       emailAddress,

--- a/api/src/shared/mail/infrastructure/providers/BrevoProvider.js
+++ b/api/src/shared/mail/infrastructure/providers/BrevoProvider.js
@@ -53,11 +53,8 @@ class BrevoProvider extends MailingProvider {
     try {
       return await this._client.sendTransacEmail(payload);
     } catch (err) {
-      if (err?.response?.text) {
-        const responseText = JSON.parse(err.response.text);
-        if (responseText.code === 'invalid_parameter') {
-          throw new MailingProviderInvalidEmailError(responseText.message);
-        }
+      if (err?.body?.code === 'invalid_parameter') {
+        throw new MailingProviderInvalidEmailError(err?.body?.message);
       }
 
       throw err;

--- a/api/src/shared/mail/infrastructure/services/mailer.js
+++ b/api/src/shared/mail/infrastructure/services/mailer.js
@@ -50,7 +50,7 @@ class Mailer {
         return EmailingAttempt.failure(options.to, EmailingAttempt.errorCode.INVALID_EMAIL, err.message);
       }
 
-      return EmailingAttempt.failure(options.to);
+      return EmailingAttempt.failure(options.to, EmailingAttempt.errorCode.PROVIDER_ERROR, err.message);
     }
 
     return EmailingAttempt.success(options.to);

--- a/api/src/team/domain/services/certification-center-invitation-service.js
+++ b/api/src/team/domain/services/certification-center-invitation-service.js
@@ -65,7 +65,7 @@ async function _sendInvitationEmail(
   locale,
   certificationCenterInvitationRepository,
 ) {
-  const mailerResponse = await mailService.sendCertificationCenterInvitationEmail({
+  const emailingAttempt = await mailService.sendCertificationCenterInvitationEmail({
     certificationCenterInvitationId: certificationCenterInvitation.id,
     certificationCenterName: certificationCenter.name,
     code: certificationCenterInvitation.code,
@@ -73,13 +73,13 @@ async function _sendInvitationEmail(
     locale,
   });
 
-  if (mailerResponse.status !== 'SUCCESS') {
-    if (mailerResponse.hasFailedBecauseDomainWasInvalid()) {
+  if (emailingAttempt.status !== 'SUCCESS') {
+    if (emailingAttempt.hasFailedBecauseDomainWasInvalid()) {
       throw new SendingEmailToInvalidDomainError(email);
     }
 
-    if (mailerResponse.hasFailedBecauseEmailWasInvalid()) {
-      throw new SendingEmailToInvalidEmailAddressError(email, mailerResponse.errorMessage);
+    if (emailingAttempt.hasFailedBecauseEmailWasInvalid()) {
+      throw new SendingEmailToInvalidEmailAddressError(email, emailingAttempt.errorMessage);
     }
 
     throw new SendingEmailError();

--- a/api/src/team/domain/services/certification-center-invitation-service.js
+++ b/api/src/team/domain/services/certification-center-invitation-service.js
@@ -73,7 +73,7 @@ async function _sendInvitationEmail(
     locale,
   });
 
-  if (emailingAttempt.status !== 'SUCCESS') {
+  if (emailingAttempt.hasFailed()) {
     if (emailingAttempt.hasFailedBecauseDomainWasInvalid()) {
       throw new SendingEmailToInvalidDomainError(email);
     }

--- a/api/src/team/domain/services/certification-center-invitation-service.js
+++ b/api/src/team/domain/services/certification-center-invitation-service.js
@@ -82,7 +82,7 @@ async function _sendInvitationEmail(
       throw new SendingEmailToInvalidEmailAddressError(email, emailingAttempt.errorMessage);
     }
 
-    throw new SendingEmailError();
+    throw new SendingEmailError(email);
   }
 
   await certificationCenterInvitationRepository.updateModificationDate(certificationCenterInvitation.id);

--- a/api/src/team/domain/services/organization-invitation.service.js
+++ b/api/src/team/domain/services/organization-invitation.service.js
@@ -47,7 +47,7 @@ const createOrUpdateOrganizationInvitation = async ({
 
   const organization = await organizationRepository.get(organizationId);
 
-  const mailerResponse = await dependencies.mailService.sendOrganizationInvitationEmail({
+  const emailingAttempt = await dependencies.mailService.sendOrganizationInvitationEmail({
     email,
     organizationName: organization.name,
     organizationInvitationId: organizationInvitation.id,
@@ -55,13 +55,13 @@ const createOrUpdateOrganizationInvitation = async ({
     locale,
     tags,
   });
-  if (mailerResponse?.status === 'FAILURE') {
-    if (mailerResponse.hasFailedBecauseDomainWasInvalid()) {
+  if (emailingAttempt?.status === 'FAILURE') {
+    if (emailingAttempt.hasFailedBecauseDomainWasInvalid()) {
       throw new SendingEmailToInvalidDomainError(email);
     }
 
-    if (mailerResponse.hasFailedBecauseEmailWasInvalid()) {
-      throw new SendingEmailToInvalidEmailAddressError(email, mailerResponse.errorMessage);
+    if (emailingAttempt.hasFailedBecauseEmailWasInvalid()) {
+      throw new SendingEmailToInvalidEmailAddressError(email, emailingAttempt.errorMessage);
     }
 
     throw new SendingEmailError();

--- a/api/src/team/domain/services/organization-invitation.service.js
+++ b/api/src/team/domain/services/organization-invitation.service.js
@@ -55,7 +55,7 @@ const createOrUpdateOrganizationInvitation = async ({
     locale,
     tags,
   });
-  if (emailingAttempt?.status === 'FAILURE') {
+  if (emailingAttempt.hasFailed()) {
     if (emailingAttempt.hasFailedBecauseDomainWasInvalid()) {
       throw new SendingEmailToInvalidDomainError(email);
     }

--- a/api/src/team/domain/services/organization-invitation.service.js
+++ b/api/src/team/domain/services/organization-invitation.service.js
@@ -64,7 +64,7 @@ const createOrUpdateOrganizationInvitation = async ({
       throw new SendingEmailToInvalidEmailAddressError(email, emailingAttempt.errorMessage);
     }
 
-    throw new SendingEmailError();
+    throw new SendingEmailError(email);
   }
 
   return await organizationInvitationRepository.updateModificationDate(organizationInvitation.id);

--- a/api/src/team/domain/usecases/create-or-update-certification-center-invitation-for-admin.js
+++ b/api/src/team/domain/usecases/create-or-update-certification-center-invitation-for-admin.js
@@ -41,7 +41,7 @@ const createOrUpdateCertificationCenterInvitationForAdmin = async function ({
       throw new SendingEmailToInvalidDomainError(email);
     }
 
-    throw new SendingEmailError();
+    throw new SendingEmailError(email);
   }
 
   return { isInvitationCreated, certificationCenterInvitation };

--- a/api/src/team/domain/usecases/create-or-update-certification-center-invitation-for-admin.js
+++ b/api/src/team/domain/usecases/create-or-update-certification-center-invitation-for-admin.js
@@ -29,15 +29,15 @@ const createOrUpdateCertificationCenterInvitationForAdmin = async function ({
     isInvitationCreated = false;
   }
 
-  const mailerResponse = await mailService.sendCertificationCenterInvitationEmail({
+  const emailingAttempt = await mailService.sendCertificationCenterInvitationEmail({
     email,
     locale,
     certificationCenterName: certificationCenterInvitation.certificationCenterName,
     certificationCenterInvitationId: certificationCenterInvitation.id,
     code: certificationCenterInvitation.code,
   });
-  if (mailerResponse?.status === 'FAILURE') {
-    if (mailerResponse.hasFailedBecauseDomainWasInvalid()) {
+  if (emailingAttempt?.status === 'FAILURE') {
+    if (emailingAttempt.hasFailedBecauseDomainWasInvalid()) {
       throw new SendingEmailToInvalidDomainError(email);
     }
 

--- a/api/src/team/domain/usecases/create-or-update-certification-center-invitation-for-admin.js
+++ b/api/src/team/domain/usecases/create-or-update-certification-center-invitation-for-admin.js
@@ -36,7 +36,7 @@ const createOrUpdateCertificationCenterInvitationForAdmin = async function ({
     certificationCenterInvitationId: certificationCenterInvitation.id,
     code: certificationCenterInvitation.code,
   });
-  if (emailingAttempt?.status === 'FAILURE') {
+  if (emailingAttempt.hasFailed()) {
     if (emailingAttempt.hasFailedBecauseDomainWasInvalid()) {
       throw new SendingEmailToInvalidDomainError(email);
     }

--- a/api/src/team/domain/usecases/create-or-update-certification-center-invitation-for-admin.js
+++ b/api/src/team/domain/usecases/create-or-update-certification-center-invitation-for-admin.js
@@ -1,4 +1,8 @@
-import { SendingEmailError, SendingEmailToInvalidDomainError } from '../../../shared/domain/errors.js';
+import {
+  SendingEmailError,
+  SendingEmailToInvalidDomainError,
+  SendingEmailToInvalidEmailAddressError,
+} from '../../../shared/domain/errors.js';
 import { CertificationCenterInvitation } from '../models/CertificationCenterInvitation.js';
 
 const createOrUpdateCertificationCenterInvitationForAdmin = async function ({
@@ -39,6 +43,10 @@ const createOrUpdateCertificationCenterInvitationForAdmin = async function ({
   if (emailingAttempt.hasFailed()) {
     if (emailingAttempt.hasFailedBecauseDomainWasInvalid()) {
       throw new SendingEmailToInvalidDomainError(email);
+    }
+
+    if (emailingAttempt.hasFailedBecauseEmailWasInvalid()) {
+      throw new SendingEmailToInvalidEmailAddressError(email, emailingAttempt.errorMessage);
     }
 
     throw new SendingEmailError(email);

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -747,12 +747,12 @@ describe('Integration | API | Controller Error', function () {
     const SERVICE_UNAVAILABLE_ERROR = 503;
 
     it('responds ServiceUnavailable when a SendingEmailError error occurs', async function () {
-      routeHandler.throws(new DomainErrors.SendingEmailError(['toto@pix.fr', 'titi@pix.fr']));
+      routeHandler.throws(new DomainErrors.SendingEmailError('toto@pix.fr'));
 
       const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(SERVICE_UNAVAILABLE_ERROR);
-      expect(responseDetail(response)).to.equal("Échec lors de l'envoi de l'email.");
+      expect(responseDetail(response)).to.equal('Failed to send email to "toto@pix.fr" for some unknown reason.');
     });
 
     it('responds ServiceUnavailable when a SendingEmailToResultRecipientError error occurs', async function () {

--- a/api/tests/shared/unit/mail/infrastructure/providers/BrevoProvider_test.js
+++ b/api/tests/shared/unit/mail/infrastructure/providers/BrevoProvider_test.js
@@ -152,7 +152,7 @@ describe('Unit | Class | BrevoProvider', function () {
             template: templateId,
           };
           stubbedBrevoSMTPApi.sendTransacEmail.rejects({
-            response: { text: '{"code":"invalid_parameter","message":"email is not valid in to"}' },
+            body: { code: 'invalid_parameter', message: 'email is not valid in to' },
           });
 
           // when

--- a/api/tests/shared/unit/mail/infrastructure/services/mailer_test.js
+++ b/api/tests/shared/unit/mail/infrastructure/services/mailer_test.js
@@ -145,7 +145,9 @@ describe('Unit | Infrastructure | Mailers | mailer', function () {
 
           // then
           expect(logger.warn).to.have.been.calledOnceWith({ err: error }, "Could not send email to 'test@example.net'");
-          expect(result).to.deep.equal(EmailingAttempt.failure('test@example.net'));
+          expect(result).to.deep.equal(
+            EmailingAttempt.failure('test@example.net', EmailingAttempt.errorCode.PROVIDER_ERROR, 'fail'),
+          );
         });
       });
 

--- a/api/tests/team/integration/domain/services/organization-invitation.service.test.js
+++ b/api/tests/team/integration/domain/services/organization-invitation.service.test.js
@@ -111,7 +111,7 @@ describe('Integration | Team | Domain | Service | organization-invitation', func
         // then
         expect(error).to.be.an.instanceOf(SendingEmailToInvalidDomainError);
         expect(error.message).to.equal(
-          'Failed to send email to someone@consideredInvalidDomain.net because domain seems to be invalid.',
+          'Failed to send email to "someone@consideredInvalidDomain.net" because domain seems to be invalid.',
         );
       });
     });
@@ -144,7 +144,7 @@ describe('Integration | Team | Domain | Service | organization-invitation', func
         // then
         expect(error).to.be.an.instanceOf(SendingEmailToInvalidEmailAddressError);
         expect(error.message).to.equal(
-          'Failed to send email to considered_invalid@example.net because email address seems to be invalid.',
+          'Failed to send email to "considered_invalid@example.net" because email address seems to be invalid.',
         );
       });
     });

--- a/api/tests/team/integration/domain/services/organization-invitation.service.test.js
+++ b/api/tests/team/integration/domain/services/organization-invitation.service.test.js
@@ -102,6 +102,7 @@ describe('Integration | Team | Domain | Service | organization-invitation', func
 
       // then
       expect(result).to.be.an.instanceOf(SendingEmailError);
+      expect(result.message).to.equal('Failed to send email to "invitation@example.net" for some unknown reason.');
     });
   });
 });

--- a/api/tests/team/integration/domain/services/organization-invitation.service.test.js
+++ b/api/tests/team/integration/domain/services/organization-invitation.service.test.js
@@ -85,9 +85,9 @@ describe('Integration | Team | Domain | Service | organization-invitation', func
       });
       await databaseBuilder.commit();
 
-      const mailerResponse = EmailingAttempt.failure(email);
+      const emailingAttempt = EmailingAttempt.failure(email);
       sinon.stub(mailService, 'sendOrganizationInvitationEmail');
-      mailService.sendOrganizationInvitationEmail.resolves(mailerResponse);
+      mailService.sendOrganizationInvitationEmail.resolves(emailingAttempt);
 
       // when
       const result = await catchErr(organizationInvitationService.createOrUpdateOrganizationInvitation)({

--- a/api/tests/team/integration/domain/usecases/create-or-update-certification-center-invitation-for-admin_test.js
+++ b/api/tests/team/integration/domain/usecases/create-or-update-certification-center-invitation-for-admin_test.js
@@ -168,6 +168,7 @@ describe('Integration | Team | UseCase | create-or-update-certification-center-i
 
     // then
     expect(result).to.be.an.instanceOf(SendingEmailError);
+    expect(result.message).to.equal('Failed to send email to "some.user@example.net" for some unknown reason.');
   });
 
   context('when recipient email has an invalid domain', function () {

--- a/api/tests/team/integration/domain/usecases/create-or-update-certification-center-invitation-for-admin_test.js
+++ b/api/tests/team/integration/domain/usecases/create-or-update-certification-center-invitation-for-admin_test.js
@@ -172,7 +172,7 @@ describe('Integration | Team | UseCase | create-or-update-certification-center-i
       // then
       expect(error).to.be.an.instanceOf(SendingEmailToInvalidDomainError);
       expect(error.message).to.equal(
-        'Failed to send email to someone@consideredInvalidDomain.net because domain seems to be invalid.',
+        'Failed to send email to "someone@consideredInvalidDomain.net" because domain seems to be invalid.',
       );
     });
   });
@@ -205,7 +205,7 @@ describe('Integration | Team | UseCase | create-or-update-certification-center-i
       // then
       expect(error).to.be.an.instanceOf(SendingEmailToInvalidEmailAddressError);
       expect(error.message).to.equal(
-        'Failed to send email to considered_invalid@example.net because email address seems to be invalid.',
+        'Failed to send email to "considered_invalid@example.net" because email address seems to be invalid.',
       );
     });
   });

--- a/api/tests/team/integration/domain/usecases/create-or-update-certification-center-invitation-for-admin_test.js
+++ b/api/tests/team/integration/domain/usecases/create-or-update-certification-center-invitation-for-admin_test.js
@@ -152,8 +152,8 @@ describe('Integration | Team | UseCase | create-or-update-certification-center-i
     }).id;
     await databaseBuilder.commit();
 
-    const mailerResponse = EmailingAttempt.failure(email);
-    mailService.sendCertificationCenterInvitationEmail.resolves(mailerResponse);
+    const emailingAttempt = EmailingAttempt.failure(email);
+    mailService.sendCertificationCenterInvitationEmail.resolves(emailingAttempt);
 
     // when
     const result = await catchErr(usecases.createOrUpdateCertificationCenterInvitationForAdmin)({
@@ -180,8 +180,9 @@ describe('Integration | Team | UseCase | create-or-update-certification-center-i
         status: CertificationCenterInvitation.StatusType.PENDING,
       });
       await databaseBuilder.commit();
-      const emailAttemptFailure = EmailingAttempt.failure(email, EmailingAttempt.errorCode.INVALID_DOMAIN);
-      mailService.sendCertificationCenterInvitationEmail.resolves(emailAttemptFailure);
+
+      const emailingAttempt = EmailingAttempt.failure(email, EmailingAttempt.errorCode.INVALID_DOMAIN);
+      mailService.sendCertificationCenterInvitationEmail.resolves(emailingAttempt);
 
       // when
       const error = await catchErr(usecases.createOrUpdateCertificationCenterInvitationForAdmin)({

--- a/api/tests/team/integration/domain/usecases/create-or-update-certification-center-invitation-for-admin_test.js
+++ b/api/tests/team/integration/domain/usecases/create-or-update-certification-center-invitation-for-admin_test.js
@@ -11,7 +11,9 @@ describe('Integration | Team | UseCase | create-or-update-certification-center-i
 
   beforeEach(function () {
     clock = sinon.useFakeTimers({ now: now.getTime(), toFake: ['Date'] });
-    sinon.stub(mailService, 'sendCertificationCenterInvitationEmail');
+    sinon
+      .stub(mailService, 'sendCertificationCenterInvitationEmail')
+      .resolves(EmailingAttempt.success('stub@example.net'));
   });
 
   afterEach(async function () {

--- a/api/tests/team/unit/domain/services/certification-center-invitation-service_test.js
+++ b/api/tests/team/unit/domain/services/certification-center-invitation-service_test.js
@@ -1,4 +1,8 @@
-import { SendingEmailError } from '../../../../../src/shared/domain/errors.js';
+import {
+  SendingEmailError,
+  SendingEmailToInvalidDomainError,
+  SendingEmailToInvalidEmailAddressError,
+} from '../../../../../src/shared/domain/errors.js';
 import { EmailingAttempt } from '../../../../../src/shared/domain/models/index.js';
 import { CertificationCenterInvitation } from '../../../../../src/team/domain/models/CertificationCenterInvitation.js';
 import {
@@ -133,29 +137,29 @@ describe('Unit | Team | Domain | Services | CertificationCenterInvitationService
     });
 
     context('failure', function () {
-      context('when email sending fails for some unknown reason', function () {
-        it('throws a generic SendingEmailError', async function () {
+      context('when recipient email has an invalid domain', function () {
+        it('throws a SendingEmailToInvalidDomainError', async function () {
           // given
+          const emailWithInvalidDomain = 'someone@consideredInvalidDomain.net';
           const certificationCenter = domainBuilder.buildCertificationCenter({
-            id: 202310130,
             name: 'Best Certification Center',
           });
-          const code = 'AZERTY007';
-          const email = 'dick.cionère@example.net';
+          const code = 'AZERTY005';
           const locale = 'fr-fr';
           const certificationCenterInvitation = new CertificationCenterInvitation({
             certificationCenterId: certificationCenter.id,
             code,
             createdAt: new Date('2023-10-10'),
-            email,
-            id: 202310131,
+            email: emailWithInvalidDomain,
             updatedAt: new Date('2023-10-11'),
           });
 
           certificationCenterInvitationRepository.findOnePendingByEmailAndCertificationCenterId.resolves(
             certificationCenterInvitation,
           );
-          mailService.sendCertificationCenterInvitationEmail.resolves(EmailingAttempt.failure(email));
+          mailService.sendCertificationCenterInvitationEmail.resolves(
+            EmailingAttempt.failure(emailWithInvalidDomain, EmailingAttempt.errorCode.INVALID_DOMAIN),
+          );
 
           // when
           const error = await catchErr(
@@ -165,14 +169,102 @@ describe('Unit | Team | Domain | Services | CertificationCenterInvitationService
             }),
           )({
             certificationCenter,
-            email,
+            email: emailWithInvalidDomain,
             locale,
           });
 
           // then
-          expect(error).to.be.instanceOf(SendingEmailError);
-          expect(error.message).to.equal('Failed to send email to "dick.cionère@example.net" for some unknown reason.');
+          expect(error).to.be.an.instanceOf(SendingEmailToInvalidDomainError);
+          expect(error.message).to.equal(
+            'Failed to send email to someone@consideredInvalidDomain.net because domain seems to be invalid.',
+          );
         });
+      });
+    });
+
+    context('when recipient email is invalid', function () {
+      it('throws a SendingEmailToInvalidEmailAddressError', async function () {
+        // given
+        const invalidEmail = 'considered_invalid@example.net';
+        const certificationCenter = domainBuilder.buildCertificationCenter({
+          name: 'Best Certification Center',
+        });
+        const code = 'AZERTY006';
+        const locale = 'fr-fr';
+        const certificationCenterInvitation = new CertificationCenterInvitation({
+          certificationCenterId: certificationCenter.id,
+          code,
+          createdAt: new Date('2023-10-10'),
+          email: invalidEmail,
+          updatedAt: new Date('2023-10-11'),
+        });
+
+        certificationCenterInvitationRepository.findOnePendingByEmailAndCertificationCenterId.resolves(
+          certificationCenterInvitation,
+        );
+        mailService.sendCertificationCenterInvitationEmail.resolves(
+          EmailingAttempt.failure(invalidEmail, EmailingAttempt.errorCode.INVALID_EMAIL),
+        );
+
+        // when
+        const error = await catchErr(
+          createOrUpdateCertificationCenterInvitation({
+            certificationCenterInvitationRepository,
+            mailService,
+          }),
+        )({
+          certificationCenter,
+          email: invalidEmail,
+          locale,
+        });
+
+        // then
+        expect(error).to.be.an.instanceOf(SendingEmailToInvalidEmailAddressError);
+        expect(error.message).to.equal(
+          'Failed to send email to considered_invalid@example.net because email address seems to be invalid.',
+        );
+      });
+    });
+
+    context('when email sending fails for some unknown reason', function () {
+      it('throws a generic SendingEmailError', async function () {
+        // given
+        const certificationCenter = domainBuilder.buildCertificationCenter({
+          id: 202310130,
+          name: 'Best Certification Center',
+        });
+        const code = 'AZERTY007';
+        const email = 'dick.cionère@example.net';
+        const locale = 'fr-fr';
+        const certificationCenterInvitation = new CertificationCenterInvitation({
+          certificationCenterId: certificationCenter.id,
+          code,
+          createdAt: new Date('2023-10-10'),
+          email,
+          id: 202310131,
+          updatedAt: new Date('2023-10-11'),
+        });
+
+        certificationCenterInvitationRepository.findOnePendingByEmailAndCertificationCenterId.resolves(
+          certificationCenterInvitation,
+        );
+        mailService.sendCertificationCenterInvitationEmail.resolves(EmailingAttempt.failure(email));
+
+        // when
+        const error = await catchErr(
+          createOrUpdateCertificationCenterInvitation({
+            certificationCenterInvitationRepository,
+            mailService,
+          }),
+        )({
+          certificationCenter,
+          email,
+          locale,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(SendingEmailError);
+        expect(error.message).to.equal('Failed to send email to "dick.cionère@example.net" for some unknown reason.');
       });
     });
   });

--- a/api/tests/team/unit/domain/services/certification-center-invitation-service_test.js
+++ b/api/tests/team/unit/domain/services/certification-center-invitation-service_test.js
@@ -171,6 +171,7 @@ describe('Unit | Team | Domain | Services | CertificationCenterInvitationService
 
           // then
           expect(error).to.be.instanceOf(SendingEmailError);
+          expect(error.message).to.equal('Failed to send email to "dick.cionère@example.net" for some unknown reason.');
         });
       });
     });

--- a/api/tests/team/unit/domain/services/certification-center-invitation-service_test.js
+++ b/api/tests/team/unit/domain/services/certification-center-invitation-service_test.js
@@ -32,7 +32,6 @@ describe('Unit | Team | Domain | Services | CertificationCenterInvitationService
         it('creates an invitation, sends an email and updates invitation modification date', async function () {
           // given
           const certificationCenter = domainBuilder.buildCertificationCenter({
-            id: 202310130,
             name: 'Best Certification Center',
           });
           const code = 'AZERTY007';
@@ -46,7 +45,6 @@ describe('Unit | Team | Domain | Services | CertificationCenterInvitationService
           });
           const createdCertificationCenterInvitation = new CertificationCenterInvitation({
             ...certificationCenterInvitationToCreate,
-            id: 202310131,
           });
 
           certificationCenterInvitationRepository.create.resolves(createdCertificationCenterInvitation);
@@ -91,7 +89,6 @@ describe('Unit | Team | Domain | Services | CertificationCenterInvitationService
         it('sends an email and updates invitation modification date', async function () {
           // given
           const certificationCenter = domainBuilder.buildCertificationCenter({
-            id: 202310130,
             name: 'Best Certification Center',
           });
           const code = 'AZERTY007';
@@ -102,7 +99,6 @@ describe('Unit | Team | Domain | Services | CertificationCenterInvitationService
             code,
             createdAt: new Date('2023-10-10'),
             email,
-            id: 202310131,
             updatedAt: new Date('2023-10-11'),
           });
 
@@ -230,7 +226,6 @@ describe('Unit | Team | Domain | Services | CertificationCenterInvitationService
       it('throws a generic SendingEmailError', async function () {
         // given
         const certificationCenter = domainBuilder.buildCertificationCenter({
-          id: 202310130,
           name: 'Best Certification Center',
         });
         const code = 'AZERTY007';
@@ -241,7 +236,6 @@ describe('Unit | Team | Domain | Services | CertificationCenterInvitationService
           code,
           createdAt: new Date('2023-10-10'),
           email,
-          id: 202310131,
           updatedAt: new Date('2023-10-11'),
         });
 
@@ -289,7 +283,6 @@ describe('Unit | Team | Domain | Services | CertificationCenterInvitationService
         it('sends an email and updates invitation modification date', async function () {
           // given
           const certificationCenter = domainBuilder.buildCertificationCenter({
-            id: 202310130,
             name: 'Best Certification Center',
           });
           const code = 'AZERTY007';
@@ -300,7 +293,6 @@ describe('Unit | Team | Domain | Services | CertificationCenterInvitationService
             code,
             createdAt: new Date('2023-10-10'),
             email,
-            id: 202310131,
             updatedAt: new Date('2023-10-11'),
           });
 

--- a/api/tests/team/unit/domain/services/certification-center-invitation-service_test.js
+++ b/api/tests/team/unit/domain/services/certification-center-invitation-service_test.js
@@ -133,8 +133,8 @@ describe('Unit | Team | Domain | Services | CertificationCenterInvitationService
     });
 
     context('failure', function () {
-      context('when an error occurs', function () {
-        it('throws an error', async function () {
+      context('when email sending fails for some unknown reason', function () {
+        it('throws a generic SendingEmailError', async function () {
           // given
           const certificationCenter = domainBuilder.buildCertificationCenter({
             id: 202310130,

--- a/api/tests/team/unit/domain/services/certification-center-invitation-service_test.js
+++ b/api/tests/team/unit/domain/services/certification-center-invitation-service_test.js
@@ -172,7 +172,7 @@ describe('Unit | Team | Domain | Services | CertificationCenterInvitationService
           // then
           expect(error).to.be.an.instanceOf(SendingEmailToInvalidDomainError);
           expect(error.message).to.equal(
-            'Failed to send email to someone@consideredInvalidDomain.net because domain seems to be invalid.',
+            'Failed to send email to "someone@consideredInvalidDomain.net" because domain seems to be invalid.',
           );
         });
       });
@@ -217,7 +217,7 @@ describe('Unit | Team | Domain | Services | CertificationCenterInvitationService
         // then
         expect(error).to.be.an.instanceOf(SendingEmailToInvalidEmailAddressError);
         expect(error.message).to.equal(
-          'Failed to send email to considered_invalid@example.net because email address seems to be invalid.',
+          'Failed to send email to "considered_invalid@example.net" because email address seems to be invalid.',
         );
       });
     });

--- a/api/tests/team/unit/domain/services/organization-invitation.service.test.js
+++ b/api/tests/team/unit/domain/services/organization-invitation.service.test.js
@@ -113,7 +113,7 @@ describe('Unit | Team | Domain | Service | organization-invitation', function ()
           // then
           expect(error).to.be.an.instanceOf(SendingEmailToInvalidDomainError);
           expect(error.message).to.equal(
-            'Failed to send email to user@example.net because domain seems to be invalid.',
+            'Failed to send email to "user@example.net" because domain seems to be invalid.',
           );
         });
       });
@@ -226,7 +226,7 @@ describe('Unit | Team | Domain | Service | organization-invitation', function ()
         // then
         expect(error).to.be.an.instanceOf(SendingEmailToInvalidEmailAddressError);
         expect(error.message).to.equal(
-          'Failed to send email to user@example.net because email address seems to be invalid.',
+          'Failed to send email to "user@example.net" because email address seems to be invalid.',
         );
         expect(error.meta).to.deepEqualInstance({
           emailAddress: userEmailAddress,

--- a/api/tests/team/unit/domain/services/organization-invitation.service.test.js
+++ b/api/tests/team/unit/domain/services/organization-invitation.service.test.js
@@ -25,8 +25,8 @@ describe('Unit | Team | Domain | Service | organization-invitation', function ()
       get: sinon.stub(),
     };
     mailService = {
-      sendOrganizationInvitationEmail: sinon.stub().resolves(),
-      sendScoOrganizationInvitationEmail: sinon.stub().resolves(),
+      sendOrganizationInvitationEmail: sinon.stub().resolves(EmailingAttempt.success('stub@example.net')),
+      sendScoOrganizationInvitationEmail: sinon.stub().resolves(EmailingAttempt.success('stub@example.net')),
     };
   });
 


### PR DESCRIPTION
## :unicorn: Problème

Lorsqu'une invitation est envoyée à une adresse email invalide, une erreur `503` est renvoyée générant une alerte, alors que l'erreur vient de la saisie de l'utilisateur et qu'il devrait donc s'agir d'une erreur `400`.

Par exemple un examen des logs indiquent que certaines adresses email sont entrées avec des https://en.wikipedia.org/wiki/Zero-width_space qui ne s'affichent pas mais qui sont bien présents et qui rendent l'adresse email invalide.

## :robot: Proposition

L'analyse de la réponse d'erreur de Brevo était erronée. Elle a peut-être été correcte un jour, mais elle ne l'est plus.

L'analyse de la réponse d'erreur de Brevo n'est pas documentée dans la documentation de Brevo, mais l'analyse des fichiers suivants indique qu'une `HttpError` est envoyée en cas d'erreur et que celle-ci contient un `body`. Et c'est dans ce `body` que l'on va trouver les propriétés `code` et `message` :

* https://github.com/getbrevo/brevo-node/blob/main/api/transactionalEmailsApi.ts
* https://github.com/getbrevo/brevo-node/blob/main/api/apis.ts

Corriger l'analyse de la réponse d'erreur de Brevo.

D'autres modifications ont été faites pour gérer tous les cas d'erreur qui n'étaient pas toujours pris en compte dans l'envoi des invitations.

## :rainbow: Remarques

Il faudrait ajouter des nettoyage+validation dans d'autres PR : 
* suppression des zero-width space dans l'input HTML recevant email
* contribuer pour rendre la validation `Joi.string().email()` sensible au zero-width space

## :100: Pour tester

1. S'authentifier sur Pix Orga ou Pix Admin
2. Envoyer une invitation à une adresse  email invalide contenant par exemple un zero-width space https://en.wikipedia.org/wiki/Zero-width_space . En effet pour que l'adresse email invalide arrive jusqu'à l'API Brevo il faut qu'elle passe les barrières de l'input HTML et de la validation `Joi.string().email()`. 
3. Vérifier dans la console développeur du navigateur que le code status HTTP est `400`

💡 Impossible de fournir une adresse email avec des zero-width space dedans dans GitHub qui doit filtrer avec succès tous les caractères potentiellement dangereux. Pour créer une adresse email avec un tel caractère il faut effectuer un copier-coller d'exemples fournis dans https://en.wikipedia.org/wiki/Zero-width_space