### PR TITLE
[FEATURE] Afficher un signalement d'extension de Companion dans l’espace surveillant (PIX-14731)

### DIFF
--- a/api/src/certification/session-management/domain/models/CertificationCandidateForSupervising.js
+++ b/api/src/certification/session-management/domain/models/CertificationCandidateForSupervising.js
@@ -16,6 +16,8 @@ class CertificationCandidateForSupervising {
     enrolledComplementaryCertification,
     stillValidBadgeAcquisitions = [],
     accessibilityAdjustmentNeeded,
+    challengeLiveAlert,
+    companionLiveAlert,
   } = {}) {
     this.id = id;
     this.userId = userId;
@@ -30,6 +32,8 @@ class CertificationCandidateForSupervising {
     this.enrolledComplementaryCertification = enrolledComplementaryCertification;
     this.stillValidBadgeAcquisitions = stillValidBadgeAcquisitions;
     this.accessibilityAdjustmentNeeded = accessibilityAdjustmentNeeded;
+    this.challengeLiveAlert = challengeLiveAlert?.status ? challengeLiveAlert : null;
+    this.companionLiveAlert = companionLiveAlert?.status ? companionLiveAlert : null;
   }
 
   authorizeToStart() {

--- a/api/src/certification/session-management/domain/models/CertificationCandidateForSupervisingV3.js
+++ b/api/src/certification/session-management/domain/models/CertificationCandidateForSupervisingV3.js
@@ -1,8 +1,0 @@
-import { CertificationCandidateForSupervising } from './CertificationCandidateForSupervising.js';
-
-export class CertificationCandidateForSupervisingV3 extends CertificationCandidateForSupervising {
-  constructor({ liveAlert = null, ...rest }) {
-    super({ ...rest });
-    this.liveAlert = liveAlert?.status ? liveAlert : null;
-  }
-}

--- a/api/src/certification/session-management/infrastructure/repositories/session-for-supervising-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/session-for-supervising-repository.js
@@ -16,7 +16,6 @@ const get = async function ({ id }) {
       examiner: 'sessions.examiner',
       accessCode: 'sessions.accessCode',
       address: 'sessions.address',
-      version: 'sessions.version',
       certificationCandidates: knex.raw(`
         json_agg(json_build_object(
           'userId', "certification-candidates"."userId",

--- a/api/src/certification/session-management/infrastructure/repositories/session-for-supervising-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/session-for-supervising-repository.js
@@ -1,20 +1,13 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { CertificationChallengeLiveAlertStatus } from '../../../shared/domain/models/CertificationChallengeLiveAlert.js';
-import { CertificationVersion } from '../../../shared/domain/models/CertificationVersion.js';
+import { CertificationCompanionLiveAlertStatus } from '../../../shared/domain/models/CertificationCompanionLiveAlert.js';
 import { CertificationCandidateForSupervising } from '../../domain/models/CertificationCandidateForSupervising.js';
-import { CertificationCandidateForSupervisingV3 } from '../../domain/models/CertificationCandidateForSupervisingV3.js';
 import { ComplementaryCertificationForSupervising } from '../../domain/models/ComplementaryCertificationForSupervising.js';
 import { SessionForSupervising } from '../../domain/read-models/SessionForSupervising.js';
 
 const get = async function ({ id }) {
   const results = await knex
-    .with('ongoing-live-alerts', (queryBuilder) => {
-      queryBuilder
-        .select('*')
-        .from('certification-challenge-live-alerts')
-        .where({ status: CertificationChallengeLiveAlertStatus.ONGOING });
-    })
     .select({
       id: 'sessions.id',
       date: 'sessions.date',
@@ -35,19 +28,24 @@ const get = async function ({ id }) {
           'authorizedToStart', "certification-candidates"."authorizedToStart",
           'assessmentStatus', "assessments"."state",
           'startDateTime', "certification-courses"."createdAt",
-          'liveAlert', json_build_object(
-            'status', "ongoing-live-alerts".status,
-            'hasImage',"ongoing-live-alerts"."hasImage",
-            'hasAttachment', "ongoing-live-alerts"."hasAttachment",
-            'hasEmbed', "ongoing-live-alerts"."hasEmbed",
-            'isFocus', "ongoing-live-alerts"."isFocus"
+          'challengeLiveAlert', json_build_object(
+            'type', 'challenge',
+            'status', "certification-challenge-live-alerts".status,
+            'hasImage',"certification-challenge-live-alerts"."hasImage",
+            'hasAttachment', "certification-challenge-live-alerts"."hasAttachment",
+            'hasEmbed', "certification-challenge-live-alerts"."hasEmbed",
+            'isFocus', "certification-challenge-live-alerts"."isFocus"
+          ),
+          'companionLiveAlert', json_build_object(
+            'type', 'companion',
+            'status', "certification-companion-live-alerts".status
           ),
           'complementaryCertification', json_build_object(
             'key', "complementary-certifications"."key",
             'label', "complementary-certifications"."label",
             'certificationExtraTime', "complementary-certifications"."certificationExtraTime"
           )
-        ) order by "ongoing-live-alerts".status, lower("certification-candidates"."lastName"), lower("certification-candidates"."firstName"))
+        ) order by "certification-companion-live-alerts".status, "certification-challenge-live-alerts".status, lower("certification-candidates"."lastName"), lower("certification-candidates"."firstName"))
     `),
     })
     .from('sessions')
@@ -67,7 +65,20 @@ const get = async function ({ id }) {
       'complementary-certifications.id',
       'certification-subscriptions.complementaryCertificationId',
     )
-    .leftJoin('ongoing-live-alerts', 'ongoing-live-alerts.assessmentId', 'assessments.id')
+    .leftJoin('certification-challenge-live-alerts', function () {
+      this.on('certification-challenge-live-alerts.assessmentId', '=', 'assessments.id').andOnVal(
+        'certification-challenge-live-alerts.status',
+        '=',
+        CertificationChallengeLiveAlertStatus.ONGOING,
+      );
+    })
+    .leftJoin('certification-companion-live-alerts', function () {
+      this.on('certification-companion-live-alerts.assessmentId', '=', 'assessments.id').andOnVal(
+        'certification-companion-live-alerts.status',
+        '=',
+        CertificationCompanionLiveAlertStatus.ONGOING,
+      );
+    })
     .groupBy('sessions.id')
     .where({ 'sessions.id': id })
     .first();
@@ -93,21 +104,10 @@ function _buildCertificationCandidateForSupervising(candidateDto) {
   });
 }
 
