### PR TITLE
[BUGFIX] Corriger le chevauchement d'affichage des écrans focus et timer lors de la certification sur Pix App (PIX-14970).

### DIFF
--- a/mon-pix/app/components/timed-challenge-instructions.hbs
+++ b/mon-pix/app/components/timed-challenge-instructions.hbs
@@ -1,26 +1,22 @@
 <div class="rounded-panel rounded-panel--no-margin-bottom timed-challenge-instructions">
-  <div class="timed-challenge-instructions__primary">
+  <h1 class="timed-challenge-instructions__primary">
     {{t "pages.timed-challenge-instructions.primary" time=this.allocatedTime htmlSafe=true}}
-  </div>
+  </h1>
 
-  <div class="timed-challenge-instructions__secondary">
+  <p class="timed-challenge-instructions__secondary">
     {{t "pages.timed-challenge-instructions.secondary"}}
-  </div>
+  </p>
 
   <div class="timed-challenge-instructions__allocated-time">
-    <div class="timed-challenge-instructions-allocated-time__gauge">
-      <img class="timed-challenge-instructions-gauge__icon" src="/images/icons/icon-timed-challenge.svg" alt="" />
-      <span class="timed-challenge-instructions-gauge__value">{{this.allocatedTime}}</span>
-    </div>
+    <PixIcon @name="clock" @ariaHidden={{true}} class="timed-challenge-instructions-allocated-time__icon" />
+    <span>{{this.allocatedTime}}</span>
   </div>
 
