### PR TITLE
[FEATURE] Envoyer en un batch les alertes Joi pour le métier (PIX-15124)

### DIFF
--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-schema.js
@@ -18,22 +18,22 @@ const qcuElementSchema = Joi.object({
     invalid: htmlSchema,
   }),
   solution: proposalIdSchema.required(),
-}).custom((qcuElement, helpers) => {
+}).external(async (qcuElement, helpers) => {
   const hasGlobalFeedbacks = qcuElement.feedbacks !== undefined;
   const hasSpecificFeedbacks = qcuElement.proposals.some((proposal) => proposal.feedback !== undefined);
   if (hasGlobalFeedbacks && hasSpecificFeedbacks) {
-    return helpers.message('Un QCU ne peut pas avoir à la fois des feedbacks spécifiques et globales');
+    return helpers.error('Un QCU ne peut pas avoir à la fois des feedbacks spécifiques et globales');
   }
   if (hasSpecificFeedbacks) {
     const someProposalsDoNotHaveSpecificFeedback = qcuElement.proposals.some(
       (proposal) => proposal.feedback === undefined,
     );
     if (someProposalsDoNotHaveSpecificFeedback) {
-      return helpers.message('Dans ce QCU, au moins une proposition ne possède pas de feedback spécifique');
+      return helpers.error('Dans ce QCU, au moins une proposition ne possède pas de feedback spécifique');
     }
   }
   if (!hasGlobalFeedbacks && !hasSpecificFeedbacks) {
-    return helpers.message("Dans ce QCU, il n'y a ni feedbacks spécifiques, ni feedbacks globales");
+    return helpers.error("Dans ce QCU, il n'y a ni feedbacks spécifiques, ni feedbacks globales");
   }
 
   return qcuElement;

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
@@ -84,21 +84,21 @@ const grainSchema = Joi.object({
         ],
       }),
     )
-    .custom((value, helpers) => {
+    .external(async (value, helpers) => {
       const steppersInArray = value.filter(({ type }) => type === 'stepper');
       if (steppersInArray.length > 1) {
-        return helpers.message("Il ne peut y avoir qu'un stepper par grain");
+        return helpers.error("Il ne peut y avoir qu'un stepper par grain");
       }
       return value;
     })
-    .custom((value, helpers) => {
+    .external(async (value, helpers) => {
       const steppersInArray = value.filter(({ type }) => type === 'stepper');
       const elementsInArray = value.filter(({ type }) => type === 'element');
       const containsAnswerableElement = elementsInArray.some(({ element }) =>
         ['qcu', 'qcm', 'qrocm'].includes(element.type),
       );
       if (steppersInArray.length === 1 && containsAnswerableElement) {
-        return helpers.message(
+        return helpers.error(
           "Un grain ne peut pas être composé d'un composant 'stepper' et d'un composant 'element' répondable (QCU, QCM ou QROCM)",
         );
       }


### PR DESCRIPTION
## :fallen_leaf: Problème
Quand il y a des erreurs dans les json de Module, transmettre les erreurs en une seule fois, et pas en plusieurs passages.

## :chestnut: Proposition
Utiliser external, async et errors pour que le moduleSchema.validateAsync fonctionne en un batch.

## :jack_o_lantern: Remarques
- .custom() est uniquement synchrone et ne gère pas l'asynchrone : https://joi.dev/api/?v=17.13.3#anycustommethod-description
- pour valider le html contenu dans certains Element, une validation asynchrone est nécéssaire
- les tests ici sont pour l'instant KO, car on veut voir le rendu de la console pour les alertes Joi

## :wood: Pour tester
- Lancer les tests API de devComp
- Constater que toutes les erreurs du json du didacticiel sont remontées dans la console en une fois

