### PR TITLE
[FEATURE] Ajoute un endpoint pour récupérer les résultats de quêtes dans le cadre d'une campagne (PIX-14837).

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -28,6 +28,7 @@ import { organizationLearnerRoutes } from './src/prescription/organization-learn
 import { organizationPlaceRoutes } from './src/prescription/organization-place/routes.js';
 import { targetProfileRoutes } from './src/prescription/target-profile/routes.js';
 import { profileRoutes } from './src/profile/routes.js';
+import { questRoutes } from './src/quest/routes.js';
 import { schoolRoutes } from './src/school/routes.js';
 import { config } from './src/shared/config.js';
 import { monitoringTools } from './src/shared/infrastructure/monitoring-tools.js';
@@ -155,6 +156,7 @@ const setupRoutesAndPlugins = async function (server) {
     organizationalEntitiesRoutes,
     sharedRoutes,
     profileRoutes,
+    questRoutes,
     evaluationRoutes,
     flashCertificationRoutes,
     devcompRoutes,

--- a/api/src/prescription/campaign/application/http-error-mapper-configuration.js
+++ b/api/src/prescription/campaign/application/http-error-mapper-configuration.js
@@ -1,6 +1,7 @@
 import { HttpErrors } from '../../../shared/application/http-errors.js';
 import {
   CampaignCodeFormatError,
+  CampaignParticipationDoesNotBelongToUser,
   CampaignUniqueCodeError,
   IsForAbsoluteNoviceUpdateError,
   MultipleSendingsUpdateError,
@@ -34,6 +35,10 @@ const campaignDomainErrorMappingConfiguration = [
   {
     name: CampaignCodeFormatError.name,
     httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+  },
+  {
+    name: CampaignParticipationDoesNotBelongToUser.name,
+    httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message, error.code, error.meta),
   },
 ];
 

--- a/api/src/prescription/campaign/application/usecases/checkCampaignParticipationBelongsToUser.js
+++ b/api/src/prescription/campaign/application/usecases/checkCampaignParticipationBelongsToUser.js
@@ -1,0 +1,15 @@
+import * as campaignParticipationRepository from '../../../campaign-participation/infrastructure/repositories/campaign-participation-repository.js';
+import { CampaignParticipationDoesNotBelongToUser } from '../../domain/errors.js';
+
+const execute = async function ({
+  userId,
+  campaignParticipationId,
+  dependencies = { campaignParticipationRepository },
+}) {
+  const campaignParticipation = await dependencies.campaignParticipationRepository.get(campaignParticipationId);
+  if (!campaignParticipation || campaignParticipation.userId !== userId) {
+    throw new CampaignParticipationDoesNotBelongToUser();
+  }
+};
+
+export { execute };

--- a/api/src/prescription/campaign/domain/errors.js
+++ b/api/src/prescription/campaign/domain/errors.js
@@ -52,9 +52,16 @@ class DeletedCampaignError extends DomainError {
   }
 }
 
+class CampaignParticipationDoesNotBelongToUser extends DomainError {
+  constructor(message = "La participation n'est pas liée à l'utilisateur") {
+    super(message);
+  }
+}
+
 export {
   ArchivedCampaignError,
   CampaignCodeFormatError,
+  CampaignParticipationDoesNotBelongToUser,
   CampaignUniqueCodeError,
   DeletedCampaignError,
   IsForAbsoluteNoviceUpdateError,

--- a/api/src/prescription/organization-learner/application/api/read-models/OrganizationLearnerWithParticipations.js
+++ b/api/src/prescription/organization-learner/application/api/read-models/OrganizationLearnerWithParticipations.js
@@ -5,10 +5,11 @@ export class OrganizationLearnerWithParticipations {
       MEFCode: organizationLearner.MEFCode,
     };
     this.organization = {
+      id: organization.id,
       isManagingStudents: organization.isManagingStudents,
       tags: tagNames,
       type: organization.type,
     };
-    this.campaignParticipations = campaignParticipations.map(({ targetProfileId }) => ({ targetProfileId }));
+    this.campaignParticipations = campaignParticipations.map(({ id, targetProfileId }) => ({ id, targetProfileId }));
   }
 }

--- a/api/src/profile/application/api/reward-api.js
+++ b/api/src/profile/application/api/reward-api.js
@@ -1,0 +1,5 @@
+import { usecases } from '../../domain/usecases/index.js';
+
+export const getByIdAndType = ({ rewardId, rewardType }) => {
+  return usecases.getRewardByIdAndType({ rewardId, rewardType });
+};

--- a/api/src/profile/domain/errors.js
+++ b/api/src/profile/domain/errors.js
@@ -6,4 +6,10 @@ class AttestationNotFoundError extends DomainError {
   }
 }
 
-export { AttestationNotFoundError };
+class RewardTypeDoesNotExistError extends DomainError {
+  constructor(message = 'Reward Type does not exist') {
+    super(message);
+  }
+}
+
+export { AttestationNotFoundError, RewardTypeDoesNotExistError };

