### PR TITLE
[FEATURE] Afficher un bandeau d'information concernant l'extension Companion dans la page du surveillant sur Pix Certif (PIX-12779).

### DIFF
--- a/certif/app/components/session-supervising/header.hbs
+++ b/certif/app/components/session-supervising/header.hbs
@@ -55,6 +55,21 @@
     </div>
   </dl>
 
+  {{#if this.isPixCompanionExtensionEnabled}}
+    <PixMessage @type="info" @withIcon={{true}}>
+      {{t "pages.session-supervising.header.companion.message"}}
+      <a
+        href={{this.pixCompanionDocumentationUrl}}
+        target="_blank"
+        class="link session-supervising-header__companion-link"
+        rel="noopener noreferrer"
+      >
+        {{t "pages.session-supervising.header.companion.link"}}
+        <PixIcon @name="openNew" @alternativeText={{t "navigation.external-link-title"}} />
+      </a>
+    </PixMessage>
+  {{/if}}
+
   <SessionSupervising::ConfirmationModal
     @showModal={{this.isConfirmationModalDisplayed}}
     @closeConfirmationModal={{this.closeConfirmationModal}}

--- a/certif/app/components/session-supervising/header.js
+++ b/certif/app/components/session-supervising/header.js
@@ -6,6 +6,8 @@ import { tracked } from '@glimmer/tracking';
 export default class Header extends Component {
   @service router;
   @service intl;
+  @service url;
+  @service featureToggles;
 
   @tracked modalDescriptionText;
   @tracked modalCancelText;
@@ -33,5 +35,13 @@ export default class Header extends Component {
   actionConfirmation() {
     this.closeConfirmationModal();
     return this.router.replaceWith('login-session-supervisor');
+  }
+
+  get pixCompanionDocumentationUrl() {
+    return this.url.pixCompanionDocumentationUrl;
+  }
+
+  get isPixCompanionExtensionEnabled() {
+    return this.featureToggles.featureToggles?.isPixCompanionEnabled;
   }
 }

--- a/certif/app/models/feature-toggle.js
+++ b/certif/app/models/feature-toggle.js
@@ -2,4 +2,5 @@ import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
   @attr('boolean') isNeedToAdjustCertificationAccessibilityEnabled;
+  @attr('boolean') isPixCompanionEnabled;
 }

--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -74,6 +74,10 @@ export default class Url extends Service {
     return 'https://form-eu.123formbuilder.com/41052/form';
   }
 
+  get pixCompanionDocumentationUrl() {
+    return 'https://cloud.pix.fr/s/fpeEyDpYEkMeqRX';
+  }
+
   #isFrenchSpoken() {
     return this.intl.primaryLocale === 'fr';
   }

--- a/certif/app/styles/components/session-supervising/header.scss
+++ b/certif/app/styles/components/session-supervising/header.scss
@@ -44,6 +44,11 @@
     font-weight: 500;
     margin: 0;
     padding: 8px 0;
+
+    &:last-child {
+      border-bottom: unset;
+      margin-bottom: var(--pix-spacing-4x);
+    }
   }
 
   &__label {
@@ -52,5 +57,16 @@
     flex-shrink: 0;
     font-weight: normal;
     margin-right: 8px;
+  }
+
+  &__companion-link {
+    align-items: center;
+    gap: var(--pix-spacing-1x);
+
+    svg {
+      width: 1rem;
+      height: 1rem;
+      fill: var(--pix-primary-500);
+    }
   }
 }

--- a/certif/tests/integration/components/session-supervising/header-test.js
+++ b/certif/tests/integration/components/session-supervising/header-test.js
@@ -147,4 +147,64 @@ module('Integration | Component | SessionSupervising::Header', function (hooks) 
       assert.dom(screen.queryByRole('heading', { name: 'Quitter la surveillance de la session 12345' })).doesNotExist();
     });
   });
