### PR TITLE
[FEATURE] Créer une alerte en cas de non détection de l'extension Companion lors de la certification sur Pix App (PIX-14727).

### DIFF
--- a/api/db/database-builder/factory/build-certification-companion-live-alert.js
+++ b/api/db/database-builder/factory/build-certification-companion-live-alert.js
@@ -1,0 +1,30 @@
+import _ from 'lodash';
+
+import { CertificationCompanionLiveAlertStatus } from '../../../src/certification/shared/domain/models/CertificationCompanionLiveAlert.js';
+import { Assessment } from '../../../src/shared/domain/models/index.js';
+import { databaseBuffer } from '../database-buffer.js';
+import { buildAssessment } from './build-assessment.js';
+
+const buildCertificationCompanionLiveAlert = function ({
+  id = databaseBuffer.getNextId(),
+  assessmentId,
+  status = CertificationCompanionLiveAlertStatus.ONGOING,
+  createdAt = new Date('2020-01-01'),
+  updatedAt = new Date('2020-02-01'),
+} = {}) {
+  assessmentId = _.isUndefined(assessmentId) ? buildAssessment({ state: Assessment.states.STARTED }).id : assessmentId;
+
+  const values = {
+    id,
+    assessmentId,
+    status,
+    createdAt,
+    updatedAt,
+  };
+  return databaseBuffer.pushInsertable({
+    tableName: 'certification-companion-live-alerts',
+    values,
+  });
+};
+
+export { buildCertificationCompanionLiveAlert };

--- a/api/db/migrations/20241011074058_create-certification-companion-live-alert-table.js
+++ b/api/db/migrations/20241011074058_create-certification-companion-live-alert-table.js
@@ -1,0 +1,32 @@
+import { CertificationCompanionLiveAlertStatus } from '../../src/certification/shared/domain/models/CertificationCompanionLiveAlert.js';
+
+const TABLE_NAME = 'certification-companion-live-alerts';
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.increments().primary().notNullable();
+    table.integer('assessmentId').notNullable().unsigned().references('assessments.id').index();
+    table
+      .string('status')
+      .notNullable()
+      .defaultTo(CertificationCompanionLiveAlertStatus.ONGOING)
+      .comment(
+        `Alert status, which can be ${CertificationCompanionLiveAlertStatus.ONGOING} when the alert is created and ${CertificationCompanionLiveAlertStatus.CLEARED} when the alert is processed by the invigilator`,
+      );
+    table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    table.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
+    table.comment(`Missing companion extension alerts raised during certification assessments.`);
+  });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+const down = async function (knex) {
+  return knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };

--- a/api/server.js
+++ b/api/server.js
@@ -12,6 +12,7 @@ import {
 } from './src/certification/complementary-certification/routes.js';
 import { certificationConfigurationRoutes, scoWhitelistRoutes } from './src/certification/configuration/routes.js';
 import { certificationEnrolmentRoutes } from './src/certification/enrolment/routes.js';
+import { certificationEvaluationRoutes } from './src/certification/evaluation/routes.js';
 import { flashCertificationRoutes } from './src/certification/flash-certification/routes.js';
 import { certificationResultRoutes } from './src/certification/results/routes.js';
 import { scoringRoutes } from './src/certification/scoring/routes.js';
