### PR TITLE
[TECH] Suppression temporaire des habilitations aux complementaires sauf CLEA (PIX-14881).

### DIFF
--- a/api/scripts/certification/next-gen/remove-not-clea-centers-habilitations.js
+++ b/api/scripts/certification/next-gen/remove-not-clea-centers-habilitations.js
@@ -1,0 +1,52 @@
+import 'dotenv/config';
+
+import * as url from 'node:url';
+
+import { disconnect as disconnectFromDb } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../lib/infrastructure/DomainTransaction.js';
+import { usecases } from '../../../src/certification/configuration/domain/usecases/index.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
+
+const modulePath = url.fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === modulePath;
+
+/**
+ * Usage: DRY_RUN=true node scripts/certification/next-gen/remove-not-clea-centers-habilitations.js
+ * @param {Object} params
+ * @param {boolean} params.[isDryRun] - default true
+ **/
+async function main({ isDryRun = true }) {
+  logger.info(`Removing centers habilitations that are not CLEA...`);
+
+  await DomainTransaction.execute(async () => {
+    const numberOfHabiliationsRemoved = await usecases.removeCentersHabilitationsExceptCLEA();
+
+    if (isDryRun) {
+      const transaction = DomainTransaction.getConnection();
+      logger.warn(`DRY RUN: Habilitations removal estimated to ${numberOfHabiliationsRemoved} !`);
+      await transaction.rollback();
+      return;
+    }
+
+    logger.info(`Habilitations removal is successfull for ${numberOfHabiliationsRemoved} !`);
+  });
+}
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    let exitCode = 0;
+    try {
+      const isDryRun = process.env.DRY_RUN === 'true';
+      await main({ isDryRun });
+    } catch (error) {
+      logger.error(error);
+      exitCode = 1;
+    } finally {
+      await disconnectFromDb();
+      // eslint-disable-next-line n/no-process-exit
+      process.exit(exitCode);
+    }
+  }
+})();
+
+export { main };

--- a/api/src/certification/configuration/domain/usecases/index.js
+++ b/api/src/certification/configuration/domain/usecases/index.js
@@ -7,6 +7,7 @@ import * as complementaryCertificationRepository from '../../../complementary-ce
 import * as attachableTargetProfileRepository from '../../infrastructure/repositories/attachable-target-profiles-repository.js';
 import * as centerPilotFeaturesRepository from '../../infrastructure/repositories/center-pilot-features-repository.js';
 import * as centerRepository from '../../infrastructure/repositories/center-repository.js';
+import * as habilitationRepository from '../../infrastructure/repositories/habilitation-repository.js';
 /**
  * @typedef {import('../../infrastructure/repositories/index.js').SessionsRepository} SessionsRepository
  */
@@ -23,6 +24,7 @@ import { convertCenterToV3JobRepository } from '../../infrastructure/repositorie
  * @typedef {centerRepository} CentersRepository
  * @typedef {convertCenterToV3JobRepository} ConvertCenterToV3JobRepository
  * @typedef {sessionsRepository} SessionsRepository
