### PR TITLE
[TECH]  insere les idPixLabel dans la table campaign-features lors des seed (pix-14874)

### DIFF
--- a/api/db/database-builder/factory/build-campaign.js
+++ b/api/db/database-builder/factory/build-campaign.js
@@ -11,7 +11,7 @@ const buildCampaign = function ({
   name = 'Name',
   code,
   title = 'Title',
-  idPixLabel = 'IdPixLabel',
+  idPixLabel,
   externalIdHelpImageUrl = null,
   alternativeTextToExternalIdHelpImage = null,
   customLandingPageText = 'Some landing page text ',

--- a/api/db/seeds/data/common/tooling/campaign-tooling.js
+++ b/api/db/seeds/data/common/tooling/campaign-tooling.js
@@ -1,10 +1,14 @@
 import dayjs from 'dayjs';
 import _ from 'lodash';
 
-import { CampaignParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
+import {
+  CampaignExternalIdTypes,
+  CampaignParticipationStatuses,
+} from '../../../../../src/prescription/shared/domain/constants.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import { KnowledgeElement } from '../../../../../src/shared/domain/models/KnowledgeElement.js';
 import { getPlacementProfile } from '../../../../../src/shared/domain/services/placement-profile-service.js';
+import { FEATURE_CAMPAIGN_EXTERNAL_ID } from '../constants.js';
 import * as generic from './generic.js';
 import * as learningContent from './learning-content.js';
 import * as profileTooling from './profile-tooling.js';
@@ -442,7 +446,6 @@ function _buildCampaign({
     name,
     code,
     title,
-    idPixLabel,
     externalIdHelpImageUrl,
     alternativeTextToExternalIdHelpImage,
     customLandingPageText,
@@ -461,6 +464,13 @@ function _buildCampaign({
     multipleSendings,
     assessmentMethod,
   });
+  if (idPixLabel) {
+    databaseBuilder.factory.buildCampaignFeature({
+      campaignId: realCampaignId,
+      featureId: FEATURE_CAMPAIGN_EXTERNAL_ID,
+      params: { type: CampaignExternalIdTypes.STRING, label: idPixLabel },
+    });
+  }
   return { realCampaignId, realOrganizationId, realCreatedAt };
 }
 

--- a/api/db/seeds/data/team-certification/data-builder.js
+++ b/api/db/seeds/data/team-certification/data-builder.js
@@ -584,6 +584,7 @@ async function _createComplementaryCertificationCampaign({ databaseBuilder }) {
       targetProfileId,
       name: 'Campagne evaluation team-certif',
       code: campaignCode,
+      idPixLabel: 'IdPixLabel',
       title: 'Campagne evaluation team-certif',
       configCampaign: {
         participantCount: 0,

--- a/api/db/seeds/data/team-devcomp/build-campaigns.js
+++ b/api/db/seeds/data/team-devcomp/build-campaigns.js
@@ -9,6 +9,7 @@ async function _createScoCampaigns(databaseBuilder, trainingIds) {
     ownerId: USER_ID_ADMIN_ORGANIZATION,
     name: 'PIX+ EDU - SCO - envoi simple',
     code: 'EDUSIMPLE',
+    idPixLabel: 'IdPixLabel',
     targetProfileId: PIX_EDU_SMALL_TARGET_PROFILE_ID,
     configCampaign: {
       participantCount: 3,
@@ -22,6 +23,7 @@ async function _createScoCampaigns(databaseBuilder, trainingIds) {
     ownerId: USER_ID_ADMIN_ORGANIZATION,
     name: 'PIX+ EDU - SCO- envoi multiple',
     code: 'EDUMULTIP',
+    idPixLabel: 'IdPixLabel',
     multipleSendings: true,
     targetProfileId: PIX_EDU_SMALL_TARGET_PROFILE_ID,
     configCampaign: {

--- a/api/db/seeds/data/team-prescription/build-campaigns.js
+++ b/api/db/seeds/data/team-prescription/build-campaigns.js
@@ -20,6 +20,7 @@ async function _createScoCampaigns(databaseBuilder) {
     ownerId: USER_ID_ADMIN_ORGANIZATION,
     name: "Campagne d'évaluation SCO",
     code: 'SCOASSIMP',
+    idPixLabel: 'IdPixLabel',
     createdAt: dayjs().subtract(30, 'days').toDate(),
     configCampaign: {
       participantCount: 10,
@@ -39,6 +40,7 @@ async function _createScoCampaigns(databaseBuilder) {
     ownerId: USER_ID_ADMIN_ORGANIZATION,
     name: "Campagne d'évaluation SCO envoi multiple",
     code: 'SCOASSMUL',
+    idPixLabel: 'IdPixLabel',
     multipleSendings: true,
     createdAt: dayjs().subtract(30, 'days').toDate(),
     configCampaign: {
@@ -60,6 +62,7 @@ async function _createScoCampaigns(databaseBuilder) {
     multipleSendings: true,
     type: 'PROFILES_COLLECTION',
     code: 'SCOCOLMUL',
+    idPixLabel: 'IdPixLabel',
     title: null,
     configCampaign: { participantCount: 3, profileDistribution: { beginner: 1, perfect: 1, blank: 1 } },
   });
@@ -73,6 +76,7 @@ async function _createSupCampaigns(databaseBuilder) {
     ownerId: USER_ID_ADMIN_ORGANIZATION,
     name: "Campagne d'évaluation SUP",
     code: 'SUPASSIMP',
+    idPixLabel: 'IdPixLabel',
     createdAt: dayjs().subtract(30, 'days').toDate(),
     configCampaign: {
       participantCount: 10,
@@ -92,6 +96,7 @@ async function _createSupCampaigns(databaseBuilder) {
     ownerId: USER_ID_ADMIN_ORGANIZATION,
     name: "Campagne d'évaluation SUP envoi multiple",
     code: 'SUPASSMUL',
+    idPixLabel: 'IdPixLabel',
     multipleSendings: true,
     createdAt: dayjs().subtract(30, 'days').toDate(),
     configCampaign: {
@@ -111,6 +116,7 @@ async function _createSupCampaigns(databaseBuilder) {
     ownerId: USER_ID_ADMIN_ORGANIZATION,
     name: 'Campagne de collecte de profil SUP',
     code: 'SUPCOLMUL',
+    idPixLabel: 'IdPixLabel',
     multipleSendings: true,
     type: 'PROFILES_COLLECTION',
     title: null,
@@ -126,6 +132,7 @@ async function _createProGenericCampaigns(databaseBuilder) {
     name: 'Campagne de collecte de profil PRO',
     multipleSendings: true,
     code: 'PROGENCOL',
+    idPixLabel: 'IdPixLabel',
     type: 'PROFILES_COLLECTION',
     title: null,
   });
@@ -139,6 +146,7 @@ async function _createProCampaigns(databaseBuilder) {
     name: 'Campagne de collecte de profil PRO',
     multipleSendings: true,
     code: 'PROCOLMUL',
+    idPixLabel: 'IdPixLabel',
     type: 'PROFILES_COLLECTION',
     title: null,
     configCampaign: { participantCount: 3, profileDistribution: { beginner: 1, perfect: 1, blank: 1 } },
@@ -152,6 +160,7 @@ async function _createProCampaigns(databaseBuilder) {
     isForAbsoluteNovice: true,
     name: "Campagne d'évaluation PRO",
     code: 'PROASSIMP',
+    idPixLabel: 'IdPixLabel',
     createdAt: dayjs().subtract(30, 'days').toDate(),
     configCampaign: {
       participantCount: 10,
@@ -172,6 +181,7 @@ async function _createProCampaigns(databaseBuilder) {
     ownerId: USER_ID_ADMIN_ORGANIZATION,
     name: "Campagne d'évaluation PRO envoi multiple",
     code: 'PROASSMUL',
+    idPixLabel: 'IdPixLabel',
     multipleSendings: true,
     createdAt: dayjs().subtract(30, 'days').toDate(),
     configCampaign: {

--- a/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
@@ -175,7 +175,6 @@ describe('Integration | Repository | Campaign', function () {
         'createdAt',
         'archivedAt',
         'customLandingPageText',
-        'idPixLabel',
         'externalIdHelpImageUrl',
         'alternativeTextToExternalIdHelpImage',
         'title',

--- a/api/tests/prescription/campaign/integration/domain/usecases/update-campaign-details_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/update-campaign-details_test.js
@@ -33,6 +33,7 @@ describe('Integration | UseCases | update-campaign-details', function () {
       organizationId,
       multipleSendings: false,
       isForAbsoluteNovice: false,
+      idPixLabel: null,
     });
 
     campaignId = campaign.id;

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-administration-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-administration-repository_test.js
@@ -42,8 +42,8 @@ describe('Integration | Repository | Campaign Administration', function () {
 
     it('should return campaigns for given ids', async function () {
       // given
-      const firstCampaign = new Campaign(databaseBuilder.factory.buildCampaign());
-      const secondCampaign = new Campaign(databaseBuilder.factory.buildCampaign());
+      const firstCampaign = new Campaign(databaseBuilder.factory.buildCampaign({ idPixLabel: null }));
+      const secondCampaign = new Campaign(databaseBuilder.factory.buildCampaign({ idPixLabel: null }));
       databaseBuilder.factory.buildCampaign();
 
       await databaseBuilder.commit();


### PR DESCRIPTION
## :unicorn: Problème
Suite au travail entamé dans la PR  #10254 , les seed ne sont plus bons. car on insère toujours les `idPixlabel` dans la table `campaigns`

## :robot: Proposition
On corrige les seeds pour qu'il insère les idPixLabel dans la table `campaign-feature`

## :rainbow: Remarques
Certains tests ont été modifiés car comme le champ `idPixLabel` est toujours présent dans la table `campaigns` on se retrouve avec un champ à `null`.

## :100: Pour tester
CI verte
