### PR TITLE
[BUGFIX] Pouvoir rafraîchir les pages d’instructions et d'entrée en session (PIX-14590)

### DIFF
--- a/api/src/certification/enrolment/application/certification-candidate-controller.js
+++ b/api/src/certification/enrolment/application/certification-candidate-controller.js
@@ -60,9 +60,20 @@ const validateCertificationInstructions = async function (
   return dependencies.certificationCandidateSerializer.serialize(candidate);
 };
 
+const getCandidate = async function (request, h, dependencies = { candidateSerializer }) {
+  const certificationCandidateId = request.params.certificationCandidateId;
+
+  const candidate = await usecases.getCandidate({
+    certificationCandidateId,
+  });
+
+  return dependencies.candidateSerializer.serializeForParticipation(candidate);
+};
+
 const certificationCandidateController = {
   addCandidate,
   getEnrolledCandidates,
+  getCandidate,
   deleteCandidate,
   validateCertificationInstructions,
   updateEnrolledCandidate,

--- a/api/src/certification/enrolment/application/certification-candidate-route.js
+++ b/api/src/certification/enrolment/application/certification-candidate-route.js
@@ -94,6 +94,29 @@ const register = async function (server) {
       },
     },
     {
+      method: 'GET',
+      path: '/api/certification-candidates/{certificationCandidateId}',
+      config: {
+        validate: {
+          params: Joi.object({
+            certificationCandidateId: identifiersType.certificationCandidateId,
+          }),
+        },
+        pre: [
+          {
+            method: securityPreHandlers.checkUserIsCandidate,
+            assign: 'authorizationCheck',
+          },
+        ],
+        handler: certificationCandidateController.getCandidate,
+        tags: ['api', 'certification-candidates'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs authentifiés',
+          'Elle permet à un candidat de récupérer ses informations',
+        ],
+      },
+    },
+    {
       method: 'DELETE',
       path: '/api/sessions/{sessionId}/certification-candidates/{certificationCandidateId}',
       config: {

--- a/api/src/certification/enrolment/domain/usecases/get-candidate.js
+++ b/api/src/certification/enrolment/domain/usecases/get-candidate.js
@@ -1,0 +1,11 @@
+/**
+ * @typedef {import('./index.js').CandidateRepository} CandidateRepository
+ */
+
+/**
+ * @param {Object} params
+ * @param {CandidateRepository} params.candidateRepository
+ */
+export async function getCandidate({ certificationCandidateId, candidateRepository }) {
+  return candidateRepository.get({ certificationCandidateId });
+}

--- a/api/tests/certification/enrolment/acceptance/application/certification-candidate-route_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/certification-candidate-route_test.js
@@ -208,6 +208,56 @@ describe('Certification | Enrolment | Acceptance | Application | Routes | certif
     });
   });
 
