### PR TITLE
[FEATURE] Modifier le ton et la voix des pages d'authentification (PIX-15062)

### DIFF
--- a/mon-pix/app/components/authentication/other-authentication-providers.gjs
+++ b/mon-pix/app/components/authentication/other-authentication-providers.gjs
@@ -16,9 +16,9 @@ export default class OtherAuthenticationProviders extends Component {
     <section class="authentication-other-authentication-providers-section">
       <h2 class="authentication-other-authentication-providers-section__heading">
         {{#if @isForSignup}}
-          {{t "components.authentication.other-authentication-providers.signup-heading"}}
+          {{t "components.authentication.other-authentication-providers.signup.heading"}}
         {{else}}
-          {{t "components.authentication.other-authentication-providers.login-heading"}}
+          {{t "components.authentication.other-authentication-providers.login.heading"}}
         {{/if}}
       </h2>
 
@@ -34,11 +34,18 @@ export default class OtherAuthenticationProviders extends Component {
             alt=""
             class="authentication-other-authentication-providers-section__featured-identity-provider-logo"
           />
-
-          {{t
-            "components.authentication.other-authentication-providers.continue-with-featured-identity-provider-link"
-            featuredIdentityProvider=this.oidcIdentityProviders.featuredIdentityProvider.organizationName
-          }}</PixButtonLink>
+          {{#if @isForSignup}}
+            {{t
+              "components.authentication.other-authentication-providers.signup.signup-with-featured-identity-provider-link"
+              featuredIdentityProvider=this.oidcIdentityProviders.featuredIdentityProvider.organizationName
+            }}
+          {{else}}
+            {{t
+              "components.authentication.other-authentication-providers.login.login-with-featured-identity-provider-link"
+              featuredIdentityProvider=this.oidcIdentityProviders.featuredIdentityProvider.organizationName
+            }}
+          {{/if}}
+        </PixButtonLink>
       {{/if}}
 
       {{#if this.oidcIdentityProviders.hasOtherIdentityProviders}}

--- a/mon-pix/app/components/authentication/signup-form/index.scss
+++ b/mon-pix/app/components/authentication/signup-form/index.scss
@@ -38,7 +38,7 @@
     @extend %pix-body-s;
 
     a {
-      color: var(--pix-neutral-800);
+      color: var(--pix-primary-500);
       font-weight: var(--pix-font-bold);
     }
   }

--- a/mon-pix/tests/integration/components/authentication/other-authentication-providers-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/other-authentication-providers-test.gjs
@@ -18,7 +18,7 @@ module('Integration | Component | Authentication | other-authentication-provider
       assert
         .dom(
           screen.getByRole('heading', {
-            name: t('components.authentication.other-authentication-providers.login-heading'),
+            name: t('components.authentication.other-authentication-providers.login.heading'),
           }),
         )
         .exists();
@@ -34,7 +34,7 @@ module('Integration | Component | Authentication | other-authentication-provider
       assert
         .dom(
           screen.getByRole('heading', {
-            name: t('components.authentication.other-authentication-providers.signup-heading'),
+            name: t('components.authentication.other-authentication-providers.signup.heading'),
           }),
         )
         .exists();
@@ -42,7 +42,8 @@ module('Integration | Component | Authentication | other-authentication-provider
   });
 
   module('when there is a featured identity provider', function () {
-    test('it displays a continue featured identity provider link', async function (assert) {
+    module('when it’s for login');
+    test('it displays a login featured identity provider link', async function (assert) {
       // given
       class OidcIdentityProvidersServiceStub extends Service {
         get featuredIdentityProvider() {
@@ -57,7 +58,32 @@ module('Integration | Component | Authentication | other-authentication-provider
       // then
       const link = await screen.findByRole('link', {
         name: t(
-          'components.authentication.other-authentication-providers.continue-with-featured-identity-provider-link',
+          'components.authentication.other-authentication-providers.login.login-with-featured-identity-provider-link',
+          {
+            featuredIdentityProvider: 'Some Identity Provider',
+          },
+        ),
+      });
+      assert.dom(link).exists();
+      assert.strictEqual(link.getAttribute('href'), '/connexion/some-identity-provider');
+    });
+    module('when it’s for signup');
+    test('it displays a signup featured identity provider link', async function (assert) {
+      // given
+      class OidcIdentityProvidersServiceStub extends Service {
+        get featuredIdentityProvider() {
+          return { organizationName: 'Some Identity Provider', slug: 'some-identity-provider' };
+        }
+      }
+      this.owner.register('service:oidcIdentityProviders', OidcIdentityProvidersServiceStub);
+
+      // when
+      const screen = await render(<template><OtherAuthenticationProviders @isForSignup="true" /></template>);
+
+      // then
+      const link = await screen.findByRole('link', {
+        name: t(
+          'components.authentication.other-authentication-providers.signup.signup-with-featured-identity-provider-link',
           {
             featuredIdentityProvider: 'Some Identity Provider',
           },
@@ -86,7 +112,19 @@ module('Integration | Component | Authentication | other-authentication-provider
         .dom(
           screen.queryByText(
             t(
-              'components.authentication.other-authentication-providers.continue-with-featured-identity-provider-link',
+              'components.authentication.other-authentication-providers.login.login-with-featured-identity-provider-link',
+              {
+                featuredIdentityProvider: 'Some Identity Provider',
+              },
+            ),
+          ),
+        )
+        .doesNotExist();
+      assert
+        .dom(
+          screen.queryByText(
+            t(
+              'components.authentication.other-authentication-providers.signup.signup-with-featured-identity-provider-link',
               {
                 featuredIdentityProvider: 'Some Identity Provider',
               },

--- a/mon-pix/tests/integration/components/authentication/signin-form-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/signin-form-test.gjs
@@ -224,7 +224,7 @@ module('Integration | Component | Authentication | SigninForm', function (hooks)
       await clickByName(t(I18N_KEYS.submitButton));
 
       // then
-      const errorMessage = 'Impossible de se connecter. Merci de réessayer dans quelques instants.';
+      const errorMessage = 'Impossible de se connecter. Veuillez réessayer dans quelques instants.';
       assert.dom(screen.getByText(errorMessage, { exact: false })).exists();
 
       const errorMessageLink = screen.getByRole('link', { name: 'merci de nous contacter' });

--- a/mon-pix/tests/integration/components/authentication/signup-form/index-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/signup-form/index-test.gjs
@@ -256,7 +256,7 @@ module('Integration | Component | Authentication | SignupForm | index', function
       await clickByName(t(I18N_KEYS.submitButton));
 
       // then
-      const errorMessage = 'Impossible de se connecter. Merci de réessayer dans quelques instants.';
+      const errorMessage = 'Impossible de se connecter. Veuillez réessayer dans quelques instants.';
       assert.dom(screen.getByText(errorMessage, { exact: false })).exists();
 
       const errorMessageLink = screen.getByRole('link', { name: 'merci de nous contacter' });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -66,7 +66,7 @@
       "error": "You must agree to the Pix terms of use and personal data protection policy to create an account.",
       "label": "Agree Pix terms of use and personal data protection policy",
       "message": "I agree to the '<'a href=\"{cguUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'Pix terms of use'</a>' and '<'a href=\"{dataProtectionPolicyUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'personal data protection policy'</a>'",
-      "read-message": "Read the '<'a href=\"{cguUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'Pix terms of use'</a>' et la '<'a href=\"{dataProtectionPolicyUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'personal data protection policy'</a>'."
+      "read-message": "Read the '<'a href=\"{cguUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'Pix terms of use'</a>' and the '<'a href=\"{dataProtectionPolicyUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'personal data protection policy'</a>'."
     },
     "companion": {
       "not-detected": {
@@ -148,10 +148,15 @@
         "searchLabel": "Keyword search"
       },
       "other-authentication-providers": {
-        "continue-with-featured-identity-provider-link": "Continue with {featuredIdentityProvider}",
-        "login-heading": "Other ways to log in",
+        "login": {
+          "heading": "Other ways to log in",
+          "login-with-featured-identity-provider-link": "Login with {featuredIdentityProvider}"
+        },
         "select-another-organization-link": "Choose another organisation",
-        "signup-heading": "Other ways to sign up"
+        "signup": {
+          "heading": "Other ways to sign up",
+          "signup-with-featured-identity-provider-link": "Register with {featuredIdentityProvider}"
+        }
       },
       "password-reset-demand-form": {
         "actions": {
@@ -165,7 +170,7 @@
           "email": {
             "error-message-invalid": "Your email address is invalid.",
             "label": "Email address",
-            "placeholder": "ex: john.doe@email.com"
+            "placeholder": "e.g. john.smith@example.com"
           }
         },
         "no-email-question": "No email address?",
@@ -207,17 +212,17 @@
           "email": {
             "error": "Your email address is invalid.",
             "label": "Email address",
-            "placeholder": "ex: john.doe@email.fr"
+            "placeholder": "e.g. john.smith@example.com"
           },
           "firstname": {
             "error": "You have not entered your first name.",
             "label": "First name",
-            "placeholder": "ex: John"
+            "placeholder": "e.g. John"
           },
           "lastname": {
             "error": "You have not entered your last name.",
             "label": "Last name",
-            "placeholder": "ex: Doe"
+            "placeholder": "e.g. Smith"
           },
           "legend": "Information required for sign up."
         }
@@ -446,7 +451,7 @@
     },
     "authentication": {
       "login": {
-        "signup-button": "Sign up to Pix"
+        "signup-button": "Sign up"
       },
       "sso-selection": {
         "signin": {
@@ -457,7 +462,7 @@
           "link": "Sign up",
           "title": "Don't have an account?"
         },
-        "title": "Choose another organization"
+        "title": "Choose your organization"
       }
     },
     "autonomous-course": {
@@ -1411,7 +1416,7 @@
           "cgu": "I agree to the '<a href=\"https://pix.org/en/terms-and-conditions\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\">'terms and conditions of use of the Pix platform'</a>'",
           "email": {
             "error": "Your email address is invalid.",
-            "help": "(eg. name@example.org)",
+            "help": "(e.g. name@example.org)",
             "label": "Email address"
           },
           "firstname": {
@@ -1748,7 +1753,7 @@
         "legend": "Information required for sign in.",
         "login": {
           "label": "Email address or username",
-          "placeholder": "ex: jean.dupont@email.com"
+          "placeholder": "e.g. john.smith@example.com"
         },
         "password": {
           "label": "Password"
@@ -1777,7 +1782,7 @@
     },
     "sign-up": {
       "actions": {
-        "login": "Log in to Pix",
+        "login": "Log in",
         "submit": "Sign up"
       },
       "errors": {
@@ -1787,7 +1792,7 @@
       "fields": {
         "email": {
           "error": "Your email address is invalid.",
-          "help": "(eg. name@example.org)",
+          "help": "(e.g. name@example.org)",
           "label": "Email address"
         },
         "firstname": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -149,10 +149,15 @@
         "searchLabel": "Búsqueda por palabras clave"
       },
       "other-authentication-providers": {
-        "continue-with-featured-identity-provider-link": "Continuar con {featuredIdentityProvider}",
-        "login-heading": "Otros medios de conexión",
+        "login": {
+          "heading": "Otros medios de conexión",
+          "login-with-featured-identity-provider-link": "Continuar con {featuredIdentityProvider}"
+        },
         "select-another-organization-link": "Elegir otra organización",
-        "signup-heading": "Otros medios de registro"
+        "signup": {
+          "heading": "Otros medios de registro",
+          "signup-with-featured-identity-provider-link": "Continuar con {featuredIdentityProvider}"
+        }
       },
       "password-reset-demand-form": {
         "404-message": "Esta dirección de correo electrónico no corresponde a ninguna cuenta",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -56,7 +56,7 @@
       "gateway-timeout-error": "Le service subit des ralentissements. Veuillez réessayer ultérieurement.",
       "internal-server-error": "Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.",
       "login-unauthorized-error": "L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects.",
-      "login-unexpected-error": "Impossible de se connecter. Merci de réessayer dans quelques instants. Si le problème persiste, '<'a href=\"https://pix.fr/support\" target=\"blank\"'>'merci de nous contacter'</a>'.",
+      "login-unexpected-error": "Impossible de se connecter. Veuillez réessayer dans quelques instants. Si le problème persiste, '<'a href=\"https://pix.fr/support\" target=\"blank\"'>'merci de nous contacter'</a>'.",
       "login-user-blocked-error": "Votre compte est bloqué car vous avez effectué trop de tentatives de connexion. Pour le débloquer, '<'a href=\"{url}\"'>'contactez-nous'</a>'.",
       "login-user-temporary-blocked-error": "Vous avez effectué trop de tentatives de connexion. Réessayez plus tard ou cliquez sur '<'a href=\"{url}\"'>'mot de passe oublié'</a>' pour le réinitialiser."
     },
@@ -148,10 +148,15 @@
         "searchLabel": "Recherche par mots-clés"
       },
       "other-authentication-providers": {
-        "continue-with-featured-identity-provider-link": "Continuer avec {featuredIdentityProvider}",
-        "login-heading": "Autres moyens de connexion",
+        "login": {
+          "heading": "Autres moyens de connexion",
+          "login-with-featured-identity-provider-link": "Se connecter avec {featuredIdentityProvider}"
+        },
         "select-another-organization-link": "Choisir une autre organisation",
-        "signup-heading": "Autres moyens d’inscription"
+        "signup": {
+          "heading": "Autres moyens d’inscription",
+          "signup-with-featured-identity-provider-link": "S'inscrire avec {featuredIdentityProvider}"
+        }
       },
       "password-reset-demand-form": {
         "actions": {
@@ -180,7 +185,7 @@
       "password-reset-form": {
         "actions": {
           "login": "Je me connecte",
-          "submit": "Je réinitialise mon mot de passe"
+          "submit": "Réinitialiser mon mot de passe"
         },
         "errors": {
           "expired-demand": "Nous sommes désolés, mais votre demande de réinitialisation de mot de passe a déjà été utilisée ou est expirée. Merci de recommencer.",
@@ -262,7 +267,7 @@
     "footer": {
       "a11y": "Accessibilité : partiellement conforme",
       "data-protection-policy": "Politique de protection des données",
-      "eula": "CGU",
+      "eula": "Conditions Générales d’Utilisation",
       "help-center": "Centre d'aide",
       "label": "Menu de bas de page",
       "legal-notice": "Mentions légales",
@@ -446,7 +451,7 @@
     },
     "authentication": {
       "login": {
-        "signup-button": "S'inscrire sur Pix"
+        "signup-button": "S'inscrire"
       },
       "sso-selection": {
         "signin": {
@@ -457,7 +462,7 @@
           "link": "Inscrivez-vous",
           "title": "Vous n'avez pas de compte ?"
         },
-        "title": "Choisir une autre organisation"
+        "title": "Choisissez votre organisation"
       }
     },
     "autonomous-course": {
@@ -1777,7 +1782,7 @@
     },
     "sign-up": {
       "actions": {
-        "login": "Se connecter sur Pix",
+        "login": "Se connecter",
         "submit": "Je m'inscris"
       },
       "errors": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -149,10 +149,15 @@
         "searchLabel": "Zoeken op trefwoorden"
       },
       "other-authentication-providers": {
-        "continue-with-featured-identity-provider-link": "Doorgaan met {featuredIdentityProvider}",
-        "login-heading": "Andere verbindingsmethoden",
+        "login": {
+          "heading": "Andere verbindingsmethoden",
+          "login-with-featured-identity-provider-link": "Doorgaan met {featuredIdentityProvider}"
+        },
         "select-another-organization-link": "Kies een andere organisatie",
-        "signup-heading": "Andere manieren van registratie"
+        "signup": {
+          "heading": "Andere manieren van registratie",
+          "signup-with-featured-identity-provider-link": "Doorgaan met {featuredIdentityProvider}"
+        }
       },
       "password-reset-demand-form": {
         "404-message": "Dit e-mailadres komt niet overeen met een account",


### PR DESCRIPTION
## :fallen_leaf: Problème
Le ton et la voix des nouvelles mires d'inscription doivent évoluer.

## :chestnut: Proposition
**Les deux mires**

“Choisir une autre organisation” est maintenu sur les pages d'inscription et de connexion MAIS devient “Choisissez votre organisation” en sous titre de la page d'inscription  https://app.dev.pix.fr/inscription/sso-selection ET de la page de connexion https://app.dev.pix.fr/connexion/sso-selection

**Mire de connexion**

- “S’inscrire sur Pix” devient “S’inscrire”

- CGU à écrire au complet dans le footer : “Conditions Générales d’Utilisation”

- Supprimer le double “merci”  dans le message d’erreur 
Avant: “Impossible de se connecter. Merci de réessayer dans quelques instants. Si le problème persiste, merci de nous contacter”
Après: “Impossible de se connecter. Veuillez réessayer dans quelques instants. Si le problème persiste, merci de nous contacter”

- Sur [app.pix.fr](http://app.pix.fr/) : Modifier le wording “Continuer avec France Travail” par “Se connecter avec France Travail”

- Sur [app.pix.org](http://app.pix.org/) : Modifier le wording “Continuer avec Fédération Wallonie-Bruxelles” par “Se connecter avec Fédération Wallonie-Bruxelles”



**Mire d’inscription**

- “Se connecter sur Pix” devient “Se connecter”

- Mettre en bleu les liens URL “conditions d’utilisation” et “politique de confidentialité”

- Sur [app.pix.fr](http://app.pix.fr/) : Modifier le wording “Continuer avec France Travail” par “S’inscrire avec France Travail”

- Sur [app.pix.org](http://app.pix.org/) : Modifier le wording “Continuer avec Fédération Wallonie-Bruxelles” par “S’inscrire avec Fédération Wallonie-Bruxelles”



**Ré-initialisation du mot de passe**

Le bouton “Je réinitialise mon mot de passe” devient “Réinitialiser mon mot de passe”

**corrections de bugs / incorrections antérieures dans le fichier de traduction en anglais**
Corriger “Read the [Pix terms of use](https://pix.org/en/terms-and-conditions) et la [personal data protection policy](https://pix.org/en/personal-data-protection-policy).” en Read the [Pix terms of use](https://pix.org/en/terms-and-conditions) and the [personal data protection policy](https://pix.org/en/personal-data-protection-policy).”

Modifier dans le placeholder e-mail de la version anglophone sur page de connexion, inscription, mot de passe oublié 

ex: en e.g

le placeholder doit être  [john.smith@example.com](mailto:john.smith@example.com)

## :jack_o_lantern: Remarques
ras

## :wood: Pour tester
Reprendre les points ci-dessus
