### PR TITLE
[TECH] Créer le feature toggle FT_PIX_COMPANION_ENABLED (PIX-14733).

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -802,6 +802,13 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: false
 #FT_ENABLE_V3_ELIGIBILITY_CHECK=false
 
+# Consider the Pix Companion extension as active
+#
+# presence: optional
+# type: boolean
+# default: false
+# FT_PIX_COMPANION_ENABLED=false
+
 # =====
 # CPF
 # =====

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -213,6 +213,7 @@ const configuration = (function () {
       isTextToSpeechButtonEnabled: toBoolean(process.env.FT_ENABLE_TEXT_TO_SPEECH_BUTTON),
       showExperimentalMissions: toBoolean(process.env.FT_SHOW_EXPERIMENTAL_MISSIONS),
       showNewResultPage: toBoolean(process.env.FT_SHOW_NEW_RESULT_PAGE),
+      isPixCompanionEnabled: toBoolean(process.env.FT_PIX_COMPANION_ENABLED),
     },
     hapi: {
       options: {},
@@ -414,6 +415,7 @@ const configuration = (function () {
     config.featureToggles.isNeedToAdjustCertificationAccessibilityEnabled = false;
     config.featureToggles.showNewResultPage = false;
     config.featureToggles.showExperimentalMissions = false;
+    config.featureToggles.isPixCompanionEnabled = false;
 
     config.mailing.enabled = false;
     config.mailing.provider = 'brevo';

--- a/api/src/shared/infrastructure/validate-environment-variables.js
+++ b/api/src/shared/infrastructure/validate-environment-variables.js
@@ -39,6 +39,7 @@ const schema = Joi.object({
   FT_ENABLE_NEED_TO_ADJUST_CERTIFICATION_ACCESSIBILITY: Joi.string().optional().valid('true', 'false'),
   FT_ENABLE_PIX_PLUS_LOWER_LEVEL: Joi.string().optional().valid('true', 'false'),
   FT_ENABLE_TEXT_TO_SPEECH_BUTTON: Joi.string().optional().valid('true', 'false'),
+  FT_PIX_COMPANION_ENABLED: Joi.string().optional().valid('true', 'false'),
   KNEX_ASYNC_STACKTRACE_ENABLED: Joi.string().optional().valid('true', 'false'),
   LCMS_API_KEY: Joi.string().required(),
   LCMS_API_URL: Joi.string().uri().required(),

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -31,6 +31,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-text-to-speech-button-enabled': false,
             'show-new-result-page': false,
             'show-experimental-missions': false,
+            'is-pix-companion-enabled': false,
           },
         },
       };

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -4,4 +4,5 @@ export default class FeatureToggle extends Model {
   @attr('boolean') isNewAuthenticationDesignEnabled;
   @attr('boolean') isTextToSpeechButtonEnabled;
   @attr('boolean') showNewResultPage;
+  @attr('boolean') isPixCompanionEnabled;
 }

--- a/mon-pix/app/services/pix-companion.js
+++ b/mon-pix/app/services/pix-companion.js
@@ -8,11 +8,13 @@ export default class PixCompanion extends Service {
   #checkExtensionIsEnabledInterval;
 
   startCertification(windowRef = window) {
+    if (!this.featureToggles.featureToggles.isPixCompanionEnabled) return;
     windowRef.dispatchEvent(new CustomEvent('pix:certification:start'));
     windowRef.postMessage({ event: 'pix:certification:start' }, windowRef.location.origin);
   }
 
   stopCertification(windowRef = window) {
+    if (!this.featureToggles.featureToggles.isPixCompanionEnabled) return;
     windowRef.dispatchEvent(new CustomEvent('pix:certification:stop'));
     windowRef.postMessage({ event: 'pix:certification:stop' }, windowRef.location.origin);
   }

--- a/mon-pix/app/services/pix-companion.js
+++ b/mon-pix/app/services/pix-companion.js
@@ -1,8 +1,8 @@
-import Service from '@ember/service';
+import Service, { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import ENV from 'mon-pix/config/environment';
 
 export default class PixCompanion extends Service {
+  @service featureToggles;
   @tracked _isExtensionEnabled = true;
 
   #checkExtensionIsEnabledInterval;
@@ -18,13 +18,13 @@ export default class PixCompanion extends Service {
   }
 
   startCheckingExtensionIsEnabled(windowRef = window) {
-    if (!ENV.APP.FT_IS_PIX_COMPANION_MANDATORY) return;
+    if (!this.featureToggles.featureToggles.isPixCompanionEnabled) return;
     this.checkExtensionIsEnabled(windowRef);
     this.#checkExtensionIsEnabledInterval = windowRef.setInterval(() => this.checkExtensionIsEnabled(windowRef), 1000);
   }
 
   stopCheckingExtensionIsEnabled(windowRef = window) {
-    if (!ENV.APP.FT_IS_PIX_COMPANION_MANDATORY) return;
+    if (!this.featureToggles.featureToggles.isPixCompanionEnabled) return;
     windowRef.clearInterval(this.#checkExtensionIsEnabledInterval);
   }
 
@@ -50,7 +50,7 @@ export default class PixCompanion extends Service {
   }
 
   get isExtensionEnabled() {
-    if (!ENV.APP.FT_IS_PIX_COMPANION_MANDATORY) return true;
+    if (!this.featureToggles.featureToggles.isPixCompanionEnabled) return true;
     return this._isExtensionEnabled;
   }
 }

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -43,7 +43,6 @@ module.exports = function (environment) {
       // when it is created
       API_HOST: process.env.API_HOST || '',
       FT_FOCUS_CHALLENGE_ENABLED: _isFeatureEnabled(process.env.FT_FOCUS_CHALLENGE_ENABLED) || false,
-      FT_IS_PIX_COMPANION_MANDATORY: _isFeatureEnabled(process.env.FT_IS_PIX_COMPANION_MANDATORY) || false,
       isTimerCountdownEnabled: true,
       LOAD_EXTERNAL_SCRIPT: true,
       NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS: 5,
@@ -172,7 +171,6 @@ module.exports = function (environment) {
     ENV.APP.isTimerCountdownEnabled = false;
     ENV.APP.LOAD_EXTERNAL_SCRIPT = false;
     ENV.APP.FT_FOCUS_CHALLENGE_ENABLED = true;
-    ENV.APP.FT_IS_PIX_COMPANION_MANDATORY = false;
     ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID = 999;
     ENV.metrics.enabled = false;
   }

--- a/mon-pix/tests/unit/services/feature-toggles-test.js
+++ b/mon-pix/tests/unit/services/feature-toggles-test.js
@@ -11,6 +11,7 @@ module('Unit | Service | feature-toggles', function (hooks) {
     const featureToggles = Object.create({
       isTextToSpeechButtonEnabled: false,
       isNewAuthenticationDesignEnabled: false,
+      isPixCompanionEnabled: false,
     });
 
     let storeStub;
@@ -45,7 +46,7 @@ module('Unit | Service | feature-toggles', function (hooks) {
       assert.false(featureToggleService.featureToggles.isTextToSpeechButtonEnabled);
     });
 
-    test('it initializes the feature toggle isNewAuthenticationDesignEnabled to true', async function (assert) {
+    test('it initializes the feature toggle isNewAuthenticationDesignEnabled to false', async function (assert) {
       // given
       const featureToggleService = this.owner.lookup('service:featureToggles');
       featureToggleService.set('store', storeStub);
@@ -55,6 +56,18 @@ module('Unit | Service | feature-toggles', function (hooks) {
 
       // then
       assert.false(featureToggleService.featureToggles.isNewAuthenticationDesignEnabled);
+    });
+
+    test('it initializes the feature toggle isPixCompanionEnabled to false', async function (assert) {
+      // given
+      const featureToggleService = this.owner.lookup('service:featureToggles');
+      featureToggleService.set('store', storeStub);
+
+      // when
+      await featureToggleService.load();
+
+      // then
+      assert.false(featureToggleService.featureToggles.isPixCompanionEnabled);
     });
   });
 });

--- a/mon-pix/tests/unit/services/pix-companion-test.js
+++ b/mon-pix/tests/unit/services/pix-companion-test.js
@@ -1,19 +1,14 @@
 import { setupTest } from 'ember-qunit';
-import ENV from 'mon-pix/config/environment';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
 module('Unit | Service | pix-companion', function (hooks) {
   setupTest(hooks);
+  let pixCompanion;
 
-  const ORIGINAL_FT_IS_PIX_COMPANION_MANDATORY = ENV.APP.FT_IS_PIX_COMPANION_MANDATORY;
-
-  hooks.beforeEach(() => {
-    ENV.APP.FT_IS_PIX_COMPANION_MANDATORY = true;
-  });
-
-  hooks.afterEach(() => {
-    ENV.APP.FT_IS_PIX_COMPANION_MANDATORY = ORIGINAL_FT_IS_PIX_COMPANION_MANDATORY;
+  hooks.beforeEach(function () {
+    pixCompanion = this.owner.lookup('service:pix-companion');
+    pixCompanion.featureToggles = { featureToggles: { isPixCompanionEnabled: true } };
   });
 
   module('#startCertification', function () {
@@ -24,7 +19,6 @@ module('Unit | Service | pix-companion', function (hooks) {
         postMessage: sinon.stub(),
         location: { origin: 'test' },
       };
-      const pixCompanion = this.owner.lookup('service:pix-companion');
 
       // When
       pixCompanion.startCertification(windowStub);
@@ -44,7 +38,6 @@ module('Unit | Service | pix-companion', function (hooks) {
         postMessage: sinon.stub(),
         location: { origin: 'test' },
       };
-      const pixCompanion = this.owner.lookup('service:pix-companion');
 
       // When
       pixCompanion.stopCertification(windowStub);
@@ -69,7 +62,6 @@ module('Unit | Service | pix-companion', function (hooks) {
         assert.strictEqual(type, 'pix:companion:pong');
         listener();
       });
-      const pixCompanion = this.owner.lookup('service:pix-companion');
       pixCompanion._isExtensionEnabled = false;
 
       // When
@@ -93,7 +85,6 @@ module('Unit | Service | pix-companion', function (hooks) {
         assert.strictEqual(timeout, 100);
         callback();
       });
-      const pixCompanion = this.owner.lookup('service:pix-companion');
       pixCompanion._isExtensionEnabled = true;
 
       // When
@@ -107,10 +98,9 @@ module('Unit | Service | pix-companion', function (hooks) {
   });
 
   module('#startCheckingExtensionIsEnabled', function () {
-    module('when FT_IS_PIX_COMPANION_MANDATORY is false', function () {
+    module('when the feature toggle isPixCompanionEnabled is false', function () {
       test('do nothing', async function (assert) {
         // Given
-        ENV.APP.FT_IS_PIX_COMPANION_MANDATORY = false;
         const windowStub = {
           addEventListener: sinon.stub(),
           dispatchEvent: sinon.stub(),
@@ -118,7 +108,7 @@ module('Unit | Service | pix-companion', function (hooks) {
           setInterval: sinon.stub(),
           setTimeout: sinon.stub(),
         };
-        const pixCompanion = this.owner.lookup('service:pix-companion');
+        pixCompanion.featureToggles.featureToggles.isPixCompanionEnabled = false;
 
         // When
         pixCompanion.startCheckingExtensionIsEnabled(windowStub);
@@ -136,14 +126,13 @@ module('Unit | Service | pix-companion', function (hooks) {
   });
 
   module('#stopCheckingExtensionIsEnabled', function () {
-    module('when FT_IS_PIX_COMPANION_MANDATORY is false', function () {
+    module('when the feature toggle isPixCompanionEnabled is false', function () {
       test('do nothing', async function (assert) {
         // Given
-        ENV.APP.FT_IS_PIX_COMPANION_MANDATORY = false;
         const windowStub = {
           clearInterval: sinon.stub(),
         };
-        const pixCompanion = this.owner.lookup('service:pix-companion');
+        pixCompanion.featureToggles.featureToggles.isPixCompanionEnabled = false;
 
         // When
         pixCompanion.stopCheckingExtensionIsEnabled(windowStub);
@@ -156,11 +145,10 @@ module('Unit | Service | pix-companion', function (hooks) {
   });
 
   module('#isExtensionEnabled', function () {
-    module('when FT_IS_PIX_COMPANION_MANDATORY is false', function () {
+    module('when the feature toggle isPixCompanionEnabled is false', function () {
       test('always return true', async function (assert) {
         // Given
-        ENV.APP.FT_IS_PIX_COMPANION_MANDATORY = false;
-        const pixCompanion = this.owner.lookup('service:pix-companion');
+        pixCompanion.featureToggles.featureToggles.isPixCompanionEnabled = false;
 
         // When
         pixCompanion._isExtensionEnabled = false;

--- a/mon-pix/tests/unit/services/pix-companion-test.js
+++ b/mon-pix/tests/unit/services/pix-companion-test.js
@@ -28,6 +28,26 @@ module('Unit | Service | pix-companion', function (hooks) {
       sinon.assert.calledWith(windowStub.postMessage, { event: 'pix:certification:start' }, 'test');
       assert.ok(true);
     });
+
+    module('when the feature toggle isPixCompanionEnabled is false', function () {
+      test('do nothing', async function (assert) {
+        // Given
+        pixCompanion.featureToggles.featureToggles.isPixCompanionEnabled = false;
+        const windowStub = {
+          dispatchEvent: sinon.stub(),
+          postMessage: sinon.stub(),
+          location: { origin: 'test' },
+        };
+
+        // When
+        pixCompanion.startCertification(windowStub);
+
+        // Then
+        sinon.assert.notCalled(windowStub.dispatchEvent);
+        sinon.assert.notCalled(windowStub.postMessage);
+        assert.ok(true);
+      });
+    });
   });
 
   module('#stopCertification', function () {
@@ -46,6 +66,26 @@ module('Unit | Service | pix-companion', function (hooks) {
       sinon.assert.calledWith(windowStub.dispatchEvent, new CustomEvent('pix:certification:stop'));
       sinon.assert.calledWith(windowStub.postMessage, { event: 'pix:certification:stop' }, 'test');
       assert.ok(true);
+    });
+
+    module('when the feature toggle isPixCompanionEnabled is false', function () {
+      test('do nothing', async function (assert) {
+        // Given
+        pixCompanion.featureToggles.featureToggles.isPixCompanionEnabled = false;
+        const windowStub = {
+          dispatchEvent: sinon.stub(),
+          postMessage: sinon.stub(),
+          location: { origin: 'test' },
+        };
+
+        // When
+        pixCompanion.stopCertification(windowStub);
+
+        // Then
+        sinon.assert.notCalled(windowStub.dispatchEvent);
+        sinon.assert.notCalled(windowStub.postMessage);
+        assert.ok(true);
+      });
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement on utilise un FT coté Pix App `FT_IS_PIX_COMPANION_MANDATORY` pour activer la vérification de la présence de l'extension en certification.

Les nouvelles fonctionnalités à venir vont toucher Pix Certif, ce qui nous amène a repenser l'usage de ce FT uniquement disponible sur Pix App

## :robot: Proposition

- Créer le FT au niveau de l'API pour être utilisé par plusieurs front.
- Remplacer l'ancien FT coté Pix App par le nouveau.

## :100: Pour tester

Vérifier que le blocage et le filtrage sont désactivés quand le FT est à false.
Vérifier qu’ils sont actifs quand le FT est à true.