### PR TITLE
[TECH] Empêcher l'autocompletion sur les adresses email dans la modale d'ajout de candidat sur Pix Certif (PIX-13937).

### DIFF
--- a/certif/app/components/sessions/session-details/enrolled-candidates/candidate-creation-modal.gjs
+++ b/certif/app/components/sessions/session-details/enrolled-candidates/candidate-creation-modal.gjs
@@ -428,7 +428,7 @@ export default class CandidateCreationModal extends Component {
               @id='result-recipient-email'
               {{on 'input' (fn @updateCandidateData @candidateData 'resultRecipientEmail')}}
               type='email'
-              autocomplete='off'
+              autocomplete='nope'
             >
               <:label>{{t 'common.forms.certification-labels.email-results'}}</:label>
             </PixInput>
@@ -443,7 +443,7 @@ export default class CandidateCreationModal extends Component {
               @id='email'
               {{on 'input' (fn @updateCandidateData @candidateData 'email')}}
               type='email'
-              autocomplete='off'
+              autocomplete='nope'
             >
               <:label>{{t 'common.forms.certification-labels.email-convocation'}}</:label>
             </PixInput>


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix Certif, dans la modale d’inscription de candidat se trouve 2 champs email qu'il est possible de remplir : le champ “E-mail du destinataire des résultats (formateur, enseignant…)” et le champ “E-mail de convocation”.

Lorsqu'on utilise la suggestion de saisie pour compléter l'adresse mail du destinataire des résultats, c'est cette même adresse qui se remplit automatiquement dans le champ adresse mail de convocation ce qui n’a aucun sens car il n'y a aucune correspondance entre les deux champs e-mail.

## :robot: Proposition
Empêcher l’auto-complétion sur les champs emails

## :rainbow: Remarques

Les deux champs étaient initialement en autocomplete=”off”. Pourtant si l'utilisateur à une suggestion de saisie sur une adresse mail et qu'il l'utilise, le navigateur va automatiquement remplir les champs de type email. 

Mais d’après cet article [Turn off autocomplete in modern browsers](https://medium.com/nerd-for-tech/turn-off-autocomplete-in-modern-browsers-e7829bdfa0a3) et après avoir testé, si on met une valeur unique à l’autocomplete de nos deux champs (exemple: autocomplete=”Coucou”) alors ça empêche également les auto-completion de chrome.
Le `nope` fonctionne également.

## :100: Pour tester
- Tester avec plusieurs navigateurs !!
- Sur Pix Certif, se connecter avec certif-pro@example.net
- Aller sur la modale d'ajout de candidat 
- Sur les champs concernés, verifier que la suggestion de saisie n'est plus proposé.
