### PR TITLE
[FEATURE] Ajoute un endpoint pour télécharger un zip des attestations pour une organisation (PIX-13824).

### DIFF
--- a/api/src/identity-access-management/application/api/models/UserDTO.js
+++ b/api/src/identity-access-management/application/api/models/UserDTO.js
@@ -2,5 +2,6 @@ export class UserDTO {
   constructor(user) {
     this.firstName = user.firstName;
     this.lastName = user.lastName;
+    this.id = user.id;
   }
 }

--- a/api/src/prescription/organization-learner/application/organization-learners-controller.js
+++ b/api/src/prescription/organization-learner/application/organization-learners-controller.js
@@ -1,0 +1,17 @@
+import { usecases } from '../domain/usecases/index.js';
+
+const getAttestationZipForDivisions = async function (request, h) {
+  const organizationId = request.params.organizationId;
+  const attestationKey = request.params.attestationKey;
+  const divisions = request.query.divisions;
+
+  const buffer = await usecases.getAttestationZipForDivisions({ attestationKey, organizationId, divisions });
+
+  return h.response(buffer).header('Content-Type', 'application/zip');
+};
+
+const organizationLearnersController = {
+  getAttestationZipForDivisions,
+};
+
+export { organizationLearnersController };

--- a/api/src/prescription/organization-learner/application/organization-learners-route.js
+++ b/api/src/prescription/organization-learner/application/organization-learners-route.js
@@ -1,0 +1,41 @@
+import Joi from 'joi';
+
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
+import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { organizationLearnersController } from './organization-learners-controller.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/organizations/{organizationId}/attestations/{attestationKey}',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserBelongsToOrganization,
+            assign: 'checkUserBelongsToOrganization',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            organizationId: identifiersType.organizationId,
+            attestationKey: Joi.string(),
+          }),
+          query: Joi.object({
+            divisions: Joi.array().items(Joi.string()).default([]),
+          }),
+        },
+        handler: organizationLearnersController.getAttestationZipForDivisions,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            "- Génération d'un zip d'attestations pour une liste de classes d'une organisation" +
+            "- L'utisateur doit être au moins membre de l'organisation'",
+        ],
+        tags: ['api', 'organization', 'attestations'],
+      },
+    },
+  ]);
+};
+
+const name = 'organization-learners-route';
+export { name, register };

