### PR TITLE
[FEATURE] Convertir les sessions et les centres de certification à la version 3 (PIX-14429).

### DIFF
--- a/api/scripts/certification/next-gen/convert-all-centers-to-v3.js
+++ b/api/scripts/certification/next-gen/convert-all-centers-to-v3.js
@@ -1,0 +1,42 @@
+import 'dotenv/config';
+
+import * as url from 'node:url';
+
+import { disconnect as disconnectFromDb } from '../../../db/knex-database-connection.js';
+import { usecases } from '../../../src/certification/configuration/domain/usecases/index.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
+
+/**
+ * Usage: DRY_RUN=true node scripts/certification/next-gen/convert-all-centers-to-v3.js <file.csv>
+ * file.csv is a csv file containing a single id column to specify certification center ids we want to preserve
+ * ie. these centers will not be converted to v3
+ **/
+
+const modulePath = url.fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === modulePath;
+
+async function main({ isDryRun, dependencies }) {
+  await dependencies.convertSessionsWithNoCoursesToV3({ isDryRun });
+  return 0;
+}
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    let exitCode = 0;
+    try {
+      const isDryRun = process.env.DRY_RUN === 'true';
+      logger.info(`Converting centers to v3...`);
+      await main({ isDryRun, dependencies: usecases });
+      logger.info(`Converting centers to v3 successfully!`);
+    } catch (error) {
+      logger.error(error, `Error while converting centers to v3`);
+      exitCode = 1;
+    } finally {
+      await disconnectFromDb();
+      // eslint-disable-next-line n/no-process-exit
+      process.exit(exitCode);
+    }
+  }
+})();
+
+export { main };

