### PR TITLE
[FEATURE] Afficher la bonne réception de demande de réinitialisation de mot de passe (PIX-14112)

### DIFF
--- a/mon-pix/app/components/authentication/password-reset-demand-form.gjs
+++ b/mon-pix/app/components/authentication/password-reset-demand-form.gjs
@@ -56,13 +56,11 @@ export default class PasswordResetDemandForm extends Component {
         method: 'POST',
         body: JSON.stringify({ email }),
       });
-      if (response.status == 404) {
-        this.errorMessage = this.intl.t('components.authentication.password-reset-demand-form.404-message');
-      } else if (!response.ok) {
+      if (!response.ok && response.status != 404) {
         throw new Error(`Response status: ${response.status}`);
-      } else {
-        this.isPasswordResetDemandReceived = true;
       }
+
+      this.isPasswordResetDemandReceived = true;
     } catch (error) {
       this.errorMessage = this.intl.t('common.api-error-messages.internal-server-error');
     } finally {

--- a/mon-pix/app/components/authentication/password-reset-demand-form.gjs
+++ b/mon-pix/app/components/authentication/password-reset-demand-form.gjs
@@ -22,6 +22,7 @@ export default class PasswordResetDemandForm extends Component {
   );
   @tracked emailInputvalidationStatus;
   @tracked emailInputvalidationErrorMessage;
+  @tracked isPasswordResetDemandReceived = false;
 
   email;
 
@@ -59,6 +60,8 @@ export default class PasswordResetDemandForm extends Component {
         this.errorMessage = this.intl.t('components.authentication.password-reset-demand-form.404-message');
       } else if (!response.ok) {
         throw new Error(`Response status: ${response.status}`);
+      } else {
+        this.isPasswordResetDemandReceived = true;
       }
     } catch (error) {
       this.errorMessage = this.intl.t('common.api-error-messages.internal-server-error');
@@ -68,55 +71,82 @@ export default class PasswordResetDemandForm extends Component {
   }
 
   <template>
-    <form {{on "submit" this.handlePasswordResetDemand}} class="authentication-password-reset-demand-form">
-      <p class="authentication-password-reset-demand-form__rule">
-        {{t "components.authentication.password-reset-demand-form.rule"}}
-      </p>
+    {{#if this.isPasswordResetDemandReceived}}
+      <PasswordResetDemandReceivedInfo />
+    {{else}}
+      <form {{on "submit" this.handlePasswordResetDemand}} class="authentication-password-reset-demand-form">
+        <p class="authentication-password-reset-demand-form__rule">
+          {{t "components.authentication.password-reset-demand-form.rule"}}
+        </p>
 
-      {{#if this.errorMessage}}
-        <PixMessage
-          @type="error"
-          @withIcon={{true}}
-          class="authentication-password-reset-demand-form__error"
-          role="alert"
-        >
-          {{this.errorMessage}}
-        </PixMessage>
-      {{/if}}
-      <div class="authentication-password-reset-demand-form__input-block">
-        <PixInput
-          @value={{this.email}}
-          type="email"
-          {{on "change" this.handleEmailChange}}
-          @validationStatus={{this.emailInputvalidationStatus}}
-          @errorMessage={{this.emailInputvalidationErrorMessage}}
-          placeholder={{this.emailInputPlaceholder}}
-          required={{true}}
-        >
-          <:label>{{t "components.authentication.password-reset-demand-form.fields.email.label"}}</:label>
-        </PixInput>
-      </div>
-      <div>
-        <PixButton
-          @type="submit"
-          @size="large"
-          @isLoading={{this.isLoading}}
-          class="authentication-password-reset-demand-form__button"
-        >
-          {{t "components.authentication.password-reset-demand-form.actions.receive-reset-button"}}
-        </PixButton>
-      </div>
-      <p class="authentication-password-reset-demand-form__help">
-        {{t "components.authentication.password-reset-demand-form.no-email-question"}}
-        <PixButtonLink
-          @variant="tertiary"
-          @href="{{t 'components.authentication.password-reset-demand-form.contact-us-link.link-url'}}"
-          target="_blank"
-          class="authentication-password-reset-demand-form__help-contact-us-link"
-        >
-          {{t "components.authentication.password-reset-demand-form.contact-us-link.link-text"}}
-        </PixButtonLink>
-      </p>
-    </form>
+        {{#if this.errorMessage}}
+          <PixMessage
+            @type="error"
+            @withIcon={{true}}
+            class="authentication-password-reset-demand-form__error"
+            role="alert"
+          >
+            {{this.errorMessage}}
+          </PixMessage>
+        {{/if}}
+        <div class="authentication-password-reset-demand-form__input-block">
+          <PixInput
+            @value={{this.email}}
+            type="email"
+            {{on "change" this.handleEmailChange}}
+            @validationStatus={{this.emailInputvalidationStatus}}
+            @errorMessage={{this.emailInputvalidationErrorMessage}}
+            placeholder={{this.emailInputPlaceholder}}
+            required={{true}}
+          >
+            <:label>{{t "components.authentication.password-reset-demand-form.fields.email.label"}}</:label>
+          </PixInput>
+        </div>
+        <div>
+          <PixButton
+            @type="submit"
+            @size="large"
+            @isLoading={{this.isLoading}}
+            class="authentication-password-reset-demand-form__button"
+          >
+            {{t "components.authentication.password-reset-demand-form.actions.receive-reset-button"}}
+          </PixButton>
+        </div>
+        <p class="authentication-password-reset-demand-form__help">
+          {{t "components.authentication.password-reset-demand-form.no-email-question"}}
+          <PixButtonLink
+            @variant="tertiary"
+            @href="{{t 'components.authentication.password-reset-demand-form.contact-us-link.link-url'}}"
+            target="_blank"
+            class="authentication-password-reset-demand-form__help-contact-us-link"
+          >
+            {{t "components.authentication.password-reset-demand-form.contact-us-link.link-text"}}
+          </PixButtonLink>
+        </p>
+      </form>
+    {{/if}}
   </template>
 }
+
+const PasswordResetDemandReceivedInfo = <template>
+  <div class="authentication-password-reset-demand-received-info">
+    <img src="/images/mail.svg" alt="" />
+    <h2 class="authentication-password-reset-demand-received-info__heading">
+      {{t "components.authentication.password-reset-demand-received-info.heading"}}
+    </h2>
+    <p class="authentication-password-reset-demand-received-info__message">
+      {{t "components.authentication.password-reset-demand-received-info.message"}}
+    </p>
+    <p class="authentication-password-reset-demand-received-info__help">
+      {{t "components.authentication.password-reset-demand-received-info.no-email-received-question"}}
+      <PixButtonLink
+        @variant="tertiary"
+        @route="password-reset-demand"
+        target="_blank"
+        class="authentication-password-reset-demand-form__help-contact-us-link"
+      >
+        {{t "components.authentication.password-reset-demand-received-info.try-again"}}
+      </PixButtonLink>
+    </p>
+  </div>
+</template>;

--- a/mon-pix/app/components/authentication/password-reset-demand.scss
+++ b/mon-pix/app/components/authentication/password-reset-demand.scss
@@ -39,3 +39,30 @@
         padding: 0;
     }
 }
+
+.authentication-password-reset-demand-received-info {
+    margin-top: var(--pix-spacing-6x);
+    padding: var(--pix-spacing-6x);
+    color: var(--pix-neutral-900);
+    text-align: center;
+    background-color: var(--pix-primary-10);
+    border-radius: var(--pix-spacing-4x);
+
+    &__heading {
+        @extend %pix-title-xs;
+
+        margin-top: var(--pix-spacing-8x);
+    }
+
+    &__message {
+        @extend %pix-body-m;
+
+        margin-top: var(--pix-spacing-4x);
+    }
+
+    &__help {
+        @extend %pix-body-m;
+
+        margin-top: var(--pix-spacing-4x);
+    }
+}

--- a/mon-pix/public/images/mail.svg
+++ b/mon-pix/public/images/mail.svg
@@ -1,0 +1,15 @@
+<svg width="79" height="76" viewBox="0 0 79 76" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M23.043 49.8689L37.041 37.8406C38.4572 36.6254 40.5475 36.6254 41.9636 37.8406L55.9586 49.8689L52.8912 52.4014L39.5023 40.8956L26.1103 52.4045L23.0461 49.872L23.043 49.8689Z" fill="#CEC3F4"/>
+<path d="M22.4695 9.75812C22.4695 7.73279 24.1114 6.09087 26.1367 6.09087H76.6929V5.66725C76.6929 3.64191 75.0509 2 73.0256 2H22.3118C20.2864 2 18.6445 3.64191 18.6445 5.66725V30.2372C18.6445 32.2626 20.2864 33.9045 22.3118 33.9045H22.4695V9.75812Z" fill="#CEC3F4"/>
+<path d="M27.0829 33.9045L27.0767 42.4171L38.833 33.9045H73.0256C75.051 33.9045 76.6929 32.2626 76.6929 30.2372V5.66725C76.6929 3.64191 75.051 2 73.0256 2H22.3118C20.2864 2 18.6445 3.64191 18.6445 5.66725V30.2372C18.6445 32.2626 20.2864 33.9045 22.3118 33.9045H27.086H27.0829Z" stroke="#452D9D" stroke-width="2.06244" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1.6875 32.1606V74.0001H77.3114V35.8372" stroke="#452D9D" stroke-width="2.06244" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15.1135 20.4385L1.6875 32.1607" stroke="#452D9D" stroke-width="2.06244" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M77.3114 73.9997L39.501 40.979L1.6875 73.9997" stroke="#452D9D" stroke-width="2.06244" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M26.1091 52.6738L1.6875 32.1606" stroke="#452D9D" stroke-width="2.06244" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M52.8945 52.6738L71.6204 36.9473" stroke="#452D9D" stroke-width="2.06244" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15.2031 32.1606H1.6875" stroke="#452D9D" stroke-width="2.06244" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M32.4609 17.9027L34.7677 20.6393L38.1071 15.5713" stroke="#452D9D" stroke-width="2.06244" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M42.7054 10.3706H27.8633V25.2128H42.7054V10.3706Z" stroke="#452D9D" stroke-width="2.06244" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M48.8867 19.9126H68.4691" stroke="#452D9D" stroke-width="2.06244" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M48.8867 15.6704H59.5978" stroke="#452D9D" stroke-width="2.06244" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/mon-pix/tests/integration/components/authentication/password-reset-demand-form-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/password-reset-demand-form-test.gjs
@@ -22,6 +22,20 @@ module('Integration | Component | Authentication | password-reset-demand-form', 
     assert.strictEqual(link.getAttribute('href'), 'https://pix.fr/support');
   });
 
+  test('it doesn’t display a "password reset demand received" info', async function (assert) {
+    // given
+    const screen = await render(<template><PasswordResetDemandForm /></template>);
+
+    // then
+    assert
+      .dom(
+        screen.queryByRole('heading', {
+          name: t('components.authentication.password-reset-demand-received-info.heading'),
+        }),
+      )
+      .doesNotExist();
+  });
+
   module('email input validation', function () {
     module('when the email input is valid', function () {
       test('it doesn’t display any error message', async function (assert) {
@@ -68,7 +82,7 @@ module('Integration | Component | Authentication | password-reset-demand-form', 
     });
 
     module('when the password-reset-demand is successful', function () {
-      test('it doesn’t display any error message', async function (assert) {
+      test('it displays a "password reset demand received" info (without any error message)', async function (assert) {
         // given
         window.fetch.resolves(
           fetchMock({
@@ -89,6 +103,20 @@ module('Integration | Component | Authentication | password-reset-demand-form', 
 
         // then
         assert.dom(screen.queryByRole('alert')).doesNotExist();
+
+        assert
+          .dom(
+            screen.queryByRole('heading', {
+              name: t('components.authentication.password-reset-demand-received-info.heading'),
+            }),
+          )
+          .exists();
+
+        const tryAgainLink = await screen.queryByRole('link', {
+          name: t('components.authentication.password-reset-demand-received-info.try-again'),
+        });
+        assert.dom(tryAgainLink).exists();
+        assert.strictEqual(tryAgainLink.getAttribute('href'), '/mot-de-passe-oublie');
       });
     });
 

--- a/mon-pix/tests/integration/components/authentication/password-reset-demand-form-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/password-reset-demand-form-test.gjs
@@ -120,8 +120,9 @@ module('Integration | Component | Authentication | password-reset-demand-form', 
       });
     });
 
+    // TODO: This test module will need to be removed when the API doesn't leak anymore that an account doesn't exist with a "404 Not Found".
     module('when there is no corresponding user account', function () {
-      test('it displays an "account not found" error message', async function (assert) {
+      test('it displays a "password reset demand received" info (without any error message to avoid email enumeration)', async function (assert) {
         // given
         window.fetch.resolves(
           fetchMock({
@@ -144,9 +145,15 @@ module('Integration | Component | Authentication | password-reset-demand-form', 
         );
 
         // then
-        // The following doesn’t work because of a PixUi span inside the role element
-        //assert.dom(screen.queryByRole('alert', { name: t('pages.password-reset-demand.error.message') })).exists();
-        assert.dom(screen.queryByText(t('components.authentication.password-reset-demand-form.404-message'))).exists();
+        assert.dom(screen.queryByRole('alert')).doesNotExist();
+
+        assert
+          .dom(
+            screen.queryByRole('heading', {
+              name: t('components.authentication.password-reset-demand-received-info.heading'),
+            }),
+          )
+          .exists();
       });
     });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -171,6 +171,12 @@
         "no-email-question": "No email address?",
         "rule": "All fields are required."
       },
+      "password-reset-demand-received-info": {
+        "heading": "Check your email address",
+        "message": "If your address is associated with a Pix account, instructions for resetting your password have been sent to you by e-mail.",
+        "no-email-received-question": "You haven’t received anything?",
+        "try-again": "Try again with another demand"
+      },
       "password-reset-form": {
         "actions": {
           "submit": "Reset my password"

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -153,7 +153,6 @@
         "signup-heading": "Other ways to sign up"
       },
       "password-reset-demand-form": {
-        "404-message": "The email address entered does not match any Pix account",
         "actions": {
           "receive-reset-button": "Receive a reset link"
         },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -187,7 +187,6 @@
         }
       },
       "password-reset-demand-form": {
-        "404-message": "Esta dirección de correo electrónico no corresponde a ninguna cuenta",
         "rule": "All fields are required.",
         "no-email-question": "No email address?",
         "contact-us-link": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -204,6 +204,12 @@
         "actions": {
           "receive-reset-button": "Receive a reset link"
         }
+      },
+      "password-reset-demand-received-info": {
+        "heading": "Check your email address",
+        "message": "If your address is associated with a Pix account, instructions for resetting your password have been sent to you by e-mail.",
+        "no-email-received-question": "You haven’t received anything?",
+        "try-again": "Try again with another demand"
       }
     },
     "invited": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -153,7 +153,6 @@
         "signup-heading": "Autres moyens d’inscription"
       },
       "password-reset-demand-form": {
-        "404-message": "Cette adresse e-mail ne correspond à aucun compte",
         "actions": {
           "receive-reset-button": "Recevoir un lien de réinitialisation"
         },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -171,6 +171,12 @@
         "no-email-question": "Pas d’adresse e-mail renseignée ?",
         "rule": "Tous les champs sont obligatoires."
       },
+      "password-reset-demand-received-info": {
+        "heading": "Vérifiez votre messagerie électronique",
+        "message": "Si votre adresse est bien associée à un compte Pix, les instructions pour réinitialiser votre mot de passe vous ont été envoyées par e-mail.",
+        "no-email-received-question": "Vous n’avez pas reçu d’e-mail ?",
+        "try-again": "Renvoyer l’e-mail de réinitialisation"
+      },
       "password-reset-form": {
         "actions": {
           "submit": "Je réinitialise mon mot de passe"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -187,7 +187,6 @@
         }
       },
       "password-reset-demand-form": {
-        "404-message": "Dit e-mailadres komt niet overeen met een account",
         "rule": "All fields are required.",
         "no-email-question": "No email address?",
         "contact-us-link": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -204,6 +204,12 @@
         "actions": {
           "receive-reset-button": "Receive a reset link"
         }
+      },
+      "password-reset-demand-received-info": {
+        "heading": "Check your email address",
+        "message": "If your address is associated with a Pix account, instructions for resetting your password have been sent to you by e-mail.",
+        "no-email-received-question": "You haven’t received anything?",
+        "try-again": "Try again with another demand"
       }
     },
     "invited": {


### PR DESCRIPTION
## :unicorn: Problème

Il faut afficher la bonne réception de demande de réinitialisation de mot de passe.

![Desktop - Mot de passe oublié - 2](https://github.com/user-attachments/assets/2bd31a31-190d-4323-b5b6-30c7a404894a)

## :robot: Proposition

Afficher une zone d'information dans le même composant plutôt que de créer une nouvelle page + un nouveau composant.

Cette PR contient également la modification de ne plus afficher qu'un compte n'existe pas si l'utilisateur fournit une adresse email ne correspondant à aucun compte existant, même si pour l'instant l'API continue de renvoyer une réponse `404`.

## :rainbow: Remarques

RAS

## :100: Pour tester

1. Activer le feature flag `FT_NEW_AUTHENTICATION_DESIGN_ENABLED=true`
2. Aller sur https://app.dev.pix.fr/mot-de-passe-oublie
3. Vérifier qu'on ne peut envoyer le formulaire qu'avec une adresse email valide
4. Vérifier qu'en envoyant le formulaire **avec une adresse email présente dans la table `users`**, le formulaire affiche une zone d'information avec le message _« Si votre adresse est bien associée à un compte Pix, les instructions pour réinitialiser votre mot de passe vous ont été envoyées par e-mail. »_
5. Vérifier qu'en envoyant le formulaire **avec une adresse email NON présente dans la table `users`**, le formulaire affiche une zone d'information avec le message _« Si votre adresse est bien associée à un compte Pix, les instructions pour réinitialiser votre mot de passe vous ont été envoyées par e-mail. »_
6. Cliquer sur le lien _« Renvoyer l’e-mail de réinitialisation »_ et vérifier qu'il renvoie bien sur le formulaire de mot de passe oublié
7. Aller sur https://app.dev.pix.org/mot-de-passe-oublie et sélectionner différentes langues avec le LanguageSwitcher pour vérifier les traductions de la zone d'information
8. Arrêter l'API et vérifier que le formulaire affiche une erreur ` Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.` (il faut généralement attendre environ 20s ou 30s pour que la connexion arrive en timeout avant qu'une erreur soit déclenchée)

