### PR TITLE
[FEATURE] Ne pas contraindre les formats d'image (PIX-14861)

### DIFF
--- a/mon-pix/app/components/module/element/_image.scss
+++ b/mon-pix/app/components/module/element/_image.scss
@@ -9,5 +9,6 @@
     display: block;
     width: 100%;
     object-fit: contain;
+    border-radius: var(--modulix-radius-s);
   }
 }

--- a/mon-pix/app/components/module/element/_image.scss
+++ b/mon-pix/app/components/module/element/_image.scss
@@ -1,6 +1,5 @@
 .element-image {
   &__container {
-    aspect-ratio: auto 16 / 9;
     margin: 0 auto var(--pix-spacing-3x) auto;
   }
 }
@@ -8,7 +7,7 @@
 .element-image-container {
   &__image {
     display: block;
-    height: 100%;
+    width: 100%;
     object-fit: contain;
   }
 }


### PR DESCRIPTION
## :fallen_leaf: Problème:
Les éléments "Image" de Modulix devaient obligatoirement être en 16/9. Cette contrainte est trop restrictive.

## :chestnut: Proposition
Supprimer cette contrainte.

## :jack_o_lantern: Remarques
En profiter pour arrondir les bordures comme prévu dans les maquettes.

## :wood: Pour tester
Vérifier que les images ont un comportement plus joli qu'avant : 
- images pas assez hautes sur [Distinguer vrai faux sur internet](https://app-pr10445.review.pix.fr/modules/distinguer-vrai-faux-sur-internet/passage)
- images vectorielles qui ne prennent pas 100% de largeur automatiquement sur le [Didacticiel](https://app-pr10445.review.pix.fr/modules/didacticiel-modulix/passage)
- la non reg du plus beau module [Bien écrire son adresse mail](https://app-pr10445.review.pix.fr/modules/bien-ecrire-son-adresse-mail/passage)