--- a/api/src/profile/domain/usecases/get-reward-by-id-and-type.js
+++ b/api/src/profile/domain/usecases/get-reward-by-id-and-type.js
@@ -1,0 +1,3 @@
+export const getRewardByIdAndType = ({ rewardId, rewardType, rewardRepository }) => {
+  return rewardRepository.getByIdAndType({ rewardId, rewardType });
+};

--- a/api/src/profile/domain/usecases/index.js
+++ b/api/src/profile/domain/usecases/index.js
@@ -10,6 +10,7 @@ import * as competenceRepository from '../../../shared/infrastructure/repositori
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as attestationRepository from '../../infrastructure/repositories/attestation-repository.js';
+import * as rewardRepository from '../../infrastructure/repositories/reward-repository.js';
 
 const path = dirname(fileURLToPath(import.meta.url));
 
@@ -25,6 +26,7 @@ const dependencies = {
   profileRewardRepository,
   userRepository: repositories.userRepository,
   attestationRepository,
+  rewardRepository,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/profile/infrastructure/repositories/reward-repository.js
+++ b/api/src/profile/infrastructure/repositories/reward-repository.js
@@ -1,0 +1,16 @@
+import { knex } from '../../../../db/knex-database-connection.js';
+import { REWARD_TYPES } from '../../../quest/domain/constants.js';
+import { RewardTypeDoesNotExistError } from '../../domain/errors.js';
+import { Attestation } from '../../domain/models/Attestation.js';
+
+export const getByIdAndType = async ({ rewardId, rewardType }) => {
+  try {
+    const result = await knex(rewardType).where({ id: rewardId }).first();
+    switch (rewardType) {
+      case REWARD_TYPES.ATTESTATION:
+        return new Attestation(result);
+    }
+  } catch (error) {
+    throw new RewardTypeDoesNotExistError(error);
+  }
+};

--- a/api/src/quest/application/index.js
+++ b/api/src/quest/application/index.js
@@ -1,0 +1,34 @@
+import Joi from 'joi';
+
+import { securityPreHandlers } from '../../shared/application/security-pre-handlers.js';
+import { identifiersType } from '../../shared/domain/types/identifiers-type.js';
+import { questController } from './quest-controller.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/campaign-participations/{campaignParticipationId}/quest-results',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkCampaignParticipationBelongsToUser,
+          },
+        ],
+        handler: questController.getQuestResults,
+        validate: {
+          params: Joi.object({
+            campaignParticipationId: identifiersType.campaignParticipationId,
+          }),
+        },
+        notes: [
+          '- **Route nécessitant une authentification**\n' +
+            "- Récupère le résultat d'une quête pour une participation et un user donné",
+        ],
+        tags: ['api', 'quest'],
+      },
+    },
+  ]);
+};
+const name = 'quest-api';
+export { name, register };

--- a/api/src/quest/application/quest-controller.js
+++ b/api/src/quest/application/quest-controller.js
@@ -1,0 +1,20 @@
+import * as requestResponseUtils from '../../shared/infrastructure/utils/request-response-utils.js';
+import { usecases } from '../domain/usecases/index.js';
+import * as questResultSerializer from '../infrastructure/serializers/quest-result-serializer.js';
+
+const getQuestResults = async function (request, h, dependencies = { questResultSerializer, requestResponseUtils }) {
+  const { campaignParticipationId } = request.params;
+  const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+
+  const questResults = await usecases.getQuestResultsForCampaignParticipation({ userId, campaignParticipationId });
+
+  const serializedQuestResults = dependencies.questResultSerializer.serialize(questResults);
+
+  return h.response(serializedQuestResults);
+};
+
+const questController = {
+  getQuestResults,
+};
+
+export { questController };

--- a/api/src/quest/domain/models/Eligibility.js
+++ b/api/src/quest/domain/models/Eligibility.js
@@ -1,11 +1,33 @@
 export class Eligibility {
+  #campaignParticipations;
+
   constructor({ organizationLearner, organization, campaignParticipations = [] }) {
     this.organizationLearner = {
       MEFCode: organizationLearner?.MEFCode,
     };
     this.organization = organization;
-    this.campaignParticipations = {
-      targetProfileIds: campaignParticipations.map(({ targetProfileId }) => targetProfileId),
+    this.#campaignParticipations = campaignParticipations;
+  }
+
+  get campaignParticipations() {
+    return {
+      targetProfileIds: this.#campaignParticipations.map(({ targetProfileId }) => targetProfileId),
     };
+  }
+
+  hasCampaignParticipation(campaignParticipationId) {
+    return Boolean(
+      this.#campaignParticipations.find(
+        (campaignParticipation) => campaignParticipation.id === campaignParticipationId,
+      ),
+    );
+  }
+
+  getTargetProfileForCampaignParticipation(campaignParticipationId) {
+    const campaignParticipation = this.#campaignParticipations.find(
+      (campaignParticipation) => campaignParticipation.id === campaignParticipationId,
+    );
+
+    return campaignParticipation?.targetProfileId ?? null;
   }
 }

