### PR TITLE
[FEATURE] Supprime la phrase sur les 120 pix professionalisants sur les certificats v3 (PIX-15161)

### DIFF
--- a/api/src/certification/results/domain/models/PrivateCertificate.js
+++ b/api/src/certification/results/domain/models/PrivateCertificate.js
@@ -32,6 +32,7 @@ class PrivateCertificate {
    * @param {Object} props.resultCompetenceTree
    * @param {string} props.verificationCode
    * @param {Date} props.maxReachableLevelOnCertificationDate
+   * @param {number} props.version
    */
   constructor({
     id,
@@ -51,6 +52,7 @@ class PrivateCertificate {
     resultCompetenceTree = null,
     verificationCode,
     maxReachableLevelOnCertificationDate,
+    version,
   } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -69,6 +71,7 @@ class PrivateCertificate {
     this.resultCompetenceTree = resultCompetenceTree;
     this.verificationCode = verificationCode;
     this.maxReachableLevelOnCertificationDate = maxReachableLevelOnCertificationDate;
+    this.version = version;
   }
 
   static buildFrom({
@@ -91,6 +94,7 @@ class PrivateCertificate {
     maxReachableLevelOnCertificationDate,
     assessmentResultStatus,
     isCancelled,
+    version,
   }) {
     const status = _computeStatus(assessmentResultStatus, isCancelled);
     const juryComment = new JuryComment({
@@ -116,6 +120,7 @@ class PrivateCertificate {
       verificationCode,
       maxReachableLevelOnCertificationDate,
       status,
+      version,
     });
   }
 

--- a/api/src/certification/results/domain/models/ShareableCertificate.js
+++ b/api/src/certification/results/domain/models/ShareableCertificate.js
@@ -14,6 +14,7 @@ class ShareableCertificate {
     certifiedBadgeImages,
     resultCompetenceTree = null,
     maxReachableLevelOnCertificationDate,
+    version,
   } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -29,6 +30,7 @@ class ShareableCertificate {
     this.certifiedBadgeImages = certifiedBadgeImages;
     this.resultCompetenceTree = resultCompetenceTree;
     this.maxReachableLevelOnCertificationDate = maxReachableLevelOnCertificationDate;
+    this.version = version;
   }
 
   setResultCompetenceTree(resultCompetenceTree) {

--- a/api/src/certification/results/infrastructure/repositories/certificate-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certificate-repository.js
@@ -201,6 +201,7 @@ function _selectShareableCertificates() {
       maxReachableLevelOnCertificationDate: 'certification-courses.maxReachableLevelOnCertificationDate',
       pixScore: 'assessment-results.pixScore',
       assessmentResultId: 'assessment-results.id',
+      version: 'sessions.version',
       competenceMarks: knex.raw(`
         json_agg(
           json_build_object('score', "competence-marks".score, 'level', "competence-marks".level, 'competence_code', "competence-marks"."competence_code")

--- a/api/src/certification/results/infrastructure/repositories/certificate-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certificate-repository.js
@@ -182,6 +182,7 @@ function _selectPrivateCertificates() {
           json_build_object('score', "competence-marks".score, 'level', "competence-marks".level, 'competence_code', "competence-marks"."competence_code")
           ORDER BY "competence-marks"."competence_code" asc
         )`),
+    version: 'sessions.version',
   });
 }
 

--- a/api/src/certification/results/infrastructure/serializers/private-certificate-serializer.js
+++ b/api/src/certification/results/infrastructure/serializers/private-certificate-serializer.js
@@ -48,6 +48,7 @@ const attributes = [
   'certifiedBadgeImages',
   'verificationCode',
   'maxReachableLevelOnCertificationDate',
+  'version',
 ];
 
 const serialize = function (certificate, { translate }) {

--- a/api/src/certification/results/infrastructure/serializers/shareable-certificate-serializer.js
+++ b/api/src/certification/results/infrastructure/serializers/shareable-certificate-serializer.js
@@ -44,6 +44,7 @@ const attributes = [
   'resultCompetenceTree',
   'certifiedBadgeImages',
   'maxReachableLevelOnCertificationDate',
+  'version',
 ];
 
 const serialize = function (certificate) {

--- a/api/tests/certification/results/acceptance/application/certification-route_test.js
+++ b/api/tests/certification/results/acceptance/application/certification-route_test.js
@@ -1,5 +1,6 @@
 import { generateCertificateVerificationCode } from '../../../../../lib/domain/services/verify-certificate-code-service.js';
 import { AutoJuryCommentKeys } from '../../../../../src/certification/shared/domain/models/JuryComment.js';
+import { SESSIONS_VERSIONS } from '../../../../../src/certification/shared/domain/models/SessionVersion.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import {
   createServer,
@@ -428,7 +429,7 @@ describe('Certification | Results | Acceptance | Application | Certification', f
         userId = databaseBuilder.factory.buildUser().id;
         session = databaseBuilder.factory.buildSession({
           publishedAt: new Date('2018-12-01T01:02:03Z'),
-          version: 3,
+          version: SESSIONS_VERSIONS.V3,
         });
         certificationCourse = databaseBuilder.factory.buildCertificationCourse({
           sessionId: session.id,
@@ -436,7 +437,7 @@ describe('Certification | Results | Acceptance | Application | Certification', f
           isPublished: true,
           maxReachableLevelOnCertificationDate: 3,
           verificationCode: await generateCertificateVerificationCode(),
-          version: 3,
+          version: SESSIONS_VERSIONS.V3,
         });
 
         assessment = databaseBuilder.factory.buildAssessment({
@@ -638,6 +639,7 @@ describe('Certification | Results | Acceptance | Application | Certification', f
                 },
               ],
               'max-reachable-level-on-certification-date': certificationCourse.maxReachableLevelOnCertificationDate,
+              version: session.version,
             },
             id: `${certificationCourse.id}`,
             relationships: {
@@ -770,7 +772,10 @@ describe('Certification | Results | Acceptance | Application | Certification', f
 
 async function _buildDatabaseForV2Certification() {
   const userId = databaseBuilder.factory.buildUser().id;
-  const session = databaseBuilder.factory.buildSession({ publishedAt: new Date('2018-12-01T01:02:03Z') });
+  const session = databaseBuilder.factory.buildSession({
+    version: SESSIONS_VERSIONS.V2,
+    publishedAt: new Date('2018-12-01T01:02:03Z'),
+  });
   const badge = databaseBuilder.factory.buildBadge({ key: 'charlotte_aux_fraises' });
   const cc = databaseBuilder.factory.buildComplementaryCertification({ key: 'A' });
   const ccBadge = databaseBuilder.factory.buildComplementaryCertificationBadge({

--- a/api/tests/certification/results/acceptance/application/certification-route_test.js
+++ b/api/tests/certification/results/acceptance/application/certification-route_test.js
@@ -157,6 +157,7 @@ describe('Certification | Results | Acceptance | Application | Certification', f
             ],
             'verification-code': certificationCourse.verificationCode,
             'max-reachable-level-on-certification-date': certificationCourse.maxReachableLevelOnCertificationDate,
+            version: SESSIONS_VERSIONS.V2,
           },
           id: `${certificationCourse.id}`,
           relationships: {
@@ -399,6 +400,7 @@ describe('Certification | Results | Acceptance | Application | Certification', f
               'certified-badge-images': [],
               'verification-code': certificationCourse.verificationCode,
               'max-reachable-level-on-certification-date': certificationCourse.maxReachableLevelOnCertificationDate,
+              version: SESSIONS_VERSIONS.V2,
             },
             relationships: {
               'result-competence-tree': {
@@ -488,6 +490,7 @@ describe('Certification | Results | Acceptance | Application | Certification', f
               'certified-badge-images': [],
               'verification-code': certificationCourse.verificationCode,
               'max-reachable-level-on-certification-date': certificationCourse.maxReachableLevelOnCertificationDate,
+              version: SESSIONS_VERSIONS.V3,
             },
             relationships: {
               'result-competence-tree': {

--- a/api/tests/certification/results/integration/infrastructure/repositories/certificate-repository_test.js
+++ b/api/tests/certification/results/integration/infrastructure/repositories/certificate-repository_test.js
@@ -1,5 +1,4 @@
 import * as certificateRepository from '../../../../../../src/certification/results/infrastructure/repositories/certificate-repository.js';
-import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { AutoJuryCommentKeys } from '../../../../../../src/certification/shared/domain/models/JuryComment.js';
 import { SESSIONS_VERSIONS } from '../../../../../../src/certification/shared/domain/models/SessionVersion.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
@@ -1258,12 +1257,14 @@ describe('Integration | Infrastructure | Repository | Certification', function (
         deliveredAt: new Date('2021-05-05'),
         certificationCenter: 'Centre des poules bien dodues',
         pixScore: 51,
+        version: SESSIONS_VERSIONS.V3,
       };
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
       const sessionId = databaseBuilder.factory.buildSession({
         publishedAt: privateCertificateData.deliveredAt,
         certificationCenter: privateCertificateData.certificationCenter,
         certificationCenterId,
+        version: SESSIONS_VERSIONS.V3,
       }).id;
       const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
         firstName: privateCertificateData.firstName,
@@ -1415,6 +1416,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
         certificationCenter: 'Centre des poules bien dodues',
         pixScore: 51,
         commentForCandidate: 'Il aime beaucoup les mangues, et ça se voit !',
+        version: SESSIONS_VERSIONS.V3,
       };
 
       const { certificationCourseId } = await _buildValidPrivateCertificate(privateCertificateData);
@@ -1471,6 +1473,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
         certificationCenter: 'Centre des poules bien dodues',
         pixScore: 51,
         commentForCandidate: 'Il aime beaucoup les mangues, et ça se voit !',
+        version: SESSIONS_VERSIONS.V3,
       };
 
       const { certificationCourseId } = await _buildValidPrivateCertificateWithSeveralResults(privateCertificateData);
@@ -1729,6 +1732,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
         certificationCenter: 'Centre des poules bien dodues',
         pixScore: 51,
         commentForCandidate: 'Il aime beaucoup les mangues, et ça se voit !',
+        version: SESSIONS_VERSIONS.V3,
       };
 
       const { certificationCourseId } = await _buildValidPrivateCertificate(privateCertificateData);
@@ -2064,6 +2068,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
               message: 'temporary message badge 2',
             },
           ],
+          version: SESSIONS_VERSIONS.V3,
         };
 
         const { certificationCourseId } = await _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
@@ -2728,6 +2733,7 @@ async function _buildValidPrivateCertificate(privateCertificateData, buildCompet
     publishedAt: privateCertificateData.deliveredAt,
     certificationCenter: privateCertificateData.certificationCenter,
     certificationCenterId,
+    version: SESSIONS_VERSIONS.V3,
   }).id;
   const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
     firstName: privateCertificateData.firstName,
@@ -2768,6 +2774,7 @@ async function _buildValidPrivateCertificateWithSeveralResults(privateCertificat
     publishedAt: privateCertificateData.deliveredAt,
     certificationCenter: privateCertificateData.certificationCenter,
     certificationCenterId,
+    version: SESSIONS_VERSIONS.V3,
   }).id;
   const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
     firstName: privateCertificateData.firstName,
@@ -2913,6 +2920,7 @@ async function _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
     publishedAt: privateCertificateData.deliveredAt,
     certificationCenter: privateCertificateData.certificationCenter,
     certificationCenterId,
+    version: SESSIONS_VERSIONS.V3,
   }).id;
   const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
     firstName: privateCertificateData.firstName,
@@ -3035,7 +3043,6 @@ async function _buildValidShareableCertificateWithAcquiredBadges({ shareableCert
     maxReachableLevelOnCertificationDate: shareableCertificateData.maxReachableLevelOnCertificationDate,
     sessionId,
     userId: shareableCertificateData.userId,
-    version: AlgorithmEngineVersion.V2,
   }).id;
   const assessmentResultId = databaseBuilder.factory.buildAssessmentResult.last({
     certificationCourseId,

--- a/api/tests/certification/results/integration/infrastructure/repositories/certificate-repository_test.js
+++ b/api/tests/certification/results/integration/infrastructure/repositories/certificate-repository_test.js
@@ -1,5 +1,7 @@
 import * as certificateRepository from '../../../../../../src/certification/results/infrastructure/repositories/certificate-repository.js';
+import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { AutoJuryCommentKeys } from '../../../../../../src/certification/shared/domain/models/JuryComment.js';
+import { SESSIONS_VERSIONS } from '../../../../../../src/certification/shared/domain/models/SessionVersion.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { status } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
 import {
@@ -2347,6 +2349,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
           deliveredAt: new Date('2021-05-05'),
           certificationCenter: 'Centre des poules bien dodues',
           pixScore: 51,
+          version: SESSIONS_VERSIONS.V3,
         };
 
         const { certificationCourseId, assessmentResultId } = await _buildValidShareableCertificate(
@@ -2459,6 +2462,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
           deliveredAt: new Date('2021-05-05'),
           certificationCenter: 'Centre des poules bien dodues',
           pixScore: 51,
+          version: SESSIONS_VERSIONS.V3,
         };
 
         const { certificationCourseId, assessmentResultId } = await _buildValidShareableCertificate(
@@ -2595,6 +2599,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
           deliveredAt: new Date('2021-05-05'),
           certificationCenter: 'Centre des poules bien dodues',
           pixScore: 51,
+          version: SESSIONS_VERSIONS.V3,
           certifiedBadgeImages: [
             {
               imageUrl: 'https://images.pix.fr/badge1.svg',
@@ -2969,6 +2974,7 @@ async function _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
 async function _buildValidShareableCertificate(shareableCertificateData, buildCompetenceMark = true) {
   const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
   const sessionId = databaseBuilder.factory.buildSession({
+    version: shareableCertificateData.version,
     id: shareableCertificateData.sessionId,
     publishedAt: shareableCertificateData.deliveredAt,
     certificationCenter: shareableCertificateData.certificationCenter,
@@ -2987,6 +2993,7 @@ async function _buildValidShareableCertificate(shareableCertificateData, buildCo
     maxReachableLevelOnCertificationDate: shareableCertificateData.maxReachableLevelOnCertificationDate,
     sessionId,
     userId: shareableCertificateData.userId,
+    version: shareableCertificateData.version,
   }).id;
 
   const assessmentResultId = databaseBuilder.factory.buildAssessmentResult.last({
@@ -3010,6 +3017,7 @@ async function _buildValidShareableCertificate(shareableCertificateData, buildCo
 async function _buildValidShareableCertificateWithAcquiredBadges({ shareableCertificateData, acquiredBadges }) {
   const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
   const sessionId = databaseBuilder.factory.buildSession({
+    version: shareableCertificateData.version,
     publishedAt: shareableCertificateData.deliveredAt,
     certificationCenter: shareableCertificateData.certificationCenter,
     certificationCenterId,
@@ -3027,6 +3035,7 @@ async function _buildValidShareableCertificateWithAcquiredBadges({ shareableCert
     maxReachableLevelOnCertificationDate: shareableCertificateData.maxReachableLevelOnCertificationDate,
     sessionId,
     userId: shareableCertificateData.userId,
+    version: AlgorithmEngineVersion.V2,
   }).id;
   const assessmentResultId = databaseBuilder.factory.buildAssessmentResult.last({
     certificationCourseId,

--- a/api/tests/certification/results/unit/application/certification-controller_test.js
+++ b/api/tests/certification/results/unit/application/certification-controller_test.js
@@ -1,5 +1,6 @@
 import { certificationController } from '../../../../../src/certification/results/application/certification-controller.js';
 import { usecases } from '../../../../../src/certification/results/domain/usecases/index.js';
+import { SESSIONS_VERSIONS } from '../../../../../src/certification/shared/domain/models/SessionVersion.js';
 import { domainBuilder, expect, hFake, sinon } from '../../../../test-helper.js';
 import { getI18n } from '../../../../tooling/i18n/i18n.js';
 
@@ -23,6 +24,7 @@ describe('Certification | Results | Unit | Application | certifications-controll
         pixScore: 456,
         certifiedBadgeImages: ['/img/1'],
         maxReachableLevelOnCertificationDate: 6,
+        version: SESSIONS_VERSIONS.V3,
       });
       sinon.stub(usecases, 'getShareableCertificate');
       usecases.getShareableCertificate
@@ -52,6 +54,7 @@ describe('Certification | Results | Unit | Application | certifications-controll
             'pix-score': 456,
             'certified-badge-images': ['/img/1'],
             'max-reachable-level-on-certification-date': 6,
+            version: SESSIONS_VERSIONS.V3,
           },
           relationships: {
             'result-competence-tree': {

--- a/api/tests/certification/results/unit/application/certification-controller_test.js
+++ b/api/tests/certification/results/unit/application/certification-controller_test.js
@@ -93,6 +93,7 @@ describe('Certification | Results | Unit | Application | certifications-controll
         certifiedBadgeImages: [],
         verificationCode: 'P-SUPERCODE',
         maxReachableLevelOnCertificationDate: 6,
+        version: SESSIONS_VERSIONS.V3,
       });
       sinon.stub(usecases, 'getPrivateCertificate');
       usecases.getPrivateCertificate.withArgs({ userId, certificationCourseId, locale }).resolves(privateCertificate);
@@ -123,6 +124,7 @@ describe('Certification | Results | Unit | Application | certifications-controll
             'certified-badge-images': [],
             'verification-code': 'P-SUPERCODE',
             'max-reachable-level-on-certification-date': 6,
+            version: SESSIONS_VERSIONS.V3,
           },
           relationships: {
             'result-competence-tree': {
@@ -154,6 +156,7 @@ describe('Certification | Results | Unit | Application | certifications-controll
         certifiedBadgeImages: [],
         verificationCode: 'P-SUPERCODE',
         maxReachableLevelOnCertificationDate: 6,
+        version: SESSIONS_VERSIONS.V3,
       });
       sinon.stub(usecases, 'findUserPrivateCertificates');
       usecases.findUserPrivateCertificates.withArgs({ userId }).resolves([privateCertificate1]);
@@ -182,6 +185,7 @@ describe('Certification | Results | Unit | Application | certifications-controll
               'certified-badge-images': [],
               'verification-code': 'P-SUPERCODE',
               'max-reachable-level-on-certification-date': 6,
+              version: SESSIONS_VERSIONS.V3,
             },
             relationships: {
               'result-competence-tree': {

--- a/api/tests/certification/results/unit/domain/models/PrivateCertificate_test.js
+++ b/api/tests/certification/results/unit/domain/models/PrivateCertificate_test.js
@@ -1,29 +1,35 @@
 import { PrivateCertificate } from '../../../../../../src/certification/results/domain/models/PrivateCertificate.js';
 import { AutoJuryCommentKeys } from '../../../../../../src/certification/shared/domain/models/JuryComment.js';
+import { SESSIONS_VERSIONS } from '../../../../../../src/certification/shared/domain/models/SessionVersion.js';
 import { status as assessmentResultStatuses } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
 import { domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Domain | Models | PrivateCertificate', function () {
   context('#static buildFrom', function () {
-    const commonData = {
-      id: 1,
-      firstName: 'Jean',
-      lastName: 'Bon',
-      birthdate: '2000-03-20',
-      birthplace: 'Sarajevo',
-      isPublished: true,
-      userId: 123,
-      date: '2019-01-01',
-      deliveredAt: new Date('2019-05-05'),
-      certificationCenter: 'Centre des fruits et légumes',
-      pixScore: 250,
-      commentForCandidate: 'Bravo !',
-      commentByAutoJury: null,
-      certifiedBadgeImages: [],
-      resultCompetenceTree: null,
-      verificationCode: 'someVerifCode',
-      maxReachableLevelOnCertificationDate: 5,
-    };
+    let commonData;
+
+    beforeEach(function () {
+      commonData = {
+        id: 1,
+        firstName: 'Jean',
+        lastName: 'Bon',
+        birthdate: '2000-03-20',
+        birthplace: 'Sarajevo',
+        isPublished: true,
+        userId: 123,
+        date: '2019-01-01',
+        deliveredAt: new Date('2019-05-05'),
+        certificationCenter: 'Centre des fruits et légumes',
+        pixScore: 250,
+        commentForCandidate: 'Bravo !',
+        commentByAutoJury: null,
+        certifiedBadgeImages: [],
+        resultCompetenceTree: null,
+        verificationCode: 'someVerifCode',
+        maxReachableLevelOnCertificationDate: 5,
+        version: SESSIONS_VERSIONS.V3,
+      };
+    });
 
     it('builds a cancelled PrivateCertificate', async function () {
       // when

--- a/api/tests/certification/results/unit/infrastructure/serializers/private-certificate-serializer_test.js
+++ b/api/tests/certification/results/unit/infrastructure/serializers/private-certificate-serializer_test.js
@@ -2,6 +2,7 @@ import { ResultCompetence } from '../../../../../../src/certification/results/do
 import { ResultCompetenceTree } from '../../../../../../src/certification/results/domain/models/ResultCompetenceTree.js';
 import * as serializer from '../../../../../../src/certification/results/infrastructure/serializers/private-certificate-serializer.js';
 import { AutoJuryCommentKeys } from '../../../../../../src/certification/shared/domain/models/JuryComment.js';
+import { SESSIONS_VERSIONS } from '../../../../../../src/certification/shared/domain/models/SessionVersion.js';
 import { domainBuilder, expect } from '../../../../../test-helper.js';
 import { getI18n } from '../../../../../tooling/i18n/i18n.js';
 
@@ -26,6 +27,7 @@ describe('Certification | Results | Unit | Infrastructure | Serializers | privat
       certifiedBadgeImages: ['/img/1', '/img/2'],
       verificationCode: 'P-SUPERCODE',
       maxReachableLevelOnCertificationDate: 6,
+      version: SESSIONS_VERSIONS.V3,
     };
   });
 
@@ -85,6 +87,7 @@ describe('Certification | Results | Unit | Infrastructure | Serializers | privat
           'certified-badge-images': ['/img/1', '/img/2'],
           'verification-code': 'P-SUPERCODE',
           'max-reachable-level-on-certification-date': 6,
+          version: SESSIONS_VERSIONS.V3,
         },
         relationships: {
           'result-competence-tree': {

--- a/api/tests/certification/results/unit/infrastructure/serializers/shareable-certificate-serializer_test.js
+++ b/api/tests/certification/results/unit/infrastructure/serializers/shareable-certificate-serializer_test.js
@@ -1,6 +1,7 @@
 import { ResultCompetence } from '../../../../../../src/certification/results/domain/models/ResultCompetence.js';
 import { ResultCompetenceTree } from '../../../../../../src/certification/results/domain/models/ResultCompetenceTree.js';
 import * as serializer from '../../../../../../src/certification/results/infrastructure/serializers/shareable-certificate-serializer.js';
+import { SESSIONS_VERSIONS } from '../../../../../../src/certification/shared/domain/models/SessionVersion.js';
 import { domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | shareable-certificate-serializer', function () {
@@ -47,6 +48,7 @@ describe('Unit | Serializer | JSONAPI | shareable-certificate-serializer', funct
         certifiedBadgeImages: ['/img/1', '/img/2'],
         resultCompetenceTree,
         maxReachableLevelOnCertificationDate: 6,
+        version: SESSIONS_VERSIONS.V3,
       });
 
       // when
@@ -68,6 +70,7 @@ describe('Unit | Serializer | JSONAPI | shareable-certificate-serializer', funct
           'pix-score': 456,
           'certified-badge-images': ['/img/1', '/img/2'],
           'max-reachable-level-on-certification-date': 6,
+          version: SESSIONS_VERSIONS.V3,
         },
         relationships: {
           'result-competence-tree': {

--- a/api/tests/tooling/domain-builder/factory/build-private-certificate.js
+++ b/api/tests/tooling/domain-builder/factory/build-private-certificate.js
@@ -1,5 +1,6 @@
 import { PrivateCertificate } from '../../../../src/certification/results/domain/models/PrivateCertificate.js';
 import { JuryComment, JuryCommentContexts } from '../../../../src/certification/shared/domain/models/JuryComment.js';
+import { SESSIONS_VERSIONS } from '../../../../src/certification/shared/domain/models/SessionVersion.js';
 
 const buildPrivateCertificate = function ({
   id = 1,
@@ -20,6 +21,7 @@ const buildPrivateCertificate = function ({
   resultCompetenceTree = null,
   verificationCode = 'P-BBBCCCDD',
   maxReachableLevelOnCertificationDate = 5,
+  version = SESSIONS_VERSIONS.V3,
 } = {}) {
   const juryComment = new JuryComment({
     commentByAutoJury,
@@ -44,6 +46,7 @@ const buildPrivateCertificate = function ({
     certifiedBadgeImages,
     verificationCode,
     maxReachableLevelOnCertificationDate,
+    version,
   });
 };
 
@@ -65,6 +68,7 @@ buildPrivateCertificate.cancelled = function ({
   resultCompetenceTree,
   verificationCode,
   maxReachableLevelOnCertificationDate,
+  version,
 }) {
   return buildPrivateCertificate({
     id,
@@ -85,6 +89,7 @@ buildPrivateCertificate.cancelled = function ({
     verificationCode,
     maxReachableLevelOnCertificationDate,
     status: PrivateCertificate.status.CANCELLED,
+    version,
   });
 };
 
@@ -106,6 +111,7 @@ buildPrivateCertificate.validated = function ({
   resultCompetenceTree,
   verificationCode,
   maxReachableLevelOnCertificationDate,
+  version,
 }) {
   return buildPrivateCertificate({
     id,
@@ -126,6 +132,7 @@ buildPrivateCertificate.validated = function ({
     verificationCode,
     maxReachableLevelOnCertificationDate,
     status: PrivateCertificate.status.VALIDATED,
+    version,
   });
 };
 
@@ -147,6 +154,7 @@ buildPrivateCertificate.rejected = function ({
   resultCompetenceTree,
   verificationCode,
   maxReachableLevelOnCertificationDate,
+  version,
 }) {
   return buildPrivateCertificate({
     id,
@@ -167,6 +175,7 @@ buildPrivateCertificate.rejected = function ({
     verificationCode,
     maxReachableLevelOnCertificationDate,
     status: PrivateCertificate.status.REJECTED,
+    version,
   });
 };
 
@@ -188,6 +197,7 @@ buildPrivateCertificate.error = function ({
   resultCompetenceTree,
   verificationCode,
   maxReachableLevelOnCertificationDate,
+  version,
 }) {
   return buildPrivateCertificate({
     id,
@@ -208,6 +218,7 @@ buildPrivateCertificate.error = function ({
     verificationCode,
     maxReachableLevelOnCertificationDate,
     status: PrivateCertificate.status.ERROR,
+    version,
   });
 };
 
@@ -229,6 +240,7 @@ buildPrivateCertificate.started = function ({
   resultCompetenceTree,
   verificationCode,
   maxReachableLevelOnCertificationDate,
+  version,
 }) {
   return buildPrivateCertificate({
     id,
@@ -249,6 +261,7 @@ buildPrivateCertificate.started = function ({
     verificationCode,
     maxReachableLevelOnCertificationDate,
     status: PrivateCertificate.status.STARTED,
+    version,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/build-shareable-certificate.js
+++ b/api/tests/tooling/domain-builder/factory/build-shareable-certificate.js
@@ -15,6 +15,7 @@ const buildShareableCertificate = function ({
   maxReachableLevelOnCertificationDate = 5,
   certifiedBadgeImages = [],
   resultCompetenceTree = null,
+  version = 3,
 } = {}) {
   return new ShareableCertificate({
     id,
@@ -31,6 +32,7 @@ const buildShareableCertificate = function ({
     maxReachableLevelOnCertificationDate,
     resultCompetenceTree,
     certifiedBadgeImages,
+    version,
   });
 };
 

--- a/mon-pix/app/models/certification.js
+++ b/mon-pix/app/models/certification.js
@@ -26,6 +26,7 @@ export default class Certification extends Model {
   @attr('string') verificationCode;
   @attr() certifiedBadgeImages;
   @attr('number') maxReachableLevelOnCertificationDate;
+  @attr('number') version;
 
   // includes
   @belongsTo('resultCompetenceTree', { async: true, inverse: null }) resultCompetenceTree;
@@ -42,7 +43,11 @@ export default class Certification extends Model {
   }
 
   get shouldDisplayProfessionalizingWarning() {
-    return this.currentDomain.isFranceDomain && new Date(this.deliveredAt).getTime() >= professionalizingDate.getTime();
+    return (
+      this.version === 2 &&
+      this.currentDomain.isFranceDomain &&
+      new Date(this.deliveredAt).getTime() >= professionalizingDate.getTime()
+    );
   }
 
   get maxReachablePixCountOnCertificationDate() {

--- a/mon-pix/tests/integration/components/user-certifications-detail-header-test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-header-test.js
@@ -30,6 +30,7 @@ module('Integration | Component | user certifications detail header', function (
         pixScore: 654,
         status: 'validated',
         commentForCandidate: 'Comment for candidate',
+        version: 2,
       });
       this.set('certification', certification);
 
@@ -100,7 +101,7 @@ module('Integration | Component | user certifications detail header', function (
       this.owner.register('service:currentDomain', CurrentDomainServiceStub);
     });
 
-    module('when certification is delivered after 2022-01-01', function () {
+    module('when certification is v2 and delivered after 2022-01-01', function () {
       test('should display the professionalizing warning', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
@@ -117,6 +118,7 @@ module('Integration | Component | user certifications detail header', function (
           pixScore: 654,
           status: 'validated',
           commentForCandidate: 'Comment for candidate',
+          version: 2,
         });
         this.set('certification', certification);
 
@@ -151,6 +153,42 @@ module('Integration | Component | user certifications detail header', function (
           pixScore: 654,
           status: 'validated',
           commentForCandidate: 'Comment for candidate',
+          version: 2,
+        });
+        this.set('certification', certification);
+
+        // when
+        const screen = await renderScreen(
+          hbs`<UserCertificationsDetailHeader @certification={{this.certification}} />`,
+        );
+
+        // then
+        assert.notOk(
+          screen.queryByText(
+            'Le certificat Pix est reconnu comme professionnalisant par France compétences à compter d’un score minimal de 120 pix',
+          ),
+        );
+      });
+    });
+
+    module('when certification is v3', function () {
+      test('should not display the professionalizing warning', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const certification = store.createRecord('certification', {
+          id: 1,
+          birthdate: '2000-01-22',
+          birthplace: 'Paris',
+          firstName: 'Jean',
+          lastName: 'Bon',
+          date: new Date('2018-02-15T15:15:52Z'),
+          deliveredAt: '2022-05-28',
+          certificationCenter: 'Université de Lyon',
+          isPublished: true,
+          pixScore: 654,
+          status: 'validated',
+          commentForCandidate: 'Comment for candidate',
+          version: 3,
         });
         this.set('certification', certification);
 

--- a/mon-pix/tests/unit/models/certification-test.js
+++ b/mon-pix/tests/unit/models/certification-test.js
@@ -34,24 +34,45 @@ module('Unit | Model | certification', function (hooks) {
         this.owner.register('service:currentDomain', CurrentDomainServiceStub);
       });
 
-      test('should be true when deliveredAt >= 2022-01-01 ', function (assert) {
-        // given
-        const model = store.createRecord('certification', { deliveredAt: '2022-01-01' });
+      module('when version is 2', function () {
+        const version = 2;
 
-        // when / then
-        assert.true(model.shouldDisplayProfessionalizingWarning);
+        test('should be true when deliveredAt >= 2022-01-01 ', function (assert) {
+          // given
+          const model = store.createRecord('certification', { version, deliveredAt: '2022-01-01' });
+
+          // when / then
+          assert.true(model.shouldDisplayProfessionalizingWarning);
+        });
+
+        test('should be false when when deliveredAt < 2022-01-01', function (assert) {
+          // given
+          const model = store.createRecord('certification', { version, deliveredAt: '2021-01-01' });
+
+          // when / then
+          assert.false(model.shouldDisplayProfessionalizingWarning);
+        });
       });
+    });
 
-      test('should be false when when deliveredAt < 2022-01-01', function (assert) {
+    module('when domain is not french', function () {
+      test('should be false', function (assert) {
         // given
-        const model = store.createRecord('certification', { deliveredAt: '2021-01-01' });
+        class CurrentDomainServiceStub extends Service {
+          get isFranceDomain() {
+            return false;
+          }
+        }
+
+        this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+        const model = store.createRecord('certification', { deliveredAt: '2022-01-01' });
 
         // when / then
         assert.false(model.shouldDisplayProfessionalizingWarning);
       });
     });
 
-    module('when domain is not french', function () {
+    module('when version is not 2', function () {
       test('should be false', function (assert) {
         // given
         class CurrentDomainServiceStub extends Service {

--- a/mon-pix/tests/unit/models/certification-test.js
+++ b/mon-pix/tests/unit/models/certification-test.js
@@ -77,12 +77,12 @@ module('Unit | Model | certification', function (hooks) {
         // given
         class CurrentDomainServiceStub extends Service {
           get isFranceDomain() {
-            return false;
+            return true;
           }
         }
 
         this.owner.register('service:currentDomain', CurrentDomainServiceStub);
-        const model = store.createRecord('certification', { deliveredAt: '2022-01-01' });
+        const model = store.createRecord('certification', { deliveredAt: '2022-01-01', version: 3 });
 
         // when / then
         assert.false(model.shouldDisplayProfessionalizingWarning);


### PR DESCRIPTION
## :fallen_leaf: Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

L’ancien certificat/certificat partagé/attestation comporte la mention “Le certificat Pix est reconnu comme professionnalisant par France compétences à compter d’un score minimal de 120 pix”, ce qui n’est plus vrai pour la nouvelle Certification.

## :chestnut: Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

Conditionner l'affichage de la mention aux seuls certificats v2.
Pour cela on ajoute la version du `session` dans le `ShareableCertificate`.

## :wood: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

Utiliser la page `/verification-certificat` pour un certificat v2.
Constater la présence de la mention sur la professionnalisation.

Utiliser la page `/verification-certificat` pour un certificat v3.
Constater l'absence de la mention sur la professionnalisation.

Effectuer les mêmes tests pour le certificat privé
