### PR TITLE
[BUGFIX] Corriger l'inscription en local sur la double mire SCO (PIX-15290)

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/sco-organization-learner-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/sco-organization-learner-serializer.js
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import jsonapiSerializer from 'jsonapi-serializer';
 
 const { Serializer } = jsonapiSerializer;
@@ -13,6 +11,12 @@ const serializeIdentity = function (scoOrganizationLearner) {
 const serializeWithUsernameGeneration = function (scoOrganizationLearner) {
   return new Serializer('sco-organization-learner', {
     attributes: ['lastName', 'firstName', 'birthdate', 'username'],
+    transform(scoOrganizationLearner) {
+      return {
+        ...scoOrganizationLearner,
+        id: scoOrganizationLearner.username,
+      };
+    },
   }).serialize(scoOrganizationLearner);
 };
 
@@ -21,7 +25,7 @@ const serializeExternal = function (scoOrganizationLearner) {
     transform(externalUser) {
       return {
         ...externalUser,
-        id: randomUUID(),
+        id: externalUser.accessToken,
       };
     },
     attributes: ['accessToken'],

--- a/api/tests/acceptance/application/sco-organization-learners/sco-organization-learner-controller_test.js
+++ b/api/tests/acceptance/application/sco-organization-learners/sco-organization-learner-controller_test.js
@@ -113,7 +113,7 @@ describe('Acceptance | Controller | sco-organization-learners', function () {
   });
 
   describe('PUT /api/sco-organization-learners/possibilities', function () {
-    it('should return the organizationLearner linked to the user and a 200 status code response', async function () {
+    it('returns the organizationLearner linked to the user and a 200 status code response', async function () {
       //given
       const organization = databaseBuilder.factory.buildOrganization({
         isManagingStudents: true,
@@ -150,6 +150,8 @@ describe('Acceptance | Controller | sco-organization-learners', function () {
       });
 
       // then
+      const expectedUsername = 'billy.thekid0508';
+
       expect(response.statusCode).to.equal(200);
       expect(response.result).to.deep.equal({
         data: {
@@ -157,8 +159,9 @@ describe('Acceptance | Controller | sco-organization-learners', function () {
             birthdate: '2005-08-05',
             'first-name': 'Billy',
             'last-name': 'TheKid',
-            username: 'billy.thekid0508',
+            username: expectedUsername,
           },
+          id: expectedUsername,
           type: 'sco-organization-learners',
         },
       });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/sco-organization-learner-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/sco-organization-learner-serializer_test.js
@@ -1,7 +1,5 @@
-import _ from 'lodash';
-
 import * as serializer from '../../../../../lib/infrastructure/serializers/jsonapi/sco-organization-learner-serializer.js';
-import { OrganizationLearner } from '../../../../../src/shared/domain/models/OrganizationLearner.js';
+import { OrganizationLearner } from '../../../../../src/shared/domain/models/index.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | sco-organization-learner-serializer', function () {
@@ -36,7 +34,7 @@ describe('Unit | Serializer | JSONAPI | sco-organization-learner-serializer', fu
   });
 
   describe('#serializeWithUsernameGeneration', function () {
-    it('should convert into JSON API data', function () {
+    it('converts into JSON API data with id set to a unique value being the username', function () {
       // given
       const organizationLearner = {
         firstName: 'John',
@@ -47,13 +45,14 @@ describe('Unit | Serializer | JSONAPI | sco-organization-learner-serializer', fu
 
       const expectedSerializedOrganizationLearner = {
         data: {
-          type: 'sco-organization-learners',
           attributes: {
             'first-name': organizationLearner.firstName,
             'last-name': organizationLearner.lastName,
             birthdate: organizationLearner.birthdate,
             username: organizationLearner.username,
           },
+          id: organizationLearner.username,
+          type: 'sco-organization-learners',
         },
       };
 
@@ -66,7 +65,7 @@ describe('Unit | Serializer | JSONAPI | sco-organization-learner-serializer', fu
   });
 
   describe('#serializeExternal', function () {
-    it('should convert into JSON API data and generate random id', function () {
+    it('converts into JSON API data with id set to a unique value being the accessToken', function () {
       // given
       const organizationLearner = {
         accessToken: 'some token',
@@ -77,6 +76,7 @@ describe('Unit | Serializer | JSONAPI | sco-organization-learner-serializer', fu
           attributes: {
             'access-token': organizationLearner.accessToken,
           },
+          id: organizationLearner.accessToken,
           type: 'external-users',
         },
       };
@@ -85,8 +85,7 @@ describe('Unit | Serializer | JSONAPI | sco-organization-learner-serializer', fu
       const json = serializer.serializeExternal(organizationLearner);
 
       // then
-      expect(_.omit(json, 'data.id')).to.deep.equal(expectedSerializedOrganizationLearner);
-      expect(json.data.id).to.be.a('string');
+      expect(json).to.deep.equal(expectedSerializedOrganizationLearner);
     });
   });
 

--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -162,7 +162,7 @@ export default class RegisterForm extends Component {
       (errorResponse) => {
         this.scoOrganizationLearner.unloadRecord();
         this.isLoading = false;
-        errorResponse.errors.forEach((error) => {
+        errorResponse.errors?.forEach((error) => {
           if (error.status === '404') {
             return (this.errorMessage =
               'Vous êtes un élève ? <br> Vérifiez vos informations (prénom, nom et date de naissance) ou contactez un enseignant. <br><br> Vous êtes un enseignant ? <br> L’accès à un parcours n’est pas disponible pour le moment.');


### PR DESCRIPTION
## :fallen_leaf: Problème
Lorsqu'on veut s'inscrire, en local, sur la double mire SCO, la route `/api/sco-organization-learners/possibilities` est appelée avec succès mais la suite du formulaire ne s'affiche pas.

C'est causé par l'erreur Ember Data suivante : 

> Error: Expected an id [CLIENT_ORIGINATED] sco-organization-learner:null (@lid:sco-organization-learner-SCOBADGE1_Potter) in response {"id":null,"type":"sco-organization-learner","attributes":{"birthdate":"2012-12-12","firstName":"Harry","lastName":"Potter","username":"harry.potter1212"},"relationships":{}}

## :chestnut: Proposition
Ajouter, dans le serializer correspondant, un id avec comme valeur le username qui est unique pour ce cas.

## :jack_o_lantern: Remarques
- On a aussi mis une vérification sur l'objet `errorResponse.errors` dans la gestion des erreurs pour éviter une autre erreur lorsque que le champ `errors` est `undefined`.
- Une correction a aussi été effectuée sur le serializer `serializeExternal` pour éviter d'utiliser la fonction `randomUUID` mais plutôt l'access token comme id 😄 

## :wood: Pour tester (en local)
- Rejoindre une campagne SCO (ex: SCOBADGE1) sur la route `/campagnes/SCOBADGE1/presentation`.
- Cliquer sur le bouton `Je commence`.
- Remplir les informations du formulaire Je m'inscris sur Pix avec un compte n'ayant pas de méthodes de connexion (ex: Harry Potter 12/12/2012).
- Cliquer sur le bouton `Je m'inscris`.
- Vérifier que la suite du formulaire s'affiche bien 🎉 
