### PR TITLE
[FEATURE] ajoute le type d'external Id (Pix-14699)

### DIFF
--- a/api/db/seeds/data/common/tooling/campaign-tooling.js
+++ b/api/db/seeds/data/common/tooling/campaign-tooling.js
@@ -1,10 +1,14 @@
 import dayjs from 'dayjs';
 import _ from 'lodash';
 
-import { CampaignParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
+import {
+  CampaignExternalIdTypes,
+  CampaignParticipationStatuses,
+} from '../../../../../src/prescription/shared/domain/constants.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import { KnowledgeElement } from '../../../../../src/shared/domain/models/KnowledgeElement.js';
 import { getPlacementProfile } from '../../../../../src/shared/domain/services/placement-profile-service.js';
+import { FEATURE_CAMPAIGN_EXTERNAL_ID } from '../constants.js';
 import * as generic from './generic.js';
 import * as learningContent from './learning-content.js';
 import * as profileTooling from './profile-tooling.js';
@@ -442,10 +446,10 @@ function _buildCampaign({
     name,
     code,
     title,
-    idPixLabel,
     externalIdHelpImageUrl,
     alternativeTextToExternalIdHelpImage,
     customLandingPageText,
+    idPixLabel: null,
     isForAbsoluteNovice,
     archivedAt,
     archivedBy,
@@ -461,6 +465,16 @@ function _buildCampaign({
     multipleSendings,
     assessmentMethod,
   });
+  if (idPixLabel) {
+    databaseBuilder.factory.buildCampaignFeature({
+      campaignId: realCampaignId,
+      featureId: FEATURE_CAMPAIGN_EXTERNAL_ID,
+      params: {
+        type: CampaignExternalIdTypes.STRING,
+        label: idPixLabel,
+      },
+    });
+  }
   return { realCampaignId, realOrganizationId, realCreatedAt };
 }
 

--- a/api/db/seeds/data/team-prescription/build-campaigns.js
+++ b/api/db/seeds/data/team-prescription/build-campaigns.js
@@ -137,6 +137,7 @@ async function _createProCampaigns(databaseBuilder) {
     organizationId: PRO_ORGANIZATION_ID,
     ownerId: USER_ID_ADMIN_ORGANIZATION,
     name: 'Campagne de collecte de profil PRO',
+    idPixLabel: 'IdPixLabel',
     multipleSendings: true,
     code: 'PROCOLMUL',
     type: 'PROFILES_COLLECTION',
@@ -151,6 +152,7 @@ async function _createProCampaigns(databaseBuilder) {
     ownerId: USER_ID_ADMIN_ORGANIZATION,
     isForAbsoluteNovice: true,
     name: "Campagne d'évaluation PRO",
+    idPixLabel: 'IdPixLabel',
     code: 'PROASSIMP',
     createdAt: dayjs().subtract(30, 'days').toDate(),
     configCampaign: {
@@ -172,6 +174,7 @@ async function _createProCampaigns(databaseBuilder) {
     ownerId: USER_ID_ADMIN_ORGANIZATION,
     name: "Campagne d'évaluation PRO envoi multiple",
     code: 'PROASSMUL',
+    idPixLabel: 'IdPixLabel',
     multipleSendings: true,
     createdAt: dayjs().subtract(30, 'days').toDate(),
     configCampaign: {

--- a/api/src/prescription/campaign/domain/models/CampaignForCreation.js
+++ b/api/src/prescription/campaign/domain/models/CampaignForCreation.js
@@ -1,4 +1,3 @@
-import { CampaignExternalIdTypes } from '../../../shared/domain/constants.js';
 import { validate } from '../validators/campaign-creation-validator.js';
 
 class CampaignForCreation {
@@ -21,8 +20,8 @@ class CampaignForCreation {
   } = {}) {
     this.name = name;
     this.title = title;
-    this.idPixLabel = idPixLabel === '' ? null : idPixLabel;
-    this.idPixType = idPixType ? idPixType : null;
+    this.idPixLabel = idPixLabel?.trim() || undefined;
+    this.idPixType = idPixType?.trim() || undefined;
     this.customLandingPageText = customLandingPageText;
     this.type = type;
     this.targetProfileId = targetProfileId;
@@ -34,9 +33,6 @@ class CampaignForCreation {
     this.customResultPageText = customResultPageText;
     this.customResultPageButtonText = customResultPageButtonText;
     this.customResultPageButtonUrl = customResultPageButtonUrl;
-    if (idPixLabel && !idPixType) {
-      this.idPixType = CampaignExternalIdTypes.STRING;
-    }
     validate(this);
   }
 }

--- a/api/src/prescription/campaign/domain/validators/campaign-creation-validator.js
+++ b/api/src/prescription/campaign/domain/validators/campaign-creation-validator.js
@@ -63,11 +63,13 @@ const schema = Joi.object({
     'any.required': 'CUSTOM_RESULT_PAGE_BUTTON_URL_IS_REQUIRED_WHEN_CUSTOM_RESULT_PAGE_BUTTON_TEXT_IS_FILLED',
   }),
 
-  idPixType: Joi.string()
-    .required()
-    .valid(...Object.values(CampaignExternalIdTypes))
-    .allow(null)
-    .default(null),
+  idPixType: Joi.when('idPixLabel', {
+    is: Joi.string().required(),
+    then: Joi.string()
+      .required()
+      .valid(...Object.values(CampaignExternalIdTypes)),
+    otherwise: Joi.valid(null),
+  }).messages({ 'any.required': 'MISSING_ID_PIX_TYPE' }),
 
   ownerId: Joi.number().integer().required().messages({
     'any.required': 'MISSING_OWNER',

--- a/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
@@ -228,6 +228,10 @@ async function parseForCampaignsImport(cleanedData, { parseCsvData } = csvHelper
     name: data['Nom de la campagne*'],
     targetProfileId: data['Identifiant du profil cible*'],
     idPixLabel: data["Libellé de l'identifiant externe"],
+    idPixType:
+      data["Libellé de l'identifiant externe"]?.trim()?.length > 0
+        ? data["Type de l'identifiant externe"] || 'STRING'
+        : '',
     creatorId: data['Identifiant du créateur*'],
     title: data['Titre du parcours'],
     customLandingPageText: data['Descriptif du parcours'],

--- a/api/tests/prescription/campaign/integration/domain/usecases/create-campaign_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/create-campaign_test.js
@@ -44,6 +44,7 @@ describe('Integration | UseCases | create-campaign', function () {
       type: CampaignTypes.ASSESSMENT,
       title: 'a title',
       idPixLabel: 'id Pix label',
+      idPixType: 'STRING',
       customLandingPageText: 'Hello',
       creatorId: userId,
       ownerId: userId,
@@ -73,14 +74,13 @@ describe('Integration | UseCases | create-campaign', function () {
     const campaign = {
       name: 'a name',
       type: CampaignTypes.PROFILES_COLLECTION,
-      idPixLabel: 'id Pix label',
       customLandingPageText: 'Hello',
       creatorId: userId,
       ownerId: userId,
       organizationId,
     };
 
-    const expectedAttributes = ['type', 'idPixLabel', 'name', 'customLandingPageText'];
+    const expectedAttributes = ['type', 'name', 'customLandingPageText'];
 
     // when
     const result = await createCampaign({

--- a/api/tests/prescription/campaign/unit/domain/models/CampaignForCreation_test.js
+++ b/api/tests/prescription/campaign/unit/domain/models/CampaignForCreation_test.js
@@ -283,8 +283,8 @@ describe('Unit | Domain | Models | CampaignForCreation', function () {
     });
 
     context('idPixLabel & idPixType', function () {
-      context('when it is empty string', function () {
-        it('should save null instead of empty string', function () {
+      context('when idPixLabel is empty', function () {
+        it('should save if both idPixLabel and idPixType are empty', function () {
           const attributes = {
             name: 'CampaignName',
             type: CampaignTypes.ASSESSMENT,
@@ -302,10 +302,31 @@ describe('Unit | Domain | Models | CampaignForCreation', function () {
 
           const campaignForCreation = new CampaignForCreation(attributes);
 
-          expect(campaignForCreation.idPixLabel).to.be.null;
-          expect(campaignForCreation.idPixType).to.be.null;
+          expect(campaignForCreation.idPixLabel).to.be.undefined;
+          expect(campaignForCreation.idPixType).to.be.undefined;
         });
-        it('should default idPixType to STRING', function () {
+        it('should save if both idPixLabel and idPixType are not provided', function () {
+          const attributes = {
+            name: 'CampaignName',
+            type: CampaignTypes.ASSESSMENT,
+            targetProfileId: 1,
+            creatorId: 2,
+            ownerId: 2,
+            organizationId: 3,
+            title: '',
+            customLandingPageText: '',
+            customResultPageButtonText: null,
+            customResultPageButtonUrl: null,
+          };
+
+          const campaignForCreation = new CampaignForCreation(attributes);
+
+          expect(campaignForCreation.idPixLabel).to.be.undefined;
+          expect(campaignForCreation.idPixType).to.be.undefined;
+        });
+      });
+      context('when idPixLabel is provided', function () {
+        it('should throws if  idPixType is empty', function () {
           const attributes = {
             name: 'CampaignName',
             type: CampaignTypes.ASSESSMENT,
@@ -321,10 +342,52 @@ describe('Unit | Domain | Models | CampaignForCreation', function () {
             customResultPageButtonUrl: null,
           };
 
-          const campaignForCreation = new CampaignForCreation(attributes);
+          expect(() => {
+            new CampaignForCreation(attributes);
+          }).to.throw(EntityValidationError);
+        });
+        it('should throws if idPixType is null', function () {
+          const attributes = {
+            name: 'CampaignName',
+            type: CampaignTypes.ASSESSMENT,
+            targetProfileId: 1,
+            creatorId: 2,
+            ownerId: 2,
+            organizationId: 3,
+            title: '',
+            idPixLabel: 'toto',
+            idPixType: null,
+            customLandingPageText: '',
+            customResultPageButtonText: null,
+            customResultPageButtonUrl: null,
+          };
 
-          expect(campaignForCreation.idPixLabel).to.be.equal('toto');
-          expect(campaignForCreation.idPixType).to.equal(CampaignExternalIdTypes.STRING);
+          expect(() => {
+            new CampaignForCreation(attributes);
+          }).to.throw(EntityValidationError);
+        });
+      });
+
+      context('when idPixType is empty', function () {
+        it('should throws if there is a idPixType but no idPixLabel', function () {
+          const attributes = {
+            name: 'CampaignName',
+            type: CampaignTypes.ASSESSMENT,
+            targetProfileId: 1,
+            creatorId: 2,
+            ownerId: 2,
+            organizationId: 3,
+            title: '',
+            idPixLabel: '',
+            idPixType: 'toto',
+            customLandingPageText: '',
+            customResultPageButtonText: null,
+            customResultPageButtonUrl: null,
+          };
+
+          expect(() => {
+            new CampaignForCreation(attributes);
+          }).to.throw(EntityValidationError);
         });
       });
 

--- a/api/tests/shared/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -1430,7 +1430,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
     it('should return parsed campaign data', async function () {
       // given
-      const csv = `${headerCsv}1;chaussette;1234;numéro étudiant;789;titre 1;descriptif 1;Oui;45\n2;chapeau;1234;identifiant;666;titre 2;descriptif 2;Non;77\n3;chausson;1234;identifiant;123;titre 3;descriptif 3;Non;88;Bravo !;Cliquez ici;https://hmpg.net/`;
+      const csv = `${headerCsv}1;chaussette;1234;numéro étudiant;789;titre 1;descriptif 1;Oui;45\n2;chapeau;1234;identifiant;666;titre 2;descriptif 2;Non;77\n3;chausson;1234;;123;titre 3;descriptif 3;Non;88;Bravo !;Cliquez ici;https://hmpg.net/`;
 
       // when
       const parsedData = await csvSerializer.parseForCampaignsImport(csv);
@@ -1442,6 +1442,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
           name: 'chaussette',
           targetProfileId: 1234,
           idPixLabel: 'numéro étudiant',
+          idPixType: 'STRING',
           title: 'titre 1',
           customLandingPageText: 'descriptif 1',
           creatorId: 789,
@@ -1456,6 +1457,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
           name: 'chapeau',
           targetProfileId: 1234,
           idPixLabel: 'identifiant',
+          idPixType: 'STRING',
           title: 'titre 2',
           customLandingPageText: 'descriptif 2',
           creatorId: 666,
@@ -1469,7 +1471,8 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
           organizationId: 3,
           name: 'chausson',
           targetProfileId: 1234,
-          idPixLabel: 'identifiant',
+          idPixLabel: '',
+          idPixType: '',
           title: 'titre 3',
           customLandingPageText: 'descriptif 3',
           creatorId: 123,
@@ -1607,6 +1610,71 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
         expect(error).to.be.instanceOf(FileValidationError);
         expect(error.code).to.equal('CSV_CONTENT_NOT_VALID');
         expect(error.meta).to.equal('"empty" is not a valid value for "Nom de la campagne*"');
+      });
+    });
+
+    describe('when idPixLabel is provided', function () {
+      const headerWithidPixtype =
+        "Identifiant de l'organisation*;Nom de la campagne*;Identifiant du profil cible*;Libellé de l'identifiant externe;Type de l'identifiant externe;Identifiant du créateur*;Titre du parcours;Descriptif du parcours;Envoi multiple;Identifiant du propriétaire*;Texte de la page de fin de parcours;Texte du bouton de la page de fin de parcours;URL du bouton de la page de fin de parcours\n";
+
+      describe('if idPixType is present', function () {
+        it('should default to STRING', async function () {
+          // given
+          const csv = `${headerWithidPixtype}1;chaussette;1234;numéro étudiant;;789;titre 1;descriptif 1;Oui;45`;
+
+          // when
+          const parsedData = await csvSerializer.parseForCampaignsImport(csv);
+
+          // then
+          const expectedParsedData = [
+            {
+              organizationId: 1,
+              name: 'chaussette',
+              targetProfileId: 1234,
+              idPixLabel: 'numéro étudiant',
+              idPixType: 'STRING',
+              title: 'titre 1',
+              customLandingPageText: 'descriptif 1',
+              creatorId: 789,
+              multipleSendings: true,
+              ownerId: 45,
+              customResultPageText: null,
+              customResultPageButtonText: null,
+              customResultPageButtonUrl: null,
+            },
+          ];
+          expect(parsedData).to.have.deep.members(expectedParsedData);
+        });
+      });
+
+      describe('if idPixType i not present', function () {
+        it('should default to STRING', async function () {
+          // given
+          const csv = `${headerCsv}1;chaussette;1234;numéro étudiant;789;titre 1;descriptif 1;Oui;45`;
+
+          // when
+          const parsedData = await csvSerializer.parseForCampaignsImport(csv);
+
+          // then
+          const expectedParsedData = [
+            {
+              organizationId: 1,
+              name: 'chaussette',
+              targetProfileId: 1234,
+              idPixLabel: 'numéro étudiant',
+              idPixType: 'STRING',
+              title: 'titre 1',
+              customLandingPageText: 'descriptif 1',
+              creatorId: 789,
+              multipleSendings: true,
+              ownerId: 45,
+              customResultPageText: null,
+              customResultPageButtonText: null,
+              customResultPageButtonUrl: null,
+            },
+          ];
+          expect(parsedData).to.have.deep.members(expectedParsedData);
+        });
       });
     });
   });

--- a/orga/app/components/campaign/create-form.gjs
+++ b/orga/app/components/campaign/create-form.gjs
@@ -11,15 +11,15 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
-import { gt, not } from 'ember-truth-helpers';
+import { eq, gt, not } from 'ember-truth-helpers';
 import _orderBy from 'lodash/orderBy';
+import { ID_PIX_TYPES } from 'pix-orga/helpers/id-pix-types.js';
 
 import displayCampaignErrors from '../../helpers/display-campaign-errors';
 import TargetProfileDetails from '../campaign/target-profile-details';
 import ExplanationCard from '../ui/explanation-card';
 import FormField from '../ui/form-field';
 import PixFieldset from '../ui/pix-fieldset';
-
 export default class CreateForm extends Component {
   @service currentUser;
   @service intl;
@@ -88,16 +88,22 @@ export default class CreateForm extends Component {
     return this.wantIdPix === true;
   }
 
+  get isExternalIdTypeNotSelectedChecked() {
+    return this.args.campaign.idPixType === '';
+  }
+
   @action
   askLabelIdPix() {
     this.wantIdPix = true;
     this.args.campaign.idPixLabel = '';
+    this.args.campaign.idPixType = '';
   }
 
   @action
   doNotAskLabelIdPix() {
     this.wantIdPix = false;
     this.args.campaign.idPixLabel = null;
+    this.args.campaign.idPixType = '';
   }
 
   @action
@@ -137,6 +143,10 @@ export default class CreateForm extends Component {
   @action
   onChangeCampaignCustomLandingPageText(event) {
     this.args.campaign.customLandingPageText = event.target.value;
+  }
+  @action
+  onChangeIdPixType(event) {
+    this.args.campaign.idPixType = event.target.value;
   }
 
   @action
@@ -372,6 +382,35 @@ export default class CreateForm extends Component {
 
       {{#if this.wantIdPix}}
         <FormField>
+          <PixFieldset @required={{true}} aria-labelledby="external-ids-types" role="radiogroup">
+            <:title>{{t "pages.campaign-creation.external-id-type.question-label"}}</:title>
+            <:content>
+              <PixRadioButton
+                name="external-id-types"
+                @value="EMAIL"
+                {{on "change" (fn this.onChangeCampaignValue "idPixType")}}
+                checked={{eq @campaign.idPixType "EMAIL"}}
+              >
+                <:label>{{t ID_PIX_TYPES.EMAIL}}</:label>
+
+              </PixRadioButton>
+              <PixRadioButton
+                name="external-id-types"
+                @value="STRING"
+                {{on "change" (fn this.onChangeCampaignValue "idPixType")}}
+                checked={{eq @campaign.idPixType "STRING"}}
+              >
+                <:label>{{t ID_PIX_TYPES.STRING}}</:label>
+              </PixRadioButton>
+              {{#if @errors.idPixType}}
+                <div class="form__error error-message">
+                  {{displayCampaignErrors @errors.idPixType}}
+                </div>
+              {{/if}}
+            </:content>
+          </PixFieldset>
+        </FormField>
+        <FormField>
           <PixInput
             @id="external-id-label"
             @name="external-id-label"
@@ -383,6 +422,7 @@ export default class CreateForm extends Component {
           >
             <:label>{{t "pages.campaign-creation.external-id-label.label"}}</:label>
           </PixInput>
+
           {{#if @errors.idPixLabel}}
             <div class="form__error error-message">
               {{displayCampaignErrors @errors.idPixLabel}}

--- a/orga/app/routes/authenticated/campaigns/new.js
+++ b/orga/app/routes/authenticated/campaigns/new.js
@@ -32,6 +32,7 @@ export default class NewRoute extends Route {
           'ownerId',
           'multipleSendings',
           'idPixLabel',
+          'idPixType',
           'customLandingPageText',
         ]);
         campaignAttributes.name = `${this.intl.t('pages.campaign-creation.copy-of')} ${from.name}`;

--- a/orga/app/services/error-messages.js
+++ b/orga/app/services/error-messages.js
@@ -8,6 +8,7 @@ const CAMPAIGN_CREATION_ERRORS = {
   OWNER_NOT_IN_ORGANIZATION: 'api-error-messages.campaign-creation.owner_not_in_organization',
   CAMPAIGN_TITLE_IS_TOO_LONG: 'api-error-messages.campaign-creation.title_too_long',
   CUSTOM_LANDING_PAGE_TEXT_IS_TOO_LONG: 'api-error-messages.campaign-creation.custom-landing-page-text_too_long',
+  MISSING_ID_PIX_TYPE: 'api-error-messages.campaign-creation.id-pix-type-required',
 };
 
 const CSV_IMPORT_ERRORS = {

--- a/orga/tests/integration/components/campaign/create-form-test.js
+++ b/orga/tests/integration/components/campaign/create-form-test.js
@@ -898,6 +898,45 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       const label = screen.getByLabelText(new RegExp(t('pages.campaign-creation.external-id-label.label')));
       assert.true(label.hasAttribute('aria-required', false));
     });
+    test('it asks for external id type', async function (assert) {
+      // when
+      const screen = await render(
+        hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
+  @onSubmit={{this.createCampaignSpy}}
+  @onCancel={{this.cancelSpy}}
+  @errors={{this.errors}}
+  @targetProfiles={{this.targetProfiles}}
+  @membersSortedByFullName={{this.defaultMembers}}
+/>`,
+      );
+      await clickByName(t('pages.campaign-creation.yes'));
+
+      // then
+      const radioGroup = screen.getByRole('radiogroup', {
+        name: t('pages.campaign-creation.external-id-type.question-label'),
+      });
+      assert.ok(radioGroup);
+    });
+
+    test('it updates campaign model when select a type', async function (assert) {
+      // when
+      const screen = await render(
+        hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
+  @onSubmit={{this.createCampaignSpy}}
+  @onCancel={{this.cancelSpy}}
+  @errors={{this.errors}}
+  @targetProfiles={{this.targetProfiles}}
+  @membersSortedByFullName={{this.defaultMembers}}
+/>`,
+      );
+      await clickByName(t('pages.campaign-creation.yes'));
+
+      const checkedRadio = screen.getByLabelText(t('pages.campaign-settings.external-user-id-types.email'));
+      await checkedRadio.click();
+      assert.strictEqual(this.campaign.idPixType, 'EMAIL');
+    });
   });
 
   test('it should fill campaign title', async function (assert) {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -3,6 +3,7 @@
     "campaign-creation": {
       "custom-landing-page_too_long": "Please choose a shorter text to display on the starting page.",
       "external-user-id-required": "Please specify the type of external user ID which the participants will be required to fill when starting the customised test.",
+      "id-pix-type-required": "Please select an external identifier type.",
       "name-required": "Please name your campaign.",
       "owner_not_in_organization": "Please select a member of your organization.",
       "purpose-required": "Please select the purpose of your campaign: assess participants or collect their profiles.",
@@ -497,6 +498,9 @@
         "required": "The external user ID label is mandatory.",
         "suggestion": "Example : \"Student Number\" or \"Email address\" *"
       },
+      "external-id-type": {
+        "question-label": "What is the type of the external ID ?"
+      },
       "landing-page-text": {
         "label": "Text to display on the starting page"
       },
@@ -687,8 +691,8 @@
       "direct-link": "Direct link",
       "external-user-id-label": "External user ID label",
       "external-user-id-types": {
-        "email": "email",
-        "string": "free text"
+        "email": "Email",
+        "string": "Other"
       },
       "landing-page-text": "Text to display on the starting page",
       "multiple-sendings": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -3,6 +3,7 @@
     "campaign-creation": {
       "custom-landing-page_too_long": "Le texte de présentation de la campagne est trop long.",
       "external-user-id-required": "Veuillez préciser le libellé du champ qui sera demandé à vos participants au démarrage du parcours.",
+      "id-pix-type-required": "Veuillez sélectionnez un type d'identifiant externe.",
       "name-required": "Veuillez donner un nom à votre campagne.",
       "owner_not_in_organization": "Le propriétaire ne fait pas partie de l'organisation.",
       "purpose-required": "Veuillez choisir l’objectif de votre campagne : Évaluation ou Collecte de profils.",
@@ -497,6 +498,9 @@
         "required": "L'id externe est obligatoire",
         "suggestion": "Exemple: \"Numéro de l'étudiant\" ou \"Adresse e-mail professionnelle\" *"
       },
+      "external-id-type": {
+        "question-label": "Quel est le type de l'identifiant externe ?"
+      },
       "landing-page-text": {
         "label": "Texte de la page d'accueil"
       },
@@ -687,8 +691,8 @@
       "direct-link": "Lien direct",
       "external-user-id-label": "Libellé de l'identifiant",
       "external-user-id-types": {
-        "email": "email",
-        "string": "texte libre"
+        "email": "Email",
+        "string": "Autre"
       },
       "landing-page-text": "Texte de la page d'accueil",
       "multiple-sendings": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -7,7 +7,8 @@
       "owner_not_in_organization": "De eigenaar maakt geen deel uit van de organisatie.",
       "purpose-required": "Kies het doel van je campagne: Beoordeling of Verzameling van profielen.",
       "target-profile-required": "Selecteer een traject voor je campagne.",
-      "title_too_long": "De campagnetitel is te lang."
+      "title_too_long": "De campagnetitel is te lang.",
+      "id-pix-type-required": "Selecteer een extern identificatietype."
     },
     "csv-import": {
       "property-not-uniq": "Regel {line}: Het veld “{field}” moet uniek zijn binnen het bestand."
@@ -460,6 +461,9 @@
         "required": "De externe id is verplicht",
         "suggestion": "Voorbeeld: \"Studentnummer\" of \"Professioneel e-mailadres\" *."
       },
+      "external-id-type": {
+        "question-label": "Wat is het type externe identifier?"
+      },
       "landing-page-text": {
         "label": "Tekst op de startpagina"
       },
@@ -650,8 +654,8 @@
       "direct-link": "Directe link",
       "external-user-id-label": "Type externe user-ID",
       "external-user-id-types": {
-        "string": "vrije tekst",
-        "email": "e-mail"
+        "email": "E-mail",
+        "string": "Andere"
       },
       "landing-page-text": "Tekst op de startpagina",
       "multiple-sendings": {


### PR DESCRIPTION
## :unicorn: Problème
Lors du RDB autour du stockage d’un identifiant, a été évoqué le fait que environ 30% des identifiants externes demandés étaient des emails mais comprenaient souvent des coquilles car c’est un champ libre. 

## :robot: Proposition
On rajoute la possibilité de choisir un type d'identifiant externe

## :rainbow: Remarques
RAS

## :100: Pour tester
- ORGA: créer une campagne et choisir le type
- Admin: importer un fichier avec la colonne "Type de l'identifiant externe"  pour créer des campagnes en masse.

Afficher le contenu de la table `campaign-features` depuis `pgsql-console`