### PR TITLE
[TECH] Permettre la désactivation des CRON liés au CPF (PIX-14388).

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -863,6 +863,12 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: 3
 # sample: CPF_PLANNER_JOB_MINIMUM_RELIABILITY_PERIOD=3
 
+# Toggle of the cpf planner job
+#
+# presence: optional
+# type: string
+# sample: PGBOSS_PLANNER_JOB_ENABLED=true
+
 # Cron of the cpf planner job
 #
 # presence: required for CPF xml file generation, optional otherwise

--- a/api/sample.env
+++ b/api/sample.env
@@ -881,6 +881,12 @@ TEST_REDIS_URL=redis://localhost:6379
 # type: string
 # sample:CPF_SEND_EMAIL_JOB_RECIPIENT=
 
+# Toggle of the cpf email job
+#
+# presence: optional
+# type: string
+# sample: PGBOSS_EXPORT_SENDER_JOB_ENABLED=true
+
 # Cron of the cpf email job
 #
 # presence: required for CPF xml file generation, optional otherwise

--- a/api/src/certification/session-management/application/jobs/cpf-export-planner-job-controller.js
+++ b/api/src/certification/session-management/application/jobs/cpf-export-planner-job-controller.js
@@ -19,6 +19,10 @@ class CpfExportPlannerJobController extends JobScheduleController {
     super('CpfExportPlannerJob', { jobCron: config.cpf.plannerJob.cron });
   }
 
+  get isJobEnabled() {
+    return config.pgBoss.plannerJobEnabled;
+  }
+
   async handle({ jobId, dependencies = { cpfCertificationResultRepository, cpfExportBuilderJobRepository, logger } }) {
     const startDate = dayjs()
       .utc()

--- a/api/src/certification/session-management/application/jobs/cpf-export-sender-job-controller.js
+++ b/api/src/certification/session-management/application/jobs/cpf-export-sender-job-controller.js
@@ -11,6 +11,10 @@ class CpfExportSenderJobController extends JobScheduleController {
     super('CpfExportSenderJob', { jobCron: config.cpf.sendEmailJob.cron });
   }
 
+  get isJobEnabled() {
+    return config.pgBoss.exportSenderJobEnabled;
+  }
+
   async handle({ dependencies = { mailService } }) {
     const generatedFiles = await usecases.getPreSignedUrls();
 

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -301,6 +301,9 @@ const configuration = (function () {
       plannerJobEnabled: process.env.PGBOSS_PLANNER_JOB_ENABLED
         ? toBoolean(process.env.PGBOSS_PLANNER_JOB_ENABLED)
         : true,
+      exportSenderJobEnabled: process.env.PGBOSS_EXPORT_SENDER_JOB_ENABLED
+        ? toBoolean(process.env.PGBOSS_EXPORT_SENDER_JOB_ENABLED)
+        : true,
     },
     poleEmploi: {
       clientId: process.env.POLE_EMPLOI_CLIENT_ID,

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -490,6 +490,7 @@ const configuration = (function () {
 
     config.cpf.sendEmailJob = {
       recipient: 'team-all-star-certif-de-ouf@example.net',
+      cron: '0 3 * * *',
     };
 
     config.jwtConfig.livretScolaire = { secret: 'secretosmose', tokenLifespan: '1h' };

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -298,6 +298,9 @@ const configuration = (function () {
       importFileJobEnabled: process.env.PGBOSS_IMPORT_FILE_JOB_ENABLED
         ? toBoolean(process.env.PGBOSS_IMPORT_FILE_JOB_ENABLED)
         : true,
+      plannerJobEnabled: process.env.PGBOSS_PLANNER_JOB_ENABLED
+        ? toBoolean(process.env.PGBOSS_PLANNER_JOB_ENABLED)
+        : true,
     },
     poleEmploi: {
       clientId: process.env.POLE_EMPLOI_CLIENT_ID,

--- a/api/tests/unit/worker_test.js
+++ b/api/tests/unit/worker_test.js
@@ -157,5 +157,24 @@ describe('#registerJobs', function () {
         'legyNameForScheduleComputeOrganizationLearnersCertificabilityJobController',
       );
     });
+
+    context('when a cron job is disabled', function () {
+      it('unschedule the job', async function () {
+        //given
+        sinon.stub(config.cpf.sendEmailJob, 'cron').value('0 21 * * *');
+        sinon.stub(config.pgBoss, 'exportSenderJobEnabled').value(false);
+
+        await registerJobs({
+          jobGroup: JobGroup.DEFAULT,
+          dependencies: {
+            startPgBoss: startPgBossStub,
+            createJobQueues: createJobQueuesStub,
+          },
+        });
+
+        // then
+        expect(jobQueueStub.unscheduleCronJob).to.have.been.calledWithExactly('CpfExportSenderJob');
+      });
+    });
   });
 });

--- a/api/worker.js
+++ b/api/worker.js
@@ -113,6 +113,12 @@ export async function registerJobs({ jobGroup, dependencies = { startPgBoss, cre
       }
     } else {
       logger.warn(`Job "${job.jobName}" is disabled.`);
+
+      // For cronJob we need to unschedule older cron
+      if (job.jobCron) {
+        await jobQueues.unscheduleCronJob(job.jobName);
+        logger.info(`Job CRON "${job.jobName}" is unscheduled.`);
+      }
     }
   }
 


### PR DESCRIPTION
## :unicorn: Problème

On a des CRON annuels sur le CPF qui génère et upload des fichiers.
On ne désire plus utiliser ce CRON.

## :robot: Proposition

Suite au tech dev evenementiels, on peut maintenant gérer une propriété isJobEnabled dans l’enregistrement des jobs. Du coup demande vu avec les [Team Captains](https://1024pix.atlassian.net/people/team/c6637f8d-8382-4952-a4ea-306a9748d21d) (@Bérengère CLAUDEAU @Emmanuel FELLER @Mathieu Gilet @Yoan DE LUCA)

Mettre en place le isJobEnabled (ajout de la propriété dans le code + d’une variable d’env)

## :rainbow: Remarques

* On a mis à jour la documentation interne
* On a aussi mis à jour le template de création des RA

## :100: Pour tester

Sur la RA: 
* Passer les variables d'environnement `PGBOSS_PLANNER_JOB_ENABLED` et `PGBOSS_EXPORT_SENDER_JOB_ENABLED` à `true`
* Redemarrer l'API **en verifiant que le worker est bien scale a 1**
* Vérifier la présence des cron jobs dans la table `pgboss.schedule`, c'est a dire `CpfExportSenderJob` et `CpfExportPlannerJob`
* Passer les mêmes variables d'environnement `PGBOSS_PLANNER_JOB_ENABLED` et `PGBOSS_EXPORT_SENDER_JOB_ENABLED` à `false`
* Redémarrer l'API et le worker
* Vérifier la disparition des cron jobs dans la table `pgboss.schedule`, c'est a dire `CpfExportSenderJob` et `CpfExportPlannerJob`
* Enfin : repasser les variables à `true`, redemarrer, et verifier que les cron jobs sont de retour dans la table  `pgboss.schedule`
