### PR TITLE
[FEATURE] Enregistrer l'auto-évaluation de l'utilisateur dans Matomo (PIX-14313)

### DIFF
--- a/mon-pix/app/components/module/element.gjs
+++ b/mon-pix/app/components/module/element.gjs
@@ -32,7 +32,7 @@ export default class ModulixElement extends Component {
     {{else if (eq @element.type "separator")}}
       <SeparatorElement />
     {{else if (eq @element.type "flashcards")}}
-      <FlashcardsElement @flashcards={{@element}} />
+      <FlashcardsElement @flashcards={{@element}} @onSelfAssessment={{@onSelfAssessment}} />
     {{else if (eq @element.type "qcu")}}
       <QcuElement
         @element={{@element}}

--- a/mon-pix/app/components/module/element/flashcards/flashcards.gjs
+++ b/mon-pix/app/components/module/element/flashcards/flashcards.gjs
@@ -1,3 +1,4 @@
+import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
@@ -55,10 +56,19 @@ export default class ModulixFlashcards extends Component {
     this.displayedSideName = this.displayedSideName === 'recto' ? 'verso' : 'recto';
   }
 
-  @action
   goToNextCard() {
     this.currentCardIndex++;
     this.displayedSideName = 'recto';
+  }
+
+  @action
+  onSelfAssessment(userAssessment) {
+    const selfAssessmentData = {
+      userAssessment,
+      cardId: this.currentCard.id,
+    };
+    this.args.onSelfAssessment(selfAssessmentData);
+    this.goToNextCard();
   }
 
   <template>
@@ -96,21 +106,21 @@ export default class ModulixFlashcards extends Component {
               <button
                 class="element-flashcards__footer__answer__button element-flashcards__footer__answer__button--no"
                 type="button"
-                {{on "click" this.goToNextCard}}
+                {{on "click" (fn this.onSelfAssessment "no")}}
               >
                 {{t "pages.modulix.buttons.flashcards.answers.notAtAll"}}
               </button>
               <button
                 class="element-flashcards__footer__answer__button element-flashcards__footer__answer__button--almost"
                 type="button"
-                {{on "click" this.goToNextCard}}
+                {{on "click" (fn this.onSelfAssessment "almost")}}
               >
                 {{t "pages.modulix.buttons.flashcards.answers.almost"}}
               </button>
               <button
                 class="element-flashcards__footer__answer__button element-flashcards__footer__answer__button--yes"
                 type="button"
-                {{on "click" this.goToNextCard}}
+                {{on "click" (fn this.onSelfAssessment "yes")}}
               >
                 {{t "pages.modulix.buttons.flashcards.answers.yes"}}
               </button>

--- a/mon-pix/app/components/module/grain.gjs
+++ b/mon-pix/app/components/module/grain.gjs
@@ -187,6 +187,7 @@ export default class ModuleGrain extends Component {
                   @onVideoTranscriptionOpen={{@onVideoTranscriptionOpen}}
                   @onElementAnswer={{@onElementAnswer}}
                   @onElementRetry={{@onElementRetry}}
+                  @onSelfAssessment={{@onSelfAssessment}}
                   @onVideoPlay={{@onVideoPlay}}
                   @getLastCorrectionForElement={{this.getLastCorrectionForElement}}
                   @onFileDownload={{@onFileDownload}}

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -132,6 +132,16 @@ export default class ModulePassage extends Component {
   }
 
   @action
+  async onSelfAssessment({ userAssessment, cardId }) {
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Modulix',
+      'pix-event-action': `Passage du module : ${this.args.module.id}`,
+      'pix-event-name': `Click sur le bouton '${userAssessment}' de la flashcard : ${cardId}`,
+    });
+  }
+
+  @action
   async onElementRetry(answerData) {
     this.metrics.add({
       event: 'custom-event',
@@ -204,6 +214,7 @@ export default class ModulePassage extends Component {
             @onImageAlternativeTextOpen={{this.onImageAlternativeTextOpen}}
             @onVideoTranscriptionOpen={{this.onVideoTranscriptionOpen}}
             @onElementAnswer={{this.onElementAnswer}}
+            @onSelfAssessment={{this.onSelfAssessment}}
             @onStepperNextStep={{this.onStepperNextStep}}
             @canMoveToNextGrain={{this.grainCanMoveToNextGrain index}}
             @onGrainContinue={{this.onGrainContinue}}

--- a/mon-pix/tests/integration/components/module/flashcards_test.gjs
+++ b/mon-pix/tests/integration/components/module/flashcards_test.gjs
@@ -3,6 +3,7 @@ import { t } from 'ember-intl/test-support';
 import ModulixFlashcards from 'mon-pix/components/module/element/flashcards/flashcards';
 // eslint-disable-next-line no-restricted-imports
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -173,8 +174,8 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
       assert.ok(screen.getByText(t('pages.modulix.buttons.flashcards.answers.notAtAll')));
     });
 
-    module('then user gives an answer', function () {
-      test('should display the next card', async function (assert) {
+    module('when the user self-assesses their response', function () {
+      test('should display the next card and send self-assessment', async function (assert) {
         // given
         const firstCard = {
           id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
@@ -214,8 +215,14 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
           cards: [firstCard, secondCard],
         };
 
+        const onSelfAssessmentStub = sinon.stub();
+
         // when
-        const screen = await render(<template><ModulixFlashcards @flashcards={{flashcards}} /></template>);
+        const screen = await render(
+          <template>
+            <ModulixFlashcards @flashcards={{flashcards}} @onSelfAssessment={{onSelfAssessmentStub}} />
+          </template>,
+        );
         await clickByName(t('pages.modulix.buttons.flashcards.start'));
         await clickByName(t('pages.modulix.buttons.flashcards.seeAnswer'));
         await clickByName(t('pages.modulix.buttons.flashcards.answers.notAtAll'));
@@ -223,6 +230,7 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
         // then
         assert.ok(screen.getByText('Qui a écrit le Dormeur du Val ?'));
         assert.ok(screen.getByText(t('pages.modulix.flashcards.position', { currentCardPosition: 2, totalCards: 2 })));
+        assert.true(onSelfAssessmentStub.calledOnce);
       });
     });
   });

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -49,7 +49,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
     assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
   });
 
-  module('When a grain contains non existing elements', function () {
+  module('when a grain contains non existing elements', function () {
     test('should not display the grain if it contains only non existing elements', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
@@ -160,7 +160,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
     assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists({ count: 1 });
   });
 
-  module('when user click on skip button', function () {
+  module('when user clicks on skip button', function () {
     test('should display next grain', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
@@ -223,7 +223,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
     });
   });
 
-  module('when user click on continue button', function (hooks) {
+  module('when user clicks on continue button', function (hooks) {
     let continueButtonName;
     hooks.beforeEach(function () {
       continueButtonName = t('pages.modulix.buttons.grain.continue');
@@ -321,7 +321,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
     });
   });
 
-  module('when user click on an answerable element verify button', function () {
+  module('when user clicks on an answerable element verify button', function () {
     test('should save the element answer', async function (assert) {
       // given
       const metrics = this.owner.lookup('service:metrics');
@@ -401,7 +401,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
     });
   });
 
-  module('when user click on an answerable element retry button', function () {
+  module('when user clicks on an answerable element retry button', function () {
     test('should push metrics event', async function (assert) {
       // given
       const metrics = this.owner.lookup('service:metrics');
@@ -504,7 +504,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
     });
   });
 
-  module('when user opens an video transcription modal', function () {
+  module('when user opens a video transcription modal', function () {
     test('should push metrics event', async function (assert) {
       // given
       const metrics = this.owner.lookup('service:metrics');
@@ -578,7 +578,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
     });
   });
 
-  module('when user click on next step button', function () {
+  module('when user clicks on next step button', function () {
     test('should push event', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
@@ -903,7 +903,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
     });
   });
 
-  module('When click on terminate button', function () {
+  module('when user clicks on terminate button', function () {
     test('should push an event', async function (assert) {
       // given
       class PassageAdapterStub extends ApplicationAdapter {


### PR DESCRIPTION
## :unicorn: Problème

A chaque Flashcard, l'utilisateur peut auto-évaluer sa connaissance et répondre si oui on non il connaissait bien le sujet, mais sa réponse n'est pas transmise à Matomo.

## :robot: Proposition

Front
- envoyer un événement Matomo à chaque réponse de l'utilisateur à une carte

## :rainbow: Remarques

PR associée au ticket PIX-14310 auparavant. Mais le scope ayant changé, nous avons gardé la branche pour la transformer plutôt que de repartir de zéro (on appelle désormais Matomo au lieu de l'API).

## :100: Pour tester

1. Se rendre sur le [didacticiel Modulix](https://app-pr10354.review.pix.fr/modules/didacticiel-modulix/details)
2. Répondre différemment aux trois flashcards
3. Constater à l'aide du mode preview de Matomo que l'événement a été transmis.