@@ -47,6 +48,7 @@ const certificationRoutes = [
   complementaryCertificationRoutes,
   scoringRoutes,
   scoWhitelistRoutes,
+  certificationEvaluationRoutes,
 ];
 
 const prescriptionRoutes = [

--- a/api/src/certification/evaluation/application/companion-alert-controller.js
+++ b/api/src/certification/evaluation/application/companion-alert-controller.js
@@ -1,0 +1,13 @@
+import { usecases } from '../domain/usecases/index.js';
+
+const createCertificationCompanionLiveAlert = async function (request, h) {
+  const assessmentId = request.params.assessmentId;
+  await usecases.createCompanionAlert({ assessmentId });
+  return h.response().code(204);
+};
+
+const companionAlertController = {
+  createCertificationCompanionLiveAlert,
+};
+
+export { companionAlertController };

--- a/api/src/certification/evaluation/application/companion-alert-route.js
+++ b/api/src/certification/evaluation/application/companion-alert-route.js
@@ -1,0 +1,33 @@
+import Joi from 'joi';
+
+import { assessmentAuthorization } from '../../../evaluation/application/pre-handlers/assessment-authorization.js';
+import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { companionAlertController } from './companion-alert-controller.js';
+
+const register = async function (server) {
+  const routes = [
+    {
+      method: 'POST',
+      path: '/api/assessments/{assessmentId}/companion-alert',
+      config: {
+        pre: [
+          {
+            method: assessmentAuthorization.verify,
+            assign: 'authorizationCheck',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            assessmentId: identifiersType.assessmentId,
+          }),
+        },
+        handler: companionAlertController.createCertificationCompanionLiveAlert,
+        tags: ['api', 'companion-alert'],
+      },
+    },
+  ];
+  server.route(routes);
+};
+
+const name = 'companion-alert-api';
+export { name, register };

--- a/api/src/certification/evaluation/domain/usecases/create-companion-alert.js
+++ b/api/src/certification/evaluation/domain/usecases/create-companion-alert.js
@@ -1,0 +1,24 @@
+import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import {
+  CertificationCompanionLiveAlert,
+  CertificationCompanionLiveAlertStatus,
+} from '../../../shared/domain/models/CertificationCompanionLiveAlert.js';
+
+/**
+ * @typedef {import('../../../evaluation/domain/usecases/index.js').CertificationCompanionAlertRepository} CertificationCompanionAlertRepository
+ */
+
+export const createCompanionAlert = withTransaction(
+  /**
+   * @param {Object} params
+   * @param {number} params.assessmentId
+   * @param {CertificationCompanionAlertRepository} params.certificationCompanionAlertRepository
+   **/
+  async function ({ assessmentId, certificationCompanionAlertRepository }) {
+    const companionAlert = new CertificationCompanionLiveAlert({
+      assessmentId,
+      status: CertificationCompanionLiveAlertStatus.ONGOING,
+    });
+    await certificationCompanionAlertRepository.create(companionAlert);
+  },
+);

--- a/api/src/certification/evaluation/domain/usecases/index.js
+++ b/api/src/certification/evaluation/domain/usecases/index.js
@@ -18,6 +18,7 @@ import {
   sharedCompetenceMarkRepository,
 } from '../../../session-management/infrastructure/repositories/index.js';
 import * as certificationCandidateRepository from '../../infrastructure/repositories/certification-candidate-repository.js';
