### PR TITLE
[BUGFIX] ✏️ Correction du titre "Objectif.s" (PIX-15326)

### DIFF
--- a/junior/translations/fr.json
+++ b/junior/translations/fr.json
@@ -78,7 +78,7 @@
         "cards": {
           "finished": "Terminé"
         },
-        "purpose-title": "Objectif de la mission :",
+        "purpose-title": "Objectifs de la mission :",
         "start-mission": "C'est parti !",
         "welcome": "Prépare-toi à résoudre des épreuves et relever des défis."
       },


### PR DESCRIPTION
## :fallen_leaf: Problème
Sur la page de présentation d'une mission, le titre est "Objectif de la mission".
Or, les missions ont plusieurs objectifs.

## :chestnut: Proposition
Ajouter un -s à "Objectif" => "Objectifs de la mission"

## :wood: Pour tester
- Connexion à PixJunior
- CM1B, Aya Pas (ou n'importe quelle classe / élève)
- Choisir une mission qui n'a pas commencé
- Vérifier que le titre est bien "Objectifs de la mission"
