### PR TITLE
[FEATURE] Bloquer le test de certif si l’extension n’est pas détectée (PIX-12780)

### DIFF
--- a/mon-pix/app/components/assessments/assessments.gjs
+++ b/mon-pix/app/components/assessments/assessments.gjs
@@ -1,0 +1,11 @@
+import CompanionBlocker from '../companion/blocker';
+
+<template>
+  {{#if @assessment.isCertification}}
+    <CompanionBlocker>
+      {{yield}}
+    </CompanionBlocker>
+  {{else}}
+    {{yield}}
+  {{/if}}
+</template>

--- a/mon-pix/app/components/companion/blocker.gjs
+++ b/mon-pix/app/components/companion/blocker.gjs
@@ -2,7 +2,6 @@
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
-import ENV from 'mon-pix/config/environment';
 
 import ShieldIcon from './shield-icon';
 
@@ -11,16 +10,16 @@ export default class CompanionBlocker extends Component {
 
   constructor(...args) {
     super(...args);
-    if (ENV.APP.FT_IS_PIX_COMPANION_MANDATORY) this.pixCompanion.startCheckingExtensionIsEnabled();
+    this.pixCompanion.startCheckingExtensionIsEnabled();
   }
 
   willDestroy(...args) {
     super.willDestroy(...args);
-    if (ENV.APP.FT_IS_PIX_COMPANION_MANDATORY) this.pixCompanion.stopCheckingExtensionIsEnabled();
+    this.pixCompanion.stopCheckingExtensionIsEnabled();
   }
 
   get isBlocked() {
-    return ENV.APP.FT_IS_PIX_COMPANION_MANDATORY && !this.pixCompanion.isExtensionEnabled;
+    return !this.pixCompanion.isExtensionEnabled;
   }
 
   <template>

--- a/mon-pix/app/templates/assessments.hbs
+++ b/mon-pix/app/templates/assessments.hbs
@@ -1,3 +1,5 @@
 {{page-title @model.title}}
 
-{{outlet}}
+<Assessments::Assessments @assessment={{@model}}>
+  {{outlet}}
+</Assessments::Assessments>

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -172,7 +172,7 @@ module.exports = function (environment) {
     ENV.APP.isTimerCountdownEnabled = false;
     ENV.APP.LOAD_EXTERNAL_SCRIPT = false;
     ENV.APP.FT_FOCUS_CHALLENGE_ENABLED = true;
-    ENV.APP.FT_IS_PIX_COMPANION_MANDATORY = true;
+    ENV.APP.FT_IS_PIX_COMPANION_MANDATORY = false;
     ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID = 999;
     ENV.metrics.enabled = false;
   }

--- a/mon-pix/tests/integration/components/assessments/assessment-test.gjs
+++ b/mon-pix/tests/integration/components/assessments/assessment-test.gjs
@@ -1,0 +1,144 @@
+import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import Assessments from 'mon-pix/components/assessments/assessments';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Assessments | assessments', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('when extension is enabled', function () {
+    test('it displays assessment page', async function (assert) {
+      // given
+      const startCheckingExtensionIsEnabledStub = sinon.stub();
+      const stopCheckingExtensionIsEnabledStub = sinon.stub();
+
+      class PixCompanionStub extends Service {
+        startCheckingExtensionIsEnabled = startCheckingExtensionIsEnabledStub;
+        stopCheckingExtensionIsEnabled = stopCheckingExtensionIsEnabledStub;
+        isExtensionEnabled = true;
+      }
+
+      this.owner.register('service:pix-companion', PixCompanionStub);
+
+      const assessment = { isCertification: true };
+      const title = 'Première question';
+
+      // when
+      const screen = await render(
+        <template>
+          <Assessments @assessment={{assessment}}>
+            <h1>{{title}}</h1>
+          </Assessments>
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByRole('heading', { name: title })).exists();
+    });
+
+    module("when assessment's type is not certification", function () {
+      test('it displays assessment page', async function (assert) {
+        // given
+        const startCheckingExtensionIsEnabledStub = sinon.stub();
+        const stopCheckingExtensionIsEnabledStub = sinon.stub();
+
+        class PixCompanionStub extends Service {
+          startCheckingExtensionIsEnabled = startCheckingExtensionIsEnabledStub;
+          stopCheckingExtensionIsEnabled = stopCheckingExtensionIsEnabledStub;
+          isExtensionEnabled = true;
+        }
+
+        this.owner.register('service:pix-companion', PixCompanionStub);
+
+        const assessment = { isCertification: false };
+        const title = 'Première question';
+
+        // when
+        const screen = await render(
+          <template>
+            <Assessments @assessment={{assessment}}>
+              <h1>{{title}}</h1>
+            </Assessments>
+          </template>,
+        );
+
+        // then
+        assert.dom(screen.getByRole('heading', { name: title })).exists();
+        assert
+          .dom(screen.queryByRole('heading', { name: 'L’extension Pix Companion n’est pas détectée' }))
+          .doesNotExist();
+      });
+    });
+  });
+
+  module('when extension is disabled', function () {
+    test('it displays companion blocker page', async function (assert) {
+      // given
+      const startCheckingExtensionIsEnabledStub = sinon.stub();
+      const stopCheckingExtensionIsEnabledStub = sinon.stub();
+
+      class PixCompanionStub extends Service {
+        startCheckingExtensionIsEnabled = startCheckingExtensionIsEnabledStub;
+        stopCheckingExtensionIsEnabled = stopCheckingExtensionIsEnabledStub;
+        isExtensionEnabled = false;
+      }
+
+      this.owner.register('service:pix-companion', PixCompanionStub);
+
+      const assessment = { isCertification: true };
+      const title = 'Première question';
+
+      // when
+      const screen = await render(
+        <template>
+          <Assessments @assessment={{assessment}}>
+            <h1>{{title}}</h1>
+          </Assessments>
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.queryByRole('heading', { name: title })).doesNotExist();
+      assert
+        .dom(screen.getByRole('heading', { level: 1, name: 'L’extension Pix Companion n’est pas détectée' }))
+        .exists();
+    });
+
+    module("when assessment's type is not certification", function () {
+      test('it displays assessment page', async function (assert) {
+        // given
+        const startCheckingExtensionIsEnabledStub = sinon.stub();
+        const stopCheckingExtensionIsEnabledStub = sinon.stub();
+
+        class PixCompanionStub extends Service {
+          startCheckingExtensionIsEnabled = startCheckingExtensionIsEnabledStub;
+          stopCheckingExtensionIsEnabled = stopCheckingExtensionIsEnabledStub;
+          isExtensionEnabled = false;
+        }
+
+        this.owner.register('service:pix-companion', PixCompanionStub);
+
+        const assessment = { isCertification: false };
+        const title = 'Première question';
+
+        // when
+        const screen = await render(
+          <template>
+            <Assessments @assessment={{assessment}}>
+              <h1>{{title}}</h1>
+            </Assessments>
+          </template>,
+        );
+
+        // then
+        assert.dom(screen.getByRole('heading', { name: title })).exists();
+        assert
+          .dom(screen.queryByRole('heading', { name: 'L’extension Pix Companion n’est pas détectée' }))
+          .doesNotExist();
+      });
+    });
+  });
+});

