### PR TITLE
[FEATURE] Ajout d'une route pour récupérer les infos de début de parcours (PIX-14813).

### DIFF
--- a/api/src/prescription/campaign/application/campaign-controller.js
+++ b/api/src/prescription/campaign/application/campaign-controller.js
@@ -3,6 +3,7 @@ import * as campaignAnalysisSerializer from '../../campaign-participation/infras
 import { usecases } from '../domain/usecases/index.js';
 import * as divisionSerializer from '../infrastructure/serializers/jsonapi/division-serializer.js';
 import * as groupSerializer from '../infrastructure/serializers/jsonapi/group-serializer.js';
+import * as presentationStepsSerializer from '../infrastructure/serializers/jsonapi/presentation-steps-serializer.js';
 
 const division = async function (request) {
   const { userId } = request.auth.credentials;
@@ -28,10 +29,24 @@ const getAnalysis = async function (request, h, dependencies = { campaignAnalysi
   return dependencies.campaignAnalysisSerializer.serialize(campaignAnalysis);
 };
 
+const getPresentationSteps = async function (
+  request,
+  _,
+  dependencies = { presentationStepsSerializer, extractLocaleFromRequest },
+) {
+  const { userId } = request.auth.credentials;
+  const campaignCode = request.params.campaignCode;
+  const locale = dependencies.extractLocaleFromRequest(request);
+
+  const presentationSteps = await usecases.getPresentationSteps({ userId, campaignCode, locale });
+  return dependencies.presentationStepsSerializer.serialize(presentationSteps);
+};
+
 const campaignController = {
   division,
   getAnalysis,
   getGroups,
+  getPresentationSteps,
 };
 
 export { campaignController };

--- a/api/src/prescription/campaign/application/campaign-route.js
+++ b/api/src/prescription/campaign/application/campaign-route.js
@@ -1,6 +1,7 @@
 import Joi from 'joi';
 
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { identifiersType as prescriptionIdentifiersType } from '../../shared/domain/types/identifiers-type.js';
 import { campaignController } from './campaign-controller.js';
 
 const register = async function (server) {
@@ -54,6 +55,23 @@ const register = async function (server) {
             "- Récupération de l'analyse de la campagne par son id",
         ],
         tags: ['api', 'campaign'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/campaigns/{campaignCode}/presentation-steps',
+      config: {
+        handler: campaignController.getPresentationSteps,
+        validate: {
+          params: Joi.object({
+            campaignCode: prescriptionIdentifiersType.campaignCode,
+          }),
+        },
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            '- Récupération des infos des écrans de présentation de début de parcours',
+        ],
+        tags: ['api', 'campaign', 'presentation'],
       },
     },
   ]);

--- a/api/src/prescription/campaign/domain/usecases/get-presentation-steps.js
+++ b/api/src/prescription/campaign/domain/usecases/get-presentation-steps.js
@@ -1,0 +1,35 @@
+import { CampaignCodeError, UserNotAuthorizedToAccessEntityError } from '../../../../shared/domain/errors.js';
+import { ArchivedCampaignError, DeletedCampaignError } from '../errors.js';
+
+const getPresentationSteps = async function ({
+  userId,
+  campaignCode,
+  locale,
+  badgeRepository,
+  campaignRepository,
+  learningContentRepository,
+}) {
+  const campaign = await campaignRepository.getByCode(campaignCode);
+
+  if (!campaign) throw new CampaignCodeError();
+  if (campaign.archivedAt) throw new ArchivedCampaignError();
+  if (campaign.deletedAt) throw new DeletedCampaignError();
+
+  const hasUserAccessToResult = await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(
+    campaign.id,
+    userId,
+  );
+  if (!hasUserAccessToResult)
+    throw new UserNotAuthorizedToAccessEntityError('User does not have access to this campaign');
+
+  const campaignBadges = await badgeRepository.findByCampaignId(campaign.id);
+  const learningContent = await learningContentRepository.findByCampaignId(campaign.id, locale);
+
+  return {
+    customLandingPageText: campaign.customLandingPageText,
+    badges: campaignBadges,
+    competences: learningContent?.competences,
+  };
+};
+
+export { getPresentationSteps };

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/presentation-steps-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/presentation-steps-serializer.js
@@ -1,0 +1,19 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (presentationSteps) {
+  return new Serializer('campaign-presentation-step', {
+    attributes: ['customLandingPageText', 'badges', 'competences'],
+    badges: {
+      ref: 'id',
+      attributes: ['altMessage', 'imageUrl', 'isAlwaysVisible', 'isCertifiable', 'key', 'message', 'title'],
+    },
+    competences: {
+      ref: 'id',
+      attributes: ['index', 'name'],
+    },
+  }).serialize(presentationSteps);
+};
+
+export { serialize };

