### PR TITLE
[FEATURE] Séparer les schémas d'éléments acceptés dans le stepper par rapport au component element (PIX-15063) 

### DIFF
--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
@@ -41,6 +41,19 @@ const elementSchema = Joi.alternatives().conditional('.type', {
   ],
 });
 
+const stepperElementSchema = Joi.alternatives().conditional('.type', {
+  switch: [
+    { is: 'download', then: downloadElementSchema },
+    { is: 'image', then: imageElementSchema },
+    { is: 'qcu', then: qcuElementSchema },
+    { is: 'qcm', then: qcmElementSchema },
+    { is: 'qrocm', then: qrocmElementSchema },
+    { is: 'separator', then: separatorElementSchema },
+    { is: 'text', then: textElementSchema },
+    { is: 'video', then: videoElementSchema },
+  ],
+});
+
 const componentElementSchema = Joi.object({
   type: Joi.string().valid('element').required(),
   element: elementSchema.required(),
@@ -51,7 +64,7 @@ const componentStepperSchema = Joi.object({
   steps: Joi.array()
     .items(
       Joi.object({
-        elements: Joi.array().items(elementSchema).required(),
+        elements: Joi.array().items(stepperElementSchema).required(),
       }),
     )
     .min(2)


### PR DESCRIPTION
## :fallen_leaf: Problème
Les éléments possibles pour Stepper et Element sont identiques. Or, certains ne doivent pas être ajoutés dans un Stepper (Embed et Flashcards).

## :chestnut: Proposition
Modifier modulix-schema.json pour distinguer les éléments dispo entre chaque Component.

## :jack_o_lantern: Remarques
Le schéma a été mis à jour côté Modulix Editor, [dans cette PR](https://github.com/1024pix/modulix-editor/pull/8).

## :wood: Pour tester
TODO
