### PR TITLE
[FEATURE] Afficher un menu Élèves personnalisé pour les écoles (PIX-13536)

### DIFF
--- a/orga/app/components/layout/sidebar.hbs
+++ b/orga/app/components/layout/sidebar.hbs
@@ -23,20 +23,20 @@
         {{t "navigation.main.certifications"}}
       </LinkTo>
     {{/if}}
-    {{#if this.shouldDisplayParticipantsEntry}}
-      <LinkTo @route={{this.organizationLearnersList.route}} class="sidebar-nav__item">
-        <span class="sidebar-nav__item-icon">
-          <img src="{{this.rootURL}}/icons/address-book-light.svg" alt="" role="none" />
-        </span>
-        {{t this.organizationLearnersList.label}}
-      </LinkTo>
-    {{/if}}
     {{#if this.shouldDisplayMissionsEntry}}
       <LinkTo @route="authenticated.missions" class="sidebar-nav__item">
         <span class="sidebar-nav__item-icon">
           <img src="{{this.rootURL}}/icons/chevron-square-right.svg" alt="" role="none" />
         </span>
         {{t "navigation.main.missions"}}
+      </LinkTo>
+    {{/if}}
+    {{#if this.shouldDisplayParticipantsEntry}}
+      <LinkTo @route={{this.organizationLearnersList.route}} class="sidebar-nav__item">
+        <span class="sidebar-nav__item-icon">
+          <img src="{{this.rootURL}}/icons/address-book-light.svg" alt="" role="none" />
+        </span>
+        {{t this.organizationLearnersList.label}}
       </LinkTo>
     {{/if}}
     <LinkTo @route="authenticated.team" class="sidebar-nav__item">

--- a/orga/app/components/layout/sidebar.js
+++ b/orga/app/components/layout/sidebar.js
@@ -24,12 +24,15 @@ export default class SidebarMenu extends Component {
   get shouldDisplayPlacesEntry() {
     return this.currentUser.canAccessPlacesPage;
   }
+
   get shouldDisplayMissionsEntry() {
     return this.currentUser.canAccessMissionsPage;
   }
+
   get shouldDisplayCampaignsEntry() {
     return this.currentUser.canAccessCampaignsPage;
   }
+
   get shouldDisplayParticipantsEntry() {
     return this.currentUser.canAccessParticipantsPage;
   }
@@ -44,6 +47,11 @@ export default class SidebarMenu extends Component {
       return {
         route: 'authenticated.sup-organization-participants',
         label: 'navigation.main.sup-organization-participants',
+      };
+    } else if (this.currentUser.canAccessMissionsPage) {
+      return {
+        route: 'authenticated.organization-participants',
+        label: 'navigation.main.sco-organization-participants',
       };
     } else {
       return {

--- a/orga/app/components/organization-participant/header.gjs
+++ b/orga/app/components/organization-participant/header.gjs
@@ -5,14 +5,21 @@ import { t } from 'ember-intl';
 
 export default class Header extends Component {
   @service currentUser;
+  @service intl;
 
   get displayImportButton() {
     return this.currentUser.isAdminInOrganization && this.currentUser.hasLearnerImportFeature;
   }
 
+  get title() {
+    return this.currentUser.canAccessMissionsPage
+      ? this.intl.t('components.organization-participants-header.sco-title', { count: this.args.participantCount })
+      : this.intl.t('components.organization-participants-header.title', { count: this.args.participantCount });
+  }
+
   <template>
     <h1 class="organization-participant-list-page__header page-title">
-      {{t "components.organization-participants-header.title" count=@participantCount}}
+      {{this.title}}
 
       {{#if this.displayImportButton}}
         <div class="organization-participant-list-page__import-students-button hide-on-mobile">

--- a/orga/app/components/organization-participant/learner-filters.gjs
+++ b/orga/app/components/organization-participant/learner-filters.gjs
@@ -30,7 +30,9 @@ export default class LearnerFilters extends Component {
   }
 
   get isClearFiltersButtonDisabled() {
-    return !this.args.fullName && this.args.certificabilityFilter.length === 0;
+    const hasCustomFiltersValues =
+      this.args.customFiltersValues && Object.values(this.args.customFiltersValues).length > 0;
+    return !this.args.fullName && this.args.certificabilityFilter.length === 0 && !hasCustomFiltersValues;
   }
 
   get learnerCountTranslation() {

--- a/orga/app/components/organization-participant/learner-filters.gjs
+++ b/orga/app/components/organization-participant/learner-filters.gjs
@@ -10,6 +10,7 @@ import UiSearchInputFilter from '../ui/search-input-filter';
 
 export default class LearnerFilters extends Component {
   @service intl;
+  @service currentUser;
 
   get certificabilityOptions() {
     return [
@@ -32,12 +33,18 @@ export default class LearnerFilters extends Component {
     return !this.args.fullName && this.args.certificabilityFilter.length === 0;
   }
 
+  get learnerCountTranslation() {
+    return this.currentUser.canAccessMissionsPage
+      ? this.intl.t('pages.organization-participants.filters.students-count', { count: this.args.learnersCount })
+      : this.intl.t('pages.organization-participants.filters.participations-count', { count: this.args.learnersCount });
+  }
+
   <template>
     <PixFilterBanner
       @title={{t "common.filters.title"}}
       class="participant-filter-banner hide-on-mobile"
       aria-label={{t "pages.organization-participants.filters.aria-label"}}
-      @details={{t "pages.organization-participants.filters.participations-count" count=@learnersCount}}
+      @details={{this.learnerCountTranslation}}
       @clearFiltersLabel={{t "common.filters.actions.clear"}}
       @onClearFilters={{@onResetFilter}}
       @isClearFilterButtonDisabled={{this.isClearFiltersButtonDisabled}}
@@ -49,15 +56,18 @@ export default class LearnerFilters extends Component {
         @label={{t "common.filters.fullname.label"}}
         @triggerFiltering={{@onTriggerFiltering}}
       />
-      <UiMultiSelectFilter
-        @field="certificability"
-        @label={{t "pages.organization-participants.filters.type.certificability.label"}}
-        @onSelect={{@onTriggerFiltering}}
-        @selectedOption={{@certificabilityFilter}}
-        @options={{this.certificabilityOptions}}
-        @placeholder={{t "pages.organization-participants.filters.type.certificability.placeholder"}}
-        @emptyMessage=""
-      />
+
+      {{#unless this.currentUser.canAccessMissionsPage}}
+        <UiMultiSelectFilter
+          @field="certificability"
+          @label={{t "pages.organization-participants.filters.type.certificability.label"}}
+          @onSelect={{@onTriggerFiltering}}
+          @selectedOption={{@certificabilityFilter}}
+          @options={{this.certificabilityOptions}}
+          @placeholder={{t "pages.organization-participants.filters.type.certificability.placeholder"}}
+          @emptyMessage=""
+        />
+      {{/unless}}
       {{#each @customFilters as |customFilter|}}
         {{#let (t (getColumnName customFilter)) as |columnName|}}
           <UiSearchInputFilter

--- a/orga/app/components/organization-participant/list.gjs
+++ b/orga/app/components/organization-participant/list.gjs
@@ -179,6 +179,7 @@ export default class List extends Component {
                 @onClickLearner={{fn @onClickLearner participant.id}}
                 @customRows={{this.customColumns}}
                 @hideCertifiableDate={{@hasComputeOrganizationLearnerCertificabilityEnabled}}
+                @hasOrganizationParticipantPage={{@hasOrganizationParticipantPage}}
               />
             </:item>
           </SelectableList>

--- a/orga/app/components/organization-participant/table-headers.gjs
+++ b/orga/app/components/organization-participant/table-headers.gjs
@@ -1,5 +1,7 @@
 import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
 import { on } from '@ember/modifier';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 import { not } from 'ember-truth-helpers';
 
@@ -8,67 +10,73 @@ import Tooltip from '../certificability/tooltip';
 import Header from '../table/header';
 import HeaderSort from '../table/header-sort';
 
-<template>
-  <tr>
-    {{#if @showCheckbox}}
-      <Header class="table__column--small">
-        <PixCheckbox
-          @screenReaderOnly={{true}}
-          @checked={{@someSelected}}
-          @isIndeterminate={{not @allSelected}}
-          disabled={{not @hasParticipants}}
-          {{on "click" @onToggleAll}}
-        ><:label>{{t "pages.organization-participants.table.column.mainCheckbox"}}</:label></PixCheckbox>
-      </Header>
-    {{/if}}
-    <HeaderSort
-      @display="left"
-      @size="medium"
-      @onSort={{@onSortByLastname}}
-      @order={{@lastnameSort}}
-      @ariaLabelDefaultSort={{t "pages.organization-participants.table.column.last-name.ariaLabelDefaultSort"}}
-      @ariaLabelSortUp={{t "pages.organization-participants.table.column.last-name.ariaLabelSortUp"}}
-      @ariaLabelSortDown={{t "pages.organization-participants.table.column.last-name.ariaLabelSortDown"}}
-    >
-      {{t "pages.organization-participants.table.column.last-name.label"}}
-    </HeaderSort>
-    <Header>{{t "pages.organization-participants.table.column.first-name"}}</Header>
-    {{#each @customHeadings as |heading|}}
-      <Header>{{t (getColumnName heading)}}</Header>
-    {{/each}}
-    <HeaderSort
-      @size="medium"
-      @align="center"
-      @onSort={{@onSortByParticipationCount}}
-      @order={{@participationCountOrder}}
-      @ariaLabelDefaultSort={{t
-        "pages.organization-participants.table.column.participation-count.ariaLabelDefaultSort"
-      }}
-      @ariaLabelSortUp={{t "pages.organization-participants.table.column.participation-count.ariaLabelSortUp"}}
-      @ariaLabelSortDown={{t "pages.organization-participants.table.column.participation-count.ariaLabelSortDown"}}
-    >
-      {{t "pages.organization-participants.table.column.participation-count.label"}}
-    </HeaderSort>
-    <HeaderSort
-      @size="medium"
-      @align="center"
-      @onSort={{@onSortByLatestParticipation}}
-      @order={{@latestParticipationOrder}}
-      @ariaLabelDefaultSort={{t
-        "pages.organization-participants.table.column.latest-participation.ariaLabelDefaultSort"
-      }}
-      @ariaLabelSortUp={{t "pages.organization-participants.table.column.latest-participation.ariaLabelSortUp"}}
-      @ariaLabelSortDown={{t "pages.organization-participants.table.column.latest-participation.ariaLabelSortDown"}}
-    >
-      {{t "pages.organization-participants.table.column.latest-participation.label"}}
-    </HeaderSort>
-    <Header @size="medium" @align="center">
-      <div class="organization-participant-list-page__certificability-header">
-        {{t "pages.organization-participants.table.column.is-certifiable.label"}}
-        <Tooltip
-          @hasComputeOrganizationLearnerCertificabilityEnabled={{@hasComputeOrganizationLearnerCertificabilityEnabled}}
-        />
-      </div>
-    </Header>
-  </tr>
-</template>
+export default class TableHeaders extends Component {
+  @service currentUser;
+
+  <template>
+    <tr>
+      {{#if @showCheckbox}}
+        <Header class="table__column--small">
+          <PixCheckbox
+            @screenReaderOnly={{true}}
+            @checked={{@someSelected}}
+            @isIndeterminate={{not @allSelected}}
+            disabled={{not @hasParticipants}}
+            {{on "click" @onToggleAll}}
+          ><:label>{{t "pages.organization-participants.table.column.mainCheckbox"}}</:label></PixCheckbox>
+        </Header>
+      {{/if}}
+      <HeaderSort
+        @display="left"
+        @onSort={{@onSortByLastname}}
+        @order={{@lastnameSort}}
+        @ariaLabelDefaultSort={{t "pages.organization-participants.table.column.last-name.ariaLabelDefaultSort"}}
+        @ariaLabelSortUp={{t "pages.organization-participants.table.column.last-name.ariaLabelSortUp"}}
+        @ariaLabelSortDown={{t "pages.organization-participants.table.column.last-name.ariaLabelSortDown"}}
+      >
+        {{t "pages.organization-participants.table.column.last-name.label"}}
+      </HeaderSort>
+      <Header>{{t "pages.organization-participants.table.column.first-name"}}</Header>
+      {{#each @customHeadings as |heading|}}
+        <Header>{{t (getColumnName heading)}}</Header>
+      {{/each}}
+
+      {{#unless this.currentUser.canAccessMissionsPage}}
+        <HeaderSort
+          @size="medium"
+          @align="center"
+          @onSort={{@onSortByParticipationCount}}
+          @order={{@participationCountOrder}}
+          @ariaLabelDefaultSort={{t
+            "pages.organization-participants.table.column.participation-count.ariaLabelDefaultSort"
+          }}
+          @ariaLabelSortUp={{t "pages.organization-participants.table.column.participation-count.ariaLabelSortUp"}}
+          @ariaLabelSortDown={{t "pages.organization-participants.table.column.participation-count.ariaLabelSortDown"}}
+        >
+          {{t "pages.organization-participants.table.column.participation-count.label"}}
+        </HeaderSort>
+        <HeaderSort
+          @size="medium"
+          @align="center"
+          @onSort={{@onSortByLatestParticipation}}
+          @order={{@latestParticipationOrder}}
+          @ariaLabelDefaultSort={{t
+            "pages.organization-participants.table.column.latest-participation.ariaLabelDefaultSort"
+          }}
+          @ariaLabelSortUp={{t "pages.organization-participants.table.column.latest-participation.ariaLabelSortUp"}}
+          @ariaLabelSortDown={{t "pages.organization-participants.table.column.latest-participation.ariaLabelSortDown"}}
+        >
+          {{t "pages.organization-participants.table.column.latest-participation.label"}}
+        </HeaderSort>
+        <Header @size="medium" @align="center">
+          <div class="organization-participant-list-page__certificability-header">
+            {{t "pages.organization-participants.table.column.is-certifiable.label"}}
+            <Tooltip
+              @hasComputeOrganizationLearnerCertificabilityEnabled={{@hasComputeOrganizationLearnerCertificabilityEnabled}}
+            />
+          </div>
+        </Header>
+      {{/unless}}
+    </tr>
+  </template>
+}

--- a/orga/app/components/organization-participant/table-row.gjs
+++ b/orga/app/components/organization-participant/table-row.gjs
@@ -1,78 +1,98 @@
 import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
 import { on } from '@ember/modifier';
 import { LinkTo } from '@ember/routing';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
 import dayjs from 'dayjs';
 import { t } from 'ember-intl';
 
 import CertificabilityCell from '../certificability/cell';
 import LastParticipationDateTooltip from '../ui/last-participation-date-tooltip';
 
-function displayDate(date) {
-  return dayjs(date).format('DD/MM/YYYY');
-}
+export default class TableRow extends Component {
+  @service currentUser;
 
-function getCustomRowData(extraColumns, key) {
-  const data = extraColumns[key];
-
-  if (!data) return '';
-
-  if (dayjs(data).isValid()) {
-    return displayDate(data);
-  } else {
-    return data;
+  displayDate(date) {
+    return dayjs(date).format('DD/MM/YYYY');
   }
-}
 
-<template>
-  <tr
-    aria-label={{t "pages.organization-participants.table.row-title"}}
-    {{on "click" @onClickLearner}}
-    class="tr--clickable"
-  >
-    {{#if @showCheckbox}}
-      <td class="table__column" {{on "click" @onToggleParticipant}}>
-        <PixCheckbox @screenReaderOnly={{true}} @checked={{@isParticipantSelected}}>
-          <:label>
-            {{t
-              "pages.organization-participants.table.column.checkbox"
-              firstname=@participant.firstName
-              lastname=@participant.lastName
-            }}
-          </:label>
-        </PixCheckbox>
-      </td>
-    {{/if}}
-    <td class="table__column">
-      <LinkTo @route="authenticated.organization-participants.organization-participant" @model={{@participant.id}}>
-        {{@participant.lastName}}
-      </LinkTo>
-    </td>
-    <td class="ellipsis" title={{@participant.firstName}}>{{@participant.firstName}}</td>
-    {{#each @customRows as |key|}}
-      <td>{{getCustomRowData @participant.extraColumns key}}</td>
-    {{/each}}
-    <td class="table__column--center">
-      {{@participant.participationCount}}
-    </td>
-    <td>
-      <div class="organization-participant-list-page__last-participation">
-        {{#if @participant.lastParticipationDate}}
-          <span>{{displayDate @participant.lastParticipationDate}}</span>
-          <LastParticipationDateTooltip
-            @id={{@participant.id}}
-            @campaignName={{@participant.campaignName}}
-            @campaignType={{@participant.campaignType}}
-            @participationStatus={{@participant.participationStatus}}
-          />
+  getCustomRowData(extraColumns, key) {
+    const data = extraColumns[key];
+
+    if (!data) return '';
+
+    if (dayjs(data).isValid()) {
+      return this.displayDate(data);
+    } else {
+      return data;
+    }
+  }
+
+  get rowClass() {
+    if (this.args.hasOrganizationParticipantPage) {
+      return 'tr--clickable';
+    }
+    return '';
+  }
+
+  <template>
+    <tr
+      aria-label={{t "pages.organization-participants.table.row-title"}}
+      {{on "click" @onClickLearner}}
+      class={{this.rowClass}}
+    >
+
+      {{#if @showCheckbox}}
+        <td class="table__column" {{on "click" @onToggleParticipant}}>
+          <PixCheckbox @screenReaderOnly={{true}} @checked={{@isParticipantSelected}}>
+            <:label>
+              {{t
+                "pages.organization-participants.table.column.checkbox"
+                firstname=@participant.firstName
+                lastname=@participant.lastName
+              }}
+            </:label>
+          </PixCheckbox>
+        </td>
+      {{/if}}
+      <td class="table__column">
+        {{#if @hasOrganizationParticipantPage}}
+          <LinkTo @route="authenticated.organization-participants.organization-participant" @model={{@participant.id}}>
+            {{@participant.lastName}}
+          </LinkTo>
+        {{else}}
+          {{@participant.lastName}}
         {{/if}}
-      </div>
-    </td>
-    <td class="table__column--center">
-      <CertificabilityCell
-        @certifiableAt={{@participant.certifiableAt}}
-        @isCertifiable={{@participant.isCertifiable}}
-        @hideCertifiableDate={{@hideCertifiableDate}}
-      />
-    </td>
-  </tr>
-</template>
+      </td>
+      <td class="ellipsis" title={{@participant.firstName}}>{{@participant.firstName}}</td>
+      {{#each @customRows as |key|}}
+        <td>{{this.getCustomRowData @participant.extraColumns key}}</td>
+      {{/each}}
+      {{#unless this.currentUser.canAccessMissionsPage}}
+        <td class="table__column--center">
+          {{@participant.participationCount}}
+        </td>
+        <td>
+          <div class="organization-participant-list-page__last-participation">
+            {{#if @participant.lastParticipationDate}}
+              <span>{{this.displayDate @participant.lastParticipationDate}}</span>
+              <LastParticipationDateTooltip
+                @id={{@participant.id}}
+                @campaignName={{@participant.campaignName}}
+                @campaignType={{@participant.campaignType}}
+                @participationStatus={{@participant.participationStatus}}
+              />
+            {{/if}}
+          </div>
+        </td>
+        <td class="table__column--center">
+          <CertificabilityCell
+            @certifiableAt={{@participant.certifiableAt}}
+            @isCertifiable={{@participant.isCertifiable}}
+            @hideCertifiableDate={{@hideCertifiableDate}}
+          />
+        </td>
+      {{/unless}}
+    </tr>
+  </template>
+}

--- a/orga/app/controllers/authenticated/organization-participants/list.js
+++ b/orga/app/controllers/authenticated/organization-participants/list.js
@@ -29,6 +29,10 @@ export default class ListController extends Controller {
     return !this.currentUser.canAccessMissionsPage;
   }
 
+  get decodedExtraFilters() {
+    return decodeExtraFilters(this.extraFilters);
+  }
+
   @action
   triggerFiltering(fieldName, value) {
     if (fieldName.includes('.')) {

--- a/orga/app/controllers/authenticated/organization-participants/list.js
+++ b/orga/app/controllers/authenticated/organization-participants/list.js
@@ -25,6 +25,10 @@ export default class ListController extends Controller {
     return this.currentUser.prescriber.computeOrganizationLearnerCertificability;
   }
 
+  get hasOrganizationParticipantPage() {
+    return !this.currentUser.canAccessMissionsPage;
+  }
+
   @action
   triggerFiltering(fieldName, value) {
     if (fieldName.includes('.')) {
@@ -72,8 +76,10 @@ export default class ListController extends Controller {
 
   @action
   goToLearnerPage(learnerId, event) {
-    event.preventDefault();
-    this.router.transitionTo('authenticated.organization-participants.organization-participant', learnerId);
+    if (this.hasOrganizationParticipantPage) {
+      event.preventDefault();
+      this.router.transitionTo('authenticated.organization-participants.organization-participant', learnerId);
+    }
   }
 
   @action

--- a/orga/app/styles/globals/tables.scss
+++ b/orga/app/styles/globals/tables.scss
@@ -60,11 +60,6 @@ tbody {
     }
   }
 
-  .row--not-clickable {
-    background-color: var(--pix-neutral-0);
-    cursor: auto;
-  }
-
   th.th--clickable {
     background-color: var(--pix-neutral-0);
 

--- a/orga/app/templates/authenticated/organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/organization-participants/list.hbs
@@ -20,6 +20,7 @@
       @latestParticipationOrder={{this.latestParticipationOrder}}
       @deleteParticipants={{this.deleteOrganizationLearners}}
       @hasComputeOrganizationLearnerCertificabilityEnabled={{this.hasComputeOrganizationLearnerCertificabilityEnabled}}
+      @hasOrganizationParticipantPage={{this.hasOrganizationParticipantPage}}
     />
   {{else}}
     <OrganizationParticipant::NoParticipantPanel />

--- a/orga/app/templates/authenticated/organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/organization-participants/list.hbs
@@ -8,7 +8,7 @@
       @participants={{@model}}
       @triggerFiltering={{this.triggerFiltering}}
       @onResetFilter={{this.resetFilters}}
-      @customFiltersValues={{this.decodeExtraFilters this.extraFilters}}
+      @customFiltersValues={{this.decodedExtraFilters}}
       @fullName={{this.fullName}}
       @certificabilityFilter={{this.certificability}}
       @onClickLearner={{this.goToLearnerPage}}

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -308,7 +308,8 @@
     },
     "organization-participants-header": {
       "title": "{count, plural, =0 {Participants} =1 {Participant ({count})} other {Participants ({count})}}",
-      "import-button": "Import"
+      "import-button": "Import",
+      "sco-title": "{count, plural, =0 {Students} =1 {Student ({count})} other {Students ({count})}}"
     },
     "participation-status": {
       "SHARED-ASSESSMENT": "Submitted results",
@@ -1065,6 +1066,7 @@
       "filters": {
         "aria-label": "Filters on participants",
         "participations-count": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count} participants}}",
+        "students-count": "{count, plural, =0 {0 students} =1 {1 student} other {{count} students}}",
         "type": {
           "certificability": {
             "label": "Search by certificability",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -308,7 +308,14 @@
     },
     "organization-participants-header": {
       "title": "{count, plural, =0 {Participants} =1 {Participant ({count})} other {Participants ({count})}}",
-      "import-button": "Importer"
+      "default": {
+        "title": "{count, plural, =0 {Participants} =1 {Participant ({count})} other {Participants ({count})}}"
+      },
+      "import-button": "Importer",
+      "sco": {
+        "title": "{count, plural, =0 {Élèves} =1 {Élèves ({count})} other {Élèves ({count})}}"
+      },
+      "sco-title": "{count, plural, =0 {Élèves} =1 {Élève ({count})} other {Élèves ({count})}}"
     },
     "participation-status": {
       "SHARED-ASSESSMENT": "Résultats reçus",
@@ -1065,6 +1072,7 @@
       "filters": {
         "aria-label": "Filtres sur les participants",
         "participations-count": "{count, plural, =0 {0 participant} =1 {1 participant} other {{count} participants}}",
+        "students-count": "{count, plural, =0 {0 élèves} =1 {1 élève} other {{count} élèves}}",
         "type": {
           "certificability": {
             "label": "Rechercher par certificabilité",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -308,6 +308,7 @@
     },
     "organization-participants-header": {
       "import-button": "Importeren",
+      "sco-title": "{count, plural, =0 {Leerling} =1 {Leerling ({count})} other {Leerlingen ({count})}}",
       "title": "{count, plural, =0 {Deelnemer} =1 {Deelnemer ({count})} other {Deelnemers ({count})}}"
     },
     "participation-status": {
@@ -1119,6 +1120,7 @@
       "filters": {
         "aria-label": "Filters deelnemers",
         "participations-count": "{count, plural, =0 {0 deelnemer} =1 {1 deelnemer} other {{count} deelnemers}}",
+        "students-count": "{count, plural, =0 {0 leerling} =1 {1 leerling} other {{count} leerlingen}}",
         "type": {
           "certificability": {
             "label": "Zoeken op certificeerbaarheid",


### PR DESCRIPTION
## :unicorn: Problème
La liste des élèves n'est disponible que par le biais du détail des missions.

## :robot: Proposition
Ajouter un menu Élèves affichant la liste des élèves de l'école avec leur classe.

## :100: Pour tester
Accéder à une école depuis Pix Orga. 
-> La page Élèves n'est pas visible dans les menus, mais elle est accessible depuis le path `/participants`. Les noms, prénoms et classes sont affichés. Il est possible de filtrer sur toutes ces informations.
-> L'import est accessible depuis cette page, mais redirige toujours sur la page missions sur le bouton de retour.
L'affichage des pages participants pour le PRO ou la FWB est inchangé.