+
+  module('when the FT_PIX_COMPANION_ENABLED feature toggle is enabled', function () {
+    test('should display a companion information with documentation url', async function (assert) {
+      // given
+      class FeatureTogglesStub extends Service {
+        featureToggles = { isPixCompanionEnabled: true };
+      }
+      this.owner.register('service:featureToggles', FeatureTogglesStub);
+      const sessionForSupervising = store.createRecord('session-for-supervising', {
+        id: '12345',
+        date: '2020-01-01',
+        time: '12:00:00',
+        room: 'Salle 12',
+        examiner: 'Star Lord',
+        certificationCandidates: [],
+      });
+      this.set('sessionForSupervising', sessionForSupervising);
+
+      // when
+      const screen = await renderScreen(hbs`<SessionSupervising::Header @session={{this.sessionForSupervising}} />`);
+
+      // then
+      assert
+        .dom(screen.getByText('L’extension Pix Companion est désormais obligatoire pour tous les candidats.'))
+        .exists();
+      assert
+        .dom(screen.getByRole('link', { name: 'Lien vers la documentation d’installation/activation' }))
+        .hasAttribute('href', 'https://cloud.pix.fr/s/fpeEyDpYEkMeqRX');
+    });
+  });
+
+  module('when the FT_PIX_COMPANION_ENABLED feature toggle is disabled', function () {
+    test('should not display a companion information with documentation url', async function (assert) {
+      // given
+      class FeatureTogglesStub extends Service {
+        featureToggles = { isPixCompanionEnabled: false };
+      }
+      this.owner.register('service:featureToggles', FeatureTogglesStub);
+      const sessionForSupervising = store.createRecord('session-for-supervising', {
+        id: '12345',
+        date: '2020-01-01',
+        time: '12:00:00',
+        room: 'Salle 12',
+        examiner: 'Star Lord',
+        certificationCandidates: [],
+      });
+      this.set('sessionForSupervising', sessionForSupervising);
+
+      // when
+      const screen = await renderScreen(hbs`<SessionSupervising::Header @session={{this.sessionForSupervising}} />`);
+
+      // then
+      assert
+        .dom(screen.queryByText('L’extension Pix Companion est désormais obligatoire pour tous les candidats.'))
+        .doesNotExist();
+      assert
+        .dom(screen.queryByRole('link', { name: 'Lien vers la documentation d’installation/activation' }))
+        .doesNotExist();
+    });
+  });
 });

--- a/certif/tests/unit/services/url-test.js
+++ b/certif/tests/unit/services/url-test.js
@@ -283,4 +283,17 @@ module('Unit | Service | url', function (hooks) {
       });
     });
   });
+
+  module('#pixCompanionDocumentationUrl', function () {
+    test('should return the pix companion documentation url', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+
+      // when
+      const pixCompanionDocumentationUrl = service.pixCompanionDocumentationUrl;
+
+      // then
+      assert.strictEqual(pixCompanionDocumentationUrl, 'https://cloud.pix.fr/s/fpeEyDpYEkMeqRX');
+    });
+  });
 });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -537,6 +537,10 @@
           "exit-extra-information": "Exit the session’s invigilation {sessionId}"
         },
         "address": "Location name",
+        "companion": {
+          "link": "Link to installation/activation documentation",
+          "message": "The Pix Companion extension is now mandatory for all candidates."
+        },
         "information": "Warning, make sure that all the candidates have finished their exam before exiting the invigilation. To resume the invigilation of this session, you will have to enter again it’s session number and it’s password.",
         "invigilator": "Invigilator(s)",
         "room": "Room",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -537,6 +537,10 @@
           "exit-extra-information": "Quitter la surveillance de la session {sessionId}"
         },
         "address": "Nom du site",
+        "companion": {
+          "link": "Lien vers la documentation d’installation/activation",
+          "message": "L’extension Pix Companion est désormais obligatoire pour tous les candidats."
+        },
         "information": "Attention, assurez-vous que tous les candidats aient terminé leur test avant de quitter la surveillance. Pour reprendre la surveillance de cette session, vous devrez entrer à nouveau son numéro de session et son mot de passe.",
         "invigilator": "Surveillant(s)",
         "room": "Salle",


### PR DESCRIPTION
## :unicorn: Problème
Avec l'arrivée de l'extension Companion, il nous faut informer les surveillants que celle-ci est obligatoire en session de certification.

## :robot: Proposition
Mettre un message au niveau de l'espace surveillant pour l'informer de l'obligation de l'extension et lui proposer un lien pour consulter la documentation en cas de soucis rencontré sur le poste d’un candidat. 

## :100: Pour tester

- Se connecter sur Pix Certif et aller sur l'espace surveillant
- Constater la présence de la bannière d'infos
<img width="722" alt="Capture d’écran 2024-10-18 à 15 18 00" src="https://github.com/user-attachments/assets/4652bfa7-d842-4257-802d-84f1c095660b">
<img width="722" alt="Capture d’écran 2024-10-18 à 15 18 04" src="https://github.com/user-attachments/assets/09295a2a-0b0c-419d-a566-ca4ee4af9134">

- passer le FT à false et constater que le bandeau n'apparaît pas

