### PR TITLE
[FEATURE] Mise à jour du CTA de fin de parcours autonomes (PIX-15070).

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
@@ -208,7 +208,7 @@ export default class EvaluationResultsHero extends Component {
           {{else}}
             {{#unless @campaign.hasCustomResultPageButton}}
               <PixButtonLink @route="authentication.login" @size="large">
-                {{t "navigation.back-to-homepage"}}
+                {{if this.currentUser.user.isAnonymous (t "common.actions.login") (t "navigation.back-to-homepage")}}
               </PixButtonLink>
             {{/unless}}
           {{/if}}

--- a/mon-pix/app/routes/authentication/login.js
+++ b/mon-pix/app/routes/authentication/login.js
@@ -2,11 +2,14 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
 export default class LoginRoute extends Route {
+  @service currentUser;
   @service session;
   @service store;
   @service router;
 
   beforeModel() {
-    this.session.prohibitAuthentication('authenticated.user-dashboard');
+    if (!this.currentUser?.user?.isAnonymous) {
+      this.session.prohibitAuthentication('authenticated.user-dashboard');
+    }
   }
 }

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/hero/evaluation-results-hero-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/hero/evaluation-results-hero-test.js
@@ -237,28 +237,68 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
 
   module('when campaign is simplified access', function () {
     module('when there is no custom link', function () {
-      test('it should display only a homepage link', async function (assert) {
-        // given
-        this.set('campaign', {
-          isSimplifiedAccess: true,
-          hasCustomResultPageButton: false,
-        });
-        this.set('campaignParticipationResult', { masteryRate: 0.75 });
+      module('when user is anonymous', function () {
+        test('it should display only a connection link', async function (assert) {
+          // given
+          class currentUserService extends Service {
+            user = { isAnonymous: true };
+          }
+          this.owner.register('service:current-user', currentUserService);
 
-        // when
-        const screen = await render(
-          hbs`<Campaigns::Assessment::Results::EvaluationResultsHero
+          this.set('campaign', {
+            isSimplifiedAccess: true,
+            hasCustomResultPageButton: false,
+          });
+          this.set('campaignParticipationResult', { masteryRate: 0.75 });
+
+          // when
+          const screen = await render(
+            hbs`<Campaigns::Assessment::Results::EvaluationResultsHero
   @campaign={{this.campaign}}
   @campaignParticipationResult={{this.campaignParticipationResult}}
 />`,
-        );
+          );
 
-        // then
-        assert.dom(screen.queryByText(t('pages.skill-review.hero.explanations.send-results'))).doesNotExist();
+          // then
+          assert.dom(screen.queryByText(t('pages.skill-review.hero.explanations.send-results'))).doesNotExist();
 
-        assert.dom(screen.getByRole('link', { name: t('navigation.back-to-homepage') })).exists();
-        assert.dom(screen.queryByRole('button', { name: t('pages.skill-review.hero.see-trainings') })).doesNotExist();
-        assert.dom(screen.queryByRole('button', { name: t('pages.skill-review.actions.send') })).doesNotExist();
+          assert.dom(screen.getByRole('link', { name: t('common.actions.login') })).exists();
+          assert.dom(screen.queryByRole('button', { name: t('pages.skill-review.hero.see-trainings') })).doesNotExist();
+          assert.dom(screen.queryByRole('button', { name: t('pages.skill-review.actions.send') })).doesNotExist();
+        });
+      });
+
+      module('when user is connected', function () {
+        test('it should display only a connection link', async function (assert) {
+          // given
+          class currentUserService extends Service {
+            user = {
+              firstName: 'Hermione',
+            };
+          }
+          this.owner.register('service:currentUser', currentUserService);
+
+          this.set('campaign', {
+            isSimplifiedAccess: true,
+            hasCustomResultPageButton: false,
+          });
+          this.set('campaignParticipationResult', { masteryRate: 0.75 });
+
+          // when
+          const screen = await render(
+            hbs`<Campaigns::Assessment::Results::EvaluationResultsHero
+  @campaign={{this.campaign}}
+  @campaignParticipationResult={{this.campaignParticipationResult}}
+/>`,
+          );
+
+          // then
+          assert.dom(screen.queryByText(t('pages.skill-review.hero.explanations.send-results'))).doesNotExist();
+
+          assert.dom(screen.getByRole('link', { name: t('navigation.back-to-homepage') })).exists();
+          assert.dom(screen.queryByRole('button', { name: t('pages.skill-review.hero.see-trainings') })).doesNotExist();
+          assert.dom(screen.queryByRole('button', { name: t('pages.skill-review.actions.send') })).doesNotExist();
+        });
       });
     });
 


### PR DESCRIPTION
## :fallen_leaf: Problème

On ne veut pas renvoyer vers le dashboard à la fin d'un parcours autonome avec un utilisateur non connecté.

## :chestnut: Proposition

Le CTA indique maintenant qu'il dirige vers l'écran de connexion.

## :jack_o_lantern: Remarques

Il a fallu revoir la redirection dans la route du login car elle laissait passer les utilisateurs anonymes (considérés comme connectés, avec un token).

## :wood: Pour tester

- Connecté et non connecté : lancer https://app-pr10491.review.pix.fr/campagnes/AUTOCOURS1/presentation
- Aller à la fin de parcours et voir le bouton qui propose de se connecter
