### PR TITLE
[FEATURE] Récupérer les inscriptions candidats après réconciliation (v3 uniquement) (PIX-14209)

### DIFF
--- a/api/src/certification/enrolment/domain/read-models/CertificationCandidateSubscription.js
+++ b/api/src/certification/enrolment/domain/read-models/CertificationCandidateSubscription.js
@@ -1,8 +1,8 @@
 class CertificationCandidateSubscription {
-  constructor({ id, sessionId, eligibleSubscription, nonEligibleSubscription, sessionVersion }) {
+  constructor({ id, sessionId, eligibleSubscriptions, nonEligibleSubscription, sessionVersion }) {
     this.id = id;
     this.sessionId = sessionId;
-    this.eligibleSubscription = eligibleSubscription;
+    this.eligibleSubscriptions = eligibleSubscriptions;
     this.nonEligibleSubscription = nonEligibleSubscription;
     this.sessionVersion = sessionVersion;
   }

--- a/api/src/certification/enrolment/domain/usecases/get-certification-candidate-subscription.js
+++ b/api/src/certification/enrolment/domain/usecases/get-certification-candidate-subscription.js
@@ -17,7 +17,7 @@ const getCertificationCandidateSubscription = async function ({
     return new CertificationCandidateSubscription({
       id: certificationCandidateId,
       sessionId: certificationCandidate.sessionId,
-      eligibleSubscription: null,
+      eligibleSubscriptions: [],
       nonEligibleSubscription: null,
       sessionVersion: session.version,
     });
@@ -27,10 +27,11 @@ const getCertificationCandidateSubscription = async function ({
     id: session.certificationCenterId,
   });
 
-  let eligibleSubscription = null;
+  let eligibleSubscriptions = [];
   let nonEligibleSubscription = null;
   const certifiableBadgeAcquisitions = await certificationBadgesService.findStillValidBadgeAcquisitions({
     userId: certificationCandidate.userId,
+    limitDate: certificationCandidate.reconciledAt,
   });
 
   if (center.isHabilitated(certificationCandidate.complementaryCertification.key)) {
@@ -40,7 +41,12 @@ const getCertificationCandidateSubscription = async function ({
     );
 
     if (isSubscriptionEligible) {
-      eligibleSubscription = certificationCandidate.complementaryCertification;
+      eligibleSubscriptions = certificationCandidate.subscriptions.map((subscription) => {
+        return {
+          label: subscription.type === 'COMPLEMENTARY' ? certificationCandidate.complementaryCertification.label : null,
+          type: subscription.type,
+        };
+      });
     } else {
       nonEligibleSubscription = certificationCandidate.complementaryCertification;
     }
@@ -49,7 +55,7 @@ const getCertificationCandidateSubscription = async function ({
   return new CertificationCandidateSubscription({
     id: certificationCandidateId,
     sessionId: certificationCandidate.sessionId,
-    eligibleSubscription,
+    eligibleSubscriptions,
     nonEligibleSubscription,
     sessionVersion: session.version,
   });

--- a/api/src/certification/enrolment/infrastructure/serializers/certification-candidate-subscription-serializer.js
+++ b/api/src/certification/enrolment/infrastructure/serializers/certification-candidate-subscription-serializer.js
@@ -4,7 +4,7 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (certificationCandidateSubscription) {
   return new Serializer('certification-candidate-subscription', {
-    attributes: ['sessionId', 'eligibleSubscription', 'nonEligibleSubscription', 'sessionVersion'],
+    attributes: ['sessionId', 'eligibleSubscriptions', 'nonEligibleSubscription', 'sessionVersion'],
   }).serialize(certificationCandidateSubscription);
 };
 

--- a/api/src/shared/domain/models/CertificationCandidate.js
+++ b/api/src/shared/domain/models/CertificationCandidate.js
@@ -1,7 +1,6 @@
 import lodash from 'lodash';
 
-import { Subscription } from '../../../certification/enrolment/domain/models/Subscription.js';
-import { BILLING_MODES, SUBSCRIPTION_TYPES } from '../../../certification/shared/domain/constants.js';
+import { BILLING_MODES } from '../../../certification/shared/domain/constants.js';
 
 const { isNil } = lodash;
 
@@ -65,27 +64,6 @@ class CertificationCandidate {
     this.hasSeenCertificationInstructions = hasSeenCertificationInstructions;
     this.accessibilityAdjustmentNeeded = accessibilityAdjustmentNeeded;
     this.reconciledAt = reconciledAt;
-
-    Object.defineProperty(this, 'complementaryCertification', {
-      enumerable: true,
-      get: function () {
-        return this.#complementaryCertification;
-      },
-
-      set: function (complementaryCertification) {
-        this.#complementaryCertification = complementaryCertification;
-        this.subscriptions = this.subscriptions.filter((subscription) => subscription.type === SUBSCRIPTION_TYPES.CORE);
-        if (complementaryCertification?.id) {
-          this.subscriptions.push(
-            Subscription.buildComplementary({
-              certificationCandidateId: this.id,
-              complementaryCertificationId: complementaryCertification.id,
-            }),
-          );
-        }
-      },
-    });
-
     this.complementaryCertification = complementaryCertification;
   }
 

--- a/api/tests/certification/enrolment/acceptance/application/subscription-route_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/subscription-route_test.js
@@ -4,6 +4,8 @@ import {
   databaseBuilder,
   expect,
   generateValidRequestAuthorizationHeader,
+  learningContentBuilder,
+  mockLearningContent,
 } from '../../../../test-helper.js';
 
 describe('Certification | Enrolment | Acceptance | Application | Routes | subscription', function () {
@@ -11,29 +13,220 @@ describe('Certification | Enrolment | Acceptance | Application | Routes | subscr
     it('should return the certification candidate subscriptions', async function () {
       // given
       const server = await createServer();
+
+      const learningContent = learningContentBuilder.fromAreas([
+        {
+          id: 'recvoGdo7z2z7pXWa',
+          title_i18n: {
+            fr: 'Information et données',
+          },
+          color: 'jaffa',
+          code: '1',
+          competences: [
+            {
+              id: 'recCompetence1',
+              name_i18n: {
+                fr: 'Mener une recherche et une veille d’information',
+              },
+              index: '1.1',
+              origin: 'Pix',
+              areaId: 'recvoGdo7z2z7pXWa',
+              thematics: [
+                {
+                  id: 'recThemCompetence1',
+                  tubes: [
+                    {
+                      id: 'recTubeCompetence1',
+                      skills: [
+                        {
+                          id: 'skillId@web3',
+                          name: '@web3',
+                          status: 'actif',
+                          level: 3,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              id: 'recCompetence2',
+              name_i18n: {
+                fr: 'Gérer les données',
+              },
+              index: '1.2',
+              origin: 'Pix',
+              areaId: 'recvoGdo7z2z7pXWa',
+              thematics: [
+                {
+                  id: 'recThemCompetence2',
+                  tubes: [
+                    {
+                      id: 'recTubeCompetence2',
+                      skills: [
+                        {
+                          id: 'skillId@fichier3',
+                          name: '@fichier3',
+                          status: 'actif',
+                          level: 3,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              id: 'recCompetence3',
+              name_i18n: {
+                fr: 'Traiter les données',
+              },
+              index: '1.3',
+              origin: 'Pix',
+              areaId: 'recvoGdo7z2z7pXWa',
+              thematics: [
+                {
+                  id: 'recThemCompetence3',
+                  tubes: [
+                    {
+                      id: 'recTubeCompetence3',
+                      skills: [
+                        {
+                          id: 'skillId@tri3',
+                          name: '@tri3',
+                          status: 'actif',
+                          level: 3,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'recDH19F7kKrfL3Ii',
+          title_i18n: {
+            fr: 'Communication et collaboration',
+          },
+          color: 'jaffa',
+          code: '1',
+          competences: [
+            {
+              id: 'recCompetence4',
+              name_i18n: {
+                fr: 'Intéragir',
+              },
+              index: '2.1',
+              origin: 'Pix',
+              areaId: 'recDH19F7kKrfL3Ii',
+              thematics: [
+                {
+                  id: 'recThemCompetence4',
+                  tubes: [
+                    {
+                      id: 'recTubeCompetence4',
+                      skills: [
+                        {
+                          id: 'skillId@spam3',
+                          name: '@spam3',
+                          status: 'actif',
+                          level: 3,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              id: 'recCompetence5',
+              name_i18n: {
+                fr: 'Partager et publier',
+              },
+              index: '2.2',
+              origin: 'Pix',
+              areaId: 'recDH19F7kKrfL3Ii',
+              thematics: [
+                {
+                  id: 'recThemCompetence5',
+                  tubes: [
+                    {
+                      id: 'recTubeCompetence5',
+                      skills: [
+                        {
+                          id: 'skillId@vocRS3',
+                          name: '@vocRS3',
+                          status: 'actif',
+                          level: 3,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ]);
+      mockLearningContent(learningContent);
+
       const userId = databaseBuilder.factory.buildUser().id;
+
+      learningContent.skills.forEach(({ id: skillId, competenceId }) => {
+        databaseBuilder.factory.buildKnowledgeElement({ userId, earnedPix: 10, competenceId, skillId });
+      });
+
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      const badgeId = databaseBuilder.factory.buildBadge({ isCertifiable: true, targetProfileId }).id;
+      const campaignId = databaseBuilder.factory.buildCampaign({
+        targetProfileId,
+      }).id;
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        isCertifiable: true,
+        userId,
+      }).id;
+
+      learningContent.skills.forEach(({ id: skillId }) => {
+        databaseBuilder.factory.buildCampaignSkill({
+          campaignId,
+          skillId,
+        });
+      });
+
+      databaseBuilder.factory.buildBadgeCriterion({
+        badgeId,
+        threshold: 75,
+        cappedTubes: JSON.stringify(
+          learningContent.tubes.map(({ id }) => ({
+            id,
+            level: 8,
+          })),
+        ),
+      });
+
       const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
       const cleaComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
         key: ComplementaryCertificationKeys.CLEA,
         label: 'CléA Numérique',
       });
-      const pixPlusDroitComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
-        key: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
-        label: 'Pix+ Droit',
-      });
+
       databaseBuilder.factory.buildComplementaryCertificationHabilitation({
         certificationCenterId: certificationCenter.id,
         complementaryCertificationId: cleaComplementaryCertification.id,
       });
-      databaseBuilder.factory.buildComplementaryCertificationHabilitation({
-        certificationCenterId: certificationCenter.id,
-        complementaryCertificationId: pixPlusDroitComplementaryCertification.id,
-      });
+
       const session = databaseBuilder.factory.buildSession({
         certificationCenterId: certificationCenter.id,
       });
+
       const candidate = databaseBuilder.factory.buildCertificationCandidate({
         sessionId: session.id,
+        userId,
+        reconciledAt: new Date('2021-01-01'),
       });
 
       databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidate.id });
@@ -42,6 +235,19 @@ describe('Certification | Enrolment | Acceptance | Application | Routes | subscr
         certificationCandidateId: candidate.id,
         complementaryCertificationId: cleaComplementaryCertification.id,
       });
+
+      databaseBuilder.factory.buildComplementaryCertificationBadge({
+        badgeId,
+        complementaryCertificationId: cleaComplementaryCertification.id,
+      });
+
+      databaseBuilder.factory.buildBadgeAcquisition({
+        userId,
+        badgeId,
+        campaignParticipationId,
+        createdAt: new Date('2020-01-01'),
+      });
+
       await databaseBuilder.commit();
 
       const options = {
@@ -61,12 +267,17 @@ describe('Certification | Enrolment | Acceptance | Application | Routes | subscr
         attributes: {
           'session-id': session.id,
           'session-version': session.version,
-          'eligible-subscription': null,
-          'non-eligible-subscription': {
-            id: cleaComplementaryCertification.id,
-            label: 'CléA Numérique',
-            key: ComplementaryCertificationKeys.CLEA,
-          },
+          'eligible-subscriptions': [
+            {
+              label: null,
+              type: 'CORE',
+            },
+            {
+              label: 'CléA Numérique',
+              type: 'COMPLEMENTARY',
+            },
+          ],
+          'non-eligible-subscription': null,
         },
       });
     });

--- a/api/tests/certification/enrolment/acceptance/application/subscription-route_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/subscription-route_test.js
@@ -14,163 +14,7 @@ describe('Certification | Enrolment | Acceptance | Application | Routes | subscr
       // given
       const server = await createServer();
 
-      const learningContent = learningContentBuilder.fromAreas([
-        {
-          id: 'recvoGdo7z2z7pXWa',
-          title_i18n: {
-            fr: 'Information et données',
-          },
-          color: 'jaffa',
-          code: '1',
-          competences: [
-            {
-              id: 'recCompetence1',
-              name_i18n: {
-                fr: 'Mener une recherche et une veille d’information',
-              },
-              index: '1.1',
-              origin: 'Pix',
-              areaId: 'recvoGdo7z2z7pXWa',
-              thematics: [
-                {
-                  id: 'recThemCompetence1',
-                  tubes: [
-                    {
-                      id: 'recTubeCompetence1',
-                      skills: [
-                        {
-                          id: 'skillId@web3',
-                          name: '@web3',
-                          status: 'actif',
-                          level: 3,
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-            {
-              id: 'recCompetence2',
-              name_i18n: {
-                fr: 'Gérer les données',
-              },
-              index: '1.2',
-              origin: 'Pix',
-              areaId: 'recvoGdo7z2z7pXWa',
-              thematics: [
-                {
-                  id: 'recThemCompetence2',
-                  tubes: [
-                    {
-                      id: 'recTubeCompetence2',
-                      skills: [
-                        {
-                          id: 'skillId@fichier3',
-                          name: '@fichier3',
-                          status: 'actif',
-                          level: 3,
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-            {
-              id: 'recCompetence3',
-              name_i18n: {
-                fr: 'Traiter les données',
-              },
-              index: '1.3',
-              origin: 'Pix',
-              areaId: 'recvoGdo7z2z7pXWa',
-              thematics: [
-                {
-                  id: 'recThemCompetence3',
-                  tubes: [
-                    {
-                      id: 'recTubeCompetence3',
-                      skills: [
-                        {
-                          id: 'skillId@tri3',
-                          name: '@tri3',
-                          status: 'actif',
-                          level: 3,
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-        {
-          id: 'recDH19F7kKrfL3Ii',
-          title_i18n: {
-            fr: 'Communication et collaboration',
-          },
-          color: 'jaffa',
-          code: '1',
-          competences: [
-            {
-              id: 'recCompetence4',
-              name_i18n: {
-                fr: 'Intéragir',
-              },
-              index: '2.1',
-              origin: 'Pix',
-              areaId: 'recDH19F7kKrfL3Ii',
-              thematics: [
-                {
-                  id: 'recThemCompetence4',
-                  tubes: [
-                    {
-                      id: 'recTubeCompetence4',
-                      skills: [
-                        {
-                          id: 'skillId@spam3',
-                          name: '@spam3',
-                          status: 'actif',
-                          level: 3,
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-            {
-              id: 'recCompetence5',
-              name_i18n: {
-                fr: 'Partager et publier',
-              },
-              index: '2.2',
-              origin: 'Pix',
-              areaId: 'recDH19F7kKrfL3Ii',
-              thematics: [
-                {
-                  id: 'recThemCompetence5',
-                  tubes: [
-                    {
-                      id: 'recTubeCompetence5',
-                      skills: [
-                        {
-                          id: 'skillId@vocRS3',
-                          name: '@vocRS3',
-                          status: 'actif',
-                          level: 3,
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      ]);
+      const learningContent = _buildLearningContent();
       mockLearningContent(learningContent);
 
       const userId = databaseBuilder.factory.buildUser().id;
@@ -283,3 +127,163 @@ describe('Certification | Enrolment | Acceptance | Application | Routes | subscr
     });
   });
 });
+
+function _buildLearningContent() {
+  return learningContentBuilder.fromAreas([
+    {
+      id: 'recvoGdo7z2z7pXWa',
+      title_i18n: {
+        fr: 'Information et données',
+      },
+      color: 'jaffa',
+      code: '1',
+      competences: [
+        {
+          id: 'recCompetence1',
+          name_i18n: {
+            fr: 'Mener une recherche et une veille d’information',
+          },
+          index: '1.1',
+          origin: 'Pix',
+          areaId: 'recvoGdo7z2z7pXWa',
+          thematics: [
+            {
+              id: 'recThemCompetence1',
+              tubes: [
+                {
+                  id: 'recTubeCompetence1',
+                  skills: [
+                    {
+                      id: 'skillId@web3',
+                      name: '@web3',
+                      status: 'actif',
+                      level: 3,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'recCompetence2',
+          name_i18n: {
+            fr: 'Gérer les données',
+          },
+          index: '1.2',
+          origin: 'Pix',
+          areaId: 'recvoGdo7z2z7pXWa',
+          thematics: [
+            {
+              id: 'recThemCompetence2',
+              tubes: [
+                {
+                  id: 'recTubeCompetence2',
+                  skills: [
+                    {
+                      id: 'skillId@fichier3',
+                      name: '@fichier3',
+                      status: 'actif',
+                      level: 3,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'recCompetence3',
+          name_i18n: {
+            fr: 'Traiter les données',
+          },
+          index: '1.3',
+          origin: 'Pix',
+          areaId: 'recvoGdo7z2z7pXWa',
+          thematics: [
+            {
+              id: 'recThemCompetence3',
+              tubes: [
+                {
+                  id: 'recTubeCompetence3',
+                  skills: [
+                    {
+                      id: 'skillId@tri3',
+                      name: '@tri3',
+                      status: 'actif',
+                      level: 3,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'recDH19F7kKrfL3Ii',
+      title_i18n: {
+        fr: 'Communication et collaboration',
+      },
+      color: 'jaffa',
+      code: '1',
+      competences: [
+        {
+          id: 'recCompetence4',
+          name_i18n: {
+            fr: 'Intéragir',
+          },
+          index: '2.1',
+          origin: 'Pix',
+          areaId: 'recDH19F7kKrfL3Ii',
+          thematics: [
+            {
+              id: 'recThemCompetence4',
+              tubes: [
+                {
+                  id: 'recTubeCompetence4',
+                  skills: [
+                    {
+                      id: 'skillId@spam3',
+                      name: '@spam3',
+                      status: 'actif',
+                      level: 3,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'recCompetence5',
+          name_i18n: {
+            fr: 'Partager et publier',
+          },
+          index: '2.2',
+          origin: 'Pix',
+          areaId: 'recDH19F7kKrfL3Ii',
+          thematics: [
+            {
+              id: 'recThemCompetence5',
+              tubes: [
+                {
+                  id: 'recTubeCompetence5',
+                  skills: [
+                    {
+                      id: 'skillId@vocRS3',
+                      name: '@vocRS3',
+                      status: 'actif',
+                      level: 3,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ]);
+}

--- a/api/tests/certification/enrolment/unit/domain/usecases/get-certification-candidate-subscription_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/get-certification-candidate-subscription_test.js
@@ -28,6 +28,7 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-certificatio
       userId,
       sessionId,
       subscriptions: [domainBuilder.buildCoreSubscription()],
+      reconciledAt: new Date('2024-10-09'),
     };
 
     sessionRepository = {
@@ -90,7 +91,7 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-certificatio
           domainBuilder.buildCertificationCandidateSubscription({
             id: certificationCandidateId,
             sessionId,
-            eligibleSubscription: null,
+            eligibleSubscriptions: [],
             nonEligibleSubscription: null,
             sessionVersion: 2,
           }),
@@ -128,6 +129,7 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-certificatio
         const candidateWithoutComplementaryCertification = domainBuilder.buildCertificationCandidate({
           ...certificationCandidateData,
           complementaryCertification: null,
+          subscriptions: [],
         });
         certificationCandidateRepository.getWithComplementaryCertification
           .withArgs({ id: certificationCandidateId })
@@ -143,7 +145,7 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-certificatio
         centerRepository.getById.withArgs({ id: 777 }).resolves(center);
 
         certificationBadgesService.findStillValidBadgeAcquisitions
-          .withArgs({ userId })
+          .withArgs({ userId, limitDate: certificationCandidateData.reconciledAt })
           .resolves([certifiableBadgeAcquisition]);
 
         // when
@@ -160,8 +162,167 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-certificatio
           domainBuilder.buildCertificationCandidateSubscription({
             id: certificationCandidateId,
             sessionId,
-            eligibleSubscription: null,
+            eligibleSubscriptions: [],
             nonEligibleSubscription: null,
+            sessionVersion: 2,
+          }),
+        );
+      });
+    });
+
+    context('when the candidate is registered and eligible to one complementary certification', function () {
+      it('should return the candidate with one complementary certification', async function () {
+        // given
+        const certificationCandidateId = 123;
+        const userId = 456;
+        const sessionId = 789;
+
+        const complementaryCertification = domainBuilder.buildComplementaryCertification({ key: 'PIX+' });
+
+        const center = domainBuilder.certification.enrolment.buildCenter({
+          habilitations: [
+            domainBuilder.certification.enrolment.buildHabilitation({
+              key: 'PIX+',
+            }),
+          ],
+        });
+
+        const certifiableBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
+          badge: domainBuilder.buildBadge({
+            key: 'PIX+_BADGE',
+            isCertifiable: true,
+          }),
+          complementaryCertificationKey: complementaryCertification.key,
+          complementaryCertification,
+        });
+
+        const candidateWithoutComplementaryCertification = domainBuilder.buildCertificationCandidate({
+          ...certificationCandidateData,
+          complementaryCertification,
+          subscriptions: [
+            domainBuilder.certification.enrolment.buildComplementarySubscription({
+              certificationCandidateId,
+              complementaryCertificationId: complementaryCertification.id,
+            }),
+          ],
+        });
+        certificationCandidateRepository.getWithComplementaryCertification
+          .withArgs({ id: certificationCandidateId })
+          .resolves(candidateWithoutComplementaryCertification);
+
+        sessionRepository.get.withArgs({ id: sessionId }).resolves(
+          domainBuilder.certification.enrolment.buildSession({
+            certificationCenterId: 777,
+            version: 2,
+          }),
+        );
+
+        centerRepository.getById.withArgs({ id: 777 }).resolves(center);
+
+        certificationBadgesService.findStillValidBadgeAcquisitions
+          .withArgs({ userId, limitDate: certificationCandidateData.reconciledAt })
+          .resolves([certifiableBadgeAcquisition]);
+
+        // when
+        const certificationCandidateSubscription = await getCertificationCandidateSubscription({
+          certificationCandidateId,
+          certificationBadgesService,
+          certificationCandidateRepository,
+          centerRepository,
+          sessionRepository,
+        });
+
+        // then
+        expect(certificationCandidateSubscription).to.deep.equal(
+          domainBuilder.buildCertificationCandidateSubscription({
+            id: certificationCandidateId,
+            sessionId,
+            eligibleSubscriptions: [
+              {
+                label: 'Complementary certification name',
+                type: 'COMPLEMENTARY',
+              },
+            ],
+            nonEligibleSubscription: null,
+            sessionVersion: 2,
+          }),
+        );
+      });
+    });
+
+    context('when the candidate is registered and not eligible to any complementary certification', function () {
+      it('should return the candidate without any complementary certification', async function () {
+        // given
+        const certificationCandidateId = 123;
+        const userId = 456;
+        const sessionId = 789;
+
+        const complementaryCertification = domainBuilder.buildComplementaryCertification({ key: 'PIX+' });
+
+        const center = domainBuilder.certification.enrolment.buildCenter({
+          habilitations: [
+            domainBuilder.certification.enrolment.buildHabilitation({
+              key: 'PIX+',
+            }),
+          ],
+        });
+
+        const certifiableBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
+          badge: domainBuilder.buildBadge({
+            key: 'PIX+_BADGE',
+            isCertifiable: true,
+          }),
+          complementaryCertificationKey: 'OTHER PIX+ KEY',
+          complementaryCertification,
+        });
+
+        const candidateWithoutComplementaryCertification = domainBuilder.buildCertificationCandidate({
+          ...certificationCandidateData,
+          complementaryCertification,
+          subscriptions: [
+            domainBuilder.certification.enrolment.buildComplementarySubscription({
+              certificationCandidateId,
+              complementaryCertificationId: complementaryCertification.id,
+            }),
+          ],
+        });
+        certificationCandidateRepository.getWithComplementaryCertification
+          .withArgs({ id: certificationCandidateId })
+          .resolves(candidateWithoutComplementaryCertification);
+
+        sessionRepository.get.withArgs({ id: sessionId }).resolves(
+          domainBuilder.certification.enrolment.buildSession({
+            certificationCenterId: 777,
+            version: 2,
+          }),
+        );
+
+        centerRepository.getById.withArgs({ id: 777 }).resolves(center);
+
+        certificationBadgesService.findStillValidBadgeAcquisitions
+          .withArgs({ userId, limitDate: certificationCandidateData.reconciledAt })
+          .resolves([certifiableBadgeAcquisition]);
+
+        // when
+        const certificationCandidateSubscription = await getCertificationCandidateSubscription({
+          certificationCandidateId,
+          certificationBadgesService,
+          certificationCandidateRepository,
+          centerRepository,
+          sessionRepository,
+        });
+
+        // then
+        expect(certificationCandidateSubscription).to.deep.equal(
+          domainBuilder.buildCertificationCandidateSubscription({
+            id: certificationCandidateId,
+            sessionId,
+            eligibleSubscriptions: [],
+            nonEligibleSubscription: {
+              id: 1,
+              key: 'PIX+',
+              label: 'Complementary certification name',
+            },
             sessionVersion: 2,
           }),
         );

--- a/api/tests/certification/enrolment/unit/domain/usecases/get-certification-candidate-subscription_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/get-certification-candidate-subscription_test.js
@@ -104,10 +104,6 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-certificatio
     context('when the candidate is not registered but eligible to one complementary certification', function () {
       it('should return the candidate without any complementary certification', async function () {
         // given
-        const certificationCandidateId = 123;
-        const userId = 456;
-        const sessionId = 789;
-
         const complementaryCertification = domainBuilder.buildComplementaryCertification({ key: 'PIX+' });
 
         const center = domainBuilder.certification.enrolment.buildCenter({
@@ -173,10 +169,6 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-certificatio
     context('when the candidate is registered and eligible to one complementary certification', function () {
       it('should return the candidate with one complementary certification', async function () {
         // given
-        const certificationCandidateId = 123;
-        const userId = 456;
-        const sessionId = 789;
-
         const complementaryCertification = domainBuilder.buildComplementaryCertification({ key: 'PIX+' });
 
         const center = domainBuilder.certification.enrolment.buildCenter({
@@ -253,10 +245,6 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-certificatio
     context('when the candidate is registered and not eligible to any complementary certification', function () {
       it('should return the candidate without any complementary certification', async function () {
         // given
-        const certificationCandidateId = 123;
-        const userId = 456;
-        const sessionId = 789;
-
         const complementaryCertification = domainBuilder.buildComplementaryCertification({ key: 'PIX+' });
 
         const center = domainBuilder.certification.enrolment.buildCenter({

--- a/api/tests/certification/enrolment/unit/infrastructure/serializers/certification-candidate-subscription-serializer_test.js
+++ b/api/tests/certification/enrolment/unit/infrastructure/serializers/certification-candidate-subscription-serializer_test.js
@@ -7,12 +7,8 @@ describe('Certification | Enrolment | Unit | Serializer | certification-candidat
       const certificationCandidateSubscription = domainBuilder.buildCertificationCandidateSubscription({
         id: 123,
         sessionId: 456,
-        eligibleSubscription: domainBuilder.buildComplementaryCertification({
-          key: 'FIRST_COMPLEMENTARY',
-          label: 'First Complementary Certification',
-        }),
+        eligibleSubscriptions: [{ type: 'COMPLEMENTARY', label: 'First Complementary Certification' }],
         sessionVersion: 2,
-
         nonEligibleSubscription: domainBuilder.buildComplementaryCertification({
           key: 'SECOND_COMPLEMENTARY',
           label: 'Second Complementary Certification',
@@ -24,11 +20,12 @@ describe('Certification | Enrolment | Unit | Serializer | certification-candidat
           id: '123',
           type: 'certification-candidate-subscriptions',
           attributes: {
-            'eligible-subscription': {
-              id: 1,
-              key: 'FIRST_COMPLEMENTARY',
-              label: 'First Complementary Certification',
-            },
+            'eligible-subscriptions': [
+              {
+                type: 'COMPLEMENTARY',
+                label: 'First Complementary Certification',
+              },
+            ],
             'non-eligible-subscription': {
               id: 1,
               key: 'SECOND_COMPLEMENTARY',

--- a/api/tests/tooling/domain-builder/factory/build-certification-candidate-subscription.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-candidate-subscription.js
@@ -3,14 +3,14 @@ import { CertificationCandidateSubscription } from '../../../../src/certificatio
 const buildCertificationCandidateSubscription = function ({
   id = 1234,
   sessionId = 1234,
-  eligibleSubscription = null,
+  eligibleSubscriptions = [],
   nonEligibleSubscription = null,
   sessionVersion = 2,
 } = {}) {
   return new CertificationCandidateSubscription({
     id,
     sessionId,
-    eligibleSubscription,
+    eligibleSubscriptions,
     nonEligibleSubscription,
     sessionVersion,
   });

--- a/api/tests/unit/domain/models/CertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidate_test.js
@@ -71,10 +71,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         expectedData = {
           ...expectedData,
           complementaryCertification: { id: 99 },
-          subscriptions: [
-            coreSubscription,
-            domainBuilder.buildComplementarySubscription({ complementaryCertificationId: 99 }),
-          ],
+          subscriptions: [coreSubscription],
         };
 
         // when

--- a/mon-pix/app/components/certification-starter.hbs
+++ b/mon-pix/app/components/certification-starter.hbs
@@ -16,7 +16,7 @@
                   @icon="circle-check"
                   class="certification-starter-subscriptions-container-items__eligible-icon"
                 />
-                {{get @certificationCandidateSubscription.eligibleSubscriptions "0.label"}}
+                {{this.complementarySubscriptionLabel}}
               </span>
             {{else}}
               <span class="certification-starter-subscriptions-container-items__non-eligible-item">

--- a/mon-pix/app/components/certification-starter.hbs
+++ b/mon-pix/app/components/certification-starter.hbs
@@ -6,7 +6,7 @@
       <div class="certification-starter-subscriptions">
         <div class="certification-starter-subscriptions-container">
           <p class="certification-starter-subscriptions-container-title">
-            {{t "pages.certification-start.subscription"}}
+            {{this.subscriptionTitle}}
           </p>
           <div class="certification-starter-subscriptions-container-items">
 

--- a/mon-pix/app/components/certification-starter.hbs
+++ b/mon-pix/app/components/certification-starter.hbs
@@ -8,10 +8,11 @@
           {{t "pages.certification-start.subscription"}}
         </p>
         <div class="certification-starter-subscriptions-container-items">
-          {{#if @certificationCandidateSubscription.eligibleSubscription}}
+
+          {{#if (gt @certificationCandidateSubscription.eligibleSubscriptions.length 0)}}
             <span class="certification-starter-subscriptions-container-items__eligible-item">
               <FaIcon @icon="circle-check" class="certification-starter-subscriptions-container-items__eligible-icon" />
-              {{@certificationCandidateSubscription.eligibleSubscription.label}}
+              {{get @certificationCandidateSubscription.eligibleSubscriptions "0.label"}}
             </span>
           {{else}}
             <span class="certification-starter-subscriptions-container-items__non-eligible-item">

--- a/mon-pix/app/components/certification-starter.hbs
+++ b/mon-pix/app/components/certification-starter.hbs
@@ -2,41 +2,46 @@
   <h2 class="certification-start-page__title">{{t "pages.certification-start.first-title"}}</h2>
 
   {{#if @certificationCandidateSubscription.hasSubscription}}
-    <div class="certification-starter-subscriptions">
-      <div class="certification-starter-subscriptions-container">
-        <p class="certification-starter-subscriptions-container-title">
-          {{t "pages.certification-start.subscription"}}
-        </p>
-        <div class="certification-starter-subscriptions-container-items">
+    {{#unless @certificationCandidateSubscription.isV3CoreOnly}}
+      <div class="certification-starter-subscriptions">
+        <div class="certification-starter-subscriptions-container">
+          <p class="certification-starter-subscriptions-container-title">
+            {{t "pages.certification-start.subscription"}}
+          </p>
+          <div class="certification-starter-subscriptions-container-items">
 
-          {{#if (gt @certificationCandidateSubscription.eligibleSubscriptions.length 0)}}
-            <span class="certification-starter-subscriptions-container-items__eligible-item">
-              <FaIcon @icon="circle-check" class="certification-starter-subscriptions-container-items__eligible-icon" />
-              {{get @certificationCandidateSubscription.eligibleSubscriptions "0.label"}}
-            </span>
-          {{else}}
-            <span class="certification-starter-subscriptions-container-items__non-eligible-item">
-              <FaIcon
-                @icon="circle-check"
-                class="certification-starter-subscriptions-container-items__non-eligible-icon"
-              />
-              {{@certificationCandidateSubscription.nonEligibleSubscription.label}}
-            </span>
-          {{/if}}
+            {{#if (gt @certificationCandidateSubscription.eligibleSubscriptions.length 0)}}
+              <span class="certification-starter-subscriptions-container-items__eligible-item">
+                <FaIcon
+                  @icon="circle-check"
+                  class="certification-starter-subscriptions-container-items__eligible-icon"
+                />
+                {{get @certificationCandidateSubscription.eligibleSubscriptions "0.label"}}
+              </span>
+            {{else}}
+              <span class="certification-starter-subscriptions-container-items__non-eligible-item">
+                <FaIcon
+                  @icon="circle-check"
+                  class="certification-starter-subscriptions-container-items__non-eligible-icon"
+                />
+                {{@certificationCandidateSubscription.nonEligibleSubscription.label}}
+              </span>
+            {{/if}}
+          </div>
         </div>
+        {{#if @certificationCandidateSubscription.nonEligibleSubscription}}
+          <div class="certification-starter-subscriptions-container__non-eligible">
+            <FaIcon @icon="circle-exclamation" class="certification-starter-subscriptions-container__info-icon" />
+            <span>
+              {{t
+                "pages.certification-start.non-eligible-subscription"
+                nonEligibleSubscriptionLabel=@certificationCandidateSubscription.nonEligibleSubscription.label
+              }}
+            </span>
+          </div>
+        {{/if}}
       </div>
-      {{#if @certificationCandidateSubscription.nonEligibleSubscription}}
-        <div class="certification-starter-subscriptions-container__non-eligible">
-          <FaIcon @icon="circle-exclamation" class="certification-starter-subscriptions-container__info-icon" />
-          <span>
-            {{t
-              "pages.certification-start.non-eligible-subscription"
-              nonEligibleSubscriptionLabel=@certificationCandidateSubscription.nonEligibleSubscription.label
-            }}
-          </span>
-        </div>
-      {{/if}}
-    </div>
+    {{/unless}}
   {{/if}}
   <label for="certificationStarterSessionCode" class="certification-start-page__order">
     {{t "pages.certification-start.access-code"}}

--- a/mon-pix/app/components/certification-starter.js
+++ b/mon-pix/app/components/certification-starter.js
@@ -28,14 +28,12 @@ export default class CertificationStarter extends Component {
   }
 
   get subscriptionTitle() {
-    if (
-      !this.args.certificationCandidateSubscription.isSessionVersion3 ||
-      this.args.certificationCandidateSubscription.isV3CoreAndComplementary
-    ) {
-      return this.intl.t('pages.certification-start.core-and-complementary-subscriptions');
-    } else {
-      return this.intl.t('pages.certification-start.complementary-subscription');
-    }
+    const { isSessionVersion3, isV3CoreAndComplementary } = this.args.certificationCandidateSubscription;
+
+    const complementaryAlone = isSessionVersion3 && !isV3CoreAndComplementary;
+    const intlSuffix = complementaryAlone ? 'complementary-subscription' : 'core-and-complementary-subscriptions';
+
+    return this.intl.t(`pages.certification-start.${intlSuffix}`);
   }
 
   @action

--- a/mon-pix/app/components/certification-starter.js
+++ b/mon-pix/app/components/certification-starter.js
@@ -21,6 +21,12 @@ export default class CertificationStarter extends Component {
     return this.inputAccessCode.toUpperCase();
   }
 
+  get complementarySubscriptionLabel() {
+    return this.args.certificationCandidateSubscription.eligibleSubscriptions.find(
+      (subscription) => subscription.type === 'COMPLEMENTARY',
+    ).label;
+  }
+
   @action
   async submit(e) {
     e.preventDefault();

--- a/mon-pix/app/components/certification-starter.js
+++ b/mon-pix/app/components/certification-starter.js
@@ -27,6 +27,17 @@ export default class CertificationStarter extends Component {
     ).label;
   }
 
+  get subscriptionTitle() {
+    if (
+      !this.args.certificationCandidateSubscription.isSessionVersion3 ||
+      this.args.certificationCandidateSubscription.isV3CoreAndComplementary
+    ) {
+      return this.intl.t('pages.certification-start.core-and-complementary-subscriptions');
+    } else {
+      return this.intl.t('pages.certification-start.complementary-subscription');
+    }
+  }
+
   @action
   async submit(e) {
     e.preventDefault();

--- a/mon-pix/app/models/certification-candidate-subscription.js
+++ b/mon-pix/app/models/certification-candidate-subscription.js
@@ -23,7 +23,6 @@ export default class CertificationCandidateSubscription extends Model {
   get isV3CoreAndComplementary() {
     return (
       this.isSessionVersion3 &&
-      this.eligibleSubscriptions.length === 2 &&
       this.eligibleSubscriptions.some((eligibleSubscription) => eligibleSubscription.type === 'CORE') &&
       this.eligibleSubscriptions.some((eligibleSubscription) => eligibleSubscription.type === 'COMPLEMENTARY')
     );

--- a/mon-pix/app/models/certification-candidate-subscription.js
+++ b/mon-pix/app/models/certification-candidate-subscription.js
@@ -10,6 +10,16 @@ export default class CertificationCandidateSubscription extends Model {
     return this.eligibleSubscriptions?.length || this.nonEligibleSubscription;
   }
 
+  get hasV3Subscription() {
+    return this.isSessionVersion3 && this.eligibleSubscriptions?.length;
+  }
+
+  get isV3CoreOnly() {
+    return (
+      this.isSessionVersion3 && this.eligibleSubscriptions.length === 1 && this.eligibleSubscriptions[0].type === 'CORE'
+    );
+  }
+
   get isSessionVersion3() {
     return this.sessionVersion === 3;
   }

--- a/mon-pix/app/models/certification-candidate-subscription.js
+++ b/mon-pix/app/models/certification-candidate-subscription.js
@@ -20,6 +20,15 @@ export default class CertificationCandidateSubscription extends Model {
     );
   }
 
+  get isV3CoreAndComplementary() {
+    return (
+      this.isSessionVersion3 &&
+      this.eligibleSubscriptions.length === 2 &&
+      this.eligibleSubscriptions.some((eligibleSubscription) => eligibleSubscription.type === 'CORE') &&
+      this.eligibleSubscriptions.some((eligibleSubscription) => eligibleSubscription.type === 'COMPLEMENTARY')
+    );
+  }
+
   get isSessionVersion3() {
     return this.sessionVersion === 3;
   }

--- a/mon-pix/app/models/certification-candidate-subscription.js
+++ b/mon-pix/app/models/certification-candidate-subscription.js
@@ -2,12 +2,12 @@ import Model, { attr } from '@ember-data/model';
 
 export default class CertificationCandidateSubscription extends Model {
   @attr sessionId;
-  @attr eligibleSubscription;
+  @attr eligibleSubscriptions;
   @attr nonEligibleSubscription;
   @attr sessionVersion;
 
   get hasSubscription() {
-    return this.eligibleSubscription || this.nonEligibleSubscription;
+    return this.eligibleSubscriptions?.length || this.nonEligibleSubscription;
   }
 
   get isSessionVersion3() {

--- a/mon-pix/tests/acceptance/authenticated/certifications/information-test.js
+++ b/mon-pix/tests/acceptance/authenticated/certifications/information-test.js
@@ -26,7 +26,7 @@ module('Acceptance | Certifications | Information', function (hooks) {
       server.create('certification-candidate-subscription', {
         id: 2,
         sessionId: 123,
-        eligibleSubscription: null,
+        eligibleSubscriptions: null,
         nonEligibleSubscription: null,
         sessionVersion: 3,
       });
@@ -61,7 +61,7 @@ module('Acceptance | Certifications | Information', function (hooks) {
         server.create('certification-candidate-subscription', {
           id: 2,
           sessionId: 123,
-          eligibleSubscription: null,
+          eligibleSubscriptions: null,
           nonEligibleSubscription: null,
           sessionVersion: 3,
         });
@@ -102,7 +102,7 @@ module('Acceptance | Certifications | Information', function (hooks) {
         server.create('certification-candidate-subscription', {
           id: 2,
           sessionId: 123,
-          eligibleSubscription: null,
+          eligibleSubscriptions: null,
           nonEligibleSubscription: null,
           sessionVersion: 3,
         });

--- a/mon-pix/tests/acceptance/certification-course-test.js
+++ b/mon-pix/tests/acceptance/certification-course-test.js
@@ -211,7 +211,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
             this.server.create('certification-candidate-subscription', {
               id: 1,
               sessionId: 1,
-              eligibleSubscription: null,
+              eligibleSubscriptions: null,
               nonEligibleSubscription: null,
             });
 
@@ -238,7 +238,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
             this.server.create('certification-candidate-subscription', {
               id: 2,
               sessionId: 1,
-              eligibleSubscription: null,
+              eligibleSubscriptions: null,
               nonEligibleSubscription: null,
             });
 
@@ -279,7 +279,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
             this.server.create('certification-candidate-subscription', {
               id: 2,
               sessionId: 1,
-              eligibleSubscription: null,
+              eligibleSubscriptions: null,
               nonEligibleSubscription: null,
             });
           });
@@ -402,7 +402,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
         this.server.create('certification-candidate-subscription', {
           id: 2,
           sessionId: 1,
-          eligibleSubscription: null,
+          eligibleSubscriptions: null,
           nonEligibleSubscription: null,
         });
 
@@ -477,7 +477,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
             server.create('certification-candidate-subscription', {
               id: 2,
               sessionId: 1,
-              eligibleSubscription: null,
+              eligibleSubscriptions: null,
               nonEligibleSubscription: null,
             });
 
@@ -556,7 +556,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
           this.server.create('certification-candidate-subscription', {
             id: 2,
             sessionId: 1,
-            eligibleSubscription: null,
+            eligibleSubscriptions: null,
             nonEligibleSubscription: null,
           });
 
@@ -607,7 +607,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
           this.server.create('certification-candidate-subscription', {
             id: 2,
             sessionId: 1,
-            eligibleSubscription: null,
+            eligibleSubscriptions: null,
             nonEligibleSubscription: null,
           });
 
@@ -653,7 +653,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
             this.server.create('certification-candidate-subscription', {
               id: 2,
               sessionId: 1,
-              eligibleSubscription: null,
+              eligibleSubscriptions: null,
               nonEligibleSubscription: null,
             });
 
@@ -709,7 +709,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
             this.server.create('certification-candidate-subscription', {
               id: 2,
               sessionId: 1,
-              eligibleSubscription: null,
+              eligibleSubscriptions: null,
               nonEligibleSubscription: null,
             });
 

--- a/mon-pix/tests/integration/components/certification-starter-test.js
+++ b/mon-pix/tests/integration/components/certification-starter-test.js
@@ -40,6 +40,35 @@ module('Integration | Component | certification-starter', function (hooks) {
     });
   });
 
+  module('when the session is v3', function () {
+    module('when the candidate has only core subscription', function () {
+      test('should not display subscription eligible panel', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        this.set(
+          'certificationCandidateSubscription',
+          store.createRecord('certification-candidate-subscription', {
+            eligibleSubscriptions: [{ label: null, type: 'CORE' }],
+            nonEligibleSubscription: null,
+            sessionVersion: 3,
+          }),
+        );
+
+        // when
+        const screen = await render(
+          hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}} />`,
+        );
+
+        // then
+        assert.notOk(screen.queryByText('Vous n’êtes pas éligible à'));
+        assert.notOk(
+          screen.queryByText(
+            'Vous êtes inscrit à la certification complémentaire suivante en plus de la certification Pix :',
+          ),
+        );
+      });
+    });
+  });
   module('when the candidate has complementary certification subscription', function () {
     module('when the candidate is eligible', function () {
       test('should display subscription eligible panel', async function (assert) {

--- a/mon-pix/tests/integration/components/certification-starter-test.js
+++ b/mon-pix/tests/integration/components/certification-starter-test.js
@@ -19,11 +19,11 @@ module('Integration | Component | certification-starter', function (hooks) {
       this.set(
         'certificationCandidateSubscription',
         store.createRecord('certification-candidate-subscription', {
-          eligibleSubscription: null,
+          eligibleSubscriptions: null,
           nonEligibleSubscription: null,
         }),
       );
-      this.set('certificationCandidateSubscription', { eligibleSubscription: null, nonEligibleSubscription: null });
+      this.set('certificationCandidateSubscription', { eligibleSubscriptions: null, nonEligibleSubscription: null });
 
       // when
       const screen = await render(
@@ -48,7 +48,7 @@ module('Integration | Component | certification-starter', function (hooks) {
         this.set(
           'certificationCandidateSubscription',
           store.createRecord('certification-candidate-subscription', {
-            eligibleSubscription: { label: 'Certif complémentaire 1' },
+            eligibleSubscriptions: [{ label: 'Certif complémentaire 1' }],
             nonEligibleSubscription: null,
           }),
         );
@@ -73,7 +73,7 @@ module('Integration | Component | certification-starter', function (hooks) {
         this.set(
           'certificationCandidateSubscription',
           store.createRecord('certification-candidate-subscription', {
-            eligibleSubscription: { label: 'Certif complémentaire 1' },
+            eligibleSubscriptions: [{ label: 'Certif complémentaire 1' }],
             nonEligibleSubscription: null,
           }),
         );
@@ -95,7 +95,7 @@ module('Integration | Component | certification-starter', function (hooks) {
         this.set(
           'certificationCandidateSubscription',
           store.createRecord('certification-candidate-subscription', {
-            eligibleSubscription: null,
+            eligibleSubscriptions: null,
             nonEligibleSubscription: { label: 'Certif complémentaire 1' },
           }),
         );
@@ -119,7 +119,7 @@ module('Integration | Component | certification-starter', function (hooks) {
         this.set(
           'certificationCandidateSubscription',
           store.createRecord('certification-candidate-subscription', {
-            eligibleSubscription: null,
+            eligibleSubscriptions: null,
             nonEligibleSubscription: { label: 'Certif complémentaire 1' },
           }),
         );

--- a/mon-pix/tests/integration/components/certification-starter-test.js
+++ b/mon-pix/tests/integration/components/certification-starter-test.js
@@ -154,25 +154,6 @@ module('Integration | Component | certification-starter', function (hooks) {
             ),
           );
           assert.ok(screen.getByText('Certif complémentaire 1'));
-        });
-
-        test('should not display subscription non eligible panel', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          this.set(
-            'certificationCandidateSubscription',
-            store.createRecord('certification-candidate-subscription', {
-              eligibleSubscriptions: [{ label: 'Certif complémentaire 1', type: 'COMPLEMENTARY' }],
-              nonEligibleSubscription: null,
-            }),
-          );
-
-          // when
-          const screen = await render(
-            hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}} />`,
-          );
-
-          // then
           assert.notOk(screen.queryByText('Vous n’êtes pas éligible à'));
         });
       });
@@ -201,26 +182,6 @@ module('Integration | Component | certification-starter', function (hooks) {
               "Vous n'êtes pas éligible à Certif complémentaire 1. Vous pouvez néanmoins passer votre certification Pix.",
             ),
           );
-        });
-
-        test('should not display subscription eligible panel', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          this.set(
-            'certificationCandidateSubscription',
-            store.createRecord('certification-candidate-subscription', {
-              eligibleSubscriptions: null,
-              nonEligibleSubscription: { label: 'Certif complémentaire 1' },
-              sessionVersion: 2,
-            }),
-          );
-
-          // when
-          const screen = await render(
-            hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}} />`,
-          );
-
-          // then
           assert.notOk(
             screen.queryByText(
               'Vous êtes inscrit aux certifications complémentaires suivantes en plus de la certification Pix :',

--- a/mon-pix/tests/integration/components/certification-starter-test.js
+++ b/mon-pix/tests/integration/components/certification-starter-test.js
@@ -68,42 +68,20 @@ module('Integration | Component | certification-starter', function (hooks) {
         );
       });
     });
-  });
-  module('when the candidate has complementary certification subscription', function () {
-    module('when the candidate is eligible', function () {
+
+    module('when the candidate has core and complementary subscriptions', function () {
       test('should display subscription eligible panel', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
         this.set(
           'certificationCandidateSubscription',
           store.createRecord('certification-candidate-subscription', {
-            eligibleSubscriptions: [{ label: 'Certif complémentaire 1' }],
+            eligibleSubscriptions: [
+              { label: null, type: 'CORE' },
+              { label: 'Pix+ toto', type: 'COMPLEMENTARY' },
+            ],
             nonEligibleSubscription: null,
-          }),
-        );
-
-        // when
-        const screen = await render(
-          hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}} />`,
-        );
-
-        // then
-        assert.ok(
-          screen.getByText(
-            'Vous êtes inscrit à la certification complémentaire suivante en plus de la certification Pix :',
-          ),
-        );
-        assert.ok(screen.getByText('Certif complémentaire 1'));
-      });
-
-      test('should not display subscription non eligible panel', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        this.set(
-          'certificationCandidateSubscription',
-          store.createRecord('certification-candidate-subscription', {
-            eligibleSubscriptions: [{ label: 'Certif complémentaire 1' }],
-            nonEligibleSubscription: null,
+            sessionVersion: 3,
           }),
         );
 
@@ -114,18 +92,25 @@ module('Integration | Component | certification-starter', function (hooks) {
 
         // then
         assert.notOk(screen.queryByText('Vous n’êtes pas éligible à'));
+        assert.ok(
+          screen.queryByText(
+            'Vous êtes inscrit à la certification complémentaire suivante en plus de la certification Pix :',
+          ),
+        );
+        assert.ok(screen.getByText('Pix+ toto'));
       });
     });
 
-    module('when the candidate is not eligible', function () {
-      test('should display subscription non eligible panel', async function (assert) {
+    module('when the candidate has only a complementary subscriptions', function () {
+      test('should display subscription eligible panel', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
         this.set(
           'certificationCandidateSubscription',
           store.createRecord('certification-candidate-subscription', {
-            eligibleSubscriptions: null,
-            nonEligibleSubscription: { label: 'Certif complémentaire 1' },
+            eligibleSubscriptions: [{ label: 'Pix+ toto', type: 'COMPLEMENTARY' }],
+            nonEligibleSubscription: null,
+            sessionVersion: 3,
           }),
         );
 
@@ -135,35 +120,113 @@ module('Integration | Component | certification-starter', function (hooks) {
         );
 
         // then
-        assert.ok(
-          screen.getByText(
-            "Vous n'êtes pas éligible à Certif complémentaire 1. Vous pouvez néanmoins passer votre certification Pix.",
-          ),
-        );
+        assert.notOk(screen.queryByText('Vous n’êtes pas éligible à'));
+        assert.ok(screen.queryByText('Vous êtes inscrit à la certification complémentaire suivante :'));
+        assert.ok(screen.getByText('Pix+ toto'));
+      });
+    });
+  });
+
+  module('when the session is v2', function () {
+    module('when the candidate has complementary certification subscription', function () {
+      module('when the candidate is eligible', function () {
+        test('should display subscription eligible panel', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          this.set(
+            'certificationCandidateSubscription',
+            store.createRecord('certification-candidate-subscription', {
+              eligibleSubscriptions: [{ label: 'Certif complémentaire 1', type: 'COMPLEMENTARY' }],
+              nonEligibleSubscription: null,
+              sessionVersion: 2,
+            }),
+          );
+
+          // when
+          const screen = await render(
+            hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}} />`,
+          );
+
+          // then
+          assert.ok(
+            screen.getByText(
+              'Vous êtes inscrit à la certification complémentaire suivante en plus de la certification Pix :',
+            ),
+          );
+          assert.ok(screen.getByText('Certif complémentaire 1'));
+        });
+
+        test('should not display subscription non eligible panel', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          this.set(
+            'certificationCandidateSubscription',
+            store.createRecord('certification-candidate-subscription', {
+              eligibleSubscriptions: [{ label: 'Certif complémentaire 1', type: 'COMPLEMENTARY' }],
+              nonEligibleSubscription: null,
+            }),
+          );
+
+          // when
+          const screen = await render(
+            hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}} />`,
+          );
+
+          // then
+          assert.notOk(screen.queryByText('Vous n’êtes pas éligible à'));
+        });
       });
 
-      test('should not display subscription eligible panel', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        this.set(
-          'certificationCandidateSubscription',
-          store.createRecord('certification-candidate-subscription', {
-            eligibleSubscriptions: null,
-            nonEligibleSubscription: { label: 'Certif complémentaire 1' },
-          }),
-        );
+      module('when the candidate is not eligible', function () {
+        test('should display subscription non eligible panel', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          this.set(
+            'certificationCandidateSubscription',
+            store.createRecord('certification-candidate-subscription', {
+              eligibleSubscriptions: null,
+              nonEligibleSubscription: { label: 'Certif complémentaire 1' },
+              sessionVersion: 2,
+            }),
+          );
 
-        // when
-        const screen = await render(
-          hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}} />`,
-        );
+          // when
+          const screen = await render(
+            hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}} />`,
+          );
 
-        // then
-        assert.notOk(
-          screen.queryByText(
-            'Vous êtes inscrit aux certifications complémentaires suivantes en plus de la certification Pix :',
-          ),
-        );
+          // then
+          assert.ok(
+            screen.getByText(
+              "Vous n'êtes pas éligible à Certif complémentaire 1. Vous pouvez néanmoins passer votre certification Pix.",
+            ),
+          );
+        });
+
+        test('should not display subscription eligible panel', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          this.set(
+            'certificationCandidateSubscription',
+            store.createRecord('certification-candidate-subscription', {
+              eligibleSubscriptions: null,
+              nonEligibleSubscription: { label: 'Certif complémentaire 1' },
+              sessionVersion: 2,
+            }),
+          );
+
+          // when
+          const screen = await render(
+            hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}} />`,
+          );
+
+          // then
+          assert.notOk(
+            screen.queryByText(
+              'Vous êtes inscrit aux certifications complémentaires suivantes en plus de la certification Pix :',
+            ),
+          );
+        });
       });
     });
   });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -676,7 +676,8 @@
       "first-title": "You are about to begin your certification test.",
       "link-to-user-certification": "See my certificates",
       "non-eligible-subscription": "You are not eligible to {nonEligibleSubscriptionLabel}. However, you can still take your Pix Certification.",
-      "subscription": "You are registered for the following additional certification in combination with the Pix Certification:"
+      "core-and-complementary-subscriptions": "You are registered for the following additional certification in combination with the Pix Certification:",
+      "complementary-subscription": "You are registered for the following additional certification :"
     },
     "certifications-list": {
       "title": "My Certifications",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -667,7 +667,7 @@
       "first-title": "Estás a punto de empezar tu prueba de certificación",
       "link-to-user-certification": "Ver mis certificaciones",
       "non-eligible-subscription": "No eres elegible para {nonEligibleSubscriptionLabel}. Sin embargo, puedes presentarte a la certificación Pix.",
-      "subscription": "Además de la certificación Pix, estás inscrito en la siguiente certificación complementaria:",
+      "core-and-complementary-subscriptions": "Además de la certificación Pix, estás inscrito en la siguiente certificación complementaria:",
       "title": "Unirse a una sesión de certificación"
     },
     "certifications-list": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -676,7 +676,8 @@
       "first-title": "Vous allez commencer votre test de certification",
       "link-to-user-certification": "Voir mes certifications",
       "non-eligible-subscription": "Vous n'êtes pas éligible à {nonEligibleSubscriptionLabel}. Vous pouvez néanmoins passer votre certification Pix.",
-      "subscription": "Vous êtes inscrit à la certification complémentaire suivante en plus de la certification Pix :"
+      "core-and-complementary-subscriptions": "Vous êtes inscrit à la certification complémentaire suivante en plus de la certification Pix :",
+      "complementary-subscription": "Vous êtes inscrit à la certification complémentaire suivante :"
     },
     "certifications-list": {
       "title": "Mes Certifications",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -667,7 +667,7 @@
       "first-title": "Je staat op het punt om aan je certificeringstest te beginnen",
       "link-to-user-certification": "Bekijk mijn certificaten",
       "non-eligible-subscription": "Je komt niet in aanmerking voor {nonEligibleSubscriptionLabel}. Je kunt echter wel je Pix-certificering behalen.",
-      "subscription": "Je bent geregistreerd voor de volgende aanvullende certificering naast de Pix-certificering:",
+      "core-and-complementary-subscriptions": "Je bent geregistreerd voor de volgende aanvullende certificering naast de Pix-certificering:",
       "title": "Doe mee aan een certificeringssessie"
     },
     "certifications-list": {


### PR DESCRIPTION
## :unicorn: Problème

La route de réconciliation, /candidate-participation, vérifie désormais les conditions d'éligibilité du candidat. La route qui suit est un GET /subscriptions qui retourne les informations d’éligibilité pour le double bandeau dans la page “Code candidat” 

En v2, ce route va calculer la validité des badges du candidats. Les badges non valides sont retournés pour que le bandeau jaune indique que le candidat s’est inscrit à une complémentaire mais n’est plus éligible.

On ne touche pas au comportement de la v2, en revanche il faut que le retour V2 et V3 soit iso pour le front.

## :robot: Proposition

Est-ce que la session est V3 ? 
NON, next
OUI, retourner ses subscriptions.

En V3, comme la route précédente s’est chargé de vérifier les conditions d’éligibilités, on va uniquement récupérer les subscriptions du candidat et les retourner au front.

Si cléA => on doit avoir 2 subscriptions et retourner le message “Vous êtes inscrit à la certification complémentaire suivante en plus de la certification Pix: CléA” (car double certification)

Si juste coeur => pas de bandeau 

Si autres complémentaires => retourner le message “Vous êtes inscrit à la certification complémentaire suivante : certif complémentaire”

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

- Créer une session V2 avec certif complémentaire et un candidat qui n'est plus éligible à cette complémentaire, vérifier que le bandeau apparaisse sans régression ✅
- Créer une session V3 avec certif complémentaire et un candidat qui est éligible à cette complémentaire, vérifier que le bandeau apparaisse avec le nouveau message ✅
- Créer une session V3 avec certif complémentaire et coeur et un candidat  qui n'est plus éligible à cette complémentaire, vérifier que le bandeau apparaisse avec le nouveau message pour les deux certifs ✅
