### PR TITLE
[FEATURE] Envoi de l'email de creation de compte en asynchrone (PIX-15112)

### DIFF
--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -4,6 +4,7 @@ import { config } from '../../../src/shared/config.js';
 import { LOCALE } from '../../../src/shared/domain/constants.js';
 import { tokenService } from '../../../src/shared/domain/services/token-service.js';
 import { urlBuilder } from '../../../src/shared/infrastructure/utils/url-builder.js';
+import { getEmailDefaultVariables } from '../../../src/shared/mail/domain/emails-default-variables.js';
 import { mailer } from '../../../src/shared/mail/infrastructure/services/mailer.js';
 import * as translations from '../../../translations/index.js';
 
@@ -17,10 +18,6 @@ const SCO_ACCOUNT_RECOVERY_TAG = 'SCO_ACCOUNT_RECOVERY';
 const PIX_HOME_NAME_FRENCH_FRANCE = `pix${config.domain.tldFr}`;
 const PIX_HOME_URL_FRENCH_FRANCE = `${config.domain.pix + config.domain.tldFr}`;
 const PIX_APP_URL_FRENCH_FRANCE = `${config.domain.pixApp + config.domain.tldFr}`;
-const PIX_APP_CONNECTION_URL_FRENCH_FRANCE = `${PIX_APP_URL_FRENCH_FRANCE}/connexion`;
-const PIX_ORGA_HOME_URL_FRENCH_FRANCE = `${config.domain.pixOrga + config.domain.tldFr}`;
-const PIX_CERTIF_HOME_URL_FRENCH_FRANCE = `${config.domain.pixCertif + config.domain.tldFr}`;
-const HELPDESK_FRENCH_FRANCE = 'https://pix.fr/support';
 
 // INTERNATIONAL
 const PIX_HOME_NAME_INTERNATIONAL = `pix${config.domain.tldOrg}`;
@@ -29,20 +26,7 @@ const PIX_HOME_URL_INTERNATIONAL = {
   fr: `${config.domain.pix + config.domain.tldOrg}/fr/`,
   nl: `${config.domain.pix + config.domain.tldOrg}/nl-be/`,
 };
-const PIX_ORGA_HOME_URL_INTERNATIONAL = `${config.domain.pixOrga + config.domain.tldOrg}`;
-const PIX_CERTIF_HOME_URL_INTERNATIONAL = `${config.domain.pixCertif + config.domain.tldOrg}`;
 const PIX_APP_URL_INTERNATIONAL = `${config.domain.pixApp + config.domain.tldOrg}`;
