### PR TITLE
[TECH] Changer les dates du bandeau SCO dans Pix Certif (PIX-15268).

### DIFF
--- a/certif/tests/acceptance/authenticated-test.js
+++ b/certif/tests/acceptance/authenticated-test.js
@@ -118,7 +118,7 @@ module('Acceptance | authenticated', function (hooks) {
           assert
             .dom(
               screen.getByText(
-                'La certification Pix se déroulera du 6 novembre 2023 au 29 mars 2024 pour les lycées et du 4 mars au 14 juin 2024 pour les collèges. Pensez à consulter la',
+                'La certification Pix se déroulera du 7 novembre 2024 au 7 mars 2025 pour les lycées et du 17 mars au 13 juin 2025 pour les collèges. Pensez à consulter la',
               ),
             )
             .exists();
@@ -137,7 +137,7 @@ module('Acceptance | authenticated', function (hooks) {
 
           // then
           const certificationBannerMessage = screen.queryByText(
-            'La certification Pix se déroulera du 6 novembre 2023 au 29 mars 2024 pour les lycées et du 4 mars au 14 juin 2024 pour les collèges. Pensez à consulter la',
+            'La certification Pix se déroulera du 7 novembre 2024 au 7 mars 2025 pour les lycées et du 17 mars au 13 juin 2025 pour les collèges. Pensez à consulter la',
           );
           assert.dom(certificationBannerMessage).doesNotExist();
         });

--- a/certif/tests/acceptance/session-list-test.js
+++ b/certif/tests/acceptance/session-list-test.js
@@ -164,7 +164,7 @@ module('Acceptance | Session List', function (hooks) {
         assert
           .dom(
             screen.queryByText(
-              'La certification Pix se déroulera du 6 novembre 2023 au 29 mars 2024 pour les lycées et du 4 mars au 14 juin 2024 pour les collèges. Pensez à consulter la',
+              'La certification Pix se déroulera du 7 novembre 2024 au 7 mars 2025 pour les lycées et du 17 mars au 13 juin 2025 pour les collèges. Pensez à consulter la',
             ),
           )
           .doesNotExist();
@@ -184,7 +184,7 @@ module('Acceptance | Session List', function (hooks) {
         assert
           .dom(
             screen.getByText(
-              'La certification Pix se déroulera du 6 novembre 2023 au 29 mars 2024 pour les lycées et du 4 mars au 14 juin 2024 pour les collèges. Pensez à consulter la',
+              'La certification Pix se déroulera du 7 novembre 2024 au 7 mars 2025 pour les lycées et du 17 mars au 13 juin 2025 pour les collèges. Pensez à consulter la',
             ),
           )
           .exists();

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -275,7 +275,7 @@
     },
     "sco": {
       "banner": {
-        "information": "La certification Pix se déroulera du 6 novembre 2023 au 29 mars 2024 pour les lycées et du 4 mars au 14 juin 2024 pour les collèges. Pensez à consulter la",
+        "information": "La certification Pix se déroulera du 7 novembre 2024 au 7 mars 2025 pour les lycées et du 17 mars au 13 juin 2025 pour les collèges. Pensez à consulter la",
         "url-label": "documentation pour voir les nouveautés."
       },
       "enrol-candidates-in-session": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -275,7 +275,7 @@
     },
     "sco": {
       "banner": {
-        "information": "La certification Pix se déroulera du 6 novembre 2023 au 29 mars 2024 pour les lycées et du 4 mars au 14 juin 2024 pour les collèges. Pensez à consulter la",
+        "information": "La certification Pix se déroulera du 7 novembre 2024 au 7 mars 2025 pour les lycées et du 17 mars au 13 juin 2025 pour les collèges. Pensez à consulter la",
         "url-label": "documentation pour voir les nouveautés."
       },
       "enrol-candidates-in-session": {


### PR DESCRIPTION
## :fallen_leaf: Problème
Les dates de la certification Pix pour les lycées et collèges ne sont plus à jour.

## :chestnut: Proposition
Changer ces dernières sur le bandeau visible dans les espaces SCO sur Pix Certif.

## :wood: Pour tester

- Se connecter sur Pix Certif avec certif-sco-v3@example.net
- Constater les nouvelles dates : 7 novembre 2024 au 7 mars 2025 pour les lycées, 17 mars au 13 juin 2025 pour les collèges

<img width="1502" alt="Capture d’écran 2024-11-12 à 14 13 25" src="https://github.com/user-attachments/assets/c88c716f-40fe-4d91-b3e7-d33c6f851437">
