### PR TITLE
[BUGFIX] Ne pas permettre de partager une campagne STARTED (PIX-15151)

### DIFF
--- a/api/src/prescription/campaign-participation/application/http-error-mapper-configuration.js
+++ b/api/src/prescription/campaign-participation/application/http-error-mapper-configuration.js
@@ -1,0 +1,13 @@
+import { HttpErrors } from '../../../shared/application/http-errors.js';
+import { CampaignParticiationInvalidStatus } from '../domain/errors.js';
+
+const campaignParticipationDomainErrorMappingConfiguration = [
+  {
+    name: CampaignParticiationInvalidStatus.name,
+    httpErrorFn: (error) => {
+      return new HttpErrors.PreconditionFailedError(error.message, error.code, error.meta);
+    },
+  },
+];
+
+export { campaignParticipationDomainErrorMappingConfiguration };

--- a/api/src/prescription/campaign-participation/domain/errors.js
+++ b/api/src/prescription/campaign-participation/domain/errors.js
@@ -6,4 +6,12 @@ class CampaignParticipationDeletedError extends DomainError {
   }
 }
 
-export { CampaignParticipationDeletedError };
+class CampaignParticiationInvalidStatus extends DomainError {
+  constructor(campaignParticipationId, acceptedStatus) {
+    super(
+      `Campaign participation: ${campaignParticipationId} status do not fulfill requirement. Accepted Status : ${acceptedStatus}`,
+    );
+  }
+}
+
+export { CampaignParticiationInvalidStatus, CampaignParticipationDeletedError };

--- a/api/src/prescription/campaign-participation/domain/models/CampaignParticipation.js
+++ b/api/src/prescription/campaign-participation/domain/models/CampaignParticipation.js
@@ -7,7 +7,7 @@ import {
 } from '../../../../../src/shared/domain/errors.js';
 import { ArchivedCampaignError } from '../../../campaign/domain/errors.js';
 import { CampaignParticipationStatuses } from '../../../shared/domain/constants.js';
