### PR TITLE
[FEATURE] Masquer le pourcentage de progression dans la navbar Modulix (PIX-15306)

### DIFF
--- a/mon-pix/app/components/module/navbar.gjs
+++ b/mon-pix/app/components/module/navbar.gjs
@@ -20,7 +20,7 @@ export default class ModulixNavbar extends Component {
           {{@currentStep}}/{{@totalSteps}}
         </div>
 
-        <PixProgressGauge @value={{this.progressValue}} @label="Avancement du module" />
+        <PixProgressGauge @hidePercentage={{true}} @isDecorative={{true}} @value={{this.progressValue}} />
       </div>
     </nav>
   </template>

--- a/mon-pix/tests/integration/components/module/navbar_test.gjs
+++ b/mon-pix/tests/integration/components/module/navbar_test.gjs
@@ -15,7 +15,7 @@ module('Integration | Component | Module | Navbar', function (hooks) {
       // then
       assert.ok(screen);
       assert.dom(screen.getByRole('navigation', { name: 'Étape 1 sur 3' })).exists();
-      assert.dom(screen.getByRole('progressbar', { name: 'Avancement du module' })).hasValue(0);
+      assert.dom('.progress-gauge__bar').hasValue(0);
     });
   });
 
@@ -27,7 +27,7 @@ module('Integration | Component | Module | Navbar', function (hooks) {
       // then
       assert.ok(screen);
       assert.dom(screen.getByRole('navigation', { name: 'Étape 2 sur 3' })).exists();
-      assert.dom(screen.getByRole('progressbar', { name: 'Avancement du module' })).hasValue(50);
+      assert.dom('.progress-gauge__bar').hasValue(50);
     });
   });
 
@@ -39,7 +39,7 @@ module('Integration | Component | Module | Navbar', function (hooks) {
       // then
       assert.ok(screen);
       assert.dom(screen.getByRole('navigation', { name: 'Étape 3 sur 3' })).exists();
-      assert.dom(screen.getByRole('progressbar', { name: 'Avancement du module' })).hasValue(100);
+      assert.dom('.progress-gauge__bar').hasValue(100);
     });
   });
 
@@ -51,7 +51,7 @@ module('Integration | Component | Module | Navbar', function (hooks) {
       // then
       assert.ok(screen);
       assert.dom(screen.getByRole('navigation', { name: 'Étape 1 sur 1' })).exists();
-      assert.dom(screen.getByRole('progressbar', { name: 'Avancement du module' })).hasValue(100);
+      assert.dom('.progress-gauge__bar').hasValue(100);
     });
   });
 });


### PR DESCRIPTION
## :fallen_leaf: Problème

Dans la barre de navigation Modulix, il y a un pourcentage de progression qui apparaît avant la barre de progression.

![Capture d’écran 2024-11-15 à 09 45 13](https://github.com/user-attachments/assets/a3bb4005-c54e-4a65-a840-04d64af8506b)

## :chestnut: Proposition

Mettre à jour Pix UI pour profiter de la nouvelle version de la barre de progression qui ajoute une option pour masquer le pourcentage.

![Capture d’écran 2024-11-15 à 09 52 53](https://github.com/user-attachments/assets/d086c243-2f10-4a24-9508-229867a285a1)

## :jack_o_lantern: Remarques

Pix UI est monté en version X.Y

## :wood: Pour tester

1. Se rendre sur [le didacticiel Modulix](https://app-pr10549.review.pix.fr/modules/didacticiel-modulix/passage)
2. Constater la disparition du pourcentage dans la barre de progression