--- a/api/src/prescription/organization-learner/domain/read-models/OrganizationLearner.js
+++ b/api/src/prescription/organization-learner/domain/read-models/OrganizationLearner.js
@@ -15,6 +15,7 @@ class OrganizationLearner {
     isCertifiableFromLearner,
     organizationId,
     certifiableAtFromLearner,
+    userId,
   } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -25,6 +26,7 @@ class OrganizationLearner {
     this.username = username;
     this.authenticationMethods = authenticationMethods;
     this.organizationId = organizationId;
+    this.userId = userId;
 
     this._buildCertificability({
       isCertifiableFromCampaign,

--- a/api/src/prescription/organization-learner/domain/usecases/get-attestation-zip-for-divisions.js
+++ b/api/src/prescription/organization-learner/domain/usecases/get-attestation-zip-for-divisions.js
@@ -1,0 +1,16 @@
+export const getAttestationZipForDivisions = async ({
+  attestationKey,
+  organizationId,
+  divisions,
+  organizationLearnerRepository,
+}) => {
+  const organizationLearners = await organizationLearnerRepository.findOrganizationLearnersByDivisions({
+    organizationId,
+    divisions,
+  });
+
+  return organizationLearnerRepository.getAttestationsForOrganizationLearnersAndKey({
+    attestationKey,
+    organizationLearners,
+  });
+};

--- a/api/src/prescription/organization-learner/domain/usecases/get-organization-learner.js
+++ b/api/src/prescription/organization-learner/domain/usecases/get-organization-learner.js
@@ -1,5 +1,5 @@
 const getOrganizationLearner = async function ({ organizationLearnerId, organizationLearnerRepository }) {
-  return organizationLearnerRepository.get(organizationLearnerId);
+  return organizationLearnerRepository.get({ organizationLearnerId });
 };
 
 export { getOrganizationLearner };

--- a/api/src/prescription/organization-learner/domain/usecases/index.js
+++ b/api/src/prescription/organization-learner/domain/usecases/index.js
@@ -17,8 +17,8 @@ import { importNamedExportsFromDirectory } from '../../../../shared/infrastructu
 import * as divisionRepository from '../../../campaign/infrastructure/repositories/division-repository.js';
 import * as groupRepository from '../../../campaign/infrastructure/repositories/group-repository.js';
 import * as organizationLearnerImportFormatRepository from '../../../learner-management/infrastructure/repositories/organization-learner-import-format-repository.js';
+import { repositories } from '../../infrastructure/repositories/index.js';
 import * as organizationLearnerActivityRepository from '../../infrastructure/repositories/organization-learner-activity-repository.js';
-import * as organizationLearnerRepository from '../../infrastructure/repositories/organization-learner-repository.js';
 import * as organizationParticipantRepository from '../../infrastructure/repositories/organization-participant-repository.js';
 import * as registrationOrganizationLearnerRepository from '../../infrastructure/repositories/registration-organization-learner-repository.js';
 import * as scoOrganizationParticipantRepository from '../../infrastructure/repositories/sco-organization-participant-repository.js';
@@ -33,7 +33,7 @@ const dependencies = {
   organizationRepository,
   organizationParticipantRepository,
   organizationLearnerActivityRepository,
-  organizationLearnerRepository,
+  organizationLearnerRepository: repositories.organizationLearnerRepository,
   organizationLearnerImportFormatRepository,
   organizationFeaturesAPI,
   campaignRepository,

--- a/api/src/prescription/organization-learner/infrastructure/repositories/index.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/index.js
@@ -1,0 +1,15 @@
+import * as attestationsApi from '../../../../profile/application/api/attestations-api.js';
+import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
+import * as organizationLearnerRepository from './organization-learner-repository.js';
+
+const repositoriesWithoutInjectedDependencies = {
+  organizationLearnerRepository,
+};
+
+const dependencies = {
+  attestationsApi,
+};
+
+const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies);
+
+export { repositories };

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
@@ -1,5 +1,6 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { filterByFullName } from '../../../../shared/infrastructure/utils/filter-utils.js';
 import { fetchPage } from '../../../../shared/infrastructure/utils/knex-utils.js';
 import { CampaignParticipationStatuses, CampaignTypes } from '../../../shared/domain/constants.js';
@@ -105,6 +106,15 @@ async function findPaginatedLearners({ organizationId, page, filter }) {
   return { learners, pagination };
 }
 
+async function findOrganizationLearnersByDivisions({ organizationId, divisions }) {
+  const knexConnection = DomainTransaction.getConnection();
+  const organizationLearners = await knexConnection
+    .from('view-active-organization-learners')
+    .where({ organizationId })
+    .whereIn('division', divisions);
+  return organizationLearners.map((organizationLearner) => new OrganizationLearner(organizationLearner));
+}
+
 async function getAttestationsForOrganizationLearnersAndKey({ attestationKey, organizationLearners, attestationsApi }) {
   const userIds = organizationLearners.map((learner) => learner.userId);
   return attestationsApi.generateAttestations({
@@ -113,4 +123,9 @@ async function getAttestationsForOrganizationLearnersAndKey({ attestationKey, or
   });
 }
 
-export { findPaginatedLearners, get, getAttestationsForOrganizationLearnersAndKey };
+export {
+  findOrganizationLearnersByDivisions,
+  findPaginatedLearners,
+  get,
+  getAttestationsForOrganizationLearnersAndKey,
+};

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
@@ -105,4 +105,12 @@ async function findPaginatedLearners({ organizationId, page, filter }) {
   return { learners, pagination };
 }
 
-export { findPaginatedLearners, get };
+async function getAttestationsForOrganizationLearnersAndKey({ attestationKey, organizationLearners, attestationsApi }) {
+  const userIds = organizationLearners.map((learner) => learner.userId);
+  return attestationsApi.generateAttestations({
+    attestationKey,
+    userIds,
+  });
+}
+
+export { findPaginatedLearners, get, getAttestationsForOrganizationLearnersAndKey };

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
@@ -30,7 +30,7 @@ function _buildIsCertifiable(queryBuilder, organizationLearnerId) {
     .where('campaign-participations.deletedAt', null);
 }
 
-async function get(organizationLearnerId) {
+async function get({ organizationLearnerId }) {
   const row = await knex
     .with('subquery', (qb) => _buildIsCertifiable(qb, organizationLearnerId))
     .select(

--- a/api/src/prescription/organization-learner/routes.js
+++ b/api/src/prescription/organization-learner/routes.js
@@ -1,5 +1,6 @@
 import * as learnerActivityRoute from './application/learner-activity-route.js';
 import * as learnerListRoute from './application/learner-list-route.js';
+import * as organizationLearnersRoute from './application/organization-learners-route.js';
 import * as registrationOrganizationLearnerRoutes from './application/registration-organization-learner-route.js';
 import * as scoLearnerListRoute from './application/sco-learner-list-route.js';
 import * as supLearnerListRoute from './application/sup-learner-list-route.js';
@@ -10,6 +11,7 @@ const organizationLearnerRoutes = [
   learnerActivityRoute,
   registrationOrganizationLearnerRoutes,
   supLearnerListRoute,
+  organizationLearnersRoute,
 ];
 
 export { organizationLearnerRoutes };

--- a/api/src/profile/application/api/attestations-api.js
+++ b/api/src/profile/application/api/attestations-api.js
@@ -11,9 +11,11 @@ export const generateAttestations = async function ({
   userIds,
   dependencies = { pdfWithFormSerializer },
 }) {
-  const { templateName, data } = await usecases.getAttestationDataForUsers({ attestationKey, userIds });
+  const data = await usecases.getAttestationDataForUsers({ attestationKey, userIds });
+
+  const templateName = 'sixth-grade-attestation-template';
 
   const templatePath = path.join(__dirname, `../../infrastructure/serializers/pdf/templates/${templateName}.pdf`);
 
-  return dependencies.pdfWithFormSerializer.generate(templatePath, data);
+  return dependencies.pdfWithFormSerializer.serialize(templatePath, data);
 };

--- a/api/src/profile/domain/models/ProfileReward.js
+++ b/api/src/profile/domain/models/ProfileReward.js
@@ -1,6 +1,7 @@
 export class ProfileReward {
-  constructor({ id, rewardId, rewardType, createdAt } = {}) {
+  constructor({ id, rewardId, rewardType, createdAt, userId } = {}) {
     this.id = id;
+    this.userId = userId;
     this.rewardId = rewardId;
     this.rewardType = rewardType;
     this.createdAt = createdAt;

--- a/api/src/profile/infrastructure/repositories/profile-reward-repository.js
+++ b/api/src/profile/infrastructure/repositories/profile-reward-repository.js
@@ -44,7 +44,8 @@ export const getByAttestationKeyAndUserIds = async ({ attestationKey, userIds })
     .select(PROFILE_REWARDS_TABLE_NAME + '.*')
     .join(ATTESTATIONS_TABLE_NAME, ATTESTATIONS_TABLE_NAME + '.id', PROFILE_REWARDS_TABLE_NAME + '.rewardId')
     .whereIn('userId', userIds)
-    .where(ATTESTATIONS_TABLE_NAME + '.key', attestationKey);
+    .where(ATTESTATIONS_TABLE_NAME + '.key', attestationKey)
+    .orderBy('id');
   return profileRewards.map(toDomain);
 };
 

--- a/api/tests/prescription/learner-management/unit/infrastructure/organization-learner-repository_test.js
+++ b/api/tests/prescription/learner-management/unit/infrastructure/organization-learner-repository_test.js
@@ -1,0 +1,31 @@
+import { getAttestationsForOrganizationLearnersAndKey } from '../../../../../src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Prescription | Learner-Management | Unit | Infrastructure | organization-learner-repository', function () {
+  describe('#getAttestationsForOrganizationLearnersAndKey', function () {
+    it('should call attestation api with attestationKey and userIds', async function () {
+      //given
+      const attestationApiStub = { generateAttestations: sinon.stub() };
+      const attestationKey = Symbol('attestation');
+      const userId1 = 1;
+      const userId2 = 2;
+      const organizationLearners = [{ userId: userId1 }, { userId: userId2 }];
+
+      const expectedResult = Symbol('expectedResult');
+
+      attestationApiStub.generateAttestations
+        .withArgs({ attestationKey, userIds: [userId1, userId2] })
+        .resolves(expectedResult);
+
+      //when
+      const result = await getAttestationsForOrganizationLearnersAndKey({
+        attestationKey,
+        organizationLearners,
+        attestationsApi: attestationApiStub,
+      });
+
+      //then
+      expect(result).to.be.equal(expectedResult);
+    });
+  });
+});

--- a/api/tests/prescription/organization-learner/acceptance/application/organization-learner-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/application/organization-learner-route_test.js
@@ -1,0 +1,57 @@
+import { REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
+import { Membership } from '../../../../../src/shared/domain/models/index.js';
+import {
+  createServer,
+  databaseBuilder,
+  expect,
+  generateValidRequestAuthorizationHeader,
+  insertUserWithRoleSuperAdmin,
+} from '../../../../test-helper.js';
+
+describe('Prescription | Organization Learner | Acceptance | Application | OrganizationLearnerRoute', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+    await insertUserWithRoleSuperAdmin();
+  });
+
+  describe('GET /api/organizations/{organizationId}/attestations/{attestationKey}', function () {
+    it('should return 200 status code and right content type', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildMembership({
+        userId,
+        organizationId,
+        organizationRole: Membership.roles.MEMBER,
+      });
+      const attestation = databaseBuilder.factory.buildAttestation();
+      const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId,
+        division: '6emeA',
+      });
+      databaseBuilder.factory.buildProfileReward({
+        userId: organizationLearner.userId,
+        rewardId: attestation.id,
+        rewardType: REWARD_TYPES.ATTESTATION,
+      });
+
+      await databaseBuilder.commit();
+
+      const request = {
+        method: 'GET',
+        url: `/api/organizations/${organizationId}/attestations/${attestation.key}?divisions[]=6emeA`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      };
+
+      // when
+
+      const response = await server.inject(request);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.headers['content-type']).to.equal('application/zip');
+    });
+  });
+});

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/get-attestation-zip-for-divisions_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/get-attestation-zip-for-divisions_test.js
@@ -1,0 +1,26 @@
+import { Buffer } from 'node:buffer';
+
+import { usecases } from '../../../../../../src/prescription/organization-learner/domain/usecases/index.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Integration | Prescription | Learner Management | Domain | UseCase | get-attestation-zip-for-divisions', function () {
+  it('returns a zip attestation', async function () {
+    // given
+    const organizationId = databaseBuilder.factory.buildOrganization().id;
+    databaseBuilder.factory.buildOrganizationLearner({ organizationId, division: '6eme A' });
+    databaseBuilder.factory.buildOrganizationLearner({ organizationId, division: '6eme B' });
+    const attestation = databaseBuilder.factory.buildAttestation();
+
+    await databaseBuilder.commit();
+
+    // when
+    const result = await usecases.getAttestationZipForDivisions({
+      attestationKey: attestation.key,
+      divisions: ['6eme A', '6eme B'],
+      organizationId,
+    });
+
+    // then
+    expect(Buffer.isBuffer(result)).to.be.true;
+  });
+});

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -641,4 +641,71 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
       });
     });
   });