-function _buildCertificationCandidateForSupervisingV3(candidateDto) {
-  return new CertificationCandidateForSupervisingV3({
-    ...candidateDto,
-    enrolledComplementaryCertification: _toDomainComplementaryCertification(candidateDto.complementaryCertification),
-  });
-}
-
 function _toDomain(results) {
   const certificationCandidates = results.certificationCandidates
     .filter((candidate) => candidate?.id !== null)
-    .map((candidate) =>
-      CertificationVersion.isV3(results.version)
-        ? _buildCertificationCandidateForSupervisingV3(candidate)
-        : _buildCertificationCandidateForSupervising(candidate),
-    );
+    .map((candidate) => _buildCertificationCandidateForSupervising(candidate));
 
   return new SessionForSupervising({
     ...results,

--- a/api/src/certification/session-management/infrastructure/serializers/session-for-supervising-serializer.js
+++ b/api/src/certification/session-management/infrastructure/serializers/session-for-supervising-serializer.js
@@ -10,7 +10,6 @@ const serialize = function (sessions) {
 
       cloneSession.certificationCandidates.forEach((candidate) => {
         candidate.enrolledComplementaryCertificationLabel = candidate.enrolledComplementaryCertification?.label ?? null;
-        candidate.liveAlert = candidate.liveAlert ?? null;
       });
 
       return cloneSession;
@@ -34,7 +33,8 @@ const serialize = function (sessions) {
         'theoricalEndDateTime',
         'enrolledComplementaryCertificationLabel',
         'isStillEligibleToComplementaryCertification',
-        'liveAlert',
+        'challengeLiveAlert',
+        'companionLiveAlert',
       ],
     },
   }).serialize(sessions);

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/session-for-supervising-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/session-for-supervising-repository_test.js
@@ -11,447 +11,402 @@ import { catchErr, databaseBuilder, expect } from '../../../../../test-helper.js
 
 describe('Integration | Repository | SessionForSupervising', function () {
   describe('#get', function () {
-    describe('when certification session is v2', function () {
-      it('should return session informations in a SessionForSupervising Object', async function () {
-        // given
-        databaseBuilder.factory.buildCertificationCenter({ name: 'Toto', id: 1234 });
-        const session = databaseBuilder.factory.buildSession({
-          certificationCenter: 'Tour Gamma',
+    it('should return session informations in a SessionForSupervising Object', async function () {
+      // given
+      databaseBuilder.factory.buildCertificationCenter({ name: 'Toto', id: 1234 });
+      const session = databaseBuilder.factory.buildSession({
+        certificationCenter: 'Tour Gamma',
+        address: 'centre de certification 1',
+        room: 'Salle A',
+        examiner: 'Monsieur Examinateur',
+        accessCode: 'CODE12',
+        date: '2018-02-23',
+        time: '12:00:00',
+        certificationCenterId: 1234,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const actualSession = await sessionForSupervisingRepository.get({ id: session.id });
+
+      // then
+      expect(actualSession).to.be.deepEqualInstance(
+        new SessionForSupervising({
+          id: session.id,
           address: 'centre de certification 1',
           room: 'Salle A',
           examiner: 'Monsieur Examinateur',
           accessCode: 'CODE12',
           date: '2018-02-23',
           time: '12:00:00',
-          certificationCenterId: 1234,
-        });
-
-        await databaseBuilder.commit();
-
-        // when
-        const actualSession = await sessionForSupervisingRepository.get({ id: session.id });
-
-        // then
-        expect(actualSession).to.be.deepEqualInstance(
-          new SessionForSupervising({
-            id: session.id,
-            address: 'centre de certification 1',
-            room: 'Salle A',
-            examiner: 'Monsieur Examinateur',
-            accessCode: 'CODE12',
-            date: '2018-02-23',
-            time: '12:00:00',
-            certificationCandidates: [],
-          }),
-        );
-      });
-
-      it('should return associated certifications candidates ordered by lastname and firstname', async function () {
-        // given
-        databaseBuilder.factory.buildCertificationCenter({ name: 'Toto', id: 1234 });
-        const session = databaseBuilder.factory.buildSession({
-          certificationCenter: 'Tour Gamma',
-          room: 'Salle A',
-          examiner: 'Monsieur Examinateur',
-          date: '2018-02-23',
-          time: '12:00:00',
-          certificationCenterId: 1234,
-        });
-
-        databaseBuilder.factory.buildUser({ id: 11111 });
-        const candidateA = databaseBuilder.factory.buildCertificationCandidate({
-          userId: 11111,
-          lastName: 'Jackson',
-          firstName: 'Michael',
-          sessionId: session.id,
-          authorizedToStart: true,
-        });
-        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidateA.id });
-
-        databaseBuilder.factory.buildUser({ id: 22222 });
-        const candidateB = databaseBuilder.factory.buildCertificationCandidate({
-          userId: 22222,
-          lastName: 'Stardust',
-          firstName: 'Ziggy',
-          sessionId: session.id,
-        });
-        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidateB.id });
-
-        databaseBuilder.factory.buildUser({ id: 33333 });
-        const candidateC = databaseBuilder.factory.buildCertificationCandidate({
-          userId: 33333,
-          lastName: 'Jackson',
-          firstName: 'Janet',
-          sessionId: session.id,
-        });
-        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidateC.id });
-
-        databaseBuilder.factory.buildUser({ id: 12345 });
-        const candidateD = databaseBuilder.factory.buildCertificationCandidate({
-          lastName: 'Joplin',
-          firstName: 'Janis',
-          sessionId: session.id,
-          userId: 12345,
-          authorizedToStart: true,
-        });
-        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidateD.id });
-
-        const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
-          userId: 12345,
-          sessionId: session.id,
-          createdAt: new Date('2022-10-19T13:37:00Z'),
-        });
-
-        databaseBuilder.factory.buildAssessment({
-          certificationCourseId: certificationCourse.id,
-          state: Assessment.states.STARTED,
-        });
-
-        databaseBuilder.factory.buildCertificationCandidate();
-        await databaseBuilder.commit();
-
-        // when
-        const actualSession = await sessionForSupervisingRepository.get({ id: session.id });
-
-        // then
-        const actualCandidates = _.map(actualSession.certificationCandidates, (item) =>
-          _.pick(item, [
-            'userId',
-            'sessionId',
-            'lastName',
-            'firstName',
-            'authorizedToStart',
-            'assessmentStatus',
-            'startDateTime',
-          ]),
-        );
-        expect(actualCandidates).to.have.deep.ordered.members([
-          {
-            userId: 33333,
-            lastName: 'Jackson',
-            firstName: 'Janet',
-            authorizedToStart: false,
-            assessmentStatus: null,
-            startDateTime: null,
-          },
-          {
-            userId: 11111,
-            lastName: 'Jackson',
-            firstName: 'Michael',
-            authorizedToStart: true,
-            assessmentStatus: null,
-            startDateTime: null,
-          },
-          {
-            userId: 12345,
-            lastName: 'Joplin',
-            firstName: 'Janis',
-            authorizedToStart: true,
-            assessmentStatus: Assessment.states.STARTED,
-            startDateTime: '2022-10-19T13:37:00+00:00',
-          },
-          {
-            userId: 22222,
-            lastName: 'Stardust',
-            firstName: 'Ziggy',
-            authorizedToStart: false,
-            assessmentStatus: null,
-            startDateTime: null,
-          },
-        ]);
-      });
-
-      it('should return certifications candidates with subscribed complementary certifications', async function () {
-        // given
-        databaseBuilder.factory.buildCertificationCenter({ name: 'Toto', id: 1234 });
-        const session = databaseBuilder.factory.buildSession({
-          certificationCenter: 'Tour Gamma',
-          room: 'Salle A',
-          examiner: 'Monsieur Examinateur',
-          date: '2018-02-23',
-          time: '12:00:00',
-          certificationCenterId: 1234,
-        });
-
-        databaseBuilder.factory.buildUser({ id: 11111 });
-        const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
-          userId: 11111,
-          lastName: 'Jackson',
-          firstName: 'Janet',
-          sessionId: session.id,
-        });
-        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: certificationCandidate.id });
-
-        databaseBuilder.factory.buildUser({ id: 22222 });
-        const candidateB = databaseBuilder.factory.buildCertificationCandidate({
-          userId: 22222,
-          lastName: 'Joplin',
-          firstName: 'Janis',
-          sessionId: session.id,
-        });
-        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidateB.id });
-
-        const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
-          label: 'Pix+ Édu 1er degré',
-          key: 'EDU_1ER_DEGRE',
-          certificationExtraTime: 45,
-        });
-
-        databaseBuilder.factory.buildComplementaryCertificationSubscription({
-          certificationCandidateId: certificationCandidate.id,
-          complementaryCertificationId: complementaryCertification.id,
-        });
-
-        await databaseBuilder.commit();
-
-        // when
-        const actualSession = await sessionForSupervisingRepository.get({ id: session.id });
-
-        // then
-        const actualCandidates = _.map(actualSession.certificationCandidates, (item) =>
-          _.pick(item, ['userId', 'sessionId', 'lastName', 'firstName', 'enrolledComplementaryCertification']),
-        );
-
-        expect(actualCandidates).to.have.deep.ordered.members([
-          {
-            userId: 11111,
-            lastName: 'Jackson',
-            firstName: 'Janet',
-            enrolledComplementaryCertification: {
-              key: complementaryCertification.key,
-              label: complementaryCertification.label,
-              certificationExtraTime: complementaryCertification.certificationExtraTime,
-            },
-          },
-          {
-            userId: 22222,
-            lastName: 'Joplin',
-            firstName: 'Janis',
-            enrolledComplementaryCertification: null,
-          },
-        ]);
-      });
-
-      it('should return a Not found error when no session was found', async function () {
-        // when
-        const error = await catchErr(sessionForSupervisingRepository.get)({ id: 123123 });
-
-        // then
-        expect(error).to.be.instanceOf(NotFoundError);
-      });
+          certificationCandidates: [],
+        }),
+      );
     });
 
