### PR TITLE
[BUGFIX] Ne pas retourner une erreur 500 lors de la vérification de l'éligibilité d'un utilisateur sans badges (PIX-14764).

### DIFF
--- a/api/src/certification/enrolment/domain/usecases/verify-candidate-subscriptions.js
+++ b/api/src/certification/enrolment/domain/usecases/verify-candidate-subscriptions.js
@@ -59,7 +59,7 @@ export async function verifyCandidateSubscriptions({
       certificationBadgesService,
     });
 
-    if (_isSubscribedUserBadgeOutDated(subscribedHighestBadgeAcquisition)) {
+    if (!subscribedHighestBadgeAcquisition || _isSubscribedUserBadgeOutDated(subscribedHighestBadgeAcquisition)) {
       throw new CertificationCandidateEligibilityError();
     }
 


### PR DESCRIPTION
## :fallen_leaf: Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Lors de la réconciliation, si l’utilisateur est inscrit à une certification complémentaire et n’a pas de badge, on a une erreur 500.

## :chestnut: Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

Si l'utilisateur n'a aucun badge, considérer que celui-ci n'est pas éligible.

## :jack_o_lantern: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :wood: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

Essayer de se réconcilier dans une certification complémentaire seule avec un candidat n'ayant pas passé de campagne mais ayant une certification Pix Coeur valide.
