### PR TITLE
[FEATURE] Compléter la page de non détection de l'extension (PIX-14726).

### DIFF
--- a/mon-pix/app/components/companion/blocker.gjs
+++ b/mon-pix/app/components/companion/blocker.gjs
@@ -1,4 +1,6 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
@@ -28,6 +30,11 @@ export default class CompanionBlocker extends Component {
     return !this.pixCompanion.isExtensionEnabled;
   }
 
+  @action
+  refreshPage() {
+    window.location.reload(true);
+  }
+
   <template>
     {{#if this.isBlocked}}
       <section class="companion-blocker">
@@ -36,7 +43,21 @@ export default class CompanionBlocker extends Component {
           {{t "common.companion.not-detected.title" htmlSafe=true}}
         </h1>
         <p>{{t "common.companion.not-detected.description"}}</p>
-        <PixButtonLink @href="https://cloud.pix.fr/s/KocingDC4mFJ3R6" target="_blank">{{t "common.companion.not-detected.link"}}</PixButtonLink>
+
+        <ul class="companion-blocker__list">
+          <li>
+            <PixButtonLink @href="https://cloud.pix.fr/s/KocingDC4mFJ3R6" target="_blank">{{t
+                "common.companion.not-detected.link"
+              }}</PixButtonLink>
+          </li>
+          <li>
+            <PixButton
+              @variant="secondary"
+              @triggerAction={{this.refreshPage}}
+              class="companion-blocker-list__refresh-button"
+            >{{t "common.actions.refresh-page"}}</PixButton>
+          </li>
+        </ul>
       </section>
     {{else}}
       {{yield}}

--- a/mon-pix/app/components/companion/blocker.gjs
+++ b/mon-pix/app/components/companion/blocker.gjs
@@ -1,4 +1,4 @@
-// import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
@@ -36,7 +36,7 @@ export default class CompanionBlocker extends Component {
           {{t "common.companion.not-detected.title" htmlSafe=true}}
         </h1>
         <p>{{t "common.companion.not-detected.description"}}</p>
-        {{!-- <PixButtonLink @href="https://pix.fr" target="_blank">{{t "common.companion.not-detected.link"}}</PixButtonLink> --}}
+        <PixButtonLink @href="https://cloud.pix.fr/s/KocingDC4mFJ3R6" target="_blank">{{t "common.companion.not-detected.link"}}</PixButtonLink>
       </section>
     {{else}}
       {{yield}}

--- a/mon-pix/app/styles/components/companion/blocker.scss
+++ b/mon-pix/app/styles/components/companion/blocker.scss
@@ -18,4 +18,20 @@
 
     max-width: 500px;
   }
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-2x);
+    padding-top: var(--pix-spacing-2x);
+  }
+}
+
+.companion-blocker-list {
+  &__refresh-button {
+    width: 100%;
+    color: var(--pix-neutral-0);
+    background-color: var(--pix-certif-500);
+    border: 2px solid var(--pix-neutral-0);
+  }
 }

--- a/mon-pix/tests/integration/components/companion/blocker-test.gjs
+++ b/mon-pix/tests/integration/components/companion/blocker-test.gjs
@@ -62,6 +62,9 @@ module('Integration | Component | Companion | blocker', function (hooks) {
       .dom(screen.getByRole('heading', { level: 1, name: 'L’extension Pix Companion n’est pas détectée' }))
       .exists();
     assert.dom(screen.queryByText(t('common.companion.not-detected.description'))).exists();
-    assert.dom(screen.getByRole('link', { name: t('common.companion.not-detected.link') })).hasAttribute('href', 'https://cloud.pix.fr/s/KocingDC4mFJ3R6');
+    assert
+      .dom(screen.getByRole('link', { name: t('common.companion.not-detected.link') }))
+      .hasAttribute('href', 'https://cloud.pix.fr/s/KocingDC4mFJ3R6');
+    assert.dom(screen.getByRole('button', { name: t('common.actions.refresh-page') })).exists();
   });
 });

