### PR TITLE
[FEATURE] Permettre d'avoir un `campaignParticipationId` `NULL` dans `user-recommended-trainings` (PIX-15303)

### DIFF
--- a/api/db/migrations/20241119103307_devcomp-user-recommended-trainings-remove-nullable-constraint-on-campaign-participation-id.js
+++ b/api/db/migrations/20241119103307_devcomp-user-recommended-trainings-remove-nullable-constraint-on-campaign-participation-id.js
@@ -1,0 +1,25 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/EDTDT/pages/3849323922/Cr+er+une+migration
+
+// If your migrations target `answers` or `knowledge-elements`
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+const TABLE_NAME = 'user-recommended-trainings';
+const COLUMN_NAME = 'campaignParticipationId';
+
+const up = async (knex) => {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.integer(COLUMN_NAME).nullable().alter();
+  });
+};
+
+const down = async (knex) => {
+  await knex.schema.table(TABLE_NAME, (table) => {
+    table.integer(COLUMN_NAME).notNullable().alter();
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## :fallen_leaf: Problème
Pour anonymiser les utilisateurs qui le demandent, et éviter de permettre de remonter à l'“utilisateur” depuis l'“organisation”, on souhaite rompre le lien entre des éventuels trainings acquis par l’utilisateur et l’organisation via laquelle il a passé la campagne. En particulier aujourd’hui le champ `campaignParticipationId` de la table `user-recommended-trainings` n’est pas nullable.

## :chestnut: Proposition
On souhaite permettre de modifier sa valeur pour la rendre null dans le contexte de l’anonymisation.

Le champ `campaignParticipationId` n'est utilisé que sur la page de fin de parcours, lorsque l'on y revient pour récupérer les trainings associés. Ça correspond au usecase `findCampaignParticipationTrainings`. En l'état si on supprime la valeur du champ, on ne retrouve juste plus les contenus formatifs ce qui nous semble convenable.

## :jack_o_lantern: Remarques
Lors de la création des lignes dans `user-recommended-trainings`, la `campaignParticipationId` reste obligatoire. Ça correspond au usecase `handleTrainingRecommendation`. On ne voit pas de cas où ce champ serait vide donc ça nous semble safe ainsi.

## :wood: Pour tester
En local, utiliser l'utilisateur `learneremail8000_0@example.net` qui a déjà acquis des CFs.

Lancer la migration avec `npm run db:migrate`.

En BDD, dans la table `user-recommended-trainings`, passer à `null` les champs `campaignParticipationId` du user 100064.

Aller sur l'écran "Mes parcours" puis accéder à un des 2 parcours déjà passé. On ne doit plus retrouver de CFs sur cet écran.

Par contre on doit bien retrouver un CF sur l'écran "Mes formations".