### PR TITLE
[FEATURE] Permettre de filtrer sur les category des Profil Cible sur PixAdmin(PIX-14651)

### DIFF
--- a/admin/app/components/target-profiles/list-summary-items.gjs
+++ b/admin/app/components/target-profiles/list-summary-items.gjs
@@ -1,16 +1,33 @@
 import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
+import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
 import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import { fn } from '@ember/helper';
+import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
 import formatDate from '../../helpers/format-date';
+import { categories } from '../../helpers/target-profile-categories.js';
 
 export default class TargetProfileListSummaryItems extends Component {
+  @service intl;
+  @tracked selectedValues = [];
+
   get isClearFiltersButtonDisabled() {
-    return !this.args.id && !this.args.name;
+    return !this.args.id && !this.args.name && this.args.categories?.length === 0;
+  }
+
+  get categoryOptions() {
+    return Object.entries(categories).map(([key, value]) => ({ label: this.intl.t(value), value: key }));
+  }
+
+  @action
+  triggerCategoriesFiltering(values) {
+    this.args.triggerFiltering('categories', { target: { value: values } });
   }
 
   <template>
@@ -42,6 +59,18 @@ export default class TargetProfileListSummaryItems extends Component {
       >
         <:label>{{t "pages.target-profiles.filters.search-by-name.name"}}</:label>
       </PixInput>
+      <PixMultiSelect
+        @id="categories"
+        @screenReaderOnly={{true}}
+        @placeholder={{t "common.filters.target-profile.placeholder"}}
+        @onChange={{this.triggerCategoriesFiltering}}
+        @values={{@categories}}
+        @options={{this.categoryOptions}}
+      >
+        <:label>{{t "common.filters.target-profile.label"}}</:label>
+        <:default as |option|>{{option.label}}</:default>
+      </PixMultiSelect>
+
     </PixFilterBanner>
 
     <div class="content-text content-text--small">

--- a/admin/app/components/target-profiles/list-summary-items.gjs
+++ b/admin/app/components/target-profiles/list-summary-items.gjs
@@ -51,6 +51,7 @@ export default class TargetProfileListSummaryItems extends Component {
             <tr>
               <th class="table__column table__column--id">{{t "common.fields.id"}}</th>
               <th>{{t "common.fields.name"}}</th>
+              <th>{{t "common.fields.target-profile.category.name"}}</th>
               <th class="col-date">{{t "common.fields.createdAt"}}</th>
               <th class="col-status">{{t "common.fields.status"}}</th>
             </tr>
@@ -60,14 +61,15 @@ export default class TargetProfileListSummaryItems extends Component {
             <tbody>
               {{#each @summaries as |summary|}}
                 <tr aria-label="Profil cible">
-                  <td headers="target-profile-id" class="table__column table__column--id">{{summary.id}}</td>
-                  <td headers="target-profile-name">
+                  <td class="table__column table__column--id">{{summary.id}}</td>
+                  <td>
                     <LinkTo @route="authenticated.target-profiles.target-profile" @model={{summary.id}}>
                       {{summary.name}}
                     </LinkTo>
                   </td>
+                  <td class="table__column table__column--id">{{t summary.translationKeyCategory}}</td>
                   <td class="table__column">{{formatDate summary.createdAt}}</td>
-                  <td headers="target-profile-status" class="target-profile-table-column__status">
+                  <td class="target-profile-table-column__status">
                     {{if summary.outdated "Obsolète" "Actif"}}
                   </td>
                 </tr>

--- a/admin/app/components/target-profiles/list-summary-items.gjs
+++ b/admin/app/components/target-profiles/list-summary-items.gjs
@@ -1,46 +1,58 @@
+import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import { fn } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
 import Component from '@glimmer/component';
+import { t } from 'ember-intl';
 
 import formatDate from '../../helpers/format-date';
 
 export default class TargetProfileListSummaryItems extends Component {
-  searchedId = this.args.id;
-  searchedName = this.args.name;
+  get isClearFiltersButtonDisabled() {
+    return !this.args.id && !this.args.name;
+  }
 
   <template>
+    <PixFilterBanner
+      class="page-body-template__content"
+      @title={{t "common.filters.title"}}
+      aria-label={{t "pages.target-profiles.filters.aria-label"}}
+      @details={{t "pages.target-profiles.filters.count" count=@summaries.meta.rowCount}}
+      @clearFiltersLabel={{t "common.filters.actions.clear"}}
+      @onClearFilters={{@onResetFilter}}
+      @isClearFilterButtonDisabled={{this.isClearFiltersButtonDisabled}}
+    >
+      <PixInput
+        type="text"
+        value={{@id}}
+        oninput={{fn @triggerFiltering "id"}}
+        placeholder={{t "pages.target-profiles.filters.search-by-id.placeholder"}}
+        @screenReaderOnly={{true}}
+      >
+        <:label>{{t "pages.target-profiles.filters.search-by-id.name"}}</:label>
+      </PixInput>
+
+      <PixInput
+        type="text"
+        value={{@name}}
+        placeholder={{t "pages.target-profiles.filters.search-by-name.placeholder"}}
+        oninput={{fn @triggerFiltering "name"}}
+        @screenReaderOnly={{true}}
+      >
+        <:label>{{t "pages.target-profiles.filters.search-by-name.name"}}</:label>
+      </PixInput>
+    </PixFilterBanner>
+
     <div class="content-text content-text--small">
       <div class="table-admin">
         <table>
-
           <thead>
             <tr>
-              <th class="table__column table__column--id" id="target-profile-id">ID</th>
-              <th id="target-profile-name">Nom</th>
-              <th class="col-date">Date de création</th>
-              <th class="col-status" id="target-profile-status">Statut</th>
-            </tr>
-            <tr>
-              <td class="table__column table__column--id">
-                <PixInput
-                  type="text"
-                  value={{this.searchedId}}
-                  oninput={{fn @triggerFiltering "id"}}
-                  aria-label="Filtrer les profils cible par un id"
-                />
-              </td>
-              <td>
-                <PixInput
-                  type="text"
-                  value={{this.searchedName}}
-                  oninput={{fn @triggerFiltering "name"}}
-                  aria-label="Filtrer les profils cible par un nom"
-                />
-              </td>
-              <td></td>
-              <td></td>
+              <th class="table__column table__column--id">{{t "common.fields.id"}}</th>
+              <th>{{t "common.fields.name"}}</th>
+              <th class="col-date">{{t "common.fields.createdAt"}}</th>
+              <th class="col-status">{{t "common.fields.status"}}</th>
             </tr>
           </thead>
 

--- a/admin/app/controllers/authenticated/target-profiles/list.js
+++ b/admin/app/controllers/authenticated/target-profiles/list.js
@@ -7,13 +7,14 @@ import config from 'pix-admin/config/environment';
 const DEFAULT_PAGE_NUMBER = 1;
 
 export default class ListController extends Controller {
-  queryParams = ['pageNumber', 'pageSize', 'id', 'name'];
+  queryParams = ['pageNumber', 'pageSize', 'id', 'name', 'categories'];
   DEBOUNCE_MS = config.pagination.debounce;
 
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
   @tracked pageSize = 10;
   @tracked id = null;
   @tracked name = null;
+  @tracked categories = [];
 
   updateFilters(filters) {
     for (const filterKey of Object.keys(filters)) {
@@ -31,5 +32,6 @@ export default class ListController extends Controller {
   onResetFilter() {
     this.id = null;
     this.name = null;
+    this.categories = [];
   }
 }

--- a/admin/app/controllers/authenticated/target-profiles/list.js
+++ b/admin/app/controllers/authenticated/target-profiles/list.js
@@ -26,4 +26,10 @@ export default class ListController extends Controller {
   triggerFiltering(fieldName, event) {
     debounceTask(this, 'updateFilters', { [fieldName]: event.target.value }, this.DEBOUNCE_MS);
   }
+
+  @action
+  onResetFilter() {
+    this.id = null;
+    this.name = null;
+  }
 }

--- a/admin/app/helpers/target-profile-categories.js
+++ b/admin/app/helpers/target-profile-categories.js
@@ -1,0 +1,11 @@
+export const categories = {
+  OTHER: 'common.fields.target-profile.category.tags.OTHER',
+  DISCIPLINE: 'common.fields.target-profile.category.tags.DISCIPLINE',
+  COMPETENCES: 'common.fields.target-profile.category.tags.COMPETENCES',
+  PREDEFINED: 'common.fields.target-profile.category.tags.PREDEFINED',
+  CUSTOM: 'common.fields.target-profile.category.tags.CUSTOM',
+  PIX_PLUS: 'common.fields.target-profile.category.tags.PIX_PLUS',
+  SUBJECT: 'common.fields.target-profile.category.tags.SUBJECT',
+  TARGETED: 'common.fields.target-profile.category.tags.TARGETED',
+  BACK_TO_SCHOOL: 'common.fields.target-profile.category.tags.BACK_TO_SCHOOL',
+};

--- a/admin/app/models/target-profile-summary.js
+++ b/admin/app/models/target-profile-summary.js
@@ -1,8 +1,14 @@
 import Model, { attr } from '@ember-data/model';
 
+import { categories } from '../helpers/target-profile-categories';
 export default class TargetProfileSummary extends Model {
   @attr() name;
   @attr() outdated;
+  @attr() category;
   @attr() createdAt;
   @attr() canDetach;
+
+  get translationKeyCategory() {
+    return categories[this.category];
+  }
 }

--- a/admin/app/routes/authenticated/target-profiles/list.js
+++ b/admin/app/routes/authenticated/target-profiles/list.js
@@ -12,6 +12,7 @@ export default class ListRoute extends Route {
     pageSize: { refreshModel: true },
     id: { refreshModel: true },
     name: { refreshModel: true },
+    categories: { refreshModel: true },
   };
 
   beforeModel() {
@@ -25,6 +26,7 @@ export default class ListRoute extends Route {
         filter: {
           id: params.id ? params.id.trim() : '',
           name: params.name ? params.name.trim() : '',
+          categories: params.categories ?? [],
         },
         page: {
           number: params.pageNumber,
@@ -46,6 +48,7 @@ export default class ListRoute extends Route {
       controller.pageSize = 10;
       controller.id = null;
       controller.name = null;
+      controller.categories = [];
     }
   }
 }

--- a/admin/app/styles/globals/page.scss
+++ b/admin/app/styles/globals/page.scss
@@ -76,4 +76,12 @@
       }
     }
   }
+
+  .page-body-template {
+    padding: var(--pix-spacing-8x);
+
+    &__content {
+      margin-bottom: var(--pix-spacing-8x);
+    }
+  }
 }

--- a/admin/app/styles/globals/table-admin.scss
+++ b/admin/app/styles/globals/table-admin.scss
@@ -1,6 +1,7 @@
 /* stylelint-disable selector-class-pattern */
 .table-admin {
-  margin-bottom: $pix-spacing-s;
+  margin-bottom: var(--pix-spacing-2x);
+  background-color: var(--pix-neutral-0);
 
   thead label {
     margin-bottom: 0;

--- a/admin/app/templates/authenticated/target-profiles/list.hbs
+++ b/admin/app/templates/authenticated/target-profiles/list.hbs
@@ -8,13 +8,14 @@
   </div>
 </header>
 
-<main class="page-body">
-  <section class="page-section">
+<main class="page-body-template">
+  <section>
     <TargetProfiles::ListSummaryItems
       @summaries={{@model}}
       @id={{this.id}}
       @name={{this.name}}
       @triggerFiltering={{this.triggerFiltering}}
+      @onResetFilter={{this.onResetFilter}}
     />
   </section>
 </main>

--- a/admin/app/templates/authenticated/target-profiles/list.hbs
+++ b/admin/app/templates/authenticated/target-profiles/list.hbs
@@ -14,6 +14,7 @@
       @summaries={{@model}}
       @id={{this.id}}
       @name={{this.name}}
+      @categories={{this.categories}}
       @triggerFiltering={{this.triggerFiltering}}
       @onResetFilter={{this.onResetFilter}}
     />

--- a/admin/tests/acceptance/authenticated/target-profiles/list-test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/list-test.js
@@ -1,13 +1,17 @@
 import { clickByName, visit } from '@1024pix/ember-testing-library';
 import { currentURL } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 import { module, test } from 'qunit';
 
+import setupIntl from '../../../helpers/setup-intl';
+
 module('Acceptance | Target Profiles | List', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks);
 
   module('When admin member is not logged in', function () {
     test('it should not be accessible by an unauthenticated user', async function (assert) {
@@ -104,7 +108,9 @@ module('Acceptance | Target Profiles | List', function (hooks) {
           const screen = await visit('/target-profiles/list?id=123');
 
           // then
-          assert.dom(screen.getByRole('textbox', { name: 'Filtrer les profils cible par un id' })).hasValue('123');
+          assert
+            .dom(screen.getByRole('textbox', { name: t('pages.target-profiles.filters.search-by-id.name') }))
+            .hasValue('123');
         });
       });
     });

--- a/admin/tests/integration/components/routes/authenticated/target-profiles/list-items-test.gjs
+++ b/admin/tests/integration/components/routes/authenticated/target-profiles/list-items-test.gjs
@@ -1,10 +1,11 @@
 import { render } from '@1024pix/ember-testing-library';
-import { setupRenderingTest } from 'ember-qunit';
 import ListSummaryItems from 'pix-admin/components/target-profiles/list-summary-items';
 import { module, test } from 'qunit';
 
+import setupIntlRenderingTest, { t } from '../../../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | routes/authenticated/target-profiles | list-items', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   const triggerFiltering = function () {};
   const goToTargetProfilePage = function () {};
@@ -18,9 +19,9 @@ module('Integration | Component | routes/authenticated/target-profiles | list-it
     );
 
     // then
-    assert.dom(screen.getByText('ID')).exists();
-    assert.dom(screen.getByText('Nom')).exists();
-    assert.dom(screen.getByText('Statut')).exists();
+    assert.ok(screen.getByText(t('common.fields.id')));
+    assert.ok(screen.getByText(t('common.fields.name')));
+    assert.ok(screen.getByText(t('common.fields.status')));
   });
 
   test('it should display search inputs', async function (assert) {
@@ -32,8 +33,8 @@ module('Integration | Component | routes/authenticated/target-profiles | list-it
     );
 
     // then
-    assert.dom(screen.getByRole('textbox', { name: 'Filtrer les profils cible par un id' })).exists();
-    assert.dom(screen.getByRole('textbox', { name: 'Filtrer les profils cible par un nom' })).exists();
+    assert.dom(screen.getByRole('textbox', { name: t('pages.target-profiles.filters.search-by-id.name') })).exists();
+    assert.dom(screen.getByRole('textbox', { name: t('pages.target-profiles.filters.search-by-name.name') })).exists();
   });
 
   test('it should display target profile summaries list', async function (assert) {

--- a/admin/tests/integration/components/target-profiles/list-summary-items-test.gjs
+++ b/admin/tests/integration/components/target-profiles/list-summary-items-test.gjs
@@ -1,9 +1,11 @@
 import { render } from '@1024pix/ember-testing-library';
-import { setupRenderingTest } from 'ember-qunit';
 import ListSummaryItems from 'pix-admin/components/target-profiles/list-summary-items';
 import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | TargetProfiles::ListSummaryItems', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   const triggerFiltering = () => {};
 

--- a/admin/tests/integration/components/target-profiles/list-summary-items-test.gjs
+++ b/admin/tests/integration/components/target-profiles/list-summary-items-test.gjs
@@ -1,6 +1,9 @@
-import { render } from '@1024pix/ember-testing-library';
+import { render, within } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
 import ListSummaryItems from 'pix-admin/components/target-profiles/list-summary-items';
+import { categories as CATEGORIES } from 'pix-admin/helpers/target-profile-categories.js';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -37,5 +40,120 @@ module('Integration | Component | TargetProfiles::ListSummaryItems', function (h
     assert.dom(screen.getByText('Actif')).exists();
     assert.dom(screen.getByText('01/01/2021')).exists();
     assert.dom(screen.getByText('Actif')).exists();
+  });
+  module('resetFilters', function () {
+    test('it should be disabled if no filters is set', async function (assert) {
+      // given
+      const summaries = [];
+      summaries.meta = { page: 1, pageSize: 1 };
+      const id = undefined;
+      const name = undefined;
+      const categories = [];
+
+      // when
+      const screen = await render(
+        <template>
+          <ListSummaryItems
+            @id={{id}}
+            @summaries={{summaries}}
+            @name={{name}}
+            @categories={{categories}}
+            @triggerFiltering={{triggerFiltering}}
+          />
+        </template>,
+      );
+
+      // then
+      const button = screen.getByRole('button', { name: t('common.filters.actions.clear'), hidden: true });
+
+      assert.true(button.disabled);
+    });
+  });
+  module('filter', function () {
+    test('it should display categories filter', async function (assert) {
+      // given
+      const summaries = [];
+      summaries.meta = { page: 1, pageSize: 1 };
+      const id = undefined;
+      const name = undefined;
+      const categories = undefined;
+
+      // when
+      const screen = await render(
+        <template>
+          <ListSummaryItems
+            @id={{id}}
+            @summaries={{summaries}}
+            @name={{name}}
+            @categories={{categories}}
+            @triggerFiltering={{triggerFiltering}}
+          />
+        </template>,
+      );
+
+      // then
+      assert.ok(screen.getByLabelText(t('common.filters.target-profile.label')));
+    });
+
+    test('it should display selected categories', async function (assert) {
+      // given
+      const summaries = [];
+      summaries.meta = { page: 1, pageSize: 1 };
+      const id = undefined;
+      const name = undefined;
+      const categories = ['OTHER'];
+
+      // when
+      const screen = await render(
+        <template>
+          <ListSummaryItems
+            @id={{id}}
+            @summaries={{summaries}}
+            @name={{name}}
+            @categories={{categories}}
+            @triggerFiltering={{triggerFiltering}}
+          />
+        </template>,
+      );
+
+      // then
+      const domNode = screen.getByLabelText(t('common.filters.target-profile.label'));
+      await domNode.click();
+      const menu = await screen.findByRole('menu');
+      const checkbox = within(menu).getByRole('checkbox', { name: t(CATEGORIES.OTHER) });
+      assert.true(checkbox.checked);
+    });
+
+    test('it should call triggerFiltering', async function (assert) {
+      // given
+      const summaries = [];
+      summaries.meta = { page: 1, pageSize: 1 };
+      const id = undefined;
+      const name = undefined;
+      const categories = [];
+
+      const triggerFilteringSpy = sinon.spy();
+
+      // when
+      const screen = await render(
+        <template>
+          <ListSummaryItems
+            @id={{id}}
+            @summaries={{summaries}}
+            @name={{name}}
+            @categories={{categories}}
+            @triggerFiltering={{triggerFilteringSpy}}
+          />
+        </template>,
+      );
+
+      // then
+      const domNode = screen.getByLabelText(t('common.filters.target-profile.label'));
+      await domNode.click();
+      const menu = await screen.findByRole('menu');
+      const checkbox = within(menu).getByRole('checkbox', { name: t(CATEGORIES.OTHER) });
+      await checkbox.click();
+      assert.true(triggerFilteringSpy.calledWithExactly('categories', { target: { value: ['OTHER'] } }));
+    });
   });
 });

--- a/admin/tests/unit/controllers/authenticated/target-profiles/list-test.js
+++ b/admin/tests/unit/controllers/authenticated/target-profiles/list-test.js
@@ -1,0 +1,86 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Controller | authenticated/target-profiles/list', function (hooks) {
+  setupTest(hooks);
+  let controller;
+
+  hooks.beforeEach(function () {
+    controller = this.owner.lookup('controller:authenticated.target-profiles.list');
+  });
+
+  module('#updateFilters', function () {
+    module('resetting page number', function () {
+      test('it should reset page number', async function (assert) {
+        // given
+        controller.pageNumber = 10;
+        const expectedValue = 1;
+
+        // when
+        await controller.updateFilters({});
+
+        // then
+        assert.strictEqual(controller.pageNumber, expectedValue);
+      });
+    });
+
+    module('updating name', function () {
+      test('it should update controller name field', async function (assert) {
+        // given
+        controller.name = 'someName';
+        const expectedValue = 'someOtherName';
+
+        // when
+        await controller.updateFilters({ name: expectedValue });
+
+        // then
+        assert.strictEqual(controller.name, expectedValue);
+      });
+    });
+
+    module('updating id', function () {
+      test('it should update controller id field', async function (assert) {
+        // given
+        controller.id = 'someId';
+        const expectedValue = 'someOtherId';
+
+        // when
+        await controller.updateFilters({ id: expectedValue });
+
+        // then
+        assert.strictEqual(controller.id, expectedValue);
+      });
+    });
+
+    module('updating categories', function () {
+      test('it should update controller categories field', async function (assert) {
+        // given
+        controller.categories = ['someCategories'];
+        const expectedValue = ['someOtherCategories'];
+
+        // when
+        await controller.updateFilters({ categories: expectedValue });
+
+        // then
+        assert.strictEqual(controller.categories, expectedValue);
+      });
+    });
+  });
+
+  module('#onResetFilter', function () {
+    test('it should reset controller filter', async function (assert) {
+      // given
+      controller.name = 'someName';
+      controller.id = 'someId';
+      controller.categories = ['someCategories'];
+
+      // when
+      await controller.onResetFilter();
+
+      // then
+      assert.strictEqual(controller.name, null);
+      assert.strictEqual(controller.id, null);
+      assert.strictEqual(controller.categories.length, 0);
+    });
+  });
+});

--- a/admin/tests/unit/routes/authenticated/target-profiles/list-test.js
+++ b/admin/tests/unit/routes/authenticated/target-profiles/list-test.js
@@ -14,15 +14,20 @@ module('Unit | Route | authenticated/target-profiles/list', function (hooks) {
   module('#model', function (hooks) {
     const params = {};
     const expectedQueryArgs = {};
+    let queryStub;
 
     hooks.beforeEach(function () {
-      route.store.query = sinon.stub().resolves();
+      queryStub = sinon.stub(route.store, 'query').resolves();
       params.pageNumber = 'somePageNumber';
       params.pageSize = 'somePageSize';
       expectedQueryArgs.page = {
         number: 'somePageNumber',
         size: 'somePageSize',
       };
+    });
+
+    hooks.afterEach(function () {
+      sinon.restore();
     });
 
     module('when queryParams filters are falsy', function () {
@@ -32,6 +37,7 @@ module('Unit | Route | authenticated/target-profiles/list', function (hooks) {
         expectedQueryArgs.filter = {
           name: '',
           id: '',
+          categories: [],
         };
 
         // then
@@ -45,17 +51,18 @@ module('Unit | Route | authenticated/target-profiles/list', function (hooks) {
         // given
         params.name = ' someName';
         params.id = 'someId ';
+        params.categories = ['OTHER'];
         expectedQueryArgs.filter = {
           name: 'someName',
           id: 'someId',
+          categories: ['OTHER'],
         };
 
         // when
         await route.model(params);
 
         // then
-        sinon.assert.calledWith(route.store.query, 'target-profile-summary', expectedQueryArgs);
-        assert.ok(true);
+        assert.ok(queryStub.calledWith('target-profile-summary', expectedQueryArgs));
       });
     });
   });
@@ -69,6 +76,7 @@ module('Unit | Route | authenticated/target-profiles/list', function (hooks) {
         pageSize: 'somePageSize',
         name: 'someName',
         id: 'someId',
+        categories: ['OTHER'],
       };
     });
 
@@ -78,10 +86,11 @@ module('Unit | Route | authenticated/target-profiles/list', function (hooks) {
         route.resetController(controller, true);
 
         // then
-        assert.deepEqual(controller.pageNumber, 1);
-        assert.deepEqual(controller.pageSize, 10);
-        assert.deepEqual(controller.name, null);
-        assert.deepEqual(controller.id, null);
+        assert.strictEqual(controller.pageNumber, 1);
+        assert.strictEqual(controller.pageSize, 10);
+        assert.strictEqual(controller.name, null);
+        assert.strictEqual(controller.id, null);
+        assert.strictEqual(controller.categories.length, 0);
       });
     });
 
@@ -91,10 +100,11 @@ module('Unit | Route | authenticated/target-profiles/list', function (hooks) {
         route.resetController(controller, false);
 
         // then
-        assert.deepEqual(controller.pageNumber, 'somePageNumber');
-        assert.deepEqual(controller.pageSize, 'somePageSize');
-        assert.deepEqual(controller.name, 'someName');
-        assert.deepEqual(controller.id, 'someId');
+        assert.strictEqual(controller.pageNumber, 'somePageNumber');
+        assert.strictEqual(controller.pageSize, 'somePageSize');
+        assert.strictEqual(controller.name, 'someName');
+        assert.strictEqual(controller.id, 'someId');
+        assert.deepEqual(controller.categories, ['OTHER']);
       });
     });
   });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -18,6 +18,18 @@
       "login-user-temporary-blocked-error": "You have reached too many failed login attempts. Please try again later or '<'a href=\"{url}\"'>'reset your password here'</a>'.",
       "organization-not-found-error": "The organization \"{organizationId}\" does not exist."
     },
+    "fields": {
+      "createdAt": "Date of creation",
+      "id": "ID",
+      "name": "Name",
+      "status": "Status"
+    },
+    "filters": {
+      "title": "Filters",
+      "actions": {
+        "clear": "Clear filters"
+      }
+    },
     "forms": {
       "loading": "Loading...",
       "mandatory": "Champ obligatoire",
@@ -640,6 +652,18 @@
         },
         "notifications": {
           "success": "The target profile has been duplicated."
+        }
+      },
+      "filters": {
+        "aria-label": "Target profile filters",
+        "count": "{count, plural, =0 {0 target profile} =1 {1 target profile} other {{count} target profiles}}",
+        "search-by-id": {
+          "name": "Filter target profiles by ID",
+          "placeholder": "Search by ID"
+        },
+        "search-by-name": {
+          "name": "Filter target profiles by name",
+          "placeholder": "Search by name"
         }
       },
       "resettable-checkbox": {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -19,10 +19,26 @@
       "organization-not-found-error": "The organization \"{organizationId}\" does not exist."
     },
     "fields": {
-      "createdAt": "Date of creation",
-      "id": "ID",
-      "name": "Name",
-      "status": "Status"
+      "createdAt": "creation date",
+      "id": "id",
+      "name": "name",
+      "status": "status",
+      "target-profile": {
+        "category": {
+          "name": "category",
+          "tags": {
+            "BACK_TO_SCHOOL": "Back to school",
+            "COMPETENCES": "Pix Competences",
+            "CUSTOM": "Created for you",
+            "DISCIPLINE": "Schools",
+            "OTHER": "Other",
+            "PIX_PLUS": "Pix+",
+            "PREDEFINED": "Ready-made",
+            "SUBJECT": "Subject",
+            "TARGETED": "Targeted"
+          }
+        }
+      }
     },
     "filters": {
       "title": "Filters",

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -44,6 +44,10 @@
       "title": "Filters",
       "actions": {
         "clear": "Clear filters"
+      },
+      "target-profile": {
+        "label": "Category",
+        "placeholder": "Pix+, Other ..."
       }
     },
     "forms": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -18,6 +18,18 @@
       "login-user-temporary-blocked-error": "Vous avez effectué trop de tentatives de connexion. Réessayez plus tard ou cliquez sur '<'a href=\"{url}\"'>'mot de passe oublié'</a>' pour le réinitialiser.",
       "organization-not-found-error": "L’organisation \"{organizationId}\" n’existe pas."
     },
