### PR TITLE
[FEATURE] Créer la page de vérification d'extension Pix Companion (PIX-15113).

### DIFF
--- a/mon-pix/app/components/companion/check.gjs
+++ b/mon-pix/app/components/companion/check.gjs
@@ -1,0 +1,47 @@
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+
+export default class CompanionCheck extends Component {
+  @service intl;
+  @service pixCompanion;
+
+  constructor(...args) {
+    super(...args);
+    this.pixCompanion.checkExtensionIsEnabled();
+  }
+
+  get version() {
+    if (!this.pixCompanion.version) return '';
+    return this.intl.t('common.companion.check.detected.version', { version: this.pixCompanion.version });
+  }
+
+  <template>
+    {{#if this.pixCompanion.hasMinimalVersionForCertification}}
+      <section class="companion-check companion-check--success">
+        <PixIcon @name="checkCircle" @plainIcon={{true}} @ariaHidden={{true}} class="companion-check__icon" />
+        <h1 class="companion-check__title">
+          {{t "common.companion.check.detected.description" version=this.version htmlSafe=true}}
+        </h1>
+      </section>
+    {{else}}
+      <section class="companion-check companion-check--error">
+        <PixIcon @name="cancel" @plainIcon={{true}} @ariaHidden={{true}} class="companion-check__icon" />
+        <h1 class="companion-check__title">
+          {{t "common.companion.check.not-detected.description" htmlSafe=true}}
+        </h1>
+
+        <PixButtonLink
+          @href="https://cloud.pix.fr/s/KocingDC4mFJ3R6"
+          target="_blank"
+          class="companion-check__link"
+          @variant="primary-bis"
+        >
+          {{t "common.companion.check.not-detected.link"}}
+        </PixButtonLink>
+      </section>
+    {{/if}}
+  </template>
+}

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -139,6 +139,8 @@ Router.map(function () {
     this.route('update-sco-record', { path: '/:temporary_key' });
   });
 
+  this.route('companion', { path: '/verification-extension-certification' });
+
   // XXX: this route is used for any request that did not match any of the previous routes. SHOULD ALWAYS BE THE LAST ONE
   this.route('not-found', { path: '/*path' });
 });

--- a/mon-pix/app/routes/companion.js
+++ b/mon-pix/app/routes/companion.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class CompanionRoute extends Route {}

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -33,6 +33,7 @@
 @import 'components/certifications-list-item';
 @import 'components/certifications/certification-ender';
 @import 'components/companion/blocker';
+@import 'components/companion/check';
 @import 'components/congratulations-certification-banner';
 @import 'components/challenge-actions';
 @import 'components/challenge-illustration';

--- a/mon-pix/app/styles/components/companion/check.scss
+++ b/mon-pix/app/styles/components/companion/check.scss
@@ -1,0 +1,31 @@
+.companion-check {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  color: var(--pix-neutral-0);
+  text-align: center;
+
+  &--success {
+    background-color: var(--pix-certif-500);
+  }
+
+  &--error {
+    background-color: var(--pix-error-500);
+  }
+
+  &__icon {
+    width: 6rem;
+    fill: var(--pix-neutral-0);
+  }
+
+  &__title {
+    @extend  %pix-title-m;
+  }
+
+  &__link {
+    margin-top: 2rem;
+  }
+}

--- a/mon-pix/app/templates/companion.hbs
+++ b/mon-pix/app/templates/companion.hbs
@@ -1,0 +1,1 @@
+<Companion::Check />

--- a/mon-pix/tests/integration/components/assessments/assessment-test.gjs
+++ b/mon-pix/tests/integration/components/assessments/assessment-test.gjs
@@ -66,7 +66,7 @@ module('Integration | Component | Assessments | assessments', function (hooks) {
         // then
         assert.dom(screen.getByRole('heading', { name: title })).exists();
         assert
-          .dom(screen.queryByRole('heading', { name: 'L’extension Pix Companion n’est pas détectée' }))
+          .dom(screen.queryByRole('heading', { name: 'L’extension Pix Companionn’est pas détectée' }))
           .doesNotExist();
       });
     });
