### PR TITLE
[BUGFIX] N'afficher que les RT non-acquis qui sont en lacune (PIX-14969).

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/skill-review/evaluation-results-tabs/rewards/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/skill-review/evaluation-results-tabs/rewards/index.gjs
@@ -17,7 +17,7 @@ export default class Rewards extends Component {
   }
 
   get notAcquiredBadges() {
-    return this.getFilteredAndSortedBadges(false);
+    return this.getFilteredAndSortedBadges(false).filter(({ isAlwaysVisible }) => isAlwaysVisible);
   }
 
   <template>

--- a/mon-pix/tests/integration/components/campaigns/assessment/skill-review/rewards/rewards-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/skill-review/rewards/rewards-test.js
@@ -1,4 +1,4 @@
-import { render } from '@1024pix/ember-testing-library';
+import { render, within } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
@@ -22,11 +22,13 @@ module('Integration | Components | Campaigns | Assessment | Evaluation Results T
 
     const badgeNotAcquired1 = store.createRecord('campaign-participation-badge', {
       isAcquired: false,
+      isAlwaysVisible: true,
       acquisitionPercentage: 30,
     });
 
     const badgeNotAcquired2 = store.createRecord('campaign-participation-badge', {
       isAcquired: false,
+      isAlwaysVisible: true,
       acquisitionPercentage: 70,
     });
 
@@ -94,6 +96,43 @@ module('Integration | Components | Campaigns | Assessment | Evaluation Results T
   });
 
   module('in not acquired badges list', function () {
+    test('it should only display isAlwaysVisible badges', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const notVisibleBadge1 = store.createRecord('campaign-participation-badge', {
+        isAcquired: false,
+        isAlwaysVisible: false,
+        acquisitionPercentage: 66,
+      });
+      const notVisibleBadge2 = store.createRecord('campaign-participation-badge', {
+        isAcquired: false,
+        isAlwaysVisible: false,
+        acquisitionPercentage: 66,
+      });
+
+      const alwaysVisibleBadge = store.createRecord('campaign-participation-badge', {
+        isAcquired: false,
+        isAlwaysVisible: true,
+        acquisitionPercentage: 33,
+      });
+
+      this.set('badges', [notVisibleBadge1, notVisibleBadge2, alwaysVisibleBadge]);
+
+      // when
+      const screen = await render(
+        hbs`<Campaigns::Assessment::SkillReview::EvaluationResultsTabs::Rewards @badges={{this.badges}} />`,
+      );
+
+      // then
+      const notAcquiredBadges = screen.getAllByRole('listitem', {
+        name: t('pages.skill-review.badge-card.not-acquired-full'),
+      });
+
+      assert.strictEqual(notAcquiredBadges.length, 1);
+      assert.ok(within(notAcquiredBadges[0]).getAllByText(/33/).length);
+    });
+
     test('it should display certifiable badge first', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
@@ -101,17 +140,20 @@ module('Integration | Components | Campaigns | Assessment | Evaluation Results T
       const certifiableBadge = store.createRecord('campaign-participation-badge', {
         isAcquired: false,
         isCertifiable: true,
+        isAlwaysVisible: true,
         acquisitionPercentage: 60,
       });
 
       const notCertifiableBadge1 = store.createRecord('campaign-participation-badge', {
         isAcquired: false,
         isCertifiable: false,
+        isAlwaysVisible: true,
         acquisitionPercentage: 60,
       });
       const notCertifiableBadge2 = store.createRecord('campaign-participation-badge', {
         isAcquired: false,
         isCertifiable: false,
+        isAlwaysVisible: true,
         acquisitionPercentage: 60,
       });
 


### PR DESCRIPTION
## :unicorn: Problème

Dans la nouvelle page de fin de parcours, dans l'onglet Récompenses, on affichait tous les RTs possibles.

## :robot: Proposition

Pour la liste des RTs non-acquis, n'afficher que ceux qui sont en lacune.

## :100: Pour tester

- Se connecter avec l'utilisateur `eval-campaign-with-badges@example.net`
- Visualiser dans la page de fin de parcours de sa campagne en cours
