### PR TITLE
[TECH] Ajouter un index manquant sur la table supervisor-accesses

### DIFF
--- a/api/db/migrations/20241022082432_add_index_on_table_supervisor_accesses.js
+++ b/api/db/migrations/20241022082432_add_index_on_table_supervisor_accesses.js
@@ -1,0 +1,15 @@
+const TABLE_NAME = 'supervisor-accesses';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.index(['sessionId', 'userId']);
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropIndex(['sessionId', 'userId']);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, la plupart des lignes de la table supervisor-accesses sont récupérées via un seq scan et ne passent pas par un index (voir https://metabase.pix.fr/question/991-sollicitation-des-tables).

## :robot: Proposition
Ajouter l'index manquant sur la table supervisor-accesses.

## :100: Pour tester
```
scalingo --region osc-fr1 -a pix-api-review-pr10381 pgsql-console
\d "supervisor-accesses"
```
Vérifier que l'index est bien créé
`"supervisor_accesses_sessionid_userid_index" btree ("sessionId", "userId")`

