### PR TITLE
[FEATURE] Ajuster les boutons utilisés dans les pages d'authentification (PIX-15057)

### DIFF
--- a/mon-pix/app/components/authentication/other-authentication-providers.gjs
+++ b/mon-pix/app/components/authentication/other-authentication-providers.gjs
@@ -27,7 +27,6 @@ export default class OtherAuthenticationProviders extends Component {
           @route="authentication.login-oidc"
           @model="{{this.oidcIdentityProviders.featuredIdentityProvider.slug}}"
           @variant="secondary"
-          @size="large"
           class="authentication-other-authentication-providers-section__button-link"
         >
           <img
@@ -46,7 +45,6 @@ export default class OtherAuthenticationProviders extends Component {
         <PixButtonLink
           @route={{this.ssoSelectionRoute}}
           @variant="secondary"
-          @size="large"
           class="authentication-other-authentication-providers-section__button-link"
         >
           {{t "components.authentication.other-authentication-providers.select-another-organization-link"}}

--- a/mon-pix/app/components/authentication/other-authentication-providers.scss
+++ b/mon-pix/app/components/authentication/other-authentication-providers.scss
@@ -20,6 +20,7 @@
   }
 
   &__button-link {
+    white-space: normal;
     border: 1px solid;
   }
 

--- a/mon-pix/app/components/authentication/other-authentication-providers.scss
+++ b/mon-pix/app/components/authentication/other-authentication-providers.scss
@@ -25,6 +25,7 @@
 
   &__featured-identity-provider-logo {
     width: var(--pix-spacing-6x);
+    height: 20px;
     margin-right: var(--pix-spacing-4x);
   }
 

--- a/mon-pix/app/components/authentication/password-reset-demand-form.gjs
+++ b/mon-pix/app/components/authentication/password-reset-demand-form.gjs
@@ -103,7 +103,6 @@ export default class PasswordResetDemandForm extends Component {
         <div>
           <PixButton
             @type="submit"
-            @size="large"
             @isLoading={{this.isLoading}}
             class="authentication-password-reset-demand-form__button"
           >

--- a/mon-pix/app/components/authentication/password-reset-form/password-reset-form.gjs
+++ b/mon-pix/app/components/authentication/password-reset-form/password-reset-form.gjs
@@ -85,12 +85,7 @@ export default class PasswordResetForm extends Component {
           <:label>{{t "components.authentication.password-reset-form.fields.password.label"}}</:label>
         </NewPasswordInput>
 
-        <PixButton
-          class="password-reset-form__submit-button"
-          @isLoading={{this.isLoading}}
-          @size="large"
-          @type="submit"
-        >
+        <PixButton class="password-reset-form__submit-button" @isLoading={{this.isLoading}} @type="submit">
           {{t "components.authentication.password-reset-form.actions.submit"}}
         </PixButton>
       </form>
@@ -106,7 +101,7 @@ const PasswordResetSucceededInfo = <template>
     </h2>
   </div>
 
-  <PixButtonLink @route="authentication.login" @size="large">
+  <PixButtonLink @route="authentication.login">
     {{t "components.authentication.password-reset-form.actions.login"}}
   </PixButtonLink>
 </template>;

--- a/mon-pix/app/components/authentication/signin-form.gjs
+++ b/mon-pix/app/components/authentication/signin-form.gjs
@@ -152,7 +152,7 @@ export default class SigninForm extends Component {
         </div>
       </fieldset>
 
-      <PixButton @type="submit" @isLoading={{this.isLoading}} @isDisabled={{this.isFormDisabled}} @size="large">
+      <PixButton @type="submit" @isLoading={{this.isLoading}} @isDisabled={{this.isFormDisabled}}>
         {{t "pages.sign-in.actions.submit"}}
       </PixButton>
     </form>

--- a/mon-pix/app/components/authentication/signup-form/index.gjs
+++ b/mon-pix/app/components/authentication/signup-form/index.gjs
@@ -172,7 +172,7 @@ export default class SignupForm extends Component {
         />
       </fieldset>
 
-      <PixButton @type="submit" @isLoading={{this.isLoading}} @size="large">
+      <PixButton @type="submit" @isLoading={{this.isLoading}}>
         {{t "components.authentication.signup-form.actions.submit"}}
       </PixButton>
     </form>

--- a/mon-pix/app/components/authentication/sso-selection-form.gjs
+++ b/mon-pix/app/components/authentication/sso-selection-form.gjs
@@ -54,7 +54,6 @@ export default class SsoSelectionForm extends Component {
           aria-describedby="signin-message"
           @route="authentication.login-oidc"
           @model={{this.selectedProviderId}}
-          @size="large"
         >
           {{t "pages.authentication.sso-selection.signin.link"}}
         </PixButtonLink>
@@ -63,7 +62,7 @@ export default class SsoSelectionForm extends Component {
           {{t "pages.authentication.sso-selection.signin.message" providerName=this.selectedProviderName}}
         </p>
       {{else}}
-        <PixButton @type="button" @isDisabled={{true}} @size="large">
+        <PixButton @type="button" @isDisabled={{true}}>
           {{t "pages.authentication.sso-selection.signin.link"}}
         </PixButton>
       {{/if}}


### PR DESCRIPTION
## :fallen_leaf: Problème
La taille des boutons, sur les nouvelles pages d'authentification, sont trop gros.

## :chestnut: Proposition
- Réduire la taille des boutons 
- Corriger l'affichage des boutons / liens sur un écran petit.

## :jack_o_lantern: Remarques
RAS

## :wood: Pour tester
### Page de connexion
- Aller sur les pages https://app-pr10427.review.pix.fr/connexion et https://app-pr10427.review.pix.org/connexion.
- Vérifier que les boutons sur ces pages ont la bonne taille.

### Page d'inscription
- Aller sur les pages https://app-pr10427.review.pix.fr/inscription et https://app-pr10427.review.pix.org/inscription.
- Vérifier que les boutons sur ces pages ont la bonne taille.

### Choisir une autre organisation
- Aller sur la page https://app-pr10427.review.pix.fr/connexion/sso-selection.
- Vérifier que les boutons sur cette page ont la bonne taille.

### Mot de passe oublié
- Aller sur la page https://app-pr10427.review.pix.fr/mot-de-passe-oublie.
- Vérifier que les boutons sur cette page ont la bonne taille.

### Réinitialisation du mot de passe
- Aller sur la page https://app-pr10427.review.pix.fr/mot-de-passe-oublie.
- Saisir une adresse email d'un compte existant (ex: james-paledroits@example.net).
- Cliquer sur le bouton.
- Aller dans la console de Scalingo API.
- Récupérer le lien pour afficher la page de réinitialisation dans les logs.
- Remplacer le domaine dans le lien par celui de la RA : https://app-pr10427.review.pix.fr/
- Aller sur la page en question.
- Vérifier que les boutons sur cette page ont la bonne taille.

### Test responsive bouton France Travail et FWB
- Aller sur la page https://app-pr10427.review.pix.fr/connexion.
- Passer en mode _responsive design_ (Afficher la console navigateur => cliquer sur la 3ème icône en partant de la droite sur firefox).
- Sélectionner l'iphone SE (ou autre mobile avec une petite taille d'écran).
- Réduire la taille de cet écran et remarquer que le texte des boutons _France Travail_ et _Choisir une autre Organisation_ passent maintenant sur 2 voire 3 lignes.
- Faire de même pour le bouton _FWB_ sur cette page https://app-pr10427.review.pix.org/connexion.
