### PR TITLE
[BUGFIX] Ne pas afficher l'encart attestation pour les participations a des campagnes sans lien avec les quêtes (PIX-15308)

### DIFF
--- a/api/src/quest/domain/usecases/get-quest-results-for-campaign-participation.js
+++ b/api/src/quest/domain/usecases/get-quest-results-for-campaign-participation.js
@@ -16,11 +16,13 @@ export const getQuestResultsForCampaignParticipation = async ({
 
   if (!eligibility) return [];
 
-  eligibility.campaignParticipations.targetProfileIds = [
-    // getTargetProfileForCampaignParticipation returns null but this usecase is used for campaign participation result page for now, so the campaign participation ID always exists
-    // if this usecase is to be used in another context, the edge case must be handled
-    eligibility.getTargetProfileForCampaignParticipation(campaignParticipationId),
-  ];
+  /*
+  This effectively overrides the existing campaignParticipations property with a new getter that always returns the updated targetProfileIds array based on the provided campaignParticipationId.
+  We can't just reassign the getter with the new value, because the getter will still be called and the new value would be ignored
+  */
+  Object.defineProperty(eligibility, 'campaignParticipations', {
+    get: () => ({ targetProfileIds: [eligibility.getTargetProfileForCampaignParticipation(campaignParticipationId)] }),
+  });
 
   const questResults = [];
   for (const quest of quests) {


### PR DESCRIPTION
## :fallen_leaf: Problème
Pendant des tests fonctionnels sur cette PR : https://github.com/1024pix/pix/pull/10411
Nous nous sommes rendus compte que l'on affichait l'encart pour n'importe quelle participation a une campagne.
On essayait de réecrire la valeur d'une propriété d'un objet, sauf que cette propriété était un getter. Donc ça ne fonctionnait pas, car à chaque fois le getter renvoyait la donnée d'origine

## :chestnut: Proposition
Ecrire un test mettant en avant le bug que nous avons rencontré, et corriger ce soucis bloquant pour la suite du dev. 
On utilise Object.defineProperty pour nous permettre de faire ce qu'on veut. C'est une des solutions qu'on a trouvé pour corriger le bug sans avoir besoin de retoucher a tout le code utilisant l'objet Eligibility

## :jack_o_lantern: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :wood: Pour tester
Participer a une campagne n'ayant aucun lien avec une qûete
Verifier que l'encart d'attestation n'apparait pas a la fin du parcours
Verifier que par contre dans un parcours avec lien sur une quête cet encart apparait bien