-  <div class="timed-challenge-instructions__action">
-    <PixButton
-      @triggerAction={{@hasUserConfirmedWarning}}
-      class="timed-challenge-instructions-action__confirmation-button"
-      @variant="success"
-    >
-      {{t "pages.timed-challenge-instructions.action"}}
-    </PixButton>
-  </div>
+  <PixButton
+    @triggerAction={{@hasUserConfirmedWarning}}
+    class="timed-challenge-instructions-action__confirmation-button"
+    @variant="success"
+  >
+    {{t "pages.timed-challenge-instructions.action"}}
+  </PixButton>
 </div>

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -60,6 +60,7 @@ export default class ChallengeController extends Controller {
   get couldDisplayInfoAlert() {
     return (
       !this.hasFocusedOutOfWindow &&
+      this.displayChallenge &&
       !this.model.answer &&
       this.model.challenge.focused &&
       !this.model.assessment.hasFocusedOutChallenge
@@ -163,6 +164,13 @@ export default class ChallengeController extends Controller {
       return true;
     }
 
+    if (this._isTimedChallenge && this._isFocusedCertificationChallenge) {
+      return !!(
+        (this.hasConfirmedFocusChallengeWarningScreen && this.hasUserConfirmedTimedChallengeWarning) ||
+        this.model.assessment.hasTimeoutChallenge
+      );
+    }
+
     if (this._isTimedChallenge) {
       if (this.hasUserConfirmedTimedChallengeWarning || this.model.assessment.hasTimeoutChallenge) return true;
     }
@@ -201,6 +209,15 @@ export default class ChallengeController extends Controller {
   }
 
   get displayTimedChallengeInstructions() {
+    if (this.isTimedChallengeWithoutAnswer && this.isFocusedCertificationChallengeWithoutAnswer) {
+      return (
+        this.hasConfirmedFocusChallengeWarningScreen &&
+        this.isTimedChallengeWithoutAnswer &&
+        !this.hasUserConfirmedTimedChallengeWarning &&
+        !this.model.assessment.hasTimeoutChallenge
+      );
+    }
+
     return (
       this.isTimedChallengeWithoutAnswer &&
       !this.hasUserConfirmedTimedChallengeWarning &&

--- a/mon-pix/app/styles/components/_focused-certification-challenge-instructions.scss
+++ b/mon-pix/app/styles/components/_focused-certification-challenge-instructions.scss
@@ -10,44 +10,27 @@
   justify-content: center;
 
   &__image {
-    img {
-      width: 158px;
-      height: 158px;
-    }
+    width: 158px;
+    height: 158px;
   }
 
   &__title {
-    margin-top: 22px;
+    @extend %pix-title-l;
+
+    margin: var(--pix-spacing-6x) 0;
     color: var(--pix-neutral-800);
-    font-size: 3rem;
-    font-family: $font-open-sans;
-    font-style: normal;
-    font-stretch: normal;
-    line-height: 56px;
   }
 
   &__description {
+    @extend %pix-body-l;
+
     max-width: 450px;
-    margin-top: 24px;
-    margin-bottom: 50px;
+    margin-bottom: var(--pix-spacing-6x);
     color: var(--pix-neutral-800);
-    font-weight: 500;
-    font-size: 1.25rem;
-    font-family: $font-roboto;
-    font-style: normal;
-    font-stretch: normal;
     text-align: center;
   }
 
-  &__action {
-    display: flex;
-    justify-content: center;
-  }
-}
-
-.focused-challenge-instructions-action {
   &__confirmation-button {
-    font-size: 0.875rem;
-    text-transform: uppercase;
+    margin-top: var(--pix-spacing-6x);
   }
 }

--- a/mon-pix/app/styles/components/_timed-challenge-instructions.scss
+++ b/mon-pix/app/styles/components/_timed-challenge-instructions.scss
@@ -1,27 +1,25 @@
 .timed-challenge-instructions {
   display: flex;
   flex-direction: column;
+  align-items: center;
   justify-content: center;
-  padding: 20px;
+  padding: var(--pix-spacing-10x) var(--pix-spacing-6x);
   overflow: hidden;
   text-align: center;
 
   &__primary {
-    margin-top: 22px;
+    @extend %pix-title-s;
+
     color: var(--pix-neutral-800);
     font-weight: var(--pix-font-bold);
-    font-size: 1.5rem;
-    font-style: normal;
-    font-stretch: normal;
   }
 
   &__secondary {
-    margin-top: 9px;
+    @extend %pix-body-l;
+
+    margin-top: var(--pix-spacing-3x);
     margin-bottom: 50px;
     color: var(--pix-neutral-800);
-    font-size: 1.125rem;
-    font-style: normal;
-    font-stretch: normal;
   }
 
   &__time {
@@ -29,44 +27,28 @@
   }
 
   &__allocated-time {
-    color: var(--pix-neutral-800);
-    font-size: 1.7375rem;
-  }
-
-  &__action {
     display: flex;
-    justify-content: center;
-  }
-}
-
-.timed-challenge-instructions-allocated-time {
-  &__gauge {
-    display: flex;
-    flex-direction: row;
+    gap: var(--pix-spacing-2x);
     align-items: center;
-    justify-content: center;
-    width: fit-content;
     height: 50px;
     margin: 0 auto;
-    padding: 4px 12px;
-    line-height: 3.125rem;
+    padding: var(--pix-spacing-1x) var(--pix-spacing-3x);
+    color: var(--pix-neutral-800);
+    font-size: 1.5rem;
     background-color: var(--pix-neutral-20);
     border-radius: 7px;
   }
 }
 
-.timed-challenge-instructions-gauge {
+.timed-challenge-instructions-allocated-time {
   &__icon {
-    width: 42px;
-    padding-right: 6px;
-    padding-bottom: 6px;
+    width: 2.5rem;
+    fill: var(--pix-neutral-800);
   }
 }
 
 .timed-challenge-instructions-action {
   &__confirmation-button {
-    margin-top: 22px;
-    font-size: 0.875rem;
-    text-transform: uppercase;
+    margin-top: var(--pix-spacing-6x);
   }
 }

--- a/mon-pix/app/templates/components/focused-certification-challenge-instructions.hbs
+++ b/mon-pix/app/templates/components/focused-certification-challenge-instructions.hbs
@@ -1,22 +1,19 @@
 <div class="focused-certification-challenge-instructions">
-  <div class="focused-certification-challenge-instructions__image">
-    <img src="/images/icone-pix-focus-rounded.svg" alt="" />
-  </div>
-  <div class="focused-certification-challenge-instructions__title">
+  <img src="/images/icone-pix-focus-rounded.svg" alt="" class="focused-certification-challenge-instructions__image" />
+
+  <h1 class="focused-certification-challenge-instructions__title">
     {{t "pages.focused-certification-challenge-instructions.title"}}
-  </div>
+  </h1>
 
-  <div class="focused-certification-challenge-instructions__description">
+  <p class="focused-certification-challenge-instructions__description">
     {{t "pages.focused-certification-challenge-instructions.description"}}
-  </div>
+  </p>
 
-  <div class="focused-certification-challenge-instructions__action">
-    <PixButton
-      @triggerAction={{@hasUserConfirmedWarning}}
-      class="focused-certification-challenge-instructions-action__confirmation-button"
-      @variant="success"
-    >
-      {{t "pages.focused-certification-challenge-instructions.action"}}
-    </PixButton>
-  </div>
+  <PixButton
+    @triggerAction={{@hasUserConfirmedWarning}}
+    class="focused-certification-challenge-instructions__confirmation-button"
+    @variant="success"
+  >
+    {{t "pages.focused-certification-challenge-instructions.action"}}
+  </PixButton>
 </div>


### PR DESCRIPTION
## :fallen_leaf: Problème
Lorsqu'une épreuve est à la fois timée et focus, un chevauchement des 2 écrans s'affiche : 
<img width="575" alt="Capture d’écran 2024-11-06 à 17 37 42" src="https://github.com/user-attachments/assets/b80b1d67-6963-42e5-aabe-dc1f7bcdf44e">


## :chestnut: Proposition
Corriger ce chevauchement et faire apparaître les écrans un par un.

1 écran que l'on doit voir => Focus
2 ème écran => Timer
3ème écran => l'épreuve en mode focus avec un timer

## :jack_o_lantern: Remarques
Un autre bug a été détecté en corrigeant ce chevauchement, au tab sur la page, la bulle info du focus apparaîssait. Nous l'avons masqué.

Une amélioration des pages de focus et du timer a été réalisé. (stop aux divs)

## :wood: Pour tester

- Se connecter sur pix App avec certif-success@example
- Entrer en session avec = sessionId (1), prénom et nom (oui), date (10/10/2000)
- Entrer le code candidat GCBX86
- Première question classique, passer
- Seconde question focus ET timé 
- Constater que l'on affiche d'abord la page de focus, valider
- Constater que l'on affiche la page de timer, valider
- Constater que l'on voit l'épreuve avec le timer et l'habillage du focus
- Passer cette question
- Troisième question juste timé
- Constater que l'on voit uniquement la page du timer, valider
- Puis chercher dans le reste des questions une nouvelle question juste focus
- Constater que l'on voit uniquement la page de focus, valider

- Se connecter avec certifiable-contenu-user@example.net sur pix App
- Entrer en session avec sessionId (7409), prénom et nom (oui), date (10/10/2000)
- Entrer le code JRHD49
- Constater que l'habillage est toujours bon (certif avec aménagement accessible)