+
+  describe('#findOrganizationLearnersByDivisions', function () {
+    let organizationId;
+
+    beforeEach(async function () {
+      organizationId = databaseBuilder.factory.buildOrganization().id;
+
+      await databaseBuilder.commit();
+    });
+
+    it('should return organization learners', async function () {
+      // given
+      const learner1 = databaseBuilder.factory.buildOrganizationLearner({ organizationId, division: '6eme A' });
+      const learner2 = databaseBuilder.factory.buildOrganizationLearner({ organizationId, division: '6eme B' });
+
+      await databaseBuilder.commit();
+
+      // when
+      const learners = await organizationLearnerRepository.findOrganizationLearnersByDivisions({
+        organizationId,
+        divisions: ['6eme A', '6eme B'],
+      });
+
+      // then
+      expect(learners).to.deep.equal([new OrganizationLearner(learner1), new OrganizationLearner(learner2)]);
+    });
+
+    context('when there is no organization with organizationId', function () {
+      const notExistingOrganizationId = '999999';
+
+      it('should return an empty array', async function () {
+        // given
+        databaseBuilder.factory.buildOrganizationLearner({ organizationId, division: '6eme A' });
+        databaseBuilder.factory.buildOrganizationLearner({ organizationId, division: '6eme B' });
+
+        await databaseBuilder.commit();
+
+        // when
+        const result = await organizationLearnerRepository.findOrganizationLearnersByDivisions({
+          organizationId: notExistingOrganizationId,
+          divisions: ['6eme A', '6eme B'],
+        });
+
+        // then
+        expect(result).to.be.empty;
+      });
+    });
+    context('when there is no organizationLearners with these divisions', function () {
+      it('should return an empty array', async function () {
+        // given
+        databaseBuilder.factory.buildOrganizationLearner({ organizationId, division: '6eme A' });
+        databaseBuilder.factory.buildOrganizationLearner({ organizationId, division: '6eme B' });
+        const notExistingDivisions = ['6eme C', '6eme D'];
+
+        await databaseBuilder.commit();
+
+        // when
+        const result = await organizationLearnerRepository.findOrganizationLearnersByDivisions({
+          organizationId,
+          divisions: notExistingDivisions,
+        });
+
+        // then
+        expect(result).to.be.empty;
+      });
+    });
+  });
 });

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -11,7 +11,9 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
         //given
         const randomOrganizationLearnerId = 123;
         //when
