### PR TITLE
[BUGFIX] Ajouter des paramètres dans l'URL du lien custom de fin de parcours (PIX-15184).

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/custom-organization-block.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/custom-organization-block.gjs
@@ -1,29 +1,59 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import Component from '@glimmer/component';
 import { t } from 'ember-intl';
-import { and } from 'ember-truth-helpers';
 
 import MarkdownToHtml from '../../../../markdown-to-html';
 
-<template>
-  <div class="evaluation-results-hero__organization-block">
-    <h3 class="evaluation-results-hero-organization-block__title">
-      {{t "pages.skill-review.organization-message"}}
-    </h3>
-    {{#if @customResultPageText}}
-      <MarkdownToHtml
-        class="evaluation-results-hero-organization-block__message"
-        @isInline={{true}}
-        @markdown={{@customResultPageText}}
-      />
-    {{/if}}
-    {{#if (and @customResultPageButtonUrl @customResultPageButtonText)}}
-      <PixButtonLink
-        class="evaluation-results-hero-organization-block__link"
-        @href={{@customResultPageButtonUrl}}
-        @variant="secondary"
-      >
-        {{@customResultPageButtonText}}
-      </PixButtonLink>
-    {{/if}}
-  </div>
-</template>
+export default class EvaluationResultsCustomOrganizationBlock extends Component {
+  get customButtonUrl() {
+    if (this.args.campaign.customResultPageButtonUrl && this.args.campaign.customResultPageButtonText) {
+      const params = {};
+
+      if (Number.isFinite(this.args.campaignParticipationResult.masteryRate)) {
+        params.masteryPercentage = Number(this.args.campaignParticipationResult.masteryRate * 100).toFixed(0);
+      }
+      params.externalId = this.args.campaignParticipationResult.participantExternalId ?? undefined;
+      params.stage = this.args.campaignParticipationResult.reachedStage?.get('threshold') ?? undefined;
+
+      return buildUrl(this.args.campaign.customResultPageButtonUrl, params);
+    } else {
+      return null;
+    }
+  }
+
+  <template>
+    <div class="evaluation-results-hero__organization-block">
+      <h3 class="evaluation-results-hero-organization-block__title">
+        {{t "pages.skill-review.organization-message"}}
+      </h3>
+      {{#if @campaign.customResultPageText}}
+        <MarkdownToHtml
+          class="evaluation-results-hero-organization-block__message"
+          @isInline={{true}}
+          @markdown={{@campaign.customResultPageText}}
+        />
+      {{/if}}
+      {{#if this.customButtonUrl}}
+        <PixButtonLink
+          class="evaluation-results-hero-organization-block__link"
+          @href={{this.customButtonUrl}}
+          @variant="secondary"
+        >
+          {{@campaign.customResultPageButtonText}}
+        </PixButtonLink>
+      {{/if}}
+    </div>
+  </template>
+}
+
+function buildUrl(baseUrl, params) {
+  const Url = new URL(baseUrl);
+  const urlParams = new URLSearchParams(Url.search);
+  for (const key in params) {
+    if (params[key] !== undefined) {
+      urlParams.set(key, params[key]);
+    }
+  }
+  Url.search = urlParams.toString();
+  return Url.toString();
+}

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
@@ -210,9 +210,8 @@ export default class EvaluationResultsHero extends Component {
       </div>
       {{#if this.showCustomOrganizationBlock}}
         <CustomOrganizationBlock
-          @customResultPageText={{@campaign.customResultPageText}}
-          @customResultPageButtonText={{@campaign.customResultPageButtonText}}
-          @customResultPageButtonUrl={{@campaign.customResultPageButtonUrl}}
+          @campaign={{@campaign}}
+          @campaignParticipationResult={{@campaignParticipationResult}}
         />
       {{/if}}
       {{#if @campaignParticipationResult.canRetry}}

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/hero/custom-organization-block-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/hero/custom-organization-block-test.js
@@ -11,9 +11,12 @@ module(
     setupIntlRenderingTest(hooks);
 
     test('displays the block title', async function (assert) {
+      // given
+      this.set('campaign', {});
+
       // when
       const screen = await render(
-        hbs`<Campaigns::Assessment::Results::EvaluationResultsHero::CustomOrganizationBlock />`,
+        hbs`<Campaigns::Assessment::Results::EvaluationResultsHero::CustomOrganizationBlock @campaign={{this.campaign}} />`,
       );
 
       // then
@@ -25,13 +28,14 @@ module(
         test('displays organization custom text', async function (assert) {
           // given
           const customResultPageText = 'My custom result page text';
-          this.set('customResultPageText', customResultPageText);
+
+          this.set('campaign', {
+            customResultPageText,
+          });
 
           // when
           const screen = await render(
-            hbs`<Campaigns::Assessment::Results::EvaluationResultsHero::CustomOrganizationBlock
-  @customResultPageText={{this.customResultPageText}}
-/>`,
+            hbs`<Campaigns::Assessment::Results::EvaluationResultsHero::CustomOrganizationBlock @campaign={{this.campaign}} />`,
           );
 
           // then
@@ -42,13 +46,13 @@ module(
       module('when organization custom text is not defined', function () {
         test('not display organization custom text', async function (assert) {
           // given
-          this.set('customResultPageText', null);
+          this.set('campaign', {
+            customResultPageText: null,
+          });
 
           // when
           const screen = await render(
-            hbs`<Campaigns::Assessment::Results::EvaluationResultsHero::CustomOrganizationBlock
-  @customResultPageText={{this.customResultPageText}}
-/>`,
+            hbs`<Campaigns::Assessment::Results::EvaluationResultsHero::CustomOrganizationBlock @campaign={{this.campaign}} />`,
           );
 
           // then
@@ -62,23 +66,29 @@ module(
         test('displays organization custom link', async function (assert) {
           // given
           const customResultPageButtonUrl = 'https://pix.org/';
-          this.set('customResultPageButtonUrl', customResultPageButtonUrl);
-
           const customResultPageButtonText = 'My custom button';
-          this.set('customResultPageButtonText', customResultPageButtonText);
+
+          this.set('campaign', {
+            customResultPageButtonUrl,
+            customResultPageButtonText,
+          });
+
+          this.set('campaignParticipationResult', {
+            masteryRate: 0.75,
+          });
 
           // when
           const screen = await render(
             hbs`<Campaigns::Assessment::Results::EvaluationResultsHero::CustomOrganizationBlock
-  @customResultPageButtonUrl={{this.customResultPageButtonUrl}}
-  @customResultPageButtonText={{this.customResultPageButtonText}}
+  @campaign={{this.campaign}}
+  @campaignParticipationResult={{this.campaignParticipationResult}}
 />`,
           );
 
           // then
           assert.strictEqual(
             screen.getByRole('link', { name: customResultPageButtonText }).href,
-            customResultPageButtonUrl,
+            `${customResultPageButtonUrl}?masteryPercentage=75`,
           );
         });
       });
@@ -87,16 +97,14 @@ module(
         test('not display organization custom link', async function (assert) {
           // given
           const customResultPageButtonUrl = 'https://pix.org/';
-          this.set('customResultPageButtonUrl', customResultPageButtonUrl);
 
-          this.set('customResultPageButtonText', null);
+          this.set('campaign', {
+            customResultPageButtonUrl,
+          });
 
           // when
           const screen = await render(
-            hbs`<Campaigns::Assessment::Results::EvaluationResultsHero::CustomOrganizationBlock
-  @customResultPageButtonUrl={{this.customResultPageButtonUrl}}
-  @customResultPageButtonText={{this.customResultPageButtonText}}
-/>`,
+            hbs`<Campaigns::Assessment::Results::EvaluationResultsHero::CustomOrganizationBlock @campaign={{this.campaign}} />`,
           );
 
           // then
@@ -107,15 +115,15 @@ module(
       module('when organization custom link label is defined but url is not', function () {
         test('not display organization custom link', async function (assert) {
           // given
-          this.set('customResultPageButtonUrl', null);
-          this.set('customResultPageButtonText', 'Some custom button text');
+
+          this.set('campaign', {
+            customResultPageButtonUrl: null,
+            customResultPageButtonText: 'Some custom button text',
+          });
 
           // when
           const screen = await render(
-            hbs`<Campaigns::Assessment::Results::EvaluationResultsHero::CustomOrganizationBlock
-  @customResultPageButtonUrl={{this.customResultPageButtonUrl}}
-  @customResultPageButtonText={{this.customResultPageButtonText}}
-/>`,
+            hbs`<Campaigns::Assessment::Results::EvaluationResultsHero::CustomOrganizationBlock @campaign={{this.campaign}} />`,
           );
 
           // then

--- a/mon-pix/tests/unit/components/campaigns/assessment/hero/custom-organization-block-test.js
+++ b/mon-pix/tests/unit/components/campaigns/assessment/hero/custom-organization-block-test.js
@@ -1,0 +1,163 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import createGlimmerComponent from '../../../../../helpers/create-glimmer-component';
+
+module('Unit | Component | Campaigns | Assessment | Results | Hero | Custom Organization Block', function (hooks) {
+  setupTest(hooks);
+
+  module('#customButtonUrl', function () {
+    module('when there is no custom link', function () {
+      test('should return null', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+
+        const component = createGlimmerComponent(
+          'campaigns/assessment/results/evaluation-results-hero/custom-organization-block',
+        );
+
+        component.args.campaign = store.createRecord('campaign', {
+          customResultPageButtonUrl: null,
+          customResultPageButtonText: 'useless label',
+        });
+
+        // when
+        const url = component.customButtonUrl;
+
+        // then
+        assert.strictEqual(url, null);
+      });
+    });
+
+    module('when there is a custom link', function () {
+      test('should return the custom link', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+
+        const component = createGlimmerComponent(
+          'campaigns/assessment/results/evaluation-results-hero/custom-organization-block',
+        );
+
+        component.args.campaign = store.createRecord('campaign', {
+          customResultPageButtonUrl: 'https://pix.org/',
+          customResultPageButtonText: 'custom label',
+        });
+        component.args.campaignParticipationResult = store.createRecord('campaign-participation-result', {});
+
+        // when
+        const url = component.customButtonUrl;
+
+        // then
+        assert.strictEqual(url, 'https://pix.org/');
+      });
+
+      module('when there is a mastery rate', function () {
+        test('should return the custom link with a rounded mastery percentage search param', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+
+          const component = createGlimmerComponent(
+            'campaigns/assessment/results/evaluation-results-hero/custom-organization-block',
+          );
+
+          component.args.campaign = store.createRecord('campaign', {
+            customResultPageButtonUrl: 'https://pix.org/',
+            customResultPageButtonText: 'custom label',
+          });
+          component.args.campaignParticipationResult = store.createRecord('campaign-participation-result', {
+            masteryRate: 0.755,
+          });
+
+          // when
+          const url = component.customButtonUrl;
+
+          // then
+          assert.strictEqual(url, 'https://pix.org/?masteryPercentage=76');
+        });
+      });
+
+      module('when there is an external id', function () {
+        test('should return the custom link with external id search param', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+
+          const component = createGlimmerComponent(
+            'campaigns/assessment/results/evaluation-results-hero/custom-organization-block',
+          );
+
+          component.args.campaign = store.createRecord('campaign', {
+            customResultPageButtonUrl: 'https://pix.org/',
+            customResultPageButtonText: 'custom label',
+          });
+          component.args.campaignParticipationResult = store.createRecord('campaign-participation-result', {
+            participantExternalId: 'externalId',
+          });
+
+          // when
+          const url = component.customButtonUrl;
+
+          // then
+          assert.strictEqual(url, 'https://pix.org/?externalId=externalId');
+        });
+      });
+
+      module('when there is a stage', function () {
+        test('should return the custom link with stage threshold search param', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+
+          const component = createGlimmerComponent(
+            'campaigns/assessment/results/evaluation-results-hero/custom-organization-block',
+          );
+
+          component.args.campaign = store.createRecord('campaign', {
+            customResultPageButtonUrl: 'https://pix.org/',
+            customResultPageButtonText: 'custom label',
+          });
+          const reachedStage = store.createRecord('reached-stage', {
+            threshold: 5,
+          });
+          component.args.campaignParticipationResult = store.createRecord('campaign-participation-result', {
+            reachedStage,
+          });
+
+          // when
+          const url = component.customButtonUrl;
+
+          // then
+          assert.strictEqual(url, 'https://pix.org/?stage=5');
+        });
+      });
+
+      module('when there is all parameters', function () {
+        test('should return the custom link with all parameters', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+
+          const component = createGlimmerComponent(
+            'campaigns/assessment/results/evaluation-results-hero/custom-organization-block',
+          );
+
+          component.args.campaign = store.createRecord('campaign', {
+            customResultPageButtonUrl: 'https://pix.org/',
+            customResultPageButtonText: 'custom label',
+          });
+          const reachedStage = store.createRecord('reached-stage', {
+            threshold: 5,
+          });
+          component.args.campaignParticipationResult = store.createRecord('campaign-participation-result', {
+            reachedStage,
+            masteryRate: 0.75,
+            participantExternalId: 'externalId',
+          });
+
+          // when
+          const url = component.customButtonUrl;
+
+          // then
+          assert.strictEqual(url, 'https://pix.org/?masteryPercentage=75&externalId=externalId&stage=5');
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :fallen_leaf: Problème

Lors de la création de la nouvelle page de fin de parcours, l'intégration de search params dans le lien custom de fin de parcours a été oublié.

## :chestnut: Proposition

Permettre l'ajout de 3 paramètres dans l'URL custom de fin de parcours (stage, masteryRate, externalId).

## :jack_o_lantern: Remarques

Ce code existait ici : https://github.com/1024pix/pix/blob/c582ae453897206646747460419038e55d8085c0/mon-pix/app/components/routes/campaigns/assessment/skill-review.js#L151

## :wood: Pour tester

- En RA, se connecter avec `eval-campaign-with-stages@example.net`
- Voir [ce parcours](https://app-pr10505.review.pix.fr/campagnes/EVALSTAG3/evaluation/resultats)
- Constater que l'URL du bouton du bloc "Message de votre organisation" a bien des les 3 query params souhaités.