--- a/api/src/certification/configuration/domain/usecases/convert-centers-to-v3.js
+++ b/api/src/certification/configuration/domain/usecases/convert-centers-to-v3.js
@@ -13,6 +13,9 @@ import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 export async function convertCentersToV3({ isDryRun, preservedCenterIds, centerRepository }) {
   if (isDryRun) {
     logger.info('Dry run requested, no centers are actually converted');
+    const centerIdsToConvert = await centerRepository.findV2CenterIds({ preservedCenterIds });
+    logger.info(`${centerIdsToConvert.length} centers would have been converted`);
+    logger.info(`Following centers would have been converted: ${centerIdsToConvert}`);
     return;
   }
   const convertedCentersCount = await centerRepository.updateCentersToV3({ preservedCenterIds });

--- a/api/src/certification/configuration/domain/usecases/convert-centers-to-v3.js
+++ b/api/src/certification/configuration/domain/usecases/convert-centers-to-v3.js
@@ -1,5 +1,15 @@
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
+/**
+ * @typedef {import ('./index.js').CentersRepository} CentersRepository
+ */
 
+/**
+ * @param {Object} params
+ * @param {boolean} params.isDryRun
+ * @param {preservedCenterIds} params.preservedCenterIds
+ * @param {CentersRepository} params.centerRepository
+ * @returns {Promise<void>}
+ */
 export async function convertCentersToV3({ isDryRun, preservedCenterIds, centerRepository }) {
   if (isDryRun) {
     logger.info('Dry run requested, no centers are actually converted');

--- a/api/src/certification/configuration/domain/usecases/convert-centers-to-v3.js
+++ b/api/src/certification/configuration/domain/usecases/convert-centers-to-v3.js
@@ -1,0 +1,10 @@
+import { logger } from '../../../../shared/infrastructure/utils/logger.js';
+
+export async function convertCentersToV3({ isDryRun, preservedCenterIds, centerRepository }) {
+  if (isDryRun) {
+    logger.info('Dry run requested, no centers are actually converted');
+    return;
+  }
+  const convertedCentersCount = await centerRepository.updateCentersToV3({ preservedCenterIds });
+  logger.info(`${convertedCentersCount} centers successfully converted to v3`);
+}

--- a/api/src/certification/configuration/domain/usecases/convert-sessions-with-no-courses-to-v3.js
+++ b/api/src/certification/configuration/domain/usecases/convert-sessions-with-no-courses-to-v3.js
@@ -3,6 +3,9 @@ import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 export async function convertSessionsWithNoCoursesToV3({ isDryRun, sessionsRepository }) {
   if (isDryRun) {
     logger.info('Dry run requested, no sessions are actually converted');
+    const sessionIdsToConvert = await sessionsRepository.findV2SessionIdsWithNoCourses();
+    logger.info(`${sessionIdsToConvert.length} sessions would have been converted`);
+    logger.info(`Following sessions would have been converted: ${sessionIdsToConvert}`);
     return;
   }
   const convertedSessionsCount = await sessionsRepository.updateV2SessionsWithNoCourses();

--- a/api/src/certification/configuration/domain/usecases/convert-sessions-with-no-courses-to-v3.js
+++ b/api/src/certification/configuration/domain/usecases/convert-sessions-with-no-courses-to-v3.js
@@ -1,0 +1,10 @@
+import { logger } from '../../../../shared/infrastructure/utils/logger.js';
+
+export async function convertSessionsWithNoCoursesToV3({ isDryRun, sessionsRepository }) {
+  if (isDryRun) {
+    logger.info('Dry run requested, no sessions are actually converted');
+    return;
+  }
+  const convertedSessionsCount = await sessionsRepository.updateV2SessionsWithNoCourses();
+  logger.info(`${convertedSessionsCount} sessions successfully converted to v3`);
+}

--- a/api/src/certification/configuration/infrastructure/repositories/center-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/center-repository.js
@@ -69,3 +69,18 @@ export const updateCentersToV3 = async ({ preservedCenterIds }) => {
 
   return results.length;
 };
+
+/**
+ * @param {Object} params
+ * @param {Array<number>} params.preservedCenterIds
+ * @returns {Promise<Array<number>>} v2 center ids excluding preservedCenterIds
+ */
+export const findV2CenterIds = async ({ preservedCenterIds }) => {
+  const knexConn = DomainTransaction.getConnection();
+  const centers = await knexConn('certification-centers')
+    .select('id')
+    .where({ isV3Pilot: false })
+    .whereNotIn('id', preservedCenterIds);
+
+  return centers.map(({ id }) => id);
+};

--- a/api/src/certification/configuration/infrastructure/repositories/center-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/center-repository.js
@@ -54,3 +54,18 @@ export const resetWhitelist = async () => {
     .update({ isScoBlockedAccessWhitelist: false, updatedAt: knexConn.fn.now() })
     .where({ type: CenterTypes.SCO });
 };
+
+/**
+ * @param {Object} params
+ * @param {Array<number>} params.preservedCenterIds
+ * @returns {Promise<number>} updated centers count
+ */
+export const updateCentersToV3 = async ({ preservedCenterIds }) => {
+  const knexConn = DomainTransaction.getConnection();
+  const results = await knexConn('certification-centers')
+    .update({ isV3Pilot: true, updatedAt: knexConn.fn.now() }, ['id'])
+    .where({ isV3Pilot: false })
+    .whereNotIn('id', preservedCenterIds);
+
+  return results.length;
+};

--- a/api/src/certification/configuration/infrastructure/repositories/sessions-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/sessions-repository.js
@@ -45,3 +45,22 @@ export const deleteUnstartedSession = async function ({ sessionId, sessionsApi }
     throw error;
   }
 };
+
+/**
+ * @returns {Promise<number>} updated sessions count
+ */
+export const updateV2SessionsWithNoCourses = async function () {
+  const knexConn = DomainTransaction.getConnection();
+
+  const updatedSessions = await knexConn('sessions')
+    .update({ version: 3 }, ['id'])
+    .whereIn('id', function () {
+      this.select('sessions.id')
+        .from('sessions')
+        .leftJoin('certification-courses', 'sessions.id', 'certification-courses.sessionId')
+        .where('sessions.version', '=', 2)
+        .whereNull('certification-courses.sessionId');
+    });
+
+  return updatedSessions.length;
+};

--- a/api/src/certification/configuration/infrastructure/repositories/sessions-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/sessions-repository.js
@@ -66,3 +66,24 @@ export const updateV2SessionsWithNoCourses = async function () {
 
   return updatedSessions.length;
 };
+
+/**
+ * @returns {Promise<Array<number>>} ids of v2 sessions with no courses
+ */
+export const findV2SessionIdsWithNoCourses = async function () {
+  const knexConn = DomainTransaction.getConnection();
+
+  const sessions = await knexConn('sessions')
+    .select('id')
+    .whereIn('id', function () {
+      this.select('sessions.id')
+        .from('sessions')
+        .leftJoin('certification-courses', 'sessions.id', 'certification-courses.sessionId')
+        .where('sessions.version', 2)
+        .whereNull('certification-courses.sessionId')
+        .join('certification-centers', 'certification-centers.id', 'sessions.certificationCenterId')
+        .where('certification-centers.isV3Pilot', true);
+    });
+
+  return sessions.map(({ id }) => id);
+};

--- a/api/src/certification/configuration/infrastructure/repositories/sessions-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/sessions-repository.js
@@ -58,8 +58,10 @@ export const updateV2SessionsWithNoCourses = async function () {
       this.select('sessions.id')
         .from('sessions')
         .leftJoin('certification-courses', 'sessions.id', 'certification-courses.sessionId')
-        .where('sessions.version', '=', 2)
-        .whereNull('certification-courses.sessionId');
+        .where('sessions.version', 2)
+        .whereNull('certification-courses.sessionId')
+        .join('certification-centers', 'certification-centers.id', 'sessions.certificationCenterId')
+        .where('certification-centers.isV3Pilot', true);
     });
 
   return updatedSessions.length;

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/center-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/center-repository_test.js
@@ -196,4 +196,37 @@ describe('Certification | Configuration | Integration | Repository | center-repo
       expect(updatedCenter.isScoBlockedAccessWhitelist).to.be.true;
     });
   });