-        const err = await catchErr(organizationLearnerRepository.get)(randomOrganizationLearnerId);
+        const err = await catchErr(organizationLearnerRepository.get)({
+          organizationLearnerId: randomOrganizationLearnerId,
+        });
         //then
         expect(err.message).to.equal(`Student not found for ID ${randomOrganizationLearnerId}`);
         expect(err).to.be.an.instanceOf(NotFoundError);
@@ -37,7 +39,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
         });
         await databaseBuilder.commit();
 
-        const organizationLearner = await organizationLearnerRepository.get(1233);
+        const organizationLearner = await organizationLearnerRepository.get({ organizationLearnerId: 1233 });
         expect(organizationLearner.id).to.equal(1233);
         expect(organizationLearner.firstName).to.equal('Dark');
         expect(organizationLearner.lastName).to.equal('Sasuke');
@@ -54,7 +56,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
 
         await databaseBuilder.commit();
 
-        const organizationLearner = await organizationLearnerRepository.get(id);
+        const organizationLearner = await organizationLearnerRepository.get({ organizationLearnerId: id });
 
         expect(organizationLearner.id).to.equal(id);
       });
@@ -70,7 +72,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
             });
             await databaseBuilder.commit();
 
-            const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
+            const organizationLearner = await organizationLearnerRepository.get({ organizationLearnerId });
 
             expect(organizationLearner.group).to.equal('L3');
             expect(organizationLearner.division).to.equal(null);
