### PR TITLE
[BUGFIX] Corrige le problème de finalisation de session pour les sessions à cheval sur 2 calibrations (PIX-15005).

### DIFF
--- a/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
+++ b/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
@@ -64,6 +64,7 @@ export const handleV3CertificationScoring = async ({
     locale,
   );
 
+  _restoreCalibrationValues(certificationChallengesForScoring, answeredChallenges);
   const certificationCourse = await certificationCourseRepository.get({ id: certificationCourseId });
 
   const abortReason = certificationCourse.getAbortReason();
@@ -126,6 +127,14 @@ export const handleV3CertificationScoring = async ({
 
   return certificationCourse;
 };
+
+function _restoreCalibrationValues(certificationChallengesForScoring, answeredChallenges) {
+  certificationChallengesForScoring.forEach((certificationChallengeForScoring) => {
+    const answeredChallenge = answeredChallenges.find(({ id }) => id === certificationChallengeForScoring.id);
+    answeredChallenge.discriminant = certificationChallengeForScoring.discriminant;
+    answeredChallenge.difficulty = certificationChallengeForScoring.difficulty;
+  });
+}
 
 function _createV3AssessmentResult({
   allAnswers,

--- a/api/src/certification/scoring/domain/models/CertificationAssessmentHistory.js
+++ b/api/src/certification/scoring/domain/models/CertificationAssessmentHistory.js
@@ -1,10 +1,20 @@
+/**
+ * @typedef {import('../../../flash-certification/domain/models/FlashAssessmentAlgorithm.js').FlashAssessmentAlgorithm} FlashAssessmentAlgorithm
+ * @typedef {import('./CertificationChallengeForScoring.js').CertificationChallengeForScoring} CertificationChallengeForScoring
+ * @typedef {import('../../../../evaluation/domain/models/Answer.js').Answer} Answer
+ */
 import { CertificationChallengeCapacity } from './CertificationChallengeCapacity.js';
 
 export class CertificationAssessmentHistory {
   constructor({ capacityHistory }) {
     this.capacityHistory = capacityHistory;
   }
-  // WARN: challenges are not Array<Challenge> but Array<CertificationChallengeForScoring>
+  /**
+   * @param {Object} params
+   * @param {FlashAssessmentAlgorithm } params.algorithm
+   * @param {Array<CertificationChallengeForScoring>} params.challenges
+   * @param {Array<Answer>} params.allAnswers
+   **/
   static fromChallengesAndAnswers({ algorithm, challenges, allAnswers }) {
     const capacityAndErrorRateHistory = algorithm.getCapacityAndErrorRateHistory({
       allAnswers,

--- a/api/src/certification/scoring/domain/models/CertificationAssessmentScoreV3.js
+++ b/api/src/certification/scoring/domain/models/CertificationAssessmentScoreV3.js
@@ -43,7 +43,13 @@ class CertificationAssessmentScoreV3 {
       allAnswers,
     });
 
-    if (_shouldDowngradeCapacity({ flashAssessmentAlgorithmConfiguration, answers: allAnswers, abortReason })) {
+    if (
+      _shouldDowngradeCapacity({
+        maximumAssessmentLength: flashAssessmentAlgorithmConfiguration.maximumAssessmentLength,
+        answers: allAnswers,
+        abortReason,
+      })
+    ) {
       capacity = scoringDegradationService.downgradeCapacity({
         algorithm,
         capacity,


### PR DESCRIPTION
## :fallen_leaf: Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Lorsqu'un test de certification a été commencé avec une calibration, il n'est pas possible de le finaliser si une nouvelle calibration a exclue certaines épreuves déjà répondues.

## :chestnut: Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

Lors du scoring d'une session de certification, on récupère bien la configuration en vigueur lors du démarrage de la certification.
En revanche, lors de la dégradation - si celle-ci est nécessaire - on se base sur les épreuves cerifiantes au moment de la finalisation.

Si une nouvelle calibration a eu lieu et que celle-ci a exclue des épreuves précédemment répondues, le code lève une erreur car on ne retrouve pas l'épreuve associée à la réponse.
Pour pallier à ce problème, on récupère les épreuves via l'identifiant de la réponse et on leur affecte les valeurs de difficulté et discriminant connues lors du test de certification (ces valeurs sont stockées dans `certification-challenges`).

## :jack_o_lantern: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

On en a profité pour corrigé un appel de fonction qui ne se basait pas sur le bon nom de paramètre.

## :wood: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

Commencer un test de certification
Répondre à au moins 20 épreuves mais moins de 32 épreuves.
Modifier le LCMS de la review app pour forcer les valeurs discriminant et difficulté d'une des épreuves répondues à `null`.
Abandonner le test de certification pour raison candidat.
Finaliser la session de certification.
Vérifier que la finalisation est un succès.
