### PR TITLE
[FEATURE] Migration vers PixIcon sur Junior (Pix-14628)

### DIFF
--- a/junior/app/components/challenge/challenge-media.gjs
+++ b/junior/app/components/challenge/challenge-media.gjs
@@ -1,6 +1,6 @@
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import { on } from '@ember/modifier';
 import { action, trySet } from '@ember/object';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
@@ -21,9 +21,9 @@ export default class ChallengeMedia extends Component {
     {{#if this.displayPlaceholder}}
       <div class="challenge-media__placeholder" aria-label="{{t 'pages.challenge.media.placeholder'}}">
         {{#if (eq @type "video")}}
-          <FaIcon @icon="video" @prefix="fapix" />
+          <PixIcon @name="videocam" @ariaHidden={{true}} />
         {{else}}
-          <FaIcon @icon="image" @prefix="fapix" />
+          <PixIcon @name="image" @ariaHidden={{true}} />
         {{/if}}
       </div>
     {{/if}}

--- a/junior/app/styles/pages/identified/missions/introduction.scss
+++ b/junior/app/styles/pages/identified/missions/introduction.scss
@@ -3,6 +3,13 @@
   flex-direction: column;
   align-content: center;
 
+  .button-actions__icon {
+    width: 20px;
+    height: 20px;
+    margin-left: 10px;
+    fill: var(--pix-neutral-0);
+  }
+
   &__media {
     display: flex;
     justify-content: center;

--- a/junior/app/styles/pages/identified/missions/mission.scss
+++ b/junior/app/styles/pages/identified/missions/mission.scss
@@ -24,7 +24,10 @@
       border-radius: 100px;
 
       &__icon {
+        width: 25px;
+        height: 25px;
         margin-left: 10px;
+        fill: var(--pix-neutral-0);
       }
 
       @include device-is('tablet') {

--- a/junior/app/templates/assessment/results.hbs
+++ b/junior/app/templates/assessment/results.hbs
@@ -23,7 +23,7 @@
 
       <PixButtonLink @route="identified.missions" @shape="rounded" class="details-action">
         <p>{{t "pages.missions.end-page.back-to-missions"}}</p>
-        <FaIcon @icon="arrow-right" class="details-action__icon" />
+        <PixIcon @name="arrowRight" class="details-action__icon" @ariaHidden={{true}} />
       </PixButtonLink>
 
     </div>

--- a/junior/app/templates/identified/missions/mission/index.hbs
+++ b/junior/app/templates/identified/missions/mission/index.hbs
@@ -27,10 +27,10 @@
         {{on "click" this.activeLoadingButton}}
       >
         <p>{{t "pages.missions.start-page.start-mission"}}</p>
-        <FaIcon @icon="arrow-right" class="button__icon-after" />
+        <PixIcon @name="arrowRight" class="details-action__icon" @ariaHidden={{true}} />
       </PixButtonLink>
 
-      <PixButton class="details-action details-action__loader" @isLoading="true" />
+      <PixButton class="details-action details-action__loader" @isLoading="true" @ariaHidden={{true}} />
     </div>
   </div>
 </div>

--- a/junior/app/templates/identified/missions/mission/introduction.hbs
+++ b/junior/app/templates/identified/missions/mission/introduction.hbs
@@ -15,7 +15,7 @@
     <div class="mission-introduction__actions">
       <PixButtonLink @route="identified.missions.mission.resume" size="large" class="details-action">
         <p>{{t "pages.missions.introduction-page.start-mission"}}</p>
-        <FaIcon @icon="arrow-right" class="button__icon-after" />
+        <PixIcon @name="arrowRight" class="button-actions__icon" @ariaHidden={{true}} />
 
       </PixButtonLink>
     </div>

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -12,8 +12,8 @@
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.6",
         "@1024pix/eslint-config": "^1.3.8",
-        "@1024pix/pix-ui": "^46.14.0",
-        "@1024pix/stylelint-config": "^5.1.20",
+        "@1024pix/pix-ui": "^46.15.0",
+        "@1024pix/stylelint-config": "^5.1.19",
         "@1024pix/web-components": "^0.2.6",
         "@babel/eslint-parser": "^7.11.0",
         "@ember/optional-features": "^2.0.0",
@@ -122,12 +122,11 @@
       "dev": true
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "46.14.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-46.14.0.tgz",
-      "integrity": "sha512-wjte7OI1BdaPlqqcI3SlhlXMWP7bvIjsnz71LFMOxj9NSESSG9wR24TKJSP80H5rj947OT0sof06UOcsefPqcQ==",
+      "version": "46.15.2",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-46.15.2.tgz",
+      "integrity": "sha512-vAq2EcYoQu7G+OIf1EIC6/HXoTyv4X1STEZuufqSIwg0O4pOW8ujisOAH57z4xzYV4LKePG2kxgKJom2tO1tFw==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "@formatjs/intl": "^2.5.1",
         "ember-auto-import": "^2.5.0",

--- a/junior/package.json
+++ b/junior/package.json
@@ -37,8 +37,8 @@
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.6",
     "@1024pix/eslint-config": "^1.3.8",
-    "@1024pix/pix-ui": "^46.14.0",
-    "@1024pix/stylelint-config": "^5.1.20",
+    "@1024pix/pix-ui": "^46.15.0",
+    "@1024pix/stylelint-config": "^5.1.19",
     "@1024pix/web-components": "^0.2.6",
     "@babel/eslint-parser": "^7.11.0",
     "@ember/optional-features": "^2.0.0",


### PR DESCRIPTION
## :unicorn: Problème
On change de bibliothèque d'icon.

## :robot: Proposition
Importer les éléments PixIcon à la place des FaIcon

## :rainbow: Remarques
RAS

## :100: Pour tester
Lancer l'app pix junior et vérifier que les icon sont affichés aux endroits changés.