### PR TITLE
[FEATURE] Supprimer les colonnes "Identifiant externe" et "tarification part Pix" de la liste des candidats Pix Certif (PIX-15160).

### DIFF
--- a/certif/app/components/sessions/session-details/enrolled-candidates/index.gjs
+++ b/certif/app/components/sessions/session-details/enrolled-candidates/index.gjs
@@ -375,22 +375,12 @@ export default class EnrolledCandidates extends Component {
                     {{t 'common.forms.certification-labels.email-results'}}
                   </th>
                 {{/unless}}
-                {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
-                  <th class='certification-candidates-table__external-id'>
-                    {{t 'common.forms.certification-labels.external-id'}}
-                  </th>
-                {{/unless}}
                 <th class='certification-candidates-table__column-time'>
                   {{t 'common.forms.certification-labels.extratime'}}
                 </th>
                 {{#if this.shouldDisplayAccessibilityAdjustmentNeededFeature}}
                   <th class='certification-candidates-table__column-accessibility'>
                     {{t 'common.forms.certification-labels.accessibility'}}
-                  </th>
-                {{/if}}
-                {{#if @shouldDisplayPaymentOptions}}
-                  <th class='certification-candidates-table__payment-options'>
-                    {{t 'common.forms.certification-labels.pricing'}}
                   </th>
                 {{/if}}
                 <th>
@@ -428,17 +418,9 @@ export default class EnrolledCandidates extends Component {
                   {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
                     <td>{{candidate.resultRecipientEmail}}</td>
                   {{/unless}}
-                  {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
-                    <td>{{candidate.externalId}}</td>
-                  {{/unless}}
                   <td>{{this.formattedCandidateExtratimePercentage candidate.extraTimePercentage}}</td>
                   {{#if this.shouldDisplayAccessibilityAdjustmentNeededFeature}}
                     <td>{{candidate.accessibilityAdjustmentNeededLabel}}</td>
-                  {{/if}}
-                  {{#if @shouldDisplayPaymentOptions}}
-                    <td>{{candidate.billingModeLabel}}
-                      {{candidate.prepaymentCode}}
-                    </td>
                   {{/if}}
 
                   <td>

--- a/certif/tests/acceptance/session-details-certification-candidates-test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates-test.js
@@ -176,10 +176,14 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
         assert
           .dom(within(rows[1]).getByRole('cell', { name: dayjs.self('10-10-2000', 'YYYY-MM-DD').format('DD/MM/YYYY') }))
           .exists();
-        assert.dom(within(rows[1]).getByRole('cell', { name: 'EXTERNAL-ID' })).exists();
         assert.dom(within(rows[1]).getByRole('cell', { name: '30 %' })).exists();
         assert.dom(within(rows[1]).getByRole('cell', { name: 'Certification Pix' })).exists();
         assert.dom(within(rows[2]).getByRole('cell', { name: 'Pix+Droit' })).exists();
+
+        await click(screen.getByRole('button', { name: 'Voir le détail du candidat Alin Cendy' }));
+
+        const modal = await screen.findByRole('dialog');
+        assert.dom(within(modal).getByText('EXTERNAL-ID')).exists();
       });
 
       module(
@@ -630,7 +634,6 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
             assert.dom(within(rows[1]).getByRole('cell', { name: 'Threepwood' })).exists();
             assert.dom(within(rows[1]).getByRole('cell', { name: '28/04/2019' })).exists();
             assert.dom(within(rows[1]).getByRole('cell', { name: '20 %' })).exists();
-            assert.dom(within(rows[1]).getByRole('cell', { name: 'Gratuite' })).exists();
             assert.dom(within(rows[1]).getByRole('cell', { name: 'email.destinataire@example.net' })).exists();
           });
 
@@ -663,9 +666,11 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
               await click(screen.getByRole('button', { name: 'Inscrire le candidat' }));
 
               // then
-              const table = screen.getByRole('table');
-              const rows = await within(table).findAllByRole('row');
-              assert.dom(within(rows[1]).getByRole('cell', { name: 'Prépayée 12345' })).exists();
+              await click(screen.getByRole('button', { name: 'Voir le détail du candidat Guybrush Threepwood' }));
+
+              const modal = await screen.findByRole('dialog');
+              assert.dom(within(modal).getByText('Prépayée')).exists();
+              assert.dom(within(modal).getByText('12345')).exists();
             });
           });
         });

--- a/certif/tests/integration/components/sessions/session-details/enrolled-candidates/index-test.gjs
+++ b/certif/tests/integration/components/sessions/session-details/enrolled-candidates/index-test.gjs
@@ -108,7 +108,6 @@ module('Integration | Component | Sessions | SessionDetails | EnrolledCandidates
 
     // then
     assert.dom(screen.queryByRole('columnheader', { name: 'Accessibilité' })).doesNotExist();
-    assert.dom(screen.getByRole('cell', { name: certificationCandidates[0].externalId })).exists();
     assert.dom(screen.getByRole('cell', { name: certificationCandidates[0].lastName })).exists();
     assert.dom(screen.getByRole('cell', { name: certificationCandidates[0].firstName })).exists();
     assert.dom(screen.getByRole('cell', { name: certificationCandidates[0].resultRecipientEmail })).exists();
@@ -450,36 +449,6 @@ module('Integration | Component | Sessions | SessionDetails | EnrolledCandidates
     });
   });
 
-  module('when certification center is not SCO', function () {
-    test('it displays candidate billing information', async function (assert) {
-      // given
-      const candidate = _buildCertificationCandidate({
-        billingMode: 'PREPAID',
-        prepaymentCode: 'CODE01',
-        subscriptions: [],
-      });
-
-      const certificationCandidates = [store.createRecord('certification-candidate', candidate)];
-      const countries = [store.createRecord('country', { name: 'CANADA', code: 99401 })];
-
-      // when
-      const screen = await render(
-        <template>
-          <EnrolledCandidates
-            @sessionId='1'
-            @certificationCandidates={{certificationCandidates}}
-            @shouldDisplayPaymentOptions={{true}}
-            @countries={{countries}}
-          />
-        </template>,
-      );
-
-      // then
-      assert.dom(screen.queryByRole('columnheader', { name: 'Tarification part Pix' })).exists();
-      assert.dom(screen.getByRole('cell', { name: 'Prépayée CODE01' })).exists();
-    });
-  });
-
   module('when prescription SCO is allowed', function () {
     test('it should display button to add multiple candidates', async function (assert) {
       // given
@@ -552,7 +521,7 @@ module('Integration | Component | Sessions | SessionDetails | EnrolledCandidates
       assert.dom(screen.getByRole('button', { name: 'Inscrire un candidat' })).isVisible();
     });
 
-    test('it shows externalId and email columns', async function (assert) {
+    test('it shows email columns', async function (assert) {
       // given
       const candidate = _buildCertificationCandidate({
         subscriptions: [],
@@ -573,7 +542,6 @@ module('Integration | Component | Sessions | SessionDetails | EnrolledCandidates
       );
 
       // then
-      assert.dom(screen.getByRole('cell', { name: candidate.externalId })).exists();
       assert.dom(screen.getByRole('cell', { name: candidate.resultRecipientEmail })).exists();
     });
   });


### PR DESCRIPTION
## :fallen_leaf: Problème
Dans le cadre de la nouvelle Certification Pix, un champ “Accessibilité” a été ajouté dans la liste des sessions dans Pix Certif.
Cet ajout impacte le tableau où les champs se superposent.

## :chestnut: Proposition
Supprimer les colonnes les colonnes "Identifiant externe" et "tarification part Pix",  jugées non prio (ces colonnes sont toujours visible dans la modale de détails de candidat)

## :wood: Pour tester
Se connecter sur certif-pro@example.net sur Certif
Aller sur une session
Aller dans l'onglet candidat


https://github.com/user-attachments/assets/9745e3f8-e634-47a4-b4a1-b691529c4511


