### PR TITLE
[FEATURE] Générer un test de certification v2 avec des questions du référentiel Pix+ seul (PIX-14715)

### DIFF
--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -93,18 +93,6 @@ const retrieveLastOrCreateCertificationCourse = async function ({
     };
   }
 
-  let lang;
-  if (SessionVersion.isV3(session.version)) {
-    const user = await userRepository.get(userId);
-    const isUserLanguageValid = _validateUserLanguage(languageService, user.lang);
-
-    if (!isUserLanguageValid) {
-      throw new LanguageNotSupportedError(user.lang);
-    }
-
-    lang = user.lang;
-  }
-
   return _startNewCertification({
     session,
     userId,
@@ -113,11 +101,12 @@ const retrieveLastOrCreateCertificationCourse = async function ({
     assessmentRepository,
     certificationCourseRepository,
     certificationCenterRepository,
+    userRepository,
+    languageService,
     certificationChallengesService,
     placementProfileService,
     verifyCertificateCodeService,
     certificationBadgesService,
-    lang,
   });
 };
 
@@ -187,7 +176,9 @@ async function _blockCandidateFromRestartingWithoutExplicitValidation(
  * @param {CertificationCourseRepository} params.certificationCourseRepository
  * @param {PlacementProfileService} params.placementProfileService
  * @param {CertificationCenterRepository} params.certificationCenterRepository
+ * @param {UserRepository} params.userRepository
  * @param {CertificationBadgesService} params.certificationBadgesService
+ * @param {LanguageService} params.languageService
  * @param {AssessmentRepository} params.assessmentRepository
  * @param {CertificationChallengesService} params.certificationChallengesService
  * @param {VerifyCertificateCodeService} params.verifyCertificateCodeService
@@ -200,12 +191,25 @@ async function _startNewCertification({
   assessmentRepository,
   certificationCourseRepository,
   certificationCenterRepository,
+  userRepository,
   certificationChallengesService,
+  languageService,
   placementProfileService,
   certificationBadgesService,
   verifyCertificateCodeService,
-  lang,
 }) {
+  let lang;
+  if (SessionVersion.isV3(session.version)) {
+    const user = await userRepository.get(userId);
+    const isUserLanguageValid = _validateUserLanguage(languageService, user.lang);
+
+    if (!isUserLanguageValid) {
+      throw new LanguageNotSupportedError(user.lang);
+    }
+
+    lang = user.lang;
+  }
+
   const challengesForCertification = [];
 
   const certificationCenter = await certificationCenterRepository.getBySessionId({ sessionId: session.id });

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -246,7 +246,7 @@ async function _startNewCertification({
 
   let challengesForPixCertification = [];
 
-  if (!AlgorithmEngineVersion.isV3(algorithmEngineVersion)) {
+  if (_shouldPickCoreReferentialChallenges({ algorithmEngineVersion, certificationCandidate })) {
     const placementProfile = await placementProfileService.getPlacementProfile({
       userId,
       limitDate: certificationCandidate.reconciledAt,
@@ -287,6 +287,25 @@ async function _startNewCertification({
   });
 }
 
+/**
+ * @param {Object} params
+ * @param {AlgorithmEngineVersion} params.algorithmEngineVersion
+ * @param {CertificationCandidate} params.certificationCandidate
+ * @returns {boolean}
+ */
+function _shouldPickCoreReferentialChallenges({ algorithmEngineVersion, certificationCandidate }) {
+  return (
+    !AlgorithmEngineVersion.isV3(algorithmEngineVersion) && !certificationCandidate.isEnrolledToComplementaryOnly()
+  );
+}
+
+/**
+ * @param {Object} params
+ * @param {CertificationCourseRepository} params.certificationCourseRepository
+ * @param {UserId} params.userId
+ * @param {SessionId} params.sessionId
+ * @returns {Promise<CertificationCourse>}
+ */
 async function _getCertificationCourseIfCreatedMeanwhile(certificationCourseRepository, userId, sessionId) {
   return certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId({
     userId,

--- a/api/src/certification/evaluation/domain/services/scoring/scoring-v2.js
+++ b/api/src/certification/evaluation/domain/services/scoring/scoring-v2.js
@@ -5,8 +5,6 @@
  * @typedef {import('../index.js').ScoringDegradationService} ScoringDegradationService
  * @typedef {import('../index.js').ScoringCertificationService} ScoringCertificationService
  * @typedef {import('../index.js').ScoringService} ScoringService
- * @typedef {import('../index.js').CertificationCandidateRepository} CertificationCandidateRepository
- * @typedef {import('../../models/Candidate.js').Candidate} Candidate
  */
 
 import _ from 'lodash';
@@ -33,7 +31,6 @@ import { AlgorithmEngineVersion } from '../../../../shared/domain/models/Algorit
  * @param {AreaRepository} params.areaRepository
  * @param {PlacementProfileService} params.placementProfileService
  * @param {ScoringService} params.scoringService
- * @param {CertificationCandidateRepository} params.certificationCandidateRepository
  */
 export const handleV2CertificationScoring = async ({
   event,
@@ -46,12 +43,9 @@ export const handleV2CertificationScoring = async ({
   areaRepository,
   placementProfileService,
   scoringService,
-  certificationCandidateRepository,
   dependencies = { calculateCertificationAssessmentScore },
 }) => {
-  const candidate = certificationCandidateRepository.findByAssessmentId({ assessmentId: certificationAssessment.id });
   const certificationAssessmentScore = await dependencies.calculateCertificationAssessmentScore({
-    candidate,
     certificationAssessment,
     continueOnError: false,
     areaRepository,
@@ -84,11 +78,9 @@ export const handleV2CertificationScoring = async ({
 
 /**
  * @param {Object} params
- * @param {Candidate} params.candidate
  * @param {ScoringService} params.dependencies.scoringService
  */
 export const calculateCertificationAssessmentScore = async function ({
-  candidate,
   certificationAssessment,
   continueOnError,
   areaRepository,
@@ -97,7 +89,7 @@ export const calculateCertificationAssessmentScore = async function ({
 }) {
   const testedCompetences = await _getTestedCompetences({
     userId: certificationAssessment.userId,
-    limitDate: candidate.reconciledAt,
+    limitDate: certificationAssessment.createdAt,
     version: AlgorithmEngineVersion.V2,
     placementProfileService,
   });

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v2_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v2_test.js
@@ -234,14 +234,12 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
       competenceMarkRepository,
       certificationCourseRepository,
       scoringCertificationService,
-      certificationCandidateRepository,
       dependencies;
 
     beforeEach(function () {
       competenceMarkRepository = { save: sinon.stub() };
       assessmentResultRepository = { save: sinon.stub() };
       certificationCourseRepository = { get: sinon.stub() };
-      certificationCandidateRepository = { findByAssessmentId: sinon.stub() };
       dependencies = { calculateCertificationAssessmentScore: sinon.stub() };
       scoringCertificationService = {
         isLackOfAnswersForTechnicalReason: sinon.stub(),
@@ -250,20 +248,14 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
 
     context('for scoring certification', function () {
       context('when candidate has enough correct answers to be certified', function () {
-        let certificationCourseId,
-          certificationAssessmentScore,
-          certificationAssessment,
-          certificationCourse,
-          candidate;
+        let certificationCourseId, certificationAssessmentScore, certificationAssessment, certificationCourse;
 
         beforeEach(function () {
           const assessmentResultId = 123123;
           certificationCourseId = 123;
           const competenceMark1 = domainBuilder.buildCompetenceMark({ assessmentResultId, score: 5 });
           const competenceMark2 = domainBuilder.buildCompetenceMark({ assessmentResultId, score: 4 });
-          candidate = domainBuilder.certification.evaluation.buildCandidate({
-            reconciledAt: new Date('2020-01-01'),
-          });
+
           certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
             competenceMarks: [competenceMark1, competenceMark2],
             percentageCorrectAnswers: 80,
@@ -287,7 +279,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
             assessmentId: certificationAssessment.id,
           });
 
-          certificationCandidateRepository.findByAssessmentId.resolves(candidate);
           dependencies.calculateCertificationAssessmentScore.resolves(certificationAssessmentScore);
           scoringCertificationService.isLackOfAnswersForTechnicalReason.returns(false);
           certificationCourseRepository.get
@@ -308,7 +299,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
             certificationCourseRepository,
             competenceMarkRepository,
             scoringCertificationService,
-            certificationCandidateRepository,
             dependencies,
           });
 
@@ -335,7 +325,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
             certificationCourseRepository,
             competenceMarkRepository,
             scoringCertificationService,
-            certificationCandidateRepository,
             dependencies,
           });
 
@@ -352,9 +341,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
             id: certificationCourseId,
             abortReason: null,
           });
-          const candidate = domainBuilder.certification.evaluation.buildCandidate({
-            reconciledAt: new Date('2020-01-01'),
-          });
           const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
             competenceMarks: [],
             percentageCorrectAnswers: 49,
@@ -367,7 +353,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
           });
           const savedAssessmentResult = { id: 123123 };
 
-          certificationCandidateRepository.findByAssessmentId.resolves(candidate);
           dependencies.calculateCertificationAssessmentScore.resolves(certificationAssessmentScore);
           scoringCertificationService.isLackOfAnswersForTechnicalReason.returns(false);
           certificationCourseRepository.get
@@ -384,7 +369,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
             certificationCourseRepository,
             competenceMarkRepository,
             scoringCertificationService,
-            certificationCandidateRepository,
             dependencies,
           });
 
@@ -435,9 +419,7 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
         });
         const competenceMark2 = domainBuilder.buildCompetenceMark({ score: 5 });
         const competenceMark1 = domainBuilder.buildCompetenceMark({ score: 4 });
-        const candidate = domainBuilder.certification.evaluation.buildCandidate({
-          reconciledAt: new Date('2020-01-01'),
-        });
+
         const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
           nbPix: 9,
           status: AssessmentResult.status.VALIDATED,
@@ -461,7 +443,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
           assessmentResult: savedAssessmentResult,
         });
 
-        certificationCandidateRepository.findByAssessmentId.resolves(candidate);
         dependencies.calculateCertificationAssessmentScore.resolves(certificationAssessmentScore);
         scoringCertificationService.isLackOfAnswersForTechnicalReason.returns(false);
         certificationCourseRepository.get
@@ -479,7 +460,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
           certificationCourseRepository,
           competenceMarkRepository,
           scoringCertificationService,
-          certificationCandidateRepository,
           dependencies,
         });
 
@@ -520,9 +500,7 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
           // given
           const competenceMark2 = domainBuilder.buildCompetenceMark({ score: 12 });
           const competenceMark1 = domainBuilder.buildCompetenceMark({ score: 18 });
-          const candidate = domainBuilder.certification.evaluation.buildCandidate({
-            reconciledAt: new Date('2020-01-01'),
-          });
+
           const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
             status: AssessmentResult.status.VALIDATED,
             competenceMarks: [competenceMark1, competenceMark2],
@@ -543,7 +521,7 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
             certificationCourseId: 789,
             assessmentResult: savedAssessmentResult,
           });
-          certificationCandidateRepository.findByAssessmentId.resolves(candidate);
+
           dependencies.calculateCertificationAssessmentScore.resolves(certificationAssessmentScore);
           scoringCertificationService.isLackOfAnswersForTechnicalReason.returns(false);
           certificationCourseRepository.get
@@ -561,7 +539,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
             certificationCourseRepository,
             competenceMarkRepository,
             scoringCertificationService,
-            certificationCandidateRepository,
             dependencies,
           });
 
@@ -575,9 +552,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
         context('when it has insufficient correct answers', function () {
           it('builds and save a not trustable assessment result', async function () {
             // given
-            const candidate = domainBuilder.certification.evaluation.buildCandidate({
-              reconciledAt: new Date('2020-01-01'),
-            });
             const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
               status: AssessmentResult.status.REJECTED,
               percentageCorrectAnswers: 45,
@@ -597,7 +571,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
               certificationCourseId: 789,
               assessmentResult: savedAssessmentResult,
             });
-            certificationCandidateRepository.findByAssessmentId.resolves(candidate);
             dependencies.calculateCertificationAssessmentScore.resolves(certificationAssessmentScore);
             scoringCertificationService.isLackOfAnswersForTechnicalReason.returns(false);
             certificationCourseRepository.get
@@ -615,7 +588,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
               certificationCourseRepository,
               competenceMarkRepository,
               scoringCertificationService,
-              certificationCandidateRepository,
               dependencies,
             });
 
@@ -651,9 +623,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
           certificationCourseRepository.get.withArgs({ id: 789 }).resolves(certificationCourse);
           const competenceMark2 = domainBuilder.buildCompetenceMark({ score: 12 });
           const competenceMark1 = domainBuilder.buildCompetenceMark({ score: 18 });
-          const candidate = domainBuilder.certification.evaluation.buildCandidate({
-            reconciledAt: new Date('2020-01-01'),
-          });
           const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
             status: AssessmentResult.status.VALIDATED,
             competenceMarks: [competenceMark1, competenceMark2],
@@ -674,7 +643,7 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
             certificationCourseId: 789,
             assessmentResult: savedAssessmentResult,
           });
-          certificationCandidateRepository.findByAssessmentId.resolves(candidate);
+
           dependencies.calculateCertificationAssessmentScore.resolves(certificationAssessmentScore);
           scoringCertificationService.isLackOfAnswersForTechnicalReason.returns(false);
           certificationCourseRepository.get
@@ -692,7 +661,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
             certificationCourseRepository,
             competenceMarkRepository,
             scoringCertificationService,
-            certificationCandidateRepository,
             dependencies,
           });
 
@@ -730,9 +698,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
             });
             const competenceMark2 = domainBuilder.buildCompetenceMark({ score: 12 });
             const competenceMark1 = domainBuilder.buildCompetenceMark({ score: 18 });
-            const candidate = domainBuilder.certification.evaluation.buildCandidate({
-              reconciledAt: new Date('2020-01-01'),
-            });
             const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
               status: AssessmentResult.status.VALIDATED,
               competenceMarks: [competenceMark1, competenceMark2],
@@ -750,7 +715,7 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
               certificationCourseId: 789,
               assessmentResult: savedAssessmentResult,
             });
