### PR TITLE
[BUGFIX] Supporter les descriptions de parcours autonomes en markdown (PIX-14214).

### DIFF
--- a/api/db/seeds/data/team-evaluation/autonomous-courses/create-autonomous-courses.js
+++ b/api/db/seeds/data/team-evaluation/autonomous-courses/create-autonomous-courses.js
@@ -61,8 +61,7 @@ export default async function initUser(databaseBuilder) {
       code: `AUTOCOURS${i}`,
       name: `Parcours autonome n°${i}`,
       title: `Titre principal du parcours autonome n°${i}`,
-      customLandingPageText:
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eget tortor ut diam dictum viverra quis at purus. Morbi id quam a massa blandit gravida.',
+      customLandingPageText: `<strong>Lorem ipsum dolor sit amet</strong>, consectetur adipiscing elit. Mauris eget tortor ut diam dictum viverra quis at purus. Morbi id quam a massa blandit gravida.`,
       createdAt: dayjs().subtract(30, 'days').toDate(),
       idPixLabel: null,
       configCampaign: {

--- a/mon-pix/app/components/autonomous-course/landing-page-start-block.hbs
+++ b/mon-pix/app/components/autonomous-course/landing-page-start-block.hbs
@@ -6,9 +6,9 @@
     {{t "pages.autonomous-course.landing-page.texts.title"}}<br />
     {{@campaign.title}}
   </h1>
-  <p class="autonomous-course-landing-page-start-block__description">
-    {{@campaign.customLandingPageText}}
-  </p>
+  <div class="autonomous-course-landing-page-start-block__description">
+    <MarkdownToHtml @markdown={{@campaign.customLandingPageText}} @isInline={{true}} />
+  </div>
   {{#if this.isUserConnected}}
     <PixButton
       id="autonomous-course-connected-start-button"


### PR DESCRIPTION
## :unicorn: Problème

Aujourd'hui, les descriptions de parcours en markdown ne sont pas supportées.

## :robot: Proposition

Supporter le markdown pour ces descriptions.

## :100: Pour tester

Aller sur https://app-pr10253.review.pix.fr/campagnes/AUTOCOURS1/presentation et voir du gras au début de la description.
