### PR TITLE
[TECH] Réduire la latence lors de scale massif de containers ou de mise en production en chargeant le référentiel et en initialisant la connexion à la base de données avant de démarrer l'API

### DIFF
--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -118,4 +118,9 @@ async function emptyAllTables() {
   return configuredKnex.raw(`${query}${tables}`);
 }
 
-export { disconnect, emptyAllTables, configuredKnex as knex };
+async function prepareDatabaseConnection() {
+  await configuredKnex.raw('SELECT 1');
+  logger.info('Connection to database established.');
+}
+
+export { disconnect, emptyAllTables, configuredKnex as knex, prepareDatabaseConnection };

--- a/api/index.js
+++ b/api/index.js
@@ -6,6 +6,7 @@ validateEnvironmentVariables();
 
 import { disconnect, prepareDatabaseConnection } from './db/knex-database-connection.js';
 import { createServer } from './server.js';
+import { config } from './src/shared/config.js';
 import { learningContentCache } from './src/shared/infrastructure/caches/learning-content-cache.js';
 import { initLearningContent } from './src/shared/infrastructure/datasources/learning-content/datasource.js';
 import { temporaryStorage } from './src/shared/infrastructure/temporary-storage/index.js';
@@ -30,7 +31,9 @@ async function _setupEcosystem() {
 }
 
 const start = async function () {
-  await _setupEcosystem();
+  if (config.featureToggles.setupEcosystemBeforeStart) {
+    await _setupEcosystem();
+  }
   server = await createServer();
   await server.start();
 };

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -214,6 +214,7 @@ const configuration = (function () {
       isQuestEnabled: toBoolean(process.env.FT_ENABLE_QUESTS),
       isTextToSpeechButtonEnabled: toBoolean(process.env.FT_ENABLE_TEXT_TO_SPEECH_BUTTON),
       isV3EligibilityCheckEnabled: toBoolean(process.env.FT_ENABLE_V3_ELIGIBILITY_CHECK),
+      setupEcosystemBeforeStart: toBoolean(process.env.FT_SETUP_ECOSYSTEM_BEFORE_START) || false,
       showExperimentalMissions: toBoolean(process.env.FT_SHOW_EXPERIMENTAL_MISSIONS),
       showNewCampaignPresentationPage: toBoolean(process.env.FT_SHOW_NEW_CAMPAIGN_PRESENTATION_PAGE),
       showNewResultPage: toBoolean(process.env.FT_SHOW_NEW_RESULT_PAGE),

--- a/api/src/shared/infrastructure/datasources/learning-content/datasource.js
+++ b/api/src/shared/infrastructure/datasources/learning-content/datasource.js
@@ -77,4 +77,6 @@ const refreshLearningContentCacheRecords = async function () {
   return learningContent;
 };
 
-export { extend, refreshLearningContentCacheRecords };
+const initLearningContent = _DatasourcePrototype._getLearningContent;
+
+export { extend, initLearningContent, refreshLearningContentCacheRecords };

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -32,6 +32,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-self-account-deletion-enabled': false,
             'is-text-to-speech-button-enabled': false,
             'is-v3-eligibility-check-enabled': false,
+            'setup-ecosystem-before-start': false,
             'show-experimental-missions': false,
             'show-new-campaign-presentation-page': false,
             'show-new-result-page': false,


### PR DESCRIPTION
## :fallen_leaf: Problème
Lors d'un scaling massif (scaling des matinées de début de classe par exemple) ou lors de MEP, on est amené à démarrer plusieurs containers en même temps. On a constaté des pics de latence lors de ces événements-là.

## :chestnut: Proposition
La première connexion à la base de données nécessite un peu de temps infra (résolution DNS etc..).
La première lecture de référentiel nécessite de charger le référentiel dans le cache mémoire depuis Redis.

Idée : faire ces deux opérations avant que l'API ne commence à répondre à des requêtes clients

## :jack_o_lantern: Remarques
On doit constater deux lignes de logs typiques désormais lors du démarrage de l'API.
`INFO: Cannot found the key from the firstLevelCache. Fetching on the second one. `
Révélateur de l'initialisation du réf dans le cache mémoire
`INFO: Connection to database established.`
Révélateur de la première connexion à PostgreSQL via knex effectuée