+
+  describe('#updateCentersToV3', function () {
+    it('should set isV3Pilot to true for v2 centers', async function () {
+      const v2Center = databaseBuilder.factory.buildCertificationCenter({
+        isV3Pilot: false,
+      });
+      await databaseBuilder.commit();
+
+      const count = await centerRepository.updateCentersToV3({ preservedCenterIds: [] });
+
+      const updatedCenter = await knex('certification-centers').where({ id: v2Center.id }).first();
+      expect(updatedCenter.isV3Pilot).to.be.true;
+      expect(count).to.equal(1);
+    });
+
+    it('should avoid setting isV3Pilot to true for v2 centers of preservedCenterIds', async function () {
+      const v2Center = databaseBuilder.factory.buildCertificationCenter({
+        isV3Pilot: false,
+      });
+      const v2CenterToPreserve = databaseBuilder.factory.buildCertificationCenter({
+        isV3Pilot: false,
+      });
+      await databaseBuilder.commit();
+
+      await centerRepository.updateCentersToV3({ preservedCenterIds: [v2CenterToPreserve.id] });
+
+      const updatedCenter = await knex('certification-centers').where({ id: v2Center.id }).first();
+      expect(updatedCenter.isV3Pilot).to.be.true;
+
+      const preservedCenter = await knex('certification-centers').where({ id: v2CenterToPreserve.id }).first();
+      expect(preservedCenter.isV3Pilot).to.be.false;
+    });
+  });
 });

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/center-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/center-repository_test.js
@@ -229,4 +229,20 @@ describe('Certification | Configuration | Integration | Repository | center-repo
       expect(preservedCenter.isV3Pilot).to.be.false;
     });
   });
+
+  describe('#findV2Centers', function () {
+    it('should avoid setting isV3Pilot to true for v2 centers of preservedCenterIds', async function () {
+      const v2Center = databaseBuilder.factory.buildCertificationCenter({
+        isV3Pilot: false,
+      });
+      const v2CenterToPreserve = databaseBuilder.factory.buildCertificationCenter({
+        isV3Pilot: false,
+      });
+      await databaseBuilder.commit();
+
+      const centerIds = await centerRepository.findV2CenterIds({ preservedCenterIds: [v2CenterToPreserve.id] });
+
+      expect(centerIds).to.deep.equal([v2Center.id]);
+    });
+  });
 });

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/sessions-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/sessions-repository_test.js
@@ -129,4 +129,34 @@ describe('Certification | Configuration | Integration | Repository | sessions-re
       });
     });
   });
+
+  describe('updateV2SessionsWithNoCourses', function () {
+    it('should update v2 sessions with no courses', async function () {
+      // given
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
+        isV3Pilot: false,
+      }).id;
+      const activeSessionId = databaseBuilder.factory.buildSession({
+        version: 2,
+        certificationCenterId,
+      }).id;
+      databaseBuilder.factory.buildCertificationCourse({ sessionId: activeSessionId });
+      const inactiveSessionId = databaseBuilder.factory.buildSession({
+        version: 2,
+        certificationCenterId,
+      }).id;
+      await databaseBuilder.commit();
+
+      // when
+      const count = await configurationRepositories.sessionsRepository.updateV2SessionsWithNoCourses();
+
+      // then
+      expect(count).to.equal(1);
+      const sessions = await knex('sessions').select('id', 'version').orderBy('version');
+      expect(sessions).to.deep.equal([
+        { id: activeSessionId, version: 2 },
+        { id: inactiveSessionId, version: 3 },
+      ]);
+    });
+  });
 });

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/sessions-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/sessions-repository_test.js
@@ -187,4 +187,35 @@ describe('Certification | Configuration | Integration | Repository | sessions-re
       ]);
     });
   });
