### PR TITLE
[TECH] Corriger un lien cassé dans api-dependencies.md

### DIFF
--- a/docs/api-dependencies.md
+++ b/docs/api-dependencies.md
@@ -36,7 +36,7 @@ module.exports = async function attachTargetProfilesToOrganization({
 
 Déclarer le composant et ses dépendances dans le fichier [répertoire](../../api/lib/domain/usecases/index.js).
 
-Utiliser l'[injection automatique](../../api/lib/infrastructure/utils/dependency-injection.js) des dépendances en
+Utiliser l'[injection automatique](../api/src/shared/infrastructure/utils/dependency-injection.js) des dépendances en
 utilisant les paramètres objets JS.
 
 #### Test unitaire


### PR DESCRIPTION
## :fallen_leaf: Problème
Dans le guide de gestion des dépendances API, le lien vers l'implémentation de la DI est cassé depuis https://github.com/1024pix/pix/commit/fc4b2cf749d3e3aac7cd7bd84f514e7eae7d94fc

## :chestnut: Proposition
Corriger le lien

## :jack_o_lantern: Remarques
On a déjà essayé de le prévenir avec un linter de lien, mais il n'était pas assez fiable pour le mettre dans la CI.

## :wood: Pour tester
Suivre le lien et vérifier qu'il renvoie à l'implémentation
