### PR TITLE
[FEATURE] Bloquer la finalisation de session selon certaines conditions sur Pix Certif (PIX-14717).

### DIFF
--- a/certif/app/controllers/authenticated/sessions/details/parameters.js
+++ b/certif/app/controllers/authenticated/sessions/details/parameters.js
@@ -19,6 +19,13 @@ export default class SessionParametersController extends Controller {
     return this.certificationCandidates.some(({ isLinked }) => isLinked);
   }
 
+  get isSessionFinalizationTemporarilyBlocked() {
+    return (
+      this.certificationCandidates.some((candidate) => candidate.hasOnlyComplementarySubscription) &&
+      this.sessionManagement.version === 3
+    );
+  }
+
   @action
   async showSessionIdTooltip() {
     await navigator.clipboard.writeText(this.session.id);

--- a/certif/app/models/certification-candidate.js
+++ b/certif/app/models/certification-candidate.js
@@ -58,4 +58,10 @@ export default class CertificationCandidate extends Model {
     const hasCleaSubscription = this.subscriptions.some((sub) => sub.isClea(centerHabilitations));
     return hasCoreSubscription && hasCleaSubscription;
   }
+
+  get hasOnlyComplementarySubscription() {
+    const hasCoreSubscription = this.subscriptions.some((sub) => sub.isCore);
+    const hasComplementarySubscription = this.subscriptions.some((sub) => sub.isComplementary);
+    return !hasCoreSubscription && hasComplementarySubscription;
+  }
 }

--- a/certif/app/models/subscription.js
+++ b/certif/app/models/subscription.js
@@ -17,6 +17,10 @@ export default class SubscriptionModel extends Model {
     return this.type === SUBSCRIPTION_TYPES.CORE;
   }
 
