### PR TITLE
[FEATURE] Partager sa récompense de quête à une organisation (PIX-15314)

### DIFF
--- a/api/db/database-builder/factory/build-organizations-profile-rewards.js
+++ b/api/db/database-builder/factory/build-organizations-profile-rewards.js
@@ -1,0 +1,26 @@
+import { ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME } from '../../migrations/20241118134739_create-organizations-profile-rewards-table.js';
+import { databaseBuffer } from '../database-buffer.js';
+import { buildOrganization } from './build-organization.js';
+import { buildProfileReward } from './build-profile-reward.js';
+
+const buildOrganizationsProfileRewards = function ({
+  id = databaseBuffer.getNextId(),
+  profileRewardId,
+  organizationId,
+} = {}) {
+  profileRewardId ?? buildProfileReward().id;
+  organizationId ?? buildOrganization().id;
+
+  const values = {
+    id,
+    profileRewardId,
+    organizationId,
+  };
+
+  return databaseBuffer.pushInsertable({
+    tableName: ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME,
+    values,
+  });
+};
+
+export { buildOrganizationsProfileRewards };

--- a/api/db/migrations/20240820101213_add-profile-rewards-table.js
+++ b/api/db/migrations/20240820101213_add-profile-rewards-table.js
@@ -1,12 +1,3 @@
-// Make sure you properly test your migration, especially DDL (Data Definition Language)
-// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
-
-// You can design and test your migration to avoid this by following this guide
-// https://1024pix.atlassian.net/wiki/spaces/DEV/pages/2153512965/Cr+er+une+migration
-
-// If your migrations target `answers` or `knowledge-elements`
-// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
-// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
 import { REWARD_TYPES } from '../../src/quest/domain/constants.js';
 export const PROFILE_REWARDS_TABLE_NAME = 'profile-rewards';
 

--- a/api/db/migrations/20241118134739_create-organizations-profile-rewards-table.js
+++ b/api/db/migrations/20241118134739_create-organizations-profile-rewards-table.js
@@ -1,0 +1,26 @@
+import { PROFILE_REWARDS_TABLE_NAME } from './20240820101213_add-profile-rewards-table.js';
+
+export const ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME = 'organizations-profile-rewards';
+const ORGANIZATION_ID_COLUMN = 'organizationId';
+const PROFILE_REWARD_ID_COLUMN = 'profileRewardId';
+const CONSTRAINT_NAME = 'organizationId_profileRewardId_unique';
+
+const up = async function (knex) {
+  await knex.schema.createTable(ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME, function (table) {
+    table.increments().primary().notNullable();
+    table.integer(ORGANIZATION_ID_COLUMN).notNullable().unsigned().references('organizations.id').index();
+    table
+      .integer(PROFILE_REWARD_ID_COLUMN)
+      .notNullable()
+      .unsigned()
+      .references(`${PROFILE_REWARDS_TABLE_NAME}.id`)
+      .index();
+    table.unique([ORGANIZATION_ID_COLUMN, PROFILE_REWARD_ID_COLUMN], { indexName: CONSTRAINT_NAME });
+  });
+};
+
+const down = async function (knex) {
+  return knex.schema.dropTable(ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME);
+};
+
+export { down, up };

--- a/api/src/profile/application/http-error-mapper-configuration.js
+++ b/api/src/profile/application/http-error-mapper-configuration.js
@@ -1,11 +1,27 @@
 import { HttpErrors } from '../../shared/application/http-errors.js';
-import { AttestationNotFoundError } from '../domain/errors.js';
+import {
+  AttestationNotFoundError,
+  ProfileRewardCantBeSharedError,
+  RewardTypeDoesNotExistError,
+} from '../domain/errors.js';
 
 const profileDomainErrorMappingConfiguration = [
   {
     name: AttestationNotFoundError.name,
     httpErrorFn: (error) => {
       return new HttpErrors.NotFoundError(error.message, error.code, error.meta);
+    },
+  },
+  {
+    name: ProfileRewardCantBeSharedError.name,
+    httpErrorFn: (error) => {
+      return new HttpErrors.PreconditionFailedError(error.message, error.code, error.meta);
+    },
+  },
+  {
+    name: RewardTypeDoesNotExistError.name,
+    httpErrorFn: (error) => {
+      return new HttpErrors.BadRequestError(error.message, error.code, error.meta);
     },
   },
 ];