-const PIX_APP_CONNECTION_URL_INTERNATIONAL = {
-  en: `${PIX_APP_URL_INTERNATIONAL}/connexion/?lang=en`,
-  es: `${PIX_APP_URL_INTERNATIONAL}/connexion/?lang=es`,
-  fr: `${PIX_APP_URL_INTERNATIONAL}/connexion/?lang=fr`,
-  nl: `${PIX_APP_URL_INTERNATIONAL}/connexion/?lang=nl`,
-};
-const PIX_HELPDESK_URL_INTERNATIONAL = {
-  en: 'https://pix.org/en/support',
-  fr: 'https://pix.org/fr/support',
-  nl: 'https://pix.org/nl-be/support',
-};
 
 /**
  * @param email
@@ -410,30 +394,20 @@ function sendNotificationToOrganizationMembersForTargetProfileDetached({ email, 
  * @private
  */
 function _getMailerConfig(locale) {
+  const defaultVariables = getEmailDefaultVariables(locale);
+
   switch (locale) {
     case FRENCH_SPOKEN:
     case SPANISH_SPOKEN:
     case ENGLISH_SPOKEN:
     case DUTCH_SPOKEN:
       return {
-        homeName: PIX_HOME_NAME_INTERNATIONAL,
-        homeUrl: PIX_HOME_URL_INTERNATIONAL[locale] ?? PIX_HOME_URL_INTERNATIONAL.en,
-        pixOrgaHomeUrl: PIX_ORGA_HOME_URL_INTERNATIONAL,
-        pixCertifHomeUrl: PIX_CERTIF_HOME_URL_INTERNATIONAL,
-        pixAppConnectionUrl: PIX_APP_CONNECTION_URL_INTERNATIONAL[locale] ?? PIX_APP_CONNECTION_URL_INTERNATIONAL.en,
-        helpdeskUrl: PIX_HELPDESK_URL_INTERNATIONAL[locale] ?? PIX_HELPDESK_URL_INTERNATIONAL.en,
-        displayNationalLogo: false,
+        ...defaultVariables,
         translation: translations[locale],
       };
     default:
       return {
-        homeName: PIX_HOME_NAME_FRENCH_FRANCE,
-        homeUrl: PIX_HOME_URL_FRENCH_FRANCE,
-        pixOrgaHomeUrl: PIX_ORGA_HOME_URL_FRENCH_FRANCE,
-        pixCertifHomeUrl: PIX_CERTIF_HOME_URL_FRENCH_FRANCE,
-        pixAppConnectionUrl: PIX_APP_CONNECTION_URL_FRENCH_FRANCE,
-        helpdeskUrl: HELPDESK_FRENCH_FRANCE,
-        displayNationalLogo: true,
+        ...defaultVariables,
         translation: translations.fr,
       };
   }

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -3,7 +3,6 @@ import dayjs from 'dayjs';
 import { config } from '../../../src/shared/config.js';
 import { LOCALE } from '../../../src/shared/domain/constants.js';
 import { tokenService } from '../../../src/shared/domain/services/token-service.js';
-import { urlBuilder } from '../../../src/shared/infrastructure/utils/url-builder.js';
 import { getEmailDefaultVariables } from '../../../src/shared/mail/domain/emails-default-variables.js';
 import { mailer } from '../../../src/shared/mail/infrastructure/services/mailer.js';
 import * as translations from '../../../translations/index.js';
@@ -27,38 +26,6 @@ const PIX_HOME_URL_INTERNATIONAL = {
   nl: `${config.domain.pix + config.domain.tldOrg}/nl-be/`,
 };
 const PIX_APP_URL_INTERNATIONAL = `${config.domain.pixApp + config.domain.tldOrg}`;
-
-/**
- * @param email
- * @param locale
- * @param redirectionUrl
- * @returns {Promise<EmailingAttempt>}
- */
-function sendAccountCreationEmail({ email, firstName, locale = FRENCH_FRANCE, token, redirectionUrl, i18n }) {
-  const mailerConfig = _getMailerConfig(locale);
-  const redirectUrl = redirectionUrl || mailerConfig.pixAppConnectionUrl;
-
-  const templateVariables = {
-    homeName: mailerConfig.homeName,
-    homeUrl: mailerConfig.homeUrl,
-    redirectionUrl: urlBuilder.getEmailValidationUrl({ locale, redirectUrl, token }),
-    helpdeskUrl: mailerConfig.helpdeskUrl,
-    displayNationalLogo: mailerConfig.displayNationalLogo,
-    ...mailerConfig.translation['pix-account-creation-email'].params,
-    title: i18n.__({ phrase: 'pix-account-creation-email.params.title', locale }, { firstName }),
-  };
-  const pixName = mailerConfig.translation['email-sender-name']['pix-app'];
-  const accountCreationEmailSubject = mailerConfig.translation['pix-account-creation-email'].subject;
-
-  return mailer.sendEmail({
-    from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: pixName,
-    to: email,
-    subject: accountCreationEmailSubject,
-    template: mailer.accountCreationTemplateId,
-    variables: templateVariables,
-  });
-}
 
 function sendCertificationResultEmail({
   email,
@@ -430,7 +397,6 @@ function _formatUrlWithLocale(url, locale) {
 }
 
 const mailService = {
-  sendAccountCreationEmail,
   sendAccountRecoveryEmail,
   sendCertificationResultEmail,
   sendOrganizationInvitationEmail,
@@ -445,7 +411,6 @@ const mailService = {
 
 /**
  * @typedef {Object} MailService
- * @property {function} sendAccountCreationEmail
  * @property {function} sendAccountRecoveryEmail
  * @property {function} sendCertificationCenterInvitationEmail
  * @property {function} sendCertificationResultEmail
@@ -459,7 +424,6 @@ const mailService = {
  */
 export {
   mailService,
-  sendAccountCreationEmail,
   sendAccountRecoveryEmail,
   sendCertificationCenterInvitationEmail,
   sendCertificationResultEmail,

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -104,6 +104,7 @@ import * as writeCsvUtils from '../../../src/shared/infrastructure/utils/csv/wri
 import * as dateUtils from '../../../src/shared/infrastructure/utils/date-utils.js';
 import { injectDependencies } from '../../../src/shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../src/shared/infrastructure/utils/import-named-exports-from-directory.js';
+import * as emailRepository from '../../../src/shared/mail/infrastructure/repositories/email.repository.js';
 import * as certificationCenterInvitationService from '../../../src/team/domain/services/certification-center-invitation-service.js';
 import { organizationInvitationService } from '../../../src/team/domain/services/organization-invitation.service.js';
 import * as certificationCenterInvitationRepository from '../../../src/team/infrastructure/repositories/certification-center-invitation-repository.js';
@@ -254,6 +255,7 @@ const dependencies = {
   dataProtectionOfficerRepository,
   dateUtils,
   divisionRepository,
+  emailRepository,
   emailValidationDemandRepository,
   finalizedSessionRepository,
   flashAlgorithmConfigurationRepository,

--- a/api/src/identity-access-management/domain/emails/create-account-creation.email.js
+++ b/api/src/identity-access-management/domain/emails/create-account-creation.email.js
@@ -1,0 +1,34 @@
+import { urlBuilder } from '../../../shared/infrastructure/utils/url-builder.js';
+import { EmailFactory } from '../../../shared/mail/domain/models/EmailFactory.js';
+import { mailer } from '../../../shared/mail/infrastructure/services/mailer.js';
+
+export function createAccountCreationEmail({ locale, email, firstName, token, redirectionUrl }) {
+  const factory = new EmailFactory({ app: 'pix-app', locale });
+
+  const { i18n, defaultVariables } = factory;
+
+  const redirectUrl = redirectionUrl || defaultVariables.pixAppConnectionUrl;
+
+  return factory.buildEmail({
+    template: mailer.accountCreationTemplateId,
+    subject: i18n.__('pix-account-creation-email.subject'),
+    to: email,
+    variables: {
+      homeName: defaultVariables.homeName,
+      homeUrl: defaultVariables.homeUrl,
+      helpdeskUrl: defaultVariables.helpdeskUrl,
+      displayNationalLogo: defaultVariables.displayNationalLogo,
+      askForHelp: i18n.__('pix-account-creation-email.params.askForHelp'),
+      disclaimer: i18n.__('pix-account-creation-email.params.disclaimer'),
+      doNotAnswer: i18n.__('pix-account-creation-email.params.doNotAnswer'),
+      goToPix: i18n.__('pix-account-creation-email.params.goToPix'),
+      helpdeskLinkLabel: i18n.__('pix-account-creation-email.params.helpdeskLinkLabel'),
+      moreOn: i18n.__('pix-account-creation-email.params.moreOn'),
+      pixPresentation: i18n.__('pix-account-creation-email.params.pixPresentation'),
+      subtitle: i18n.__('pix-account-creation-email.params.subtitle'),
+      subtitleDescription: i18n.__('pix-account-creation-email.params.subtitleDescription'),
+      title: i18n.__('pix-account-creation-email.params.title', { firstName }),
+      redirectionUrl: urlBuilder.getEmailValidationUrl({ locale, redirectUrl, token }),
+    },
+  });
+}

--- a/api/src/identity-access-management/domain/usecases/index.js
+++ b/api/src/identity-access-management/domain/usecases/index.js
@@ -21,6 +21,7 @@ import * as userLoginRepository from '../../../shared/infrastructure/repositorie
 import * as codeUtils from '../../../shared/infrastructure/utils/code-utils.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
+import * as emailRepository from '../../../shared/mail/infrastructure/repositories/email.repository.js';
 import { accountRecoveryDemandRepository } from '../../infrastructure/repositories/account-recovery-demand.repository.js';
 import * as authenticationMethodRepository from '../../infrastructure/repositories/authentication-method.repository.js';
 import { emailValidationDemandRepository } from '../../infrastructure/repositories/email-validation-demand.repository.js';
@@ -48,6 +49,7 @@ const repositories = {
   campaignRepository,
   campaignToJoinRepository: campaignRepositories.campaignToJoinRepository,
   emailValidationDemandRepository,
+  emailRepository,
   eventLoggingJobRepository,
   oidcProviderRepository,
   organizationLearnerRepository,

--- a/api/src/shared/mail/application/jobs/send-email.job-controller.js
+++ b/api/src/shared/mail/application/jobs/send-email.job-controller.js
@@ -1,0 +1,14 @@
+import { JobController } from '../../../application/jobs/job-controller.js';
+import { Email } from '../../domain/models/Email.js';
+import * as emailRepository from '../../infrastructure/repositories/email.repository.js';
+
+export class SendEmailJobController extends JobController {
+  constructor() {
+    super('SendEmailJob');
+  }
+
+  async handle({ data, dependencies = { emailRepository } }) {
+    const email = new Email(data);
+    await dependencies.emailRepository.sendEmail(email);
+  }
+}

--- a/api/src/shared/mail/domain/emails-default-variables.js
+++ b/api/src/shared/mail/domain/emails-default-variables.js
@@ -1,0 +1,64 @@
+import { config } from '../../config.js';
+import { LOCALE } from '../../domain/constants.js';
+
+// FRENCH_FRANCE
+const PIX_HOME_URL_FRENCH_FRANCE = `${config.domain.pix + config.domain.tldFr}`;
+const PIX_APP_URL_FRENCH_FRANCE = `${config.domain.pixApp + config.domain.tldFr}`;
+const PIX_ORGA_HOME_URL_FRENCH_FRANCE = `${config.domain.pixOrga + config.domain.tldFr}`;
+const PIX_CERTIF_HOME_URL_FRENCH_FRANCE = `${config.domain.pixCertif + config.domain.tldFr}`;
+
+const PIX_APP_CONNECTION_URL_FRENCH_FRANCE = `${PIX_APP_URL_FRENCH_FRANCE}/connexion`;
+const HELPDESK_FRENCH_FRANCE = 'https://pix.fr/support';
+
+// INTERNATIONAL
+const PIX_HOME_URL_INTERNATIONAL_BASE = `${config.domain.pix + config.domain.tldOrg}`;
+const PIX_APP_URL_INTERNATIONAL = `${config.domain.pixApp + config.domain.tldOrg}`;
+const PIX_ORGA_HOME_URL_INTERNATIONAL = `${config.domain.pixOrga + config.domain.tldOrg}`;
+const PIX_CERTIF_HOME_URL_INTERNATIONAL = `${config.domain.pixCertif + config.domain.tldOrg}`;
+
+const PIX_HOME_URL_INTERNATIONAL = {
+  en: `${PIX_HOME_URL_INTERNATIONAL_BASE}/en/`,
+  es: `${PIX_HOME_URL_INTERNATIONAL_BASE}/en/`,
+  fr: `${PIX_HOME_URL_INTERNATIONAL_BASE}/fr/`,
+  nl: `${PIX_HOME_URL_INTERNATIONAL_BASE}/nl-be/`,
+};
+const PIX_APP_CONNECTION_URL_INTERNATIONAL = {
+  en: `${PIX_APP_URL_INTERNATIONAL}/connexion/?lang=en`,
+  es: `${PIX_APP_URL_INTERNATIONAL}/connexion/?lang=es`,
+  fr: `${PIX_APP_URL_INTERNATIONAL}/connexion/?lang=fr`,
+  nl: `${PIX_APP_URL_INTERNATIONAL}/connexion/?lang=nl`,
+};
+const PIX_HELPDESK_URL_INTERNATIONAL = {
+  en: `${PIX_HOME_URL_INTERNATIONAL['en']}support`,
+  es: `${PIX_HOME_URL_INTERNATIONAL['es']}support`,
+  fr: `${PIX_HOME_URL_INTERNATIONAL['fr']}support`,
+  nl: `${PIX_HOME_URL_INTERNATIONAL['nl']}support`,
+};
+
+export function getEmailDefaultVariables(locale) {
+  switch (locale) {
+    case LOCALE.FRENCH_SPOKEN:
+    case LOCALE.SPANISH_SPOKEN:
+    case LOCALE.ENGLISH_SPOKEN:
+    case LOCALE.DUTCH_SPOKEN:
+      return {
+        homeName: `pix${config.domain.tldOrg}`,
+        homeUrl: PIX_HOME_URL_INTERNATIONAL[locale] ?? PIX_HOME_URL_INTERNATIONAL.en,
+        pixOrgaHomeUrl: PIX_ORGA_HOME_URL_INTERNATIONAL,
+        pixCertifHomeUrl: PIX_CERTIF_HOME_URL_INTERNATIONAL,
+        pixAppConnectionUrl: PIX_APP_CONNECTION_URL_INTERNATIONAL[locale] ?? PIX_APP_CONNECTION_URL_INTERNATIONAL.en,
+        helpdeskUrl: PIX_HELPDESK_URL_INTERNATIONAL[locale] ?? PIX_HELPDESK_URL_INTERNATIONAL.en,
+        displayNationalLogo: false,
+      };
+    default:
+      return {
+        homeName: `pix${config.domain.tldFr}`,
+        homeUrl: PIX_HOME_URL_FRENCH_FRANCE,
+        pixOrgaHomeUrl: PIX_ORGA_HOME_URL_FRENCH_FRANCE,
+        pixCertifHomeUrl: PIX_CERTIF_HOME_URL_FRENCH_FRANCE,
+        pixAppConnectionUrl: PIX_APP_CONNECTION_URL_FRENCH_FRANCE,
+        helpdeskUrl: HELPDESK_FRENCH_FRANCE,
+        displayNationalLogo: true,
+      };
+  }
+}

--- a/api/src/shared/mail/domain/models/Email.js
+++ b/api/src/shared/mail/domain/models/Email.js
@@ -1,0 +1,42 @@
+import Joi from 'joi';
+import isUndefined from 'lodash/isUndefined.js';
+import omitBy from 'lodash/omitBy.js';
+
+const EmailSchema = Joi.object({
+  template: Joi.string().optional(), // Should be required but empty on local env
+  subject: Joi.string().required(),
+  to: Joi.string().required(),
+  from: Joi.string().required(),
+  fromName: Joi.string().required(),
+  variables: Joi.object().optional(),
+  tags: Joi.array().items(Joi.string()).optional(),
+});
+
+export class Email {
+  constructor({ template, subject, to, from, fromName, variables, tags }) {
+    this.template = template;
+    this.subject = subject;
+    this.to = to;
+    this.from = from;
+    this.fromName = fromName;
+    this.variables = variables || {};
+    this.tags = tags;
+
+    Joi.attempt(this, EmailSchema, { abortEarly: false });
+  }
+
+  get payload() {
+    return omitBy(
+      {
+        template: this.template,
+        subject: this.subject,
+        to: this.to,
+        from: this.from,
+        fromName: this.fromName,
+        variables: this.variables,
+        tags: this.tags,
+      },
+      isUndefined,
+    );
+  }
+}

--- a/api/src/shared/mail/domain/models/EmailFactory.js
+++ b/api/src/shared/mail/domain/models/EmailFactory.js
@@ -1,0 +1,56 @@
+import { getI18n } from '../../../infrastructure/i18n/i18n.js';
+import { getEmailDefaultVariables } from '../emails-default-variables.js';
+import { Email } from './Email.js';
+
+const NO_REPLY_PIX_EMAIL = 'ne-pas-repondre@pix.fr';
+
+/**
+ * Factory class to create Email instances.
+ */
+export class EmailFactory {
+  /**
+   * Creates an instance of EmailFactory.
+   *
+   * @param {Object} options - The options for the factory.
+   * @param {string} options.app - The application name. (pix-app, pix-certif...)
+   * @param {string} options.locale - The locale for i18n.
+   */
+  constructor({ app, locale }) {
+    this.app = app;
+    this.i18n = getI18n(locale);
+    this.defaultVariables = getEmailDefaultVariables(locale);
+  }
+
+  /**
+   * Builds an Email instance.
+   *
+   * @param {Object} emailParameters - The parameters for the email.
+   * @param {string} emailParameters.template - The email template.
+   * @param {string} [emailParameters.from] - The sender email address (optional).
+   * @param {string} [emailParameters.fromName] - The sender name (optional).
+   * @param {string} emailParameters.subject - The email subject.
+   * @param {string} emailParameters.to - The recipient email address.
+   * @param {Object} emailParameters.variables - The variables for the email template.
+   * @param {Array} [emailParameters.tags] - The tags for the email (optional).
+   *
+   * @returns {Email} The created Email instance.
+   * @throws {Error} If emailParameters are not provided.
+   */
+  buildEmail(emailParameters) {
+    const { i18n, app } = this;
+
+    if (!emailParameters) {
+      throw new Error('Email parameters are required.');
+    }
+
+    return new Email({
+      template: emailParameters.template,
+      from: emailParameters.from || NO_REPLY_PIX_EMAIL,
+      fromName: emailParameters.fromName || i18n.__(`email-sender-name.${app}`),
+      subject: emailParameters.subject,
+      to: emailParameters.to,
+      variables: emailParameters.variables,
+      tags: emailParameters.tags,
+    });
+  }
+}

--- a/api/src/shared/mail/infrastructure/repositories/email.repository.js
+++ b/api/src/shared/mail/infrastructure/repositories/email.repository.js
@@ -1,0 +1,33 @@
+import { Email } from '../../domain/models/Email.js';
+import { mailer as mailerService } from '../services/mailer.js';
+import { sendEmailJobRepository } from './jobs/send-email.job-repository.js';
+
+/**
+ * Send an email synchronously
+ *
+ * @param {Email} email Email instance
+ * @returns Promise<EmailingAttempt>
+ */
+async function sendEmail(email, dependencies = { mailerService }) {
+  if (!email || !(email instanceof Email)) {
+    throw new Error('An instance of Email is required.');
+  }
+
+  return dependencies.mailerService.sendEmail(email.payload);
+}
+
+/**
+ * Send an email asynchronously via a Job
+ *
+ * @param {Email} email Email instance
+ * @returns Promise<void>
+ */
+async function sendEmailAsync(email, dependencies = { sendEmailJobRepository }) {
+  if (!email || !(email instanceof Email)) {
+    throw new Error('An instance of Email is required.');
+  }
+
+  return dependencies.sendEmailJobRepository.performAsync(email.payload);
+}
+
+export { sendEmail, sendEmailAsync };

--- a/api/src/shared/mail/infrastructure/repositories/jobs/send-email.job-repository.js
+++ b/api/src/shared/mail/infrastructure/repositories/jobs/send-email.job-repository.js
@@ -1,0 +1,13 @@
+import { JobExpireIn, JobRepository, JobRetry } from '../../../../infrastructure/repositories/jobs/job-repository.js';
+
+class SendEmailJobRepository extends JobRepository {
+  constructor() {
+    super({
+      name: 'SendEmailJob',
+      retry: JobRetry.STANDARD_RETRY,
+      expireIn: JobExpireIn.HIGH,
+    });
+  }
+}
+
+export const sendEmailJobRepository = new SendEmailJobRepository();

--- a/api/tests/identity-access-management/unit/application/user/user.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/user/user.controller.test.js
@@ -210,9 +210,6 @@ describe('Unit | Identity Access Management | Application | Controller | User', 
       const cryptoService = {
         hashPassword: sinon.stub(),
       };
-      const mailService = {
-        sendAccountCreationEmail: sinon.stub(),
-      };
       const localeService = {
         getCanonicalLocale: sinon.stub(),
       };
@@ -220,7 +217,6 @@ describe('Unit | Identity Access Management | Application | Controller | User', 
       dependencies = {
         userSerializer,
         cryptoService,
-        mailService,
         localeService,
         requestResponseUtils,
       };

--- a/api/tests/identity-access-management/unit/domain/emails/create-account-creation.email_test.js
+++ b/api/tests/identity-access-management/unit/domain/emails/create-account-creation.email_test.js
@@ -1,0 +1,55 @@
+import { createAccountCreationEmail } from '../../../../../src/identity-access-management/domain/emails/create-account-creation.email.js';
+import { Email } from '../../../../../src/shared/mail/domain/models/Email.js';
+import { mailer } from '../../../../../src/shared/mail/infrastructure/services/mailer.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Identity Access Management | Domain | Emails | create-account-creation', function () {
+  it('creates account creation email with correct parameters', function () {
+    const emailParams = {
+      locale: 'fr',
+      email: 'test@example.com',
+      firstName: 'John',
+      token: '12345',
+      redirectionUrl: 'http://example.com/redirect',
+    };
+
+    const email = createAccountCreationEmail(emailParams);
+
+    expect(email).to.be.instanceof(Email);
+    expect(email).to.have.property('subject').that.is.a('string');
+    expect(email.to).to.equal(emailParams.email);
+    expect(email.template).to.equal(mailer.accountCreationTemplateId);
+
+    const variables = email.variables;
+    expect(variables).to.have.property('askForHelp').that.is.a('string');
+    expect(variables).to.have.property('disclaimer').that.is.a('string');
+    expect(variables).to.have.property('displayNationalLogo').that.is.a('boolean');
+    expect(variables).to.have.property('doNotAnswer').that.is.a('string');
+    expect(variables).to.have.property('goToPix').that.is.a('string');
+    expect(variables).to.have.property('helpdeskLinkLabel').that.is.a('string');
+    expect(variables).to.have.property('helpdeskUrl').that.is.a('string');
+    expect(variables).to.have.property('homeName').that.is.a('string');
+    expect(variables).to.have.property('homeUrl').that.is.a('string');
+    expect(variables).to.have.property('moreOn').that.is.a('string');
+    expect(variables).to.have.property('pixPresentation').that.is.a('string');
+    expect(variables).to.have.property('subtitle').that.is.a('string');
+    expect(variables).to.have.property('subtitleDescription').that.is.a('string');
+    expect(variables).to.have.property('title').that.is.a('string');
+
+    expect(variables.redirectionUrl).to.match(/redirect/);
+  });
+
+  it('uses default redirection URL if none is provided', function () {
+    const emailParams = {
+      locale: 'fr',
+      email: 'test@example.com',
+      firstName: 'John',
+      token: '12345',
+    };
+
+    const email = createAccountCreationEmail(emailParams);
+
+    const variables = email.variables;
+    expect(variables.redirectionUrl).to.match(/connexion/);
+  });
+});

--- a/api/tests/identity-access-management/unit/domain/usecases/create-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/create-user.usecase.test.js
@@ -1,3 +1,4 @@
+import { createAccountCreationEmail } from '../../../../../src/identity-access-management/domain/emails/create-account-creation.email.js';
 import { User } from '../../../../../src/identity-access-management/domain/models/User.js';
 import { createUser } from '../../../../../src/identity-access-management/domain/usecases/create-user.usecase.js';
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
@@ -19,9 +20,9 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
   let authenticationMethodRepository;
   let userRepository;
   let userToCreateRepository;
+  let emailRepository;
   let campaignRepository;
   let cryptoService;
-  let mailService;
   let userService;
   let passwordValidator;
   let userValidator;
@@ -35,31 +36,15 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
     });
 
     authenticationMethodRepository = {};
-    userRepository = {
-      checkIfEmailIsAvailable: sinon.stub(),
-    };
-    userToCreateRepository = {
-      create: sinon.stub(),
-    };
-    campaignRepository = {
-      getByCode: sinon.stub(),
-    };
+    userRepository = { checkIfEmailIsAvailable: sinon.stub() };
+    userToCreateRepository = { create: sinon.stub() };
+    emailRepository = { sendEmailAsync: sinon.stub() };
+    campaignRepository = { getByCode: sinon.stub() };
 
-    cryptoService = {
-      hashPassword: sinon.stub(),
-    };
-    mailService = {
-      sendAccountCreationEmail: sinon.stub(),
-    };
-    userService = {
-      createUserWithPassword: sinon.stub(),
-    };
-    passwordValidator = {
-      validate: sinon.stub(),
-    };
-    userValidator = {
-      validate: sinon.stub(),
-    };
+    cryptoService = { hashPassword: sinon.stub() };
+    userService = { createUserWithPassword: sinon.stub() };
+    passwordValidator = { validate: sinon.stub() };
+    userValidator = { validate: sinon.stub() };
 
     token = '00000000-0000-0000-0000-000000000000';
     emailValidationDemandRepository = {
@@ -68,11 +53,11 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
     userRepository.checkIfEmailIsAvailable.resolves();
 
     userToCreateRepository.create.resolves(savedUser);
+    emailRepository.sendEmailAsync.resolves();
     userValidator.validate.returns();
 
     passwordValidator.validate.returns();
     cryptoService.hashPassword.resolves(hashedPassword);
-    mailService.sendAccountCreationEmail.resolves();
 
     userService.createUserWithPassword.resolves(savedUser);
 
@@ -92,11 +77,11 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
         campaignCode,
         authenticationMethodRepository,
         campaignRepository,
+        emailRepository,
         emailValidationDemandRepository,
         userRepository,
         userToCreateRepository,
         cryptoService,
-        mailService,
         userService,
         userValidator,
         passwordValidator,
@@ -115,11 +100,11 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
         campaignCode,
         authenticationMethodRepository,
         campaignRepository,
+        emailRepository,
         emailValidationDemandRepository,
         userRepository,
         userToCreateRepository,
         cryptoService,
-        mailService,
         userService,
         userValidator,
         passwordValidator,
@@ -138,11 +123,11 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
         campaignCode,
         authenticationMethodRepository,
         campaignRepository,
+        emailRepository,
         emailValidationDemandRepository,
         userRepository,
         userToCreateRepository,
         cryptoService,
-        mailService,
         userService,
         userValidator,
         passwordValidator,
@@ -175,11 +160,11 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           campaignCode,
           authenticationMethodRepository,
           campaignRepository,
+          emailRepository,
           emailValidationDemandRepository,
           userRepository,
           userToCreateRepository,
           cryptoService,
-          mailService,
           userService,
           userValidator,
           passwordValidator,
@@ -217,11 +202,11 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           campaignCode,
           authenticationMethodRepository,
           campaignRepository,
+          emailRepository,
           emailValidationDemandRepository,
           userRepository,
           userToCreateRepository,
           cryptoService,
-          mailService,
           userService,
           userValidator,
           passwordValidator,
@@ -261,11 +246,11 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           campaignCode,
           authenticationMethodRepository,
           campaignRepository,
+          emailRepository,
           emailValidationDemandRepository,
           userRepository,
           userToCreateRepository,
           cryptoService,
-          mailService,
           userService,
           userValidator,
           passwordValidator,
@@ -293,11 +278,11 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           campaignCode,
           authenticationMethodRepository,
           campaignRepository,
+          emailRepository,
           emailValidationDemandRepository,
           userRepository,
           userToCreateRepository,
           cryptoService,
-          mailService,
           userService,
           userValidator,
           passwordValidator,
@@ -324,11 +309,11 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           campaignCode,
           authenticationMethodRepository,
           campaignRepository,
+          emailRepository,
           emailValidationDemandRepository,
           userRepository,
           userToCreateRepository,
           cryptoService,
-          mailService,
           userService,
           userValidator,
           passwordValidator,
@@ -353,10 +338,10 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
         campaignCode,
         authenticationMethodRepository,
         campaignRepository,
+        emailRepository,
         emailValidationDemandRepository,
         userRepository,
         cryptoService,
-        mailService,
         userService,
         userValidator,
         passwordValidator,
@@ -378,11 +363,11 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           campaignCode,
           authenticationMethodRepository,
           campaignRepository,
+          emailRepository,
           emailValidationDemandRepository,
           userRepository,
           userToCreateRepository,
           cryptoService,
-          mailService,
           userService,
           userValidator,
           passwordValidator,
@@ -404,11 +389,11 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           campaignCode,
           authenticationMethodRepository,
           campaignRepository,
+          emailRepository,
           emailValidationDemandRepository,
           userRepository,
           userToCreateRepository,
           cryptoService,
-          mailService,
           userService,
         });
 
@@ -425,11 +410,11 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           campaignCode,
           authenticationMethodRepository,
           campaignRepository,
+          emailRepository,
           emailValidationDemandRepository,
           userRepository,
           userToCreateRepository,
           cryptoService,
-          mailService,
           userService,
 
           userValidator,
@@ -452,7 +437,13 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
       it('should send the account creation email', async function () {
         // given
         campaignRepository.getByCode.resolves({ organizationId: 1 });
-        const expectedRedirectionUrl = `https://app.pix.fr/campagnes/${campaignCode}`;
+        const expectedEmail = createAccountCreationEmail({
+          email: userEmail,
+          firstName: user.firstName,
+          locale: localeFromHeader,
+          token,
+          redirectionUrl: `https://app.pix.fr/campagnes/${campaignCode}`,
+        });
 
         // when
         await createUser({
@@ -462,25 +453,18 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           campaignCode,
           authenticationMethodRepository,
           campaignRepository,
+          emailRepository,
           emailValidationDemandRepository,
           userRepository,
           userToCreateRepository,
           cryptoService,
-          mailService,
           userService,
           userValidator,
           passwordValidator,
         });
 
         // then
-        expect(mailService.sendAccountCreationEmail).to.have.been.calledWithExactly({
-          email: userEmail,
-          firstName: user.firstName,
-          locale: localeFromHeader,
-          token,
-          redirectionUrl: expectedRedirectionUrl,
-          i18n: undefined,
-        });
+        expect(emailRepository.sendEmailAsync).to.have.been.calledWithExactly(expectedEmail);
       });
 
       describe('when campaignCode is null', function () {
@@ -488,7 +472,13 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
 
         it('should send the account creation email with null redirectionUrl', async function () {
           // given
-          const expectedRedirectionUrl = null;
+          const expectedEmail = createAccountCreationEmail({
+            email: userEmail,
+            firstName: user.firstName,
+            locale: localeFromHeader,
+            token,
+            redirectionUrl: null,
+          });
 
           // when
           await createUser({
@@ -498,25 +488,18 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
             campaignCode,
             authenticationMethodRepository,
             campaignRepository,
+            emailRepository,
             emailValidationDemandRepository,
             userRepository,
             userToCreateRepository,
             cryptoService,
-            mailService,
             userService,
             userValidator,
             passwordValidator,
           });
 
           // then
-          expect(mailService.sendAccountCreationEmail).to.have.been.calledWithExactly({
-            email: userEmail,
-            firstName: user.firstName,
-            locale: localeFromHeader,
-            token,
-            redirectionUrl: expectedRedirectionUrl,
-            i18n: undefined,
-          });
+          expect(emailRepository.sendEmailAsync).to.have.been.calledWithExactly(expectedEmail);
         });
       });
 
@@ -525,8 +508,14 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
 
         it('should send the account creation email with null redirectionUrl', async function () {
           // given
-          const expectedRedirectionUrl = null;
           campaignRepository.getByCode.resolves(null);
+          const expectedEmail = createAccountCreationEmail({
+            email: userEmail,
+            firstName: user.firstName,
+            locale: localeFromHeader,
+            token,
+            redirectionUrl: null,
+          });
 
           // when
           await createUser({
@@ -536,25 +525,18 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
             campaignCode,
             authenticationMethodRepository,
             campaignRepository,
+            emailRepository,
             emailValidationDemandRepository,
             userRepository,
             userToCreateRepository,
             cryptoService,
-            mailService,
             userService,
             userValidator,
             passwordValidator,
           });
 
           // then
-          expect(mailService.sendAccountCreationEmail).to.have.been.calledWithExactly({
-            email: userEmail,
-            firstName: user.firstName,
-            locale: localeFromHeader,
-            token,
-            redirectionUrl: expectedRedirectionUrl,
-            i18n: undefined,
-          });
+          expect(emailRepository.sendEmailAsync).to.have.been.calledWithExactly(expectedEmail);
         });
       });
     });
@@ -564,7 +546,15 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
       campaignRepository.getByCode.resolves({ organizationId: 1 });
       const redirectionUrl = 'https://redirect.uri';
       sinon.stub(urlBuilder, 'getCampaignUrl').returns(redirectionUrl);
-      mailService.sendAccountCreationEmail.resolves();
+      emailRepository.sendEmailAsync.resolves();
+
+      const expectedEmail = createAccountCreationEmail({
+        email: userEmail,
+        firstName: user.firstName,
+        locale: localeFromHeader,
+        token,
+        redirectionUrl,
+      });
 
       // when
       const createdUser = await createUser({
@@ -574,11 +564,11 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
         campaignCode,
         authenticationMethodRepository,
         campaignRepository,
+        emailRepository,
         emailValidationDemandRepository,
         userRepository,
         userToCreateRepository,
         cryptoService,
-        mailService,
         userService,
         userValidator,
         passwordValidator,
@@ -586,14 +576,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
 
       // then
       expect(emailValidationDemandRepository.save).to.have.been.calledWith(userId);
-      expect(mailService.sendAccountCreationEmail).to.have.been.calledWith({
-        email: user.email,
-        firstName: user.firstName,
-        locale: localeFromHeader,
-        token,
-        redirectionUrl,
-        i18n: undefined,
-      });
+      expect(emailRepository.sendEmailAsync).to.have.been.calledWith(expectedEmail);
       expect(createdUser).to.deep.equal(savedUser);
     });
   });