--- a/api/src/quest/domain/models/QuestResult.js
+++ b/api/src/quest/domain/models/QuestResult.js
@@ -1,0 +1,7 @@
+export class QuestResult {
+  constructor({ id, obtained, reward }) {
+    this.id = id;
+    this.obtained = obtained;
+    this.reward = reward;
+  }
+}

--- a/api/src/quest/domain/usecases/get-quest-results-for-campaign-participation.js
+++ b/api/src/quest/domain/usecases/get-quest-results-for-campaign-participation.js
@@ -1,0 +1,36 @@
+export const getQuestResultsForCampaignParticipation = async ({
+  userId,
+  campaignParticipationId,
+  questRepository,
+  eligibilityRepository,
+  rewardRepository,
+}) => {
+  const quests = await questRepository.findAll();
+
+  if (quests.length === 0) {
+    return [];
+  }
+
+  const eligibilities = await eligibilityRepository.find({ userId });
+  const eligibility = eligibilities.find((e) => e.hasCampaignParticipation(campaignParticipationId));
+
+  if (!eligibility) return [];
+
+  eligibility.campaignParticipations.targetProfileIds = [
+    // getTargetProfileForCampaignParticipation returns null but this usecase is used for campaign participation result page for now, so the campaign participation ID always exists
+    // if this usecase is to be used in another context, the edge case must be handled
+    eligibility.getTargetProfileForCampaignParticipation(campaignParticipationId),
+  ];
+
+  const questResults = [];
+  for (const quest of quests) {
+    const isEligibleForQuest = quest.isEligible(eligibility);
+
+    if (!isEligibleForQuest) continue;
+
+    const questResult = await rewardRepository.getByQuestAndUserId({ userId, quest });
+    questResults.push(questResult);
+  }
+
+  return questResults;
+};

--- a/api/src/quest/infrastructure/repositories/index.js
+++ b/api/src/quest/infrastructure/repositories/index.js
@@ -1,10 +1,14 @@
 import * as knowledgeElementsApi from '../../../evaluation/application/api/knowledge-elements-api.js';
 import * as organizationLearnerWithParticipationApi from '../../../prescription/organization-learner/application/api/organization-learners-with-participations-api.js';
 import * as profileRewardApi from '../../../profile/application/api/profile-reward-api.js';
+import * as rewardApi from '../../../profile/application/api/reward-api.js';
+import { temporaryStorage } from '../../../shared/infrastructure/temporary-storage/index.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import * as eligibilityRepository from './eligibility-repository.js';
 import * as rewardRepository from './reward-repository.js';
 import * as successRepository from './success-repository.js';
+
+const profileRewardTemporaryStorage = temporaryStorage.withPrefix('profile-rewards:');
 
 const repositoriesWithoutInjectedDependencies = {
   eligibilityRepository,
@@ -16,6 +20,8 @@ const dependencies = {
   organizationLearnerWithParticipationApi,
   knowledgeElementsApi,
   profileRewardApi,
+  profileRewardTemporaryStorage,
+  rewardApi,
 };
 
 const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies);

--- a/api/src/quest/infrastructure/repositories/reward-repository.js
+++ b/api/src/quest/infrastructure/repositories/reward-repository.js
@@ -1,7 +1,46 @@
+import { QuestResult } from '../../domain/models/QuestResult.js';
+
 export const reward = async ({ userId, rewardId, profileRewardApi }) => {
   return profileRewardApi.save(userId, rewardId);
 };
 
 export const getByUserId = async ({ userId, profileRewardApi }) => {
   return profileRewardApi.getByUserId(userId);
+};
+
+export const getByQuestAndUserId = async ({
+  userId,
+  quest,
+  rewardApi,
+  profileRewardApi,
+  profileRewardTemporaryStorage,
+}) => {
+  const reward = await rewardApi.getByIdAndType({ rewardId: quest.rewardId, rewardType: quest.rewardType });
+  const profileRewards = await profileRewardApi.getByUserId(userId);
+
+  const profileRewardForQuest = profileRewards.find(
+    (profileReward) => profileReward.rewardType === quest.rewardType && profileReward.rewardId === quest.rewardId,
+  );
+
+  if (profileRewardForQuest) {
+    return new QuestResult({
+      id: quest.id,
+      obtained: true,
+      reward,
+    });
+  }
+
+  let obtained = false;
+
+  const isProcessing = Number(await profileRewardTemporaryStorage.get(userId)) > 0;
+
+  if (isProcessing) {
+    obtained = null;
+  }
+
+  return new QuestResult({
+    id: quest.id,
+    obtained,
+    reward,
+  });
 };

--- a/api/src/quest/infrastructure/serializers/quest-result-serializer.js
+++ b/api/src/quest/infrastructure/serializers/quest-result-serializer.js
@@ -1,0 +1,11 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (questResult) {
+  return new Serializer('quest-result', {
+    attributes: ['obtained', 'reward'],
+  }).serialize(questResult);
+};
+
+export { serialize };

