### PR TITLE
[BUGFIX] Réparer le usecase récupérant les étapes de présentation de parcours (PIX-15283).

### DIFF
--- a/api/src/prescription/campaign/domain/usecases/get-presentation-steps.js
+++ b/api/src/prescription/campaign/domain/usecases/get-presentation-steps.js
@@ -7,6 +7,7 @@ const getPresentationSteps = async function ({
   locale,
   badgeRepository,
   campaignRepository,
+  campaignParticipationRepository,
   learningContentRepository,
 }) {
   const campaign = await campaignRepository.getByCode(campaignCode);
@@ -15,11 +16,11 @@ const getPresentationSteps = async function ({
   if (campaign.archivedAt) throw new ArchivedCampaignError();
   if (campaign.deletedAt) throw new DeletedCampaignError();
 
-  const hasUserAccessToResult = await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(
-    campaign.id,
+  const hasUserAccessToCampaign = await campaignParticipationRepository.findOneByCampaignIdAndUserId({
+    campaignId: campaign.id,
     userId,
-  );
-  if (!hasUserAccessToResult)
+  });
+  if (!hasUserAccessToCampaign)
     throw new UserNotAuthorizedToAccessEntityError('User does not have access to this campaign');
 
   const campaignBadges = await badgeRepository.findByCampaignId(campaign.id);

--- a/api/tests/prescription/campaign/acceptance/application/campaign-route_test.js
+++ b/api/tests/prescription/campaign/acceptance/application/campaign-route_test.js
@@ -358,10 +358,9 @@ describe('Acceptance | API | Campaign Route', function () {
       const userId = databaseBuilder.factory.buildUser().id;
       const organization = databaseBuilder.factory.buildOrganization();
 
-      databaseBuilder.factory.buildMembership({
+      const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
         userId,
         organizationId: organization.id,
-        organizationRole: Membership.roles.MEMBER,
       });
 
       const targetProfile = databaseBuilder.factory.buildTargetProfile({ organizationId: organization.id });
@@ -381,6 +380,13 @@ describe('Acceptance | API | Campaign Route', function () {
         campaignId: campaign.id,
         skillId: learningContentObjects.competences[0].skillIds[0],
       });
+
+      databaseBuilder.factory.buildCampaignParticipation({
+        userId,
+        campaignId: campaign.id,
+        organizationLearnerId: organizationLearner.id,
+      });
+
       await databaseBuilder.commit();
 
       // when

--- a/api/tests/prescription/campaign/integration/domain/usecases/get-presentation-steps_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/get-presentation-steps_test.js
@@ -22,7 +22,18 @@ describe('Integration | Campaign | UseCase | get-presentation-steps', function (
 
     campaign = databaseBuilder.factory.buildCampaign({ targetProfileId });
 
-    user = databaseBuilder.factory.buildUser.withMembership({ organizationId: campaign.organizationId });
+    user = databaseBuilder.factory.buildUser();
+
+    const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+      userId: user.id,
+      campaignId: campaign.id,
+    });
+
+    databaseBuilder.factory.buildCampaignParticipation({
+      userId: user.id,
+      campaignId: campaign.id,
+      organizationLearnerId: organizationLearner.id,
+    });
 
     badges = [
       databaseBuilder.factory.buildBadge({ targetProfileId }),

--- a/api/tests/prescription/campaign/unit/domain/usecases/get-presentation-steps_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/get-presentation-steps_test.js
@@ -12,6 +12,7 @@ const { FRENCH_SPOKEN } = LOCALE;
 describe('Unit | Domain | Use Cases | get-presentation-steps', function () {
   let badgeRepository;
   let campaignRepository;
+  let campaignParticipationRepository;
   let learningContentRepository;
 
   const locale = FRENCH_SPOKEN;
@@ -22,6 +23,9 @@ describe('Unit | Domain | Use Cases | get-presentation-steps', function () {
     campaignRepository = {
       getByCode: sinon.stub(),
       checkIfUserOrganizationHasAccessToCampaign: sinon.stub(),
+    };
+    campaignParticipationRepository = {
+      findOneByCampaignIdAndUserId: sinon.stub(),
     };
     learningContentRepository = { findByCampaignId: sinon.stub() };
   });
@@ -75,7 +79,7 @@ describe('Unit | Domain | Use Cases | get-presentation-steps', function () {
         const campaignId = Symbol('campaign-id');
 
         campaignRepository.getByCode.withArgs(campaignCode).resolves({ id: campaignId });
-        campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(false);
+        campaignParticipationRepository.findOneByCampaignIdAndUserId.withArgs({ campaignId, userId }).resolves(null);
 
         // when
         const error = await catchErr(getPresentationSteps)({
@@ -83,6 +87,7 @@ describe('Unit | Domain | Use Cases | get-presentation-steps', function () {
           campaignCode,
           locale,
           campaignRepository,
+          campaignParticipationRepository,
           badgeRepository,
           learningContentRepository,
         });
@@ -98,7 +103,9 @@ describe('Unit | Domain | Use Cases | get-presentation-steps', function () {
         const campaignId = Symbol('campaign-id');
 
         campaignRepository.getByCode.withArgs(campaignCode).resolves({ id: campaignId });
-        campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(true);
+        campaignParticipationRepository.findOneByCampaignIdAndUserId
+          .withArgs({ campaignId, userId })
+          .resolves(Symbol('a campaign participation'));
 
         // when
         await getPresentationSteps({
@@ -106,6 +113,7 @@ describe('Unit | Domain | Use Cases | get-presentation-steps', function () {
           campaignCode,
           locale,
           campaignRepository,
+          campaignParticipationRepository,
           badgeRepository,
           learningContentRepository,
         });


### PR DESCRIPTION
## :fallen_leaf: Problème

Une mauvaise méthode de repository a été utilisée [dans le usecase](https://github.com/1024pix/pix/blob/dev/api/src/prescription/campaign/domain/usecases/get-presentation-steps.js#L18) récoltant les infos de début de parcours pour les nouvelles pages.

Cette méthode vérifie que l'utilisateur est membre d'une orga. Or, ce check n'est utile que dans PixOrga.

## :chestnut: Proposition

Vérifier que l'utilisateur a bien une entrée active dans `campaign-particiption` entre son `userId` et la campagne en cours.

## :jack_o_lantern: Remarques

On avait émis l'idée d'un pré-handler...
Mais plus complexe à mettre en place avec un code campagne dans l'URL.

## :wood: Pour tester

Tests verts
