### PR TITLE
[TECH] Supprimer le précédent score et sa date de partage dans la réponse de l'API pour les résultats d'une campagne de collecte de profils (PIX-15267)

### DIFF
--- a/api/db/seeds/data/team-prescription/build-organization-learners-with-multiple-participations.js
+++ b/api/db/seeds/data/team-prescription/build-organization-learners-with-multiple-participations.js
@@ -87,16 +87,16 @@ async function _buildMultipleParticipationsForPROASSMULCampaign(databaseBuilder)
   });
 
   const secondUser = await databaseBuilder.factory.buildUser.withRawPassword({
-    firstName: 'Jean-Philippe',
-    lastName: 'Errvitemonslip',
-    email: 'jean-philippe-errvitemonslip@example.net',
+    firstName: 'Tata',
+    lastName: 'Yoyo',
+    email: 'tata-yoyo@example.net',
     cgu: true,
     lang: 'fr',
   });
 
   const secondOrganizationLearner = await databaseBuilder.factory.buildOrganizationLearner({
-    firstName: 'Jean-Philippe',
-    lastName: 'Errvitemonslip',
+    firstName: 'Tata',
+    lastName: 'Yoyo',
     userId: secondUser.id,
     organizationId: PRO_ORGANIZATION_ID,
   });

