### PR TITLE
[FEATURE] valide les que `participantExternalId` est un email valide (pix-14886)

### DIFF
--- a/api/src/prescription/campaign-participation/domain/models/CampaignParticipant.js
+++ b/api/src/prescription/campaign-participation/domain/models/CampaignParticipant.js
@@ -5,6 +5,8 @@ import {
 import { EntityValidationError, ForbiddenAccess } from '../../../../shared/domain/errors.js';
 import { Assessment } from '../../../../shared/domain/models/Assessment.js';
 import { OrganizationLearner } from '../../../../shared/domain/models/OrganizationLearner.js';
+import * as emailValidationService from '../../../../shared/domain/services/email-validation-service.js';
+import { CampaignExternalIdTypes } from '../../../shared/domain/constants.js';
 import { CampaignParticipation } from './CampaignParticipation.js';
 
 const couldNotJoinCampaignErrorMessage = "Vous n'êtes pas autorisé à rejoindre la campagne";
@@ -105,7 +107,21 @@ class CampaignParticipant {
         invalidAttributes: [
           {
             attribute: 'participantExternalId',
-            message: 'Un identifiant externe est requis pour accèder à la campagne.',
+            message: 'MISSING_EXTERNAL_ID',
+          },
+        ],
+      });
+    }
+
+    if (
+      this.campaignToStartParticipation.idPixType === CampaignExternalIdTypes.EMAIL &&
+      !emailValidationService.validateEmailSyntax(participantExternalId)
+    ) {
+      throw new EntityValidationError({
+        invalidAttributes: [
+          {
+            attribute: 'participantExternalId',
+            message: 'INVALID_EMAIL',
           },
         ],
       });

--- a/api/src/shared/domain/services/email-validation-service.js
+++ b/api/src/shared/domain/services/email-validation-service.js
@@ -1,0 +1,12 @@
+import Joi from 'joi';
+
+const emailSchema = Joi.object({
+  email: Joi.string().email(),
+});
+
+export const validateEmailSyntax = (email) => {
+  const { error } = emailSchema.validate({ email });
+  return !error;
+};
+
+export default { validateEmailSyntax };

--- a/api/tests/shared/unit/domain/services/email-validation-service_test.js
+++ b/api/tests/shared/unit/domain/services/email-validation-service_test.js
@@ -1,0 +1,19 @@
+import { validateEmailSyntax } from '../../../../../src/shared/domain/services/email-validation-service.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Shared | Domain | Services | EmailValidationService', function () {
+  describe('#validateEmailSyntax', function () {
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    [
+      ['test', false],
+      ['test@toto', false],
+      ['@toto', false],
+      ['?lionel@toto?ru', false],
+      ['valid@example.net', true],
+    ].forEach(([email, valid]) => {
+      it(`should ${valid ? 'validate' : 'not validate'} email ${email}`, function () {
+        expect(validateEmailSyntax(email)).to.equal(valid);
+      });
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-campaign-to-start-participation.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-to-start-participation.js
@@ -4,6 +4,7 @@ import { CampaignTypes } from '../../../../src/prescription/shared/domain/consta
 const buildCampaignToStartParticipation = function ({
   id = 1,
   idPixLabel = 'Un id pix label',
+  idPixType,
   archivedAt = null,
   deletedAt = null,
   type = CampaignTypes.ASSESSMENT,
@@ -17,6 +18,7 @@ const buildCampaignToStartParticipation = function ({
   return new CampaignToStartParticipation({
     id,
     idPixLabel,
+    idPixType,
     archivedAt,
     deletedAt,
     type,

--- a/mon-pix/app/components/routes/campaigns/invited/fill-in-participant-external-id.hbs
+++ b/mon-pix/app/components/routes/campaigns/invited/fill-in-participant-external-id.hbs
@@ -18,6 +18,9 @@
       @validationStatus={{if this.errorMessage "error"}}
       @requiredLabel={{true}}
       {{on "change" this.updateParticipantExternalId}}
+      @subLabel={{this.idPixInputSubLabel}}
+      type={{this.idPixInputType}}
+      aria-autocomplete="none"
     >
       <:label>{{@campaign.idPixLabel}}</:label>
     </PixInput>

--- a/mon-pix/app/components/routes/campaigns/invited/fill-in-participant-external-id.hbs
+++ b/mon-pix/app/components/routes/campaigns/invited/fill-in-participant-external-id.hbs
@@ -12,7 +12,7 @@
 
   <form {{on "submit" this.submit}} class="fill-in-participant-external-id__form">
     <PixInput
-      @id="id-pix-label"
+      @id="external-id"
       @value={{this.participantExternalId}}
       @errorMessage={{this.errorMessage}}
       @validationStatus={{if this.errorMessage "error"}}

--- a/mon-pix/app/components/routes/campaigns/invited/fill-in-participant-external-id.hbs
+++ b/mon-pix/app/components/routes/campaigns/invited/fill-in-participant-external-id.hbs
@@ -11,19 +11,16 @@
   </p>
 
   <form {{on "submit" this.submit}} class="fill-in-participant-external-id__form">
-    <div class="fill-in-participant-external-id-form__section">
-      <div class="fill-in-participant-external-id__form-field">
-        <label for="id-pix-label">{{@campaign.idPixLabel}}</label>
-        <Input required id="id-pix-label" @value={{this.participantExternalId}} />
-      </div>
-
-      <PixButton @type="submit" class="fill-in-participant-external-id__button">
-        {{t "pages.fill-in-participant-external-id.buttons.continue"}}
-      </PixButton>
-      {{#if this.errorMessage}}
-        <div class="fill-in-participant-external-id__form__error-message">{{this.errorMessage}}</div>
-      {{/if}}
-    </div>
+    <PixInput
+      @id="id-pix-label"
+      @value={{this.participantExternalId}}
+      @errorMessage={{this.errorMessage}}
+      @validationStatus={{if this.errorMessage "error"}}
+      @requiredLabel={{true}}
+      {{on "change" this.updateParticipantExternalId}}
+    >
+      <:label>{{@campaign.idPixLabel}}</:label>
+    </PixInput>
 
     {{#if @campaign.externalIdHelpImageUrl}}
       <img
@@ -33,14 +30,13 @@
       />
     {{/if}}
 
-    <PixButton
-      @variant="secondary"
-      @triggerAction={{this.cancel}}
-      @size="large"
-      @loadingColor="white"
-      class="fill-in-participant-external-id__cancel-button"
-    >
-      {{t "pages.fill-in-participant-external-id.buttons.cancel"}}
-    </PixButton>
+    <div class="fill-in-participant-external-id-form__buttonbar">
+      <PixButton @type="submit" class="fill-in-participant-external-id__button">
+        {{t "pages.fill-in-participant-external-id.buttons.continue"}}
+      </PixButton>
+      <PixButton @variant="secondary" @triggerAction={{this.cancel}} @loadingColor="white">
+        {{t "pages.fill-in-participant-external-id.buttons.cancel"}}
+      </PixButton>
+    </div>
   </form>
 </main>

--- a/mon-pix/app/components/routes/campaigns/invited/fill-in-participant-external-id.js
+++ b/mon-pix/app/components/routes/campaigns/invited/fill-in-participant-external-id.js
@@ -42,4 +42,22 @@ export default class FillInParticipantExternalId extends Component {
     this.errorMessage = null;
     return this.args.onCancel();
   }
+
+  get idPixInputType() {
+    if (this.args.campaign.idPixType === 'EMAIL') {
+      return 'email';
+    } else if (this.args.campaign.idPixType === 'STRING') {
+      return 'text';
+    }
+    return null;
+  }
+
+  get idPixInputSubLabel() {
+    if (this.args.campaign.idPixType === 'EMAIL') {
+      return this.intl.t('pages.sign-up.fields.email.help');
+    } else if (this.args.campaign.idPixInputType === 'STRING') {
+      return '';
+    }
+    return null;
+  }
 }

--- a/mon-pix/app/components/routes/campaigns/invited/fill-in-participant-external-id.js
+++ b/mon-pix/app/components/routes/campaigns/invited/fill-in-participant-external-id.js
@@ -6,7 +6,7 @@ import { tracked } from '@glimmer/tracking';
 const ERROR_MESSAGE = {
   INVALID_EMAIL: 'pages.fill-in-participant-external-id.errors.invalid-external-id-email',
   INVALID_EXTERNAL_ID: 'pages.fill-in-participant-external-id.errors.invalid-external-id',
-  MISSING_EXTERNAL_ID: 'pages.fill-in-participant-external-id.errors.missing-id-pix-label',
+  MISSING_EXTERNAL_ID: 'pages.fill-in-participant-external-id.errors.missing-external-id',
 };
 export default class FillInParticipantExternalId extends Component {
   @service intl;
@@ -28,14 +28,14 @@ export default class FillInParticipantExternalId extends Component {
     event.preventDefault();
 
     if (!this.participantExternalId) {
-      this.errorMessage = this.intl.t('pages.fill-in-participant-external-id.errors.missing-id-pix-label', {
+      this.errorMessage = this.intl.t('pages.fill-in-participant-external-id.errors.missing-external-id', {
         idPixLabel: this.args.campaign.idPixLabel,
       });
       return;
     }
 
     if (this.participantExternalId.length > 255) {
-      this.errorMessage = this.intl.t('pages.fill-in-participant-external-id.errors.max-length-id-pix-label', {
+      this.errorMessage = this.intl.t('pages.fill-in-participant-external-id.errors.max-length-external-id', {
         idPixLabel: this.args.campaign.idPixLabel,
       });
       return;

--- a/mon-pix/app/components/routes/campaigns/invited/fill-in-participant-external-id.js
+++ b/mon-pix/app/components/routes/campaigns/invited/fill-in-participant-external-id.js
@@ -3,12 +3,25 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
+const ERROR_MESSAGE = {
+  INVALID_EMAIL: 'pages.fill-in-participant-external-id.errors.invalid-external-id-email',
+  INVALID_EXTERNAL_ID: 'pages.fill-in-participant-external-id.errors.invalid-external-id',
+  MISSING_EXTERNAL_ID: 'pages.fill-in-participant-external-id.errors.missing-id-pix-label',
+};
 export default class FillInParticipantExternalId extends Component {
   @service intl;
+  @service campaignStorage;
 
-  @tracked participantExternalId = null;
+  @tracked participantExternalId = this.previousParticipantExternalId || null;
   @tracked isLoading = false;
-  @tracked errorMessage = null;
+  @tracked errorMessage = ERROR_MESSAGE[this.previousError] ? this.intl.t(ERROR_MESSAGE[this.previousError]) : null;
+
+  get previousError() {
+    return this.campaignStorage.get(this.args.campaign.code, 'error');
+  }
+  get previousParticipantExternalId() {
+    return this.campaignStorage.get(this.args.campaign.code, 'previousParticipantExternalId');
+  }
 
   @action
   submit(event) {

--- a/mon-pix/app/components/routes/campaigns/invited/fill-in-participant-external-id.js
+++ b/mon-pix/app/components/routes/campaigns/invited/fill-in-participant-external-id.js
@@ -33,6 +33,11 @@ export default class FillInParticipantExternalId extends Component {
   }
 
   @action
+  updateParticipantExternalId(event) {
+    this.participantExternalId = event.target.value;
+  }
+
+  @action
   cancel() {
     this.errorMessage = null;
     return this.args.onCancel();

--- a/mon-pix/app/models/campaign-participation-badge.js
+++ b/mon-pix/app/models/campaign-participation-badge.js
@@ -10,7 +10,7 @@ export default class CampaignParticipationBadge extends Badge {
   @attr('number') acquisitionPercentage;
 
   // includes
-  @belongsTo('campaignParticipationResult', {
+  @belongsTo('campaign-participation-result', {
     async: true,
     inverse: 'campaignParticipationBadges',
   })

--- a/mon-pix/app/models/campaign-participation-result.js
+++ b/mon-pix/app/models/campaign-participation-result.js
@@ -28,7 +28,7 @@ export default class CampaignParticipationResult extends Model {
 
   @hasMany('competenceResult', { async: false, inverse: 'campaignParticipationResult' }) competenceResults;
 
-  @belongsTo('reachedStage', { async: false, inverse: 'campaignParticipationResult' }) reachedStage;
+  @belongsTo('reached-stage', { async: false, inverse: 'campaignParticipationResult' }) reachedStage;
 
   get hasReachedStage() {
     return this.reachedStage !== null;

--- a/mon-pix/app/models/campaign-participation.js
+++ b/mon-pix/app/models/campaign-participation.js
@@ -14,7 +14,7 @@ export default class CampaignParticipation extends Model {
   // includes
   @belongsTo('assessment', { async: true, inverse: null }) assessment;
   @belongsTo('campaign', { async: true, inverse: null }) campaign;
-  @belongsTo('campaignParticipationResult', { async: true, inverse: null }) campaignParticipationResult;
+  @belongsTo('campaign-participation-result', { async: true, inverse: null }) campaignParticipationResult;
   @belongsTo('user', { async: true, inverse: null }) user;
 
   @hasMany('training', { async: true, inverse: 'campaignParticipation' }) trainings;

--- a/mon-pix/app/models/campaign.js
+++ b/mon-pix/app/models/campaign.js
@@ -5,6 +5,7 @@ export default class Campaign extends Model {
   @attr('string') title;
   @attr('string') type;
   @attr('string') idPixLabel;
+  @attr('string') idPixType;
   @attr('string') customLandingPageText;
   @attr('string') externalIdHelpImageUrl;
   @attr('string') alternativeTextToExternalIdHelpImage;

--- a/mon-pix/app/models/competence-result.js
+++ b/mon-pix/app/models/competence-result.js
@@ -16,7 +16,8 @@ export default class CompetenceResult extends Model {
   @attr('number') reachedStage;
 
   // includes
-  @belongsTo('campaignParticipationResult', { async: true, inverse: 'competenceResults' }) campaignParticipationResult;
+  @belongsTo('campaign-participation-result', { async: true, inverse: 'competenceResults' })
+  campaignParticipationResult;
 
   get masteryRate() {
     return this.masteryPercentage / 100;

--- a/mon-pix/app/routes/campaigns/access.js
+++ b/mon-pix/app/routes/campaigns/access.js
@@ -43,7 +43,7 @@ export default class AccessRoute extends Route {
   }
 
   async afterModel(campaign) {
-    const ongoingCampaignParticipation = await this.store.queryRecord('campaignParticipation', {
+    const ongoingCampaignParticipation = await this.store.queryRecord('campaign-participation', {
       campaignId: campaign.id,
       userId: this.currentUser.user.id,
     });

--- a/mon-pix/app/routes/campaigns/assessment.js
+++ b/mon-pix/app/routes/campaigns/assessment.js
@@ -12,7 +12,7 @@ export default class AssessmentRoute extends Route {
 
   async model() {
     const campaign = this.modelFor('campaigns');
-    const campaignParticipation = await this.store.queryRecord('campaignParticipation', {
+    const campaignParticipation = await this.store.queryRecord('campaign-participation', {
       campaignId: campaign.id,
       userId: this.currentUser.user.id,
     });

--- a/mon-pix/app/routes/campaigns/entrance.js
+++ b/mon-pix/app/routes/campaigns/entrance.js
@@ -54,7 +54,8 @@ export default class Entrance extends Route {
       if (!this.currentUser.user?.hasAssessmentParticipations) {
         this.currentUser.load();
       }
-
+      this.campaignStorage.set(campaign.code, 'error', null);
+      this.campaignStorage.set(campaign.code, 'previousParticipantExternalId', null);
       this.campaignStorage.set(campaign.code, 'hasParticipated', true);
     } catch (err) {
       const error = get(err, 'errors[0]', {});
@@ -69,6 +70,9 @@ export default class Entrance extends Route {
 
       if (error.status == 400 && error.detail.includes('participant-external-id')) {
         this.campaignStorage.set(campaign.code, 'participantExternalId', null);
+        this.campaignStorage.set(campaign.code, 'previousParticipantExternalId', participantExternalId);
+        this.campaignStorage.set(campaign.code, 'error', 'INVALID_EXTERNAL_ID');
+
         return this.router.replaceWith('campaigns.invited.fill-in-participant-external-id', campaign.code);
       }
       if (error.detail === 'ORGANIZATION_LEARNER_HAS_ALREADY_PARTICIPATED') {

--- a/mon-pix/app/routes/campaigns/entrance.js
+++ b/mon-pix/app/routes/campaigns/entrance.js
@@ -60,6 +60,13 @@ export default class Entrance extends Route {
       const error = get(err, 'errors[0]', {});
       campaignParticipation.deleteRecord();
 
+      if (error.status == 422) {
+        this.campaignStorage.set(campaign.code, 'participantExternalId', null);
+        this.campaignStorage.set(campaign.code, 'error', error.detail);
+        this.campaignStorage.set(campaign.code, 'previousParticipantExternalId', participantExternalId);
+        return this.router.replaceWith('campaigns.invited.fill-in-participant-external-id', campaign.code);
+      }
+
       if (error.status == 400 && error.detail.includes('participant-external-id')) {
         this.campaignStorage.set(campaign.code, 'participantExternalId', null);
         return this.router.replaceWith('campaigns.invited.fill-in-participant-external-id', campaign.code);

--- a/mon-pix/app/routes/campaigns/entrance.js
+++ b/mon-pix/app/routes/campaigns/entrance.js
@@ -73,7 +73,7 @@ export default class Entrance extends Route {
   }
 
   async shouldBeginCampaignParticipation(campaign) {
-    const ongoingCampaignParticipation = await this.store.queryRecord('campaignParticipation', {
+    const ongoingCampaignParticipation = await this.store.queryRecord('campaign-participation', {
       campaignId: campaign.id,
       userId: this.currentUser.user.id,
     });

--- a/mon-pix/app/routes/campaigns/entry-point.js
+++ b/mon-pix/app/routes/campaigns/entry-point.js
@@ -50,7 +50,7 @@ export default class EntryPoint extends Route {
     let hasParticipated = false;
     if (this.session.isAuthenticated) {
       const currentUserId = this.currentUser.user.id;
-      const ongoingCampaignParticipation = await this.store.queryRecord('campaignParticipation', {
+      const ongoingCampaignParticipation = await this.store.queryRecord('campaign-participation', {
         campaignId: campaign.id,
         userId: currentUserId,
       });

--- a/mon-pix/app/routes/campaigns/profiles-collection.js
+++ b/mon-pix/app/routes/campaigns/profiles-collection.js
@@ -12,7 +12,7 @@ export default class ProfilesCollectionRoute extends Route {
 
   async model() {
     const campaign = this.modelFor('campaigns');
-    const campaignParticipation = await this.store.queryRecord('campaignParticipation', {
+    const campaignParticipation = await this.store.queryRecord('campaign-participation', {
       campaignId: campaign.id,
       userId: this.currentUser.user.id,
     });

--- a/mon-pix/app/styles/pages/_fill-in-participant-external-id.scss
+++ b/mon-pix/app/styles/pages/_fill-in-participant-external-id.scss
@@ -38,50 +38,14 @@
   align-items: center;
 }
 
-.fill-in-participant-external-id-form__section {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-
-  @include device-is('tablet') {
-    flex-direction: row;
-    align-items: flex-end;
-  }
-}
-
-.fill-in-participant-external-id__form label {
-  display: block;
-  margin-bottom: 5px;
-  font-weight: var(--pix-font-bold);
-  font-size: 0.938rem;
-}
-
-.fill-in-participant-external-id__form-field input {
-  width: 232px;
-  height: 43px;
-  margin-right: var(--pix-spacing-2x);
-  padding: 4px 8px;
-  border: solid 2px var(--pix-neutral-100);
-  border-radius: 3px;
-  outline: none;
-}
-
-.fill-in-participant-external-id__button {
-  display: inline-block;
-}
-
-.fill-in-participant-external-id__cancel-button {
-  margin-top: 50px;
-}
 
 .fill-in-participant-external-id__help {
   margin-top: 32px;
 }
 
-/* ------------------------ ERROR ------------------------ */
-
-.fill-in-participant-external-id__form__error-message {
-  margin-top: 5px;
-  color: var(--pix-error-500);
-  font-size: 0.75rem;
+.fill-in-participant-external-id-form__buttonbar {
+  display: flex;
+  flex-direction: row;
+  gap: var(--pix-spacing-2x);
+  margin-top: 50px;
 }

--- a/mon-pix/mirage/factories/campaign.js
+++ b/mon-pix/mirage/factories/campaign.js
@@ -18,6 +18,10 @@ export default Factory.extend({
     return null;
   },
 
+  idPixType() {
+    return null;
+  },
+
   organizationLogoUrl() {
     return 'data:jpeg;base64=somelogo';
   },

--- a/mon-pix/mirage/routes/campaign-participations/post-campaign-participation.js
+++ b/mon-pix/mirage/routes/campaign-participations/post-campaign-participation.js
@@ -13,7 +13,9 @@ export default function (schema, request) {
         errors: [
           {
             status: 400,
-            detail: 'participant-external-id',
+            title: 'Bad Request',
+            detail:
+              '"data.attributes.participant-external-id" length must be less than or equal to 255 characters long',
           },
         ],
       },

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment-test.js
@@ -38,12 +38,12 @@ module('Acceptance | Campaigns | Start Campaigns with type Assessment', function
         module('When participant external id is not set in the url', function () {
           test('should redirect to assessment after completion of external id', async function (assert) {
             // given
-            campaign = server.create('campaign', { idPixLabel: 'email', type: ASSESSMENT });
+            campaign = server.create('campaign', { idPixLabel: 'email', idPixType: 'EMAIL', type: ASSESSMENT });
             const screen = await startCampaignByCode(campaign.code);
             await _fillInputsToCreateUserPixAccount({ prescritUser, screen, t });
 
             // when
-            await fillIn(screen.getByRole('textbox', { name: 'email' }), 'monmail@truc.fr');
+            await fillIn(screen.getByRole('textbox', { name: /email/ }), 'monmail@truc.fr');
             await click(screen.getByRole('button', { name: 'Continuer' }));
 
             // then
@@ -184,7 +184,7 @@ module('Acceptance | Campaigns | Start Campaigns with type Assessment', function
             await fillIn(screen.getByRole('textbox', { name: 'année de naissance' }), '2000');
             await click(screen.getByRole('button', { name: t('pages.join.button') }));
             await click(screen.getByRole('button', { name: t('pages.join.sco.associate') }));
-            await fillIn(screen.getByRole('textbox', { name: 'nom de naissance de maman' }), 'truc');
+            await fillIn(screen.getByRole('textbox', { name: /nom de naissance de maman/ }), 'truc');
 
             // when
             await click(screen.getByRole('button', { name: 'Continuer' }));
@@ -203,7 +203,7 @@ module('Acceptance | Campaigns | Start Campaigns with type Assessment', function
             const screen = await startCampaignByCode(campaign.code);
 
             // when
-            await fillIn(screen.getByRole('textbox', { name: 'nom de naissance de maman' }), 'truc');
+            await fillIn(screen.getByRole('textbox', { name: /nom de naissance de maman/ }), 'truc');
             await click(screen.getByRole('button', { name: 'Continuer' }));
 
             // then
@@ -216,7 +216,7 @@ module('Acceptance | Campaigns | Start Campaigns with type Assessment', function
             const screen = await startCampaignByCode(campaign.code);
 
             // when
-            await fillIn(screen.getByRole('textbox', { name: 'nom de naissance de maman' }), 'truc');
+            await fillIn(screen.getByRole('textbox', { name: /nom de naissance de maman/ }), 'truc');
             await click(screen.getByRole('button', { name: 'Continuer' }));
             await click(screen.getByRole('button', { name: t('pages.tutorial.pass') }));
 

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection-test.js
@@ -37,7 +37,11 @@ module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection',
         module('When participant external id is not set in the url', function () {
           test('should redirect to send profile page after completion of external id', async function (assert) {
             // then
-            campaign = server.create('campaign', { type: PROFILES_COLLECTION, idPixLabel: 'Adresse e-mail' });
+            campaign = server.create('campaign', {
+              type: PROFILES_COLLECTION,
+              idPixLabel: 'Adresse e-mail',
+              idPixType: 'EMAIL',
+            });
             const screen = await startCampaignByCode(campaign.code);
             await fillIn(screen.getByRole('textbox', { name: FIRST_NAME_INPUT_LABEL }), campaignParticipant.firstName);
             await fillIn(screen.getByRole('textbox', { name: LAST_NAME_INPUT_LABEL }), campaignParticipant.lastName);
@@ -47,7 +51,7 @@ module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection',
             await click(screen.getByRole('button', { name: "Je m'inscris" }));
 
             // when
-            await fillIn(screen.getByRole('textbox', { name: 'Adresse e-mail' }), 'monmail@truc.fr');
+            await fillIn(screen.getByRole('textbox', { name: /Adresse e-mail/ }), 'monmail@truc.fr');
             await click(screen.getByRole('button', { name: 'Continuer' }));
 
             // then
@@ -196,7 +200,7 @@ module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection',
             await click(screen.getByRole('button', { name: "C'est parti !" }));
             await click(screen.getByRole('button', { name: 'Associer' }));
 
-            await fillIn(screen.getByRole('textbox', { name: 'nom de naissance de maman' }), 'truc');
+            await fillIn(screen.getByRole('textbox', { name: /nom de naissance de maman/ }), 'truc');
 
             // when
             await click(screen.getByRole('button', { name: 'Continuer' }));
@@ -262,7 +266,7 @@ module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection',
             const screen = await startCampaignByCode(campaign.code);
 
             // when
-            await fillIn(screen.getByRole('textbox', { name: 'nom de naissance de maman' }), 'truc');
+            await fillIn(screen.getByRole('textbox', { name: /nom de naissance de maman/ }), 'truc');
             await click(screen.getByRole('button', { name: 'Continuer' }));
 
             // then

--- a/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
@@ -52,7 +52,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
         module('When campaign is not restricted', function () {
           test('should display landing page', async function (assert) {
             // given
-            const campaign = server.create('campaign', { isRestricted: false });
+            const campaign = server.create('campaign', { isRestricted: false, idPixLabel: null });
             const screen = await visit('/campagnes');
 
             // when
@@ -426,7 +426,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             // when
             const screen = await visit(`/campagnes/${campaign.code}`);
             await click(screen.getByRole('button', { name: 'Je commence' }));
-            await fillIn(screen.getByRole('textbox', { name: 'Les anonymes' }), 'vu');
+            await fillIn(screen.getByRole('textbox', { name: /Les anonymes/ }), 'vu');
             await click(screen.getByRole('button', { name: 'Continuer' }));
 
             // then
@@ -766,7 +766,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
           // when
           const screen = await visit(`/campagnes/${campaign.code}`);
           await click(screen.getByRole('button', { name: 'Je commence' }));
-          await fillIn(screen.getByRole('textbox', { name: 'Les anonymes' }), 'vu');
+          await fillIn(screen.getByRole('textbox', { name: /Les anonymes/ }), 'vu');
           await click(screen.getByRole('button', { name: 'Continuer' }));
 
           // then

--- a/mon-pix/tests/helpers/campaign.js
+++ b/mon-pix/tests/helpers/campaign.js
@@ -19,7 +19,7 @@ export async function resumeCampaignOfTypeAssessmentByCode(campaignCode, hasExte
   await visit(`/campagnes/${campaignCode}`);
   await clickByLabel('Je commence');
   if (hasExternalParticipantId) {
-    await fillIn('#id-pix-label', 'monmail@truc.fr');
+    await fillIn('#external-id', 'monmail@truc.fr');
     await clickByLabel('Continuer');
   }
   await clickByLabel('Ignorer');
@@ -29,7 +29,7 @@ export async function resumeCampaignOfTypeProfilesCollectionByCode(campaignCode,
   await visit(`/campagnes/${campaignCode}`);
   await clickByLabel("C'est parti !");
   if (hasExternalParticipantId) {
-    await fillIn('#id-pix-label', 'monmail@truc.fr');
+    await fillIn('#external-id', 'monmail@truc.fr');
     await clickByLabel('Continuer');
   }
 }

--- a/mon-pix/tests/integration/components/routes/campaigns/invited/fill-in-participant-external-id-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/invited/fill-in-participant-external-id-test.js
@@ -2,6 +2,7 @@ import { render } from '@1024pix/ember-testing-library';
 // eslint-disable-next-line no-restricted-imports
 import { find } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 
 import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
@@ -60,6 +61,70 @@ module('Integration | Component | routes/campaigns/invited/fill-in-participant-e
 
       // then
       assert.dom('img').doesNotExist();
+    });
+  });
+
+  module('with idPixLabel and idPixType', function () {
+    module('idPixInputType', function () {
+      Object.entries({ STRING: 'text', EMAIL: 'email' }).forEach(function ([idPixType, inputType]) {
+        test(`returns ${inputType} input type`, async function (assert) {
+          const campaign = {
+            idPixLabel: 'idpix',
+            idPixType,
+          };
+          this.set('campaign', campaign);
+
+          // given
+          const screen = await render(
+            hbs`<Routes::Campaigns::Invited::FillInParticipantExternalId
+  @campaign={{this.campaign}}
+  @onSubmit={{this.onSubmitStub}}
+  @onCancel={{this.onCancelStub}}
+/>`,
+          );
+          const input = screen.getByLabelText(/idpix/);
+          assert.strictEqual(input.type, inputType);
+        });
+      });
+    });
+
+    module('idPixSubLabel', function () {
+      test(`returns email example key for input`, async function (assert) {
+        const campaign = {
+          idPixLabel: 'idpix',
+          idPixType: 'EMAIL',
+        };
+        this.set('campaign', campaign);
+
+        // given
+        const screen = await render(
+          hbs`<Routes::Campaigns::Invited::FillInParticipantExternalId
+  @campaign={{this.campaign}}
+  @onSubmit={{this.onSubmitStub}}
+  @onCancel={{this.onCancelStub}}
+/>`,
+        );
+        const input = screen.getByLabelText(t('pages.sign-up.fields.email.help'), { exact: false });
+        assert.ok(input);
+      });
+      test(`not return email example for string idPixType`, async function (assert) {
+        const campaign = {
+          idPixLabel: 'idpix',
+          idPixType: 'STRING',
+        };
+        this.set('campaign', campaign);
+
+        // given
+        const screen = await render(
+          hbs`<Routes::Campaigns::Invited::FillInParticipantExternalId
+  @campaign={{this.campaign}}
+  @onSubmit={{this.onSubmitStub}}
+  @onCancel={{this.onCancelStub}}
+/>`,
+        );
+        const input = screen.queryByLabelText(t('pages.sign-up.fields.email.help'), { exact: false });
+        assert.notOk(input);
+      });
     });
   });
 });

--- a/mon-pix/tests/integration/components/routes/campaigns/invited/fill-in-participant-external-id-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/invited/fill-in-participant-external-id-test.js
@@ -126,5 +126,39 @@ module('Integration | Component | routes/campaigns/invited/fill-in-participant-e
         assert.notOk(input);
       });
     });
+
+    module('with previousError', function (hooks) {
+      const campaign = {
+        code: 'ABCDE1234',
+        idPixLabel: 'idpix',
+        idPixType: 'EMAIL',
+      };
+
+      hooks.beforeEach(function () {
+        const campaignStorage = this.owner.lookup('service:campaignStorage');
+        campaignStorage.set(campaign.code, 'error', 'INVALID_EMAIL');
+        campaignStorage.set(campaign.code, 'previousParticipantExternalId', '1234TOTO');
+      });
+      hooks.afterEach(function () {
+        const campaignStorage = this.owner.lookup('service:campaignStorage');
+        campaignStorage.clear(campaign.code);
+      });
+
+      test(`initialize error and previous external id`, async function (assert) {
+        this.set('campaign', campaign);
+
+        // given
+        const screen = await render(
+          hbs`<Routes::Campaigns::Invited::FillInParticipantExternalId
+  @campaign={{this.campaign}}
+  @onSubmit={{this.onSubmitStub}}
+  @onCancel={{this.onCancelStub}}
+/>`,
+        );
+        const input = screen.getByLabelText(/idpix/);
+        assert.strictEqual(input.value, '1234TOTO');
+        assert.ok(screen.getByText(t('pages.fill-in-participant-external-id.errors.invalid-external-id-email')));
+      });
+    });
   });
 });

--- a/mon-pix/tests/unit/routes/campaigns/entrance-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/entrance-test.js
@@ -149,12 +149,13 @@ module('Unit | Route | Entrance', function (hooks) {
       assert.ok(true);
     });
 
-    test('should abort campaign participation creation and redirect to fill-in-participant-external-id when something went wrong with it', async function (assert) {
+    test('should abort campaign participation creation and redirect to fill-in-participant-external-id when api return 400', async function (assert) {
       //given
       campaign = EmberObject.create({
         code: 'SOMECODE',
       });
       route.campaignStorage.get.withArgs(campaign.code, 'hasParticipated').returns(false);
+      route.campaignStorage.get.withArgs(campaign.code, 'participantExternalId').returns('1234TOTO');
       campaignParticipationStub.save.rejects({
         errors: [{ status: 400, detail: 'participant-external-id is too long' }],
       });
@@ -165,6 +166,8 @@ module('Unit | Route | Entrance', function (hooks) {
       //then
       sinon.assert.notCalled(route.currentUser.load);
       sinon.assert.calledWith(route.campaignStorage.set, campaign.code, 'participantExternalId', null);
+      sinon.assert.calledWith(route.campaignStorage.set, campaign.code, 'error', 'INVALID_EXTERNAL_ID');
+      sinon.assert.calledWith(route.campaignStorage.set, campaign.code, 'previousParticipantExternalId', '1234TOTO');
       sinon.assert.calledWith(
         route.router.replaceWith,
         'campaigns.invited.fill-in-participant-external-id',
@@ -173,6 +176,32 @@ module('Unit | Route | Entrance', function (hooks) {
       assert.ok(true);
     });
 
+    test('should abort campaign participation creation and redirect to fill-in-participant-external-id when api return 422', async function (assert) {
+      //given
+      campaign = EmberObject.create({
+        code: 'SOMECODE',
+      });
+      route.campaignStorage.get.withArgs(campaign.code, 'hasParticipated').returns(false);
+      route.campaignStorage.get.withArgs(campaign.code, 'participantExternalId').returns('1234TOTO');
+      campaignParticipationStub.save.rejects({
+        errors: [{ status: 422, detail: 'ERROR' }],
+      });
+
+      //when
+      await route.afterModel(campaign);
+
+      //then
+      sinon.assert.notCalled(route.currentUser.load);
+      sinon.assert.calledWith(route.campaignStorage.set, campaign.code, 'participantExternalId', null);
+      sinon.assert.calledWith(route.campaignStorage.set, campaign.code, 'error', 'ERROR');
+      sinon.assert.calledWith(route.campaignStorage.set, campaign.code, 'previousParticipantExternalId', '1234TOTO');
+      sinon.assert.calledWith(
+        route.router.replaceWith,
+        'campaigns.invited.fill-in-participant-external-id',
+        campaign.code,
+      );
+      assert.ok(true);
+    });
     test('should abort campaign participation and redirect to already participated', async function (assert) {
       //given
       campaign = EmberObject.create({

--- a/mon-pix/tests/unit/routes/campaigns/entry-point-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/entry-point-test.js
@@ -130,7 +130,7 @@ module('Unit | Route | Entry Point', function (hooks) {
         await route.afterModel(campaign, transition);
 
         //then
-        sinon.assert.calledWith(route.store.queryRecord, 'campaignParticipation', {
+        sinon.assert.calledWith(route.store.queryRecord, 'campaign-participation', {
           campaignId: 3,
           userId: 12,
         });
@@ -175,7 +175,7 @@ module('Unit | Route | Entry Point', function (hooks) {
       test('should redirect to entrance when ongoing campaign participation is existing', async function (assert) {
         //given
         route.store.queryRecord
-          .withArgs('campaignParticipation', {
+          .withArgs('campaign-participation', {
             campaignId: 3,
             userId: 12,
           })
@@ -197,7 +197,7 @@ module('Unit | Route | Entry Point', function (hooks) {
         test('should redirect to campaign archived error with no participation', async function (assert) {
           //given
           route.store.queryRecord
-            .withArgs('campaignParticipation', {
+            .withArgs('campaign-participation', {
               campaignId: 3,
               userId: 12,
             })
@@ -214,7 +214,7 @@ module('Unit | Route | Entry Point', function (hooks) {
         test('should redirect to entrance with participation', async function (assert) {
           //given
           route.store.queryRecord
-            .withArgs('campaignParticipation', {
+            .withArgs('campaign-participation', {
               campaignId: 3,
               userId: 12,
             })

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1240,8 +1240,8 @@
       "errors": {
         "invalid-external-id": "The { idPixLabel } is invalid.",
         "invalid-external-id-email": "The e-mail address is invalid.",
-        "max-length-id-pix-label": "Your { idPixLabel } must not exceed 255 characters.",
-        "missing-id-pix-label": "Please enter your { idPixLabel }."
+        "max-length-external-id": "Your { idPixLabel } must not exceed 255 characters.",
+        "missing-external-id": "Please enter your { idPixLabel }."
       },
       "first-title": "Before starting"
     },

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1238,6 +1238,8 @@
         "continue": "Continue"
       },
       "errors": {
+        "invalid-external-id": "The { idPixLabel } is invalid.",
+        "invalid-external-id-email": "The e-mail address is invalid.",
         "max-length-id-pix-label": "Your { idPixLabel } must not exceed 255 characters.",
         "missing-id-pix-label": "Please enter your { idPixLabel }."
       },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1215,8 +1215,8 @@
       "errors": {
         "invalid-external-id": "Tu { idPixLabel }  no es válida.",
         "invalid-external-id-email": "La dirección de correo electrónico no es válida.",
-        "max-length-id-pix-label": "Tu { idPixLabel } no debe superar 255 caracteres.",
-        "missing-id-pix-label": "Por favor, introduce tu { idPixLabel }."
+        "max-length-external-id": "Tu { idPixLabel } no debe superar 255 caracteres.",
+        "missing-external-id": "Por favor, introduce tu { idPixLabel }."
       },
       "first-title": "Antes de empezar",
       "title": "Introducir mi nombre de usuario"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1213,6 +1213,8 @@
         "continue": "Continuar"
       },
       "errors": {
+        "invalid-external-id": "Tu { idPixLabel }  no es válida.",
+        "invalid-external-id-email": "La dirección de correo electrónico no es válida.",
         "max-length-id-pix-label": "Tu { idPixLabel } no debe superar 255 caracteres.",
         "missing-id-pix-label": "Por favor, introduce tu { idPixLabel }."
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1240,8 +1240,8 @@
       "errors": {
         "invalid-external-id": "Votre { idPixLabel } est invalide.",
         "invalid-external-id-email": "L'adresse email n'est pas valide.",
-        "max-length-id-pix-label": "Votre { idPixLabel } ne doit pas dépasser les 255 caractères.",
-        "missing-id-pix-label": "Merci de renseigner votre { idPixLabel }."
+        "max-length-external-id": "Votre { idPixLabel } ne doit pas dépasser les 255 caractères.",
+        "missing-external-id": "Merci de renseigner votre { idPixLabel }."
       },
       "first-title": "Avant de commencer"
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1238,6 +1238,8 @@
         "continue": "Continuer"
       },
       "errors": {
+        "invalid-external-id": "Votre { idPixLabel } est invalide.",
+        "invalid-external-id-email": "L'adresse email n'est pas valide.",
         "max-length-id-pix-label": "Votre { idPixLabel } ne doit pas dépasser les 255 caractères.",
         "missing-id-pix-label": "Merci de renseigner votre { idPixLabel }."
       },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1215,8 +1215,8 @@
       "errors": {
         "invalid-external-id": "Uw { idPixLabel } is ongeldig.",
         "invalid-external-id-email": "Het e-mailadres is ongeldig.",
-        "max-length-id-pix-label": "Uw { idPixLabel } mag niet langer zijn dan 255 tekens.",
-        "missing-id-pix-label": "Voer uw { idPixLabel } in."
+        "max-length-external-id": "Uw { idPixLabel } mag niet langer zijn dan 255 tekens.",
+        "missing-external-id": "Voer uw { idPixLabel } in."
       },
       "first-title": "Voordat u begint",
       "title": "Mijn login invoeren"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1213,6 +1213,8 @@
         "continue": "Ga verder met"
       },
       "errors": {
+        "invalid-external-id": "Uw { idPixLabel } is ongeldig.",
+        "invalid-external-id-email": "Het e-mailadres is ongeldig.",
         "max-length-id-pix-label": "Uw { idPixLabel } mag niet langer zijn dan 255 tekens.",
         "missing-id-pix-label": "Voer uw { idPixLabel } in."
       },


### PR DESCRIPTION
## :unicorn: Problème
Lors du RDB autour du stockage d’un identifiant, a été évoqué le fait que environ 30% des identifiants externes demandés étaient des emails mais comprenaient souvent des coquilles car c’est un champ libre. 

## :robot: Proposition
Maintenant que nous avons rajouté la possibilité de mettre un type email pour les identifiants externes, nous pouvons les valider 🎉 

## :rainbow: Remarques
RAS

## :100: Pour tester
Créer une campagne avec un identifiant externe de type email
- tenter de rejoindre la campagne en saisissant un mauvais identifiant
- tenter de rejoindre la campagne en passant un mauvais identifiant `?externalId=toto`
