### PR TITLE
[REFACTOR] Améliorer l'ergonomie de la liste des RT dans Admin (PIX-14711).

### DIFF
--- a/admin/app/components/target-profiles/badges.gjs
+++ b/admin/app/components/target-profiles/badges.gjs
@@ -1,12 +1,16 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
+import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 
-import TickOrCross from '../common/tick-or-cross';
 import ConfirmPopup from '../confirm-popup';
 
 export default class Badges extends Component {
@@ -43,44 +47,75 @@ export default class Badges extends Component {
   <template>
     <div class="content-text content-text--small">
       {{#if this.hasBadges}}
-        <table class="table-admin">
-          <thead>
+        <table class="badges-table table-admin">
+          <thead class="badges-table__header">
             <tr>
-              <th class="table__column table__column--id">ID</th>
-              <th class="badges-table__image">Image</th>
-              <th class="badges-table__key">Clé</th>
-              <th class="badges-table__name">Nom</th>
-              <th>Message</th>
-              <th class="badges-table__shortcoming">Lacune</th>
-              <th class="badges-table__actions">Actions</th>
+              <th class="badges-table-header__id">ID</th>
+              <th class="badges-table-header__image">Image</th>
+              <th class="badges-table-header__key">Clé</th>
+              <th class="badges-table-header__name">Nom</th>
+              <th class="badges-table-header__message">Message</th>
+              <th class="badges-table-header__parameters">
+                <PixTooltip @isWide={{true}}>
+                  <:triggerElement>
+                    Paramètres
+                    <PixIcon @name="help" />
+                  </:triggerElement>
+                  <:tooltip>
+                    {{t "components.badges.tooltips.parameters" htmlSafe=true}}
+                  </:tooltip>
+                </PixTooltip>
+              </th>
+              <th class="badges-table-header__actions">Actions</th>
             </tr>
           </thead>
-          <tbody>
+          <tbody class="badges-table__body">
             {{#each @badges as |badge|}}
               <tr aria-label="Informations du badge {{badge.title}}">
-                <td class="table__column table__column--id">{{badge.id}}</td>
-                <td class="badges-table__image"><img src={{badge.imageUrl}} alt={{badge.altMessage}} /></td>
-                <td class="key-table">{{badge.key}}</td>
-                <td>{{badge.title}}</td>
-                <td>{{badge.message}}</td>
-                <td>
-                  <TickOrCross @isTrue={{badge.isAlwaysVisible}} />
+                <td class="badges-table-body__id">
+                  <LinkTo
+                    @route="authenticated.target-profiles.target-profile.badges.badge"
+                    @model={{badge.id}}
+                    aria-label="Voir le détail du résultat thématique ID {{badge.id}}"
+                  >
+                    {{badge.id}}
+                  </LinkTo>
                 </td>
-                <td class="badges-table__actions">
+                <td class="badges-table-body__image"><img src={{badge.imageUrl}} alt={{badge.altMessage}} /></td>
+                <td class="badges-table-body__key">{{badge.key}}</td>
+                <td class="badges-table-body__title">{{badge.title}}</td>
+                <td class="badges-table-body__message">{{badge.message}}</td>
+                <td class="badges-table-body__parameters">
+                  <PixTag
+                    class={{if badge.isAlwaysVisible "valid" "not-valid"}}
+                    @color={{if badge.isAlwaysVisible "tertiary" "error"}}
+                  >
+                    {{if badge.isAlwaysVisible "En lacune" "Pas en lacune"}}
+                  </PixTag>
+                  <PixTag
+                    class={{if badge.isCertifiable "valid" "not-valid"}}
+                    @color={{if badge.isCertifiable "success" "error"}}
+                  >
+                    {{if badge.isCertifiable "Certifiable" "Pas certifiable"}}
+                  </PixTag>
+                </td>
+                <td class="badges-table-body__actions">
                   <PixButtonLink
                     @variant="secondary"
                     @route="authenticated.target-profiles.target-profile.badges.badge"
                     @size="small"
                     @model={{badge.id}}
-                    class="badges-table-actions__button"
-                    aria-label="Détails du badge {{badge.title}}"
-                  >Voir détail</PixButtonLink>
+                    aria-label="Voir le détail du résultat thématique {{badge.title}}"
+                  >
+                    Voir le détail
+                  </PixButtonLink>
                   <PixButton
                     @size="small"
                     @variant="error"
                     @triggerAction={{fn this.toggleDisplayConfirm badge.id}}
                     class="badges-table-actions-delete"
                     @iconBefore="trash"
+                    aria-label="Supprimer le résultat thématique {{badge.title}}"
                   >
                     Supprimer
                   </PixButton>

--- a/admin/app/styles/components/target-profiles/badges.scss
+++ b/admin/app/styles/components/target-profiles/badges.scss
@@ -1,10 +1,14 @@
 .badges-table {
+  @extend %pix-body-m;
+}
+
+.badges-table-header {
   &__id {
     width: 110px;
   }
 
   &__key {
-    width: 150px;
+    width: 120px;
   }
 
   &__name {
@@ -13,37 +17,78 @@
 
   &__image {
     width: 130px;
-
-    img {
-      width: 90px;
-    }
   }
 
-  &__shortcoming {
-    width: 140px;
+  &__parameters {
+    width: 175px;
+
+    .pix-tooltip {
+      display: block;
+    }
+
+    .pix-tooltip__trigger-element {
+      display: flex;
+      gap: var(--pix-spacing-2x);
+      align-items: center;
+
+      svg {
+        width: 1em;
+        height: 1em;
+      }
+    }
   }
 
   &__actions {
-    width: 160px;
+    width: 180px;
   }
 }
 
-.badges-table-actions {
-  &__button {
-    width: 100%;
-
-    &--delete {
-      display: flex;
-      justify-content: space-between;
-      margin-top: 8px;
+.badges-table-body {
+  &__image {
+    img {
+      display: block;
+      width: 80px;
+      height: 80px;
+      margin: 0 auto;
+      object-fit: contain;
+      object-position: center;
     }
   }
-}
 
-.badges-table-actions-delete {
-  margin-top: $pix-spacing-xs;
-}
+  &__key {
+    word-wrap: break-word;
+  }
 
-.key-table {
-  word-wrap: break-word;
+  &__parameters {
+    & > * {
+      width: 100%;
+
+      & + * {
+        margin-top: var(--pix-spacing-2x);
+      }
+    }
+
+    .valid::before,
+    .not-valid::before {
+      margin-right: 0.25ch;
+    }
+
+    .valid::before {
+      content: '✔'
+    }
+
+    .not-valid::before {
+      content: '✘'
+    }
+  }
+
+  &__actions {
+    & > * {
+      width: 100%;
+    }
+
+    & > *:not(:first-child) {
+      margin-top: var(--pix-spacing-2x);
+    }
+  }
 }

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -13,7 +13,7 @@
         "@1024pix/ember-cli-notifications": "^8.0.2",
         "@1024pix/ember-testing-library": "^3.0.6",
         "@1024pix/eslint-config": "^1.3.8",
-        "@1024pix/pix-ui": "^46.14.0",
+        "@1024pix/pix-ui": "^46.15.2",
         "@1024pix/stylelint-config": "^5.1.20",
         "@babel/eslint-parser": "^7.19.1",
         "@ember/optional-features": "^2.0.0",
@@ -798,9 +798,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "46.14.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-46.14.0.tgz",
-      "integrity": "sha512-wjte7OI1BdaPlqqcI3SlhlXMWP7bvIjsnz71LFMOxj9NSESSG9wR24TKJSP80H5rj947OT0sof06UOcsefPqcQ==",
+      "version": "46.15.2",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-46.15.2.tgz",
+      "integrity": "sha512-vAq2EcYoQu7G+OIf1EIC6/HXoTyv4X1STEZuufqSIwg0O4pOW8ujisOAH57z4xzYV4LKePG2kxgKJom2tO1tFw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/admin/package.json
+++ b/admin/package.json
@@ -45,7 +45,7 @@
     "@1024pix/ember-cli-notifications": "^8.0.2",
     "@1024pix/ember-testing-library": "^3.0.6",
     "@1024pix/eslint-config": "^1.3.8",
-    "@1024pix/pix-ui": "^46.14.0",
+    "@1024pix/pix-ui": "^46.15.2",
     "@1024pix/stylelint-config": "^5.1.20",
     "@babel/eslint-parser": "^7.19.1",
     "@ember/optional-features": "^2.0.0",

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights-test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights-test.js
@@ -446,7 +446,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         // when
         const screen = await visit('/target-profiles/1');
         await clickByName('Clés de lecture');
-        await clickByName('Détails du badge tagada');
+        await clickByName('Voir le détail du résultat thématique tagada');
 
         // then
         assert.strictEqual(currentURL(), '/target-profiles/1/badges/100');
@@ -494,7 +494,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         // when
         const screen = await visit('/target-profiles/1');
         await clickByName('Clés de lecture');
-        await clickByName('Détails du badge ancien titre');
+        await clickByName('Voir le détail du résultat thématique ancien titre');
         await clickByName('Modifier');
         await fillByLabel('* Titre :', 'nouveau titre');
         await fillByLabel('* Clé :', 'NEW_KEY');
@@ -526,7 +526,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         // when
         const screen = await visit('/target-profiles/1');
         await clickByName('Clés de lecture');
-        await clickByName('Détails du badge tagada');
+        await clickByName('Voir le détail du résultat thématique tagada');
         await clickByName('Modifier');
         await fillByLabel('* Titre :', 'tsouintsouin');
         await clickByName('Annuler');
@@ -638,7 +638,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         await waitForElementToBeRemoved(() => screen.queryByRole('listbox'));
 
         await clickByName('Enregistrer le RT');
-        await clickByName('Détails du badge Mon nouveau RT');
+        await clickByName('Voir le détail du résultat thématique Mon nouveau RT');
 
         // then
         assert.strictEqual(currentURL(), '/target-profiles/1/badges/1');

--- a/admin/tests/integration/components/target-profiles/badges-test.gjs
+++ b/admin/tests/integration/components/target-profiles/badges-test.gjs
@@ -1,6 +1,5 @@
 import { clickByName, render } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
-import { find } from '@ember/test-helpers';
 import Badges from 'pix-admin/components/target-profiles/badges';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -10,54 +9,138 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | TargetProfiles::Badges', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it should display the items', async function (assert) {
-    // given
-    const badges = [
-      EmberObject.create({
-        id: 1,
-        key: 'My key',
-        title: 'My title',
-        message: 'My message',
-        imageUrl: 'data:,',
-        altMessage: 'My alt message',
-      }),
-    ];
+  module('when there is no badge', function () {
+    test('it should display a message when empty', async function (assert) {
+      // given
+      const badges = [];
 
-    // when
-    const screen = await render(<template><Badges @badges={{badges}} /></template>);
+      // when
+      const screen = await render(<template><Badges @badges={{badges}} /></template>);
 
-    // then
-    assert.dom('table').exists();
-    assert.dom('thead').exists();
-    assert.dom('tbody').exists();
-    assert.dom(screen.getByText('ID')).exists();
-    assert.dom(screen.getByText('Image')).exists();
-    assert.dom(screen.getByText('Clé')).exists();
-    assert.dom(screen.getByText('Nom')).exists();
-    assert.dom(screen.getByText('Message')).exists();
-    assert.dom(screen.getByText('Actions')).exists();
-    assert.dom('tbody tr').exists({ count: 1 });
-    assert.strictEqual(find('tbody tr td:first-child').textContent, '1');
-    assert.dom('tbody tr td:nth-child(2) img').exists();
-    assert.strictEqual(find('tbody tr td:nth-child(2) img').getAttribute('src'), 'data:,');
-    assert.strictEqual(find('tbody tr td:nth-child(2) img').getAttribute('alt'), 'My alt message');
-    assert.dom(screen.getByText('My key')).exists();
-    assert.dom(screen.getByText('My title')).exists();
-    assert.dom(screen.getByText('My message')).exists();
-    assert.dom(screen.getByText('Voir détail')).exists();
-    assert.dom(screen.queryByText('Aucun résultat thématique associé')).doesNotExist();
+      // then
+      assert.dom('table').doesNotExist();
+      assert.dom(screen.getByText('Aucun résultat thématique associé')).exists();
+    });
   });
 
-  test('it should display a message when empty', async function (assert) {
-    // given
-    const badges = [];
+  module('when there is some badges', function () {
+    test('it should display the items', async function (assert) {
+      // given
+      const badges = [
+        EmberObject.create({
+          id: 1,
+          key: 'My key',
+          title: 'My title',
+          message: 'My message',
+          imageUrl: 'data:,',
+          altMessage: 'My alt message',
+        }),
+      ];
 
-    // when
-    const screen = await render(<template><Badges @badges={{badges}} /></template>);
+      // when
+      const screen = await render(<template><Badges @badges={{badges}} /></template>);
 
-    // then
-    assert.dom('table').doesNotExist();
-    assert.dom(screen.getByText('Aucun résultat thématique associé')).exists();
+      // then
+      assert.dom(screen.queryByText('Aucun résultat thématique associé')).doesNotExist();
+
+      assert.dom(screen.getByRole('table')).exists();
+
+      assert.dom(screen.getAllByRole('columnheader')[0]).hasText('ID');
+      assert.dom(screen.getAllByRole('columnheader')[1]).hasText('Image');
+      assert.dom(screen.getAllByRole('columnheader')[2]).hasText('Clé');
+      assert.dom(screen.getAllByRole('columnheader')[3]).hasText('Nom');
+      assert.dom(screen.getAllByRole('columnheader')[4]).hasText('Message');
+      assert.dom(screen.getAllByRole('columnheader')[5]).hasText(/Paramètres/);
+      assert.dom(screen.getAllByRole('columnheader')[6]).hasText('Actions');
+
+      assert.dom(screen.getByRole('row', { name: 'Informations du badge My title' })).exists();
+
+      assert.dom(screen.getAllByRole('cell')[0].children[0]).hasTagName('a');
+      assert
+        .dom(screen.getAllByRole('cell')[0].children[0])
+        .hasAttribute('aria-label', 'Voir le détail du résultat thématique ID 1');
+
+      assert.strictEqual(screen.getAllByRole('cell')[1].children.length, 1);
+      assert.dom(screen.getAllByRole('cell')[1].children[0]).hasTagName('img');
+      assert.dom(screen.getAllByRole('cell')[1].children[0]).hasAttribute('src', 'data:,');
+      assert.dom(screen.getAllByRole('cell')[1].children[0]).hasAttribute('alt', 'My alt message');
+
+      assert.dom(screen.getAllByRole('cell')[2]).hasText('My key');
+      assert.dom(screen.getAllByRole('cell')[3]).hasText('My title');
+      assert.dom(screen.getAllByRole('cell')[4]).hasText('My message');
+
+      assert.strictEqual(screen.getAllByRole('cell')[5].children.length, 2);
+      assert.dom(screen.getAllByRole('cell')[5].children[0]).hasText('Pas en lacune');
+      assert.dom(screen.getAllByRole('cell')[5].children[1]).hasText('Pas certifiable');
+
+      assert.strictEqual(screen.getAllByRole('cell')[6].children.length, 2);
+      assert
+        .dom(screen.getAllByRole('cell')[6].children[0])
+        .hasAttribute('aria-label', 'Voir le détail du résultat thématique My title');
+      assert
+        .dom(screen.getAllByRole('cell')[6].children[1])
+        .hasAttribute('aria-label', 'Supprimer le résultat thématique My title');
+    });
+
+    module('when the badge is always visible', function () {
+      test('it should display an always visible tag', async function (assert) {
+        // given
+        const badges = [
+          EmberObject.create({
+            isAlwaysVisible: true,
+          }),
+        ];
+
+        // when
+        const screen = await render(<template><Badges @badges={{badges}} /></template>);
+
+        // then
+        assert.dom(screen.queryByText('Pas en lacune')).doesNotExist();
+        assert.dom(screen.getAllByRole('cell')[5].children[0]).hasText('En lacune');
+      });
+    });
+
+    module('when the badge is certifiable', function () {
+      test('it should display a certifiable tag', async function (assert) {
+        // given
+        const badges = [
+          EmberObject.create({
+            isCertifiable: true,
+          }),
+        ];
+
+        // when
+        const screen = await render(<template><Badges @badges={{badges}} /></template>);
+
+        // then
+        assert.dom(screen.queryByText('Pas certifiable')).doesNotExist();
+        assert.dom(screen.getAllByRole('cell')[5].children[1]).hasText('Certifiable');
+      });
+    });
+
+    module('when there is multiple badges', function () {
+      test('it should display a specific row for each badge', async function (assert) {
+        // given
+        const badges = [
+          EmberObject.create({
+            id: 1,
+            title: 'First badge',
+          }),
+          EmberObject.create({
+            id: 2,
+            title: 'Second badge',
+          }),
+        ];
+
+        // when
+        const screen = await render(<template><Badges @badges={{badges}} /></template>);
+
+        // then
+        assert.strictEqual(screen.getAllByRole('row').length, 3);
+        assert.dom(screen.getAllByRole('row')[1]).hasAttribute('aria-label', 'Informations du badge First badge');
+        assert.dom(screen.getAllByRole('row')[2]).hasAttribute('aria-label', 'Informations du badge Second badge');
+      });
+    });
   });
 
   module('when deleting a badge', function (hooks) {
@@ -87,7 +170,7 @@ module('Integration | Component | TargetProfiles::Badges', function (hooks) {
 
       // when
       const screen = await render(<template><Badges @badges={{badges}} /></template>);
-      await clickByName('Supprimer');
+      await clickByName(/Supprimer/);
       await screen.findByRole('dialog');
 
       // then
@@ -107,7 +190,7 @@ module('Integration | Component | TargetProfiles::Badges', function (hooks) {
 
       // when
       const screen = await render(<template><Badges @badges={{badges}} /></template>);
-      await clickByName('Supprimer');
+      await clickByName(/Supprimer/);
       await screen.findByRole('dialog');
       await clickByName('Confirmer');
 

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -253,6 +253,9 @@
     "badges": {
       "api-error-messages": {
         "key-already-exists": "The badge key {badgeKey} already exists"
+      },
+      "tooltips": {
+        "parameters": "<u>Always visible</u><br/>If the badge is always visible and the learner has not fulfilled the obtaining conditions, then the badge will not be seen on the results screen.<br/><br/><u>Certifiable</u><br/>The badge becomes a prerequisite for certification."
       }
     },
     "certification-centers": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -261,6 +261,9 @@
     "badges": {
       "api-error-messages": {
         "key-already-exists": "La clé de badge {badgeKey} est déjà utilisée"
+      },
+      "tooltips": {
+        "parameters": "<u>En lacune</u><br/>Si le RT est en lacune et que l'apprenant n'a pas rempli les conditions d'obtention de ce RT, alors on ne verra le RT sur l'écran de résultats.<br/><br/><u>Certifiable</u><br/>Le RT devient un pré-requis pour une certification."
       }
     },
     "certification-centers": {


### PR DESCRIPTION
## :unicorn: Problème

Le tableau listant les RT, dans la page de profil-cible de PixAdmin, n'était pas très clair visuellement.
(Par exemple, l'intitulé "Lacune" n'était pas du tout expliqué)

## :robot: Proposition

- Transformer la colonne "Lacune" en "Paramètres":
  - afficher sous forme de tags si le RT est en lacune et certifiable.
  - ajouter un tooltip sur la colonne pour expliquer les termes
- Permettre de clique sur l'ID du RT pour voir son détail
- Réduire la taille du texte pour plus de visibilité

## ℹ️ Remarques

On profite de la PR pour monter la version de PixAdmin

## :100: Pour tester

- Visiter [cette page en RA](https://admin-pr10280.review.pix.fr/target-profiles/1000001/insights) et constater les changements
