### PR TITLE
[BUGFIX] Ne pas restreindre le scoring d'une session de certification v3 aux épreuves de la locale courante (PIX-15330).

### DIFF
--- a/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
+++ b/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
@@ -69,7 +69,6 @@ export const handleV3CertificationScoring = async ({
   );
   const askedChallenges = await challengeRepository.getMany(
     certificationChallengesForScoring.map((challengeForScoring) => challengeForScoring.id),
-    locale,
   );
 
   _restoreCalibrationValues(certificationChallengesForScoring, askedChallenges);


### PR DESCRIPTION
## :fallen_leaf: Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Certains jobs `CertifcationCompletedJob` ont échoué avec une stack trace montrant la tentative d'affectation du `discriminant` à un objet qui est `undefined`.
Cela se produit dans [la fonction `_restoreCalibration`](https://github.com/1024pix/pix/blob/dev/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js#L159).

En analysant le code, on se rend compte que l'appel à la fonction `challengeRepository.getMany` prend en deuxième argument la locale courante, ce qui a pour effet de filtrer la liste des épreuves répondues qui seraient dans une locale différente.
En regardant les données de l'assessment qui n'a pas pu être scoré, on se rend compte qu'effectivement, l'utilisateur a changé de locale au cours de son test de certification.

## :chestnut: Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

Supprimer l'argument `locale` à l'appel de `challengeRepository.getMany` afin de récupérer toutes les épreuves auxquelle l'utilisateur a réellement répondu.

## :jack_o_lantern: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

L'argument `locale` n'était déjà pas attendu dans les stub des tests unitaires, je n'ai pas réussi à reproduire le bug via un test automatisé.

## :wood: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

Commencer un test de certification sur le domaine `review.pix.fr`.
Pour la dernière question, basculer sur le domaine `review.pix.org`.
Constater que le test de certification a été correctement scoré.
Pour être sûr de la résolution, s'assurer qu'au moins une épreuve répondue dans le test n'a comme propriété `locale` que `fr-fr`.
