### PR TITLE
[BUGFIX] récupère le idpixlabel depuis la feature avant de démarrer une participation (pix-14873)

### DIFF
--- a/api/src/prescription/campaign-participation/domain/models/CampaignToStartParticipation.js
+++ b/api/src/prescription/campaign-participation/domain/models/CampaignToStartParticipation.js
@@ -4,6 +4,7 @@ class CampaignToStartParticipation {
   constructor({
     id,
     idPixLabel,
+    idPixType,
     archivedAt,
     type,
     isManagingStudents,
@@ -17,6 +18,7 @@ class CampaignToStartParticipation {
     this.id = id;
     this.type = type;
     this.idPixLabel = idPixLabel;
+    this.idPixType = idPixType;
     this.archivedAt = archivedAt;
     this.multipleSendings = multipleSendings;
     this.assessmentMethod = assessmentMethod;


### PR DESCRIPTION
 ## :unicorn: Problème
Dans la PR #10254, on a oublié de modifier la participation à une campagne pour récupérer l'idPixLabel depuis la table campaign-feature.

## :robot: Proposition
On récupère le champ depuis la bonne table

## :rainbow: Remarques
RAS

## :100: Pour tester
- CI verte
