### PR TITLE
[FEATURE] Ajouter une icône de rafraîchissement sur le bouton de l'écran d'extension.

### DIFF
--- a/mon-pix/app/components/companion/blocker.gjs
+++ b/mon-pix/app/components/companion/blocker.gjs
@@ -1,5 +1,6 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -55,7 +56,10 @@ export default class CompanionBlocker extends Component {
               @variant="secondary"
               @triggerAction={{this.refreshPage}}
               class="companion-blocker-list__refresh-button"
-            >{{t "common.actions.refresh-page"}}</PixButton>
+            >
+              <PixIcon @name="refresh" @ariaHidden={{true}} class="companion-blocker-refresh-button__icon" />
+              {{t "common.actions.refresh-page"}}
+            </PixButton>
           </li>
         </ul>
       </section>

--- a/mon-pix/app/styles/components/companion/blocker.scss
+++ b/mon-pix/app/styles/components/companion/blocker.scss
@@ -33,5 +33,26 @@
     color: var(--pix-neutral-0);
     background-color: var(--pix-certif-500);
     border: 2px solid var(--pix-neutral-0);
+
+    &:hover {
+      > svg {
+        fill: var(--pix-primary-700);
+      }
+    }
+
+    &:focus {
+      > svg {
+        fill: var(--pix-primary-900);
+      }
+    }
+  }
+}
+
+.companion-blocker-refresh-button {
+  &__icon {
+    width: 2rem;
+    height: 1rem;
+    padding-right: var(--pix-spacing-1x);
+    fill: var(--pix-neutral-0);
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Oublie de l'icône sur le bouton

## :robot: Proposition
L'ajouter

## :100: Pour tester

- Ne pas activer l'extension Companion
- Créer une session V3 sur Pix Certif (+ espace surveillant => confirmer la présence)
- Se connecter sur App avec [certif-success@example.net](mailto:certif-success@example.net)
- Remplir le formulaire d'entrée en session de certif
- Constater que le bouton pour rafraîchir la page à une icône à sa gauche