--- a/api/tests/shared/unit/mail/application/jobs/send-email.job-controller_test.js
+++ b/api/tests/shared/unit/mail/application/jobs/send-email.job-controller_test.js
@@ -1,0 +1,30 @@
+import { SendEmailJobController } from '../../../../../../src/shared/mail/application/jobs/send-email.job-controller.js';
+import { Email } from '../../../../../../src/shared/mail/domain/models/Email.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | Email | Application | Jobs | SendEmailJobController', function () {
+  it('sets up the job controller configuration', async function () {
+    const sendEmailJobController = new SendEmailJobController();
+
+    expect(sendEmailJobController.jobName).to.equal('SendEmailJob');
+  });
+
+  it('sends the email', async function () {
+    const emailRepository = {
+      sendEmail: sinon.stub().resolves(),
+    };
+
+    const emailPayload = {
+      template: 'welcome',
+      subject: 'Welcome to our service',
+      to: 'user@example.com',
+      from: 'no-reply@example.com',
+      fromName: 'Service Team',
+    };
+
+    const sendEmailJobController = new SendEmailJobController();
+    await sendEmailJobController.handle({ data: emailPayload, dependencies: { emailRepository } });
+
+    expect(emailRepository.sendEmail).to.have.been.calledWith(new Email(emailPayload));
+  });
+});