--- a/api/src/prescription/shared/domain/types/identifiers-type.js
+++ b/api/src/prescription/shared/domain/types/identifiers-type.js
@@ -3,9 +3,13 @@ import Joi from 'joi';
 import { categories } from '../../../../shared/domain/models/TargetProfile.js';
 import { certificabilityByLabel } from '../../application/helpers.js';
 
+const identifiersType = {
+  campaignCode: Joi.string().min(9).max(9).required(),
+};
+
 const filterType = {
   certificability: Joi.string().valid(...Object.keys(certificabilityByLabel)),
   targetProfileCategory: Joi.string().valid(...Object.values(categories)),
 };
 
-export { filterType };
+export { filterType, identifiersType };

--- a/api/tests/prescription/campaign/integration/domain/usecases/get-presentation-steps_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/get-presentation-steps_test.js
@@ -1,0 +1,58 @@
+import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
+import { LOCALE } from '../../../../../../src/shared/domain/constants.js';
+import {
+  databaseBuilder,
+  domainBuilder,
+  expect,
+  learningContentBuilder,
+  mockLearningContent,
+} from '../../../../../test-helper.js';
+
+const { FRENCH_SPOKEN } = LOCALE;
+
+describe('Integration | Campaign | UseCase | get-presentation-steps', function () {
+  let user, campaign, badges, competences;
+
+  beforeEach(async function () {
+    const learningContent = domainBuilder.buildLearningContent.withSimpleContent();
+    const learningContentObjects = learningContentBuilder.fromAreas(learningContent.frameworks[0].areas);
+    mockLearningContent(learningContentObjects);
+
+    const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+
+    campaign = databaseBuilder.factory.buildCampaign({ targetProfileId });
+
+    user = databaseBuilder.factory.buildUser.withMembership({ organizationId: campaign.organizationId });
+
+    badges = [
+      databaseBuilder.factory.buildBadge({ targetProfileId }),
+      databaseBuilder.factory.buildBadge({ targetProfileId }),
+    ];
+
+    competences = learningContentObjects.competences;
+
+    databaseBuilder.factory.buildCampaignSkill({
+      campaignId: campaign.id,
+      skillId: competences[0].skillIds[0],
+    });
+
+    await databaseBuilder.commit();
+  });
+
+  it('should get campaign presentation steps content', async function () {
+    // when
+    const result = await usecases.getPresentationSteps({
+      userId: user.id,
+      campaignCode: campaign.code,
+      locale: FRENCH_SPOKEN,
+    });
+
+    // then
+    expect(result.customLandingPageText).to.equal(campaign.customLandingPageText);
+    expect(result.badges).to.deep.equal(badges);
+    expect(result.competences).to.have.lengthOf(competences.length);
+    expect(result.competences[0].id).to.equal(competences[0].id);
+    expect(result.competences[0].index).to.equal(competences[0].index);
+    expect(result.competences[0].name).to.equal(competences[0].name);
+  });
+});

--- a/api/tests/prescription/campaign/unit/application/campaign-controller_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-controller_test.js
@@ -60,4 +60,43 @@ describe('Unit | Application | Controller | Campaign', function () {
       expect(errorCatched).to.be.instanceof(UserNotAuthorizedToAccessEntityError);
     });
   });
