### PR TITLE
[FEATURE] ajout de metrics sur les visites du détail de participations partagées (PIX-14814)

### DIFF
--- a/mon-pix/app/components/campaign-participation-overview/card/ended.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card/ended.hbs
@@ -24,13 +24,12 @@
         </p>
       {{/if}}
     </div>
-    <PixButtonLink
+    <PixButton
       class="campaign-participation-overview-card-content__action"
-      @route="campaigns.entry-point"
-      @model={{@model.campaignCode}}
       @variant="secondary"
+      @triggerAction={{this.onClick}}
     >
       {{t "pages.campaign-participation-overview.card.see-more"}}
-    </PixButtonLink>
+    </PixButton>
   </section>
 </article>

--- a/mon-pix/app/components/campaign-participation-overview/card/ended.js
+++ b/mon-pix/app/components/campaign-participation-overview/card/ended.js
@@ -1,6 +1,10 @@
+import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
-
 export default class Ended extends Component {
+  @service router;
+  @service metrics;
+
   get hasStages() {
     return this.args.model.totalStagesCount > 0;
   }
@@ -11,5 +15,16 @@ export default class Ended extends Component {
 
   get total() {
     return this.args.model.totalStagesCount - 1;
+  }
+
+  @action
+  onClick() {
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Campaign participation',
+      'pix-event-action': `Voir le détail d'une participation partagée`,
+      'pix-event-name': `Voir le détail d'une participation partagée`,
+    });
+    this.router.transitionTo('campaigns.entry-point', this.args.model.campaignCode);
   }
 }


### PR DESCRIPTION
## :fallen_leaf: Problème
On veut savoir combien d'utilisateurs retournent voir des participations partagées

## :chestnut: Proposition
Push des metrics à matomo

## :jack_o_lantern: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :wood: Pour tester
CI au vert
- Pix App
- page parcours
- aller sur une participation déjà partagée et juste vérifier que ça marche