--- a/api/tests/shared/unit/mail/domain/email-default-variables_test.js
+++ b/api/tests/shared/unit/mail/domain/email-default-variables_test.js
@@ -1,0 +1,77 @@
+import { LOCALE } from '../../../../../src/shared/domain/constants.js';
+import { getEmailDefaultVariables } from '../../../../../src/shared/mail/domain/emails-default-variables.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Email | Domain | email-default-variables', function () {
+  describe('#getEmailDefaultVariables', function () {
+    it('returns email default variables for France', function () {
+      const result = getEmailDefaultVariables(LOCALE.FRENCH_FRANCE);
+
+      expect(result).to.deep.equal({
+        homeName: 'pix.fr',
+        homeUrl: 'https://pix.fr',
+        pixOrgaHomeUrl: 'https://orga.pix.fr',
+        pixCertifHomeUrl: 'https://certif.pix.fr',
+        pixAppConnectionUrl: 'https://app.pix.fr/connexion',
+        helpdeskUrl: 'https://pix.fr/support',
+        displayNationalLogo: true,
+      });
+    });
+
+    it('returns email default variables for International french', function () {
+      const result = getEmailDefaultVariables(LOCALE.FRENCH_SPOKEN);
+
+      expect(result).to.deep.equal({
+        homeName: 'pix.org',
+        homeUrl: 'https://pix.org/fr/',
+        pixOrgaHomeUrl: 'https://orga.pix.org',
+        pixCertifHomeUrl: 'https://certif.pix.org',
+        pixAppConnectionUrl: 'https://app.pix.org/connexion/?lang=fr',
+        helpdeskUrl: 'https://pix.org/fr/support',
+        displayNationalLogo: false,
+      });
+    });
+
+    it('returns email default variables for International english', function () {
+      const result = getEmailDefaultVariables(LOCALE.ENGLISH_SPOKEN);
+
+      expect(result).to.deep.equal({
+        homeName: 'pix.org',
+        homeUrl: 'https://pix.org/en/',
+        pixOrgaHomeUrl: 'https://orga.pix.org',
+        pixCertifHomeUrl: 'https://certif.pix.org',
+        pixAppConnectionUrl: 'https://app.pix.org/connexion/?lang=en',
+        helpdeskUrl: 'https://pix.org/en/support',
+        displayNationalLogo: false,
+      });
+    });
+
+    it('returns email default variables for International spanish', function () {
+      const result = getEmailDefaultVariables(LOCALE.SPANISH_SPOKEN);
+
+      expect(result).to.deep.equal({
+        homeName: 'pix.org',
+        homeUrl: 'https://pix.org/en/',
+        pixOrgaHomeUrl: 'https://orga.pix.org',
+        pixCertifHomeUrl: 'https://certif.pix.org',
+        pixAppConnectionUrl: 'https://app.pix.org/connexion/?lang=es',
+        helpdeskUrl: 'https://pix.org/en/support',
+        displayNationalLogo: false,
+      });
+    });
+
+    it('returns email default variables for International dutch', function () {
+      const result = getEmailDefaultVariables(LOCALE.DUTCH_SPOKEN);
+
+      expect(result).to.deep.equal({
+        homeName: 'pix.org',
+        homeUrl: 'https://pix.org/nl-be/',
+        pixOrgaHomeUrl: 'https://orga.pix.org',
+        pixCertifHomeUrl: 'https://certif.pix.org',
+        pixAppConnectionUrl: 'https://app.pix.org/connexion/?lang=nl',
+        helpdeskUrl: 'https://pix.org/nl-be/support',
+        displayNationalLogo: false,
+      });
+    });
+  });
+});