@@ -100,7 +100,7 @@ module('Integration | Component | Assessments | assessments', function (hooks) {
       // then
       assert.dom(screen.queryByRole('heading', { name: title })).doesNotExist();
       assert
-        .dom(screen.getByRole('heading', { level: 1, name: 'L’extension Pix Companion n’est pas détectée' }))
+        .dom(screen.getByRole('heading', { level: 1, name: 'L’extension Pix Companionn’est pas détectée' }))
         .exists();
     });
 
@@ -132,7 +132,7 @@ module('Integration | Component | Assessments | assessments', function (hooks) {
         // then
         assert.dom(screen.getByRole('heading', { name: title })).exists();
         assert
-          .dom(screen.queryByRole('heading', { name: 'L’extension Pix Companion n’est pas détectée' }))
+          .dom(screen.queryByRole('heading', { name: 'L’extension Pix Companionn’est pas détectée' }))
           .doesNotExist();
       });
     });

--- a/mon-pix/tests/integration/components/certifications/start-test.gjs
+++ b/mon-pix/tests/integration/components/certifications/start-test.gjs
@@ -64,7 +64,7 @@ module('Integration | Component | Certifications | start', function (hooks) {
       .doesNotExist();
 
     assert
-      .dom(screen.queryByRole('heading', { level: 1, name: 'L’extension Pix Companion n’est pas détectée' }))
+      .dom(screen.queryByRole('heading', { level: 1, name: 'L’extension Pix Companionn’est pas détectée' }))
       .exists();
   });
 });

--- a/mon-pix/tests/integration/components/companion/blocker-test.gjs
+++ b/mon-pix/tests/integration/components/companion/blocker-test.gjs
@@ -58,9 +58,7 @@ module('Integration | Component | Companion | blocker', function (hooks) {
 
     // then
     assert.dom(screen.queryByRole('heading', { level: 1, name: 'Companion activé' })).doesNotExist();
-    assert
-      .dom(screen.getByRole('heading', { level: 1, name: 'L’extension Pix Companion n’est pas détectée' }))
-      .exists();
+    assert.dom(screen.getByRole('heading', { level: 1, name: 'L’extension Pix Companionn’est pas détectée' })).exists();
     assert.dom(screen.queryByText(t('common.companion.not-detected.description'))).exists();
     assert
       .dom(screen.getByRole('link', { name: t('common.companion.not-detected.link') }))

--- a/mon-pix/tests/integration/components/companion/check-test.gjs
+++ b/mon-pix/tests/integration/components/companion/check-test.gjs
@@ -1,0 +1,127 @@
+import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import CompanionCheck from 'mon-pix/components/companion/check';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Companion | check', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('when extension is detected', function () {
+    module('when the version is known', function () {
+      module(
+        'when the extension version is equal to or greater than the minimal version for certification session',
+        function () {
+          test('it displays the success page', async function (assert) {
+            // given
+            class PixCompanionStub extends Service {
+              checkExtensionIsEnabled = sinon.stub();
+              version = '0.0.5';
+              hasMinimalVersionForCertification = true;
+            }
+
+            this.owner.register('service:pix-companion', PixCompanionStub);
+
+            // when
+            const screen = await render(<template><CompanionCheck /></template>);
+
+            // then
+            assert
+              .dom(
+                screen.getByRole('heading', {
+                  level: 1,
+                  name: 'Extension Pix Companion (version 0.0.5)installée et activée.',
+                }),
+              )
+              .exists();
+          });
+        },
+      );
+
+      module(
+        'when the current extension version is not at least the minimal version for certification session',
+        function () {
+          test('it displays the error page', async function (assert) {
+            // given
+            class PixCompanionStub extends Service {
+              checkExtensionIsEnabled = sinon.stub();
+              hasMinimalVersionForCertification = false;
+            }
+
+            this.owner.register('service:pix-companion', PixCompanionStub);
+
+            // when
+            const screen = await render(<template><CompanionCheck /></template>);
+
+            // then
+            assert
+              .dom(
+                screen.getByRole('heading', {
+                  level: 1,
+                  name: "Extension Pix Companion non installée/activée ou dans une version obsolète, qui n'est plus supportée pour l'accès en session de certification.",
+                }),
+              )
+              .exists();
+            assert
+              .dom(screen.getByRole('link', { name: 'Accéder à la documentation' }))
+              .hasAttribute('href', 'https://cloud.pix.fr/s/KocingDC4mFJ3R6');
+          });
+        },
+      );
+    });
+
+    module('when the version is unknown', function () {
+      test('it displays the success page', async function (assert) {
+        // given
+        class PixCompanionStub extends Service {
+          checkExtensionIsEnabled = sinon.stub();
+          version = undefined;
+          hasMinimalVersionForCertification = true;
+        }
+
+        this.owner.register('service:pix-companion', PixCompanionStub);
+
+        // when
+        const screen = await render(<template><CompanionCheck /></template>);
+
+        // then
+        assert
+          .dom(
+            screen.getByRole('heading', {
+              level: 1,
+              name: 'Extension Pix Companioninstallée et activée.',
+            }),
+          )
+          .exists();
+      });
+    });
+  });
+
+  module('when extension is not detected', function () {
+    test('it displays the error page', async function (assert) {
+      // given
+      class PixCompanionStub extends Service {
+        checkExtensionIsEnabled = sinon.stub();
+        currentExtensionVersion = null;
+        hasMinimalVersionForCertification = false;
+      }
+
+      this.owner.register('service:pix-companion', PixCompanionStub);
+
+      // when
+      const screen = await render(<template><CompanionCheck /></template>);
+
+      // then
+      assert
+        .dom(
+          screen.getByRole('heading', {
+            level: 1,
+            name: "Extension Pix Companion non installée/activée ou dans une version obsolète, qui n'est plus supportée pour l'accès en session de certification.",
+          }),
+        )
+        .exists();
+    });
+  });
+});

