### PR TITLE
[TECH] Changer le nombre de retry du job ParticipationResultCalculationJob (PIX-15258)

### DIFF
--- a/api/src/prescription/campaign-participation/infrastructure/repositories/jobs/participation-result-calculation-job-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/jobs/participation-result-calculation-job-repository.js
@@ -5,7 +5,7 @@ class ParticipationResultCalculationJobRepository extends JobRepository {
   constructor() {
     super({
       name: ParticipationResultCalculationJob.name,
-      retry: JobRetry.STANDARD_RETRY,
+      retry: JobRetry.FEW_RETRY,
     });
   }
 }

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/jobs/participation-result-calculation-job-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/jobs/participation-result-calculation-job-repository_test.js
@@ -1,5 +1,6 @@
 import { ParticipationResultCalculationJob } from '../../../../../../../src/prescription/campaign-participation/domain/models/ParticipationResultCalculationJob.js';
 import { participationResultCalculationJobRepository } from '../../../../../../../src/prescription/campaign-participation/infrastructure/repositories/jobs/participation-result-calculation-job-repository.js';
+import { JobRetry } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Integration | Prescription | Infrastructure | Repository | Jobs | participationResultCalculationJobRepository', function () {
@@ -11,9 +12,9 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | part
       // then
       await expect(ParticipationResultCalculationJob.name).to.have.been.performed.withJob({
         name: ParticipationResultCalculationJob.name,
-        retrylimit: 10,
-        retrydelay: 30,
-        retrybackoff: true,
+        retrylimit: JobRetry.FEW_RETRY.retryLimit,
+        retrydelay: JobRetry.FEW_RETRY.retryDelay,
+        retrybackoff: JobRetry.FEW_RETRY.retryBackoff,
         data: { campaignParticipationId: 3 },
       });
     });


### PR DESCRIPTION
## :fallen_leaf: Problème
On a un cas actuellement qui fait échouer le job, même en cas de retry le job ne passera de toute façon jamais car c'est une règle métier qui le fait echouer. 
On a prévu d'investiguer et corriger les raisons qui amènent ce job a échouer, mais en attendant, nous voulons réduire le bruit que les captains ont a cause des 10 retry 

## :chestnut: Proposition
Descendre la config de retry a une valeur de 2. On ne le mets pas a 0 non plus dans le cas d'erreur pouvant être résolues d'elle même ( Crash bdd etc .. )

## :jack_o_lantern: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :wood: Pour tester
Tests tout beau tout vert ✅ 
🐈‍⬛ 