-    describe('when certification session is v3', function () {
-      it('should return session informations in a SessionForSupervising Object', async function () {
-        // given
-        databaseBuilder.factory.buildCertificationCenter({ name: 'Toto', id: 1234 });
-        const session = databaseBuilder.factory.buildSession({
-          version: CERTIFICATION_VERSIONS.V3,
-          address: 'centre de certification 1',
-          certificationCenter: 'Tour Gamma',
-          room: 'Salle A',
-          examiner: 'Monsieur Examinateur',
-          accessCode: 'CODE12',
-          date: '2018-02-23',
-          time: '12:00:00',
-          certificationCenterId: 1234,
-        });
-
-        await databaseBuilder.commit();
-
-        // when
-        const actualSession = await sessionForSupervisingRepository.get({ id: session.id });
-
-        // then
-        expect(actualSession).to.be.deepEqualInstance(
-          new SessionForSupervising({
-            id: session.id,
-            address: 'centre de certification 1',
-            room: 'Salle A',
-            examiner: 'Monsieur Examinateur',
-            accessCode: 'CODE12',
-            date: '2018-02-23',
-            time: '12:00:00',
-            certificationCandidates: [],
-          }),
-        );
+    it('should return associated certifications candidates ordered by lastname and firstname', async function () {
+      // given
+      databaseBuilder.factory.buildCertificationCenter({ name: 'Toto', id: 1234 });
+      const session = databaseBuilder.factory.buildSession({
+        certificationCenter: 'Tour Gamma',
+        room: 'Salle A',
+        examiner: 'Monsieur Examinateur',
+        date: '2018-02-23',
+        time: '12:00:00',
+        certificationCenterId: 1234,
       });
 
-      it('should return associated certifications candidates ordered by live alert status, lastname and firstname', async function () {
-        // given
-        databaseBuilder.factory.buildCertificationCenter({ name: 'Toto', id: 1234 });
-        const session = databaseBuilder.factory.buildSession({
-          version: CERTIFICATION_VERSIONS.V3,
-          certificationCenter: 'Tour Gamma',
-          room: 'Salle A',
-          examiner: 'Monsieur Examinateur',
-          date: '2018-02-23',
-          time: '12:00:00',
-          certificationCenterId: 1234,
-        });
+      databaseBuilder.factory.buildUser({ id: 11111 });
+      const candidateA = databaseBuilder.factory.buildCertificationCandidate({
+        userId: 11111,
+        lastName: 'Jackson',
+        firstName: 'Michael',
+        sessionId: session.id,
+        authorizedToStart: true,
+      });
+      databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidateA.id });
 
-        databaseBuilder.factory.buildUser({ id: 11111 });
-        const candidateA = databaseBuilder.factory.buildCertificationCandidate({
-          userId: 11111,
-          lastName: 'Jackson',
-          firstName: 'Michael',
-          sessionId: session.id,
-          authorizedToStart: true,
-        });
-        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidateA.id });
+      databaseBuilder.factory.buildUser({ id: 22222 });
+      const candidateB = databaseBuilder.factory.buildCertificationCandidate({
+        userId: 22222,
+        lastName: 'Stardust',
+        firstName: 'Ziggy',
+        sessionId: session.id,
+      });
+      databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidateB.id });
 
-        databaseBuilder.factory.buildUser({ id: 22222 });
-        const candidateB = databaseBuilder.factory.buildCertificationCandidate({
-          userId: 22222,
-          lastName: 'Stardust',
-          firstName: 'Ziggy',
-          sessionId: session.id,
-        });
-        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidateB.id });
+      databaseBuilder.factory.buildUser({ id: 33333 });
+      const candidateC = databaseBuilder.factory.buildCertificationCandidate({
+        userId: 33333,
+        lastName: 'Jackson',
+        firstName: 'Janet',
+        sessionId: session.id,
+      });
+      databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidateC.id });
 
