### PR TITLE
[BUGFIX] Corriger la taille des boutons sur les Flashcards (PIX-14955)

### DIFF
--- a/mon-pix/app/styles/components/module/_flashcards.scss
+++ b/mon-pix/app/styles/components/module/_flashcards.scss
@@ -53,6 +53,7 @@
       padding-bottom: var(--button-border-size-hover);
 
       &__button {
+        width: calc(100% / 3 - 4px);
         padding: var(--pix-spacing-4x) 0;
         font-weight: var(--pix-font-bold);
         line-height: 24px;


### PR DESCRIPTION
## :unicorn: Problème
- L'affichage des boutons est moche !!!

## :robot: Proposition
Corriger ça 😸 

## :rainbow: Remarques
RAS

## :100: Pour tester
- Aller sur le [didacticiel](https://app-pr10376.review.pix.fr/modules/didacticiel-modulix/passage) 
- Vérifier que l'affichage des boutons de la Flashcard est corrigée 🎉 
