### PR TITLE
[FEATURE] Trier les participations aux campagnes par date de début sur Pix Admin (PIX-14621)

### DIFF
--- a/api/src/prescription/campaign-participation/infrastructure/repositories/participations-for-user-management-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/participations-for-user-management-repository.js
@@ -26,6 +26,7 @@ const findByUserId = async function (userId) {
     )
     .leftJoin('users as deletedByUsers', 'deletedByUsers.id', 'campaign-participations.deletedBy')
     .where('campaign-participations.userId', userId)
+    .orderBy('createdAt', 'desc')
     .orderBy('campaignCode', 'asc')
     .orderBy('sharedAt', 'desc');
 


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix Admin, les participations aux campagnes d'un prescrit sont classées par ordre alphabétique du code campagne, puis par ordre de date de partage en cas de plusieurs participations à la même campagne. La participation la plus récente peut donc se retrouver en bas de la liste si le code de la campagne concernée commence par les dernières lettres de l'alphabet.

## :robot: Proposition
Afficher par défaut la liste des participations par dates de début (plus récente en premier).
Modifier dans l'API le repository concerné pour rajouter une condition de tri sur les participations renvoyées.

## :rainbow: Remarques
Pourquoi pas dans le futur ajouter une fonctionnalité de tri côté front pour que l'Admin User puisse trier comme bon lui semble.

## :100: Pour tester
Dans Pix Admin :
1) Sélectionner un user ayant plusieurs participations à des campagnes (100066 ou 100069 par exemple)
2) Constater que leurs participations s'affichent dans l'ordre de date de début la plus récente
