### PR TITLE
[BUGFIX] Utiliser la bonne couleur sur le logo d'informations des places dans PixOrga(PIX-15281)

### DIFF
--- a/orga/app/styles/components/places/place-info.scss
+++ b/orga/app/styles/components/places/place-info.scss
@@ -12,7 +12,7 @@
   &__illustration {
     width:4rem;
     height:4rem;
-    fill: var(--pix-neutral-0);
+    color: var(--pix-neutral-900);
   }
 
   &__description {


### PR DESCRIPTION
## :fallen_leaf: Problème
L'icône est blanche sur fond blanc 👻 , halloween c'est finit

## :chestnut: Proposition
Afficher l'icône avec la bonne couleur.

## :jack_o_lantern: Remarques
RAS

## :wood: Pour tester
Vérifier que l'icône s'affiche correctement sur PixOrga avec le compte admin-orga@example.net / Orga PRO Classic