### PR TITLE
[FEATURE] Afficher le message d'erreur "adresse email invalide ou déjà utilisée" (PIX-14689)

### DIFF
--- a/api/lib/domain/usecases/create-and-reconcile-user-to-organization-learner.js
+++ b/api/lib/domain/usecases/create-and-reconcile-user-to-organization-learner.js
@@ -119,6 +119,7 @@ function _createDomainUser(userAttributes) {
 }
 
 function _manageEmailAvailabilityError(error) {
+  error = new AlreadyRegisteredEmailError();
   return _manageError(
     error,
     AlreadyRegisteredEmailError,

--- a/api/src/identity-access-management/application/http-error-mapper-configuration.js
+++ b/api/src/identity-access-management/application/http-error-mapper-configuration.js
@@ -3,6 +3,7 @@ import { DomainErrorMappingConfiguration } from '../../shared/application/models
 import {
   AuthenticationKeyExpired,
   DifferentExternalIdentifierError,
+  InvalidOrAlreadyUsedEmailError,
   MissingOrInvalidCredentialsError,
   MissingUserAccountError,
   PasswordNotMatching,
@@ -19,6 +20,10 @@ const authenticationDomainErrorMappingConfiguration = [
   {
     name: DifferentExternalIdentifierError.name,
     httpErrorFn: (error) => new HttpErrors.ConflictError(error.message),
+  },
+  {
+    name: InvalidOrAlreadyUsedEmailError.name,
+    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code),
   },
   {
     name: MissingOrInvalidCredentialsError.name,

--- a/api/src/identity-access-management/domain/errors.js
+++ b/api/src/identity-access-management/domain/errors.js
@@ -14,6 +14,12 @@ class DifferentExternalIdentifierError extends DomainError {
   }
 }
 
+class InvalidOrAlreadyUsedEmailError extends DomainError {
+  constructor() {
+    super('Invalid or already used e-mail address', 'INVALID_OR_ALREADY_USED_EMAIL');
+  }
+}
+
 class OrganizationLearnerNotBelongToOrganizationIdentityError extends DomainError {
   constructor(message = 'Organization Learner identity does not belong to Organization Identity') {
     super(message);
@@ -74,6 +80,7 @@ class UserShouldChangePasswordError extends DomainError {
 export {
   AuthenticationKeyExpired,
   DifferentExternalIdentifierError,
+  InvalidOrAlreadyUsedEmailError,
   MissingOrInvalidCredentialsError,
   MissingUserAccountError,
   OrganizationLearnerIdentityNotFoundError,

--- a/api/src/identity-access-management/domain/usecases/create-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/create-user.usecase.js
@@ -1,8 +1,8 @@
 import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
-import { AlreadyRegisteredEmailError } from '../../../shared/domain/errors.js';
 import { EntityValidationError } from '../../../shared/domain/errors.js';
 import { urlBuilder } from '../../../shared/infrastructure/utils/url-builder.js';
 import { createAccountCreationEmail } from '../emails/create-account-creation.email.js';
+import { InvalidOrAlreadyUsedEmailError } from '../errors.js';
 
 /**
  * @param {Object} params
@@ -90,7 +90,7 @@ export { createUser };
  * @private
  */
 function _manageEmailAvailabilityError(error) {
-  return _manageError(error, AlreadyRegisteredEmailError, 'email', 'ALREADY_REGISTERED_EMAIL');
+  return _manageError(error, InvalidOrAlreadyUsedEmailError, 'email', 'INVALID_OR_ALREADY_USED_EMAIL');
 }
 
 /**

--- a/api/src/identity-access-management/infrastructure/repositories/user.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user.repository.js
@@ -1,4 +1,5 @@
 import { knex } from '../../../../db/knex-database-connection.js';
+import { InvalidOrAlreadyUsedEmailError } from '../../../identity-access-management/domain/errors.js';
 import * as organizationFeaturesApi from '../../../organizational-entities/application/api/organization-features-api.js';
 import { Organization } from '../../../organizational-entities/domain/models/Organization.js';
 import { OrganizationLearnerForAdmin } from '../../../prescription/learner-management/domain/read-models/OrganizationLearnerForAdmin.js';
@@ -6,7 +7,6 @@ import * as organizationLearnerImportFormatRepository from '../../../prescriptio
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import {
   AlreadyExistingEntityError,
-  AlreadyRegisteredEmailError,
   AlreadyRegisteredUsernameError,
   UserNotFoundError,
 } from '../../../shared/domain/errors.js';
@@ -249,7 +249,7 @@ const updateWithEmailConfirmed = function ({ id, userAttributes }) {
 const checkIfEmailIsAvailable = async function (email) {
   const existingUserEmail = await knex('users').whereRaw('LOWER("email") = ?', email.toLowerCase()).first();
 
-  if (existingUserEmail) throw new AlreadyRegisteredEmailError();
+  if (existingUserEmail) throw new InvalidOrAlreadyUsedEmailError();
 
   return email;
 };

--- a/api/tests/identity-access-management/acceptance/application/account-recovery/account-recovery.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/account-recovery/account-recovery.route.test.js
@@ -208,7 +208,7 @@ describe('Acceptance | Identity Access Management | Application | Route | accoun
       expect(response.statusCode).to.equal(204);
     });
 
-    it('returns 400 if email already exists', async function () {
+    it('returns 422 if email already exists', async function () {
       // given
       const newEmail = 'new_email@example.net';
       await createUserWithSeveralOrganizationLearners({ email: newEmail });
@@ -233,8 +233,8 @@ describe('Acceptance | Identity Access Management | Application | Route | accoun
       const response = await server.inject(options);
 
       // then
-      expect(response.statusCode).to.equal(400);
-      expect(response.result.errors[0].detail).to.equal('Cette adresse e-mail est déjà utilisée.');
+      expect(response.statusCode).to.equal(422);
+      expect(response.result.errors[0].detail).to.equal('Invalid or already used e-mail address');
     });
   });
 });

--- a/api/tests/identity-access-management/acceptance/application/user/user.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/user/user.route.test.js
@@ -768,7 +768,7 @@ describe('Acceptance | Identity Access Management | Application | Route | User',
 
       // then
       expect(response.statusCode).to.equal(400);
-      expect(response.result.errors[0].detail).to.equal('Cette adresse e-mail est déjà utilisée.');
+      expect(response.result.errors[0].detail).to.equal('Adresse e-mail invalide ou déjà utilisée');
     });
 
     it('should return 403 if requested user is not the same as authenticated user', async function () {

--- a/api/tests/identity-access-management/acceptance/application/user/user.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/user/user.route.test.js
@@ -730,7 +730,7 @@ describe('Acceptance | Identity Access Management | Application | Route | User',
       expect(response.statusCode).to.equal(204);
     });
 
-    it('should return 400 if email already exists', async function () {
+    it('should return 422 if email already exists', async function () {
       // given
       const server = await createServer();
 
@@ -767,8 +767,8 @@ describe('Acceptance | Identity Access Management | Application | Route | User',
       const response = await server.inject(options);
 
       // then
-      expect(response.statusCode).to.equal(400);
-      expect(response.result.errors[0].detail).to.equal('Adresse e-mail invalide ou déjà utilisée');
+      expect(response.statusCode).to.equal(422);
+      expect(response.result.errors[0].detail).to.equal('INVALID_OR_ALREADY_USED_EMAIL');
     });
 
     it('should return 403 if requested user is not the same as authenticated user', async function () {

--- a/api/tests/identity-access-management/integration/domain/usecases/update-user-email-with-validation.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/update-user-email-with-validation.usecase.test.js
@@ -1,10 +1,10 @@
 import { expect } from 'chai';
 
+import { InvalidOrAlreadyUsedEmailError } from '../../../../../src/identity-access-management/domain/errors.js';
 import { EventLoggingJob } from '../../../../../src/identity-access-management/domain/models/jobs/EventLoggingJob.js';
 import { usecases } from '../../../../../src/identity-access-management/domain/usecases/index.js';
 import { userEmailRepository } from '../../../../../src/identity-access-management/infrastructure/repositories/user-email.repository.js';
 import {
-  AlreadyRegisteredEmailError,
   EmailModificationDemandNotFoundOrExpiredError,
   InvalidVerificationCodeError,
   UserNotAuthorizedToUpdateEmailError,
@@ -137,7 +137,7 @@ describe('Integration | Identity Access Management | Domain | UseCase | updateUs
       });
 
       // then
-      expect(error).to.be.instanceOf(AlreadyRegisteredEmailError);
+      expect(error).to.be.instanceOf(InvalidOrAlreadyUsedEmailError);
     });
   });
 });

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
@@ -3,6 +3,7 @@ const { each, map, times, pick } = lodash;
 import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../../src/identity-access-management/domain/constants/identity-providers.js';
 import * as OidcIdentityProviders from '../../../../../src/identity-access-management/domain/constants/oidc-identity-providers.js';
+import { InvalidOrAlreadyUsedEmailError } from '../../../../../src/identity-access-management/domain/errors.js';
 import { User } from '../../../../../src/identity-access-management/domain/models/User.js';
 import { UserDetailsForAdmin } from '../../../../../src/identity-access-management/domain/models/UserDetailsForAdmin.js';
 import * as userRepository from '../../../../../src/identity-access-management/infrastructure/repositories/user.repository.js';
@@ -12,7 +13,6 @@ import { OrganizationLearnerForAdmin } from '../../../../../src/prescription/lea
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
 import {
   AlreadyExistingEntityError,
-  AlreadyRegisteredEmailError,
   AlreadyRegisteredUsernameError,
   UserNotFoundError,
 } from '../../../../../src/shared/domain/errors.js';
@@ -1749,7 +1749,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       expect(email).to.equal('email@example.net');
     });
 
-    it('should reject an AlreadyRegisteredEmailError when it already exists', async function () {
+    it('throws an InvalidOrAlreadyUsedEmailError when it already exists', async function () {
       // given
       const userInDb = databaseBuilder.factory.buildUser(userToInsert);
       await databaseBuilder.commit();
@@ -1758,10 +1758,10 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       const result = await catchErr(userRepository.checkIfEmailIsAvailable)(userInDb.email);
 
       // then
-      expect(result).to.be.instanceOf(AlreadyRegisteredEmailError);
+      expect(result).to.be.instanceOf(InvalidOrAlreadyUsedEmailError);
     });
 
-    it('should reject an AlreadyRegisteredEmailError when email case insensitive already exists', async function () {
+    it('throws an InvalidOrAlreadyUsedEmailError when email case insensitive already exists', async function () {
       // given
       const upperCaseEmail = 'TEST@example.net';
       const lowerCaseEmail = 'test@example.net';
@@ -1772,7 +1772,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       const result = await catchErr(userRepository.checkIfEmailIsAvailable)(lowerCaseEmail);
 
       // then
-      expect(result).to.be.instanceOf(AlreadyRegisteredEmailError);
+      expect(result).to.be.instanceOf(InvalidOrAlreadyUsedEmailError);
     });
   });
 

--- a/api/tests/identity-access-management/unit/domain/usecases/create-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/create-user.usecase.test.js
@@ -1,8 +1,8 @@
 import { createAccountCreationEmail } from '../../../../../src/identity-access-management/domain/emails/create-account-creation.email.js';
+import { InvalidOrAlreadyUsedEmailError } from '../../../../../src/identity-access-management/domain/errors.js';
 import { User } from '../../../../../src/identity-access-management/domain/models/User.js';
 import { createUser } from '../../../../../src/identity-access-management/domain/usecases/create-user.usecase.js';
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
-import { AlreadyRegisteredEmailError } from '../../../../../src/shared/domain/errors.js';
 import { EntityValidationError } from '../../../../../src/shared/domain/errors.js';
 import { urlBuilder } from '../../../../../src/shared/infrastructure/utils/url-builder.js';
 import { catchErr, expect, sinon } from '../../../../test-helper.js';
@@ -140,12 +140,12 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
     context('when user email is already used', function () {
       it('should reject with an error EntityValidationError on email already registered', async function () {
         // given
-        const emailExistError = new AlreadyRegisteredEmailError('email already exists');
+        const emailExistError = new InvalidOrAlreadyUsedEmailError('email already exists');
         const expectedValidationError = new EntityValidationError({
           invalidAttributes: [
             {
               attribute: 'email',
-              message: 'ALREADY_REGISTERED_EMAIL',
+              message: 'INVALID_OR_ALREADY_USED_EMAIL',
             },
           ],
         });
@@ -231,9 +231,9 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           },
         ],
       });
-      const emailExistError = new AlreadyRegisteredEmailError('email already exists');
+      const emailExistError = new InvalidOrAlreadyUsedEmailError('email already exists');
 
-      it('should reject with an error EntityValidationError containing the entityValidationError and the AlreadyRegisteredEmailError', async function () {
+      it('should reject with an error EntityValidationError containing the entityValidationError and the InvalidOrAlreadyUsedEmailError', async function () {
         // given
         userRepository.checkIfEmailIsAvailable.rejects(emailExistError);
         userValidator.validate.throws(entityValidationError);

--- a/certif/app/components/auth/register-form.js
+++ b/certif/app/components/auth/register-form.js
@@ -113,7 +113,7 @@ export default class RegisterForm extends Component {
       const status = get(response, 'errors[0].status');
 
       if (status === '422') {
-        this.errorMessage = this.intl.t('common.form-errors.email.already-exists');
+        this.errorMessage = this.intl.t('common.form-errors.email.invalid-or-already-used-email');
       } else {
         this.errorMessage = this.intl.t('common.form-errors.default');
       }

--- a/certif/tests/unit/components/auth/register-form-test.js
+++ b/certif/tests/unit/components/auth/register-form-test.js
@@ -134,7 +134,7 @@ module('Unit | Component | register-form', (hooks) => {
           await component.register(eventStub);
 
           // then
-          assert.strictEqual(component.errorMessage, t('common.form-errors.email.already-exists'));
+          assert.strictEqual(component.errorMessage, t('common.form-errors.email.invalid-or-already-used-email'));
           sinon.assert.calledOnce(deleteRecord);
         });
       });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -79,8 +79,8 @@
     "form-errors": {
       "default": "The service is temporarily unavailable. Please try again later.",
       "email": {
-        "already-exists": "This email address is already registered, please login.",
-        "format": "Your email address is invalid."
+        "format": "Your email address is invalid.",
+        "invalid-or-already-used-email": "Invalid or already used e-mail address"
       },
       "fill-mandatory-fields": "Please fill in all the required fields before confirming.",
       "firstname": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -79,8 +79,8 @@
     "form-errors": {
       "default": "Le service est momentanément indisponible. Veuillez réessayer ultérieurement.",
       "email": {
-        "already-exists": "Cette adresse e-mail est déjà enregistrée, connectez-vous.",
-        "format": "Le champ adresse e-mail n’est pas valide."
+        "format": "Le champ adresse e-mail n’est pas valide.",
+        "invalid-or-already-used-email": "Adresse e-mail invalide ou déjà utilisée"
       },
       "fill-mandatory-fields": "Veuillez remplir tous les champs obligatoires avant de valider.",
       "firstname": {

--- a/mon-pix/app/components/account-recovery/backup-email-confirmation-form.hbs
+++ b/mon-pix/app/components/account-recovery/backup-email-confirmation-form.hbs
@@ -43,7 +43,9 @@
         class="account-recovery__content--not-found-error"
         id="backup-email-confirmation-already-use-error-message"
       >
-        {{t "pages.account-recovery.find-sco-record.backup-email-confirmation.form.error.new-email-already-exist"}}
+        {{t
+          "pages.account-recovery.find-sco-record.backup-email-confirmation.form.error.invalid-or-already-used-email"
+        }}
       </PixMessage>
     {{/if}}
 

--- a/mon-pix/app/components/authentication/signup-form/index.gjs
+++ b/mon-pix/app/components/authentication/signup-form/index.gjs
@@ -30,7 +30,7 @@ const VALIDATION_ERRORS = {
   cgu: 'common.cgu.error',
 };
 
-const API_ERRORS = {
+const EMAIL_API_ERRORS = {
   INVALID_OR_ALREADY_USED_EMAIL: 'components.authentication.signup-form.errors.invalid-or-already-used-email',
 };
 
@@ -40,21 +40,6 @@ export default class SignupForm extends Component {
 
   @tracked isLoading = false;
   @tracked globalError = null;
-  @tracked apiErrors = API_ERRORS;
-
-  _getErrorMessageForField = (fieldName) => {
-    const apiErrorKey = this.validation[fieldName]?.apiError;
-    if (apiErrorKey) {
-      if (this.apiErrors[apiErrorKey]) {
-        const errorMessage = this.intl.t(this.apiErrors[apiErrorKey]);
-        return errorMessage;
-      }
-      return apiErrorKey;
-    }
-
-    const defaultErrorMessage = this.intl.t(this.validation[fieldName]?.error || this.intl.t('common.error'));
-    return defaultErrorMessage;
-  };
 
   validation = new FormValidation({
     firstName: {
@@ -68,6 +53,7 @@ export default class SignupForm extends Component {
     email: {
       validate: (value) => isEmailValid(value),
       error: VALIDATION_ERRORS.email,
+      apiErrors: EMAIL_API_ERRORS,
     },
     password: {
       validate: (value) => isPasswordValid(value),
@@ -168,7 +154,7 @@ export default class SignupForm extends Component {
           name="firstName"
           {{on "change" this.handleInputChange}}
           @validationStatus={{this.validation.firstName.status}}
-          @errorMessage={{this._getErrorMessageForField "firstName"}}
+          @errorMessage={{t this.validation.firstName.error}}
           placeholder={{t "components.authentication.signup-form.fields.firstname.placeholder"}}
           aria-required="true"
           autocomplete="given-name"
@@ -181,7 +167,7 @@ export default class SignupForm extends Component {
           name="lastName"
           {{on "change" this.handleInputChange}}
           @validationStatus={{this.validation.lastName.status}}
-          @errorMessage={{this._getErrorMessageForField "lastName"}}
+          @errorMessage={{t this.validation.lastName.error}}
           placeholder={{t "components.authentication.signup-form.fields.lastname.placeholder"}}
           aria-required="true"
           autocomplete="family-name"
@@ -194,7 +180,7 @@ export default class SignupForm extends Component {
           name="email"
           {{on "change" this.handleInputChange}}
           @validationStatus={{this.validation.email.status}}
-          @errorMessage={{this._getErrorMessageForField "email"}}
+          @errorMessage={{t this.validation.email.error}}
           placeholder={{t "components.authentication.signup-form.fields.email.placeholder"}}
           aria-required="true"
           autocomplete="email"
@@ -207,7 +193,7 @@ export default class SignupForm extends Component {
           name="password"
           {{on "change" this.handleInputChange}}
           @validationStatus={{this.validation.password.status}}
-          @errorMessage={{this._getErrorMessageForField "password"}}
+          @errorMessage={{t this.validation.password.error}}
           @rules={{PASSWORD_RULES}}
           aria-required="true"
         >
@@ -219,7 +205,7 @@ export default class SignupForm extends Component {
           name="cgu"
           {{on "change" this.handleInputChange}}
           @validationStatus={{this.validation.cgu.status}}
-          @errorMessage={{this._getErrorMessageForField "cgu"}}
+          @errorMessage={{t this.validation.cgu.error}}
           aria-required="true"
         />
       </fieldset>

--- a/mon-pix/app/components/authentication/signup-form/index.gjs
+++ b/mon-pix/app/components/authentication/signup-form/index.gjs
@@ -30,12 +30,31 @@ const VALIDATION_ERRORS = {
   cgu: 'common.cgu.error',
 };
 
+const API_ERRORS = {
+  INVALID_OR_ALREADY_USED_EMAIL: 'components.authentication.signup-form.errors.invalid-or-already-used-email',
+};
+
 export default class SignupForm extends Component {
   @service session;
   @service intl;
 
   @tracked isLoading = false;
   @tracked globalError = null;
+  @tracked apiErrors = API_ERRORS;
+
+  _getErrorMessageForField = (fieldName) => {
+    const apiErrorKey = this.validation[fieldName]?.apiError;
+    if (apiErrorKey) {
+      if (this.apiErrors[apiErrorKey]) {
+        const errorMessage = this.intl.t(this.apiErrors[apiErrorKey]);
+        return errorMessage;
+      }
+      return apiErrorKey;
+    }
+
+    const defaultErrorMessage = this.intl.t(this.validation[fieldName]?.error || this.intl.t('common.error'));
+    return defaultErrorMessage;
+  };
 
   validation = new FormValidation({
     firstName: {
@@ -149,11 +168,7 @@ export default class SignupForm extends Component {
           name="firstName"
           {{on "change" this.handleInputChange}}
           @validationStatus={{this.validation.firstName.status}}
-          @errorMessage={{if
-            this.validation.firstName.apiError
-            this.validation.firstName.apiError
-            (t this.validation.firstName.error)
-          }}
+          @errorMessage={{this._getErrorMessageForField "firstName"}}
           placeholder={{t "components.authentication.signup-form.fields.firstname.placeholder"}}
           aria-required="true"
           autocomplete="given-name"
@@ -166,11 +181,7 @@ export default class SignupForm extends Component {
           name="lastName"
           {{on "change" this.handleInputChange}}
           @validationStatus={{this.validation.lastName.status}}
-          @errorMessage={{if
-            this.validation.lastName.apiError
-            this.validation.lastName.apiError
-            (t this.validation.lastName.error)
-          }}
+          @errorMessage={{this._getErrorMessageForField "lastName"}}
           placeholder={{t "components.authentication.signup-form.fields.lastname.placeholder"}}
           aria-required="true"
           autocomplete="family-name"
@@ -183,11 +194,7 @@ export default class SignupForm extends Component {
           name="email"
           {{on "change" this.handleInputChange}}
           @validationStatus={{this.validation.email.status}}
-          @errorMessage={{if
-            this.validation.email.apiError
-            this.validation.email.apiError
-            (t this.validation.email.error)
-          }}
+          @errorMessage={{this._getErrorMessageForField "email"}}
           placeholder={{t "components.authentication.signup-form.fields.email.placeholder"}}
           aria-required="true"
           autocomplete="email"
@@ -200,11 +207,7 @@ export default class SignupForm extends Component {
           name="password"
           {{on "change" this.handleInputChange}}
           @validationStatus={{this.validation.password.status}}
-          @errorMessage={{if
-            this.validation.password.apiError
-            this.validation.password.apiError
-            (t this.validation.password.error)
-          }}
+          @errorMessage={{this._getErrorMessageForField "password"}}
           @rules={{PASSWORD_RULES}}
           aria-required="true"
         >
@@ -216,7 +219,7 @@ export default class SignupForm extends Component {
           name="cgu"
           {{on "change" this.handleInputChange}}
           @validationStatus={{this.validation.cgu.status}}
-          @errorMessage={{if this.validation.cgu.apiError this.validation.cgu.apiError (t this.validation.cgu.error)}}
+          @errorMessage={{this._getErrorMessageForField "cgu"}}
           aria-required="true"
         />
       </fieldset>

--- a/mon-pix/app/components/user-account/email-with-validation-form.js
+++ b/mon-pix/app/components/user-account/email-with-validation-form.js
@@ -11,6 +11,8 @@ const ERROR_INPUT_MESSAGE_MAP = {
   invalidEmail: 'pages.user-account.account-update-email-with-validation.fields.errors.invalid-email',
   emptyPassword: 'pages.user-account.account-update-email-with-validation.fields.errors.empty-password',
   emailAlreadyExist: 'pages.user-account.account-update-email-with-validation.fields.errors.new-email-already-exist',
+  invalidOrAlreadyUsedEmail:
+    'pages.user-account.account-update-email-with-validation.fields.errors.invalid-or-already-used-email',
   invalidPassword: 'pages.user-account.account-update-email-with-validation.fields.errors.invalid-password',
   unknownError: 'pages.user-account.account-update-email.fields.errors.unknown-error',
 };
@@ -81,17 +83,13 @@ export default class EmailWithValidationForm extends Component {
     if (status === '422') {
       const pointer = get(response, 'errors[0].source.pointer');
       if (pointer.endsWith('email')) {
-        this.errorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['invalidEmail']);
+        this.errorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['invalidOrAlreadyUsedEmail']);
       }
       if (pointer.endsWith('password')) {
         this.errorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['emptyPassword']);
       }
     } else if (status === '400') {
-      const code = get(response, 'errors[0].code');
       this.errorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['invalidPassword']);
-      if (code === 'ACCOUNT_WITH_EMAIL_ALREADY_EXISTS') {
-        this.errorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['emailAlreadyExist']);
-      }
     } else {
       this.errorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['unknownError']);
     }

--- a/mon-pix/app/controllers/account-recovery/find-sco-record.js
+++ b/mon-pix/app/controllers/account-recovery/find-sco-record.js
@@ -109,7 +109,7 @@ export default class FindScoRecordController extends Controller {
     const hasInternalErrorOrConflictOrAlreadyLeftSco =
       status === 403 || status === 409 || status >= 500 || isApiUnreachable;
     const isEmailAlreadyRegistered =
-      this.showBackupEmailConfirmationForm && status === 400 && code === 'ACCOUNT_WITH_EMAIL_ALREADY_EXISTS';
+      this.showBackupEmailConfirmationForm && status === 422 && code === 'INVALID_OR_ALREADY_USED_EMAIL';
 
     if (!hasInternalErrorOrConflictOrAlreadyLeftSco || isEmailAlreadyRegistered) {
       this._showErrorOnComponent(isEmailAlreadyRegistered);

--- a/mon-pix/app/utils/form-validation.js
+++ b/mon-pix/app/utils/form-validation.js
@@ -1,6 +1,8 @@
 import { tracked } from '@glimmer/tracking';
 import camelCase from 'lodash/camelCase.js';
 
+const COMMON_API_ERROR = 'common.error';
+
 /**
  * Manages form validation with configurable validation rules for each form field.
  */
@@ -39,7 +41,13 @@ export class FormValidation {
       if (!this[name]) return;
 
       this[name].status = 'error';
-      this[name].apiError = message;
+
+      const { apiErrors } = this[name].options;
+      if (apiErrors && apiErrors[message]) {
+        this[name].apiError = apiErrors[message];
+      } else {
+        this[name].apiError = COMMON_API_ERROR;
+      }
     });
   }
 }
@@ -74,6 +82,7 @@ class Validation {
    */
   get error() {
     if (this.isValid) return null;
+    if (this.apiError) return this.apiError;
     return this.options.error;
   }
 

--- a/mon-pix/mirage/routes/account-recovery/index.js
+++ b/mon-pix/mirage/routes/account-recovery/index.js
@@ -13,7 +13,7 @@ export default function index(config) {
         400,
         {},
         {
-          errors: [{ status: '400', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXISTS' }],
+          errors: [{ status: '422', code: 'INVALID_OR_ALREADY_USED_EMAIL' }],
         },
       );
     }

--- a/mon-pix/tests/acceptance/account-recovery/find-sco-record-test.js
+++ b/mon-pix/tests/acceptance/account-recovery/find-sco-record-test.js
@@ -244,7 +244,9 @@ module('Acceptance | account-recovery | FindScoRecordRoute', function (hooks) {
         // then
         assert.ok(
           screen.getByText(
-            t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.error.new-email-already-exist'),
+            t(
+              'pages.account-recovery.find-sco-record.backup-email-confirmation.form.error.invalid-or-already-used-email',
+            ),
           ),
         );
       });

--- a/mon-pix/tests/integration/components/authentication/signup-form/index-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/signup-form/index-test.gjs
@@ -148,18 +148,12 @@ module('Integration | Component | Authentication | SignupForm | index', function
   });
 
   module('When there are server errors from user creation', function () {
-    test('it displays error messages on each input', async function (assert) {
+    test('it displays error for email invalid', async function (assert) {
       // given
       class UserModel {
         errors = [];
         save() {
-          this.errors = [
-            { attribute: 'firstName', message: 'Firstname error !' },
-            { attribute: 'lastName', message: 'Lastname error !' },
-            { attribute: 'email', message: 'INVALID_OR_ALREADY_USED_EMAIL' },
-            { attribute: 'password', message: 'Password error !' },
-            { attribute: 'cgu', message: 'CGU error !' },
-          ];
+          this.errors = [{ attribute: 'email', message: 'INVALID_OR_ALREADY_USED_EMAIL' }];
           throw _buildApiReponseError({ status: 422, isAdapterError: true });
         }
       }
@@ -175,11 +169,7 @@ module('Integration | Component | Authentication | SignupForm | index', function
       await clickByName(t(I18N_KEYS.submitButton));
 
       // then
-      assert.dom(screen.getByText('Firstname error !')).exists();
-      assert.dom(screen.getByText('Lastname error !')).exists();
       assert.dom(screen.getByText('Adresse e-mail invalide ou déjà utilisée')).exists();
-      assert.dom(screen.getByText('Password error !')).exists();
-      assert.dom(screen.getByText('CGU error !')).exists();
       assert.strictEqual(sessionService.authenticateUser.callCount, 0);
     });
   });

--- a/mon-pix/tests/integration/components/authentication/signup-form/index-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/signup-form/index-test.gjs
@@ -136,7 +136,6 @@ module('Integration | Component | Authentication | SignupForm | index', function
       await fillByLabel(t(I18N_KEYS.passwordInput), invalidPassword);
       await clickByName(t(I18N_KEYS.cguCheckbox));
       await clickByName(t(I18N_KEYS.cguCheckbox)); // check twice to trigger validation
-
       // then
       assert.dom(screen.getByText(t('components.authentication.signup-form.fields.firstname.error'))).exists();
       assert.dom(screen.getByText(t('components.authentication.signup-form.fields.lastname.error'))).exists();
@@ -157,7 +156,7 @@ module('Integration | Component | Authentication | SignupForm | index', function
           this.errors = [
             { attribute: 'firstName', message: 'Firstname error !' },
             { attribute: 'lastName', message: 'Lastname error !' },
-            { attribute: 'email', message: 'Email error !' },
+            { attribute: 'email', message: 'INVALID_OR_ALREADY_USED_EMAIL' },
             { attribute: 'password', message: 'Password error !' },
             { attribute: 'cgu', message: 'CGU error !' },
           ];
@@ -178,7 +177,7 @@ module('Integration | Component | Authentication | SignupForm | index', function
       // then
       assert.dom(screen.getByText('Firstname error !')).exists();
       assert.dom(screen.getByText('Lastname error !')).exists();
-      assert.dom(screen.getByText('Email error !')).exists();
+      assert.dom(screen.getByText('Adresse e-mail invalide ou déjà utilisée')).exists();
       assert.dom(screen.getByText('Password error !')).exists();
       assert.dom(screen.getByText('CGU error !')).exists();
       assert.strictEqual(sessionService.authenticateUser.callCount, 0);

--- a/mon-pix/tests/integration/components/user-account/email-with-validation-form-test.js
+++ b/mon-pix/tests/integration/components/user-account/email-with-validation-form-test.js
@@ -90,29 +90,6 @@ module('Integration | Component | user-account | email-with-validation-form', fu
       assert.ok(true);
     });
 
-    test('should display email already exists error if response status is 400', async function (assert) {
-      // given
-      const emailAlreadyExist = 'email@example.net';
-      const password = 'password';
-      store.createRecord = () => ({
-        sendNewEmail: sinon.stub().throws({ errors: [{ status: '400', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXISTS' }] }),
-      });
-
-      const screen = await render(
-        hbs`<UserAccount::EmailWithValidationForm @showVerificationCode={{this.showVerificationCode}} />`,
-      );
-
-      // when
-      await _fillInputsAndValidateNewEmail({ screen, t, email: emailAlreadyExist, password });
-
-      // then
-      assert.ok(
-        screen.getByText(
-          t('pages.user-account.account-update-email-with-validation.fields.errors.new-email-already-exist'),
-        ),
-      );
-    });
-
     test('should display error message from server if response status is 400 or 403', async function (assert) {
       // given
       const newEmail = 'newEmail@example.net';
@@ -134,7 +111,7 @@ module('Integration | Component | user-account | email-with-validation-form', fu
       );
     });
 
-    test('should display invalid email format error if response status is 422', async function (assert) {
+    test('should display invalid or already used email error if response status is 422', async function (assert) {
       // given
       const newEmail = 'newEmail@example.net';
       const password = 'password';
@@ -151,7 +128,9 @@ module('Integration | Component | user-account | email-with-validation-form', fu
 
       // then
       assert.ok(
-        screen.getByText(t('pages.user-account.account-update-email-with-validation.fields.errors.invalid-email')),
+        screen.getByText(
+          t('pages.user-account.account-update-email-with-validation.fields.errors.invalid-or-already-used-email'),
+        ),
       );
     });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -226,6 +226,7 @@
         },
         "errors": {
           "invalid-locale-format": "Provided locale \"{invalidLocale}\" has an invalid format.",
+          "invalid-or-already-used-email" : "Invalid or already used e-mail address",
           "locale-not-supported": "Provided locale \"{localeNotSupported}\" isn't currently supported."
         },
         "fields": {
@@ -2095,6 +2096,7 @@
           "errors": {
             "empty-password": "Your password can't be empty.",
             "invalid-email": "Your email address is invalid.",
+            "invalid-or-already-used-email" : "Invalid or already used e-mail address",
             "invalid-password": "There was an error in the password entered.",
             "new-email-already-exist": "This email address is already in use."
           },

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -366,6 +366,7 @@
                 "new-email": ",if not, enter a new one."
               },
               "empty-email": "The e-mail address field is mandatory.",
+              "invalid-or-already-used-email" : "Invalid or already used e-mail address",
               "new-backup-email": "Please enter a valid e-mail address to recover your account",
               "new-email-already-exist": "This e-mail address is already in use",
               "wrong-email-format": "Your e-mail address is invalid."

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -374,6 +374,7 @@
                 "new-email": ", de lo contrario, introduce una nueva."
               },
               "empty-email": "El campo de dirección de correo electrónico es obligatorio.",
+              "invalid-or-already-used-email" : "Invalid or already used e-mail address",
               "new-backup-email": "Introduce una dirección de correo electrónico válida para restablecer tu cuenta",
               "new-email-already-exist": "Esta dirección de correo electrónico ya se está utilizando",
               "wrong-email-format": "Tu dirección de correo electrónico no es válida."

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -159,6 +159,11 @@
           }
         }
       },
+      "sign-up-form": {
+        "errors": {
+          "invalid-or-already-used-email" : "Invalid or already used e-mail address"
+        }
+      },
       "new-password-input": {
         "completed-message": "{ rulesCompleted }  { rulesCount } en .",
         "instructions-label": "Tu contraseña debe cumplir con los siguientes requisitos :",
@@ -2077,6 +2082,7 @@
           "errors": {
             "empty-password": "Tu contraseña no puede estar vacía.",
             "invalid-email": "Tu dirección de correo electrónico no es válida.",
+            "invalid-or-already-used-email" : "Invalid or already used e-mail address",
             "invalid-password": "La contraseña que has introducido no es válida.",
             "new-email-already-exist": "Esta dirección de correo electrónico ya se está utilizando."
           },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -366,6 +366,7 @@
                 "new-email": ", sinon saisissez une nouvelle."
               },
               "empty-email": "Le champ adresse e-mail est obligatoire.",
+              "invalid-or-already-used-email" : "Adresse e-mail invalide ou déjà utilisée",
               "new-backup-email": "Veuillez saisir un e-mail valide pour récupérer votre compte",
               "new-email-already-exist": "Cette adresse e-mail est déjà utilisée",
               "wrong-email-format": "Votre adresse e-mail n’est pas valide."

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -226,6 +226,7 @@
         },
         "errors": {
           "invalid-locale-format": "Votre locale \"{invalidLocale}\" n'est pas dans le bon format.",
+          "invalid-or-already-used-email" : "Adresse e-mail invalide ou déjà utilisée",
           "locale-not-supported": "Votre locale \"{localeNotSupported}\" n'est actuellement pas supportée."
         },
         "fields": {
@@ -2096,6 +2097,7 @@
           "errors": {
             "empty-password": "Votre mot de passe ne peut pas être vide.",
             "invalid-email": "Votre adresse e-mail n’est pas valide.",
+            "invalid-or-already-used-email" : "Adresse e-mail invalide ou déjà utilisée",
             "invalid-password": "Le mot de passe que vous avez saisi est invalide.",
             "new-email-already-exist": "Cette adresse e-mail est déjà utilisée."
           },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -232,6 +232,7 @@
         },
         "errors": {
           "invalid-locale-format": "Uw locale \"{invalidLocale}\" heeft de verkeerde indeling.",
+          "invalid-or-already-used-email" : "Invalid or already used e-mail address",
           "locale-not-supported": "Uw \"{localeNotSupported}\" locale wordt momenteel niet ondersteund."
         },
         "fields": {
@@ -2077,6 +2078,7 @@
           "errors": {
             "empty-password": "Je wachtwoord mag niet leeg zijn.",
             "invalid-email": "Uw e-mailadres is ongeldig.",
+            "invalid-or-already-used-email" : "Invalid or already used e-mail address",
             "invalid-password": "Het ingevoerde wachtwoord is ongeldig.",
             "new-email-already-exist": "Dit e-mailadres is al in gebruik."
           },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -370,6 +370,7 @@
                 "new-email": "Zo niet, voer dan een nieuwe in."
               },
               "empty-email": "Het e-mailadresveld is verplicht.",
+              "invalid-or-already-used-email" : "Invalid or already used e-mail address",
               "new-backup-email": "Voer een geldig e-mailadres in om uw account te herstellen",
               "new-email-already-exist": "Dit e-mailadres is al in gebruik",
               "wrong-email-format": "Uw e-mailadres is ongeldig."

--- a/orga/app/components/auth/register-form.hbs
+++ b/orga/app/components/auth/register-form.hbs
@@ -40,7 +40,11 @@
         name="email"
         type="email"
         {{on "change" this.validateEmail}}
-        @errorMessage={{this.validation.email.message}}
+        @errorMessage={{if
+          (this._getErrorMessageForField "email")
+          (this._getErrorMessageForField "email")
+          this.validation.email.message
+        }}
         @validationStatus={{this.validation.email.status}}
         required={{true}}
         aria-required={{true}}

--- a/orga/app/components/auth/register-form.js
+++ b/orga/app/components/auth/register-form.js
@@ -14,6 +14,10 @@ const STATUS = {
   ERROR: 'error',
 };
 
+const API_ERRORS = {
+  INVALID_OR_ALREADY_USED_EMAIL: 'pages.login-or-register.register-form.errors.invalid-or-already-used-email',
+};
+
 class LastName {
   @tracked status = STATUS.DEFAULT;
   @tracked message = null;
@@ -56,6 +60,7 @@ export default class RegisterForm extends Component {
   @tracked errorMessage = null;
   @tracked validation = new SignupFormValidation();
   @tracked selectedLanguage = this.intl.primaryLocale;
+  @tracked apiErrors = API_ERRORS;
 
   get cguUrl() {
     return this.url.cguUrl;
@@ -64,6 +69,16 @@ export default class RegisterForm extends Component {
   get dataProtectionPolicyUrl() {
     return this.url.dataProtectionPolicyUrl;
   }
+
+  _getErrorMessageForField = (fieldName) => {
+    const apiErrorKey = this.validation[fieldName]?.message;
+
+    if (apiErrorKey && this.apiErrors[apiErrorKey]) {
+      const errorMessage = this.intl.t(this.apiErrors[apiErrorKey]);
+      return errorMessage;
+    }
+    return false;
+  };
 
   @action
   async register(event) {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -860,7 +860,8 @@
         "button": "Sign up",
         "errors": {
           "default": "The service is temporarily unavailable. Please try again later.",
-          "email-already-exists": "This email address is already registered, please login."
+          "email-already-exists": "This email address is already registered, please login.",
+          "invalid-or-already-used-email": "Invalid or already used e-mail address"
         },
         "fields": {
           "button": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -866,7 +866,8 @@
         "button": "S'inscrire",
         "errors": {
           "default": "Le service est momentanément indisponible. Veuillez réessayer ultérieurement.",
-          "email-already-exists": "Cette adresse e-mail est déjà enregistrée, connectez-vous."
+          "email-already-exists": "Cette adresse e-mail est déjà enregistrée, connectez-vous.",
+          "invalid-or-already-used-email": "Adresse e-mail invalide ou déjà utilisée"
         },
         "fields": {
           "button": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -854,7 +854,8 @@
         "button": "Aanmelden",
         "errors": {
           "default": "De service is tijdelijk niet beschikbaar. Probeer het later nog eens.",
-          "email-already-exists": "Dit e-mailadres is al geregistreerd, log in."
+          "email-already-exists": "Dit e-mailadres is al geregistreerd, log in.",
+          "invalid-or-already-used-email": "Invalid or already used e-mail address"
         },
         "fields": {
           "button": {


### PR DESCRIPTION
## :fallen_leaf: Problème
Pour des questions de gestion d'informations personnelles, il ne faut pas divulguer l'information d'un email déjà utilisé.
Contextes concernés : 
Contextes

1. Lors de l’inscription
<img width="511" alt="Capture d’écran 2024-09-19 à 15 25 58" src="https://github.com/user-attachments/assets/5cd8512e-dfed-40ab-88ae-7fb28f9a7b4a">

2. Lors de la modification d’une adresse e-mail dans Mon Compte
<img width="1724" alt="Capture d’écran 2024-09-19 à 15 32 36" src="https://github.com/user-attachments/assets/b1693bdf-5e2c-4ac9-a521-38dc255f0c03">

3. Lors d’une invitation à rejoindre un centre de certification 
<img width="1127" alt="Capture d’écran 2024-09-19 à 15 35 45" src="https://github.com/user-attachments/assets/6bea9b73-df32-4c58-8131-871097c6a847">

4. Lors d’une invitation à rejoindre une orga 
<img width="1062" alt="Capture d’écran 2024-09-19 à 15 34 33" src="https://github.com/user-attachments/assets/2aec8e6e-e304-415d-978f-548fe025e378">

## :chestnut: Proposition
Modifier chaque message d’erreur par 
:fr:  "Adresse e-mail invalide ou déjà utilisée"

:gb:  “Invalid or already used e-mail address”

## :jack_o_lantern: Remarques
- Ne pas toucher au contexte sco
- Un autre scénario a été identifié et intégré à cette PR : celui de la récupération de compte **après sortie du sco**. Le message d'erreur a été modifié également dans ce scénario.
- Les clés de traduction précédemment utilisées  ont été retirées dans Pix Certif mais pas dans Pix App, où elles sont susceptibles d'être encore utilisées (contexte scolaire).

## :wood: Pour tester

Pour chaque point vous pouvez tester:
-le cas nominal
-un changement de langue
-la différence entre l'erreur de validation et l'erreur "Adresse e-mail invalide ou déjà utilisée".

1. Reprendre chacun des scénarios et vérifier l'affichage du message attendu :

- inscription sur pix app
- update d'email sur pix app
- creation de compte après réception d'une invitation sur pix orga
- création de compte après réception d'une invitation dur pix certif

2. Tester aussi le scénario de récupération de compte après sortie de sco 

 https://1024pix.atlassian.net/wiki/x/AYApw
 ![Capture d’écran du 2024-11-14 18-26-17](https://github.com/user-attachments/assets/e26070a9-82ef-48c7-b6e3-0dff07494d1a)

Pour cela il faut aller sur l'url dédiée et entrer les identifiants d'un organization-learner qui a un numéro INE valide (= NationalStudentId, par exemple Jean Serien)
Une nouvelle adresse e-mail est demandée > entrer une adresse déjà existante.
Constater que le message a été modifié comme dans 1.

3.  Reprendre les deux scénarios sco et vérifier que le message d'erreur est différent du 1.

-  du learner vers le user (un learner n'ayant pas de compte est "réconcilié" à un compte existant)
On attend ce message "Cette adresse e-mail est déjà enregistrée, connectez-vous." 
Pour tester ce scénario voir https://github.com/1024pix/pix/pull/10509, partie "création de compte avec réconciliation"
-  du user vers le learner (un user connecté se réconcilie à un learner pour accéder à une campagne)
On attend cette modale :
![Capture d’écran du 2024-11-15 09-05-41](https://github.com/user-attachments/assets/ffd3544f-974f-4bfe-ba2d-080aad1235a8)
Pour tester ce scénario :
-- afficher dans pix orga (connecté avec allorga@example.net) la liste des élèves du collège House of the Dragon
-- se connecter sur pix app avec un compte random (par exemple james-paledroits@example.net)
-- cliquer sur "J'ai un code", entrer SCOBADGE1
-- choisir pour la réconciliation un élève qui a déjà une méthode de connexion email dans la liste des élèves du collège 
-- constater l'affichage de la modale
