### PR TITLE
[FEATURE] Déclencher le job "AnswerJob" lorsqu'un utilisateur répond à une question (PIX-13817)

### DIFF
--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -1,4 +1,5 @@
 import { AnswerEvaluationError, EmptyAnswerError } from '../../../src/evaluation/domain/errors.js';
+import { AnswerJob } from '../../../src/quest/domain/models/AnwserJob.js';
 import { ForbiddenAccess } from '../../../src/shared/domain/errors.js';
 import {
   CertificationEndedByFinalizationError,
@@ -124,6 +125,7 @@ const correctAnswerThenUpdateAssessment = async function ({
   userId,
   locale,
   answerRepository,
+  answerJobRepository,
   assessmentRepository,
   areaRepository,
   challengeRepository,
@@ -255,6 +257,9 @@ const correctAnswerThenUpdateAssessment = async function ({
       assessmentId: assessment.id,
     });
   }
+
+  await answerJobRepository.performAsync(new AnswerJob({ userId }));
+
   return answerSaved;
 };
 

--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -258,7 +258,9 @@ const correctAnswerThenUpdateAssessment = async function ({
     });
   }
 
-  await answerJobRepository.performAsync(new AnswerJob({ userId }));
+  if (userId) {
+    await answerJobRepository.performAsync(new AnswerJob({ userId }));
+  }
 
   return answerSaved;
 };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -39,6 +39,7 @@ import * as improvementService from '../../../src/evaluation/domain/services/imp
 import { pickChallengeService } from '../../../src/evaluation/domain/services/pick-challenge-service.js';
 import * as scorecardService from '../../../src/evaluation/domain/services/scorecard-service.js';
 import * as stageAndStageAcquisitionComparisonService from '../../../src/evaluation/domain/services/stages/stage-and-stage-acquisition-comparison-service.js';
+import { answerJobRepository } from '../../../src/evaluation/infrastructure/repositories/answer-job-repository.js';
 import * as badgeCriteriaRepository from '../../../src/evaluation/infrastructure/repositories/badge-criteria-repository.js';
 import * as badgeRepository from '../../../src/evaluation/infrastructure/repositories/badge-repository.js';
 import * as competenceEvaluationRepository from '../../../src/evaluation/infrastructure/repositories/competence-evaluation-repository.js';
