### PR TITLE
[BUGFIX] Gérer une épreuve qui est périmée en cours de test de certification (PIX-14819).

### DIFF
--- a/api/src/certification/evaluation/domain/usecases/get-next-challenge.js
+++ b/api/src/certification/evaluation/domain/usecases/get-next-challenge.js
@@ -44,10 +44,8 @@ const getNextChallenge = async function ({
 }) {
   const certificationCourse = await certificationCourseRepository.get({ id: assessment.certificationCourseId });
 
-  const alreadyAnsweredChallengeIds = await _getAlreadyAnsweredChallengeIds({
-    assessmentId: assessment.id,
-    answerRepository,
-  });
+  const allAnswers = await answerRepository.findByAssessment(assessment.id);
+  const alreadyAnsweredChallengeIds = allAnswers.map(({ challengeId }) => challengeId);
 
   const validatedLiveAlertChallengeIds = await _getValidatedLiveAlertChallengeIds({
     assessmentId: assessment.id,
@@ -65,10 +63,7 @@ const getNextChallenge = async function ({
     return challengeRepository.get(lastNonAnsweredCertificationChallenge.challengeId);
   }
 
-  const [allAnswers, activeFlashCompatibleChallenges] = await Promise.all([
-    answerRepository.findByAssessment(assessment.id),
-    challengeRepository.findActiveFlashCompatible({ locale }),
-  ]);
+  const activeFlashCompatibleChallenges = await challengeRepository.findActiveFlashCompatible({ locale });
 
   const alreadyAnsweredChallenges = await challengeRepository.getMany(alreadyAnsweredChallengeIds, locale);
   const challenges = [...new Set([...alreadyAnsweredChallenges, ...activeFlashCompatibleChallenges])];
@@ -140,13 +135,6 @@ const _excludeChallengesWithASkillWithAValidatedLiveAlert = ({ validatedLiveAler
   );
 
   return challengesWithoutSkillsWithAValidatedLiveAlert;
-};
-
-const _getAlreadyAnsweredChallengeIds = async ({ assessmentId, answerRepository }) => {
-  const answers = await answerRepository.findByAssessment(assessmentId);
-  const alreadyAnsweredChallengeIds = answers.map(({ challengeId }) => challengeId);
-
-  return alreadyAnsweredChallengeIds;
 };
 
 const _getValidatedLiveAlertChallengeIds = async ({ assessmentId, certificationChallengeLiveAlertRepository }) => {

--- a/api/src/certification/evaluation/domain/usecases/get-next-challenge.js
+++ b/api/src/certification/evaluation/domain/usecases/get-next-challenge.js
@@ -65,11 +65,13 @@ const getNextChallenge = async function ({
     return challengeRepository.get(lastNonAnsweredCertificationChallenge.challengeId);
   }
 
-  const [allAnswers, challenges] = await Promise.all([
+  const [allAnswers, activeFlashCompatibleChallenges] = await Promise.all([
     answerRepository.findByAssessment(assessment.id),
     challengeRepository.findActiveFlashCompatible({ locale }),
   ]);
 
+  const alreadyAnsweredChallenges = await challengeRepository.getMany(alreadyAnsweredChallengeIds, locale);
+  const challenges = [...new Set([...alreadyAnsweredChallenges, ...activeFlashCompatibleChallenges])];
   const algorithmConfiguration = await flashAlgorithmConfigurationRepository.getMostRecentBeforeDate(
     certificationCourse.getStartDate(),
   );

--- a/api/src/certification/flash-certification/domain/models/FlashAssessmentAlgorithmChallengesBetweenCompetencesRule.js
+++ b/api/src/certification/flash-certification/domain/models/FlashAssessmentAlgorithmChallengesBetweenCompetencesRule.js
@@ -1,3 +1,5 @@
+import { logger } from '../../../../shared/infrastructure/utils/logger.js';
+
 export class FlashAssessmentAlgorithmChallengesBetweenCompetencesRule {
   static isApplicable({ challengesBetweenSameCompetence }) {
     return challengesBetweenSameCompetence > 0;
@@ -33,6 +35,10 @@ export class FlashAssessmentAlgorithmChallengesBetweenCompetencesRule {
   }
 
   static _findChallengeForAnswer(challenges, answer) {
-    return challenges.find((challenge) => challenge.id === answer.challengeId);
+    const challengeAssociatedToAnswer = challenges.find((challenge) => challenge.id === answer.challengeId);
+    if (!challengeAssociatedToAnswer) {
+      logger.warn({ answer }, 'Cannot find a challenge associated to answer.challengeId');
+    }
+    return challengeAssociatedToAnswer;
   }
 }

--- a/api/src/certification/flash-certification/domain/models/FlashAssessmentAlgorithmNonAnsweredSkillsRule.js
+++ b/api/src/certification/flash-certification/domain/models/FlashAssessmentAlgorithmNonAnsweredSkillsRule.js
@@ -1,3 +1,5 @@
+import { logger } from '../../../../shared/infrastructure/utils/logger.js';
+
 export class FlashAssessmentAlgorithmNonAnsweredSkillsRule {
   static isApplicable({ limitToOneQuestionPerTube }) {
     return !limitToOneQuestionPerTube;
@@ -17,6 +19,10 @@ export class FlashAssessmentAlgorithmNonAnsweredSkillsRule {
   }
 
   static _findChallengeForAnswer(challenges, answer) {
-    return challenges.find((challenge) => challenge.id === answer.challengeId);
+    const challengeAssociatedToAnswer = challenges.find((challenge) => challenge.id === answer.challengeId);
+    if (!challengeAssociatedToAnswer) {
+      logger.warn({ answer }, 'Cannot find a challenge associated to answer.challengeId');
+    }
+    return challengeAssociatedToAnswer;
   }
 }

--- a/api/src/certification/flash-certification/domain/services/algorithm-methods/flash.js
+++ b/api/src/certification/flash-certification/domain/services/algorithm-methods/flash.js
@@ -1,5 +1,7 @@
 import lodash from 'lodash';
 
+import { logger } from '../../../../../shared/infrastructure/utils/logger.js';
+
 const { orderBy, range, sortBy, sortedUniqBy } = lodash;
 
 const DEFAULT_CAPACITY = 0;
@@ -300,7 +302,11 @@ function getChallengePriorityForInferrence(challenge) {
 }
 
 function _findChallengeForAnswer(challenges, answer) {
-  return challenges.find((challenge) => challenge.id === answer.challengeId);
+  const challengeAssociatedToAnswer = challenges.find((challenge) => challenge.id === answer.challengeId);
+  if (!challengeAssociatedToAnswer) {
+    logger.warn({ answer }, 'Cannot find a challenge associated to answer.challengeId');
+  }
+  return challengeAssociatedToAnswer;
 }
 
 function _sumPixScoreAndScoreByCompetence(challenges) {

--- a/api/tests/certification/evaluation/unit/domain/usecases/get-next-challenge_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/get-next-challenge_test.js
@@ -92,7 +92,6 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           .resolves(null);
         challengeRepository.get.resolves();
 
-        answerRepository.findByAssessment.withArgs(assessment.id).resolves([]);
         challengeRepository.findActiveFlashCompatible.withArgs({ locale }).resolves([nextChallengeToAnswer]);
         challengeRepository.getMany.withArgs([], locale).resolves([]);
 
@@ -183,7 +182,6 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
             .withArgs(assessment.certificationCourseId, [])
             .resolves(null);
 
-          answerRepository.findByAssessment.withArgs(assessment.id).resolves([]);
           challengeRepository.findActiveFlashCompatible.withArgs({ locale }).resolves(allChallenges);
           challengeRepository.getMany.withArgs([], locale).resolves([]);
 
@@ -323,12 +321,6 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
         const answerWithOutdatedChallenge = domainBuilder.buildAnswer({ challengeId: outdatedChallenge.id });
         answerRepository.findByAssessment
           .withArgs(assessment.id)
-          .onFirstCall()
-          .resolves([answerStillValid, answerWithOutdatedChallenge]);
-
-        answerRepository.findByAssessment
-          .withArgs(assessment.id)
-          .onSecondCall()
           .resolves([answerStillValid, answerWithOutdatedChallenge]);
 
         certificationChallengeLiveAlertRepository.getLiveAlertValidatedChallengeIdsByAssessmentId
@@ -449,7 +441,6 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           })
           .returns([nextChallenge]);
 
-        answerRepository.findByAssessment.withArgs(assessment.id).resolves([]);
         certificationChallengeLiveAlertRepository.getLiveAlertValidatedChallengeIdsByAssessmentId
           .withArgs({ assessmentId: assessment.id })
           .resolves([nonAnsweredCertificationChallenge.challengeId]);
@@ -548,7 +539,6 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           })
           .returns([challengeWithOtherSkill]);
 
-        answerRepository.findByAssessment.withArgs(assessment.id).resolves([]);
         certificationChallengeLiveAlertRepository.getLiveAlertValidatedChallengeIdsByAssessmentId
           .withArgs({ assessmentId: assessment.id })
           .resolves([nonAnsweredCertificationChallenge.challengeId]);
@@ -623,7 +613,6 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           .resolves(null);
         challengeRepository.get.resolves();
 
-        answerRepository.findByAssessment.withArgs(assessment.id).resolves([answer]);
         challengeRepository.findActiveFlashCompatible.withArgs({ locale }).resolves([answeredChallenge]);
         challengeRepository.getMany.withArgs([answeredChallenge.id], locale).resolves([answeredChallenge]);
 
@@ -703,7 +692,6 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
               .resolves(null);
             challengeRepository.get.resolves();
 
-            answerRepository.findByAssessment.withArgs(assessment.id).resolves([]);
             challengeRepository.findActiveFlashCompatible.withArgs({ locale }).resolves([nextChallengeToAnswer]);
             challengeRepository.getMany.withArgs([], locale).resolves([]);
 


### PR DESCRIPTION
## :fallen_leaf: Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Lors d'un test de certification v3, les épreuves sont sélectionnées au fur et à mesure du test.
Il peut arriver qu'une épreuve à laquelle le candidat a répondu soit périmée plus tard, **avant** la fin du test de certification.
Cela entraîne une erreur lors de la lecture des paramètres de l'épreuve par l'algorithme qui ne trouve pas l'épreuve associée à la réponse du candidat.
En analysant le usecase `get-next-challenge`, on constate que seules les épreuves validées sont envoyées à l'algorithme.

## :chestnut: Proposition

On modifie le usecase `get-next-challenge` afin d'envoyer à l'algorithme l'ensemble des épreuves validées ainsi que les épreuves auxquelles le candidat a répondu.

On ajoute également un log d'avertissement si une réponse n'a pu être reliée à une épreuve au cours du test de certification.

## :jack_o_lantern: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

En faisant ce correctif, on a constaté un appel en double à `answerRepository.findByAssessmentId` au sein du usecase, on en a profité pour supprimer ce doublon et adapter les tests.

## :wood: Pour tester

Commencer un test de certification V3 en répondant à une première épreuve.
Modifier le contenu du cache LCMS (voir page confluence https://1024pix.atlassian.net/wiki/spaces/EDTDT/pages/4569202691/Customiser+le+contenu+de+la+release+LCMS+pour+une+Review+App+Pix) pour périmer l'épreuve passée.
Continuer le test de certification.
Constater qu'il n'y a aucun problème.
