### PR TITLE
[TECH] Amélioration et nettoyage des tests du scoring v3.

### DIFF
--- a/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
+++ b/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
@@ -55,8 +55,13 @@ export const handleV3CertificationScoring = async ({
   const allChallenges = await challengeRepository.findFlashCompatibleWithoutLocale({
     useObsoleteChallenges: true,
   });
+
   const certificationChallengesForScoring = await certificationChallengeForScoringRepository.getByCertificationCourseId(
     { certificationCourseId },
+  );
+  const answeredChallenges = await challengeRepository.getMany(
+    certificationChallengesForScoring.map((challengeForScoring) => challengeForScoring.id),
+    locale,
   );
 
   const certificationCourse = await certificationCourseRepository.get({ id: certificationCourseId });
@@ -84,7 +89,7 @@ export const handleV3CertificationScoring = async ({
     // so that in can be used during the assessment result creation
     allAnswers: [...candidateAnswers],
     allChallenges,
-    challenges: certificationChallengesForScoring,
+    challenges: answeredChallenges,
     maxReachableLevelOnCertificationDate: certificationCourse.getMaxReachableLevelOnCertificationDate(),
     v3CertificationScoring,
     scoringDegradationService,

--- a/api/src/certification/scoring/domain/models/CertificationAssessmentHistory.js
+++ b/api/src/certification/scoring/domain/models/CertificationAssessmentHistory.js
@@ -4,6 +4,7 @@ export class CertificationAssessmentHistory {
   constructor({ capacityHistory }) {
     this.capacityHistory = capacityHistory;
   }
+  // WARN: challenges are not Array<Challenge> but Array<CertificationChallengeForScoring>
   static fromChallengesAndAnswers({ algorithm, challenges, allAnswers }) {
     const capacityAndErrorRateHistory = algorithm.getCapacityAndErrorRateHistory({
       allAnswers,

--- a/api/src/shared/infrastructure/repositories/challenge-repository.js
+++ b/api/src/shared/infrastructure/repositories/challenge-repository.js
@@ -36,8 +36,9 @@ const get = async function (id) {
 
 const getMany = async function (ids, locale) {
   try {
-    _assertLocaleIsDefined(locale);
-    const challengeDataObjects = await challengeDatasource.getManyByLocale(ids, locale);
+    const challengeDataObjects = locale
+      ? await challengeDatasource.getManyByLocale(ids, locale)
+      : await challengeDatasource.getMany(ids);
     const skills = await skillDatasource.getMany(challengeDataObjects.map(({ skillId }) => skillId));
     return _toDomainCollection({ challengeDataObjects, skills });
   } catch (error) {

--- a/api/tests/tooling/learning-content-builder/build-learning-content.js
+++ b/api/tests/tooling/learning-content-builder/build-learning-content.js
@@ -38,8 +38,7 @@ const buildLearningContent = function (learningContent) {
                 });
               allTutorials.push(tutorials);
               const challenges =
-                skill.challenges &&
-                skill.challenges.map((challenge) => {
+                skill.challenges?.map((challenge) => {
                   return {
                     id: challenge.id,
                     competenceId: competence.id,
@@ -52,10 +51,10 @@ const buildLearningContent = function (learningContent) {
                     instruction: challenge.instruction,
                     proposals: challenge.proposals,
                     autoReply: challenge.autoReply,
-                    alpha: challenge.alpha,
-                    delta: challenge.delta,
+                    alpha: challenge.alpha ?? challenge.discriminant,
+                    delta: challenge.delta ?? challenge.difficulty,
                   };
-                });
+                }) ?? [];
               allChallenges.push(challenges);
               return {
                 id: skill.id,


### PR DESCRIPTION
## :fallen_leaf: Problème
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Afin de corriger un soucis autour du scoring de session de certification utilisant l'algorithme en version 3, nous avons besoin d'ajouter des tests.
En essayant de le faire on se rend compte que les tests sont compliqués à manipuler : certaines données sont incohérentes, d'autres sont superflues.

## :chestnut: Proposition
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
Avant de corriger le bug du scoring, nous faisons cette PR afin de remettre d'aplomb les tests du fichier `scoring_v3`.

## :jack_o_lantern: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->
On a du également modifié la fonction `getMany` du `challengeRepository` afin  de pouvoir l'appeler sans locale définie (non utile dans le cas du scoring qui se base sur des épreuves via leurs ids).

On en profite pour ajouter de la JSDoc ?

## :wood: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
La CI doit être verte.
