### PR TITLE
[FEATURE] Mettre à jour l'url vers la politique de protection des données à caractère personnel des élèves (PIX-14460)

### DIFF
--- a/junior/translations/fr.json
+++ b/junior/translations/fr.json
@@ -5,7 +5,7 @@
       "legal-notice": "Mentions légales",
       "legal-notice-url": "https://pix.fr/mentions-legales",
       "student-data-protection-policy": "Politique de protection des données des élèves",
-      "student-data-protection-policy-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39"
+      "student-data-protection-policy-url": "https://pix.fr/politique-protection-donnees-personnelles-app-eleves"
     }
   },
   "pages": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -162,7 +162,7 @@
       "server-status": "Status service",
       "sitemap": "Site map",
       "student-data-protection-policy": "Student data protection policy",
-      "student-data-protection-policy-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39"
+      "student-data-protection-policy-url": "https://pix.fr/politique-protection-donnees-personnelles-app-eleves"
     },
     "homepage": "Pix's Homepage",
     "main": {
@@ -1216,7 +1216,7 @@
       },
       "rgpd-legal-notice": "To know how your personnal data is processed, and what your rights are, you can read",
       "rgpd-legal-notice-link": "Mentions d'information.",
-      "rgpd-legal-notice-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39",
+      "rgpd-legal-notice-url": "https://pix.fr/politique-protection-donnees-personnelles-app-eleves",
       "sco": {
         "associate": "Link",
         "continue-with-pix": "Continue with my Pix account",
@@ -1326,7 +1326,7 @@
         },
         "rgpd-legal-notice": "To know how your personnal data is processed, and what your rights are, you can read",
         "rgpd-legal-notice-link": "Mentions d'information.",
-        "rgpd-legal-notice-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39"
+        "rgpd-legal-notice-url": "https://pix.fr/politique-protection-donnees-personnelles-app-eleves"
       }
     },
     "login-or-register-oidc": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -155,7 +155,7 @@
       "server-status": "Status service",
       "sitemap": "Mapa del sitio",
       "student-data-protection-policy": "Política de protección de datos de los alumnos",
-      "student-data-protection-policy-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39"
+      "student-data-protection-policy-url": "https://pix.fr/politique-protection-donnees-personnelles-app-eleves"
     },
     "homepage": "Página de inicio de Pix",
     "main": {
@@ -1195,7 +1195,7 @@
       },
       "rgpd-legal-notice": "Para saber cómo se tratan tus datos y cuáles son tus derechos, puedes leer el",
       "rgpd-legal-notice-link": "aviso legal.",
-      "rgpd-legal-notice-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39",
+      "rgpd-legal-notice-url": "https://pix.fr/politique-protection-donnees-personnelles-app-eleves",
       "sco": {
         "associate": "Asociar",
         "continue-with-pix": "Continuar con mi cuenta Pix",
@@ -1331,7 +1331,7 @@
         },
         "rgpd-legal-notice": "Para saber cómo se tratan tus datos y cuáles son tus derechos, puedes leer el",
         "rgpd-legal-notice-link": "aviso legal.",
-        "rgpd-legal-notice-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39",
+        "rgpd-legal-notice-url": "https://pix.fr/politique-protection-donnees-personnelles-app-eleves",
         "title": "Me inscribo en Pix"
       },
       "title": "Conectarse a Pix"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -162,7 +162,7 @@
       "server-status": "Statut des services",
       "sitemap": "Plan du site",
       "student-data-protection-policy": "Politique de protection des données des élèves",
-      "student-data-protection-policy-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39"
+      "student-data-protection-policy-url": "https://pix.fr/politique-protection-donnees-personnelles-app-eleves"
     },
     "homepage": "Page d'accueil de Pix",
     "main": {
@@ -1216,7 +1216,7 @@
       },
       "rgpd-legal-notice": "Pour savoir comment tes données sont traitées et quels sont tes droits, tu peux lire les",
       "rgpd-legal-notice-link": "Mentions d'information.",
-      "rgpd-legal-notice-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39",
+      "rgpd-legal-notice-url": "https://pix.fr/politique-protection-donnees-personnelles-app-eleves",
       "sco": {
         "associate": "Associer",
         "continue-with-pix": "Continuer avec mon compte Pix",
@@ -1326,7 +1326,7 @@
         },
         "rgpd-legal-notice": "Pour savoir comment tes données sont traitées et quels sont tes droits, tu peux lire les",
         "rgpd-legal-notice-link": "Mentions d'information.",
-        "rgpd-legal-notice-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39"
+        "rgpd-legal-notice-url": "https://pix.fr/politique-protection-donnees-personnelles-app-eleves"
       }
     },
     "login-or-register-oidc": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -155,7 +155,7 @@
       "server-status": "Status service",
       "sitemap": "Kaart",
       "student-data-protection-policy": "Beleid gegevensbescherming studenten",
-      "student-data-protection-policy-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39"
+      "student-data-protection-policy-url": "https://pix.fr/politique-protection-donnees-personnelles-app-eleves"
     },
     "homepage": "Startpagina Pix",
     "main": {
@@ -1195,7 +1195,7 @@
       },
       "rgpd-legal-notice": "Als u wilt weten hoe uw gegevens worden verwerkt en wat uw rechten zijn, kunt u het volgende lezen",
       "rgpd-legal-notice-link": "Informatie.",
-      "rgpd-legal-notice-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39",
+      "rgpd-legal-notice-url": "https://pix.fr/politique-protection-donnees-personnelles-app-eleves",
       "sco": {
         "associate": "Geassocieerd",
         "continue-with-pix": "Doorgaan met mijn Pix-account",
@@ -1331,7 +1331,7 @@
         },
         "rgpd-legal-notice": "Als u wilt weten hoe uw gegevens worden verwerkt en wat uw rechten zijn, kunt u het volgende lezen",
         "rgpd-legal-notice-link": "Informatie.",
-        "rgpd-legal-notice-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39",
+        "rgpd-legal-notice-url": "https://pix.fr/politique-protection-donnees-personnelles-app-eleves",
         "title": "Ik wil me registreren bij Pix"
       },
       "title": "Verbinding maken met Pix"


### PR DESCRIPTION
## :unicorn: Problème

Le site vitrine dispose désormais d’une page dédiée à la [protection des données à caractère personnel des élèves](https://pix.fr/politique-protection-donnees-personnelles-app-eleves) mais c’est encore le lien vers les fichiers PDF hébergés sur Pix Cloud qui est utilisé dans les applications.

## :robot: Proposition

Mettre à jour le lien pour pointer vers la nouvelle page.

## :rainbow: Remarques

RAS

## :100: Pour tester

### Pix Junior

1. Accéder à Pix Junior
2. Constater que le lien vers la politique de protection des données à caractère personnel des élèves mène à la nouvelle page du site vitrine

### Pix App

1. Accéder à Pix App
2. Constater que le lien vers la politique de protection des données à caractère personnel des élèves mène à la nouvelle page du site vitrine