@@ -87,7 +89,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
             });
             await databaseBuilder.commit();
 
-            const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
+            const organizationLearner = await organizationLearnerRepository.get({ organizationLearnerId });
 
             expect(organizationLearner.division).to.equal('3B');
             expect(organizationLearner.group).to.equal(null);
@@ -104,7 +106,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
             });
             await databaseBuilder.commit();
 
-            const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
+            const organizationLearner = await organizationLearnerRepository.get({ organizationLearnerId });
 
             expect(organizationLearner.group).to.equal(null);
             expect(organizationLearner.division).to.equal(null);
@@ -119,7 +121,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
             const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({ userId });
             await databaseBuilder.commit();
 
-            const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
+            const organizationLearner = await organizationLearnerRepository.get({ organizationLearnerId });
 
             expect(organizationLearner.authenticationMethods).to.be.empty;
           });
@@ -133,7 +135,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
             const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({ userId });
             await databaseBuilder.commit();
 
-            const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
+            const organizationLearner = await organizationLearnerRepository.get({ organizationLearnerId });
 
             expect(organizationLearner.authenticationMethods).to.have.members([
               NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
@@ -167,7 +169,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
             await databaseBuilder.commit();
 
             // when
-            const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
+            const organizationLearner = await organizationLearnerRepository.get({ organizationLearnerId });
 
             //then
             expect(organizationLearner.isCertifiable).to.be.true;
@@ -200,7 +202,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
             });
             await databaseBuilder.commit();
 
