### PR TITLE
[BUGFIX] Corriger la couleur de l'icone sur le lien se déconnecter dans PixOrga (PIX-15146)

### DIFF
--- a/orga/app/components/layout/user-logged-menu.hbs
+++ b/orga/app/components/layout/user-logged-menu.hbs
@@ -22,7 +22,7 @@
     </Dropdown::Item>
   {{/each}}
   <Dropdown::ItemLink @linkTo="logout">
-    <PixIcon @name="logout" @class="user-logged-menu__icon" />
+    <PixIcon @name="logout" class="user-logged-menu__icon" />
     {{t "navigation.user-logged-menu.logout"}}
   </Dropdown::ItemLink>
 </Dropdown::Content>

--- a/orga/app/styles/components/dropdown.scss
+++ b/orga/app/styles/components/dropdown.scss
@@ -29,6 +29,9 @@
 
       > a,
       > button {
+        display: flex;
+        gap: var(--pix-spacing-2x);
+        align-items: center;
         width: 100%;
         height: 100%;
         padding: 12px 16px;

--- a/orga/app/styles/components/layout/user-logged-menu.scss
+++ b/orga/app/styles/components/layout/user-logged-menu.scss
@@ -49,7 +49,6 @@
 
     &--up {
       color: var(--pix-primary-500);
-      fill: var(--pix-primary-500);
     }
   }
 }
@@ -62,7 +61,7 @@
   max-width: 100%;
 
   &__icon {
-    margin-right: 8px;
+    fill: currentcolor;
   }
 }
 


### PR DESCRIPTION
## :fallen_leaf: Problème
Le bouton se déconnecter nous est passée sous le nez

## :chestnut: Proposition
Corriger sa couleur et son alignement avec le texte

## :jack_o_lantern: Remarques
RAS

## :wood: Pour tester
Vérifier que le bouton se deconnecter sur le menu dans PixOrga est cohérent avec le reste du menu