### PR TITLE
[BUGFIX] Éviter la création mutltiple de lot de place lors du clique sur le bouton valider (PIX-14821)

### DIFF
--- a/admin/app/components/organizations/places-lot-creation-form.gjs
+++ b/admin/app/components/organizations/places-lot-creation-form.gjs
@@ -32,6 +32,7 @@ export default class PlacesLotCreationForm extends Component {
   @tracked expirationDate;
   @tracked category;
   @tracked reference;
+  @tracked isLoading = false;
 
   constructor() {
     super(...arguments);
@@ -43,13 +44,18 @@ export default class PlacesLotCreationForm extends Component {
   async onSubmit(event) {
     event.preventDefault();
 
-    this.args.create({
+    if (this.isLoading) return;
+
+    this.isLoading = true;
+
+    await this.args.create({
       count: this.count,
       activationDate: this.activationDate,
       expirationDate: this.expirationDate ? this.expirationDate : null,
       category: this.category,
       reference: this.reference,
     });
+    this.isLoading = false;
   }
 
   @action
@@ -151,7 +157,7 @@ export default class PlacesLotCreationForm extends Component {
             >
               {{t "common.actions.cancel"}}
             </PixButtonLink>
-            <PixButton @type="submit" @size="small" @variant="success">
+            <PixButton @type="submit" @size="small" @variant="success" @isLoading={{this.isLoading}}>
               {{t "common.actions.add"}}
             </PixButton>
           </div>

--- a/admin/tests/integration/components/organizations/places-lot-creation-form-test.gjs
+++ b/admin/tests/integration/components/organizations/places-lot-creation-form-test.gjs
@@ -1,4 +1,4 @@
-import { clickByName, fillByLabel, render } from '@1024pix/ember-testing-library';
+import { fillByLabel, render } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
 import PlacesLotCreationForm from 'pix-admin/components/organizations/places-lot-creation-form';
 import { module, test } from 'qunit';
@@ -24,14 +24,39 @@ module('Integration | Component | organizations/places-lot-creation-form', funct
 
     await click(select);
 
-    await screen.findByRole('listbox');
-
-    await click(screen.getByRole('option', { name: 'Tarif gratuit' }));
+    await click(await screen.findByRole('option', { name: 'Tarif gratuit' }));
 
     await fillByLabel('* Référence :', '123ABC');
-    await clickByName('Ajouter');
+    await click(screen.getByRole('button', { name: 'Ajouter' }));
     // then
     sinon.assert.calledOnce(create);
     assert.ok(true);
+  });
+
+  test('Should cannot click twice on validate button', async function (assert) {
+    // given
+    const create = sinon.stub().returns(new Promise(() => {}));
+
+    const screen = await render(<template><PlacesLotCreationForm @create={{create}} /></template>);
+
+    // when
+    await fillByLabel('Nombre :', '10');
+    await fillByLabel("* Date d'activation :", '2022-10-20');
+    await fillByLabel("Date d'expiration :", '2022-12-20');
+
+    const select = screen.getByRole('button', { name: /Catégorie/ });
+
+    await click(select);
+
+    await screen.findByRole('listbox');
+
+    await click(await screen.findByRole('option', { name: 'Tarif gratuit' }));
+
+    await fillByLabel('* Référence :', '123ABC');
+    await click(screen.getByRole('button', { name: 'Ajouter' }));
+
+    assert.throws(function () {
+      screen.getByRole('button', { name: 'Ajouter' });
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
On peut moyennant une grande dextérité créer plusieurs lot de place

## :robot: Proposition
Ajouter un loading le temps que la création se fasse permettant ainsi le non cliques sur le bouton valider

## :rainbow: Remarques
RAS

## :100: Pour tester
Tenter de reproduire ce bug requerant une grande dextérité