### PR TITLE
[TECH] Migration de PixAdmin / Composants communs et layout (PIX-15221)

### DIFF
--- a/admin/app/components/common/tick-or-cross.gjs
+++ b/admin/app/components/common/tick-or-cross.gjs
@@ -1,13 +1,13 @@
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import Component from '@glimmer/component';
 
 export default class TickOrCross extends Component {
   get icon() {
-    return this.args.isTrue ? 'check' : 'times';
+    return this.args.isTrue ? 'check' : 'close';
   }
 
   get class() {
     return this.args.isTrue ? 'tick-or-cross--valid' : 'tick-or-cross--invalid';
   }
-  <template><FaIcon @icon={{this.icon}} class="tick-or-cross {{this.class}}" /></template>
+  <template><PixIcon @name={{this.icon}} class="tick-or-cross {{this.class}}" /></template>
 }

--- a/admin/app/components/common/tubes-details/tube.gjs
+++ b/admin/app/components/common/tubes-details/tube.gjs
@@ -1,4 +1,4 @@
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
@@ -15,6 +15,14 @@ export default class Tube extends Component {
         this.skillAvailabilityMap.push({ difficulty: i, availability: hasSkill ? 'active' : 'missing' });
       }
     }
+  }
+
+  get mobileIcon() {
+    return this.args.mobile ? 'mobile' : 'mobileOff';
+  }
+
+  get tabletIcon() {
+    return this.args.tablet ? 'tablet' : 'tabletOff';
   }
 
   <template>
