### PR TITLE
[BUGFIX] Empêcher un candidat de répondre à un challenge si celui-ci dispose d'une alerte validée (PIX-15263).

### DIFF
--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -165,13 +165,13 @@ const correctAnswerThenUpdateAssessment = async function ({
   let certificationCandidate;
 
   if (assessment.isCertification()) {
-    const onGoingCertificationChallengeLiveAlert =
-      await certificationChallengeLiveAlertRepository.getOngoingByChallengeIdAndAssessmentId({
+    const ongoingOrValidatedCertificationChallengeLiveAlert =
+      await certificationChallengeLiveAlertRepository.getOngoingOrValidatedByChallengeIdAndAssessmentId({
         challengeId: challenge.id,
         assessmentId: assessment.id,
       });
 
-    if (onGoingCertificationChallengeLiveAlert) {
+    if (ongoingOrValidatedCertificationChallengeLiveAlert) {
       throw new ForbiddenAccess('An alert has been set.');
     }
 

--- a/api/src/certification/shared/infrastructure/repositories/certification-challenge-live-alert-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-challenge-live-alert-repository.js
@@ -60,6 +60,23 @@ const getOngoingByChallengeIdAndAssessmentId = async ({ challengeId, assessmentI
   return _toDomain(certificationChallengeLiveAlertDto);
 };
 
+const getOngoingOrValidatedByChallengeIdAndAssessmentId = async ({ challengeId, assessmentId }) => {
+  const certificationChallengeLiveAlertDto = await knex('certification-challenge-live-alerts')
+    .where({
+      'certification-challenge-live-alerts.challengeId': challengeId,
+      'certification-challenge-live-alerts.assessmentId': assessmentId,
+      'certification-challenge-live-alerts.status': CertificationChallengeLiveAlertStatus.ONGOING,
+    })
+    .orWhere({
+      'certification-challenge-live-alerts.challengeId': challengeId,
+      'certification-challenge-live-alerts.assessmentId': assessmentId,
+      'certification-challenge-live-alerts.status': CertificationChallengeLiveAlertStatus.VALIDATED,
+    })
+    .first();
+
+  return _toDomain(certificationChallengeLiveAlertDto);
+};
+
 const _toDomain = (certificationChallengeLiveAlertDto) => {
   if (!certificationChallengeLiveAlertDto) {
     return null;
@@ -73,5 +90,6 @@ export {
   getLiveAlertValidatedChallengeIdsByAssessmentId,
   getOngoingByChallengeIdAndAssessmentId,
   getOngoingBySessionIdAndUserId,
+  getOngoingOrValidatedByChallengeIdAndAssessmentId,
   save,
 };

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-challenge-live-alert-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-challenge-live-alert-repository_test.js
@@ -312,4 +312,91 @@ describe('Integration | Repository | Certification Challenge Live Alert', functi
       });
     });
   });
+
+  describe('getOngoingOrValidatedByChallengeIdAndAssessmentId', function () {
+    const challengeId = 'rec123';
+    const assessmentId = 456;
+
+    describe('when there are no matching live alerts', function () {
+      it('should return null', async function () {
+        // given / when
+        const liveAlert =
+          await certificationChallengeLiveAlertRepository.getOngoingOrValidatedByChallengeIdAndAssessmentId({
+            challengeId,
+            assessmentId,
+          });
+
+        // then
+        expect(liveAlert).to.be.null;
+      });
+    });
+
+    describe('when there is a matching validated live alert', function () {
+      it('should return the live alert', async function () {
+        // given
+        const certificationCourse = databaseBuilder.factory.buildCertificationCourse();
+
+        const assessment = databaseBuilder.factory.buildAssessment({
+          certificationCourseId: certificationCourse.id,
+          userId: certificationCourse.userId,
+        });
+
+        databaseBuilder.factory.buildCertificationChallengeLiveAlert({
+          assessmentId: assessment.id,
+          status: CertificationChallengeLiveAlertStatus.DISMISSED,
+        });
+
+        const certificationChallengeLiveAlert = databaseBuilder.factory.buildCertificationChallengeLiveAlert({
+          assessmentId: assessment.id,
+          status: CertificationChallengeLiveAlertStatus.VALIDATED,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const liveAlert =
+          await certificationChallengeLiveAlertRepository.getOngoingOrValidatedByChallengeIdAndAssessmentId({
+            challengeId: certificationChallengeLiveAlert.challengeId,
+            assessmentId: assessment.id,
+          });
+
+        // then
+        expect(liveAlert).to.deep.equal(certificationChallengeLiveAlert);
+      });
+    });
+
+    describe('when there is a matching ongoing validated alert', function () {
+      it('should return the live alert', async function () {
+        // given
+        const certificationCourse = databaseBuilder.factory.buildCertificationCourse();
+
+        const assessment = databaseBuilder.factory.buildAssessment({
+          certificationCourseId: certificationCourse.id,
+          userId: certificationCourse.userId,
+        });
+
+        databaseBuilder.factory.buildCertificationChallengeLiveAlert({
+          assessmentId: assessment.id,
+          status: CertificationChallengeLiveAlertStatus.DISMISSED,
+        });
+
+        const certificationChallengeLiveAlert = databaseBuilder.factory.buildCertificationChallengeLiveAlert({
+          assessmentId: assessment.id,
+          status: CertificationChallengeLiveAlertStatus.ONGOING,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const liveAlert =
+          await certificationChallengeLiveAlertRepository.getOngoingOrValidatedByChallengeIdAndAssessmentId({
+            challengeId: certificationChallengeLiveAlert.challengeId,
+            assessmentId: assessment.id,
+          });
+
+        // then
+        expect(liveAlert).to.deep.equal(certificationChallengeLiveAlert);
+      });
+    });
+  });
 });

--- a/mon-pix/app/components/challenge/item.js
+++ b/mon-pix/app/components/challenge/item.js
@@ -89,6 +89,10 @@ export default class Item extends Component {
 
   @action
   async answerValidated(challenge, assessment, answerValue, answerTimeout, answerFocusedOut) {
+    if (assessment.hasOngoingChallengeLiveAlert) {
+      return;
+    }
+
     const answer = await this._findOrCreateAnswer(challenge, assessment);
     answer.setProperties({
       value: answerValue.trim(),

--- a/mon-pix/tests/unit/components/challenge/challenge-item-test.js
+++ b/mon-pix/tests/unit/components/challenge/challenge-item-test.js
@@ -150,6 +150,27 @@ module('Unit | Component | Challenge | Item', function (hooks) {
       assert.ok(true);
     });
 
+    module('when there is an ongoing live alert', function () {
+      test('it should not save the answer', async function (assert) {
+        // given
+        const assessment = EmberObject.create({ answers: [answerToChallengeOne], hasOngoingChallengeLiveAlert: true });
+        const component = createGlimmerComponent('challenge/item', { challenge: challengeOne });
+        component.router = { transitionTo: sinon.stub().returns() };
+        component.currentUser = { isAnonymous: false };
+        component.store = {
+          createRecord: createRecordStub,
+        };
+
+        // when
+        await component.answerValidated(challengeOne, assessment, answerValue, answerFocusedOut, answerTimeout);
+
+        // then
+        sinon.assert.notCalled(answerToChallengeOne.save);
+        sinon.assert.notCalled(component.router.transitionTo);
+        assert.ok(true);
+      });
+    });
+
     module('when saving succeeds', function () {
       test('should redirect to assessment-resume route', async function (assert) {
         // given


### PR DESCRIPTION
## :fallen_leaf: Problème

Un candidat a reçu une 500  suite à un signalement validé par son surveillant.
On constate qu’il a pu répondre à la question signalée alors qu’il n’aurait pas dû. 

Il s’est donc retrouvé totalement coincé lors de sa certification.

En reproduisant on constate que les boutons d’action sont `disabled` mais lorsque la question possède un input, il est tout à fait possible de valider en faisant `Entrée` qui déclenche un submit du formulaire.

## :chestnut: Proposition

- Empêcher respectivement côté front et côté back l'envoi de la réponse si une live alert est en cours, et d'accepter une réponse si celle-ci provient d'un challenge ayant une live alert validée ou en cours.

## :jack_o_lantern: Remarques

Nous remarquons côté front que le nommage de la propriété de l'assessment `hasOngoingChallengeLiveAlert` ne correspond plus à la réalité puisque nous devons vérifier qu'il n'y ait pas à la fois de status en cours ou validé pour le challenge en cours.

Ce refacto entraîne des modifications un peu plus structurantes au niveau des modèles exposés que nous proposons de gérer ultérieurement.

## :wood: Pour tester

- Créer une session de certification V3
- Ajouter un candidat
- Commencer le test de certification
- Arriver sur une question dotée un champ input (QROC)
- Lever une alerte
- Valider l'alerte côté surveillant
- Ne pas rafraîchir le challenge mais essayer de répondre à la question en appuyant sur Entrée pour valider votre réponse
- Vérifier que la réponse n'a pas été envoyée (Appel réseau et/ou pas de nouvelle ligne dans la table `answers`)