--- a/api/src/prescription/campaign/domain/read-models/CampaignProfilesCollectionParticipationSummary.js
+++ b/api/src/prescription/campaign/domain/read-models/CampaignProfilesCollectionParticipationSummary.js
@@ -1,4 +1,6 @@
 class CampaignProfilesCollectionParticipationSummary {
+  #previousPixScore;
+
   constructor({
     campaignParticipationId,
     firstName,
@@ -8,7 +10,6 @@ class CampaignProfilesCollectionParticipationSummary {
     pixScore,
     sharedProfileCount,
     previousPixScore,
-    previousSharedAt,
     certifiable,
     certifiableCompetencesCount,
   }) {
@@ -19,9 +20,8 @@ class CampaignProfilesCollectionParticipationSummary {
     this.sharedAt = sharedAt;
     this.pixScore = pixScore;
     this.sharedProfileCount = sharedProfileCount;
-    this.previousPixScore = previousPixScore ?? null;
-    this.previousSharedAt = previousSharedAt ?? null;
-    this.evolution = this.#computeEvolution(this.pixScore, this.previousPixScore);
+    this.#previousPixScore = previousPixScore ?? null;
+    this.evolution = this.#computeEvolution(this.pixScore, this.#previousPixScore);
     this.certifiable = certifiable;
     this.certifiableCompetencesCount = certifiableCompetencesCount;
   }

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
@@ -49,7 +49,7 @@ async function _getParticipations(qb, campaignId, filters) {
   await qb
     .with('previousParticipationsInfos', (qbWith) => {
       qbWith
-        .select('pixScore AS previousPixScore', 'sharedAt AS previousSharedAt', 'organizationLearnerId', 'id')
+        .select('pixScore AS previousPixScore', 'organizationLearnerId', 'id')
         .from('campaign-participations')
         .where({ campaignId, isImproved: true })
         .whereNotNull('campaign-participations.sharedAt')
@@ -74,7 +74,6 @@ async function _getParticipations(qb, campaignId, filters) {
       'campaign-participations.sharedAt',
       'campaign-participations.pixScore AS pixScore',
       'previousParticipationsInfos.previousPixScore',
-      'previousParticipationsInfos.previousSharedAt',
       'participationsCount.sharedProfileCount',
     )
     .distinctOn('campaign-participations.organizationLearnerId')

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-profiles-collection-participation-summary-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-profiles-collection-participation-summary-serializer.js
@@ -12,8 +12,6 @@ const serialize = function ({ data, pagination }) {
       'sharedAt',
       'pixScore',
       'sharedProfileCount',
-      'previousPixScore',
-      'previousSharedAt',
       'evolution',
       'certifiable',
       'certifiableCompetencesCount',

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
@@ -406,7 +406,7 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
       });
     });
 
-    context('additionnal informations about previous participation and evolution', function () {
+    context('evolution', function () {
       let userId,
         organizationId,
         organizationLearnerId,
@@ -461,7 +461,7 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
       });
 
       describe('when participant has only one shared participation, and the other is not shared', function () {
-        it('should return null for previous participations infos and evolution', async function () {
+        it('should return null for evolution', async function () {
           // when
           const results = await campaignProfilesCollectionParticipationSummaryRepository.findPaginatedByCampaignId(
             campaign.id,
@@ -470,8 +470,6 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
           // then
           expect(results.data[0]).to.deep.include({
             pixScore: recentParticipationPixScore,
-            previousPixScore: null,
-            previousSharedAt: null,
             evolution: null,
           });
         });
@@ -481,7 +479,7 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
         const previousParticipationPixScore = 20;
         const previousParticipationSharedAt = new Date('2024-01-04');
 
-        it('should return latest participation with previous participation pixScore, sharedAt and evolution', async function () {
+        it('should return correct evolution', async function () {
           // given
           databaseBuilder.factory.buildCampaignParticipation({
             campaignId: campaign.id,
@@ -504,13 +502,11 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
           // then
           expect(results.data[0]).to.deep.include({
             pixScore: recentParticipationPixScore,
-            previousPixScore: previousParticipationPixScore,
-            previousSharedAt: previousParticipationSharedAt,
             evolution: 'increase',
           });
         });
 
-        it('should return null for previous participations infos and evolution when previous participation is deleted', async function () {
+        it('should return null for evolution when previous participation is deleted', async function () {
           // given
           databaseBuilder.factory.buildCampaignParticipation({
             campaignId: campaign.id,
@@ -534,13 +530,11 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
           // then
           expect(results.data[0]).to.deep.include({
             pixScore: recentParticipationPixScore,
-            previousPixScore: null,
-            previousSharedAt: null,
             evolution: null,
           });
         });
 
-        it('should return null for previous participations infos and evolution when learner has 2 participations to different campaigns', async function () {
+        it('should return null for evolution when learner has 2 participations to different campaigns', async function () {
           // given
           const otherCampaign = databaseBuilder.factory.buildCampaign({
             type: CampaignTypes.PROFILES_COLLECTION,
@@ -569,13 +563,11 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
           // then
           expect(results.data[0]).to.deep.include({
             pixScore: recentParticipationPixScore,
-            previousPixScore: null,
-            previousSharedAt: null,
             evolution: null,
           });
         });
 
-        it('should return null for previous participations infos and evolution when participations are from different learners', async function () {
+        it('should return null for evolution when participations are from different learners', async function () {
           // given
           const otherUserId = databaseBuilder.factory.buildUser({}).id;
 
@@ -608,22 +600,18 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
           // then
           expect(results.data[0]).to.deep.include({
             pixScore: recentParticipationPixScore,
-            previousPixScore: null,
-            previousSharedAt: null,
             evolution: null,
           });
 
           expect(results.data[1]).to.deep.include({
             pixScore: otherOrganizationLearnerParticipation.pixScore,
-            previousPixScore: null,
-            previousSharedAt: null,
             evolution: null,
           });
         });
       });
 
       describe('when participant has a third shared participation', function () {
-        it('should return latest participation and additionnal infos for participation before', async function () {
+        it('should return correct evolution, comparing recent and previous, ignoring old', async function () {
           const oldParticipationPixScore = 20;
           const oldParticipationSharedAt = new Date('2024-01-02');
 
@@ -664,8 +652,6 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
           // then
           expect(results.data[0]).to.deep.include({
             pixScore: recentParticipationPixScore,
-            previousPixScore: previousParticipationPixScore,
-            previousSharedAt: previousParticipationSharedAt,
             evolution: 'decrease',
           });
         });

--- a/api/tests/prescription/campaign/unit/domain/read-models/CampaignProfilesCollectionParticipationSummary_test.js
+++ b/api/tests/prescription/campaign/unit/domain/read-models/CampaignProfilesCollectionParticipationSummary_test.js
@@ -12,8 +12,6 @@ describe('Unit | Domain | Read-Models | CampaignResults | CampaignProfilesCollec
         sharedAt: '2024-10-28',
         pixScore: 20,
         sharedProfileCount: 2,
-        previousPixScore: null,
-        previousSharedAt: null,
         certifiable: true,
         certifiableCompetencesCount: 9,
       };
@@ -21,6 +19,7 @@ describe('Unit | Domain | Read-Models | CampaignResults | CampaignProfilesCollec
       // when
       const campaignProfilesCollectionParticipationSummary = new CampaignProfilesCollectionParticipationSummary({
         ...inputData,
+        previousPixScore: null,
         campaignParticipationId: 45,
       });
 
@@ -32,7 +31,7 @@ describe('Unit | Domain | Read-Models | CampaignResults | CampaignProfilesCollec
       });
     });
 
-    context('previous participation and evolution', function () {
+    context('evolution', function () {
       // given
       const inputCommonData = {
         campaignParticipationId: 45,
@@ -42,41 +41,35 @@ describe('Unit | Domain | Read-Models | CampaignResults | CampaignProfilesCollec
         certifiable: true,
         certifiableCompetencesCount: 9,
         sharedProfileCount: 2,
+        sharedAt: '2024-10-28',
       };
 
-      describe('when previous participation pixScore and shared date are undefined', function () {
-        it('should return null for the previous pixScore, shared date and evolution', function () {
+      describe('when previous participation pixScore is undefined', function () {
+        it('should return null for evolution', function () {
           // when
           const campaignProfilesCollectionParticipationSummary = new CampaignProfilesCollectionParticipationSummary({
             ...inputCommonData,
-            sharedAt: '2024-10-28',
             pixScore: 20,
             previousPixScore: undefined,
-            previousSharedAt: undefined,
           });
 
           // then
           expect(campaignProfilesCollectionParticipationSummary).to.include({
-            previousPixScore: null,
-            previousSharedAt: null,
             evolution: null,
           });
         });
       });
 
       describe('when previous participation is 0', function () {
-        it('should return 0 for the previous pixScore (and not null)', function () {
+        it('should not return null for evolution', function () {
           const campaignProfilesCollectionParticipationSummary = new CampaignProfilesCollectionParticipationSummary({
             ...inputCommonData,
-            sharedAt: '2024-10-28',
+
             pixScore: 0,
             previousPixScore: 0,
-            previousSharedAt: '2024-10-27',
           });
 
-          expect(campaignProfilesCollectionParticipationSummary).to.include({
-            previousPixScore: 0,
-          });
+          expect(campaignProfilesCollectionParticipationSummary.evolution).to.not.be.null;
         });
       });
 
@@ -88,7 +81,6 @@ describe('Unit | Domain | Read-Models | CampaignResults | CampaignProfilesCollec
               sharedAt: '2024-10-28',
               pixScore: 20,
               previousPixScore: 10,
-              previousSharedAt: '2024-10-27',
             });
 
             expect(campaignProfilesCollectionParticipationSummary).to.include({
@@ -104,7 +96,6 @@ describe('Unit | Domain | Read-Models | CampaignResults | CampaignProfilesCollec
               sharedAt: '2024-10-28',
               pixScore: 30,
               previousPixScore: 50,
-              previousSharedAt: '2024-10-27',
             });
 
             expect(campaignProfilesCollectionParticipationSummary).to.include({
@@ -120,7 +111,6 @@ describe('Unit | Domain | Read-Models | CampaignResults | CampaignProfilesCollec
               sharedAt: '2024-10-28',
               pixScore: 30,
               previousPixScore: 30,
-              previousSharedAt: '2024-10-27',
             });
 
             expect(campaignProfilesCollectionParticipationSummary).to.include({

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-profiles-collection-participation-summary-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-profiles-collection-participation-summary-serializer_test.js
@@ -15,7 +15,6 @@ describe('Unit | Serializer | JSONAPI | campaign-profiles-collection-participati
         pixScore: 1024,
         sharedProfileCount: 1,
         previousPixScore: 512,
-        previousSharedAt: new Date(2024, 10, 29),
         certifiable: true,
         certifiableCompetencesCount: 8,
       });
@@ -31,8 +30,6 @@ describe('Unit | Serializer | JSONAPI | campaign-profiles-collection-participati
             'shared-at': new Date(2020, 2, 2),
             'pix-score': 1024,
             'shared-profile-count': 1,
-            'previous-pix-score': 512,
-            'previous-shared-at': new Date(2024, 10, 29),
             evolution: 'increase',
             certifiable: true,
             'certifiable-competences-count': 8,


### PR DESCRIPTION
## :fallen_leaf: Problème
Dans Pix Orga : sur la page de résultats à une campagne de collectes de profils, nous n'avons finalement pas besoin d'afficher une colonne pour le précédent score et sa date de partage (cf PR [https://github.com/1024pix/pix/pull/10453](url))

## :chestnut: Proposition
Supprimer ces 2 propriétés de la réponse du endpoint `/api/campaigns/{id}/profiles-collection-participations`.
Ne garder que l'évolution.

## :jack_o_lantern: Remarques
Il reste quand même nécessaire d'aller chercher le score précédent dans le repo, afin de calculer l'évolution.

## :wood: Pour tester
Pix Orga : 
- aller sur l'onglet Résultats d'une campagne de collecte de profils (envoi simple et multiple)
- constater dans le network que la route ne renvoie plus le `previousPixScore`et `previousSharedAt`