--- a/api/src/quest/routes.js
+++ b/api/src/quest/routes.js
@@ -1,0 +1,5 @@
+import * as questRoute from './application/index.js';
+
+const questRoutes = [questRoute];
+
+export { questRoutes };

--- a/api/src/shared/application/security-pre-handlers.js
+++ b/api/src/shared/application/security-pre-handlers.js
@@ -4,6 +4,7 @@ import lodash from 'lodash';
 import { PIX_ADMIN } from '../../authorization/domain/constants.js';
 import * as checkUserIsCandidateUseCase from '../../certification/enrolment/application/usecases/check-user-is-candidate.js';
 import * as certificationIssueReportRepository from '../../certification/shared/infrastructure/repositories/certification-issue-report-repository.js';
+import * as checkCampaignParticipationBelongsToUserUsecase from '../../prescription/campaign/application/usecases/checkCampaignParticipationBelongsToUser.js';
 import * as isSchoolSessionActive from '../../school/application/usecases/is-school-session-active.js';
 import { ForbiddenAccess, NotFoundError } from '../domain/errors.js';
 import { Organization } from '../domain/models/index.js';
@@ -729,6 +730,21 @@ async function checkUserCanDisableHisOrganizationMembership(
   }
 }
 
+async function checkCampaignParticipationBelongsToUser(
+  request,
+  h,
+  dependencies = { checkCampaignParticipationBelongsToUserUsecase },
+) {
+  if (!request.auth.credentials || !request.auth.credentials.userId) {
+    return _replyForbiddenError(h);
+  }
+
+  const userId = request.auth.credentials.userId;
+  const { campaignParticipationId } = request.params;
+  await dependencies.checkCampaignParticipationBelongsToUserUsecase.execute({ userId, campaignParticipationId });
+  return h.response(true);
+}
+
 function makeCheckOrganizationHasFeature(featureKey) {
   return async function (request, h, dependencies = { checkOrganizationHasFeatureUseCase }) {
     try {
@@ -764,6 +780,7 @@ const securityPreHandlers = {
   checkSchoolSessionIsActive,
   checkUserBelongsToLearnersOrganization,
   checkUserBelongsToOrganization,
+  checkCampaignParticipationBelongsToUser,
   checkUserBelongsToOrganizationManagingStudents,
   checkUserBelongsToScoOrganizationAndManagesStudents,
   checkUserBelongsToSupOrganizationAndManagesStudents,

--- a/api/tests/prescription/campaign-participation/unit/domain/errors_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/errors_test.js
@@ -1,8 +1,0 @@
-import * as errors from '../../../../../src/prescription/campaign-participation/domain/errors.js';
-import { expect } from '../../../../test-helper.js';
-
-describe('Unit | Domain | Errors', function () {
-  it('should export a CampaignParticipationDeletedError', function () {
-    expect(errors.CampaignParticipationDeletedError).to.exist;
-  });
-});

--- a/api/tests/prescription/campaign/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/prescription/campaign/unit/application/http-error-mapper-configuration_test.js
@@ -1,0 +1,19 @@
+import { campaignDomainErrorMappingConfiguration } from '../../../../../src/prescription/campaign/application/http-error-mapper-configuration.js';
+import { CampaignParticipationDoesNotBelongToUser } from '../../../../../src/prescription/campaign/domain/errors.js';
+import { HttpErrors } from '../../../../../src/shared/application/http-errors.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Prescription | Campaign | Unit | Application | HttpErrorMapperConfiguration', function () {
+  it('instantiates ForbiddenError when CampaignParticipationDoesNotBelongToUser', async function () {
+    //given
+    const httpErrorMapper = campaignDomainErrorMappingConfiguration.find(
+      (httpErrorMapper) => httpErrorMapper.name === CampaignParticipationDoesNotBelongToUser.name,
+    );
+
+    //when
+    const error = httpErrorMapper.httpErrorFn(new CampaignParticipationDoesNotBelongToUser());
+
+    //then
+    expect(error).to.be.instanceOf(HttpErrors.ForbiddenError);
+  });
+});

--- a/api/tests/prescription/organization-learner/unit/application/api/models/OrganizationLearnerWithParticipations_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/api/models/OrganizationLearnerWithParticipations_test.js
@@ -31,13 +31,14 @@ describe('Unit | Application| API | Models | OrganizationLearnerWithParticipatio
       MEFCode: organizationLearner.MEFCode,
     });
     expect(organizationLearnerWithParticipations.organization).to.deep.equal({
+      id: organization.id,
       isManagingStudents: organization.isManagingStudents,
       tags: tagNames,
       type: organization.type,
     });
     expect(organizationLearnerWithParticipations.campaignParticipations).to.deep.have.members([
-      { targetProfileId: participationsList[0].targetProfileId },
-      { targetProfileId: participationsList[1].targetProfileId },
+      { targetProfileId: participationsList[0].targetProfileId, id: participationsList[0].id },
+      { targetProfileId: participationsList[1].targetProfileId, id: participationsList[1].id },
     ]);
   });
 });

