### PR TITLE
[TECH] Ajouter des index sur les tables pg

### DIFF
--- a/api/db/migrations/20241028125952_add-indexes.js
+++ b/api/db/migrations/20241028125952_add-indexes.js
@@ -1,0 +1,28 @@
+const indexesToAdd = [
+  { tableName: 'certification-subscriptions', index: ['complementaryCertificationId', 'certificationCandidateId'] },
+  { tableName: 'complementary-certifications', index: ['key'] },
+  { tableName: 'features', index: ['key'] },
+  { tableName: 'campaign-features', index: ['campaignId', 'featureId'] },
+  { tableName: 'complementary-certification-habilitations', index: ['certificationCenterId'] },
+  { tableName: 'complementary-certification-badges', index: ['complementaryCertificationId'] },
+  { tableName: 'complementary-certification-courses', index: ['complementaryCertificationBadgeId'] },
+  { tableName: 'organizations', index: ['externalId'] },
+  { tableName: 'organization-learners', index: ['organizationId', 'division'] },
+];
+
+const up = async function (knex) {
+  for (const { tableName, index } of indexesToAdd) {
+    await knex.schema.table(tableName, function (table) {
+      table.index(index);
+    });
+  }
+};
+
+const down = async function (knex) {
+  for (const { tableName, index } of indexesToAdd) {
+    await knex.schema.table(tableName, function (table) {
+      table.dropIndex(index);
+    });
+  }
+};
+export { down, up };


### PR DESCRIPTION
## :fallen_leaf: Problème
Plusieurs tables postgresql sont dépourvus d'index ou ont des usages non indexés.

## :jack_o_lantern: Remarques
Cette PR est une première partie, il reste des tables non indexés mais nous ne voulons pas ajouter tous les index d'un coup pour éviter un temps de MEP long.
Ils seront ajoutés progressivement.

## :wood: Pour tester
```
scalingo --region osc-fr1 -a pix-api-review-pr10441 pgsql-console
\d "certification-subscriptions"
\d "complementary-certifications"
\d "features"
\d "campaign-features"
\d "complementary-certification-habilitations"
\d "complementary-certification-badges"
\d "complementary-certification-courses"
\d "organizations"
\d "organization-learners"
```