### PR TITLE
[FEATURE]: Afficher l'onglet Formations au clic sur "Voir les formations" de la bannière (PIX-14803).

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/skill-review/evaluation-results-hero/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/skill-review/evaluation-results-hero/index.gjs
@@ -19,6 +19,7 @@ export default class EvaluationResultsHero extends Component {
   @service currentUser;
   @service router;
   @service store;
+  @service tabManager;
 
   @tracked hasGlobalError = false;
   @tracked isImproveButtonLoading = false;

--- a/mon-pix/app/components/campaigns/assessment/skill-review/evaluation-results-tabs/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/skill-review/evaluation-results-tabs/index.gjs
@@ -1,3 +1,4 @@
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
@@ -7,12 +8,14 @@ import Rewards from './rewards';
 import Trainings from './trainings';
 
 export default class EvaluationResultsTabs extends Component {
+  @service tabManager;
+
   get showRewardsTab() {
     return this.args.badges.length > 0;
   }
 
   get initialTabIndex() {
-    return this.showRewardsTab ? 0 : 1;
+    return this.showRewardsTab ? this.tabManager.setActiveTab(0) : this.tabManager.setActiveTab(1);
   }
 
   get showTrainingsTab() {

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results.gjs
@@ -1,4 +1,5 @@
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
@@ -7,6 +8,8 @@ import EvaluationResultsTabs from '../../../campaigns/assessment/skill-review/ev
 import QuitResults from '../../../campaigns/assessment/skill-review/quit-results';
 
 export default class EvaluationResults extends Component {
+  @service tabManager;
+
   get hasTrainings() {
     return Boolean(this.args.model.trainings.length);
   }
@@ -21,7 +24,7 @@ export default class EvaluationResults extends Component {
       behavior: 'smooth',
     });
 
-    // TODO: display trainings tab
+    this.tabManager.setActiveTab(2);
   }
 
   <template>

--- a/mon-pix/app/services/tab-manager.js
+++ b/mon-pix/app/services/tab-manager.js
@@ -1,0 +1,10 @@
+import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class TabManagerService extends Service {
+  @tracked activeTab = 0;
+
+  setActiveTab(tab) {
+    this.activeTab = tab;
+  }
+}

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/evaluation-results-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/evaluation-results-test.js
@@ -1,4 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
@@ -51,6 +52,34 @@ module('Integration | Components | Routes | Campaigns | Assessment | Evaluation 
 
       // then
       assert.dom(screen.getByRole('tablist', { name: t('pages.skill-review.tabs.aria-label') })).exists();
+    });
+  });
+
+  module('when the campaign is shared and has trainings', function (hooks) {
+    hooks.beforeEach(async function () {
+      // given
+      this.model.trainings = [{ duration: { days: 1, hours: 1, minutes: 1 } }];
+      this.model.campaignParticipationResult.isShared = true;
+      this.model.campaignParticipationResult.competenceResults = [Symbol('competences')];
+    });
+
+    test('it should display the training button', async function (assert) {
+      // when
+      screen = await render(hbs`<Routes::Campaigns::Assessment::EvaluationResults @model={{this.model}} />`);
+
+      // then
+      assert.dom(screen.getByRole('button', { name: /Voir les formations/ })).isVisible();
+    });
+
+    test('when the training button is clicked, it should set trainings tab active', async function (assert) {
+      // when
+      screen = await render(hbs`<Routes::Campaigns::Assessment::EvaluationResults @model={{this.model}} />`);
+
+      // then
+      await click(screen.getByRole('button', { name: /Voir les formations/ }));
+      assert
+        .dom(screen.getByRole('tab', { name: t('pages.skill-review.tabs.trainings.tab-label') }))
+        .hasAttribute('aria-selected', 'true');
     });
   });
 });

--- a/mon-pix/tests/unit/services/tab-manager-test.js
+++ b/mon-pix/tests/unit/services/tab-manager-test.js
@@ -1,0 +1,27 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Services | TabManager', function (hooks) {
+  setupTest(hooks);
+
+  module('setActiveTab', function () {
+    test('default tab', function (assert) {
+      // given
+      const tabManagerService = this.owner.lookup('service:tab-manager');
+
+      // then
+      assert.strictEqual(tabManagerService.activeTab, 0);
+    });
+
+    test('should set active tab to the given tab', function (assert) {
+      // given
+      const tabManagerService = this.owner.lookup('service:tab-manager');
+
+      // when
+      tabManagerService.setActiveTab(1);
+
+      // then
+      assert.strictEqual(tabManagerService.activeTab, 1);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, lorsqu'on a partagé les résultats d'une campagne, et qu'on se voit proposer une formation, un bouton "Voir les formations" apparaît. Lorsque l'on clique dessus, on souhaite scroller jusqu''à l'onglet des formations et l'activer. Hors ce n'est pas le cas.

## :robot: Proposition
Changer l'onglet actif lorsque l'on clique sur le bouton "Voir les formations". 

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- Aller sur [pix app](https://app-pr10364.review.pix.fr/campagnes/EDUSIMPLE)
- Se connecter avec **learneremail1003_30@example.net**
- Sur la page de résultat, cliquer sur le bouton "Voir les formations".
- Constater que l'onglet des formations est activé.