+
+  describe('#getPresentationSteps', function () {
+    it('should return expected results', async function () {
+      // given
+      const userId = Symbol('userId');
+      const campaignCode = Symbol('campaign code');
+      const locale = FRENCH_SPOKEN;
+
+      sinon.stub(usecases, 'getPresentationSteps');
+
+      const dependencies = {
+        extractLocaleFromRequestStub: sinon.stub().returns(locale),
+        presentationStepsSerializerStub: {
+          serialize: sinon.stub(),
+        },
+      };
+
+      const presentationSteps = Symbol('presentation steps');
+      const expectedResults = Symbol('results');
+
+      usecases.getPresentationSteps.withArgs({ userId, campaignCode, locale }).resolves(presentationSteps);
+      dependencies.presentationStepsSerializerStub.serialize.withArgs(presentationSteps).returns(expectedResults);
+
+      const request = {
+        auth: { credentials: { userId } },
+        params: { campaignCode },
+        headers: { 'accept-language': locale },
+      };
+
+      // when
+      const response = await campaignController.getPresentationSteps(request, hFake, {
+        extractLocaleFromRequest: dependencies.extractLocaleFromRequestStub,
+        presentationStepsSerializer: dependencies.presentationStepsSerializerStub,
+      });
+
+      // then
+      expect(response).to.equal(expectedResults);
+    });
+  });
 });

