### PR TITLE
[FEATURE] Ajout de metriques Matomo pour la page de fin de parcours (PIX-15040).

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/custom-organization-block.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/custom-organization-block.gjs
@@ -1,10 +1,14 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
 import MarkdownToHtml from '../../../../markdown-to-html';
 
 export default class EvaluationResultsCustomOrganizationBlock extends Component {
+  @service metrics;
+
   get customButtonUrl() {
     if (this.args.campaign.customResultPageButtonUrl && this.args.campaign.customResultPageButtonText) {
       const params = {};
@@ -21,6 +25,26 @@ export default class EvaluationResultsCustomOrganizationBlock extends Component 
     }
   }
 
+  @action
+  handleCustomButtonDisplay() {
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Fin de parcours',
+      'pix-event-action': "Affichage du bloc de l'organisation",
+      'pix-event-name': 'Présence d’un bouton comportant un lien externe',
+    });
+  }
+
+  @action
+  handleCustomButtonClick() {
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Fin de parcours',
+      'pix-event-action': "Affichage du bloc de l'organisation",
+      'pix-event-name': 'Clic sur le lien externe',
+    });
+  }
+
   <template>
     <div class="evaluation-results-hero__organization-block">
       <h3 class="evaluation-results-hero-organization-block__title">
@@ -34,10 +58,12 @@ export default class EvaluationResultsCustomOrganizationBlock extends Component 
         />
       {{/if}}
       {{#if this.customButtonUrl}}
+        {{this.handleCustomButtonDisplay}}
         <PixButtonLink
           class="evaluation-results-hero-organization-block__link"
           @href={{this.customButtonUrl}}
           @variant="secondary"
+          onclick={{this.handleCustomButtonClick}}
         >
           {{@campaign.customResultPageButtonText}}
         </PixButtonLink>

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/retry-or-reset-block.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/retry-or-reset-block.gjs
@@ -4,19 +4,73 @@ import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixMessage from '@1024pix/pix-ui/components/pix-message';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
 export default class EvaluationResultsHeroRetryOrResetBlock extends Component {
+  @service metrics;
+
   @tracked isResetModalVisible = false;
 
   retryQueryParams = { retry: true };
   resetQueryParams = { reset: true };
 
+  constructor() {
+    super(...arguments);
+
+    if (this.args.campaignParticipationResult.canRetry) {
+      this.metrics.add({
+        event: 'custom-event',
+        'pix-event-category': 'Fin de parcours',
+        'pix-event-action': 'Affichage du bloc RAZ/Repasser un parcours',
+        'pix-event-name': "Présence du bouton 'Repasser un parcours'",
+      });
+    }
+
+    if (this.args.campaignParticipationResult.canReset) {
+      this.metrics.add({
+        event: 'custom-event',
+        'pix-event-category': 'Fin de parcours',
+        'pix-event-action': 'Affichage du bloc RAZ/Repasser un parcours',
+        'pix-event-name': "Présence du bouton 'Remettre à zéro et tout retenter'",
+      });
+    }
+  }
+
+  @action
+  handleRetryClick() {
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Fin de parcours',
+      'pix-event-action': 'Affichage du bloc RAZ/Repasser un parcours',
+      'pix-event-name': "Clic sur le bouton 'Repasser mon parcours'",
+    });
+  }
+
   @action
   toggleResetModalVisibility() {
+    if (!this.isResetModalVisible) {
+      this.metrics.add({
+        event: 'custom-event',
+        'pix-event-category': 'Fin de parcours',
+        'pix-event-action': 'Affichage du bloc RAZ/Repasser un parcours',
+        'pix-event-name': "Ouverture de la modale 'Remettre à zéro et tout retenter'",
+      });
+    }
+
     this.isResetModalVisible = !this.isResetModalVisible;
+  }
+
+  @action
+  handleResetClick() {
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Fin de parcours',
+      'pix-event-action': 'Affichage du bloc RAZ/Repasser un parcours',
+      'pix-event-name': "Confirmation de la modale 'Remettre à zéro et tout retenter'",
+    });
   }
 
   <template>