-            certificationCandidateRepository.findByAssessmentId.resolves(candidate);
+
             dependencies.calculateCertificationAssessmentScore.resolves(certificationAssessmentScore);
             scoringCertificationService.isLackOfAnswersForTechnicalReason.returns(false);
             certificationCourseRepository.get
@@ -767,7 +732,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
               certificationCourseRepository,
               competenceMarkRepository,
               scoringCertificationService,
-              certificationCandidateRepository,
               dependencies,
             });
 
@@ -839,7 +803,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
               certificationCourseRepository,
               competenceMarkRepository,
               scoringCertificationService,
-              certificationCandidateRepository,
               dependencies,
             });
 
@@ -905,7 +868,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
                 certificationCourseRepository,
                 competenceMarkRepository,
                 scoringCertificationService,
-                certificationCandidateRepository,
                 dependencies,
               });
 
@@ -922,7 +884,7 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
   });
 
   context('#calculateCertificationAssessmentScore', function () {
-    let certificationAssessment, certificationAssessmentData, expectedCertifiedCompetences, candidate;
+    let certificationAssessment, certificationAssessmentData, expectedCertifiedCompetences;
     let competenceWithMarks_1_1, competenceWithMarks_2_2, competenceWithMarks_3_3, competenceWithMarks_4_4;
     let areaRepository;
 
@@ -1002,7 +964,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
           certificationAnswersByDate,
           certificationChallenges: challenges,
         };
-        const candidate = domainBuilder.certification.evaluation.buildCandidate();
 
         const placementProfileService = {
           getPlacementProfile: sinon.stub(),
@@ -1010,14 +971,13 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
         placementProfileService.getPlacementProfile
           .withArgs({
             userId: certificationAssessment.userId,
-            limitDate: candidate.reconciledAt,
+            limitDate: certificationAssessment.createdAt,
             version: AlgorithmEngineVersion.V2,
           })
           .resolves({ userCompetences });
 
         // when
         const error = await catchErr(calculateCertificationAssessmentScore)({
-          candidate,
           certificationAssessment,
           continueOnError: false,
           areaRepository,
@@ -1063,7 +1023,7 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
         placementProfileService.getPlacementProfile
           .withArgs({
             userId: certificationAssessment.userId,
-            limitDate: candidate.reconciledAt,
+            limitDate: certificationAssessment.createdAt,
             version: AlgorithmEngineVersion.V2,
           })
           .resolves({ userCompetences });
@@ -1178,7 +1138,7 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
         placementProfileService.getPlacementProfile
           .withArgs({
             userId: certificationAssessment.userId,
-            limitDate: candidate.reconciledAt,
+            limitDate: certificationAssessment.createdAt,
             version: AlgorithmEngineVersion.V2,
           })
           .resolves({ userCompetences });
@@ -1208,7 +1168,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
           certificationAnswersByDate: wrongAnswersForAllChallenges(),
           certificationChallenges: challenges,
         });
-        candidate = domainBuilder.certification.evaluation.buildCandidate();
 
         placementProfileService = {
           getPlacementProfile: sinon.stub(),
@@ -1216,7 +1175,7 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
         placementProfileService.getPlacementProfile
           .withArgs({
             userId: certificationAssessment.userId,
-            limitDate: candidate.reconciledAt,
+            limitDate: certificationAssessment.createdAt,
             version: AlgorithmEngineVersion.V2,
           })
           .resolves({ userCompetences });
@@ -1225,7 +1184,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
       it('should get user profile', async function () {
         // when
         await calculateCertificationAssessmentScore({
-          candidate,
           certificationAssessment,
           continueOnError,
           areaRepository,
@@ -1251,7 +1209,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
         it('should return list of competences with all certifiedLevel at -1', async function () {
           // when
           const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-            candidate,
             certificationAssessment: startedCertificationAssessment,
             continueOnError,
             areaRepository,
@@ -1268,7 +1225,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
         it('should return list of competences with all certifiedLevel at -1', async function () {
           // when
           const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-            candidate,
             certificationAssessment,
             continueOnError,
             areaRepository,
@@ -1313,7 +1269,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
 
           // when
           const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-            candidate,
             certificationAssessment,
             continueOnError,
             areaRepository,
@@ -1351,7 +1306,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
 
           // when
           const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-            candidate,
             certificationAssessment,
             continueOnError,
             areaRepository,
@@ -1393,7 +1347,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
 
           // when
           const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-            candidate,
             certificationAssessment,
             continueOnError,
             areaRepository,
@@ -1412,7 +1365,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
 
           // when
           const { percentageCorrectAnswers } = await calculateCertificationAssessmentScore({
-            candidate,
             certificationAssessment: certificationAssessmentWithNeutralizedChallenge,
             continueOnError,
             areaRepository,
@@ -1472,14 +1424,13 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
               placementProfileService.getPlacementProfile
                 .withArgs({
                   userId: certificationAssessment.userId,
-                  limitDate: candidate.reconciledAt,
+                  limitDate: certificationAssessment.createdAt,
                   version: AlgorithmEngineVersion.V2,
                 })
                 .resolves({ userCompetences });
 
               // When
               const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-                candidate,
                 certificationAssessment,
                 continueOnError,
                 areaRepository,
@@ -1505,14 +1456,13 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
           certificationAnswersByDate: wrongAnswersForAllChallenges(),
           certificationChallenges: challenges,
         });
-        candidate = domainBuilder.certification.evaluation.buildCandidate();
         placementProfileService = {
           getPlacementProfile: sinon.stub(),
         };
         placementProfileService.getPlacementProfile
           .withArgs({
             userId: certificationAssessment.userId,
-            limitDate: candidate.reconciledAt,
+            limitDate: certificationAssessment.createdAt,
             version: AlgorithmEngineVersion.V2,
           })
           .resolves({ userCompetences });
@@ -1522,7 +1472,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
         it('should return list of competences with all certifiedLevel at -1', async function () {
           // when
           const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-            candidate,
             certificationAssessment,
             continueOnError,
             areaRepository,
@@ -1567,7 +1516,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
 
           // when
           const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-            candidate,
             certificationAssessment,
             continueOnError,
             areaRepository,
@@ -1603,7 +1551,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
 
           // when
           const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-            candidate,
             certificationAssessment,
             continueOnError,
             areaRepository,
@@ -1645,7 +1592,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
 
           // when
           const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-            candidate,
             certificationAssessment,
             continueOnError,
             areaRepository,
@@ -1698,7 +1644,7 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
           placementProfileService.getPlacementProfile
             .withArgs({
               userId: certificationAssessment.userId,
-              limitDate: candidate.reconciledAt,
+              limitDate: certificationAssessment.createdAt,
               version: AlgorithmEngineVersion.V2,
             })
             .resolves({ userCompetences });
@@ -1731,7 +1677,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
 
           // when
           const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-            candidate,
             certificationAssessment,
             continueOnError,
             areaRepository,
@@ -1794,7 +1739,7 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
           placementProfileService.getPlacementProfile
             .withArgs({
               userId: certificationAssessment.userId,
-              limitDate: candidate.reconciledAt,
+              limitDate: certificationAssessment.createdAt,
               version: AlgorithmEngineVersion.V2,
             })
             .resolves({ userCompetences });
@@ -1832,7 +1777,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
 
           // when
           const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-            candidate,
             certificationAssessment,
             continueOnError,
             areaRepository,
@@ -1885,7 +1829,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
         it('should not include the extra challenges when computing reproducibility', async function () {
           // when
           const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-            candidate,
             certificationAssessment,
             continueOnError,
             areaRepository,
@@ -1908,7 +1851,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
           certificationAnswersByDate: wrongAnswersForAllChallenges(),
           certificationChallenges: challenges,
         });
-        candidate = domainBuilder.certification.evaluation.buildCandidate();
         certificationAssessment.certificationAnswersByDate = correctAnswersForAllChallenges();
         placementProfileService = {
           getPlacementProfile: sinon.stub(),
@@ -1916,7 +1858,7 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
         placementProfileService.getPlacementProfile
           .withArgs({
             userId: certificationAssessment.userId,
-            limitDate: candidate.reconciledAt,
+            limitDate: certificationAssessment.createdAt,
             version: AlgorithmEngineVersion.V2,
           })
           .resolves({ userCompetences });
@@ -1933,7 +1875,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
 
           // when
           const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-            candidate,
             certificationAssessment: certificationAssessmentWithNeutralizedChallenge,
             continueOnError: false,
             areaRepository,
@@ -1959,7 +1900,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
 
           // when
           const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-            candidate,
             certificationAssessment: certificationAssessmentWithNeutralizedChallenge,
             continueOnError: false,
             areaRepository,


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre du sujet “Compatibilité Pix v3/Pix+”, un candidat doit pouvoir passer un test de certification Pix+ seul.


Si actuellement on est capable de générer un test de certif basé sur des questions du référentiel Pix+, celui-ci comporte également des questions du référentiel Pix coeur, ce qui n’est plus possible avec la certif Pix coeur v3 (car dans le format v2 des certifications Pix+, les candidats passaient dans un même test les questions Pix+ et celles du réf Pix coeur). 


## :robot: Proposition
Lorsqu’un candidat inscrit en certification Pix+ seule lance son test de certification, générer un test avec uniquement les questions du référentiel Pix+ concerné : 


## :100: Pour tester
- créer une session dans un centre de certif taggué isV3Pilot et habilité à une certification Pix+

- inscrire un candidat à une certif Pix+ seule

- rejoindre la session avec un compte Pix éligible à cette certif Pix+

- lancer le test 

  - le test de certification se génère avec uniquement des questions du référentiel Pix+ concerné

  - le compteur d'épreuves est cohérent avec le nombre de questions du test


![image](https://github.com/user-attachments/assets/48c9b207-0a5d-43d0-9874-37c750b9feb2)


- Tester pour une session v3 Pix Coeur seul
  - constater que l'utilisateur a bien 32 questions
  ![image](https://github.com/user-attachments/assets/2d88f52f-dd37-4f35-ac7b-49de23ca1b81)
  
- Tester pour une session v3 Pix Coeur + Clea
  - constater que l'utilisateur a bien 32 questions
![image](https://github.com/user-attachments/assets/4f3726b6-0385-44de-88c9-8ecdc20ffec2)


- Tester pour une session V2 Pix Coeur
![image](https://github.com/user-attachments/assets/4bd807ba-c49b-4ea5-b508-bbcaef2e90c7)



- Test V2 Pix Coeur + Droit (certif success a le badge)
![image](https://github.com/user-attachments/assets/965afa4c-c80e-42e4-b9b3-5aeb8bc86b24)

