### PR TITLE
[BUGFIX] Ajuster la grille des badges de la bannière de fin de parcours (PIX-14931).

### DIFF
--- a/mon-pix/app/styles/pages/_evaluation-results.scss
+++ b/mon-pix/app/styles/pages/_evaluation-results.scss
@@ -165,7 +165,7 @@
 
 .evaluation-results-hero-details__acquired-badges {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(12rem, 100%), 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(12rem, 100%), 1fr));
   gap: var(--pix-spacing-6x);
 
   .image-container {


### PR DESCRIPTION
## :unicorn: Problème

Dans le cas où on a moins de 4 badges, la largeur des RT de la bannière n'est pas bonne.

## :robot: Proposition

Réparer le style.

## :100: Pour tester

Tester l'affichage avec l'utilisateur `eval-campaign-with-badges@example.net`
