### PR TITLE
[FEATURE] Afficher les flashcards à plat dans la preview (PIX-14316)

### DIFF
--- a/mon-pix/app/components/module/element/flashcards/flashcards.gjs
+++ b/mon-pix/app/components/module/element/flashcards/flashcards.gjs
@@ -1,6 +1,7 @@
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
@@ -12,6 +13,8 @@ import ModulixFlashcardsOutroCard from 'mon-pix/components/module/element/flashc
 const INITIAL_COUNTERS_VALUE = { yes: 0, almost: 0, no: 0 };
 
 export default class ModulixFlashcards extends Component {
+  @service modulixPreviewMode;
+
   @tracked
   /**
    * Displayed side of the card on the screen
@@ -57,11 +60,11 @@ export default class ModulixFlashcards extends Component {
   }
 
   get shouldDisplayIntroCard() {
-    return this.currentStep === "intro";
+    return this.currentStep === 'intro' || this.modulixPreviewMode.isEnabled;
   }
 
   get shouldDisplayOutroCard() {
-    return this.currentStep === "outro";
+    return this.currentStep === 'outro' || this.modulixPreviewMode.isEnabled;
   }
 
   @action
@@ -96,6 +99,9 @@ export default class ModulixFlashcards extends Component {
   }
 
   @action
+  noop() {}
+
+  @action
   onSelfAssessment(userAssessment) {
     const selfAssessmentData = {
       userAssessment,
@@ -123,6 +129,15 @@ export default class ModulixFlashcards extends Component {
           @displayedSideName={{this.displayedSideName}}
           @onCardFlip={{this.flipCard}}
         />
+      {{/if}}
+
+      {{#if this.modulixPreviewMode.isEnabled}}
+        {{#each @flashcards.cards as |card|}}
+          <div class="element-flashcards__recto-verso">
+            <ModulixFlashcardsCard @card={{card}} @displayedSideName="recto" @onCardFlip={{this.noop}} />
+            <ModulixFlashcardsCard @card={{card}} @displayedSideName="verso" @onCardFlip={{this.noop}} />
+          </div>
+        {{/each}}
       {{/if}}
 
       {{#if this.shouldDisplayOutroCard}}

--- a/mon-pix/app/components/module/element/flashcards/flashcards.gjs
+++ b/mon-pix/app/components/module/element/flashcards/flashcards.gjs
@@ -56,6 +56,14 @@ export default class ModulixFlashcards extends Component {
     return this.currentStep === 'intro' || this.currentStep === 'outro';
   }
 
+  get shouldDisplayIntroCard() {
+    return this.currentStep === "intro";
+  }
+
+  get shouldDisplayOutroCard() {
+    return this.currentStep === "outro";
+  }
+
   @action
   retry() {
     this.currentStep = 'intro';
@@ -101,7 +109,7 @@ export default class ModulixFlashcards extends Component {
   <template>
     <div class="element-flashcards">
 
-      {{#if (eq this.currentStep "intro")}}
+      {{#if this.shouldDisplayIntroCard}}
         <ModulixFlashcardsIntroCard
           @title={{@flashcards.title}}
           @introImage={{@flashcards.introImage}}
@@ -117,7 +125,7 @@ export default class ModulixFlashcards extends Component {
         />
       {{/if}}
 
-      {{#if (eq this.currentStep "outro")}}
+      {{#if this.shouldDisplayOutroCard}}
         <ModulixFlashcardsOutroCard @title={{@flashcards.title}} @onRetry={{this.retry}} @counters={{this.counters}} />
       {{/if}}
 

--- a/mon-pix/app/components/module/element/flashcards/flashcards.gjs
+++ b/mon-pix/app/components/module/element/flashcards/flashcards.gjs
@@ -114,74 +114,85 @@ export default class ModulixFlashcards extends Component {
 
   <template>
     <div class="element-flashcards">
-
-      {{#if this.shouldDisplayIntroCard}}
+      {{#if this.modulixPreviewMode.isEnabled}}
         <ModulixFlashcardsIntroCard
           @title={{@flashcards.title}}
           @introImage={{@flashcards.introImage}}
-          @onStart={{this.start}}
+          @onStart={{this.noop}}
         />
-      {{/if}}
 
-      {{#if (eq this.currentStep "cards")}}
-        <ModulixFlashcardsCard
-          @card={{this.currentCard}}
-          @displayedSideName={{this.displayedSideName}}
-          @onCardFlip={{this.flipCard}}
-        />
-      {{/if}}
-
-      {{#if this.modulixPreviewMode.isEnabled}}
         {{#each @flashcards.cards as |card|}}
           <div class="element-flashcards__recto-verso">
             <ModulixFlashcardsCard @card={{card}} @displayedSideName="recto" @onCardFlip={{this.noop}} />
             <ModulixFlashcardsCard @card={{card}} @displayedSideName="verso" @onCardFlip={{this.noop}} />
           </div>
         {{/each}}
-      {{/if}}
 
-      {{#if this.shouldDisplayOutroCard}}
-        <ModulixFlashcardsOutroCard @title={{@flashcards.title}} @onRetry={{this.retry}} @counters={{this.counters}} />
-      {{/if}}
-
-      <div class="element-flashcards__footer {{if this.footerIsEmpty 'element-flashcards__footer--empty'}}">
-        {{#if (eq this.currentStep "cards")}}
-          {{#if (eq this.displayedSideName "recto")}}
-            <p class="element-flashcards__footer__direction">{{t "pages.modulix.flashcards.direction"}}</p>
-            <p class="element-flashcards__footer__position">{{t
-                "pages.modulix.flashcards.position"
-                currentCardPosition=this.currentCardNumber
-                totalCards=this.numberOfCards
-              }}</p>
-          {{/if}}
-          {{#if (eq this.displayedSideName "verso")}}
-            <p class="element-flashcards__footer__question">{{t "pages.modulix.flashcards.answerDirection"}}</p>
-            <div class="element-flashcards__footer__answer">
-              <button
-                class="element-flashcards__footer__answer__button element-flashcards__footer__answer__button--no"
-                type="button"
-                {{on "click" (fn this.onSelfAssessment "no")}}
-              >
-                {{t "pages.modulix.buttons.flashcards.answers.no"}}
-              </button>
-              <button
-                class="element-flashcards__footer__answer__button element-flashcards__footer__answer__button--almost"
-                type="button"
-                {{on "click" (fn this.onSelfAssessment "almost")}}
-              >
-                {{t "pages.modulix.buttons.flashcards.answers.almost"}}
-              </button>
-              <button
-                class="element-flashcards__footer__answer__button element-flashcards__footer__answer__button--yes"
-                type="button"
-                {{on "click" (fn this.onSelfAssessment "yes")}}
-              >
-                {{t "pages.modulix.buttons.flashcards.answers.yes"}}
-              </button>
-            </div>
-          {{/if}}
+        <ModulixFlashcardsOutroCard @title={{@flashcards.title}} @onRetry={{this.noop}} @counters={{this.counters}} />
+      {{else}}
+        {{#if this.shouldDisplayIntroCard}}
+          <ModulixFlashcardsIntroCard
+            @title={{@flashcards.title}}
+            @introImage={{@flashcards.introImage}}
+            @onStart={{this.start}}
+          />
         {{/if}}
-      </div>
+
+        {{#if (eq this.currentStep "cards")}}
+          <ModulixFlashcardsCard
+            @card={{this.currentCard}}
+            @displayedSideName={{this.displayedSideName}}
+            @onCardFlip={{this.flipCard}}
+          />
+        {{/if}}
+
+        {{#if this.shouldDisplayOutroCard}}
+          <ModulixFlashcardsOutroCard
+            @title={{@flashcards.title}}
+            @onRetry={{this.retry}}
+            @counters={{this.counters}}
+          />
+        {{/if}}
+
+        <div class="element-flashcards__footer {{if this.footerIsEmpty 'element-flashcards__footer--empty'}}">
+          {{#if (eq this.currentStep "cards")}}
+            {{#if (eq this.displayedSideName "recto")}}
+              <p class="element-flashcards__footer__direction">{{t "pages.modulix.flashcards.direction"}}</p>
+              <p class="element-flashcards__footer__position">{{t
+                  "pages.modulix.flashcards.position"
+                  currentCardPosition=this.currentCardNumber
+                  totalCards=this.numberOfCards
+                }}</p>
+            {{/if}}
+            {{#if (eq this.displayedSideName "verso")}}
+              <p class="element-flashcards__footer__question">{{t "pages.modulix.flashcards.answerDirection"}}</p>
+              <div class="element-flashcards__footer__answer">
+                <button
+                  class="element-flashcards__footer__answer__button element-flashcards__footer__answer__button--no"
+                  type="button"
+                  {{on "click" (fn this.onSelfAssessment "no")}}
+                >
+                  {{t "pages.modulix.buttons.flashcards.answers.no"}}
+                </button>
+                <button
+                  class="element-flashcards__footer__answer__button element-flashcards__footer__answer__button--almost"
+                  type="button"
+                  {{on "click" (fn this.onSelfAssessment "almost")}}
+                >
+                  {{t "pages.modulix.buttons.flashcards.answers.almost"}}
+                </button>
+                <button
+                  class="element-flashcards__footer__answer__button element-flashcards__footer__answer__button--yes"
+                  type="button"
+                  {{on "click" (fn this.onSelfAssessment "yes")}}
+                >
+                  {{t "pages.modulix.buttons.flashcards.answers.yes"}}
+                </button>
+              </div>
+            {{/if}}
+          {{/if}}
+        </div>
+      {{/if}}
     </div>
   </template>
 }

--- a/mon-pix/app/styles/components/module/_flashcards.scss
+++ b/mon-pix/app/styles/components/module/_flashcards.scss
@@ -7,6 +7,14 @@
   background-repeat: no-repeat;
   background-position: top center;
 
+  &__recto-verso {
+    display: flex;
+
+    .element-flashcards-card {
+      flex-grow: 1;
+    }
+  }
+
   &__footer {
     display: flex;
     flex-direction: column;

--- a/mon-pix/tests/integration/components/module/flashcards_test.gjs
+++ b/mon-pix/tests/integration/components/module/flashcards_test.gjs
@@ -1,4 +1,5 @@
 import { clickByName, render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
 import { t } from 'ember-intl/test-support';
 import ModulixFlashcards from 'mon-pix/components/module/element/flashcards/flashcards';
 import { module, test } from 'qunit';
@@ -63,6 +64,69 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
     assert
       .dom(screen.queryByText(t('pages.modulix.flashcards.position', { currentCardPosition: 1, totalCards: 2 })))
       .doesNotExist();
+  });
+
+  module('when in preview mode', function () {
+    test('should display all sides of all cards', async function (assert) {
+      // given
+      const firstCard = {
+        id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+        recto: {
+          image: {
+            url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+          },
+          text: "A quoi sert l'arobase dans mon adresse email ?",
+        },
+        verso: {
+          image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+          text: "Parce que c'est joli",
+        },
+      };
+      const secondCard = {
+        id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+        recto: {
+          image: {
+            url: 'https://images.pix.fr/modulix/didacticiel/icon.svg',
+          },
+          text: 'Qui a écrit le Dormeur du Val ?',
+        },
+        verso: {
+          image: {
+            url: 'https://images.pix.fr/modulix/didacticiel/chaton.jpg',
+          },
+          text: 'Arthur Rimbaud',
+        },
+      };
+
+      const flashcards = {
+        id: '71de6394-ff88-4de3-8834-a40057a50ff4',
+        type: 'flashcards',
+        title: "Introduction à l'adresse e-mail",
+        instruction: '<p>...</p>',
+        introImage: { url: 'https://images.pix.fr/modulix/flashcards-intro.png' },
+        cards: [firstCard, secondCard],
+      };
+
+      class PreviewModeServiceStub extends Service {
+        isEnabled = true;
+      }
+      this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
+
+      // when
+      const screen = await render(<template><ModulixFlashcards @flashcards={{flashcards}} /></template>);
+
+      // then
+      const introCardButton = screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.start') });
+      assert.dom(introCardButton).exists();
+
+      assert.dom(screen.getByText(firstCard.recto.text)).exists();
+      assert.dom(screen.getByText(firstCard.verso.text)).exists();
+      assert.dom(screen.getByText(secondCard.recto.text)).exists();
+      assert.dom(screen.getByText(secondCard.verso.text)).exists();
+
+      const outroCardButton = screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.retry') });
+      assert.dom(outroCardButton).exists();
+    });
   });
 
   module('when user clicks on the "Start" button', function () {

--- a/mon-pix/tests/integration/components/module/flashcards_test.gjs
+++ b/mon-pix/tests/integration/components/module/flashcards_test.gjs
@@ -12,43 +12,7 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
 
   test('should display the intro card by default', async function (assert) {
     // given
-    const firstCard = {
-      id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-      recto: {
-        image: {
-          url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
-        },
-        text: "A quoi sert l'arobase dans mon adresse email ?",
-      },
-      verso: {
-        image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
-        text: "Parce que c'est joli",
-      },
-    };
-    const secondCard = {
-      id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-      recto: {
-        image: {
-          url: 'https://images.pix.fr/modulix/didacticiel/icon.svg',
-        },
-        text: 'Qui a écrit le Dormeur du Val ?',
-      },
-      verso: {
-        image: {
-          url: 'https://images.pix.fr/modulix/didacticiel/chaton.jpg',
-        },
-        text: '<p>Arthur Rimbaud</p>',
-      },
-    };
-
-    const flashcards = {
-      id: '71de6394-ff88-4de3-8834-a40057a50ff4',
-      type: 'flashcards',
-      title: "Introduction à l'adresse e-mail",
-      instruction: '<p>...</p>',
-      introImage: { url: 'https://images.pix.fr/modulix/flashcards-intro.png' },
-      cards: [firstCard, secondCard],
-    };
+    const { flashcards } = _getFlashcards();
 
     // when
     const screen = await render(<template><ModulixFlashcards @flashcards={{flashcards}} /></template>);
@@ -69,43 +33,7 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
   module('when in preview mode', function () {
     test('should display all sides of all cards', async function (assert) {
       // given
-      const firstCard = {
-        id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-        recto: {
-          image: {
-            url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
-          },
-          text: "A quoi sert l'arobase dans mon adresse email ?",
-        },
-        verso: {
-          image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
-          text: "Parce que c'est joli",
-        },
-      };
-      const secondCard = {
-        id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-        recto: {
-          image: {
-            url: 'https://images.pix.fr/modulix/didacticiel/icon.svg',
-          },
-          text: 'Qui a écrit le Dormeur du Val ?',
-        },
-        verso: {
-          image: {
-            url: 'https://images.pix.fr/modulix/didacticiel/chaton.jpg',
-          },
-          text: 'Arthur Rimbaud',
-        },
-      };
-
-      const flashcards = {
-        id: '71de6394-ff88-4de3-8834-a40057a50ff4',
-        type: 'flashcards',
-        title: "Introduction à l'adresse e-mail",
-        instruction: '<p>...</p>',
-        introImage: { url: 'https://images.pix.fr/modulix/flashcards-intro.png' },
-        cards: [firstCard, secondCard],
-      };
+      const { flashcards, firstCard, secondCard } = _getFlashcards();
 
       class PreviewModeServiceStub extends Service {
         isEnabled = true;
@@ -132,43 +60,7 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
   module('when user clicks on the "Start" button', function () {
     test('should display the first card', async function (assert) {
       // given
-      const firstCard = {
-        id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-        recto: {
-          image: {
-            url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
-          },
-          text: "A quoi sert l'arobase dans mon adresse email ?",
-        },
-        verso: {
-          image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
-          text: "Parce que c'est joli",
-        },
-      };
-      const secondCard = {
-        id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-        recto: {
-          image: {
-            url: 'https://images.pix.fr/modulix/didacticiel/icon.svg',
-          },
-          text: 'Qui a écrit le Dormeur du Val ?',
-        },
-        verso: {
-          image: {
-            url: 'https://images.pix.fr/modulix/didacticiel/chaton.jpg',
-          },
-          text: '<p>Arthur Rimbaud</p>',
-        },
-      };
-
-      const flashcards = {
-        id: '71de6394-ff88-4de3-8834-a40057a50ff4',
-        type: 'flashcards',
-        title: "Introduction à l'adresse e-mail",
-        instruction: '<p>...</p>',
-        introImage: { url: 'https://images.pix.fr/modulix/placeholder-details.svg' },
-        cards: [firstCard, secondCard],
-      };
+      const { flashcards } = _getFlashcards();
 
       // when
       const screen = await render(<template><ModulixFlashcards @flashcards={{flashcards}} /></template>);
@@ -189,43 +81,7 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
   module('when users clicks on the "Continue" button', function () {
     test('should display options buttons to answer', async function (assert) {
       // given
-      const firstCard = {
-        id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-        recto: {
-          image: {
-            url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
-          },
-          text: "A quoi sert l'arobase dans mon adresse email ?",
-        },
-        verso: {
-          image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
-          text: "Parce que c'est joli",
-        },
-      };
-      const secondCard = {
-        id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-        recto: {
-          image: {
-            url: 'https://images.pix.fr/modulix/didacticiel/icon.svg',
-          },
-          text: 'Qui a écrit le Dormeur du Val ?',
-        },
-        verso: {
-          image: {
-            url: 'https://images.pix.fr/modulix/didacticiel/chaton.jpg',
-          },
-          text: '<p>Arthur Rimbaud</p>',
-        },
-      };
-
-      const flashcards = {
-        id: '71de6394-ff88-4de3-8834-a40057a50ff4',
-        type: 'flashcards',
-        title: "Introduction à l'adresse e-mail",
-        instruction: '<p>...</p>',
-        introImage: { url: 'https://images.pix.fr/modulix/placeholder-details.svg' },
-        cards: [firstCard, secondCard],
-      };
+      const { flashcards } = _getFlashcards();
 
       // when
       const screen = await render(<template><ModulixFlashcards @flashcards={{flashcards}} /></template>);
@@ -240,43 +96,7 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
     module('when the user self-assesses their response', function () {
       test('should display the next card and send self-assessment', async function (assert) {
         // given
-        const firstCard = {
-          id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-          recto: {
-            image: {
-              url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
-            },
-            text: "A quoi sert l'arobase dans mon adresse email ?",
-          },
-          verso: {
-            image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
-            text: "Parce que c'est joli",
-          },
-        };
-        const secondCard = {
-          id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-          recto: {
-            image: {
-              url: 'https://images.pix.fr/modulix/didacticiel/icon.svg',
-            },
-            text: 'Qui a écrit le Dormeur du Val ?',
-          },
-          verso: {
-            image: {
-              url: 'https://images.pix.fr/modulix/didacticiel/chaton.jpg',
-            },
-            text: '<p>Arthur Rimbaud</p>',
-          },
-        };
-
-        const flashcards = {
-          id: '71de6394-ff88-4de3-8834-a40057a50ff4',
-          type: 'flashcards',
-          title: "Introduction à l'adresse e-mail",
-          instruction: '<p>...</p>',
-          introImage: { url: 'https://images.pix.fr/modulix/placeholder-details.svg' },
-          cards: [firstCard, secondCard],
-        };
+        const { flashcards } = _getFlashcards();
 
         const onSelfAssessmentStub = sinon.stub();
 
@@ -300,28 +120,7 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
     module('then user gives an answer for the last card', function () {
       test('should display the outro card', async function (assert) {
         // given
-        const firstCard = {
-          id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-          recto: {
-            image: {
-              url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
-            },
-            text: "A quoi sert l'arobase dans mon adresse email ?",
-          },
-          verso: {
-            image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
-            text: "Parce que c'est joli",
-          },
-        };
-
-        const flashcards = {
-          id: '71de6394-ff88-4de3-8834-a40057a50ff4',
-          type: 'flashcards',
-          title: "Introduction à l'adresse e-mail",
-          instruction: '<p>...</p>',
-          introImage: { url: 'https://images.pix.fr/modulix/placeholder-details.svg' },
-          cards: [firstCard],
-        };
+        const { flashcards } = _getFlashcards();
 
         const onSelfAssessmentStub = sinon.stub();
 
@@ -334,6 +133,8 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
         await clickByName(t('pages.modulix.buttons.flashcards.start'));
         await clickByName(t('pages.modulix.buttons.flashcards.seeAnswer'));
         await clickByName(t('pages.modulix.buttons.flashcards.answers.no'));
+        await clickByName(t('pages.modulix.buttons.flashcards.seeAnswer'));
+        await clickByName(t('pages.modulix.buttons.flashcards.answers.yes'));
 
         // then
         assert.ok(screen.getByText('Terminé'));
@@ -344,43 +145,7 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
   module('when users reaches the end of the deck', function () {
     test('should display the counters for each answer', async function (assert) {
       // given
-      const firstCard = {
-        id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-        recto: {
-          image: {
-            url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
-          },
-          text: "A quoi sert l'arobase dans mon adresse email ?",
-        },
-        verso: {
-          image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
-          text: "Parce que c'est joli",
-        },
-      };
-      const secondCard = {
-        id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-        recto: {
-          image: {
-            url: 'https://images.pix.fr/modulix/didacticiel/icon.svg',
-          },
-          text: 'Qui a écrit le Dormeur du Val ?',
-        },
-        verso: {
-          image: {
-            url: 'https://images.pix.fr/modulix/didacticiel/chaton.jpg',
-          },
-          text: '<p>Arthur Rimbaud</p>',
-        },
-      };
-
-      const flashcards = {
-        id: '71de6394-ff88-4de3-8834-a40057a50ff4',
-        type: 'flashcards',
-        title: "Introduction à l'adresse e-mail",
-        instruction: '<p>...</p>',
-        introImage: { url: 'https://images.pix.fr/modulix/placeholder-details.svg' },
-        cards: [firstCard, secondCard],
-      };
+      const { flashcards } = _getFlashcards();
 
       const onSelfAssessment = sinon.stub();
 
@@ -404,28 +169,7 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
   module('when user clicks on the "Retry" button', function () {
     test('should display intro card', async function (assert) {
       // given
-      const firstCard = {
-        id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-        recto: {
-          image: {
-            url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
-          },
-          text: "A quoi sert l'arobase dans mon adresse email ?",
-        },
-        verso: {
-          image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
-          text: "Parce que c'est joli",
-        },
-      };
-
-      const flashcards = {
-        id: '71de6394-ff88-4de3-8834-a40057a50ff4',
-        type: 'flashcards',
-        title: "Introduction à l'adresse e-mail",
-        instruction: '<p>...</p>',
-        introImage: { url: 'https://images.pix.fr/modulix/placeholder-details.svg' },
-        cards: [firstCard],
-      };
+      const { flashcards } = _getFlashcards();
 
       const onSelfAssessmentStub = sinon.stub();
 
@@ -438,6 +182,8 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
       await clickByName(t('pages.modulix.buttons.flashcards.start'));
       await clickByName(t('pages.modulix.buttons.flashcards.seeAnswer'));
       await clickByName(t('pages.modulix.buttons.flashcards.answers.yes'));
+      await clickByName(t('pages.modulix.buttons.flashcards.seeAnswer'));
+      await clickByName(t('pages.modulix.buttons.flashcards.answers.no'));
       await clickByName(t('pages.modulix.buttons.flashcards.retry'));
 
       // then
@@ -447,44 +193,7 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
     module('when user click on the "start" button', function () {
       test('displays the first flashcard', async function (assert) {
         // given
-        const firstCard = {
-          id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-          recto: {
-            image: {
-              url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
-            },
-            text: "A quoi sert l'arobase dans mon adresse email ?",
-          },
-          verso: {
-            image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
-            text: "Parce que c'est joli",
-          },
-        };
-
-        const secondCard = {
-          id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-          recto: {
-            image: {
-              url: 'https://images.pix.fr/modulix/didacticiel/icon.svg',
-            },
-            text: 'Qui a écrit le Dormeur du Val ?',
-          },
-          verso: {
-            image: {
-              url: 'https://images.pix.fr/modulix/didacticiel/chaton.jpg',
-            },
-            text: '<p>Arthur Rimbaud</p>',
-          },
-        };
-
-        const flashcards = {
-          id: '71de6394-ff88-4de3-8834-a40057a50ff4',
-          type: 'flashcards',
-          title: "Introduction à l'adresse e-mail",
-          instruction: '<p>...</p>',
-          introImage: { url: 'https://images.pix.fr/modulix/placeholder-details.svg' },
-          cards: [firstCard, secondCard],
-        };
+        const { flashcards, firstCard } = _getFlashcards();
 
         const onSelfAssessmentStub = sinon.stub();
 
@@ -512,3 +221,45 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
     });
   });
 });
+
+function _getFlashcards() {
+  const firstCard = {
+    id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+    recto: {
+      image: {
+        url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+      },
+      text: "A quoi sert l'arobase dans mon adresse email ?",
+    },
+    verso: {
+      image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+      text: "Parce que c'est joli",
+    },
+  };
+  const secondCard = {
+    id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+    recto: {
+      image: {
+        url: 'https://images.pix.fr/modulix/didacticiel/icon.svg',
+      },
+      text: 'Qui a écrit le Dormeur du Val ?',
+    },
+    verso: {
+      image: {
+        url: 'https://images.pix.fr/modulix/didacticiel/chaton.jpg',
+      },
+      text: 'Arthur Rimbaud',
+    },
+  };
+
+  const flashcards = {
+    id: '71de6394-ff88-4de3-8834-a40057a50ff4',
+    type: 'flashcards',
+    title: "Introduction à l'adresse e-mail",
+    instruction: '<p>...</p>',
+    introImage: { url: 'https://images.pix.fr/modulix/flashcards-intro.png' },
+    cards: [firstCard, secondCard],
+  };
+
+  return { flashcards, firstCard, secondCard };
+}

--- a/mon-pix/tests/integration/components/module/flashcards_test.gjs
+++ b/mon-pix/tests/integration/components/module/flashcards_test.gjs
@@ -1,5 +1,6 @@
 import { clickByName, render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
+import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import ModulixFlashcards from 'mon-pix/components/module/element/flashcards/flashcards';
 import { module, test } from 'qunit';
@@ -54,6 +55,90 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
 
       const outroCardButton = screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.retry') });
       assert.dom(outroCardButton).exists();
+
+      assert
+        .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.flashcards.answers.no') }))
+        .doesNotExist();
+      assert
+        .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.flashcards.answers.almost') }))
+        .doesNotExist();
+      assert
+        .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.flashcards.answers.yes') }))
+        .doesNotExist();
+    });
+
+    test('should not display new flashcard on "Start" button click', async function (assert) {
+      // given
+      const { flashcards, firstCard, secondCard } = _getFlashcards();
+
+      class PreviewModeServiceStub extends Service {
+        isEnabled = true;
+      }
+      this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
+
+      // when
+      const screen = await render(<template><ModulixFlashcards @flashcards={{flashcards}} /></template>);
+
+      // then
+      const introCardButton = screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.start') });
+      assert.dom(introCardButton).exists();
+      await click(introCardButton);
+
+      assert.dom(screen.getByText(firstCard.recto.text)).exists();
+      assert.dom(screen.getByText(firstCard.verso.text)).exists();
+      assert.dom(screen.getByText(secondCard.recto.text)).exists();
+      assert.dom(screen.getByText(secondCard.verso.text)).exists();
+
+      const outroCardButton = screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.retry') });
+      assert.dom(outroCardButton).exists();
+
+      assert
+        .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.flashcards.answers.no') }))
+        .doesNotExist();
+      assert
+        .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.flashcards.answers.almost') }))
+        .doesNotExist();
+      assert
+        .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.flashcards.answers.yes') }))
+        .doesNotExist();
+    });
+
+    test('should not display return on intro card on "Retry" button click', async function (assert) {
+      // given
+      const { flashcards, firstCard, secondCard } = _getFlashcards();
+
+      class PreviewModeServiceStub extends Service {
+        isEnabled = true;
+      }
+      this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
+
+      // when
+      const screen = await render(<template><ModulixFlashcards @flashcards={{flashcards}} /></template>);
+
+      // then
+      const outroCardButton = screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.retry') });
+      assert.dom(outroCardButton).exists();
+      await click(outroCardButton);
+
+      assert.dom(outroCardButton).exists();
+
+      const introCardButton = screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.start') });
+      assert.dom(introCardButton).exists();
+
+      assert.dom(screen.getByText(firstCard.recto.text)).exists();
+      assert.dom(screen.getByText(firstCard.verso.text)).exists();
+      assert.dom(screen.getByText(secondCard.recto.text)).exists();
+      assert.dom(screen.getByText(secondCard.verso.text)).exists();
+
+      assert
+        .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.flashcards.answers.no') }))
+        .doesNotExist();
+      assert
+        .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.flashcards.answers.almost') }))
+        .doesNotExist();
+      assert
+        .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.flashcards.answers.yes') }))
+        .doesNotExist();
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, il n'y a que la carte d'introduction qui s'affiche en mode preview ce qui empêche de vérifier l'affichage de toutes les cartes.

## :robot: Proposition
- Afficher toutes les flashcards (introduction, recto, verso et conclusion) en preview

## :rainbow: Remarques
- Il faut d'abord merger la PR https://github.com/1024pix/pix/pull/10405 avant celle là !
- Refacto du test des Flashcards pour mettre en commun les données de tests qui sont répétés dans chaque test

## :100: Pour tester
- Aller sur /modules/preview
- Modifier le json par celui du didacticiel modulix
- Vérifier que toutes les flashcards s'affiche bien 🎉 