--- a/mon-pix/tests/integration/components/companion/blocker-test.gjs
+++ b/mon-pix/tests/integration/components/companion/blocker-test.gjs
@@ -35,7 +35,7 @@ module('Integration | Component | Companion | blocker', function (hooks) {
     assert.dom(screen.queryByRole('heading', { level: 1, name: title })).exists();
   });
 
-  test('it displays blocking page when extension is NOT detected', async function (assert) {
+  test('it displays blocking page when extension is not detected', async function (assert) {
     // given
     class PixCompanionStub extends Service {
       startCheckingExtensionIsEnabled = sinon.stub();
@@ -58,13 +58,10 @@ module('Integration | Component | Companion | blocker', function (hooks) {
 
     // then
     assert.dom(screen.queryByRole('heading', { level: 1, name: 'Companion activé' })).doesNotExist();
-
     assert
-      .dom(screen.queryByRole('heading', { level: 1, name: 'L’extension Pix Companion n’est pas détectée' }))
+      .dom(screen.getByRole('heading', { level: 1, name: 'L’extension Pix Companion n’est pas détectée' }))
       .exists();
-
     assert.dom(screen.queryByText(t('common.companion.not-detected.description'))).exists();
-
-    // assert.dom(screen.queryByRole('link', { name: t('common.companion.not-detected.link') })).exists();
+    assert.dom(screen.getByRole('link', { name: t('common.companion.not-detected.link') })).hasAttribute('href', 'https://cloud.pix.fr/s/KocingDC4mFJ3R6');
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -46,7 +46,8 @@
       "show-more": "Show more",
       "sign-out": "Sign out",
       "stay": "Stay",
-      "validate": "Validate"
+      "validate": "Validate",
+      "refresh-page": "Refresh the page"
     },
     "api-error-messages": {
       "bad-request-error": "The data entered was not in the correct format.",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -46,7 +46,8 @@
       "show-more": "Ver más",
       "sign-out": "Desconectarse",
       "stay": "Quedarse",
-      "validate": "Validar"
+      "validate": "Validar",
+      "refresh-page": "Actualizar la página"
     },
     "api-error-messages": {
       "bad-request-error": "Los datos que has enviado no están en el formato correcto.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -46,7 +46,8 @@
       "show-more": "Afficher plus",
       "sign-out": "Se déconnecter",
       "stay": "Rester",
-      "validate": "Valider"
+      "validate": "Valider",
+      "refresh-page": "Rafraîchir la page"
     },
     "api-error-messages": {
       "bad-request-error": "Les données que vous avez soumises ne sont pas au bon format.",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -46,7 +46,8 @@
       "show-more": "Meer bekijken",
       "sign-out": "Log uit.",
       "stay": "Blijf",
-      "validate": "Valideer"
+      "validate": "Valideer",
+      "refresh-page": "Pagina verversen"
     },
     "api-error-messages": {
       "bad-request-error": "De gegevens die u hebt opgegeven, hebben niet het juiste formaat.",


### PR DESCRIPTION
## :fallen_leaf: Problème
Actuellement la page de non détection de l'extension Companion ne donne accès à aucun lien de documentation.

## :chestnut: Proposition
Ajouter un lien menant à une documentation complète sur l'installation de l'extension
Ajouter un lien pour recharger la page

## :wood: Pour tester

- Ne pas activer l'extension Companion
- Créer une session V3 sur Pix Certif (+ espace surveillant => confirmer la présence)
- Se connecter sur App avec certif-success@example.net
- Remplir le formulaire d'entrée en session de certif
- Constater que la page affiche deux boutons : l'un pour la documentation (ouverture dans une autre page)
- L'autre pour rafraîchir la page

<img width="1017" alt="Capture d’écran 2024-10-17 à 18 34 42" src="https://github.com/user-attachments/assets/7e5f2320-bc60-4b3f-8493-1484d400e884">