--- a/api/tests/shared/unit/mail/domain/models/EmailFactory_test.js
+++ b/api/tests/shared/unit/mail/domain/models/EmailFactory_test.js
@@ -1,0 +1,82 @@
+import { Email } from '../../../../../../src/shared/mail/domain/models/Email.js';
+import { expect } from '../../../../../test-helper.js';
+import { EmailFactory } from '.././../../../../../src/shared/mail/domain/models/EmailFactory.js';
+
+describe('Unit | Email | Domain | Models | EmailFactory', function () {
+  describe('buildEmail', function () {
+    it('builds an email with provided parameters', function () {
+      const emailFactory = new EmailFactory({ app: 'pix-app', locale: 'fr' });
+      const emailParameters = {
+        from: 'test@domain.com',
+        fromName: 'Test Sender',
+        subject: 'Test Subject',
+        to: 'recipient@domain.com',
+        template: 'test-template',
+        variables: { key: 'value' },
+        tags: ['tag1', 'tag2'],
+      };
+
+      const email = emailFactory.buildEmail(emailParameters);
+
+      expect(email).to.be.instanceOf(Email);
+      expect(email.from).to.equal(emailParameters.from);
+      expect(email.fromName).to.equal(emailParameters.fromName);
+      expect(email.subject).to.equal(emailParameters.subject);
+      expect(email.to).to.equal(emailParameters.to);
+      expect(email.template).to.equal(emailParameters.template);
+      expect(email.variables).to.deep.equal(emailParameters.variables);
+      expect(email.tags).to.deep.equal(emailParameters.tags);
+    });
+
+    it('builds an email with default values for missing parameters', function () {
+      const emailFactory = new EmailFactory({ app: 'pix-app', locale: 'fr-fr' });
+      const emailParameters = {
+        subject: 'Test Subject',
+        to: 'recipient@domain.com',
+        template: 'test-template',
+        variables: {
+          homeName: emailFactory.defaultVariables.homeName,
+        },
+      };
+
+      const email = emailFactory.buildEmail(emailParameters);
+
+      expect(email).to.be.instanceOf(Email);
+      expect(email.from).to.equal('ne-pas-repondre@pix.fr');
+      expect(email.fromName).to.equal('PIX - Ne pas répondre');
+      expect(email.subject).to.equal(emailParameters.subject);
+      expect(email.to).to.equal(emailParameters.to);
+      expect(email.template).to.equal(emailParameters.template);
+      expect(email.variables).to.deep.equal({ homeName: 'pix.fr' });
+      expect(email.tags).to.be.undefined;
+    });
+
+    it('builds an email for another locale than french', function () {
+      const emailFactory = new EmailFactory({ app: 'pix-app', locale: 'en' });
+      const emailParameters = {
+        subject: 'Test Subject',
+        to: 'recipient@domain.com',
+        template: 'test-template',
+        variables: {
+          homeName: emailFactory.defaultVariables.homeName,
+        },
+      };
+
+      const email = emailFactory.buildEmail(emailParameters);
+
+      expect(email).to.be.instanceOf(Email);
+      expect(email.from).to.equal('ne-pas-repondre@pix.fr');
+      expect(email.fromName).to.equal('PIX - Noreply');
+      expect(email.subject).to.equal(emailParameters.subject);
+      expect(email.to).to.equal(emailParameters.to);
+      expect(email.template).to.equal(emailParameters.template);
+      expect(email.variables).to.deep.equal({ homeName: 'pix.org' });
+      expect(email.tags).to.be.undefined;
+    });
+
+    it('throws an error if emailParameters is not provided', function () {
+      const emailFactory = new EmailFactory({ app: 'pix-app', locale: 'fr' });
+      expect(() => emailFactory.buildEmail()).to.throw('Email parameters are required.');
+    });
+  });
+});