-        databaseBuilder.factory.buildUser({ id: 33333 });
-        const candidateC = databaseBuilder.factory.buildCertificationCandidate({
+      databaseBuilder.factory.buildUser({ id: 12345 });
+      const candidateD = databaseBuilder.factory.buildCertificationCandidate({
+        lastName: 'Joplin',
+        firstName: 'Janis',
+        sessionId: session.id,
+        userId: 12345,
+        authorizedToStart: true,
+      });
+      databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidateD.id });
+
+      const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+        userId: 12345,
+        sessionId: session.id,
+        createdAt: new Date('2022-10-19T13:37:00Z'),
+      });
+
+      databaseBuilder.factory.buildAssessment({
+        certificationCourseId: certificationCourse.id,
+        state: Assessment.states.STARTED,
+      });
+
+      databaseBuilder.factory.buildCertificationCandidate();
+      await databaseBuilder.commit();
+
+      // when
+      const actualSession = await sessionForSupervisingRepository.get({ id: session.id });
+
+      // then
+      const actualCandidates = _.map(actualSession.certificationCandidates, (item) =>
+        _.pick(item, [
+          'userId',
+          'sessionId',
+          'lastName',
+          'firstName',
+          'authorizedToStart',
+          'assessmentStatus',
+          'startDateTime',
+        ]),
+      );
+      expect(actualCandidates).to.have.deep.ordered.members([
+        {
           userId: 33333,
           lastName: 'Jackson',
           firstName: 'Janet',
-          sessionId: session.id,
-        });
-        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidateC.id });
-
-        databaseBuilder.factory.buildUser({ id: 12345 });
-        const candidateD = databaseBuilder.factory.buildCertificationCandidate({
+          authorizedToStart: false,
+          assessmentStatus: null,
+          startDateTime: null,
+        },
+        {
+          userId: 11111,
+          lastName: 'Jackson',
+          firstName: 'Michael',
+          authorizedToStart: true,
+          assessmentStatus: null,
+          startDateTime: null,
+        },
+        {
+          userId: 12345,
           lastName: 'Joplin',
           firstName: 'Janis',
-          sessionId: session.id,
-          userId: 12345,
           authorizedToStart: true,
-        });
-        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidateD.id });
-
-        const certificationCourseWithBothLiveAlerts = databaseBuilder.factory.buildCertificationCourse({
-          version: CERTIFICATION_VERSIONS.V3,
-          userId: 12345,
-          sessionId: session.id,
-          createdAt: new Date('2022-10-19T13:37:00Z'),
-        });
-
-        const assessmentWithBothLiveAlerts = databaseBuilder.factory.buildAssessment({
-          certificationCourseId: certificationCourseWithBothLiveAlerts.id,
-          state: Assessment.states.STARTED,
-        });
-
-        databaseBuilder.factory.buildCertificationChallengeLiveAlert({
-          assessmentId: assessmentWithBothLiveAlerts.id,
-        });
-        databaseBuilder.factory.buildCertificationCompanionLiveAlert({
-          assessmentId: assessmentWithBothLiveAlerts.id,
-        });
-
-        const certificationCourseWithChallengeLiveAlert = databaseBuilder.factory.buildCertificationCourse({
-          version: CERTIFICATION_VERSIONS.V3,
+          assessmentStatus: Assessment.states.STARTED,
+          startDateTime: '2022-10-19T13:37:00+00:00',
+        },
+        {
           userId: 22222,
-          sessionId: session.id,
-          createdAt: new Date('2022-10-19T13:37:00Z'),
-        });
+          lastName: 'Stardust',
+          firstName: 'Ziggy',
+          authorizedToStart: false,
+          assessmentStatus: null,
+          startDateTime: null,
+        },
+      ]);
+    });
 
