### PR TITLE
[TECH] Correction du tests Flaky sur le usecase `get-data-organizations-places-statistics` (PIX-14739)

### DIFF
--- a/api/tests/prescription/organization-place/integration/domain/usecases/get-data-organizations-places-statistics_test.js
+++ b/api/tests/prescription/organization-place/integration/domain/usecases/get-data-organizations-places-statistics_test.js
@@ -51,18 +51,33 @@ describe('Integration | UseCases | get-data-organizations-places-statistics', fu
     });
 
     // then
-    expect(dataOrganizationsPlacesStatistics[0].organizationId).to.equal(firstOrganization.id);
-    expect(dataOrganizationsPlacesStatistics[0].organizationActivePlacesLotCount).to.equal(1);
-    expect(dataOrganizationsPlacesStatistics[0].organizationPlacesCount).to.equal(10);
-    expect(dataOrganizationsPlacesStatistics[0].organizationOccupiedPlacesCount).to.equal(1);
-    expect(dataOrganizationsPlacesStatistics[0].organizationName).to.equal('Mon collège');
-    expect(dataOrganizationsPlacesStatistics[0].organizationType).to.equal('SCO');
+    const results = dataOrganizationsPlacesStatistics.map((dataOrganizationsPlacesStatistic) => ({
+      organizationId: dataOrganizationsPlacesStatistic.organizationId,
+      organizationActivePlacesLotCount: dataOrganizationsPlacesStatistic.organizationActivePlacesLotCount,
+      organizationPlacesCount: dataOrganizationsPlacesStatistic.organizationPlacesCount,
+      organizationOccupiedPlacesCount: dataOrganizationsPlacesStatistic.organizationOccupiedPlacesCount,
+      organizationName: dataOrganizationsPlacesStatistic.organizationName,
+      organizationType: dataOrganizationsPlacesStatistic.organizationType,
+    }));
 
-    expect(dataOrganizationsPlacesStatistics[1].organizationId).to.equal(secondOrganization.id);
-    expect(dataOrganizationsPlacesStatistics[1].organizationActivePlacesLotCount).to.equal(1);
-    expect(dataOrganizationsPlacesStatistics[1].organizationPlacesCount).to.equal(null);
-    expect(dataOrganizationsPlacesStatistics[1].organizationName).to.equal('Pole Emploi');
-    expect(dataOrganizationsPlacesStatistics[1].organizationType).to.equal('PRO');
-    expect(dataOrganizationsPlacesStatistics[1].organizationOccupiedPlacesCount).to.equal(0);
+    expect(dataOrganizationsPlacesStatistics).lengthOf(2);
+    expect(results).to.have.deep.members([
+      {
+        organizationId: secondOrganization.id,
+        organizationActivePlacesLotCount: 1,
+        organizationPlacesCount: null,
+        organizationOccupiedPlacesCount: 0,
+        organizationName: 'Pole Emploi',
+        organizationType: 'PRO',
+      },
+      {
+        organizationId: firstOrganization.id,
+        organizationActivePlacesLotCount: 1,
+        organizationPlacesCount: 10,
+        organizationOccupiedPlacesCount: 1,
+        organizationName: 'Mon collège',
+        organizationType: 'SCO',
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
le retour API qui permet de données les lots de place n'est pas soumis à un tri. l'ordre de retour peut changer en fonction de comment la données est stockée en BDD

## :robot: Proposition
Ne plus se préoccuper de l'emplacement de la données pour vérifier l'évaluation du test

## :rainbow: Remarques
RAS

## :100: Pour tester
CI au vert 