--- a/api/tests/prescription/campaign/unit/domain/usecases/get-presentation-steps_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/get-presentation-steps_test.js
@@ -1,0 +1,138 @@
+import {
+  ArchivedCampaignError,
+  DeletedCampaignError,
+} from '../../../../../../src/prescription/campaign/domain/errors.js';
+import { getPresentationSteps } from '../../../../../../src/prescription/campaign/domain/usecases/get-presentation-steps.js';
+import { LOCALE } from '../../../../../../src/shared/domain/constants.js';
+import { CampaignCodeError, UserNotAuthorizedToAccessEntityError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErr, expect, sinon } from '../../../../../test-helper.js';
+
+const { FRENCH_SPOKEN } = LOCALE;
+
+describe('Unit | Domain | Use Cases | get-presentation-steps', function () {
+  let badgeRepository;
+  let campaignRepository;
+  let learningContentRepository;
+
+  const locale = FRENCH_SPOKEN;
+  const campaignCode = 'someCampaignCode';
+
+  beforeEach(function () {
+    badgeRepository = { findByCampaignId: sinon.stub() };
+    campaignRepository = {
+      getByCode: sinon.stub(),
+      checkIfUserOrganizationHasAccessToCampaign: sinon.stub(),
+    };
+    learningContentRepository = { findByCampaignId: sinon.stub() };
+  });
+
+  context('when campaign exists', function () {
+    context('when campaign is archived', function () {
+      it('should throw an error', async function () {
+        // given
+        campaignRepository.getByCode.withArgs(campaignCode).resolves({
+          archivedAt: new Date(),
+        });
+
+        // when
+        const error = await catchErr(getPresentationSteps)({
+          campaignCode,
+          locale,
+          campaignRepository,
+          badgeRepository,
+          learningContentRepository,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(ArchivedCampaignError);
+      });
+    });
+
+    context('when campaign is deleted', function () {
+      it('should throw an error', async function () {
+        // given
+        campaignRepository.getByCode.withArgs(campaignCode).resolves({
+          deletedAt: new Date(),
+        });
+
+        // when
+        const error = await catchErr(getPresentationSteps)({
+          campaignCode,
+          locale,
+          campaignRepository,
+          badgeRepository,
+          learningContentRepository,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(DeletedCampaignError);
+      });
+    });
+
+    context('when user does not have access to the campaign', function () {
+      it('should throw an error', async function () {
+        const userId = Symbol('user-id');
+        const campaignId = Symbol('campaign-id');
+
+        campaignRepository.getByCode.withArgs(campaignCode).resolves({ id: campaignId });
+        campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(false);
+
+        // when
+        const error = await catchErr(getPresentationSteps)({
+          userId,
+          campaignCode,
+          locale,
+          campaignRepository,
+          badgeRepository,
+          learningContentRepository,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
+      });
+    });
+
+    context('when everything is fine', function () {
+      it('should call badge and learning content repositories', async function () {
+        const userId = Symbol('user-id');
+        const campaignId = Symbol('campaign-id');
+
+        campaignRepository.getByCode.withArgs(campaignCode).resolves({ id: campaignId });
+        campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(true);
+
+        // when
+        await getPresentationSteps({
+          userId,
+          campaignCode,
+          locale,
+          campaignRepository,
+          badgeRepository,
+          learningContentRepository,
+        });
+
+        // then
+        expect(badgeRepository.findByCampaignId).to.have.been.calledOnce;
+        expect(learningContentRepository.findByCampaignId).to.have.been.calledOnce;
+      });
+    });
+  });
+
+  context('when campaign does not exist', function () {
+    it('should throw an error', async function () {
+      // given
+      campaignRepository.getByCode.withArgs(campaignCode).resolves(null);
+
+      // when
+      const error = await catchErr(getPresentationSteps)({
+        campaignCode,
+        locale,
+        campaignRepository,
+        badgeRepository,
+        learningContentRepository,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(CampaignCodeError);
+    });
+  });
+});

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/presentation-steps-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/presentation-steps-serializer_test.js
@@ -1,0 +1,102 @@
+import * as serializer from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/presentation-steps-serializer.js';
+import { domainBuilder, expect } from '../../../../../../test-helper.js';
+
+describe('Unit | Serializer | JSONAPI | Campaign Presentation Steps Serializer', function () {
+  describe('#serialize()', function () {
+    it('should convert a presentation steps object into JSON API data', function () {
+      // given
+      const customLandingPageText = 'lorem ipsum';
+
+      const competences = [
+        domainBuilder.buildCompetence({
+          id: 'competence1',
+        }),
+        domainBuilder.buildCompetence({
+          id: 'competence2',
+        }),
+      ];
+
+      const badges = [
+        domainBuilder.buildBadge({
+          id: 1,
+        }),
+        domainBuilder.buildBadge({
+          id: 2,
+        }),
+      ];
+
+      const presentationSteps = { customLandingPageText, competences, badges };
+
+      // when
+      const json = serializer.serialize(presentationSteps);
+
+      // then
+      expect(json).to.deep.equal({
+        data: {
+          attributes: {
+            'custom-landing-page-text': customLandingPageText,
+          },
+          type: 'campaign-presentation-steps',
+          relationships: {
+            badges: {
+              data: [
+                { id: '1', type: 'badges' },
+                { id: '2', type: 'badges' },
+              ],
+            },
+            competences: {
+              data: [
+                { id: 'competence1', type: 'competences' },
+                { id: 'competence2', type: 'competences' },
+              ],
+            },
+          },
+        },
+        included: [
+          {
+            attributes: {
+              'alt-message': 'altMessage',
+              'image-url': '/img/banana',
+              'is-always-visible': false,
+              'is-certifiable': false,
+              key: 'key',
+              message: 'message',
+              title: 'title',
+            },
+            id: '1',
+            type: 'badges',
+          },
+          {
+            attributes: {
+              'alt-message': 'altMessage',
+              'image-url': '/img/banana',
+              'is-always-visible': false,
+              'is-certifiable': false,
+              key: 'key',
+              message: 'message',
+              title: 'title',
+            },
+            id: '2',
+            type: 'badges',
+          },
+          {
+            attributes: {
+              index: '1.1',
+              name: 'Manger des fruits',
+            },
+            id: 'competence1',
+            type: 'competences',
+          },
+          {
+            attributes: {
+              index: '1.1',
+              name: 'Manger des fruits',
+            },
+            id: 'competence2',
+            type: 'competences',
+          },
+        ],
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Pour débuter la refonte de la page de présentation de début de parcours, nous avons besoin d'informations spécifiques.

## :robot: Proposition

Créer une route API `api/campaigns/{campaignCode}/presentation-steps`, nécessitant une authentification, qui retourne ces 3 informations :

```
{
 customLandingPageText: '...',
 badges: [...],
 competences: [...]
}
```

## :100: Pour tester

Tests verts ✅ 
