### PR TITLE
[BUGFIX] Répare la finalisation de session quand une épreuve a été exclue de la calibration (PIX-15226).

### DIFF
--- a/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v3_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v3_test.js
@@ -1060,7 +1060,7 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V3', funct
               .resolves(baseFlashAlgorithmConfiguration);
             flashAlgorithmService.getCapacityAndErrorRate
               .withArgs({
-                challenges: answeredChallenges,
+                challenges: [challengeExcludedFromCalibration, ...challengesAfterCalibration],
                 allAnswers: answers,
                 capacity: sinon.match.number,
                 variationPercent: undefined,


### PR DESCRIPTION
## :fallen_leaf: Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Les sessions qui ont commencé avec l'ancienne calibration ne peuvent être finalisées si elles nécessitent une dégradation du score.
Cela est du au fait que certaines épreuves précédemment répondues ont été exclues lors de la nouvelle calibration et ne sont pas données en entrée de l'algorithme lors de la sélection de la prochaine épreuve (sélection nécessaire lors de la dégradation du score).

## :chestnut: Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en œuvre, des difficultés ou problèmes rencontrés. -->

Ajouter les épreuves posées au pool d'épreuves utilisé par l'algorithme.

## :jack_o_lantern: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

On a réussi à reproduire le problème en local avec les données de `answers` et `certification-challenges` de l'assessment qui pose problème en production.

## :wood: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

1. Passer un test de certification v3 en répondant au nombre minimum de questions nécessaires pour avoir un score **mais en ne terminant pas le test**. (Soit entre 20 et 31 réponses).
1. En utilisant un client postgresql, il faut maintenant altérer les données pour reproduire les effets d'une épreuve qui aurait été exclue de la calibration avant la finalisation de la session.
Pour cela il faut repérer un `challengeId` répondu par l'utilisateur, par exemple dans les `answers` correspondant à l'assessment qui vient d'être passé.
Remplacer ce `challengeId` par un identifiant d'épreuve sans données de calibration (eg. `recrVuWD1YTGlhpWY`).
Remplacer également ce `challengeId` pour le `certification-challenges` associé.
1. Dans Pix certif, finaliser la session.
1. Constater que la finalisation se passe sans problème.