--- a/api/tests/prescription/organization-learner/unit/application/api/organization-learners-with-participations-api_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/api/organization-learners-with-participations-api_test.js
@@ -41,11 +41,12 @@ describe('Unit | API | Organization Learner With Participations', function () {
             MEFCode: organizationLearner1.MEFCode,
           },
           organization: {
+            id: organization1.id,
             isManagingStudents: organization1.isManagingStudents,
             tags: tagNames,
             type: organization1.type,
           },
-          campaignParticipations: campaignParticipations.map(({ targetProfileId }) => ({ targetProfileId })),
+          campaignParticipations: campaignParticipations.map(({ id, targetProfileId }) => ({ id, targetProfileId })),
         },
         {
           organizationLearner: {
@@ -53,11 +54,12 @@ describe('Unit | API | Organization Learner With Participations', function () {
             MEFCode: organizationLearner2.MEFCode,
           },
           organization: {
+            id: organization2.id,
             isManagingStudents: organization2.isManagingStudents,
             tags: tagNames,
             type: organization2.type,
           },
-          campaignParticipations: campaignParticipations.map(({ targetProfileId }) => ({ targetProfileId })),
+          campaignParticipations: campaignParticipations.map(({ id, targetProfileId }) => ({ id, targetProfileId })),
         },
       ]);
     });

--- a/api/tests/profile/integration/infrastructure/repositories/reward-repository_test.js
+++ b/api/tests/profile/integration/infrastructure/repositories/reward-repository_test.js
@@ -1,0 +1,31 @@
+import { RewardTypeDoesNotExistError } from '../../../../../src/profile/domain/errors.js';
+import { Attestation } from '../../../../../src/profile/domain/models/Attestation.js';
+import { getByIdAndType } from '../../../../../src/profile/infrastructure/repositories/reward-repository.js';
+import { REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
+import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Profile | Integration | Infrastructure | Repository | Reward', function () {
+  describe('#getByIdAndType', function () {
+    it('should return reward for given id and type', async function () {
+      // given
+      const reward = databaseBuilder.factory.buildAttestation();
+      await databaseBuilder.commit();
+
+      // when
+      const result = await getByIdAndType({ rewardId: reward.id, rewardType: REWARD_TYPES.ATTESTATION });
+
+      // then
+      expect(result).to.be.an.instanceof(Attestation);
+      expect(result.id).to.equal(reward.id);
+      expect(result.key).to.equal(reward.key);
+    });
+
+    it('should throw RewardTypeDoesNotExistError if rewardType does not exist', async function () {
+      // given&when
+      const error = await catchErr(getByIdAndType)({ rewardId: 1, rewardType: 'NOT_EXISTING_REWARD_TYPE' });
+
+      // then
+      expect(error).to.be.an.instanceof(RewardTypeDoesNotExistError);
+    });
+  });
+});

--- a/api/tests/profile/unit/application/api/reward-api_test.js
+++ b/api/tests/profile/unit/application/api/reward-api_test.js
@@ -1,0 +1,24 @@
+import { getByIdAndType } from '../../../../../src/profile/application/api/reward-api.js';
+import { usecases } from '../../../../../src/profile/domain/usecases/index.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Profile | Unit | Application | Api | reward', function () {
+  describe('#getByIdAndType', function () {
+    it('should return reward for id and type', async function () {
+      // given
+      const rewardSymbol = Symbol('reward');
+      const rewardId = 1;
+      const rewardType = 'attestations';
+
+      sinon.stub(usecases, 'getRewardByIdAndType');
+
+      usecases.getRewardByIdAndType.withArgs({ rewardId, rewardType }).resolves(rewardSymbol);
+
+      // when
+      const result = await getByIdAndType({ rewardId, rewardType });
+
+      // then
+      expect(result).to.equal(rewardSymbol);
+    });
+  });
+});

--- a/api/tests/profile/unit/domain/usecases/get-reward-by-id-and-type_test.js
+++ b/api/tests/profile/unit/domain/usecases/get-reward-by-id-and-type_test.js
@@ -1,0 +1,20 @@
+import { getRewardByIdAndType } from '../../../../../src/profile/domain/usecases/get-reward-by-id-and-type.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Profile | Unit | UseCase | get-reward-by-id-and-type', function () {
+  it('should return reward depending on the type provided', async function () {
+    // given
+    const rewardId = 1;
+    const rewardType = 'attestations';
+    const rewardSymbol = Symbol('reward');
+    const rewardRepositoryStub = {
+      getByIdAndType: sinon.stub().withArgs({ rewardId, rewardType }).resolves(rewardSymbol),
+    };
+
+    // when
+    const result = await getRewardByIdAndType({ rewardId, rewardType, rewardRepository: rewardRepositoryStub });
+
+    // then
+    expect(result).to.equal(rewardSymbol);
+  });
+});

