### PR TITLE
[FEATURE] Ajuster le wording et le design des pages d'authentification (PIX-15198)

### DIFF
--- a/mon-pix/app/components/authentication/oidc-provider-selector.scss
+++ b/mon-pix/app/components/authentication/oidc-provider-selector.scss
@@ -37,12 +37,14 @@
   }
 
   .pix-select__dropdown {
+    min-width : auto;
     max-height: 488px;
     background-color : var(--pix-neutral-20);
   }
 
   .pix-select-options-category__option {
     padding: var(--pix-spacing-3x) var(--pix-spacing-2x);
+    white-space: normal;
 
     &:first-child {
       display: none;

--- a/mon-pix/app/components/authentication/password-reset-demand/password-reset-demand-form.gjs
+++ b/mon-pix/app/components/authentication/password-reset-demand/password-reset-demand-form.gjs
@@ -1,5 +1,4 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixMessage from '@1024pix/pix-ui/components/pix-message';
 import { on } from '@ember/modifier';
@@ -114,17 +113,13 @@ export default class PasswordResetDemandForm extends Component {
           </PixButton>
         </div>
 
-        <p class="authentication-password-reset-demand-form__help">
-          {{t "components.authentication.password-reset-demand-form.no-email-question"}}
-          <PixButtonLink
-            @variant="tertiary"
-            @href="{{t 'components.authentication.password-reset-demand-form.contact-us-link.link-url'}}"
-            target="_blank"
-            class="authentication-password-reset-demand-form__help-contact-us-link"
-          >
+        <section class="authentication-password-reset-demand-form__help">
+          <h2>
+            {{t "components.authentication.password-reset-demand-form.no-email-question"}}</h2>
+          <a href="{{t 'components.authentication.password-reset-demand-form.contact-us-link.link-url'}}">
             {{t "components.authentication.password-reset-demand-form.contact-us-link.link-text"}}
-          </PixButtonLink>
-        </p>
+          </a>
+        </section>
       </form>
     {{/if}}
   </template>

--- a/mon-pix/app/components/authentication/password-reset-demand/password-reset-demand.scss
+++ b/mon-pix/app/components/authentication/password-reset-demand/password-reset-demand.scss
@@ -27,17 +27,22 @@
     }
 
     &__help {
-        @extend %pix-body-s;
+      @extend %pix-body-m;
 
-        margin-top: var(--pix-spacing-4x);
-        color: var(--pix-neutral-70);
-        text-align: center;
+      display: flex;
+      gap: var(--pix-spacing-2x);
+      margin-top: var(--pix-spacing-8x);
+      color: var(--pix-neutral-500);
+
+      > a {
+        color: var(--pix-neutral-800);
+        font-weight: var(--pix-font-bold);
+        text-decoration: underline;
+      }
+
     }
 
-    &__help-contact-us-link {
-        display: inline;
-        padding: 0;
-    }
+
 }
 
 .authentication-password-reset-demand-received-info {

--- a/mon-pix/app/components/authentication/sso-selection-form.gjs
+++ b/mon-pix/app/components/authentication/sso-selection-form.gjs
@@ -55,7 +55,11 @@ export default class SsoSelectionForm extends Component {
           @route="authentication.login-oidc"
           @model={{this.selectedProviderId}}
         >
-          {{t "pages.authentication.sso-selection.signin.link"}}
+          {{#if @isForSignup}}
+            {{t "pages.authentication.sso-selection.signup.button"}}
+          {{else}}
+            {{t "pages.authentication.sso-selection.signin.button"}}
+          {{/if}}
         </PixButtonLink>
 
         <p id="signin-message" class="sso-selection-form__signin-message" aria-live="polite">
@@ -63,7 +67,11 @@ export default class SsoSelectionForm extends Component {
         </p>
       {{else}}
         <PixButton @type="button" @isDisabled={{true}}>
-          {{t "pages.authentication.sso-selection.signin.link"}}
+          {{#if @isForSignup}}
+            {{t "pages.authentication.sso-selection.signup.button"}}
+          {{else}}
+            {{t "pages.authentication.sso-selection.signin.button"}}
+          {{/if}}
         </PixButton>
       {{/if}}
     </section>

--- a/mon-pix/app/templates/authentication/sso-selection.hbs
+++ b/mon-pix/app/templates/authentication/sso-selection.hbs
@@ -14,11 +14,11 @@
   <:content>
     {{#if this.isSigninRoute}}
       <h1 class="pix-title-m">{{t "pages.sign-in.first-title"}}</h1>
+      <Authentication::SsoSelectionForm />
     {{else}}
       <h1 class="pix-title-m">{{t "pages.sign-up.first-title"}}</h1>
+      <Authentication::SsoSelectionForm @isForSignup={{true}} />
     {{/if}}
-
-    <Authentication::SsoSelectionForm />
 
     {{#if this.isSigninRoute}}
       <section class="sso-selection-page__signup">

--- a/mon-pix/app/templates/password-reset-demand.hbs
+++ b/mon-pix/app/templates/password-reset-demand.hbs
@@ -4,7 +4,7 @@
   <AuthenticationLayout class="signin-page-layout">
     <:header>
       <PixButtonLink @variant="secondary" @route="authentication.login">
-        {{t "common.actions.login"}}
+        {{t "pages.sign-up.actions.login"}}
       </PixButtonLink>
     </:header>
 

--- a/mon-pix/tests/integration/components/authentication/sso-selection-form-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/sso-selection-form-test.gjs
@@ -30,7 +30,9 @@ module('Integration | Component | Authentication | SsoSelectionForm', function (
     const screen = await render(<template><SsoSelectionForm /></template>);
 
     // then
-    const buttonLink = await screen.findByRole('button', { name: t('pages.authentication.sso-selection.signin.link') });
+    const buttonLink = await screen.findByRole('button', {
+      name: t('pages.authentication.sso-selection.signin.button'),
+    });
     assert.dom(buttonLink).hasAttribute('disabled');
   });
 
@@ -45,7 +47,7 @@ module('Integration | Component | Authentication | SsoSelectionForm', function (
     await click(screen.getByRole('option', { name: providerName }));
 
     // then
-    const buttonLink = await screen.findByRole('link', { name: t('pages.authentication.sso-selection.signin.link') });
+    const buttonLink = await screen.findByRole('link', { name: t('pages.authentication.sso-selection.signin.button') });
     assert.strictEqual(buttonLink.getAttribute('href'), '/connexion/cem');
 
     const connexionMessage = await screen.findByText(

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -189,7 +189,7 @@
           "email": {
             "error-message-invalid": "Your email address is invalid.",
             "label": "Email address",
-            "placeholder": "e.g. john.smith@example.com"
+            "placeholder": "e.g. john.smith@email.com"
           }
         },
         "no-email-question": "No email address?",
@@ -231,7 +231,7 @@
           "email": {
             "error": "Your email address is invalid.",
             "label": "Email address",
-            "placeholder": "e.g. john.smith@example.com"
+            "placeholder": "e.g. john.smith@email.com"
           },
           "firstname": {
             "error": "You have not entered your first name.",
@@ -1767,7 +1767,7 @@
         "legend": "Information required for sign in.",
         "login": {
           "label": "Email address or username",
-          "placeholder": "e.g. john.smith@example.com"
+          "placeholder": "e.g. john.smith@email.com"
         },
         "password": {
           "label": "Password"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -231,7 +231,7 @@
           "email": {
             "error": "Votre adresse e-mail n’est pas valide.",
             "label": "Adresse e-mail",
-            "placeholder": "ex: jean.dupont@email.fr"
+            "placeholder": "ex: jean.dupont@email.com"
           },
           "firstname": {
             "error": "Votre prénom n’est pas renseigné.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -463,10 +463,11 @@
       },
       "sso-selection": {
         "signin": {
-          "link": "Je me connecte",
+          "button": "Je me connecte",
           "message": "Vous allez être redirigé(e) vers la page de connexion de « {providerName} » afin de vous identifier sur Pix."
         },
         "signup": {
+          "button": "Je m'inscris",
           "link": "Inscrivez-vous",
           "title": "Vous n'avez pas de compte ?"
         },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -163,7 +163,7 @@
       },
       "oidc-provider-selector": {
         "label": "Rechercher une organisation",
-        "placeholder": "Sélectionner un organisme",
+        "placeholder": "Sélectionner une organisation",
         "searchLabel": "Recherche par mots-clés"
       },
       "other-authentication-providers": {


### PR DESCRIPTION
## :fallen_leaf: Problème
Il faut traiter les retours de la recette des nouvelles pages d'authentification 
## :chestnut: Proposition
Traiter les points soulevés dans https://1024pix.atlassian.net/wiki/spaces/DA/pages/4647419930/Recette+des+mires+de+connexion#Phase-de-recette-2

1. Page d’inscription: pour l'input d’adresse email, en Français uniquement, avoir le placeholder suivant: jean.dupont@email.com au lieu de jean.dupont@email.fr
2. Pages de connexion, inscription, réinitialisation de mot de passe : Pour l’input d’adresse e-mail (page de connexion & inscription et réinitialisation du mot de passe), en Anglais, avoir le placeholder suivant :
`e.g john.smith@email.com`
3. Page des SSO: Bug sur mobile, le menu du dropdown est trop large (+ large que la fenetre)
4. Page des SSO: Sur le choix de l'organisation (dans un contexte d'inscription), sur le bouton il est écrit "Je me connecte" au lieu de "Je m'inscris" 
5. Page des SSO: Dans le placeholder on parle d’”organisme” au lieu de d’organisation, replacer par “Sélectionner une organisation”
6. Page de réinitialisation de mot de passe: [Français & Anglais] on a le bouton "Se connecter sur Pix" au lieu de "Se connecter"
7. Inconsistence entre les pages “Mot de passe oublié” et “Choix des SSO” sur l’affichage du sous-texte: Faire comme dans l'écran de “Choix des SSO” (à gauche et même taille et couleurs de texte) ; vérifier aussi que la marge supérieure est identique au sous-teste de la page de choix des SSO (32px au lieu de 16px)

## :jack_o_lantern: Remarques
Les clés de traduction mériteront peut-être d'être triées / réorganisées dans un autre ticket.

## :wood: Pour tester
Vérifier les points évoqués dans  https://1024pix.atlassian.net/wiki/spaces/DA/pages/4647419930/Recette+des+mires+de+connexion#Phase-de-recette-2