@@ -201,6 +202,7 @@ const dependencies = {
   accountRecoveryDemandRepository,
   certificationCompletedJobRepository,
   activityAnswerRepository,
+  answerJobRepository,
   adminMemberRepository,
   algorithmDataFetcherService,
   answerRepository,

--- a/api/sample.env
+++ b/api/sample.env
@@ -809,6 +809,22 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: false
 # FT_PIX_COMPANION_ENABLED=false
 
+# Enable quests system.
+#
+# presence: optional
+# type: boolean
+# default: false
+# FT_ENABLE_QUESTS=false
+
+# As part of user response processing, we want to deport the calculation of the quest rewards into an asynchronous job.
+# This feature toggle allows to switch between synchronous and asynchronous processing.
+# This allows us to switch off asynchronous processing in case of problems.
+#
+# presence: optional
+# type: boolean
+# default: false
+# FT_ENABLE_ASYNC_QUESTS_REWARDS_CALCULATION=false
+
 # =====
 # CPF
 # =====

--- a/api/src/evaluation/application/answers/answer-controller.js
+++ b/api/src/evaluation/application/answers/answer-controller.js
@@ -1,4 +1,6 @@
 import { usecases } from '../../../../lib/domain/usecases/index.js';
+import { usecases as questUsecases } from '../../../quest/domain/usecases/index.js';
+import { config } from '../../../shared/config.js';
 import * as requestResponseUtils from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { evaluationUsecases } from '../../domain/usecases/index.js';
 import * as answerSerializer from '../../infrastructure/serializers/jsonapi/answer-serializer.js';
@@ -9,6 +11,9 @@ const save = async function (request, h, dependencies = { answerSerializer, requ
   const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
   const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
   const createdAnswer = await usecases.correctAnswerThenUpdateAssessment({ answer, userId, locale });
+  if (!config.featureToggles.isAsyncQuestRewardingCalculationEnabled && config.featureToggles.isQuestEnabled) {
+    await questUsecases.rewardUser({ userId });
+  }
 
   return h.response(dependencies.answerSerializer.serialize(createdAnswer)).created();
 };

--- a/api/src/evaluation/infrastructure/repositories/answer-job-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/answer-job-repository.js
@@ -1,4 +1,5 @@
 import { AnswerJob } from '../../../quest/domain/models/AnwserJob.js';
+import { config } from '../../../shared/config.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { JobRepository } from '../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { temporaryStorage } from '../../../shared/infrastructure/temporary-storage/index.js';
@@ -16,6 +17,8 @@ export class AnswerJobRepository extends JobRepository {
   }
 
   async performAsync(job) {
+    if (!config.featureToggles.isAsyncQuestRewardingCalculationEnabled || !config.featureToggles.isQuestEnabled) return;
+
     const knexConn = DomainTransaction.getConnection();
 
     if (knexConn.isTransaction) {

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -207,6 +207,8 @@ const configuration = (function () {
       isNeedToAdjustCertificationAccessibilityEnabled: toBoolean(
         process.env.FT_ENABLE_NEED_TO_ADJUST_CERTIFICATION_ACCESSIBILITY,
       ),
+      isQuestEnabled: toBoolean(process.env.FT_ENABLE_QUESTS),
+      isAsyncQuestRewardingCalculationEnabled: toBoolean(process.env.FT_ENABLE_ASYNC_QUESTS_REWARDS_CALCULATION),
       isNewAuthenticationDesignEnabled: toBoolean(process.env.FT_NEW_AUTHENTICATION_DESIGN_ENABLED),
       isPix1dEnabled: toBoolean(process.env.FT_PIX_1D_ENABLED),
       isPixPlusLowerLeverEnabled: toBoolean(process.env.FT_ENABLE_PIX_PLUS_LOWER_LEVEL),

--- a/api/tests/evaluation/unit/infrastructure/repositories/answer-job-repository_test.js
+++ b/api/tests/evaluation/unit/infrastructure/repositories/answer-job-repository_test.js
@@ -1,9 +1,58 @@
 import { AnswerJobRepository } from '../../../../../src/evaluation/infrastructure/repositories/answer-job-repository.js';
+import { config } from '../../../../../src/shared/config.js';
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
 import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Evaluation | Unit | Infrastructure | Repositories | AnswerJobRepository', function () {
+  beforeEach(function () {
+    sinon.stub(config, 'featureToggles');
+    config.featureToggles.isQuestEnabled = true;
+    config.featureToggles.isAsyncQuestRewardingCalculationEnabled = true;
+  });
+
   describe('#performAsync', function () {
+    it('should do nothing if quests are disabled', async function () {
+      // given
+      const profileRewardTemporaryStorageStub = { increment: sinon.stub() };
+      const knexStub = { batchInsert: sinon.stub().resolves([]) };
+      sinon.stub(DomainTransaction, 'getConnection').returns(knexStub);
+      sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
+        return callback();
+      });
+      config.featureToggles.isQuestEnabled = false;
+      const userId = Symbol('userId');
+      const answerJobRepository = new AnswerJobRepository({
+        dependencies: { profileRewardTemporaryStorage: profileRewardTemporaryStorageStub },
+      });
+
+      // when
+      await answerJobRepository.performAsync({ userId });
+
+      // then
+      expect(profileRewardTemporaryStorageStub.increment).not.to.have.been.called;
+    });
+
+    it('should do nothing if quests are in sync mode', async function () {
+      // given
+      const profileRewardTemporaryStorageStub = { increment: sinon.stub() };
+      const knexStub = { batchInsert: sinon.stub().resolves([]) };
+      sinon.stub(DomainTransaction, 'getConnection').returns(knexStub);
+      sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
+        return callback();
+      });
+      config.featureToggles.isAsyncQuestRewardingCalculationEnabled = false;
+      const userId = Symbol('userId');
+      const answerJobRepository = new AnswerJobRepository({
+        dependencies: { profileRewardTemporaryStorage: profileRewardTemporaryStorageStub },
+      });
+
+      // when
+      await answerJobRepository.performAsync({ userId });
+
+      // then
+      expect(profileRewardTemporaryStorageStub.increment).not.to.have.been.called;
+    });
+
     it("should increment user's jobs count in temporary storage", async function () {
       // given
       const profileRewardTemporaryStorageStub = { increment: sinon.stub() };

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -32,6 +32,8 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'show-new-result-page': false,
             'show-experimental-missions': false,
             'is-pix-companion-enabled': false,
+            'is-quest-enabled': false,
+            'is-async-quest-rewarding-calculation-enabled': false,
           },
         },
       };

--- a/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
+++ b/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
@@ -227,6 +227,31 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         ]);
       });
 
