### PR TITLE
[TECH] Corriger le test flaky sur le usecase on `get-user-details-by-id-usecase` (PIX-14779)

### DIFF
--- a/api/tests/identity-access-management/integration/domain/usecases/get-user-details-by-user-ids.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/get-user-details-by-user-ids.usecase.test.js
@@ -16,7 +16,7 @@ describe('Integration | Domain | Usecases | GetUserDetailsById', function () {
       const users = await usecases.getUserDetailsByUserIds({ userIds: [1, 2] });
 
       // then
-      expect(users).to.deep.equal([firstUser, secondUser]);
+      expect(users).to.have.deep.members([firstUser, secondUser]);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Le retour API qui permet de récuperer les détails des utilisateurs ne garantit pas l'ordre de retour. 

## :robot: Proposition
Vérifier le contenu du retour dans le test, mais pas forcément l'ordre avec un have.deep.members

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
La CI est verte 
🐈‍⬛ 