-        const assessmentWithChallengeLiveAlert = databaseBuilder.factory.buildAssessment({
-          certificationCourseId: certificationCourseWithChallengeLiveAlert.id,
-          state: Assessment.states.STARTED,
-        });
-
-        databaseBuilder.factory.buildCertificationChallengeLiveAlert({
-          assessmentId: assessmentWithChallengeLiveAlert.id,
-        });
-
-        const candidate = databaseBuilder.factory.buildCertificationCandidate();
-        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidate.id });
-        await databaseBuilder.commit();
-
-        // when
-        const actualSession = await sessionForSupervisingRepository.get({ id: session.id });
-
-        // then
-        const actualCandidates = _.map(actualSession.certificationCandidates, (item) =>
-          _.pick(item, [
-            'userId',
-            'sessionId',
-            'lastName',
-            'firstName',
-            'authorizedToStart',
-            'assessmentStatus',
-            'startDateTime',
-            'challengeLiveAlert',
-            'companionLiveAlert',
-          ]),
-        );
-        expect(actualCandidates).to.have.deep.ordered.members([
-          {
-            userId: 12345,
-            lastName: 'Joplin',
-            firstName: 'Janis',
-            authorizedToStart: true,
-            assessmentStatus: Assessment.states.STARTED,
-            startDateTime: '2022-10-19T13:37:00+00:00',
-            challengeLiveAlert: {
-              type: 'challenge',
-              hasAttachment: false,
-              hasImage: false,
-              hasEmbed: false,
-              isFocus: false,
-              status: CertificationChallengeLiveAlertStatus.ONGOING,
-            },
-            companionLiveAlert: {
-              type: 'companion',
-              status: CertificationCompanionLiveAlertStatus.ONGOING,
-            },
-          },
-          {
-            userId: 22222,
-            lastName: 'Stardust',
-            firstName: 'Ziggy',
-            authorizedToStart: false,
-            assessmentStatus: Assessment.states.STARTED,
-            startDateTime: '2022-10-19T13:37:00+00:00',
-            challengeLiveAlert: {
-              type: 'challenge',
-              hasAttachment: false,
-              hasImage: false,
-              hasEmbed: false,
-              isFocus: false,
-              status: CertificationChallengeLiveAlertStatus.ONGOING,
-            },
-            companionLiveAlert: null,
-          },
-          {
-            userId: 33333,
-            lastName: 'Jackson',
-            firstName: 'Janet',
-            authorizedToStart: false,
-            assessmentStatus: null,
-            startDateTime: null,
-            challengeLiveAlert: null,
-            companionLiveAlert: null,
-          },
-          {
-            userId: 11111,
-            lastName: 'Jackson',
-            firstName: 'Michael',
-            authorizedToStart: true,
-            assessmentStatus: null,
-            startDateTime: null,
-            challengeLiveAlert: null,
-            companionLiveAlert: null,
-          },
-        ]);
+    it('should return certifications candidates with subscribed complementary certifications', async function () {
+      // given
+      databaseBuilder.factory.buildCertificationCenter({ name: 'Toto', id: 1234 });
+      const session = databaseBuilder.factory.buildSession({
+        certificationCenter: 'Tour Gamma',
+        room: 'Salle A',
+        examiner: 'Monsieur Examinateur',
+        date: '2018-02-23',
+        time: '12:00:00',
+        certificationCenterId: 1234,
       });
 
-      it('should return a Not found error when no session was found', async function () {
-        // when
-        const error = await catchErr(sessionForSupervisingRepository.get)({ id: 123123 });
-
-        // then
-        expect(error).to.be.instanceOf(NotFoundError);
+      databaseBuilder.factory.buildUser({ id: 11111 });
+      const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
+        userId: 11111,
+        lastName: 'Jackson',
+        firstName: 'Janet',
+        sessionId: session.id,
       });
+      databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: certificationCandidate.id });
+
+      databaseBuilder.factory.buildUser({ id: 22222 });
+      const candidateB = databaseBuilder.factory.buildCertificationCandidate({
+        userId: 22222,
+        lastName: 'Joplin',
+        firstName: 'Janis',
+        sessionId: session.id,
+      });
+      databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidateB.id });
+
+      const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
+        label: 'Pix+ Édu 1er degré',
+        key: 'EDU_1ER_DEGRE',
+        certificationExtraTime: 45,
+      });
+
+      databaseBuilder.factory.buildComplementaryCertificationSubscription({
+        certificationCandidateId: certificationCandidate.id,
+        complementaryCertificationId: complementaryCertification.id,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const actualSession = await sessionForSupervisingRepository.get({ id: session.id });
+
+      // then
+      const actualCandidates = _.map(actualSession.certificationCandidates, (item) =>
+        _.pick(item, ['userId', 'sessionId', 'lastName', 'firstName', 'enrolledComplementaryCertification']),
+      );
+
+      expect(actualCandidates).to.have.deep.ordered.members([
+        {
+          userId: 11111,
+          lastName: 'Jackson',
+          firstName: 'Janet',
+          enrolledComplementaryCertification: {
+            key: complementaryCertification.key,
+            label: complementaryCertification.label,
+            certificationExtraTime: complementaryCertification.certificationExtraTime,
+          },
+        },
+        {
+          userId: 22222,
+          lastName: 'Joplin',
+          firstName: 'Janis',
+          enrolledComplementaryCertification: null,
+        },
+      ]);
+    });
+
+    it('should return a Not found error when no session was found', async function () {
+      // when
+      const error = await catchErr(sessionForSupervisingRepository.get)({ id: 123123 });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
+  });
+
+  describe('when some candidates have live alerts', function () {
+    it('should return candidates ordered by live alert types, lastname and firstname', async function () {
+      // given
+      databaseBuilder.factory.buildCertificationCenter({ name: 'Toto', id: 1234 });
+      const session = databaseBuilder.factory.buildSession({
+        version: CERTIFICATION_VERSIONS.V3,
+        certificationCenter: 'Tour Gamma',
+        room: 'Salle A',
+        examiner: 'Monsieur Examinateur',
+        date: '2018-02-23',
+        time: '12:00:00',
+        certificationCenterId: 1234,
+      });
+
+      databaseBuilder.factory.buildUser({ id: 11111 });
+      const candidateA = databaseBuilder.factory.buildCertificationCandidate({
+        userId: 11111,
+        lastName: 'Jackson',
+        firstName: 'Michael',
+        sessionId: session.id,
+        authorizedToStart: true,
+      });
+      databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidateA.id });
+
+      databaseBuilder.factory.buildUser({ id: 22222 });
+      const candidateB = databaseBuilder.factory.buildCertificationCandidate({
+        userId: 22222,
+        lastName: 'Stardust',
+        firstName: 'Ziggy',
+        sessionId: session.id,
+      });
+      databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidateB.id });
+
+      databaseBuilder.factory.buildUser({ id: 33333 });
+      const candidateC = databaseBuilder.factory.buildCertificationCandidate({
+        userId: 33333,
+        lastName: 'Jackson',
+        firstName: 'Janet',
+        sessionId: session.id,
+      });
+      databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidateC.id });
+
+      databaseBuilder.factory.buildUser({ id: 12345 });
+      const candidateD = databaseBuilder.factory.buildCertificationCandidate({
+        lastName: 'Joplin',
+        firstName: 'Janis',
+        sessionId: session.id,
+        userId: 12345,
+        authorizedToStart: true,
+      });
+      databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidateD.id });
+
+      const certificationCourseWithBothLiveAlerts = databaseBuilder.factory.buildCertificationCourse({
+        version: CERTIFICATION_VERSIONS.V3,
+        userId: 12345,
+        sessionId: session.id,
+        createdAt: new Date('2022-10-19T13:37:00Z'),
+      });
+
+      const assessmentWithBothLiveAlerts = databaseBuilder.factory.buildAssessment({
+        certificationCourseId: certificationCourseWithBothLiveAlerts.id,
+        state: Assessment.states.STARTED,
+      });
+
+      databaseBuilder.factory.buildCertificationChallengeLiveAlert({
+        assessmentId: assessmentWithBothLiveAlerts.id,
+      });
+      databaseBuilder.factory.buildCertificationCompanionLiveAlert({
+        assessmentId: assessmentWithBothLiveAlerts.id,
+      });
+
+      const certificationCourseWithChallengeLiveAlert = databaseBuilder.factory.buildCertificationCourse({
+        version: CERTIFICATION_VERSIONS.V3,
+        userId: 22222,
+        sessionId: session.id,
+        createdAt: new Date('2022-10-19T13:37:00Z'),
+      });
+
+      const assessmentWithChallengeLiveAlert = databaseBuilder.factory.buildAssessment({
+        certificationCourseId: certificationCourseWithChallengeLiveAlert.id,
+        state: Assessment.states.STARTED,
+      });
+
+      databaseBuilder.factory.buildCertificationChallengeLiveAlert({
+        assessmentId: assessmentWithChallengeLiveAlert.id,
+      });
+
+      const candidate = databaseBuilder.factory.buildCertificationCandidate();
+      databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidate.id });
+      await databaseBuilder.commit();
+
+      // when
+      const actualSession = await sessionForSupervisingRepository.get({ id: session.id });
+
+      // then
+      const actualCandidates = _.map(actualSession.certificationCandidates, (item) =>
+        _.pick(item, [
+          'userId',
+          'sessionId',
+          'lastName',
+          'firstName',
+          'authorizedToStart',
+          'assessmentStatus',
+          'startDateTime',
+          'challengeLiveAlert',
+          'companionLiveAlert',
+        ]),
+      );
+      expect(actualCandidates).to.have.deep.ordered.members([
+        {
+          userId: 12345,
+          lastName: 'Joplin',
+          firstName: 'Janis',
+          authorizedToStart: true,
+          assessmentStatus: Assessment.states.STARTED,
+          startDateTime: '2022-10-19T13:37:00+00:00',
+          challengeLiveAlert: {
+            type: 'challenge',
+            hasAttachment: false,
+            hasImage: false,
+            hasEmbed: false,
+            isFocus: false,
+            status: CertificationChallengeLiveAlertStatus.ONGOING,
+          },
+          companionLiveAlert: {
+            type: 'companion',
+            status: CertificationCompanionLiveAlertStatus.ONGOING,
+          },
+        },
+        {
+          userId: 22222,
+          lastName: 'Stardust',
+          firstName: 'Ziggy',
+          authorizedToStart: false,
+          assessmentStatus: Assessment.states.STARTED,
+          startDateTime: '2022-10-19T13:37:00+00:00',
+          challengeLiveAlert: {
+            type: 'challenge',
+            hasAttachment: false,
+            hasImage: false,
+            hasEmbed: false,
+            isFocus: false,
+            status: CertificationChallengeLiveAlertStatus.ONGOING,
+          },
+          companionLiveAlert: null,
+        },
+        {
+          userId: 33333,
+          lastName: 'Jackson',
+          firstName: 'Janet',
+          authorizedToStart: false,
+          assessmentStatus: null,
+          startDateTime: null,
+          challengeLiveAlert: null,
+          companionLiveAlert: null,
+        },
+        {
+          userId: 11111,
+          lastName: 'Jackson',
+          firstName: 'Michael',
+          authorizedToStart: true,
+          assessmentStatus: null,
+          startDateTime: null,
+          challengeLiveAlert: null,
+          companionLiveAlert: null,
+        },
+      ]);
     });
   });
 });

--- a/api/tests/certification/session-management/unit/infrastructure/serializers/session-for-supervising-serializer_test.js
+++ b/api/tests/certification/session-management/unit/infrastructure/serializers/session-for-supervising-serializer_test.js
@@ -1,8 +1,8 @@
 import { CertificationCandidateForSupervising } from '../../../../../../src/certification/session-management/domain/models/CertificationCandidateForSupervising.js';
-import { CertificationCandidateForSupervisingV3 } from '../../../../../../src/certification/session-management/domain/models/CertificationCandidateForSupervisingV3.js';
 import * as serializer from '../../../../../../src/certification/session-management/infrastructure/serializers/session-for-supervising-serializer.js';
 import { CertificationChallengeLiveAlertStatus } from '../../../../../../src/certification/shared/domain/models/CertificationChallengeLiveAlert.js';
-import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
+import { CertificationCompanionLiveAlertStatus } from '../../../../../../src/certification/shared/domain/models/CertificationCompanionLiveAlert.js';
+import { Assessment } from '../../../../../../src/shared/domain/models/index.js';
 import { domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', function () {
@@ -48,7 +48,8 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
                 'enrolled-complementary-certification-label': 'Super Certification Complémentaire',
                 'is-still-eligible-to-complementary-certification': true,
                 'user-id': 6789,
-                'live-alert': null,
+                'challenge-live-alert': null,
+                'companion-live-alert': null,
               },
               id: '1234',
               type: 'certification-candidate-for-supervising',