--- a/mon-pix/tests/integration/components/companion/blocker-test.gjs
+++ b/mon-pix/tests/integration/components/companion/blocker-test.gjs
@@ -2,7 +2,6 @@ import { render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import { t } from 'ember-intl/test-support';
 import CompanionBlocker from 'mon-pix/components/companion/blocker';
-import ENV from 'mon-pix/config/environment';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -72,41 +71,5 @@ module('Integration | Component | Companion | blocker', function (hooks) {
     assert.dom(screen.queryByText(t('common.companion.not-detected.description'))).exists();
 
     // assert.dom(screen.queryByRole('link', { name: t('common.companion.not-detected.link') })).exists();
-  });
-
-  module('FT_IS_PIX_COMPANION_MANDATORY feature toggle', function (hooks) {
-    const ORIGINAL_FT_IS_PIX_COMPANION_MANDATORY = ENV.APP.FT_IS_PIX_COMPANION_MANDATORY;
-
-    hooks.afterEach(() => {
-      ENV.APP.FT_IS_PIX_COMPANION_MANDATORY = ORIGINAL_FT_IS_PIX_COMPANION_MANDATORY;
-    });
-
-    test('when FT is false should always display children content', async function (assert) {
-      // given
-      ENV.APP.FT_IS_PIX_COMPANION_MANDATORY = false;
-
-      const startCheckingExtensionIsEnabledStub = sinon.stub();
-      const stopCheckingExtensionIsEnabledStub = sinon.stub();
-
-      class PixCompanionStub extends Service {
-        startCheckingExtensionIsEnabled = startCheckingExtensionIsEnabledStub;
-        stopCheckingExtensionIsEnabled = stopCheckingExtensionIsEnabledStub;
-        isExtensionEnabled = false;
-      }
-
-      this.owner.register('service:pix-companion', PixCompanionStub);
-
-      const title = 'Companion activé';
-
-      // when
-      const screen = await render(
-        <template>
-          <CompanionBlocker><h1>{{title}}</h1></CompanionBlocker>
-        </template>,
-      );
-
-      sinon.assert.notCalled(startCheckingExtensionIsEnabledStub);
-      assert.dom(screen.queryByRole('heading', { level: 1, name: title })).exists();
-    });
   });
 });

--- a/mon-pix/tests/unit/services/pix-companion-test.js
+++ b/mon-pix/tests/unit/services/pix-companion-test.js
@@ -1,9 +1,16 @@
 import { setupTest } from 'ember-qunit';