--- a/api/tests/shared/unit/mail/domain/models/Email_test.js
+++ b/api/tests/shared/unit/mail/domain/models/Email_test.js
@@ -1,0 +1,51 @@
+import { expect } from '../../../../../test-helper.js';
+import { Email } from '.././../../../../../src/shared/mail/domain/models/Email.js';
+
+describe('Unit | Email | Domain | Models | Email', function () {
+  it('creates an email with valid properties', function () {
+    const emailData = {
+      template: 'welcome',
+      subject: 'Welcome to our service',
+      to: 'user@example.com',
+      from: 'no-reply@example.com',
+      fromName: 'Service Team',
+      variables: { name: 'User' },
+      tags: ['welcome', 'user'],
+    };
+
+    const email = new Email(emailData);
+
+    expect(email.template).to.equal(emailData.template);
+    expect(email.subject).to.equal(emailData.subject);
+    expect(email.to).to.equal(emailData.to);
+    expect(email.from).to.equal(emailData.from);
+    expect(email.fromName).to.equal(emailData.fromName);
+    expect(email.variables).to.deep.equal(emailData.variables);
+    expect(email.tags).to.deep.equal(emailData.tags);
+  });
+
+  it('throws an error if required properties are missing', function () {
+    const emailData = {
+      subject: 'Welcome to our service',
+      to: 'user@example.com',
+    };
+
+    expect(() => new Email(emailData)).to.throw();
+  });
+
+  it('has a payload getter that returns the correct data', function () {
+    const emailData = {
+      template: 'welcome',
+      subject: 'Welcome to our service',
+      to: 'user@example.com',
+      from: 'no-reply@example.com',
+      fromName: 'Service Team',
+      variables: { name: 'User' },
+      tags: ['welcome', 'user'],
+    };
+
+    const email = new Email(emailData);
+
+    expect(email.payload).to.deep.equal(emailData);
+  });
+});

