### PR TITLE
[FEATURE] Modification des roles de la page de reset de password (PIX-14114)

### DIFF
--- a/mon-pix/app/components/authentication/password-reset-demand-form.gjs
+++ b/mon-pix/app/components/authentication/password-reset-demand-form.gjs
@@ -78,7 +78,12 @@ export default class PasswordResetDemandForm extends Component {
         </p>
 
         {{#if this.errorMessage}}
-          <PixMessage @type="error" @withIcon={{true}} class="authentication-password-reset-demand-form__error">
+          <PixMessage
+            @type="error"
+            @withIcon={{true}}
+            class="authentication-password-reset-demand-form__error"
+            role="alert"
+          >
             {{this.errorMessage}}
           </PixMessage>
         {{/if}}

--- a/mon-pix/app/components/authentication/password-reset-form/password-reset-form.gjs
+++ b/mon-pix/app/components/authentication/password-reset-form/password-reset-form.gjs
@@ -99,7 +99,7 @@ export default class PasswordResetForm extends Component {
 }
 
 const PasswordResetSucceededInfo = <template>
-  <div class="password-reset-succeeded-info" role="alert">
+  <div class="password-reset-succeeded-info">
     <img src="/images/success-check.svg" alt="" />
     <h2 class="password-reset-succeeded-info__heading">
       {{t "components.authentication.password-reset-form.success-info.message"}}


### PR DESCRIPTION
## :unicorn: Problème

Suite au commentaire de la PR https://github.com/1024pix/pix/pull/10406, la correction a été mal faites et la PR mergée avec une mauvaise mise en place des `role` alert sur la page de reset de mot de passe.

## :robot: Proposition

Appliquer les bons rôles. Voir le commentaire https://github.com/1024pix/pix/pull/10406#discussion_r1815244649

## :100: Pour tester

Voir que le role `alert` n'est plus présent dans le message de confirmation de reset de mot de passe