--- a/api/src/profile/application/profile-controller.js
+++ b/api/src/profile/application/profile-controller.js
@@ -18,9 +18,18 @@ const getProfileForAdmin = function (request, h, dependencies = { profileSeriali
   return usecases.getUserProfile({ userId, locale }).then(dependencies.profileSerializer.serialize);
 };
 
+const shareProfileReward = async function (request, h) {
+  const userId = request.params.userId;
+  const { profileRewardId, campaignParticipationId } = request.payload.data.attributes;
+
+  await usecases.shareProfileReward({ userId, profileRewardId, campaignParticipationId });
+  return h.response().code(201);
+};
+
 const profileController = {
   getProfile,
   getProfileForAdmin,
+  shareProfileReward,
 };
 
 export { profileController };

--- a/api/src/profile/domain/errors.js
+++ b/api/src/profile/domain/errors.js
@@ -12,4 +12,10 @@ class RewardTypeDoesNotExistError extends DomainError {
   }
 }
 
-export { AttestationNotFoundError, RewardTypeDoesNotExistError };
+class ProfileRewardCantBeSharedError extends DomainError {
+  constructor(message = 'Profile reward cannot be shared') {
+    super(message);
+  }
+}
+
+export { AttestationNotFoundError, ProfileRewardCantBeSharedError, RewardTypeDoesNotExistError };

--- a/api/src/profile/domain/models/Campaign.js
+++ b/api/src/profile/domain/models/Campaign.js
@@ -1,0 +1,6 @@
+export class Campaign {
+  constructor({ id, organizationId }) {
+    this.id = id;
+    this.organizationId = organizationId;
+  }
+}

--- a/api/src/profile/domain/usecases/index.js
+++ b/api/src/profile/domain/usecases/index.js
@@ -10,6 +10,8 @@ import * as competenceRepository from '../../../shared/infrastructure/repositori
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as attestationRepository from '../../infrastructure/repositories/attestation-repository.js';
+import * as campaignParticipationRepository from '../../infrastructure/repositories/campaign-participation-repository.js';
+import * as organizationProfileRewardRepository from '../../infrastructure/repositories/organization-profile-reward-repository.js';
 import * as rewardRepository from '../../infrastructure/repositories/reward-repository.js';
 
 const path = dirname(fileURLToPath(import.meta.url));
