### PR TITLE
[TECH] Corriger un test flaky sur le tri des prescrits d'une organisation (PIX-15165)

### DIFF
--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -557,7 +557,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
         const thirdLearner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
           organizationId,
           firstName: 'Toto',
-          lastName: 'auberto',
+          lastName: 'auberti',
         });
 
         await databaseBuilder.commit();
@@ -565,8 +565,8 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
         const result = await organizationLearnerRepository.findPaginatedLearners({ organizationId });
 
         expect(result.learners).lengthOf(3);
-        expect(result.learners[0].id).to.equal(secondLearner.id);
-        expect(result.learners[1].id).to.equal(thirdLearner.id);
+        expect(result.learners[0].id).to.equal(thirdLearner.id);
+        expect(result.learners[1].id).to.equal(secondLearner.id);
         expect(result.learners[2].id).to.equal(firstLearner.id);
       });
     });


### PR DESCRIPTION
## :fallen_leaf: Problème
On avait un test flaky pour le tri des learners d'une organisation.

## :chestnut: Proposition
Correction du test en question

## :wood: Pour tester
CI au vert
