### PR TITLE
[FEATURE] Ajouter une API interne pour récupérer les infos d'utilisateurs (PIX-14624).

### DIFF
--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -93,7 +93,7 @@ const buildUser = function buildUser({
   username = `${firstName}.${lastName}.${id}`,
   cgu = true,
   lang = 'fr',
-  locale,
+  locale = null,
   lastTermsOfServiceValidatedAt = null,
   lastPixOrgaTermsOfServiceValidatedAt = null,
   lastPixCertifTermsOfServiceValidatedAt = null,

--- a/api/src/identity-access-management/application/api/models/UserDTO.js
+++ b/api/src/identity-access-management/application/api/models/UserDTO.js
@@ -1,0 +1,6 @@
+export class UserDTO {
+  constructor(user) {
+    this.firstName = user.firstName;
+    this.lastName = user.lastName;
+  }
+}

--- a/api/src/identity-access-management/application/api/users-api.js
+++ b/api/src/identity-access-management/application/api/users-api.js
@@ -1,4 +1,5 @@
 import { usecases } from '../../domain/usecases/index.js';
+import { UserDTO } from './models/UserDTO.js';
 /**
  * @module UserApi
  */
@@ -9,4 +10,9 @@ export const markLevelSevenInfoAsSeen = async ({ userId }) => {
 
 export const markNewDashboardInfoAsSeen = async ({ userId }) => {
   return usecases.markUserHasSeenNewDashboardInfo({ userId });
+};
+
+export const getUserDetailsByUserIds = async ({ userIds }) => {
+  const users = await usecases.getUserDetailsByUserIds({ userIds });
+  return users.map((user) => new UserDTO(user));
 };

--- a/api/src/identity-access-management/domain/usecases/get-user-details-by-user-ids.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/get-user-details-by-user-ids.usecase.js
@@ -1,0 +1,3 @@
+export const getUserDetailsByUserIds = function ({ userIds, userRepository }) {
+  return userRepository.getByIds(userIds);
+};

--- a/api/tests/identity-access-management/integration/domain/usecases/get-user-details-by-user-ids.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/get-user-details-by-user-ids.usecase.test.js
@@ -1,0 +1,22 @@
+import { User } from '../../../../../src/identity-access-management/domain/models/User.js';
+import { usecases } from '../../../../../src/identity-access-management/domain/usecases/index.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Integration | Domain | Usecases | GetUserDetailsById', function () {
+  describe('When there are users', function () {
+    it('should return user details', async function () {
+      // given
+
+      const firstUser = new User(databaseBuilder.factory.buildUser({ id: 1, firstName: 'Théo', lastName: 'Courant' }));
+      const secondUser = new User(databaseBuilder.factory.buildUser({ id: 2, firstName: 'Alex', lastName: 'Térieur' }));
+
+      await databaseBuilder.commit();
+
+      // when
+      const users = await usecases.getUserDetailsByUserIds({ userIds: [1, 2] });
+
+      // then
+      expect(users).to.deep.equal([firstUser, secondUser]);
+    });
+  });
+});

--- a/api/tests/identity-access-management/unit/application/api/users-api.test.js
+++ b/api/tests/identity-access-management/unit/application/api/users-api.test.js
@@ -1,0 +1,24 @@
+import sinon from 'sinon';
+
+import { UserDTO } from '../../../../../src/identity-access-management/application/api/models/UserDTO.js';
+import { getUserDetailsByUserIds } from '../../../../../src/identity-access-management/application/api/users-api.js';
+import { usecases } from '../../../../../src/identity-access-management/domain/usecases/index.js';
+import { domainBuilder, expect } from '../../../../test-helper.js';
+
+describe('Unit | Identity Access Management | Application | API | Users', function () {
+  it('should return users', async function () {
+    // given
+    const firstUser = domainBuilder.buildUser({ id: 1, firstName: 'Théo', lastName: 'Courant' });
+    const secondUser = domainBuilder.buildUser({ id: 2, firstName: 'Alex', lastName: 'Térieur' });
+
+    sinon.stub(usecases, 'getUserDetailsByUserIds');
+    usecases.getUserDetailsByUserIds.withArgs({ userIds: [1, 2] }).resolves([firstUser, secondUser]);
+    const expectedUsers = [new UserDTO(firstUser), new UserDTO(secondUser)];
+
+    // when
+    const users = await getUserDetailsByUserIds({ userIds: [1, 2] });
+
+    // then
+    expect(users).to.deep.equal(expectedUsers);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'Epix sur les attestations pour les 6ème, nous avons besoin d'utiliser les informations des utilisateurs pour générer les pdf. Les données des utilisateurs dépendant du context Identity Access Manager et les attestations dépendant du context Profile nous avons besoin d'une interface pour récupérer ces données.

## :robot: Proposition
On ajoute une API interne qui permet de récupérer les données de plusieurs utilisateurs.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
Les tests sont verts ✅ 
