### PR TITLE
[FEATURE] Ajouter un nouveau composant formulaire de demande de réinitialisation de mot de passe (PIX-14111)

### DIFF
--- a/api/src/identity-access-management/application/password/password.controller.js
+++ b/api/src/identity-access-management/application/password/password.controller.js
@@ -9,7 +9,7 @@ const checkResetDemand = async function (request, h, dependencies = { userSerial
   return dependencies.userSerializer.serialize(user);
 };
 const createResetPasswordDemand = async function (request, h, dependencies = { resetPasswordSerializer }) {
-  const { email } = request.payload.data.attributes;
+  const email = request.payload.email;
   const locale = extractLocaleFromRequest(request);
 
   const resetPasswordDemand = await usecases.createResetPasswordDemand({

--- a/api/src/identity-access-management/application/password/password.route.js
+++ b/api/src/identity-access-management/application/password/password.route.js
@@ -11,6 +11,10 @@ export const passwordRoutes = [
       handler: (request, h) => passwordController.createResetPasswordDemand(request, h),
       validate: {
         payload: Joi.object({
+          email: Joi.when('data.attributes.email', {
+            then: Joi.string().email().default(Joi.ref('data.attributes.email')),
+            otherwise: Joi.string().email().required(),
+          }),
           data: {
             attributes: {
               email: Joi.string().email().required(),

--- a/api/tests/identity-access-management/acceptance/application/password/password.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/password/password.route.test.js
@@ -13,44 +13,85 @@ describe('Acceptance | Identity Access Management | Application | Route | passwo
   describe('POST /api/password-reset-demands', function () {
     let options;
 
-    beforeEach(async function () {
-      options = {
-        method: 'POST',
-        url: '/api/password-reset-demands',
-        payload: {
-          data: {
-            attributes: { email },
-          },
-        },
-      };
+    context('with simple payload', function () {
+      beforeEach(async function () {
+        options = {
+          method: 'POST',
+          url: '/api/password-reset-demands',
+          payload: { email },
+        };
 
-      config.mailing.enabled = false;
+        config.mailing.enabled = false;
 
-      const userId = databaseBuilder.factory.buildUser({ email }).id;
-      databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({ userId });
-      await databaseBuilder.commit();
-    });
+        const userId = databaseBuilder.factory.buildUser({ email }).id;
+        databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({ userId });
+        await databaseBuilder.commit();
+      });
 
-    context('when email provided is unknown', function () {
-      it('replies with 404', async function () {
-        // given
-        options.payload.data.attributes.email = 'unknown@example.net';
+      context('when given email doesn’t exist', function () {
+        it('replies with 404', async function () {
+          // given
+          options.payload.email = 'unknown@example.net';
 
-        // when
-        const response = await server.inject(options);
+          // when
+          const response = await server.inject(options);
 
-        // then
-        expect(response.statusCode).to.equal(404);
+          // then
+          expect(response.statusCode).to.equal(404);
+        });
+      });
+
+      context('when given email exists', function () {
+        it('replies with 201', async function () {
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(201);
+        });
       });
     });
 
-    context('when existing email is provided', function () {
-      it('replies with 201', async function () {
-        // when
-        const response = await server.inject(options);
+    context('with deprecated ember-data-centric payload', function () {
+      beforeEach(async function () {
+        options = {
+          method: 'POST',
+          url: '/api/password-reset-demands',
+          payload: {
+            data: {
+              attributes: { email },
+            },
+          },
+        };
 
-        // then
-        expect(response.statusCode).to.equal(201);
+        config.mailing.enabled = false;
+
+        const userId = databaseBuilder.factory.buildUser({ email }).id;
+        databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({ userId });
+        await databaseBuilder.commit();
+      });
+
+      context('when given email doesn’t exist', function () {
+        it('replies with 404', async function () {
+          // given
+          options.payload.data.attributes.email = 'unknown@example.net';
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(404);
+        });
+      });
+
+      context('when given email exists', function () {
+        it('replies with 201', async function () {
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(201);
+        });
       });
     });
   });

--- a/api/tests/identity-access-management/integration/application/password/password.controller.test.js
+++ b/api/tests/identity-access-management/integration/application/password/password.controller.test.js
@@ -20,12 +20,7 @@ describe('Integration | Identity Access Management | Application | Controller | 
     const headers = {
       'accept-language': 'fr',
     };
-    const payload = {
-      data: {
-        type: 'password-reset-demands',
-        attributes: { email },
-      },
-    };
+    const payload = { email };
 
     it('returns a 201 HTTP status code with a response', async function () {
       // given

--- a/api/tests/identity-access-management/unit/application/password/password.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/password/password.controller.test.js
@@ -41,11 +41,7 @@ describe('Unit | Identity Access Management | Application | Controller | passwor
       headers: {
         'accept-language': locale,
       },
-      payload: {
-        data: {
-          attributes: { email },
-        },
-      },
+      payload: { email },
     };
     const resetPasswordDemand = {
       id: 1,

--- a/mon-pix/app/components/authentication/password-reset-demand-form.gjs
+++ b/mon-pix/app/components/authentication/password-reset-demand-form.gjs
@@ -17,6 +17,9 @@ export default class PasswordResetDemandForm extends Component {
 
   @tracked isLoading = false;
   @tracked errorMessage;
+  @tracked emailInputPlaceholder = this.intl.t(
+    'components.authentication.password-reset-demand-form.fields.email.placeholder',
+  );
   @tracked emailInputvalidationStatus;
   @tracked emailInputvalidationErrorMessage;
 
@@ -27,7 +30,7 @@ export default class PasswordResetDemandForm extends Component {
     this.email = event.target.value;
     this.emailInputvalidationStatus = isEmailValid(this.email) ? 'success' : 'error';
     this.emailInputvalidationErrorMessage = this.intl.t(
-      'components.authentication.password-reset-demand-form.invalid-email',
+      'components.authentication.password-reset-demand-form.fields.email.error-message-invalid',
     );
   }
 
@@ -53,7 +56,7 @@ export default class PasswordResetDemandForm extends Component {
         body: JSON.stringify({ email }),
       });
       if (response.status == 404) {
-        this.errorMessage = this.intl.t('pages.password-reset-demand.error.message');
+        this.errorMessage = this.intl.t('components.authentication.password-reset-demand-form.404-message');
       } else if (!response.ok) {
         throw new Error(`Response status: ${response.status}`);
       }
@@ -87,10 +90,10 @@ export default class PasswordResetDemandForm extends Component {
           {{on "change" this.handleEmailChange}}
           @validationStatus={{this.emailInputvalidationStatus}}
           @errorMessage={{this.emailInputvalidationErrorMessage}}
-          placeholder="jean.dupont@example.net"
+          placeholder={{this.emailInputPlaceholder}}
           required={{true}}
         >
-          <:label>{{t "pages.password-reset-demand.fields.email.label"}}</:label>
+          <:label>{{t "components.authentication.password-reset-demand-form.fields.email.label"}}</:label>
         </PixInput>
       </div>
       <div>

--- a/mon-pix/app/components/authentication/password-reset-demand-form.gjs
+++ b/mon-pix/app/components/authentication/password-reset-demand-form.gjs
@@ -1,0 +1,119 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixInput from '@1024pix/pix-ui/components/pix-input';
+import PixMessage from '@1024pix/pix-ui/components/pix-message';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+import ENV from 'mon-pix/config/environment';
+
+import isEmailValid from '../../utils/email-validator.js';
+
+export default class PasswordResetDemandForm extends Component {
+  @service intl;
+
+  @tracked isLoading = false;
+  @tracked errorMessage;
+  @tracked emailInputvalidationStatus;
+  @tracked emailInputvalidationErrorMessage;
+
+  email;
+
+  @action
+  handleEmailChange(event) {
+    this.email = event.target.value;
+    this.emailInputvalidationStatus = isEmailValid(this.email) ? 'success' : 'error';
+    this.emailInputvalidationErrorMessage = this.intl.t(
+      'components.authentication.password-reset-demand-form.invalid-email',
+    );
+  }
+
+  @action
+  async handlePasswordResetDemand(event) {
+    if (event) event.preventDefault();
+
+    this.errorMessage = null;
+
+    const email = this.email.trim();
+    if (!email || this.emailInputvalidationStatus === 'error') {
+      return;
+    }
+
+    try {
+      this.isLoading = true;
+      const response = await window.fetch(`${ENV.APP.API_HOST}/api/password-reset-demands`, {
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        method: 'POST',
+        body: JSON.stringify({ email }),
+      });
+      if (response.status == 404) {
+        this.errorMessage = this.intl.t('pages.password-reset-demand.error.message');
+      } else if (!response.ok) {
+        throw new Error(`Response status: ${response.status}`);
+      }
+    } catch (error) {
+      this.errorMessage = this.intl.t('common.api-error-messages.internal-server-error');
+    } finally {
+      this.isLoading = false;
+    }
+  }
+
+  <template>
+    <form {{on "submit" this.handlePasswordResetDemand}} class="authentication-password-reset-demand-form">
+      <p class="authentication-password-reset-demand-form__rule">
+        {{t "components.authentication.password-reset-demand-form.rule"}}
+      </p>
+
+      {{#if this.errorMessage}}
+        <PixMessage
+          @type="error"
+          @withIcon={{true}}
+          class="authentication-password-reset-demand-form__error"
+          role="alert"
+        >
+          {{this.errorMessage}}
+        </PixMessage>
+      {{/if}}
+      <div class="authentication-password-reset-demand-form__input-block">
+        <PixInput
+          @value={{this.email}}
+          type="email"
+          {{on "change" this.handleEmailChange}}
+          @validationStatus={{this.emailInputvalidationStatus}}
+          @errorMessage={{this.emailInputvalidationErrorMessage}}
+          placeholder="jean.dupont@example.net"
+          required={{true}}
+        >
+          <:label>{{t "pages.password-reset-demand.fields.email.label"}}</:label>
+        </PixInput>
+      </div>
+      <div>
+        <PixButton
+          @type="submit"
+          @size="large"
+          @isLoading={{this.isLoading}}
+          class="authentication-password-reset-demand-form__button"
+        >
+          {{t "components.authentication.password-reset-demand-form.actions.receive-reset-button"}}
+        </PixButton>
+      </div>
+      <p class="authentication-password-reset-demand-form__help">
+        {{t "components.authentication.password-reset-demand-form.no-email-question"}}
+        <PixButtonLink
+          @variant="tertiary"
+          @href="{{t 'components.authentication.password-reset-demand-form.contact-us-link.link-url'}}"
+          target="_blank"
+          class="authentication-password-reset-demand-form__help-contact-us-link"
+        >
+          {{t "components.authentication.password-reset-demand-form.contact-us-link.link-text"}}
+        </PixButtonLink>
+      </p>
+    </form>
+  </template>
+}

--- a/mon-pix/app/components/authentication/password-reset-demand.scss
+++ b/mon-pix/app/components/authentication/password-reset-demand.scss
@@ -1,0 +1,41 @@
+.authentication-password-reset-demand-form {
+    input {
+        padding: var(--pix-spacing-3x);
+    }
+
+    &__rule {
+        @extend %pix-body-xs;
+
+        color: var(--pix-neutral-500);
+    }
+
+    &__error {
+        margin-top: var(--pix-spacing-4x);
+    }
+
+    &__input-block {
+        margin-top: var(--pix-spacing-4x);
+
+        .pix-input {
+            width: 100%;
+        }
+    }
+
+    &__button {
+        width: 100%;
+        margin-top: var(--pix-spacing-4x);
+    }
+
+    &__help {
+        @extend %pix-body-s;
+
+        margin-top: var(--pix-spacing-4x);
+        color: var(--pix-neutral-70);
+        text-align: center;
+    }
+
+    &__help-contact-us-link {
+        display: inline;
+        padding: 0;
+    }
+}

--- a/mon-pix/app/components/form-textfield.hbs
+++ b/mon-pix/app/components/form-textfield.hbs
@@ -1,3 +1,5 @@
+{{! DEPRECATED COMPONENT: DON’T USE IT! USE COMPONENTS OF THE DESIGN SYSTEM INSTEAD!! }}
+
 {{! template-lint-disable require-input-label no-unknown-arguments-for-builtin-components }}
 <div class="form-textfield">
   <label for="{{@textfieldName}}" class="form-textfield__label">

--- a/mon-pix/app/components/form-textfield.js
+++ b/mon-pix/app/components/form-textfield.js
@@ -1,3 +1,5 @@
+// DEPRECATED COMPONENT: DON’T USE IT! USE COMPONENTS OF THE DESIGN SYSTEM INSTEAD!
+
 import { action } from '@ember/object';
 import { isEmpty } from '@ember/utils';
 import Component from '@glimmer/component';

--- a/mon-pix/app/controllers/password-reset-demand.js
+++ b/mon-pix/app/controllers/password-reset-demand.js
@@ -1,0 +1,10 @@
+import Controller from '@ember/controller';
+import { service } from '@ember/service';
+
+export default class LoginController extends Controller {
+  @service featureToggles;
+
+  get isNewAuthenticationDesignEnabled() {
+    return this.featureToggles.featureToggles.isNewAuthenticationDesignEnabled;
+  }
+}

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -136,14 +136,14 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 
 /* Styles for colocated components */
 @import 'authentication-layout';
+@import 'authentication/new-password-input/password-checklist';
+@import 'authentication/new-password-input/password-rule';
 @import 'authentication/oidc-provider-selector';
 @import 'authentication/other-authentication-providers';
 @import 'authentication/password-reset-demand';
 @import 'authentication/signin-form';
 @import 'authentication/signup-form';
 @import 'authentication/sso-selection-form';
-@import 'authentication/new-password-input/password-checklist';
-@import 'authentication/new-password-input/password-rule';
 
 /* pages */
 @import 'pages/assessment-results';

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -138,6 +138,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @import 'authentication-layout';
 @import 'authentication/oidc-provider-selector';
 @import 'authentication/other-authentication-providers';
+@import 'authentication/password-reset-demand';
 @import 'authentication/signin-form';
 @import 'authentication/signup-form';
 @import 'authentication/sso-selection-form';

--- a/mon-pix/app/templates/password-reset-demand.hbs
+++ b/mon-pix/app/templates/password-reset-demand.hbs
@@ -1,4 +1,8 @@
 {{page-title (t "pages.password-reset-demand.page-title")}}
-<div class="sign-form-page">
-  <PasswordResetDemandForm />
-</div>
+
+{{#if this.isNewAuthenticationDesignEnabled}}
+{{else}}
+  <div class="sign-form-page">
+    <PasswordResetDemandForm />
+  </div>
+{{/if}}

--- a/mon-pix/app/templates/password-reset-demand.hbs
+++ b/mon-pix/app/templates/password-reset-demand.hbs
@@ -1,6 +1,19 @@
-{{page-title (t "pages.password-reset-demand.page-title")}}
+{{page-title (t "pages.password-reset-demand.title")}}
 
 {{#if this.isNewAuthenticationDesignEnabled}}
+  <AuthenticationLayout class="signin-page-layout">
+    <:header>
+      <PixButtonLink @variant="secondary" @route="authentication.login">
+        {{t "common.actions.login"}}
+      </PixButtonLink>
+    </:header>
+
+    <:content>
+      <h1 class="pix-title-m">{{t "pages.password-reset-demand.title"}}</h1>
+      <Authentication::PasswordResetDemandForm />
+    </:content>
+  </AuthenticationLayout>
+
 {{else}}
   <div class="sign-form-page">
     <PasswordResetDemandForm />

--- a/mon-pix/tests/acceptance/password-reset-demand-form-test.js
+++ b/mon-pix/tests/acceptance/password-reset-demand-form-test.js
@@ -29,7 +29,7 @@ module('Acceptance | Password reset demand form', function (hooks) {
       assert.strictEqual(currentURL(), '/mot-de-passe-oublie');
     });
 
-    test('stays on mot de passe oublié page, and shows success message when email sent correspond to an existing user', async function (assert) {
+    test('stays on "mot de passe oublié" page, and shows success message when email sent correspond to an existing user', async function (assert) {
       // given
       this.server.create('user', {
         id: 1,

--- a/mon-pix/tests/acceptance/password-reset-demand-form-test.js
+++ b/mon-pix/tests/acceptance/password-reset-demand-form-test.js
@@ -13,50 +13,59 @@ module('Acceptance | Password reset demand form', function (hooks) {
   setupMirage(hooks);
   setupIntl(hooks);
 
-  test('can visit /mot-passe-oublie', async function (assert) {
-    // when
-    await visit('/mot-de-passe-oublie');
-
-    // then
-    assert.strictEqual(currentURL(), '/mot-de-passe-oublie');
-  });
-
-  test('should stay on mot de passe oublié page, and show success message, when email sent correspond to an existing user', async function (assert) {
-    // given
-    this.server.create('user', {
-      id: 1,
-      firstName: 'Brandone',
-      lastName: 'Martins',
-      email: 'brandone.martins@pix.com',
-      password: '1024pix!',
+  module('when "New authentication design" feature toggle is disabled', function (hooks) {
+    hooks.beforeEach(function () {
+      server.create('feature-toggle', {
+        id: 0,
+        isNewAuthenticationDesignEnabled: false,
+      });
     });
-    await visit('/mot-de-passe-oublie');
-    await fillIn('#email', 'brandone.martins@pix.com');
 
-    // when
-    await clickByLabel(t('pages.password-reset-demand.actions.reset'));
+    test('can visit /mot-passe-oublie', async function (assert) {
+      // when
+      await visit('/mot-de-passe-oublie');
 
-    assert.strictEqual(currentURL(), '/mot-de-passe-oublie');
-    assert.dom('.password-reset-demand-form__body').exists();
-  });
-
-  test('should stay in mot-passe-oublie page when sent email do not correspond to any existing user', async function (assert) {
-    // given
-    this.server.create('user', {
-      id: 1,
-      firstName: 'Brandone',
-      lastName: 'Martins',
-      email: 'brandone.martins@pix.com',
-      password: '1024pix!',
+      // then
+      assert.strictEqual(currentURL(), '/mot-de-passe-oublie');
     });
-    const screen = await visit('/mot-de-passe-oublie');
-    await fillIn('#email', 'unexisting@user.com');
 
-    // when
-    await clickByLabel(t('pages.password-reset-demand.actions.reset'));
+    test('should stay on mot de passe oublié page, and show success message, when email sent correspond to an existing user', async function (assert) {
+      // given
+      this.server.create('user', {
+        id: 1,
+        firstName: 'Brandone',
+        lastName: 'Martins',
+        email: 'brandone.martins@pix.com',
+        password: '1024pix!',
+      });
+      await visit('/mot-de-passe-oublie');
+      await fillIn('#email', 'brandone.martins@pix.com');
 
-    // then
-    assert.strictEqual(currentURL(), '/mot-de-passe-oublie');
-    assert.dom(screen.getByText(t('pages.password-reset-demand.error.message'))).exists();
+      // when
+      await clickByLabel(t('pages.password-reset-demand.actions.reset'));
+
+      assert.strictEqual(currentURL(), '/mot-de-passe-oublie');
+      assert.dom('.password-reset-demand-form__body').exists();
+    });
+
+    test('should stay in mot-passe-oublie page when sent email do not correspond to any existing user', async function (assert) {
+      // given
+      this.server.create('user', {
+        id: 1,
+        firstName: 'Brandone',
+        lastName: 'Martins',
+        email: 'brandone.martins@pix.com',
+        password: '1024pix!',
+      });
+      const screen = await visit('/mot-de-passe-oublie');
+      await fillIn('#email', 'unexisting@user.com');
+
+      // when
+      await clickByLabel(t('pages.password-reset-demand.actions.reset'));
+
+      // then
+      assert.strictEqual(currentURL(), '/mot-de-passe-oublie');
+      assert.dom(screen.getByText(t('pages.password-reset-demand.error.message'))).exists();
+    });
   });
 });

--- a/mon-pix/tests/acceptance/password-reset-demand-form-test.js
+++ b/mon-pix/tests/acceptance/password-reset-demand-form-test.js
@@ -29,7 +29,7 @@ module('Acceptance | Password reset demand form', function (hooks) {
       assert.strictEqual(currentURL(), '/mot-de-passe-oublie');
     });
 
-    test('should stay on mot de passe oublié page, and show success message, when email sent correspond to an existing user', async function (assert) {
+    test('stays on mot de passe oublié page, and shows success message when email sent correspond to an existing user', async function (assert) {
       // given
       this.server.create('user', {
         id: 1,
@@ -48,7 +48,7 @@ module('Acceptance | Password reset demand form', function (hooks) {
       assert.dom('.password-reset-demand-form__body').exists();
     });
 
-    test('should stay in mot-passe-oublie page when sent email do not correspond to any existing user', async function (assert) {
+    test('stays in mot-passe-oublie page when sent email do not correspond to any existing user', async function (assert) {
       // given
       this.server.create('user', {
         id: 1,
@@ -66,6 +66,44 @@ module('Acceptance | Password reset demand form', function (hooks) {
       // then
       assert.strictEqual(currentURL(), '/mot-de-passe-oublie');
       assert.dom(screen.getByText(t('pages.password-reset-demand.error.message'))).exists();
+    });
+  });
+
+  module('when "New authentication design" feature toggle is enabled', function (hooks) {
+    hooks.beforeEach(function () {
+      server.create('feature-toggle', {
+        id: 0,
+        isNewAuthenticationDesignEnabled: true,
+      });
+    });
+
+    test('can visit /mot-passe-oublie', async function (assert) {
+      // when
+      await visit('/mot-de-passe-oublie');
+
+      // then
+      assert.strictEqual(currentURL(), '/mot-de-passe-oublie');
+    });
+
+    test('stays on "mot de passe oublié" page, and shows success message when email sent correspond to an existing user', async function (assert) {
+      // given
+      this.server.create('user', {
+        id: 1,
+        firstName: 'Brandone',
+        lastName: 'Martins',
+        email: 'brandone.martins@pix.com',
+        password: '1024pix!',
+      });
+      const screen = await visit('/mot-de-passe-oublie');
+      await fillIn(
+        screen.getByRole('textbox', { name: t('pages.password-reset-demand.fields.email.label') }),
+        'brandone.martins@pix.com',
+      );
+
+      // when
+      await clickByLabel(t('components.authentication.password-reset-demand-form.actions.receive-reset-button'));
+
+      assert.strictEqual(currentURL(), '/mot-de-passe-oublie');
     });
   });
 });

--- a/mon-pix/tests/integration/components/authentication/password-reset-demand-form-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/password-reset-demand-form-test.gjs
@@ -1,0 +1,159 @@
+import { fillByLabel, render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import PasswordResetDemandForm from 'mon-pix/components/authentication/password-reset-demand-form';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Authentication | password-reset-demand-form', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it displays a contact us link', async function (assert) {
+    // given
+    const screen = await render(<template><PasswordResetDemandForm /></template>);
+
+    // then
+    const link = await screen.queryByRole('link', {
+      name: t('components.authentication.password-reset-demand-form.contact-us-link.link-text'),
+    });
+    assert.dom(link).exists();
+    assert.strictEqual(link.getAttribute('href'), 'https://pix.fr/support');
+  });
+
+  module('email input validation', function () {
+    module('when the email input is valid', function () {
+      test('it doesn’t display any error message', async function (assert) {
+        // given
+        const validEmail = 'someone@example.net';
+        const screen = await render(<template><PasswordResetDemandForm /></template>);
+
+        // when
+        await fillByLabel(t('pages.password-reset-demand.fields.email.label'), validEmail);
+
+        // then
+        assert.dom(screen.queryByRole('alert')).doesNotExist();
+      });
+    });
+
+    module('when the email input is invalid', function () {
+      test('it displays an "invalid email" error message', async function (assert) {
+        // given
+        const invalidEmail = 'invalid email';
+        const screen = await render(<template><PasswordResetDemandForm /></template>);
+
+        // when
+        await fillByLabel(t('pages.password-reset-demand.fields.email.label'), invalidEmail);
+
+        // then
+        assert
+          .dom(screen.queryByText(t('components.authentication.password-reset-demand-form.invalid-email')))
+          .exists();
+      });
+    });
+  });
+
+  module('password-reset-demand sending', function (hooks) {
+    hooks.beforeEach(function () {
+      sinon.stub(window, 'fetch');
+    });
+
+    hooks.afterEach(function () {
+      sinon.restore();
+    });
+
+    module('when the password-reset-demand is successful', function () {
+      test('it doesn’t display any error message', async function (assert) {
+        // given
+        window.fetch.resolves(
+          fetchMock({
+            status: 201,
+          }),
+        );
+
+        const email = 'someone@example.net';
+        const screen = await render(<template><PasswordResetDemandForm /></template>);
+
+        // when
+        await fillByLabel(t('pages.password-reset-demand.fields.email.label'), email);
+        await click(
+          screen.getByRole('button', {
+            name: t('components.authentication.password-reset-demand-form.actions.receive-reset-button'),
+          }),
+        );
+
+        // then
+        assert.dom(screen.queryByRole('alert')).doesNotExist();
+      });
+    });
+
+    module('when there is no corresponding user account', function () {
+      test('it displays an "account not found" error message', async function (assert) {
+        // given
+        window.fetch.resolves(
+          fetchMock({
+            status: 404,
+            body: {
+              errors: [{ title: 'Not Found' }],
+            },
+          }),
+        );
+
+        const email = 'someone@example.net';
+        const screen = await render(<template><PasswordResetDemandForm /></template>);
+
+        // when
+        await fillByLabel(t('pages.password-reset-demand.fields.email.label'), email);
+        await click(
+          screen.getByRole('button', {
+            name: t('components.authentication.password-reset-demand-form.actions.receive-reset-button'),
+          }),
+        );
+
+        // then
+        // The following doesn’t work because of a PixUi span inside the role element
+        //assert.dom(screen.queryByRole('alert', { name: t('pages.password-reset-demand.error.message') })).exists();
+        assert.dom(screen.queryByText(t('pages.password-reset-demand.error.message'))).exists();
+      });
+    });
+
+    module('when there is an unknown error', function () {
+      test('it displays an "unknown error" error message', async function (assert) {
+        // given
+        window.fetch.resolves(
+          fetchMock({
+            status: 500,
+          }),
+        );
+
+        const email = 'someone@example.net';
+        const screen = await render(<template><PasswordResetDemandForm /></template>);
+
+        // when
+        await fillByLabel(t('pages.password-reset-demand.fields.email.label'), email);
+        await click(
+          screen.getByRole('button', {
+            name: t('components.authentication.password-reset-demand-form.actions.receive-reset-button'),
+          }),
+        );
+
+        // then
+        // The following doesn’t work because of a PixUi span inside the role element
+        //assert
+        //  .dom(screen.queryByRole('alert', { name: t('common.api-error-messages.internal-server-error') }))
+        //  .exists();
+        assert.dom(screen.queryByText(t('common.api-error-messages.internal-server-error'))).exists();
+      });
+    });
+  });
+});
+
+function fetchMock({ body, status }) {
+  return new window.Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-type': 'application/json',
+    },
+  });
+}

--- a/mon-pix/tests/integration/components/authentication/password-reset-demand-form-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/password-reset-demand-form-test.gjs
@@ -30,7 +30,7 @@ module('Integration | Component | Authentication | password-reset-demand-form', 
         const screen = await render(<template><PasswordResetDemandForm /></template>);
 
         // when
-        await fillByLabel(t('pages.password-reset-demand.fields.email.label'), validEmail);
+        await fillByLabel(t('components.authentication.password-reset-demand-form.fields.email.label'), validEmail);
 
         // then
         assert.dom(screen.queryByRole('alert')).doesNotExist();
@@ -44,11 +44,15 @@ module('Integration | Component | Authentication | password-reset-demand-form', 
         const screen = await render(<template><PasswordResetDemandForm /></template>);
 
         // when
-        await fillByLabel(t('pages.password-reset-demand.fields.email.label'), invalidEmail);
+        await fillByLabel(t('components.authentication.password-reset-demand-form.fields.email.label'), invalidEmail);
 
         // then
         assert
-          .dom(screen.queryByText(t('components.authentication.password-reset-demand-form.invalid-email')))
+          .dom(
+            screen.queryByText(
+              t('components.authentication.password-reset-demand-form.fields.email.error-message-invalid'),
+            ),
+          )
           .exists();
       });
     });
@@ -76,7 +80,7 @@ module('Integration | Component | Authentication | password-reset-demand-form', 
         const screen = await render(<template><PasswordResetDemandForm /></template>);
 
         // when
-        await fillByLabel(t('pages.password-reset-demand.fields.email.label'), email);
+        await fillByLabel(t('components.authentication.password-reset-demand-form.fields.email.label'), email);
         await click(
           screen.getByRole('button', {
             name: t('components.authentication.password-reset-demand-form.actions.receive-reset-button'),
@@ -104,7 +108,7 @@ module('Integration | Component | Authentication | password-reset-demand-form', 
         const screen = await render(<template><PasswordResetDemandForm /></template>);
 
         // when
-        await fillByLabel(t('pages.password-reset-demand.fields.email.label'), email);
+        await fillByLabel(t('components.authentication.password-reset-demand-form.fields.email.label'), email);
         await click(
           screen.getByRole('button', {
             name: t('components.authentication.password-reset-demand-form.actions.receive-reset-button'),
@@ -114,7 +118,7 @@ module('Integration | Component | Authentication | password-reset-demand-form', 
         // then
         // The following doesn’t work because of a PixUi span inside the role element
         //assert.dom(screen.queryByRole('alert', { name: t('pages.password-reset-demand.error.message') })).exists();
-        assert.dom(screen.queryByText(t('pages.password-reset-demand.error.message'))).exists();
+        assert.dom(screen.queryByText(t('components.authentication.password-reset-demand-form.404-message'))).exists();
       });
     });
 
@@ -131,7 +135,7 @@ module('Integration | Component | Authentication | password-reset-demand-form', 
         const screen = await render(<template><PasswordResetDemandForm /></template>);
 
         // when
-        await fillByLabel(t('pages.password-reset-demand.fields.email.label'), email);
+        await fillByLabel(t('components.authentication.password-reset-demand-form.fields.email.label'), email);
         await click(
           screen.getByRole('button', {
             name: t('components.authentication.password-reset-demand-form.actions.receive-reset-button'),

--- a/mon-pix/tests/integration/components/password-reset-demand-form-test.js
+++ b/mon-pix/tests/integration/components/password-reset-demand-form-test.js
@@ -28,7 +28,7 @@ module('Integration | Component | password reset demand form', function (hooks) 
     // then
     assert.dom(screen.getByRole('img', { name: "Page d'accueil de Pix.org" })).exists();
     assert.dom(screen.getByRole('link', { name: "Page d'accueil de Pix.org" })).hasProperty('href', 'https://pix.org/');
-    assert.dom(screen.getByRole('heading', { name: 'Mot de passe oublié ?' })).exists();
+    assert.dom(screen.getByRole('heading', { name: t('pages.password-reset-demand.title') })).exists();
     assert.dom(screen.getByText("Entrez votre adresse e-mail ci-dessous, et c'est repartix")).exists();
     assert.dom(screen.getByRole('textbox', { name: '* Adresse e-mail' })).exists();
     assert.dom(screen.getByRole('button', { name: 'Réinitialiser mon mot de passe' })).exists();

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -41,14 +41,14 @@
       "close": "Close",
       "confirm": "Confirm",
       "lets-go": "Let's go!",
+      "login": "Log in to Pix",
       "quit": "Exit",
       "refresh-page": "Refresh the page",
       "show-less": "Show less",
       "show-more": "Show more",
       "sign-out": "Sign out",
       "stay": "Stay",
-      "validate": "Validate",
-      "login": "Log in to Pix"
+      "validate": "Validate"
     },
     "api-error-messages": {
       "bad-request-error": "The data entered was not in the correct format.",
@@ -151,6 +151,18 @@
         "select-another-organization-link": "Choose another organisation",
         "signup-heading": "Other ways to sign up"
       },
+      "password-reset-demand-form": {
+        "actions": {
+          "receive-reset-button": "Receive a reset link"
+        },
+        "contact-us-link": {
+          "link-text": "Contact us",
+          "link-url": "https://pix.org/en/support"
+        },
+        "invalid-email": "Your email address is invalid.",
+        "no-email-question": "No email address?",
+        "rule": "All fields are required."
+      },
       "signup-form": {
         "actions": {
           "submit": "Sign up"
@@ -176,18 +188,6 @@
             "placeholder": "ex: Doe"
           },
           "legend": "Information required for sign up."
-        }
-      },
-      "password-reset-demand-form": {
-        "invalid-email": "Your email address is invalid.",
-        "rule": "All fields are required.",
-        "no-email-question": "No email address?",
-        "contact-us-link": {
-          "link-text": "Contact us",
-          "link-url": "https://pix.org/en/support"
-        },
-        "actions": {
-          "receive-reset-button": "Receive a reset link"
         }
       }
     },

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1587,7 +1587,7 @@
         "instructions": "An email explaining how to reset your password\n has been sent to the email address {email}.",
         "subtitle": "Password reset request"
       },
-      "title": "Forgot your password?"
+      "title": "Forgotten password"
     },
     "profile": {
       "accessibility": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -152,6 +152,7 @@
         "signup-heading": "Other ways to sign up"
       },
       "password-reset-demand-form": {
+        "404-message": "The email address entered does not match any Pix account",
         "actions": {
           "receive-reset-button": "Receive a reset link"
         },
@@ -159,7 +160,13 @@
           "link-text": "Contact us",
           "link-url": "https://pix.org/en/support"
         },
-        "invalid-email": "Your email address is invalid.",
+        "fields": {
+          "email": {
+            "error-message-invalid": "Your email address is invalid.",
+            "label": "Email address",
+            "placeholder": "ex: john.doe@email.com"
+          }
+        },
         "no-email-question": "No email address?",
         "rule": "All fields are required."
       },

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -176,6 +176,18 @@
           },
           "legend": "Information required for sign up."
         }
+      },
+      "password-reset-demand-form": {
+        "invalid-email": "Your email address is invalid.",
+        "rule": "All fields are required.",
+        "no-email-question": "No email address?",
+        "contact-us-link": {
+          "link-text": "Contact us",
+          "link-url": "https://pix.org/en/support"
+        },
+        "actions": {
+          "receive-reset-button": "Receive a reset link"
+        }
       }
     },
     "invited": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -47,7 +47,8 @@
       "show-more": "Show more",
       "sign-out": "Sign out",
       "stay": "Stay",
-      "validate": "Validate"
+      "validate": "Validate",
+      "login": "Log in to Pix"
     },
     "api-error-messages": {
       "bad-request-error": "The data entered was not in the correct format.",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -172,12 +172,19 @@
         }
       },
       "password-reset-demand-form": {
-        "invalid-email": "Your email address is invalid.",
+        "404-message": "Esta dirección de correo electrónico no corresponde a ninguna cuenta",
         "rule": "All fields are required.",
         "no-email-question": "No email address?",
         "contact-us-link": {
           "link-text": "Contact us",
           "link-url": "https://pix.org/en/support"
+        },
+        "fields": {
+          "email": {
+            "invalid-email": "Your email address is invalid.",
+            "label": "Email address",
+            "placeholder": "ex: john.doe@email.com"
+          }
         },
         "actions": {
           "receive-reset-button": "Receive a reset link"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -47,7 +47,8 @@
       "sign-out": "Desconectarse",
       "stay": "Quedarse",
       "validate": "Validar",
-      "refresh-page": "Actualizar la página"
+      "refresh-page": "Actualizar la página",
+      "login": "Log in to Pix"
     },
     "api-error-messages": {
       "bad-request-error": "Los datos que has enviado no están en el formato correcto.",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -169,6 +169,18 @@
           },
           "legend": "Información necesaria para la inscripción."
         }
+      },
+      "password-reset-demand-form": {
+        "invalid-email": "Your email address is invalid.",
+        "rule": "All fields are required.",
+        "no-email-question": "No email address?",
+        "contact-us-link": {
+          "link-text": "Contact us",
+          "link-url": "https://pix.org/en/support"
+        },
+        "actions": {
+          "receive-reset-button": "Receive a reset link"
+        }
       }
     },
     "invited": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -152,6 +152,7 @@
         "signup-heading": "Autres moyens d’inscription"
       },
       "password-reset-demand-form": {
+        "404-message": "Cette adresse e-mail ne correspond à aucun compte",
         "actions": {
           "receive-reset-button": "Recevoir un lien de réinitialisation"
         },
@@ -159,7 +160,13 @@
           "link-text": "Contactez-nous",
           "link-url": "https://pix.fr/support"
         },
-        "invalid-email": "Votre adresse e-mail n’est pas valide.",
+        "fields": {
+          "email": {
+            "error-message-invalid": "Votre adresse e-mail n’est pas valide.",
+            "label": "Adresse e-mail",
+            "placeholder": "ex: jean.dupont@email.com"
+          }
+        },
         "no-email-question": "Pas d’adresse e-mail renseignée ?",
         "rule": "Tous les champs sont obligatoires."
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -41,14 +41,14 @@
       "close": "Fermer",
       "confirm": "Confirmer",
       "lets-go": "C'est parti !",
+      "login": "Se connecter sur Pix",
       "quit": "Quitter",
       "refresh-page": "Rafraîchir la page",
       "show-less": "Afficher moins",
       "show-more": "Afficher plus",
       "sign-out": "Se déconnecter",
       "stay": "Rester",
-      "validate": "Valider",
-      "login": "Se connecter sur Pix"
+      "validate": "Valider"
     },
     "api-error-messages": {
       "bad-request-error": "Les données que vous avez soumises ne sont pas au bon format.",
@@ -151,6 +151,18 @@
         "select-another-organization-link": "Choisir une autre organisation",
         "signup-heading": "Autres moyens d’inscription"
       },
+      "password-reset-demand-form": {
+        "actions": {
+          "receive-reset-button": "Recevoir un lien de réinitialisation"
+        },
+        "contact-us-link": {
+          "link-text": "Contactez-nous",
+          "link-url": "https://pix.fr/support"
+        },
+        "invalid-email": "Votre adresse e-mail n’est pas valide.",
+        "no-email-question": "Pas d’adresse e-mail renseignée ?",
+        "rule": "Tous les champs sont obligatoires."
+      },
       "signup-form": {
         "actions": {
           "submit": "Je m'inscris"
@@ -176,18 +188,6 @@
             "placeholder": "ex: Dupont"
           },
           "legend": "Information nécessaire pour l'inscription."
-        }
-      },
-      "password-reset-demand-form": {
-        "invalid-email": "Votre adresse e-mail n’est pas valide.",
-        "rule": "Tous les champs sont obligatoires.",
-        "no-email-question": "Pas d’adresse e-mail renseignée ?",
-        "contact-us-link": {
-          "link-text": "Contactez-nous",
-          "link-url": "https://pix.fr/support"
-        },
-        "actions": {
-          "receive-reset-button": "Recevoir un lien de réinitialisation"
         }
       }
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -176,6 +176,18 @@
           },
           "legend": "Information nécessaire pour l'inscription."
         }
+      },
+      "password-reset-demand-form": {
+        "invalid-email": "Votre adresse e-mail n’est pas valide.",
+        "rule": "Tous les champs sont obligatoires.",
+        "no-email-question": "Pas d’adresse e-mail renseignée ?",
+        "contact-us-link": {
+          "link-text": "Contactez-nous",
+          "link-url": "https://pix.fr/support"
+        },
+        "actions": {
+          "receive-reset-button": "Recevoir un lien de réinitialisation"
+        }
       }
     },
     "invited": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -47,7 +47,8 @@
       "show-more": "Afficher plus",
       "sign-out": "Se déconnecter",
       "stay": "Rester",
-      "validate": "Valider"
+      "validate": "Valider",
+      "login": "Se connecter sur Pix"
     },
     "api-error-messages": {
       "bad-request-error": "Les données que vous avez soumises ne sont pas au bon format.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1587,7 +1587,7 @@
         "instructions": "Un e-mail contenant la démarche à suivre afin de réinitialiser votre mot de passe\n vous a été envoyé à l’adresse e-mail {email}.",
         "subtitle": "Demande de réinitialisation de mot de passe"
       },
-      "title": "Mot de passe oublié ?"
+      "title": "Mot de passe oublié"
     },
     "profile": {
       "accessibility": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -169,6 +169,18 @@
           },
           "legend": "Vereiste informatie voor registratie."
         }
+      },
+      "password-reset-demand-form": {
+        "invalid-email": "Your email address is invalid.",
+        "rule": "All fields are required.",
+        "no-email-question": "No email address?",
+        "contact-us-link": {
+          "link-text": "Contact us",
+          "link-url": "https://pix.org/nl-be/support"
+        },
+        "actions": {
+          "receive-reset-button": "Receive a reset link"
+        }
       }
     },
     "invited": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -47,7 +47,8 @@
       "sign-out": "Log uit.",
       "stay": "Blijf",
       "validate": "Valideer",
-      "refresh-page": "Pagina verversen"
+      "refresh-page": "Pagina verversen",
+      "login": "Log in to Pix"
     },
     "api-error-messages": {
       "bad-request-error": "De gegevens die u hebt opgegeven, hebben niet het juiste formaat.",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -172,12 +172,19 @@
         }
       },
       "password-reset-demand-form": {
-        "invalid-email": "Your email address is invalid.",
+        "404-message": "Dit e-mailadres komt niet overeen met een account",
         "rule": "All fields are required.",
         "no-email-question": "No email address?",
         "contact-us-link": {
           "link-text": "Contact us",
           "link-url": "https://pix.org/nl-be/support"
+        },
+        "fields": {
+          "email": {
+            "error-message-invalid": "Your email address is invalid.",
+            "label": "Email address",
+            "placeholder": "ex: john.doe@email.com"
+          }
         },
         "actions": {
           "receive-reset-button": "Receive a reset link"


### PR DESCRIPTION
## :unicorn: Problème

On a besoin d'un nouveau composant de demande de réinitialisation de mot de passe utilisant le nouveau layout `AuthenticationLayout`.

## :robot: Proposition

Création d'un nouveau composant de demande de réinitialisation de mot de passe utilisant le nouveau layout `AuthenticationLayout`.

On a profité de la création de ce nouveau composant pour, côté API, simplifier la payload à envoyer, de manière à ce qu'on puisse ne plus envoyer qu'une propriété `email` au lieu d'envoyer tout une structure de donnée EmberData pas du tout adaptée pour ce cas d'usage. On laisse néanmoins le code nécessaire à la gestion de la structure de donnée EmberData dépréciée jusqu'à ce que le code du nouveau layout `AuthenticationLayout` soit débloqué en production avec l'activation/suppression du feature flag `FT_NEW_AUTHENTICATION_DESIGN_ENABLED`.

## :rainbow: Remarques

RAS

## :100: Pour tester

1. Activer le feature flag `FT_NEW_AUTHENTICATION_DESIGN_ENABLED=true`
2. Aller sur https://app.dev.pix.fr/mot-de-passe-oublie
3. Vérifier que le lien « Contactez-nous » est fonctionnel et pointe vers la bonne destination
4. Vérifier qu'on ne peut envoyer le formulaire qu'avec une adresse email valide
5. Vérifier qu'en envoyant le formulaire avec une adresse email non présente dans la table `users`, le formulaire affiche alors une erreur ` Cette adresse e-mail ne correspond à aucun compte `
6. Aller sur https://app.dev.pix.org/mot-de-passe-oublie et sélectionner différentes langues avec le LanguageSwitcher pour vérifier les traductions et les destinations du lien « Contact us »
7. Arrêter l'API et vérifier que le formulaire affiche une erreur ` Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.` (il faut généralement attendre environ 20s ou 30s pour que la connexion arrive en timeout avant qu'une erreur soit déclenchée)
