### PR TITLE
[FEATURE] Voir le nombre de sujets évalués lors de la consultation d'un PC sur Pix Admin (PIX-9042)

### DIFF
--- a/admin/app/components/target-profiles/target-profile.gjs
+++ b/admin/app/components/target-profiles/target-profile.gjs
@@ -208,6 +208,9 @@ export default class TargetProfile extends Component {
                   "pages.target-profiles.resettable-checkbox.label"
                 }}&#x20;:&#x20;</span>{{this.displayBooleanState this.areKnowledgeElementsResettable}}
             </li>
+            <li><span class="bold">{{t
+                  "pages.target-profiles.tubes-count"
+                }}&#x20;:&#x20;</span>{{@model.tubesCount}}</li>
             {{#if @model.description}}
               <li>
                 <span class="bold">Description&#x20;:&#x20;</span>

--- a/admin/app/models/target-profile.js
+++ b/admin/app/models/target-profile.js
@@ -33,6 +33,7 @@ export default class TargetProfile extends Model {
   @attr('boolean') hasLinkedCampaign;
   @attr('boolean') hasLinkedAutonomousCourse;
   @attr('number') maxLevel;
+  @attr('number') tubesCount;
   @attr() cappedTubes;
 
   @hasMany('badge', { async: true, inverse: null }) badges;

--- a/admin/tests/integration/components/target-profiles/target-profile-test.gjs
+++ b/admin/tests/integration/components/target-profiles/target-profile-test.gjs
@@ -23,7 +23,26 @@ module('Integration | Component | TargetProfile', function (hooks) {
     tubesCount: 6,
   };
 
-  module('campaign / autonomous course link', function () {
+  module('target profile overview section', function () {
+    module('basic informations', function () {
+      test('it should display target profile basic informations', async function (assert) {
+        //given
+        const model = { ...targetProfileSampleData };
+
+        // when
+        const screen = await render(<template><TargetProfile @model={{model}} /></template>);
+
+        // then
+        assert.ok(_findByListItemText(screen, `ID : ${model.id}`));
+        assert.ok(_findByListItemText(screen, `Organisation de référence : ${model.ownerOrganizationId}`));
+        assert.ok(_findByListItemText(screen, 'Date de création : 01/03/2024'));
+        assert.ok(_findByListItemText(screen, 'Obsolète : Non'));
+        assert.ok(_findByListItemText(screen, 'Parcours Accès Simplifié : Non'));
+        assert.ok(_findByListItemText(screen, `${t('pages.target-profiles.resettable-checkbox.label')} : Non`));
+        assert.ok(_findByListItemText(screen, `${t('pages.target-profiles.tubes-count')} : ${model.tubesCount}`));
+      });
+    });
+
     module('when no campaign is linked', function () {
       test('it should display a no-link information', async function (assert) {
         // given
@@ -73,19 +92,6 @@ module('Integration | Component | TargetProfile', function (hooks) {
         assert.dom(_findByListItemText(screen, 'Associé à une campagne ou un parcours autonome : Non')).doesNotExist();
         assert.dom(_findByListItemText(screen, 'Parcours Accès Simplifié : Oui')).exists();
       });
-    });
-  });
-
-  module('Details target profile', function () {
-    test('it should display the number of tubes information', async function (assert) {
-      //given
-      const model = { ...targetProfileSampleData };
-
-      // when
-      const screen = await render(<template><TargetProfile @model={{model}} /></template>);
-
-      // then
-      assert.ok(_findByListItemText(screen, `${t('pages.target-profiles.tubes-count')} : ${model.tubesCount}`));
     });
   });
 });

--- a/admin/tests/integration/components/target-profiles/target-profile-test.gjs
+++ b/admin/tests/integration/components/target-profiles/target-profile-test.gjs
@@ -1,4 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
 import TargetProfile from 'pix-admin/components/target-profiles/target-profile';
 import { module, test } from 'qunit';
 
@@ -19,6 +20,7 @@ module('Integration | Component | TargetProfile', function (hooks) {
     name: 'Dummy target-profile',
     outdated: false,
     ownerOrganizationId: '100',
+    tubesCount: 6,
   };
 
   module('campaign / autonomous course link', function () {
@@ -71,6 +73,19 @@ module('Integration | Component | TargetProfile', function (hooks) {
         assert.dom(_findByListItemText(screen, 'Associé à une campagne ou un parcours autonome : Non')).doesNotExist();
         assert.dom(_findByListItemText(screen, 'Parcours Accès Simplifié : Oui')).exists();
       });
+    });
+  });
+
+  module('Details target profile', function () {
+    test('it should display the number of tubes information', async function (assert) {
+      //given
+      const model = { ...targetProfileSampleData };
+
+      // when
+      const screen = await render(<template><TargetProfile @model={{model}} /></template>);
+
+      // then
+      assert.ok(_findByListItemText(screen, `${t('pages.target-profiles.tubes-count')} : ${model.tubesCount}`));
     });
   });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -644,7 +644,8 @@
       },
       "resettable-checkbox": {
         "label": "Allow resetting for evaluation-type campaigns when multiple submissions are enabled for the organisation"
-      }
+      },
+      "tubes-count": "Number of subjects included in this target profile"
     },
     "trainings": {
       "training": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -661,7 +661,8 @@
       },
       "resettable-checkbox": {
         "label": "Permettre la remise à zéro des acquis du profil cible"
-      }
+      },
+      "tubes-count": "Nombre de sujets compris dans ce profil cible"
     },
     "trainings": {
       "training": {

--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer.js
@@ -44,6 +44,7 @@ const serialize = function ({ targetProfile, filter }) {
       'stageCollection',
       'areas',
       'maxLevel',
+      'tubesCount',
       'cappedTubes',
     ],
     badges: {

--- a/api/src/shared/domain/models/TargetProfileForAdmin.js
+++ b/api/src/shared/domain/models/TargetProfileForAdmin.js
@@ -54,6 +54,7 @@ class TargetProfileForAdmin {
           allSkills: skills,
         }),
     );
+    this.tubesCount = tubes.length;
   }
 
   get cappedTubes() {

--- a/api/tests/acceptance/application/target-profiles/index_test.js
+++ b/api/tests/acceptance/application/target-profiles/index_test.js
@@ -221,6 +221,7 @@ describe('Acceptance | Route | target-profiles', function () {
         'are-knowledge-elements-resettable': false,
         'capped-tubes': [],
         category: 'TEST',
+        'tubes-count': 1,
         comment: 'Un beau profil cible',
         description: 'Une description',
         'created-at': new Date('2020-01-01'),

--- a/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer_test.js
@@ -201,6 +201,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-admin-serializer', fu
             'owner-organization-id': 12,
             'has-linked-campaign': false,
             'has-linked-autonomous-course': false,
+            'tubes-count': 3,
             'capped-tubes': [
               {
                 id: 'recTube1',


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix Admin, lorsqu'on consulte le détail d'un profil cible, le nombre total de sujets n'est pas indiqué.

## :robot: Proposition
API : Ajouter dans la réponse du endpoint une nouvelle propriété indiquant le nombre de sujets
Admin : Rajouter un champs dans les informations du PC, indiquant le nombre de sujets.

## :rainbow: Remarques
Refacto des tests front pour tester l'affichage des informations basiques du PC, en faisant l'impasse sur le champs "Public", voué à disparaître.

## :100: Pour tester
Sur Pix Admin :
1) Se rendre sur la page de détail d'un profil cible
2) Compter à la main les sujets évalués
3) Vérifier que le champs "Nombre de sujets compris dans ce profil cible" indique le bon nombre de sujets 