--- a/api/tests/quest/acceptance/application/quest-route_test.js
+++ b/api/tests/quest/acceptance/application/quest-route_test.js
@@ -1,0 +1,49 @@
+import {
+  createServer,
+  databaseBuilder,
+  expect,
+  generateValidRequestAuthorizationHeader,
+} from '../../../test-helper.js';
+
+describe('Quest | Acceptance | Application | Quest Route ', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('GET /api/campaign-participations/{campaignParticipationId}/quest-results', function () {
+    it('should return quest results for given campaignPaticipationId and userId', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO' }).id;
+      const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId,
+      });
+      const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
+        organizationLearnerId,
+        userId,
+      });
+      const rewardId = databaseBuilder.factory.buildAttestation().id;
+      databaseBuilder.factory.buildQuest({
+        rewardType: 'attestations',
+        rewardId,
+        eligibilityRequirements: [],
+        successRequirements: [],
+      }).id;
+
+      await databaseBuilder.commit();
+      const options = {
+        method: 'GET',
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        url: `/api/campaign-participations/${campaignParticipationId}/quest-results`,
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data).to.have.lengthOf(1);
+    });
+  });
+});

--- a/api/tests/quest/integration/domain/usecases/get-quest-results-for-campaign-participation_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-quest-results-for-campaign-participation_test.js
@@ -1,0 +1,38 @@
+import { COMPARISON } from '../../../../../src/quest/domain/models/Quest.js';
+import { QuestResult } from '../../../../../src/quest/domain/models/QuestResult.js';
+import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Quest | Integration | Domain | Usecases | getQuestResultsForCampaignParticipation', function () {
+  it('should get quest results for campaign participation', async function () {
+    const organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO' }).id;
+    const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+    const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
+      organizationLearnerId,
+      userId,
+    });
+    const rewardId = databaseBuilder.factory.buildAttestation().id;
+    const questId = databaseBuilder.factory.buildQuest({
+      rewardType: 'attestations',
+      rewardId,
+      eligibilityRequirements: [
+        {
+          type: 'organization',
+          data: {
+            type: 'SCO',
+          },
+          comparison: COMPARISON.ALL,
+        },
+      ],
+      successRequirements: [],
+    }).id;
+
+    await databaseBuilder.commit();
+
+    const result = await usecases.getQuestResultsForCampaignParticipation({ userId, campaignParticipationId });
+
+    expect(result[0]).to.be.instanceOf(QuestResult);
+    expect(result[0].id).to.equal(questId);
+    expect(result[0].reward.id).to.equal(rewardId);
+  });
+});

--- a/api/tests/quest/unit/application/index_test.js
+++ b/api/tests/quest/unit/application/index_test.js
@@ -1,0 +1,25 @@
+import * as moduleUnderTest from '../../../../src/quest/application/index.js';
+import { questController } from '../../../../src/quest/application/quest-controller.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
+import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
+
+describe('Quest | Unit | Router | quest-router', function () {
+  describe('GET /api/campaign-participations/{campaignParticipationId}/quest-results', function () {
+    it('should call checkCampaignParticipationBelongsToUser prehandler', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkCampaignParticipationBelongsToUser').returns(() => true);
+      sinon.stub(questController, 'getQuestResults').callsFake((request, h) => h.response());
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const campaignParticipationId = 123;
+
+      // when
+      await httpTestServer.request('GET', `/api/campaign-participations/${campaignParticipationId}/quest-results`);
+
+      // then
+      expect(securityPreHandlers.checkCampaignParticipationBelongsToUser).to.have.been.called;
+    });
+  });
+});