@@ -35,6 +89,7 @@ export default class EvaluationResultsHeroRetryOrResetBlock extends Component {
               @route="campaigns.entry-point"
               @model={{@campaign.code}}
               @query={{this.retryQueryParams}}
+              onclick={{this.handleRetryClick}}
             >
               {{t "pages.skill-review.hero.retry.actions.retry"}}
             </PixButtonLink>
@@ -68,6 +123,7 @@ export default class EvaluationResultsHeroRetryOrResetBlock extends Component {
                     @model={{@campaign.code}}
                     @query={{this.resetQueryParams}}
                     @variant="error"
+                    onclick={{this.handleResetClick}}
                   >
                     {{t "common.actions.confirm"}}
                   </PixButtonLink>

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/results-details/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/results-details/index.gjs
@@ -1,9 +1,23 @@
+import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
 import CompetenceRow from './competence-row';
 
 export default class EvaluationResultsDetailsTab extends Component {
+  @service metrics;
+
+  constructor() {
+    super(...arguments);
+
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Fin de parcours',
+      'pix-event-action': 'Affichage onglet',
+      'pix-event-name': "Affichage de l'onglet Détails",
+    });
+  }
+
   get groupedCompetencesByArea() {
     return this.args.competenceResults.reduce((areas, competenceResult) => {
       const existingArea = areas.find((area) => area.areaTitle === competenceResult.areaTitle);

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/rewards/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/rewards/index.gjs
@@ -1,3 +1,4 @@
+import { inject as service } from '@ember/service';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
@@ -5,6 +6,19 @@ import { t } from 'ember-intl';
 import RewardsBadge from './badge';
 
 export default class Rewards extends Component {
+  @service metrics;
+
+  constructor() {
+    super(...arguments);
+
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Fin de parcours',
+      'pix-event-action': 'Affichage onglet',
+      'pix-event-name': "Affichage de l'onglet Récompenses",
+    });
+  }
+
   getFilteredAndSortedBadges(acquisitionStatus) {
     return this.args.badges
       .toArray()

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/trainings.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/trainings.gjs
@@ -11,9 +11,21 @@ import TrainingCard from '../../../../training/card';
 export default class EvaluationResultsTabsTrainings extends Component {
   @service currentUser;
   @service store;
+  @service metrics;
 
   @tracked isShareResultsLoading = false;
   @tracked isShareResultsError = false;
+
+  constructor() {
+    super(...arguments);
+
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Fin de parcours',
+      'pix-event-action': 'Affichage onglet',
+      'pix-event-name': "Affichage de l'onglet Formations",
+    });
+  }
 
   @action
   async shareResults() {
@@ -33,6 +45,13 @@ export default class EvaluationResultsTabsTrainings extends Component {
         },
         { reload: true },
       );
+
+      this.metrics.add({
+        event: 'custom-event',
+        'pix-event-category': 'Fin de parcours',
+        'pix-event-action': 'Envoi des résultats',
+        'pix-event-name': "Envoi des résultats depuis l'onglet Formations",
+      });
     } catch {
       this.isShareResultsError = true;
     } finally {

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/hero/retry-or-reset-block-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/hero/retry-or-reset-block-test.js
@@ -12,8 +12,17 @@ module(
     setupIntlRenderingTest(hooks);
 
     test('displays a title, a description and a message', async function (assert) {
+      // given
+      this.set('campaign', {});
+      this.set('campaignParticipationResult', {});
+
       // when
-      const screen = await render(hbs`<Campaigns::Assessment::Results::EvaluationResultsHero::RetryOrResetBlock />`);
+      const screen = await render(
+        hbs`<Campaigns::Assessment::Results::EvaluationResultsHero::RetryOrResetBlock
+  @campaign={{this.campaign}}
+  @campaignParticipationResult={{this.campaignParticipationResult}}
+/>`,
+      );
 
       // then
       assert.dom(screen.getByText(t('pages.skill-review.hero.retry.title'))).exists();


### PR DESCRIPTION
## :fallen_leaf: Problème

Suite à la refacto de la page, on a pas encore de métriques.

## :chestnut: Proposition

Ajouter les métriques indiquées dans le ticket associé à cette PR.

## :wood: Pour tester

🤷‍♂️