--- a/api/tests/shared/unit/mail/infrastructure/repositories/email.repository_test.js
+++ b/api/tests/shared/unit/mail/infrastructure/repositories/email.repository_test.js
@@ -1,0 +1,67 @@
+import { Email } from '../../../../../../src/shared/mail/domain/models/Email.js';
+import * as emailRepository from '../../../../../../src/shared/mail/infrastructure/repositories/email.repository.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | Email | Infrastructure | Repository | EmailRepository', function () {
+  describe('#sendEmail', function () {
+    it('sends an email', async function () {
+      const mailerService = {
+        sendEmail: sinon.stub().resolves(),
+      };
+
+      const email = new Email({
+        template: 'welcome',
+        subject: 'Welcome to our service',
+        to: 'user@example.com',
+        from: 'no-reply@example.com',
+        fromName: 'Service Team',
+      });
+
+      await emailRepository.sendEmail(email, { mailerService });
+
+      expect(mailerService.sendEmail).to.have.been.calledWith(email.payload);
+    });
+
+    it('throws an error if email is not provided', async function () {
+      await expect(emailRepository.sendEmail(null)).to.be.rejectedWith('An instance of Email is required.');
+    });
+
+    it('throws an error if email is not an instance of Email', async function () {
+      const invalidEmail = { template: 'welcome' };
+
+      await expect(emailRepository.sendEmail(invalidEmail)).to.be.rejectedWith('An instance of Email is required.');
+    });
+  });
+
+  describe('#sendEmailAsync', function () {
+    it('sends an email through a job', async function () {
+      const sendEmailJobRepository = {
+        performAsync: sinon.stub().resolves(),
+      };
+
+      const email = new Email({
+        template: 'welcome',
+        subject: 'Welcome to our service',
+        to: 'user@example.com',
+        from: 'no-reply@example.com',
+        fromName: 'Service Team',
+      });
+
+      await emailRepository.sendEmailAsync(email, { sendEmailJobRepository });
+
+      expect(sendEmailJobRepository.performAsync).to.have.been.calledWith(email.payload);
+    });
+
+    it('throws an error if email is not provided', async function () {
+      await expect(emailRepository.sendEmailAsync(null)).to.be.rejectedWith('An instance of Email is required.');
+    });
+
+    it('throws an error if email is not an instance of Email', async function () {
+      const invalidEmail = { template: 'welcome' };
+
+      await expect(emailRepository.sendEmailAsync(invalidEmail)).to.be.rejectedWith(
+        'An instance of Email is required.',
+      );
+    });
+  });
+});