+  get isComplementary() {
+    return this.type === SUBSCRIPTION_TYPES.COMPLEMENTARY;
+  }
+
   isClea(centerHabilitations) {
     const matchingHabilitation = centerHabilitations.find(
       (habilitation) => habilitation.id === this.complementaryCertificationId,

--- a/certif/app/templates/authenticated/sessions/details/parameters.hbs
+++ b/certif/app/templates/authenticated/sessions/details/parameters.hbs
@@ -121,10 +121,14 @@
   </div>
 
   <div class="session-details-buttons">
+    <PixButtonLink
+      @route="authenticated.sessions.update"
+      @model={{this.session.id}}
+      aria-label={{t "pages.sessions.detail.parameters.actions.update" sessionId=this.session.id}}
+    >
+      {{t "common.actions.update"}}
+    </PixButtonLink>
     {{#if this.sessionHasStarted}}
-      <PixButtonLink @route="authenticated.sessions.update" @model={{this.session.id}}>
-        {{t "common.actions.update"}}
-      </PixButtonLink>
       {{#if this.sessionManagement.isFinalized}}
         <p class="session-details-row__session-finalized-warning">
           {{t "pages.sessions.detail.parameters.finalization-info"}}
@@ -134,14 +138,6 @@
           {{t "pages.sessions.detail.parameters.actions.finalizing"}}
         </PixButtonLink>
       {{/if}}
-    {{else}}
-      <PixButtonLink
-        @route="authenticated.sessions.update"
-        @model={{this.session.id}}
-        aria-label={{t "pages.sessions.detail.parameters.actions.update" sessionId=this.session.id}}
-      >
-        {{t "common.actions.update"}}
-      </PixButtonLink>
     {{/if}}
   </div>
 

--- a/certif/app/templates/authenticated/sessions/details/parameters.hbs
+++ b/certif/app/templates/authenticated/sessions/details/parameters.hbs
@@ -129,14 +129,20 @@
       {{t "common.actions.update"}}
     </PixButtonLink>
     {{#if this.sessionHasStarted}}
-      {{#if this.sessionManagement.isFinalized}}
+      {{#if this.isSessionFinalizationTemporarilyBlocked}}
         <p class="session-details-row__session-finalized-warning">
-          {{t "pages.sessions.detail.parameters.finalization-info"}}
+          {{t "pages.sessions.detail.parameters.finalization.temporarily-blocked"}}
         </p>
       {{else}}
-        <PixButtonLink @route="authenticated.sessions.finalize" @model={{this.session.id}} class="push-right">
-          {{t "pages.sessions.detail.parameters.actions.finalizing"}}
-        </PixButtonLink>
+        {{#if this.sessionManagement.isFinalized}}
+          <p class="session-details-row__session-finalized-warning">
+            {{t "pages.sessions.detail.parameters.finalization-info"}}
+          </p>
+        {{else}}
+          <PixButtonLink @route="authenticated.sessions.finalize" @model={{this.session.id}} class="push-right">
+            {{t "pages.sessions.detail.parameters.actions.finalizing"}}
+          </PixButtonLink>
+        {{/if}}
       {{/if}}
     {{/if}}
   </div>

--- a/certif/tests/acceptance/session-details-parameters-test.js
+++ b/certif/tests/acceptance/session-details-parameters-test.js
@@ -4,6 +4,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIntl } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { CREATED, FINALIZED } from 'pix-certif/models/session-management';
+import { SUBSCRIPTION_TYPES } from 'pix-certif/models/subscription';
 import { module, test } from 'qunit';
 
 import { authenticateSession } from '../helpers/test-init';
@@ -83,6 +84,64 @@ module('Acceptance | Session Details Parameters', function (hooks) {
         assert
           .dom(screen.getByRole('button', { name: 'Copier le mot de passe de session pour le surveillant' }))
           .exists();
+      });
+
+      module('when the session version is 3 and candidates have been enrolled for a complementary course', function () {
+        test('it should temporarily block the finalise button', async function (assert) {
+          // given
+          const allowedCertificationCenterAccess = server.create('allowed-certification-center-access', {
+            isAccessBlockedCollege: false,
+            isAccessBlockedLycee: false,
+            isAccessBlockedAEFE: false,
+            isAccessBlockedAgri: false,
+            isV3Pilot: true,
+            habilitations: [
+              {
+                id: 123,
+                label: 'Pix+Droit',
+              },
+            ],
+          });
+          certificationPointOfContact = server.create('certification-point-of-contact', {
+            firstName: 'Buffy',
+            lastName: 'Summers',
+            allowedCertificationCenterAccesses: [allowedCertificationCenterAccess],
+            pixCertifTermsOfServiceAccepted: true,
+          });
+          await authenticateSession(certificationPointOfContact.id);
+          const sessionCreated = server.create('session-enrolment', {
+            id: 123,
+            status: CREATED,
+            certificationCenterId: allowedCertificationCenterAccess.id,
+          });
+          const complementarySubscription = server.create('subscription', {
+            type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
+            complementaryCertificationId: 123,
+          });
+          server.create('certification-candidate', {
+            isLinked: true,
+            subscriptions: [complementarySubscription],
+            sessionId: sessionCreated.id,
+          });
+          server.create('session-management', {
+            id: sessionCreated.id,
+            status: CREATED,
+            version: 3,
+          });
+
+          // when
+          const screen = await visit(`/sessions/${sessionCreated.id}`);
+
+          // then
+          assert.dom(screen.queryByRole('button', { name: 'Finaliser la session' })).doesNotExist();
+          assert
+            .dom(
+              screen.getByText(
+                'Cette session ne peut pas être finalisée pour le moment. Les équipes de Pix travaillent au déblocage de la finalisation.',
+              ),
+            )
+            .exists();
+        });
       });
 
       module('when the session is not finalized', function () {

--- a/certif/tests/unit/models/certification-candidate-test.js
+++ b/certif/tests/unit/models/certification-candidate-test.js
@@ -222,6 +222,80 @@ module('Unit | Model | certification-candidate', function (hooks) {
     });
   });
 
+  module('#get hasOnlyComplementarySubscription', function () {
+    module('when candidate has only one complementary subscription', function () {
+      test('should return true', function (assert) {
+        // given
+        // when
+        const store = this.owner.lookup('service:store');
+        const habilitations = [
+          {
+            id: 123,
+            label: 'Certif Pix+Droit',
+            key: 'DROIT',
+          },
+        ];
+        const complementarySubscription = store.createRecord('subscription', {
+          type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
+          complementaryCertificationId: habilitations[0].id,
+        });
+        const candidate = store.createRecord('certification-candidate', {
+          subscriptions: [complementarySubscription],
+        });
+
+        // then
+        assert.true(candidate.hasOnlyComplementarySubscription);
+      });
+    });
+
+    module('when candidate has a core subscription', function () {
+      test('should return false', function (assert) {
+        // given
+        // when
+        const store = this.owner.lookup('service:store');
+        const coreSubscription = store.createRecord('subscription', {
+          type: SUBSCRIPTION_TYPES.CORE,
+          complementaryCertificationId: null,
+        });
+        const candidate = store.createRecord('certification-candidate', {
+          subscriptions: [coreSubscription],
+        });
+
+        // then
+        assert.false(candidate.hasOnlyComplementarySubscription);
+      });
+    });
+
+    module('when candidate has a clea subscription', function () {
+      test('should return false', function (assert) {
+        // given
+        // when
+        const habilitations = [
+          {
+            id: 123,
+            label: 'Certif CLEA',
+            key: COMPLEMENTARY_KEYS.CLEA,
+          },
+        ];
+        const store = this.owner.lookup('service:store');
+        const coreSubscription = store.createRecord('subscription', {
+          type: SUBSCRIPTION_TYPES.CORE,
+          complementaryCertificationId: null,
+        });
+        const cleaSubscription = store.createRecord('subscription', {
+          type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
+          complementaryCertificationId: habilitations[0].id,
+        });
+        const candidate = store.createRecord('certification-candidate', {
+          subscriptions: [coreSubscription, cleaSubscription],
+        });
+
+        // then
+        assert.false(candidate.hasOnlyComplementarySubscription);
+      });
+    });
+  });
+
   function _pickModelData(certificationCandidate) {
     return pick(certificationCandidate, [
       'firstName',

--- a/certif/tests/unit/models/subscription-test.js
+++ b/certif/tests/unit/models/subscription-test.js
@@ -109,4 +109,47 @@ module('Unit | Model | subscription', function (hooks) {
       assert.false(isCore);
     });
   });
+
+  module('get isComplementary', function () {
+    module('when subscription is COMPLEMENTARY', function () {
+      test('it should return true', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const habilitations = [
+          {
+            id: 123,
+            label: 'Pix+Droit',
+            key: 'DROIT',
+          },
+        ];
+        const complementarySubscription = store.createRecord('subscription', {
+          type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
+          complementaryCertificationId: habilitations[0].id,
+        });
+
+        // when
+        const isComplementary = complementarySubscription.isComplementary;
+
+        // then
+        assert.true(isComplementary);
+      });
+    });
+
+    module('when subscription is not COMPLEMENTARY', function () {
+      test('it should return false', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const coreSubscription = store.createRecord('subscription', {
+          type: SUBSCRIPTION_TYPES.CORE,
+          complementaryCertificationId: null,
+        });
+
+        // when
+        const isComplementary = coreSubscription.isComplementary;
+
+        // then
+        assert.false(isComplementary);
+      });
+    });
+  });
 });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -702,6 +702,9 @@
             "finalizing": "Finalise the session",
             "update": "Edit the details for session {sessionId}"
           },
+          "finalization": {
+            "temporarily-blocked": "This session cannot be finalised at the moment. The Pix teams are working to unblock the finalization."
+          },
           "finalization-info": "The finalisation information for the session has already been transmitted to Pix.",
           "password": {
             "copy-password": "Copy the invigilator’s session password",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -702,6 +702,9 @@
             "finalizing": "Finaliser la session",
             "update": "Modifier les informations de la session {sessionId}"
           },
+          "finalization": {
+            "temporarily-blocked": "Cette session ne peut pas être finalisée pour le moment. Les équipes de Pix travaillent au déblocage de la finalisation."
+          },
           "finalization-info": "Les informations de finalisation de la session ont déjà été transmises aux équipes de Pix.",
           "password": {
             "copy-password": "Copier le mot de passe de session pour le surveillant",


### PR DESCRIPTION
## :fallen_leaf: Problème
Dans le cadre du sujet “Compatibilité Pix v3/Pix+”, un candidat doit pouvoir passer un test de certification Pix+ seul. Néanmoins l’implémentation du scoring du Pix+ seul a été décalé dans le temps et la finalisation de session dans ce cas de figure ne peut être réalisée.

## :chestnut: Proposition
Ne pas afficher le bouton de finalisation de session dans le cas suivant : 

- La session est V3 
- Au moins 1 candidat a été inscrit à une Pix+ seul

## :jack_o_lantern: Remarques
Dans le premier commit, je fait un mini refacto en supprimant un bouton de modification de session.

Une autre PR est prévue pour la partie API

## :wood: Pour tester

Vérifier le détail d'une session V2 (Non régression)
- Tout juste créé avec un candidat inscrit => bouton modifier uniquement
- Crée avec un candidat entré en session => bouton modifier et bouton finaliser
- Finalisé => bouton modifier et message de finalisation

Vérifier le détail d'une session V3 (sans certif complémentaire) (Non régression)
- Tout juste créé avec un candidat inscrit  => bouton modifier uniquement
- Crée avec un candidat entré en session => bouton modifier et bouton finaliser
- Finalisé => bouton modifier et message de finalisation

Vérifier le détail d'une session V3 (avec Pix+ seul)
- Tout juste créé avec un candidat inscrit (pix+ seul)  => bouton modifier uniquement
- https://certif-pr10473.review.pix.fr/sessions/7407 => bouton modifier et **message de blocage**
