### PR TITLE
[TECH] Ajouter un composant local de gestion des règles de mot de passe (PIX-14149)

### DIFF
--- a/mon-pix/app/components/authentication/password-input/index.gjs
+++ b/mon-pix/app/components/authentication/password-input/index.gjs
@@ -1,0 +1,102 @@
+import PixInputPassword from '@1024pix/pix-ui/components/pix-input-password';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+
+import PasswordChecklist from './password-checklist';
+
+const CONTAINS_UPPERCASE_KEY = 'containsUppercase';
+const CONTAINS_LOWERCASE_KEY = 'containsLowercase';
+const CONTAINS_DIGIT_KEY = 'containsDigit';
+const MIN_LENGTH_KEY = 'minLength';
+
+export default class PasswordInput extends Component {
+  @service intl;
+
+  @tracked errors = [];
+  @tracked validationStatus = 'default';
+  @tracked value = '';
+
+  get hasValidationStatusError() {
+    return this.validationStatus === 'error';
+  }
+
+  get rules() {
+    return [
+      {
+        key: MIN_LENGTH_KEY,
+        description: this.intl.t('components.authentication.password-input.rules.min-length'),
+      },
+      {
+        key: CONTAINS_UPPERCASE_KEY,
+        description: this.intl.t('components.authentication.password-input.rules.contains-uppercase'),
+      },
+      {
+        key: CONTAINS_LOWERCASE_KEY,
+        description: this.intl.t('components.authentication.password-input.rules.contains-lowercase'),
+      },
+      {
+        key: CONTAINS_DIGIT_KEY,
+        description: this.intl.t('components.authentication.password-input.rules.contains-digit'),
+      },
+    ];
+  }
+
+  checkRules() {
+    const errors = [];
+    const hasDigit = (value) => /\d/.test(value);
+    const hasLowercase = (value) => /[a-zà-ÿ]/.test(value);
+    const hasUppercase = (value) => /[A-ZÀ-ß]/.test(value);
+    const hasMinLength = (value) => value.length && value.length >= 8;
+    const value = this.value;
+
+    if (!hasDigit(value)) errors.push(CONTAINS_DIGIT_KEY);
+    if (!hasLowercase(value)) errors.push(CONTAINS_LOWERCASE_KEY);
+    if (!hasUppercase(value)) errors.push(CONTAINS_UPPERCASE_KEY);
+    if (!hasMinLength(value)) errors.push(MIN_LENGTH_KEY);
+
+    return errors;
+  }
+
+  @action
+  handlePasswordChange(event) {
+    this.value = event.target.value;
+    this.errors = this.checkRules();
+
+    if (this.value && this.errors.length === 0) {
+      this.validationStatus = 'success';
+    }
+
+    const { onInput } = this.args;
+    if (onInput) onInput(event);
+  }
+
+  @action
+  handleValidationStatus() {
+    if (!this.value || this.errors.length > 0) {
+      this.validationStatus = 'error';
+    }
+  }
+
+  <template>
+    <PixInputPassword
+      aria-describedby="password-checklist"
+      aria-invalid={{this.hasValidationStatusError}}
+      autocomplete="new-password"
+      name="password"
+      @errorMessage={{t "components.authentication.password-input.error-message"}}
+      @id="password"
+      @validationStatus={{this.validationStatus}}
+      {{on "input" this.handlePasswordChange}}
+      {{on "blur" this.handleValidationStatus}}
+      ...attributes
+    >
+      <:label>{{t "pages.sign-in.fields.password.label"}}</:label>
+    </PixInputPassword>
+
+    <PasswordChecklist id="password-checklist" @errors={{this.errors}} @rules={{this.rules}} @value={{this.value}} />
+  </template>
+}

