### PR TITLE
[FEATURE] Informer l'utilisateur si la demande de réinitialisation de mot de passe est expirée ou déjà utilisée (PIX-15061)

### DIFF
--- a/mon-pix/app/components/authentication/password-reset-demand/password-reset-demand-form.gjs
+++ b/mon-pix/app/components/authentication/password-reset-demand/password-reset-demand-form.gjs
@@ -4,6 +4,7 @@ import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixMessage from '@1024pix/pix-ui/components/pix-message';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
@@ -14,8 +15,10 @@ import isEmailValid from '../../../utils/email-validator.js';
 import PasswordResetDemandReceivedInfo from './password-reset-demand-received-info';
 
 export default class PasswordResetDemandForm extends Component {
+  @service errors;
+
+  @tracked globalError = this.errors.hasErrors && this.errors.shift();
   @tracked isLoading = false;
-  @tracked globalError;
   @tracked isPasswordResetDemandReceived = false;
 
   validation = new FormValidation({

--- a/mon-pix/app/routes/reset-password.js
+++ b/mon-pix/app/routes/reset-password.js
@@ -4,9 +4,10 @@ import get from 'lodash/get';
 
 export default class ResetPasswordRoute extends Route {
   @service errors;
+  @service featureToggles;
   @service intl;
-  @service session;
   @service router;
+  @service session;
   @service store;
 
   async model(params) {
@@ -17,7 +18,12 @@ export default class ResetPasswordRoute extends Route {
     } catch (error) {
       const status = get(error, 'errors[0].status');
       if (status && (status === 401 || (status && 404))) {
-        this.errors.push(this.intl.t('pages.reset-password.error.expired-demand'));
+        let error = this.intl.t('pages.reset-password.error.expired-demand');
+
+        if (this.featureToggles.featureToggles.isNewAuthenticationDesignEnabled) {
+          error = 'pages.reset-password.error.expired-demand';
+        }
+        this.errors.push(error);
         this.router.replaceWith('password-reset-demand');
       }
     }

--- a/mon-pix/app/styles/pages/_sso-selection.scss
+++ b/mon-pix/app/styles/pages/_sso-selection.scss
@@ -5,6 +5,8 @@
   padding-top: var(--pix-spacing-6x);
 
   &__signup {
+    @extend %pix-body-m;
+
     display: flex;
     gap: var(--pix-spacing-2x);
     margin-top: var(--pix-spacing-4x);

--- a/mon-pix/app/templates/authentication/sso-selection.hbs
+++ b/mon-pix/app/templates/authentication/sso-selection.hbs
@@ -22,7 +22,7 @@
 
     {{#if this.isSigninRoute}}
       <section class="sso-selection-page__signup">
-        <h2 class="pix-body-l">{{t "pages.authentication.sso-selection.signup.title"}}</h2>
+        <h2>{{t "pages.authentication.sso-selection.signup.title"}}</h2>
         <LinkTo @route="inscription">{{t "pages.authentication.sso-selection.signup.link"}}</LinkTo>
       </section>
     {{/if}}

--- a/mon-pix/tests/integration/components/authentication/password-reset-demand/password-reset-demand-form-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/password-reset-demand/password-reset-demand-form-test.gjs
@@ -178,6 +178,21 @@ module('Integration | Component | Authentication | PasswordResetDemand | passwor
         assert.dom(screen.queryByText(t('common.api-error-messages.internal-server-error'))).exists();
       });
     });
+
+    module('when there is an error in errors service', function () {
+      test('it displays the error on the corresponding banner', async function (assert) {
+        // given
+        const errorKeyMessageToBeDisplayed = 'pages.reset-password.error.expired-demand';
+        const errorsService = this.owner.lookup('service:errors');
+
+        // when
+        errorsService.push(errorKeyMessageToBeDisplayed);
+        const screen = await render(<template><PasswordResetDemandForm /></template>);
+
+        // then
+        assert.dom(screen.getByRole('alert', { value: t(errorKeyMessageToBeDisplayed) })).exists();
+      });
+    });
   });
 });
 

--- a/mon-pix/tests/unit/routes/password-reset-demand-test.js
+++ b/mon-pix/tests/unit/routes/password-reset-demand-test.js
@@ -1,7 +1,7 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-module('Unit | Route | password reset', function (hooks) {
+module('Unit | Route | password-reset-demand', function (hooks) {
   setupTest(hooks);
 
   let route;

--- a/mon-pix/tests/unit/routes/reset-password-test.js
+++ b/mon-pix/tests/unit/routes/reset-password-test.js
@@ -1,10 +1,14 @@
 import Service from '@ember/service';
+import { t } from 'ember-intl/test-support';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntl from '../../helpers/setup-intl';
+
 module('Unit | Route | reset-password', function (hooks) {
   setupTest(hooks);
+  setupIntl(hooks);
 
   module('Route behavior', function (hooks) {
     let storeStub;
@@ -76,6 +80,32 @@ module('Unit | Route | reset-password', function (hooks) {
         // then
         assert.deepEqual(result.user, expectedUser);
         assert.deepEqual(result.temporaryKey, params.temporary_key);
+      });
+    });
+    module('when password reset demand is not valid', function () {
+      module('when error status is equal to 401', function () {
+        test('it adds an error in errors service and replace current route with "reset-password-demand"', async function (assert) {
+          // given
+          const errors = [{ status: 401 }];
+          const errorsService = this.owner.lookup('service:errors');
+          const route = this.owner.lookup('route:reset-password');
+          const replaceWithStub = sinon.stub();
+          const routerStub = Service.create({
+            replaceWith: replaceWithStub,
+          });
+
+          queryRecordStub.rejects({ errors });
+          route.set('store', storeStub);
+          route.set('router', routerStub);
+
+          // when
+          await route.model(params);
+
+          // then
+          sinon.assert.calledOnceWithExactly(replaceWithStub, 'password-reset-demand');
+          assert.strictEqual(errorsService.errors.length, 1);
+          assert.strictEqual(errorsService.errors[0], t('pages.reset-password.error.expired-demand'));
+        });
       });
     });
   });

--- a/mon-pix/tests/unit/routes/reset-password-test.js
+++ b/mon-pix/tests/unit/routes/reset-password-test.js
@@ -3,7 +3,7 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-module('Unit | Route | changer mot de passe', function (hooks) {
+module('Unit | Route | reset-password', function (hooks) {
   setupTest(hooks);
 
   module('Route behavior', function (hooks) {


### PR DESCRIPTION
## :fallen_leaf: Problème
Sur la nouvelles page de demande de réinitialisation de mot de passe, une fonctionnalité, permettant d'afficher un message d'erreur lorsque la demande a expiré ou a déjà été utilisée, n'a pas été reportée.

## :chestnut: Proposition
Ajouter cette fonctionnalité sur la page. 

## :jack_o_lantern: Remarques
- Les noms des tests unitaires pour les routes `reset-password` et `password-reset-demand` étaient mal nommés. Cette PR fixe ce renommage.
- Une gestion du feature toggle `isNewAuthenticationDesignEnabled` a été ajouté dans la route pour permettre d'envoyer uniquement la clé de traduction. Ceci afin de pouvoir gérer la traduction du message lorsque l'utilisateur change de langue avec le language switcher.
- Une correction sur la taille du texte _Vous n'avez pas de compte_ a été aussi faite sur cette PR.
## :wood: Pour tester
### Test d'affichage du message d'erreur
- Aller sur la page de demande de réinitialisation de mot de passe https://app-pr10439.review.pix.fr/mot-de-passe-oublie.
- Saisir une adresse email d'un compte existant (ex: _james-paledroits@example.net_).
- Cliquer sur le bouton "Recevoir le lien de réinitialisation".
- Récupérer le lien, [dans les logs de la console de l'API](https://dashboard.scalingo.com/apps/osc-fr1/pix-api-review-pr10439/logs), de l'url de réinitialisation de mot de passe.
- Se connecter à la base de donnée Postgres de la RA.
- Appliquer la requête suivante :  `UPDATE "reset-password-demands" SET used=true WHERE "temporaryKey"='${temporaryKey}'` en remplaçant ${temporaryKey} par celle récupérée dans le lien (après `/changer-de-mot-de-passe/`.
- Aller sur l'url de réinitialisation de mot de passe que vous avez récupéré précédemment.
- Vérifier que le message _Nous sommes désolés, mais votre demande de réinitialisation de mot de passe a déjà été utilisée ou est expirée. Merci de recommencer._ s'affiche bien sur la page
- Vérifier que le chemin de l'url correspond bien à `/mot-de-passe-oublie`.

### Correction de la taille du texte sur la page de sélection d'une organisation
- Aller sur la page https://app-pr10439.review.pix.fr/connexion/sso-selection.
- Vérifier que le texte _Vous n'avez pas de compte ? Inscrivez-vous_ a une taille plus petite (16px).
