### PR TITLE
[FEATURE] Ajouter un feature toggle pour la nouvelle page de présentation des campagnes (PIX-14946).

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -778,7 +778,14 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: false
 # FT_ENABLE_NEED_TO_ADJUST_CERTIFICATION_ACCESSIBILITY=false
 
-# Display the new result page
+# Display the new campaign presentation page
+#
+# presence: optional
+# type: boolean
+# default: false
+# FT_SHOW_NEW_CAMPAIGN_PRESENTATION_PAGE=false
+
+# Display the new campaign result page
 #
 # presence: optional
 # type: boolean

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -214,6 +214,7 @@ const configuration = (function () {
       isPixPlusLowerLeverEnabled: toBoolean(process.env.FT_ENABLE_PIX_PLUS_LOWER_LEVEL),
       isTextToSpeechButtonEnabled: toBoolean(process.env.FT_ENABLE_TEXT_TO_SPEECH_BUTTON),
       showExperimentalMissions: toBoolean(process.env.FT_SHOW_EXPERIMENTAL_MISSIONS),
+      showNewCampaignPresentationPage: toBoolean(process.env.FT_SHOW_NEW_CAMPAIGN_PRESENTATION_PAGE),
       showNewResultPage: toBoolean(process.env.FT_SHOW_NEW_RESULT_PAGE),
       isPixCompanionEnabled: toBoolean(process.env.FT_PIX_COMPANION_ENABLED),
     },

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -29,6 +29,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-pix-plus-lower-lever-enabled': false,
             'is-need-to-adjust-certification-accessibility-enabled': false,
             'is-text-to-speech-button-enabled': false,
+            'show-new-campaign-presentation-page': false,
             'show-new-result-page': false,
             'show-experimental-missions': false,
             'is-pix-companion-enabled': false,

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -3,6 +3,7 @@ import Model, { attr } from '@ember-data/model';
 export default class FeatureToggle extends Model {
   @attr('boolean') isNewAuthenticationDesignEnabled;
   @attr('boolean') isTextToSpeechButtonEnabled;
+  @attr('boolean') showNewCampaignPresentationPage;
   @attr('boolean') showNewResultPage;
   @attr('boolean') isPixCompanionEnabled;
 }

--- a/mon-pix/tests/unit/services/feature-toggles-test.js
+++ b/mon-pix/tests/unit/services/feature-toggles-test.js
@@ -12,6 +12,7 @@ module('Unit | Service | feature-toggles', function (hooks) {
       isTextToSpeechButtonEnabled: false,
       isNewAuthenticationDesignEnabled: false,
       isPixCompanionEnabled: false,
+      showNewCampaignPresentationPage: false,
     });
 
     let storeStub;
@@ -68,6 +69,18 @@ module('Unit | Service | feature-toggles', function (hooks) {
 
       // then
       assert.false(featureToggleService.featureToggles.isPixCompanionEnabled);
+    });
+
+    test('it initializes the feature toggle showNewCampaignPresentationPage to false', async function (assert) {
+      // given
+      const featureToggleService = this.owner.lookup('service:featureToggles');
+      featureToggleService.set('store', storeStub);
+
+      // when
+      await featureToggleService.load();
+
+      // then
+      assert.false(featureToggleService.featureToggles.showNewCampaignPresentationPage);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Pour plus d'agilité, nous souhaitons travailler de façon itérative sur la nouvelle page de présentation des campagnes, sans impacter l'existante.

## :robot: Proposition

Ajouter un feature toggle dédié à ce nouveau développement.

## 🌈  Remarques

Ce FT est initialisé à `false` par défaut sur les RA

## :100: Pour tester

Tests verts