--- a/mon-pix/app/components/authentication/password-input/password-checklist.gjs
+++ b/mon-pix/app/components/authentication/password-input/password-checklist.gjs
@@ -1,0 +1,44 @@
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+
+import PasswordRule from './password-rule';
+
+export default class PasswordChecklist extends Component {
+  get rules() {
+    const { rules, value, errors } = this.args;
+    return rules.map((rule) => ({
+      ...rule,
+      isValid: Boolean(value) && !errors?.includes(rule.key),
+    }));
+  }
+
+  get rulesCount() {
+    const { rules } = this.args;
+    return rules.length;
+  }
+
+  get rulesCompleted() {
+    const { rules, value, errors } = this.args;
+    return !value ? 0 : rules.length - errors?.length;
+  }
+
+  <template>
+    <div class="password-checklist" ...attributes>
+      <label class="password-checklist__instructions" for="checklist">
+        {{t "components.authentication.password-input.instructions-label"}}
+      </label>
+      <ul id="checklist">
+        {{#each this.rules as |rule|}}
+          <PasswordRule @description={{rule.description}} @isValid={{rule.isValid}} />
+        {{/each}}
+      </ul>
+      <p class="sr-only" aria-atomic="true" aria-relevant="all" aria-live="polite">
+        {{t
+          "components.authentication.password-input.rules.completed-message"
+          rulesCompleted=this.rulesCompleted
+          rulesCount=this.rulesCount
+        }}
+      </p>
+    </div>
+  </template>
+}

--- a/mon-pix/app/components/authentication/password-input/password-checklist.scss
+++ b/mon-pix/app/components/authentication/password-input/password-checklist.scss
@@ -1,0 +1,14 @@
+.password-checklist {
+  @extend %pix-body-s;
+
+  display: flex;
+  flex-direction: column;
+  padding: var(--pix-spacing-2x) var(--pix-spacing-4x);
+  background-color: var(--pix-neutral-20);
+  border-radius: var(--pix-spacing-2x);
+
+  &__instructions {
+    margin-bottom: var(--pix-spacing-2x);
+    font-weight: var(--pix-font-bold);
+  }
+}

--- a/mon-pix/app/components/authentication/password-input/password-rule.gjs
+++ b/mon-pix/app/components/authentication/password-input/password-rule.gjs
@@ -1,0 +1,26 @@
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import Component from '@glimmer/component';
+
+const RULE_STYLES = {
+  VALID: {
+    iconClass: 'circle-check',
+    listItemClass: 'password-rule',
+  },
+  INVALID: {
+    iconClass: 'circle-xmark',
+    listItemClass: 'password-rule password-rule--error',
+  },
+};
+
+export default class PasswordRule extends Component {
+  get classes() {
+    return this.args.isValid ? RULE_STYLES.VALID : RULE_STYLES.INVALID;
+  }
+
+  <template>
+    <li class="{{this.classes.listItemClass}}" aria-label="{{@description}}.">
+      <FaIcon @icon="{{this.classes.iconClass}}" />
+      <p aria-live="polite"> {{@description}} </p>
+    </li>
+  </template>
+}

--- a/mon-pix/app/components/authentication/password-input/password-rule.scss
+++ b/mon-pix/app/components/authentication/password-input/password-rule.scss
@@ -1,0 +1,17 @@
+.password-rule {
+  display: flex;
+  gap: var(--pix-spacing-2x);
+  align-items: center;
+
+  path {
+    fill: var(--pix-success-500);
+  }
+
+  &--error {
+    font-weight: var(--pix-font-bold);
+
+    path {
+      fill: var(--pix-error-500);
+    }
+  }
+}

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -137,6 +137,8 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @import 'authentication/oidc-provider-selector';
 @import 'authentication/signin-form';
 @import 'authentication/sso-selection-form';
+@import 'authentication/password-input/password-checklist';
+@import 'authentication/password-input/password-rule';
 
 /* pages */
 @import 'pages/assessment-results';

--- a/mon-pix/tests/integration/components/authentication/password-input/index-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/password-input/index-test.gjs
@@ -1,0 +1,122 @@
+import { fillByLabel, render } from '@1024pix/ember-testing-library';
+import { on } from '@ember/modifier';
+import { blur } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import PasswordInput from 'mon-pix/components/authentication/password-input';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+const I18N = {
+  PASSWORD_INPUT_LABEL: 'pages.sign-in.fields.password.label',
+  RULES_STATUS_MESSAGE: 'components.authentication.password-input.rules.completed-message',
+  ERROR_MESSAGE: 'components.authentication.password-input.error-message',
+};
+
+module('Integration | Component | authentication | password-input', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it respects all rules', async function (assert) {
+    // given
+    const validPassword = 'Pix12345';
+    const onInput = sinon.spy();
+
+    const screen = await render(<template><PasswordInput {{on "input" onInput}} /></template>);
+
+    // when
+    await fillByLabel(t(I18N.PASSWORD_INPUT_LABEL), validPassword);
+    const passwordInputElement = screen.getByLabelText(t(I18N.PASSWORD_INPUT_LABEL));
+    await blur(passwordInputElement);
+
+    // then
+    const onInputEvent = onInput.firstCall.args[0];
+    assert.strictEqual(onInputEvent.target.value, validPassword);
+
+    assert.dom(passwordInputElement).doesNotHaveAttribute('aria-invalid');
+
+    const rulesStatusMessage = t(I18N.RULES_STATUS_MESSAGE, { rulesCompleted: 4, rulesCount: 4 });
+    assert.dom(screen.getByText(rulesStatusMessage)).exists();
+  });
+
+  test('it does not respect any rules', async function (assert) {
+    // given
+    const invalidPassword = '     ';
+    const onInput = sinon.stub();
+
+    const screen = await render(<template><PasswordInput {{on "input" onInput}} /></template>);
+
+    // when
+    await fillByLabel(t(I18N.PASSWORD_INPUT_LABEL), invalidPassword);
+    const passwordInputElement = screen.getByLabelText(t(I18N.PASSWORD_INPUT_LABEL));
+    await blur(passwordInputElement);
+
+    // then
+    assert.dom(passwordInputElement).hasAttribute('aria-invalid');
+    assert.dom(screen.getByText(t(I18N.ERROR_MESSAGE))).exists();
+  });
+
+  test('it must have a minimum length of 8 chars', async function (assert) {
+    // given
+    const invalidPassword = 'Pix1234';
+    const onInput = sinon.stub();
+
+    const screen = await render(<template><PasswordInput {{on "input" onInput}} /></template>);
+
+    // when
+    await fillByLabel(t(I18N.PASSWORD_INPUT_LABEL), invalidPassword);
+    const passwordInputElement = screen.getByLabelText(t(I18N.PASSWORD_INPUT_LABEL));
+    await blur(passwordInputElement);
+
+    // then
+    assert.dom(passwordInputElement).hasAttribute('aria-invalid');
+  });
+
+  test('it must contains at least one uppercase char', async function (assert) {
+    // given
+    const invalidPassword = 'pix12345';
+    const onInput = sinon.stub();
+
+    const screen = await render(<template><PasswordInput {{on "input" onInput}} /></template>);
+
+    // when
+    await fillByLabel(t(I18N.PASSWORD_INPUT_LABEL), invalidPassword);
+    const passwordInputElement = screen.getByLabelText(t(I18N.PASSWORD_INPUT_LABEL));
+    await blur(passwordInputElement);
+
+    // then
+    assert.dom(passwordInputElement).hasAttribute('aria-invalid');
+  });
+
+  test('it must contains at least one lowercase char', async function (assert) {
+    // given
+    const invalidPassword = 'PIX12345';
+    const onInput = sinon.stub();
+
+    const screen = await render(<template><PasswordInput {{on "input" onInput}} /></template>);
+
+    // when
+    await fillByLabel(t(I18N.PASSWORD_INPUT_LABEL), invalidPassword);
+    const passwordInputElement = screen.getByLabelText(t(I18N.PASSWORD_INPUT_LABEL));
+    await blur(passwordInputElement);
+
+    // then
+    assert.dom(passwordInputElement).hasAttribute('aria-invalid');
+  });
+
+  test('it must contains at least one number', async function (assert) {
+    // given
+    const invalidPassword = 'PIXpixPIX';
+    const onInput = sinon.stub();
+
+    const screen = await render(<template><PasswordInput {{on "input" onInput}} /></template>);
+
+    // when
+    await fillByLabel(t(I18N.PASSWORD_INPUT_LABEL), invalidPassword);
+    const passwordInputElement = screen.getByLabelText(t(I18N.PASSWORD_INPUT_LABEL));
+    await blur(passwordInputElement);
+
+    // then
+    assert.dom(passwordInputElement).hasAttribute('aria-invalid');
+  });
+});