--- a/api/tests/quest/unit/domain/models/Eligibility_test.js
+++ b/api/tests/quest/unit/domain/models/Eligibility_test.js
@@ -1,0 +1,82 @@
+import { Eligibility } from '../../../../../src/quest/domain/models/Eligibility.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Quest | Unit | Domain | Models | Eligibility ', function () {
+  describe('#campaignParticipations', function () {
+    it('Should return an object with targetProfileIds property', function () {
+      // given
+      const campaignParticipations = [{ targetProfileId: 1 }, { targetProfileId: 2 }];
+      const eligiblity = new Eligibility({ campaignParticipations });
+
+      // when
+      const result = eligiblity.campaignParticipations;
+
+      // then
+      expect(result.targetProfileIds).to.deep.equal([1, 2]);
+    });
+
+    it('Should return an empty array on targetProfileIds property', function () {
+      // given
+      const campaignParticipations = [];
+      const eligiblity = new Eligibility({ campaignParticipations });
+
+      // when
+      const result = eligiblity.campaignParticipations;
+
+      // then
+      expect(result.targetProfileIds).to.deep.equal([]);
+    });
+  });
+
+  describe('#hasCampaignParticipation', function () {
+    it('Should return true if campaign participation exists', function () {
+      // given
+      const campaignParticipations = [{ id: 1 }];
+      const eligiblity = new Eligibility({ campaignParticipations });
+
+      // when
+      const result = eligiblity.hasCampaignParticipation(1);
+
+      // then
+      expect(result).to.be.true;
+    });
+
+    it('Should return false if campaign participation does not exist', function () {
+      // given
+      const campaignParticipations = [{ id: 2 }];
+      const eligiblity = new Eligibility({ campaignParticipations });
+
+      // when
+      const result = eligiblity.hasCampaignParticipation(1);
+
+      // then
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('getTargetProfileForCampaignParticipation', function () {
+    it('Should return target profile ID for campaign participation', function () {
+      // given
+      const campaignParticipations = [{ id: 1, targetProfileId: 10 }];
+      const eligiblity = new Eligibility({ campaignParticipations });
+
+      // when
+      const result = eligiblity.getTargetProfileForCampaignParticipation(1);
+
+      // then
+      expect(result).to.equal(10);
+    });
+
+    it('Should return null when the campaign participation does not exist', function () {
+      // given
+      const campaignParticipations = [{ id: 1, targetProfileId: 10 }];
+      const eligiblity = new Eligibility({ campaignParticipations });
+
+      // when
+      const result = eligiblity.getTargetProfileForCampaignParticipation(2);
+
+      // then
+      expect(result).to.be.null;
+    });
+  });
+});

--- a/api/tests/quest/unit/domain/usecases/get-quest-results-for-campaign-participation_test.js
+++ b/api/tests/quest/unit/domain/usecases/get-quest-results-for-campaign-participation_test.js
@@ -1,0 +1,99 @@
+import { Eligibility } from '../../../../../src/quest/domain/models/Eligibility.js';
+import { Quest } from '../../../../../src/quest/domain/models/Quest.js';
+import { getQuestResultsForCampaignParticipation } from '../../../../../src/quest/domain/usecases/get-quest-results-for-campaign-participation.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Quest | Unit | Domain | Usecases | getQuestResultsForCampaignParticipation', function () {
+  let questRepository, eligibilityRepository, rewardRepository, campaignParticipationId, userId;
+
+  beforeEach(function () {
+    userId = 1;
+    campaignParticipationId = 2;
+    questRepository = { findAll: sinon.stub() };
+    eligibilityRepository = { find: sinon.stub() };
+    rewardRepository = { getByQuestAndUserId: sinon.stub() };
+  });
+
+  it('should return empty array when there are no quests', async function () {
+    // given
+    questRepository.findAll.resolves([]);
+
+    // when
+    const result = await getQuestResultsForCampaignParticipation({
+      campaignParticipationId,
+      userId,
+      questRepository,
+      eligibilityRepository,
+      rewardRepository,
+    });
+
+    // then
+    expect(result.length).to.equal(0);
+  });
+
+  it('should return empty array when there is no eligibility', async function () {
+    // given
+    const wrongCampaignParticipationId = 30;
+    questRepository.findAll.resolves([
+      new Quest({
+        id: 10,
+        eligibilityRequirements: [],
+        successRequirements: [],
+        rewardType: 'attestations',
+        rewardId: 20,
+      }),
+    ]);
+
+    eligibilityRepository.find.withArgs({ userId }).resolves([
+      new Eligibility({
+        campaignParticipations: [{ id: wrongCampaignParticipationId, targetProfileId: 40 }],
+      }),
+    ]);
+
+    // when
+    const result = await getQuestResultsForCampaignParticipation({
+      campaignParticipationId,
+      userId,
+      questRepository,
+      eligibilityRepository,
+      rewardRepository,
+    });
+
+    // then
+    expect(result.length).to.equal(0);
+  });
+
+  it('should return empty array when there is no eligible quests', async function () {
+    // given
+    const wrongTargetProfileId = 41;
+    questRepository.findAll.resolves([
+      new Quest({
+        id: 10,
+        eligibilityRequirements: [
+          { type: 'campaignParticipations', data: { targetProfileIds: [wrongTargetProfileId] } },
+        ],
+        successRequirements: [],
+        rewardType: 'attestations',
+        rewardId: 20,
+      }),
+    ]);
+
+    eligibilityRepository.find.withArgs({ userId }).resolves([
+      new Eligibility({
+        campaignParticipations: [{ id: campaignParticipationId, targetProfileId: 40 }],
+      }),
+    ]);
+
+    // when
+    const result = await getQuestResultsForCampaignParticipation({
+      campaignParticipationId,
+      userId,
+      questRepository,
+      eligibilityRepository,
+      rewardRepository,
+    });
+
+    // then
+    expect(result.length).to.equal(0);
+  });
+});

--- a/api/tests/quest/unit/infrastructure/repositories/reward-repository_test.js
+++ b/api/tests/quest/unit/infrastructure/repositories/reward-repository_test.js
@@ -1,0 +1,104 @@
+import { QuestResult } from '../../../../../src/quest/domain/models/QuestResult.js';
+import { getByQuestAndUserId } from '../../../../../src/quest/infrastructure/repositories/reward-repository.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Quest | Unit | Infrastructure | Repositories | Reward', function () {
+  describe('#getByQuestAndUserId', function () {
+    let userId;
+    let quest;
+    let reward;
+    let rewardApiStub;
+    let profileRewardApiStub;
+    let profileRewardTemporaryStorageStub;
+
+    beforeEach(function () {
+      userId = Symbol('userId');
+      quest = {
+        id: 1,
+        rewardId: Symbol('rewardId'),
+        rewardType: Symbol('rewardType'),
+      };
+      reward = Symbol('reward');
+      rewardApiStub = {
+        getByIdAndType: sinon.stub(),
+      };
+      profileRewardApiStub = {
+        getByUserId: sinon.stub(),
+      };
+      profileRewardTemporaryStorageStub = {
+        get: sinon.stub(),
+      };
+
+      rewardApiStub.getByIdAndType
+        .withArgs({ rewardId: quest.rewardId, rewardType: quest.rewardType })
+        .resolves(reward);
+    });
+
+    it('should return QuestResult with obtained true when reward is obtained', async function () {
+      // given
+      const profileReward = [{ rewardId: quest.rewardId, rewardType: quest.rewardType }];
+      profileRewardApiStub.getByUserId.withArgs(userId).resolves(profileReward);
+
+      // when
+      const result = await getByQuestAndUserId({
+        userId,
+        quest,
+        rewardApi: rewardApiStub,
+        profileRewardApi: profileRewardApiStub,
+        profileRewardTemporaryStorage: profileRewardTemporaryStorageStub,
+      });
+
+      // then
+      expect(result).to.be.an.instanceof(QuestResult);
+      expect(result.id).to.equal(quest.id);
+      expect(result.reward).to.equal(reward);
+      expect(result.obtained).to.be.true;
+    });
+
+    it('should return QuestResult with obtained false when reward is not obtained', async function () {
+      // given
+      const profileReward = [];
+
+      profileRewardApiStub.getByUserId.withArgs(userId).resolves(profileReward);
+      profileRewardTemporaryStorageStub.get.withArgs(userId).resolves(0);
+
+      // when
+      const result = await getByQuestAndUserId({
+        userId,
+        quest,
+        rewardApi: rewardApiStub,
+        profileRewardApi: profileRewardApiStub,
+        profileRewardTemporaryStorage: profileRewardTemporaryStorageStub,
+      });
+
+      // then
+      expect(result).to.be.an.instanceof(QuestResult);
+      expect(result.id).to.equal(quest.id);
+      expect(result.reward).to.equal(reward);
+      expect(result.obtained).to.be.false;
+    });
+
+    it('should return QuestResult with obtained null when reward is processing', async function () {
+      // given
+      const profileReward = [];
+
+      profileRewardApiStub.getByUserId.withArgs(userId).resolves(profileReward);
+      profileRewardTemporaryStorageStub.get.withArgs(userId).resolves(1);
+
+      // when
+      const result = await getByQuestAndUserId({
+        userId,
+        quest,
+        rewardApi: rewardApiStub,
+        profileRewardApi: profileRewardApiStub,
+        profileRewardTemporaryStorage: profileRewardTemporaryStorageStub,
+      });
+
+      // then
+      expect(result).to.be.an.instanceof(QuestResult);
+      expect(result.id).to.equal(quest.id);
+      expect(result.reward).to.equal(reward);
+      expect(result.obtained).to.be.null;
+    });
+  });
+});

--- a/api/tests/quest/unit/infrastructure/serializers/quest-result-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/quest-result-serializer_test.js
@@ -1,0 +1,30 @@
+import { Attestation } from '../../../../../src/profile/domain/models/Attestation.js';
+import { QuestResult } from '../../../../../src/quest/domain/models/QuestResult.js';
+import * as questResultSerializer from '../../../../../src/quest/infrastructure/serializers/quest-result-serializer.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Quest | Unit | Infrastructure | Serializers | quest-result', function () {
+  it('#serialize', function () {
+    // given
+    const questResult = new QuestResult({
+      id: 1,
+      obtained: true,
+      reward: new Attestation({ id: 10, key: 'MY_KEY', templateName: 'my-key', createdAt: new Date('2020-10-10') }),
+    });
+
+    // when
+    const serializedQuestResult = questResultSerializer.serialize(questResult);
+
+    // then
+    expect(serializedQuestResult).to.deep.equal({
+      data: {
+        type: 'quest-results',
+        id: '1',
+        attributes: {
+          obtained: true,
+          reward: { id: 10, templateName: 'my-key', key: 'MY_KEY', createdAt: new Date('2020-10-10') },
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
On a besoin d'afficher en fin de parcours un nouveau bloc pour informer l'utilisateur le statut de son attestation (ontenu, non obtenu, en cours de calcul). On a besoin que l'API nous fournisse un endpoint pour savoir si on doit afficher ce bloc ou non.

## :robot: Proposition
On propose d'ajouter un endpoint `/api/campaign-participations/{campaignParticipationId}/quest-results` qui prends la campaignParticipationId en params et qui utilise le userId de l'utilisateur connecté

## :rainbow: Remarques
On a ajouté une API interne `reward-api` 
On a crée un prehandler qui vérifie que la campaignParticipation passée dans l'url appartient bien à l'utilisateur connecté

## :100: Pour tester
🤔 
Tests Ok ? ✅ 