+ * @typedef {habilitationRepository} HabilitationRepository
  **/
 const dependencies = {
   attachableTargetProfileRepository,
@@ -31,6 +33,7 @@ const dependencies = {
   centerRepository,
   convertCenterToV3JobRepository,
   sessionsRepository: configurationRepositories.sessionsRepository,
+  habilitationRepository,
 };
 
 const path = dirname(fileURLToPath(import.meta.url));

--- a/api/src/certification/configuration/domain/usecases/remove-center-habilitations-except-clea.js
+++ b/api/src/certification/configuration/domain/usecases/remove-center-habilitations-except-clea.js
@@ -1,0 +1,20 @@
+/**
+ * @typedef {import ('./index.js').HabilitationRepository} HabilitationRepository
+ */
+import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
+
+/**
+ * @param {Object} params
+ * @param {HabilitationRepository} params.habilitationRepository
+ * @returns {Promise<number>} number of centers impacted
+ */
+export const removeCentersHabilitationsExceptCLEA = async ({ habilitationRepository } = {}) => {
+  return habilitationRepository.deleteAllByComplementaryKey({
+    keys: [
+      ComplementaryCertificationKeys.PIX_PLUS_DROIT,
+      ComplementaryCertificationKeys.PIX_PLUS_EDU_1ER_DEGRE,
+      ComplementaryCertificationKeys.PIX_PLUS_EDU_2ND_DEGRE,
+      ComplementaryCertificationKeys.PIX_PLUS_PRO_SANTE,
+    ],
+  });
+};

--- a/api/src/certification/configuration/infrastructure/repositories/habilitation-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/habilitation-repository.js
@@ -1,0 +1,15 @@
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+
+/**
+ * @param {Object} params
+ * @param {number} params.[keys] - complementary certification key
+ * @returns {Promise<number>} - number of rows affected
+ */
+export const deleteAllByComplementaryKey = async function ({ keys } = {}) {
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn('complementary-certification-habilitations')
+    .whereIn('complementaryCertificationId', async (builder) => {
+      return builder.from('complementary-certifications').select('id').whereIn('key', keys);
+    })
+    .delete();
+};

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/habilitation-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/habilitation-repository_test.js
@@ -1,0 +1,38 @@
+import * as habilitationRepository from '../../../../../../src/certification/configuration/infrastructure/repositories/habilitation-repository.js';
+import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Certification | Configuration | Integration | Repository | habilitation-repository', function () {
+  describe('deleteAllByComplementaryKey', function () {
+    it('should delete habilitation', async function () {
+      // given
+      const clea = databaseBuilder.factory.buildComplementaryCertification({
+        key: ComplementaryCertificationKeys.CLEA,
+      });
+      const aRandomComplementary = databaseBuilder.factory.buildComplementaryCertification({
+        key: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
+      });
+
+      const center = databaseBuilder.factory.buildCertificationCenter();
+      const anotherCenter = databaseBuilder.factory.buildCertificationCenter();
+
+      databaseBuilder.factory.buildComplementaryCertificationHabilitation({
+        certificationCenterId: center.id,
+        complementaryCertificationId: clea.id,
+      });
+      databaseBuilder.factory.buildComplementaryCertificationHabilitation({
+        certificationCenterId: anotherCenter.id,
+        complementaryCertificationId: aRandomComplementary.id,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const numberOfDeletions = await habilitationRepository.deleteAllByComplementaryKey({
+        keys: [ComplementaryCertificationKeys.PIX_PLUS_DROIT],
+      });
+
+      // then
+      expect(numberOfDeletions).to.equal(1);
+    });
+  });
+});

--- a/api/tests/integration/scripts/certification/next-gen/remove-not-clea-centers-habilitations_test.js
+++ b/api/tests/integration/scripts/certification/next-gen/remove-not-clea-centers-habilitations_test.js
@@ -1,0 +1,83 @@
+import { main } from '../../../../../scripts/certification/next-gen/remove-not-clea-centers-habilitations.js';
+import { ComplementaryCertificationKeys } from '../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
+import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
+
+describe('Integration | Scripts | Certification | remove-not-clea-centers-habilitations', function () {
+  let clea, pixPlusDroit;
+
+  beforeEach(async function () {
+    clea = databaseBuilder.factory.buildComplementaryCertification({
+      key: ComplementaryCertificationKeys.CLEA,
+    });
+    pixPlusDroit = databaseBuilder.factory.buildComplementaryCertification({
+      key: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
+    });
+    await databaseBuilder.commit();
+  });
+
+  it('should delete center habilitations except for CLEA', async function () {
+    // given
+    const center = databaseBuilder.factory.buildCertificationCenter({ id: 456 });
+    const anotherCenter = databaseBuilder.factory.buildCertificationCenter({ id: 789 });
+
+    databaseBuilder.factory.buildComplementaryCertificationHabilitation({
+      certificationCenterId: center.id,
+      complementaryCertificationId: clea.id,
+    });
+    databaseBuilder.factory.buildComplementaryCertificationHabilitation({
+      certificationCenterId: center.id,
+      complementaryCertificationId: pixPlusDroit.id,
+    });
+    databaseBuilder.factory.buildComplementaryCertificationHabilitation({
+      certificationCenterId: anotherCenter.id,
+      complementaryCertificationId: pixPlusDroit.id,
+    });
+    await databaseBuilder.commit();
+
+    // when
+    await main({ isDryRun: false });
+
+    // then
+    const habilitationsRemaining = await knex('complementary-certification-habilitations').select(
+      'complementaryCertificationId',
+    );
+    expect(habilitationsRemaining).to.have.lengthOf(1);
+    expect(habilitationsRemaining[0].complementaryCertificationId).to.equal(clea.id);
+  });
+
+  context('when is DRY RUN', function () {
+    it('should not delete any center habiliations', async function () {
+      // given
+      const center = databaseBuilder.factory.buildCertificationCenter({ id: 111 });
+      const anotherCenter = databaseBuilder.factory.buildCertificationCenter({ id: 222 });
+
+      databaseBuilder.factory.buildComplementaryCertificationHabilitation({
+        certificationCenterId: center.id,
+        complementaryCertificationId: clea.id,
+      });
+      databaseBuilder.factory.buildComplementaryCertificationHabilitation({
+        certificationCenterId: center.id,
+        complementaryCertificationId: pixPlusDroit.id,
+      });
+      databaseBuilder.factory.buildComplementaryCertificationHabilitation({
+        certificationCenterId: anotherCenter.id,
+        complementaryCertificationId: pixPlusDroit.id,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      await main({});
+
+      // then
+      const habilitationsRemaining = await knex('complementary-certification-habilitations').select(
+        'complementaryCertificationId',
+      );
+      expect(habilitationsRemaining).to.have.lengthOf(3);
+      expect(habilitationsRemaining).to.deep.equal([
+        { complementaryCertificationId: clea.id },
+        { complementaryCertificationId: pixPlusDroit.id },
+        { complementaryCertificationId: pixPlusDroit.id },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Nous devons retirer temporairement les habilitations des centres a faire passer des complementaires. Mis a part pour CLEA (qui utilise que le référentiel cœur).

## :robot: Proposition

Retirer les habilitations

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
* Sur Pix Admin créer 3 centres
 * un sans habilitations complémentaires
 * un avec complémentaire CLEA seule
 * un avec toutes les complémentaires
* Dans un one-off, lancer le script avec la commande
  * `DRY_RUN=true node scripts/certification/next-gen/remove-not-clea-centers-habilitations.js`
  * Note le chiffre indique par le dry run
* Dans un one-off, lancer le script avec la commande
  * DRY_RUN=false node scripts/certification/next-gen/remove-not-clea-centers-habilitations.js
  * Le chiffre de success doit être identique au DRY RUN
* Verifier les centres sur Pix Admin (rafraîchir la page si vous etes encore dessus)
  *  centre sans complémentaires : toujours sans habilitation
  * un avec complémentaire CLEA seule : possède toujours son habilitation
  * un avec toutes les complémentaires : **ne possède plus que CLEA comme habilitation**
* J'invite les lecteurs aussi a verifier la procedure opérationnelle qui a été mise a jour (voir JIRA) 
 