### PR TITLE
[TECH] Suppression du FT pour les écrans d'instruction certif v3 (PIX-12908)

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -757,13 +757,6 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: false
 # FT_ENABLE_PIX_PLUS_LOWER_LEVEL=false
 
-# Displays the V3 certification pre-test information screens
-#
-# presence: optional
-# type: boolean
-# default: false
-# FT_ENABLE_V3_INFO_SCREENS=false
-
 # Enable the verification of the scope in certification tokens
 #
 # presence: optional

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -195,7 +195,6 @@ const configuration = (function () {
       scoAccountRecoveryKeyLifetimeMinutes: process.env.SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES,
     },
     featureToggles: {
-      areV3InfoScreensEnabled: toBoolean(process.env.FT_ENABLE_V3_INFO_SCREENS),
       isV3EligibilityCheckEnabled: toBoolean(process.env.FT_ENABLE_V3_ELIGIBILITY_CHECK),
       deprecatePoleEmploiPushNotification: toBoolean(process.env.DEPRECATE_PE_PUSH_NOTIFICATION),
       isAlwaysOkValidateNextChallengeEndpointEnabled: toBoolean(
@@ -396,7 +395,6 @@ const configuration = (function () {
     config.features.pixCertifScoBlockedAccessDateLycee = null;
     config.features.pixCertifScoBlockedAccessDateCollege = null;
 
-    config.featureToggles.areV3InfoScreensEnabled = false;
     config.featureToggles.isV3EligibilityCheckEnabled = false;
     config.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled = false;
     config.featureToggles.isPix1dEnabled = true;

--- a/api/src/shared/infrastructure/validate-environment-variables.js
+++ b/api/src/shared/infrastructure/validate-environment-variables.js
@@ -39,7 +39,6 @@ const schema = Joi.object({
   FT_ENABLE_NEED_TO_ADJUST_CERTIFICATION_ACCESSIBILITY: Joi.string().optional().valid('true', 'false'),
   FT_ENABLE_PIX_PLUS_LOWER_LEVEL: Joi.string().optional().valid('true', 'false'),
   FT_ENABLE_TEXT_TO_SPEECH_BUTTON: Joi.string().optional().valid('true', 'false'),
-  FT_ENABLE_V3_INFO_SCREENS: Joi.string().optional().valid('true', 'false'),
   KNEX_ASYNC_STACKTRACE_ENABLED: Joi.string().optional().valid('true', 'false'),
   LCMS_API_KEY: Joi.string().required(),
   LCMS_API_URL: Joi.string().uri().required(),

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -20,7 +20,6 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
           id: '0',
           type: 'feature-toggles',
           attributes: {
-            'are-v3-info-screens-enabled': false,
             'deprecate-pole-emploi-push-notification': false,
             'is-v3-eligibility-check-enabled': false,
             'is-always-ok-validate-next-challenge-endpoint-enabled': false,

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -1,7 +1,6 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
-  @attr areV3InfoScreensEnabled;
   @attr('boolean') isNewAuthenticationDesignEnabled;
   @attr('boolean') isTextToSpeechButtonEnabled;
   @attr('boolean') showNewResultPage;

--- a/mon-pix/app/routes/authenticated/certifications/start.js
+++ b/mon-pix/app/routes/authenticated/certifications/start.js
@@ -4,7 +4,6 @@ import { service } from '@ember/service';
 export default class StartRoute extends Route {
   @service store;
   @service router;
-  @service featureToggles;
 
   async model(params) {
     const [certificationCandidate, certificationCandidateSubscription] = await Promise.all([
@@ -14,11 +13,7 @@ export default class StartRoute extends Route {
 
     const hasSeenCertificationInstructions = certificationCandidate?.hasSeenCertificationInstructions;
 
-    if (
-      !hasSeenCertificationInstructions &&
-      certificationCandidateSubscription.isSessionVersion3 &&
-      this.featureToggles.featureToggles.areV3InfoScreensEnabled
-    ) {
+    if (!hasSeenCertificationInstructions && certificationCandidateSubscription.isSessionVersion3) {
       this.router.replaceWith('authenticated.certifications.information', params.certification_candidate_id);
     }
 

--- a/mon-pix/tests/acceptance/authenticated/certifications/information-test.js
+++ b/mon-pix/tests/acceptance/authenticated/certifications/information-test.js
@@ -21,13 +21,43 @@ module('Acceptance | Certifications | Information', function (hooks) {
   });
 
   module('when certification candidate participates in a V3 session', function () {
-    module('when toggle areV3InfoScreensEnabled is enabled', function () {
-      test('should display the certification instructions page', async function (assert) {
+    test('should display the certification instructions page', async function (assert) {
+      // given
+      server.create('certification-candidate-subscription', {
+        id: 2,
+        sessionId: 123,
+        eligibleSubscription: null,
+        nonEligibleSubscription: null,
+        sessionVersion: 3,
+      });
+
+      await authenticateByEmail(user);
+
+      const screen = await visit('/certifications');
+
+      // when
+      await fillCertificationJoiner({
+        sessionId: '123',
+        firstName: 'toto',
+        lastName: 'titi',
+        dayOfBirth: '01',
+        monthOfBirth: '01',
+        yearOfBirth: '2000',
+        t,
+      });
+
+      // then
+      assert.strictEqual(currentURL(), '/certifications/candidat/2/informations');
+      assert.dom(screen.getByRole('heading', { name: 'Explication de la certification', level: 1 })).exists();
+      assert
+        .dom(screen.getByRole('heading', { name: 'Bienvenue à la certification Pix Page 1 sur 5', level: 2 }))
+        .exists();
+      assert.dom(screen.getByRole('button', { name: "Continuer vers l'écran suivant" })).exists();
+    });
+
+    module('when user validates instructions', function () {
+      test('should validate checkbox and redirect to the certification start page', async function (assert) {
         // given
-        server.create('feature-toggle', {
-          id: 0,
-          areV3InfoScreensEnabled: true,
-        });
         server.create('certification-candidate-subscription', {
           id: 2,
           sessionId: 123,
@@ -50,106 +80,25 @@ module('Acceptance | Certifications | Information', function (hooks) {
           yearOfBirth: '2000',
           t,
         });
+        for (let i = 0; i < 4; i++) {
+          await click(screen.getByRole('button', { name: "Continuer vers l'écran suivant" }));
+        }
+
+        await click(
+          screen.getByRole('checkbox', {
+            name: 'En cochant cette case, je reconnais avoir pris connaissance de ces règles et je m’engage à les respecter.',
+          }),
+        );
+        await click(screen.getByRole('button', { name: "Continuer vers la page d'entrée en certification" }));
 
         // then
-        assert.strictEqual(currentURL(), '/certifications/candidat/2/informations');
-        assert.dom(screen.getByRole('heading', { name: 'Explication de la certification', level: 1 })).exists();
-        assert
-          .dom(screen.getByRole('heading', { name: 'Bienvenue à la certification Pix Page 1 sur 5', level: 2 }))
-          .exists();
-        assert.dom(screen.getByRole('button', { name: "Continuer vers l'écran suivant" })).exists();
-      });
-
-      module('when user validates instructions', function () {
-        test('should validate checkbox and redirect to the certification start page', async function (assert) {
-          // given
-          server.create('feature-toggle', {
-            id: 0,
-            areV3InfoScreensEnabled: true,
-          });
-          server.create('certification-candidate-subscription', {
-            id: 2,
-            sessionId: 123,
-            eligibleSubscription: null,
-            nonEligibleSubscription: null,
-            sessionVersion: 3,
-          });
-
-          await authenticateByEmail(user);
-
-          const screen = await visit('/certifications');
-
-          // when
-          await fillCertificationJoiner({
-            sessionId: '123',
-            firstName: 'toto',
-            lastName: 'titi',
-            dayOfBirth: '01',
-            monthOfBirth: '01',
-            yearOfBirth: '2000',
-            t,
-          });
-          for (let i = 0; i < 4; i++) {
-            await click(screen.getByRole('button', { name: "Continuer vers l'écran suivant" }));
-          }
-
-          await click(
-            screen.getByRole('checkbox', {
-              name: 'En cochant cette case, je reconnais avoir pris connaissance de ces règles et je m’engage à les respecter.',
-            }),
-          );
-          await click(screen.getByRole('button', { name: "Continuer vers la page d'entrée en certification" }));
-
-          // then
-          assert.strictEqual(currentURL(), '/certifications/candidat/2');
-        });
-      });
-
-      module('when user has already validated instructions', function () {
-        test('should redirect to the certification start page', async function (assert) {
-          // given
-          server.create('feature-toggle', {
-            id: 0,
-            areV3InfoScreensEnabled: true,
-          });
-          server.create('certification-candidate-subscription', {
-            id: 2,
-            sessionId: 123,
-            eligibleSubscription: null,
-            nonEligibleSubscription: null,
-            sessionVersion: 3,
-          });
-
-          const candidateLastName = 'hasSeenCertificationInstructions';
-
-          await authenticateByEmail(user);
-
-          await visit('/certifications');
-
-          // when
-          await fillCertificationJoiner({
-            sessionId: '123',
-            firstName: 'toto',
-            lastName: candidateLastName,
-            dayOfBirth: '01',
-            monthOfBirth: '01',
-            yearOfBirth: '2000',
-            t,
-          });
-
-          // then
-          assert.strictEqual(currentURL(), '/certifications/candidat/2');
-        });
+        assert.strictEqual(currentURL(), '/certifications/candidat/2');
       });
     });
 
-    module('when toggle areV3InfoScreensEnabled is not enabled', function () {
-      test('should not display the v3 certification information page', async function (assert) {
+    module('when user has already validated instructions', function () {
+      test('should redirect to the certification start page', async function (assert) {
         // given
-        server.create('feature-toggle', {
-          id: 0,
-          areV3InfoScreensEnabled: false,
-        });
         server.create('certification-candidate-subscription', {
           id: 2,
           sessionId: 123,
@@ -158,14 +107,17 @@ module('Acceptance | Certifications | Information', function (hooks) {
           sessionVersion: 3,
         });
 
+        const candidateLastName = 'hasSeenCertificationInstructions';
+
         await authenticateByEmail(user);
-        const screen = await visit('/certifications');
+
+        await visit('/certifications');
 
         // when
         await fillCertificationJoiner({
           sessionId: '123',
           firstName: 'toto',
-          lastName: 'titi',
+          lastName: candidateLastName,
           dayOfBirth: '01',
           monthOfBirth: '01',
           yearOfBirth: '2000',
@@ -174,8 +126,6 @@ module('Acceptance | Certifications | Information', function (hooks) {
 
         // then
         assert.strictEqual(currentURL(), '/certifications/candidat/2');
-        assert.dom(screen.getByRole('heading', { name: 'Vous allez commencer votre test de certification' })).exists();
-        assert.dom(screen.queryByRole('heading', { name: 'Explication de la certification' })).doesNotExist();
       });
     });
   });

--- a/mon-pix/tests/unit/routes/authenticated/certifications/start-test.js
+++ b/mon-pix/tests/unit/routes/authenticated/certifications/start-test.js
@@ -7,7 +7,7 @@ module('Unit | Route | Certification | Start', function (hooks) {
   setupTest(hooks);
 
   module('#model', function () {
-    module('when session is V3 and toggle is enabled', function () {
+    module('when session is V3', function () {
       module('when hasSeenCertificationInstructions is false', function () {
         test('should redirect to certification information page', async function (assert) {
           // given
@@ -23,11 +23,6 @@ module('Unit | Route | Certification | Start', function (hooks) {
             sessionId: 1234,
             sessionVersion: 3,
           });
-          const featureToggles = Object.create({
-            featureToggles: {
-              areV3InfoScreensEnabled: true,
-            },
-          });
 
           const findRecordStub = sinon.stub().returns(certificationCandidateSubscription);
           const peekRecordStub = sinon.stub().returns(certificationCandidate);
@@ -35,7 +30,6 @@ module('Unit | Route | Certification | Start', function (hooks) {
 
           const route = this.owner.lookup('route:authenticated/certifications.start');
           route.set('store', storeStub);
-          route.set('featureToggles', featureToggles);
           route.router = { replaceWith: sinon.stub() };
 
           // when
@@ -66,11 +60,6 @@ module('Unit | Route | Certification | Start', function (hooks) {
             sessionId: 1234,
             sessionVersion: 3,
           });
-          const featureToggles = Object.create({
-            featureToggles: {
-              areV3InfoScreensEnabled: true,
-            },
-          });
 
           const findRecordStub = sinon
             .stub()
@@ -83,7 +72,6 @@ module('Unit | Route | Certification | Start', function (hooks) {
 
           const route = this.owner.lookup('route:authenticated/certifications.start');
           route.set('store', storeStub);
-          route.set('featureToggles', featureToggles);
           route.router = { replaceWith: sinon.stub() };
           route.hasSeenCertificationInstructions = true;
 
@@ -97,46 +85,7 @@ module('Unit | Route | Certification | Start', function (hooks) {
       });
     });
 
-    module('when session is V3 and toggle is not enabled', function () {
-      test('should not redirect to certification information page', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const certificationCandidate = store.createRecord('certification-candidate', {
-          sessionId: 1234,
-          hasSeenCertificationInstructions: false,
-        });
-        const params = { certification_candidate_id: certificationCandidate.id };
-
-        const certificationCandidateSubscription = store.createRecord('certification-candidate-subscription', {
-          id: certificationCandidate.id,
-          sessionId: 1234,
-          sessionVersion: 3,
-        });
-        const featureToggles = Object.create({
-          featureToggles: {
-            areV3InfoScreensEnabled: false,
-          },
-        });
-
-        const findRecordStub = sinon.stub().returns(certificationCandidateSubscription);
-        const peekRecordStub = sinon.stub().returns(certificationCandidate);
-        const storeStub = Service.create({ findRecord: findRecordStub, peekRecord: peekRecordStub });
-
-        const route = this.owner.lookup('route:authenticated/certifications.start');
-        route.set('store', storeStub);
-        route.set('featureToggles', featureToggles);
-        route.router = { replaceWith: sinon.stub() };
-
-        // when
-        const model = await route.model(params);
-
-        // then
-        sinon.assert.notCalled(route.router.replaceWith);
-        assert.strictEqual(model, certificationCandidateSubscription);
-      });
-    });
-
-    module('when session is not V3 and toggle is enabled', function () {
+    module('when session is not V3', function () {
       test('should not redirect to certification information page', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
@@ -151,11 +100,6 @@ module('Unit | Route | Certification | Start', function (hooks) {
           sessionId: 1234,
           sessionVersion: 2,
         });
-        const featureToggles = Object.create({
-          featureToggles: {
-            areV3InfoScreensEnabled: true,
-          },
-        });
 
         const findRecordStub = sinon.stub().returns(certificationCandidateSubscription);
         const peekRecordStub = sinon.stub().returns(certificationCandidate);
@@ -163,46 +107,7 @@ module('Unit | Route | Certification | Start', function (hooks) {
 
         const route = this.owner.lookup('route:authenticated/certifications.start');
         route.set('store', storeStub);
-        route.set('featureToggles', featureToggles);
-        route.router = { replaceWith: sinon.stub() };
 
-        // when
-        const model = await route.model(params);
-
-        // then
-        sinon.assert.notCalled(route.router.replaceWith);
-        assert.strictEqual(model, certificationCandidateSubscription);
-      });
-    });
-
-    module('when session is not V3 and toggle is not enabled', function () {
-      test('should not redirect to certification information page', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const certificationCandidate = store.createRecord('certification-candidate', {
-          sessionId: 1234,
-          hasSeenCertificationInstructions: false,
-        });
-        const params = { certification_candidate_id: certificationCandidate.id };
-
-        const certificationCandidateSubscription = store.createRecord('certification-candidate-subscription', {
-          id: certificationCandidate.id,
-          sessionId: 1234,
-          sessionVersion: 2,
-        });
-        const featureToggles = Object.create({
-          featureToggles: {
-            areV3InfoScreensEnabled: false,
-          },
-        });
-
-        const findRecordStub = sinon.stub().returns(certificationCandidateSubscription);
-        const peekRecordStub = sinon.stub().returns(certificationCandidate);
-        const storeStub = Service.create({ findRecord: findRecordStub, peekRecord: peekRecordStub });
-
-        const route = this.owner.lookup('route:authenticated/certifications.start');
-        route.set('store', storeStub);
-        route.set('featureToggles', featureToggles);
         route.router = { replaceWith: sinon.stub() };
 
         // when


### PR DESCRIPTION
## :unicorn: Problème
Lors du développement des écrans d'instructions un FT a été mis en place que qu'ils n'apparaissent que sous condition. Le FT est désormais inutile

## :robot: Proposition
Supprimer le FT `FT_ENABLE_V3_INFO_SCREENS`

## :100: Pour tester
- Se connecter à certif avec `certif-pro@example.net`
- Aller sur mon pix et se connecter à une session de certification
- Vérifier que les écrans d'instruction ne s'affichent pas
- Se connecter à certif avec `certifv3@example.net`
- Aller sur sur mon pix et se connecter à une session de certification
- Vérifier que les écrans d'instruction s'affichent

