### PR TITLE
[TECH] :wrench: Configure matomo pour pix junior - Suite

### DIFF
--- a/junior/app/routes/application.js
+++ b/junior/app/routes/application.js
@@ -3,6 +3,7 @@ import { service } from '@ember/service';
 
 export default class ApplicationRoute extends Route {
   @service intl;
+  @service metrics;
 
   async beforeModel() {
     /*
@@ -16,5 +17,6 @@ export default class ApplicationRoute extends Route {
     Pour régler ce problème, il faut définir une locale ayant un fichier dans le dossier de traduction.
      */
     this.intl.setLocale('fr');
+    this.metrics.initialize();
   }
 }

--- a/junior/config/environment.js
+++ b/junior/config/environment.js
@@ -13,8 +13,10 @@ module.exports = function (environment) {
     environment,
     locationType: 'history',
     rootURL: '/',
-    matomo: {},
-
+    metrics: {
+      enabled: analyticsEnabled,
+      matomoUrl: process.env.WEB_ANALYTICS_URL,
+    },
     EmberENV: {
       EXTEND_PROTOTYPES: false,
       FEATURES: {
@@ -46,10 +48,6 @@ module.exports = function (environment) {
     // ENV.APP.LOG_TRANSITIONS = true;
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
-    if (analyticsEnabled) {
-      ENV.matomo.url = process.env.WEB_ANALYTICS_URL;
-      ENV.matomo.debug = true;
-    }
   }
 
   if (environment === 'test') {
@@ -62,15 +60,8 @@ module.exports = function (environment) {
 
     ENV.APP.rootElement = '#ember-testing';
     ENV.APP.autoboot = false;
-
     ENV.APP.CHALLENGE_DISPLAY_DELAY = 0;
-  }
-
-  if (environment === 'production') {
-    // here you can enable a production-specific feature
-    if (analyticsEnabled) {
-      ENV.matomo.url = process.env.WEB_ANALYTICS_URL;
-    }
+    ENV.metrics.enabled = false;
   }
 
   ENV['ember-component-css'] = {

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {
+        "@1024pix/ember-matomo-tag-manager": "^2.4.3",
         "@1024pix/ember-testing-library": "^3.0.6",
         "@1024pix/eslint-config": "^1.3.8",
         "@1024pix/pix-ui": "^46.15.2",
@@ -80,6 +81,15 @@
       },
       "engines": {
         "node": "^20.18.0"
+      }
+    },
+    "node_modules/@1024pix/ember-matomo-tag-manager": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@1024pix/ember-matomo-tag-manager/-/ember-matomo-tag-manager-2.4.3.tgz",
+      "integrity": "sha512-gsoFCZxMXO5purZh92WwgWyydRS/PftFr7+HRF9bRAHbPrqkd6NCmLEHvFZ9ETXKPB3SkF79Qh28SaljXTkb5g==",
+      "dev": true,
+      "dependencies": {
+        "@embroider/addon-shim": "^1.0.0"
       }
     },
     "node_modules/@1024pix/ember-testing-library": {

--- a/junior/package.json
+++ b/junior/package.json
@@ -35,6 +35,7 @@
     "test:lint": "run-p --continue-on-error test lint"
   },
   "devDependencies": {
+    "@1024pix/ember-matomo-tag-manager": "^2.4.3",
     "@1024pix/ember-testing-library": "^3.0.6",
     "@1024pix/eslint-config": "^1.3.8",
     "@1024pix/pix-ui": "^46.15.2",


### PR DESCRIPTION
## :fallen_leaf: Problème

Nous n'avons pas d'information sur les accès à pix junior (`junior.pix.fr`)

## :chestnut: Proposition

Installer et configuré un client matomo pour envoyer des informations d'accès à l'instance https://analytics.pix.fr/

## :jack_o_lantern: Remarques

Peu de documentation sur la mise en place du client matomo dans confluence.

## :wood: Pour tester

1. s'assurer que chaque page contient un bout de code lié à Matomo 

```Javascript
<!-- Matomo -->
<script>
  var _paq = window._paq = window._paq || [];
  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
  _paq.push(['trackPageView']);
  _paq.push(['enableLinkTracking']);
  (function() {
    var u="https://analytics.pix.fr/";
    _paq.push(['setTrackerUrl', u+'piwik.php']);
    _paq.push(['setSiteId', '16']);
    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
    g.async=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
  })();
</script>
<!-- End Matomo Code -->
```
2. vérifier que des données sont remontées dans les dashboards standards de Matomo (https://analytics.pix.fr puis pix junior)