### PR TITLE
[FEATURE] Mise à jour de l'url de support dans le formulaire de récupération d'espace (PIX-14682)

### DIFF
--- a/orga/app/templates/join-request.hbs
+++ b/orga/app/templates/join-request.hbs
@@ -12,7 +12,7 @@
         <br />
         Si vous ne le recevez pas, vérifiez les courriers indésirables,<br />
         ou
-        <a href="https://support.pix.fr/support/tickets/new">contactez le support</a>.
+        <a href="https://pix.fr/support/enseignement-scolaire">contactez le support</a>.
       </p>
     {{else}}
       <h1 class="join-request__title">Activez ou récupérez votre espace</h1>
@@ -30,14 +30,17 @@
         <p class="join-request__error-message error-message">
           {{this.errorMessage}}
           Merci de
-          <a href="https://support.pix.fr/support/tickets/new">contacter le support</a>.
+          <a href="https://pix.fr/support/enseignement-scolaire">contacter le support</a>.
         </p>
       {{/if}}
 
       <Auth::JoinRequestForm @onSubmit={{this.createScoOrganizationInvitation}} />
     {{/if}}
     <div class="join-request-form__back">
-      <LinkTo @route="login"><FaIcon @icon="arrow-left" />Revenir à la page de connexion</LinkTo>
+      <LinkTo @route="login">
+        <FaIcon @icon="arrow-left" />
+        Revenir à la page de connexion
+      </LinkTo>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## :unicorn: Problème
Le lien vers le support n'est pas à jour dans le formulaire de récupération d'espace Pix Orga.

## :robot: Proposition
Positionner la nouvelle URL destinée à l'enseignement scolaire : https://pix.fr/support/enseignement-scolaire

## :100: Pour tester
1. Accéder à la page https://orga-pr10274.review.pix.fr/demande-administration-sco. Saisir un UAI erroné, remplir les autres champs et valider.
-> Un message d'erreur apparaît avec un lien vers le support. Celui-ci oriente bien sur https://pix.fr/support/enseignement-scolaire.
2. Saisir un UAI valide (ex : SCO_SIECLE_MANAGING), remplir les autres champs et valider.
-> Un message indique qu'un mail a été envoyé et donne un lien vers le support. Celui-ci oriente également sur https://pix.fr/support/enseignement-scolaire.