### PR TITLE
[FEATURE] Ajout d'un nouvel ordre de mission (Pix-14469)

### DIFF
--- a/api/src/school/infrastructure/repositories/mission-assessment-repository.js
+++ b/api/src/school/infrastructure/repositories/mission-assessment-repository.js
@@ -103,13 +103,9 @@ const getMissionIdsByState = async function (organizationLearnerId) {
     )
     .where({ organizationLearnerId });
 
-  const missionIdsGroupByState = {};
+  const missionIdsGroupByState = { completed: [], started: [] };
   missionAssessments.forEach((missionAssessment) => {
-    if (missionIdsGroupByState[missionAssessment.state]) {
-      missionIdsGroupByState[missionAssessment.state].push(missionAssessment.missionId);
-    } else {
-      missionIdsGroupByState[missionAssessment.state] = [missionAssessment.missionId];
-    }
+    missionIdsGroupByState[missionAssessment.state].push(missionAssessment.missionId);
   });
   return missionIdsGroupByState;
 };

--- a/api/tests/school/integration/domain/usecases/get-organization-learner-with-completed-mission-ids_test.js
+++ b/api/tests/school/integration/domain/usecases/get-organization-learner-with-completed-mission-ids_test.js
@@ -78,6 +78,7 @@ describe('Integration | Usecase | get-organization-learner-with-completed-missio
           ...organizationLearner,
           division: organizationLearner.attributes['Libellé classe'],
           completedMissionIds: [completedMissionId],
+          startedMissionIds: [],
         }),
       );
     });
@@ -95,6 +96,8 @@ describe('Integration | Usecase | get-organization-learner-with-completed-missio
         new OrganizationLearner({
           ...organizationLearner,
           division: organizationLearner.attributes['Libellé classe'],
+          completedMissionIds: [],
+          startedMissionIds: [],
         }),
       );
     });

--- a/api/tests/school/integration/infrastructure/repositories/mission-assessment-repository_test.js
+++ b/api/tests/school/integration/infrastructure/repositories/mission-assessment-repository_test.js
@@ -159,7 +159,7 @@ describe('Integration | Repository | mission-assessment-repository', function ()
       await databaseBuilder.commit();
 
       const result = await missionAssessmentRepository.getMissionIdsByState(organizationLearner.id);
-      expect(result).to.deep.equal({});
+      expect(result).to.deep.equal({ completed: [], started: [] });
     });
 
     it('should group on last assessment state', async function () {
@@ -192,6 +192,7 @@ describe('Integration | Repository | mission-assessment-repository', function ()
       const result = await missionAssessmentRepository.getMissionIdsByState(organizationLearner.id);
       expect(result).to.deep.equal({
         started: [missionId],
+        completed: [],
       });
     });
   });

--- a/junior/app/controllers/identified/missions/list.js
+++ b/junior/app/controllers/identified/missions/list.js
@@ -56,4 +56,28 @@ export default class List extends Controller {
     }
     this.router.transitionTo(route, missionId);
   }
+
+  get missionListCompleted() {
+    return this.model.missions.filter((mission) =>
+      this.model.organizationLearner.completedMissionIds?.includes(mission.id),
+    );
+  }
+
+  get missionListStarted() {
+    return this.model.missions.filter((mission) =>
+      this.model.organizationLearner.startedMissionIds?.includes(mission.id),
+    );
+  }
+
+  get missionListToStart() {
+    return this.model.missions.filter(
+      (mission) =>
+        !this.model.organizationLearner.startedMissionIds?.includes(mission.id) &&
+        !this.model.organizationLearner.completedMissionIds?.includes(mission.id),
+    );
+  }
+
+  get orderedMissionList() {
+    return [...this.missionListStarted, ...this.missionListToStart, ...this.missionListCompleted];
+  }
 }

