### PR TITLE
[BUGFIX] Couper le nom de la campagne même si elle ne contient pas d'espace dans les tableaux PixAdmin (PIX-11535)

### DIFF
--- a/admin/app/components/organizations/campaigns-section.gjs
+++ b/admin/app/components/organizations/campaigns-section.gjs
@@ -35,7 +35,7 @@ import { eq } from 'ember-truth-helpers';
                       {{campaign.code}}
                     </LinkTo>
                   </td>
-                  <td>{{campaign.name}}</td>
+                  <td class="table__cell--name">{{campaign.name}}</td>
                   <td>
                     {{#if (eq campaign.type "ASSESSMENT")}}
                       <div title="Évaluation">

--- a/admin/app/styles/globals/page.scss
+++ b/admin/app/styles/globals/page.scss
@@ -22,6 +22,7 @@
         display: inline;
         font-weight: bold;
         font-size: 1rem;
+        word-break: break-all;
       }
 
       .wire {
@@ -62,6 +63,8 @@
 
       h2, &__title {
         @extend %pix-title-xs;
+
+        word-break: break-all;
 
         &--sub {
           margin-bottom: $pix-spacing-s;

--- a/admin/app/styles/globals/tables.scss
+++ b/admin/app/styles/globals/tables.scss
@@ -68,6 +68,10 @@ td.td--bold {
   }
 }
 
+.table__cell--name {
+  word-break: break-all;
+}
+
 .table__cell--percentage {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## :unicorn: Problème
la joies des underscore pour ne pas mettre d'espace empêche la césure du nom de la campagne

## :robot: Proposition
Forcer la césure n'importe où 

## :rainbow: Remarques
RAS

## :100: Pour tester
CI au vert. modifier un nom de campagnes dans PixAdmin an enlevant tout les espaces en les remplaçant par des underscore.

Vérifier que le nom de la campagne est bien sur plusieurs ligne.