@@ -42,20 +50,14 @@ export default class Tube extends Component {
           aria-label="{{if @mobile 'compatible mobile' 'incompatible mobile'}}"
           data-testid="mobile-compliant-{{@id}}"
         >
-          <FaIcon @icon="mobile-screen-button" class="fa-2x {{if @mobile 'is-responsive'}}" />
-          {{#unless @mobile}}
-            <FaIcon @icon="slash" class="fa-2x not-responsive" />
-          {{/unless}}
+          <PixIcon @name={{this.mobileIcon}} @plainIcon={{true}} class="{{if @mobile 'is-responsive'}}" />
         </div>
         <div
           class="icon-container"
           aria-label="{{if @tablet 'compatible tablette' 'incompatible tablette'}}"
           data-testid="tablet-compliant-{{@id}}"
         >
-          <FaIcon @icon="tablet-screen-button" class="fa-2x {{if @tablet 'is-responsive'}}" />
-          {{#unless @tablet}}
-            <FaIcon @icon="slash" class="fa-2x not-responsive" />
-          {{/unless}}
+          <PixIcon @name={{this.tabletIcon}} @plainIcon={{true}} class="{{if @mobile 'is-responsive'}}" />
         </div>
       </td>
     {{/if}}

--- a/admin/app/components/common/tubes-selection/tube.gjs
+++ b/admin/app/components/common/tubes-selection/tube.gjs
@@ -1,8 +1,8 @@
 import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
@@ -45,6 +45,14 @@ export default class Tube extends Component {
 
   get checked() {
     return this.state === 'checked';
+  }
+
+  get mobileIcon() {
+    return this.args.tube.mobile ? 'mobile' : 'mobileOff';
+  }
+
+  get tabletIcon() {
+    return this.args.tube.tablet ? 'tablet' : 'tabletOff';
   }
 
   @action
@@ -102,16 +110,10 @@ export default class Tube extends Component {
     {{#if @displayDeviceCompatibility}}
       <td class="table__column--center">
         <div class="icon-container" aria-label="{{if @tube.mobile 'compatible mobile' 'incompatible mobile'}}">
-          <FaIcon @icon="mobile-screen-button" class="fa-2x {{if @tube.mobile 'is-responsive'}}" />
-          {{#unless @tube.mobile}}
-            <FaIcon @icon="slash" class="fa-2x not-responsive" />
-          {{/unless}}
+          <PixIcon @name={{this.mobileIcon}} @plainIcon={{true}} class="{{if @tube.mobile 'is-responsive'}}" />
         </div>
         <div class="icon-container" aria-label="{{if @tube.tablet 'compatible tablette' 'incompatible tablette'}}">
-          <FaIcon @icon="tablet-screen-button" class="fa-2x {{if @tube.tablet 'is-responsive'}}" />
-          {{#unless @tube.tablet}}
-            <FaIcon @icon="slash" class="fa-2x not-responsive" />
-          {{/unless}}
+          <PixIcon @name={{this.tabletIcon}} @plainIcon={{true}} class="{{if @tube.tablet 'is-responsive'}}" />
         </div>
       </td>
     {{/if}}

--- a/admin/app/components/layout/breadcrumb.gjs
+++ b/admin/app/components/layout/breadcrumb.gjs
@@ -1,6 +1,6 @@
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import Component from '@glimmer/component';
 
 export default class Breadcrumb extends Component {
@@ -46,7 +46,7 @@ export default class Breadcrumb extends Component {
             <li>
               <LinkTo @route={{crumb.path}}>{{crumb.label}}</LinkTo>
             </li>
-            <FaIcon @icon="chevron-right" />
+            <PixIcon @name="chevronRight" />
           {{else}}
             <li>
               <h1>{{crumb.label}}</h1>

--- a/admin/app/components/layout/menu-bar/entry.gjs
+++ b/admin/app/components/layout/menu-bar/entry.gjs
@@ -1,13 +1,13 @@
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { LinkTo } from '@ember/routing';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 
 <template>
   <li class="menu-bar__entry">
     <PixTooltip @position="right" ...attributes>
       <:triggerElement>
         <LinkTo @route={{@path}}>
-          <FaIcon @icon={{@icon}} @title={{@title}} />
+          <PixIcon @name={{@icon}} @title={{@title}} @plainIcon={{true}} />
         </LinkTo>
       </:triggerElement>
       <:tooltip>{{@title}}</:tooltip>

--- a/admin/app/components/layout/menu-bar/index.gjs
+++ b/admin/app/components/layout/menu-bar/index.gjs
@@ -21,23 +21,23 @@ export default class MenuBar extends Component {
       <ul>
         <MenuBarEntry
           @path="authenticated.organizations"
-          @icon="building"
+          @icon="buildings"
           @title={{t "components.layout.menu-bar.entries.organizations"}}
         />
         <MenuBarEntry
           @path="authenticated.users"
-          @icon="user"
+          @icon="infoUser"
           @title={{t "components.layout.menu-bar.entries.users"}}
         />
         <MenuBarEntry
           @path="authenticated.certification-centers"
-          @icon="map-pin"
+          @icon="mapPin"
           @title={{t "components.layout.menu-bar.entries.certification-centers"}}
           @inline={{true}}
         />
         <MenuBarEntry
           @path="authenticated.sessions"
-          @icon="chalkboard-user"
+          @icon="session"
           @title={{t "components.layout.menu-bar.entries.sessions"}}
           @inline={{true}}
         />
@@ -45,21 +45,21 @@ export default class MenuBar extends Component {
         {{#if this.accessControl.hasAccessToCertificationActionsScope}}
           <MenuBarEntry
             @path="authenticated.certifications"
-            @icon="graduation-cap"
+            @icon="newRealease"
             @title={{t "components.layout.menu-bar.entries.certifications"}}
             @inline={{true}}
           />
         {{/if}}
         <MenuBarEntry
           @path="authenticated.complementary-certifications"
-          @icon="stamp"
+          @icon="extension"
           @title={{t "components.layout.menu-bar.entries.complementary-certifications"}}
           @inline={{true}}
         />
         {{#if this.accessControl.hasAccessToTargetProfilesActionsScope}}
           <MenuBarEntry
             @path="authenticated.target-profiles"
-            @icon="clipboard-list"
+            @icon="assignment"
             @title={{t "components.layout.menu-bar.entries.target-profiles"}}
             @inline={{true}}
           />
@@ -74,7 +74,7 @@ export default class MenuBar extends Component {
         }}
           <MenuBarEntry
             @path="authenticated.autonomous-courses"
-            @icon="signs-post"
+            @icon="signpost"
             @title={{t "components.layout.menu-bar.entries.autonomous-courses"}}
           />
         {{/if}}
@@ -89,26 +89,26 @@ export default class MenuBar extends Component {
         {{#if this.accessControl.hasAccessToTrainings}}
           <MenuBarEntry
             @path="authenticated.trainings"
-            @icon="book-open"
+            @icon="book"
             @title={{t "components.layout.menu-bar.entries.trainings"}}
           />
         {{/if}}
         {{#if (or this.currentUser.adminMember.isSuperAdmin this.currentUser.adminMember.isMetier)}}
           <MenuBarEntry
             @path="authenticated.tools"
-            @icon="screwdriver-wrench"
+            @icon="tools"
             @title={{t "components.layout.menu-bar.entries.tools"}}
           />
         {{/if}}
         {{#if this.currentUser.adminMember.isSuperAdmin}}
           <MenuBarEntry
             @path="authenticated.administration"
-            @icon="crown"
+            @icon="shieldPerson"
             @title={{t "components.layout.menu-bar.entries.administration"}}
           />
         {{/if}}
 
-        <MenuBarEntry @path="logout" @icon="power-off" @title={{t "components.layout.menu-bar.entries.logout"}} />
+        <MenuBarEntry @path="logout" @icon="power" @title={{t "components.layout.menu-bar.entries.logout"}} />
       </ul>
     </nav>
   </template>

--- a/admin/app/styles/components/common/tubes-selection.scss
+++ b/admin/app/styles/components/common/tubes-selection.scss
@@ -44,16 +44,13 @@
 }
 
 .select-tube-table {
-  .is-responsive {
-    color: var(--pix-success-700);
+  .icon-container > svg {
+    width: 1.8rem;
+    height: 1.8rem;
   }
 
-  .not-responsive {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    color: var(--pix-error-700);
-    transform: translate(-50%, -50%);
+  .is-responsive {
+    color: var(--pix-success-700);
   }
 
   table {

--- a/admin/app/styles/components/layout/breadcrumb.scss
+++ b/admin/app/styles/components/layout/breadcrumb.scss
@@ -11,7 +11,7 @@
   }
 
   > svg {
-    width: 0.45rem;
+    width: 1.2rem;
     margin: 0 0.4rem;
   }
 }

--- a/admin/app/styles/components/layout/menu-bar.scss
+++ b/admin/app/styles/components/layout/menu-bar.scss
@@ -14,11 +14,11 @@
 
       a {
         display: flex;
+        align-items: center;
         width: 50px;
+        height: 50px;
         border-radius: 5px;
         cursor: pointer;
-        height: 50px;
-        align-items: center;
 
         &:hover {
           text-decoration: none;
@@ -30,9 +30,9 @@
         }
 
         svg {
-          fill: var(--pix-neutral-100);
           width: 32px;
           margin: 0 10px;
+          fill: var(--pix-neutral-100);
         }
 
         &:hover svg,

--- a/admin/app/styles/components/layout/menu-bar.scss
+++ b/admin/app/styles/components/layout/menu-bar.scss
@@ -13,31 +13,31 @@
       padding: 0 15px;
 
       a {
-        position: relative;
-        display: block;
+        display: flex;
         width: 50px;
-        padding: 0;
-        color: var(--pix-neutral-100);
-        font-size: 1.25rem;
-        line-height: 50px;
-        text-align: center;
         border-radius: 5px;
         cursor: pointer;
-
-        i.fa {
-          width: 32px;
-          margin: 0 10px;
-        }
+        height: 50px;
+        align-items: center;
 
         &:hover {
-          color: var(--pix-neutral-0);
           text-decoration: none;
         }
 
         &.active {
-          color: var(--pix-neutral-0);
           font-weight: 600;
           background-color: var(--pix-neutral-500);
+        }
+
+        svg {
+          fill: var(--pix-neutral-100);
+          width: 32px;
+          margin: 0 10px;
+        }
+
+        &:hover svg,
+        &.active svg {
+          fill: var(--pix-neutral-0);
         }
       }
     }


### PR DESCRIPTION
## :fallen_leaf: Problème
Les icônes ont été migrées de FontAwesome vers MaterialUi.
Pour faciliter la maintenance des icônes, un composant `PixIcon` a été créé dans PixUI.

## :chestnut: Proposition
Passer toutes les icônes du scope commun dans PixAdmin sous `PixIcon`.

## :jack_o_lantern: Remarques
Les noms de icônes du menu n'existent plus avec le nouveau composant, leur équivalent a été mis, avec accord des UX

## :wood: Pour tester

- Aller sur PixAdmin
- Vérifier que les icônes du menu à gauche s'affichent correctement
- Aller dans les Parcours Autonomes
- Cliquer sur un parcours autonome
- Vérifier que le fil d'Ariane s'affiche correctement
- Aller dans les Profils Cibles
- Choisir l'id 6001 > Clés de lecture, scroll tout en bas pour les paliers
- Vérifier que les coches s'affichent correctement
- Aller dans les Profils Cibles
- Choisir l'id 1000002 > Clés de lecture, scroll tout en bas pour les paliers
- Vérifier que les croix s'affichent correctement
- Aller dans Profils Cibles
- Choisir l'id 56 > Details, ouvrir la compétence 3. puis 3.1, vérifier que les icônes téléphone et tablette sont OK (vertes non barrées ou grises barrées) 
- Aller dans Profils Cibles
- Créer un nouveau profil
- Choisir la compétence 1. > 1.2, vérifier que les icônes téléphone et tablette sont OK (vertes non barrées ou grises barrées) 

Cf le tableau ci-dessous

|  |  |  |

| Lien vers la page   |        Avant       |       Après      |
|-------------------|:-------------:|:-------------:|
| Menu gauche | <img width="79" alt="Capture d’écran 2024-11-07 à 09 28 25" src="https://github.com/user-attachments/assets/9bc47d00-e5a7-4e70-97de-76f01727e68b"> | <img width="79" alt="Capture d’écran 2024-11-07 à 10 01 23" src="https://github.com/user-attachments/assets/30b457dc-a71b-416f-890c-c1f68d1f39e9"> |
| Breadcrumb | <img width="419" alt="Capture d’écran 2024-11-05 à 16 47 46" src="https://github.com/user-attachments/assets/4918a3ea-d78a-4987-b499-8b4f2fdf6c27"> | <img width="419" alt="Capture d’écran 2024-11-05 à 16 52 18" src="https://github.com/user-attachments/assets/dba7906e-c6fa-4680-92ff-347b7b5c57b4"> |
| TickOrCross | <img width="300" alt="Capture d’écran 2024-11-19 à 14 49 28" src="https://github.com/user-attachments/assets/03766697-2502-48c4-9f33-83d35fecaeff"> | <img width="300" alt="Capture d’écran 2024-11-19 à 14 48 18" src="https://github.com/user-attachments/assets/7b5e0e09-f169-4cc3-857c-c8e2d326cb8c"> |
| TickOrCross | <img width="300" alt="Capture d’écran 2024-11-19 à 14 49 06" src="https://github.com/user-attachments/assets/c87c0908-2177-4c41-ba51-11189be5c502"> |<img width="300" alt="Capture d’écran 2024-11-19 à 14 48 45" src="https://github.com/user-attachments/assets/550a4337-33aa-42e0-8267-6b4aad8c89bf"> |
| responsive | <img width="93" alt="Capture d’écran 2024-11-19 à 15 29 00" src="https://github.com/user-attachments/assets/3cdae677-a612-43dc-87a6-63d4cd2f7af8"> | <img width="93" alt="Capture d’écran 2024-11-19 à 15 27 46" src="https://github.com/user-attachments/assets/6876b4c8-03c9-4e0e-8df9-3856a9087442"> | 
