### PR TITLE
[TECH] Recuperer le templateName depuis la base de données plutôt qu'en dur dans le code (PIX-14786) 

### DIFF
--- a/api/config/server-setup-error-handling.js
+++ b/api/config/server-setup-error-handling.js
@@ -4,6 +4,7 @@ import { evaluationDomainErrorMappingConfiguration } from '../src/evaluation/app
 import { authenticationDomainErrorMappingConfiguration } from '../src/identity-access-management/application/http-error-mapper-configuration.js';
 import { organizationalEntitiesDomainErrorMappingConfiguration } from '../src/organizational-entities/application/http-error-mapper-configuration.js';
 import { prescriptionDomainErrorMappingConfiguration } from '../src/prescription/shared/application/http-error-mapper-configuration.js';
+import { profileDomainErrorMappingConfiguration } from '../src/profile/application/http-error-mapper-configuration.js';
 import { schoolDomainErrorMappingConfiguration } from '../src/school/application/http-error-mapper-configuration.js';
 import { domainErrorMapper } from '../src/shared/application/domain-error-mapper.js';
 import * as preResponseUtils from '../src/shared/application/pre-response-utils.js';
@@ -19,6 +20,7 @@ const setupErrorHandling = function (server) {
     ...evaluationDomainErrorMappingConfiguration,
     ...prescriptionDomainErrorMappingConfiguration,
     ...schoolDomainErrorMappingConfiguration,
+    ...profileDomainErrorMappingConfiguration,
   ];
 
   domainErrorMapper.configure(configuration);

