### PR TITLE
[FEATURE] Afficher plusieurs cartes d'un deck de flashcards Modulix (PIX-14307)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -57,15 +57,39 @@
                 "id": "e1de6394-ff88-4de3-8834-a40057a50ff4",
                 "recto": {
                   "image": {
-                    "url": "https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg"
+                    "url": "https://images.pix.fr/modulix/didacticiel/icon.svg"
                   },
-                  "text": "A quoi sert l'arobase dans mon adresse email ?"
+                  "text": "Qui a écrit le Dormeur du Val ?"
                 },
                 "verso": {
                   "image": {
-                    "url": "https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg"
+                    "url": "https://images.pix.fr/modulix/didacticiel/chaton.jpg"
                   },
-                  "text": "<p>Parce que c'est joli</p>"
+                  "text": "<p>Arthur Rimbaud</p>"
+                }
+              },
+              {
+                "id": "48d0cd29-1e08-4b18-b15a-411ab83e5d3c",
+                "recto": {
+                  "text": "Comment s'appelait la fille de Victor Hugo, évoquée dans le poème 'Demain dès l'aube' ?"
+                },
+                "verso": {
+                  "text": "<p>Léopoldine</p>"
+                }
+              },
+              {
+                "id": "2611784c-cf3f-4445-998d-d02fa568da0c",
+                "recto": {
+                  "image": {
+                    "url": "https://images.pix.fr/modulix/didacticiel/icon.svg"
+                  },
+                  "text": "Quel animal a des yeux 'mêlés de métal et d'agathe' selon Charles Baudelaire ?"
+                },
+                "verso": {
+                  "image": {
+                    "url": "https://images.pix.fr/modulix/didacticiel/chaton.jpg"
+                  },
+                  "text": "<p>Un chat</p>"
                 }
               }
             ]

