### PR TITLE
[TECH] Logger et prévenir le crash de container lorsque la création de release est en échec

### DIFF
--- a/api/src/shared/infrastructure/lcms.js
+++ b/api/src/shared/infrastructure/lcms.js
@@ -35,6 +35,12 @@ const createRelease = async function () {
     url: lcmsConfig.url + '/releases',
     headers: { Authorization: `Bearer ${lcmsConfig.apiKey}` },
   });
+
+  if (!response.isSuccessful) {
+    logger.error(`An error occurred while creating a release on ${lcmsConfig.url}: ${JSON.stringify(response)}`);
+    throw new Error(`An error occurred while creating a release on ${lcmsConfig.url}`);
+  }
+
   return response.data.content;
 };
 

--- a/api/tests/shared/unit/infrastructure/lcms_test.js
+++ b/api/tests/shared/unit/infrastructure/lcms_test.js
@@ -77,5 +77,19 @@ describe('Unit | Infrastructure | LCMS', function () {
       // then
       expect(response).to.deep.equal(learningContent);
     });
+
+    it('throws when LCMS Api response is not successful', async function () {
+      // given
+      nock('https://lcms-test.pix.fr/api')
+        .post('/releases')
+        .matchHeader('Authorization', 'Bearer test-api-key')
+        .reply(403);
+
+      // when
+      const error = await catchErr(lcms.createRelease)();
+
+      // then
+      expect(error.message).to.deep.equal('An error occurred while creating a release on https://lcms-test.pix.fr/api');
+    });
   });
 });


### PR DESCRIPTION
## :fallen_leaf: Problème
Lors d'une erreur retournée par l'API sur la route de création de releases, elle n'était pas retenue par l'API pix et le usecase continuait son chemin tranquillement

## :chestnut: Proposition
Catcher l'erreur et logger et sortir

## :jack_o_lantern: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :wood: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