@@ -139,12 +140,17 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
                 'enrolled-complementary-certification-label': 'Super Certification Complémentaire',
                 'is-still-eligible-to-complementary-certification': true,
                 'user-id': 6789,
-                'live-alert': {
-                  status: 'ongoing',
+                'challenge-live-alert': {
+                  type: 'challenge',
+                  status: CertificationChallengeLiveAlertStatus.ONGOING,
                   hasAttachment: false,
                   hasImage: false,
                   hasEmbed: false,
                   isFocus: false,
+                },
+                'companion-live-alert': {
+                  type: 'companion',
+                  status: CertificationCompanionLiveAlertStatus.ONGOING,
                 },
               },
               id: '1234',
@@ -162,7 +168,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
           date: '2017-01-20',
           time: '14:30',
           certificationCandidates: [
-            new CertificationCandidateForSupervisingV3({
+            new CertificationCandidateForSupervising({
               id: 1234,
               userId: 6789,
               firstName: 'toto',
@@ -183,12 +189,17 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
                   complementaryCertificationBadgeLabel: 'Super Certification Complémentaire',
                 }),
               ],
-              liveAlert: {
+              challengeLiveAlert: {
+                type: 'challenge',
                 status: CertificationChallengeLiveAlertStatus.ONGOING,
                 hasImage: false,
                 hasAttachment: false,
                 hasEmbed: false,
                 isFocus: false,
+              },
+              companionLiveAlert: {
+                type: 'companion',
+                status: CertificationCompanionLiveAlertStatus.ONGOING,
               },
             }),
           ],

--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -7,10 +7,10 @@
               "common.forms.certification-labels.candidate-status.authorized-to-resume"
             }}</PixTag>
         {{else}}
