### PR TITLE
[FEATURE] :lipstick: Ajoute un tootltip sur un entête de colonne pour préciser un titre (PIX-15016)

### DIFF
--- a/orga/app/components/organization-participant/table-headers.gjs
+++ b/orga/app/components/organization-participant/table-headers.gjs
@@ -1,9 +1,11 @@
 import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { on } from '@ember/modifier';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
-import { not } from 'ember-truth-helpers';
+import { eq, not } from 'ember-truth-helpers';
 
 import { getColumnName } from '../../helpers/import-format.js';
 import Tooltip from '../certificability/tooltip';
@@ -38,7 +40,28 @@ export default class TableHeaders extends Component {
       </HeaderSort>
       <Header>{{t "pages.organization-participants.table.column.first-name"}}</Header>
       {{#each @customHeadings as |heading|}}
-        <Header>{{t (getColumnName heading)}}</Header>
+        <Header>
+          <div class="organization-participant-list-page__header-with-tooltip">
+            {{t (getColumnName heading)}}
+            {{#if (eq heading "ORALIZATION")}}
+              <PixTooltip @id="organization-participants-oralization-tooltip" @isWide="true">
+                <:triggerElement>
+                  <PixIcon
+                    @name="help"
+                    @plainIcon="true"
+                    aria-label={{t "pages.organization-participants.table.oralization-header-tooltip-aria-label"}}
+                    aria-describedby="organization-participants-oralization-tooltip"
+                  />
+                </:triggerElement>
+
+                <:tooltip>
+                  {{t "pages.organization-participants.table.oralization-header-tooltip"}}
+                </:tooltip>
+              </PixTooltip>
+            {{/if}}
+
+          </div>
+        </Header>
       {{/each}}
 
       {{#unless this.currentUser.canAccessMissionsPage}}

--- a/orga/app/styles/pages/authenticated/organization-participants/list.scss
+++ b/orga/app/styles/pages/authenticated/organization-participants/list.scss
@@ -17,6 +17,18 @@ $margin-right: 32px;
     justify-content: center;
   }
 
+  &__header-with-tooltip {
+    display: flex;
+
+    .pix-tooltip {
+      margin-left: 5px;
+
+      &__trigger-element {
+        display: flex;
+      }
+    }
+  }
+
   &__actions-header {
     width: 10%;
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1124,6 +1124,7 @@
         },
         "description": "Table of participants, sorted by name.",
         "empty": "No participants",
+        "oralization-header-tooltip": "Activate “read the instruction” to have the student's oral transcription.",
         "row-title": "Participant",
         "row-value": {
           "oralization": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1130,6 +1130,7 @@
         },
         "description": "Tableau des participants trié par nom.",
         "empty": "Aucun participant",
+        "oralization-header-tooltip": "Activer “lecture de la consigne” permettra à l'élève d’avoir sa transcription orale.",
         "row-title": "Participant",
         "row-value": {
           "oralization": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1184,7 +1184,8 @@
         },
         "description": "Tabel met deelnemers gesorteerd op naam.",
         "empty": "Geen deelnemers",
-        "row-title": "Deelnemer"
+        "row-title": "Deelnemer",
+        "oralization-header-tooltip": "Door ‘leesinstructies’ te activeren, kan de student zijn mondelinge transcriptie krijgen."
       }
     },
     "participants-list": {


### PR DESCRIPTION
## :fallen_leaf: Problème

On a peur que le libellé lecture de la consigne semble un peu abstrait pour le prescripteur. 

![image](https://github.com/user-attachments/assets/e7ef5fbd-cf3d-44b7-b7eb-315dbfed9f05)


## :chestnut: Proposition

Affichage d’un petit i à côté du nom de la colonne avec comme texte au over le suivant : Activer “lecture de la consigne” permettra à l'élève d’avoir sa transcription orale.

![image](https://github.com/user-attachments/assets/96c4db44-a289-4616-b34e-75d70047f4dc)


## :jack_o_lantern: Remarques

Pour le moment, il y a un `if` en dur qui test si nous sommes sur l'oralisation. Il y a sans doute moyen de mettre en place une solution plus générique sur l'affichage de tooltip quant à ces colonnes un peu « flexible ».

## :wood: Pour tester

Se connecter sur pix orga avec un compte qui accède à une organisation de type scolaire (SCO-1D), le compte `member-orga@example.net` par exemple ;
Modifier l'URL pour aller sur la page cachée des élèves (/participants) ;
Constaté que le tooltip s'affiche dans la colonne, et que le texte correspond lorsque l'on passe dessus et que ça s'affiche.