### PR TITLE
[TECH] Suppression du FT_ENABLE_PIX_PLUS_LOWER_LEVEL (PIX-15053).

### DIFF
--- a/api/lib/domain/events/handle-complementary-certifications-scoring.js
+++ b/api/lib/domain/events/handle-complementary-certifications-scoring.js
@@ -1,5 +1,4 @@
 import { ComplementaryCertificationCourseResult } from '../../../src/certification/shared/domain/models/ComplementaryCertificationCourseResult.js';
-import { config } from '../../../src/shared/config.js';
 import { AnswerCollectionForScoring } from '../../../src/shared/domain/models/AnswerCollectionForScoring.js';
 import { ComplementaryCertificationScoringWithComplementaryReferential } from '../../../src/shared/domain/models/ComplementaryCertificationScoringWithComplementaryReferential.js';
 import { ComplementaryCertificationScoringWithoutComplementaryReferential } from '../../../src/shared/domain/models/ComplementaryCertificationScoringWithoutComplementaryReferential.js';
@@ -82,11 +81,7 @@ async function _getComplementaryCertificationResultInformation({
   assessmentResult,
   minimumReproducibilityRateLowerLevel,
 }) {
-  if (
-    config.featureToggles.isPixPlusLowerLeverEnabled &&
-    hasComplementaryReferential &&
-    assessmentResult.isValidated()
-  ) {
+  if (hasComplementaryReferential && assessmentResult.isValidated()) {
     const lowerLevelComplementaryCertificationBadge = await _getNextLowerLevelBadge(
       complementaryCertificationBadgesRepository,
       complementaryCertificationScoring.complementaryCertificationBadgeId,

--- a/api/sample.env
+++ b/api/sample.env
@@ -750,13 +750,6 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: false
 # FT_PIX_1D_ENABLED=false
 
-# Enable the Pix+ lower level granting when a candidate fails a certification by a slim margin
-#
-# presence: optional
-# type: boolean
-# default: false
-# FT_ENABLE_PIX_PLUS_LOWER_LEVEL=false
-
 # Enable the verification of the scope in certification tokens
 #
 # presence: optional

--- a/api/src/certification/enrolment/domain/usecases/get-V2-user-certification-eligibility.js
+++ b/api/src/certification/enrolment/domain/usecases/get-V2-user-certification-eligibility.js
@@ -17,7 +17,6 @@
 
 import _ from 'lodash';
 
-import { config } from '../../../../shared/config.js';
 import { ComplementaryCertificationBadgesHistory } from '../../../complementary-certification/application/api/models/ComplementaryCertificationBadgesHistory.js';
 import {
   ComplementaryCertificationBadge,
@@ -260,12 +259,9 @@ function _isAcquiredByPixSourceOrOutdatedByMoreThanOneVersion({
   isAcquiredExpectedLevel,
 }) {
   return (
-    // TODO: Remove check on isPixPlusLowerLeverEnabled if enabled in PROD
-    (config.featureToggles.isPixPlusLowerLeverEnabled &&
-      _isOutdatedBadgeAcquisitionByMoreThanOneVersion({
-        stillValidBadgeAcquisitionComplementaryCertificationBadgeId,
-        outdatedVersions: complementaryCertificationVersioning,
-      })) ||
-    isAcquiredExpectedLevel
+    _isOutdatedBadgeAcquisitionByMoreThanOneVersion({
+      stillValidBadgeAcquisitionComplementaryCertificationBadgeId,
+      outdatedVersions: complementaryCertificationVersioning,
+    }) || isAcquiredExpectedLevel
   );
 }

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -211,7 +211,6 @@ const configuration = (function () {
       isAsyncQuestRewardingCalculationEnabled: toBoolean(process.env.FT_ENABLE_ASYNC_QUESTS_REWARDS_CALCULATION),
       isNewAuthenticationDesignEnabled: toBoolean(process.env.FT_NEW_AUTHENTICATION_DESIGN_ENABLED),
       isPix1dEnabled: toBoolean(process.env.FT_PIX_1D_ENABLED),
-      isPixPlusLowerLeverEnabled: toBoolean(process.env.FT_ENABLE_PIX_PLUS_LOWER_LEVEL),
       isTextToSpeechButtonEnabled: toBoolean(process.env.FT_ENABLE_TEXT_TO_SPEECH_BUTTON),
       showExperimentalMissions: toBoolean(process.env.FT_SHOW_EXPERIMENTAL_MISSIONS),
       showNewCampaignPresentationPage: toBoolean(process.env.FT_SHOW_NEW_CAMPAIGN_PRESENTATION_PAGE),
@@ -412,7 +411,6 @@ const configuration = (function () {
     config.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled = false;
     config.featureToggles.isPix1dEnabled = true;
     config.featureToggles.isCertificationTokenScopeEnabled = false;
-    config.featureToggles.isPixPlusLowerLeverEnabled = false;
     config.featureToggles.isTextToSpeechButtonEnabled = false;
     config.featureToggles.deprecatePoleEmploiPushNotification = false;
     config.featureToggles.isNeedToAdjustCertificationAccessibilityEnabled = false;

--- a/api/src/shared/infrastructure/validate-environment-variables.js
+++ b/api/src/shared/infrastructure/validate-environment-variables.js
@@ -37,7 +37,6 @@ const schema = Joi.object({
   FORCE_DROP_DATABASE: Joi.string().optional().valid('true', 'false'),
   FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE: Joi.string().optional().valid('true', 'false'),
   FT_ENABLE_NEED_TO_ADJUST_CERTIFICATION_ACCESSIBILITY: Joi.string().optional().valid('true', 'false'),
-  FT_ENABLE_PIX_PLUS_LOWER_LEVEL: Joi.string().optional().valid('true', 'false'),
   FT_ENABLE_TEXT_TO_SPEECH_BUTTON: Joi.string().optional().valid('true', 'false'),
   FT_PIX_COMPANION_ENABLED: Joi.string().optional().valid('true', 'false'),
   KNEX_ASYNC_STACKTRACE_ENABLED: Joi.string().optional().valid('true', 'false'),

--- a/api/tests/certification/enrolment/unit/domain/usecases/get-V2-user-certification-eligibility_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/get-V2-user-certification-eligibility_test.js
@@ -1,5 +1,4 @@
 import { getV2UserCertificationEligibility } from '../../../../../../src/certification/enrolment/domain/usecases/get-V2-user-certification-eligibility.js';
-import { config } from '../../../../../../src/shared/config.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | get-v2-user-certification-eligibility', function () {
@@ -275,185 +274,87 @@ describe('Unit | UseCase | get-v2-user-certification-eligibility', function () {
           });
 
           context('when there is more than one new version', function () {
-            context('if FT_ENABLE_PIX_PLUS_LOWER_LEVEL is enabled', function () {
-              it('should return the user certification eligibility without complementary certification', async function () {
-                // given
-                sinon.stub(config.featureToggles, 'isPixPlusLowerLeverEnabled').value(true);
-
-                const detachedTargetProfileHistory1 = domainBuilder.buildTargetProfileHistoryForAdmin({
-                  badges: [
-                    domainBuilder.buildComplementaryCertificationBadgeForAdmin({
-                      id: 3,
-                      complementaryCertificationBadgeId: 32,
-                    }),
-                    domainBuilder.buildComplementaryCertificationBadgeForAdmin({
-                      id: 3,
-                      complementaryCertificationBadgeId: 33,
-                    }),
-                  ],
-                  attachedAt: new Date('2020-01-01'),
-                  detachedAt: new Date('2021-01-01'),
-                });
-                const detachedTargetProfileHistory2 = domainBuilder.buildTargetProfileHistoryForAdmin({
-                  badges: [
-                    domainBuilder.buildComplementaryCertificationBadgeForAdmin({
-                      id: 3,
-                      complementaryCertificationBadgeId: 34,
-                    }),
-                  ],
-                  attachedAt: new Date('2021-01-01'),
-                  detachedAt: new Date('2022-01-01'),
-                });
-                const attachedTargetProfileHistory = domainBuilder.buildTargetProfileHistoryForAdmin({
-                  detachedAt: null,
-                  attachedAt: new Date('2024-01-01'),
-                  badges: [
-                    domainBuilder.buildComplementaryCertificationBadgeForAdmin({
-                      id: 3,
-                      complementaryCertificationBadgeId: 35,
-                    }),
-                  ],
-                });
-
-                targetProfileHistoryRepository.getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId
-                  .withArgs({ complementaryCertificationId: 1 })
-                  .resolves([attachedTargetProfileHistory]);
-
-                targetProfileHistoryRepository.getDetachedTargetProfilesHistoryByComplementaryCertificationId
-                  .withArgs({ complementaryCertificationId: 1 })
-                  .resolves([detachedTargetProfileHistory2, detachedTargetProfileHistory1]);
-
-                const placementProfile = { isCertifiable: () => true };
-                placementProfileService.getPlacementProfile
-                  .withArgs({ userId: 2, limitDate: now })
-                  .resolves(placementProfile);
-
-                const badgeAcquisition = _getOutdatedBadgeAcquisition({ complementaryCertificationBadgeId: 33 });
-
-                certificationBadgesService.findLatestBadgeAcquisitions.resolves([badgeAcquisition]);
-
-                complementaryCertificationCourseRepository.findByUserId.resolves([
-                  domainBuilder.certification.enrolment.buildComplementaryCertificationCourseWithResults({
-                    id: 1,
-                    hasExternalJury: false,
-                    complementaryCertificationBadgeId: 33,
-                    results: [
-                      {
-                        id: 3,
-                        acquired: true,
-                        source: 'PIX',
-                        complementaryCertificationBadgeId: 32,
-                      },
-                    ],
+            it('should return the user certification eligibility without complementary certification', async function () {
+              // given
+              const detachedTargetProfileHistory1 = domainBuilder.buildTargetProfileHistoryForAdmin({
+                badges: [
+                  domainBuilder.buildComplementaryCertificationBadgeForAdmin({
+                    id: 3,
+                    complementaryCertificationBadgeId: 32,
                   }),
-                ]);
-
-                // when
-                const certificationEligibility = await getV2UserCertificationEligibility({
-                  userId: 2,
-                  placementProfileService,
-                  certificationBadgesService,
-                  complementaryCertificationCourseRepository,
-                  targetProfileHistoryRepository,
-                });
-
-                // then
-                expect(certificationEligibility.complementaryCertifications).to.deep.equal([]);
-              });
-            });
-
-            context('if FT_ENABLE_PIX_PLUS_LOWER_LEVEL is not enabled', function () {
-              it('should return the user certification eligibility with complementary certification', async function () {
-                // given
-                sinon.stub(config.featureToggles, 'isPixPlusLowerLeverEnabled').value(false);
-
-                const detachedTargetProfileHistory1 = domainBuilder.buildTargetProfileHistoryForAdmin({
-                  badges: [
-                    domainBuilder.buildComplementaryCertificationBadgeForAdmin({
-                      id: 3,
-                      complementaryCertificationBadgeId: 32,
-                    }),
-                    domainBuilder.buildComplementaryCertificationBadgeForAdmin({
-                      id: 3,
-                      complementaryCertificationBadgeId: 33,
-                    }),
-                  ],
-                  attachedAt: new Date('2020-01-01'),
-                  detachedAt: new Date('2021-01-01'),
-                });
-                const detachedTargetProfileHistory2 = domainBuilder.buildTargetProfileHistoryForAdmin({
-                  badges: [
-                    domainBuilder.buildComplementaryCertificationBadgeForAdmin({
-                      id: 3,
-                      complementaryCertificationBadgeId: 34,
-                    }),
-                  ],
-                  attachedAt: new Date('2021-01-01'),
-                  detachedAt: new Date('2022-01-01'),
-                });
-                const attachedTargetProfileHistory = domainBuilder.buildTargetProfileHistoryForAdmin({
-                  detachedAt: null,
-                  attachedAt: new Date('2024-01-01'),
-                  badges: [
-                    domainBuilder.buildComplementaryCertificationBadgeForAdmin({
-                      id: 3,
-                      complementaryCertificationBadgeId: 35,
-                    }),
-                  ],
-                });
-
-                targetProfileHistoryRepository.getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId
-                  .withArgs({ complementaryCertificationId: 1 })
-                  .resolves([attachedTargetProfileHistory]);
-
-                targetProfileHistoryRepository.getDetachedTargetProfilesHistoryByComplementaryCertificationId
-                  .withArgs({ complementaryCertificationId: 1 })
-                  .resolves([detachedTargetProfileHistory2, detachedTargetProfileHistory1]);
-
-                const placementProfile = { isCertifiable: () => true };
-                placementProfileService.getPlacementProfile
-                  .withArgs({ userId: 2, limitDate: now })
-                  .resolves(placementProfile);
-
-                const badgeAcquisition = _getOutdatedBadgeAcquisition({ complementaryCertificationBadgeId: 33 });
-
-                certificationBadgesService.findLatestBadgeAcquisitions.resolves([badgeAcquisition]);
-
-                complementaryCertificationCourseRepository.findByUserId.resolves([
-                  domainBuilder.certification.enrolment.buildComplementaryCertificationCourseWithResults({
-                    id: 1,
-                    hasExternalJury: false,
+                  domainBuilder.buildComplementaryCertificationBadgeForAdmin({
+                    id: 3,
                     complementaryCertificationBadgeId: 33,
-                    results: [
-                      {
-                        id: 3,
-                        acquired: true,
-                        source: 'PIX',
-                        complementaryCertificationBadgeId: 32,
-                      },
-                    ],
                   }),
-                ]);
-
-                // when
-                const certificationEligibility = await getV2UserCertificationEligibility({
-                  userId: 2,
-                  placementProfileService,
-                  certificationBadgesService,
-                  complementaryCertificationCourseRepository,
-                  targetProfileHistoryRepository,
-                });
-
-                // then
-                expect(certificationEligibility.complementaryCertifications).to.deep.equal([
-                  {
-                    label: 'BADGE_LABEL',
-                    imageUrl: 'http://www.image-url.com',
-                    isOutdated: true,
-                    isAcquiredExpectedLevel: false,
-                  },
-                ]);
+                ],
+                attachedAt: new Date('2020-01-01'),
+                detachedAt: new Date('2021-01-01'),
               });
+              const detachedTargetProfileHistory2 = domainBuilder.buildTargetProfileHistoryForAdmin({
+                badges: [
+                  domainBuilder.buildComplementaryCertificationBadgeForAdmin({
+                    id: 3,
+                    complementaryCertificationBadgeId: 34,
+                  }),
+                ],
+                attachedAt: new Date('2021-01-01'),
+                detachedAt: new Date('2022-01-01'),
+              });
+              const attachedTargetProfileHistory = domainBuilder.buildTargetProfileHistoryForAdmin({
+                detachedAt: null,
+                attachedAt: new Date('2024-01-01'),
+                badges: [
+                  domainBuilder.buildComplementaryCertificationBadgeForAdmin({
+                    id: 3,
+                    complementaryCertificationBadgeId: 35,
+                  }),
+                ],
+              });
+
+              targetProfileHistoryRepository.getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId
+                .withArgs({ complementaryCertificationId: 1 })
+                .resolves([attachedTargetProfileHistory]);
+
+              targetProfileHistoryRepository.getDetachedTargetProfilesHistoryByComplementaryCertificationId
+                .withArgs({ complementaryCertificationId: 1 })
+                .resolves([detachedTargetProfileHistory2, detachedTargetProfileHistory1]);
+
+              const placementProfile = { isCertifiable: () => true };
+              placementProfileService.getPlacementProfile
+                .withArgs({ userId: 2, limitDate: now })
+                .resolves(placementProfile);
+
+              const badgeAcquisition = _getOutdatedBadgeAcquisition({ complementaryCertificationBadgeId: 33 });
+
+              certificationBadgesService.findLatestBadgeAcquisitions.resolves([badgeAcquisition]);
+
+              complementaryCertificationCourseRepository.findByUserId.resolves([
+                domainBuilder.certification.enrolment.buildComplementaryCertificationCourseWithResults({
+                  id: 1,
+                  hasExternalJury: false,
+                  complementaryCertificationBadgeId: 33,
+                  results: [
+                    {
+                      id: 3,
+                      acquired: true,
+                      source: 'PIX',
+                      complementaryCertificationBadgeId: 32,
+                    },
+                  ],
+                }),
+              ]);
+
+              // when
+              const certificationEligibility = await getV2UserCertificationEligibility({
+                userId: 2,
+                placementProfileService,
+                certificationBadgesService,
+                complementaryCertificationCourseRepository,
+                targetProfileHistoryRepository,
+              });
+
+              // then
+              expect(certificationEligibility.complementaryCertifications).to.deep.equal([]);
             });
           });
         });

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -26,7 +26,6 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-certification-token-scope-enabled': false,
             'is-new-authentication-design-enabled': false,
             'is-pix1d-enabled': true,
-            'is-pix-plus-lower-lever-enabled': false,
             'is-need-to-adjust-certification-accessibility-enabled': false,
             'is-text-to-speech-button-enabled': false,
             'show-new-campaign-presentation-page': false,


### PR DESCRIPTION
## :fallen_leaf: Problème

La possibilité de scorer au niveau N-1 les certifs Pix+ est en PROD depuis un moment, le FT lié à cette fonctionnalité n’a donc plus de sens d’exister.

## :chestnut: Proposition

Supprimer le FT

## :jack_o_lantern: Remarques

## :wood: Pour tester

Il vous faudra un centre V2...

* Avec un profil candidat, par exemple `perfect-user-profile@example.net`
  * passer une campagne sur une complementaire, je recommande Pix+Edu FI Confirme
  * faire en sorte de pas obtenir le niveau Confirme, mais de valider le N-1
* Creer une session et un candidat sur cette complementaire, et rentrer en session avec le profil precedent
  * Verifier l'affichage du N-1 sur le bandeau d'acces a la Certif
* Entrer en session, repondre et faire en sorte de valider le N-1 mais de ne pas valider le niveau N
 * finaliser et publier 
 * verifier l'obtention sur Pix Admin et Pix App 