--- a/junior/app/routes/identified/missions/list.js
+++ b/junior/app/routes/identified/missions/list.js
@@ -7,10 +7,10 @@ export default class MissionsRoute extends Route {
   @service currentLearner;
 
   async model() {
-    const result = await this.store.findAll('mission');
+    const missions = await this.store.findAll('mission');
     const organizationLearner = await this.store.findRecord('organization-learner', this.currentLearner.learner.id);
     return {
-      missions: [...result].sort((mission) => mission.id),
+      missions,
       organizationLearner,
     };
   }

--- a/junior/app/templates/identified/missions/list.hbs
+++ b/junior/app/templates/identified/missions/list.hbs
@@ -12,7 +12,8 @@
   </RobotDialog>
 
   <div class="cards">
-    {{#each @model.missions as |mission|}}
+
+    {{#each this.orderedMissionList as |mission|}}
       <PixButton @triggerAction={{fn this.goToMission mission.id}} class="card">
         {{#if (this.isMissionCompleted mission.id)}}
           <MissionCard::CompletedMissionCard

--- a/junior/tests/acceptance/display-missions-list-test.js
+++ b/junior/tests/acceptance/display-missions-list-test.js
@@ -8,32 +8,36 @@ import identifyLearner from '../helpers/identify-learner';
 
 module('Acceptance | Display missions list', function (hooks) {
   setupApplicationTest(hooks);
-  test('displays all the available missions with their corresponding status', async function (assert) {
-    this.server.create('mission', { id: '1', name: 'mission_1' });
-    this.server.create('mission', { id: '2', name: 'mission_2' });
-    this.server.create('mission', { id: '3', name: 'mission_3' });
+  test('displays all the available missions with their corresponding status and good order', async function (assert) {
+    this.server.create('mission', { id: 1, name: 'mission_1' });
+    this.server.create('mission', { id: 2, name: 'mission_2' });
+    this.server.create('mission', { id: 3, name: 'mission_3' });
     const learner = this.server.create('organization-learner', {
       name: 'learner',
-      completedMissionIds: ['2'],
-      startedMissionIds: ['1'],
+      completedMissionIds: ['1'],
+      startedMissionIds: ['2'],
     });
-    identifyLearner(this.owner, { id: learner.id });
+
+    identifyLearner(this.owner, {
+      id: learner.id,
+      completedMissionIds: learner.completedMissionIds,
+      startedMissionIds: learner.startedMissionIds,
+    });
 
     // when
     const screen = await visit('/');
 
     // then
-    //In progress mission card
     assert
       .dom(
-        within(screen.getByText('mission_1').parentElement.parentElement.parentElement).getByText(
+        within(screen.getByText('mission_2').parentElement.parentElement.parentElement).getByText(
           t('pages.missions.list.status.started.label'),
         ),
       )
       .exists();
     assert
       .dom(
-        within(screen.getByText('mission_1').parentElement.parentElement).getByText(
+        within(screen.getByText('mission_2').parentElement.parentElement).getByText(
           t('pages.missions.list.status.started.button-label'),
         ),
       )
@@ -42,7 +46,7 @@ module('Acceptance | Display missions list', function (hooks) {
     //Completed mission card
     assert
       .dom(
-        within(screen.getByText('mission_2').parentElement.parentElement).getByText(
+        within(screen.getByText('mission_1').parentElement.parentElement).getByText(
           t('pages.missions.list.status.completed.label'),
         ),
       )
@@ -63,6 +67,13 @@ module('Acceptance | Display missions list', function (hooks) {
         ),
       )
       .exists();
+
+    const missionsList = screen.getAllByRole('button');
+    assert.strictEqual(missionsList.length, 3);
+
+    assert.true(missionsList[0].innerHTML.includes('mission_2'));
+    assert.true(missionsList[1].innerHTML.includes('mission_3'));
+    assert.true(missionsList[2].innerHTML.includes('mission_1'));
   });
   test('redirect to the challenge when user has already started the mission', async function (assert) {
     this.server.create('mission', { id: '1', name: 'started_mission' });


### PR DESCRIPTION
## :unicorn: Problème
Les missions sont ordonnées selon leur ID, ce qui n'est pas pratique.

## :robot: Proposition

Afficher les missions en cours, ensuite les missions à faire puis terminer par les missions finit.

![image](https://github.com/user-attachments/assets/a1e17805-f1ca-48e9-af19-24b5b6927f68)

## :rainbow: Remarques

Fonctionnel, mais peut-être du refacto à faire

## :100: Pour tester
Faire des missions avec un user (1 finit / 1 en cours / 1 pas commencé) et voir que l'ordre est:
	1/ En cours
	2/ À faire
	3/ Terminé