### PR TITLE
[BUGFIX] Corriger l'affichage du tableau des résultats d'une campagne de collecte de profils (PIX-15329)

### DIFF
--- a/orga/app/components/campaign/results/profile-list.gjs
+++ b/orga/app/components/campaign/results/profile-list.gjs
@@ -44,7 +44,9 @@ import ParticipationEvolutionIcon from './participation-evolution-icon';
           {{/if}}
           <col class="hide-on-mobile" />
           <col class="hide-on-mobile" />
-          <col />
+          {{#if @campaign.multipleSendings}}
+            <col />
+          {{/if}}
         </colgroup>
         <thead>
           <tr>
@@ -113,8 +115,10 @@ import ParticipationEvolutionIcon from './participation-evolution-icon';
                     </PixTag>
                   {{/if}}
                 </td>
-                <td class="table__column--center">
-                  <ParticipationEvolutionIcon @evolution={{profile.evolution}} /></td>
+                {{#if @campaign.multipleSendings}}
+                  <td class="table__column--center">
+                    <ParticipationEvolutionIcon @evolution={{profile.evolution}} /></td>
+                {{/if}}
                 <td class="table__column--center hide-on-mobile">
                   {{#if profile.certifiable}}
                     <PixTag @color="green-light">{{t "pages.profiles-list.table.column.certifiable"}}</PixTag>
@@ -123,9 +127,11 @@ import ParticipationEvolutionIcon from './participation-evolution-icon';
                 <td class="table__column--center hide-on-mobile">
                   {{profile.certifiableCompetencesCount}}
                 </td>
-                <td class="table__column--center">
-                  {{profile.sharedProfileCount}}
-                </td>
+                {{#if @campaign.multipleSendings}}
+                  <td class="table__column--center">
+                    {{profile.sharedProfileCount}}
+                  </td>
+                {{/if}}
               </tr>
             {{/each}}
           </tbody>

--- a/orga/tests/integration/components/campaign/results/profile-list-test.js
+++ b/orga/tests/integration/components/campaign/results/profile-list-test.js
@@ -156,7 +156,42 @@ module('Integration | Component | Campaign::Results::ProfileList', function (hoo
       assert.ok(screen.getByRole('cell', { name: '01/02/2020' }));
     });
 
-    test('it should display correct evolution', async function (assert) {
+    test('it should not display evolution if campaign is not multiple sendings', async function (assert) {
+      // given
+      this.campaign = store.createRecord('campaign', {
+        id: '1',
+        name: 'campagne 1',
+        participationsCount: 1,
+        multipleSendings: false,
+      });
+      this.profiles = [
+        {
+          firstName: 'Alice',
+          lastName: 'Red',
+          participantExternalId: '789',
+          evolution: null,
+          sharedAt: new Date(2020, 1, 1),
+        },
+      ];
+      this.profiles.meta = { rowCount: 1 };
+
+      // when
+      const screen = await render(
+        hbs`<Campaign::Results::ProfileList
+  @campaign={{this.campaign}}
+  @profiles={{this.profiles}}
+  @onClickParticipant={{this.noop}}
+  @onFilter={{this.noop}}
+  @selectedDivisions={{this.divisions}}
+  @selectedGroups={{this.groups}}
+/>`,
+      );
+
+      // then
+      assert.notOk(screen.queryByRole('cell', { name: t('pages.profiles-list.table.evolution.unavailable') }));
+    });
+
+    test('it should display correct evolution if campaign is multiple sendings', async function (assert) {
       // given
       this.campaign = store.createRecord('campaign', {
         id: '1',
@@ -215,7 +250,7 @@ module('Integration | Component | Campaign::Results::ProfileList', function (hoo
       assert.ok(screen.getByRole('cell', { name: t('pages.profiles-list.table.evolution.unavailable') }));
     });
 
-    test('it should display number of profiles shares', async function (assert) {
+    test('it should display number of profiles shares if campaign is multiple sendings', async function (assert) {
       // given
       this.campaign = store.createRecord('campaign', {
         id: '1',
@@ -249,6 +284,42 @@ module('Integration | Component | Campaign::Results::ProfileList', function (hoo
 
       // then
       assert.ok(screen.getByRole('cell', { name: '3' }));
+    });
+
+    test('it should not display number of profiles shares if campaign is not multiple sendings', async function (assert) {
+      // given
+      this.campaign = store.createRecord('campaign', {
+        id: '1',
+        name: 'campagne 1',
+        participationsCount: 1,
+        multipleSendings: false,
+      });
+      this.profiles = [
+        {
+          firstName: 'John',
+          lastName: 'Doe',
+          participantExternalId: '123',
+          sharedProfileCount: 1,
+          evolution: 'decrease',
+          sharedAt: new Date(2020, 1, 1),
+        },
+      ];
+      this.profiles.meta = { rowCount: 1 };
+
+      // when
+      const screen = await render(
+        hbs`<Campaign::Results::ProfileList
+  @campaign={{this.campaign}}
+  @profiles={{this.profiles}}
+  @onClickParticipant={{this.noop}}
+  @onFilter={{this.noop}}
+  @selectedDivisions={{this.divisions}}
+  @selectedGroups={{this.groups}}
+/>`,
+      );
+
+      // then
+      assert.notOk(screen.queryByRole('cell', { name: '1' }));
     });
 
     test('it should display the profile list with external id', async function (assert) {

--- a/orga/tests/integration/components/campaign/results/profile-list-test.js
+++ b/orga/tests/integration/components/campaign/results/profile-list-test.js
@@ -45,8 +45,9 @@ module('Integration | Component | Campaign::Results::ProfileList', function (hoo
       assert.ok(screen.getByRole('table', { name: t('pages.profiles-list.table.caption') }));
     });
   });
-  module('table headers for multiple sendings campaign', function () {
-    test('it should display evolution header and tooltip and shared profile count when campaign is multiple sendings', async function (assert) {
+
+  module('table headers', function () {
+    test('it should display evolution header with tooltip and shared profile count when campaign is multiple sendings', async function (assert) {
       // given
       this.campaign = store.createRecord('campaign', {
         id: '1',
@@ -243,11 +244,13 @@ module('Integration | Component | Campaign::Results::ProfileList', function (hoo
 />`,
       );
 
+      const rows = screen.getAllByRole('row');
+
       // then
-      assert.ok(screen.getByRole('cell', { name: t('pages.profiles-list.table.evolution.increase') }));
-      assert.ok(screen.getByRole('cell', { name: t('pages.profiles-list.table.evolution.decrease') }));
-      assert.ok(screen.getByRole('cell', { name: t('pages.profiles-list.table.evolution.stable') }));
-      assert.ok(screen.getByRole('cell', { name: t('pages.profiles-list.table.evolution.unavailable') }));
+      assert.ok(within(rows[1]).getByRole('cell', { name: t('pages.profiles-list.table.evolution.decrease') }));
+      assert.ok(within(rows[2]).getByRole('cell', { name: t('pages.profiles-list.table.evolution.increase') }));
+      assert.ok(within(rows[3]).getByRole('cell', { name: t('pages.profiles-list.table.evolution.stable') }));
+      assert.ok(within(rows[4]).getByRole('cell', { name: t('pages.profiles-list.table.evolution.unavailable') }));
     });
 
     test('it should display number of profiles shares if campaign is multiple sendings', async function (assert) {
@@ -263,7 +266,7 @@ module('Integration | Component | Campaign::Results::ProfileList', function (hoo
           firstName: 'John',
           lastName: 'Doe',
           participantExternalId: '123',
-          sharedProfileCount: 3,
+          sharedProfileCount: 'My profileCount',
           evolution: 'decrease',
           sharedAt: new Date(2020, 1, 1),
         },
@@ -283,7 +286,7 @@ module('Integration | Component | Campaign::Results::ProfileList', function (hoo
       );
 
       // then
-      assert.ok(screen.getByRole('cell', { name: '3' }));
+      assert.ok(screen.getByRole('cell', { name: 'My profileCount' }));
     });
 
     test('it should not display number of profiles shares if campaign is not multiple sendings', async function (assert) {
@@ -299,8 +302,7 @@ module('Integration | Component | Campaign::Results::ProfileList', function (hoo
           firstName: 'John',
           lastName: 'Doe',
           participantExternalId: '123',
-          sharedProfileCount: 1,
-          evolution: 'decrease',
+          sharedProfileCount: 'My profileCount',
           sharedAt: new Date(2020, 1, 1),
         },
       ];
@@ -319,7 +321,7 @@ module('Integration | Component | Campaign::Results::ProfileList', function (hoo
       );
 
       // then
-      assert.notOk(screen.queryByRole('cell', { name: '1' }));
+      assert.notOk(screen.queryByRole('cell', { name: 'My profileCount' }));
     });
 
     test('it should display the profile list with external id', async function (assert) {


### PR DESCRIPTION
## :fallen_leaf: Problème
Sur la page des résultats d'une campagne de collectes de profils à envoi simple, le tableau affichait l'évolution et le nombre de profils partagés (forcément 1 par participation), mais les en-têtes du tableau n'étaient quant à elles, pas affichées.

## :chestnut: Proposition
Ne pas afficher les colonnes évolution et nombre de participations dans le cas d'une campagne de collecte de profils à envoi simple.

## :jack_o_lantern: Remarques
Des tests ont été ajoutés pour les colonnes, en plus des headers du tableau.

## :wood: Pour tester
Sur Pix Orga : 
- aller sur l'onglet résultats d'une campagne de profils à envoi simple
- constater l'absence des colonnes évolution et Nombre de profils partagés
- vérifier qu'il n'y a pas de décalage dans les colonnes afichées
- aller sur une campagne de collecte de profils à envois multiples
- constater la présence des colonnes évolution et Nombre de profils partagés
