### PR TITLE
[TECH] Forcer le HTTPS sur les environnements non dev 

### DIFF
--- a/admin/servers.conf.erb
+++ b/admin/servers.conf.erb
@@ -59,6 +59,14 @@ split_clients "${request_id}" $upstream_host {
   * <%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>;
 }
 
+#add a catch all on http port to forward to the convenient https
+server {
+    listen 80 default_server;
+    server_name _;
+    add_header Strict-Transport-Security "max-age=31536001; includeSubDomains; preload";
+    return 301 https://$host$request_uri;
+}
+
 server {
   access_log logs/access.log keyvalue;
   server_name localhost;
@@ -119,6 +127,7 @@ server {
   add_header X-Content-Type-Options "nosniff";
   add_header X-Frame-Options "SAMEORIGIN";
   add_header X-XSS-Protection 1;
+  add_header Strict-Transport-Security "max-age=31536001; includeSubDomains; preload";
 
   <% ENV.each do |key,value|
     if key.start_with? 'ADD_HTTP_HEADER' %>

--- a/api/server.js
+++ b/api/server.js
@@ -108,6 +108,17 @@ const createBareServer = function () {
     },
   };
 
+  // Force https on non-dev environments
+  if (config.environment !== 'development') {
+    serverConfiguration.routes.security = {
+      hsts: {
+        includeSubDomains: true,
+        preload: true,
+        maxAge: 31536000,
+      },
+    };
+  }
+
   return new Hapi.server(serverConfiguration);
 };
 

--- a/certif/servers.conf.erb
+++ b/certif/servers.conf.erb
@@ -59,6 +59,14 @@ split_clients "${request_id}" $upstream_host {
   * <%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>;
 }
 
+#add a catch all on http port to forward to the convenient https
+server {
+    listen 80 default_server;
+    server_name _;
+    add_header Strict-Transport-Security "max-age=31536001; includeSubDomains; preload";
+    return 301 https://$host$request_uri;
+}
+
 server {
   access_log logs/access.log keyvalue;
   server_name localhost;
@@ -136,6 +144,7 @@ server {
   add_header X-Content-Type-Options "nosniff";
   add_header X-Frame-Options "SAMEORIGIN";
   add_header X-XSS-Protection 1;
+  add_header Strict-Transport-Security "max-age=31536001; includeSubDomains; preload";
 
   <% ENV.each do |key,value|
     if key.start_with? 'ADD_HTTP_HEADER' %>

--- a/junior/servers.conf.erb
+++ b/junior/servers.conf.erb
@@ -36,6 +36,14 @@ upstream api {
     server <%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>:443 max_fails=<%= ENV['NGINX_UPSTREAM_MAX_FAILS'] || 3 %> fail_timeout=<%= ENV['NGINX_UPSTREAM_FAIL_TIMEOUT'] || '5s' %>;
 }
 
+#add a catch all on http port to forward to the convenient https
+server {
+    listen 80 default_server;
+    server_name _;
+    add_header Strict-Transport-Security "max-age=31536001; includeSubDomains; preload";
+    return 301 https://$host$request_uri;
+}
+
 server {
   access_log logs/access.log keyvalue;
   server_name localhost;
@@ -114,6 +122,7 @@ server {
   add_header X-Content-Type-Options "nosniff";
   add_header X-Frame-Options "SAMEORIGIN";
   add_header X-XSS-Protection 1;
+  add_header Strict-Transport-Security "max-age=31536001; includeSubDomains; preload";
 
   <% ENV.each do |key,value|
     if key.start_with? 'ADD_HTTP_HEADER' %>

--- a/mon-pix/servers.conf.erb
+++ b/mon-pix/servers.conf.erb
@@ -59,6 +59,14 @@ split_clients "${request_id}" $upstream_host {
   * <%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>;
 }
 
+#add a catch all on http port to forward to the convenient https
+server {
+    listen 80 default_server;
+    server_name _;
+    add_header Strict-Transport-Security "max-age=31536001; includeSubDomains; preload";
+    return 301 https://$host$request_uri;
+}
+
 server {
   access_log logs/access.log keyvalue;
   server_name localhost;
@@ -143,6 +151,7 @@ server {
   add_header X-Content-Type-Options "nosniff";
   add_header X-Frame-Options "SAMEORIGIN";
   add_header X-XSS-Protection 1;
+  add_header Strict-Transport-Security "max-age=31536001; includeSubDomains; preload";
 
   <% ENV.each do |key,value|
     if key.start_with? 'ADD_HTTP_HEADER' %>

--- a/orga/servers.conf.erb
+++ b/orga/servers.conf.erb
@@ -59,6 +59,14 @@ split_clients "${request_id}" $upstream_host {
   * <%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>;
 }
 
+#add a catch all on http port to forward to the convenient https
+server {
+    listen 80 default_server;
+    server_name _;
+    add_header Strict-Transport-Security "max-age=31536001; includeSubDomains; preload";
+    return 301 https://$host$request_uri;
+}
+
 server {
   access_log logs/access.log keyvalue;
   server_name localhost;
@@ -136,6 +144,7 @@ server {
   add_header X-Content-Type-Options "nosniff";
   add_header X-Frame-Options "SAMEORIGIN";
   add_header X-XSS-Protection 1;
+  add_header Strict-Transport-Security "max-age=31536001; includeSubDomains; preload";
 
   <% ENV.each do |key,value|
     if key.start_with? 'ADD_HTTP_HEADER' %>

--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -16,6 +16,14 @@ log_format keyvalue
 # as we are about to override it in the server directive here below
 access_log off;
 
+#add a catch all on http port to forward to the convenient https
+server {
+    listen 80 default_server;
+    server_name _;
+    add_header Strict-Transport-Security "max-age=31536001; includeSubDomains; preload";
+    return 301 https://$host$request_uri;
+}
+
 server {
   access_log logs/access.log keyvalue;
   server_name localhost;
@@ -39,6 +47,7 @@ server {
   add_header X-Content-Type-Options "nosniff";
   add_header X-Frame-Options "SAMEORIGIN";
   add_header X-XSS-Protection 1;
+  add_header Strict-Transport-Security "max-age=31536001; includeSubDomains; preload";
 
   <% ENV.each do |key,value|
     if key.start_with? 'ADD_HTTP_HEADER' %>


### PR DESCRIPTION
## :unicorn: Problème
Le mécanisme de force https de Scalingo n'est pas suffisant pour assurer la présence du header HSTS.

## :robot: Proposition
Gérer nous même le positionnement du header.

## :rainbow: Remarques
Une fois la PR en production, il faudra désactiver le force https de Scalingo.