### PR TITLE
[BUGFIX] Rafraîchir la page lorsque le candidat clique sur le bouton lors d'un signalement en certification (PIX-14959).

### DIFF
--- a/mon-pix/app/components/assessments/live-alert.gjs
+++ b/mon-pix/app/components/assessments/live-alert.gjs
@@ -2,13 +2,16 @@ import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixMessage from '@1024pix/pix-ui/components/pix-message';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
 export default class LiveAlert extends Component {
+  @service router;
+
   @action
-  reloadAssessment() {
-    this.args.assessment.reload();
+  refreshPage() {
+    this.router.refresh();
   }
 
   <template>
@@ -20,7 +23,7 @@ export default class LiveAlert extends Component {
         <PixButton
           @variant="tertiary"
           @loadingColor="grey"
-          @triggerAction={{this.reloadAssessment}}
+          @triggerAction={{this.refreshPage}}
           class="refresh-information-live-alert__button"
         >
           <PixIcon @name="refresh" @ariaHidden={{true}} class="refresh-information-live-alert__icon" />

--- a/mon-pix/app/components/feedback-panel-v3.hbs
+++ b/mon-pix/app/components/feedback-panel-v3.hbs
@@ -1,6 +1,6 @@
 {{! template-lint-disable require-input-label no-unknown-arguments-for-builtin-components }}
 {{#if this.isAssessmentPaused}}
-  <Assessments::LiveAlert @message={{t "pages.challenge.live-alerts.challenge.message"}} @assessment={{@assessment}} />
+  <Assessments::LiveAlert @message={{t "pages.challenge.live-alerts.challenge.message"}} />
 {{else}}
   <div class="feedback-panel-v3">
     <h2 class="screen-reader-only">{{t "pages.challenge.parts.feedback-v3"}}</h2>

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -94,10 +94,7 @@
         {{/unless}}
 
         {{#if @model.assessment.hasOngoingCompanionLiveAlert}}
-          <Assessments::LiveAlert
-            @message={{t "pages.challenge.live-alerts.companion.message"}}
-            @assessment={{@model.assessment}}
-          />
+          <Assessments::LiveAlert @message={{t "pages.challenge.live-alerts.companion.message"}} />
         {{/if}}
       </div>
 

--- a/mon-pix/tests/integration/components/assessments/live-alert-test.gjs
+++ b/mon-pix/tests/integration/components/assessments/live-alert-test.gjs
@@ -1,9 +1,7 @@
 import { render } from '@1024pix/ember-testing-library';
-import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import LiveAlert from 'mon-pix/components/assessments/live-alert';
 import { module, test } from 'qunit';
-import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -12,34 +10,14 @@ module('Integration | Component | Assessments | live-alert', function (hooks) {
 
   test('it displays challenge live alert', async function (assert) {
     // given
-    const assessment = {
-      reload: sinon.stub(),
-    };
     const message = t('pages.challenge.live-alerts.companion.message');
 
     // when
-    const screen = await render(<template><LiveAlert @assessment={{assessment}} @message={{message}} /></template>);
+    const screen = await render(<template><LiveAlert @message={{message}} /></template>);
 
     // then
     assert.dom(screen.getByText(message)).exists();
     assert.dom(screen.getByText(t('pages.challenge.live-alerts.waiting-information'))).exists();
     assert.dom(screen.getByRole('button', { name: t('pages.challenge.live-alerts.refresh') })).exists();
-  });
-
-  module('when user clicks refresh button', function () {
-    test('it should reload assessment', async function (assert) {
-      // given
-      const assessment = {
-        reload: sinon.stub(),
-      };
-      const screen = await render(<template><LiveAlert @assessment={{assessment}} /></template>);
-
-      // when
-      await click(screen.getByRole('button', { name: t('pages.challenge.live-alerts.refresh') }));
-
-      // then
-      sinon.assert.calledOnce(assessment.reload);
-      assert.ok(true);
-    });
   });
 });

--- a/mon-pix/tests/unit/components/assessments/live-alert-test.js
+++ b/mon-pix/tests/unit/components/assessments/live-alert-test.js
@@ -1,0 +1,24 @@
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from 'mon-pix/tests/helpers/create-glimmer-component';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Component | Assessments | Live alert', function (hooks) {
+  setupTest(hooks);
+
+  module('#refreshPage', function () {
+    test('should refresh page', async function (assert) {
+      // given
+      const routerService = this.owner.lookup('service:router');
+      sinon.stub(routerService, 'refresh');
+      const component = createGlimmerComponent('assessments/live-alert');
+
+      // when
+      await component.refreshPage();
+
+      // then
+      sinon.assert.calledOnce(component.router.refresh);
+      assert.ok(true);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Un bug a été introduit avec cette PR https://github.com/1024pix/pix/pull/10348
Le bouton de rafraîchissement de la page ne déclenche plus l'appel API permettant de soumettre une nouvelle question au candidat lorsqu'un signalement d'épreuve à été validé par le surveillant.

<img width="1065" alt="Capture d’écran 2024-10-22 à 11 47 42" src="https://github.com/user-attachments/assets/d7eefca6-2e9f-4a7d-b531-44f4a0d6a1e2">

## :robot: Proposition
Rafraîchir la page et relancer tous les appels API pour la question en cours.

## :rainbow: Remarques
J'ai reappliqué le router.refresh() existant avant notre création de composant LiveAlert

## :100: Pour testerActiver l'extension Companion

- Créer une session V3 sur Pix Certif (+ espace surveillant => confirmer la présence)
- Se connecter sur App avec [certif-success@example.net](mailto:certif-success@example.net)
- Remplir le formulaire d'entrée en session de certif
- Entrer en session
- Signaler la question
- Dans l'espace surveillant, valider le signalement en choisissant une des options
- Rafraîchir la page coté candidat via le bouton et constater que la question a été changé
- Passer ou valider la question courante, constater que l'épreuve se déroule bien