+  describe('GET /api/certification-candidates/{certificationCandidateId}', function () {
+    it('should respond with a 200 and candidate information', async function () {
+      // given
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
+      const candidateUserId = databaseBuilder.factory.buildUser().id;
+      const candidateId = databaseBuilder.factory.buildCertificationCandidate({
+        id: 1001,
+        sessionId,
+        userId: candidateUserId,
+        firstName: 'Lemmy',
+        lastName: 'Kilmister',
+        birthdate: '1945-12-24',
+        hasSeenCertificationInstructions: true,
+      }).id;
+      databaseBuilder.factory.buildCoreSubscription({
+        certificationCandidateId: candidateId,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const options = {
+        method: 'GET',
+        url: `/api/certification-candidates/${candidateId}`,
+        payload: {},
+        headers: { authorization: generateValidRequestAuthorizationHeader(candidateUserId, 'pix') },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result).to.deep.equal({
+        data: {
+          attributes: {
+            birthdate: '1945-12-24',
+            'first-name': 'Lemmy',
+            'has-seen-certification-instructions': true,
+            'last-name': 'Kilmister',
+            'session-id': sessionId,
+          },
+          id: '1001',
+          type: 'certification-candidates',
+        },
+      });
+    });
+  });
+
   describe('PATCH /api/sessions/{sessionId}/certification-candidates/{certificationCandidateId}', function () {
     it('should respond with a 200', async function () {
       // given

--- a/api/tests/certification/enrolment/unit/domain/usecases/get-candidate_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/get-candidate_test.js
@@ -1,0 +1,30 @@
+import { Candidate } from '../../../../../../src/certification/enrolment/domain/models/Candidate.js';
+import { getCandidate } from '../../../../../../src/certification/enrolment/domain/usecases/get-candidate.js';
+import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+
+describe('Certification | Enrolment | Unit | UseCase | get-candidate', function () {
+  let candidate;
+  let candidateRepository;
+
+  beforeEach(function () {
+    candidate = domainBuilder.certification.enrolment.buildCandidate({ id: 1234 });
+    candidateRepository = {
+      get: sinon.stub(),
+    };
+  });
+
+  it('should get the candidate by id', async function () {
+    // given
+    candidateRepository.get.withArgs({ certificationCandidateId: 1234 }).resolves(candidate);
+
+    // when
+    const actualCandidate = await getCandidate({
+      certificationCandidateId: 1234,
+      candidateRepository,
+    });
+
+    // then
+    expect(actualCandidate.id).to.equal(1234);
+    expect(actualCandidate).to.be.instanceOf(Candidate);
+  });
+});

--- a/mon-pix/app/routes/authenticated/certifications/information.js
+++ b/mon-pix/app/routes/authenticated/certifications/information.js
@@ -6,7 +6,7 @@ export default class InformationRoute extends Route {
   @service router;
 
   async model(params) {
-    const certificationCandidate = await this.store.peekRecord(
+    const certificationCandidate = await this.store.findRecord(
       'certification-candidate',
       params.certification_candidate_id,
     );

--- a/mon-pix/app/routes/authenticated/certifications/start.js
+++ b/mon-pix/app/routes/authenticated/certifications/start.js
@@ -7,15 +7,10 @@ export default class StartRoute extends Route {
   @service featureToggles;
 
   async model(params) {
-    const certificationCandidateSubscription = await this.store.findRecord(
-      'certification-candidate-subscription',
-      params.certification_candidate_id,
-    );
-
-    const certificationCandidate = await this.store.peekRecord(
-      'certification-candidate',
-      params.certification_candidate_id,
-    );
+    const [certificationCandidate, certificationCandidateSubscription] = await Promise.all([
+      this.store.findRecord('certification-candidate', params.certification_candidate_id),
+      this.store.findRecord('certification-candidate-subscription', params.certification_candidate_id),
+    ]);
 
     const hasSeenCertificationInstructions = certificationCandidate?.hasSeenCertificationInstructions;
 

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -13,6 +13,7 @@ import deleteUserSavedTutorial from './routes/delete-user-saved-tutorial';
 import getAreas from './routes/get-areas';
 import getCampaigns from './routes/get-campaigns';
 import getCertification from './routes/get-certification';
+import getCertificationCandidate from './routes/get-certification-candidate';
 import getCertificationCandidatesSubscriptions from './routes/get-certification-candidates-subscriptions';
 import getCertifications from './routes/get-certifications';
 import getChallenge from './routes/get-challenge';
@@ -104,6 +105,7 @@ function routes() {
 
   this.post('/shared-certifications', postSharedCertifications);
 
+  this.get('/certification-candidates/:id', getCertificationCandidate);
   this.get('/certification-candidates/:id/subscriptions', getCertificationCandidatesSubscriptions);
 
   this.get('/certification-courses/:id');

--- a/mon-pix/mirage/routes/get-certification-candidate.js
+++ b/mon-pix/mirage/routes/get-certification-candidate.js
@@ -1,0 +1,3 @@
+export default function (schema, { params: { id } }) {
+  return schema.certificationCandidates.find(id);
+}

--- a/mon-pix/tests/unit/routes/authenticated/certifications/information-test.js
+++ b/mon-pix/tests/unit/routes/authenticated/certifications/information-test.js
@@ -14,8 +14,8 @@ module('Unit | Route | Certifications | Information', function (hooks) {
       const certificationCandidate = store.createRecord('certification-candidate', {
         id: '1234',
       });
-      const peekRecordStub = sinon.stub().resolves(certificationCandidate);
-      const storeStub = Service.create({ peekRecord: peekRecordStub });
+      const findRecordStub = sinon.stub().resolves(certificationCandidate);
+      const storeStub = Service.create({ findRecord: findRecordStub });
       const route = this.owner.lookup('route:authenticated/certifications.information');
       route.set('store', storeStub);
 
@@ -29,8 +29,8 @@ module('Unit | Route | Certifications | Information', function (hooks) {
     module('when no candidate exist', function () {
       test('should return to certification form', async function (assert) {
         // given
-        const peekRecordStub = sinon.stub().resolves();
-        const storeStub = Service.create({ peekRecord: peekRecordStub });
+        const findRecordStub = sinon.stub().resolves();
+        const storeStub = Service.create({ findRecord: findRecordStub });
         const route = this.owner.lookup('route:authenticated/certifications.information');
         route.set('store', storeStub);
         route.router = { replaceWith: sinon.stub() };

--- a/mon-pix/tests/unit/routes/authenticated/certifications/start-test.js
+++ b/mon-pix/tests/unit/routes/authenticated/certifications/start-test.js
@@ -72,9 +72,14 @@ module('Unit | Route | Certification | Start', function (hooks) {
             },
           });
 
-          const findRecordStub = sinon.stub().returns(certificationCandidateSubscription);
-          const peekRecordStub = sinon.stub().returns(certificationCandidate);
-          const storeStub = Service.create({ findRecord: findRecordStub, peekRecord: peekRecordStub });
+          const findRecordStub = sinon
+            .stub()
+            .withArgs('certification-candidate-subscription', certificationCandidate.id)
+            .returns(certificationCandidateSubscription)
+            .withArgs('certification-candidate', certificationCandidate.id)
+            .returns(certificationCandidate);
+
+          const storeStub = Service.create({ findRecord: findRecordStub });
 
           const route = this.owner.lookup('route:authenticated/certifications.start');
           route.set('store', storeStub);


### PR DESCRIPTION
## :unicorn: Problème
Lors de l’arrivée en session, quand on est sur la page avec le mot de passe et qu’on rafraîchit la page, on est redirigé vers la page de réconciliation (avec id de session, nom prénom etc).
C'est un problème pour Companion, car quand on affiche l'écran de blocage, les utilisateurs doivent pouvoir être redirigés vers la page de mot de passe quand ils rechargent la page.

## :robot: Proposition
Faire en sorte que les pages après la réconciliation puissent être rafraîchies.

## :rainbow: Remarques
C’est une régression suite à l’ajout des instructions de certif next gen.

## :100: Pour tester
- Aller sur mon-pix, dans Certifications, avec le user `certifiable-contenu-user`
- Entrer les informations du candidat : session 7404, firstname1-7404, lastname1-7404, 04/01/2000
- Sur la page d’instructions, rafraîchir et vérifier qu’on reste sur la page
- Sur la page avec le mot de passe, rafraîchir et vérifier qu’on reste sur la page