### PR TITLE
[TECH] Mise à jour de webpack et un plugin babel (pix-14825)

### DIFF
--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -30,7 +30,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.2.1",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
-        "babel-plugin-ember-template-compilation": "^2.2.5",
+        "babel-plugin-ember-template-compilation": "^2.3.0",
         "dotenv": "^16.3.1",
         "ember-auto-import": "^2.7.2",
         "ember-cli": "^5.8.1",
@@ -75,7 +75,7 @@
         "stylelint": "^16.0.0",
         "stylelint-order": "^6.0.3",
         "tracked-built-ins": "^3.3.0",
-        "webpack": "^5.91.0",
+        "webpack": "^5.95.0",
         "xss": "^1.0.14"
       },
       "engines": {
@@ -13887,10 +13887,11 @@
       }
     },
     "node_modules/babel-plugin-ember-template-compilation": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-2.2.5.tgz",
-      "integrity": "sha512-NQ2DT0DsYyHVrEpFQIy2U8S91JaKSE8NOSZzMd7KZFJVgA6KodJq3Uj852HcH9LsSfvwppnM+dRo1G8bzTnnFw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-2.3.0.tgz",
+      "integrity": "sha512-4ZrKVSqdw5PxEKRbqfOpPhrrNBDG3mFPhyT6N1Oyyem81ZIkCvNo7TPKvlTHeFxqb6HtUvCACP/pzFpZ74J4pg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@glimmer/syntax": "^0.84.3",
         "babel-import-util": "^3.0.0"
@@ -42685,9 +42686,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.94.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
-      "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
+      "version": "5.95.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.95.0.tgz",
+      "integrity": "sha512-2t3XstrKULz41MNMBF+cJ97TyHdyQ8HCt//pqErqDvNjU9YQBnZxIHa11VXsi7F3mb5/aO2tuDxdeTPdU7xu9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/junior/package.json
+++ b/junior/package.json
@@ -55,7 +55,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.2.1",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
-    "babel-plugin-ember-template-compilation": "^2.2.5",
+    "babel-plugin-ember-template-compilation": "^2.3.0",
     "dotenv": "^16.3.1",
     "ember-auto-import": "^2.7.2",
     "ember-cli": "^5.8.1",
@@ -100,7 +100,7 @@
     "stylelint": "^16.0.0",
     "stylelint-order": "^6.0.3",
     "tracked-built-ins": "^3.3.0",
-    "webpack": "^5.91.0",
+    "webpack": "^5.95.0",
     "xss": "^1.0.14"
   },
   "overrides": {


### PR DESCRIPTION
## :unicorn: Problème

Nous avons beaucoup de message d'alerte dans la console depuis quelques jours. Beaucoup de librairies obsolètes.

## :robot: Proposition

Mise à jour de certaines lib. Ici, Webpack et un plugin Babel.

## :rainbow: Remarques


## :100: Pour tester

Un petit tour rapide sur l'application pix junior pour s'assurer que tout s'affiche correctement.