--- a/api/src/profile/application/api/attestations-api.js
+++ b/api/src/profile/application/api/attestations-api.js
@@ -11,9 +11,7 @@ export const generateAttestations = async function ({
   userIds,
   dependencies = { pdfWithFormSerializer },
 }) {
-  const data = await usecases.getAttestationDataForUsers({ attestationKey, userIds });
-
-  const templateName = 'sixth-grade-attestation-template';
+  const { data, templateName } = await usecases.getAttestationDataForUsers({ attestationKey, userIds });
 
   const templatePath = path.join(__dirname, `../../infrastructure/serializers/pdf/templates/${templateName}.pdf`);
 

--- a/api/src/profile/application/attestation-controller.js
+++ b/api/src/profile/application/attestation-controller.js
@@ -11,9 +11,11 @@ const getUserAttestation = async function (request, h, dependencies = { pdfWithF
   const userId = request.params.userId;
   const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
   const attestationKey = request.params.attestationKey;
-  // TODO: Modifier le usecase pour qu'il retourne le templateName
-  const templateName = 'sixth-grade-attestation-template';
-  const data = await usecases.getAttestationDataForUsers({ attestationKey, userIds: [userId], locale });
+  const { data, templateName } = await usecases.getAttestationDataForUsers({
+    attestationKey,
+    userIds: [userId],
+    locale,
+  });
 
   const templatePath = path.join(__dirname, `../infrastructure/serializers/pdf/templates/${templateName}.pdf`);
 

--- a/api/src/profile/application/http-error-mapper-configuration.js
+++ b/api/src/profile/application/http-error-mapper-configuration.js
@@ -1,0 +1,13 @@
+import { HttpErrors } from '../../shared/application/http-errors.js';
+import { AttestationNotFoundError } from '../domain/errors.js';
+
+const profileDomainErrorMappingConfiguration = [
+  {
+    name: AttestationNotFoundError.name,
+    httpErrorFn: (error) => {
+      return new HttpErrors.NotFoundError(error.message, error.code, error.meta);
+    },
+  },
+];
+
+export { profileDomainErrorMappingConfiguration };

--- a/api/src/profile/domain/errors.js
+++ b/api/src/profile/domain/errors.js
@@ -1,0 +1,9 @@
+import { DomainError } from '../../shared/domain/errors.js';
+
+class AttestationNotFoundError extends DomainError {
+  constructor(message = 'Attestation does not exist') {
+    super(message);
+  }
+}
+
+export { AttestationNotFoundError };

--- a/api/src/profile/domain/models/Attestation.js
+++ b/api/src/profile/domain/models/Attestation.js
@@ -1,0 +1,8 @@
+export class Attestation {
+  constructor({ id, templateName, key, createdAt } = {}) {
+    this.id = id;
+    this.templateName = templateName;
+    this.key = key;
+    this.createdAt = createdAt;
+  }
+}

--- a/api/src/profile/domain/usecases/get-attestation-data-for-users.js
+++ b/api/src/profile/domain/usecases/get-attestation-data-for-users.js
@@ -1,15 +1,27 @@
+import { AttestationNotFoundError } from '../errors.js';
+
 export async function getAttestationDataForUsers({
   attestationKey,
   userIds,
   locale,
   userRepository,
   profileRewardRepository,
+  attestationRepository,
 }) {
   const users = await userRepository.getByIds({ userIds });
   const profileRewards = await profileRewardRepository.getByAttestationKeyAndUserIds({ attestationKey, userIds });
 
-  return profileRewards.map(({ userId, createdAt }) => {
-    const user = users.find((user) => user.id === userId);
-    return user.toForm(createdAt, locale);
-  });
+  const attestationData = await attestationRepository.getByKey({ attestationKey });
+
+  if (!attestationData) {
+    throw new AttestationNotFoundError();
+  }
+
+  return {
+    data: profileRewards.map(({ userId, createdAt }) => {
+      const user = users.find((user) => user.id === userId);
+      return user.toForm(createdAt, locale);
+    }),
+    templateName: attestationData.templateName,
+  };
 }

--- a/api/src/profile/domain/usecases/index.js
+++ b/api/src/profile/domain/usecases/index.js
@@ -9,6 +9,7 @@ import * as areaRepository from '../../../shared/infrastructure/repositories/are
 import * as competenceRepository from '../../../shared/infrastructure/repositories/competence-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
+import * as attestationRepository from '../../infrastructure/repositories/attestation-repository.js';
 
 const path = dirname(fileURLToPath(import.meta.url));
 
@@ -23,6 +24,7 @@ const dependencies = {
   knowledgeElementRepository,
   profileRewardRepository,
   userRepository: repositories.userRepository,
+  attestationRepository,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/profile/infrastructure/repositories/attestation-repository.js
+++ b/api/src/profile/infrastructure/repositories/attestation-repository.js
@@ -1,0 +1,11 @@
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { Attestation } from '../../domain/models/Attestation.js';
+
+export const getByKey = async ({ attestationKey }) => {
+  const knexConnection = await DomainTransaction.getConnection();
+  const attestation = await knexConnection('attestations').where({ key: attestationKey }).first();
+
+  if (!attestation) return null;
+
+  return new Attestation(attestation);
+};

--- a/api/tests/prescription/organization-learner/acceptance/application/organization-learner-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/application/organization-learner-route_test.js
@@ -26,7 +26,9 @@ describe('Prescription | Organization Learner | Acceptance | Application | Organ
         organizationId,
         organizationRole: Membership.roles.MEMBER,
       });
-      const attestation = databaseBuilder.factory.buildAttestation();
+      const attestation = databaseBuilder.factory.buildAttestation({
+        templateName: 'sixth-grade-attestation-template',
+      });
       const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
         organizationId,
         division: '6emeA',

--- a/api/tests/profile/integration/domain/usecases/get-attestation-data-for-users_test.js
+++ b/api/tests/profile/integration/domain/usecases/get-attestation-data-for-users_test.js
@@ -1,6 +1,7 @@
+import { AttestationNotFoundError } from '../../../../../src/profile/domain/errors.js';
 import { User } from '../../../../../src/profile/domain/models/User.js';
 import { usecases } from '../../../../../src/profile/domain/usecases/index.js';
-import { databaseBuilder, expect, sinon } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Profile | Integration | Domain | get-attestation-data-for-users', function () {
   let clock;
@@ -40,12 +41,33 @@ describe('Profile | Integration | Domain | get-attestation-data-for-users', func
         locale,
       });
 
-      expect(results).to.deep.equal([
-        firstUser.toForm(firstCreatedAt, locale),
-        secondUser.toForm(secondCreatedAt, locale),
-      ]);
-      expect(results[0].get('fullName')).to.equal('Alex TERIEUR');
-      expect(results[1].get('fullName')).to.equal('Theo COURANT');
+      expect(results).to.deep.equal({
+        data: [firstUser.toForm(firstCreatedAt, locale), secondUser.toForm(secondCreatedAt, locale)],
+        templateName: attestation.templateName,
+      });
+      expect(results.data[0].get('fullName')).to.equal('Alex TERIEUR');
+      expect(results.data[1].get('fullName')).to.equal('Theo COURANT');
+    });
+
+    it('should return AttestationNotFound error if attestation does not exist', async function () {
+      //given
+      const locale = 'FR-fr';
+      const firstUser = new User(databaseBuilder.factory.buildUser());
+
+      databaseBuilder.factory.buildProfileReward({
+        userId: firstUser.id,
+      });
+      await databaseBuilder.commit();
+
+      //when
+      const error = await catchErr(usecases.getAttestationDataForUsers)({
+        attestationKey: 'NOT_EXISTING_ATTESTATION',
+        userIds: [firstUser.id],
+        locale,
+      });
+
+      //then
+      expect(error).to.be.an.instanceof(AttestationNotFoundError);
     });
   });
 });