+import * as certificationCompanionAlertRepository from '../../infrastructure/repositories/certification-companion-alert-repository.js';
 
 const dependencies = {
   ...sessionRepositories,
@@ -33,6 +34,7 @@ const dependencies = {
   flashAlgorithmConfigurationRepository,
   flashAlgorithmService,
   pickChallengeService,
+  certificationCompanionAlertRepository,
 };
 
 const path = dirname(fileURLToPath(import.meta.url));

--- a/api/src/certification/evaluation/infrastructure/repositories/certification-companion-alert-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/certification-companion-alert-repository.js
@@ -1,0 +1,13 @@
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+const TABLE_NAME = 'certification-companion-live-alerts';
+
+export async function create({ assessmentId, status }, { knex = DomainTransaction.getConnection() } = {}) {
+  // Lock assessment in order to guarantee consistency
+  // between select and insert on certification-companion-live-alerts
+  await knex.select().from('assessments').where('id', '=', assessmentId).forUpdate();
+
+  const { count } = await knex.count().from(TABLE_NAME).where({ assessmentId, status }).first();
+  if (count > 0) return;
+
+  await knex(TABLE_NAME).insert({ assessmentId, status });
+}

--- a/api/src/certification/evaluation/routes.js
+++ b/api/src/certification/evaluation/routes.js
@@ -1,0 +1,5 @@
+import * as companionAlert from '../evaluation/application/companion-alert-route.js';
+
+const certificationEvaluationRoutes = [companionAlert];
+
+export { certificationEvaluationRoutes };

--- a/api/src/certification/shared/domain/models/CertificationCompanionLiveAlert.js
+++ b/api/src/certification/shared/domain/models/CertificationCompanionLiveAlert.js
@@ -1,0 +1,22 @@
+export class CertificationCompanionLiveAlert {
+  constructor({ assessmentId, status }) {
+    this.assessmentId = assessmentId;
+    this.status = status;
+  }
+}
+/**
+ * Companion live alert statuses.
+ * @readonly
+ * @enum {string}
+ */
+export const CertificationCompanionLiveAlertStatus = Object.freeze({
+  /**
+   * Ongoing alert for missing extension.
+   */
+  ONGOING: 'ONGOING',
+
+  /**
+   * Invigilator has confirmed extension is active.
+   */
+  CLEARED: 'CLEARED',
+});

--- a/api/src/evaluation/application/pre-handlers/assessment-authorization.js
+++ b/api/src/evaluation/application/pre-handlers/assessment-authorization.js
@@ -9,7 +9,7 @@ const verify = function (
 ) {
   const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
   // eslint-disable-next-line no-restricted-syntax
-  const assessmentId = parseInt(request.params.id);
+  const assessmentId = parseInt(request.params.id) || parseInt(request.params.assessmentId);
 
   return dependencies.assessmentRepository.getByAssessmentIdAndUserId(assessmentId, userId).catch(() => {
     const buildError = _handleWhenInvalidAuthorization('Vous n’êtes pas autorisé à accéder à cette évaluation');

--- a/api/tests/certification/evaluation/acceptance/application/companion-live-alert-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/companion-live-alert-route_test.js
@@ -1,0 +1,62 @@
+import { Assessment } from '../../../../../src/shared/domain/models/index.js';
+import {
+  createServer,
+  databaseBuilder,
+  expect,
+  generateValidRequestAuthorizationHeader,
+  knex,
+} from '../../../../test-helper.js';
+
+describe('Certification | Evaluation | Acceptance | Application | Routes | companion-alert', function () {
+  describe('POST /api/assessments/{assessmentId}/companion-alert', function () {
+    let server;
+    let user;
+    let assessment;
+    let options;
+
+    beforeEach(async function () {
+      server = await createServer();
+      user = databaseBuilder.factory.buildUser();
+      assessment = databaseBuilder.factory.buildAssessment({
+        state: Assessment.states.STARTED,
+        userId: user.id,
+      });
+      options = {
+        method: 'POST',
+        url: `/api/assessments/${assessment.id}/companion-alert`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+      };
+
+      return databaseBuilder.commit();
+    });
+
+    it('should respond with a 401 if requested user is not the same as the user of the assessment', async function () {
+      // given
+      const otherUserId = 9999;
+      options.headers.authorization = generateValidRequestAuthorizationHeader(otherUserId);
+      options.payload = {};
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(401);
+    });
+
+    it('should save a companion alert', async function () {
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+      const certificationCompanionAlert = await knex
+        .select('assessmentId', 'status')
+        .from('certification-companion-live-alerts')
+        .first();
+      expect(certificationCompanionAlert).to.deep.equal({
+        assessmentId: assessment.id,
+        status: 'ONGOING',
+      });
+    });
+  });
+});

--- a/api/tests/certification/evaluation/acceptance/application/companion-live-alert-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/companion-live-alert-route_test.js
@@ -1,3 +1,4 @@
+import { CertificationCompanionLiveAlertStatus } from '../../../../../src/certification/shared/domain/models/CertificationCompanionLiveAlert.js';
 import { Assessment } from '../../../../../src/shared/domain/models/index.js';
 import {
   createServer,
@@ -55,7 +56,7 @@ describe('Certification | Evaluation | Acceptance | Application | Routes | compa
         .first();
       expect(certificationCompanionAlert).to.deep.equal({
         assessmentId: assessment.id,
-        status: 'ONGOING',
+        status: CertificationCompanionLiveAlertStatus.ONGOING,
       });
     });
   });

--- a/api/tests/certification/evaluation/integration/domain/usecases/create-companion-alert_test.js
+++ b/api/tests/certification/evaluation/integration/domain/usecases/create-companion-alert_test.js
@@ -1,0 +1,43 @@
+import { usecases } from '../../../../../../src/certification/evaluation/domain/usecases/index.js';
+import * as certificationCompanionAlertRepository from '../../../../../../src/certification/evaluation/infrastructure/repositories/certification-companion-alert-repository.js';
+import { CertificationCompanionLiveAlertStatus } from '../../../../../../src/certification/shared/domain/models/CertificationCompanionLiveAlert.js';
+import { databaseBuilder, expect, knex } from '../../../../../test-helper.js';
+
+const { createCompanionAlert } = usecases;
+
+describe('Certification | Evaluation | Integration | Domain | UseCase | create-companion-alert', function () {
+  it('should create an alert', async function () {
+    // given
+    const { id: assessmentId } = databaseBuilder.factory.buildAssessment();
+    await databaseBuilder.commit();
+
+    // when
+    await createCompanionAlert({
+      assessmentId,
+      certificationCompanionAlertRepository,
+    });
+
+    // then
+    const companionAlert = await knex('certification-companion-live-alerts').select('status', 'assessmentId');
+    expect(companionAlert).to.deep.equal([{ status: CertificationCompanionLiveAlertStatus.ONGOING, assessmentId }]);
+  });
+
+  describe('when an ongoing alert already exists for assessment', function () {
+    it('should NOT create an alert', async function () {
+      // given
+      const { id: assessmentId } = databaseBuilder.factory.buildAssessment();
+      databaseBuilder.factory.buildCertificationCompanionLiveAlert({ assessmentId });
+      await databaseBuilder.commit();
+
+      // when
+      await createCompanionAlert({
+        assessmentId,
+        certificationCompanionAlertRepository,
+      });
+
+      // then
+      const companionAlert = await knex('certification-companion-live-alerts').select('status', 'assessmentId');
+      expect(companionAlert).to.deep.equal([{ status: CertificationCompanionLiveAlertStatus.ONGOING, assessmentId }]);
+    });
+  });
+});

--- a/mon-pix/app/adapters/assessment.js
+++ b/mon-pix/app/adapters/assessment.js
@@ -23,4 +23,9 @@ export default class Assessment extends ApplicationAdapter {
     const payload = { data: { data: { attributes: { 'challenge-id': challengeId } } } };
     return this.ajax(url, 'POST', payload);
   }
+
+  createCompanionLiveAlert({ assessmentId }) {
+    const url = `${this.host}/${this.namespace}/assessments/${assessmentId}/companion-alert`;
+    return this.ajax(url, 'POST');
+  }
 }

--- a/mon-pix/app/components/assessments/assessments.gjs
+++ b/mon-pix/app/components/assessments/assessments.gjs
@@ -1,11 +1,25 @@
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+
 import CompanionBlocker from '../companion/blocker';
 
-<template>
-  {{#if @assessment.isCertification}}
-    <CompanionBlocker>
+export default class Assessments extends Component {
+  @service store;
+
+  @action
+  async createLiveAlert() {
+    const adapter = this.store.adapterFor('assessment');
+    await adapter.createCompanionLiveAlert({ assessmentId: this.args.assessment.id });
+  }
+
+  <template>
+    {{#if @assessment.isCertification}}
+      <CompanionBlocker @onBlock={{this.createLiveAlert}}>
+        {{yield}}
+      </CompanionBlocker>
+    {{else}}
       {{yield}}
-    </CompanionBlocker>
-  {{else}}
-    {{yield}}
-  {{/if}}
-</template>
+    {{/if}}
+  </template>
+}

--- a/mon-pix/app/components/companion/blocker.gjs
+++ b/mon-pix/app/components/companion/blocker.gjs
@@ -10,12 +10,18 @@ export default class CompanionBlocker extends Component {
 
   constructor(...args) {
     super(...args);
+    if (this.args.onBlock) {
+      this.pixCompanion.addEventListener('block', this.args.onBlock);
+    }
     this.pixCompanion.startCheckingExtensionIsEnabled();
   }
 
   willDestroy(...args) {
     super.willDestroy(...args);
     this.pixCompanion.stopCheckingExtensionIsEnabled();
+    if (this.args.onBlock) {
+      this.pixCompanion.removeEventListener('block', this.args.onBlock);
+    }
   }
 
   get isBlocked() {

--- a/mon-pix/app/services/pix-companion.js
+++ b/mon-pix/app/services/pix-companion.js
@@ -6,6 +6,7 @@ export default class PixCompanion extends Service {
   @tracked _isExtensionEnabled = true;
 
   #checkExtensionIsEnabledInterval;
+  #eventTarget = new EventTarget();
 
   startCertification(windowRef = window) {
     if (!this.featureToggles.featureToggles.isPixCompanionEnabled) return;
@@ -46,9 +47,26 @@ export default class PixCompanion extends Service {
         this._isExtensionEnabled = true;
       })
       .catch(() => {
+        if (this._isExtensionEnabled) {
+          this.#eventTarget.dispatchEvent(new CustomEvent('block'));
+        }
         this._isExtensionEnabled = false;
         windowRef.removeEventListener('pix:companion:pong', pongListener);
       });
+  }
+
+  /**
+   * @type EventTarget['addEventListener']
+   */
+  addEventListener(...args) {
+    this.#eventTarget.addEventListener(...args);
+  }
+
+  /**
+   * @type EventTarget['removeEventListener']
+   */
+  removeEventListener(...args) {
+    this.#eventTarget.removeEventListener(...args);
   }
 
   get isExtensionEnabled() {

--- a/mon-pix/tests/integration/components/assessments/assessment-test.gjs
+++ b/mon-pix/tests/integration/components/assessments/assessment-test.gjs
@@ -12,12 +12,11 @@ module('Integration | Component | Assessments | assessments', function (hooks) {
   module('when extension is enabled', function () {
     test('it displays assessment page', async function (assert) {
       // given
-      const startCheckingExtensionIsEnabledStub = sinon.stub();
-      const stopCheckingExtensionIsEnabledStub = sinon.stub();
-
       class PixCompanionStub extends Service {
-        startCheckingExtensionIsEnabled = startCheckingExtensionIsEnabledStub;
-        stopCheckingExtensionIsEnabled = stopCheckingExtensionIsEnabledStub;
+        addEventListener = sinon.stub();
+        removeEventListener = sinon.stub();
+        startCheckingExtensionIsEnabled = sinon.stub();
+        stopCheckingExtensionIsEnabled = sinon.stub();
         isExtensionEnabled = true;
       }
 
@@ -42,12 +41,11 @@ module('Integration | Component | Assessments | assessments', function (hooks) {
     module("when assessment's type is not certification", function () {
       test('it displays assessment page', async function (assert) {
         // given
-        const startCheckingExtensionIsEnabledStub = sinon.stub();
-        const stopCheckingExtensionIsEnabledStub = sinon.stub();
-
         class PixCompanionStub extends Service {
-          startCheckingExtensionIsEnabled = startCheckingExtensionIsEnabledStub;
-          stopCheckingExtensionIsEnabled = stopCheckingExtensionIsEnabledStub;
+          addEventListener = sinon.stub();
+          removeEventListener = sinon.stub();
+          startCheckingExtensionIsEnabled = sinon.stub();
+          stopCheckingExtensionIsEnabled = sinon.stub();
           isExtensionEnabled = true;
         }
 
@@ -77,12 +75,11 @@ module('Integration | Component | Assessments | assessments', function (hooks) {
   module('when extension is disabled', function () {
     test('it displays companion blocker page', async function (assert) {
       // given
-      const startCheckingExtensionIsEnabledStub = sinon.stub();
-      const stopCheckingExtensionIsEnabledStub = sinon.stub();
-
       class PixCompanionStub extends Service {
-        startCheckingExtensionIsEnabled = startCheckingExtensionIsEnabledStub;
-        stopCheckingExtensionIsEnabled = stopCheckingExtensionIsEnabledStub;
+        addEventListener = sinon.stub();
+        removeEventListener = sinon.stub();
+        startCheckingExtensionIsEnabled = sinon.stub();
+        stopCheckingExtensionIsEnabled = sinon.stub();
         isExtensionEnabled = false;
       }
 
@@ -110,12 +107,11 @@ module('Integration | Component | Assessments | assessments', function (hooks) {
     module("when assessment's type is not certification", function () {
       test('it displays assessment page', async function (assert) {
         // given
-        const startCheckingExtensionIsEnabledStub = sinon.stub();
-        const stopCheckingExtensionIsEnabledStub = sinon.stub();
-
         class PixCompanionStub extends Service {
-          startCheckingExtensionIsEnabled = startCheckingExtensionIsEnabledStub;
-          stopCheckingExtensionIsEnabled = stopCheckingExtensionIsEnabledStub;
+          addEventListener = sinon.stub();
+          removeEventListener = sinon.stub();
+          startCheckingExtensionIsEnabled = sinon.stub();
+          stopCheckingExtensionIsEnabled = sinon.stub();
           isExtensionEnabled = false;
         }
 

--- a/mon-pix/tests/integration/components/companion/blocker-test.gjs
+++ b/mon-pix/tests/integration/components/companion/blocker-test.gjs
@@ -12,13 +12,12 @@ module('Integration | Component | Companion | blocker', function (hooks) {
 
   test('it display children elements when extension is detected', async function (assert) {
     // given
-    const startCheckingExtensionIsEnabledStub = sinon.stub();
-    const stopCheckingExtensionIsEnabledStub = sinon.stub();
-
     class PixCompanionStub extends Service {
-      startCheckingExtensionIsEnabled = startCheckingExtensionIsEnabledStub;
-      stopCheckingExtensionIsEnabled = stopCheckingExtensionIsEnabledStub;
+      startCheckingExtensionIsEnabled = sinon.stub();
+      stopCheckingExtensionIsEnabled = sinon.stub();
       isExtensionEnabled = true;
+      addEventListener = sinon.stub();
+      removeEventListener = sinon.stub();
     }
 
     this.owner.register('service:pix-companion', PixCompanionStub);
@@ -33,19 +32,17 @@ module('Integration | Component | Companion | blocker', function (hooks) {
     );
 
     // then
-    sinon.assert.calledOnce(startCheckingExtensionIsEnabledStub);
     assert.dom(screen.queryByRole('heading', { level: 1, name: title })).exists();
   });
 
   test('it displays blocking page when extension is NOT detected', async function (assert) {
     // given
-    const startCheckingExtensionIsEnabledStub = sinon.stub();
-    const stopCheckingExtensionIsEnabledStub = sinon.stub();
-
     class PixCompanionStub extends Service {
-      startCheckingExtensionIsEnabled = startCheckingExtensionIsEnabledStub;
-      stopCheckingExtensionIsEnabled = stopCheckingExtensionIsEnabledStub;
+      startCheckingExtensionIsEnabled = sinon.stub();
+      stopCheckingExtensionIsEnabled = sinon.stub();
       isExtensionEnabled = false;
+      addEventListener = sinon.stub();
+      removeEventListener = sinon.stub();
     }
 
     this.owner.register('service:pix-companion', PixCompanionStub);
@@ -60,8 +57,6 @@ module('Integration | Component | Companion | blocker', function (hooks) {
     );
 
     // then
-    sinon.assert.calledOnce(startCheckingExtensionIsEnabledStub);
-
     assert.dom(screen.queryByRole('heading', { level: 1, name: 'Companion activé' })).doesNotExist();
 
     assert

--- a/mon-pix/tests/unit/adapters/assessment-test.js
+++ b/mon-pix/tests/unit/adapters/assessment-test.js
@@ -67,4 +67,20 @@ module('Unit | Adapters | assessment', function (hooks) {
       );
     });
   });
+
+  module('#createCompanionLiveAlert', function () {
+    test('should call companion live alert endpoint', async function (assert) {
+      // given
+      adapter.ajax = sinon.stub();
+      const assessmentId = 123;
+
+      // when
+      await adapter.createCompanionLiveAlert({ assessmentId });
+
+      // then
+      assert.ok(
+        adapter.ajax.calledWith(`http://localhost:3000/api/assessments/${assessmentId}/companion-alert`, 'POST'),
+      );
+    });
+  });
 });

--- a/mon-pix/tests/unit/components/assessments/assessments-test.js
+++ b/mon-pix/tests/unit/components/assessments/assessments-test.js
@@ -1,0 +1,30 @@
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from 'mon-pix/tests/helpers/create-glimmer-component';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Component | Assessments | Assessments', function (hooks) {
+  setupTest(hooks);
+
+  module('#createLiveAlert', function () {
+    test('should create a companion live alert', async function (assert) {
+      // given
+      const component = createGlimmerComponent('assessments/assessments', {
+        assessment: {
+          id: 123,
+          isCertification: true,
+        },
+      });
+      const store = this.owner.lookup('service:store');
+      const adapter = store.adapterFor('assessment');
+      const createCompanionLiveAlertStub = sinon.stub(adapter, 'createCompanionLiveAlert');
+
+      // when
+      await component.createLiveAlert();
+
+      // then
+      sinon.assert.calledWithExactly(createCompanionLiveAlertStub, { assessmentId: 123 });
+      assert.ok(true);
+    });
+  });
+});

--- a/mon-pix/tests/unit/components/companion/blocker-test.js
+++ b/mon-pix/tests/unit/components/companion/blocker-test.js
@@ -1,0 +1,146 @@
+import Service from '@ember/service';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from 'mon-pix/tests/helpers/create-glimmer-component';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Component | Companion | Blocker', function (hooks) {
+  setupTest(hooks);
+
+  module('#constructor', function () {
+    test('should start checking extension is enabled', function (assert) {
+      // given
+      const startCheckingExtensionIsEnabledStub = sinon.stub();
+      class PixCompanionStub extends Service {
+        startCheckingExtensionIsEnabled = startCheckingExtensionIsEnabledStub;
+        stopCheckingExtensionIsEnabled = sinon.stub();
+        isExtensionEnabled = true;
+        addEventListener = sinon.stub();
+        removeEventListener = sinon.stub();
+      }
+      this.owner.register('service:pix-companion', PixCompanionStub);
+
+      // when
+      createGlimmerComponent('companion/blocker', { onBlock: undefined });
+
+      // then
+      sinon.assert.calledOnce(startCheckingExtensionIsEnabledStub);
+      assert.ok(true);
+    });
+
+    module('when no onBlock callback is given', function () {
+      test('should not add block event listener', function (assert) {
+        // given
+        const addEventListenerStub = sinon.stub();
+        class PixCompanionStub extends Service {
+          startCheckingExtensionIsEnabled = sinon.stub();
+          stopCheckingExtensionIsEnabled = sinon.stub();
+          isExtensionEnabled = true;
+          addEventListener = addEventListenerStub;
+          removeEventListener = sinon.stub();
+        }
+        this.owner.register('service:pix-companion', PixCompanionStub);
+
+        // when
+        createGlimmerComponent('companion/blocker', { onBlock: undefined });
+
+        // then
+        sinon.assert.notCalled(addEventListenerStub);
+        assert.ok(true);
+      });
+    });
+
+    module('when onBlock callback is given', function () {
+      test('should add block event listener', function (assert) {
+        // given
+        const addEventListenerStub = sinon.stub();
+        class PixCompanionStub extends Service {
+          startCheckingExtensionIsEnabled = sinon.stub();
+          stopCheckingExtensionIsEnabled = sinon.stub();
+          isExtensionEnabled = true;
+          addEventListener = addEventListenerStub;
+          removeEventListener = sinon.stub();
+        }
+        this.owner.register('service:pix-companion', PixCompanionStub);
+        const onBlock = sinon.stub();
+
+        // when
+        createGlimmerComponent('companion/blocker', { onBlock });
+
+        // then
+        sinon.assert.calledWith(addEventListenerStub, 'block', onBlock);
+        assert.ok(true);
+      });
+    });
+  });
+
+  module('#willDestroy', function () {
+    test('should stop checking extension is enabled', function (assert) {
+      // given
+      const stopCheckingExtensionIsEnabledStub = sinon.stub();
+      class PixCompanionStub extends Service {
+        startCheckingExtensionIsEnabled = sinon.stub();
+        stopCheckingExtensionIsEnabled = stopCheckingExtensionIsEnabledStub;
+        isExtensionEnabled = true;
+        addEventListener = sinon.stub();
+        removeEventListener = sinon.stub();
+      }
+      this.owner.register('service:pix-companion', PixCompanionStub);
+      const component = createGlimmerComponent('companion/blocker', { onBlock: undefined });
+
+      // when
+      component.willDestroy();
+
+      // then
+      sinon.assert.calledOnce(stopCheckingExtensionIsEnabledStub);
+      assert.ok(true);
+    });
+
+    module('when no onBlock callback is given', function () {
+      test('should not remove block event listener', function (assert) {
+        // given
+        const removeEventListenerStub = sinon.stub();
+        class PixCompanionStub extends Service {
+          startCheckingExtensionIsEnabled = sinon.stub();
+          stopCheckingExtensionIsEnabled = sinon.stub();
+          isExtensionEnabled = true;
+          addEventListener = sinon.stub();
+          removeEventListener = removeEventListenerStub;
+        }
+        this.owner.register('service:pix-companion', PixCompanionStub);
+        const component = createGlimmerComponent('companion/blocker', { onBlock: undefined });
+
+        // when
+        component.willDestroy();
+
+        // then
+        sinon.assert.notCalled(removeEventListenerStub);
+        assert.ok(true);
+      });
+    });
+
+    module('when onBlock callback is given', function () {
+      test('should remove block event listener', function (assert) {
+        // given
+        const removeEventListenerStub = sinon.stub();
+        class PixCompanionStub extends Service {
+          startCheckingExtensionIsEnabled = sinon.stub();
+          stopCheckingExtensionIsEnabled = sinon.stub();
+          isExtensionEnabled = true;
+          addEventListener = sinon.stub();
+          removeEventListener = removeEventListenerStub;
+        }
+        this.owner.register('service:pix-companion', PixCompanionStub);
+        const onBlock = sinon.stub();
+        const component = createGlimmerComponent('companion/blocker', { onBlock });
+
+        // when
+        component.willDestroy();
+
+        // then
+        sinon.assert.calledWith(removeEventListenerStub, 'block', onBlock);
+        assert.ok(true);
+      });
+    });
+  });
+});

--- a/mon-pix/tests/unit/services/pix-companion-test.js
+++ b/mon-pix/tests/unit/services/pix-companion-test.js
@@ -113,7 +113,7 @@ module('Unit | Service | pix-companion', function (hooks) {
       assert.true(pixCompanion.isExtensionEnabled);
     });
 
-    test('set isExtensionEnabled to false if pong is NOT received', async function (assert) {
+    test('set isExtensionEnabled to false and emit block event if pong is NOT received', async function (assert) {
       // Given
       const windowStub = {
         addEventListener: sinon.stub(),
@@ -126,6 +126,14 @@ module('Unit | Service | pix-companion', function (hooks) {
         callback();
       });
       pixCompanion._isExtensionEnabled = true;
+      let blockEventReceived = false;
+      pixCompanion.addEventListener(
+        'block',
+        () => {
+          blockEventReceived = true;
+        },
+        { once: true },
+      );
 
       // When
       pixCompanion.checkExtensionIsEnabled(windowStub);
@@ -134,6 +142,7 @@ module('Unit | Service | pix-companion', function (hooks) {
       // Then
       sinon.assert.calledWith(windowStub.dispatchEvent, new CustomEvent('pix:companion:ping'));
       assert.false(pixCompanion.isExtensionEnabled);
+      assert.true(blockEventReceived);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
En certification, lorsque Pix App ne détecte plus l'extension, la page Blocker s'affiche mais ça n'entraîne rien de plus.
On souhaiterait pouvoir bloquer l'utilisateur sur la question en cours tant que le surveillant n'a pas confirmé l'activation de l'extension. Pour cela nous avons besoin d'enregistrer une alerte en BDD.

## :robot: Proposition
Créer une alerte spécifique à Companion.

## :rainbow: Remarques
Création d'une nouvelle table 'certfication-companion-live-alerts'

## :100: Pour tester
- Activer l'extension Companion
- Se connecter sur App avec certif-success@example.net
- Remplir le formulaire d'entrée en session de certif (7402 firstname0... 01/01/2000)
- Entrer en session
- Désactiver l'extension
- Vérifier en BDD l'enregistrement d'une alerte en cours ('ongoing')



