### PR TITLE
[TECH] Renommage + déplacement de mass-create-user-account (PIX-14974)

### DIFF
--- a/api/src/identity-access-management/scripts/mass-create-user-accounts.js
+++ b/api/src/identity-access-management/scripts/mass-create-user-accounts.js
@@ -1,12 +1,14 @@
+/* eslint-disable no-console */
+
 import * as url from 'node:url';
 
-import { disconnect } from '../db/knex-database-connection.js';
-import * as authenticationMethodRepository from '../src/identity-access-management/infrastructure/repositories/authentication-method.repository.js';
-import { userToCreateRepository } from '../src/identity-access-management/infrastructure/repositories/user-to-create.repository.js';
-import { DomainTransaction } from '../src/shared/domain/DomainTransaction.js';
-import { cryptoService } from '../src/shared/domain/services/crypto-service.js';
-import * as userService from '../src/shared/domain/services/user-service.js';
-import { parseCsvWithHeader } from './helpers/csvHelpers.js';
+import { disconnect } from '../../../db/knex-database-connection.js';
+import { parseCsvWithHeader } from '../../../scripts/helpers/csvHelpers.js';
+import { DomainTransaction } from '../../shared/domain/DomainTransaction.js';
+import { cryptoService } from '../../shared/domain/services/crypto-service.js';
+import * as userService from '../../shared/domain/services/user-service.js';
+import * as authenticationMethodRepository from '../infrastructure/repositories/authentication-method.repository.js';
+import { userToCreateRepository } from '../infrastructure/repositories/user-to-create.repository.js';
 
 function prepareDataForInsert(rawUsers) {
   return rawUsers.map(({ firstName, lastName, email, password }) => {
@@ -78,5 +80,7 @@ async function main() {
     }
   }
 })();
+
+/* eslint-enable no-console */
 
 export { createUsers, prepareDataForInsert };

--- a/api/tests/identity-access-management/acceptance/scripts/mass-create-user-accounts.script.test.js
+++ b/api/tests/identity-access-management/acceptance/scripts/mass-create-user-accounts.script.test.js
@@ -1,7 +1,7 @@
-import { createUsers } from '../../../scripts/create-users-accounts-for-contest.js';
-import { expect, knex, sinon } from '../../test-helper.js';
+import { createUsers } from '../../../../src/identity-access-management/scripts/mass-create-user-accounts.js';
+import { expect, knex, sinon } from '../../../test-helper.js';
 
-describe('Acceptance | Scripts | create-users-accounts-for-contest', function () {
+describe('Acceptance | Identity Access Management | Scripts | mass-create-user-accounts', function () {
   describe('#createUsers', function () {
     const now = new Date();
     let clock;

--- a/api/tests/unit/scripts/identity-access-management/mass-create-user-accounts.script.test.js
+++ b/api/tests/unit/scripts/identity-access-management/mass-create-user-accounts.script.test.js
@@ -1,7 +1,7 @@
-import { prepareDataForInsert } from '../../../scripts/create-users-accounts-for-contest.js';
-import { expect } from '../../test-helper.js';
+import { prepareDataForInsert } from '../../../../src/identity-access-management/scripts/mass-create-user-accounts.js';
+import { expect } from '../../../test-helper.js';
 
-describe('Unit | Scripts | create-users-accounts-for-contest.js', function () {
+describe('Unit | Identity Access Management | Scripts | mass-create-user-accounts', function () {
   describe('#prepareDataForInsert', function () {
     it('should trim firstName, lastName, email and password', function () {
       // given


### PR DESCRIPTION
## :unicorn: Problème

Le script `create-users-accounts-for-contest.js` est mal nommé et les développeurs se posent la question de son utilité et s'il est encore pertinent de le garder, alors qu'il est utile.

## :robot: Proposition

Renommer ce script en `mass-create-user-accounts`, tout en le déplaçant dans le contexte `identity-access-management` auquel il appartient.

## :rainbow: Remarques

RAS

## :100: Pour tester

Vérifier que la commande suivante crée bien 2 comptes :
 
```shell
node src/identity-access-management/scripts/mass-create-user-accounts.js mass-create-user-accounts.csv
```

Fichier `mass-create-user-accounts.csv` : 

```csv
firstName,lastName,email,password
Dik,Tektive,dik.tektive@example.net,P@ssW0rd
Dik2,Tektive2,dik2.tektive2@example.net,P@ssW0rd
```