### PR TITLE
[FEATURE] Rendre obligatoire le champs propriétaire lors de la création de campagne en masse sur Pix Admin (PIX-12577)

### DIFF
--- a/api/src/prescription/campaign/domain/usecases/create-campaigns.js
+++ b/api/src/prescription/campaign/domain/usecases/create-campaigns.js
@@ -2,23 +2,12 @@ import { CampaignTypes } from '../../../shared/domain/constants.js';
 
 const createCampaigns = async function ({
   campaignsToCreate,
-  membershipRepository,
   campaignAdministrationRepository,
   campaignCreatorRepository,
   codeGenerator,
 }) {
   const enrichedCampaignsData = await Promise.all(
     campaignsToCreate.map(async (campaign) => {
-      let ownerId;
-      if (campaign.ownerId) {
-        ownerId = campaign.ownerId;
-      } else {
-        const [administrator] = await membershipRepository.findAdminsByOrganizationId({
-          organizationId: campaign.organizationId,
-        });
-        ownerId = administrator.user.id;
-      }
-
       const generatedCampaignCode = await codeGenerator.generate(campaignAdministrationRepository);
       const campaignCreator = await campaignCreatorRepository.get(campaign.organizationId);
 
@@ -26,7 +15,6 @@ const createCampaigns = async function ({
         ...campaign,
         type: CampaignTypes.ASSESSMENT,
         code: generatedCampaignCode,
-        ownerId,
       });
     }),
   );

--- a/api/src/prescription/campaign/domain/usecases/create-campaigns.js
+++ b/api/src/prescription/campaign/domain/usecases/create-campaigns.js
@@ -5,9 +5,14 @@ const createCampaigns = async function ({
   campaignAdministrationRepository,
   campaignCreatorRepository,
   codeGenerator,
+  userRepository,
+  organizationRepository,
 }) {
   const enrichedCampaignsData = await Promise.all(
     campaignsToCreate.map(async (campaign) => {
+      await _checkIfOwnerIsExistingUser(userRepository, campaign.ownerId);
+      await _checkIfOrganizationExists(organizationRepository, campaign.organizationId);
+
       const generatedCampaignCode = await codeGenerator.generate(campaignAdministrationRepository);
       const campaignCreator = await campaignCreatorRepository.get(campaign.organizationId);
 
@@ -20,6 +25,14 @@ const createCampaigns = async function ({
   );
 
   return campaignAdministrationRepository.save(enrichedCampaignsData);
+};
+
+const _checkIfOwnerIsExistingUser = async function (userRepository, userId) {
+  await userRepository.get(userId);
+};
+
+const _checkIfOrganizationExists = async function (organizationRepository, organizationId) {
+  await organizationRepository.get(organizationId);
 };
 
 export { createCampaigns };

--- a/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
@@ -181,6 +181,7 @@ const requiredFieldNamesForCampaignsImport = [
   "Identifiant de l'organisation*",
   'Nom de la campagne*',
   'Identifiant du profil cible*',
+  'Identifiant du propriétaire*',
   'Identifiant du créateur*',
 ];
 
@@ -206,7 +207,7 @@ async function parseForCampaignsImport(cleanedData, { parseCsvData } = csvHelper
           "Identifiant de l'organisation*",
           'Identifiant du profil cible*',
           'Identifiant du créateur*',
-          'Identifiant du propriétaire',
+          'Identifiant du propriétaire*',
         ].includes(columnName)
       ) {
         value = parseInt(value, 10);
@@ -231,7 +232,7 @@ async function parseForCampaignsImport(cleanedData, { parseCsvData } = csvHelper
     title: data['Titre du parcours'],
     customLandingPageText: data['Descriptif du parcours'],
     multipleSendings: data['Envoi multiple'].toLowerCase() === 'oui' ? true : false,
-    ownerId: data['Identifiant du propriétaire'] || null,
+    ownerId: data['Identifiant du propriétaire*'],
     customResultPageText: data['Texte de la page de fin de parcours'] || null,
     customResultPageButtonText: data['Texte du bouton de la page de fin de parcours'] || null,
     customResultPageButtonUrl: data['URL du bouton de la page de fin de parcours'] || null,

--- a/api/tests/prescription/campaign/acceptance/application/campaign-administration-route_test.js
+++ b/api/tests/prescription/campaign/acceptance/application/campaign-administration-route_test.js
@@ -236,9 +236,9 @@ describe('Acceptance | API | campaign-administration-route', function () {
         const targetProfileId = databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organizationId }).id;
         await databaseBuilder.commit();
 
-        const buffer = `Identifiant de l'organisation*;Nom de la campagne*;Identifiant du profil cible*;Libellé de l'identifiant externe;Identifiant du créateur*;Titre du parcours;Descriptif du parcours;Envoi multiple
-          ${organizationId};Parcours importé par CSV;${targetProfileId};numéro d'étudiant;${userId};;;non
-          ${organizationId};Autre parcours importé par CSV;${targetProfileId};numéro d'étudiant;${userId};Titre;Superbe descriptif de parcours;oui`;
+        const buffer = `Identifiant de l'organisation*;Nom de la campagne*;Identifiant du profil cible*;Libellé de l'identifiant externe;Identifiant du créateur*;Titre du parcours;Descriptif du parcours;Envoi multiple;Identifiant du propriétaire*
+          ${organizationId};Parcours importé par CSV;${targetProfileId};numéro d'étudiant;${userId};;;non;${userId};
+          ${organizationId};Autre parcours importé par CSV;${targetProfileId};numéro d'étudiant;${userId};Titre;Superbe descriptif de parcours;oui;${userId};`;
         const options = {
           method: 'POST',
           url: '/api/admin/campaigns',

--- a/api/tests/prescription/campaign/unit/domain/usecases/create-campaigns_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/create-campaigns_test.js
@@ -9,15 +9,9 @@ describe('Unit | UseCase | campaign-administration | create-campaigns', function
     };
     const code1 = Symbol('code1');
     const code2 = Symbol('code2');
-    const administrator = domainBuilder.buildUser();
     const someoneId = 454756;
     const otherOrganization = domainBuilder.buildOrganization({ id: 3 });
     const organization = domainBuilder.buildOrganization({ id: 4 });
-    const administratorMembership = domainBuilder.buildMembership({
-      user: administrator,
-      organization: otherOrganization,
-      organizationRole: 'ADMIN',
-    });
 
     const codeGeneratorStub = {
       generate: sinon
@@ -42,6 +36,7 @@ describe('Unit | UseCase | campaign-administration | create-campaigns', function
         name: 'My other Campaign',
         targetProfileId: 3,
         creatorId: 1,
+        ownerId: someoneId,
       },
     ];
 
@@ -54,7 +49,7 @@ describe('Unit | UseCase | campaign-administration | create-campaigns', function
       {
         ...campaignsToCreate[1],
         type: 'ASSESSMENT',
-        ownerId: administrator.id,
+        ownerId: someoneId,
         code: code2,
       },
     ];
@@ -67,7 +62,7 @@ describe('Unit | UseCase | campaign-administration | create-campaigns', function
       .withArgs({ ...campaignsToCreate[0], type: CampaignTypes.ASSESSMENT, code: code1, ownerId: someoneId })
       .resolves(campaignsWithAllData[0]);
     campaignCreatorPOJO.createCampaign
-      .withArgs({ ...campaignsToCreate[1], type: CampaignTypes.ASSESSMENT, code: code2, ownerId: administrator.id })
+      .withArgs({ ...campaignsToCreate[1], type: CampaignTypes.ASSESSMENT, code: code2, ownerId: someoneId })
       .resolves(campaignsWithAllData[1]);
 
     const campaignCreatorRepositoryStub = {
@@ -80,16 +75,8 @@ describe('Unit | UseCase | campaign-administration | create-campaigns', function
     const createdCampaignsSymbol = Symbol('');
     campaignAdministrationRepository.save.withArgs(campaignsWithAllData).resolves(createdCampaignsSymbol);
 
-    const membershipRepository = {
-      findAdminsByOrganizationId: sinon.stub(),
-    };
-    membershipRepository.findAdminsByOrganizationId
-      .withArgs({ organizationId: otherOrganization.id })
-      .resolves([administratorMembership]);
-
     const result = await createCampaigns({
       campaignsToCreate,
-      membershipRepository,
       campaignAdministrationRepository,
       codeGenerator: codeGeneratorStub,
       campaignCreatorRepository: campaignCreatorRepositoryStub,

--- a/api/tests/prescription/campaign/unit/domain/usecases/create-campaigns_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/create-campaigns_test.js
@@ -1,87 +1,290 @@
 import { createCampaigns } from '../../../../../../src/prescription/campaign/domain/usecases/create-campaigns.js';
 import { CampaignTypes } from '../../../../../../src/prescription/shared/domain/constants.js';
-import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+import { NotFoundError, UserNotFoundError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | campaign-administration | create-campaigns', function () {
-  it('should create campaigns', async function () {
-    const campaignAdministrationRepository = {
-      save: sinon.stub(),
-    };
-    const code1 = Symbol('code1');
-    const code2 = Symbol('code2');
-    const someoneId = 454756;
-    const otherOrganization = domainBuilder.buildOrganization({ id: 3 });
-    const organization = domainBuilder.buildOrganization({ id: 4 });
+  describe('success case', function () {
+    it('should create campaigns', async function () {
+      const campaignAdministrationRepository = {
+        save: sinon.stub(),
+      };
+      const userRepositoryStub = {
+        get: sinon.stub(),
+      };
+      const organizationRepositoryStub = {
+        get: sinon.stub(),
+      };
+      const code1 = Symbol('code1');
+      const code2 = Symbol('code2');
+      const someoneId = 454756;
+      const otherOrganization = domainBuilder.buildOrganization({ id: 3 });
+      const organization = domainBuilder.buildOrganization({ id: 4 });
 
-    const codeGeneratorStub = {
-      generate: sinon
-        .stub()
-        .withArgs(campaignAdministrationRepository)
-        .onFirstCall()
-        .resolves(code1)
-        .onSecondCall()
-        .resolves(code2),
-    };
+      const codeGeneratorStub = {
+        generate: sinon
+          .stub()
+          .withArgs(campaignAdministrationRepository)
+          .onFirstCall()
+          .resolves(code1)
+          .onSecondCall()
+          .resolves(code2),
+      };
 
-    const campaignsToCreate = [
-      {
-        organizationId: organization.id,
-        name: 'My Campaign',
-        targetProfileId: 3,
-        creatorId: 2,
-        ownerId: someoneId,
-      },
-      {
-        organizationId: otherOrganization.id,
-        name: 'My other Campaign',
-        targetProfileId: 3,
-        creatorId: 1,
-        ownerId: someoneId,
-      },
-    ];
+      const campaignsToCreate = [
+        {
+          organizationId: organization.id,
+          name: 'My Campaign',
+          targetProfileId: 3,
+          creatorId: 2,
+          ownerId: someoneId,
+        },
+        {
+          organizationId: otherOrganization.id,
+          name: 'My other Campaign',
+          targetProfileId: 3,
+          creatorId: 1,
+          ownerId: someoneId,
+        },
+      ];
 
-    const campaignsWithAllData = [
-      {
-        ...campaignsToCreate[0],
-        type: 'ASSESSMENT',
-        code: code1,
-      },
-      {
-        ...campaignsToCreate[1],
-        type: 'ASSESSMENT',
-        ownerId: someoneId,
-        code: code2,
-      },
-    ];
+      const campaignsWithAllData = [
+        {
+          ...campaignsToCreate[0],
+          type: 'ASSESSMENT',
+          code: code1,
+        },
+        {
+          ...campaignsToCreate[1],
+          type: 'ASSESSMENT',
+          code: code2,
+        },
+      ];
 
-    const campaignCreatorPOJO = {
-      createCampaign: sinon.stub(),
-    };
+      const campaignCreatorPOJO = {
+        createCampaign: sinon.stub(),
+      };
 
-    campaignCreatorPOJO.createCampaign
-      .withArgs({ ...campaignsToCreate[0], type: CampaignTypes.ASSESSMENT, code: code1, ownerId: someoneId })
-      .resolves(campaignsWithAllData[0]);
-    campaignCreatorPOJO.createCampaign
-      .withArgs({ ...campaignsToCreate[1], type: CampaignTypes.ASSESSMENT, code: code2, ownerId: someoneId })
-      .resolves(campaignsWithAllData[1]);
+      campaignCreatorPOJO.createCampaign
+        .withArgs({ ...campaignsToCreate[0], type: CampaignTypes.ASSESSMENT, code: code1, ownerId: someoneId })
+        .resolves(campaignsWithAllData[0]);
+      campaignCreatorPOJO.createCampaign
+        .withArgs({ ...campaignsToCreate[1], type: CampaignTypes.ASSESSMENT, code: code2, ownerId: someoneId })
+        .resolves(campaignsWithAllData[1]);
 
-    const campaignCreatorRepositoryStub = {
-      get: sinon.stub(),
-    };
+      const campaignCreatorRepositoryStub = {
+        get: sinon.stub(),
+      };
 
-    campaignCreatorRepositoryStub.get.withArgs(campaignsToCreate[0].organizationId).resolves(campaignCreatorPOJO);
-    campaignCreatorRepositoryStub.get.withArgs(campaignsToCreate[1].organizationId).resolves(campaignCreatorPOJO);
+      organizationRepositoryStub.get.withArgs(campaignsToCreate[0].organizationId).resolves();
+      userRepositoryStub.get.withArgs(campaignsToCreate[0].ownerId).resolves();
+      organizationRepositoryStub.get.withArgs(campaignsToCreate[1].organizationId).resolves();
+      userRepositoryStub.get.withArgs(campaignsToCreate[1].ownerId).resolves();
 
-    const createdCampaignsSymbol = Symbol('');
-    campaignAdministrationRepository.save.withArgs(campaignsWithAllData).resolves(createdCampaignsSymbol);
+      campaignCreatorRepositoryStub.get.withArgs(campaignsToCreate[0].organizationId).resolves(campaignCreatorPOJO);
+      campaignCreatorRepositoryStub.get.withArgs(campaignsToCreate[1].organizationId).resolves(campaignCreatorPOJO);
 
-    const result = await createCampaigns({
-      campaignsToCreate,
-      campaignAdministrationRepository,
-      codeGenerator: codeGeneratorStub,
-      campaignCreatorRepository: campaignCreatorRepositoryStub,
+      const createdCampaignsSymbol = Symbol('');
+      campaignAdministrationRepository.save.withArgs(campaignsWithAllData).resolves(createdCampaignsSymbol);
+
+      const result = await createCampaigns({
+        campaignsToCreate,
+        campaignAdministrationRepository,
+        codeGenerator: codeGeneratorStub,
+        campaignCreatorRepository: campaignCreatorRepositoryStub,
+        userRepository: userRepositoryStub,
+        organizationRepository: organizationRepositoryStub,
+      });
+
+      expect(result).to.equal(createdCampaignsSymbol);
+    });
+  });
+
+  describe('errors case', function () {
+    it('should throw error if ownerId does not exist', async function () {
+      const campaignAdministrationRepository = {
+        save: sinon.stub(),
+      };
+      const userRepositoryStub = {
+        get: sinon.stub(),
+      };
+      const organizationRepositoryStub = {
+        get: sinon.stub(),
+      };
+      const code1 = Symbol('code1');
+      const code2 = Symbol('code2');
+      const someoneId = 454756;
+      const otherOrganization = domainBuilder.buildOrganization({ id: 3 });
+      const organization = domainBuilder.buildOrganization({ id: 4 });
+
+      const codeGeneratorStub = {
+        generate: sinon
+          .stub()
+          .withArgs(campaignAdministrationRepository)
+          .onFirstCall()
+          .resolves(code1)
+          .onSecondCall()
+          .resolves(code2),
+      };
+
+      const campaignsToCreate = [
+        {
+          organizationId: organization.id,
+          name: 'My Campaign',
+          targetProfileId: 3,
+          creatorId: 2,
+          ownerId: someoneId,
+        },
+        {
+          organizationId: otherOrganization.id,
+          name: 'My other Campaign',
+          targetProfileId: 3,
+          creatorId: 1,
+          ownerId: someoneId,
+        },
+      ];
+
+      const campaignsWithAllData = [
+        {
+          ...campaignsToCreate[0],
+          type: 'ASSESSMENT',
+          code: code1,
+        },
+        {
+          ...campaignsToCreate[1],
+          type: 'ASSESSMENT',
+          code: code2,
+        },
+      ];
+
+      const campaignCreatorPOJO = {
+        createCampaign: sinon.stub(),
+      };
+
+      campaignCreatorPOJO.createCampaign
+        .withArgs({ ...campaignsToCreate[0], type: CampaignTypes.ASSESSMENT, code: code1, ownerId: someoneId })
+        .resolves(campaignsWithAllData[0]);
+      campaignCreatorPOJO.createCampaign
+        .withArgs({ ...campaignsToCreate[1], type: CampaignTypes.ASSESSMENT, code: code2, ownerId: someoneId })
+        .resolves(campaignsWithAllData[1]);
+
+      const campaignCreatorRepositoryStub = {
+        get: sinon.stub(),
+      };
+
+      organizationRepositoryStub.get.withArgs(campaignsToCreate[0].organizationId).resolves();
+      userRepositoryStub.get.withArgs(campaignsToCreate[0].ownerId).rejects(new UserNotFoundError());
+
+      campaignCreatorRepositoryStub.get.withArgs(campaignsToCreate[0].organizationId).resolves(campaignCreatorPOJO);
+      campaignCreatorRepositoryStub.get.withArgs(campaignsToCreate[1].organizationId).resolves(campaignCreatorPOJO);
+
+      const createdCampaignsSymbol = Symbol('');
+      campaignAdministrationRepository.save.withArgs(campaignsWithAllData).resolves(createdCampaignsSymbol);
+
+      const error = await catchErr(createCampaigns)({
+        campaignsToCreate,
+        campaignAdministrationRepository,
+        codeGenerator: codeGeneratorStub,
+        campaignCreatorRepository: campaignCreatorRepositoryStub,
+        userRepository: userRepositoryStub,
+        organizationRepository: organizationRepositoryStub,
+      });
+
+      expect(error).to.throw;
+      expect(error).to.be.an.instanceof(UserNotFoundError);
     });
 
-    expect(result).to.equal(createdCampaignsSymbol);
+    it('should throw error if organization does not exist', async function () {
+      const campaignAdministrationRepository = {
+        save: sinon.stub(),
+      };
+      const userRepositoryStub = {
+        get: sinon.stub(),
+      };
+      const organizationRepositoryStub = {
+        get: sinon.stub(),
+      };
+      const code1 = Symbol('code1');
+      const code2 = Symbol('code2');
+      const someoneId = 454756;
+      const otherOrganization = domainBuilder.buildOrganization({ id: 3 });
+      const organization = domainBuilder.buildOrganization({ id: 4 });
+
+      const codeGeneratorStub = {
+        generate: sinon
+          .stub()
+          .withArgs(campaignAdministrationRepository)
+          .onFirstCall()
+          .resolves(code1)
+          .onSecondCall()
+          .resolves(code2),
+      };
+
+      const campaignsToCreate = [
+        {
+          organizationId: organization.id,
+          name: 'My Campaign',
+          targetProfileId: 3,
+          creatorId: 2,
+          ownerId: someoneId,
+        },
+        {
+          organizationId: otherOrganization.id,
+          name: 'My other Campaign',
+          targetProfileId: 3,
+          creatorId: 1,
+          ownerId: someoneId,
+        },
+      ];
+
+      const campaignsWithAllData = [
+        {
+          ...campaignsToCreate[0],
+          type: 'ASSESSMENT',
+          code: code1,
+        },
+        {
+          ...campaignsToCreate[1],
+          type: 'ASSESSMENT',
+          code: code2,
+        },
+      ];
+
+      const campaignCreatorPOJO = {
+        createCampaign: sinon.stub(),
+      };
+
+      campaignCreatorPOJO.createCampaign
+        .withArgs({ ...campaignsToCreate[0], type: CampaignTypes.ASSESSMENT, code: code1, ownerId: someoneId })
+        .resolves(campaignsWithAllData[0]);
+      campaignCreatorPOJO.createCampaign
+        .withArgs({ ...campaignsToCreate[1], type: CampaignTypes.ASSESSMENT, code: code2, ownerId: someoneId })
+        .resolves(campaignsWithAllData[1]);
+
+      const campaignCreatorRepositoryStub = {
+        get: sinon.stub(),
+      };
+
+      organizationRepositoryStub.get.withArgs(campaignsToCreate[0].organizationId).rejects(new NotFoundError());
+      userRepositoryStub.get.withArgs(campaignsToCreate[0].ownerId).resolves();
+
+      campaignCreatorRepositoryStub.get.withArgs(campaignsToCreate[0].organizationId).resolves(campaignCreatorPOJO);
+      campaignCreatorRepositoryStub.get.withArgs(campaignsToCreate[1].organizationId).resolves(campaignCreatorPOJO);
+
+      const createdCampaignsSymbol = Symbol('');
+      campaignAdministrationRepository.save.withArgs(campaignsWithAllData).resolves(createdCampaignsSymbol);
+
+      const error = await catchErr(createCampaigns)({
+        campaignsToCreate,
+        campaignAdministrationRepository,
+        codeGenerator: codeGeneratorStub,
+        campaignCreatorRepository: campaignCreatorRepositoryStub,
+        userRepository: userRepositoryStub,
+        organizationRepository: organizationRepositoryStub,
+      });
+
+      expect(error).to.throw;
+      expect(error).to.be.an.instanceof(NotFoundError);
+    });
   });
 });

--- a/api/tests/prescription/campaign/unit/domain/usecases/create-campaigns_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/create-campaigns_test.js
@@ -4,92 +4,102 @@ import { NotFoundError, UserNotFoundError } from '../../../../../../src/shared/d
 import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | campaign-administration | create-campaigns', function () {
+  let codeGeneratorStub;
+  let campaignsToCreate;
+  let campaignAdministrationRepositoryStub;
+  let campaignCreatorRepositoryStub;
+  let userRepositoryStub;
+  let organizationRepositoryStub;
+  let createdCampaignsSymbol;
+
+  beforeEach(function () {
+    campaignAdministrationRepositoryStub = {
+      save: sinon.stub(),
+    };
+    userRepositoryStub = {
+      get: sinon.stub(),
+    };
+    organizationRepositoryStub = {
+      get: sinon.stub(),
+    };
+    const code1 = Symbol('code1');
+    const code2 = Symbol('code2');
+    const someoneId = 454756;
+    const otherOrganization = domainBuilder.buildOrganization({ id: 3 });
+    const organization = domainBuilder.buildOrganization({ id: 4 });
+
+    codeGeneratorStub = {
+      generate: sinon
+        .stub()
+        .withArgs(campaignAdministrationRepositoryStub)
+        .onFirstCall()
+        .resolves(code1)
+        .onSecondCall()
+        .resolves(code2),
+    };
+
+    campaignsToCreate = [
+      {
+        organizationId: organization.id,
+        name: 'My Campaign',
+        targetProfileId: 3,
+        creatorId: 2,
+        ownerId: someoneId,
+      },
+      {
+        organizationId: otherOrganization.id,
+        name: 'My other Campaign',
+        targetProfileId: 3,
+        creatorId: 1,
+        ownerId: someoneId,
+      },
+    ];
+
+    const campaignsWithAllData = [
+      {
+        ...campaignsToCreate[0],
+        type: 'ASSESSMENT',
+        code: code1,
+      },
+      {
+        ...campaignsToCreate[1],
+        type: 'ASSESSMENT',
+        code: code2,
+      },
+    ];
+
+    const campaignCreatorPOJO = {
+      createCampaign: sinon.stub(),
+    };
+
+    campaignCreatorPOJO.createCampaign
+      .withArgs({ ...campaignsToCreate[0], type: CampaignTypes.ASSESSMENT, code: code1, ownerId: someoneId })
+      .resolves(campaignsWithAllData[0]);
+    campaignCreatorPOJO.createCampaign
+      .withArgs({ ...campaignsToCreate[1], type: CampaignTypes.ASSESSMENT, code: code2, ownerId: someoneId })
+      .resolves(campaignsWithAllData[1]);
+
+    campaignCreatorRepositoryStub = {
+      get: sinon.stub(),
+    };
+
+    campaignCreatorRepositoryStub.get.withArgs(campaignsToCreate[0].organizationId).resolves(campaignCreatorPOJO);
+    campaignCreatorRepositoryStub.get.withArgs(campaignsToCreate[1].organizationId).resolves(campaignCreatorPOJO);
+
+    createdCampaignsSymbol = Symbol('');
+    campaignAdministrationRepositoryStub.save.withArgs(campaignsWithAllData).resolves(createdCampaignsSymbol);
+  });
+
   describe('success case', function () {
     it('should create campaigns', async function () {
-      const campaignAdministrationRepository = {
-        save: sinon.stub(),
-      };
-      const userRepositoryStub = {
-        get: sinon.stub(),
-      };
-      const organizationRepositoryStub = {
-        get: sinon.stub(),
-      };
-      const code1 = Symbol('code1');
-      const code2 = Symbol('code2');
-      const someoneId = 454756;
-      const otherOrganization = domainBuilder.buildOrganization({ id: 3 });
-      const organization = domainBuilder.buildOrganization({ id: 4 });
-
-      const codeGeneratorStub = {
-        generate: sinon
-          .stub()
-          .withArgs(campaignAdministrationRepository)
-          .onFirstCall()
-          .resolves(code1)
-          .onSecondCall()
-          .resolves(code2),
-      };
-
-      const campaignsToCreate = [
-        {
-          organizationId: organization.id,
-          name: 'My Campaign',
-          targetProfileId: 3,
-          creatorId: 2,
-          ownerId: someoneId,
-        },
-        {
-          organizationId: otherOrganization.id,
-          name: 'My other Campaign',
-          targetProfileId: 3,
-          creatorId: 1,
-          ownerId: someoneId,
-        },
-      ];
-
-      const campaignsWithAllData = [
-        {
-          ...campaignsToCreate[0],
-          type: 'ASSESSMENT',
-          code: code1,
-        },
-        {
-          ...campaignsToCreate[1],
-          type: 'ASSESSMENT',
-          code: code2,
-        },
-      ];
-
-      const campaignCreatorPOJO = {
-        createCampaign: sinon.stub(),
-      };
-
-      campaignCreatorPOJO.createCampaign
-        .withArgs({ ...campaignsToCreate[0], type: CampaignTypes.ASSESSMENT, code: code1, ownerId: someoneId })
-        .resolves(campaignsWithAllData[0]);
-      campaignCreatorPOJO.createCampaign
-        .withArgs({ ...campaignsToCreate[1], type: CampaignTypes.ASSESSMENT, code: code2, ownerId: someoneId })
-        .resolves(campaignsWithAllData[1]);
-
-      const campaignCreatorRepositoryStub = {
-        get: sinon.stub(),
-      };
-
       organizationRepositoryStub.get.withArgs(campaignsToCreate[0].organizationId).resolves();
       userRepositoryStub.get.withArgs(campaignsToCreate[0].ownerId).resolves();
       organizationRepositoryStub.get.withArgs(campaignsToCreate[1].organizationId).resolves();
       userRepositoryStub.get.withArgs(campaignsToCreate[1].ownerId).resolves();
 
-      campaignCreatorRepositoryStub.get.withArgs(campaignsToCreate[0].organizationId).resolves(campaignCreatorPOJO);
-      campaignCreatorRepositoryStub.get.withArgs(campaignsToCreate[1].organizationId).resolves(campaignCreatorPOJO);
-
-      const createdCampaignsSymbol = Symbol('');
-      campaignAdministrationRepository.save.withArgs(campaignsWithAllData).resolves(createdCampaignsSymbol);
-
       const result = await createCampaigns({
         campaignsToCreate,
-        campaignAdministrationRepository,
+        campaignAdministrationRepository: campaignAdministrationRepositoryStub,
         codeGenerator: codeGeneratorStub,
         campaignCreatorRepository: campaignCreatorRepositoryStub,
         userRepository: userRepositoryStub,
@@ -102,88 +112,12 @@ describe('Unit | UseCase | campaign-administration | create-campaigns', function
 
   describe('errors case', function () {
     it('should throw error if ownerId does not exist', async function () {
-      const campaignAdministrationRepository = {
-        save: sinon.stub(),
-      };
-      const userRepositoryStub = {
-        get: sinon.stub(),
-      };
-      const organizationRepositoryStub = {
-        get: sinon.stub(),
-      };
-      const code1 = Symbol('code1');
-      const code2 = Symbol('code2');
-      const someoneId = 454756;
-      const otherOrganization = domainBuilder.buildOrganization({ id: 3 });
-      const organization = domainBuilder.buildOrganization({ id: 4 });
-
-      const codeGeneratorStub = {
-        generate: sinon
-          .stub()
-          .withArgs(campaignAdministrationRepository)
-          .onFirstCall()
-          .resolves(code1)
-          .onSecondCall()
-          .resolves(code2),
-      };
-
-      const campaignsToCreate = [
-        {
-          organizationId: organization.id,
-          name: 'My Campaign',
-          targetProfileId: 3,
-          creatorId: 2,
-          ownerId: someoneId,
-        },
-        {
-          organizationId: otherOrganization.id,
-          name: 'My other Campaign',
-          targetProfileId: 3,
-          creatorId: 1,
-          ownerId: someoneId,
-        },
-      ];
-
-      const campaignsWithAllData = [
-        {
-          ...campaignsToCreate[0],
-          type: 'ASSESSMENT',
-          code: code1,
-        },
-        {
-          ...campaignsToCreate[1],
-          type: 'ASSESSMENT',
-          code: code2,
-        },
-      ];
-
-      const campaignCreatorPOJO = {
-        createCampaign: sinon.stub(),
-      };
-
-      campaignCreatorPOJO.createCampaign
-        .withArgs({ ...campaignsToCreate[0], type: CampaignTypes.ASSESSMENT, code: code1, ownerId: someoneId })
-        .resolves(campaignsWithAllData[0]);
-      campaignCreatorPOJO.createCampaign
-        .withArgs({ ...campaignsToCreate[1], type: CampaignTypes.ASSESSMENT, code: code2, ownerId: someoneId })
-        .resolves(campaignsWithAllData[1]);
-
-      const campaignCreatorRepositoryStub = {
-        get: sinon.stub(),
-      };
-
       organizationRepositoryStub.get.withArgs(campaignsToCreate[0].organizationId).resolves();
       userRepositoryStub.get.withArgs(campaignsToCreate[0].ownerId).rejects(new UserNotFoundError());
 
-      campaignCreatorRepositoryStub.get.withArgs(campaignsToCreate[0].organizationId).resolves(campaignCreatorPOJO);
-      campaignCreatorRepositoryStub.get.withArgs(campaignsToCreate[1].organizationId).resolves(campaignCreatorPOJO);
-
-      const createdCampaignsSymbol = Symbol('');
-      campaignAdministrationRepository.save.withArgs(campaignsWithAllData).resolves(createdCampaignsSymbol);
-
       const error = await catchErr(createCampaigns)({
         campaignsToCreate,
-        campaignAdministrationRepository,
+        campaignAdministrationRepository: campaignAdministrationRepositoryStub,
         codeGenerator: codeGeneratorStub,
         campaignCreatorRepository: campaignCreatorRepositoryStub,
         userRepository: userRepositoryStub,
@@ -195,88 +129,12 @@ describe('Unit | UseCase | campaign-administration | create-campaigns', function
     });
 
     it('should throw error if organization does not exist', async function () {
-      const campaignAdministrationRepository = {
-        save: sinon.stub(),
-      };
-      const userRepositoryStub = {
-        get: sinon.stub(),
-      };
-      const organizationRepositoryStub = {
-        get: sinon.stub(),
-      };
-      const code1 = Symbol('code1');
-      const code2 = Symbol('code2');
-      const someoneId = 454756;
-      const otherOrganization = domainBuilder.buildOrganization({ id: 3 });
-      const organization = domainBuilder.buildOrganization({ id: 4 });
-
-      const codeGeneratorStub = {
-        generate: sinon
-          .stub()
-          .withArgs(campaignAdministrationRepository)
-          .onFirstCall()
-          .resolves(code1)
-          .onSecondCall()
-          .resolves(code2),
-      };
-
-      const campaignsToCreate = [
-        {
-          organizationId: organization.id,
-          name: 'My Campaign',
-          targetProfileId: 3,
-          creatorId: 2,
-          ownerId: someoneId,
-        },
-        {
-          organizationId: otherOrganization.id,
-          name: 'My other Campaign',
-          targetProfileId: 3,
-          creatorId: 1,
-          ownerId: someoneId,
-        },
-      ];
-
-      const campaignsWithAllData = [
-        {
-          ...campaignsToCreate[0],
-          type: 'ASSESSMENT',
-          code: code1,
-        },
-        {
-          ...campaignsToCreate[1],
-          type: 'ASSESSMENT',
-          code: code2,
-        },
-      ];
-
-      const campaignCreatorPOJO = {
-        createCampaign: sinon.stub(),
-      };
-
-      campaignCreatorPOJO.createCampaign
-        .withArgs({ ...campaignsToCreate[0], type: CampaignTypes.ASSESSMENT, code: code1, ownerId: someoneId })
-        .resolves(campaignsWithAllData[0]);
-      campaignCreatorPOJO.createCampaign
-        .withArgs({ ...campaignsToCreate[1], type: CampaignTypes.ASSESSMENT, code: code2, ownerId: someoneId })
-        .resolves(campaignsWithAllData[1]);
-
-      const campaignCreatorRepositoryStub = {
-        get: sinon.stub(),
-      };
-
       organizationRepositoryStub.get.withArgs(campaignsToCreate[0].organizationId).rejects(new NotFoundError());
       userRepositoryStub.get.withArgs(campaignsToCreate[0].ownerId).resolves();
 
-      campaignCreatorRepositoryStub.get.withArgs(campaignsToCreate[0].organizationId).resolves(campaignCreatorPOJO);
-      campaignCreatorRepositoryStub.get.withArgs(campaignsToCreate[1].organizationId).resolves(campaignCreatorPOJO);
-
-      const createdCampaignsSymbol = Symbol('');
-      campaignAdministrationRepository.save.withArgs(campaignsWithAllData).resolves(createdCampaignsSymbol);
-
       const error = await catchErr(createCampaigns)({
         campaignsToCreate,
-        campaignAdministrationRepository,
+        campaignAdministrationRepository: campaignAdministrationRepositoryStub,
         codeGenerator: codeGeneratorStub,
         campaignCreatorRepository: campaignCreatorRepositoryStub,
         userRepository: userRepositoryStub,


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix Admin, lors de l'import d'un fichier CSV pour la création de campagnes en masse, le champs du propriétaire de la campagne (ownerId) est facultatif. Si ce dernier n'est pas rempli, on va chercher le premier admin de l'organisation et on l'assigne en propriétaire.
Or dans le cas où l'orga en question n'as pas d'admin, l'API renvoie une erreur 500.

## :robot: Proposition
Rendre le champs du propriétaire obligatoire lors de l'import du fichier CSV et supprimer le contournement implémenté pour aller chercher un admin. Renvoyer une erreur de fichier CSV invalide si le champs n'est pas rempli.

## :rainbow: Remarques
On ajoute une vérification de l'existence du propriétaire et de l'organisation et une erreur correspondante.
La gestion d'erreur pourra être améliorée sur Pix Admin pour indiquer exactement quels champs sont incorrects ou non remplis.

## :100: Pour tester
Sur Pix Admin : 
1) Remplir un fichier CSV via le template d'import de campagnes en omettant de remplir le champs Propriétaire et tenter de l'importer
2) Constater qu'une erreur de CSV invalide est renvoyée
3) Refaire un import avec une valeur non numérique dans le champs propriétaire
4) Constater qu'une erreur de CSV invalide est renvoyée
5) Remplir un nouveau fichier en spécifiant un propriétaire non existant et tenter de l'importer
6) Constater qu'une erreur différente est renvoyée

Bonus : refaire le même scénario avec une orga qui n'existe pas.
