### PR TITLE
[FEATURE] Ajoute le suivi du nombre d'answer jobs par utilisateur dans redis (PIX-14878)

### DIFF
--- a/api/src/evaluation/infrastructure/repositories/answer-job-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/answer-job-repository.js
@@ -1,11 +1,22 @@
 import { AnswerJob } from '../../../quest/domain/models/AnwserJob.js';
 import { JobRepository } from '../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { temporaryStorage } from '../../../shared/infrastructure/temporary-storage/index.js';
 
-class AnswerJobRepository extends JobRepository {
-  constructor() {
+const profileRewardTemporaryStorage = temporaryStorage.withPrefix('profile-rewards:');
+
+export class AnswerJobRepository extends JobRepository {
+  #profileRewardTemporaryStorage;
+
+  constructor({ dependencies = { profileRewardTemporaryStorage } } = {}) {
     super({
       name: AnswerJob.name,
     });
+    this.#profileRewardTemporaryStorage = dependencies.profileRewardTemporaryStorage;
+  }
+
+  async performAsync(job) {
+    super.performAsync(job);
+    await this.#profileRewardTemporaryStorage.increment(job.userId);
   }
 }
 

--- a/api/src/quest/application/jobs/answer-job-controller.js
+++ b/api/src/quest/application/jobs/answer-job-controller.js
@@ -1,15 +1,23 @@
 import { JobController, JobGroup } from '../../../shared/application/jobs/job-controller.js';
+import { temporaryStorage } from '../../../shared/infrastructure/temporary-storage/index.js';
 import { AnswerJob } from '../../domain/models/AnwserJob.js';
 import { usecases } from '../../domain/usecases/index.js';
 
+const profileRewardTemporaryStorage = temporaryStorage.withPrefix('profile-rewards:');
+
 export class AnswerJobController extends JobController {
-  constructor() {
+  #profileRewardTemporaryStorage;
+
+  constructor({ dependencies = { profileRewardTemporaryStorage } } = {}) {
     super(AnswerJob.name, { jobGroup: JobGroup.FAST });
+    this.#profileRewardTemporaryStorage = dependencies.profileRewardTemporaryStorage;
   }
 
   async handle({ data }) {
     const { userId } = data;
 
-    return usecases.rewardUser({ userId });
+    await usecases.rewardUser({ userId });
+
+    this.#profileRewardTemporaryStorage.decrement(userId);
   }
 }

--- a/api/src/quest/application/jobs/answer-job-controller.js
+++ b/api/src/quest/application/jobs/answer-job-controller.js
@@ -1,4 +1,5 @@
 import { JobController, JobGroup } from '../../../shared/application/jobs/job-controller.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { temporaryStorage } from '../../../shared/infrastructure/temporary-storage/index.js';
 import { AnswerJob } from '../../domain/models/AnwserJob.js';
 import { usecases } from '../../domain/usecases/index.js';
@@ -15,9 +16,10 @@ export class AnswerJobController extends JobController {
 
   async handle({ data }) {
     const { userId } = data;
+    DomainTransaction.execute(async () => {
+      await usecases.rewardUser({ userId });
 
-    await usecases.rewardUser({ userId });
-
-    this.#profileRewardTemporaryStorage.decrement(userId);
+      await this.#profileRewardTemporaryStorage.decrement(userId);
+    });
   }
 }

--- a/api/src/shared/infrastructure/temporary-storage/InMemoryTemporaryStorage.js
+++ b/api/src/shared/infrastructure/temporary-storage/InMemoryTemporaryStorage.js
@@ -29,6 +29,22 @@ class InMemoryTemporaryStorage extends TemporaryStorage {
     return this._client.get(key);
   }
 
+  async increment(key) {
+    let value = Number(this.get(key));
+    if (Number.isNaN(value)) {
+      value = 0;
+    }
+    this.update(key, `${value + 1}`);
+  }
+
+  async decrement(key) {
+    let value = Number(this.get(key));
+    if (Number.isNaN(value)) {
+      value = 0;
+    }
+    this.update(key, `${value - 1}`);
+  }
+
   async delete(key) {
     return this._client.del(key);
   }

--- a/api/src/shared/infrastructure/temporary-storage/RedisTemporaryStorage.js
+++ b/api/src/shared/infrastructure/temporary-storage/RedisTemporaryStorage.js
@@ -27,6 +27,18 @@ class RedisTemporaryStorage extends TemporaryStorage {
     return storageKey;
   }
 
+  async increment(key) {
+    const storageKey = trim(key);
+
+    await this._client.incr(storageKey);
+  }
+
+  async decrement(key) {
+    const storageKey = trim(key);
+
+    await this._client.decr(storageKey);
+  }
+
   async update(key, value) {
     const storageKey = trim(key);
 

--- a/api/src/shared/infrastructure/temporary-storage/TemporaryStorage.js
+++ b/api/src/shared/infrastructure/temporary-storage/TemporaryStorage.js
@@ -25,6 +25,14 @@ class TemporaryStorage {
     throw new Error('Method #expire({ key, expirationDelaySeconds }) must be overridden');
   }
 
+  async increment(/* key */) {
+    throw new Error('Method #increment(key) must be overridden');
+  }
+
+  async decrement(/* key */) {
+    throw new Error('Method #decrement(key) must be overridden');
+  }
+
   async ttl(/* key */) {
     throw new Error('Method #ttl(key) must be overridden');
   }

--- a/api/src/shared/infrastructure/utils/RedisClient.js
+++ b/api/src/shared/infrastructure/utils/RedisClient.js
@@ -24,6 +24,8 @@ class RedisClient {
 
     this.ttl = this._wrapWithPrefix(this._client.ttl).bind(this._client);
     this.get = this._wrapWithPrefix(this._client.get).bind(this._client);
+    this.incr = this._wrapWithPrefix(this._client.incr).bind(this._client);
+    this.decr = this._wrapWithPrefix(this._client.decr).bind(this._client);
     this.set = this._wrapWithPrefix(this._client.set).bind(this._client);
     this.del = this._wrapWithPrefix(this._client.del).bind(this._client);
     this.expire = this._wrapWithPrefix(this._client.expire).bind(this._client);

--- a/api/tests/evaluation/unit/infrastructure/repositories/answer-job-repository_test.js
+++ b/api/tests/evaluation/unit/infrastructure/repositories/answer-job-repository_test.js
@@ -1,0 +1,24 @@
+import { AnswerJobRepository } from '../../../../../src/evaluation/infrastructure/repositories/answer-job-repository.js';
+import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Evaluation | Unit | Infrastructure | Repositories | AnswerJobRepository', function () {
+  describe('#preformAsync', function () {
+    it("should increment user's jobs count in temporary storage", async function () {
+      // given
+      const profileRewardTemporaryStorageStub = { increment: sinon.stub() };
+      const knexStub = { batchInsert: sinon.stub().resolves([]) };
+      sinon.stub(DomainTransaction, 'getConnection').returns(knexStub);
+      const userId = Symbol('userId');
+      const answerJobRepository = new AnswerJobRepository({
+        dependencies: { profileRewardTemporaryStorage: profileRewardTemporaryStorageStub },
+      });
+
+      // when
+      await answerJobRepository.performAsync({ userId });
+
+      // then
+      expect(profileRewardTemporaryStorageStub.increment).to.have.been.calledWith(userId);
+    });
+  });
+});

--- a/api/tests/quest/unit/application/answer-job-controller_test.js
+++ b/api/tests/quest/unit/application/answer-job-controller_test.js
@@ -2,6 +2,7 @@ import { AnswerJobController } from '../../../../src/quest/application/jobs/answ
 import { AnswerJob } from '../../../../src/quest/domain/models/AnwserJob.js';
 import { usecases } from '../../../../src/quest/domain/usecases/index.js';
 import { JobGroup } from '../../../../src/shared/application/jobs/job-controller.js';
+import { DomainTransaction } from '../../../../src/shared/domain/DomainTransaction.js';
 import { expect, sinon } from '../../../test-helper.js';
 
 describe('Unit | Application | Jobs | AnswerJobController', function () {
@@ -12,6 +13,9 @@ describe('Unit | Application | Jobs | AnswerJobController', function () {
     profileRewardTemporaryStorageStub = { decrement: sinon.stub() };
     jobController = new AnswerJobController({
       dependencies: { profileRewardTemporaryStorage: profileRewardTemporaryStorageStub },
+    });
+    sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
+      return callback();
     });
   });
 
@@ -25,6 +29,13 @@ describe('Unit | Application | Jobs | AnswerJobController', function () {
     const userId = Symbol('userId');
     await jobController.handle({ data: { userId } });
     expect(usecases.rewardUser).to.have.been.calledWith({ userId });
+  });
+
+  it('should use transaction', async function () {
+    sinon.stub(usecases, 'rewardUser').resolves();
+    const userId = Symbol('userId');
+    await jobController.handle({ data: { userId } });
+    expect(DomainTransaction.execute).to.have.been.called;
   });
 
   it("decrement user's job count in temporary storage", async function () {

--- a/api/tests/quest/unit/application/answer-job-controller_test.js
+++ b/api/tests/quest/unit/application/answer-job-controller_test.js
@@ -5,17 +5,33 @@ import { JobGroup } from '../../../../src/shared/application/jobs/job-controller
 import { expect, sinon } from '../../../test-helper.js';
 
 describe('Unit | Application | Jobs | AnswerJobController', function () {
+  let jobController;
+  let profileRewardTemporaryStorageStub;
+
+  beforeEach(function () {
+    profileRewardTemporaryStorageStub = { decrement: sinon.stub() };
+    jobController = new AnswerJobController({
+      dependencies: { profileRewardTemporaryStorage: profileRewardTemporaryStorageStub },
+    });
+  });
+
   it('setup the job controller configuration', async function () {
-    const jobController = new AnswerJobController();
     expect(jobController.jobName).to.equal(AnswerJob.name);
     expect(jobController.jobGroup).to.equal(JobGroup.FAST);
   });
 
   it('triggers the usecase', async function () {
     sinon.stub(usecases, 'rewardUser').resolves();
-    const userId = Symbol('data');
-    const jobController = new AnswerJobController();
+    const userId = Symbol('userId');
     await jobController.handle({ data: { userId } });
     expect(usecases.rewardUser).to.have.been.calledWith({ userId });
+  });
+
+  it("decrement user's job count in temporary storage", async function () {
+    sinon.stub(usecases, 'rewardUser').resolves();
+    const userId = Symbol('data');
+    await jobController.handle({ data: { userId } });
+
+    expect(profileRewardTemporaryStorageStub.decrement).to.have.been.calledWith(userId);
   });
 });

--- a/api/tests/shared/integration/infrastructure/utils/RedisClient_test.js
+++ b/api/tests/shared/integration/infrastructure/utils/RedisClient_test.js
@@ -85,6 +85,52 @@ describe('Integration | Infrastructure | Utils | RedisClient', function () {
     await redisClient.del(keyToRemove);
   });
 
+  it('should create value and decrement it to -1', async function () {
+    // given
+    const client = new RedisClient(config.redis.url);
+
+    // when
+    await client.decr('toto');
+
+    // then
+    expect(await client.get('toto')).to.equal('-1');
+  });
+
+  it('should decrement value', async function () {
+    // given
+    const client = new RedisClient(config.redis.url);
+    await client.set('toto', 1);
+
+    // when
+    await client.decr('toto');
+
+    // then
+    expect(await client.get('toto')).to.equal('0');
+  });
+
+  it('should create value and increment it to 1', async function () {
+    // given
+    const client = new RedisClient(config.redis.url);
+
+    // when
+    await client.incr('toto');
+
+    // then
+    expect(await client.get('toto')).to.equal('1');
+  });
+
+  it('should increment value', async function () {
+    // given
+    const client = new RedisClient(config.redis.url);
+    await client.set('toto', 1);
+
+    // when
+    await client.incr('toto');
+
+    // then
+    expect(await client.get('toto')).to.equal('2');
+  });
+
   it('should flush all values', async function () {
     // given
     const client = new RedisClient(config.redis.url);

--- a/api/tests/shared/unit/infrastructure/temporary-storage/InMemoryTemporaryStorage_test.js
+++ b/api/tests/shared/unit/infrastructure/temporary-storage/InMemoryTemporaryStorage_test.js
@@ -8,6 +8,34 @@ describe('Unit | Infrastructure | temporary-storage | InMemoryTemporaryStorage',
     inMemoryTemporaryStorage = new InMemoryTemporaryStorage();
   });
 
+  describe('#increment', function () {
+    it('should call client incr to increment value', async function () {
+      // given
+      const key = 'valueKey';
+      const inMemoryTemporaryStorage = new InMemoryTemporaryStorage();
+
+      // when
+      await inMemoryTemporaryStorage.increment(key);
+
+      // then
+      expect(await inMemoryTemporaryStorage.get(key)).to.equal('1');
+    });
+  });
+
+  describe('#decrement', function () {
+    it('should call client incr to decrement value', async function () {
+      // given
+      const key = 'valueKey';
+      const inMemoryTemporaryStorage = new InMemoryTemporaryStorage();
+
+      // when
+      await inMemoryTemporaryStorage.decrement(key);
+
+      // then
+      expect(await inMemoryTemporaryStorage.get(key)).to.equal('-1');
+    });
+  });
+
   describe('#save', function () {
     let clock;
 

--- a/api/tests/shared/unit/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
+++ b/api/tests/shared/unit/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
@@ -10,6 +10,8 @@ describe('Unit | Infrastructure | temporary-storage | RedisTemporaryStorage', fu
     clientStub = {
       get: sinon.stub(),
       set: sinon.stub(),
+      incr: sinon.stub(),
+      decr: sinon.stub(),
       del: sinon.stub(),
       expire: sinon.stub(),
       ttl: sinon.stub(),
@@ -92,6 +94,34 @@ describe('Unit | Infrastructure | temporary-storage | RedisTemporaryStorage', fu
         EXPIRATION_PARAMETER,
         expirationDelaySeconds,
       );
+    });
+  });
+
+  describe('#increment', function () {
+    it('should call client incr to increment value', async function () {
+      // given
+      const key = 'valueKey';
+      const redisTemporaryStorage = new RedisTemporaryStorage(REDIS_URL);
+
+      // when
+      await redisTemporaryStorage.increment(key);
+
+      // then
+      expect(clientStub.incr).to.have.been.calledWith(key);
+    });
+  });
+
+  describe('#decrement', function () {
+    it('should call client incr to decrement value', async function () {
+      // given
+      const key = 'valueKey';
+      const redisTemporaryStorage = new RedisTemporaryStorage(REDIS_URL);
+
+      // when
+      await redisTemporaryStorage.decrement(key);
+
+      // then
+      expect(clientStub.decr).to.have.been.calledWith(key);
     });
   });
 

--- a/api/tests/shared/unit/infrastructure/temporary-storage/TemporaryStorage_test.js
+++ b/api/tests/shared/unit/infrastructure/temporary-storage/TemporaryStorage_test.js
@@ -15,6 +15,32 @@ describe('Unit | Infrastructure | temporary-storage | TemporaryStorage', functio
     });
   });
 
+  describe('#decrement', function () {
+    it('should reject an error (because this class actually mocks an interface)', function () {
+      // given
+      const temporaryStorageInstance = new TemporaryStorage();
+
+      // when
+      const result = temporaryStorageInstance.decrement('key');
+
+      // then
+      expect(result).to.be.rejected;
+    });
+  });
+
+  describe('#increment', function () {
+    it('should reject an error (because this class actually mocks an interface)', function () {
+      // given
+      const temporaryStorageInstance = new TemporaryStorage();
+
+      // when
+      const result = temporaryStorageInstance.increment('key');
+
+      // then
+      expect(result).to.be.rejected;
+    });
+  });
+
   describe('#get', function () {
     it('should reject an error (because this class actually mocks an interface)', function () {
       // given


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'Epix sur les attestations, nous avons besoin sur la fin de parcours d'informer l'utilisateur si son attestation est toujours en cours de calcul. Cette information est disponible dans PGBoss cependant, faire des requêtes sur les tables de PGBoss directement aurait plusieurs conséquents que nous souhaitons éviter : 
- se coupler fortement à cette librairie
- ajouter une charge non désiré sur cette table entraînant un ralentissement du traitement des jobs

## :robot: Proposition
Sur conseil de la @1024pix/team-captains, nous allons utiliser redis pour stocker le nombre de job en cours par utilisateur. On pourra alors récupérer la valeur dans redis afin d'informer l'utilisateur si le calcul est toujours en cours.

## :rainbow: Remarques
Nous avons du ajouter les méthodes incr et decr dans la classe RedisClient. Nous avons utilisé ces méthodes pour éviter les race conditions.

## :100: Pour tester
La CI est verte ✅ 
