### PR TITLE
[FEATURE] API verifiant si un utilisateur a été candidat de certif (PIX-14984)

### DIFF
--- a/api/src/certification/enrolment/application/api/candidates-api.js
+++ b/api/src/certification/enrolment/application/api/candidates-api.js
@@ -1,0 +1,17 @@
+import { usecases } from '../../../enrolment/domain/usecases/index.js';
+
+/**
+ * Checks if a user has been candidate to a certification
+ *
+ * @function
+ * @param {Object} params
+ * @param {number} params.userId user id to search for candidates
+ * @returns {Promise<boolean>}
+ * @throws {TypeError} preconditions failed
+ */
+export const hasBeenCandidate = async ({ userId }) => {
+  if (!userId) {
+    throw new TypeError('user identifier is required');
+  }
+  return usecases.hasBeenCandidate({ userId });
+};

--- a/api/src/certification/enrolment/domain/usecases/has-been-candidate.js
+++ b/api/src/certification/enrolment/domain/usecases/has-been-candidate.js
@@ -1,0 +1,13 @@
+/**
+ * @typedef {import('./index.js').CandidateRepository} CandidateRepository
+ */
+
+/**
+ * @param {Object} params
+ * @param {number} params.userId
+ * @param {CandidateRepository} params.candidateRepository
+ */
+export async function hasBeenCandidate({ userId, candidateRepository }) {
+  const candidates = await candidateRepository.findByUserId({ userId });
+  return candidates.some((candidate) => candidate.isReconciled());
+}

--- a/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
@@ -37,6 +37,19 @@ export async function findBySessionId({ sessionId }) {
 
 /**
  * @function
+ * @param {Object} params
+ * @param {number} params.userId
+ *
+ * @return {Promise<Array<Candidate>>}
+ */
+export async function findByUserId({ userId }) {
+  const knexTransaction = DomainTransaction.getConnection();
+  const candidatesData = await buildBaseReadQuery(knexTransaction).where({ 'certification-candidates.userId': userId });
+  return candidatesData.map(toDomain);
+}
+
+/**
+ * @function
  * @param {Object} candidate
  *
  * @throws {CertificationCandidateNotFoundError} Certification candidate not found

--- a/api/tests/certification/enrolment/unit/application/api/candidates-api_test.js
+++ b/api/tests/certification/enrolment/unit/application/api/candidates-api_test.js
@@ -1,0 +1,30 @@
+import { hasBeenCandidate } from '../../../../../../src/certification/enrolment/application/api/candidates-api.js';
+import { usecases } from '../../../../../../src/certification/enrolment/domain/usecases/index.js';
+import { catchErr, expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | Certification | Enrolment | API | candidates-api', function () {
+  describe('hasBeenCandidate', function () {
+    it('should check if a user has been candidate', async function () {
+      // given
+      sinon.stub(usecases, 'hasBeenCandidate').resolves();
+
+      // when
+      await hasBeenCandidate({ userId: 12 });
+
+      // then
+      expect(usecases.hasBeenCandidate).to.have.been.calledOnceWithExactly({ userId: 12 });
+    });
+
+    it('should reject calls without a userId', async function () {
+      // given
+      sinon.stub(usecases, 'hasBeenCandidate').resolves();
+
+      // when
+      const error = await catchErr(() => hasBeenCandidate({ userId: null }))();
+
+      // then
+      expect(error).to.be.instanceOf(TypeError);
+      expect(error.message).to.equals('user identifier is required');
+    });
+  });
+});

--- a/api/tests/certification/enrolment/unit/domain/usecases/has-been-candidate_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/has-been-candidate_test.js
@@ -1,0 +1,58 @@
+import { hasBeenCandidate } from '../../../../../../src/certification/enrolment/domain/usecases/has-been-candidate.js';
+import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+
+describe('Certification | Enrolment | Unit | UseCase | has-been-candidate', function () {
+  let candidateRepository;
+
+  beforeEach(function () {
+    candidateRepository = { findByUserId: sinon.stub() };
+  });
+
+  context('when at least one candidate is reconciled', function () {
+    it('should return true', async function () {
+      // given
+      const candidate1 = domainBuilder.certification.enrolment.buildCandidate({
+        userId: 4321,
+        reconciledAt: new Date(),
+      });
+      const candidate2 = domainBuilder.certification.enrolment.buildCandidate({ userId: 4321 });
+
+      candidateRepository.findByUserId.withArgs({ userId: 4321 }).resolves([candidate1, candidate2]);
+
+      // when
+      const result = await hasBeenCandidate({ userId: 4321, candidateRepository });
+
+      // then
+      expect(result).to.be.true;
+    });
+  });
+
+  context('when no candidates are reconciled', function () {
+    it('should return false', async function () {
+      // given
+      const candidate1 = domainBuilder.certification.enrolment.buildCandidate({ userId: 4321 });
+      const candidate2 = domainBuilder.certification.enrolment.buildCandidate({ userId: 4321 });
+
+      candidateRepository.findByUserId.withArgs({ userId: 4321 }).resolves([candidate1, candidate2]);
+
+      // when
+      const result = await hasBeenCandidate({ userId: 4321, candidateRepository });
+
+      // then
+      expect(result).to.be.false;
+    });
+  });
+
+  context('when no candidates are returned', function () {
+    it('should return false', async function () {
+      // given
+      candidateRepository.findByUserId.withArgs({ userId: 4321 }).resolves([]);
+
+      // when
+      const result = await hasBeenCandidate({ userId: 4321, candidateRepository });
+
+      // then
+      expect(result).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
## :fallen_leaf: Problème

Dans le cadre d'une nouvelle fonctionnalité permettant à un utilisateur de supprimer son compte lui-même (ie. anonymiser le compte), nous souhaitons restreindre la fonctionnalité aux utilisateurs qui n'ont jamais été candidat à une certification. (car l'anonymisation des données utilisateurs de certification n'est pas effective aujourd'hui)

## :chestnut: Proposition

Depuis un contexte "Privacy" (lié à l'anonymisation), nous allons appelé une API du contexte `certification/enrolment` afin d'identifier si un utilisateur (via `userId`) a déjà été candidat à une certification.

* **API Implementation `candidates-api.js`:** Ajout de `hasBeenCandidate` vérifiant si un utilisateur a été candidat via le use-case.

* **Domain Use Case `has-been-candidate.js`:** Ajout de `hasBeenCandidate` vérifiant si au moins une candidature de l'utilisateur est réconciliée (`isReconciled`) .

* **Repository `candidate-repository.js`:** Ajout `findByUserId` récupérant toutes les candidatures et ses subscriptions pour un `userId` spécifique.

**Exemple d'utilisation de l'api**

```js
import { hasBeenCandidate } from 'src/certification/enrolment/application/api/candidates-api.js';

await hasBeenCandidate({ userId: 123 }); // true or false
```