--- a/api/tests/profile/integration/infrastructure/repositories/attestation-repository_test.js
+++ b/api/tests/profile/integration/infrastructure/repositories/attestation-repository_test.js
@@ -1,0 +1,30 @@
+import { Attestation } from '../../../../../src/profile/domain/models/Attestation.js';
+import { getByKey } from '../../../../../src/profile/infrastructure/repositories/attestation-repository.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Profile | Integration | Infrastructure | Repository | Attestation', function () {
+  describe('#getByKey', function () {
+    it('should return attestation informations for given key', async function () {
+      // given
+      const templateName = 'Velodrome';
+      const attestation = databaseBuilder.factory.buildAttestation({ templateName });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await getByKey({ attestationKey: attestation.key });
+
+      // then
+
+      expect(result).to.be.an.instanceof(Attestation);
+      expect(result.templateName).to.equal(templateName);
+    });
+
+    it('should return null if no attestation exist for given key', async function () {
+      // given&when
+      const result = await getByKey({ attestationKey: 'BAD_KEY' });
+
+      // then
+      expect(result).to.be.null;
+    });
+  });
+});

--- a/api/tests/profile/unit/application/api/attestations-api_test.js
+++ b/api/tests/profile/unit/application/api/attestations-api_test.js
@@ -18,7 +18,9 @@ describe('Profile | Unit | Application | Api | attestations', function () {
 
       sinon.stub(usecases, 'getAttestationDataForUsers');
 
-      usecases.getAttestationDataForUsers.withArgs({ attestationKey, userIds }).resolves(data);
+      usecases.getAttestationDataForUsers
+        .withArgs({ attestationKey, userIds })
+        .resolves({ data, templateName: 'sixth-grade-attestation-template' });
 
       dependencies.pdfWithFormSerializer.serialize
         .withArgs(sinon.match(/(\w*\/)*sixth-grade-attestation-template.pdf/), data)

--- a/api/tests/profile/unit/application/attestation-controller_test.js
+++ b/api/tests/profile/unit/application/attestation-controller_test.js
@@ -23,14 +23,14 @@ describe('Profile | Unit | Controller | attestation-controller', function () {
       sinon.stub(hFake, 'response');
       hFake.response.callThrough();
 
-      const expectedUsecaseResponse = Symbol('expectedUsecaseResponse');
+      const expectedUsecaseResponse = { data: Symbol('data'), templateName: 'sixth-grade-attestation-template' };
       const expectedBuffer = Symbol('expectedBuffer');
 
       usecases.getAttestationDataForUsers
         .withArgs({ attestationKey, userIds: [userId], locale })
         .resolves(expectedUsecaseResponse);
       pdfWithFormSerializerStub.serialize
-        .withArgs(sinon.match(/(\w*\/)*sixth-grade-attestation-template.pdf/), expectedUsecaseResponse)
+        .withArgs(sinon.match(/(\w*\/)*sixth-grade-attestation-template.pdf/), expectedUsecaseResponse.data)
         .resolves(expectedBuffer);
 
       // when

--- a/api/tests/profile/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/profile/unit/application/http-error-mapper-configuration_test.js
@@ -1,0 +1,19 @@
+import { profileDomainErrorMappingConfiguration } from '../../../../src/profile/application/http-error-mapper-configuration.js';
+import { AttestationNotFoundError } from '../../../../src/profile/domain/errors.js';
+import { HttpErrors } from '../../../../src/shared/application/http-errors.js';
+import { expect } from '../../../test-helper.js';
+
+describe('Profile | Unit | Application | HttpErrorMapperConfiguration', function () {
+  it('instantiates NotFoundError when AttestationNotFoundError', async function () {
+    //given
+    const httpErrorMapper = profileDomainErrorMappingConfiguration.find(
+      (httpErrorMapper) => httpErrorMapper.name === AttestationNotFoundError.name,
+    );
+
+    //when
+    const error = httpErrorMapper.httpErrorFn(new AttestationNotFoundError());
+
+    //then
+    expect(error).to.be.instanceOf(HttpErrors.NotFoundError);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Pour notre Epix sur les attestations, nous avions dans un premier temps écrit le nom du template utilisé en dur dans le code.

## :robot: Proposition
Ajouter le mécanisme pour récuperer ce nom de template depuis la base de données avec une clé en entrée. Et refacto notre code précédent pour qu'il l'utilise

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
La CI est verte ✅ 
🐈‍⬛ 
