### PR TITLE
[BUGFIX] Ne pas tenir compte de la locale lors de la séléction du prochain challenge de certification (PIX-15008)

### DIFF
--- a/api/src/certification/evaluation/domain/usecases/get-next-challenge.js
+++ b/api/src/certification/evaluation/domain/usecases/get-next-challenge.js
@@ -65,7 +65,7 @@ const getNextChallenge = async function ({
 
   const activeFlashCompatibleChallenges = await challengeRepository.findActiveFlashCompatible({ locale });
 
-  const alreadyAnsweredChallenges = await challengeRepository.getMany(alreadyAnsweredChallengeIds, locale);
+  const alreadyAnsweredChallenges = await challengeRepository.getMany(alreadyAnsweredChallengeIds);
   const challenges = [...new Set([...alreadyAnsweredChallenges, ...activeFlashCompatibleChallenges])];
   const algorithmConfiguration = await flashAlgorithmConfigurationRepository.getMostRecentBeforeDate(
     certificationCourse.getStartDate(),

--- a/api/tests/certification/evaluation/unit/domain/usecases/get-next-challenge_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/get-next-challenge_test.js
@@ -93,7 +93,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
         challengeRepository.get.resolves();
 
         challengeRepository.findActiveFlashCompatible.withArgs({ locale }).resolves([nextChallengeToAnswer]);
-        challengeRepository.getMany.withArgs([], locale).resolves([]);
+        challengeRepository.getMany.withArgs([]).resolves([]);
 
         flashAlgorithmService.getCapacityAndErrorRate
           .withArgs({
@@ -183,7 +183,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
             .resolves(null);
 
           challengeRepository.findActiveFlashCompatible.withArgs({ locale }).resolves(allChallenges);
-          challengeRepository.getMany.withArgs([], locale).resolves([]);
+          challengeRepository.getMany.withArgs([]).resolves([]);
 
           flashAlgorithmService.getCapacityAndErrorRate
             .withArgs({
@@ -340,7 +340,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           .resolves([alreadyAnsweredChallenge, nextChallengeToAnswer]);
 
         challengeRepository.getMany
-          .withArgs([alreadyAnsweredChallenge.id, outdatedChallenge.id], locale)
+          .withArgs([alreadyAnsweredChallenge.id, outdatedChallenge.id])
           .resolves([alreadyAnsweredChallenge, outdatedChallenge]);
 
         flashAlgorithmService.getCapacityAndErrorRate
@@ -420,7 +420,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
 
         answerRepository.findByAssessment.withArgs(assessment.id).resolves([]);
         challengeRepository.findActiveFlashCompatible.withArgs({ locale }).resolves([nextChallenge, lastSeenChallenge]);
-        challengeRepository.getMany.withArgs([], locale).resolves([]);
+        challengeRepository.getMany.withArgs([]).resolves([]);
 
         flashAlgorithmService.getCapacityAndErrorRate
           .withArgs({
@@ -518,7 +518,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
         challengeRepository.findActiveFlashCompatible
           .withArgs()
           .resolves([challengeWithLiveAlert, challengeWithOtherSkill, challengeWithLiveAlertedSkill]);
-        challengeRepository.getMany.withArgs([], locale).resolves([]);
+        challengeRepository.getMany.withArgs([]).resolves([]);
 
         flashAlgorithmService.getCapacityAndErrorRate
           .withArgs({
@@ -614,7 +614,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
         challengeRepository.get.resolves();
 
         challengeRepository.findActiveFlashCompatible.withArgs({ locale }).resolves([answeredChallenge]);
-        challengeRepository.getMany.withArgs([answeredChallenge.id], locale).resolves([answeredChallenge]);
+        challengeRepository.getMany.withArgs([answeredChallenge.id]).resolves([answeredChallenge]);
 
         // when
         const error = await catchErr(getNextChallenge)({
@@ -693,7 +693,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
             challengeRepository.get.resolves();
 
             challengeRepository.findActiveFlashCompatible.withArgs({ locale }).resolves([nextChallengeToAnswer]);
-            challengeRepository.getMany.withArgs([], locale).resolves([]);
+            challengeRepository.getMany.withArgs([]).resolves([]);
 
             flashAlgorithmService.getCapacityAndErrorRate
               .withArgs({


### PR DESCRIPTION
## :fallen_leaf: Problème
Plusieurs candidats en session de certification v3 ont eu une “page oups” avec une erreur 500, et n’ont jamais pu reprendre leur test. 

Il semblerait que ça soit dû à un souci dans la sélection d’une question de leur test, qui a mis  la génération de la suite du test en erreur.


## :chestnut: Proposition
Retirer la locale des arguments de l'appel au getMany du challengeRepository


## :wood: Pour tester
- Répondre des questions sur pix-app.fr
- Basculer sur pix-app.org
- continuer le test et s'assurer que ça ne plante pas