-          {{#if (eq @candidate.liveAlert.status "ongoing")}}
-            <PixTag class="session-supervising-candidate-in-list__status-container--ongoing-alert">{{t
-                "common.forms.certification-labels.candidate-status.ongoing-live-alert"
-              }}</PixTag>
+          {{#if @candidate.currentLiveAlert}}
+            <PixTag class="session-supervising-candidate-in-list__status-container--ongoing-alert">
+              {{this.currentLiveAlertLabel}}
+            </PixTag>
           {{else}}
             <PixTag class="session-supervising-candidate-in-list__status-container--started">{{t
                 "common.forms.certification-labels.candidate-status.ongoing"
@@ -108,7 +108,7 @@
         @close={{this.closeMenu}}
         aria-label={{t "pages.session-supervising.candidate-in-list.candidate-options"}}
       >
-        {{#if @candidate.liveAlert}}
+        {{#if @candidate.hasOngoingChallengeLiveAlert}}
           <Dropdown::Item @onClick={{this.askUserToHandleLiveAlert}}>
             {{t "pages.session-supervising.candidate-in-list.resume-test-modal.handle-live-alert"}}
           </Dropdown::Item>
@@ -139,7 +139,7 @@
     </:description>
   </SessionSupervising::ConfirmationModal>
 
-  {{#if (eq @candidate.liveAlert.status "ongoing")}}
+  {{#if @candidate.hasOngoingChallengeLiveAlert}}
     <SessionSupervising::HandleLiveAlertModal
       @showModal={{this.isHandleLiveAlertModalDisplayed}}
       @closeConfirmationModal={{this.closeHandleLiveAlertModal}}
@@ -147,7 +147,7 @@
       @rejectLiveAlert={{this.rejectLiveAlert}}
       @validateLiveAlert={{this.validateLiveAlert}}
       @candidateId={{@candidate.id}}
-      @liveAlert={{@candidate.liveAlert}}
+      @liveAlert={{@candidate.challengeLiveAlert}}
     />
   {{/if}}
 

--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -142,7 +142,7 @@ export default class CandidateInList extends Component {
 
   @action
   askUserToHandleLiveAlert() {
-    if (this._hasCertificationOngoingLiveAlert) {
+    if (this.args.candidate.hasOngoingChallengeLiveAlert) {
       this.displayedModal = Modals.HandleLiveAlert;
     } else {
       this.notifications.error(
@@ -270,7 +270,9 @@ export default class CandidateInList extends Component {
     return theoricalEndDateTime;
   }
 
-  get _hasCertificationOngoingLiveAlert() {
-    return this.args.candidate.liveAlert.status === 'ongoing';
+  get currentLiveAlertLabel() {
+    const alertType = this.args.candidate.currentLiveAlert?.type;
+
+    return this.intl.t(`common.forms.certification-labels.candidate-status.live-alerts.${alertType}.ongoing`);
   }
 }

--- a/certif/app/models/certification-candidate-for-supervising.js
+++ b/certif/app/models/certification-candidate-for-supervising.js
@@ -20,7 +20,8 @@ export default class CertificationCandidateForSupervising extends Model {
   @attr('string') enrolledComplementaryCertificationLabel;
   @attr('string') userId;
   @attr('boolean') isStillEligibleToComplementaryCertification;
-  @attr() liveAlert;
+  @attr() challengeLiveAlert;
+  @attr() companionLiveAlert;
 
   get hasStarted() {
     return this.assessmentStatus === 'started';
@@ -32,6 +33,14 @@ export default class CertificationCandidateForSupervising extends Model {
 
   get hasCompleted() {
     return [assessmentStates.COMPLETED, assessmentStates.ENDED_BY_SUPERVISOR].includes(this.assessmentStatus);
+  }
+
+  get hasOngoingChallengeLiveAlert() {
+    return this.challengeLiveAlert?.status === 'ongoing';
+  }
+
+  get currentLiveAlert() {
+    return this.companionLiveAlert ?? this.challengeLiveAlert;
   }
 
   updateAuthorizedToStart = memberAction({

--- a/certif/tests/acceptance/session-supervising-test.js
+++ b/certif/tests/acceptance/session-supervising-test.js
@@ -47,7 +47,8 @@ module('Acceptance | Session supervising', function (hooks) {
             birthdate: '1984-05-28',
             extraTimePercentage: '8',
             authorizedToStart: true,
-            liveAlert: {
+            challengeLiveAlert: {
+              type: 'challenge',
               status: 'ongoing',
               hasEmbed: false,
               hasAttachment: false,
@@ -62,7 +63,7 @@ module('Acceptance | Session supervising', function (hooks) {
             birthdate: '1983-06-28',
             extraTimePercentage: 12,
             authorizedToStart: false,
-            liveAlert: null,
+            challengeLiveAlert: null,
           }),
           server.create('certification-candidate-for-supervising', {
             id: 789,
@@ -71,7 +72,7 @@ module('Acceptance | Session supervising', function (hooks) {
             birthdate: '1987-05-28',
             extraTimePercentage: '6',
             authorizedToStart: true,
-            liveAlert: null,
+            challengeLiveAlert: null,
           }),
           server.create('certification-candidate-for-supervising', {
             id: 1000,
@@ -80,7 +81,7 @@ module('Acceptance | Session supervising', function (hooks) {
             birthdate: '1934-06-28',
             extraTimePercentage: '15',
             authorizedToStart: false,
-            liveAlert: null,
+            challengeLiveAlert: null,
           }),
         ],
       });
@@ -137,7 +138,8 @@ module('Acceptance | Session supervising', function (hooks) {
           birthdate: '1984-05-28',
           extraTimePercentage: '8',
           authorizedToStart: false,
-          liveAlert: {
+          challengeLiveAlert: {
+            type: 'challenge',
             status: 'ongoing',
             hasEmbed: false,
             hasAttachment: false,
@@ -284,7 +286,8 @@ module('Acceptance | Session supervising', function (hooks) {
                 extraTimePercentage: null,
                 authorizedToStart: true,
                 assessmentStatus: 'started',
-                liveAlert: {
+                challengeLiveAlert: {
+                  type: 'challenge',
                   status: 'ongoing',
                   hasEmbed: false,
                   hasAttachment: false,
@@ -327,8 +330,13 @@ module('Acceptance | Session supervising', function (hooks) {
                 extraTimePercentage: null,
                 authorizedToStart: true,
                 assessmentStatus: 'started',
-                liveAlert: {
+                challengeLiveAlert: {
+                  type: 'challenge',
                   status: 'ongoing',
+                  hasEmbed: false,
+                  hasAttachment: false,
+                  isFocus: false,
+                  hasImage: false,
                 },
               }),
             ],
@@ -377,7 +385,8 @@ module('Acceptance | Session supervising', function (hooks) {
                 extraTimePercentage: null,
                 authorizedToStart: true,
                 assessmentStatus: 'started',
-                liveAlert: {
+                challengeLiveAlert: {
+                  type: 'challenge',
                   status: 'ongoing',
                   hasEmbed: false,
                   hasAttachment: false,
@@ -432,7 +441,8 @@ module('Acceptance | Session supervising', function (hooks) {
                 extraTimePercentage: null,
                 authorizedToStart: true,
                 assessmentStatus: 'started',
-                liveAlert: {
+                challengeLiveAlert: {
+                  type: 'challenge',
                   status: 'ongoing',
                   hasEmbed: false,
                   hasAttachment: false,
@@ -482,7 +492,8 @@ module('Acceptance | Session supervising', function (hooks) {
                 extraTimePercentage: null,
                 authorizedToStart: true,
                 assessmentStatus: 'started',
-                liveAlert: {
+                challengeLiveAlert: {
+                  type: 'challenge',
                   status: 'ongoing',
                   hasEmbed: false,
                   hasAttachment: false,
@@ -531,7 +542,8 @@ module('Acceptance | Session supervising', function (hooks) {
                 extraTimePercentage: null,
                 authorizedToStart: true,
                 assessmentStatus: 'started',
-                liveAlert: {
+                challengeLiveAlert: {
+                  type: 'challenge',
                   status: 'ongoing',
                   hasEmbed: false,
                   hasAttachment: false,

--- a/certif/tests/integration/components/session-supervising/candidate-in-list-test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list-test.js
@@ -328,8 +328,13 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
           extraTimePercentage: 0.12,
           authorizedToStart: false,
           assessmentStatus: 'started',
-          liveAlert: {
+          challengeLiveAlert: {
+            type: 'challenge',
             status: 'ongoing',
+            hasEmbed: false,
+            hasAttachment: false,
+            isFocus: false,
+            hasImage: false,
           },
         });
 
@@ -398,61 +403,96 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
   });
 
   module('when the candidate has alerted the invigilator', function () {
-    test('it displays the live alert tag', async function (assert) {
-      // given
-      this.candidate = store.createRecord('certification-candidate-for-supervising', {
-        id: '456',
-        startDateTime: new Date('2022-10-19T14:30:15Z'),
-        theoricalEndDateTime: new Date('2022-10-19T16:00:00Z'),
-        extraTimePercentage: 0.12,
-        authorizedToStart: false,
-        assessmentStatus: 'started',
-        liveAlert: {
-          status: 'ongoing',
-        },
+    module('when the live alert type is challenge', function () {
+      test('it displays the live alert tag', async function (assert) {
+        // given
+        this.candidate = store.createRecord('certification-candidate-for-supervising', {
+          id: '456',
+          startDateTime: new Date('2022-10-19T14:30:15Z'),
+          theoricalEndDateTime: new Date('2022-10-19T16:00:00Z'),
+          extraTimePercentage: 0.12,
+          authorizedToStart: false,
+          assessmentStatus: 'started',
+          challengeLiveAlert: {
+            type: 'challenge',
+            status: 'ongoing',
+            hasEmbed: false,
+            hasAttachment: false,
+            isFocus: false,
+            hasImage: false,
+          },
+          companionLiveAlert: null,
+        });
+
+        // when
+        const screen = await renderScreen(hbs`<SessionSupervising::CandidateInList @candidate={{this.candidate}} />`);
+
+        // then
+        assert.dom(screen.getByText('Signalement en cours')).exists();
+        assert.dom(screen.queryByText('En cours')).doesNotExist();
+        assert.dom(screen.queryByText('Autorisé à reprendre')).doesNotExist();
+        assert.dom(screen.queryByText('Terminé')).doesNotExist();
       });
 
-      // when
-      const screen = await renderScreen(hbs`<SessionSupervising::CandidateInList @candidate={{this.candidate}} />`);
+      test('it displays the alert', async function (assert) {
+        // given
+        this.candidate = store.createRecord('certification-candidate-for-supervising', {
+          id: '456',
+          startDateTime: new Date('2022-10-19T14:30:15Z'),
+          theoricalEndDateTime: new Date('2022-10-19T16:00:00Z'),
+          extraTimePercentage: 0.12,
+          authorizedToStart: false,
+          assessmentStatus: 'started',
+          challengeLiveAlert: {
+            type: 'challenge',
+            status: 'ongoing',
+            hasEmbed: false,
+            hasAttachment: false,
+            isFocus: false,
+            hasImage: false,
+          },
+        });
 
-      // then
-      assert.dom(screen.getByText('Signalement en cours')).exists();
-      assert.dom(screen.queryByText('En cours')).doesNotExist();
-      assert.dom(screen.queryByText('Autorisé à reprendre')).doesNotExist();
-      assert.dom(screen.queryByText('Terminé')).doesNotExist();
+        // when
+        const screen = await renderScreen(hbs`<SessionSupervising::CandidateInList @candidate={{this.candidate}} />`);
+        await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
+        await click(screen.getByRole('button', { name: 'Gérer le signalement' }));
+
+        // then
+        assert
+          .dom(screen.getByText('Refuser le signalement permet la reprise de la question en cours.', { exact: false }))
+          .exists();
+        assert
+          .dom(
+            screen.getByText(
+              'Sélectionnez un motif pour valider le signalement et permettre le changement de question.',
+              { exact: false },
+            ),
+          )
+          .exists();
+      });
     });
 
-    test('it displays the alert', async function (assert) {
-      // given
-      this.candidate = store.createRecord('certification-candidate-for-supervising', {
-        id: '456',
-        startDateTime: new Date('2022-10-19T14:30:15Z'),
-        theoricalEndDateTime: new Date('2022-10-19T16:00:00Z'),
-        extraTimePercentage: 0.12,
-        authorizedToStart: false,
-        assessmentStatus: 'started',
-        liveAlert: {
-          status: 'ongoing',
-        },
+    module('when the live alert type is companion', function () {
+      test('it displays the live alert tag', async function (assert) {
+        // given
+        this.candidate = store.createRecord('certification-candidate-for-supervising', {
+          id: '456',
+          startDateTime: new Date('2022-10-19T14:30:15Z'),
+          theoricalEndDateTime: new Date('2022-10-19T16:00:00Z'),
+          extraTimePercentage: 0.12,
+          authorizedToStart: false,
+          assessmentStatus: 'started',
+          companionLiveAlert: { type: 'companion', status: 'ONGOING' },
+        });
+
+        // when
+        const screen = await renderScreen(hbs`<SessionSupervising::CandidateInList @candidate={{this.candidate}} />`);
+
+        // then
+        assert.dom(screen.getByText('Extension non détectée')).exists();
+        assert.dom(screen.queryByText('Signalement en cours')).doesNotExist();
       });
-
-      // when
-      const screen = await renderScreen(hbs`<SessionSupervising::CandidateInList @candidate={{this.candidate}} />`);
-      await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
-      await click(screen.getByRole('button', { name: 'Gérer le signalement' }));
-
-      // then
-      assert
-        .dom(screen.getByText('Refuser le signalement permet la reprise de la question en cours.', { exact: false }))
-        .exists();
-      assert
-        .dom(
-          screen.getByText(
-            'Sélectionnez un motif pour valider le signalement et permettre le changement de question.',
-            { exact: false },
-          ),
-        )
-        .exists();
     });
   });
 });

--- a/certif/tests/integration/components/session-supervising/handle-live-alert-modal-test.js
+++ b/certif/tests/integration/components/session-supervising/handle-live-alert-modal-test.js
@@ -103,8 +103,13 @@ module('Integration | Component | handle-live-alert-modal', function (hooks) {
     const candidate = store.createRecord('certification-candidate', {
       firstName: 'Jean-Paul',
       lastName: 'Candidat',
-      liveAlert: {
+      challengeLiveAlert: {
+        type: 'challenge',
         status: 'ongoing',
+        hasEmbed: false,
+        hasAttachment: false,
+        isFocus: false,
+        hasImage: false,
       },
     });
 

--- a/certif/tests/integration/components/session-supervising/live-alert-handled-modal-test.js
+++ b/certif/tests/integration/components/session-supervising/live-alert-handled-modal-test.js
@@ -14,8 +14,13 @@ module('Integration | Component | live-alert-handled-modal', function (hooks) {
     const candidate = store.createRecord('certification-candidate', {
       firstName: 'Jean-Paul',
       lastName: 'Candidat',
-      liveAlert: {
+      challengeLiveAlert: {
+        type: 'challenge',
         status: 'ongoing',
+        hasEmbed: false,
+        hasAttachment: false,
+        isFocus: false,
+        hasImage: false,
       },
     });
 
@@ -43,8 +48,13 @@ module('Integration | Component | live-alert-handled-modal', function (hooks) {
     const candidate = store.createRecord('certification-candidate', {
       firstName: 'Jean-Paul',
       lastName: 'Candidat',
-      liveAlert: {
+      challengeLiveAlert: {
+        type: 'challenge',
         status: 'ongoing',
+        hasEmbed: false,
+        hasAttachment: false,
+        isFocus: false,
+        hasImage: false,
       },
     });
 

--- a/certif/tests/unit/models/certification-candidate-for-supervising-test.js
+++ b/certif/tests/unit/models/certification-candidate-for-supervising-test.js
@@ -141,6 +141,60 @@ module('Unit | Model | certification-candidate-for-supervising', function (hooks
     });
   });
 
+  module('#hasOngoingChallengeLiveAlert', function () {
+    module('when the live alert status is ongoing', function () {
+      test('it returns true', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const challengeLiveAlert = { status: 'ongoing' };
+
+        // when
+        const certificationCandidateForSupervising = store.createRecord('certification-candidate-for-supervising', {
+          challengeLiveAlert,
+        });
+
+        // then
+        assert.true(certificationCandidateForSupervising.hasOngoingChallengeLiveAlert);
+      });
+    });
+
+    module('when the live alert status is not ongoing', function () {
+      test('it returns false', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const challengeLiveAlert = { status: 'validated' };
+
+        // when
+        const certificationCandidateForSupervising = store.createRecord('certification-candidate-for-supervising', {
+          challengeLiveAlert,
+        });
+
+        // then
+        assert.false(certificationCandidateForSupervising.hasOngoingChallengeLiveAlert);
+      });
+    });
+  });
+
+  module('#currentLiveAlert', function () {
+    module('when challenge and companion live alerts both exists', function () {
+      test('it returns companion live alert', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const challengeLiveAlert = { type: 'challenge', status: 'ongoing' };
+        const companionLiveAlert = { type: 'companion', status: 'ONGOING' };
+
+        // when
+        const certificationCandidateForSupervising = store.createRecord('certification-candidate-for-supervising', {
+          challengeLiveAlert,
+          companionLiveAlert,
+        });
+
+        // then
+        assert.deepEqual(certificationCandidateForSupervising.currentLiveAlert, companionLiveAlert);
+      });
+    });
+  });
+
   function _pickModelData(certificationCandidate) {
     return pick(certificationCandidate, [
       'firstName',

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -103,8 +103,15 @@
         "candidate-status": {
           "authorized-to-resume": "Allowed to resume",
           "finished": "Finished",
+          "live-alerts": {
+            "challenge": {
+              "ongoing": "Report in progress"
+            },
+            "companion": {
+              "ongoing": "Extension not detected"
+            }
+          },
           "ongoing": "In progress",
-          "ongoing-live-alert": "Signalement en cours",
           "start": "Start"
         },
         "complementary-alone": "Which tests will the candidate take?",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -103,8 +103,15 @@
         "candidate-status": {
           "authorized-to-resume": "Autorisé à reprendre",
           "finished": "Terminé",
+          "live-alerts": {
+            "challenge": {
+              "ongoing": "Signalement en cours"
+            },
+            "companion": {
+              "ongoing": "Extension non détectée"
+            }
+          },
           "ongoing": "En cours",
-          "ongoing-live-alert": "Signalement en cours",
           "start": "Début"
         },
         "complementary-alone": "Quelles épreuves le candidat passera-t-il ?",


### PR DESCRIPTION
## :unicorn: Problème
Sur l’espace surveillant, quand un candidat est bloqué car on ne détecte pas l’extension sur son navigateur, on ne voit rien.

## :robot: Proposition
 Remplacer le badge “En cours” par un badge “Extension non détectée” signalé en rouge.

## :rainbow: Remarques
Une PR à part permettra au surveillant de traiter le signalement.

## :100: Pour tester

- Activer l'extension Companion
- Créer une session V3 sur Pix Certif (+ espace surveillant => confirmer la présence)
- Se connecter sur App avec `certif-success@example.net`
- Remplir le formulaire d'entrée en session de certif
- Entrer en session
- Signaler la première épreuve pour lancer une alerte d'épreuve
- Puis désactiver l'extension
- (on se retrouve dans un cas avec deux alertes : challenge et companion)
- Dans l'espace surveillant, constater que le candidat concerné possède un badge `Extension non détectée` (il est prioritaire à l'alerte d'épreuve)

La PR ne traite pas la gestion du signalement d'extension par le surveillant mais vous pouvez modifier en BDD le statut de l'extension pour qu'elle ne soit plus ONGOING (`certification-companion-live-alerts`).
Vous pourrez constater que le candidat possède désormais le badge signalement en cours (de l'alerte d'épreuve)
