### PR TITLE
[TECH] Limite la taille mémoire utilisée par node lors du seed de la base de données.

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -131,7 +131,7 @@
     "db:migrate": "knex --knexfile db/knexfile.js migrate:latest && node scripts/database/pg-boss-migration.js",
     "db:rollback:latest": "knex --knexfile db/knexfile.js migrate:down",
     "db:prepare": "npm run db:delete && npm run db:create && npm run db:migrate",
-    "db:seed": "knex --knexfile db/knexfile.js seed:run",
+    "db:seed": "NODE_OPTIONS=\"--max-old-space-size=380\" knex --knexfile db/knexfile.js seed:run",
     "db:reload": "npm run db:empty && npm run db:seed",
     "db:reset": "npm run db:prepare && npm run db:seed",
     "doc:api:prescription": "node scripts/generate-api-documentation.js src/prescription > src/prescription/API.md",


### PR DESCRIPTION
## :fallen_leaf: Problème

Les Review App ne parviennent plus à seed leur base de données.
En regardant les logs, on constate un problème de surconsommation mémoire lors du seed.

## :chestnut: Proposition

On limite la mémoire allouée à NODE via la variable `--max-old-space-size` lors de la commande `npm run db:seed`

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## :jack_o_lantern: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :wood: Pour tester
La review app doit se déployer **et** se seed du premier coup.
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
