### PR TITLE
[BUGFIX] Vérifier l'éligibilité de l'utilisateur en fonction du profil cible du badge acquis (PIX-14763)

### DIFF
--- a/api/src/certification/enrolment/infrastructure/repositories/complementary-certification-badge-with-offset-version-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/complementary-certification-badge-with-offset-version-repository.js
@@ -31,7 +31,7 @@ export async function getAllWithSameTargetProfile({ complementaryCertificationBa
 function _toDomain(data) {
   return new ComplementaryCertificationBadgeWithOffsetVersion({
     id: data.id,
-    requiredPixScore: data.minimumEarnedPix,
+    requiredPixScore: data?.minimumEarnedPix || 0,
     offsetVersion: data.offsetVersion,
     currentAttachedComplementaryCertificationBadgeId: data.currentAttachedComplementaryCertificationBadgeId,
   });

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/complementary-certification-badge-with-offset-version-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/complementary-certification-badge-with-offset-version-repository_test.js
@@ -3,64 +3,85 @@ import { databaseBuilder, expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
 describe('Certification | Enrolment | Integration | Repository | complementary-certification-badge-with-offset-version-repository', function () {
-  describe('#findAll', function () {
-    it('should return all complementarycertificationbadge models from DB', async function () {
+  describe('#getAllWithSameTargetProfile', function () {
+    it('should return all complementary certification badges with offset version for the same target profile', async function () {
       // given
-      const complementaryCertificationId1 = databaseBuilder.factory.buildComplementaryCertification({ key: 'key1' }).id;
+      const { id: targetProfileId1 } = databaseBuilder.factory.buildTargetProfile();
+      const { id: targetProfileId2 } = databaseBuilder.factory.buildTargetProfile();
+
+      const { id: badgeId1 } = databaseBuilder.factory.buildBadge({ targetProfileId1 });
+      const { id: badgeId2 } = databaseBuilder.factory.buildBadge({ targetProfileId2 });
+
+      const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({ key: 'key1' }).id;
       databaseBuilder.factory.buildComplementaryCertificationBadge({
         id: 1,
         minimumEarnedPix: 150,
-        complementaryCertificationId: complementaryCertificationId1,
+        badgeId: badgeId1,
+        complementaryCertificationId,
+        label: 'Pix+ toto FI confirmé',
         detachedAt: '2020-01-01',
       });
       databaseBuilder.factory.buildComplementaryCertificationBadge({
         id: 4,
+        badgeId: badgeId1,
+        label: 'Pix+ toto FI confirmé',
         minimumEarnedPix: 150,
-        complementaryCertificationId: complementaryCertificationId1,
+        complementaryCertificationId,
       });
-      const complementaryCertificationId2 = databaseBuilder.factory.buildComplementaryCertification({ key: 'key2' }).id;
+
       databaseBuilder.factory.buildComplementaryCertificationBadge({
-        id: 3,
-        minimumEarnedPix: 350,
-        complementaryCertificationId: complementaryCertificationId2,
+        id: 5,
+        minimumEarnedPix: 150,
+        badgeId: badgeId2,
+        label: 'Pix+ toto FC confirmé',
+        level: 1,
+        complementaryCertificationId,
+        detachedAt: '2020-01-01',
       });
-      const complementaryCertificationId3 = databaseBuilder.factory.buildComplementaryCertification({ key: 'key3' }).id;
       databaseBuilder.factory.buildComplementaryCertificationBadge({
-        id: 2,
-        minimumEarnedPix: 0,
-        complementaryCertificationId: complementaryCertificationId3,
+        id: 6,
+        minimumEarnedPix: 150,
+        badgeId: badgeId2,
+        label: 'Pix+ toto FC confirmé',
+        level: 1,
+        complementaryCertificationId,
       });
+      databaseBuilder.factory.buildComplementaryCertificationBadge({
+        id: 7,
+        minimumEarnedPix: 300,
+        badgeId: badgeId2,
+        label: 'Pix+ toto FC expert',
+        level: 2,
+        complementaryCertificationId,
+      });
+
       await databaseBuilder.commit();
 
       // when
       const actualComplementaryCertificationBadges =
-        await complementaryCertificationBadgeWithOffsetVersionRepository.findAll();
+        await complementaryCertificationBadgeWithOffsetVersionRepository.getAllWithSameTargetProfile({
+          complementaryCertificationBadgeId: 6,
+        });
 
       // then
       const expectedResult = [
         domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
-          id: 1,
+          id: 5,
           requiredPixScore: 150,
           offsetVersion: 1,
-          currentAttachedComplementaryCertificationBadgeId: 4,
+          currentAttachedComplementaryCertificationBadgeId: 6,
         }),
         domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
-          id: 2,
-          requiredPixScore: 0,
-          offsetVersion: 0,
-          currentAttachedComplementaryCertificationBadgeId: 2,
-        }),
-        domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
-          id: 3,
-          requiredPixScore: 350,
-          offsetVersion: 0,
-          currentAttachedComplementaryCertificationBadgeId: 3,
-        }),
-        domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
-          id: 4,
+          id: 6,
           requiredPixScore: 150,
           offsetVersion: 0,
-          currentAttachedComplementaryCertificationBadgeId: 4,
+          currentAttachedComplementaryCertificationBadgeId: 6,
+        }),
+        domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
+          id: 7,
+          requiredPixScore: 300,
+          offsetVersion: 0,
+          currentAttachedComplementaryCertificationBadgeId: 7,
         }),
       ];
       expect(actualComplementaryCertificationBadges).to.have.deep.members(expectedResult);
@@ -69,7 +90,9 @@ describe('Certification | Enrolment | Integration | Repository | complementary-c
     it('should return empty array when there are none', async function () {
       // when
       const actualComplementaryCertificationBadges =
-        await complementaryCertificationBadgeWithOffsetVersionRepository.findAll();
+        await complementaryCertificationBadgeWithOffsetVersionRepository.getAllWithSameTargetProfile({
+          complementaryCertificationBadgeId: 6,
+        });
 
       // then
       expect(actualComplementaryCertificationBadges).to.deepEqualArray([]);

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/complementary-certification-badge-with-offset-version-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/complementary-certification-badge-with-offset-version-repository_test.js
@@ -31,7 +31,7 @@ describe('Certification | Enrolment | Integration | Repository | complementary-c
 
       databaseBuilder.factory.buildComplementaryCertificationBadge({
         id: 5,
-        minimumEarnedPix: 150,
+        minimumEarnedPix: null,
         badgeId: badgeId2,
         label: 'Pix+ toto FC confirmé',
         level: 1,
@@ -67,7 +67,7 @@ describe('Certification | Enrolment | Integration | Repository | complementary-c
       const expectedResult = [
         domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
           id: 5,
-          requiredPixScore: 150,
+          requiredPixScore: 0,
           offsetVersion: 1,
           currentAttachedComplementaryCertificationBadgeId: 6,
         }),

--- a/api/tests/certification/enrolment/unit/domain/usecases/get-user-certification-eligibility_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/get-user-certification-eligibility_test.js
@@ -19,7 +19,7 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
     certificationBadgesService.findLatestBadgeAcquisitions = sinon.stub();
     complementaryCertificationCourseRepository.findByUserId = sinon.stub();
     pixCertificationRepository.findByUserId = sinon.stub();
-    complementaryCertificationBadgeWithOffsetVersionRepository.findAll = sinon.stub();
+    complementaryCertificationBadgeWithOffsetVersionRepository.getAllWithSameTargetProfile = sinon.stub();
     dependencies = {
       userId,
       limitDate,
@@ -36,7 +36,7 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
       certificationBadgesService.findLatestBadgeAcquisitions.resolves([]);
       complementaryCertificationCourseRepository.findByUserId.resolves([]);
       pixCertificationRepository.findByUserId.resolves([]);
-      complementaryCertificationBadgeWithOffsetVersionRepository.findAll.resolves([]);
+      complementaryCertificationBadgeWithOffsetVersionRepository.getAllWithSameTargetProfile.resolves([]);
     });
     context('when user is certifiable', function () {
       it('returns a user certification eligibility with is certifiable set to true', async function () {
@@ -121,7 +121,7 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
         context('when acquired badge is outdated', function () {
           const isOutdated = true;
           beforeEach(function () {
-            complementaryCertificationBadgeWithOffsetVersionRepository.findAll.resolves([
+            complementaryCertificationBadgeWithOffsetVersionRepository.getAllWithSameTargetProfile.resolves([
               domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
                 id: '1234',
                 requiredPixScore,
@@ -195,7 +195,7 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
 
               context('when badge is outdated by more than one version', function () {
                 beforeEach(function () {
-                  complementaryCertificationBadgeWithOffsetVersionRepository.findAll.resolves([
+                  complementaryCertificationBadgeWithOffsetVersionRepository.getAllWithSameTargetProfile.resolves([
                     domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
                       id: '1234',
                       requiredPixScore,
@@ -418,7 +418,7 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
         context('when acquired badge is not outdated', function () {
           const isOutdated = false;
           beforeEach(function () {
-            complementaryCertificationBadgeWithOffsetVersionRepository.findAll.resolves([
+            complementaryCertificationBadgeWithOffsetVersionRepository.getAllWithSameTargetProfile.resolves([
               domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
                 id: complementaryCertificationBadgeId,
                 requiredPixScore,
@@ -645,7 +645,7 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
             }),
           );
           complementaryCertificationKey = 'NOT CLEA';
-          complementaryCertificationBadgeWithOffsetVersionRepository.findAll.resolves([
+          complementaryCertificationBadgeWithOffsetVersionRepository.getAllWithSameTargetProfile.resolves([
             domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
               id: complementaryCertificationBadgeId,
               requiredPixScore,
@@ -966,7 +966,7 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
             context('when user has an acquired certification for this badge', function () {
               it('should not be added in the eligibilities of the model', async function () {
                 // given
-                complementaryCertificationBadgeWithOffsetVersionRepository.findAll.resolves([
+                complementaryCertificationBadgeWithOffsetVersionRepository.getAllWithSameTargetProfile.resolves([
                   domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
                     id: '1234',
                     requiredPixScore,
@@ -1065,7 +1065,7 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
             const isOutdated = true;
             it('should not be added in the eligibilities of the model', async function () {
               // given
-              complementaryCertificationBadgeWithOffsetVersionRepository.findAll.resolves([
+              complementaryCertificationBadgeWithOffsetVersionRepository.getAllWithSameTargetProfile.resolves([
                 domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
                   id: '1234',
                   requiredPixScore,


### PR DESCRIPTION
## :unicorn: Problème
Pour Pix+Edu, le bandeau se perd dans les niveaux car il ne distingue pas les targetProfile entre Pix Edu FI et FC

## :robot: Proposition
Distinguer les complémentary certification badges lié à la badge acquisition de l'utilisateur par le target profile rattaché au badge


## :100: Pour tester
Test de non regression sur le bandeau ( cas listés [ICI](https://github.com/1024pix/pix/pull/10115))