--- a/mon-pix/app/components/module/element/flashcards-card.gjs
+++ b/mon-pix/app/components/module/element/flashcards-card.gjs
@@ -1,0 +1,43 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+import { eq } from 'ember-truth-helpers';
+import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
+
+export default class ModulixFlashcardsCard extends Component {
+  get currentSide() {
+    const side = this.args.displayedSideName;
+    return this.args.card[side];
+  }
+
+  <template>
+    <div class="element-flashcards__card">
+      {{#if this.currentSide.image}}
+        <div class="element-flashcards-card__image">
+          <img src={{this.currentSide.image.url}} alt="" />
+        </div>
+      {{/if}}
+
+      <div class="element-flashcards-card__text">
+        {{#if (eq @displayedSideName "recto")}}
+          <p class="element-flashcards-card__text--recto">{{this.currentSide.text}}</p>
+        {{else if (eq @displayedSideName "verso")}}
+          {{htmlUnsafe this.currentSide.text}}
+        {{/if}}
+      </div>
+
+      <div class="element-flashcards-card__footer element-flashcards-card__footer--{{@displayedSideName}}">
+        {{#if (eq @displayedSideName "recto")}}
+          <PixButton @triggerAction={{@onCardFlip}} @variant="primary" @size="small" @iconAfter="rotate-right">
+            {{t "pages.modulix.buttons.flashcards.seeAnswer"}}
+          </PixButton>
+        {{/if}}
+        {{#if (eq @displayedSideName "verso")}}
+          <PixButton @triggerAction={{@onCardFlip}} @variant="tertiary" @size="small">
+            {{t "pages.modulix.buttons.flashcards.seeAgain"}}
+          </PixButton>
+        {{/if}}
+      </div>
+    </div>
+  </template>
+}

--- a/mon-pix/app/components/module/element/flashcards.gjs
+++ b/mon-pix/app/components/module/element/flashcards.gjs
@@ -1,10 +1,9 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
-import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
+import ModulixFlashcardsCard from 'mon-pix/components/module/element/flashcards-card';
 
 export default class ModulixFlashcards extends Component {
   @tracked
@@ -12,7 +11,7 @@ export default class ModulixFlashcards extends Component {
    * Displayed side of the card on the screen
    * @type {'recto'|'verso'}
    */
-  displayedSide = 'recto';
+  displayedSideName = 'recto';
 
   /**
    * Index of the displayed card in the deck
@@ -20,49 +19,25 @@ export default class ModulixFlashcards extends Component {
    */
   currentCardIndex = 0;
 
-  get currentCardSide() {
-    const side = this.displayedSide;
-    return this.args.flashcards.cards[this.currentCardIndex][side];
+  get currentCard() {
+    return this.args.flashcards.cards[this.currentCardIndex];
   }
 
   @action
   flipCard() {
-    this.displayedSide = this.displayedSide === 'recto' ? 'verso' : 'recto';
+    this.displayedSideName = this.displayedSideName === 'recto' ? 'verso' : 'recto';
   }
 
   <template>
     <div class="element-flashcards">
-      <div class="element-flashcards__card">
-        {{#if this.currentCardSide.image}}
-          <div class="element-flashcards-card__image">
-            <img src={{this.currentCardSide.image.url}} alt="" />
-          </div>
-        {{/if}}
-
-        <div class="element-flashcards-card__text">
-          {{#if (eq this.displayedSide "recto")}}
-            <p class="element-flashcards-card__text--recto">{{this.currentCardSide.text}}</p>
-          {{else if (eq this.displayedSide "verso")}}
-            {{htmlUnsafe this.currentCardSide.text}}
-          {{/if}}
-        </div>
-
-        <div class="element-flashcards-card__footer element-flashcards-card__footer--{{this.displayedSide}}">
-          {{#if (eq this.displayedSide "recto")}}
-            <PixButton @triggerAction={{this.flipCard}} @variant="primary" @size="small" @iconAfter="rotate-right">
-              {{t "pages.modulix.buttons.flashcards.seeAnswer"}}
-            </PixButton>
-          {{/if}}
-          {{#if (eq this.displayedSide "verso")}}
-            <PixButton @triggerAction={{this.flipCard}} @variant="tertiary" @size="small">
-              {{t "pages.modulix.buttons.flashcards.seeAgain"}}
-            </PixButton>
-          {{/if}}
-        </div>
-      </div>
+      <ModulixFlashcardsCard
+        @card={{this.currentCard}}
+        @displayedSideName={{this.displayedSideName}}
+        @onCardFlip={{this.flipCard}}
+      />
 
       <div class="element-flashcards__footer">
-        {{#if (eq this.displayedSide "recto")}}
+        {{#if (eq this.displayedSideName "recto")}}
           <p class="element-flashcards-footer__direction">{{t "pages.modulix.flashcards.direction"}}</p>
           <p class="element-flashcards-footer__position">{{t
               "pages.modulix.flashcards.position"
@@ -70,7 +45,7 @@ export default class ModulixFlashcards extends Component {
               totalCards=1
             }}</p>
         {{/if}}
-        {{#if (eq this.displayedSide "verso")}}
+        {{#if (eq this.displayedSideName "verso")}}
           <button type="button">{{t "pages.modulix.buttons.flashcards.nextCard"}}</button>
         {{/if}}
       </div>

--- a/mon-pix/app/components/module/element/flashcards.gjs
+++ b/mon-pix/app/components/module/element/flashcards.gjs
@@ -1,3 +1,4 @@
+import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -13,6 +14,7 @@ export default class ModulixFlashcards extends Component {
    */
   displayedSideName = 'recto';
 
+  @tracked
   /**
    * Index of the displayed card in the deck
    * @type {number}
@@ -23,9 +25,23 @@ export default class ModulixFlashcards extends Component {
     return this.args.flashcards.cards[this.currentCardIndex];
   }
 
+  get currentCardNumber() {
+    return this.currentCardIndex + 1;
+  }
+
+  get numberOfCards() {
+    return this.args.flashcards.cards.length;
+  }
+
   @action
   flipCard() {
     this.displayedSideName = this.displayedSideName === 'recto' ? 'verso' : 'recto';
+  }
+
+  @action
+  goToNextCard() {
+    this.currentCardIndex++;
+    this.displayedSideName = 'recto';
   }
 
   <template>
@@ -41,12 +57,14 @@ export default class ModulixFlashcards extends Component {
           <p class="element-flashcards-footer__direction">{{t "pages.modulix.flashcards.direction"}}</p>
           <p class="element-flashcards-footer__position">{{t
               "pages.modulix.flashcards.position"
-              currentCardPosition=1
-              totalCards=1
+              currentCardPosition=this.currentCardNumber
+              totalCards=this.numberOfCards
             }}</p>
         {{/if}}
         {{#if (eq this.displayedSideName "verso")}}
-          <button type="button">{{t "pages.modulix.buttons.flashcards.nextCard"}}</button>
+          <button type="button" {{on "click" this.goToNextCard}}>{{t
+              "pages.modulix.buttons.flashcards.nextCard"
+            }}</button>
         {{/if}}
       </div>
     </div>

--- a/mon-pix/tests/integration/components/module/flashcards-card_test.gjs
+++ b/mon-pix/tests/integration/components/module/flashcards-card_test.gjs
@@ -1,0 +1,182 @@
+import { clickByName, render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import ModulixFlashcardsCard from 'mon-pix/components/module/element/flashcards-card';
+// eslint-disable-next-line no-restricted-imports
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Module | Flashcards Card', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('when recto is displayed', function () {
+    test('should display the recto of given card', async function (assert) {
+      // given
+      const card = {
+        id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+        recto: {
+          image: {
+            url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+          },
+          text: "A quoi sert l'arobase dans mon adresse email ?",
+        },
+        verso: {
+          image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+          text: "Parce que c'est joli",
+        },
+      };
+
+      // when
+      const screen = await render(
+        <template><ModulixFlashcardsCard @card={{card}} @displayedSideName="recto" /></template>,
+      );
+
+      // then
+      assert.ok(screen.getByText("A quoi sert l'arobase dans mon adresse email ?"));
+      assert.strictEqual(
+        screen.getByRole('presentation').getAttribute('src'),
+        'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+      );
+      assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.seeAnswer') })).exists();
+    });
+
+    test('should not display recto image if no one is provided', async function (assert) {
+      // given
+      const card = {
+        id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+        recto: {
+          text: "A quoi sert l'arobase dans mon adresse email ?",
+        },
+        verso: {
+          image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+          text: "Parce que c'est joli",
+        },
+      };
+
+      // when
+      const screen = await render(
+        <template><ModulixFlashcardsCard @card={{card}} @displayedSideName="recto" /></template>,
+      );
+
+      // then
+      assert.dom(screen.queryByRole('img')).doesNotExist();
+    });
+  });
+
+  module('when verso is displayed', function () {
+    test('should display the verso of given card', async function (assert) {
+      // given
+      const card = {
+        id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+        recto: {
+          image: {
+            url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+          },
+          text: "A quoi sert l'arobase dans mon adresse email ?",
+        },
+        verso: {
+          image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+          text: "Parce que c'est joli",
+        },
+      };
+
+      // when
+      const screen = await render(
+        <template><ModulixFlashcardsCard @card={{card}} @displayedSideName="verso" /></template>,
+      );
+
+      // then
+      assert.ok(screen.getByText("Parce que c'est joli"));
+      assert.strictEqual(
+        screen.getByRole('presentation').getAttribute('src'),
+        'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg',
+      );
+      assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.seeAgain') })).exists();
+    });
+
+    test('should not display verso image if no one is provided', async function (assert) {
+      // given
+      const card = {
+        id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+        recto: {
+          text: "A quoi sert l'arobase dans mon adresse email ?",
+        },
+        verso: {
+          image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+          text: "Parce que c'est joli",
+        },
+      };
+
+      // when
+      const screen = await render(
+        <template><ModulixFlashcardsCard @card={{card}} @displayedSideName="recto" /></template>,
+      );
+
+      // then
+      assert.dom(screen.queryByRole('img')).doesNotExist();
+    });
+  });
+
+  module('when we click on "Voir la réponse"', function () {
+    test('should call the onCardFlip method', async function (assert) {
+      // given
+      const card = {
+        id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+        recto: {
+          image: {
+            url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+          },
+          text: "A quoi sert l'arobase dans mon adresse email ?",
+        },
+        verso: {
+          image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+          text: "Parce que c'est joli",
+        },
+      };
+      const onCardFlipStub = sinon.stub();
+      await render(
+        <template>
+          <ModulixFlashcardsCard @card={{card}} @displayedSideName="recto" @onCardFlip={{onCardFlipStub}} />
+        </template>,
+      );
+
+      // when
+      await clickByName(t('pages.modulix.buttons.flashcards.seeAnswer'));
+
+      // then
+      assert.true(onCardFlipStub.calledOnce);
+    });
+  });
+
+  module('when we click on "Revoir la question"', function () {
+    test('should call the onCardFlip method', async function (assert) {
+      // given
+      const card = {
+        id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+        recto: {
+          image: {
+            url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+          },
+          text: "A quoi sert l'arobase dans mon adresse email ?",
+        },
+        verso: {
+          image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+          text: "Parce que c'est joli",
+        },
+      };
+      const onCardFlipStub = sinon.stub();
+      await render(
+        <template>
+          <ModulixFlashcardsCard @card={{card}} @displayedSideName="verso" @onCardFlip={{onCardFlipStub}} />
+        </template>,
+      );
+
+      // when
+      await clickByName(t('pages.modulix.buttons.flashcards.seeAgain'));
+
+      // then
+      assert.true(onCardFlipStub.calledOnce);
+    });
+  });
+});

--- a/mon-pix/tests/integration/components/module/flashcards_test.gjs
+++ b/mon-pix/tests/integration/components/module/flashcards_test.gjs
@@ -1,8 +1,8 @@
-import {render} from '@1024pix/ember-testing-library';
-import {t} from 'ember-intl/test-support';
+import { clickByName, render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
 import ModulixFlashcards from 'mon-pix/components/module/element/flashcards';
 // eslint-disable-next-line no-restricted-imports
-import {module, test} from 'qunit';
+import { module, test } from 'qunit';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -11,27 +11,42 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
 
   test('should display the given card', async function (assert) {
     // given
+    const firstCard = {
+      id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+      recto: {
+        image: {
+          url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+        },
+        text: "A quoi sert l'arobase dans mon adresse email ?",
+      },
+      verso: {
+        image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+        text: "Parce que c'est joli",
+      },
+    };
+    const secondCard = {
+      id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+      recto: {
+        image: {
+          url: 'https://images.pix.fr/modulix/didacticiel/icon.svg',
+        },
+        text: 'Qui a écrit le Dormeur du Val ?',
+      },
+      verso: {
+        image: {
+          url: 'https://images.pix.fr/modulix/didacticiel/chaton.jpg',
+        },
+        text: '<p>Arthur Rimbaud</p>',
+      },
+    };
+
     const flashcards = {
       id: '71de6394-ff88-4de3-8834-a40057a50ff4',
       type: 'flashcards',
       title: "Introduction à l'adresse e-mail",
       instruction: '<p>...</p>',
       introImage: { url: 'https://images.pix.fr/modulix/placeholder-details.svg' },
-      cards: [
-        {
-          id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-          recto: {
-            image: {
-              url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
-            },
-            text: "A quoi sert l'arobase dans mon adresse email ?",
-          },
-          verso: {
-            image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
-            text: "Parce que c'est joli",
-          },
-        },
-      ],
+      cards: [firstCard, secondCard],
     };
 
     // when
@@ -45,6 +60,58 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
     );
     assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.seeAnswer') })).exists();
     assert.ok(screen.getByText(t('pages.modulix.flashcards.direction')));
-    assert.ok(screen.getByText(t('pages.modulix.flashcards.position', { currentCardPosition: 1, totalCards: 1 })));
+    assert.ok(screen.getByText(t('pages.modulix.flashcards.position', { currentCardPosition: 1, totalCards: 2 })));
+  });
+
+  module('when we click on Next button', function () {
+    test('should display the next card', async function (assert) {
+      // given
+      const firstCard = {
+        id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+        recto: {
+          image: {
+            url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+          },
+          text: "A quoi sert l'arobase dans mon adresse email ?",
+        },
+        verso: {
+          image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+          text: "Parce que c'est joli",
+        },
+      };
+      const secondCard = {
+        id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+        recto: {
+          image: {
+            url: 'https://images.pix.fr/modulix/didacticiel/icon.svg',
+          },
+          text: 'Qui a écrit le Dormeur du Val ?',
+        },
+        verso: {
+          image: {
+            url: 'https://images.pix.fr/modulix/didacticiel/chaton.jpg',
+          },
+          text: '<p>Arthur Rimbaud</p>',
+        },
+      };
+
+      const flashcards = {
+        id: '71de6394-ff88-4de3-8834-a40057a50ff4',
+        type: 'flashcards',
+        title: "Introduction à l'adresse e-mail",
+        instruction: '<p>...</p>',
+        introImage: { url: 'https://images.pix.fr/modulix/placeholder-details.svg' },
+        cards: [firstCard, secondCard],
+      };
+
+      // when
+      const screen = await render(<template><ModulixFlashcards @flashcards={{flashcards}} /></template>);
+      await clickByName(t('pages.modulix.buttons.flashcards.seeAnswer'));
+      await clickByName(t('pages.modulix.buttons.flashcards.nextCard'));
+
+      // then
+      assert.ok(screen.getByText('Qui a écrit le Dormeur du Val ?'));
+      assert.ok(screen.getByText(t('pages.modulix.flashcards.position', { currentCardPosition: 2, totalCards: 2 })));
+    });
   });
 });

--- a/mon-pix/tests/integration/components/module/flashcards_test.gjs
+++ b/mon-pix/tests/integration/components/module/flashcards_test.gjs
@@ -1,15 +1,15 @@
-import { clickByName, render } from '@1024pix/ember-testing-library';
-import { t } from 'ember-intl/test-support';
+import {render} from '@1024pix/ember-testing-library';
+import {t} from 'ember-intl/test-support';
 import ModulixFlashcards from 'mon-pix/components/module/element/flashcards';
 // eslint-disable-next-line no-restricted-imports
-import { module, test } from 'qunit';
+import {module, test} from 'qunit';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Module | Flashcards', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('should display the recto of given card', async function (assert) {
+  test('should display the given card', async function (assert) {
     // given
     const flashcards = {
       id: '71de6394-ff88-4de3-8834-a40057a50ff4',
@@ -46,136 +46,5 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
     assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.seeAnswer') })).exists();
     assert.ok(screen.getByText(t('pages.modulix.flashcards.direction')));
     assert.ok(screen.getByText(t('pages.modulix.flashcards.position', { currentCardPosition: 1, totalCards: 1 })));
-  });
-
-  test('should not display recto image if no one is provided', async function (assert) {
-    // given
-    const flashcards = {
-      id: '71de6394-ff88-4de3-8834-a40057a50ff4',
-      type: 'flashcards',
-      title: "Introduction à l'adresse e-mail",
-      instruction: '<p>...</p>',
-      introImage: { url: 'https://images.pix.fr/modulix/placeholder-details.svg' },
-      cards: [
-        {
-          id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-          recto: {
-            text: "A quoi sert l'arobase dans mon adresse email ?",
-          },
-          verso: {
-            image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
-            text: "Parce que c'est joli",
-          },
-        },
-      ],
-    };
-
-    // when
-    const screen = await render(<template><ModulixFlashcards @flashcards={{flashcards}} /></template>);
-
-    // then
-    assert.dom(screen.queryByRole('img')).doesNotExist();
-  });
-
-  test('should display the verso when click on button', async function (assert) {
-    // given
-    const flashcards = {
-      id: '71de6394-ff88-4de3-8834-a40057a50ff4',
-      type: 'flashcards',
-      title: "Introduction à l'adresse e-mail",
-      instruction: '<p>...</p>',
-      introImage: { url: 'https://images.pix.fr/modulix/placeholder-details.svg' },
-      cards: [
-        {
-          id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-          recto: {
-            image: {
-              url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
-            },
-            text: "A quoi sert l'arobase dans mon adresse email ?",
-          },
-          verso: {
-            image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
-            text: "Parce que c'est joli",
-          },
-        },
-      ],
-    };
-    const screen = await render(<template><ModulixFlashcards @flashcards={{flashcards}} /></template>);
-
-    // when
-    await clickByName(t('pages.modulix.buttons.flashcards.seeAnswer'));
-
-    // then
-    assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.seeAgain') })).exists();
-    assert.ok(screen.getByText("Parce que c'est joli"));
-  });
-
-  test('should not display verso image if no one is provided', async function (assert) {
-    // given
-    const flashcards = {
-      id: '71de6394-ff88-4de3-8834-a40057a50ff4',
-      type: 'flashcards',
-      title: "Introduction à l'adresse e-mail",
-      instruction: '<p>...</p>',
-      introImage: { url: 'https://images.pix.fr/modulix/placeholder-details.svg' },
-      cards: [
-        {
-          id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-          recto: {
-            image: {
-              url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
-            },
-            text: "A quoi sert l'arobase dans mon adresse email ?",
-          },
-          verso: {
-            text: "Parce que c'est joli",
-          },
-        },
-      ],
-    };
-    const screen = await render(<template><ModulixFlashcards @flashcards={{flashcards}} /></template>);
-
-    // when
-    await clickByName(t('pages.modulix.buttons.flashcards.seeAnswer'));
-
-    // then
-    assert.dom(screen.queryByRole('img')).doesNotExist();
-  });
-
-  module('when we click on "Revoir la question"', function () {
-    test('should go back to recto', async function (assert) {
-      // given
-      const flashcards = {
-        id: '71de6394-ff88-4de3-8834-a40057a50ff4',
-        type: 'flashcards',
-        title: "Introduction à l'adresse e-mail",
-        instruction: '<p>...</p>',
-        introImage: { url: 'https://images.pix.fr/modulix/placeholder-details.svg' },
-        cards: [
-          {
-            id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-            recto: {
-              image: {
-                url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
-              },
-              text: "A quoi sert l'arobase dans mon adresse email ?",
-            },
-            verso: {
-              image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
-              text: "Parce que c'est joli",
-            },
-          },
-        ],
-      };
-      const screen = await render(<template><ModulixFlashcards @flashcards={{flashcards}} /></template>);
-      await clickByName(t('pages.modulix.buttons.flashcards.seeAnswer'));
-
-      // when
-      await clickByName(t('pages.modulix.buttons.flashcards.seeAgain'));
-
-      // then
-      assert.ok(screen.getByText("A quoi sert l'arobase dans mon adresse email ?"));
-    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

L'élément Flashcards n'affiche que la première carte.

## :robot: Proposition

- Afficher un bouton “suivant” temporaire pour passer à la carte suivante sans répondre à “vous aviez la réponse ?”
- Changer le numéro de la carte en fonction de la carte affichée (ex Carte 2/3)

## :rainbow: Remarques

- Le bouton "suivant" est temporaire et va disparaître.
- Les cas limites qui n'existeront pas plus tard (ex. suivant qui apparaît sur la dernière carte) n'ont pas été gérés ni testés dans cette PR.
- On a extrait un composant `Card` mais on a laissé la gestion du côté affiché dans l'élément `Flashcards` car il a un impact sur ce qui est affiché sous la carte.

## :100: Pour tester

1. Se rendre sur le didacticiel Modulix.
2. Constater l'affichage de la première carte avec la pagination "1/3"
3. Cliquer sur suivant
4. Constater l'affichage de la deuxième carte avec la pagination "2/3"