--- a/mon-pix/tests/integration/components/authentication/password-input/password-checklist-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/password-input/password-checklist-test.gjs
@@ -1,0 +1,85 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import PasswordChecklist from 'mon-pix/components/authentication/password-input/password-checklist';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+const I18N = {
+  RULES_STATUS_MESSAGE: 'components.authentication.password-input.rules.completed-message',
+};
+
+module('Integration | Component | authentication | password-input | password-checklist', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('when a password value is set', function () {
+    module('when there is no validation error', function () {
+      test('it displays rules and indicates that all rules completed', async function (assert) {
+        // given
+        const value = 'my-value';
+        const rules = [
+          { key: 'rule1', description: 'Rule 1' },
+          { key: 'rule2', description: 'Rule 2' },
+        ];
+        const errors = [];
+
+        // when
+        const screen = await render(
+          <template><PasswordChecklist @value={{value}} @rules={{rules}} @errors={{errors}} /></template>,
+        );
+
+        // then
+        const rule1Element = screen.getByRole('listitem', { name: 'Rule 1.' });
+        assert.dom(rule1Element).exists();
+
+        const rule2Element = screen.getByRole('listitem', { name: 'Rule 2.' });
+        assert.dom(rule2Element).exists();
+
+        const rulesStatusMessage = t(I18N.RULES_STATUS_MESSAGE, { rulesCompleted: 2, rulesCount: 2 });
+        assert.dom(screen.getByText(rulesStatusMessage)).exists();
+      });
+    });
+
+    module('when there is a validation error', function () {
+      test('it indicates number of valid rules completed', async function (assert) {
+        // given
+        const value = 'my-value';
+        const rules = [
+          { key: 'rule1', description: 'Rule 1' },
+          { key: 'rule2', description: 'Rule 2' },
+        ];
+        const errors = ['rule1'];
+
+        // when
+        const screen = await render(
+          <template><PasswordChecklist @value={{value}} @rules={{rules}} @errors={{errors}} /></template>,
+        );
+
+        // then
+        const rulesStatusMessage = t(I18N.RULES_STATUS_MESSAGE, { rulesCompleted: 1, rulesCount: 2 });
+        assert.dom(screen.getByText(rulesStatusMessage)).exists();
+      });
+    });
+  });
+
+  module('when no password value is set', function () {
+    test('it indicates no rule is completed', async function (assert) {
+      // given
+      const value = null;
+      const rules = [
+        { key: 'rule1', description: 'Rule 1' },
+        { key: 'rule2', description: 'Rule 2' },
+      ];
+      const errors = [];
+
+      // when
+      const screen = await render(
+        <template><PasswordChecklist @value={{value}} @rules={{rules}} @errors={{errors}} /></template>,
+      );
+
+      // then
+      const rulesStatusMessage = t(I18N.RULES_STATUS_MESSAGE, { rulesCompleted: 0, rulesCount: 2 });
+      assert.dom(screen.getByText(rulesStatusMessage)).exists();
+    });
+  });
+});