-            const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
+            const organizationLearner = await organizationLearnerRepository.get({ organizationLearnerId });
 
             expect(organizationLearner.isCertifiable).to.be.true;
             expect(organizationLearner.certifiableAt).to.deep.equal(certifiableParticipation.sharedAt);
@@ -242,7 +244,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
             await databaseBuilder.commit();
 
             // when
-            const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
+            const organizationLearner = await organizationLearnerRepository.get({ organizationLearnerId });
 
             //then
             expect(organizationLearner.isCertifiable).to.be.false;
@@ -263,7 +265,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
             await databaseBuilder.commit();
 
             // when
-            const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
+            const organizationLearner = await organizationLearnerRepository.get({ organizationLearnerId });
 
             //then
             expect(organizationLearner.isCertifiable).to.be.true;
@@ -293,7 +295,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
             });
             await databaseBuilder.commit();
 
-            const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
+            const organizationLearner = await organizationLearnerRepository.get({ organizationLearnerId });
 
             expect(organizationLearner.isCertifiable).to.be.false;
             expect(organizationLearner).to.be.an.instanceOf(OrganizationLearner);
@@ -321,7 +323,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
 
             await databaseBuilder.commit();
 
-            const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
+            const organizationLearner = await organizationLearnerRepository.get({ organizationLearnerId });
 
             expect(organizationLearner.isCertifiable).to.be.null;
             expect(organizationLearner.certifiableAt).to.be.null;
@@ -346,7 +348,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
             });
             await databaseBuilder.commit();
 
-            const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
+            const organizationLearner = await organizationLearnerRepository.get({ organizationLearnerId });
 
             expect(organizationLearner.isCertifiable).to.be.null;
             expect(organizationLearner.certifiableAt).to.equal(null);
@@ -385,7 +387,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
 
             await databaseBuilder.commit();
 
-            const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
+            const organizationLearner = await organizationLearnerRepository.get({ organizationLearnerId });
 
             expect(organizationLearner.isCertifiable).to.equal(certifiableParticipation.isCertifiable);
             expect(organizationLearner.certifiableAt).to.deep.equal(certifiableParticipation.sharedAt);
@@ -417,7 +419,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
               });
               await databaseBuilder.commit();
 
-              const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
+              const organizationLearner = await organizationLearnerRepository.get({ organizationLearnerId });
 
               expect(organizationLearner.isCertifiable).to.equal(notDeletedParticipation.isCertifiable);
               expect(organizationLearner.certifiableAt).to.deep.equal(notDeletedParticipation.sharedAt);

--- a/api/tests/prescription/organization-learner/unit/domain/usecases/get-organization-learner_test.js
+++ b/api/tests/prescription/organization-learner/unit/domain/usecases/get-organization-learner_test.js
@@ -23,7 +23,7 @@ describe('Unit | UseCase | get-organisation-learner', function () {
     });
 
     // then
-    expect(organizationLearnerRepository.get).to.have.been.calledWithExactly(organizationLearnerId);
+    expect(organizationLearnerRepository.get).to.have.been.calledWithExactly({ organizationLearnerId });
     expect(organizationLearner).to.be.an.instanceOf(OrganizationLearner);
     expect(organizationLearner.firstName).to.be.equal('Michael');
     expect(organizationLearner.lastName).to.be.equal('Jackson');