-import { CampaignParticipationDeletedError } from '../errors.js';
+import { CampaignParticiationInvalidStatus, CampaignParticipationDeletedError } from '../errors.js';
 
 class CampaignParticipation {
   constructor({
@@ -98,6 +98,10 @@ class CampaignParticipation {
   }
 
   _canBeShared() {
+    if (this.status === CampaignParticipationStatuses.STARTED) {
+      throw new CampaignParticiationInvalidStatus(this.id, CampaignParticipationStatuses.STARTED);
+    }
+
     if (this.isShared) {
       throw new AlreadySharedCampaignParticipationError();
     }

--- a/api/src/prescription/campaign-participation/domain/models/CampaignParticipation.js
+++ b/api/src/prescription/campaign-participation/domain/models/CampaignParticipation.js
@@ -92,6 +92,10 @@ class CampaignParticipation {
   }
 
   _canBeImproved() {
+    if (this.status !== CampaignParticipationStatuses.TO_SHARE) {
+      throw new CampaignParticiationInvalidStatus(this.id, CampaignParticipationStatuses.TO_SHARE);
+    }
+
     if (this.campaign.isProfilesCollection()) {
       throw new CantImproveCampaignParticipationError();
     }

--- a/api/src/prescription/campaign-participation/domain/usecases/begin-campaign-participation-improvement.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/begin-campaign-participation-improvement.js
@@ -1,7 +1,4 @@
-import {
-  AlreadySharedCampaignParticipationError,
-  UserNotAuthorizedToAccessEntityError,
-} from '../../../../shared/domain/errors.js';
+import { UserNotAuthorizedToAccessEntityError } from '../../../../shared/domain/errors.js';
 import { Assessment } from '../../../../shared/domain/models/Assessment.js';
 
 const beginCampaignParticipationImprovement = async function ({
@@ -15,11 +12,8 @@ const beginCampaignParticipationImprovement = async function ({
     throw new UserNotAuthorizedToAccessEntityError();
   }
 
-  if (campaignParticipation.isShared) {
-    throw new AlreadySharedCampaignParticipationError();
-  }
-
   campaignParticipation.improve();
+
   await campaignParticipationRepository.update(campaignParticipation);
 
   if (campaignParticipation.lastAssessment.isImproving && !campaignParticipation.lastAssessment.isCompleted()) {

--- a/api/src/prescription/shared/application/http-error-mapper-configuration.js
+++ b/api/src/prescription/shared/application/http-error-mapper-configuration.js
@@ -1,9 +1,11 @@
 import { DomainErrorMappingConfiguration } from '../../../shared/application/models/domain-error-mapping-configuration.js';
 import { campaignDomainErrorMappingConfiguration } from '../../campaign/application/http-error-mapper-configuration.js';
+import { campaignParticipationDomainErrorMappingConfiguration } from '../../campaign-participation/application/http-error-mapper-configuration.js';
 import { learnerManagementDomainErrorMappingConfiguration } from '../../learner-management/application/http-error-mapper-configuration.js';
 import { targetProfileDomainErrorMappingConfiguration } from '../../target-profile/application/http-error-mapper-configuration.js';
 
 const prescriptionDomainErrorMappingConfiguration = []
+  .concat(campaignParticipationDomainErrorMappingConfiguration)
   .concat(campaignDomainErrorMappingConfiguration)
   .concat(learnerManagementDomainErrorMappingConfiguration)
   .concat(targetProfileDomainErrorMappingConfiguration)

--- a/api/tests/prescription/campaign-participation/acceptance/application/learner-participation-route_test.js
+++ b/api/tests/prescription/campaign-participation/acceptance/application/learner-participation-route_test.js
@@ -291,7 +291,7 @@ describe('Acceptance | Routes | Campaign Participations', function () {
       const userId = databaseBuilder.factory.buildUser().id;
       const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
         userId,
-        status: STARTED,
+        status: TO_SHARE,
       }).id;
       databaseBuilder.factory.buildAssessment({
         userId,
@@ -317,7 +317,11 @@ describe('Acceptance | Routes | Campaign Participations', function () {
     it('should return 412 HTTP status code when user has already shared his results', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
-      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ userId }).id;
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+        userId,
+        status: SHARED,
+        sharedAt: new Date(),
+      }).id;
       databaseBuilder.factory.buildAssessment({
         userId,
         campaignParticipationId,

--- a/api/tests/prescription/campaign-participation/acceptance/application/learner-participation-route_test.js
+++ b/api/tests/prescription/campaign-participation/acceptance/application/learner-participation-route_test.js
@@ -19,7 +19,7 @@ import {
 } from '../../../../test-helper.js';
 import { buildLearningContent } from '../../../../tooling/learning-content-builder/build-learning-content.js';
 
-const { SHARED, STARTED } = CampaignParticipationStatuses;
+const { SHARED, STARTED, TO_SHARE } = CampaignParticipationStatuses;
 
 describe('Acceptance | Routes | Campaign Participations', function () {
   let server, options, user;
@@ -73,7 +73,7 @@ describe('Acceptance | Routes | Campaign Participations', function () {
       const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
         id: campaignParticipationId,
         userId: user.id,
-        status: STARTED,
+        status: TO_SHARE,
         sharedAt: null,
         campaignId: campaign.id,
       });

--- a/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipation_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipation_test.js
@@ -92,15 +92,26 @@ describe('Unit | Domain | Models | CampaignParticipation', function () {
     context('when the campaign has the type PROFILES_COLLECTION', function () {
       it('throws an CantImproveCampaignParticipationError', async function () {
         const campaign = domainBuilder.buildCampaign({ type: CampaignTypes.PROFILES_COLLECTION });
-        const campaignParticipation = new CampaignParticipation({ campaign });
+        const campaignParticipation = new CampaignParticipation({ campaign, status: TO_SHARE });
 
-        const error = await catchErr(campaignParticipation.improve, campaignParticipation)();
+        const error = catchErrSync(campaignParticipation.improve, campaignParticipation)();
 
         expect(error).to.be.an.instanceOf(CantImproveCampaignParticipationError);
       });
     });
 
-    context('when the campaign participation status is different from STARTED', function () {
+    context('when the campaign participation status is STARTED', function () {
+      it('throws an CampaignParticiationInvalidStatus', async function () {
+        const campaign = domainBuilder.buildCampaign({ type: CampaignTypes.ASSESSMENT });
+        const campaignParticipation = new CampaignParticipation({ campaign, status: STARTED });
+
+        const error = catchErrSync(campaignParticipation.improve, campaignParticipation)();
+
+        expect(error).to.be.an.instanceOf(CampaignParticiationInvalidStatus);
+      });
+    });
+
+    context('when the campaign participation status is TO_SHARE', function () {
       it('changes the status to STARTED', async function () {
         const campaign = domainBuilder.buildCampaign({ type: CampaignTypes.ASSESSMENT });
         const campaignParticipation = new CampaignParticipation({ campaign, status: TO_SHARE });

--- a/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipation_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipation_test.js
@@ -1,5 +1,8 @@
 import { ArchivedCampaignError } from '../../../../../../src/prescription/campaign/domain/errors.js';
-import { CampaignParticipationDeletedError } from '../../../../../../src/prescription/campaign-participation/domain/errors.js';
+import {
+  CampaignParticiationInvalidStatus,
+  CampaignParticipationDeletedError,
+} from '../../../../../../src/prescription/campaign-participation/domain/errors.js';
 import { CampaignParticipation } from '../../../../../../src/prescription/campaign-participation/domain/models/CampaignParticipation.js';
 import {
   CampaignParticipationStatuses,
@@ -11,9 +14,9 @@ import {
   CantImproveCampaignParticipationError,
 } from '../../../../../../src/shared/domain/errors.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
-import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+import { catchErr, catchErrSync, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
-const { TO_SHARE, SHARED } = CampaignParticipationStatuses;
+const { TO_SHARE, SHARED, STARTED } = CampaignParticipationStatuses;
 
 describe('Unit | Domain | Models | CampaignParticipation', function () {
   describe('#getTargetProfileId', function () {
@@ -120,6 +123,17 @@ describe('Unit | Domain | Models | CampaignParticipation', function () {
 
       afterEach(function () {
         clock.restore();
+      });
+
+      context('when the campaign is started', function () {
+        it('throws an CampaignParticiationInvalidStatus error', function () {
+          const campaign = domainBuilder.buildCampaign({ type: CampaignTypes.PROFILES_COLLECTION });
+          const campaignParticipation = new CampaignParticipation({ campaign, status: STARTED });
+
+          const error = catchErrSync(campaignParticipation.share, campaignParticipation)();
+
+          expect(error).to.be.an.instanceOf(CampaignParticiationInvalidStatus);
+        });
       });
 
       context('when the campaign is already shared', function () {

--- a/api/tests/prescription/campaign-participation/unit/domain/usecases/begin-campaign-participation-improvement_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/usecases/begin-campaign-participation-improvement_test.js
@@ -1,9 +1,6 @@
 import { usecases } from '../../../../../../src/prescription/campaign-participation/domain/usecases/index.js';
 import { CampaignParticipationStatuses } from '../../../../../../src/prescription/shared/domain/constants.js';
-import {
-  AlreadySharedCampaignParticipationError,
-  UserNotAuthorizedToAccessEntityError,
-} from '../../../../../../src/shared/domain/errors.js';
+import { UserNotAuthorizedToAccessEntityError } from '../../../../../../src/shared/domain/errors.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
@@ -46,28 +43,6 @@ describe('Unit | Usecase | begin-campaign-participation-improvement', function (
     expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
   });
 
-  it('should throw an error if the campaign participation is shared', async function () {
-    // given
-    const userId = 1;
-    const campaignParticipationId = 2;
-    const campaignParticipation = domainBuilder.prescription.campaignParticipation.buildCampaignParticipation({
-      userId,
-      id: campaignParticipationId,
-      status: CampaignParticipationStatuses.SHARED,
-    });
-    campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(campaignParticipation);
-
-    // when
-    const error = await catchErr(beginCampaignParticipationImprovement)({
-      campaignParticipationId,
-      userId,
-      ...dependencies,
-    });
-
-    // then
-    expect(error).to.be.instanceOf(AlreadySharedCampaignParticipationError);
-  });
-
   it('should not start another assessment when the current assessment of the campaign is of improving type and still ongoing', async function () {
     // given
     const userId = 1;
@@ -81,7 +56,7 @@ describe('Unit | Usecase | begin-campaign-participation-improvement', function (
     const campaignParticipation = domainBuilder.prescription.campaignParticipation.buildCampaignParticipation({
       userId,
       id: campaignParticipationId,
-      status: CampaignParticipationStatuses.STARTED,
+      status: CampaignParticipationStatuses.TO_SHARE,
       assessments: [ongoingAssessment],
     });
     campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(campaignParticipation);
@@ -106,7 +81,7 @@ describe('Unit | Usecase | begin-campaign-participation-improvement', function (
     const campaignParticipation = domainBuilder.prescription.campaignParticipation.buildCampaignParticipation({
       userId,
       id: campaignParticipationId,
-      status: CampaignParticipationStatuses.STARTED,
+      status: CampaignParticipationStatuses.TO_SHARE,
       assessments: [latestAssessment],
     });
     campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(campaignParticipation);

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
@@ -21,8 +21,7 @@ export default class EvaluationResultsHero extends Component {
   @service tabManager;
 
   @tracked hasGlobalError = false;
-  @tracked isImproveButtonLoading = false;
-  @tracked isShareResultsLoading = false;
+  @tracked isButtonLoading = false;
 
   get isAutonomousCourse() {
     return this.args.campaign.organizationId === ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID;
@@ -58,11 +57,11 @@ export default class EvaluationResultsHero extends Component {
 
   @action
   async improveResults() {
-    if (this.isImproveButtonLoading) return;
+    if (this.isButtonLoading) return;
 
     try {
       this.hasGlobalError = false;
-      this.isImproveButtonLoading = true;
+      this.isButtonLoading = true;
 
       const campaignParticipationResult = this.args.campaignParticipationResult;
       const adapter = this.store.adapterFor('campaign-participation-result');
@@ -71,17 +70,17 @@ export default class EvaluationResultsHero extends Component {
     } catch {
       this.hasGlobalError = true;
     } finally {
-      this.isImproveButtonLoading = false;
+      this.isButtonLoading = false;
     }
   }
 
   @action
   async handleShareResultsClick() {
-    if (this.isShareResultsLoading) return;
+    if (this.isButtonLoading) return;
 
     try {
       this.hasGlobalError = false;
-      this.isShareResultsLoading = true;
+      this.isButtonLoading = true;
 
       const campaignParticipationResult = this.args.campaignParticipationResult;
       const adapter = this.store.adapterFor('campaign-participation-result');
@@ -92,7 +91,7 @@ export default class EvaluationResultsHero extends Component {
     } catch {
       this.hasGlobalError = true;
     } finally {
-      this.isShareResultsLoading = false;
+      this.isButtonLoading = false;
     }
   }
 
@@ -178,7 +177,7 @@ export default class EvaluationResultsHero extends Component {
               <PixButton
                 @triggerAction={{this.handleShareResultsClick}}
                 @size="large"
-                @isLoading={{this.isShareResultsLoading}}
+                @isLoading={{this.isButtonLoading}}
               >
                 {{t "pages.skill-review.actions.send"}}
               </PixButton>
@@ -190,7 +189,7 @@ export default class EvaluationResultsHero extends Component {
               @variant="tertiary"
               @size="large"
               @triggerAction={{this.improveResults}}
-              @isLoading={{this.isImproveButtonLoading}}
+              @isLoading={{this.isButtonLoading}}
             >
               {{t "pages.skill-review.actions.improve"}}
             </PixButton>

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/retry-or-reset-block.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/retry-or-reset-block.gjs
@@ -9,26 +9,10 @@ import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
 export default class EvaluationResultsHeroRetryOrResetBlock extends Component {
-  @tracked isImproveButtonLoading = false;
   @tracked isResetModalVisible = false;
 
   retryQueryParams = { retry: true };
   resetQueryParams = { reset: true };
-
-  @action
-  async improveResults() {
-    if (this.isImproveButtonLoading) return;
-
-    try {
-      this.isImproveButtonLoading = true;
-      const campaignParticipationResult = this.args.model.campaignParticipationResult;
-      const adapter = this.store.adapterFor('campaign-participation-result');
-      await adapter.beginImprovement(campaignParticipationResult.id);
-      this.router.transitionTo('campaigns.entry-point', this.args.campaign.code);
-    } finally {
-      this.isImproveButtonLoading = false;
-    }
-  }
 
   @action
   toggleResetModalVisibility() {


### PR DESCRIPTION
## :fallen_leaf: Problème
Suite à certains log erreur nous nous sommes rendu compte qu'il est possible de partagé une campagne non finit. Ce qui engendre des erreurs côté job asynchrone

## :chestnut: Proposition
Être plus restrictif sur la qualification d'une campagne à partager ou à improved

## :jack_o_lantern: Remarques
Mutualisation des loaders côté front pour les deux action retenter et partager. l'une ne pouvant fonctionner avec l'autre

## :wood: Pour tester
Faire une participation avec la possibilité de retenter. Vérifier que l'on ne peut plus cliquer sur les deux boutons