### PR TITLE
[TECH] Lancer la CI des PRs au statut draft

### DIFF
--- a/.github/workflows/trigger-ci.yaml
+++ b/.github/workflows/trigger-ci.yaml
@@ -12,8 +12,6 @@ jobs:
 
     steps:
       - name: Trigger CircleCI
-        # ensure PR is not draft
-        if: '! github.event.pull_request.draft'
         uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.0.5
         env:
           CCI_TOKEN: ${{ secrets.PIX_SERVICE_CIRCLE_CI_TOKEN }}


### PR DESCRIPTION
## :fallen_leaf: Problème
Depuis #10133, on limite les déclenchements de CI pour diminuer notre consommation. L'équipe DevComp métier a l'habitude d'utiliser le statut de PR "Draft" pour indiquer qu'une PR est toujours en cours de construction mais nécessite tout de même une boucle de feedback de tests principalement pour valider techniquement les modifications de contenu (exemple dans #10423).

## :chestnut: Proposition
On propose pendant un mois de relancer la CI sur les PRs au statut "Draft" et de voir l'incidence sur la consommation.

## :jack_o_lantern: Remarques
Il y a un sujet plus long terme suivi côté DevComp de ne pas lancer l'intégralité des tests du monorepo lors des modifications de contenu Modulix. Mais nous n'avons pas identifié d'alternative simple à mettre en place.

## :wood: Pour tester
Cette PR a été ouverte en "Draft" pour vérifier que la CI est bien déclenchée. => Le vérifier via [les logs GhA](https://github.com/1024pix/pix/actions/runs/11591098554/job/32270109396?pr=10444) et [CircleCI](https://app.circleci.com/pipelines/github/1024pix/pix/93704/workflows/9b3bc6ec-9236-416d-89b7-a381a35c506a)
Elle est ensuite passée en "Ready for review".