### PR TITLE
[TECH] Définir la locale a FRENCH dans le cas des attestations (PIX-14836)

### DIFF
--- a/api/src/profile/application/attestation-controller.js
+++ b/api/src/profile/application/attestation-controller.js
@@ -2,6 +2,7 @@ import * as path from 'node:path';
 import * as url from 'node:url';
 
 import * as requestResponseUtils from '../../../src/shared/infrastructure/utils/request-response-utils.js';
+import { LOCALE } from '../../shared/domain/constants.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as pdfWithFormSerializer from '../infrastructure/serializers/pdf/pdf-with-form-serializer.js';
 
@@ -9,8 +10,9 @@ const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 const getUserAttestation = async function (request, h, dependencies = { pdfWithFormSerializer, requestResponseUtils }) {
   const userId = request.params.userId;
-  const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
   const attestationKey = request.params.attestationKey;
+
+  const locale = LOCALE.FRENCH_FRANCE;
   const { data, templateName } = await usecases.getAttestationDataForUsers({
     attestationKey,
     userIds: [userId],

--- a/api/tests/profile/unit/application/attestation-controller_test.js
+++ b/api/tests/profile/unit/application/attestation-controller_test.js
@@ -1,5 +1,6 @@
 import { attestationController } from '../../../../src/profile/application/attestation-controller.js';
 import { usecases } from '../../../../src/profile/domain/usecases/index.js';
+import { LOCALE } from '../../../../src/shared/domain/constants.js';
 import * as requestResponseUtils from '../../../../src/shared/infrastructure/utils/request-response-utils.js';
 import { expect, hFake, sinon } from '../../../test-helper.js';
 
@@ -10,7 +11,7 @@ describe('Profile | Unit | Controller | attestation-controller', function () {
       const pdfWithFormSerializerStub = { serialize: sinon.stub() };
       sinon.stub(usecases, 'getAttestationDataForUsers');
       const userId = '12';
-      const locale = 'fr';
+      const locale = LOCALE.FRENCH_FRANCE;
       const attestationKey = 'key';
 
       const request = {


### PR DESCRIPTION
## :fallen_leaf: Problème
Dans le cadre de l'Epix Attestations, nous avions utilisé la locale de l'utilisateur pour générer l'attestation. Cependant nos attestations ne sont pas prévue (au moins pour le moment) pour être traduite. On se retrouve donc avec des dates possiblement en format anglais alors que l'attestation est générée en FR

## :chestnut: Proposition
Ecrire en dur dans le code la valeur FRENCH pour la locale qui est utilisée pour générer les attestations

## :jack_o_lantern: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :wood: Pour tester

- Se connecter a un compte ayant une attestation de dispo
- Mettre le compte en anglais
- Télécharger l'attestation
- Constater que le format de la date est bien en français
- 🐈‍⬛ 
