### PR TITLE
[FEATURE] Lister les RT certifiants des campagnes en premier (PIX-14560).

### DIFF
--- a/api/src/evaluation/infrastructure/repositories/badge-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/badge-repository.js
@@ -16,7 +16,8 @@ const findByCampaignId = async (campaignId) => {
     .join('target-profiles', 'target-profiles.id', `${TABLE_NAME}.targetProfileId`)
     .join('campaigns', 'campaigns.targetProfileId', 'target-profiles.id')
     .where('campaigns.id', campaignId)
-    .orderBy('id');
+    .orderBy('isCertifiable', 'DESC')
+    .orderBy('id', 'ASC');
 };
 
 const isAssociated = async (badgeId) => {


### PR DESCRIPTION
## :unicorn: Problème

Sur PixApp, dans les pages de début et de fin de parcours, on affiche une liste de RT.
Cette liste affiche toujours les RT certifiants en premier, mais on traitait ce tri dans le front.

## :robot: Proposition

Gérer le tri dans le back, dans la méthode `findByCampaignId` du `badge-repository`.

## ℹ️ Remarques

Après cette PR, on pourra enlever les tris faits dans le front :
- https://github.com/1024pix/pix/blob/dev/mon-pix/app/components/campaigns/assessment/skill-review/evaluation-results-tabs/rewards/index.gjs#L12
- Dans le hero de la page de fin de parcours

## :100: Pour tester

Tests verts.
