### PR TITLE
[FEATURE] :art: Ajout d'un bouton dans la liste des missions pour aller sur la page de détail d'une mission (PIX-14992)

### DIFF
--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -75,6 +75,7 @@
 @import 'pages/authenticated/campaigns/participant-profile';
 @import 'pages/authenticated/certifications';
 @import 'pages/authenticated/mission';
+@import 'pages/authenticated/mission/list';
 @import 'pages/authenticated/organization-participants/list';
 @import 'pages/authenticated/organization-participants/deletion-modal';
 @import 'pages/authenticated/sup-organization-participants/list';

--- a/orga/app/styles/pages/authenticated/mission/list.scss
+++ b/orga/app/styles/pages/authenticated/mission/list.scss
@@ -1,0 +1,16 @@
+.mission-list {
+  &__table {
+    th {
+      color: var(--pix-neutral-900);
+      font-weight: 700;
+    }
+
+    td {
+      color: var(--pix-neutral-900);
+    }
+
+    a {
+      text-decoration: underline;
+    }
+  }
+}

--- a/orga/app/templates/authenticated/missions/list.hbs
+++ b/orga/app/templates/authenticated/missions/list.hbs
@@ -71,7 +71,7 @@
           <Table::Header scope="col">{{t "pages.missions.list.headers.name"}}</Table::Header>
           <Table::Header scope="col">{{t "pages.missions.list.headers.competences"}}</Table::Header>
           <Table::Header scope="col">{{t "pages.missions.list.headers.started-by"}}</Table::Header>
-          <Table::Header scope="col">{{t "pages.missions.list.headers.actions"}}</Table::Header>
+          <Table::Header scope="col" @align="center">{{t "pages.missions.list.headers.actions"}}</Table::Header>
         </tr>
       </thead>
       <tbody>
@@ -95,9 +95,9 @@
               {{/if}}
             </td>
             <td>
-              <a href="#" {{on "click" (fn this.goToMissionDetails mission.id)}}>{{t
-                  "pages.missions.list.actions.see-mission-details"
-                }}</a>
+              <PixButtonLink @route="authenticated.missions.mission" @model={{mission.id}} @variant="tertiary">
+                {{t "pages.missions.list.actions.see-mission-details"}}
+              </PixButtonLink>
             </td>
           </tr>
         {{/each}}

--- a/orga/app/templates/authenticated/missions/list.hbs
+++ b/orga/app/templates/authenticated/missions/list.hbs
@@ -64,13 +64,14 @@
 {{#if @model.missions}}
   <div class="panel">
 
-    <table class="table content-text content-text--small participation-list__table">
+    <table class="table content-text content-text--small mission-list__table">
       <caption class="screen-reader-only">{{t "pages.missions.list.caption"}}</caption>
       <thead>
         <tr>
           <Table::Header scope="col">{{t "pages.missions.list.headers.name"}}</Table::Header>
           <Table::Header scope="col">{{t "pages.missions.list.headers.competences"}}</Table::Header>
           <Table::Header scope="col">{{t "pages.missions.list.headers.started-by"}}</Table::Header>
+          <Table::Header scope="col">{{t "pages.missions.list.headers.actions"}}</Table::Header>
         </tr>
       </thead>
       <tbody>
@@ -92,6 +93,11 @@
               {{else}}
                 {{mission.startedBy}}
               {{/if}}
+            </td>
+            <td>
+              <a href="#" {{on "click" (fn this.goToMissionDetails mission.id)}}>{{t
+                  "pages.missions.list.actions.see-mission-details"
+                }}</a>
             </td>
           </tr>
         {{/each}}

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -888,6 +888,9 @@
     "missions": {
       "title": "Missions",
       "list": {
+        "actions": {
+          "see-mission-details": "See details"
+        },
         "aria-label": "Mission",
         "banner": {
           "copypaste-container": {
@@ -921,6 +924,7 @@
         "caption": "List of missions",
         "empty-state": "There is not any mission",
         "headers": {
+          "actions": "Actions",
           "competences": "Targeted DigComp competence",
           "name": "Mission",
           "started-by": "Started by"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -894,6 +894,9 @@
     "missions": {
       "title": "Missions",
       "list": {
+        "actions": {
+          "see-mission-details": "Voir le détail"
+        },
         "aria-label": "Mission",
         "banner": {
           "copypaste-container": {
@@ -927,6 +930,7 @@
         "caption": "Liste des missions",
         "empty-state": "Il n'y a pas de missions",
         "headers": {
+          "actions": "Actions",
           "competences": "Compétences du CRCN travaillées",
           "name": "Mission",
           "started-by": "Commencé par"

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -922,7 +922,11 @@
         "headers": {
           "competences": "Vaardigheden waaraan is gewerkt",
           "name": "Opdracht",
-          "started-by": "Gestart door"
+          "started-by": "Gestart door",
+          "actions": "Acties"
+        },
+        "actions": {
+          "see-mission-details": "Zie details"
         },
         "no-division": "Geen klas",
         "non-admin": {


### PR DESCRIPTION
## :fallen_leaf: Problème

Dans la page de liste des missions ; 
Malgré la ligne surlignée ;
Malgré le curseur qui devient un doigt pointé ;
Les utilisateurs testés éprouvent des difficultés à comprendre qu'il faut cliquer dessus pour ouvrir la page de détail d'une mission.

## :chestnut: Proposition

Ajouter un (faux) lien vers le détail de la mission

![image](https://github.com/user-attachments/assets/53aad0e2-49f6-4cd9-820d-2d26bccfb269)

## :jack_o_lantern: Remarques

Le faux lien a été ajouté dans une colonne action. Il serait peut-être mieux à côté du nom de la mission ? Voir le nom de la mission pourrait être souligné pour faire référence à un lien ?

Pourquoi le reset CSS que nous utilisons supprime cette référence mondiale au lien cliquable en mettant un `text-decoration: none` ?

## :wood: Pour tester

Se connecter sur PixOrga avec un compte accédant à l'école des Pyrénées (member-orga@example.net) ;
Aller sur la page des missions, constater la présence du lien, cliquer dessus pour aller à la page de détail d'une mission.