--- a/mon-pix/tests/unit/routes/companion-test.js
+++ b/mon-pix/tests/unit/routes/companion-test.js
@@ -1,0 +1,15 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Route | companion', function (hooks) {
+  setupTest(hooks);
+
+  test('exists', function (assert) {
+    // given
+    // when
+    const route = this.owner.lookup('route:companion');
+
+    // then
+    assert.ok(route);
+  });
+});

--- a/mon-pix/tests/unit/services/pix-companion-test.js
+++ b/mon-pix/tests/unit/services/pix-companion-test.js
@@ -195,7 +195,7 @@ module('Unit | Service | pix-companion', function (hooks) {
 
   module('#isExtensionEnabled', function () {
     module('when the feature toggle isPixCompanionEnabled is false', function () {
-      test('always return true', async function (assert) {
+      test('always returns true', function (assert) {
         // Given
         pixCompanion.featureToggles.featureToggles.isPixCompanionEnabled = false;
 
@@ -204,6 +204,55 @@ module('Unit | Service | pix-companion', function (hooks) {
 
         // Then
         assert.true(pixCompanion.isExtensionEnabled);
+      });
+    });
+  });
+
+  module('#hasMinimalVersionForCertification', function () {
+    module('when extension is not detected', function () {
+      test('returns false', function (assert) {
+        // given
+        pixCompanion._isExtensionEnabled = false;
+        pixCompanion.version = '0.0.1';
+
+        // then
+        assert.false(pixCompanion.hasMinimalVersionForCertification);
+      });
+    });
+
+    module('when extension is detected', function (hooks) {
+      hooks.beforeEach(function () {
+        pixCompanion._isExtensionEnabled = true;
+      });
+
+      module('when version is known and is 0.0.5 or greater', function () {
+        test('returns true', function (assert) {
+          // given
+          pixCompanion.version = '0.0.10';
+
+          // then
+          assert.true(pixCompanion.hasMinimalVersionForCertification);
+        });
+      });
+
+      module('when version is known and is lower than 0.0.5', function () {
+        test('returns false', function (assert) {
+          // given
+          pixCompanion.version = '0.0.4';
+
+          // then
+          assert.false(pixCompanion.hasMinimalVersionForCertification);
+        });
+      });
+
+      module('when version is unknown', function () {
+        test('returns true', function (assert) {
+          // given
+          pixCompanion.version = undefined;
+
+          // then
+          assert.true(pixCompanion.hasMinimalVersionForCertification);
+        });
       });
     });
   });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -69,10 +69,20 @@
       "read-message": "Read the '<'a href=\"{cguUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'Pix terms of use'</a>' and the '<'a href=\"{dataProtectionPolicyUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'personal data protection policy'</a>'."
     },
     "companion": {
+      "check": {
+        "detected": {
+          "description": "Pix Companion extension{version}<br />installed and activated.",
+          "version": " (version {version})"
+        },
+        "not-detected": {
+          "description": "Pix Companion extension not installed/activated or in an obsolete version,<br /> which is no longer supported for certification session access.",
+          "link": "Go to documentation"
+        }
+      },
       "not-detected": {
         "description": " The extension may not be installed or enabled. Read the following documentation in order to resume your certification session.  If necessary ask your invigilator.",
         "link": "Go to documentation",
-        "title": "The Pix Companion extension<br /> is not detected"
+        "title": "The Pix Companion extension<br />is not detected"
       }
     },
     "data-protection-policy-information-banner": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -69,10 +69,20 @@
       "read-message": "Lire les '<'a href=\"{cguUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'conditions d'utilisation'</a>' et la '<'a href=\"{dataProtectionPolicyUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'politique de confidentialité'</a>'."
     },
     "companion": {
+      "check": {
+        "detected": {
+          "description": "Extension Pix Companion{version}<br />installée et activée.",
+          "version": " (version {version})"
+        },
+        "not-detected": {
+          "description": "Extension Pix Companion non installée/activée ou dans une version obsolète,<br /> qui n'est plus supportée pour l'accès en session de certification.",
+          "link": "Accéder à la documentation"
+        }
+      },
       "not-detected": {
         "description": "L’extension n’est peut-être pas installée ou activée. Consultez le document suivant afin de reprendre votre session de certification. Si besoin contactez le surveillant.",
         "link": "Accéder à la documentation",
-        "title": "L’extension Pix Companion<br /> n’est pas détectée"
+        "title": "L’extension Pix Companion<br />n’est pas détectée"
       }
     },
     "data-protection-policy-information-banner": {


### PR DESCRIPTION
## :fallen_leaf: Problème
Les utilisateurs ont besoin de connaître l'état d'installation de l'extension Pix Companion

Selon la présence de l'extension sur le navigateur et de sa version, on affiche une page de "succès" ou "d'erreur"

## :chestnut: Proposition
<img width="1027" alt="Capture d’écran 2024-10-31 à 14 13 33" src="https://github.com/user-attachments/assets/2d5ddb58-45e6-4a8d-9d3c-863d685a1f47">
<img width="1027" alt="Capture d’écran 2024-10-31 à 15 48 32" src="https://github.com/user-attachments/assets/40e7fb25-aa16-4e94-b552-f5f094563d8c">

## :wood: Pour tester

1. Installer l'extension Pix Companion
2. Sur Pix App, aller sur https://app-pr10457.review.pix.fr/verification-extension-certification
3. Constater que la page de succès s'affiche avec la version de l'extension installé sur votre navigateur
4. (Si l'extension était déjà installé avec une version inférieure à 0.0.5 => page d'erreur)
---

1. Désactiver l'extension
2. Constater que la page d'erreur s'affiche avec un bouton permettant d'accéder à la documentation

---

La page ne tient pas compte du featureToggle `FT_PIX_COMPANION_ENABLED`, les utilisateurs doivent pouvoir vérifier l'état de leur extension même si la fonctionnalité est rendu indisponible en production

1. Changer la valeur du feature toggle
3. Constater que la page s'affiche avec les bonnes informations selon l'état de votre extension