### PR TITLE
[FEATURE] Permettre la prévisualisation depuis Modulix Editor (PIX-14709)

### DIFF
--- a/mon-pix/app/components/module/preview.gjs
+++ b/mon-pix/app/components/module/preview.gjs
@@ -120,7 +120,7 @@ export default class ModulixPreview extends Component {
   }
 
   <template>
-    {{pageTitle this.module.title}}
+    {{pageTitle this.formattedModule.title}}
 
     <div class="module-preview">
       <aside class="module-preview__passage">

--- a/mon-pix/app/components/module/preview.gjs
+++ b/mon-pix/app/components/module/preview.gjs
@@ -77,6 +77,12 @@ export default class ModulixPreview extends Component {
     super(owner, args);
 
     this.modulixPreviewMode.enable();
+
+    window.addEventListener('message', () => {
+      if (event.data?.from === 'modulix-editor') {
+        this.module = JSON.stringify(event.data.moduleContent, null, 2);
+      }
+    });
   }
 
   get passage() {

--- a/mon-pix/app/components/module/preview.gjs
+++ b/mon-pix/app/components/module/preview.gjs
@@ -78,11 +78,16 @@ export default class ModulixPreview extends Component {
 
     this.modulixPreviewMode.enable();
 
-    window.addEventListener('message', () => {
-      if (event.data?.from === 'modulix-editor') {
-        this.module = JSON.stringify(event.data.moduleContent, null, 2);
-      }
-    });
+    const isWindowOpenedFromModulixEditor = window.opener !== null;
+    if (isWindowOpenedFromModulixEditor) {
+      window.addEventListener('message', (event) => {
+        if (event.data?.from === 'modulix-editor') {
+          this.module = JSON.stringify(event.data.moduleContent, null, 2);
+        }
+      });
+
+      window.opener.postMessage({ from: 'pix-app', message: 'Ready to receive content !' }, '*');
+    }
   }
 
   get passage() {


### PR DESCRIPTION
## :unicorn: Problème

Lorsqu'on travaille sur Modulix Editor, il faut copier coller le json dans le champ côté prévisualisation Modulix. C'est fastidieux. 

## :robot: Proposition

Transmettre à la prévisualisation le contenu du module en cours d'édition dans Modulix Editor.

## :rainbow: Remarques

💃💃💃💃💃💃💃💃💃💃💃💃💃
🪩 PR créée en Tech Time 🪩
🕺🕺🕺🕺🕺🕺🕺🕺🕺🕺🕺🕺🕺

## :100: Pour tester

1. Lancer [Modulix Editor](https://github.com/1024pix/modulix-editor) en local
2. Dans le fichier `index.html` de Modulix Editor, changer l'adresse `app.pix.fr` ou `app.dev.pix.fr`
3. Dans Modulix Editor, cliquer sur *Prévisualiser* et constater que la preview s'ouvre dans un nouvel onglet avec le contenu créé côté Modulix Editor
4. Dans Modulix Editor, modifier le module et constater sur l'autre onglet que la prévisualisation se met à jour 
