### PR TITLE
[BUGFIX] Positionner à gauche le logo sur la page de code école de Pix Junior

### DIFF
--- a/junior/app/components/issue.gjs
+++ b/junior/app/components/issue.gjs
@@ -58,6 +58,6 @@ export default class Issue extends Component {
         >{{t "pages.error.backHome"}}</PixButton>
       </div>
     </div>
-    <img src="/images/logo.svg" alt="Pix Junior" class="logo" />
+    <img src="/images/logo.svg" alt="Pix Junior" class="issue-logo" />
   </template>
 }

--- a/junior/app/styles/components/issue.scss
+++ b/junior/app/styles/components/issue.scss
@@ -53,11 +53,10 @@
   }
 }
 
-.logo {
+.issue-logo {
   position: absolute;
   bottom: 15px;
   align-self: center;
   width: 129px;
   height: 80px;
 }
-


### PR DESCRIPTION
## :fallen_leaf: Problème
Le logo sur la page de code école est centré au lieu d'être positionné à gauche sous le code.

## :chestnut: Proposition
Repositionner le logo à la place voulue.

## :jack_o_lantern: Remarques
Il s'agit d'une régression suite au changement de gestion de l'erreur sur un code incorrect. Le composant affichant l'erreur est maintenant dans la page de code école et partage le même CSS.

## :wood: Pour tester
Accéder à la page par défaut de Pix Junior.
--> Le logo est bien positionné à gauche sous le code.
Saisir une code école erroné.
--> Le logo s'affiche bien en bas, centré sur l'écran d'erreur.