### PR TITLE
[TECH] Redimensionner les colonnes du tableau des candidats sur Pix Certif.

### DIFF
--- a/certif/app/components/import-candidates.js
+++ b/certif/app/components/import-candidates.js
@@ -22,7 +22,8 @@ export default class ImportCandidates extends Component {
       await this.args.reloadCertificationCandidate();
     } catch (errorResponse) {
       const errorMessage = this._handleErrorMessage(errorResponse);
-      this.notifications.error(htmlSafe(errorMessage), { cssClasses: 'certification-candidates-notification' });
+
+      this.notifications.error(htmlSafe(errorMessage));
     } finally {
       this.isLoading = false;
     }

--- a/certif/app/components/sessions/session-details/enrolled-candidates/index.gjs
+++ b/certif/app/components/sessions/session-details/enrolled-candidates/index.gjs
@@ -343,7 +343,7 @@ export default class EnrolledCandidates extends Component {
       </div>
       <div class='table content-text content-text--small certification-candidates-table'>
         {{#if (or @certificationCandidates this.candidatesInStaging)}}
-          <table class='certification-candidates-table-cpf-toggle-enabled'>
+          <table>
             <caption class='screen-reader-only'>
               {{#if @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
                 {{t 'pages.sessions.detail.candidates.list.without-details-description'}}
@@ -353,17 +353,17 @@ export default class EnrolledCandidates extends Component {
             </caption>
             <thead>
               <tr>
-                <th class='certification-candidates-table__column-last-name'>
+                <th class='table__column--medium'>
                   {{t 'common.labels.candidate.birth-name'}}
                 </th>
-                <th class='certification-candidates-table__column-first-name'>
+                <th class='table__column--small'>
                   {{t 'common.labels.candidate.firstname'}}
                 </th>
-                <th class='certification-candidates-table__column-birthdate'>
+                <th class='table__column--small'>
                   {{t 'common.labels.candidate.birth-date'}}
                 </th>
                 {{#if @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
-                  <th class='certification-candidates-table__birth-city'>
+                  <th>
                     {{t 'common.labels.candidate.birth-city'}}
                   </th>
                   <th>
@@ -371,15 +371,15 @@ export default class EnrolledCandidates extends Component {
                   </th>
                 {{/if}}
                 {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
-                  <th class='certification-candidates-table__recipient-email'>
+                  <th>
                     {{t 'common.forms.certification-labels.email-results'}}
                   </th>
                 {{/unless}}
-                <th class='certification-candidates-table__column-time'>
+                <th class='table__column--small'>
                   {{t 'common.forms.certification-labels.extratime'}}
                 </th>
                 {{#if this.shouldDisplayAccessibilityAdjustmentNeededFeature}}
-                  <th class='certification-candidates-table__column-accessibility'>
+                  <th class='table__column--small'>
                     {{t 'common.forms.certification-labels.accessibility'}}
                   </th>
                 {{/if}}

--- a/certif/app/styles/globals/tables.scss
+++ b/certif/app/styles/globals/tables.scss
@@ -40,6 +40,10 @@
       width: 10%;
     }
 
+    &--medium {
+      width: 12%;
+    }
+
     &--wide {
       width: 25%;
     }

--- a/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
@@ -1,195 +1,166 @@
-.certification-candidates-table th:last-child, td:last-child {
-  padding-right: 0;
-}
+.certification-candidates-table {
+ td,th {
+    padding-left: 16px;
+  }
 
-.table__empty {
-  text-align: center;
-  padding: 2rem 0;
-  box-sizing: border-box;
-}
-
-.panel-actions  {
-  margin-bottom: 1.25rem;
-  padding: 1.25rem 2.5rem 0.3rem 2.58rem;
-}
-
-.panel-actions__header {
-  display: flex;
-  align-items: center;
-  flex-flow: row nowrap;
-  margin-bottom: 2.5rem;
-}
-
-.panel-actions__header-title {
-  margin-left: 1rem;
-
-  @extend %pix-title-s;
-}
-
-.panel-actions__header-icon {
-  fill: var(--pix-neutral-500);
-  width: 2rem;
-  height: 2rem;
-}
-
-.panel-actions__action-row {
-  display: flex;
-  align-items: center;
-  padding: 1.25rem 0 1.25rem 1.25rem;
-  box-sizing: border-box;
-  flex-flow: row nowrap;
-  margin-bottom: 1.3rem;
-  border: 0.062rem solid var(--pix-neutral-100);
-  border-radius: 1.25rem;
-  background: var(--pix-neutral-20);
-  position: relative;
-}
-
-.panel-actions__action-icon {
-  fill: var(--pix-neutral-500);
-  width: 3rem;
-  height: 3rem;
-}
-
-.panel-actions__action-icon svg {
-  margin: 0 auto;
-}
-
-.panel-actions__description {
-  display: flex;
-  flex-flow: column nowrap;
-  margin-left: 1.25rem;
-  width: 65%;
-  color: var(--pix-neutral-500);
-  font-size: 0.8rem;
-}
-
-.panel-actions__title {
-  @extend %pix-title-xs;
-
-  color: var(--pix-neutral-800);
-}
-
-.panel-actions__button {
-  display: flex;
-  align-items: center;
-  padding-right: 0.625rem;
-  margin-left: auto;
-  margin-right: 1.25rem;
-
-  > label, a {
-    min-width: 164px;
+  th:last-child,td:last-child {
+    padding-right: 0;
   }
 }
 
-.panel-actions__warning {
-  display: flex;
-  align-items: center;
-}
-
-.panel-actions__warning-icon {
-  fill: var(--pix-warning-500);
-  width: 2.2rem;
-  height: 2.2rem;
-  margin-left: var(--pix-spacing-1x);
-}
-
-.panel-actions-description  {
-
-  &__information {
-    margin-bottom: 0;
+  .table__empty {
+    text-align: center;
+    padding: 2rem 0;
+    box-sizing: border-box;
   }
-}
 
-.panel-header {
-  display: flex;
-  align-items: center;
-  color: var(--pix-neutral-500);
-  padding: 20px;
+  .panel-actions  {
+    margin-bottom: 1.25rem;
+    padding: 1.25rem 2.5rem 0.3rem 2.58rem;
+  }
 
-  &__title {
+  .panel-actions__header {
     display: flex;
-    flex-grow: 1;
+    align-items: center;
+    flex-flow: row nowrap;
+    margin-bottom: 2.5rem;
+  }
+
+  .panel-actions__header-title {
+    margin-left: 1rem;
 
     @extend %pix-title-s;
   }
 
-  &__action {
+  .panel-actions__header-icon {
+    fill: var(--pix-neutral-500);
+    width: 2rem;
+    height: 2rem;
+  }
+
+  .panel-actions__action-row {
     display: flex;
     align-items: center;
-    cursor: pointer;
+    padding: 1.25rem 0 1.25rem 1.25rem;
+    box-sizing: border-box;
+    flex-flow: row nowrap;
+    margin-bottom: 1.3rem;
+    border: 0.062rem solid var(--pix-neutral-100);
+    border-radius: 1.25rem;
+    background: var(--pix-neutral-20);
+    position: relative;
   }
 
-  &__mandatory-warning {
-    padding-top: 4px;
-    margin-left: 16px;
-    font-size: 0.82rem;
-    font-weight: normal;
+  .panel-actions__action-icon {
+    fill: var(--pix-neutral-500);
+    width: 3rem;
+    height: 3rem;
+  }
+
+  .panel-actions__action-icon svg {
+    margin: 0 auto;
+  }
+
+  .panel-actions__description {
+    display: flex;
+    flex-flow: column nowrap;
+    margin-left: 1.25rem;
+    width: 65%;
     color: var(--pix-neutral-500);
-  }
-}
-
-.certification-candidates-table td, .certification-candidates-table th {
-  padding-left: 16px;
-}
-
-.certification-candidates-table__column-last-name {
-  width: 160px;
-}
-
-.certification-candidates-table__column-first-name {
-  width: 130px;
-}
-
-.certification-candidates-table__column-birthdate {
-  width: 130px;
-}
-
-.certification-candidates-table__external-id {
-  width: 130px;
-}
-
-.certification-candidates-table__column-time {
-  width: 50px;
-  box-sizing: content-box;
-}
-
-.certification-candidates-table__column-accessibility {
-  width: 64px;
-}
-
-.certification-candidates-table__payment-options {
-  width: 100px;
-  box-sizing: content-box;
-}
-
-.certification-candidates-table__selected-subscriptions {
-  align-items: center;
-  display: flex;
-  gap: 0.5rem;
-  width: 100px;
-  box-sizing: content-box;
-
-  svg {
-    width: 1rem;
-    height: 1rem;
-    fill: var(--pix-neutral-800);
-  }
-}
-
-.certification-candidates-actions {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  padding-right: 16px;
-  gap: var(--pix-spacing-2x);
-
-  &__display-details {
-    margin-right: 16px;
+    font-size: 0.8rem;
   }
 
-  &__delete, &__edit {
+  .panel-actions__title {
+    @extend %pix-title-xs;
+
+    color: var(--pix-neutral-800);
+  }
+
+  .panel-actions__button {
+    display: flex;
+    align-items: center;
+    padding-right: 0.625rem;
+    margin-left: auto;
+    margin-right: 1.25rem;
+
+    > label, a {
+      min-width: 164px;
+    }
+  }
+
+  .panel-actions__warning {
+    display: flex;
+    align-items: center;
+  }
+
+  .panel-actions__warning-icon {
+    fill: var(--pix-warning-500);
+    width: 2.2rem;
+    height: 2.2rem;
+    margin-left: var(--pix-spacing-1x);
+  }
+
+  .panel-actions-description  {
+
+    &__information {
+      margin-bottom: 0;
+    }
+  }
+
+  .panel-header {
+    display: flex;
+    align-items: center;
+    color: var(--pix-neutral-500);
+    padding: 20px;
+
+    &__title {
+      display: flex;
+      flex-grow: 1;
+
+      @extend %pix-title-s;
+    }
+
+    &__action {
+      display: flex;
+      align-items: center;
+      cursor: pointer;
+    }
+
+    &__mandatory-warning {
+      padding-top: 4px;
+      margin-left: 16px;
+      font-size: 0.82rem;
+      font-weight: normal;
+      color: var(--pix-neutral-500);
+    }
+  }
+
+  .certification-candidates-table__selected-subscriptions {
+    align-items: center;
+    display: flex;
+    gap: 0.5rem;
+    width: 100px;
+
+    svg {
+      width: 1rem;
+      height: 1rem;
+      fill: var(--pix-neutral-800);
+    }
+  }
+
+  .certification-candidates-actions {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    padding-right: 16px;
+    gap: var(--pix-spacing-2x);
+
+    &__display-details {
+      margin-right: 16px;
+    }
+
+    &__delete, &__edit {
 
     display: flex;
     justify-content: center;

--- a/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
@@ -167,13 +167,3 @@
     align-items: center;
   }
 }
-
-.certification-candidates-notification {
-  p {
-    margin: 0;
-    flex-direction: column;
-  }
-  b {
-    font-weight: bold;
-  }
-}


### PR DESCRIPTION
## :fallen_leaf: Problème
Depuis la suppression de 2 colonnes sur le tableau de détails des candidats, les autres colonnes étaient toujours dimensionner à la plus petite largeur possible alors qu'on a désormais de la place.

## :chestnut: Proposition
Redimensionner les colonnes

## :wood: Pour tester
Se rendre sur le tableau d'une session, onglet candidat et constater que les colonnes prennent la place disponible :)
