### PR TITLE
[FEATURE] Supprimer le lien de la documentation v3 sur Pix Certif (PIX-15150).

### DIFF
--- a/certif/app/components/layout/sidebar.gjs
+++ b/certif/app/components/layout/sidebar.gjs
@@ -6,15 +6,11 @@ import { t } from 'ember-intl';
 
 const LINK_SCO = 'http://cloud.pix.fr/s/GqwW6dFDDrHezfS';
 const LINK_OTHER = 'http://cloud.pix.fr/s/fLSG4mYCcX7GDRF';
-const LINK_V3_PILOT = 'https://cloud.pix.fr/s/f2PNGLajBypbaiJ';
 
 export default class Sidebar extends Component {
   @service currentUser;
 
   get documentationLink() {
-    if (this.currentUser.currentAllowedCertificationCenterAccess.isV3Pilot) {
-      return LINK_V3_PILOT;
-    }
     if (this.currentUser.currentAllowedCertificationCenterAccess.isScoManagingStudents) {
       return LINK_SCO;
     }

--- a/certif/tests/integration/components/layout/sidebar_test.gjs
+++ b/certif/tests/integration/components/layout/sidebar_test.gjs
@@ -9,7 +9,6 @@ import setupRenderingIntlTest from '../../../helpers/setup-intl-rendering';
 
 const LINK_SCO = 'http://cloud.pix.fr/s/GqwW6dFDDrHezfS';
 const LINK_OTHER = 'http://cloud.pix.fr/s/fLSG4mYCcX7GDRF';
-const LINK_V3_PILOT = 'https://cloud.pix.fr/s/f2PNGLajBypbaiJ';
 
 module('Integration | Component | Layout | Sidebar', function (hooks) {
   setupRenderingIntlTest(hooks);
@@ -91,38 +90,6 @@ module('Integration | Component | Layout | Sidebar', function (hooks) {
       assert
         .dom(screen.getByRole('link', { name: t('navigation.main.documentation') }))
         .hasAttribute('href', LINK_OTHER);
-    });
-
-    test('should return the dedicated link for V3 pilot certification center', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
-        id: '789',
-        name: 'AllowedCenter',
-        type: 'SCO',
-        isRelatedToManagingStudentsOrganization: true,
-        isV3Pilot: true,
-      });
-      certificationPointOfContact = {
-        firstName: 'Alain',
-        lastName: 'Proviste',
-      };
-
-      class CurrentUserStub extends Service {
-        currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
-        certificationPointOfContact = certificationPointOfContact;
-        updateCurrentCertificationCenter = sinon.stub();
-      }
-
-      this.owner.register('service:current-user', CurrentUserStub);
-
-      // when
-      const screen = await render(<template><Sidebar /></template>);
-
-      // then
-      assert
-        .dom(screen.getByRole('link', { name: t('navigation.main.documentation') }))
-        .hasAttribute('href', LINK_V3_PILOT);
     });
 
     test('should return the dedicated link for SCO isManagingStudents certification center', async function (assert) {


### PR DESCRIPTION
## :fallen_leaf: Problème
Dans le cadre de la phase pilote de la nouvelle Certification, une documentation spécifique avait été mise en place pour les centres pilotes (donc pour les centres tagués “pilote certif v3)

La phase pilote étant terminée, ce lien de redirection vers la doc pilote n’est plus pertinent.

## :chestnut: Proposition
Supprimer le lien v3

## :wood: Pour tester

- Se connecter à Pix Certif avec certif-sco-v3@example.net
- cliquer sur le menu, onglet documentation
- constater que l'on tombe sur la doc suivante :  https://cloud.pix.fr/s/GqwW6dFDDrHezfS
- Se connecter avec la certif-pro
- Avoir la doc suivante : https://cloud.pix.fr/s/fLSG4mYCcX7GDRF
