### PR TITLE
[TECH] Nouveau contexte Privacy et API (PIX-14907)

### DIFF
--- a/api/src/privacy/application/api/users-api.js
+++ b/api/src/privacy/application/api/users-api.js
@@ -1,0 +1,12 @@
+import { usecases } from '../../domain/usecases/index.js';
+
+/**
+ * Determines if a user can self-delete their account.
+ *
+ * @param {Object} params - The parameters for the function.
+ * @param {number} params.userId - The ID of the user.
+ * @returns {Promise<boolean>} - A promise that resolves to a boolean indicating if the user can self-delete their account.
+ */
+export const canSelfDeleteAccount = async ({ userId }) => {
+  return usecases.canSelfDeleteAccount({ userId });
+};

--- a/api/src/privacy/domain/usecases/can-self-delete-account.usecase.js
+++ b/api/src/privacy/domain/usecases/can-self-delete-account.usecase.js
@@ -1,0 +1,19 @@
+import { config } from '../../../shared/config.js';
+
+/**
+ * Determines if a user can self-delete their account.
+ *
+ * @param {Object} params - The parameters for the use case.
+ * @param {number} params.userId - The ID of the user.
+ * @param {Object} [params.featureToggles] - The feature toggles configuration.
+ * @returns {Promise<boolean>} - A promise that resolves to a boolean indicating if self-account deletion is enabled.
+ */
+const canSelfDeleteAccount = async ({ featureToggles = config.featureToggles }) => {
+  const { isSelfAccountDeletionEnabled } = featureToggles;
+
+  if (!isSelfAccountDeletionEnabled) return false;
+
+  return true;
+};
+
+export { canSelfDeleteAccount };

--- a/api/src/privacy/domain/usecases/index.js
+++ b/api/src/privacy/domain/usecases/index.js
@@ -1,0 +1,17 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
+import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
+
+const path = dirname(fileURLToPath(import.meta.url));
+
+const usecasesWithoutInjectedDependencies = {
+  ...(await importNamedExportsFromDirectory({ path: join(path, './'), ignoredFileNames: ['index.js'] })),
+};
+
+const dependencies = {};
+
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+
+export { usecases };

--- a/api/tests/privacy/integration/domain/usecases/can-self-delete-account.usecase.test.js
+++ b/api/tests/privacy/integration/domain/usecases/can-self-delete-account.usecase.test.js
@@ -1,0 +1,34 @@
+import { usecases } from '../../../../../src/privacy/domain/usecases/index.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Integration | Privacy | Domain | UseCase | can-self-delete-account', function () {
+  context('Feature flag is disabled', function () {
+    it('returns false', async function () {
+      // given
+      const featureToggles = { isSelfAccountDeletionEnabled: false };
+      const user = databaseBuilder.factory.buildUser();
+      await databaseBuilder.commit();
+
+      // when
+      const result = await usecases.canSelfDeleteAccount({ userId: user.id, featureToggles });
+
+      // then
+      expect(result).to.be.false;
+    });
+  });
+
+  context('Feature flag is enabled', function () {
+    it('returns true', async function () {
+      // given
+      const featureToggles = { isSelfAccountDeletionEnabled: true };
+      const user = databaseBuilder.factory.buildUser();
+      await databaseBuilder.commit();
+
+      // when
+      const result = await usecases.canSelfDeleteAccount({ userId: user.id, featureToggles });
+
+      // then
+      expect(result).to.be.true;
+    });
+  });
+});

--- a/api/tests/privacy/unit/application/api/users-api.test.js
+++ b/api/tests/privacy/unit/application/api/users-api.test.js
@@ -1,0 +1,21 @@
+import { canSelfDeleteAccount } from '../../../../../src/privacy/application/api/users-api.js';
+import { usecases } from '../../../../../src/privacy/domain/usecases/index.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Privacy | Application | Api | users', function () {
+  describe('#canSelfDeleteAccount', function () {
+    it('indicates if a user can self delete an account', async function () {
+      // given
+      const userId = Symbol('123');
+
+      sinon.stub(usecases, 'canSelfDeleteAccount');
+      usecases.canSelfDeleteAccount.withArgs({ userId }).resolves(true);
+
+      // when
+      const result = await canSelfDeleteAccount({ userId });
+
+      // then
+      expect(result).to.equal(true);
+    });
+  });
+});


### PR DESCRIPTION
## :fallen_leaf: Problème

Dans le cadre de la création de la suppression de compte en autonomie, nous avons besoin d'une API pour savoir si l'utilisateur est éligible à cette feature. Actuellement, il n'y a pas de contexte autour de la gestion de la vie privé dans le monorepo, qui devrait contenir cette API.

## :chestnut: Proposition

1. Créer le contexte Privacy
2. Créer une API dans ce contexte permettant de savoir si un utilisateur peut supprimer un compte en autonomie: `UserAPI.canSelfDeleteAccount({ userId });`

> Dans un premier temps, l'API retournera `true` ou `false` uniquement en fonction du feature toggle `isSelfAccountDeletionEnabled`, les règles métier seront ajoutées dans une PR à venir.

## :wood: Pour tester

Les tests CI suffisent, car l'API n'est pas encore utilisée.