--- a/api/tests/profile/integration/domain/usecases/get-attestation-data-for-users_test.js
+++ b/api/tests/profile/integration/domain/usecases/get-attestation-data-for-users_test.js
@@ -21,8 +21,8 @@ describe('Profile | Integration | Domain | get-attestation-data-for-users', func
     it('should return profile rewards', async function () {
       const locale = 'FR-fr';
       const attestation = databaseBuilder.factory.buildAttestation();
-      const firstUser = new User(databaseBuilder.factory.buildUser());
-      const secondUser = new User(databaseBuilder.factory.buildUser());
+      const firstUser = new User(databaseBuilder.factory.buildUser({ firstName: 'Alex', lastName: 'Terieur' }));
+      const secondUser = new User(databaseBuilder.factory.buildUser({ firstName: 'Theo', lastName: 'Courant' }));
       const firstCreatedAt = databaseBuilder.factory.buildProfileReward({
         rewardId: attestation.id,
         userId: firstUser.id,
@@ -44,6 +44,8 @@ describe('Profile | Integration | Domain | get-attestation-data-for-users', func
         firstUser.toForm(firstCreatedAt, locale),
         secondUser.toForm(secondCreatedAt, locale),
       ]);
+      expect(results[0].get('fullName')).to.equal('Alex TERIEUR');
+      expect(results[1].get('fullName')).to.equal('Theo COURANT');
     });
   });
 });

--- a/api/tests/profile/integration/infrastructure/repositories/profile-reward-repository_test.js
+++ b/api/tests/profile/integration/infrastructure/repositories/profile-reward-repository_test.js
@@ -138,6 +138,31 @@ describe('Profile | Integration | Repository | profile-reward', function () {
       expect(result[1]).to.be.an.instanceof(ProfileReward);
     });
 
+    it('should return attestation ordered by id asc to prevent flakyness', async function () {
+      // given
+      const attestation = databaseBuilder.factory.buildAttestation();
+
+      const firstReward = new ProfileReward(
+        databaseBuilder.factory.buildProfileReward({ id: 2, rewardId: attestation.id }),
+      );
+
+      const secondReward = new ProfileReward(
+        databaseBuilder.factory.buildProfileReward({ id: 1, rewardId: attestation.id }),
+      );
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await getByAttestationKeyAndUserIds({
+        attestationKey: attestation.key,
+        userIds: [firstReward.userId, secondReward.userId],
+      });
+
+      // then
+      expect(result[0].id).to.equal(secondReward.id);
+      expect(result[1].id).to.equal(firstReward.id);
+    });
+
     it('should not return attestations of other users', async function () {
       // given
       const attestation = databaseBuilder.factory.buildAttestation();

--- a/api/tests/profile/unit/application/api/attestations-api_test.js
+++ b/api/tests/profile/unit/application/api/attestations-api_test.js
@@ -7,22 +7,21 @@ describe('Profile | Unit | Application | Api | attestations', function () {
     it('should return a zip archive with users attestations', async function () {
       const attestationKey = Symbol('attestationKey');
       const userIds = Symbol('userIds');
-      const templateName = 'templateName';
       const data = Symbol('data');
       const expectedBuffer = Symbol('expectedBuffer');
 
       const dependencies = {
         pdfWithFormSerializer: {
-          generate: sinon.stub(),
+          serialize: sinon.stub(),
         },
       };
 
       sinon.stub(usecases, 'getAttestationDataForUsers');
 
-      usecases.getAttestationDataForUsers.withArgs({ attestationKey, userIds }).resolves({ templateName, data });
+      usecases.getAttestationDataForUsers.withArgs({ attestationKey, userIds }).resolves(data);
 
-      dependencies.pdfWithFormSerializer.generate
-        .withArgs(sinon.match(/(\w*\/)*templateName.pdf/), data)
+      dependencies.pdfWithFormSerializer.serialize
+        .withArgs(sinon.match(/(\w*\/)*sixth-grade-attestation-template.pdf/), data)
         .resolves(expectedBuffer);
       const result = await generateAttestations({ attestationKey, userIds, dependencies });
 


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'épix de génération des attestations et suite à la [PR de génération d'une attestation au format PDF pour un utilisateur](https://github.com/1024pix/pix/pull/10255), on souhaite désormais proposer une route pour télécharger les attestations de classes liées à une organisation sous forme d'une archive Zip. 

## :robot: Proposition
Créer une route qui prendra en paramètres une organisation et des classes et renverra, si elles existent, les attestations des élèves de cette classe dans une archive Zip. 

## :100: Pour tester
```
curl 'https://orga-pr10268.review.pix.fr/api/organizations/1000/attestations/SIXTH_GRADE' \
  -H 'Authorization: Bearer BEARER_ICI' \
--output test.zip

```