### PR TITLE
[FEATURE] Bloquer le scoring des certifications Pix+ seule (PIX-14716)

### DIFF
--- a/api/lib/domain/events/handle-certification-rescoring.js
+++ b/api/lib/domain/events/handle-certification-rescoring.js
@@ -1,5 +1,5 @@
 import { AssessmentResultFactory } from '../../../src/certification/scoring/domain/models/factories/AssessmentResultFactory.js';
-import { SessionVersion } from '../../../src/certification/shared/domain/models/SessionVersion.js';
+import { AlgorithmEngineVersion } from '../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { V3_REPRODUCIBILITY_RATE } from '../../../src/shared/domain/constants.js';
 import { CertificationComputeError } from '../../../src/shared/domain/errors.js';
 import { CertificationResult } from '../../../src/shared/domain/models/CertificationResult.js';
@@ -35,8 +35,11 @@ async function handleCertificationRescoring({
     certificationCourseId: event.certificationCourseId,
   });
 
-  // TODO: switch to certif-course version, not session
-  if (SessionVersion.isV3(certificationAssessment.version)) {
+  if (certificationAssessment.isScoringBlockedDueToComplementaryOnlyChallenges) {
+    return;
+  }
+
+  if (AlgorithmEngineVersion.isV3(certificationAssessment.version)) {
     return _handleV3CertificationScoring({
       certificationAssessment,
       event,

--- a/api/src/certification/evaluation/application/jobs/certification-completed-job-controller.js
+++ b/api/src/certification/evaluation/application/jobs/certification-completed-job-controller.js
@@ -43,6 +43,10 @@ export class CertificationCompletedJobController extends JobController {
     const certificationAssessment = await certificationAssessmentRepository.get(assessmentId);
     let certificationScoringCompletedEvent;
 
+    if (certificationAssessment.isScoringBlockedDueToComplementaryOnlyChallenges) {
+      return;
+    }
+
     if (AlgorithmEngineVersion.isV3(certificationAssessment.version)) {
       certificationScoringCompletedEvent = await _handleV3CertificationScoring({
         certificationAssessment,

--- a/api/src/certification/session-management/domain/models/CertificationAssessment.js
+++ b/api/src/certification/session-management/domain/models/CertificationAssessment.js
@@ -179,6 +179,16 @@ class CertificationAssessment {
     return [states.STARTED, states.ENDED_BY_SUPERVISOR, states.ENDED_DUE_TO_FINALIZATION];
   }
 
+  get isComplementaryOnly() {
+    return this.certificationChallenges.every(
+      (certificationChallenge) => certificationChallenge.certifiableBadgeKey !== null,
+    );
+  }
+
+  get isScoringBlockedDueToComplementaryOnlyChallenges() {
+    return this.isComplementaryOnly;
+  }
+
   _getLastChallenge() {
     return _.orderBy(this.certificationChallenges, 'createdAt', 'desc')[0];
   }

--- a/api/tests/certification/session-management/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/certification/session-management/unit/domain/models/CertificationAssessment_test.js
@@ -911,4 +911,158 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
       ]);
     });
   });
+
+  describe('#get isComplementaryOnly', function () {
+    it('should return true if challenges are only complementary', function () {
+      //given
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationChallenges: [
+          domainBuilder.buildCertificationChallengeWithType({
+            challengeId: 'rec123',
+            certifiableBadgeKey: 'TOTO',
+          }),
+          domainBuilder.buildCertificationChallengeWithType({
+            challengeId: 'rec456',
+            certifiableBadgeKey: 'TOTO',
+          }),
+          domainBuilder.buildCertificationChallengeWithType({
+            challengeId: 'rec789',
+            certifiableBadgeKey: 'TOTO',
+          }),
+        ],
+        certificationAnswersByDate: [
+          domainBuilder.buildAnswer({
+            challengeId: 'rec123',
+          }),
+          domainBuilder.buildAnswer({
+            challengeId: 'rec456',
+          }),
+          domainBuilder.buildAnswer({
+            challengeId: 'rec789',
+          }),
+        ],
+      });
+
+      // when
+      const isComplementaryOnly = certificationAssessment.isComplementaryOnly;
+
+      // then
+      expect(isComplementaryOnly).to.be.true;
+    });
+
+    it('should return false if challenges are not complementary', function () {
+      //given
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationChallenges: [
+          domainBuilder.buildCertificationChallengeWithType({
+            challengeId: 'rec123',
+            certifiableBadgeKey: null,
+          }),
+          domainBuilder.buildCertificationChallengeWithType({
+            challengeId: 'rec456',
+            certifiableBadgeKey: null,
+          }),
+          domainBuilder.buildCertificationChallengeWithType({
+            challengeId: 'rec789',
+            certifiableBadgeKey: null,
+          }),
+        ],
+        certificationAnswersByDate: [
+          domainBuilder.buildAnswer({
+            challengeId: 'rec123',
+          }),
+          domainBuilder.buildAnswer({
+            challengeId: 'rec456',
+          }),
+          domainBuilder.buildAnswer({
+            challengeId: 'rec789',
+          }),
+        ],
+      });
+
+      // when
+      const isComplementaryOnly = certificationAssessment.isComplementaryOnly;
+
+      // then
+      expect(isComplementaryOnly).to.be.false;
+    });
+  });
+
+  describe('#get isScoringBlockedDueToComplementaryOnlyChallenges', function () {
+    it('should return true if challenges are only complementary', function () {
+      //given
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationChallenges: [
+          domainBuilder.buildCertificationChallengeWithType({
+            challengeId: 'rec123',
+            certifiableBadgeKey: 'TOTO',
+          }),
+          domainBuilder.buildCertificationChallengeWithType({
+            challengeId: 'rec456',
+            certifiableBadgeKey: 'TOTO',
+          }),
+          domainBuilder.buildCertificationChallengeWithType({
+            challengeId: 'rec789',
+            certifiableBadgeKey: 'TOTO',
+          }),
+        ],
+        certificationAnswersByDate: [
+          domainBuilder.buildAnswer({
+            challengeId: 'rec123',
+          }),
+          domainBuilder.buildAnswer({
+            challengeId: 'rec456',
+          }),
+          domainBuilder.buildAnswer({
+            challengeId: 'rec789',
+          }),
+        ],
+      });
+
+      // when
+      const isScoringBlockedDueToComplementaryOnlyChallenges =
+        certificationAssessment.isScoringBlockedDueToComplementaryOnlyChallenges;
+
+      // then
+      expect(isScoringBlockedDueToComplementaryOnlyChallenges).to.be.true;
+    });
+
+    it('should return false if challenges are not complementary', function () {
+      //given
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationChallenges: [
+          domainBuilder.buildCertificationChallengeWithType({
+            challengeId: 'rec123',
+            certifiableBadgeKey: null,
+          }),
+          domainBuilder.buildCertificationChallengeWithType({
+            challengeId: 'rec456',
+            certifiableBadgeKey: null,
+          }),
+          domainBuilder.buildCertificationChallengeWithType({
+            challengeId: 'rec789',
+            certifiableBadgeKey: null,
+          }),
+        ],
+        certificationAnswersByDate: [
+          domainBuilder.buildAnswer({
+            challengeId: 'rec123',
+          }),
+          domainBuilder.buildAnswer({
+            challengeId: 'rec456',
+          }),
+          domainBuilder.buildAnswer({
+            challengeId: 'rec789',
+          }),
+        ],
+      });
+
+      // when
+      const isScoringBlockedDueToComplementaryOnlyChallenges =
+        certificationAssessment.isScoringBlockedDueToComplementaryOnlyChallenges;
+
+      // then
+      expect(isScoringBlockedDueToComplementaryOnlyChallenges).to.be.false;
+    });
+  });
 });


### PR DESCRIPTION
## :fallen_leaf: Problème
Dans le cadre du sujet “Compatibilité Pix v3/Pix+”, un candidat doit pouvoir passer un test de certification Pix+ seul. Néanmoins, dans l’optique de sécuriser un maximum la généralisation du 4/11, l’implémentation du scoring de ce test Pix+ seul a été décalé dans le temps, dans un épix à part.

Des erreurs vont arriver à la fin d’un test de certif Pix+ et à la finalisation d’une session avec des tests Pix+ seuls puisque le scoring n’est pas encore prêt.

## :chestnut: Proposition
Bloquer le scoring des certifs Pix+ seules en attendant que celui-ci soit implémenté.


## :wood: Pour tester
- Passer une certification V3 uniquement pix+
- Aller au bout du test
- Constater qu'il n'y a pas d'assessement result de créé, ni de complementaryCertificationCourseResult