+
+  describe('findV2SessionIdsWithNoCourses', function () {
+    it('should return v2 session ids with no courses of v3 centers', async function () {
+      // given
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
+        isV3Pilot: true,
+      }).id;
+      const activeSessionId = databaseBuilder.factory.buildSession({
+        version: 2,
+        certificationCenterId,
+      }).id;
+      databaseBuilder.factory.buildCertificationCourse({ sessionId: activeSessionId });
+      const inactiveSessionId = databaseBuilder.factory.buildSession({
+        version: 2,
+        certificationCenterId,
+      }).id;
+      const v2CertificationCenterId = databaseBuilder.factory.buildCertificationCenter({
+        isV2Pilot: true,
+      }).id;
+      databaseBuilder.factory.buildSession({
+        version: 2,
+        certificationCenterId: v2CertificationCenterId,
+      }).id;
+      await databaseBuilder.commit();
+
+      // when
+      const sessionIds = await configurationRepositories.sessionsRepository.findV2SessionIdsWithNoCourses();
+
+      expect(sessionIds).to.deep.equal([inactiveSessionId]);
+    });
+  });
 });

--- a/api/tests/certification/configuration/unit/domain/usecases/convert-centers-to-v3_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/convert-centers-to-v3_test.js
@@ -1,0 +1,34 @@
+import { convertCentersToV3 } from '../../../../../../src/certification/configuration/domain/usecases/convert-centers-to-v3.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+
+describe('Certification | Configuration | Unit | UseCase | convert-centers-to-v3', function () {
+  it('should update v2 certification courses to v3', async function () {
+    const centerRepository = {
+      updateCentersToV3: sinon.stub().resolves(),
+    };
+    const preservedCenterIds = ['123'];
+    await convertCentersToV3({
+      isDryRun: false,
+      preservedCenterIds,
+      centerRepository,
+    });
+
+    expect(centerRepository.updateCentersToV3).to.have.been.calledWithExactly({ preservedCenterIds });
+  });
+
+  context('when isDryRun is true', function () {
+    it('should skip update', async function () {
+      const centerRepository = {
+        updateCentersToV3: sinon.stub().resolves(),
+      };
+      const preservedCenterIds = ['123'];
+      await convertCentersToV3({
+        isDryRun: true,
+        preservedCenterIds,
+        centerRepository,
+      });
+
+      expect(centerRepository.updateCentersToV3).not.to.have.been.called;
+    });
+  });
+});

--- a/api/tests/certification/configuration/unit/domain/usecases/convert-centers-to-v3_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/convert-centers-to-v3_test.js
@@ -20,6 +20,7 @@ describe('Certification | Configuration | Unit | UseCase | convert-centers-to-v3
     it('should skip update', async function () {
       const centerRepository = {
         updateCentersToV3: sinon.stub().resolves(),
+        findV2CenterIds: sinon.stub().resolves(['v2CenterId']),
       };
       const preservedCenterIds = ['123'];
       await convertCentersToV3({
@@ -29,6 +30,7 @@ describe('Certification | Configuration | Unit | UseCase | convert-centers-to-v3
       });
 
       expect(centerRepository.updateCentersToV3).not.to.have.been.called;
+      expect(centerRepository.findV2CenterIds).to.have.been.calledWithExactly({ preservedCenterIds });
     });
   });
 });

--- a/api/tests/certification/configuration/unit/domain/usecases/convert-sessions-with-no-courses-to-v3_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/convert-sessions-with-no-courses-to-v3_test.js
@@ -16,11 +16,13 @@ describe('Certification | Configuration | Unit | UseCase | convert-sessions-with
     it('should skip update', async function () {
       const sessionsRepository = {
         updateV2SessionsWithNoCourses: sinon.stub().resolves(),
+        findV2SessionIdsWithNoCourses: sinon.stub().resolves(['123']),
       };
 
       await convertSessionsWithNoCoursesToV3({ isDryRun: true, sessionsRepository });
 
       expect(sessionsRepository.updateV2SessionsWithNoCourses).not.to.have.been.called;
+      expect(sessionsRepository.findV2SessionIdsWithNoCourses).to.have.been.calledOnceWith();
     });
   });
 });