@@ -25,8 +27,10 @@ const dependencies = {
   knowledgeElementRepository,
   profileRewardRepository,
   userRepository: repositories.userRepository,
+  organizationProfileRewardRepository,
   attestationRepository,
   rewardRepository,
+  campaignParticipationRepository,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/profile/domain/usecases/share-profile-reward.js
+++ b/api/src/profile/domain/usecases/share-profile-reward.js
@@ -1,0 +1,23 @@
+import { ProfileRewardCantBeSharedError } from '../errors.js';
+
+export const shareProfileReward = async function ({
+  userId,
+  profileRewardId,
+  campaignParticipationId,
+  profileRewardRepository,
+  organizationProfileRewardRepository,
+  campaignParticipationRepository,
+}) {
+  const profileReward = await profileRewardRepository.getById({ profileRewardId });
+
+  if (profileReward?.userId !== userId) {
+    throw new ProfileRewardCantBeSharedError();
+  }
+
+  const campaign = await campaignParticipationRepository.getCampaignByParticipationId({ campaignParticipationId });
+
+  await organizationProfileRewardRepository.save({
+    organizationId: campaign.organizationId,
+    profileRewardId,
+  });
+};

--- a/api/src/profile/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/profile/infrastructure/repositories/campaign-participation-repository.js
@@ -1,0 +1,13 @@
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { Campaign } from '../../domain/models/Campaign.js';
+
+export async function getCampaignByParticipationId({ campaignParticipationId }) {
+  const knexConnection = DomainTransaction.getConnection();
+  const campaign = await knexConnection('campaign-participations')
+    .select('campaigns.id', 'campaigns.organizationId')
+    .innerJoin('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
+    .where({ 'campaign-participations.id': campaignParticipationId })
+    .first();
+
+  return campaign ? new Campaign(campaign) : null;
+}

--- a/api/src/profile/infrastructure/repositories/organization-profile-reward-repository.js
+++ b/api/src/profile/infrastructure/repositories/organization-profile-reward-repository.js
@@ -1,0 +1,13 @@
+import { ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME } from '../../../../db/migrations/20241118134739_create-organizations-profile-rewards-table.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+
+export const save = async ({ organizationId, profileRewardId }) => {
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn(ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME)
+    .insert({
+      organizationId,
+      profileRewardId,
+    })
+    .onConflict()
+    .ignore();
+};

--- a/api/src/profile/infrastructure/repositories/profile-reward-repository.js
+++ b/api/src/profile/infrastructure/repositories/profile-reward-repository.js
@@ -34,6 +34,18 @@ export const getByUserId = async ({ userId }) => {
 
 /**
  * @param {Object} args
+ * @param {number} args.profileRewardId
+ * @returns {Promise<ProfileReward>}
+ */
+export const getById = async ({ profileRewardId }) => {
+  const knexConnection = await DomainTransaction.getConnection();
+  const profileReward = await knexConnection(PROFILE_REWARDS_TABLE_NAME).where({ id: profileRewardId }).first();
+
+  return profileReward ? toDomain(profileReward) : null;
+};
+
+/**
+ * @param {Object} args
  * @param {string} args.attestationKey
  * @param {Array<number>} args.userIds
  * @returns {Promise<Array<ProfileReward>>}

--- a/api/src/shared/domain/types/identifiers-type.js
+++ b/api/src/shared/domain/types/identifiers-type.js
@@ -55,6 +55,7 @@ const typesPositiveInteger32bits = [
   'ownerId',
   'passageId',
   'placeId',
+  'profileRewardId',
   'schoolingRegistrationId',
   'sessionId',
   'stageCollectionId',

--- a/api/tests/profile/acceptance/application/share-profile-reward-route_test.js
+++ b/api/tests/profile/acceptance/application/share-profile-reward-route_test.js
@@ -1,0 +1,76 @@
+import {
+  createServer,
+  databaseBuilder,
+  expect,
+  generateValidRequestAuthorizationHeader,
+} from '../../../test-helper.js';
+
+describe('Profile | Acceptance | Application | Share Profile Route ', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('POST /api/users/{userId}/profile/share-reward', function () {
+    describe('when profile reward exists and is linked to user', function () {
+      it('should return a success code', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const profileReward = databaseBuilder.factory.buildProfileReward({ userId });
+        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation();
+
+        await databaseBuilder.commit();
+        const options = {
+          method: 'POST',
+          headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+          url: `/api/users/${userId}/profile/share-reward`,
+          payload: {
+            data: {
+              attributes: {
+                profileRewardId: profileReward.id,
+                campaignParticipationId: campaignParticipation.id,
+              },
+            },
+          },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(201);
+      });
+    });
+  });
+
+  describe('when profile reward is not linked to user', function () {
+    it('should return a 412 code', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const profileReward = databaseBuilder.factory.buildProfileReward();
+      const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation();
+
+      await databaseBuilder.commit();
+      const options = {
+        method: 'POST',
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        url: `/api/users/${userId}/profile/share-reward`,
+        payload: {
+          data: {
+            attributes: {
+              profileRewardId: profileReward.id,
+              campaignParticipationId: campaignParticipation.id,
+            },
+          },
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(412);
+    });
+  });
+});

--- a/api/tests/profile/integration/domain/usecases/share-profile-reward_test.js
+++ b/api/tests/profile/integration/domain/usecases/share-profile-reward_test.js
@@ -1,0 +1,84 @@
+import { ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME } from '../../../../../db/migrations/20241118134739_create-organizations-profile-rewards-table.js';
+import { ProfileRewardCantBeSharedError } from '../../../../../src/profile/domain/errors.js';
+import { usecases } from '../../../../../src/profile/domain/usecases/index.js';
+import { catchErr, databaseBuilder, expect, knex } from '../../../../test-helper.js';
+
+describe('Profile | Integration | Domain | Usecases | share-profile-reward', function () {
+  describe('#shareProfileReward', function () {
+    describe('if the reward does not exist', function () {
+      let user;
+
+      before(async function () {
+        user = databaseBuilder.factory.buildUser();
+        await databaseBuilder.commit();
+      });
+
+      it('should throw an ProfileRewardCantBeSharedError', async function () {
+        const error = await catchErr(usecases.shareProfileReward)({
+          userId: user.id,
+          profileRewardId: 1,
+          campaignParticipationId: 1,
+        });
+        expect(error).to.be.instanceOf(ProfileRewardCantBeSharedError);
+      });
+    });
+
+    describe('if the reward does not belong to the user', function () {
+      let profileReward;
+      let user;
+
+      before(async function () {
+        const otherUserId = databaseBuilder.factory.buildUser().id;
+        user = databaseBuilder.factory.buildUser();
+        profileReward = databaseBuilder.factory.buildProfileReward({
+          rewardId: 1,
+          userId: otherUserId,
+        });
+
+        await databaseBuilder.commit();
+      });
+
+      it('should throw an ProfileRewardCantBeSharedError', async function () {
+        expect(
+          await catchErr(usecases.shareProfileReward)({
+            userId: user.id,
+            profileRewardId: profileReward.id,
+            campaignParticipationId: 1,
+          }),
+        ).to.be.instanceOf(ProfileRewardCantBeSharedError);
+      });
+    });
+
+    describe('if the reward belongs to the user', function () {
+      let profileRewardId;
+      let campaignParticipationId;
+      let userId;
+
+      before(async function () {
+        userId = databaseBuilder.factory.buildUser().id;
+        profileRewardId = databaseBuilder.factory.buildProfileReward({
+          rewardId: 1,
+          userId: userId,
+        }).id;
+        campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+          userId,
+        }).id;
+
+        await databaseBuilder.commit();
+      });
+
+      it('should insert a new line in organization-profile-rewards table', async function () {
+        await usecases.shareProfileReward({
+          userId,
+          profileRewardId,
+          campaignParticipationId,
+        });
+
+        const organizationsProfileRewards = await knex(ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME);
+
+        expect(organizationsProfileRewards).to.have.lengthOf(1);
+        expect(organizationsProfileRewards[0].profileRewardId).to.equal(profileRewardId);
+      });
+    });
+  });
+});

--- a/api/tests/profile/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/profile/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -1,0 +1,46 @@
+import { Campaign } from '../../../../../src/profile/domain/models/Campaign.js';
+import { getCampaignByParticipationId } from '../../../../../src/profile/infrastructure/repositories/campaign-participation-repository.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Profile | Integration | Infrastructure | Repository | campaign-participation-repository', function () {
+  describe('#getCampaignByParticipationId', function () {
+    it('return campaign informations for given campaignParticipationId', async function () {
+      // given
+      const campaign = databaseBuilder.factory.buildCampaign();
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+      }).id;
+      await databaseBuilder.commit();
+
+      // when
+      const result = await getCampaignByParticipationId({ campaignParticipationId });
+
+      // then
+      expect(result).to.be.an.instanceOf(Campaign);
+      expect(result.id).to.equal(campaign.id);
+      expect(result.organizationId).to.equal(campaign.organizationId);
+    });
+
+    it('return null if campaignParticipation does not exist', async function () {
+      // given
+      const notExistingCampaignParticipation = 123;
+
+      // when
+      const result = await getCampaignByParticipationId({ campaignParticipationId: notExistingCampaignParticipation });
+
+      // then
+      expect(result).to.be.null;
+    });
+
+    it('return null if campaignParticipation does not have linked campaign', async function () {
+      // given
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ campaignId: null }).id;
+
+      // when
+      const result = await getCampaignByParticipationId({ campaignParticipationId });
+
+      // then
+      expect(result).to.be.null;
+    });
+  });
+});

--- a/api/tests/profile/integration/infrastructure/repositories/organizations-profile-rewards-repository_test.js
+++ b/api/tests/profile/integration/infrastructure/repositories/organizations-profile-rewards-repository_test.js
@@ -1,0 +1,73 @@
+import { ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME } from '../../../../../db/migrations/20241118134739_create-organizations-profile-rewards-table.js';
+import { save } from '../../../../../src/profile/infrastructure/repositories/organization-profile-reward-repository.js';
+import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
+
+describe('Profile | Integration | Infrastructure | Repository | organizations-profile-rewards-repository', function () {
+  describe('#save', function () {
+    it('should save organization profile reward', async function () {
+      // given
+      const profileReward = databaseBuilder.factory.buildProfileReward();
+      const organization = databaseBuilder.factory.buildOrganization();
+      await databaseBuilder.commit();
+
+      // when
+      await save({ organizationId: organization.id, profileRewardId: profileReward.id });
+
+      // then
+      const organizationProfileReward = await knex(ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME).where({
+        organizationId: organization.id,
+        profileRewardId: profileReward.id,
+      });
+      expect(organizationProfileReward).to.have.lengthOf(1);
+    });
+
+    it('should save organization profile reward for other profile reward id but for the same organization', async function () {
+      // given
+      const profileReward = databaseBuilder.factory.buildProfileReward();
+      const otherProfileReward = databaseBuilder.factory.buildProfileReward({ rewardId: 11 });
+      const organization = databaseBuilder.factory.buildOrganization();
+      databaseBuilder.factory.buildOrganizationsProfileRewards({
+        organizationId: organization.id,
+        profileRewardId: profileReward.id,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      await save({ organizationId: organization.id, profileRewardId: otherProfileReward.id });
+
+      // then
+      const organizationProfileReward = await knex(ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME)
+        .select('profileRewardId')
+        .where({
+          organizationId: organization.id,
+        });
+      expect(organizationProfileReward).to.have.lengthOf(2);
+      expect(organizationProfileReward).to.have.deep.members([
+        { profileRewardId: profileReward.id },
+        { profileRewardId: otherProfileReward.id },
+      ]);
+    });
+
+    it('should do nothing if profile reward is already existing for same organization', async function () {
+      // given
+      const profileReward = databaseBuilder.factory.buildProfileReward();
+      const organization = databaseBuilder.factory.buildOrganization();
+      databaseBuilder.factory.buildOrganizationsProfileRewards({
+        organizationId: organization.id,
+        profileRewardId: profileReward.id,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      await save({ organizationId: organization.id, profileRewardId: profileReward.id });
+
+      // then
+      const organizationProfileReward = await knex(ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME).where({
+        organizationId: organization.id,
+        profileRewardId: profileReward.id,
+      });
+      expect(organizationProfileReward).to.have.lengthOf(1);
+    });
+  });
+});

--- a/api/tests/profile/integration/infrastructure/repositories/profile-reward-repository_test.js
+++ b/api/tests/profile/integration/infrastructure/repositories/profile-reward-repository_test.js
@@ -3,6 +3,7 @@ import { ATTESTATIONS } from '../../../../../src/profile/domain/constants.js';
 import { ProfileReward } from '../../../../../src/profile/domain/models/ProfileReward.js';
 import {
   getByAttestationKeyAndUserIds,
+  getById,
   getByUserId,
   save,
 } from '../../../../../src/profile/infrastructure/repositories/profile-reward-repository.js';
@@ -31,6 +32,37 @@ describe('Profile | Integration | Repository | profile-reward', function () {
       expect(result[0].userId).to.equal(userId);
       expect(result[0].rewardId).to.equal(rewardId);
       expect(result[0].rewardType).to.equal(REWARD_TYPES.ATTESTATION);
+    });
+  });
+
+  describe('#getById', function () {
+    it('should return null if the profile reward does not exist', async function () {
+      // given
+      const notExistingProfileRewardId = 12;
+
+      // when
+      const result = await getById({ profileRewardId: notExistingProfileRewardId });
+
+      // then
+      expect(result).to.be.null;
+    });
+
+    it('should return the expected profile reward', async function () {
+      // given
+      const attestation = databaseBuilder.factory.buildAttestation({ key: 'key' });
+      const expectedProfileReward = databaseBuilder.factory.buildProfileReward({ rewardId: attestation.id });
+
+      const otherAttestation = databaseBuilder.factory.buildAttestation({ key: 'otherkey' });
+      databaseBuilder.factory.buildProfileReward({ rewardId: otherAttestation.id });
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await getById({ profileRewardId: expectedProfileReward.id });
+
+      // then
+      expect(result).to.be.an.instanceof(ProfileReward);
+      expect(result.id).to.equal(expectedProfileReward.id);
     });
   });
 

--- a/api/tests/profile/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/profile/unit/application/http-error-mapper-configuration_test.js
@@ -1,5 +1,9 @@
 import { profileDomainErrorMappingConfiguration } from '../../../../src/profile/application/http-error-mapper-configuration.js';
-import { AttestationNotFoundError } from '../../../../src/profile/domain/errors.js';
+import {
+  AttestationNotFoundError,
+  ProfileRewardCantBeSharedError,
+  RewardTypeDoesNotExistError,
+} from '../../../../src/profile/domain/errors.js';
 import { HttpErrors } from '../../../../src/shared/application/http-errors.js';
 import { expect } from '../../../test-helper.js';
 
@@ -15,5 +19,31 @@ describe('Profile | Unit | Application | HttpErrorMapperConfiguration', function
 
     //then
     expect(error).to.be.instanceOf(HttpErrors.NotFoundError);
+  });
+
+  it('instantiates PreconditionFailedError when ProfileRewardCantBeShared', async function () {
+    //given
+    const httpErrorMapper = profileDomainErrorMappingConfiguration.find(
+      (httpErrorMapper) => httpErrorMapper.name === ProfileRewardCantBeSharedError.name,
+    );
+
+    //when
+    const error = httpErrorMapper.httpErrorFn(new ProfileRewardCantBeSharedError());
+
+    //then
+    expect(error).to.be.instanceOf(HttpErrors.PreconditionFailedError);
+  });
+
+  it('instantiates BadRequestError when RewardTypeDoesNotExistError', async function () {
+    //given
+    const httpErrorMapper = profileDomainErrorMappingConfiguration.find(
+      (httpErrorMapper) => httpErrorMapper.name === RewardTypeDoesNotExistError.name,
+    );
+
+    //when
+    const error = httpErrorMapper.httpErrorFn(new RewardTypeDoesNotExistError());
+
+    //then
+    expect(error).to.be.instanceOf(HttpErrors.BadRequestError);
   });
 });

--- a/api/tests/profile/unit/application/profile-controller_test.js
+++ b/api/tests/profile/unit/application/profile-controller_test.js
@@ -38,4 +38,46 @@ describe('Profile | Unit | Controller | profile-controller', function () {
       expect(usecases.getUserProfile).to.have.been.calledWithExactly({ userId, locale });
     });
   });
+
+  describe('#shareProfileReward', function () {
+    beforeEach(function () {
+      sinon.stub(usecases, 'shareProfileReward').resolves();
+    });
+
+    it('should call the expected usecase', async function () {
+      // given
+      const profileRewardId = '11';
+      const campaignParticipationId = '22';
+      const userId = '33';
+
+      const request = {
+        auth: {
+          credentials: {
+            userId,
+          },
+        },
+        params: {
+          userId,
+        },
+        payload: {
+          data: {
+            attributes: {
+              profileRewardId,
+              campaignParticipationId,
+            },
+          },
+        },
+      };
+
+      // when
+      await profileController.shareProfileReward(request, hFake);
+
+      // then
+      expect(usecases.shareProfileReward).to.have.been.calledWithExactly({
+        userId,
+        profileRewardId,
+        campaignParticipationId,
+      });
+    });
+  });
 });


### PR DESCRIPTION
## :fallen_leaf: Problème
Le prescripteur actuellement peut télécharger les attestations de tous ses prescrits ayant obtenu celle ci. 
Pour des soucis liés au RGPD nous devons faire en sorte que le prescripteur ne puisse télécharger uniquement les attestations obtenues des prescrits ayant partagés leur résultat a la campagne.

## :chestnut: Proposition
On crée une table de jointure entre les profile rewards des utilisateurs et l'organisation.
On mets ensuite a disposition une route qui sera appelée au moment du partage de ses résultats afin de créer une liaison avec l'organisation. 
Celle ci, via PixOrga ne pourra donc télécharger que les attestations obtenue ET partagée (Mécanisme utilisant la table de jointure crée ici qui va être mis en place dans une prochaine PR)

## :jack_o_lantern: Remarques
Afin de ne pas faire trop de fichiers/code a revoir dans cette PR, nous avons fait le choix d'appeler dans le campaign-repository directement les tables et ses jointures dont nous avons besoin. Il faudrait créer une api interne qui se chargerait de renvoyer les infos nécessaires sans toucher a toutes les tables.

## :wood: Pour tester
Vérifier en BDD que la table organizations-profile-rewards existe bien
Faire une requête HTTP a la main pour appeler le endpoint avec une participation et un profileReward
Vérifier que la ligne à bien été ajoutée dans la table de jointure

```curl
curl -X POST 'https://api-pr10576.review.pix.fr/api/users/{ID_USER_SUCCESS}/profile/share-reward' \
  -H 'Authorization: Bearer TOKEN_ICI' \
  -H 'Content-Type: application/json' \
  -d '{
"data": {
  "attributes": {
    "profileRewardId": "{PROFILE_REWARD_SUCCESS_USER_ID}",
      "campaignParticipationId": "{CAMPAIGN_PARTICIPATION_SUCCESS_USER_ID}"
  }
}
};
```