--- a/mon-pix/tests/integration/components/authentication/password-input/password-rule-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/password-input/password-rule-test.gjs
@@ -1,0 +1,49 @@
+import { render } from '@1024pix/ember-testing-library';
+import PasswordRule from 'mon-pix/components/authentication/password-input/password-rule';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | authentication | password-input | password-rule', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it renders a valid rule', async function (assert) {
+    // given
+    const description = 'rule description';
+    const isValid = true;
+    const key = 'ruleId';
+
+    // when
+    const screen = await render(
+      <template><PasswordRule @description={{description}} @key={{key}} @isValid={{isValid}} /></template>,
+    );
+
+    // then
+    const listItemElement = screen.getByRole('listitem');
+
+    assert.dom(listItemElement).exists();
+    assert.dom(listItemElement).hasAttribute('aria-label', `${description}.`);
+    assert.dom(listItemElement).hasAttribute('class', 'password-rule');
+    assert.dom(screen.getByText(description)).exists();
+  });
+
+  test('it renders an invalid rule', async function (assert) {
+    // given
+    const description = 'rule description';
+    const isValid = false;
+    const key = 'ruleId';
+
+    // when
+    const screen = await render(
+      <template><PasswordRule @description={{description}} @key={{key}} @isValid={{isValid}} /></template>,
+    );
+
+    // then
+    const listItemElement = screen.getByRole('listitem');
+
+    assert.dom(listItemElement).exists();
+    assert.dom(listItemElement).hasAttribute('aria-label', `${description}.`);
+    assert.dom(listItemElement).hasAttribute('class', 'password-rule password-rule--error');
+    assert.dom(screen.getByText(description)).exists();
+  });
+});

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -124,6 +124,17 @@
         "label": "Search for an organization",
         "placeholder": "Select an organization",
         "searchLabel": "Keyword search"
+      },
+      "password-input": {
+        "error-message": "You have entered the wrong password. Your password must be longer than 8 characters and contain at least one number, one lower case letter and one upper case letter.",
+        "instructions-label": "Your password must comply with the following rules:",
+        "rules": {
+          "completed-message": "{ rulesCompleted } out of { rulesCount } requirements completed.",
+          "contains-digit": "at least one number",
+          "contains-lowercase": "at least one lower case letter",
+          "contains-uppercase": "at least one capital letter",
+          "min-length": "at least 8 characters"
+        }
       }
     },
     "invited": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -117,6 +117,17 @@
         "label": "Search for an organization",
         "placeholder": "Select an organization",
         "searchLabel": "Keyword search"
