### PR TITLE
[TECH] Filtrer sur les organizations ayant la feature places management pour la remontée des statistiques de places pour l'API pix-data (PIX-15155)

### DIFF
--- a/api/src/prescription/organization-place/domain/usecases/get-data-organizations-places-statistics.js
+++ b/api/src/prescription/organization-place/domain/usecases/get-data-organizations-places-statistics.js
@@ -7,7 +7,7 @@ const getDataOrganizationsPlacesStatistics = withTransaction(async function ({
   organizationPlacesLotRepository,
   organizationLearnerRepository,
 }) {
-  const organizationWithPlaces = await organizationRepository.getOrganizationsWithPlaces();
+  const organizationWithPlaces = await organizationRepository.getOrganizationsWithPlacesManagementFeatureEnabled();
 
   const organizationWithPlacesIds = organizationWithPlaces.map((organization) => organization.id);
 

--- a/api/tests/prescription/organization-place/integration/domain/usecases/get-data-organizations-places-statistics_test.js
+++ b/api/tests/prescription/organization-place/integration/domain/usecases/get-data-organizations-places-statistics_test.js
@@ -1,6 +1,7 @@
 import * as organizationLearnerRepository from '../../../../../../lib/infrastructure/repositories/organization-learner-repository.js';
 import { getDataOrganizationsPlacesStatistics } from '../../../../../../src/prescription/organization-place/domain/usecases/get-data-organizations-places-statistics.js';
 import * as organizationPlacesLotRepository from '../../../../../../src/prescription/organization-place/infrastructure/repositories/organization-places-lot-repository.js';
+import { ORGANIZATION_FEATURE } from '../../../../../../src/shared/domain/constants.js';
 import * as organizationRepository from '../../../../../../src/shared/infrastructure/repositories/organization-repository.js';
 import { databaseBuilder, expect, sinon } from '../../../../../test-helper.js';
 
@@ -23,6 +24,14 @@ describe('Integration | UseCases | get-data-organizations-places-statistics', fu
       name: 'Mon collège',
       type: 'SCO',
     });
+    const placesManagementFeatureId = databaseBuilder.factory.buildFeature({
+      key: ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key,
+    }).id;
+    databaseBuilder.factory.buildOrganizationFeature({
+      organizationId: firstOrganization.id,
+      featureId: placesManagementFeatureId,
+    });
+
     const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({
       organizationId: firstOrganization.id,
     }).id;
@@ -41,6 +50,12 @@ describe('Integration | UseCases | get-data-organizations-places-statistics', fu
       activationDate: new Date('2021-04-01'),
       expirationDate: new Date('2021-05-15'),
     });
+
+    databaseBuilder.factory.buildOrganizationFeature({
+      organizationId: secondOrganization.id,
+      featureId: placesManagementFeatureId,
+    });
+
     await databaseBuilder.commit();
 
     // when


### PR DESCRIPTION
## :fallen_leaf: Problème
Actuellement on filtre les organisations qui ont au moins un lot de places. Aprés discussions avec le produit et les utilisateurs du board associé, on préfère filtrer sur les organisations qui ont la feature de places activée

## :chestnut: Proposition
Faire une jointure sur les organisations ayant la feature activée

## :jack_o_lantern: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :wood: Pour tester
Tests ok ? 