### PR TITLE
[TEMPORAIRE] Tester le PixToast sur Pix Certif.

### DIFF
--- a/certif/app/components/dropdown/icon-trigger.hbs
+++ b/certif/app/components/dropdown/icon-trigger.hbs
@@ -1,6 +1,6 @@
 <div id="icon-trigger" class="dropdown" ...attributes>
   <PixIconButton
-    @icon={{@icon}}
+    @iconName={{@icon}}
     aria-label="{{@ariaLabel}}"
     class="{{@dropdownButtonClass}}"
     @triggerAction={{this.toggle}}

--- a/certif/app/components/members-list-item.hbs
+++ b/certif/app/components/members-list-item.hbs
@@ -21,7 +21,7 @@
     <td>
       {{#if this.shouldDisplayMemberManageButton}}
         <Dropdown::IconTrigger
-          @icon="ellipsis-vertical"
+          @icon="moreVert"
           @dropdownButtonClass="zone-edit-role__dropdown-button"
           @dropdownContentClass="managing-member__dropdown-content"
           @ariaLabel={{t "pages.team.members.actions.manage"}}

--- a/certif/app/components/members-list-item.js
+++ b/certif/app/components/members-list-item.js
@@ -10,6 +10,7 @@ export default class MembersListItem extends Component {
   @service currentUser;
   @service notifications;
   @service intl;
+  @service pixToast;
   @tracked isEditionMode = false;
 
   roleOptions = [
@@ -73,10 +74,16 @@ export default class MembersListItem extends Component {
     this.isEditionMode = false;
     try {
       await member.save();
-      this.notifications.success(this.intl.t('pages.team.members.notifications.change-member-role.success'));
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('pages.team.members.notifications.change-member-role.success'),
+        ariaLabel: 'Fermer la notification',
+      });
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t('pages.team.members.notifications.change-member-role.error', { htmlSafe: true }),
+        ariaLabel: 'Fermer la notification',
+      });
     } catch (e) {
       member.rollbackAttributes();
-      this.notifications.error(this.intl.t('pages.team.members.notifications.change-member-role.error'));
     }
   }
 

--- a/certif/app/templates/application.hbs
+++ b/certif/app/templates/application.hbs
@@ -1,4 +1,4 @@
 {{page-title "Pix Certif"}}
 <CommunicationBanner />
 {{outlet}}
-<NotificationContainer @position="bottom-right" />
+<PixToastContainer />

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -13,7 +13,7 @@
         "@1024pix/ember-api-actions": "^1.1.0",
         "@1024pix/ember-testing-library": "^3.0.6",
         "@1024pix/eslint-config": "^1.3.8",
-        "@1024pix/pix-ui": "^46.15.2",
+        "@1024pix/pix-ui": "github:1024pix/pix-ui#pix-9580-add-pix-toaster-component",
         "@1024pix/stylelint-config": "^5.1.21",
         "@babel/eslint-parser": "^7.22.15",
         "@babel/plugin-proposal-decorators": "^7.22.15",
@@ -784,9 +784,8 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "46.15.2",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-46.15.2.tgz",
-      "integrity": "sha512-vAq2EcYoQu7G+OIf1EIC6/HXoTyv4X1STEZuufqSIwg0O4pOW8ujisOAH57z4xzYV4LKePG2kxgKJom2tO1tFw==",
+      "version": "47.2.0",
+      "resolved": "git+ssh://git@github.com/1024pix/pix-ui.git#bc192822e3a43acc285072c115def2837e1cd367",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/certif/package.json
+++ b/certif/package.json
@@ -53,7 +53,7 @@
     "@1024pix/ember-api-actions": "^1.1.0",
     "@1024pix/ember-testing-library": "^3.0.6",
     "@1024pix/eslint-config": "^1.3.8",
-    "@1024pix/pix-ui": "^46.15.2",
+    "@1024pix/pix-ui": "github:1024pix/pix-ui#pix-9580-add-pix-toaster-component",
     "@1024pix/stylelint-config": "^5.1.21",
     "@babel/eslint-parser": "^7.22.15",
     "@babel/plugin-proposal-decorators": "^7.22.15",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1545,7 +1545,7 @@
       },
       "notifications": {
         "change-member-role": {
-          "error": "Une erreur est survenue lors de la modification du rôle du membre.",
+          "error": "Une erreur est survenue '<br>' lors de la modification du rôle du membre.",
           "success": "Le rôle a bien été changé."
         },
         "leave-organization": {


### PR DESCRIPTION
## :unicorn: Proposition
PR créée pour voir le fonctionnement du PixToast dans une application.

Voué à être clôturé lorsque le PixToast sera validé coté Pix UI (j'ai mis le label blocked pour ne pas risquer qu'elle soit mergé)

## :100: Pour tester

- Se connecter avec certif-pro@example.net
- [Aller dans Equipe](https://certif-pr10395.review.pix.fr/equipe/membres)
- changer le rôle du membre
- Constater l'affichage de deux notifs (une de succès et une d'erreur s'affichent, pour voir le comportement en cas de contenu différents entre les notifs)
- Tester le comportement des notifs
- (pour le design des autres notifs, aller sur la PR Pix UI https://github.com/1024pix/pix-ui/pull/482)