--- a/api/tests/shared/unit/mail/infrastructure/repositories/jobs/send-email.job-repository_test.js
+++ b/api/tests/shared/unit/mail/infrastructure/repositories/jobs/send-email.job-repository_test.js
@@ -1,0 +1,14 @@
+import {
+  JobExpireIn,
+  JobRetry,
+} from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import { sendEmailJobRepository } from '../../../../../../../src/shared/mail/infrastructure/repositories/jobs/send-email.job-repository.js';
+import { expect } from '../../../../../../test-helper.js';
+
+describe('Unit | Email | Infrastructure | Jobs | SendEmailJobRepository', function () {
+  it('sets up the send email job configuration', function () {
+    expect(sendEmailJobRepository.name).to.equal('SendEmailJob');
+    expect(sendEmailJobRepository.retry).to.equal(JobRetry.STANDARD_RETRY);
+    expect(sendEmailJobRepository.expireIn).to.equal(JobExpireIn.HIGH);
+  });
+});


### PR DESCRIPTION
## :fallen_leaf: Problème

Quand un utilisateur créé un compte, si Brevo est down, l'envoi de l'email de "Création de compte" bloque l'appel HTTP de création de compte.

## :chestnut: Proposition

La solution prise est de réaliser l'envoi de cet email via un Job afin que l'envoi de cet email soit asynchrone et ne bloque pas l'appel de création de compte. De plus, cela permet de bénéficier des stratégies de retry des jobs en cas d'indisponibilité de Brevo.

Nous profitons de cette modification pour mettre en place de nouvelles conventions autour de la création et l'envoi d'emails via l'API, afin d'étendre cette pratique aux autres emails transactionnels.

Voici les modifications apportées:
1. Ajout d'une factory `EmailFactory` permettant l'instanciation d'un modèle d'`Email`.
2. Le modèle `Email` est une représentation sérialisable des informations nécessaires à l'envoie d'un email.
3. Le modèle `Email` porte la validation des informations nécessaires (`template`, `from`, `to`, `subject`...)
4. Ce modèle est utilisé en entrée du `emailRepository` proposant 2 fonctions:
  - `sendEmail(email: Email)`: Envoi un email de façon synchrone.
  - `sendEmailAsync(email: Email)`: Envoi un email via un Job asynchrone. 
5. `emailRepository` pourra être utilisé dans tous les use-cases afin d'envoyer un email créé via l'`EmailFactory`

```js
const emailFactory = new EmailFactory({ app: 'pix-app', locale });
const email = emailFactory.buildEmail({ to: ... });

await emailRepository.sendEmailAsync(email);
```

## :jack_o_lantern: Remarques

> [!NOTE]
> Ce type d'architecture permettra:
> 1. Une migration progressive de tous les envois d'email existants en asynchrone.
> 2. De faire évoluer facilement la factory (`EmailFactory`) afin de gérer les modèles de template dans la codebase au lieu de Brevo (et de le faire de manière progressive). 

## :wood: Pour tester

> [!IMPORTANT]
> Il faut désormais lancer les workers en local pour recevoir l'email de création de compte.
> `npm run start:worker` (les logs seront à regarder dedans)

**Création de compte utilisateur**

Sur Pix.fr:
1. Créer un compte 
2. Vérifier que l'email est bien reçu et correctement formaté

Sur Pix.org
1. Créer un compte et changer la langue
2. Vérifier que l'email est bien reçu et correctement formaté


**Création de compte utilisateur avec réconciliation**
> [!NOTE]
> A faire en RA tant que le correctif correspondant n'est pas mergé https://github.com/1024pix/pix/pull/10537
1. Rejoindre une campagne SCO sur la RA de Pix App https://app-pr10509.review.pix.fr/campagnes/SCOBADGE1/presentation
2. Cliquer sur le bouton _Je commence_ et remplir le formulaire avec un élève n'ayant pas de méthodes de connexion (ex: Harry Potter 12/12/2012)
3. Sélection _Je m'inscris avec mon adresse e-mail_ et remplir les champs concernées
4. Soumettre le formulaire et vérifier que l'email et bien reçu et correctement formaté !
