### PR TITLE
[FEATURE] Mise à jour du wording lors du défocus pour candidats avec besoins d'ajustements (PIX-14428).

### DIFF
--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -83,6 +83,8 @@ const retrieveLastOrCreateCertificationCourse = async function ({
   );
 
   if (existingCertificationCourse) {
+    existingCertificationCourse.adjustForAccessibility(certificationCandidate.accessibilityAdjustmentNeeded);
+
     return {
       created: false,
       certificationCourse: existingCertificationCourse,

--- a/api/lib/infrastructure/serializers/jsonapi/certification-course-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-course-serializer.js
@@ -18,6 +18,7 @@ const serialize = function (certificationCourse) {
       'firstName',
       'lastName',
       'version',
+      'isAdjustedForAccessibility',
     ],
     assessment: {
       ref: 'id',

--- a/api/src/certification/shared/domain/models/CertificationCourse.js
+++ b/api/src/certification/shared/domain/models/CertificationCourse.js
@@ -310,6 +310,7 @@ class CertificationCourse {
       completedAt: this._completedAt,
       isPublished: this._isPublished,
       isRejectedForFraud: this._isRejectedForFraud,
+      isAdjustedForAccessibility: this._isAdjustedForAccessibility,
       verificationCode: this._verificationCode,
       assessment: this._assessment,
       challenges: this._challenges,

--- a/api/src/certification/shared/domain/models/CertificationCourse.js
+++ b/api/src/certification/shared/domain/models/CertificationCourse.js
@@ -97,6 +97,7 @@ class CertificationCourse {
       sex: certificationCandidate.sex,
       birthplace: certificationCandidate.birthCity,
       externalId: certificationCandidate.externalId,
+      isAdjustedForAccessibility: certificationCandidate.accessibilityAdjustmentNeeded,
       challenges,
       numberOfChallenges,
       verificationCode,

--- a/api/src/certification/shared/domain/models/CertificationCourse.js
+++ b/api/src/certification/shared/domain/models/CertificationCourse.js
@@ -41,6 +41,7 @@ class CertificationCourse {
     numberOfChallenges,
     version = CERTIFICATION_VERSIONS.V2,
     isRejectedForFraud = false,
+    isAdjustedForAccessibility,
     lang,
   } = {}) {
     this._id = id;
@@ -69,6 +70,7 @@ class CertificationCourse {
     this._abortReason = abortReason;
     this._complementaryCertificationCourses = complementaryCertificationCourses;
     this._isRejectedForFraud = isRejectedForFraud;
+    this._isAdjustedForAccessibility = isAdjustedForAccessibility;
     this._numberOfChallenges = numberOfChallenges;
     this._lang = lang;
   }
@@ -142,6 +144,10 @@ class CertificationCourse {
 
   isRejectedForFraud() {
     return this._isRejectedForFraud;
+  }
+
+  adjustForAccessibility(isAdjustmentNeeded) {
+    this._isAdjustedForAccessibility = !!isAdjustmentNeeded;
   }
 
   abort(reason) {

--- a/api/src/certification/shared/domain/models/CertificationCourse.js
+++ b/api/src/certification/shared/domain/models/CertificationCourse.js
@@ -151,6 +151,10 @@ class CertificationCourse {
     this._isAdjustedForAccessibility = !!isAdjustmentNeeded;
   }
 
+  isAdjustementNeeded() {
+    return this._isAdjustedForAccessibility;
+  }
+
   abort(reason) {
     const { error } = Joi.string()
       .valid(...Object.values(ABORT_REASONS))

--- a/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
@@ -92,7 +92,7 @@ async function get({ id }) {
 
   const challengesDTO = await _findAllChallenges(id, knexConn);
 
-  let candidateDTO;
+  let accessibilityAdjustmentNeeded;
   if (certificationCourseDTO.version === 3) {
     const configuration = await _getV3ConfigurationForCertificationCreationDate(
       certificationCourseDTO.createdAt,
@@ -102,12 +102,13 @@ async function get({ id }) {
     certificationCourseDTO.numberOfChallenges =
       configuration?.maximumAssessmentLength ?? config.v3Certification.numberOfChallengesPerCourse;
 
-    candidateDTO = await knexConn('certification-candidates')
+    ({ accessibilityAdjustmentNeeded } = await knexConn('certification-candidates')
+      .select('accessibilityAdjustmentNeeded')
       .where({
         userId: certificationCourseDTO.userId,
         sessionId: certificationCourseDTO.sessionId,
       })
-      .first();
+      .first());
   }
 
   return _toDomain({
@@ -116,7 +117,7 @@ async function get({ id }) {
     assessmentDTO,
     complementaryCertificationCoursesDTO,
     certificationIssueReportsDTO,
-    candidateDTO,
+    accessibilityAdjustmentNeeded,
   });
 }
 
@@ -126,7 +127,7 @@ function _toDomain({
   assessmentDTO = {},
   complementaryCertificationCoursesDTO = [],
   certificationIssueReportsDTO = [],
-  candidateDTO,
+  accessibilityAdjustmentNeeded,
 }) {
   const complementaryCertificationCourses = complementaryCertificationCoursesDTO.map(
     (complementaryCertificationCourseDTO) => new ComplementaryCertificationCourse(complementaryCertificationCourseDTO),
@@ -144,7 +145,7 @@ function _toDomain({
     challenges: challengesDTO,
     complementaryCertificationCourses,
     certificationIssueReports,
-    isAdjustedForAccessibility: candidateDTO?.accessibilityAdjustmentNeeded,
+    isAdjustedForAccessibility: accessibilityAdjustmentNeeded,
   });
 }
 

--- a/api/tests/acceptance/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-courses/certification-course-controller_test.js
@@ -62,6 +62,7 @@ describe('Acceptance | API | Certification Course', function () {
           'nb-challenges': 0,
           'first-name': certificationCourse.firstName,
           'last-name': certificationCourse.lastName,
+          'is-adjusted-for-accessibility': undefined,
           version: certificationCourse.version,
         },
         relationships: {

--- a/api/tests/certification/scoring/integration/application/jobs/certification-completed-job-controller_test.js
+++ b/api/tests/certification/scoring/integration/application/jobs/certification-completed-job-controller_test.js
@@ -426,13 +426,19 @@ describe('Integration | Certification | Application | jobs | CertificationComple
           const limitDate = new Date('2020-01-01T00:00:00Z');
           const certifiableUserId = databaseBuilder.factory.buildUser().id;
 
-          const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+          const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
             userId: certifiableUserId,
             createdAt: limitDate,
             version: 3,
-          }).id;
+          });
+
+          databaseBuilder.factory.buildCertificationCandidate({
+            userId: certifiableUserId,
+            sessionId: certificationCourse.sessionId,
+          });
+
           const certificationAssessment = databaseBuilder.factory.buildAssessment({
-            certificationCourseId,
+            certificationCourseId: certificationCourse.id,
             userId: certifiableUserId,
             state: Assessment.states.STARTED,
             type: Assessment.types.CERTIFICATION,
@@ -441,14 +447,14 @@ describe('Integration | Certification | Application | jobs | CertificationComple
 
           _buildValidAnswersAndCertificationChallenges({
             assessmentId: certificationAssessment.id,
-            certificationCourseId,
+            certificationCourseId: certificationCourse.id,
           });
 
           await databaseBuilder.commit();
 
           const data = new CertificationCompletedJob({
             assessmentId: certificationAssessment.id,
-            certificationCourseId,
+            certificationCourseId: certificationCourse.id,
             userId: certifiableUserId,
             locale: LOCALE.FRENCH_FRANCE,
           });
@@ -472,13 +478,19 @@ describe('Integration | Certification | Application | jobs | CertificationComple
           const limitDate = new Date('2020-01-01T00:00:00Z');
           const certifiableUserId = databaseBuilder.factory.buildUser().id;
 
-          const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+          const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
             userId: certifiableUserId,
             createdAt: limitDate,
             version: 3,
-          }).id;
+          });
+
+          databaseBuilder.factory.buildCertificationCandidate({
+            userId: certifiableUserId,
+            sessionId: certificationCourse.sessionId,
+          });
+
           const certificationAssessment = databaseBuilder.factory.buildAssessment({
-            certificationCourseId,
+            certificationCourseId: certificationCourse.id,
             userId: certifiableUserId,
             state: Assessment.states.STARTED,
             type: Assessment.types.CERTIFICATION,
@@ -487,14 +499,14 @@ describe('Integration | Certification | Application | jobs | CertificationComple
 
           _buildValidAnswersAndCertificationChallenges({
             assessmentId: certificationAssessment.id,
-            certificationCourseId,
+            certificationCourseId: certificationCourse.id,
           });
 
           await databaseBuilder.commit();
 
           const data = new CertificationCompletedJob({
             assessmentId: certificationAssessment.id,
-            certificationCourseId,
+            certificationCourseId: certificationCourse.id,
             userId: certifiableUserId,
             locale: LOCALE.FRENCH_FRANCE,
           });
@@ -510,7 +522,7 @@ describe('Integration | Certification | Application | jobs | CertificationComple
               'certification-challenge-capacities.certificationChallengeId',
             )
             .where({
-              courseId: certificationCourseId,
+              courseId: certificationCourse.id,
             });
 
           expect(certificationChallengeCapacities.length).to.equal(9);
@@ -522,13 +534,19 @@ describe('Integration | Certification | Application | jobs | CertificationComple
             const limitDate = new Date('2020-01-01T00:00:00Z');
             const certifiableUserId = databaseBuilder.factory.buildUser().id;
 
-            const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+            const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
               userId: certifiableUserId,
               createdAt: limitDate,
               version: 3,
-            }).id;
+            });
+
+            databaseBuilder.factory.buildCertificationCandidate({
+              userId: certifiableUserId,
+              sessionId: certificationCourse.sessionId,
+            });
+
             const certificationAssessment = databaseBuilder.factory.buildAssessment({
-              certificationCourseId,
+              certificationCourseId: certificationCourse.id,
               userId: certifiableUserId,
               state: Assessment.states.STARTED,
               type: Assessment.types.CERTIFICATION,
@@ -537,7 +555,7 @@ describe('Integration | Certification | Application | jobs | CertificationComple
 
             _buildValidAnswersAndCertificationChallenges({
               assessmentId: certificationAssessment.id,
-              certificationCourseId,
+              certificationCourseId: certificationCourse.id,
               difficulty: 9,
             });
 
@@ -545,7 +563,7 @@ describe('Integration | Certification | Application | jobs | CertificationComple
 
             const data = new CertificationCompletedJob({
               assessmentId: certificationAssessment.id,
-              certificationCourseId,
+              certificationCourseId: certificationCourse.id,
               userId: certifiableUserId,
               locale: LOCALE.FRENCH_FRANCE,
             });

--- a/api/tests/certification/session-management/acceptance/application/certification-course-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/certification-course-route_test.js
@@ -9,7 +9,7 @@ import {
 } from '../../../../test-helper.js';
 import { createSuccessfulCertificationCourse } from '../../../shared/fixtures/certification-course.js';
 
-describe('Certification | Session Management | Unit | Application | Routes | Certification Course', function () {
+describe('Certification | Session Management | Acceptance | Application | Routes | Certification Course', function () {
   describe('PATCH /api/admin/certification-courses/{certificationCourseId}', function () {
     context('when the user does not have role super admin', function () {
       it('should return 403 HTTP status code', async function () {
@@ -215,6 +215,11 @@ describe('Certification | Session Management | Unit | Application | Routes | Cer
           sessionId: session.id,
           userId,
           version: 3,
+        });
+
+        databaseBuilder.factory.buildCertificationCandidate({
+          userId: userId,
+          sessionId: certificationCourse.sessionId,
         });
 
         const { assessment, assessmentResult } = await createSuccessfulCertificationCourse({

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -92,6 +92,7 @@ describe('Integration | Repository | Certification Course', function () {
         const userId = databaseBuilder.factory.buildUser().id;
         const sessionId = databaseBuilder.factory.buildSession({ version: 3 }).id;
 
+        databaseBuilder.factory.buildCertificationCandidate({ userId, sessionId });
         certificationCourse = domainBuilder.buildCertificationCourse.unpersisted({
           userId,
           sessionId,

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -254,7 +254,7 @@ describe('Integration | Repository | Certification Course', function () {
 
           // then
           expect(actualCertificationCourse.getNumberOfChallenges()).to.equal(maximumAssessmentLength);
-          expect(actualCertificationCourse._isAdjustedForAccessibility).to.equal(
+          expect(actualCertificationCourse.isAdjustementNeeded()).to.equal(
             certificationCandidate.accessibilityAdjustmentNeeded,
           );
         });

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -221,7 +221,7 @@ describe('Integration | Repository | Certification Course', function () {
       context('When the certification course is v3', function () {
         it('should retrieve the number of challenges from the configuration', async function () {
           const maximumAssessmentLength = 10;
-          const { expectedCertificationCourse } = _buildCertificationCourse({
+          const { expectedCertificationCourse, certificationCandidate } = _buildCertificationCourse({
             description,
             version: 3,
             createdAt: new Date('2022-01-03'),
@@ -253,6 +253,9 @@ describe('Integration | Repository | Certification Course', function () {
 
           // then
           expect(actualCertificationCourse.getNumberOfChallenges()).to.equal(maximumAssessmentLength);
+          expect(actualCertificationCourse._isAdjustedForAccessibility).to.equal(
+            certificationCandidate.accessibilityAdjustmentNeeded,
+          );
         });
       });
     });
@@ -538,6 +541,11 @@ describe('Integration | Repository | Certification Course', function () {
 function _buildCertificationCourse({ createdAt, description, version = 2 }) {
   const userId = databaseBuilder.factory.buildUser().id;
   const sessionId = databaseBuilder.factory.buildSession().id;
+  const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
+    userId,
+    sessionId,
+    accessibilityAdjustmentNeeded: true,
+  });
   const expectedCertificationCourse = databaseBuilder.factory.buildCertificationCourse({
     userId,
     sessionId,
@@ -605,5 +613,6 @@ function _buildCertificationCourse({ createdAt, description, version = 2 }) {
     userId,
     sessionId,
     expectedCertificationCourse,
+    certificationCandidate,
   };
 }

--- a/api/tests/certification/shared/unit/domain/models/CertificationCourse_test.js
+++ b/api/tests/certification/shared/unit/domain/models/CertificationCourse_test.js
@@ -397,7 +397,7 @@ describe('Unit | Domain | Models | CertificationCourse', function () {
         certificationCourse.adjustForAccessibility(isAdjustmentNeeded);
 
         // then
-        expect(certificationCourse._isAdjustedForAccessibility).to.be.true;
+        expect(certificationCourse.isAdjustementNeeded()).to.be.true;
       });
     });
 
@@ -411,7 +411,7 @@ describe('Unit | Domain | Models | CertificationCourse', function () {
         certificationCourse.adjustForAccessibility(isAdjustmentNeeded);
 
         // then
-        expect(certificationCourse._isAdjustedForAccessibility).to.be.false;
+        expect(certificationCourse.isAdjustementNeeded()).to.be.false;
       });
     });
   });

--- a/api/tests/certification/shared/unit/domain/models/CertificationCourse_test.js
+++ b/api/tests/certification/shared/unit/domain/models/CertificationCourse_test.js
@@ -385,4 +385,34 @@ describe('Unit | Domain | Models | CertificationCourse', function () {
       expect(isAvailable).to.be.false;
     });
   });
+
+  describe('#adjustForAccessibility', function () {
+    describe('when an adjustment is needed', function () {
+      it('sets the certification adjustment property to true', function () {
+        // given
+        const certificationCourse = new CertificationCourse();
+        const isAdjustmentNeeded = true;
+
+        // when
+        certificationCourse.adjustForAccessibility(isAdjustmentNeeded);
+
+        // then
+        expect(certificationCourse._isAdjustedForAccessibility).to.be.true;
+      });
+    });
+
+    describe('when an adjustment is not needed', function () {
+      it('sets the certification adjustment property to false', function () {
+        // given
+        const certificationCourse = new CertificationCourse();
+        const isAdjustmentNeeded = false;
+
+        // when
+        certificationCourse.adjustForAccessibility(isAdjustmentNeeded);
+
+        // then
+        expect(certificationCourse._isAdjustedForAccessibility).to.be.false;
+      });
+    });
+  });
 });

--- a/api/tests/tooling/domain-builder/factory/build-certification-course.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-course.js
@@ -32,6 +32,7 @@ function buildCertificationCourse({
   complementaryCertificationCourses = [],
   maxReachableLevelOnCertificationDate = 7,
   numberOfChallenges = 20,
+  isAdjustedForAccessibility = false,
   lang,
 } = {}) {
   const certificationIssueReports = [];
@@ -75,6 +76,7 @@ function buildCertificationCourse({
     complementaryCertificationCourses,
     maxReachableLevelOnCertificationDate,
     numberOfChallenges,
+    isAdjustedForAccessibility,
     lang,
   });
 }

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -258,7 +258,12 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
               .withArgs({ sessionId: 1, userId: 2 })
               .resolves(foundCertificationCandidate);
 
-            const existingCertificationCourse = domainBuilder.buildCertificationCourse({ userId: 2, sessionId: 1 });
+            const existingCertificationCourse = domainBuilder.buildCertificationCourse({
+              userId: 2,
+              sessionId: 1,
+            });
+            existingCertificationCourse.adjustForAccessibility = sinon.stub();
+
             certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
               .withArgs({ userId: 2, sessionId: 1 })
               .resolves(existingCertificationCourse);
@@ -273,6 +278,9 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
             });
 
             // then
+            expect(existingCertificationCourse.adjustForAccessibility).to.have.been.calledOnceWith(
+              foundCertificationCandidate.accessibilityAdjustmentNeeded,
+            );
             expect(result).to.deep.equal({
               created: false,
               certificationCourse: existingCertificationCourse,

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -517,6 +517,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                     authorizedToStart: true,
                     subscriptions: [domainBuilder.buildCoreSubscription()],
                     reconciledAt,
+                    accessibilityAdjustmentNeeded: true,
                   });
                   certificationCandidateRepository.getBySessionIdAndUserId
                     .withArgs({ sessionId: 1, userId })
@@ -553,6 +554,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                     maxReachableLevelOnCertificationDate: MAX_REACHABLE_LEVEL,
                     version: 3,
                     lang: user.lang,
+                    isAdjustedForAccessibility: foundCertificationCandidate.accessibilityAdjustmentNeeded,
                   });
 
                   const savedCertificationCourse = domainBuilder.buildCertificationCourse(
@@ -593,6 +595,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       challenges: [],
                       version: 3,
                       lang: user.lang,
+                      isAdjustedForAccessibility: true,
                     }),
                   );
                 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-course-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-course-serializer_test.js
@@ -19,6 +19,7 @@ describe('Unit | Serializer | JSONAPI | certification-course-serializer', functi
         certificationIssueReports: [],
         hasSeenEndTestScreen: true,
         version: 2,
+        isAdjustedForAccessibility: true,
       });
 
       const issueReport = new CertificationIssueReport({
@@ -40,6 +41,7 @@ describe('Unit | Serializer | JSONAPI | certification-course-serializer', functi
             'has-seen-end-test-screen': true,
             'first-name': certificationCourse.toDTO().firstName,
             'last-name': certificationCourse.toDTO().lastName,
+            'is-adjusted-for-accessibility': true,
             version: 2,
           },
           relationships: {
@@ -71,6 +73,7 @@ describe('Unit | Serializer | JSONAPI | certification-course-serializer', functi
         certificationIssueReports: undefined,
         hasSeenEndTestScreen: true,
         version: 2,
+        isAdjustedForAccessibility: false,
       });
 
       const jsonCertificationCourseWithAssessment = {
@@ -84,6 +87,7 @@ describe('Unit | Serializer | JSONAPI | certification-course-serializer', functi
             'first-name': certificationCourse.toDTO().firstName,
             'last-name': certificationCourse.toDTO().lastName,
             version: 2,
+            'is-adjusted-for-accessibility': false,
           },
           relationships: {
             assessment: {
@@ -114,6 +118,7 @@ describe('Unit | Serializer | JSONAPI | certification-course-serializer', functi
         certificationIssueReports: undefined,
         hasSeenEndTestScreen: true,
         version: 2,
+        isAdjustedForAccessibility: false,
       });
 
       const jsonCertificationCourseWithAssessment = {
@@ -127,6 +132,7 @@ describe('Unit | Serializer | JSONAPI | certification-course-serializer', functi
             'first-name': certificationCourse.toDTO().firstName,
             'last-name': certificationCourse.toDTO().lastName,
             version: 2,
+            'is-adjusted-for-accessibility': false,
           },
           relationships: {
             assessment: {

--- a/mon-pix/app/components/challenge-actions.hbs
+++ b/mon-pix/app/components/challenge-actions.hbs
@@ -42,25 +42,27 @@
         aria-live="assertive"
       >
         <FaIcon @icon="circle-info" class="challenge-actions-alert-message__icon" />
-        {{#if @isCertification}}
-          {{#if (eq @certificationVersion 3)}}
-            {{#if @isAdjustedCourseForAccessibility}}
-              <span data-test="certification-v3-focused-out-error-message">{{t
-                "pages.challenge.has-focused-out-of-window.v3-accessible-certification"
-              }}</span>
-            {{else}}
-              <span data-test="certification-v3-focused-out-error-message">{{t
-                "pages.challenge.has-focused-out-of-window.v3-certification"
-              }}</span>
-            {{/if}}
-          {{else}}
-            <span data-test="certification-focused-out-error-message">{{t
-                "pages.challenge.has-focused-out-of-window.certification"
-              }}</span>
-          {{/if}}
-        {{else}}
+        {{#if this.isNotCertification}}
           <span data-test="default-focused-out-error-message">{{t
               "pages.challenge.has-focused-out-of-window.default"
+            }}</span>
+        {{/if}}
+
+        {{#if this.isV2Certification}}
+          <span data-test="certification-focused-out-error-message">{{t
+              "pages.challenge.has-focused-out-of-window.certification"
+            }}</span>
+        {{/if}}
+
+        {{#if this.isV3CertificationAdjustedForAccessibility}}
+          <span data-test="certification-v3-focused-out-error-message">{{t
+              "pages.challenge.has-focused-out-of-window.v3-accessible-certification"
+            }}</span>
+        {{/if}}
+
+        {{#if this.isV3CertificationNotAdjusted}}
+          <span data-test="certification-v3-focused-out-error-message">{{t
+              "pages.challenge.has-focused-out-of-window.v3-certification"
             }}</span>
         {{/if}}
       </div>

--- a/mon-pix/app/components/challenge-actions.hbs
+++ b/mon-pix/app/components/challenge-actions.hbs
@@ -44,9 +44,15 @@
         <FaIcon @icon="circle-info" class="challenge-actions-alert-message__icon" />
         {{#if @isCertification}}
           {{#if (eq @certificationVersion 3)}}
-            <span data-test="certification-v3-focused-out-error-message">{{t
+            {{#if @isAdjustedCourseForAccessibility}}
+              <span data-test="certification-v3-focused-out-error-message">{{t
+                "pages.challenge.has-focused-out-of-window.v3-accessible-certification"
+              }}</span>
+            {{else}}
+              <span data-test="certification-v3-focused-out-error-message">{{t
                 "pages.challenge.has-focused-out-of-window.v3-certification"
               }}</span>
+            {{/if}}
           {{else}}
             <span data-test="certification-focused-out-error-message">{{t
                 "pages.challenge.has-focused-out-of-window.certification"

--- a/mon-pix/app/components/challenge-actions.js
+++ b/mon-pix/app/components/challenge-actions.js
@@ -4,4 +4,20 @@ export default class ChallengeActions extends Component {
   get areActionButtonsDisabled() {
     return this.args.disabled || this.args.hasOngoingLiveAlert;
   }
+
+  get isNotCertification() {
+    return !this.args.isCertification;
+  }
+
+  get isV2Certification() {
+    return this.args.certificationVersion === 2;
+  }
+
+  get isV3CertificationAdjustedForAccessibility() {
+    return this.args.certificationVersion === 3 && this.args.isAdjustedCourseForAccessibility;
+  }
+
+  get isV3CertificationNotAdjusted() {
+    return this.args.certificationVersion === 3 && !this.args.isAdjustedCourseForAccessibility;
+  }
 }

--- a/mon-pix/app/components/challenge-item/challenge-item-qcm.hbs
+++ b/mon-pix/app/components/challenge-item/challenge-item-qcm.hbs
@@ -51,6 +51,7 @@
       @isDisabled={{this.isAnswerFieldDisabled}}
       @hasOngoingLiveAlert={{@assessment.hasOngoingLiveAlert}}
       @certificationVersion={{@assessment.certificationCourse.version}}
+      @isAdjustedCourseForAccessibility={{@assessment.certificationCourse.isAdjustedForAccessibility}}
     />
   {{/if}}
 </form>

--- a/mon-pix/app/components/challenge-item/challenge-item-qcu.hbs
+++ b/mon-pix/app/components/challenge-item/challenge-item-qcu.hbs
@@ -51,6 +51,7 @@
       @isDisabled={{this.isAnswerFieldDisabled}}
       @hasOngoingLiveAlert={{@assessment.hasOngoingLiveAlert}}
       @certificationVersion={{@assessment.certificationCourse.version}}
+      @isAdjustedCourseForAccessibility={{@assessment.certificationCourse.isAdjustedForAccessibility}}
     />
   {{/if}}
 </form>

--- a/mon-pix/app/components/challenge-item/challenge-item-qroc.hbs
+++ b/mon-pix/app/components/challenge-item/challenge-item-qroc.hbs
@@ -134,6 +134,7 @@
       @hasFocusedOutOfWindow={{@hasFocusedOutOfWindow}}
       @hasOngoingLiveAlert={{@assessment.hasOngoingLiveAlert}}
       @certificationVersion={{@assessment.certificationCourse.version}}
+      @isAdjustedCourseForAccessibility={{@assessment.certificationCourse.isAdjustedForAccessibility}}
     />
   {{/if}}
 </form>

--- a/mon-pix/app/components/challenge-item/challenge-item-qrocm.hbs
+++ b/mon-pix/app/components/challenge-item/challenge-item-qrocm.hbs
@@ -50,6 +50,7 @@
       @isDisabled={{this.isAnswerFieldDisabled}}
       @hasOngoingLiveAlert={{@assessment.hasOngoingLiveAlert}}
       @certificationVersion={{@assessment.certificationCourse.version}}
+      @isAdjustedCourseForAccessibility={{@assessment.certificationCourse.isAdjustedForAccessibility}}
     />
   {{/if}}
 </form>

--- a/mon-pix/app/models/certification-course.js
+++ b/mon-pix/app/models/certification-course.js
@@ -7,6 +7,7 @@ export default class CertificationCourse extends Model {
   @attr('string') firstName;
   @attr('string') lastName;
   @attr('number') version;
+  @attr('boolean') isAdjustedForAccessibility;
 
   // references
   @attr('number') sessionId;

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -8,12 +8,18 @@
     aria-live="assertive"
   >
     <div class="challenge-info-alert__icon"></div>
-    <p class="challenge-info-alert__title">
-      {{t "pages.challenge.is-focused-challenge.info-alert.title"}}
-    </p>
-    <p class="challenge-info-alert__subtitle">
-      {{t "pages.challenge.is-focused-challenge.info-alert.subtitle"}}
-    </p>
+    {{#if @model.assessment.certificationCourse.isAdjustedForAccessibility}}
+      <p class="challenge-info-alert__title">
+        {{t "pages.challenge.is-focused-challenge.info-alert.adjusted-course-title"}}
+      </p>
+    {{else}}
+      <p class="challenge-info-alert__title">
+        {{t "pages.challenge.is-focused-challenge.info-alert.title"}}
+      </p>
+      <p class="challenge-info-alert__subtitle">
+        {{t "pages.challenge.is-focused-challenge.info-alert.subtitle"}}
+      </p>
+    {{/if}}
   </div>
 {{/if}}
 
@@ -102,12 +108,18 @@
       aria-live="assertive"
     >
       <div class="challenge-info-alert__icon"></div>
-      <p class="challenge-info-alert__title">
-        {{t "pages.challenge.is-focused-challenge.info-alert.title"}}
-      </p>
-      <p class="challenge-info-alert__subtitle">
-        {{t "pages.challenge.is-focused-challenge.info-alert.subtitle"}}
-      </p>
+      {{#if @model.assessment.certificationCourse.isAdjustedForAccessibility}}
+        <p class="challenge-info-alert__title">
+          {{t "pages.challenge.is-focused-challenge.info-alert.adjusted-course-title"}}
+        </p>
+      {{else}}
+        <p class="challenge-info-alert__title">
+          {{t "pages.challenge.is-focused-challenge.info-alert.title"}}
+        </p>
+        <p class="challenge-info-alert__subtitle">
+          {{t "pages.challenge.is-focused-challenge.info-alert.subtitle"}}
+        </p>
+      {{/if}}
     </div>
   {{/if}}
 </div>

--- a/mon-pix/mirage/serializers/certification-course.js
+++ b/mon-pix/mirage/serializers/certification-course.js
@@ -1,7 +1,15 @@
 import ApplicationSerializer from './application';
 
 export default ApplicationSerializer.extend({
-  attrs: ['nbChallenges', 'examinerComment', 'hasSeenEndTestScreen', 'firstName', 'lastName', 'version'],
+  attrs: [
+    'nbChallenges',
+    'examinerComment',
+    'hasSeenEndTestScreen',
+    'firstName',
+    'lastName',
+    'version',
+    'isAdjustedForAccessibility',
+  ],
   links(certificationCourse) {
     return {
       assessment: {

--- a/mon-pix/tests/integration/components/challenge-actions-test.js
+++ b/mon-pix/tests/integration/components/challenge-actions-test.js
@@ -67,18 +67,19 @@ module('Integration | Component | challenge actions', function (hooks) {
       });
 
       module('when certification course version is 3', function () {
-        test("should show certification focus out's error message", async function (assert) {
-          // given
-          this.set('isValidateButtonEnabled', true);
-          this.set('isCertification', true);
-          this.set('hasFocusedOutOfWindow', true);
-          this.set('hasChallengeTimedOut', false);
-          this.set('isSkipButtonEnabled', true);
-          this.set('validateActionStub', () => {});
-          this.set('certificationVersion', 3);
+        module('when the candidate does not need an accessibility adjustment', function () {
+          test("should show a specific certification focus out's error message", async function (assert) {
+            // given
+            this.set('isValidateButtonEnabled', true);
+            this.set('isCertification', true);
+            this.set('hasFocusedOutOfWindow', true);
+            this.set('hasChallengeTimedOut', false);
+            this.set('isSkipButtonEnabled', true);
+            this.set('validateActionStub', () => {});
+            this.set('certificationVersion', 3);
 
-          // when
-          const screen = await render(hbs`<ChallengeActions
+            // when
+            const screen = await render(hbs`<ChallengeActions
   @isCertification={{this.isCertification}}
   @validateAnswer={{this.validateActionStub}}
   @hasFocusedOutOfWindow={{this.hasFocusedOutOfWindow}}
@@ -88,28 +89,92 @@ module('Integration | Component | challenge actions', function (hooks) {
   @certificationVersion={{this.certificationVersion}}
 />`);
 
-          // then
-          assert
-            .dom(
-              screen.queryByText(
-                'Nous avons détecté un changement de page. En certification, votre réponse ne serait pas validée.',
-              ),
-            )
-            .doesNotExist();
-          assert
-            .dom(
-              screen.queryByText(
-                'Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, prévenez votre surveillant et répondez à la question en sa présence.',
-              ),
-            )
-            .doesNotExist();
-          assert
-            .dom(
-              screen.getByText(
-                "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, prévenez votre surveillant afin qu'il puisse le constater et le signaler, le cas échéant.",
-              ),
-            )
-            .exists();
+            // then
+            assert
+              .dom(
+                screen.queryByText(
+                  'Nous avons détecté un changement de page. En certification, votre réponse ne serait pas validée.',
+                ),
+              )
+              .doesNotExist();
+            assert
+              .dom(
+                screen.queryByText(
+                  'Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, prévenez votre surveillant et répondez à la question en sa présence.',
+                ),
+              )
+              .doesNotExist();
+            assert
+              .dom(
+                screen.getByText(
+                  "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, prévenez votre surveillant afin qu'il puisse le constater et le signaler, le cas échéant.",
+                ),
+              )
+              .exists();
+            assert
+              .dom(
+                screen.queryByText(
+                  "Nous avons détecté un changement de page. Si vous avez été contraint de changer de page pour utiliser un outil d’accessibilité numérique (tel qu'un lecteur d'écran ou un clavier virtuel), répondez tout de même à la question.",
+                ),
+              )
+              .doesNotExist();
+          });
+        });
+
+        module('when the candidate needs an accessibility adjustment', function () {
+          test("should show another specific certification focus out's error message", async function (assert) {
+            // given
+            this.set('isValidateButtonEnabled', true);
+            this.set('isCertification', true);
+            this.set('hasFocusedOutOfWindow', true);
+            this.set('hasChallengeTimedOut', false);
+            this.set('isSkipButtonEnabled', true);
+            this.set('validateActionStub', () => {});
+            this.set('certificationVersion', 3);
+            this.set('isAdjustedCourseForAccessibility', true);
+
+            // when
+            const screen = await render(hbs`<ChallengeActions
+  @isCertification={{this.isCertification}}
+  @validateAnswer={{this.validateActionStub}}
+  @hasFocusedOutOfWindow={{this.hasFocusedOutOfWindow}}
+  @hasChallengeTimedOut={{this.hasChallengeTimedOut}}
+  @isValidateButtonEnabled={{this.isValidateButtonEnabled}}
+  @isSkipButtonEnabled={{this.isSkipButtonEnabled}}
+  @certificationVersion={{this.certificationVersion}}
+  @isAdjustedCourseForAccessibility={{this.isAdjustedCourseForAccessibility}}
+/>`);
+
+            // then
+            assert
+              .dom(
+                screen.queryByText(
+                  'Nous avons détecté un changement de page. En certification, votre réponse ne serait pas validée.',
+                ),
+              )
+              .doesNotExist();
+            assert
+              .dom(
+                screen.queryByText(
+                  'Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, prévenez votre surveillant et répondez à la question en sa présence.',
+                ),
+              )
+              .doesNotExist();
+            assert
+              .dom(
+                screen.queryByText(
+                  "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, prévenez votre surveillant afin qu'il puisse le constater et le signaler, le cas échéant.",
+                ),
+              )
+              .doesNotExist();
+            assert
+              .dom(
+                screen.getByText(
+                  "Nous avons détecté un changement de page. Si vous avez été contraint de changer de page pour utiliser un outil d’accessibilité numérique (tel qu'un lecteur d'écran ou un clavier virtuel), répondez tout de même à la question.",
+                ),
+              )
+              .exists();
+          });
         });
       });
     });

--- a/mon-pix/tests/integration/components/challenge-actions-test.js
+++ b/mon-pix/tests/integration/components/challenge-actions-test.js
@@ -78,7 +78,7 @@ module('Integration | Component | challenge actions', function (hooks) {
           this.set('certificationVersion', 3);
 
           // when
-          await render(hbs`<ChallengeActions
+          const screen = await render(hbs`<ChallengeActions
   @isCertification={{this.isCertification}}
   @validateAnswer={{this.validateActionStub}}
   @hasFocusedOutOfWindow={{this.hasFocusedOutOfWindow}}
@@ -89,9 +89,27 @@ module('Integration | Component | challenge actions', function (hooks) {
 />`);
 
           // then
-          assert.dom('[data-test="default-focused-out-error-message"]').doesNotExist();
-          assert.dom('[data-test="certification-focused-out-error-message"]').doesNotExist();
-          assert.dom('[data-test="certification-v3-focused-out-error-message"]').exists();
+          assert
+            .dom(
+              screen.queryByText(
+                'Nous avons détecté un changement de page. En certification, votre réponse ne serait pas validée.',
+              ),
+            )
+            .doesNotExist();
+          assert
+            .dom(
+              screen.queryByText(
+                'Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, prévenez votre surveillant et répondez à la question en sa présence.',
+              ),
+            )
+            .doesNotExist();
+          assert
+            .dom(
+              screen.getByText(
+                "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, prévenez votre surveillant afin qu'il puisse le constater et le signaler, le cas échéant.",
+              ),
+            )
+            .exists();
         });
       });
     });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -852,6 +852,7 @@
       "has-focused-out-of-window": {
         "certification": "We have detected a page switch. Your answer will not be validated. If you have been forced to change pages, please inform your invigilator and answer the question in their presence.",
         "default": "We have detected a page switch. During a certification test, your answer would not be validated.",
+        "v3-accessible-certification": "We have detected a page switch. If you have been forced to change pages in order to use a digital accessibility tool (such as a screen reader or virtual keyboard), please answer the question anyways.",
         "v3-certification": "We have detected a page change. Your answer will be counted as wrong. If you have been forced to change page, tell your supervisor so that he or she can see this and report it, if necessary."
       },
       "illustration": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -861,6 +861,7 @@
       "is-focused-challenge": {
         "info-alert": {
           "title": "Answer this question without searching the internet or using any piece of software.",
+          "adjusted-course-title": "Answer this question without using the Internet or any applications.",
           "subtitle": "If you switch pages or tabs during a certification test, you answer will not be validated."
         }
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -852,6 +852,7 @@
       "has-focused-out-of-window": {
         "certification": "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, prévenez votre surveillant et répondez à la question en sa présence.",
         "default": "Nous avons détecté un changement de page. En certification, votre réponse ne serait pas validée.",
+        "v3-accessible-certification": "Nous avons détecté un changement de page. Si vous avez été contraint de changer de page pour utiliser un outil d’accessibilité numérique (tel qu'un lecteur d'écran ou un clavier virtuel), répondez tout de même à la question.",
         "v3-certification": "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, prévenez votre surveillant afin qu'il puisse le constater et le signaler, le cas échéant."
       },
       "illustration": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -861,6 +861,7 @@
       "is-focused-challenge": {
         "info-alert": {
           "title": "Essayez de répondre à cette question sans vous aider d’internet ou d’applications.",
+          "adjusted-course-title": "Répondez à cette question sans vous aider d’internet ou d’applications.",
           "subtitle": "En certification, si vous changez de page, votre réponse ne sera pas validée."
         }
       },


### PR DESCRIPTION
## :unicorn: Problème

Dans le cadre de l’epix a11y , une version “accessible” des focus va être implémentée.

Si on permet à un candidat ayant un test aménagé a11y de valider une question focus bien répondue, même en cas de défocus, le message en cas de défocus actuel est trompeur.

## :robot: Proposition

Mise à à jour du wording des warning des questions focus pour un test aménagé a11y : pour un test de certification v3, pour lequel la case “aménagement a11y a été coché” : 

______

Lorsque le candidat sort de la zone de question

![image](https://github.com/user-attachments/assets/16797e15-b803-4ae6-80dc-113837e4cba0)

Nouveau wording : 
🇫🇷  “Répondez à cette question sans vous aider d’internet ou d’applications.”
🇬🇧  “Answer this question without using the Internet or any applications.”

_____________________________________________________

Lorsque le candidat défocus de l'épreuve

![image](https://github.com/user-attachments/assets/c134461c-2bfe-476c-a4a4-5e5739c09191)

Nouveau wording : 
🇫🇷  “Nous avons détecté un changement de page. Si vous avez été contraint de changer de page pour utiliser un outil d’accessibilité numérique (tel qu'un lecteur d'écran ou un clavier virtuel), répondez tout de même à la question.”
🇬🇧  “We have detected a page switch. If you have been forced to change pages in order to use a digital accessibility tool (such as a screen reader or virtual keyboard), please answer the question anyways.”

## :rainbow: Remarques

On décide de renvoyer `undefined` dans le payload du serializer pour le mois à venir avant la généralisation.

## :100: Pour tester

- Créer une session de certification V3 dans un centre featurisé a11y (`certifv3@example.net`)
- Ajouter deux candidats à cette session
- Modifier les infos d'un des candidats afin d'y ajouter un besoin d'ajustement
- Passer les sessions des deux candidats et vérifier que les messages de défocus lors des épreuves focus correspondent aux différents besoins d'ajustements des candidats

- Créer une session V2 et y ajouter un candidat
- Passer le test de certification et vérifier que les messages de défocus lors des épreuves focus n'ont pas changé