+import ENV from 'mon-pix/config/environment';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
 module('Unit | Service | pix-companion', function (hooks) {
   setupTest(hooks);
+
+  const ORIGINAL_FT_IS_PIX_COMPANION_MANDATORY = ENV.APP.FT_IS_PIX_COMPANION_MANDATORY;
+
+  hooks.afterEach(() => {
+    ENV.APP.FT_IS_PIX_COMPANION_MANDATORY = ORIGINAL_FT_IS_PIX_COMPANION_MANDATORY;
+  });
 
   module('#startCertification', function () {
     test('call the window.postMessage and window.dispatchEvent with certification start event', function (assert) {
@@ -59,7 +66,7 @@ module('Unit | Service | pix-companion', function (hooks) {
         listener();
       });
       const pixCompanion = this.owner.lookup('service:pix-companion');
-      pixCompanion.isExtensionEnabled = false;
+      pixCompanion._isExtensionEnabled = false;
 
       // When
       pixCompanion.checkExtensionIsEnabled(windowStub);
@@ -83,7 +90,7 @@ module('Unit | Service | pix-companion', function (hooks) {
         callback();
       });
       const pixCompanion = this.owner.lookup('service:pix-companion');
-      pixCompanion.isExtensionEnabled = true;
+      pixCompanion._isExtensionEnabled = true;
 
       // When
       pixCompanion.checkExtensionIsEnabled(windowStub);
@@ -92,6 +99,71 @@ module('Unit | Service | pix-companion', function (hooks) {
       // Then
       sinon.assert.calledWith(windowStub.dispatchEvent, new CustomEvent('pix:companion:ping'));
       assert.false(pixCompanion.isExtensionEnabled);
+    });
+  });
+
+  module('#startCheckingExtensionIsEnabled', function () {
+    module('when FT_IS_PIX_COMPANION_MANDATORY is false', function () {
+      test('do nothing', async function (assert) {
+        // Given
+        ENV.APP.FT_IS_PIX_COMPANION_MANDATORY = false;
+        const windowStub = {
+          addEventListener: sinon.stub(),
+          dispatchEvent: sinon.stub(),
+          removeEventListener: sinon.stub(),
+          setInterval: sinon.stub(),
+          setTimeout: sinon.stub(),
+        };
+        const pixCompanion = this.owner.lookup('service:pix-companion');
+
+        // When
+        pixCompanion.startCheckingExtensionIsEnabled(windowStub);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        // Then
+        sinon.assert.notCalled(windowStub.addEventListener);
+        sinon.assert.notCalled(windowStub.dispatchEvent);
+        sinon.assert.notCalled(windowStub.removeEventListener);
+        sinon.assert.notCalled(windowStub.setInterval);
+        sinon.assert.notCalled(windowStub.setTimeout);
+        assert.ok(true);
+      });
+    });
+  });
+
+  module('#stopCheckingExtensionIsEnabled', function () {
+    module('when FT_IS_PIX_COMPANION_MANDATORY is false', function () {
+      test('do nothing', async function (assert) {
+        // Given
+        ENV.APP.FT_IS_PIX_COMPANION_MANDATORY = false;
+        const windowStub = {
+          clearInterval: sinon.stub(),
+        };
+        const pixCompanion = this.owner.lookup('service:pix-companion');
+
+        // When
+        pixCompanion.stopCheckingExtensionIsEnabled(windowStub);
+
+        // Then
+        sinon.assert.notCalled(windowStub.clearInterval);
+        assert.ok(true);
+      });
+    });
+  });
+
+  module('#isExtensionEnabled', function () {
+    module('when FT_IS_PIX_COMPANION_MANDATORY is false', function () {
+      test('always return true', async function (assert) {
+        // Given
+        ENV.APP.FT_IS_PIX_COMPANION_MANDATORY = false;
+        const pixCompanion = this.owner.lookup('service:pix-companion');
+
+        // When
+        pixCompanion._isExtensionEnabled = false;
+
+        // Then
+        assert.true(pixCompanion.isExtensionEnabled);
+      });
     });
   });
 });

--- a/mon-pix/tests/unit/services/pix-companion-test.js
+++ b/mon-pix/tests/unit/services/pix-companion-test.js
@@ -8,6 +8,10 @@ module('Unit | Service | pix-companion', function (hooks) {
 
   const ORIGINAL_FT_IS_PIX_COMPANION_MANDATORY = ENV.APP.FT_IS_PIX_COMPANION_MANDATORY;
 
+  hooks.beforeEach(() => {
+    ENV.APP.FT_IS_PIX_COMPANION_MANDATORY = true;
+  });
+
   hooks.afterEach(() => {
     ENV.APP.FT_IS_PIX_COMPANION_MANDATORY = ORIGINAL_FT_IS_PIX_COMPANION_MANDATORY;
   });


### PR DESCRIPTION
## :unicorn: Problème
Lorsque le candidat est entré dans une session de certification et joue les épreuves, dès qu’on ne détecte plus l’extension, afficher la page de blocage.
Dès que l’on détecte à nouveau l’extension, réafficher l'épreuve sur laquelle le candidat se trouvait.

## :robot: Proposition
Mettre en place le Companion blocker sur la route assessments.

## :rainbow: Remarques
Côté Chrome le débloquage nécessite un rafraîchissement de la page.

## :100: Pour tester
Démarrer une session de certification v3 et désactiver l’extension durant la certification, puis vérifier que la page de blocage s’affiche.
Réactiver l’extension, puis vérifier qu’il est possible de reprendre le test.