### PR TITLE
[TECH] Supprimer la colonne isPublic de `target-profiles` (PIX-14626)

### DIFF
--- a/api/db/migrations/20241004130635_remove-is-public-column-target-profile.js
+++ b/api/db/migrations/20241004130635_remove-is-public-column-target-profile.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'target-profiles';
+const COLUMN_NAME = 'isPublic';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.boolean(COLUMN_NAME).defaultTo(false);
+  });
+};
+
+export { down, up };

--- a/high-level-tests/e2e/cypress/fixtures/target-profiles.json
+++ b/high-level-tests/e2e/cypress/fixtures/target-profiles.json
@@ -2,7 +2,6 @@
   {
     "id": 1,
     "name": "Compétences pour un Mestre",
-    "isPublic": true,
     "ownerOrganizationId": 1
   }
 ]


### PR DESCRIPTION
## :unicorn: Problème
Cette colonne ne sert plus

## :robot: Proposition
La supprimer

## :rainbow: Remarques
Ne pas merger cette PR avant les deux précendentes [PR 1](https://github.com/1024pix/pix/pull/10241) [PR 2](https://github.com/1024pix/pix/pull/10244)

## :100: Pour tester
Plus d'usage de trace dans la colonne dans la bdd 