+      },
+      "password-input": {
+        "error-message": "You have entered the wrong password. Your password must be longer than 8 characters and contain at least one number, one lower case letter and one upper case letter.",
+        "instructions-label": "Your password must comply with the following rules:",
+        "rules": {
+          "completed-message": "{ rulesCompleted } out of { rulesCount } requirements completed.",
+          "contains-digit": "at least one number",
+          "contains-lowercase": "at least one lower case letter",
+          "contains-uppercase": "at least one capital letter",
+          "min-length": "at least 8 characters"
+        }
       }
     },
     "invited": {
@@ -1357,8 +1368,8 @@
           }
         },
         "flashcards": {
-          "start" : "Para empezar",
-          "seeAnswer" : "ver la respuesta",
+          "start": "Para empezar",
+          "seeAnswer": "ver la respuesta",
           "seeAgain": "Revisa la pregunta",
           "nextCard": "Siguiente"
         },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -124,6 +124,17 @@
         "label": "Rechercher une organisation",
         "placeholder": "Sélectionner un organisme",
         "searchLabel": "Recherche par mots-clés"
+      },
+      "password-input": {
+        "error-message": "Le mot de passe saisi est erroné. Votre mot de passe doit être supérieur à 8 caractères et contenir au minimum un chiffre, une minuscule et une majuscule.",
+        "instructions-label": "Votre mot de passe doit respecter les règles suivantes :",
+        "rules": {
+          "completed-message": "{ rulesCompleted } sur { rulesCount } complétées.",
+          "contains-digit": "un chiffre minimum",
+          "contains-lowercase": "une minuscule minimum",
+          "contains-uppercase": "une majuscule minimum",
+          "min-length": "8 caractères minimum"
+        }
       }
     },
     "invited": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -117,6 +117,17 @@
         "label": "Search for an organization",
         "placeholder": "Select an organization",
         "searchLabel": "Keyword search"
+      },
+      "password-input": {
+        "error-message": "You have entered the wrong password. Your password must be longer than 8 characters and contain at least one number, one lower case letter and one upper case letter.",
+        "instructions-label": "Your password must comply with the following rules:",
+        "rules": {
+          "completed-message": "{ rulesCompleted } out of { rulesCount } requirements completed.",
+          "contains-digit": "at least one number",
+          "contains-lowercase": "at least one lower case letter",
+          "contains-uppercase": "at least one capital letter",
+          "min-length": "at least 8 characters"
+        }
       }
     },
     "invited": {
@@ -1358,7 +1369,7 @@
         },
         "flashcards": {
           "start": "Beginnen",
-          "seeAnswer" : "Zie het antwoord",
+          "seeAnswer": "Zie het antwoord",
           "seeAgain": "Bekijk de vraag",
           "nextCard": "Volgende"
         },


### PR DESCRIPTION
## :unicorn: Problème
Le component input avec mot de passe, utilisé sur les pages d'inscription, n'est pas complètement accessible. On s'est aperçu que: 
- la progression n'est pas clairement énoncée lorsque l'utilisateur saisit un mot de passe
- les règles ne sont présentes uniquement dans le label.

## :robot: Proposition
- Ajouter un component PasswordCheckListInput permettant de gérer ces cas en s'inspirant de ce qui a été fait sur le codepen fourni par Tanaguru.

## :rainbow: Remarques
- Le message d'erreur, lors de la sortie d'input, n'est pas vocalisé par le lecteur d'écran. Il manque sans doute un aria-live=polite sur le message d'erreur sur le composant pix-ui [PixInputPassword](https://github.com/1024pix/pix-ui/blob/dev/addon/components/pix-input-password.hbs#L54) (A faire dans un autre ticket).
- Le dernier commit est à retirer lors du merge de la PR !

## :100: Pour tester
### Cas nominal
- Aller sur la page `/connexion`
- Tester chaque règle du composant (saisir un chiffre, une minuscule, une majuscule, 8 caractères)
- Vérifier que le picto correspondant à la règle en question se met bien à jour lors de la saisie dans le champ

### Cas d'erreur
- Enlever des caractères dans votre saisie
- Vérifier que le picto correspondant à la règle en question se met bien à jour 
- Sortir du focus du champ en cliquant par exemple à côté.
- Vérifier que le message d'erreur _Le mot de passe saisi est erroné. Votre mot de passe doit être supérieur à 8 caractères et contenir au minimum un chiffre, une minuscule et une majuscule_. s'affiche bien.

### Accessibilité 
- Ouvrir un logiciel de lecteur d'écran
- Aller sur le nouveau composant Input (par clic ou tabulation)
- Vérifier que les règles sont bien énoncées par le lecteur d'écran
- Saisir un mot de passe correspondant aux règles mentionées
- Vérifier que la progression est vocalisée (_X sur Y règles complétées_)