### PR TITLE
[BUGFIX] Corriger l'affichage de la page Participant External Id (PIX-15141)

### DIFF
--- a/mon-pix/app/components/routes/campaigns/invited/fill-in-participant-external-id.hbs
+++ b/mon-pix/app/components/routes/campaigns/invited/fill-in-participant-external-id.hbs
@@ -1,45 +1,47 @@
 {{! template-lint-disable no-action require-input-label no-unknown-arguments-for-builtin-components }}
-<main
-  class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner fill-in-participant-external-id__container"
-  role="main"
->
-  <h1 class="fill-in-participant-external-id-text fill-in-participant-external-id-text__title">{{t
-      "pages.fill-in-participant-external-id.first-title"
-    }}</h1>
-  <p class="fill-in-participant-external-id-text fill-in-participant-external-id-text__announcement">
-    {{t "pages.fill-in-participant-external-id.announcement"}}
-  </p>
+<main role="main">
+  <PixBackgroundHeader>
+    <PixBlock class="fill-in-participant-external-id">
+      <h1 class="fill-in-participant-external-id__title">{{t "pages.fill-in-participant-external-id.first-title"}}
+      </h1>
+      <p class="fill-in-participant-external-id__announcement">
+        {{t "pages.fill-in-participant-external-id.announcement"}}
+      </p>
 
-  <form {{on "submit" this.submit}} class="fill-in-participant-external-id__form">
-    <PixInput
-      @id="external-id"
-      @value={{this.participantExternalId}}
-      @errorMessage={{this.errorMessage}}
-      @validationStatus={{if this.errorMessage "error"}}
-      @requiredLabel={{true}}
-      {{on "change" this.updateParticipantExternalId}}
-      @subLabel={{this.idPixInputSubLabel}}
-      type={{this.idPixInputType}}
-      aria-autocomplete="none"
-    >
-      <:label>{{@campaign.idPixLabel}}</:label>
-    </PixInput>
+      <form {{on "submit" this.submit}} class="fill-in-participant-external-id__form">
+        <PixInput
+          @id="external-id"
+          @value={{this.participantExternalId}}
+          @errorMessage={{this.errorMessage}}
+          @validationStatus={{if this.errorMessage "error"}}
+          @requiredLabel={{true}}
+          {{on "change" this.updateParticipantExternalId}}
+          @subLabel={{this.idPixInputSubLabel}}
+          type={{this.idPixInputType}}
+          aria-autocomplete="none"
+        >
+          <:label>{{@campaign.idPixLabel}}</:label>
+        </PixInput>
 
-    {{#if @campaign.externalIdHelpImageUrl}}
-      <img
-        class="fill-in-participant-external-id__help"
-        src={{@campaign.externalIdHelpImageUrl}}
-        alt={{@campaign.alternativeTextToExternalIdHelpImage}}
-      />
-    {{/if}}
+        {{#if @campaign.externalIdHelpImageUrl}}
+          <img
+            class="fill-in-participant-external-id__help"
+            src={{@campaign.externalIdHelpImageUrl}}
+            alt={{@campaign.alternativeTextToExternalIdHelpImage}}
+          />
+        {{/if}}
 
-    <div class="fill-in-participant-external-id-form__buttonbar">
-      <PixButton @type="submit" class="fill-in-participant-external-id__button">
-        {{t "pages.fill-in-participant-external-id.buttons.continue"}}
-      </PixButton>
-      <PixButton @variant="secondary" @triggerAction={{this.cancel}} @loadingColor="white">
-        {{t "pages.fill-in-participant-external-id.buttons.cancel"}}
-      </PixButton>
-    </div>
-  </form>
+        <div class="fill-in-participant-external-id__buttonbar">
+          <PixButton @variant="secondary" @triggerAction={{this.cancel}}>
+            {{t "pages.fill-in-participant-external-id.buttons.cancel"}}
+          </PixButton>
+
+          <PixButton @type="submit">
+            {{t "pages.fill-in-participant-external-id.buttons.continue"}}
+          </PixButton>
+        </div>
+      </form>
+    </PixBlock>
+  </PixBackgroundHeader>
+
 </main>

--- a/mon-pix/app/styles/pages/_fill-in-participant-external-id.scss
+++ b/mon-pix/app/styles/pages/_fill-in-participant-external-id.scss
@@ -1,51 +1,41 @@
-.fill-in-participant-external-id__container {
+.fill-in-participant-external-id {
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-bottom: 10px;
-  padding-top: 10px;
-  padding-bottom: 20px;
+  padding: var(--pix-spacing-3x);
 
   @include device-is('tablet') {
-    margin-bottom: 25px;
-    padding-top: 80px;
-    padding-bottom: 40px;
+    margin-bottom: var(--pix-spacing-6x);
+    padding-top: var(--pix-spacing-12x);
+    padding-bottom: var(--pix-spacing-12x);
   }
-}
-
-.fill-in-participant-external-id-text {
-  padding: 5px;
-  font-family: $font-open-sans;
 
   &__title {
-    font-weight: var(--pix-font-bold);
-    font-size: 1.875rem;
-
-    @include device-is('tablet') {
-      font-size: 2rem;
-    }
+    @extend %pix-title-l;
   }
 
   &__announcement {
-    margin-bottom: 40px;
-    font-size: 1.125rem;
+    @extend %pix-body-l;
+
+    margin-bottom: var(--pix-spacing-10x);
   }
-}
 
-.fill-in-participant-external-id__form {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
+  &__form {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    min-width: 30%;
+  }
 
+  &__help {
+    margin-top: var(--pix-spacing-8x);
+  }
 
-.fill-in-participant-external-id__help {
-  margin-top: 32px;
-}
-
-.fill-in-participant-external-id-form__buttonbar {
-  display: flex;
-  flex-direction: row;
-  gap: var(--pix-spacing-2x);
-  margin-top: 50px;
+  &__buttonbar {
+    display: flex;
+    flex-direction: row;
+    gap: var(--pix-spacing-2x);
+    justify-content: space-between;
+    margin-top: var(--pix-spacing-12x);
+  }
 }

--- a/mon-pix/app/templates/campaigns/invited/fill-in-participant-external-id.hbs
+++ b/mon-pix/app/templates/campaigns/invited/fill-in-participant-external-id.hbs
@@ -1,9 +1,7 @@
 {{page-title (t "pages.fill-in-participant-external-id.title")}}
-<div class="background-banner-wrapper">
-  <div class="background-banner"></div>
-  <Routes::Campaigns::Invited::FillInParticipantExternalId
-    @campaign={{@model}}
-    @onSubmit={{this.onSubmitParticipantExternalId}}
-    @onCancel={{this.onCancel}}
-  />
-</div>
+
+<Routes::Campaigns::Invited::FillInParticipantExternalId
+  @campaign={{@model}}
+  @onSubmit={{this.onSubmitParticipantExternalId}}
+  @onCancel={{this.onCancel}}
+/>


### PR DESCRIPTION
## :fallen_leaf: Problème
La page participant external id, n'utilisait pas les design tokens, le bouton valider était à gauche au lieu d'être à droite (sur la page)

## :chestnut: Proposition
les utiliser

## :jack_o_lantern: Remarques
petit revamp avec du css plus simple pour cette page
Utilisation de PixBackgroundHeader qui est là pour ça

## :wood: Pour tester
Est-ce que la page de remplissage de l'externalId nous va comme ça
- PixApp
- Se connecter : admin-orga@example.net
- Saisie du code `PROCOLMUL` 
- voir la page Participant External Id