+    "fields": {
+      "createdAt": "Date de création",
+      "id": "ID",
+      "name": "Nom",
+      "status": "Statut"
+    },
+    "filters": {
+      "title": "Filtres",
+      "actions": {
+        "clear": "Effacer les filtres"
+      }
+    },
     "forms": {
       "loading": "Chargement...",
       "mandatory": "Champ obligatoire",
@@ -657,6 +669,18 @@
         },
         "notifications": {
           "success": "Le profil cible a bien été copié."
+        }
+      },
+      "filters": {
+        "aria-label": "Filtres sur les profils cibles",
+        "count": "{count, plural, =0 {0 profil cible} =1 {1 profil cible} other {{count} profils cibles}}",
+        "search-by-id": {
+          "name": "Filtrer les profils cible par un ID",
+          "placeholder": "Rechercher par ID"
+        },
+        "search-by-name": {
+          "name": "Filtrer les profils cible par un nom",
+          "placeholder": "Rechercher par nom"
         }
       },
       "resettable-checkbox": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -19,6 +19,10 @@
       "organization-not-found-error": "L’organisation \"{organizationId}\" n’existe pas."
     },
     "fields": {
+      "createdAt": "date de création",
+      "id": "ID",
+      "name": "nom",
+      "status": "statut",
       "target-profile": {
         "category": {
           "name": "catégorie",
@@ -34,16 +38,16 @@
             "TARGETED": "Parcours ciblés"
           }
         }
-      },
-      "createdAt": "date de création",
-      "id": "ID",
-      "name": "nom",
-      "status": "statut"
+      }
     },
     "filters": {
       "title": "Filtres",
       "actions": {
         "clear": "Effacer les filtres"
+      },
+      "target-profile": {
+        "label": "Catégorie",
+        "placeholder": "Pix+, Autres..."
       }
     },
     "forms": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -19,10 +19,26 @@
       "organization-not-found-error": "L’organisation \"{organizationId}\" n’existe pas."
     },
     "fields": {
-      "createdAt": "Date de création",
+      "target-profile": {
+        "category": {
+          "name": "catégorie",
+          "tags": {
+            "BACK_TO_SCHOOL": "Parcours de rentrée / 6e",
+            "COMPETENCES": "Les 16 compétences",
+            "CUSTOM": "Parcours sur-mesure",
+            "DISCIPLINE": "Disciplinaires",
+            "OTHER": "Autres",
+            "PIX_PLUS": "Pix+",
+            "PREDEFINED": "Parcours prédéfinis",
+            "SUBJECT": "Thématiques",
+            "TARGETED": "Parcours ciblés"
+          }
+        }
+      },
+      "createdAt": "date de création",
       "id": "ID",
-      "name": "Nom",
-      "status": "Statut"
+      "name": "nom",
+      "status": "statut"
     },
     "filters": {
       "title": "Filtres",

--- a/api/src/prescription/shared/domain/types/identifiers-type.js
+++ b/api/src/prescription/shared/domain/types/identifiers-type.js
@@ -1,9 +1,11 @@
 import Joi from 'joi';
 
+import { categories } from '../../../../shared/domain/models/TargetProfile.js';
 import { certificabilityByLabel } from '../../application/helpers.js';
 
 const filterType = {
   certificability: Joi.string().valid(...Object.keys(certificabilityByLabel)),
+  targetProfileCategory: Joi.string().valid(...Object.values(categories)),
 };
 
 export { filterType };

--- a/api/src/prescription/target-profile/application/admin-target-profile-controller.js
+++ b/api/src/prescription/target-profile/application/admin-target-profile-controller.js
@@ -143,18 +143,30 @@ const copyTargetProfile = withTransaction(async (request) => {
   return copiedTargetProfileId;
 });
 
-const findTargetProfileSummariesForAdmin = async function (request) {
+const findTargetProfileSummariesForAdmin = async function (
+  request,
+  _,
+  dependencies = { targetProfileSummaryForAdminSerializer },
+) {
   const organizationId = request.params.id;
   const targetProfileSummaries = await prescriptionTargetProfileUsecases.findOrganizationTargetProfileSummariesForAdmin(
     {
       organizationId,
     },
   );
-  return targetProfileSummaryForAdminSerializer.serialize(targetProfileSummaries);
+  return dependencies.targetProfileSummaryForAdminSerializer.serialize(targetProfileSummaries);
 };
 
-const findPaginatedFilteredTargetProfileSummariesForAdmin = async function (request) {
+const findPaginatedFilteredTargetProfileSummariesForAdmin = async function (
+  request,
+  _,
+  dependencies = { targetProfileSummaryForAdminSerializer },
+) {
   const options = request.query;
+
+  if (options.filter.categories && !Array.isArray(options.filter.categories)) {
+    options.filter.categories = [options.filter.categories];
+  }
 
   const { models: targetProfileSummaries, meta } =
     await prescriptionTargetProfileUsecases.findPaginatedFilteredTargetProfileSummariesForAdmin({
@@ -162,7 +174,7 @@ const findPaginatedFilteredTargetProfileSummariesForAdmin = async function (requ
       page: options.page,
     });
 
-  return targetProfileSummaryForAdminSerializer.serialize(targetProfileSummaries, meta);
+  return dependencies.targetProfileSummaryForAdminSerializer.serialize(targetProfileSummaries, meta);
 };
 
 const targetProfileController = {

--- a/api/src/prescription/target-profile/application/admin-target-profile-route.js
+++ b/api/src/prescription/target-profile/application/admin-target-profile-route.js
@@ -3,6 +3,7 @@ import Joi from 'joi';
 import { BadRequestError, NotFoundError, sendJsonApiError } from '../../../shared/application/http-errors.js';
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType, optionalIdentifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { filterType } from '../../shared/domain/types/identifiers-type.js';
 import { targetProfileController } from './admin-target-profile-controller.js';
 
 const register = async function (server) {
@@ -374,6 +375,7 @@ const register = async function (server) {
             filter: Joi.object({
               id: Joi.number().integer().empty('').allow(null).optional(),
               name: Joi.string().empty('').allow(null).optional(),
+              categories: [filterType.targetProfileCategory, Joi.array().items(filterType.targetProfileCategory)],
             }).default({}),
             page: Joi.object({
               number: Joi.number().integer().empty('').allow(null).optional(),

--- a/api/src/prescription/target-profile/domain/models/TargetProfileSummaryForAdmin.js
+++ b/api/src/prescription/target-profile/domain/models/TargetProfileSummaryForAdmin.js
@@ -6,6 +6,7 @@ class TargetProfileSummaryForAdmin {
     this.id = params.id;
     this.name = params.name;
     this.outdated = params.outdated;
+    this.category = params.category;
     this.createdAt = params.createdAt;
     this.#sharedOrganizationId = params.sharedOrganizationId;
     this.#ownerOrganizationId = params.ownerOrganizationId;

--- a/api/src/prescription/target-profile/infrastructure/repositories/target-profile-summary-for-admin-repository.js
+++ b/api/src/prescription/target-profile/infrastructure/repositories/target-profile-summary-for-admin-repository.js
@@ -5,7 +5,7 @@ import { TargetProfileSummaryForAdmin } from '../../domain/models/TargetProfileS
 
 const findPaginatedFiltered = async function ({ filter, page }) {
   const query = knex('target-profiles')
-    .select('id', 'name', 'outdated', 'createdAt')
+    .select('id', 'name', 'outdated', 'category', 'createdAt')
     .orderBy('outdated', 'ASC')
     .orderBy('name', 'ASC')
     .modify(_applyFilters, filter);

--- a/api/src/prescription/target-profile/infrastructure/repositories/target-profile-summary-for-admin-repository.js
+++ b/api/src/prescription/target-profile/infrastructure/repositories/target-profile-summary-for-admin-repository.js
@@ -36,12 +36,15 @@ const findByTraining = async function ({ trainingId }) {
 export { findByTraining, findPaginatedFiltered };
 
 function _applyFilters(qb, filter) {
-  const { name, id } = filter;
+  const { name, id, categories } = filter;
   if (name) {
     qb.whereILike('name', `%${name}%`);
   }
   if (id) {
     qb.where({ id });
+  }
+  if (categories) {
+    qb.whereIn('category', categories);
   }
   return qb;
 }

--- a/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer.js
+++ b/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer.js
@@ -4,7 +4,7 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (targetProfileSummaries, meta) {
   return new Serializer('target-profile-summary', {
-    attributes: ['name', 'outdated', 'createdAt', 'canDetach'],
+    attributes: ['name', 'outdated', 'createdAt', 'category', 'canDetach'],
     meta,
   }).serialize(targetProfileSummaries);
 };

--- a/api/tests/devcomp/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/trainings/training-controller_test.js
@@ -458,6 +458,7 @@ describe('Acceptance | Controller | training-controller', function () {
           outdated: false,
           'created-at': undefined,
           'can-detach': false,
+          category: undefined,
         },
       };
 

--- a/api/tests/prescription/target-profile/acceptance/application/admin-target-profile-route_test.js
+++ b/api/tests/prescription/target-profile/acceptance/application/admin-target-profile-route_test.js
@@ -1,3 +1,4 @@
+import * as TargetProfile from '../../../../../src/shared/domain/models/TargetProfile.js';
 import {
   createServer,
   databaseBuilder,
@@ -567,20 +568,40 @@ describe('Acceptance | TargetProfile | Application | Route | admin-target-profil
 
       // then
       expect(response.statusCode).to.equal(200);
-      expect(response.result).to.deep.equal({
-        data: [
-          {
-            type: 'target-profile-summaries',
-            id: '1',
-            attributes: {
-              name: 'Super profil cible',
-              outdated: false,
-              'created-at': undefined,
-              'can-detach': false,
-            },
-          },
-        ],
+      expect(response.result.data).to.have.lengthOf(1);
+    });
+  });
+
+  describe('GET /api/admin/target-profile-summaries', function () {
+    let userId;
+    let organizationId;
+
+    beforeEach(async function () {
+      userId = databaseBuilder.factory.buildUser.withRole().id;
+      organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildTargetProfile({
+        id: 1,
+        ownerOrganizationId: organizationId,
+        name: 'Super profil cible',
+        outdated: false,
+        category: TargetProfile.categories.OTHER,
       });
+      await databaseBuilder.commit();
+    });
+
+    it('should return 200', async function () {
+      // given
+      const options = {
+        method: 'GET',
+        url: `/api/admin/target-profile-summaries`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
     });
   });
 });

--- a/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-summary-for-admin-repository_test.js
+++ b/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-summary-for-admin-repository_test.js
@@ -1,11 +1,17 @@
 import * as targetProfileSummaryForAdminRepository from '../../../../../../src/prescription/target-profile/infrastructure/repositories/target-profile-summary-for-admin-repository.js';
+import { TargetProfile } from '../../../../../../src/shared/domain/models/TargetProfile.js';
 import { databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
-
 describe('Integration | Repository | Target-profile-summary-for-admin', function () {
   describe('#findPaginatedFiltered', function () {
     it('return TargetProfileSummaryForAdmins model', async function () {
       // given
-      const targetProfile = { id: 1, name: 'Go go target profile', outdated: false, createdAt: new Date('2021-01-01') };
+      const targetProfile = {
+        id: 1,
+        name: 'Go go target profile',
+        outdated: false,
+        createdAt: new Date('2021-01-01'),
+        category: TargetProfile.categories.PREDEFINED,
+      };
       databaseBuilder.factory.buildTargetProfile(targetProfile);
       await databaseBuilder.commit();
 
@@ -145,10 +151,34 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
         let targetProfileData;
         beforeEach(function () {
           targetProfileData = [
-            { id: 1, name: 'paTtErN', outdated: false, createdAt: new Date('2021-01-01') },
-            { id: 2, name: 'AApatterNOo', outdated: true, createdAt: new Date('2021-01-01') },
-            { id: 3, name: 'NotUnderTheRadar', outdated: false, createdAt: new Date('2021-01-01') },
-            { id: 4, name: 'PaTternXXXX', outdated: true, createdAt: new Date('2021-01-01') },
+            {
+              id: 1,
+              name: 'paTtErN',
+              outdated: false,
+              createdAt: new Date('2021-01-01'),
+              category: TargetProfile.categories.DISCIPLINE,
+            },
+            {
+              id: 2,
+              name: 'AApatterNOo',
+              outdated: true,
+              createdAt: new Date('2021-01-01'),
+              category: TargetProfile.categories.DISCIPLINE,
+            },
+            {
+              id: 3,
+              name: 'NotUnderTheRadar',
+              outdated: false,
+              createdAt: new Date('2021-01-01'),
+              category: TargetProfile.categories.DISCIPLINE,
+            },
+            {
+              id: 4,
+              name: 'PaTternXXXX',
+              outdated: true,
+              createdAt: new Date('2021-01-01'),
+              category: TargetProfile.categories.DISCIPLINE,
+            },
           ];
           targetProfileData.map(databaseBuilder.factory.buildTargetProfile);
           return databaseBuilder.commit();
@@ -173,18 +203,21 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
               name: 'paTtErN',
               outdated: false,
               createdAt: new Date('2021-01-01'),
+              category: TargetProfile.categories.DISCIPLINE,
             }),
             domainBuilder.buildTargetProfileSummaryForAdmin({
               id: 2,
               name: 'AApatterNOo',
               outdated: true,
               createdAt: new Date('2021-01-01'),
+              category: TargetProfile.categories.DISCIPLINE,
             }),
             domainBuilder.buildTargetProfileSummaryForAdmin({
               id: 4,
               name: 'PaTternXXXX',
               outdated: true,
               createdAt: new Date('2021-01-01'),
+              category: TargetProfile.categories.DISCIPLINE,
             }),
           ];
           expect(actualTargetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);
@@ -194,7 +227,13 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
         let targetProfileData;
         beforeEach(function () {
           targetProfileData = [
-            { id: 1, name: 'TPA', outdated: false, createdAt: new Date('2021-01-01') },
+            {
+              id: 1,
+              name: 'TPA',
+              outdated: false,
+              createdAt: new Date('2021-01-01'),
+              category: TargetProfile.categories.PIX_PLUS,
+            },
             { id: 11, name: 'TPB', outdated: true, createdAt: new Date('2021-01-01') },
             { id: 21, name: 'TPC', outdated: false, createdAt: new Date('2021-01-01') },
             { id: 4, name: 'TPD', outdated: true, createdAt: new Date('2021-01-01') },
@@ -222,6 +261,7 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
               name: 'TPA',
               outdated: false,
               createdAt: new Date('2021-01-01'),
+              category: TargetProfile.categories.PIX_PLUS,
             }),
           ];
           expect(actualTargetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);
@@ -287,8 +327,16 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
 
       // then
       const expectedTargetProfileSummaries = [
-        domainBuilder.buildTargetProfileSummaryForAdmin({ ...targetProfile1, createdAt: undefined }),
-        domainBuilder.buildTargetProfileSummaryForAdmin({ ...targetProfile2, createdAt: undefined }),
+        domainBuilder.buildTargetProfileSummaryForAdmin({
+          ...targetProfile1,
+          createdAt: undefined,
+          category: undefined,
+        }),
+        domainBuilder.buildTargetProfileSummaryForAdmin({
+          ...targetProfile2,
+          createdAt: undefined,
+          category: undefined,
+        }),
       ];
       expect(targetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);
     });

--- a/api/tests/prescription/target-profile/unit/application/admin-target-profiles-route_test.js
+++ b/api/tests/prescription/target-profile/unit/application/admin-target-profiles-route_test.js
@@ -1,6 +1,7 @@
 import { targetProfileController } from '../../../../../src/prescription/target-profile/application/admin-target-profile-controller.js';
 import * as moduleUnderTest from '../../../../../src/prescription/target-profile/application/admin-target-profile-route.js';
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
+import { categories } from '../../../../../src/shared/domain/models/TargetProfile.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Application | Admin Target Profiles | Routes', function () {
@@ -1072,11 +1073,25 @@ describe('Unit | Application | Admin Target Profiles | Routes', function () {
         // when
         const response = await httpTestServer.request(
           method,
-          `${url}?filter[id]=1&filter[name]=azerty&page[size]=10&page[number]=1`,
+          `${url}?filter[id]=1&filter[name]=azerty&filter[categories][]=${categories.COMPETENCES}&filter[categories][]=${categories.OTHER}&page[size]=10&page[number]=1`,
         );
 
         // then
         expect(response.statusCode).to.equal(200);
+      });
+    });
+
+    context('when category is not valid', function () {
+      it('should reject request with HTTP code 400', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request(method, `${url}?filter[categories][]=pifpof`);
+
+        // then
+        expect(response.statusCode).to.equal(400);
       });
     });
 

--- a/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer_test.js
+++ b/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer_test.js
@@ -10,11 +10,13 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
           id: 1,
           name: 'TPA',
           outdated: false,
+          category: 'OTHER',
           createdAt: new Date('2021-01-01'),
         }),
         domainBuilder.buildTargetProfileSummaryForAdmin({
           id: 2,
           name: 'TPB',
+          category: 'POUET',
           outdated: true,
           createdAt: new Date('2021-01-01'),
         }),
@@ -33,6 +35,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
             attributes: {
               name: 'TPA',
               outdated: false,
+              category: 'OTHER',
               'created-at': new Date('2021-01-01'),
               'can-detach': false,
             },
@@ -42,6 +45,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
             id: '2',
             attributes: {
               name: 'TPB',
+              category: 'POUET',
               outdated: true,
               'created-at': new Date('2021-01-01'),
               'can-detach': false,

--- a/api/tests/tooling/domain-builder/factory/build-target-profile-summary-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-target-profile-summary-for-admin.js
@@ -3,6 +3,7 @@ import { TargetProfileSummaryForAdmin } from '../../../../src/prescription/targe
 const buildTargetProfileSummaryForAdmin = function ({
   id = 123,
   name = 'Profil cible super cool',
+  category,
   outdated = false,
   createdAt,
   ownerOrganizationId,
@@ -12,6 +13,7 @@ const buildTargetProfileSummaryForAdmin = function ({
     id,
     name,
     outdated,
+    category,
     createdAt,
     ownerOrganizationId,
     sharedOrganizationId,


### PR DESCRIPTION
## :unicorn: Problème
Nous n'avons pas la possibilité de faire des filtres fin sur les profil cible

## :robot: Proposition
Ajouter la possibilité de filtrer sur les categories d'un profil cible

## :rainbow: Remarques
Petit rework du template page-body .

## :100: Pour tester
Se connecter sur PixAdmin et pouvoir filtrer sur les catégories dans la page des profil cibles