+      context('when there is no user ID', function () {
+        beforeEach(function () {
+          // given
+          knowledgeElementRepository.findUniqByUserIdAndAssessmentId
+            .withArgs({ userId: null, assessmentId: assessment.id })
+            .resolves([]);
+        });
+
+        it('should not call performAsync from answerJobRepository', async function () {
+          // given
+          assessment.userId = null;
+
+          // when
+          await correctAnswerThenUpdateAssessment({
+            answer,
+            userId: null,
+            ...dependencies,
+            locale,
+          });
+
+          // then
+          expect(answerJobRepository.performAsync).not.to.have.been.called;
+        });
+      });
+
       it('should call performAsync from answerJobRepository', async function () {
         // given
         answerJobRepository.performAsync.resolves();

--- a/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
+++ b/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
@@ -1,5 +1,6 @@
 import { correctAnswerThenUpdateAssessment } from '../../../../lib/domain/usecases/correct-answer-then-update-assessment.js';
 import { EmptyAnswerError } from '../../../../src/evaluation/domain/errors.js';
+import { AnswerJob } from '../../../../src/quest/domain/models/AnwserJob.js';
 import {
   CertificationEndedByFinalizationError,
   CertificationEndedBySupervisorError,
@@ -37,7 +38,8 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
     certificationChallengeLiveAlertRepository,
     certificationEvaluationCandidateRepository,
     flashAlgorithmService,
-    algorithmDataFetcherService;
+    algorithmDataFetcherService,
+    answerJobRepository;
   const competenceEvaluationRepository = {};
 
   const nowDate = new Date('2021-03-11T11:00:04Z');
@@ -60,6 +62,9 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
     certificationEvaluationCandidateRepository = { findByAssessmentId: sinon.stub() };
     flashAlgorithmService = { getCapacityAndErrorRate: sinon.stub() };
     algorithmDataFetcherService = { fetchForFlashLevelEstimation: sinon.stub() };
+    answerJobRepository = {
+      performAsync: sinon.stub(),
+    };
     dateUtils = {
       getNowDate: sinon.stub(),
     };
@@ -93,6 +98,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
       flashAlgorithmService,
       algorithmDataFetcherService,
       dateUtils,
+      answerJobRepository,
     };
   });
 
@@ -219,6 +225,22 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
           firstCreatedKnowledgeElement,
           secondCreatedKnowledgeElement,
         ]);
+      });
+
+      it('should call performAsync from answerJobRepository', async function () {
+        // given
+        answerJobRepository.performAsync.resolves();
+
+        // when
+        await correctAnswerThenUpdateAssessment({
+          answer,
+          userId,
+          ...dependencies,
+          locale,
+        });
+
+        // then
+        expect(answerJobRepository.performAsync).to.have.been.calledWith(new AnswerJob({ userId }));
       });
 
       it('should call repositories to get needed information', async function () {


### PR DESCRIPTION
## :unicorn: Problème
Suite à une discussion avec la @1024pix/team-captains, nous avons besoin de différer la mise en production des attestations pour ne pas surcharger la production avec la mise en production de la certif nextgen. De plus, ils souhaitent prévoir la possibilité de se passer de PGBoss si besoin.

## :robot: Proposition
On ajoute donc deux variables d'environnements : 
- **FT_ENABLE_QUESTS** : qui permet de désactiver/activer le système de quêtes
- **FT_ENABLE_ASYNC_QUESTS_REWARDS_CALCULATION** : qui permet au système de quête de fonctionner en se passant de PGBoss.

## :rainbow: Remarques
Il est maintenant possible de tester fonctionnellement le système de quête 🎉 

## :100: Pour tester
- Vérifier en BDD qu'on a bien obtenu la récompense de quête (en synchrone et en asynchrone)
- Vérifier si on désactive le système de quête lorsqu'on n'obtient pas de récompense
