### PR TITLE
[FEATURE] Journaliser le changement d'email par le support (PIX-14363)

### DIFF
--- a/api/src/identity-access-management/application/user/user.admin.controller.js
+++ b/api/src/identity-access-management/application/user/user.admin.controller.js
@@ -39,10 +39,11 @@ const unblockUserAccount = async function (request, h, dependencies = { userLogi
  * @return {Promise<*>}
  */
 const updateUserDetailsByAdmin = async function (request, h, dependencies = { userDetailsForAdminSerializer }) {
+  const updatedByAdminId = request.auth.credentials.userId;
   const userId = request.params.id;
   const userDetailsToUpdate = dependencies.userDetailsForAdminSerializer.deserialize(request.payload);
 
-  const updatedUser = await usecases.updateUserDetailsByAdmin({ userId, userDetailsToUpdate });
+  const updatedUser = await usecases.updateUserDetailsByAdmin({ userId, userDetailsToUpdate, updatedByAdminId });
 
   return dependencies.userDetailsForAdminSerializer.serializeForUpdate(updatedUser);
 };

--- a/api/src/identity-access-management/domain/usecases/update-user-details-by-admin.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/update-user-details-by-admin.usecase.js
@@ -7,32 +7,40 @@ import {
   AlreadyRegisteredEmailAndUsernameError,
   AlreadyRegisteredUsernameError,
 } from '../../../../src/shared/domain/errors.js';
+import { EventLoggingJob } from '../models/jobs/EventLoggingJob.js';
 
-const updateUserDetailsByAdmin = async function ({ userId, userDetailsToUpdate, userRepository }) {
+const updateUserDetailsByAdmin = async function ({
+  userId,
+  userDetailsToUpdate,
+  updatedByAdminId,
+  userRepository,
+  eventLoggingJobRepository,
+}) {
   const { email, username } = userDetailsToUpdate;
 
-  const foundUsersWithEmailAlreadyUsed = email && (await userRepository.findAnotherUserByEmail(userId, email));
-  const foundUsersWithUsernameAlreadyUsed =
-    username && (await userRepository.findAnotherUserByUsername(userId, username));
+  await _checkEmailAndUsernameAreAvailable({ userId, email, username, userRepository });
 
-  await _checkEmailAndUsernameAreAvailable({
-    usersWithEmail: foundUsersWithEmailAlreadyUsed,
-    usersWithUsername: foundUsersWithUsernameAlreadyUsed,
-  });
+  const currentUser = await userRepository.get(userId);
 
-  const userMustValidateTermsOfService = await _isAddingEmailForFirstTime({ userId, email, userRepository });
+  const userMustValidateTermsOfService = _isAddingEmailForFirstTime({ currentUser, newEmail: email });
   if (userMustValidateTermsOfService) {
     userDetailsToUpdate.mustValidateTermsOfService = true;
   }
 
   await userRepository.updateUserDetailsForAdministration({ id: userId, userAttributes: userDetailsToUpdate });
 
+  await _auditLogForEmailChanged({ currentUser, newEmail: email, updatedByAdminId, eventLoggingJobRepository });
+
   return userRepository.getUserDetailsForAdmin(userId);
 };
 
-async function _checkEmailAndUsernameAreAvailable({ usersWithEmail, usersWithUsername }) {
-  const isEmailAlreadyUsed = has(usersWithEmail, '[0].email');
-  const isUsernameAlreadyUsed = has(usersWithUsername, '[0].username');
+async function _checkEmailAndUsernameAreAvailable({ userId, email, username, userRepository }) {
+  const foundUsersWithEmailAlreadyUsed = email && (await userRepository.findAnotherUserByEmail(userId, email));
+  const isEmailAlreadyUsed = has(foundUsersWithEmailAlreadyUsed, '[0].email');
+
+  const foundUsersWithUsernameAlreadyUsed =
+    username && (await userRepository.findAnotherUserByUsername(userId, username));
+  const isUsernameAlreadyUsed = has(foundUsersWithUsernameAlreadyUsed, '[0].username');
 
   if (isEmailAlreadyUsed && isUsernameAlreadyUsed) {
     throw new AlreadyRegisteredEmailAndUsernameError();
@@ -43,12 +51,27 @@ async function _checkEmailAndUsernameAreAvailable({ usersWithEmail, usersWithUse
   }
 }
 
-async function _isAddingEmailForFirstTime({ userId, email, userRepository }) {
-  const user = await userRepository.get(userId);
-  const userWithoutEmail = !user.email;
-  const userHasUsername = !!user.username;
-  const shouldChangeEmail = !!email;
+function _isAddingEmailForFirstTime({ currentUser, newEmail }) {
+  const userWithoutEmail = !currentUser.email;
+  const userHasUsername = !!currentUser.username;
+  const shouldChangeEmail = !!newEmail;
   return userWithoutEmail && userHasUsername && shouldChangeEmail;
+}
+
+async function _auditLogForEmailChanged({ currentUser, newEmail, updatedByAdminId, eventLoggingJobRepository }) {
+  if (!newEmail || newEmail === currentUser.email) return;
+
+  // Currently only used in Pix Admin, which is why app name is hard-coded for the audit log
+  await eventLoggingJobRepository.performAsync(
+    new EventLoggingJob({
+      client: 'PIX_ADMIN',
+      action: 'EMAIL_CHANGED',
+      role: 'SUPPORT',
+      userId: updatedByAdminId,
+      targetUserId: currentUser.id,
+      data: { oldEmail: currentUser.email, newEmail },
+    }),
+  );
 }
 
 export { updateUserDetailsByAdmin };

--- a/api/tests/identity-access-management/unit/application/user/user.admin.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/user/user.admin.controller.test.js
@@ -111,31 +111,17 @@ describe('Unit | Identity Access Management | Application | Controller | Admin |
     });
 
     it('updates email, firstName, lastName', async function () {
-      const lastName = 'newLastName';
-      const firstName = 'newFirstName';
-      const payload = {
-        data: {
-          attributes: {
-            email: newEmail,
-            lastName: 'newLastName',
-            firstName: 'newFirstName',
-          },
-        },
-      };
+      // given
+      const userDetails = { email: newEmail, lastName: 'newLastName', firstName: 'newFirstName' };
+      const payload = { data: { attributes: userDetails } };
       const request = {
-        params: {
-          id: userId,
-        },
+        auth: { credentials: { userId: 'adminId' } },
+        params: { id: userId },
         payload,
       };
 
-      // given
-      dependencies.userDetailsForAdminSerializer.deserialize.withArgs(payload).returns({
-        email: newEmail,
-        lastName,
-        firstName,
-      });
-      usecases.updateUserDetailsByAdmin.resolves({ email: newEmail, lastName, firstName });
+      dependencies.userDetailsForAdminSerializer.deserialize.withArgs(payload).returns(userDetails);
+      usecases.updateUserDetailsByAdmin.withArgs({ ...userDetails, updatedByAdminId: 'adminId' }).resolves();
       dependencies.userDetailsForAdminSerializer.serializeForUpdate.returns('updated');
 
       // when
@@ -155,6 +141,7 @@ describe('Unit | Identity Access Management | Application | Controller | Admin |
         },
       };
       const request = {
+        auth: { credentials: { userId: 'adminId' } },
         params: {
           id: userId,
         },


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, nous n’avons pas de suivi des opérations effectuées (par qui, quand?) sur les données sensibles des utilisateurs comme le changement d’adresse email.

## :robot: Proposition

Lorsque un utilisateur fait changer son adresse email par le support, on souhaite réaliser une journalisation de l’opération.

Que souhaites-t’on journaliser quand l’utilisateur change l’adresse email ?

```
client         // PIX_ADMIN
action         // EMAIL_CHANGED
role           // SUPPORT
userId         // Id de l'agent Pix
targetUserId   // Id de l'utilisateur concerné
occurredAt     // date de changement de l'adresse email
data           // { oldEmail, newEmail }
```

## :100: Pour tester

**Préquis:** En local, il est nécessaire de démarrer
- API: `npm run dev:api`
- Pix Admin: `npm run dev:admin`
- Workers de Job: `cd api && npm run start:job`
- Audit logger: `cd audit-logger && npm run dev`

1. Se connecter sur Pix Admin
2. Aller sur un utilisateur
3. Changer l'adresse email
4. Vérifier que le changement a été journalisé dans l’audit logger avec toutes les informations (directement dans le BDD de l'audit logger):
```sql
select * from "audit-log";
```

_Faire également en modifiant uniquement le nom et prénom, on ne doit pas avoir log apparaître dans l'audit logger dans ce cas._