--- a/api/tests/certification/configuration/unit/domain/usecases/convert-sessions-with-no-courses-to-v3_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/convert-sessions-with-no-courses-to-v3_test.js
@@ -1,0 +1,26 @@
+import { convertSessionsWithNoCoursesToV3 } from '../../../../../../src/certification/configuration/domain/usecases/convert-sessions-with-no-courses-to-v3.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+
+describe('Certification | Configuration | Unit | UseCase | convert-sessions-with-no-courses-to-v3', function () {
+  it('should update v2 sessions with no certification courses to v3', async function () {
+    const sessionsRepository = {
+      updateV2SessionsWithNoCourses: sinon.stub().resolves(),
+    };
+
+    await convertSessionsWithNoCoursesToV3({ isDryRun: false, sessionsRepository });
+
+    expect(sessionsRepository.updateV2SessionsWithNoCourses).to.have.been.calledOnceWith();
+  });
+
+  context('when isDryRun is true', function () {
+    it('should skip update', async function () {
+      const sessionsRepository = {
+        updateV2SessionsWithNoCourses: sinon.stub().resolves(),
+      };
+
+      await convertSessionsWithNoCoursesToV3({ isDryRun: true, sessionsRepository });
+
+      expect(sessionsRepository.updateV2SessionsWithNoCourses).not.to.have.been.called;
+    });
+  });
+});

--- a/api/tests/integration/scripts/certification/next-gen/convert-all-centers-to-v3_test.js
+++ b/api/tests/integration/scripts/certification/next-gen/convert-all-centers-to-v3_test.js
@@ -2,13 +2,31 @@ import { main } from '../../../../../scripts/certification/next-gen/convert-all-
 import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Scripts | Certification | convert-centers-to-v3', function () {
-  it('should save call convertSessionsWithNoCoursesToV3 usecase', async function () {
+  it('should call convertSessionsWithNoCoursesToV3 usecase', async function () {
     const dependencies = {
       convertSessionsWithNoCoursesToV3: sinon.stub().resolves(),
+      convertCentersToV3: sinon.stub().resolves(),
     };
-    await main({ dependencies });
+    const isDryRun = Symbol('isDryRun');
+    await main({ isDryRun, dependencies });
 
     // then
-    expect(dependencies.convertSessionsWithNoCoursesToV3).to.have.been.calledOnce;
+    expect(dependencies.convertSessionsWithNoCoursesToV3).to.have.been.calledOnceWith({ isDryRun });
+  });
+
+  it('should call convertCentersToV3 usecase', async function () {
+    const dependencies = {
+      convertSessionsWithNoCoursesToV3: sinon.stub().resolves(),
+      convertCentersToV3: sinon.stub().resolves(),
+    };
+    const isDryRun = Symbol('isDryRun');
+    const preservedCenterIds = Symbol('preservedCenterIds');
+    await main({ isDryRun, preservedCenterIds, dependencies });
+
+    // then
+    expect(dependencies.convertCentersToV3).to.have.been.calledOnceWith({
+      isDryRun,
+      preservedCenterIds,
+    });
   });
 });

--- a/api/tests/integration/scripts/certification/next-gen/convert-all-centers-to-v3_test.js
+++ b/api/tests/integration/scripts/certification/next-gen/convert-all-centers-to-v3_test.js
@@ -1,0 +1,14 @@
+import { main } from '../../../../../scripts/certification/next-gen/convert-all-centers-to-v3.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Integration | Scripts | Certification | convert-centers-to-v3', function () {
+  it('should save call convertSessionsWithNoCoursesToV3 usecase', async function () {
+    const dependencies = {
+      convertSessionsWithNoCoursesToV3: sinon.stub().resolves(),
+    };
+    await main({ dependencies });
+
+    // then
+    expect(dependencies.convertSessionsWithNoCoursesToV3).to.have.been.calledOnce;
+  });
+});


### PR DESCRIPTION
## :fallen_leaf: Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

La généralisation de la nouvelle certification Pix a été annoncée pour le 4/11. A partir de cette date, toutes les sessions de certification et les centres de certification doivent utiliser la version 3.
Un script doit donc être lancé pour transformer tous les centres de certif en “isV3Pilot”.

## :chestnut: Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

Le script en question change la valeur de `isV3Pilot` à `true` pour tous les centres de certification actuellement en v2.
Afin de traiter le cas des centres de certifications faisant encore des certifications v2 dans la semaine d'intervalle (entre le 28/10 et le 04/11), un fichier csv contenant les identifiants des centres à préserver en v2 peut être passer en paramètre du script.
Le script convertit également les sessions sans `certification-courses` à la version 3.

## :jack_o_lantern: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :wood: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

Exécuter le script sur la review app en faisant `node ./scripts/certification/next-gen/convert-centers-to-v3.js /path/to/certification-center-ids.csv`

A tester sur l'appli déployée par les captains :

`scalingo --region <REGION> -a <APPLI> run --file="<PATH_LOCAL_CSV>" "node ./scripts/certification/next-gen/convert-centers-to-v3.js /tmp/uploads/<CSV_NAME>"`
