### PR TITLE
[FEATURE] Ajouter le nouveau design du formulaire de réinitialisation de mot de passe (PIX-14113)

### DIFF
--- a/mon-pix/app/components/authentication/new-password-input/index.gjs
+++ b/mon-pix/app/components/authentication/new-password-input/index.gjs
@@ -3,7 +3,6 @@ import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { t } from 'ember-intl';
 
 import PasswordChecklist from './password-checklist';
 
@@ -34,7 +33,7 @@ export default class NewPasswordInput extends Component {
       autocomplete="new-password"
       ...attributes
     >
-      <:label>{{t "components.authentication.new-password-input.label"}}</:label>
+      <:label>{{yield to="label"}}</:label>
     </PixInputPassword>
 
     <PasswordChecklist id="password-checklist" @rules={{@rules}} @value={{this.value}} />

--- a/mon-pix/app/components/authentication/password-reset-form/password-reset-form-validation.js
+++ b/mon-pix/app/components/authentication/password-reset-form/password-reset-form-validation.js
@@ -1,0 +1,32 @@
+import { tracked } from '@glimmer/tracking';
+
+import isPasswordValid from '../../../utils/password-validator';
+
+export class PasswordResetFormValidation {
+  passwordField = new PasswordField();
+
+  constructor(intl) {
+    this.intl = intl;
+  }
+
+  get isValid() {
+    return this.passwordField.status !== 'error';
+  }
+
+  validateField(value) {
+    const isValidInput = this.passwordField.validate(value);
+    const status = isValidInput ? 'success' : 'error';
+
+    this.passwordField.status = status;
+    this.passwordField.errorMessage = status === 'error' ? this.intl.t('common.validation.password.error') : null;
+  }
+}
+
+class PasswordField {
+  @tracked status = 'default';
+  @tracked errorMessage = null;
+
+  validate(value) {
+    return isPasswordValid(value);
+  }
+}

--- a/mon-pix/app/components/authentication/password-reset-form/password-reset-form.gjs
+++ b/mon-pix/app/components/authentication/password-reset-form/password-reset-form.gjs
@@ -1,0 +1,89 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixMessage from '@1024pix/pix-ui/components/pix-message';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+import get from 'lodash/get';
+
+import { PASSWORD_RULES } from '../../../utils/password-validator.js';
+import NewPasswordInput from '../new-password-input';
+import { PasswordResetFormValidation } from './password-reset-form-validation';
+
+const HTTP_ERROR_MESSAGES = {
+  400: 'common.validation.password.error',
+  403: 'components.authentication.password-reset-form.errors.forbidden',
+  404: 'components.authentication.password-reset-form.errors.expired-demand',
+  default: 'common.api-error-messages.internal-server-error',
+};
+
+export default class PasswordResetForm extends Component {
+  @service intl;
+
+  @tracked hasSucceeded = false;
+  @tracked isLoading = false;
+  @tracked validation = new PasswordResetFormValidation(this.intl);
+  @tracked globalErrorMessage;
+
+  @action
+  handleInputChange(event) {
+    const { user } = this.args;
+    user.password = event.target.value;
+    this.validation.validateField(user.password);
+  }
+
+  @action
+  async handleResetPassword(event) {
+    if (event) event.preventDefault();
+
+    if (!this.validation.isValid) return;
+
+    this.hasSucceeded = false;
+    this.globalErrorMessage = null;
+    this.isLoading = true;
+    try {
+      const { user, temporaryKey } = this.args;
+      await user.save({ adapterOptions: { updatePassword: true, temporaryKey } });
+      user.password = null;
+      this.hasSucceeded = true;
+    } catch (response) {
+      const status = get(response, 'errors[0].status');
+      this.globalErrorMessage = this.intl.t(HTTP_ERROR_MESSAGES[status] || HTTP_ERROR_MESSAGES['default']);
+    } finally {
+      this.isLoading = false;
+    }
+  }
+
+  <template>
+    <form class="password-reset-form" type="submit" {{on "submit" this.handleResetPassword}}>
+      {{#if this.globalErrorMessage}}
+        <PixMessage @type="error" @withIcon={{true}} role="alert">
+          {{this.globalErrorMessage}}
+        </PixMessage>
+      {{/if}}
+
+      <p class="password-reset-form__mandatory-fields-message">
+        {{t "common.form.mandatory-all-fields"}}
+      </p>
+
+      <NewPasswordInput
+        @id="password"
+        class="password-reset-form__password-input"
+        name="password"
+        {{on "change" this.handleInputChange}}
+        @validationStatus={{this.validation.password.status}}
+        @errorMessage={{this.validation.password.errorMessage}}
+        @rules={{PASSWORD_RULES}}
+        required
+      >
+        <:label>{{t "components.authentication.password-reset-form.fields.password.label"}}</:label>
+      </NewPasswordInput>
+
+      <PixButton class="password-reset-form__submit-button" @isLoading={{this.isLoading}} @size="large" @type="submit">
+        {{t "components.authentication.password-reset-form.actions.submit"}}
+      </PixButton>
+    </form>
+  </template>
+}

--- a/mon-pix/app/components/authentication/password-reset-form/password-reset-form.scss
+++ b/mon-pix/app/components/authentication/password-reset-form/password-reset-form.scss
@@ -1,0 +1,20 @@
+.password-reset-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pix-spacing-4x);
+
+  input {
+    width: 100%;
+    padding: var(--pix-spacing-3x);
+  }
+
+  &__mandatory-fields-message {
+    @extend %pix-body-xs;
+
+    color: var(--pix-neutral-500);
+  }
+
+  &__password-input, &__submit-button {
+    width: 100%;
+  }
+}

--- a/mon-pix/app/components/authentication/signin-form.gjs
+++ b/mon-pix/app/components/authentication/signin-form.gjs
@@ -112,7 +112,7 @@ export default class SigninForm extends Component {
   <template>
     <form {{on "submit" this.signin}} class="signin-form">
       {{#if this.globalError}}
-        <PixMessage @type="error" @withIcon="true" role="alert">
+        <PixMessage @type="error" @withIcon={{true}} role="alert">
           {{t this.globalError.key this.globalError.values}}
         </PixMessage>
       {{/if}}

--- a/mon-pix/app/components/authentication/signup-form/index.gjs
+++ b/mon-pix/app/components/authentication/signup-form/index.gjs
@@ -158,7 +158,9 @@ export default class SignupForm extends Component {
           @errorMessage={{this.validation.password.errorMessage}}
           @rules={{PASSWORD_RULES}}
           required
-        />
+        >
+          <:label>{{t "common.password"}}</:label>
+        </NewPasswordInput>
 
         <CguCheckbox
           @id="cgu"

--- a/mon-pix/app/controllers/reset-password.js
+++ b/mon-pix/app/controllers/reset-password.js
@@ -1,0 +1,10 @@
+import Controller from '@ember/controller';
+import { service } from '@ember/service';
+
+export default class ResetPasswordController extends Controller {
+  @service featureToggles;
+
+  get isNewAuthenticationDesignEnabled() {
+    return this.featureToggles.featureToggles.isNewAuthenticationDesignEnabled;
+  }
+}

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -141,6 +141,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @import 'authentication/oidc-provider-selector';
 @import 'authentication/other-authentication-providers';
 @import 'authentication/password-reset-demand';
+@import 'authentication/password-reset-form/password-reset-form';
 @import 'authentication/signin-form';
 @import 'authentication/signup-form';
 @import 'authentication/sso-selection-form';

--- a/mon-pix/app/templates/reset-password.hbs
+++ b/mon-pix/app/templates/reset-password.hbs
@@ -1,4 +1,22 @@
 {{page-title (t "pages.reset-password.title")}}
-<div class="sign-form-page">
-  <ResetPasswordForm @user={{@model.user}} @temporaryKey={{@model.temporaryKey}} />
-</div>
+
+{{#if this.isNewAuthenticationDesignEnabled}}
+  <AuthenticationLayout class="signup-page-layout">
+    <:header>
+      <PixButtonLink @variant="secondary" @route="authentication.login">
+        {{t "pages.sign-up.actions.login"}}
+      </PixButtonLink>
+    </:header>
+    <:content>
+      <h1 class="pix-title-m">{{t "pages.reset-password.first-title"}}</h1>
+      <Authentication::PasswordResetForm::PasswordResetForm
+        @temporaryKey={{@model.temporaryKey}}
+        @user={{@model.user}}
+      />
+    </:content>
+  </AuthenticationLayout>
+{{else}}
+  <div class="sign-form-page">
+    <ResetPasswordForm @user={{@model.user}} @temporaryKey={{@model.temporaryKey}} />
+  </div>
+{{/if}}

--- a/mon-pix/tests/acceptance/authentication/password-reset-demand-form-test.js
+++ b/mon-pix/tests/acceptance/authentication/password-reset-demand-form-test.js
@@ -5,8 +5,8 @@ import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-import { clickByLabel } from '../helpers/click-by-label';
-import setupIntl from '../helpers/setup-intl';
+import { clickByLabel } from '../../helpers/click-by-label';
+import setupIntl from '../../helpers/setup-intl';
 
 module('Acceptance | Password reset demand form', function (hooks) {
   setupApplicationTest(hooks);

--- a/mon-pix/tests/acceptance/authentication/reset-password-form-test.js
+++ b/mon-pix/tests/acceptance/authentication/reset-password-form-test.js
@@ -5,9 +5,9 @@ import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-import { authenticate } from '../helpers/authentication';
-import { clickByLabel } from '../helpers/click-by-label';
-import setupIntl from '../helpers/setup-intl';
+import { authenticate } from '../../helpers/authentication';
+import { clickByLabel } from '../../helpers/click-by-label';
+import setupIntl from '../../helpers/setup-intl';
 
 module('Acceptance | Reset Password Form', function (hooks) {
   setupApplicationTest(hooks);

--- a/mon-pix/tests/acceptance/authentication/signup-test.js
+++ b/mon-pix/tests/acceptance/authentication/signup-test.js
@@ -12,7 +12,7 @@ const I18N_KEYS = {
   firstNameInput: 'components.authentication.signup-form.fields.firstname.label',
   lastNameInput: 'components.authentication.signup-form.fields.lastname.label',
   emailInput: 'components.authentication.signup-form.fields.email.label',
-  passwordInput: 'components.authentication.new-password-input.label',
+  passwordInput: 'common.password',
   cguCheckbox: 'common.cgu.label',
   submitButton: 'components.authentication.signup-form.actions.submit',
 };

--- a/mon-pix/tests/acceptance/reset-password-form-test.js
+++ b/mon-pix/tests/acceptance/reset-password-form-test.js
@@ -14,75 +14,84 @@ module('Acceptance | Reset Password Form', function (hooks) {
   setupMirage(hooks);
   setupIntl(hooks);
 
-  test('can visit /changer-mot-de-passe when temporaryKey exists', async function (assert) {
-    // given
-    server.create('user', {
-      id: 1000,
-      firstName: 'Brandone',
-      lastName: 'Martins',
-      email: 'brandone.martins@pix.com',
-      password: '1024pix!',
+  module('when "New authentication design" feature toggle is disabled', function (hooks) {
+    hooks.beforeEach(function () {
+      server.create('feature-toggle', {
+        id: 0,
+        isNewAuthenticationDesignEnabled: false,
+      });
     });
 
-    server.create('password-reset-demand', {
-      temporaryKey: 'temporaryKey',
-      email: 'brandone.martins@pix.com',
+    test('can visit /changer-mot-de-passe when temporaryKey exists', async function (assert) {
+      // given
+      server.create('user', {
+        id: 1000,
+        firstName: 'Brandone',
+        lastName: 'Martins',
+        email: 'brandone.martins@pix.com',
+        password: '1024pix!',
+      });
+
+      server.create('password-reset-demand', {
+        temporaryKey: 'temporaryKey',
+        email: 'brandone.martins@pix.com',
+      });
+
+      // when
+      await visit('/changer-mot-de-passe/temporaryKey');
+
+      // then
+      assert.strictEqual(currentURL(), '/changer-mot-de-passe/temporaryKey');
     });
 
-    // when
-    await visit('/changer-mot-de-passe/temporaryKey');
+    test('stays on /changer-mot-de-passe when password is successfully reset', async function (assert) {
+      // given
+      server.create('user', {
+        id: 1000,
+        firstName: 'Brandone',
+        lastName: 'Martins',
+        email: 'brandone.martins@pix.com',
+        password: '1024pix!',
+      });
 
-    // then
-    assert.strictEqual(currentURL(), '/changer-mot-de-passe/temporaryKey');
-  });
+      server.create('password-reset-demand', {
+        temporaryKey: 'brandone-reset-key',
+        email: 'brandone.martins@pix.com',
+      });
 
-  test('should stay on changer-mot-de-passe when password is successfully reset', async function (assert) {
-    // given
-    server.create('user', {
-      id: 1000,
-      firstName: 'Brandone',
-      lastName: 'Martins',
-      email: 'brandone.martins@pix.com',
-      password: '1024pix!',
+      const screen = await visit('/changer-mot-de-passe/brandone-reset-key');
+      const passwordInput = screen.getByLabelText('Mot de passe');
+      await fillIn(passwordInput, 'newPass12345!');
+
+      // when
+      await clickByLabel(t('pages.reset-password.actions.submit'));
+
+      // then
+      assert.strictEqual(currentURL(), '/changer-mot-de-passe/brandone-reset-key');
     });
 
-    server.create('password-reset-demand', {
-      temporaryKey: 'brandone-reset-key',
-      email: 'brandone.martins@pix.com',
+    test('allows connected user to visit reset-password page', async function (assert) {
+      // given
+      const user = server.create('user', {
+        id: 1000,
+        firstName: 'Brandone',
+        lastName: 'Martins',
+        email: 'brandone.martins@pix.com',
+        password: '1024pix!',
+      });
+
+      server.create('password-reset-demand', {
+        temporaryKey: 'brandone-reset-key',
+        email: 'brandone.martins@pix.com',
+      });
+
+      await authenticate(user);
+
+      // when
+      await visit('/changer-mot-de-passe/brandone-reset-key');
+
+      // then
+      assert.strictEqual(currentURL(), '/changer-mot-de-passe/brandone-reset-key');
     });
-
-    const screen = await visit('/changer-mot-de-passe/brandone-reset-key');
-    const passwordInput = screen.getByLabelText('Mot de passe');
-    await fillIn(passwordInput, 'newPass12345!');
-
-    // when
-    await clickByLabel(t('pages.reset-password.actions.submit'));
-
-    // then
-    assert.strictEqual(currentURL(), '/changer-mot-de-passe/brandone-reset-key');
-  });
-
-  test('should allow connected user to visit reset-password page', async function (assert) {
-    // given
-    const user = server.create('user', {
-      id: 1000,
-      firstName: 'Brandone',
-      lastName: 'Martins',
-      email: 'brandone.martins@pix.com',
-      password: '1024pix!',
-    });
-
-    server.create('password-reset-demand', {
-      temporaryKey: 'brandone-reset-key',
-      email: 'brandone.martins@pix.com',
-    });
-
-    await authenticate(user);
-
-    // when
-    await visit('/changer-mot-de-passe/brandone-reset-key');
-
-    // then
-    assert.strictEqual(currentURL(), '/changer-mot-de-passe/brandone-reset-key');
   });
 });

--- a/mon-pix/tests/acceptance/reset-password-form-test.js
+++ b/mon-pix/tests/acceptance/reset-password-form-test.js
@@ -94,4 +94,87 @@ module('Acceptance | Reset Password Form', function (hooks) {
       assert.strictEqual(currentURL(), '/changer-mot-de-passe/brandone-reset-key');
     });
   });
+
+  module('when "New authentication design" feature toggle is enabled', function (hooks) {
+    hooks.beforeEach(function () {
+      server.create('feature-toggle', {
+        id: 0,
+        isNewAuthenticationDesignEnabled: true,
+      });
+    });
+
+    test('can visit /changer-mot-de-passe when temporaryKey exists', async function (assert) {
+      // given
+      server.create('user', {
+        id: 1000,
+        firstName: 'Brandone',
+        lastName: 'Martins',
+        email: 'brandone.martins@pix.com',
+        password: '1024pix!',
+      });
+
+      server.create('password-reset-demand', {
+        temporaryKey: 'temporaryKey',
+        email: 'brandone.martins@pix.com',
+      });
+
+      // when
+      await visit('/changer-mot-de-passe/temporaryKey');
+
+      // then
+      assert.strictEqual(currentURL(), '/changer-mot-de-passe/temporaryKey');
+    });
+
+    test('stays on /changer-mot-de-passe when password is successfully reset', async function (assert) {
+      // given
+      server.create('user', {
+        id: 1000,
+        firstName: 'Brandone',
+        lastName: 'Martins',
+        email: 'brandone.martins@pix.com',
+        password: '1024pix!',
+      });
+
+      server.create('password-reset-demand', {
+        temporaryKey: 'brandone-reset-key',
+        email: 'brandone.martins@pix.com',
+      });
+
+      const screen = await visit('/changer-mot-de-passe/brandone-reset-key');
+      const passwordInput = screen.getByLabelText(
+        t('components.authentication.password-reset-form.fields.password.label'),
+      );
+      await fillIn(passwordInput, 'newPass12345!');
+
+      // when
+      await clickByLabel(t('components.authentication.password-reset-form.actions.submit'));
+
+      // then
+      assert.strictEqual(currentURL(), '/changer-mot-de-passe/brandone-reset-key');
+    });
+
+    test('allows connected user to visit reset-password page', async function (assert) {
+      // given
+      const user = server.create('user', {
+        id: 1000,
+        firstName: 'Brandone',
+        lastName: 'Martins',
+        email: 'brandone.martins@pix.com',
+        password: '1024pix!',
+      });
+
+      server.create('password-reset-demand', {
+        temporaryKey: 'brandone-reset-key',
+        email: 'brandone.martins@pix.com',
+      });
+
+      await authenticate(user);
+
+      // when
+      await visit('/changer-mot-de-passe/brandone-reset-key');
+
+      // then
+      assert.strictEqual(currentURL(), '/changer-mot-de-passe/brandone-reset-key');
+    });
+  });
 });

--- a/mon-pix/tests/integration/components/authentication/password-input/index-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/password-input/index-test.gjs
@@ -8,7 +8,7 @@ import sinon from 'sinon';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 const I18N = {
-  PASSWORD_INPUT_LABEL: 'components.authentication.new-password-input.label',
+  PASSWORD_INPUT_LABEL: 'common.password',
   RULES_STATUS_MESSAGE: 'components.authentication.new-password-input.completed-message',
   ERROR_MESSAGE: 'common.validation.password.error',
   RULE_1: 'common.validation.password.rules.min-length',
@@ -24,7 +24,13 @@ module('Integration | Component | authentication | new-password-input', function
     const rules = [];
     const onInput = sinon.spy();
 
-    await render(<template><NewPasswordInput {{on "input" onInput}} @rules={{rules}} /></template>);
+    await render(
+      <template>
+        <NewPasswordInput {{on "input" onInput}} @rules={{rules}}>
+          <:label>{{t "common.password"}}</:label>
+        </NewPasswordInput>
+      </template>,
+    );
 
     // when
     await fillByLabel(t(I18N.PASSWORD_INPUT_LABEL), password);
@@ -43,7 +49,13 @@ module('Integration | Component | authentication | new-password-input', function
       { i18nKey: I18N.RULE_2, validate: (value) => value.includes('1234') },
     ];
 
-    const screen = await render(<template><NewPasswordInput @rules={{rules}} /></template>);
+    const screen = await render(
+      <template>
+        <NewPasswordInput @rules={{rules}}>
+          <:label>{{t "common.password"}}</:label>
+        </NewPasswordInput>
+      </template>,
+    );
 
     // when
     await fillByLabel(t(I18N.PASSWORD_INPUT_LABEL), passwordPartiallyValid);
@@ -79,7 +91,9 @@ module('Integration | Component | authentication | new-password-input', function
           @rules={{rules}}
           @validationStatus={{validationStatus}}
           @errorMessage={{errorMessage}}
-        />
+        >
+          <:label>{{t "common.password"}}</:label>
+        </NewPasswordInput>
       </template>,
     );
     await fillByLabel(t(I18N.PASSWORD_INPUT_LABEL), password);

--- a/mon-pix/tests/integration/components/authentication/password-reset-form/password-reset-form-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/password-reset-form/password-reset-form-test.gjs
@@ -1,0 +1,110 @@
+import { clickByName, fillByLabel, render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import PasswordResetForm from 'mon-pix/components/authentication/password-reset-form/password-reset-form';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+const I18N_KEYS = {
+  passwordInputErrorMessage: 'components.authentication.password-reset-form.fields.password.label',
+  passwordInputLabel: 'components.authentication.password-reset-form.fields.password.label',
+  mandatoryFieldsMessage: 'common.form.mandatory-all-fields',
+  resetPasswordButton: 'components.authentication.password-reset-form.actions.submit',
+};
+
+const I18N_ERROR_KEYS = {
+  '400': 'common.validation.password.error',
+  '403': 'components.authentication.password-reset-form.errors.forbidden',
+  '404': 'components.authentication.password-reset-form.errors.expired-demand',
+  '500': 'common.api-error-messages.internal-server-error',
+  unknownError: 'common.api-error-messages.internal-server-error',
+};
+
+module('Integration | Component | Authentication | PasswordResetForm | PasswordResetForm', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('displays all elements of component successfully', async function (assert) {
+    // given
+    const user = { save: sinon.stub() };
+    const temporaryKey = 'temporaryKey';
+
+    // when
+    const screen = await render(
+      <template><PasswordResetForm @temporaryKey={{temporaryKey}} @user={{user}} /></template>,
+    );
+
+    // then
+    assert.dom(screen.getByText(t(I18N_KEYS.mandatoryFieldsMessage))).exists();
+    assert.dom(screen.getByLabelText(t(I18N_KEYS.passwordInputLabel))).hasAttribute('required');
+    assert.dom(screen.getByRole('button', { name: t(I18N_KEYS.resetPasswordButton) })).exists();
+  });
+
+  test('resets password successfully', async function (assert) {
+    // given
+    const validPassword = 'Pix12345';
+    const user = { save: sinon.stub() };
+    const temporaryKey = 'temporaryKey';
+
+    // when
+    await render(<template><PasswordResetForm @temporaryKey={{temporaryKey}} @user={{user}} /></template>);
+
+    await fillByLabel(t(I18N_KEYS.passwordInputLabel), validPassword);
+    await clickByName(t(I18N_KEYS.resetPasswordButton));
+
+    // then
+    const userSavePayload = {
+      adapterOptions: { updatePassword: true, temporaryKey },
+    };
+    assert.strictEqual(user.password, null);
+    sinon.assert.calledWith(user.save, userSavePayload);
+  });
+
+  module('when there is a validationError on the password field', function () {
+    test('displays an error message on the password input', async function (assert) {
+      // given
+      const invalidPassword = 'pix';
+      const user = { save: sinon.stub() };
+      const temporaryKey = 'temporaryKey';
+
+      // when
+      const screen = await render(
+        <template><PasswordResetForm @temporaryKey={{temporaryKey}} @user={{user}} /></template>,
+      );
+
+      await fillByLabel(t(I18N_KEYS.passwordInputLabel), invalidPassword);
+      await clickByName(t(I18N_KEYS.resetPasswordButton));
+
+      // then
+      assert.dom(screen.getByText(t(I18N_KEYS.passwordInputErrorMessage))).exists();
+      sinon.assert.notCalled(user.save);
+    });
+  });
+
+  module('When there is an error from server', function () {
+    const HTTP_ERROR_SERVER = ['400', '403', '404', '500', 'unknownError'];
+
+    HTTP_ERROR_SERVER.forEach((httpErrorCode) => {
+      test(`displays, for the ${httpErrorCode} error code, a specific error message`, async function (assert) {
+        // given
+        const validPassword = 'Pix12345';
+        const user = { save: sinon.stub() };
+        const temporaryKey = 'temporaryKey';
+
+        user.save.rejects({ errors: [{ status: httpErrorCode }] });
+
+        // when
+        const screen = await render(
+          <template><PasswordResetForm @temporaryKey={{temporaryKey}} @user={{user}} /></template>,
+        );
+
+        await fillByLabel(t(I18N_KEYS.passwordInputLabel), validPassword);
+        await clickByName(t(I18N_KEYS.resetPasswordButton));
+
+        // then
+        assert.dom(screen.getByRole('alert')).exists();
+        assert.dom(screen.getByText(t(I18N_ERROR_KEYS[httpErrorCode]))).exists();
+      });
+    });
+  });
+});

--- a/mon-pix/tests/integration/components/authentication/signup-form/index-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/signup-form/index-test.gjs
@@ -10,7 +10,7 @@ const I18N_KEYS = {
   firstNameInput: 'components.authentication.signup-form.fields.firstname.label',
   lastNameInput: 'components.authentication.signup-form.fields.lastname.label',
   emailInput: 'components.authentication.signup-form.fields.email.label',
-  passwordInput: 'components.authentication.new-password-input.label',
+  passwordInput: 'common.password',
   cguCheckbox: 'common.cgu.label',
   submitButton: 'components.authentication.signup-form.actions.submit',
 };

--- a/mon-pix/tests/unit/components/authentication/password-reset-form/password-reset-form-validation-test.js
+++ b/mon-pix/tests/unit/components/authentication/password-reset-form/password-reset-form-validation-test.js
@@ -1,0 +1,49 @@
+import { setupTest } from 'ember-qunit';
+import { PasswordResetFormValidation } from 'mon-pix/components/authentication/password-reset-form/password-reset-form-validation';
+import { module, test } from 'qunit';
+
+module('Unit | Component | authentication | password-reset-form | password-reset-form-validation', function (hooks) {
+  setupTest(hooks);
+  let passwordResetFormValidation;
+
+  hooks.beforeEach(function () {
+    const intlMock = { t: (key) => key };
+    passwordResetFormValidation = new PasswordResetFormValidation(intlMock);
+  });
+
+  test('instantiates with default value', function (assert) {
+    // then
+    assert.strictEqual(passwordResetFormValidation.passwordField.errorMessage, null);
+    assert.strictEqual(passwordResetFormValidation.passwordField.status, 'default');
+  });
+
+  module('when password field value is valid', () => {
+    test("returns 'success' validation", function (assert) {
+      // given
+      const validPassword = 'Pix12345';
+
+      // when
+      passwordResetFormValidation.validateField(validPassword);
+
+      // then
+      assert.strictEqual(passwordResetFormValidation.passwordField.status, 'success');
+      assert.strictEqual(passwordResetFormValidation.passwordField.errorMessage, null);
+      assert.true(passwordResetFormValidation.isValid);
+    });
+  });
+
+  module('when password field value is not valid', () => {
+    test("returns 'error' validation", function (assert) {
+      // given
+      const validPassword = 'pix';
+
+      // when
+      passwordResetFormValidation.validateField(validPassword);
+
+      // then
+      assert.strictEqual(passwordResetFormValidation.passwordField.status, 'error');
+      assert.strictEqual(passwordResetFormValidation.passwordField.errorMessage, 'common.validation.password.error');
+      assert.false(passwordResetFormValidation.isValid);
+    });
+  });
+});

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -116,6 +116,7 @@
       "page-results": "{total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}",
       "result-by-page": "See"
     },
+    "password": "Password",
     "pix": "pix",
     "skip-links": {
       "skip-to-content": "Skip to main content",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1668,6 +1668,7 @@
           "label": "Password"
         }
       },
+      "first-title": "Resetting the password",
       "instruction": "Enter your new password",
       "succeed": "Your password has been changed successfully.",
       "title": "Change my password"

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -171,6 +171,16 @@
         "no-email-question": "No email address?",
         "rule": "All fields are required."
       },
+      "password-reset-form": {
+        "actions": {
+          "submit": "Reset my password"
+        },
+        "fields": {
+          "password": {
+            "label": "Please enter your new password"
+          }
+        }
+      },
       "signup-form": {
         "actions": {
           "submit": "Sign up"

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -175,6 +175,10 @@
         "actions": {
           "submit": "Reset my password"
         },
+        "errors": {
+          "expired-demand": "We’re sorry, but your request to reset your password has already been used or has expired. Please start again.",
+          "forbidden": "An error occurred, please contact the support."
+        },
         "fields": {
           "password": {
             "label": "Please enter your new password"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -149,6 +149,10 @@
         "actions": {
           "submit": "Reset my password"
         },
+        "errors": {
+          "expired-demand": "Lo sentimos, pero tu solicitud de restablecimiento de contraseña ya ha sido utilizada o ha caducado. Por favor, vuelve a intentarlo.",
+          "forbidden": "Se ha producido un error, ponte en contacto con el servicio de asistencia."
+        },
         "fields": {
           "password": {
             "label": "Please enter your new password"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1644,6 +1644,7 @@
           "label": "Contraseña"
         }
       },
+      "first-title": "Resetting the password",
       "instruction": "Introduce tu nueva contraseña",
       "succeed": "Tu contraseña ha sido cambiada con éxito.",
       "title": "Cambiar mi contraseña"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -145,6 +145,16 @@
         "instructions-label": "Your password must comply with the following rules:",
         "completed-message": "{ rulesCompleted } out of { rulesCount } requirements completed."
       },
+      "password-reset-form": {
+        "actions": {
+          "submit": "Reset my password"
+        },
+        "fields": {
+          "password": {
+            "label": "Please enter your new password"
+          }
+        }
+      },
       "signup-form": {
         "actions": {
           "submit": "Me inscribo"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -109,6 +109,7 @@
       "page-results": "{total, plural, =0 {0 elementos} =1 {1 elemento} other {{total, number} elementos}}",
       "result-by-page": "Ver"
     },
+    "password": "Password",
     "pix": "pix",
     "skip-links": {
       "skip-to-content": "Ir al contenido",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -116,6 +116,7 @@
       "page-results": "{total, plural, =0 {0 élément} =1 {1 élément} other {{total, number} éléments}}",
       "result-by-page": "Voir"
     },
+    "password": "Mot de passe",
     "pix": "pix",
     "skip-links": {
       "skip-to-content": "Aller au contenu",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1668,6 +1668,7 @@
           "label": "Mot de passe"
         }
       },
+      "first-title": "Réinitialisation du mot de passe",
       "instruction": "Saisissez votre nouveau mot de passe",
       "succeed": "Votre mot de passe a été modifié avec succès.",
       "title": "Changer mon mot de passe"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -175,6 +175,10 @@
         "actions": {
           "submit": "Je réinitialise mon mot de passe"
         },
+        "errors": {
+          "expired-demand": "Nous sommes désolés, mais votre demande de réinitialisation de mot de passe a déjà été utilisée ou est expirée. Merci de recommencer.",
+          "forbidden": "Une erreur est survenue, veuillez contacter le support."
+        },
         "fields": {
           "password": {
             "label": "Saisissez votre nouveau mot de passe"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -171,6 +171,16 @@
         "no-email-question": "Pas d’adresse e-mail renseignée ?",
         "rule": "Tous les champs sont obligatoires."
       },
+      "password-reset-form": {
+        "actions": {
+          "submit": "Je réinitialise mon mot de passe"
+        },
+        "fields": {
+          "password": {
+            "label": "Saisissez votre nouveau mot de passe"
+          }
+        }
+      },
       "signup-form": {
         "actions": {
           "submit": "Je m'inscris"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -145,6 +145,16 @@
         "instructions-label": "Your password must comply with the following rules:",
         "completed-message": "{ rulesCompleted } out of { rulesCount } requirements completed."
       },
+      "password-reset-form": {
+        "actions": {
+          "submit": "Reset my password"
+        },
+        "fields": {
+          "password": {
+            "label": "Please enter your new password"
+          }
+        }
+      },
       "signup-form": {
         "actions": {
           "submit": "Ik wil graag registreren"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1644,6 +1644,7 @@
           "label": "Wachtwoord"
         }
       },
+      "first-title": "Resetting the password",
       "instruction": "Voer uw nieuwe wachtwoord in",
       "succeed": "Uw wachtwoord is gewijzigd.",
       "title": "Mijn wachtwoord wijzigen"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -149,6 +149,10 @@
         "actions": {
           "submit": "Reset my password"
         },
+        "errors": {
+          "expired-demand": "Het spijt ons, maar uw wachtwoordaanvraag is al gebruikt of verlopen. Probeer het opnieuw.",
+          "forbidden": "Er is een fout opgetreden, neem contact op met ondersteuning."
+        },
         "fields": {
           "password": {
             "label": "Please enter your new password"
@@ -574,9 +578,9 @@
       "steps": {
         "1": {
           "paragraphs": {
-            "1":  "'<strong>'Dit is een adaptieve test'</strong>'. Met andere woorden, uw vermogen om vragen correct te beantwoorden (of niet) bepaalt de moeilijkheidsgraad van de volgende vragen in real time.",
-            "2":  "Als u een vraag niet kunt beantwoorden, '<strong>'kunt u die vraag \"overslaan\"'</strong>'. '<br>'Overgeslagen vragen worden als mislukt beschouwd en worden niet opnieuw aangeboden.",
-            "3":  "'<strong>'Het is belangrijk dat u de toets afmaakt'</strong>' en dus goed met uw tijd omgaat. Er wordt een '<strong>'boete'</strong>' toegepast waarbij rekening wordt gehouden met het aantal resterende vragen.",
+            "1": "'<strong>'Dit is een adaptieve test'</strong>'. Met andere woorden, uw vermogen om vragen correct te beantwoorden (of niet) bepaalt de moeilijkheidsgraad van de volgende vragen in real time.",
+            "2": "Als u een vraag niet kunt beantwoorden, '<strong>'kunt u die vraag \"overslaan\"'</strong>'. '<br>'Overgeslagen vragen worden als mislukt beschouwd en worden niet opnieuw aangeboden.",
+            "3": "'<strong>'Het is belangrijk dat u de toets afmaakt'</strong>' en dus goed met uw tijd omgaat. Er wordt een '<strong>'boete'</strong>' toegepast waarbij rekening wordt gehouden met het aantal resterende vragen.",
             "4": "To obtain a score as close as possible to your ability, '<strong>'you need to complete the test'</strong>'."
           },
           "question": "Hoe werkt de certificeringstest?",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -109,6 +109,7 @@
       "page-results": "{total, plural, =0 {0 item} =1 {1 item} other {{total, number} items}}",
       "result-by-page": "Zie"
     },
+    "password": "Password",
     "pix": "Pix",
     "skip-links": {
       "skip-to-content": "Ga naar inhoud",


### PR DESCRIPTION
## :unicorn: Contexte

Avec la refonte des pages de connexion, inscription, nous avons aussi besoin de revoir le design de la page du formulaire de réinitialisation de mot de passe. Ceci afin d'être cohérent avec la refonte.

## :robot: Proposition

Ajouter un nouveau composant PasswordResetForm contenant le nouveau design. 

## :rainbow: Remarques

RAS

## :100: Pour tester
Pré-requis: Positionner le feature toggle `FT_NEW_AUTHENTICATION_DESIGN_ENABLED` à true et la variable d'env `DEBUG="pix:mailer:email"`
- Aller sur la page /mot-de-passe-oublie et saisir dans le champ correspondant une adresse email valide (ex: james-paledroits@example.net)
- Cliquer sur le bouton `Réinitialiser mon mot de passe`
- Dans les logs du back, Récupérer l'url généré contenant `/changer-mot-de-passe/`
- Aller sur cette url en changeant le domaine

### Succès

Sur cet URL vérifier la conformité de l'affichage au nouveau design.

### Cas d'erreur

Aller sur cet URL avec un mauvais token et vérifier là aussi la conformité de l'affichage au nouveau design.
