### PR TITLE
[TECH] Dans les tests utiliser l'assertion dédiée lengthOf qui est plus sémantique

### DIFF
--- a/api/tests/acceptance/application/authentication/authentication-route_test.js
+++ b/api/tests/acceptance/application/authentication/authentication-route_test.js
@@ -94,7 +94,7 @@ describe('Acceptance | Controller | authentication-controller', function () {
           userId: user.id,
           externalIdentifier: 'SAMLJACKSONID',
         });
-        expect(authenticationMethods.length).to.equal(1);
+        expect(authenticationMethods).to.have.lengthOf(1);
         expect(authenticationMethods[0].authenticationComplement).to.deep.equal({
           firstName: 'saml',
           lastName: 'jackson',

--- a/api/tests/acceptance/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-courses/certification-course-controller_test.js
@@ -402,7 +402,7 @@ describe('Acceptance | API | Certification Course', function () {
 
           // then
           const certificationChallenges = await knex('certification-challenges');
-          expect(certificationChallenges.length).to.equal(2);
+          expect(certificationChallenges).to.have.lengthOf(2);
           expect(certificationChallenges[0].challengeId).to.equal('recChallenge5_1_1');
           expect(certificationChallenges[1].challengeId).to.equal('recChallenge5_0_0');
         });
@@ -420,7 +420,7 @@ describe('Acceptance | API | Certification Course', function () {
 
           // then
           const certificationChallenges = await knex('certification-challenges');
-          expect(certificationChallenges.length).to.equal(2);
+          expect(certificationChallenges).to.have.lengthOf(2);
           expect(certificationChallenges[0].challengeId).to.equal('recChallenge6_1_0');
           expect(certificationChallenges[1].challengeId).to.equal('recChallenge6_0_0');
         });

--- a/api/tests/acceptance/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-courses/certification-course-controller_test.js
@@ -343,7 +343,7 @@ describe('Acceptance | API | Certification Course', function () {
 
           // then
           const certificationCourses = await knex('certification-courses').where({ userId, sessionId });
-          expect(certificationCourses).to.have.length(1);
+          expect(certificationCourses).to.have.lengthOf(1);
           expect(certificationCourses[0].version).to.equal(SESSIONS_VERSIONS.V2);
           expect(response.result.data.attributes).to.include({
             'nb-challenges': 2,
@@ -455,7 +455,7 @@ describe('Acceptance | API | Certification Course', function () {
           userId,
           sessionId,
         });
-        expect(otherCertificationCourses).to.have.length(0);
+        expect(otherCertificationCourses).to.have.lengthOf(0);
         expect(certificationCourse.id + '').to.equal(response.result.data.id);
         expect(certificationCourse.version).to.equal(SESSIONS_VERSIONS.V2);
       });

--- a/api/tests/acceptance/application/tags/tag-api_test.js
+++ b/api/tests/acceptance/application/tags/tag-api_test.js
@@ -104,7 +104,7 @@ describe('Acceptance | Route | tag-router', function () {
 
         // then
         expect(statusCode).to.equal(200);
-        expect(result.data.length).to.equal(3);
+        expect(result.data).to.have.lengthOf(3);
       });
     });
 

--- a/api/tests/acceptance/application/users/find-user-certification-centers-for-admin-route-get_test.js
+++ b/api/tests/acceptance/application/users/find-user-certification-centers-for-admin-route-get_test.js
@@ -39,7 +39,7 @@ describe('Acceptance | Route | Users', function () {
       // then
       expect(response.statusCode).to.equal(200);
       expect(response.result.data).to.be.instanceOf(Array);
-      expect(response.result.data).to.have.length(1);
+      expect(response.result.data).to.have.lengthOf(1);
       expect(response.result.data[0]).to.have.property('id', certificationCenterMembership.id.toString());
     });
   });

--- a/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
+++ b/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
@@ -331,7 +331,7 @@ describe('Acceptance | Controller | users-controller-reset-scorecard', function 
           competenceId: otherStartedCompetenceId,
         });
 
-        expect(knowledgeElement).to.have.length(10);
+        expect(knowledgeElement).to.have.lengthOf(10);
         expect(knowledgeElement[0].earnedPix).to.equal(0);
         expect(knowledgeElement[0].status).to.equal('reset');
         expect(knowledgeElementsOtherCompetence[0].earnedPix).to.equal(3);

--- a/api/tests/acceptance/scripts/add-many-divisions-and-students-to-sco-organization_test.js
+++ b/api/tests/acceptance/scripts/add-many-divisions-and-students-to-sco-organization_test.js
@@ -30,7 +30,7 @@ describe('Acceptance | Scripts | add-many-divisions-and-students-to-sco-organiza
 
       // then
       expect(numberOfCreatedOrganizationLearners).to.equal(numberOfOrganizationLearnerToCreate);
-      expect(createdDivisions.length).to.equal(numberOfDivisionsToCreate);
+      expect(createdDivisions).to.have.lengthOf(numberOfDivisionsToCreate);
     });
   });
 });

--- a/api/tests/certification/complementary-certification/integration/infrastucture/repositories/organization-repository_test.js
+++ b/api/tests/certification/complementary-certification/integration/infrastucture/repositories/organization-repository_test.js
@@ -100,7 +100,7 @@ describe('Integration | Repository | Certification | Complementary-certification
         );
 
         // then
-        expect(organizationSaved).to.have.length(1);
+        expect(organizationSaved).to.have.lengthOf(1);
       });
     });
   });

--- a/api/tests/certification/enrolment/acceptance/application/certification-candidate-controller-post-certification-candidate_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/certification-candidate-controller-post-certification-candidate_test.js
@@ -152,7 +152,7 @@ describe('Acceptance | Controller | Certification | Enrolment | session-controll
           .select(['type', 'complementaryCertificationId'])
           .where({ certificationCandidateId: parseInt(response.result.data.id) })
           .orderBy('type');
-        expect(subscriptions.length).to.equal(2);
+        expect(subscriptions).to.have.lengthOf(2);
         expect(subscriptions[0]).to.deep.equal({
           type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
           complementaryCertificationId,
@@ -271,7 +271,7 @@ describe('Acceptance | Controller | Certification | Enrolment | session-controll
           .select(['type', 'complementaryCertificationId'])
           .where({ certificationCandidateId: parseInt(response.result.data.id) })
           .orderBy('type');
-        expect(subscriptions.length).to.equal(2);
+        expect(subscriptions).to.have.lengthOf(2);
         expect(subscriptions[0]).to.deep.equal({
           type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
           complementaryCertificationId: cleaCertificationId,

--- a/api/tests/certification/enrolment/acceptance/application/session-mass-import-route_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/session-mass-import-route_test.js
@@ -213,7 +213,7 @@ describe('Acceptance | Controller | Session | session-mass-import-route', functi
 
           // then
           const sessions = await knex('sessions');
-          expect(sessions.length).to.equal(1);
+          expect(sessions).to.have.lengthOf(1);
           expect(sessions[0].certificationCenter).to.equal(certificationCenter);
           expect(sessions[0].invigilatorPassword).to.equal(sessionToSave.invigilatorPassword);
           expect(sessions[0].version).to.equal(2);
@@ -272,7 +272,7 @@ describe('Acceptance | Controller | Session | session-mass-import-route', functi
 
           // then
           const sessions = await knex('sessions');
-          expect(sessions.length).to.equal(1);
+          expect(sessions).to.have.lengthOf(1);
           expect(sessions[0].certificationCenter).to.equal(certificationCenter);
           expect(sessions[0].invigilatorPassword).to.equal(sessionToSave.invigilatorPassword);
           expect(sessions[0].version).to.equal(3);

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
@@ -350,7 +350,7 @@ describe('Integration | Certification | Enrolment | Repository | Candidate', fun
         'extraTimePercentage',
       ]);
       expect(parseFloat(savedCandidateData.extraTimePercentage)).to.equal(candidateData.extraTimePercentage);
-      expect(savedSubscriptionsData.length).to.equal(2);
+      expect(savedSubscriptionsData).to.have.lengthOf(2);
       expect(savedSubscriptionsData[0]).to.deepEqualInstanceOmitting(
         {
           certificationCandidateId: candidateId,

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/country-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/country-repository_test.js
@@ -41,7 +41,7 @@ describe('Certification | Enrolment | Integration | Repository | country-reposit
           name: 'NABOO',
           matcher: 'ABNOO',
         });
-        expect(countries.length).to.equal(2);
+        expect(countries).to.have.lengthOf(2);
         expect(countries[0]).to.be.instanceOf(Country);
         expect(countries).to.deep.equal([nabooCountry, togoCountry]);
       });

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/sco-certification-candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/sco-certification-candidate-repository_test.js
@@ -155,7 +155,7 @@ describe('Certification | Enrolment | Integration | Repository | SCOCertificatio
 
       // then
       const subscriptions = await knex('certification-subscriptions');
-      expect(subscriptions.length).to.equal(4);
+      expect(subscriptions).to.have.lengthOf(4);
       sinon.assert.match(subscriptions[0], {
         certificationCandidateId: scoCandidateAlreadySaved1.id,
         complementaryCertificationId: null,

--- a/api/tests/certification/enrolment/unit/domain/models/SessionMassImportReport_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/SessionMassImportReport_test.js
@@ -14,7 +14,7 @@ describe('Unit | Certification | Enrolment | Domain | Models | SessionMassImport
         sessionMassImportReport.addErrorReports([1, 2, 3]);
 
         // then
-        expect(sessionMassImportReport.errorReports.length).to.equal(4);
+        expect(sessionMassImportReport.errorReports).to.have.lengthOf(4);
       });
     });
 
@@ -27,7 +27,7 @@ describe('Unit | Certification | Enrolment | Domain | Models | SessionMassImport
         sessionMassImportReport.addErrorReports();
 
         // then
-        expect(sessionMassImportReport.errorReports.length).to.equal(1);
+        expect(sessionMassImportReport.errorReports).to.have.lengthOf(1);
       });
     });
   });

--- a/api/tests/certification/evaluation/integration/evaluation/jobs/certification-completed-job-controller_test.js
+++ b/api/tests/certification/evaluation/integration/evaluation/jobs/certification-completed-job-controller_test.js
@@ -587,7 +587,7 @@ describe('Integration | Certification | Application | jobs | CertificationComple
               })
               .orderBy('competenceId');
 
-            expect(competenceMarks).to.have.length(1);
+            expect(competenceMarks).to.have.lengthOf(1);
 
             expect(competenceMarks[0].level).to.equal(1);
           });

--- a/api/tests/certification/evaluation/integration/evaluation/jobs/certification-completed-job-controller_test.js
+++ b/api/tests/certification/evaluation/integration/evaluation/jobs/certification-completed-job-controller_test.js
@@ -525,7 +525,7 @@ describe('Integration | Certification | Application | jobs | CertificationComple
               courseId: certificationCourse.id,
             });
 
-          expect(certificationChallengeCapacities.length).to.equal(9);
+          expect(certificationChallengeCapacities).to.have.lengthOf(9);
         });
 
         describe('when user estimatedLevel is too high', function () {

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/certification-challenge-for-scoring-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/certification-challenge-for-scoring-repository_test.js
@@ -22,7 +22,7 @@ describe('Integration | Infrastructure | Repository | CertificationChallengeForS
       it('should return an empty array', async function () {
         const challenges = await getByCertificationCourseId({ certificationCourseId });
 
-        expect(challenges.length).to.equal(0);
+        expect(challenges).to.have.lengthOf(0);
       });
     });
 
@@ -59,7 +59,7 @@ describe('Integration | Infrastructure | Repository | CertificationChallengeForS
 
         const challenges = await getByCertificationCourseId({ certificationCourseId });
 
-        expect(challenges.length).to.equal(3);
+        expect(challenges).to.have.lengthOf(3);
         expect(challenges[0]).to.be.instanceOf(CertificationChallengeForScoring);
         expect(challenges[0].id).to.equal('challenge_id_1');
         expect(challenges[1].id).to.equal('challenge_id_2');

--- a/api/tests/certification/results/integration/infrastructure/repositories/certificate-repository_test.js
+++ b/api/tests/certification/results/integration/infrastructure/repositories/certificate-repository_test.js
@@ -877,7 +877,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
         domainBuilder.buildCertificationAttestation(certificationAttestationDataB);
       const expectedCertificationAttestationC =
         domainBuilder.buildCertificationAttestation(certificationAttestationDataC);
-      expect(certificationAttestations).to.have.length(3);
+      expect(certificationAttestations).to.have.lengthOf(3);
 
       expect(certificationAttestations[0]).deepEqualInstanceOmitting(expectedCertificationAttestationB, [
         'resultCompetenceTree',
@@ -1000,7 +1000,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
       const expectedCertificationAttestationB =
         domainBuilder.buildCertificationAttestation(certificationAttestationDataB);
 
-      expect(certificationAttestations).to.have.length(2);
+      expect(certificationAttestations).to.have.lengthOf(2);
       expect(certificationAttestations[0]).to.deepEqualInstanceOmitting(expectedCertificationAttestationB, [
         'resultCompetenceTree',
       ]);
@@ -1090,7 +1090,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
         // then
         const expectedCertificationAttestation =
           domainBuilder.buildCertificationAttestation(certificationAttestationData);
-        expect(certificationAttestations).to.have.length(1);
+        expect(certificationAttestations).to.have.lengthOf(1);
         expect(certificationAttestations[0]).to.deepEqualInstanceOmitting(expectedCertificationAttestation, [
           'resultCompetenceTree',
         ]);
@@ -1178,7 +1178,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
       const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation(
         certificationAttestationDataNewest,
       );
-      expect(certificationAttestations).to.have.length(1);
+      expect(certificationAttestations).to.have.lengthOf(1);
       expect(certificationAttestations[0]).to.deepEqualInstanceOmitting(expectedCertificationAttestation, [
         'resultCompetenceTree',
       ]);
@@ -1293,7 +1293,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
       const result = await certificateRepository.findPrivateCertificatesByUserId({ userId });
 
       // then
-      expect(result).to.have.length(1);
+      expect(result).to.have.lengthOf(1);
     });
 
     it('should return the certificate when it is not published', async function () {
@@ -1345,7 +1345,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
       const result = await certificateRepository.findPrivateCertificatesByUserId({ userId });
 
       // then
-      expect(result).to.have.length(1);
+      expect(result).to.have.lengthOf(1);
     });
 
     it('should return the certificate when it is rejected', async function () {
@@ -1397,7 +1397,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
       const result = await certificateRepository.findPrivateCertificatesByUserId({ userId });
 
       // then
-      expect(result).to.have.length(1);
+      expect(result).to.have.lengthOf(1);
     });
 
     it('should return a collection of PrivateCertificate', async function () {
@@ -1430,7 +1430,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
         id: certificationCourseId,
         ...privateCertificateData,
       });
-      expect(privateCertificates).to.have.length(1);
+      expect(privateCertificates).to.have.lengthOf(1);
       expect(privateCertificates[0]).to.deepEqualInstance(expectedPrivateCertificate);
     });
 
@@ -1452,7 +1452,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
       const privateCertificates = await certificateRepository.findPrivateCertificatesByUserId({ userId });
 
       // then
-      expect(privateCertificates).to.have.length(3);
+      expect(privateCertificates).to.have.lengthOf(3);
       expect(privateCertificates[0].id).to.equal(certificationCourseId3);
       expect(privateCertificates[1].id).to.equal(certificationCourseId2);
       expect(privateCertificates[2].id).to.equal(certificationCourseId);

--- a/api/tests/certification/results/integration/infrastructure/repositories/certification-livret-scolaire-repository_test.js
+++ b/api/tests/certification/results/integration/infrastructure/repositories/certification-livret-scolaire-repository_test.js
@@ -298,7 +298,7 @@ describe('Integration | Repository | Certification-ls ', function () {
       const certificationResults = await certificationLsRepository.getCertificatesByOrganizationUAI(uai);
 
       // then
-      expect(certificationResults).to.have.length(1);
+      expect(certificationResults).to.have.lengthOf(1);
       expect(certificationResults[0].id).to.equal(lastCertificationCourse.id);
     });
 

--- a/api/tests/certification/scoring/acceptance/application/scoring-configuration-route_test.js
+++ b/api/tests/certification/scoring/acceptance/application/scoring-configuration-route_test.js
@@ -135,7 +135,7 @@ describe('Acceptance | Application | scoring-configuration-route', function () {
           expect(response.statusCode).to.equal(201);
 
           const configurations = await knex('competence-scoring-configurations');
-          expect(configurations.length).to.equal(1);
+          expect(configurations).to.have.lengthOf(1);
         });
       });
     });
@@ -254,7 +254,7 @@ describe('Acceptance | Application | scoring-configuration-route', function () {
           expect(response.statusCode).to.equal(201);
 
           const configurations = await knex('certification-scoring-configurations');
-          expect(configurations.length).to.equal(1);
+          expect(configurations).to.have.lengthOf(1);
         });
       });
     });

--- a/api/tests/certification/session-management/acceptance/application/certification-course-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/certification-course-route_test.js
@@ -161,7 +161,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
           .orderBy('createdAt');
 
         expect(rejectedCertificationCourse.isRejectedForFraud).to.equal(true);
-        expect(assessmentResults).to.have.length(2);
+        expect(assessmentResults).to.have.lengthOf(2);
         expect(assessmentResults[0].id).to.deep.equal(assessmentResult.id);
         expect(assessmentResults[1].status).to.equal('rejected');
 
@@ -246,7 +246,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
           .orderBy('createdAt');
 
         expect(rejectedCertificationCourse.isRejectedForFraud).to.equal(true);
-        expect(assessmentResults).to.have.length(2);
+        expect(assessmentResults).to.have.lengthOf(2);
         expect(assessmentResults[0].id).to.equal(assessmentResult.id);
         expect(assessmentResults[1].status).to.equal('rejected');
 
@@ -299,7 +299,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
         .orderBy('createdAt');
 
       expect(unrejectedCertificationCourse.isRejectedForFraud).to.equal(false);
-      expect(assessmentResults).to.have.length(2);
+      expect(assessmentResults).to.have.lengthOf(2);
       expect(assessmentResults[0].id).to.equal(assessmentResult.id);
       expect(assessmentResults[1].status).to.equal('validated');
 

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
@@ -480,8 +480,8 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
             // then
             expect(juryCertificationSummaries[0].id).to.equal(certificationWithOneImpactfulCategoryIssueReportId);
             expect(juryCertificationSummaries[1].id).to.equal(certificationWithNotImpactfulCategoryIssueReportId);
-            expect(juryCertificationSummaries[0].certificationIssueReports.length).to.equal(1);
-            expect(juryCertificationSummaries[1].certificationIssueReports.length).to.equal(1);
+            expect(juryCertificationSummaries[0].certificationIssueReports).to.have.lengthOf(1);
+            expect(juryCertificationSummaries[1].certificationIssueReports).to.have.lengthOf(1);
           });
         });
 
@@ -533,8 +533,8 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
             expect(juryCertificationSummaries[0].id).to.equal(certificationWithOneImpactfulSubcategoryIssueReportsId);
             expect(juryCertificationSummaries[1].id).to.equal(certificationWithoutImpactfulIssueReportId);
 
-            expect(juryCertificationSummaries[0].certificationIssueReports.length).to.equal(1);
-            expect(juryCertificationSummaries[1].certificationIssueReports.length).to.equal(0);
+            expect(juryCertificationSummaries[0].certificationIssueReports).to.have.lengthOf(1);
+            expect(juryCertificationSummaries[1].certificationIssueReports).to.have.lengthOf(0);
           });
         });
       });

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
@@ -25,7 +25,7 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
         const juryCertificationSummaries = await juryCertificationSummaryRepository.findBySessionId({ sessionId });
 
         // then
-        expect(juryCertificationSummaries).to.have.length(0);
+        expect(juryCertificationSummaries).to.have.lengthOf(0);
       });
     });
 
@@ -102,7 +102,7 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
           ],
           complementaryCertificationTakenLabel: null,
         });
-        expect(juryCertificationSummaries).to.have.length(3);
+        expect(juryCertificationSummaries).to.have.lengthOf(3);
         expect(juryCertificationSummaries[0]).to.deepEqualInstance(expectedJuryCertificationSummary);
         expect(juryCertificationSummaries[1].id).to.equal(startedCertification.id);
       });
@@ -285,7 +285,7 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
         });
 
         // then
-        expect(juryCertificationSummaries).to.have.length(0);
+        expect(juryCertificationSummaries).to.have.lengthOf(0);
       });
     });
 
@@ -423,7 +423,7 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
           });
 
         // then
-        expect(juryCertificationSummaries).to.have.length(2);
+        expect(juryCertificationSummaries).to.have.lengthOf(2);
         expect(pagination).to.deep.equal({ rowCount: 5, pageCount: 3, page: page.number, pageSize: page.size });
       });
 

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/jury-session-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/jury-session-repository_test.js
@@ -240,7 +240,7 @@ describe('Integration | Repository | JurySession', function () {
 
           // then
           expect(pagination).to.deep.equal(expectedPagination);
-          expect(jurySessions).to.have.length(2);
+          expect(jurySessions).to.have.lengthOf(2);
         });
       });
 
@@ -297,7 +297,7 @@ describe('Integration | Repository | JurySession', function () {
           // then
           expect(pagination).to.deep.equal(expectedPagination);
           expect(jurySessions[0].id).to.equal(expectedSession.id);
-          expect(jurySessions).to.have.length(1);
+          expect(jurySessions).to.have.lengthOf(1);
         });
       });
 
@@ -340,7 +340,7 @@ describe('Integration | Repository | JurySession', function () {
           // then
           expect(pagination).to.deep.equal(expectedPagination);
           expect(jurySessions[0].id).to.equal(expectedSCOSession.id);
-          expect(jurySessions).to.have.length(1);
+          expect(jurySessions).to.have.lengthOf(1);
         });
 
         it('should return all sessions if certification type filter is null', async function () {
@@ -357,7 +357,7 @@ describe('Integration | Repository | JurySession', function () {
           expect(jurySessions[0].id).to.equal(expectedSCOSession.id);
           expect(jurySessions[1].id).to.equal(expectedSUPSession.id);
           expect(jurySessions[2].id).to.equal(expectedPROSession.id);
-          expect(jurySessions).to.have.length(3);
+          expect(jurySessions).to.have.lengthOf(3);
         });
       });
 
@@ -404,7 +404,7 @@ describe('Integration | Repository | JurySession', function () {
           // then
           expect(pagination).to.deep.equal(expectedPagination);
           expect(jurySessions[0].id).to.equal(expectedSession.id);
-          expect(jurySessions).to.have.length(1);
+          expect(jurySessions).to.have.lengthOf(1);
         });
 
         it('should return all sessions if certification center external id filter is null', async function () {
@@ -418,7 +418,7 @@ describe('Integration | Repository | JurySession', function () {
 
           // then
           expect(pagination).to.deep.equal(expectedPagination);
-          expect(jurySessions).to.have.length(3);
+          expect(jurySessions).to.have.lengthOf(3);
         });
       });
 
@@ -442,7 +442,7 @@ describe('Integration | Repository | JurySession', function () {
             const { jurySessions } = await jurySessionRepository.findPaginatedFiltered({ filters, page });
 
             // then
-            expect(jurySessions).to.have.length(1);
+            expect(jurySessions).to.have.lengthOf(1);
             expect(jurySessions[0].id).to.equal(expectedSessionId);
           });
         });
@@ -475,7 +475,7 @@ describe('Integration | Repository | JurySession', function () {
             const { jurySessions } = await jurySessionRepository.findPaginatedFiltered({ filters, page });
 
             // then
-            expect(jurySessions).to.have.length(1);
+            expect(jurySessions).to.have.lengthOf(1);
             expect(jurySessions[0].id).to.equal(expectedSessionId);
           });
         });
@@ -505,7 +505,7 @@ describe('Integration | Repository | JurySession', function () {
             const { jurySessions } = await jurySessionRepository.findPaginatedFiltered({ filters, page });
 
             // then
-            expect(jurySessions).to.have.length(1);
+            expect(jurySessions).to.have.lengthOf(1);
             expect(jurySessions[0].id).to.equal(expectedSessionId);
           });
         });
@@ -530,7 +530,7 @@ describe('Integration | Repository | JurySession', function () {
             const { jurySessions } = await jurySessionRepository.findPaginatedFiltered({ filters, page });
 
             // then
-            expect(jurySessions).to.have.length(1);
+            expect(jurySessions).to.have.lengthOf(1);
             expect(jurySessions[0].id).to.equal(expectedSessionId);
           });
         });
@@ -558,7 +558,7 @@ describe('Integration | Repository | JurySession', function () {
             const { jurySessions } = await jurySessionRepository.findPaginatedFiltered({ filters, page });
 
             // then
-            expect(jurySessions).to.have.length(1);
+            expect(jurySessions).to.have.lengthOf(1);
             expect(jurySessions[0].id).to.equal(expectedSessionId);
           });
         });
@@ -580,7 +580,7 @@ describe('Integration | Repository | JurySession', function () {
             const { jurySessions } = await jurySessionRepository.findPaginatedFiltered({ filters, page });
 
             // then
-            expect(jurySessions).to.have.length(2);
+            expect(jurySessions).to.have.lengthOf(2);
           });
         });
       });

--- a/api/tests/certification/shared/integration/application/helpers/csvHelpers_test.js
+++ b/api/tests/certification/shared/integration/application/helpers/csvHelpers_test.js
@@ -47,7 +47,7 @@ describe('Certification | Shared | Integration | Application | Helpers | csvHelp
       const data = await parseCsv(validFilePath, options);
 
       // then
-      expect(data.length).to.equal(2);
+      expect(data).to.have.lengthOf(2);
       expect(data[0][2]).to.equal('Salle Beagle');
     });
 
@@ -56,7 +56,7 @@ describe('Certification | Shared | Integration | Application | Helpers | csvHelp
       const data = await parseCsv(utf8FilePath);
 
       // then
-      expect(data.length).to.equal(4);
+      expect(data).to.have.lengthOf(4);
     });
   });
 
@@ -86,7 +86,7 @@ describe('Certification | Shared | Integration | Application | Helpers | csvHelp
       const items = await parseCsvWithHeader(withHeaderFilePath);
 
       // then
-      expect(items.length).to.equal(2);
+      expect(items).to.have.lengthOf(2);
       expect(items).to.have.deep.members(expectedItems);
     });
 

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-assessment-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-assessment-repository_test.js
@@ -141,8 +141,8 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
         expect(certificationAssessment.version).to.equal(2);
         expect(dayjs(certificationAssessment.endedAt).toISOString()).to.equal(dayjs(expectedEndedAt).toISOString());
 
-        expect(certificationAssessment.certificationAnswersByDate).to.have.length(2);
-        expect(certificationAssessment.certificationChallenges).to.have.length(2);
+        expect(certificationAssessment.certificationAnswersByDate).to.have.lengthOf(2);
+        expect(certificationAssessment.certificationChallenges).to.have.lengthOf(2);
         expect(certificationAssessment.certificationChallenges[0].isNeutralized).to.be.true;
         expect(certificationAssessment.certificationChallenges[0].type).to.equal(Challenge.Type.QCU);
       });
@@ -231,8 +231,8 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
         expect(certificationAssessment.version).to.equal(2);
         expect(dayjs(certificationAssessment.endedAt).toISOString()).to.equal(dayjs(expectedEndedAt).toISOString());
 
-        expect(certificationAssessment.certificationAnswersByDate).to.have.length(2);
-        expect(certificationAssessment.certificationChallenges).to.have.length(2);
+        expect(certificationAssessment.certificationAnswersByDate).to.have.lengthOf(2);
+        expect(certificationAssessment.certificationChallenges).to.have.lengthOf(2);
       });
 
       it('should return the certification answers ordered by date', async function () {
@@ -559,8 +559,8 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
       expect(certificationAssessment.version).to.equal(2);
       expect(dayjs(certificationAssessment.endedAt).toISOString()).to.equal(dayjs(expectedEndedAt).toISOString());
 
-      expect(certificationAssessment.certificationAnswersByDate).to.have.length(2);
-      expect(certificationAssessment.certificationChallenges).to.have.length(2);
+      expect(certificationAssessment.certificationAnswersByDate).to.have.lengthOf(2);
+      expect(certificationAssessment.certificationChallenges).to.have.lengthOf(2);
     });
   });
 });

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-challenge-live-alert-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-challenge-live-alert-repository_test.js
@@ -82,7 +82,7 @@ describe('Integration | Repository | Certification Challenge Live Alert', functi
         });
 
         // then
-        expect(liveAlerts).to.have.length(0);
+        expect(liveAlerts).to.have.lengthOf(0);
       });
     });
 
@@ -105,7 +105,7 @@ describe('Integration | Repository | Certification Challenge Live Alert', functi
         });
 
         // then
-        expect(liveAlerts).to.have.length(1);
+        expect(liveAlerts).to.have.lengthOf(1);
         expect(_.pick(liveAlerts[0], ['questionNumber', 'assessmentId'])).to.deep.equal({
           questionNumber,
           assessmentId: assessmentIdWithLiveAlert,
@@ -167,7 +167,7 @@ describe('Integration | Repository | Certification Challenge Live Alert', functi
           });
 
         // then
-        expect(liveAlertValidatedChallengeIds).to.have.length(0);
+        expect(liveAlertValidatedChallengeIds).to.have.lengthOf(0);
       });
     });
 

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -193,7 +193,7 @@ describe('Integration | Repository | Certification Course', function () {
           });
 
           // then
-          expect(thisCertificationCourse.toDTO().challenges.length).to.equal(2);
+          expect(thisCertificationCourse.toDTO().challenges).to.have.lengthOf(2);
         });
         context('When the certification course has one assessment', function () {
           let assessmentId;

--- a/api/tests/certification/shared/integration/infrastructure/repositories/scoring-configuration-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/scoring-configuration-repository_test.js
@@ -163,7 +163,7 @@ describe('Integration | Repository | scoring-configuration-repository', function
 
       // then
       const configurations = await knex('competence-scoring-configurations');
-      expect(configurations.length).to.equal(1);
+      expect(configurations).to.have.lengthOf(1);
       expect(configurations[0].configuration).to.deep.equal({ some: 'data' });
       expect(configurations[0].createdByUserId).to.equal(userId);
     });
@@ -182,7 +182,7 @@ describe('Integration | Repository | scoring-configuration-repository', function
 
       // then
       const configurations = await knex('certification-scoring-configurations');
-      expect(configurations.length).to.equal(1);
+      expect(configurations).to.have.lengthOf(1);
       expect(configurations[0].configuration).to.deep.equal({ some: 'data' });
       expect(configurations[0].createdByUserId).to.equal(userId);
     });

--- a/api/tests/devcomp/integration/infrastructure/repositories/tutorial-evaluation-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/tutorial-evaluation-repository_test.js
@@ -19,7 +19,7 @@ describe('Integration | Infrastructure | Repository | tutorialEvaluationReposito
 
       // then
       const tutorialEvaluations = await knex('tutorial-evaluations').where({ userId, tutorialId });
-      expect(tutorialEvaluations).to.have.length(1);
+      expect(tutorialEvaluations).to.have.lengthOf(1);
     });
 
     it('should return the created tutorial evaluation', async function () {
@@ -63,7 +63,7 @@ describe('Integration | Infrastructure | Repository | tutorialEvaluationReposito
 
         // then
         const tutorialEvaluations = await knex('tutorial-evaluations').where({ userId, tutorialId });
-        expect(tutorialEvaluations).to.have.length(1);
+        expect(tutorialEvaluations).to.have.lengthOf(1);
         expect(tutorialEvaluation.id).to.equal(tutorialEvaluations[0].id);
         expect(tutorialEvaluation.userId).to.equal(tutorialEvaluations[0].userId);
         expect(tutorialEvaluation.tutorialId).to.equal(tutorialEvaluations[0].tutorialId);
@@ -85,7 +85,7 @@ describe('Integration | Infrastructure | Repository | tutorialEvaluationReposito
         const tutorialEvaluations = await tutorialEvaluationRepository.find({ userId });
 
         // then
-        expect(tutorialEvaluations).to.have.length(1);
+        expect(tutorialEvaluations).to.have.lengthOf(1);
         expect(tutorialEvaluations[0]).to.have.property('tutorialId', tutorialId);
         expect(tutorialEvaluations[0]).to.have.property('userId', userId);
       });

--- a/api/tests/devcomp/integration/infrastructure/repositories/tutorial-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/tutorial-repository_test.js
@@ -143,7 +143,7 @@ describe('Integration | Repository | tutorial-repository', function () {
         });
 
         // then
-        expect(tutorialsForUser).to.have.length(2);
+        expect(tutorialsForUser).to.have.lengthOf(2);
         expect(tutorialsForUser[0]).to.be.instanceOf(TutorialForUser);
         expect(tutorialsForUser[0].userSavedTutorial).to.be.instanceOf(UserSavedTutorial);
         expect(tutorialsForUser[0].userSavedTutorial.userId).to.equal(userId);
@@ -238,7 +238,7 @@ describe('Integration | Repository | tutorial-repository', function () {
           });
 
           // then
-          expect(tutorialsForUser).to.have.length(2);
+          expect(tutorialsForUser).to.have.lengthOf(2);
           expect(tutorialsForUser.map(({ id }) => id)).to.deep.equal([tutorialId3, tutorialId2]);
         });
       });

--- a/api/tests/devcomp/integration/infrastructure/repositories/user-recommended-training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/user-recommended-training-repository_test.js
@@ -96,7 +96,7 @@ describe('Integration | Repository | user-recommended-training-repository', func
       });
 
       // then
-      expect(result.length).to.equal(2);
+      expect(result).to.have.lengthOf(2);
       expect(result[0]).to.be.instanceOf(UserRecommendedTraining);
       expect(result[0]).to.deep.equal(new UserRecommendedTraining({ ...training, duration: { hours: 6 } }));
     });
@@ -126,7 +126,7 @@ describe('Integration | Repository | user-recommended-training-repository', func
       });
 
       // then
-      expect(result.length).to.equal(1);
+      expect(result).to.have.lengthOf(1);
       expect(result[0]).to.be.instanceOf(UserRecommendedTraining);
       expect(result[0]).to.deep.equal(new UserRecommendedTraining({ ...training, duration: { hours: 6 } }));
     });
@@ -150,7 +150,7 @@ describe('Integration | Repository | user-recommended-training-repository', func
       });
 
       // then
-      expect(result.length).to.equal(0);
+      expect(result).to.have.lengthOf(0);
     });
   });
 

--- a/api/tests/devcomp/integration/infrastructure/repositories/user-saved-tutorial-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/user-saved-tutorial-repository_test.js
@@ -22,7 +22,7 @@ describe('Integration | Infrastructure | Repository | user-saved-tutorial-reposi
 
         // then
         const userSavedTutorials = await knex('user-saved-tutorials').where({ userId, tutorialId });
-        expect(userSavedTutorials).to.have.length(1);
+        expect(userSavedTutorials).to.have.lengthOf(1);
       });
 
       it('should return the created user saved tutorial', async function () {
@@ -48,7 +48,7 @@ describe('Integration | Infrastructure | Repository | user-saved-tutorial-reposi
 
         // then
         const userSavedTutorials = await knex('user-saved-tutorials').where({ userId, tutorialId });
-        expect(userSavedTutorials).to.have.length(1);
+        expect(userSavedTutorials).to.have.lengthOf(1);
       });
 
       it('should return the created user saved tutorial', async function () {
@@ -79,7 +79,7 @@ describe('Integration | Infrastructure | Repository | user-saved-tutorial-reposi
 
           // then
           const savedUserSavedTutorials = await knex('user-saved-tutorials').where({ userId, tutorialId });
-          expect(savedUserSavedTutorials).to.have.length(1);
+          expect(savedUserSavedTutorials).to.have.lengthOf(1);
           expect(userSavedTutorial).to.be.instanceOf(UserSavedTutorial);
           expect(userSavedTutorial.id).to.equal(savedUserSavedTutorials[0].id);
           expect(userSavedTutorial.userId).to.equal(savedUserSavedTutorials[0].userId);
@@ -100,7 +100,7 @@ describe('Integration | Infrastructure | Repository | user-saved-tutorial-reposi
 
           // then
           const savedUserSavedTutorials = await knex('user-saved-tutorials').where({ userId, tutorialId });
-          expect(savedUserSavedTutorials).to.have.length(1);
+          expect(savedUserSavedTutorials).to.have.lengthOf(1);
           expect(userSavedTutorial).to.be.instanceOf(UserSavedTutorial);
           expect(userSavedTutorial.id).to.equal(savedUserSavedTutorials[0].id);
           expect(userSavedTutorial.userId).to.equal(savedUserSavedTutorials[0].userId);
@@ -131,7 +131,7 @@ describe('Integration | Infrastructure | Repository | user-saved-tutorial-reposi
         const userSavedTutorials = await userSavedTutorialRepository.find({ userId });
 
         // then
-        expect(userSavedTutorials).to.have.length(2);
+        expect(userSavedTutorials).to.have.lengthOf(2);
         expect(userSavedTutorials[0]).to.be.instanceOf(UserSavedTutorial);
         expect(userSavedTutorials[0]).to.have.property('tutorialId', 'recTutorial2');
         expect(userSavedTutorials[0]).to.have.property('userId', userId);
@@ -166,7 +166,7 @@ describe('Integration | Infrastructure | Repository | user-saved-tutorial-reposi
       const userSavedTutorials = await knex('user-saved-tutorials').where({ userId, tutorialId });
 
       // then
-      expect(userSavedTutorials).to.have.length(0);
+      expect(userSavedTutorials).to.have.lengthOf(0);
     });
 
     context('when the tutorialId does not exist in the user list', function () {
@@ -176,7 +176,7 @@ describe('Integration | Infrastructure | Repository | user-saved-tutorial-reposi
         const userSavedTutorials = await knex('user-saved-tutorials').where({ userId, tutorialId });
 
         // then
-        expect(userSavedTutorials).to.have.length(0);
+        expect(userSavedTutorials).to.have.lengthOf(0);
       });
     });
   });

--- a/api/tests/devcomp/unit/domain/models/Grain_test.js
+++ b/api/tests/devcomp/unit/domain/models/Grain_test.js
@@ -17,7 +17,7 @@ describe('Unit | Devcomp | Domain | Models | Grain', function () {
       // then
       expect(grain.id).to.equal(id);
       expect(grain.title).to.equal(title);
-      expect(grain.components).to.have.length(components.length);
+      expect(grain.components).to.have.lengthOf(components.length);
     });
 
     describe('if a grain does not have an id', function () {

--- a/api/tests/devcomp/unit/domain/models/module/Module_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/Module_test.js
@@ -22,7 +22,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
       expect(module.slug).to.equal(slug);
       expect(module.title).to.equal(title);
       expect(module.transitionTexts).to.equal(transitionTexts);
-      expect(module.grains).to.have.length(grains.length);
+      expect(module.grains).to.have.lengthOf(grains.length);
       expect(module.details).to.deep.equal(details);
     });
 

--- a/api/tests/devcomp/unit/domain/read-models/TrainingTriggerForAdmin_test.js
+++ b/api/tests/devcomp/unit/domain/read-models/TrainingTriggerForAdmin_test.js
@@ -84,23 +84,23 @@ describe('Unit | Domain | Read-Models | TrainingTriggerForAdmin', function () {
       });
 
       // then
-      expect(trainingTrigger.areas).to.have.length(1);
+      expect(trainingTrigger.areas).to.have.lengthOf(1);
       expect(trainingTrigger.areas[0]).to.have.property('id', `${area1.id}_${trainingTrigger.id}`);
       expect(trainingTrigger.areas[0]).to.have.property('title', area1.title);
       expect(trainingTrigger.areas[0]).to.have.property('code', area1.code);
       expect(trainingTrigger.areas[0]).to.have.property('color', area1.color);
-      expect(trainingTrigger.areas[0].competences).to.have.length(1);
+      expect(trainingTrigger.areas[0].competences).to.have.lengthOf(1);
       expect(trainingTrigger.areas[0].competences[0]).to.have.property('id', `${competence1.id}_${trainingTrigger.id}`);
       expect(trainingTrigger.areas[0].competences[0]).to.have.property('name', competence1.name);
       expect(trainingTrigger.areas[0].competences[0]).to.have.property('index', competence1.index);
-      expect(trainingTrigger.areas[0].competences[0].thematics).to.have.length(2);
+      expect(trainingTrigger.areas[0].competences[0].thematics).to.have.lengthOf(2);
       expect(trainingTrigger.areas[0].competences[0].thematics[0]).to.have.property(
         'id',
         `${thematic1.id}_${trainingTrigger.id}`,
       );
       expect(trainingTrigger.areas[0].competences[0].thematics[0]).to.have.property('name', thematic1.name);
       expect(trainingTrigger.areas[0].competences[0].thematics[0]).to.have.property('index', thematic1.index);
-      expect(trainingTrigger.areas[0].competences[0].thematics[0].triggerTubes).to.have.length(1);
+      expect(trainingTrigger.areas[0].competences[0].thematics[0].triggerTubes).to.have.lengthOf(1);
       expect(trainingTrigger.areas[0].competences[0].thematics[0].triggerTubes[0]).to.have.property(
         'id',
         trainingTriggerTube1.id,
@@ -111,7 +111,7 @@ describe('Unit | Domain | Read-Models | TrainingTriggerForAdmin', function () {
       );
       expect(trainingTrigger.areas[0].competences[0].thematics[1]).to.have.property('name', thematic2.name);
       expect(trainingTrigger.areas[0].competences[0].thematics[1]).to.have.property('index', thematic2.index);
-      expect(trainingTrigger.areas[0].competences[0].thematics[1].triggerTubes).to.have.length(1);
+      expect(trainingTrigger.areas[0].competences[0].thematics[1].triggerTubes).to.have.lengthOf(1);
       expect(trainingTrigger.areas[0].competences[0].thematics[1].triggerTubes[0]).to.have.property(
         'id',
         trainingTriggerTube2.id,

--- a/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
@@ -1509,7 +1509,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         // then
         expect(module.grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
         expect(module.grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
-        expect(module.grains[0].components[0].steps[0].elements).to.have.length(1);
+        expect(module.grains[0].components[0].steps[0].elements).to.have.lengthOf(1);
         expect(module.grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Text);
       });
 
@@ -1664,7 +1664,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
       // then
       expect(module).to.be.an.instanceOf(Module);
       expect(module.grains).not.to.be.empty;
-      expect(module.grains[0].components).to.have.length(1);
+      expect(module.grains[0].components).to.have.lengthOf(1);
       expect(module.grains[0].components[0].element).not.to.be.empty;
     });
 
@@ -1715,7 +1715,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
       // then
       expect(module).to.be.an.instanceOf(Module);
       expect(module.grains).not.to.be.empty;
-      expect(module.grains[0].components).to.have.length(1);
+      expect(module.grains[0].components).to.have.lengthOf(1);
       expect(module.grains[0].components[0].element).not.to.be.empty;
     });
   });

--- a/api/tests/evaluation/acceptance/application/answers/answer-controller-find_test.js
+++ b/api/tests/evaluation/acceptance/application/answers/answer-controller-find_test.js
@@ -196,7 +196,7 @@ describe('Acceptance | Controller | answer-controller-find', function () {
 
         // then
         const answerReceived = response.result.data;
-        expect(answerReceived.length).to.equal(2);
+        expect(answerReceived).to.have.lengthOf(2);
         expect(answerReceived[0].type).to.equal('answers');
         expect(answerReceived[1].type).to.equal('answers');
         expect([answerReceived[0].id, answerReceived[1].id]).to.have.members([

--- a/api/tests/evaluation/acceptance/application/autonomous-courses/autonomous-course-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/autonomous-courses/autonomous-course-controller_test.js
@@ -172,7 +172,7 @@ describe('Acceptance | API | Autonomous Course', function () {
 
       // then
       expect(response.statusCode).to.equal(200);
-      expect(response.result.data).to.have.length(2);
+      expect(response.result.data).to.have.lengthOf(2);
       expect(response.result.data).to.deep.have.members(expectedResponse.data);
     });
   });

--- a/api/tests/evaluation/acceptance/application/autonomous-courses/autonomous-course-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/autonomous-courses/autonomous-course-controller_test.js
@@ -378,7 +378,7 @@ describe('Acceptance | API | Autonomous Course', function () {
 
       // then
       expect(response.statusCode).to.equal(200);
-      expect(response.result.data.length).to.equal(2);
+      expect(response.result.data).to.have.lengthOf(2);
       expect(response.result.data).to.deep.have.members(expectedResult);
     });
   });

--- a/api/tests/evaluation/integration/infrastructure/repositories/autonomous-course-repository_test.js
+++ b/api/tests/evaluation/integration/infrastructure/repositories/autonomous-course-repository_test.js
@@ -165,7 +165,7 @@ describe('Integration | Repository | Autonomous Course', function () {
         });
 
         // then
-        expect(autonomousCourses).to.have.length(0);
+        expect(autonomousCourses).to.have.lengthOf(0);
         expect(meta).to.deep.equal({
           page: 2,
           pageCount: 0,
@@ -197,7 +197,7 @@ describe('Integration | Repository | Autonomous Course', function () {
         });
 
         // then
-        expect(autonomousCourses).to.have.length(2);
+        expect(autonomousCourses).to.have.lengthOf(2);
         expect(meta).to.deep.equal({
           page: 2,
           pageCount: 3,

--- a/api/tests/evaluation/integration/infrastructure/repositories/badge-criteria-repository_test.js
+++ b/api/tests/evaluation/integration/infrastructure/repositories/badge-criteria-repository_test.js
@@ -24,7 +24,7 @@ describe('Integration | Repository | Badge Criteria Repository', function () {
       const savedBadgeCriterion = await knex('badge-criteria')
         .select('name', 'threshold', 'cappedTubes', 'scope')
         .where({ badgeId });
-      expect(savedBadgeCriterion).to.have.length(1);
+      expect(savedBadgeCriterion).to.have.lengthOf(1);
       expect(savedBadgeCriterion[0]).to.deep.equal({
         name: null,
         threshold: 90,
@@ -55,7 +55,7 @@ describe('Integration | Repository | Badge Criteria Repository', function () {
       const savedBadgeCriterion = await knex('badge-criteria')
         .select('name', 'threshold', 'cappedTubes', 'scope')
         .where({ badgeId });
-      expect(savedBadgeCriterion).to.have.length(1);
+      expect(savedBadgeCriterion).to.have.lengthOf(1);
       expect(savedBadgeCriterion[0]).to.deep.equal({
         name: 'Un nom pour mon critère',
         threshold: 50,

--- a/api/tests/evaluation/integration/infrastructure/repositories/badge-repository_test.js
+++ b/api/tests/evaluation/integration/infrastructure/repositories/badge-repository_test.js
@@ -51,7 +51,7 @@ describe('Integration | Repository | Badge', function () {
 
       it('should return two badges for same target profile', async function () {
         // then
-        expect(badges).to.have.length(2);
+        expect(badges).to.have.lengthOf(2);
       });
 
       it('should return certifiable badges first', async function () {
@@ -483,7 +483,7 @@ describe('Integration | Repository | Badge', function () {
       const badges = await badgeRepository.findAllByTargetProfileId(targetProfileId);
 
       // then
-      expect(badges).to.have.length(2);
+      expect(badges).to.have.lengthOf(2);
       const [badge1, badge2] = badges;
       expect(badge1.key).to.equal('BADGE_1');
       expect(badge2.key).to.equal('BADGE_2');
@@ -500,7 +500,7 @@ describe('Integration | Repository | Badge', function () {
       const badges = await badgeRepository.findAllByTargetProfileId(targetProfileId);
 
       // then
-      expect(badges).to.have.length(0);
+      expect(badges).to.have.lengthOf(0);
     });
   });
 });

--- a/api/tests/evaluation/integration/infrastructure/repositories/competence-evaluation-repository_test.js
+++ b/api/tests/evaluation/integration/infrastructure/repositories/competence-evaluation-repository_test.js
@@ -93,7 +93,7 @@ describe('Integration | Repository | Competence Evaluation', function () {
         .from('competence-evaluations')
         .where({ id: savedCompetenceEvaluation.id })
         .then((result) => {
-          expect(result.length).to.equal(1);
+          expect(result).to.have.lengthOf(1);
           expect(result[0].id).to.equal(savedCompetenceEvaluation.id);
           expect(result[0].assessmentId).to.equal(competenceEvaluationToSave.assessmentId);
           expect(result[0].competenceId).to.equal(competenceEvaluationToSave.competenceId);

--- a/api/tests/evaluation/integration/infrastructure/repositories/competence-evaluation-repository_test.js
+++ b/api/tests/evaluation/integration/infrastructure/repositories/competence-evaluation-repository_test.js
@@ -280,7 +280,7 @@ describe('Integration | Repository | Competence Evaluation', function () {
 
       // then
       return promise.then((competenceEvaluation) => {
-        expect(competenceEvaluation).to.have.length(2);
+        expect(competenceEvaluation).to.have.lengthOf(2);
         expect(_.omit(competenceEvaluation[0], ['assessment', 'scorecard'])).to.deep.equal(
           _.omit(competenceEvaluationExpected, ['assessment']),
         );
@@ -319,7 +319,7 @@ describe('Integration | Repository | Competence Evaluation', function () {
       const competenceEvaluations = await competenceEvaluationRepository.findByAssessmentId(assessmentId);
 
       // then
-      expect(competenceEvaluations).to.have.length(1);
+      expect(competenceEvaluations).to.have.lengthOf(1);
       expect(_.omit(competenceEvaluations[0], ['assessment', 'scorecard'])).to.deep.equal(
         _.omit(competenceEvaluationExpected, ['assessment']),
       );

--- a/api/tests/evaluation/unit/domain/services/smart-random/skills-filter_test.js
+++ b/api/tests/evaluation/unit/domain/services/smart-random/skills-filter_test.js
@@ -402,7 +402,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', function () {
         const difficultyTwoSkills = focusOnDefaultLevel(skills);
 
         // then
-        expect(difficultyTwoSkills.length).to.equal(2);
+        expect(difficultyTwoSkills).to.have.lengthOf(2);
         expect(difficultyTwoSkills[0].id).to.equal(1);
         expect(difficultyTwoSkills[1].id).to.equal(4);
       });
@@ -422,7 +422,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', function () {
         const lowestDifficultySkills = focusOnDefaultLevel(skills);
 
         // then
-        expect(lowestDifficultySkills.length).to.equal(2);
+        expect(lowestDifficultySkills).to.have.lengthOf(2);
         expect(lowestDifficultySkills[0].id).to.equal(1);
         expect(lowestDifficultySkills[1].id).to.equal(2);
       });

--- a/api/tests/identity-access-management/acceptance/application/user/user.admin.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/user/user.admin.route.test.js
@@ -69,7 +69,7 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
         // then
         const { result, statusCode } = response;
         expect(statusCode).to.equal(200);
-        expect(result.data).to.have.length(3);
+        expect(result.data).to.have.lengthOf(3);
       });
     });
   });

--- a/api/tests/identity-access-management/integration/domain/usecases/anonymize-user.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/anonymize-user.usecase.test.js
@@ -96,30 +96,30 @@ describe('Integration | Identity Access Management | Domain | UseCase | anonymiz
     });
 
     const authenticationMethods = await knex('authentication-methods').where({ userId });
-    expect(authenticationMethods).to.have.length(0);
+    expect(authenticationMethods).to.have.lengthOf(0);
 
     const refreshTokens = await refreshTokenRepository.findAllByUserId(userId);
-    expect(refreshTokens).to.have.length(0);
+    expect(refreshTokens).to.have.lengthOf(0);
 
     const resetPasswordDemands = await knex('reset-password-demands').whereRaw('LOWER("email") = LOWER(?)', user.email);
-    expect(resetPasswordDemands).to.have.length(0);
+    expect(resetPasswordDemands).to.have.lengthOf(0);
 
     const enabledMemberships = await knex('memberships').where({ userId }).whereNull('disabledAt');
-    expect(enabledMemberships).to.have.length(0);
+    expect(enabledMemberships).to.have.lengthOf(0);
     const disabledMemberships = await knex('memberships').where({ userId }).whereNotNull('disabledAt');
-    expect(disabledMemberships).to.have.length(1);
+    expect(disabledMemberships).to.have.lengthOf(1);
 
     const enabledCertificationCenterMemberships = await knex('certification-center-memberships')
       .where({ userId })
       .whereNull('disabledAt');
-    expect(enabledCertificationCenterMemberships).to.have.length(0);
+    expect(enabledCertificationCenterMemberships).to.have.lengthOf(0);
     const disabledCertificationCenterMemberships = await knex('certification-center-memberships')
       .where({ userId })
       .whereNotNull('disabledAt');
-    expect(disabledCertificationCenterMemberships).to.have.length(1);
+    expect(disabledCertificationCenterMemberships).to.have.lengthOf(1);
 
     const organizationLearners = await knex('organization-learners').where({ userId });
-    expect(organizationLearners).to.have.length(0);
+    expect(organizationLearners).to.have.lengthOf(0);
 
     const anonymizedUserLogin = await knex('user-logins').where({ id: userLogin.id }).first();
     expect(anonymizedUserLogin.createdAt.toISOString()).to.equal('2012-12-01T00:00:00.000Z');

--- a/api/tests/identity-access-management/integration/domain/usecases/update-user-details-by-admin.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/update-user-details-by-admin.usecase.test.js
@@ -99,7 +99,7 @@ describe('Integration | Identity Access Management | Domain | UseCase | updateUs
     });
 
     // then
-    expect(result.organizationLearners.length).to.equal(2);
+    expect(result.organizationLearners).to.have.lengthOf(2);
     expect(result.email).to.equal(userDetailsToUpdate.email);
   });
 

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/account-recovery-demand.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/account-recovery-demand.repository.test.js
@@ -212,7 +212,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
 
       // then
       const accountRecoveryDemands = await knex('account-recovery-demands').select();
-      expect(accountRecoveryDemands).to.have.length(1);
+      expect(accountRecoveryDemands).to.have.lengthOf(1);
       expect(result).to.be.instanceOf(AccountRecoveryDemand);
       expect(result.userId).to.equal(userId);
       expect(result.newEmail).to.equal(newEmail);

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/oidc-provider-repository_test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/oidc-provider-repository_test.js
@@ -108,7 +108,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repositori
       const oidcProviders = await oidcProviderRepository.findAllOidcProviders();
 
       // then
-      expect(oidcProviders).to.have.length(2);
+      expect(oidcProviders).to.have.lengthOf(2);
       const oidcIdentityProviders = oidcProviders.map(({ identityProvider }) => identityProvider);
       expect(oidcIdentityProviders).to.deep.equal(['OIDC_EXAMPLE1', 'OIDC_EXAMPLE2']);
     });

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
@@ -1032,7 +1032,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         const user = await userRepository.getWithCertificationCenterMemberships(userInDB.id);
 
         // then
-        expect(user.certificationCenterMemberships.length).to.equal(1);
+        expect(user.certificationCenterMemberships).to.have.lengthOf(1);
 
         const foundCertificationCenterMembership = user.certificationCenterMemberships[0];
         expect(foundCertificationCenterMembership).to.be.an.instanceof(CertificationCenterMembership);
@@ -1212,7 +1212,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
           const userDetailsForAdmin = await userRepository.getUserDetailsForAdmin(userInDB.id);
 
           // then
-          expect(userDetailsForAdmin.organizationLearners.length).to.equal(2);
+          expect(userDetailsForAdmin.organizationLearners).to.have.lengthOf(2);
           const organizationLearners = userDetailsForAdmin.organizationLearners;
           expect(organizationLearners[0]).to.be.instanceOf(OrganizationLearnerForAdmin);
 
@@ -1246,7 +1246,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
           const userDetailsForAdmin = await userRepository.getUserDetailsForAdmin(userInDB.id);
 
           // then
-          expect(userDetailsForAdmin.organizationLearners.length).to.equal(0);
+          expect(userDetailsForAdmin.organizationLearners).to.have.lengthOf(0);
         });
       });
 
@@ -1268,7 +1268,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
           const pixAuthenticationMethod = userDetailsForAdmin.authenticationMethods.find(
             ({ identityProvider }) => identityProvider === NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
           );
-          expect(userDetailsForAdmin.authenticationMethods.length).to.equal(2);
+          expect(userDetailsForAdmin.authenticationMethods).to.have.lengthOf(2);
           expect(pixAuthenticationMethod).to.deep.equal({
             authenticationComplement: {
               shouldChangePassword: false,
@@ -1293,7 +1293,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
           const userDetailsForAdmin = await userRepository.getUserDetailsForAdmin(userInDB.id);
 
           // then
-          expect(userDetailsForAdmin.authenticationMethods.length).to.equal(0);
+          expect(userDetailsForAdmin.authenticationMethods).to.have.lengthOf(0);
           expect(userDetailsForAdmin.hasBeenAnonymised).to.be.true;
 
           const { hasBeenAnonymisedBy } = await knex('users').where({ id: userInDB.id }).first();

--- a/api/tests/identity-access-management/integration/scripts/mass-create-user-accounts.script.test.js
+++ b/api/tests/identity-access-management/integration/scripts/mass-create-user-accounts.script.test.js
@@ -128,7 +128,7 @@ describe('Integration | Identity Access Management | Scripts | mass-create-user-
 
       // then
       const usersInDatabases = await knex('authentication-methods');
-      expect(usersInDatabases.length).to.equal(2);
+      expect(usersInDatabases).to.have.lengthOf(2);
 
       const firstUserFound = await knex('users').where({ lastName: 'Kilo' }).first();
       const firstAuthenticationMethodFound = await knex('authentication-methods')

--- a/api/tests/identity-access-management/unit/application/oidc-provider.admin.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/oidc-provider.admin.controller.test.js
@@ -124,7 +124,7 @@ describe('Unit | Identity Access Management | Application | Controller | Admin |
       // then
       expect(usecases.getAllIdentityProviders).to.have.been.called;
       expect(response.statusCode).to.equal(200);
-      expect(response.source.data.length).to.equal(2);
+      expect(response.source.data).to.have.lengthOf(2);
       expect(response.source.data).to.deep.equal([
         {
           type: 'oidc-identity-providers',

--- a/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
@@ -254,7 +254,7 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
       // then
       expect(usecases.getReadyIdentityProviders).to.have.been.called;
       expect(response.statusCode).to.equal(200);
-      expect(response.source.data.length).to.equal(1);
+      expect(response.source.data).to.have.lengthOf(1);
       expect(response.source.data).to.deep.contain({
         type: 'oidc-identity-providers',
         id: 'some-oidc-provider',

--- a/api/tests/identity-access-management/unit/domain/models/User.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/User.test.js
@@ -46,7 +46,7 @@ describe('Unit | Identity Access Management | Domain | Model | User', function (
         ];
 
         //then
-        expect(users.length).to.equal(3);
+        expect(users).to.have.lengthOf(3);
       });
 
       it('validates and canonicalizes the locale', function () {

--- a/api/tests/identity-access-management/unit/domain/models/UserDetailsForAdmin_test.js
+++ b/api/tests/identity-access-management/unit/domain/models/UserDetailsForAdmin_test.js
@@ -22,7 +22,7 @@ describe('Unit | Domain | Models | UserDetailsForAdmin', function () {
       ];
 
       //then
-      expect(users.length).to.equal(3);
+      expect(users).to.have.lengthOf(3);
     });
 
     it('validates and canonicalizes the locale', function () {

--- a/api/tests/identity-access-management/unit/domain/models/UserToCreate.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/UserToCreate.test.js
@@ -12,7 +12,7 @@ describe('Unit | Identity Access Management | Domain | Model | UserToCreate', fu
       ];
 
       // then
-      expect(users.length).to.equal(3);
+      expect(users).to.have.lengthOf(3);
     });
 
     it('validates and canonicalizes the locale', function () {

--- a/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service-registry_test.js
+++ b/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service-registry_test.js
@@ -243,7 +243,7 @@ describe('Unit | Identity Access Management | Domain | Services | oidc-authentic
         const services = oidcAuthenticationServiceRegistry.getAllOidcProviderServices();
 
         // then
-        expect(services).to.have.length(3);
+        expect(services).to.have.lengthOf(3);
 
         const genericService = services.find((service) => service.identityProvider === 'GENERIC');
         expect(genericService).not.to.be.empty;

--- a/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service-registry_test.js
+++ b/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service-registry_test.js
@@ -35,7 +35,7 @@ describe('Unit | Identity Access Management | Domain | Services | oidc-authentic
 
       // then
       const serviceCodes = services.map((service) => service.code);
-      expect(serviceCodes.length).to.equal(2);
+      expect(serviceCodes).to.have.lengthOf(2);
       expect(serviceCodes).to.contain('FIRST');
       expect(serviceCodes).to.contain('SECOND');
     });
@@ -62,7 +62,7 @@ describe('Unit | Identity Access Management | Domain | Services | oidc-authentic
 
       // then
       const serviceCodes = services.map((service) => service.code);
-      expect(serviceCodes.length).to.equal(1);
+      expect(serviceCodes).to.have.lengthOf(1);
       expect(serviceCodes).to.contain('SECOND');
     });
   });
@@ -88,7 +88,7 @@ describe('Unit | Identity Access Management | Domain | Services | oidc-authentic
 
       // then
       const serviceCodes = services.map((service) => service.code);
-      expect(serviceCodes.length).to.equal(1);
+      expect(serviceCodes).to.have.lengthOf(1);
       expect(serviceCodes).to.contain('FIRST');
     });
   });

--- a/api/tests/integration/domain/services/certification-challenges-service_test.js
+++ b/api/tests/integration/domain/services/certification-challenges-service_test.js
@@ -481,7 +481,7 @@ describe('Integration | CertificationChallengeService | pickCertificationChallen
       answerRepository,
       challengeRepository,
     );
-    expect(challenges.length).to.equal(1);
+    expect(challenges).to.have.lengthOf(1);
     expect(challenges[0].challengeId).to.be.oneOf([
       'recArea1_Competence1_Tube1_Skill1_Challenge2',
       'recArea1_Competence1_Tube1_Skill1_Challenge3',
@@ -581,7 +581,7 @@ describe('Integration | CertificationChallengeService | pickCertificationChallen
       answerRepository,
       challengeRepository,
     );
-    expect(challenges.length).to.equal(1);
+    expect(challenges).to.have.lengthOf(1);
     expect([
       'recArea1_Competence1_Tube1_Skill1_Challenge1',
       'recArea1_Competence1_Tube1_Skill1_Challenge2',
@@ -722,7 +722,7 @@ describe('Integration | CertificationChallengeService | pickCertificationChallen
       answerRepository,
       challengeRepository,
     );
-    expect(challenges.length).to.equal(3);
+    expect(challenges).to.have.lengthOf(3);
     expect(challenges.map((challenge) => challenge.challengeId)).to.deep.equal([
       'recArea1_Competence1_Tube1_Skill4_Challenge1',
       'recArea1_Competence1_Tube1_Skill3_Challenge1',

--- a/api/tests/integration/domain/usecases/copy-target-profile-badges_test.js
+++ b/api/tests/integration/domain/usecases/copy-target-profile-badges_test.js
@@ -42,7 +42,7 @@ describe('Integration | UseCases | copy-badges', function () {
       const destinationTargetProfileBadges = await knex('badges').where({
         targetProfileId: destinationTargetProfileId,
       });
-      expect(destinationTargetProfileBadges.length).to.equal(2);
+      expect(destinationTargetProfileBadges).to.have.lengthOf(2);
     });
   });
 
@@ -94,7 +94,7 @@ describe('Integration | UseCases | copy-badges', function () {
       const badgeCriteria = await knex('badge-criteria').where({
         badgeId: certifiableBadge.id,
       });
-      expect(badgeCriteria.length).to.equal(2);
+      expect(badgeCriteria).to.have.lengthOf(2);
       expect(badgeCriteria[0].name).to.equal('badge criterion 1');
     });
   });
@@ -135,8 +135,8 @@ describe('Integration | UseCases | copy-badges', function () {
       // then
       const badges = await knex('badges').select('*');
       const badgesCriteria = await knex('badge-criteria').select('*');
-      expect(badges.length).to.equal(1);
-      expect(badgesCriteria.length).to.equal(1);
+      expect(badges).to.have.lengthOf(1);
+      expect(badgesCriteria).to.have.lengthOf(1);
     });
   });
 });

--- a/api/tests/integration/domain/usecases/copy-target-profile-stages_test.js
+++ b/api/tests/integration/domain/usecases/copy-target-profile-stages_test.js
@@ -22,7 +22,7 @@ describe('Integration | UseCases | copy-stages', function () {
       const destinationTargetProfileStages = await knex('stages').where({
         targetProfileId: destinationTargetProfileId,
       });
-      expect(destinationTargetProfileStages.length).to.equal(2);
+      expect(destinationTargetProfileStages).to.have.lengthOf(2);
       expect(destinationTargetProfileStages[0].title).to.equal(firstStage.title);
       expect(destinationTargetProfileStages[1].title).to.equal(secondStage.title);
     });

--- a/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
+++ b/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
@@ -352,9 +352,9 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
         expect(error).to.be.instanceOf(OrganizationTagNotFound);
         expect(error.message).to.be.equal("Le tag TagNotFound de l'organisation Mathieu Bâtiment n'existe pas.");
         const organizationsInDB = await knex('organizations').select();
-        expect(organizationsInDB.length).to.equal(0);
+        expect(organizationsInDB).to.have.lengthOf(0);
         const organizationTagsInDB = await knex('organization-tags').select();
-        expect(organizationTagsInDB.length).to.equal(0);
+        expect(organizationTagsInDB).to.have.lengthOf(0);
       });
     });
   });
@@ -429,9 +429,9 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
 
       // then
       const organizationsInDB = await knex('organizations').select();
-      expect(organizationsInDB.length).to.equal(3);
+      expect(organizationsInDB).to.have.lengthOf(3);
       const organizationTagsInDB = await knex('organization-tags').select();
-      expect(organizationTagsInDB.length).to.equal(6);
+      expect(organizationTagsInDB).to.have.lengthOf(6);
 
       for (const organization of organizationsWithTagsAlreadyExist) {
         const organizationInDB = await knex('organizations')
@@ -454,7 +454,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
         const organizationTagInDB = await knex('organization-tags')
           .select()
           .where({ organizationId: organizationInDB.id });
-        expect(organizationTagInDB.length).to.equal(2);
+        expect(organizationTagInDB).to.have.lengthOf(2);
       }
     });
   });
@@ -529,9 +529,9 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
       expect(error).to.be.instanceOf(TargetProfileInvalidError);
       expect(error.message).to.be.equal("Le profil cible 1 n'existe pas.");
       const organizationsInDB = await knex('organizations').select();
-      expect(organizationsInDB.length).to.equal(0);
+      expect(organizationsInDB).to.have.lengthOf(0);
       const organizationTargetProfilesInDB = await knex('target-profile-shares').select();
-      expect(organizationTargetProfilesInDB.length).to.equal(0);
+      expect(organizationTargetProfilesInDB).to.have.lengthOf(0);
     });
   });
 
@@ -605,9 +605,9 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
 
       // then
       const organizationsInDB = await knex('organizations').select();
-      expect(organizationsInDB.length).to.equal(3);
+      expect(organizationsInDB).to.have.lengthOf(3);
       const organizationTargetProfilesInDB = await knex('target-profile-shares').select();
-      expect(organizationTargetProfilesInDB.length).to.equal(3);
+      expect(organizationTargetProfilesInDB).to.have.lengthOf(3);
 
       for (const organization of organizationsWithExistingTargetProfiles) {
         const organizationInDB = await knex('organizations')
@@ -630,7 +630,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
         const organizationTargetProfilesInDB = await knex('target-profile-shares')
           .select()
           .where({ organizationId: organizationInDB.id });
-        expect(organizationTargetProfilesInDB.length).to.equal(1);
+        expect(organizationTargetProfilesInDB).to.have.lengthOf(1);
       }
     });
   });
@@ -740,7 +740,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
 
       // then
       const savedOrganizationFeatures = await knex('organization-features');
-      expect(savedOrganizationFeatures.length).to.equal(3);
+      expect(savedOrganizationFeatures).to.have.lengthOf(3);
       const organizationId = createdOrganizations[0].id;
       expect(
         savedOrganizationFeatures.map((organizationFeature) => omit(organizationFeature, 'id')),
@@ -814,10 +814,10 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
 
       // then
       const savedSchools = await knex('schools');
-      expect(savedSchools.length).to.equal(1);
+      expect(savedSchools).to.have.lengthOf(1);
 
       const savedSco1dOrganizations = await knex('organizations').where({ type: 'SCO-1D' });
-      expect(savedSco1dOrganizations.length).to.equal(1);
+      expect(savedSco1dOrganizations).to.have.lengthOf(1);
       expect(savedSco1dOrganizations[0].email).to.equal('youness@example.net');
 
       expect(savedSchools[0].organizationId).to.equal(savedSco1dOrganizations[0].id);

--- a/api/tests/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -404,7 +404,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
 
         // then
         const usersAfter = await knex('users');
-        expect(usersAfter.length).to.equal(usersBefore.length);
+        expect(usersAfter).to.have.lengthOf(usersBefore.length);
       });
     });
   });

--- a/api/tests/integration/domain/usecases/get-recently-used-tags_test.js
+++ b/api/tests/integration/domain/usecases/get-recently-used-tags_test.js
@@ -40,7 +40,7 @@ describe('Integration | UseCase | get-recently-used-tags', function () {
     const recentlyUsedTags = await getRecentlyUsedTags({ tagId: basedTag.id, organizationTagRepository });
 
     // then
-    expect(recentlyUsedTags.length).to.equal(10);
+    expect(recentlyUsedTags).to.have.lengthOf(10);
     expect(recentlyUsedTags[0]).to.deepEqualInstance(new Tag(mostUsedTag));
     expect(recentlyUsedTags[recentlyUsedTags.length - 1]).to.deepEqualInstance(new Tag(leastUsedTag));
   });

--- a/api/tests/integration/domain/usecases/handle-badge-acquisition_test.js
+++ b/api/tests/integration/domain/usecases/handle-badge-acquisition_test.js
@@ -125,7 +125,7 @@ describe('Integration | Usecase | Handle Badge Acquisition', function () {
           expect(transactionBadgeAcquisitions).to.deep.equal([{ userId, badgeId: badgeCompleted.id }]);
 
           const realBadgeAcquisitions = await knex('badge-acquisitions').where({ userId });
-          expect(realBadgeAcquisitions.length).to.equal(0);
+          expect(realBadgeAcquisitions).to.have.lengthOf(0);
         });
       });
     });

--- a/api/tests/integration/domain/usecases/handle-stage-acquisition_test.js
+++ b/api/tests/integration/domain/usecases/handle-stage-acquisition_test.js
@@ -128,9 +128,9 @@ describe('Integration | Usecase | Handle Stage Acquisition', function () {
           });
 
           // then
-          expect(stageAcquisitionsBefore.length).to.equal(3);
+          expect(stageAcquisitionsBefore).to.have.lengthOf(3);
           const stageAcquisitionsAfter = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ userId });
-          expect(stageAcquisitionsAfter.length).to.equal(4);
+          expect(stageAcquisitionsAfter).to.have.lengthOf(4);
         });
       });
 
@@ -178,7 +178,7 @@ describe('Integration | Usecase | Handle Stage Acquisition', function () {
             ]);
 
             const stageAcquisitions = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ userId });
-            expect(stageAcquisitions.length).to.equal(0);
+            expect(stageAcquisitions).to.have.lengthOf(0);
           });
         });
       });
@@ -200,7 +200,7 @@ describe('Integration | Usecase | Handle Stage Acquisition', function () {
 
           // then
           const stageAcquisitions = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ userId });
-          expect(stageAcquisitions.length).to.equal(0);
+          expect(stageAcquisitions).to.have.lengthOf(0);
         });
       });
 
@@ -224,7 +224,7 @@ describe('Integration | Usecase | Handle Stage Acquisition', function () {
 
           // then
           const stageAcquisitions = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ userId });
-          expect(stageAcquisitions.length).to.equal(4);
+          expect(stageAcquisitions).to.have.lengthOf(4);
         });
       });
     });
@@ -255,7 +255,7 @@ describe('Integration | Usecase | Handle Stage Acquisition', function () {
 
         // then
         const stageAcquisitionsAfter = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ userId });
-        expect(stageAcquisitionsAfter.length).to.equal(1);
+        expect(stageAcquisitionsAfter).to.have.lengthOf(1);
       });
     });
   });

--- a/api/tests/integration/domain/usecases/send-completed-participation-results-to-pole-emploi_test.js
+++ b/api/tests/integration/domain/usecases/send-completed-participation-results-to-pole-emploi_test.js
@@ -59,7 +59,7 @@ describe('Integration | Domain | UseCases | send-completed-participation-results
 
     // then
     const poleEmploiSendings = await knex('pole-emploi-sendings').where({ campaignParticipationId });
-    expect(poleEmploiSendings.length).to.equal(1);
+    expect(poleEmploiSendings).to.have.lengthOf(1);
     expect(poleEmploiSendings[0].responseCode).to.equal(responseCode.toString());
     expect(poleEmploiSendings[0].type).to.equal('CAMPAIGN_PARTICIPATION_COMPLETION');
   });
@@ -72,7 +72,7 @@ describe('Integration | Domain | UseCases | send-completed-participation-results
 
     // then
     const poleEmploiSendings = await knex('pole-emploi-sendings').where({ campaignParticipationId });
-    expect(poleEmploiSendings.length).to.equal(1);
+    expect(poleEmploiSendings).to.have.lengthOf(1);
     expect(poleEmploiSendings[0].isSuccessful).to.be.false;
     expect(poleEmploiSendings[0].responseCode).to.equal('SENDING-DISABLED');
     expect(poleEmploiSendings[0].type).to.equal('CAMPAIGN_PARTICIPATION_COMPLETION');

--- a/api/tests/integration/domain/usecases/send-shared-participation-results-to-pole-emploi_test.js
+++ b/api/tests/integration/domain/usecases/send-shared-participation-results-to-pole-emploi_test.js
@@ -59,7 +59,7 @@ describe('Integration | Domain | UseCases | send-shared-participation-results-to
 
     // then
     const poleEmploiSendings = await knex('pole-emploi-sendings').where({ campaignParticipationId });
-    expect(poleEmploiSendings.length).to.equal(1);
+    expect(poleEmploiSendings).to.have.lengthOf(1);
     expect(poleEmploiSendings[0].responseCode).to.equal(responseCode.toString());
     expect(poleEmploiSendings[0].type).to.equal('CAMPAIGN_PARTICIPATION_SHARING');
   });
@@ -72,7 +72,7 @@ describe('Integration | Domain | UseCases | send-shared-participation-results-to
 
     // then
     const poleEmploiSendings = await knex('pole-emploi-sendings').where({ campaignParticipationId });
-    expect(poleEmploiSendings.length).to.equal(1);
+    expect(poleEmploiSendings).to.have.lengthOf(1);
     expect(poleEmploiSendings[0].isSuccessful).to.be.false;
     expect(poleEmploiSendings[0].responseCode).to.equal('SENDING-DISABLED');
     expect(poleEmploiSendings[0].type).to.equal('CAMPAIGN_PARTICIPATION_SHARING');

--- a/api/tests/integration/domain/usecases/send-started-participation-results-to-pole-emploi_test.js
+++ b/api/tests/integration/domain/usecases/send-started-participation-results-to-pole-emploi_test.js
@@ -59,7 +59,7 @@ describe('Integration | Application | send-started-participation-results-to-pole
 
     // then
     const poleEmploiSendings = await knex('pole-emploi-sendings').where({ campaignParticipationId });
-    expect(poleEmploiSendings.length).to.equal(1);
+    expect(poleEmploiSendings).to.have.lengthOf(1);
     expect(poleEmploiSendings[0].responseCode).to.equal(responseCode.toString());
     expect(poleEmploiSendings[0].type).to.equal('CAMPAIGN_PARTICIPATION_START');
   });
@@ -72,7 +72,7 @@ describe('Integration | Application | send-started-participation-results-to-pole
 
     // then
     const poleEmploiSendings = await knex('pole-emploi-sendings').where({ campaignParticipationId });
-    expect(poleEmploiSendings.length).to.equal(1);
+    expect(poleEmploiSendings).to.have.lengthOf(1);
     expect(poleEmploiSendings[0].isSuccessful).to.be.false;
     expect(poleEmploiSendings[0].responseCode).to.equal('SENDING-DISABLED');
     expect(poleEmploiSendings[0].type).to.equal('CAMPAIGN_PARTICIPATION_START');

--- a/api/tests/integration/domain/usecases/update-certification-center_test.js
+++ b/api/tests/integration/domain/usecases/update-certification-center_test.js
@@ -55,7 +55,7 @@ describe('Integration | UseCases | update-certification-center', function () {
     expect(updatedCertificationCenter.dataProtectionOfficerLastName).to.equal('Ptipeu');
     expect(updatedCertificationCenter.dataProtectionOfficerEmail).to.equal('justin.ptipeu@example.net');
 
-    expect(updatedCertificationCenter.habilitations.length).to.equal(1);
+    expect(updatedCertificationCenter.habilitations).to.have.lengthOf(1);
     expect(updatedCertificationCenter.habilitations[0].complementaryCertificationId).to.equal(
       complementaryCertification.id,
     );

--- a/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
@@ -111,7 +111,7 @@ describe('Integration | Repository | Badge Acquisition', function () {
       });
 
       // then
-      expect(acquiredBadgeIds.length).to.equal(0);
+      expect(acquiredBadgeIds).to.have.lengthOf(0);
     });
 
     context('when no  is passed in parameters', function () {
@@ -184,7 +184,7 @@ describe('Integration | Repository | Badge Acquisition', function () {
             });
 
           // then
-          expect(acquiredBadgesByCampaignParticipations[campaignParticipationId].length).to.equal(2);
+          expect(acquiredBadgesByCampaignParticipations[campaignParticipationId]).to.have.lengthOf(2);
         });
       });
     });

--- a/api/tests/integration/infrastructure/repositories/certifiable-badge-acquisition-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certifiable-badge-acquisition-repository_test.js
@@ -227,7 +227,7 @@ describe('Integration | Repository | Certifiable Badge Acquisition', function ()
           });
 
           // then
-          expect(certifiableBadgesAcquiredByUser.length).to.equal(2);
+          expect(certifiableBadgesAcquiredByUser).to.have.lengthOf(2);
           expect(certifiableBadgesAcquiredByUser.map(({ badgeKey }) => badgeKey)).to.deep.equal(['level-2', 'level-3']);
         });
 
@@ -300,7 +300,7 @@ describe('Integration | Repository | Certifiable Badge Acquisition', function ()
             });
 
             // then
-            expect(certifiableBadgesAcquiredByUser.length).to.equal(1);
+            expect(certifiableBadgesAcquiredByUser).to.have.lengthOf(1);
             expect(certifiableBadgesAcquiredByUser[0].badgeKey).to.equal('level-2');
             expect(certifiableBadgesAcquiredByUser[0].isOutdated).to.equal(true);
           });
@@ -358,7 +358,7 @@ describe('Integration | Repository | Certifiable Badge Acquisition', function ()
             });
 
             // then
-            expect(certifiableBadgesAcquiredByUser.length).to.equal(1);
+            expect(certifiableBadgesAcquiredByUser).to.have.lengthOf(1);
             expect(certifiableBadgesAcquiredByUser[0].badgeKey).to.equal('level-2');
             expect(certifiableBadgesAcquiredByUser[0].isOutdated).to.equal(false);
           });
@@ -398,7 +398,7 @@ describe('Integration | Repository | Certifiable Badge Acquisition', function ()
           });
 
           // then
-          expect(certifiableBadgesAcquiredByUser.length).to.equal(1);
+          expect(certifiableBadgesAcquiredByUser).to.have.lengthOf(1);
           expect(certifiableBadgesAcquiredByUser.map(({ badgeKey }) => badgeKey)).to.deep.equal(['level-2']);
         });
       });

--- a/api/tests/integration/infrastructure/repositories/certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-repository_test.js
@@ -20,7 +20,7 @@ describe('Integration | Repository | Certification', function () {
 
       // then
 
-      expect(statuses).to.have.length(3);
+      expect(statuses).to.have.lengthOf(3);
       expect(statuses).to.deep.equal([
         {
           certificationCourseId: 1,

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -229,8 +229,8 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
         await knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId({ userId });
 
       // then
-      expect(actualKnowledgeElementsGroupedByCompetenceId[1]).to.have.length(2);
-      expect(actualKnowledgeElementsGroupedByCompetenceId[2]).to.have.length(1);
+      expect(actualKnowledgeElementsGroupedByCompetenceId[1]).to.have.lengthOf(2);
+      expect(actualKnowledgeElementsGroupedByCompetenceId[2]).to.have.lengthOf(1);
       expect(actualKnowledgeElementsGroupedByCompetenceId[1][0]).to.be.instanceOf(KnowledgeElement);
     });
   });
@@ -1361,7 +1361,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       const knowledgeElements = await knowledgeElementRepository.findInvalidatedAndDirectByUserId(userId);
 
       // Then
-      expect(knowledgeElements).to.have.length(2);
+      expect(knowledgeElements).to.have.lengthOf(2);
       expect(knowledgeElements[0]).to.be.instanceOf(KnowledgeElement);
       expect(knowledgeElements[0].id).to.equal(2);
     });
@@ -1375,7 +1375,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       const knowledgeElements = await knowledgeElementRepository.findInvalidatedAndDirectByUserId(userId);
 
       // Then
-      expect(knowledgeElements).to.have.length(0);
+      expect(knowledgeElements).to.have.lengthOf(0);
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -43,7 +43,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       });
 
       // then
-      expect(savedKnowledgeElements.length).to.equal(2);
+      expect(savedKnowledgeElements).to.have.lengthOf(2);
       expect(savedKnowledgeElements[0]).to.deepEqualInstanceOmitting(knowledgeElementsToSave[0], ['createdAt', 'id']);
       expect(savedKnowledgeElements[1]).to.deepEqualInstanceOmitting(knowledgeElementsToSave[1], ['createdAt', 'id']);
       expect(savedKnowledgeElements[0].createdAt).to.deep.equal(savedKnowledgeElements[1].createdAt);
@@ -375,7 +375,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
 
       // then
       expect(knowledgeElementsByUserIdAndCompetenceId[userId1][competence1][0]).to.be.instanceOf(KnowledgeElement);
-      expect(knowledgeElementsByUserIdAndCompetenceId[userId1][competence1].length).to.equal(2);
+      expect(knowledgeElementsByUserIdAndCompetenceId[userId1][competence1]).to.have.lengthOf(2);
       expect(knowledgeElementsByUserIdAndCompetenceId[userId1][competence1]).to.deep.include.members([
         knowledgeElement1_1,
         knowledgeElement1_2,
@@ -445,7 +445,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
             .select('*')
             .from('knowledge-element-snapshots')
             .where({ userId: userId1 });
-          expect(actualUserSnapshots.length).to.equal(0);
+          expect(actualUserSnapshots).to.have.lengthOf(0);
         });
       });
 
@@ -581,7 +581,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
 
           // then
           const actualUserSnapshots = await knex.select('*').from('knowledge-element-snapshots').where({ userId });
-          expect(actualUserSnapshots.length).to.equal(0);
+          expect(actualUserSnapshots).to.have.lengthOf(0);
         });
       });
 
@@ -804,7 +804,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
 
           // then
           const actualUserSnapshots = await knex.select('*').from('knowledge-element-snapshots').where({ userId });
-          expect(actualUserSnapshots.length).to.equal(0);
+          expect(actualUserSnapshots).to.have.lengthOf(0);
         });
       });
 
@@ -1077,7 +1077,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
 
           // then
           const actualUserSnapshots = await knex.select('*').from('knowledge-element-snapshots').where({ userId });
-          expect(actualUserSnapshots.length).to.equal(0);
+          expect(actualUserSnapshots).to.have.lengthOf(0);
         });
       });
 
@@ -1229,8 +1229,8 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
 
       // then
       expect(knowledgeElementsByUserIdAndCompetenceId[userId1][0]).to.be.instanceOf(KnowledgeElement);
-      expect(knowledgeElementsByUserIdAndCompetenceId[userId1].length).to.equal(2);
-      expect(knowledgeElementsByUserIdAndCompetenceId[userId2].length).to.equal(2);
+      expect(knowledgeElementsByUserIdAndCompetenceId[userId1]).to.have.lengthOf(2);
+      expect(knowledgeElementsByUserIdAndCompetenceId[userId2]).to.have.lengthOf(2);
       expect(knowledgeElementsByUserIdAndCompetenceId[userId1]).to.deep.include.members([
         user1knowledgeElement1,
         user1knowledgeElement2,
@@ -1298,7 +1298,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
             .select('*')
             .from('knowledge-element-snapshots')
             .where({ userId: userId1 });
-          expect(actualUserSnapshots.length).to.equal(0);
+          expect(actualUserSnapshots).to.have.lengthOf(0);
         });
       });
 

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -1063,7 +1063,7 @@ describe('Integration | Repository | Organization', function () {
           await organizationRepository.getOrganizationsWithPlacesManagementFeatureEnabled();
 
         // then
-        expect(organizationsWithPlaces.length).to.equal(1);
+        expect(organizationsWithPlaces).to.have.lengthOf(1);
         expect(organizationsWithPlaces[0]).to.be.instanceOf(Organization);
         expect(organizationsWithPlaces[0].id).to.equal(firstOrganization.id);
         expect(organizationsWithPlaces[0].name).to.equal(firstOrganization.name);
@@ -1103,7 +1103,7 @@ describe('Integration | Repository | Organization', function () {
           await organizationRepository.getOrganizationsWithPlacesManagementFeatureEnabled();
 
         // then
-        expect(organizationsWithPlaces.length).to.equal(1);
+        expect(organizationsWithPlaces).to.have.lengthOf(1);
       });
 
       it('should return organization instead if they have unlimited places', async function () {
@@ -1135,7 +1135,7 @@ describe('Integration | Repository | Organization', function () {
           await organizationRepository.getOrganizationsWithPlacesManagementFeatureEnabled();
 
         // then
-        expect(organizationsWithPlaces.length).to.equal(1);
+        expect(organizationsWithPlaces).to.have.lengthOf(1);
       });
     });
 

--- a/api/tests/integration/infrastructure/repositories/organization-tag-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-tag-repository_test.js
@@ -93,7 +93,7 @@ describe('Integration | Repository | OrganizationTagRepository', function () {
 
       // then
       const foundOrganizations = await knex('organization-tags').select();
-      expect(foundOrganizations.length).to.equal(2);
+      expect(foundOrganizations).to.have.lengthOf(2);
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/target-profile-share-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-share-repository_test.js
@@ -29,7 +29,7 @@ describe('Integration | Repository | Target-profile-share', function () {
 
       // then
       const foundTargetProfileShares = await knex('target-profile-shares').select();
-      expect(foundTargetProfileShares.length).to.equal(3);
+      expect(foundTargetProfileShares).to.have.lengthOf(3);
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/tube-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tube-repository_test.js
@@ -112,7 +112,7 @@ describe('Integration | Repository | tube-repository', function () {
       const tubes = await tubeRepository.list();
 
       // then
-      expect(tubes).to.have.length(2);
+      expect(tubes).to.have.lengthOf(2);
       expect(tubes[0]).to.deep.equal(tube0);
       expect(tubes[1]).to.deep.equal(tube1);
     });

--- a/api/tests/integration/infrastructure/repositories/user-campaign-results/stage-collection-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-campaign-results/stage-collection-repository_test.js
@@ -72,7 +72,7 @@ describe('Integration | Infrastructure | Repository | stage-collection-repositor
 
       const stages = result.stages;
 
-      expect(stages).to.have.length(4);
+      expect(stages).to.have.lengthOf(4);
       expect(stages[0].threshold).to.equal(0);
       expect(stages[1].isFirstSkill).to.be.true;
       expect(stages[2].threshold).to.equal(50);
@@ -91,7 +91,7 @@ describe('Integration | Infrastructure | Repository | stage-collection-repositor
 
       const stages = result.stages;
 
-      expect(stages).to.have.length(4);
+      expect(stages).to.have.lengthOf(4);
       expect(stages[0].threshold).to.equal(0);
       expect(stages[1].isFirstSkill).to.be.true;
       expect(stages[2].threshold).to.equal(67);

--- a/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
+++ b/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
@@ -141,7 +141,7 @@ describe('Integration | Scripts | create-certification-center-memberships-from-o
       const memberships = await getAdminMembershipsUserIdByOrganizationExternalId(organization.externalId);
 
       // then
-      expect(memberships).to.have.length(0);
+      expect(memberships).to.have.lengthOf(0);
     });
   });
 

--- a/api/tests/integration/scripts/data-generation/generate-campaign-with-participant_test.js
+++ b/api/tests/integration/scripts/data-generation/generate-campaign-with-participant_test.js
@@ -20,7 +20,7 @@ describe('Integration | Scripts | generate-campaign-with-participants', function
     // then
     const participants = await knex('campaign-participations');
 
-    expect(participants.length).to.equal(2);
+    expect(participants).to.have.lengthOf(2);
   });
 
   it('should create a assessment campaign with participants', async function () {
@@ -41,6 +41,6 @@ describe('Integration | Scripts | generate-campaign-with-participants', function
     // then
     const participants = await knex('campaign-participations');
 
-    expect(participants.length).to.equal(2);
+    expect(participants).to.have.lengthOf(2);
   });
 });

--- a/api/tests/integration/scripts/data-generation/generate-certif-cli_test.js
+++ b/api/tests/integration/scripts/data-generation/generate-certif-cli_test.js
@@ -68,7 +68,7 @@ describe('Integration | Scripts | generate-certif-cli.js', function () {
             );
             expect(session.accessCode).to.exist;
             expect(hasAuthenticationMethod).to.exist;
-            expect(certificationCandidates).to.have.length(2);
+            expect(certificationCandidates).to.have.lengthOf(2);
             const name = `${type}1`.toLowerCase();
             expect(
               _.pick(organizationLearner, ['birthdate', 'firstName', 'lastName', 'email', 'sessionId']),
@@ -158,7 +158,7 @@ describe('Integration | Scripts | generate-certif-cli.js', function () {
           expect(session.accessCode).to.exist;
           expect(session.certificationCenterId).to.be.greaterThan(1);
           expect(hasAuthenticationMethod).to.exist;
-          expect(certificationCandidates).to.have.length(2);
+          expect(certificationCandidates).to.have.lengthOf(2);
           expect(certificationCandidates[0]).to.deep.equals({
             birthdate: '2000-01-01',
             firstName: 'sco1',

--- a/api/tests/integration/scripts/prod/create-profiles-collection-campaigns_test.js
+++ b/api/tests/integration/scripts/prod/create-profiles-collection-campaigns_test.js
@@ -74,7 +74,7 @@ describe('Integration | Scripts | create-profile-collection-campaigns', function
       const campaigns = await prepareCampaigns([campaignData1, campaignData2]);
 
       // then
-      expect(campaigns).to.have.length(2);
+      expect(campaigns).to.have.lengthOf(2);
       expect(campaigns[0].organizationId).to.equal(organizationId1);
       expect(campaigns[0].name).to.equal(campaignData1.name);
       expect(campaigns[0].customLandingPageText).to.equal(campaignData1.customLandingPageText);

--- a/api/tests/integration/scripts/prod/generate-knowledge-element-snapshots-for-campaigns_test.js
+++ b/api/tests/integration/scripts/prod/generate-knowledge-element-snapshots-for-campaigns_test.js
@@ -18,7 +18,7 @@ describe('Integration | Scripts | generate-knowledge-element-snapshots-for-campa
       const campaignParticipationData = await getEligibleCampaignParticipations(maxParticipationCountToGet);
 
       // then
-      expect(campaignParticipationData.length).to.equal(0);
+      expect(campaignParticipationData).to.have.lengthOf(0);
     });
 
     it('should avoid returning campaign participations that already have a corresponding snasphot', async function () {
@@ -37,7 +37,7 @@ describe('Integration | Scripts | generate-knowledge-element-snapshots-for-campa
       const campaignParticipationData = await getEligibleCampaignParticipations(maxParticipationCountToGet);
 
       // then
-      expect(campaignParticipationData.length).to.equal(0);
+      expect(campaignParticipationData).to.have.lengthOf(0);
     });
 
     it('should return shared campaign participations from active campaigns that does not have a corresponding snapshot', async function () {
@@ -55,7 +55,7 @@ describe('Integration | Scripts | generate-knowledge-element-snapshots-for-campa
       const campaignParticipationData = await getEligibleCampaignParticipations(maxParticipationCountToGet);
 
       // then
-      expect(campaignParticipationData.length).to.equal(1);
+      expect(campaignParticipationData).to.have.lengthOf(1);
       expect(campaignParticipationData[0]).to.deep.equal({
         userId: campaignParticipation.userId,
         sharedAt: campaignParticipation.sharedAt,
@@ -79,7 +79,7 @@ describe('Integration | Scripts | generate-knowledge-element-snapshots-for-campa
       const campaignParticipationData = await getEligibleCampaignParticipations(maxParticipationCountToGet);
 
       // then
-      expect(campaignParticipationData.length).to.equal(1);
+      expect(campaignParticipationData).to.have.lengthOf(1);
       expect(campaignParticipationData[0]).to.deep.equal({
         userId: campaignParticipationWithoutSnapshot.userId,
         sharedAt: campaignParticipationWithoutSnapshot.sharedAt,
@@ -107,7 +107,7 @@ describe('Integration | Scripts | generate-knowledge-element-snapshots-for-campa
       const campaignParticipationData = await getEligibleCampaignParticipations(1);
 
       // then
-      expect(campaignParticipationData.length).to.equal(1);
+      expect(campaignParticipationData).to.have.lengthOf(1);
       expect(campaignParticipationData[0]).to.deep.equal({
         userId: campaignParticipation.userId,
         sharedAt: campaignParticipation.sharedAt,

--- a/api/tests/organizational-entities/integration/application/organization-administration.controller.test.js
+++ b/api/tests/organizational-entities/integration/application/organization-administration.controller.test.js
@@ -103,8 +103,8 @@ describe('Integration | Organizational Entities | Application | Controller | Org
     //then
     const organizationTag = await knex('organization-tags').where('organizationId', organization.id);
 
-    expect(organizationTag.length).to.equal(1);
-    expect(response.source.data.relationships.tags.data.length).to.equal(1);
+    expect(organizationTag).to.have.lengthOf(1);
+    expect(response.source.data.relationships.tags.data).to.have.lengthOf(1);
     expect(response.source.data.relationships.tags.data[0].id).to.equal(newTag.id.toString());
   });
 
@@ -167,7 +167,7 @@ describe('Integration | Organizational Entities | Application | Controller | Org
       .join('features', 'organization-features.featureId', 'features.id')
       .where('organizationId', organization.id);
 
-    expect(organizationFeature.length).to.equal(1);
+    expect(organizationFeature).to.have.lengthOf(1);
     expect(organizationFeature[0].key).to.equal(ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key);
     expect(
       response.source.data.attributes['features'][ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key].active,
@@ -200,7 +200,7 @@ describe('Integration | Organizational Entities | Application | Controller | Org
       .join('features', 'organization-features.featureId', 'features.id')
       .where('organizationId', organization.id);
 
-    expect(organizationFeature.length).to.equal(0);
+    expect(organizationFeature).to.have.lengthOf(0);
     expect(
       response.source.data.attributes['features'][ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key].active,
     ).to.equal(false);

--- a/api/tests/organizational-entities/integration/domain/usecases/add-tags-to-organizations.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/add-tags-to-organizations.usecase.test.js
@@ -90,7 +90,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | add-tags-to
 
         // then
         const organizationTagsInDB = await knex('organization-tags');
-        expect(organizationTagsInDB.length).to.equal(3);
+        expect(organizationTagsInDB).to.have.lengthOf(3);
         expect(await knex('organization-tags').where({ organizationId: firstOrganizationId, tagId: firstTag.id })).to
           .exist;
         expect(await knex('organization-tags').where({ organizationId: secondOrganizationId, tagId: secondTag.id })).to

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/certification-center.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/certification-center.repository.test.js
@@ -82,7 +82,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
           await certificationCenterRepository.findPaginatedFiltered({ filter, page });
 
         // then
-        expect(matchingCertificationCenters.length).to.equal(3);
+        expect(matchingCertificationCenters).to.have.lengthOf(3);
         expect(matchingCertificationCenters).to.deep.include.members([
           expectedCertificationCenter1,
           expectedCertificationCenter2,

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/complementary-certification-habilitation.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/complementary-certification-habilitation.repository.test.js
@@ -57,12 +57,12 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
         .select('*')
         .from('complementary-certification-habilitations')
         .where({ certificationCenterId });
-      expect(complementaryCertificationHabilitationsForCertificationCenterId.length).to.equal(0);
+      expect(complementaryCertificationHabilitationsForCertificationCenterId).to.have.lengthOf(0);
       const complementaryCertificationHabilitationThatShouldHaveBeenDeleted = await knex
         .select('*')
         .from('complementary-certification-habilitations')
         .where({ certificationCenterId: otherCertificationCenterId });
-      expect(complementaryCertificationHabilitationThatShouldHaveBeenDeleted.length).to.equal(1);
+      expect(complementaryCertificationHabilitationThatShouldHaveBeenDeleted).to.have.lengthOf(1);
     });
   });
 });

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/data-protection-officer.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/data-protection-officer.repository.test.js
@@ -34,7 +34,7 @@ describe('Integration | Organizational Entities | Repository | data-protection-o
 
       // then
       const foundDataProtectionOfficers = await knex('data-protection-officers').select();
-      expect(foundDataProtectionOfficers.length).to.equal(2);
+      expect(foundDataProtectionOfficers).to.have.lengthOf(2);
       expect(foundDataProtectionOfficers[0]).to.contain({
         ...dataProtectionOfficerA,
         organizationId: firstOrganization.id,

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -148,7 +148,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       expect(archivedOrganization.archivedAt).to.deep.equal(now);
 
       const organizations = await knex('organizations').where({ archivedBy: null });
-      expect(organizations).to.have.length(1);
+      expect(organizations).to.have.lengthOf(1);
       expect(organizations[0].id).to.equal(2);
     });
 

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -583,7 +583,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
           organizationId: savedOrganization.id,
         });
 
-        expect(savedOrganizationFeatures.length).to.equal(3);
+        expect(savedOrganizationFeatures).to.have.lengthOf(3);
         const savedOrganizationFeatureIds = savedOrganizationFeatures.map(
           (organizationFeature) => organizationFeature.featureId,
         );
@@ -644,7 +644,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
 
       // then
       const enabledFeatures = await knex('organization-features').where({ organizationId: organization.id });
-      expect(enabledFeatures.length).to.equal(1);
+      expect(enabledFeatures).to.have.lengthOf(1);
       expect(enabledFeatures[0].featureId).to.equal(featureId);
     });
 
@@ -673,7 +673,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
 
       // then
       const enabledFeatures = await knex('organization-features').where({ organizationId: organization.id });
-      expect(enabledFeatures.length).to.equal(1);
+      expect(enabledFeatures).to.have.lengthOf(1);
       expect(enabledFeatures[0].featureId).to.equal(featureId);
     });
 
@@ -708,7 +708,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
 
       //then
       const enabledFeatures = await knex('organization-features');
-      expect(enabledFeatures.length).to.equal(1);
+      expect(enabledFeatures).to.have.lengthOf(1);
       expect(enabledFeatures[0].organizationId).to.equal(otherOrganization.id);
     });
 
@@ -824,7 +824,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
 
       // then
       const addedTags = await knex('organization-tags').where({ organizationId });
-      expect(addedTags.length).to.equal(1);
+      expect(addedTags).to.have.lengthOf(1);
     });
 
     it('should remove tags', async function () {
@@ -852,7 +852,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
 
       // then
       const result = await knex('organization-tags').where({ organizationId });
-      expect(result.length).to.equal(0);
+      expect(result).to.have.lengthOf(0);
     });
 
     it('should not add row in table "organizations"', async function () {

--- a/api/tests/organizational-entities/unit/domain/models/Organization_test.js
+++ b/api/tests/organizational-entities/unit/domain/models/Organization_test.js
@@ -42,7 +42,7 @@ describe('Unit | Organizational Entities | Domain | Model | Organization', funct
 
       // then
       expect(organization.id).to.equal(1);
-      expect(organization.targetProfileShares.length).to.equal(1);
+      expect(organization.targetProfileShares).to.have.lengthOf(1);
     });
 
     it('should build an Organization with default values for credit when not specified', function () {

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/delete-campaign-participation-for-admin_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/delete-campaign-participation-for-admin_test.js
@@ -36,7 +36,7 @@ describe('Integration | UseCases | delete-campaign-participation-for-admin', fun
     // then
     const results = await knex('campaign-participations').where({ organizationLearnerId });
 
-    expect(results.length).to.equal(2);
+    expect(results).to.have.lengthOf(2);
     results.forEach((campaignParticipaton) => {
       expect(campaignParticipaton.deletedAt).not.to.equal(null);
       expect(campaignParticipaton.deletedBy).to.equal(adminUserId);

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/delete-campaign-participation_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/delete-campaign-participation_test.js
@@ -35,7 +35,7 @@ describe('Integration | UseCases | delete-campaign-participation', function () {
     // then
     const results = await knex('campaign-participations').where({ organizationLearnerId });
 
-    expect(results.length).to.equal(2);
+    expect(results).to.have.lengthOf(2);
     results.forEach((campaignParticipaton) => {
       expect(campaignParticipaton.deletedAt).not.to.equal(null);
       expect(campaignParticipaton.deletedBy).to.equal(adminUserId);

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/find-user-campaign-participation-overviews_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/find-user-campaign-participation-overviews_test.js
@@ -59,7 +59,7 @@ describe('Integration | UseCase | find-user-campaign-participation-overviews_tes
       });
 
       // then
-      expect(result.campaignParticipationOverviews.length).to.equal(2);
+      expect(result.campaignParticipationOverviews).to.have.lengthOf(2);
     });
 
     it('should return acquired stages', async function () {
@@ -131,7 +131,7 @@ describe('Integration | UseCase | find-user-campaign-participation-overviews_tes
       });
 
       // then
-      expect(result.campaignParticipationOverviews.length).to.equal(2);
+      expect(result.campaignParticipationOverviews).to.have.lengthOf(2);
     });
 
     it('should return acquired stages', async function () {

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-assessment-participation-result-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-assessment-participation-result-repository_test.js
@@ -142,7 +142,7 @@ describe('Integration | Repository | Campaign Assessment Participation Result', 
           });
 
         expect(campaignAssessmentParticipationResult.isShared).to.equal(true);
-        expect(campaignAssessmentParticipationResult.competenceResults.length).to.equal(2);
+        expect(campaignAssessmentParticipationResult.competenceResults).to.have.lengthOf(2);
         expect(campaignAssessmentParticipationResult.competenceResults).to.deep.equal(expectedResult);
       });
     });

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
@@ -631,7 +631,7 @@ describe('Integration | Repository | Campaign Participation Overview', function 
           await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
 
         // then
-        expect(campaignParticipationOverviews.length).to.equal(0);
+        expect(campaignParticipationOverviews).to.have.lengthOf(0);
       });
     });
   });

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -249,7 +249,7 @@ describe('Integration | Repository | Campaign Participation', function () {
       const participations = await campaignParticipationRepository.getByCampaignIds([deletedParticipation.campaignId]);
 
       // then
-      expect(participations.length).to.equal(0);
+      expect(participations).to.have.lengthOf(0);
     });
   });
 
@@ -768,7 +768,7 @@ describe('Integration | Repository | Campaign Participation', function () {
         const campaignParticipationInfos =
           await campaignParticipationRepository.findProfilesCollectionResultDataByCampaignId(campaign.id);
 
-        expect(campaignParticipationInfos.length).to.equal(1);
+        expect(campaignParticipationInfos).to.have.lengthOf(1);
         expect(campaignParticipationInfos[0].division).to.equal('3eme');
       });
     });

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -75,7 +75,7 @@ describe('Integration | Repository | Campaign Participation', function () {
 
       // then
       const snapshotInDB = await knex.select('id').from('knowledge-element-snapshots');
-      expect(snapshotInDB).to.have.length(1);
+      expect(snapshotInDB).to.have.lengthOf(1);
     });
 
     context('when there is a transaction', function () {
@@ -85,7 +85,7 @@ describe('Integration | Repository | Campaign Participation', function () {
         await withTransaction(async () => campaignParticipationRepository.updateWithSnapshot(campaignParticipation))();
 
         const snapshotInDB = await knex.select('id').from('knowledge-element-snapshots');
-        expect(snapshotInDB).to.have.length(1);
+        expect(snapshotInDB).to.have.lengthOf(1);
       });
 
       it('does not save a snapshot when there is an error', async function () {

--- a/api/tests/prescription/campaign/integration/domain/usecases/find-assessment-participation-result-list_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/find-assessment-participation-result-list_test.js
@@ -41,7 +41,7 @@ describe('Integration | UseCase | find-assessment-participation-result-list', fu
         page,
       });
 
-      expect(participations.length).to.equal(1);
+      expect(participations).to.have.lengthOf(1);
     });
   });
 });

--- a/api/tests/prescription/campaign/integration/domain/usecases/find-campaign-profiles-collection-participation-summaries_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/find-campaign-profiles-collection-participation-summaries_test.js
@@ -38,7 +38,7 @@ describe('Integration | UseCase | find-campaign-profiles-collection-participatio
         campaignId,
         filters: { search: 'Tonari N' },
       });
-      expect(data.length).to.equal(1);
+      expect(data).to.have.lengthOf(1);
     });
   });
 });

--- a/api/tests/prescription/campaign/integration/domain/usecases/find-paginated-campaign-participant-activities_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/find-paginated-campaign-participant-activities_test.js
@@ -81,7 +81,7 @@ describe('Integration | UseCase | find-paginated-campaign-participants-activitie
         filters: { search: 'Tonari N' },
       });
 
-      expect(campaignParticipantsActivities.length).to.equal(1);
+      expect(campaignParticipantsActivities).to.have.lengthOf(1);
     });
   });
 });

--- a/api/tests/prescription/campaign/integration/domain/usecases/get-campaign_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/get-campaign_test.js
@@ -80,8 +80,8 @@ describe('Integration | UseCase | get-campaign', function () {
 
       // then
       expect(resultCampaign.name).to.equal(campaign.name);
-      expect(resultCampaign.badges.length).to.equal(0);
-      expect(resultCampaign.stages.length).to.equal(0);
+      expect(resultCampaign.badges).to.have.lengthOf(0);
+      expect(resultCampaign.stages).to.have.lengthOf(0);
       expect(resultCampaign.reachedStage).to.be.null;
       expect(resultCampaign.totalStage).to.be.null;
     });
@@ -102,7 +102,7 @@ describe('Integration | UseCase | get-campaign', function () {
       });
 
       // then
-      expect(resultCampaign.stages.length).to.equal(1);
+      expect(resultCampaign.stages).to.have.lengthOf(1);
       expect(resultCampaign.reachedStage).to.equal(1);
       expect(resultCampaign.totalStage).to.equal(1);
     });
@@ -122,7 +122,7 @@ describe('Integration | UseCase | get-campaign', function () {
       });
 
       // then
-      expect(resultCampaign.badges.length).to.equal(1);
+      expect(resultCampaign.badges).to.have.lengthOf(1);
     });
 
     it('should get the average result of participations', async function () {

--- a/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -682,7 +682,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
         const csvFirstLineCells = csvLines[0].split(';');
 
         // then
-        expect(csvLines.length).to.equals(4);
+        expect(csvLines).to.have.lengthOf(4);
         expect(csvFirstLineCells[0]).to.equal(expectedCsvFirstCell);
         expect(csvLines[1]).to.equals(csvSecondLine);
         expect(csvLines[2]).to.equal(csvThirdLine);

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-administration-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-administration-repository_test.js
@@ -592,7 +592,7 @@ describe('Integration | Repository | Campaign Administration', function () {
 
       // then
       const rowCountAfterUpdate = await knex.select('id').from('campaigns');
-      expect(rowCountAfterUpdate.length).to.equal(rowsCountBeforeUpdate.length);
+      expect(rowCountAfterUpdate).to.have.lengthOf(rowsCountBeforeUpdate.length);
     });
 
     it('should only update model in database', async function () {

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
@@ -1302,7 +1302,7 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
         });
 
         // then
-        expect(participations.length).to.equal(1);
+        expect(participations).to.have.lengthOf(1);
       });
 
       it('return Choupette participant when we search part its firstname', async function () {
@@ -1338,7 +1338,7 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
         });
 
         // then
-        expect(participations.length).to.equal(1);
+        expect(participations).to.have.lengthOf(1);
         expect(participations[0].firstName).to.equal('Choupette');
       });
 
@@ -1364,7 +1364,7 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
         });
 
         // then
-        expect(participations.length).to.equal(1);
+        expect(participations).to.have.lengthOf(1);
         expect(participations[0].firstName).to.equal('Choupette');
       });
 
@@ -1390,7 +1390,7 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
         });
 
         // then
-        expect(participations.length).to.equal(1);
+        expect(participations).to.have.lengthOf(1);
         expect(participations[0].firstName).to.equal('Choupette');
       });
 
@@ -1426,7 +1426,7 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
         });
 
         // then
-        expect(participations.length).to.equal(1);
+        expect(participations).to.have.lengthOf(1);
         expect(participations[0].lastName).to.equal('Eurasier');
       });
 
@@ -1462,7 +1462,7 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
         });
 
         // then
-        expect(participations.length).to.equal(1);
+        expect(participations).to.have.lengthOf(1);
         expect(participations[0].firstName).to.equal('Choupette');
       });
 
@@ -1500,7 +1500,7 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
         });
 
         // then
-        expect(participations.length).to.equal(1);
+        expect(participations).to.have.lengthOf(1);
         expect(participations[0].lastName).to.equal('Eurasier');
       });
 
@@ -1536,7 +1536,7 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
         });
 
         // then
-        expect(participations.length).to.equal(2);
+        expect(participations).to.have.lengthOf(2);
         expect(participations[0].firstName).to.equal('Salto');
         expect(participations[1].firstName).to.equal('Saphira');
       });

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participation-info-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participation-info-repository_test.js
@@ -382,7 +382,7 @@ describe('Integration | Repository | Campaign Participation Info', function () {
       it('return the first name and the last name of the correct organization-learner', async function () {
         const campaignParticipationInfos = await campaignParticipationInfoRepository.findByCampaignId(campaign.id);
 
-        expect(campaignParticipationInfos.length).to.equal(1);
+        expect(campaignParticipationInfos).to.have.lengthOf(1);
         expect(campaignParticipationInfos[0].participantFirstName).to.equal('John');
         expect(campaignParticipationInfos[0].participantLastName).to.equal('Doe');
       });

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
@@ -33,7 +33,7 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
         await campaignProfilesCollectionParticipationSummaryRepository.findPaginatedByCampaignId(campaignId);
 
       // then
-      expect(results.data.length).to.equal(0);
+      expect(results.data).to.have.lengthOf(0);
     });
 
     it('should not return participant data summary for a not shared campaign participation', async function () {
@@ -811,7 +811,7 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
         );
 
         // then
-        expect(results.data.length).to.equal(2);
+        expect(results.data).to.have.lengthOf(2);
       });
 
       it('returns Laa-Laa when we search part of its firstname', async function () {
@@ -854,7 +854,7 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
         );
 
         // then
-        expect(results.data.length).to.equal(1);
+        expect(results.data).to.have.lengthOf(1);
         expect(results.data[0].firstName).to.equal('Laa-Laa');
       });
 
@@ -898,7 +898,7 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
         );
 
         // then
-        expect(results.data.length).to.equal(1);
+        expect(results.data).to.have.lengthOf(1);
         expect(results.data[0].firstName).to.equal('Laa-Laa');
       });
 
@@ -942,7 +942,7 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
         );
 
         // then
-        expect(results.data.length).to.equal(1);
+        expect(results.data).to.have.lengthOf(1);
         expect(results.data[0].firstName).to.equal('Laa-Laa');
       });
 
@@ -986,7 +986,7 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
         );
 
         // then
-        expect(results.data.length).to.equal(1);
+        expect(results.data).to.have.lengthOf(1);
         expect(results.data[0].firstName).to.equal('Laa-Laa');
       });
 
@@ -1038,7 +1038,7 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
         );
 
         // then
-        expect(results.data.length).to.equal(2);
+        expect(results.data).to.have.lengthOf(2);
         expect(results.data[0].firstName).to.equal('Dipsy');
         expect(results.data[1].firstName).to.equal('Laa-Laa');
       });

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/helpers/get-latest-participation-shared-for-one-learner_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/helpers/get-latest-participation-shared-for-one-learner_test.js
@@ -34,7 +34,7 @@ describe('Integration | Infrastructure | Repository | Helpers | get-latest-parti
         .where({ campaignId })
         .groupBy('organizationLearnerId');
 
-      expect(result.length).to.equal(1);
+      expect(result).to.have.lengthOf(1);
       expect(result[0].organizationLearnerId).to.equal(firstLearnerId);
       expect(result[0].masteryRate).to.equal('0.70');
     });

--- a/api/tests/prescription/campaign/unit/domain/read-models/CampaignAnalysis_test.js
+++ b/api/tests/prescription/campaign/unit/domain/read-models/CampaignAnalysis_test.js
@@ -24,7 +24,7 @@ describe('Unit | Domain | Read-Models | CampaignAnalysis', function () {
       });
 
       // then
-      expect(campaignAnalysis.campaignTubeRecommendations).to.have.length(2);
+      expect(campaignAnalysis.campaignTubeRecommendations).to.have.lengthOf(2);
     });
 
     it('should initialize CampaignTubeRecommendation with appropriate properties', function () {

--- a/api/tests/prescription/campaign/unit/domain/read-models/CampaignCollectiveResult_test.js
+++ b/api/tests/prescription/campaign/unit/domain/read-models/CampaignCollectiveResult_test.js
@@ -18,7 +18,7 @@ describe('Unit | Domain | Read-Models | CampaignCollectiveResult', function () {
       const campaignCollectiveResult = new CampaignCollectiveResult({ id: 123, campaignLearningContent });
 
       // then
-      expect(campaignCollectiveResult.campaignCompetenceCollectiveResults).to.have.length(2);
+      expect(campaignCollectiveResult.campaignCompetenceCollectiveResults).to.have.lengthOf(2);
     });
 
     it('should order CampaignCompetenceCollectiveResult by competenceIndex', function () {

--- a/api/tests/prescription/campaign/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -638,7 +638,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
     const csvLines = csv.split('\n');
 
     // then
-    expect(csvLines).to.have.length(3);
+    expect(csvLines).to.have.lengthOf(3);
     expect(csvLines[0]).equal(csvHeaderExpected);
     expect(csvLines[1]).equal(csvParticipantResultExpected);
     expect(csvLines[2]).equal('');

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -70,7 +70,7 @@ describe('Integration | Repository | Organization Learners Management | Campaign
         .whereIn('organizationLearnerId', [organizationLearnerId1, organizationLearnerId2])
         .whereNull('deletedAt');
 
-      expect(campaignParticipationResult.length).to.equal(0);
+      expect(campaignParticipationResult).to.have.lengthOf(0);
     });
 
     it('should not override participations already deleted', async function () {

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -332,7 +332,7 @@ describe('Integration | Repository | Organization Learner Management | Organizat
             const existingOrganizationLearners = await organizationLearnerRepository.findByIds({
               ids: [existingOrganizationLearner.id],
             });
-            expect(existingOrganizationLearners).to.have.length(1);
+            expect(existingOrganizationLearners).to.have.lengthOf(1);
             expect(existingOrganizationLearner).to.deep.contain(existingOrganizationLearners[0]);
 
             const [newOrganizationLearner] = await organizationLearnerRepository.findByOrganizationId({
@@ -392,7 +392,7 @@ describe('Integration | Repository | Organization Learner Management | Organizat
         const actualOrganizationLearners = await organizationLearnerRepository.findByOrganizationId({
           organizationId,
         });
-        expect(actualOrganizationLearners).to.have.length(1);
+        expect(actualOrganizationLearners).to.have.lengthOf(1);
         expect(
           _.omit(actualOrganizationLearners[0], ['updatedAt', 'id', 'certifiableAt', 'isCertifiable']),
         ).to.deep.equal(_.omit(firstOrganizationLearner, ['updatedAt', 'id', 'certifiableAt', 'isCertifiable']));

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -151,7 +151,7 @@ describe('Integration | Repository | Organization Learner Management | Organizat
 
       // then
       const learners = await knex('view-active-organization-learners').where({ organizationId });
-      expect(learners.length).to.equal(1);
+      expect(learners).to.have.lengthOf(1);
       expect(learners[0].id).to.equal(thirdOrganisationLearnerId);
     });
   });

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/sup-organization-learner-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/sup-organization-learner-repository_test.js
@@ -292,7 +292,7 @@ describe('Integration | Infrastructure | Repository | sup-organization-learner-r
           .where({ organizationId: organization.id })
           .orderBy('studentNumber');
 
-        expect(results.length).to.equal(2);
+        expect(results).to.have.lengthOf(2);
         expect(results[0].studentNumber).to.equal('4');
         expect(results[1].studentNumber).to.equal('5');
       });
@@ -324,7 +324,7 @@ describe('Integration | Infrastructure | Repository | sup-organization-learner-r
             .where({ organizationId: organization.id })
             .orderBy('studentNumber');
 
-          expect(results.length).to.equal(1);
+          expect(results).to.have.lengthOf(1);
           expect(results[0].lastName).to.equal('Ishii updated');
           expect(results[0].updatedAt).to.not.deep.equal(new Date('2000-01-01'));
         });
@@ -380,7 +380,7 @@ describe('Integration | Infrastructure | Repository | sup-organization-learner-r
             .where({ organizationId: organization2.id })
             .orderBy('studentNumber');
 
-          expect(results.length).to.equal(1);
+          expect(results).to.have.lengthOf(1);
           expect(results[0].studentNumber).to.equal('4');
         });
       });
@@ -425,7 +425,7 @@ describe('Integration | Infrastructure | Repository | sup-organization-learner-r
           .where({ organizationId: organization.id })
           .orderBy('studentNumber');
 
-        expect(results.length).to.equal(2);
+        expect(results).to.have.lengthOf(2);
         expect(results[0].studentNumber).to.equal('4');
         expect(results[1].studentNumber).to.equal('5');
       });
@@ -473,7 +473,7 @@ describe('Integration | Infrastructure | Repository | sup-organization-learner-r
             .where({ organizationId: organization.id })
             .whereNull('deletedAt');
 
-          expect(results.length).to.equal(1);
+          expect(results).to.have.lengthOf(1);
           expect(results[0].lastName).to.equal(expectedOrganizationLearner.lastName);
           expect(results[0].updatedAt).to.not.deep.equal(new Date('2000-01-01'));
         });
@@ -595,7 +595,7 @@ describe('Integration | Infrastructure | Repository | sup-organization-learner-r
           const activatedOrganizationLearnerFromAnotherOrganization =
             await knex('organization-learners').whereNull('deletedAt');
 
-          expect(activatedOrganizationLearnerFromAnotherOrganization.length).to.equal(2);
+          expect(activatedOrganizationLearnerFromAnotherOrganization).to.have.lengthOf(2);
           expect([
             activatedOrganizationLearnerFromAnotherOrganization[0].lastName,
             activatedOrganizationLearnerFromAnotherOrganization[1].lastName,
@@ -701,7 +701,7 @@ describe('Integration | Infrastructure | Repository | sup-organization-learner-r
           .where({ organizationId: organization2.id })
           .orderBy('studentNumber');
 
-        expect(results.length).to.equal(1);
+        expect(results).to.have.lengthOf(1);
         expect(results[0].studentNumber).to.equal('4');
       });
     });

--- a/api/tests/prescription/learner-management/unit/domain/models/SupOrganizationLearnerSet_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/models/SupOrganizationLearnerSet_test.js
@@ -30,7 +30,7 @@ describe('Unit | Models | SupOrganizationLearnerSet', function () {
   describe('#addLearner', function () {
     it('should add a learner', function () {
       learnerSet.addLearner(learnerAttributes);
-      expect(learnerSet.learners.length).to.equal(1);
+      expect(learnerSet.learners).to.have.lengthOf(1);
       expect(learnerSet.learners[0]).to.eql(learnerAttributes);
     });
 
@@ -73,7 +73,7 @@ describe('Unit | Models | SupOrganizationLearnerSet', function () {
     it('should throw if there are 2 learners with the same studentNumber', async function () {
       learnerSet.addLearner(learnerAttributes);
       const errors = await catchErr(learnerSet.addLearner, learnerSet)(learnerAttributes);
-      expect(learnerSet.learners.length).to.equal(1);
+      expect(learnerSet.learners).to.have.lengthOf(1);
       expect(learnerSet.learners[0]).to.eql(learnerAttributes);
       expect(errors[0]).to.be.an.instanceOf(DomainError);
       expect(errors[0].key).to.equal('studentNumber');

--- a/api/tests/prescription/learner-management/unit/domain/validators/common-organization-learner-validator_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/validators/common-organization-learner-validator_test.js
@@ -26,7 +26,7 @@ describe('Unit | Domain | Common Organization Learner Validator', function () {
             required: true,
           },
         ]);
-        expect(errors.length).to.equal(1);
+        expect(errors).to.have.lengthOf(1);
         expect(errors[0]).to.be.an.instanceOf(ModelValidationError);
         expect(errors[0].code).to.equal('FIELD_REQUIRED');
         expect(errors[0].key).to.equal('nom');
@@ -149,7 +149,7 @@ describe('Unit | Domain | Common Organization Learner Validator', function () {
             required: true,
           },
         ]);
-        expect(errors.length).to.equal(1);
+        expect(errors).to.have.lengthOf(1);
         expect(errors[0]).to.be.an.instanceOf(ModelValidationError);
         expect(errors[0].code).to.equal('FIELD_DATE_FORMAT');
         expect(errors[0].key).to.equal('birthdate');
@@ -167,7 +167,7 @@ describe('Unit | Domain | Common Organization Learner Validator', function () {
           },
         ]);
 
-        expect(errors.length).to.equal(1);
+        expect(errors).to.have.lengthOf(1);
         expect(errors[0]).to.be.an.instanceOf(ModelValidationError);
         expect(errors[0].code).to.equal('FIELD_DATE_FORMAT');
         expect(errors[0].key).to.equal('birthdate');
@@ -184,7 +184,7 @@ describe('Unit | Domain | Common Organization Learner Validator', function () {
           },
         ]);
 
-        expect(errors.length).to.equal(1);
+        expect(errors).to.have.lengthOf(1);
         expect(errors[0]).to.be.an.instanceOf(ModelValidationError);
         expect(errors[0].code).to.equal('FIELD_DATE_FORMAT');
         expect(errors[0].key).to.equal('birthdate');
@@ -201,7 +201,7 @@ describe('Unit | Domain | Common Organization Learner Validator', function () {
             required: true,
           },
         ]);
-        expect(errors.length).to.equal(1);
+        expect(errors).to.have.lengthOf(1);
         expect(errors[0]).to.be.an.instanceOf(ModelValidationError);
         expect(errors[0].code).to.equal('FIELD_REQUIRED');
         expect(errors[0].key).to.equal('birthdate');
@@ -218,7 +218,7 @@ describe('Unit | Domain | Common Organization Learner Validator', function () {
             required: false,
           },
         ]);
-        expect(errors.length).to.equal(0);
+        expect(errors).to.have.lengthOf(0);
       });
     });
   });

--- a/api/tests/prescription/learner-management/unit/domain/validators/sup-organization-learner-validator_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/validators/sup-organization-learner-validator_test.js
@@ -21,7 +21,7 @@ describe('Unit | Domain | Sup Organization Learner Validator', function () {
     ['studentNumber', 'firstName', 'lastName', 'birthdate', 'organizationId'].forEach((field) => {
       it(`returns an EntityValidationError error if ${field} is missing`, function () {
         const errors = validateSupOrganizationLearner({ ...learner, [field]: undefined });
-        expect(errors.length).to.equal(1);
+        expect(errors).to.have.lengthOf(1);
         expect(errors[0]).to.be.an.instanceof(EntityValidationError);
         expect(errors[0].key).to.equal(field);
         expect(errors[0].why).to.equal('required');
@@ -45,7 +45,7 @@ describe('Unit | Domain | Sup Organization Learner Validator', function () {
     ].forEach((field) => {
       it(`throw an error when ${field} has more than 255 characters`, async function () {
         const errors = validateSupOrganizationLearner({ ...learner, [field]: '1'.repeat(256) });
-        expect(errors.length).to.equal(1);
+        expect(errors).to.have.lengthOf(1);
         expect(errors[0]).to.be.an.instanceof(EntityValidationError);
         expect(errors[0].key).to.equal(field);
         expect(errors[0].why).to.equal('max_length');
@@ -53,7 +53,7 @@ describe('Unit | Domain | Sup Organization Learner Validator', function () {
     });
     it(`throw an error when email has more than 255 characters`, async function () {
       const errors = validateSupOrganizationLearner({ ...learner, email: `${'1'.repeat(256)}@email.com` });
-      expect(errors.length).to.equal(1);
+      expect(errors).to.have.lengthOf(1);
       expect(errors[0]).to.be.an.instanceof(EntityValidationError);
       expect(errors[0].key).to.equal('email');
       expect(errors[0].why).to.equal('email_format');
@@ -64,7 +64,7 @@ describe('Unit | Domain | Sup Organization Learner Validator', function () {
     context('when birthdate is not a date', function () {
       it('throws an error', async function () {
         const errors = await validateSupOrganizationLearner({ ...learner, birthdate: '123456' });
-        expect(errors.length).to.equal(1);
+        expect(errors).to.have.lengthOf(1);
         expect(errors[0]).to.be.an.instanceof(EntityValidationError);
         expect(errors[0].key).to.equal('birthdate');
         expect(errors[0].why).to.equal('date_format');
@@ -74,7 +74,7 @@ describe('Unit | Domain | Sup Organization Learner Validator', function () {
     context('when birthdate has not a valid format', function () {
       it('throws an error', function () {
         const errors = validateSupOrganizationLearner({ ...learner, birthdate: '2020/01/01' });
-        expect(errors.length).to.equal(1);
+        expect(errors).to.have.lengthOf(1);
         expect(errors[0]).to.be.an.instanceof(EntityValidationError);
         expect(errors[0].key).to.equal('birthdate');
         expect(errors[0].why).to.equal('date_format');
@@ -84,7 +84,7 @@ describe('Unit | Domain | Sup Organization Learner Validator', function () {
     context('when birthdate is null', function () {
       it('throws an error', function () {
         const errors = validateSupOrganizationLearner({ ...learner, birthdate: null });
-        expect(errors.length).to.equal(1);
+        expect(errors).to.have.lengthOf(1);
         expect(errors[0]).to.be.an.instanceof(EntityValidationError);
         expect(errors[0].key).to.equal('birthdate');
         expect(errors[0].why).to.equal('required');
@@ -94,7 +94,7 @@ describe('Unit | Domain | Sup Organization Learner Validator', function () {
   context('multiple error on the same line', function () {
     it('throw an error with all bad element in the line', function () {
       const errors = validateSupOrganizationLearner({ ...learner, email: 'email', studentNumber: 'é&"' });
-      expect(errors.length).to.equal(2);
+      expect(errors).to.have.lengthOf(2);
       expect(errors[0]).to.be.an.instanceof(EntityValidationError);
       expect(errors[0].key).to.equal('studentNumber');
       expect(errors[0].why).to.equal('student_number_format');

--- a/api/tests/prescription/organization-learner/acceptance/sup-learner-list-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/sup-learner-list-route_test.js
@@ -55,7 +55,7 @@ describe('Acceptance | Application | sup-leaner-list-route', function () {
 
         // then
         expect(response.statusCode).to.equal(200);
-        expect(response.result.data.length).to.equal(1);
+        expect(response.result.data).to.have.lengthOf(1);
       });
     });
 

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-activity-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-activity-repository_test.js
@@ -24,14 +24,14 @@ describe('Integration | Infrastructure | Repository | organization-learner-activ
       //when
       const organizationLearnerActivity = await organizationLearnerActivityRepository.get(organizationLearnerId);
       //then
-      expect(organizationLearnerActivity.participations.length).to.equal(0);
+      expect(organizationLearnerActivity.participations).to.have.lengthOf(0);
     });
 
     it('Should return an activity with an empty participation list when organization learner does not exist ', async function () {
       //given //when
       const organizationLearnerActivity = await organizationLearnerActivityRepository.get(404);
       //then
-      expect(organizationLearnerActivity.participations.length).to.equal(0);
+      expect(organizationLearnerActivity.participations).to.have.lengthOf(0);
     });
 
     it('Should return an activity with all related attributes', async function () {
@@ -102,7 +102,7 @@ describe('Integration | Infrastructure | Repository | organization-learner-activ
       const { participations } = await organizationLearnerActivityRepository.get(organizationLearnerId);
 
       //then
-      expect(participations.length).to.equal(1);
+      expect(participations).to.have.lengthOf(1);
       expect(participations[0].id).to.equal(1);
     });
 
@@ -125,7 +125,7 @@ describe('Integration | Infrastructure | Repository | organization-learner-activ
       const { participations } = await organizationLearnerActivityRepository.get(organizationLearnerId);
 
       //then
-      expect(participations.length).to.equal(1);
+      expect(participations).to.have.lengthOf(1);
       expect(participations[0].id).to.equal(1);
     });
 
@@ -148,7 +148,7 @@ describe('Integration | Infrastructure | Repository | organization-learner-activ
       const { participations } = await organizationLearnerActivityRepository.get(organizationLearnerId);
 
       //then
-      expect(participations.length).to.equal(1);
+      expect(participations).to.have.lengthOf(1);
       expect(participations[0].id).to.equal(1);
     });
 

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -652,7 +652,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
             rowCount: 1,
             pageCount: 1,
           });
-          expect(result.learners.length).to.equal(1);
+          expect(result.learners).to.have.lengthOf(1);
           expect(result.learners[0].id).to.equal(rogueLearner.id);
         });
       });

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-participant-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-participant-repository_test.js
@@ -44,7 +44,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
             });
 
           // then
-          expect(organizationParticipants.length).to.equal(0);
+          expect(organizationParticipants).to.have.lengthOf(0);
         });
 
         it('from other organization', async function () {
@@ -60,7 +60,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
             });
 
           // then
-          expect(organizationParticipants.length).to.equal(0);
+          expect(organizationParticipants).to.have.lengthOf(0);
         });
 
         it('from participant with deleted participations', async function () {
@@ -74,7 +74,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
             });
 
           // then
-          expect(organizationParticipants.length).to.equal(0);
+          expect(organizationParticipants).to.have.lengthOf(0);
         });
 
         it('from disabled participant', async function () {
@@ -92,7 +92,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
             });
 
           // then
-          expect(organizationParticipants.length).to.equal(0);
+          expect(organizationParticipants).to.have.lengthOf(0);
         });
 
         it('from participant with anonymous users linked', async function () {
@@ -109,7 +109,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
             });
 
           // then
-          expect(organizationParticipants.length).to.equal(0);
+          expect(organizationParticipants).to.have.lengthOf(0);
         });
       });
 
@@ -123,7 +123,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
         });
 
         // then
-        expect(organizationParticipants.length).to.equal(1);
+        expect(organizationParticipants).to.have.lengthOf(1);
       });
     });
 
@@ -183,7 +183,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
           organizationId,
         });
         // then
-        expect(organizationParticipants.length).to.equal(1);
+        expect(organizationParticipants).to.have.lengthOf(1);
       });
 
       it('should return 1 as result even when the participant has participated to several campaigns from different the organization with the same organizationLearner', async function () {
@@ -482,7 +482,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
                 });
 
               // then
-              expect(organizationParticipants.length).to.equal(3);
+              expect(organizationParticipants).to.have.lengthOf(3);
               expect(organizationParticipants[0].id).to.equal(organizationLearnerId2);
               expect(organizationParticipants[1].id).to.equal(organizationLearnerId3);
               expect(organizationParticipants[2].id).to.equal(organizationLearnerId1);
@@ -499,7 +499,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
                 });
 
               // then
-              expect(organizationParticipants.length).to.equal(3);
+              expect(organizationParticipants).to.have.lengthOf(3);
               expect(organizationParticipants[0].id).to.equal(organizationLearnerId1);
               expect(organizationParticipants[1].id).to.equal(organizationLearnerId3);
               expect(organizationParticipants[2].id).to.equal(organizationLearnerId2);
@@ -554,7 +554,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
               });
 
             // then
-            expect(organizationParticipants.length).to.equal(3);
+            expect(organizationParticipants).to.have.lengthOf(3);
             expect(organizationParticipants[0].id).to.equal(organizationLearnerId3);
             expect(organizationParticipants[1].id).to.equal(organizationLearnerId2);
             expect(organizationParticipants[2].id).to.equal(organizationLearnerId1);
@@ -613,7 +613,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
                 });
 
               // then
-              expect(organizationParticipants.length).to.equal(3);
+              expect(organizationParticipants).to.have.lengthOf(3);
               expect(organizationParticipants[0].id).to.equal(organizationLearnerId2);
               expect(organizationParticipants[1].id).to.equal(organizationLearnerId3);
               expect(organizationParticipants[2].id).to.equal(organizationLearnerId1);
@@ -630,7 +630,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
                 });
 
               // then
-              expect(organizationParticipants.length).to.equal(3);
+              expect(organizationParticipants).to.have.lengthOf(3);
               expect(organizationParticipants[0].id).to.equal(organizationLearnerId1);
               expect(organizationParticipants[1].id).to.equal(organizationLearnerId3);
               expect(organizationParticipants[2].id).to.equal(organizationLearnerId2);
@@ -682,7 +682,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
               });
 
             // then
-            expect(organizationParticipants.length).to.equal(3);
+            expect(organizationParticipants).to.have.lengthOf(3);
             expect(organizationParticipants[0].id).to.equal(organizationLearnerId3);
             expect(organizationParticipants[1].id).to.equal(organizationLearnerId1);
             expect(organizationParticipants[2].id).to.equal(organizationLearnerId2);
@@ -737,7 +737,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
             });
 
           // then
-          expect(organizationParticipants.length).to.equal(3);
+          expect(organizationParticipants).to.have.lengthOf(3);
           expect(organizationParticipants[0].id).to.equal(organizationLearnerId3);
           expect(organizationParticipants[1].id).to.equal(organizationLearnerId2);
           expect(organizationParticipants[2].id).to.equal(organizationLearnerId1);
@@ -796,7 +796,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
               });
 
             // then
-            expect(organizationParticipants.length).to.equal(3);
+            expect(organizationParticipants).to.have.lengthOf(3);
             expect(organizationParticipants[0].id).to.equal(eminemLearnerId);
             expect(organizationParticipants[1].id).to.equal(jacksonLearnerId);
             expect(organizationParticipants[2].id).to.equal(timberlakeLearnerId);
@@ -813,7 +813,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
               });
 
             // then
-            expect(organizationParticipants.length).to.equal(3);
+            expect(organizationParticipants).to.have.lengthOf(3);
             expect(organizationParticipants[0].id).to.equal(timberlakeLearnerId);
             expect(organizationParticipants[1].id).to.equal(jacksonLearnerId);
             expect(organizationParticipants[2].id).to.equal(eminemLearnerId);
@@ -999,7 +999,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
             });
 
           //then
-          expect(organizationParticipants.length).to.equal(1);
+          expect(organizationParticipants).to.have.lengthOf(1);
           expect(organizationParticipants[0].isCertifiable).to.equal(true);
         });
 
@@ -1030,7 +1030,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
             });
 
           //then
-          expect(organizationParticipants.length).to.equal(2);
+          expect(organizationParticipants).to.have.lengthOf(2);
           expect(organizationParticipants[0].isCertifiable).to.equal(false);
           expect(organizationParticipants[1].isCertifiable).to.equal(null);
         });
@@ -1550,7 +1550,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
             });
 
           // then
-          expect(organizationParticipants.length).to.equal(0);
+          expect(organizationParticipants).to.have.lengthOf(0);
         });
 
         it('from other organization', async function () {
@@ -1566,7 +1566,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
             });
 
           // then
-          expect(organizationParticipants.length).to.equal(0);
+          expect(organizationParticipants).to.have.lengthOf(0);
         });
 
         it('from disabled participant', async function () {
@@ -1584,7 +1584,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
             });
 
           // then
-          expect(organizationParticipants.length).to.equal(0);
+          expect(organizationParticipants).to.have.lengthOf(0);
         });
       });
 
@@ -1601,7 +1601,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
             });
 
           // then
-          expect(organizationParticipants.length).to.equal(1);
+          expect(organizationParticipants).to.have.lengthOf(1);
         });
 
         it('should return extra parameters from participant', async function () {
@@ -1634,7 +1634,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
             });
 
           // then
-          expect(organizationParticipants.length).to.equal(1);
+          expect(organizationParticipants).to.have.lengthOf(1);
         });
       });
     });
@@ -1697,7 +1697,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
             organizationId,
           });
         // then
-        expect(organizationParticipants.length).to.equal(1);
+        expect(organizationParticipants).to.have.lengthOf(1);
       });
 
       it('should return 1 as result even when the participant has participated to several campaigns from different the organization with the same organizationLearner', async function () {
@@ -1983,7 +1983,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
                 });
 
               // then
-              expect(organizationParticipants.length).to.equal(3);
+              expect(organizationParticipants).to.have.lengthOf(3);
               expect(organizationParticipants[0].id).to.equal(organizationLearnerId2);
               expect(organizationParticipants[1].id).to.equal(organizationLearnerId3);
               expect(organizationParticipants[2].id).to.equal(organizationLearnerId1);
@@ -2000,7 +2000,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
                 });
 
               // then
-              expect(organizationParticipants.length).to.equal(3);
+              expect(organizationParticipants).to.have.lengthOf(3);
               expect(organizationParticipants[0].id).to.equal(organizationLearnerId1);
               expect(organizationParticipants[1].id).to.equal(organizationLearnerId3);
               expect(organizationParticipants[2].id).to.equal(organizationLearnerId2);
@@ -2058,7 +2058,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
               });
 
             // then
-            expect(organizationParticipants.length).to.equal(3);
+            expect(organizationParticipants).to.have.lengthOf(3);
             expect(organizationParticipants[0].id).to.equal(organizationLearnerId3);
             expect(organizationParticipants[1].id).to.equal(organizationLearnerId2);
             expect(organizationParticipants[2].id).to.equal(organizationLearnerId1);
@@ -2120,7 +2120,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
                 });
 
               // then
-              expect(organizationParticipants.length).to.equal(3);
+              expect(organizationParticipants).to.have.lengthOf(3);
               expect(organizationParticipants[0].id).to.equal(organizationLearnerId2);
               expect(organizationParticipants[1].id).to.equal(organizationLearnerId3);
               expect(organizationParticipants[2].id).to.equal(organizationLearnerId1);
@@ -2137,7 +2137,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
                 });
 
               // then
-              expect(organizationParticipants.length).to.equal(3);
+              expect(organizationParticipants).to.have.lengthOf(3);
               expect(organizationParticipants[0].id).to.equal(organizationLearnerId1);
               expect(organizationParticipants[1].id).to.equal(organizationLearnerId3);
               expect(organizationParticipants[2].id).to.equal(organizationLearnerId2);
@@ -2192,7 +2192,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
               });
 
             // then
-            expect(organizationParticipants.length).to.equal(3);
+            expect(organizationParticipants).to.have.lengthOf(3);
             expect(organizationParticipants[0].id).to.equal(organizationLearnerId3);
             expect(organizationParticipants[1].id).to.equal(organizationLearnerId1);
             expect(organizationParticipants[2].id).to.equal(organizationLearnerId2);
@@ -2250,7 +2250,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
             });
 
           // then
-          expect(organizationParticipants.length).to.equal(3);
+          expect(organizationParticipants).to.have.lengthOf(3);
           expect(organizationParticipants[0].id).to.equal(organizationLearnerId3);
           expect(organizationParticipants[1].id).to.equal(organizationLearnerId2);
           expect(organizationParticipants[2].id).to.equal(organizationLearnerId1);
@@ -2309,7 +2309,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
               });
 
             // then
-            expect(organizationParticipants.length).to.equal(3);
+            expect(organizationParticipants).to.have.lengthOf(3);
             expect(organizationParticipants[0].id).to.equal(eminemLearnerId);
             expect(organizationParticipants[1].id).to.equal(jacksonLearnerId);
             expect(organizationParticipants[2].id).to.equal(timberlakeLearnerId);
@@ -2326,7 +2326,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
               });
 
             // then
-            expect(organizationParticipants.length).to.equal(3);
+            expect(organizationParticipants).to.have.lengthOf(3);
             expect(organizationParticipants[0].id).to.equal(timberlakeLearnerId);
             expect(organizationParticipants[1].id).to.equal(jacksonLearnerId);
             expect(organizationParticipants[2].id).to.equal(eminemLearnerId);
@@ -2541,7 +2541,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
             });
 
           //then
-          expect(organizationParticipants.length).to.equal(1);
+          expect(organizationParticipants).to.have.lengthOf(1);
           expect(organizationParticipants[0].isCertifiable).to.equal(true);
         });
 
@@ -2572,7 +2572,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
             });
 
           //then
-          expect(organizationParticipants.length).to.equal(2);
+          expect(organizationParticipants).to.have.lengthOf(2);
           expect(organizationParticipants[0].isCertifiable).to.equal(false);
           expect(organizationParticipants[1].isCertifiable).to.equal(null);
         });

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
@@ -1071,7 +1071,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
               });
 
             // then
-            expect(participants.length).to.equal(3);
+            expect(participants).to.have.lengthOf(3);
             expect(participants[0].id).to.equal(organizationLearnerId2);
             expect(participants[1].id).to.equal(organizationLearnerId3);
             expect(participants[2].id).to.equal(organizationLearnerId1);
@@ -1088,7 +1088,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
               });
 
             // then
-            expect(participants.length).to.equal(3);
+            expect(participants).to.have.lengthOf(3);
             expect(participants[0].id).to.equal(organizationLearnerId1);
             expect(participants[1].id).to.equal(organizationLearnerId3);
             expect(participants[2].id).to.equal(organizationLearnerId2);
@@ -1127,7 +1127,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
             });
 
           // then
-          expect(participants.length).to.equal(3);
+          expect(participants).to.have.lengthOf(3);
           expect(participants[0].id).to.equal(organizationLearnerId3);
           expect(participants[1].id).to.equal(organizationLearnerId2);
           expect(participants[2].id).to.equal(organizationLearnerId1);
@@ -1161,7 +1161,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
             });
 
           // then
-          expect(participants.length).to.equal(3);
+          expect(participants).to.have.lengthOf(3);
           expect(participants[0].id).to.equal(itachiId);
           expect(participants[1].id).to.equal(narutoId);
           expect(participants[2].id).to.equal(sasukeId);
@@ -1193,7 +1193,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
             });
 
           // then
-          expect(participants.length).to.equal(3);
+          expect(participants).to.have.lengthOf(3);
           expect(participants[0].id).to.equal(sasukeId);
           expect(participants[1].id).to.equal(narutoId);
           expect(participants[2].id).to.equal(itachiId);
@@ -1230,7 +1230,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
             });
 
           // then
-          expect(participants.length).to.equal(3);
+          expect(participants).to.have.lengthOf(3);
           expect(participants[0].id).to.equal(narutoId);
           expect(participants[1].id).to.equal(itachiId);
           expect(participants[2].id).to.equal(sasukeId);
@@ -1265,7 +1265,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
             });
 
           // then
-          expect(participants.length).to.equal(3);
+          expect(participants).to.have.lengthOf(3);
           expect(participants[0].id).to.equal(sasukeId);
           expect(participants[1].id).to.equal(itachiId);
           expect(participants[2].id).to.equal(narutoId);

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/sup-organization-participant-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/sup-organization-participant-repository_test.js
@@ -241,7 +241,7 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         });
 
         // then
-        expect(data.length).to.equal(1);
+        expect(data).to.have.lengthOf(1);
         expect(data[0].id).to.equal(expectedOrganizationLearner.id);
       });
 
@@ -301,7 +301,7 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         });
 
         // then
-        expect(data.length).to.equal(2);
+        expect(data).to.have.lengthOf(2);
         expect(_.map(data, 'id')).to.have.members([
           notCommunicatedOrganizationLearner.id,
           notEligibleOrganizationLearner.id,
@@ -698,7 +698,7 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
             });
 
           // then
-          expect(participants.length).to.equal(3);
+          expect(participants).to.have.lengthOf(3);
           expect(participants[0].id).to.equal(organizationLearnerId2);
           expect(participants[1].id).to.equal(organizationLearnerId3);
           expect(participants[2].id).to.equal(organizationLearnerId1);
@@ -715,7 +715,7 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
             });
 
           // then
-          expect(participants.length).to.equal(3);
+          expect(participants).to.have.lengthOf(3);
           expect(participants[0].id).to.equal(organizationLearnerId1);
           expect(participants[1].id).to.equal(organizationLearnerId3);
           expect(participants[2].id).to.equal(organizationLearnerId2);
@@ -753,7 +753,7 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         });
 
         // then
-        expect(participants.length).to.equal(3);
+        expect(participants).to.have.lengthOf(3);
         expect(participants[0].id).to.equal(organizationLearnerId3);
         expect(participants[1].id).to.equal(organizationLearnerId2);
         expect(participants[2].id).to.equal(organizationLearnerId1);
@@ -784,7 +784,7 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         });
 
         // then
-        expect(participants.length).to.equal(3);
+        expect(participants).to.have.lengthOf(3);
         expect(participants[0].id).to.equal(kenobiId);
         expect(participants[1].id).to.equal(skywalkerId);
         expect(participants[2].id).to.equal(vadorId);
@@ -815,7 +815,7 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         });
 
         // then
-        expect(participants.length).to.equal(3);
+        expect(participants).to.have.lengthOf(3);
         expect(participants[0].id).to.equal(vadorId);
         expect(participants[1].id).to.equal(skywalkerId);
         expect(participants[2].id).to.equal(kenobiId);

--- a/api/tests/prescription/organization-learner/unit/application/api/organization-learners-with-participations-api_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/api/organization-learners-with-participations-api_test.js
@@ -31,7 +31,7 @@ describe('Unit | API | Organization Learner With Participations', function () {
       // then
       expect(useCaseStub.calledOnce).to.be.true;
 
-      expect(apiResponse.length).to.equal(2);
+      expect(apiResponse).to.have.lengthOf(2);
       expect(apiResponse[0]).to.be.instanceOf(OrganizationLearnerWithParticipations);
       expect(apiResponse[1]).to.be.instanceOf(OrganizationLearnerWithParticipations);
       expect(apiResponse).to.deep.have.members([

--- a/api/tests/prescription/organization-learner/unit/domain/usecases/get-organization-learner-activity_test.js
+++ b/api/tests/prescription/organization-learner/unit/domain/usecases/get-organization-learner-activity_test.js
@@ -33,7 +33,7 @@ describe('Unit | UseCase | get-organisation-learner-activity', function () {
     // then
     expect(organizationLearnerActivityRepository.get).to.have.been.calledWithExactly(organizationLearnerId);
     expect(organizationLearnerActivity).to.be.an.instanceOf(OrganizationLearnerActivity);
-    expect(organizationLearnerActivity.participations.length).to.equal(1);
+    expect(organizationLearnerActivity.participations).to.have.lengthOf(1);
     expect(organizationLearnerActivity.participations[0]).to.deep.equal(organizationLearnerParticipation);
   });
 });

--- a/api/tests/prescription/organization-place/acceptance/application/find-organization-places_test.js
+++ b/api/tests/prescription/organization-place/acceptance/application/find-organization-places_test.js
@@ -67,7 +67,7 @@ describe('Acceptance | Route | Find Organization Places', function () {
       const response = await server.inject(options);
 
       // then
-      expect(response.result.data.length).to.equal(1);
+      expect(response.result.data).to.have.lengthOf(1);
 
       expect(response.result.data[0].id).to.equal(place.id.toString());
       expect(response.result.data[0].attributes.reference).to.equal(place.reference);

--- a/api/tests/prescription/organization-place/integration/infrastructure/repositories/organization-places-lot-repository_test.js
+++ b/api/tests/prescription/organization-place/integration/infrastructure/repositories/organization-places-lot-repository_test.js
@@ -66,7 +66,7 @@ describe('Integration | Repository | Organization Places Lot', function () {
       const foundOrganizationPlace = await organizationPlacesLotRepository.findByOrganizationId(organizationId);
 
       // then
-      expect(foundOrganizationPlace.length).to.equal(2);
+      expect(foundOrganizationPlace).to.have.lengthOf(2);
       expect([foundOrganizationPlace[0].reference, foundOrganizationPlace[1].reference]).to.have.members([
         placeSG1.reference,
         placeAtlantis.reference,
@@ -82,7 +82,7 @@ describe('Integration | Repository | Organization Places Lot', function () {
       // when
       const foundOrganizationPlace = await organizationPlacesLotRepository.findByOrganizationId(organizationId);
       // then
-      expect(foundOrganizationPlace.length).to.equal(0);
+      expect(foundOrganizationPlace).to.have.lengthOf(0);
     });
 
     it('should not take into account deleted places', async function () {
@@ -101,7 +101,7 @@ describe('Integration | Repository | Organization Places Lot', function () {
       const foundOrganizationPlace = await organizationPlacesLotRepository.findByOrganizationId(organizationId);
 
       // then
-      expect(foundOrganizationPlace.length).to.equal(0);
+      expect(foundOrganizationPlace).to.have.lengthOf(0);
     });
 
     it("should return creator place's name for given id", async function () {
@@ -249,7 +249,7 @@ describe('Integration | Repository | Organization Places Lot', function () {
 
       const places = await organizationPlacesLotRepository.findAllByOrganizationId(organizationId);
 
-      expect(places.length).to.equal(2);
+      expect(places).to.have.lengthOf(2);
       expect(places[0].count).to.equal(7);
       expect(places[1].count).to.equal(3);
     });
@@ -262,7 +262,7 @@ describe('Integration | Repository | Organization Places Lot', function () {
 
       const places = await organizationPlacesLotRepository.findAllByOrganizationId(anotherOrganizationId);
 
-      expect(places.length).to.equal(0);
+      expect(places).to.have.lengthOf(0);
     });
   });
 
@@ -298,7 +298,7 @@ describe('Integration | Repository | Organization Places Lot', function () {
 
       const places = await organizationPlacesLotRepository.findAllByOrganizationIds(organizationIds);
 
-      expect(places.length).to.equal(2);
+      expect(places).to.have.lengthOf(2);
       expect(places[0]).to.be.an.instanceOf(PlacesLot);
       expect(places[1]).to.be.an.instanceOf(PlacesLot);
 
@@ -322,7 +322,7 @@ describe('Integration | Repository | Organization Places Lot', function () {
       const organizationIds = [firstOrganizationId];
 
       const places = await organizationPlacesLotRepository.findAllByOrganizationIds(organizationIds);
-      expect(places.length).to.equal(1);
+      expect(places).to.have.lengthOf(1);
       expect(places[0].organizationId).to.equal(firstOrganizationId);
     });
   });
@@ -496,7 +496,7 @@ describe('Integration | Repository | Organization Places Lot', function () {
         await organizationPlacesLotRepository.findAllNotDeletedByOrganizationId(organizationId);
 
       // then
-      expect(foundOrganizationPlace.length).to.equal(2);
+      expect(foundOrganizationPlace).to.have.lengthOf(2);
       expect([foundOrganizationPlace[0].count, foundOrganizationPlace[1].count]).to.have.members([
         placeSG1.count,
         placeAtlantis.count,
@@ -512,7 +512,7 @@ describe('Integration | Repository | Organization Places Lot', function () {
       // when
       const foundOrganizationPlace = await organizationPlacesLotRepository.findByOrganizationId(organizationId);
       // then
-      expect(foundOrganizationPlace.length).to.equal(0);
+      expect(foundOrganizationPlace).to.have.lengthOf(0);
     });
 
     it('should not take into account deleted places', async function () {
@@ -531,7 +531,7 @@ describe('Integration | Repository | Organization Places Lot', function () {
       const foundOrganizationPlace = await organizationPlacesLotRepository.findByOrganizationId(organizationId);
 
       // then
-      expect(foundOrganizationPlace.length).to.equal(0);
+      expect(foundOrganizationPlace).to.have.lengthOf(0);
     });
 
     describe('the right order', function () {

--- a/api/tests/prescription/target-profile/integration/domain/usecases/copy-target-profile_test.js
+++ b/api/tests/prescription/target-profile/integration/domain/usecases/copy-target-profile_test.js
@@ -81,7 +81,7 @@ describe('Integration | UseCases | copy-target-profile', function () {
         targetProfileId: newlyCreatedTargetProfile.id,
       });
 
-      expect(newlyCreatedTargetProfileTubes.length).to.equal(tubesData.length);
+      expect(newlyCreatedTargetProfileTubes).to.have.lengthOf(tubesData.length);
       newlyCreatedTargetProfileTubes.forEach((targetProfileTube) => {
         delete targetProfileTube.id;
         delete targetProfileTube.targetProfileId;

--- a/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-administration-repository_test.js
+++ b/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-administration-repository_test.js
@@ -940,7 +940,7 @@ describe('Integration | Repository | Target-profile', function () {
       const tubes = await targetProfileAdministrationRepository.getTubesByTargetProfileId(targetProfile1.id);
 
       // Then
-      expect(tubes.length).to.equal(2);
+      expect(tubes).to.have.lengthOf(2);
       expect(tubes[0].tubeId).to.equal(targetProfileTube1.tubeId);
       expect(tubes[1].tubeId).to.equal(targetProfileTube2.tubeId);
     });

--- a/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-bond-repository_test.js
+++ b/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-bond-repository_test.js
@@ -28,7 +28,7 @@ describe('Integration | Repository | Target Profile Management | Target Profile 
         .from('target-profile-shares')
         .where('targetProfileId', targetProfile.id);
 
-      expect(result.length).to.equal(1);
+      expect(result).to.have.lengthOf(1);
       expect(result).to.not.deep.include({ organizationId: targetProfile.organizationIdsToDetach[0] });
     });
 
@@ -57,7 +57,7 @@ describe('Integration | Repository | Target Profile Management | Target Profile 
         .from('target-profile-shares')
         .where('targetProfileId', targetProfile.id);
 
-      expect(result.length).to.equal(0);
+      expect(result).to.have.lengthOf(0);
     });
 
     it('should return detached organization ids', async function () {

--- a/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-for-update-repository_test.js
+++ b/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-for-update-repository_test.js
@@ -66,7 +66,7 @@ describe('Integration | Repository | Target-profile-for-update', function () {
         const targetProfileTubesFromDB = await knex('target-profile_tubes').where({
           targetProfileId: existingTargetProfile.id,
         });
-        expect(targetProfileTubesFromDB).to.have.length(2);
+        expect(targetProfileTubesFromDB).to.have.lengthOf(2);
         // eslint-disable-next-line no-unused-vars
         expect(targetProfileTubesFromDB.map(({ id, ...tube }) => tube)).to.deep.equal([
           {
@@ -108,7 +108,7 @@ describe('Integration | Repository | Target-profile-for-update', function () {
         const targetProfileTubesFromDB = await knex('target-profile_tubes').where({
           targetProfileId: existingTargetProfile.id,
         });
-        expect(targetProfileTubesFromDB).to.have.length(2);
+        expect(targetProfileTubesFromDB).to.have.lengthOf(2);
         // eslint-disable-next-line no-unused-vars
         expect(targetProfileTubesFromDB.map(({ id, ...tube }) => tube)).to.deep.equal([tube1, tube2]);
       });

--- a/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-summary-for-admin-repository_test.js
+++ b/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-summary-for-admin-repository_test.js
@@ -55,7 +55,7 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
           });
 
         // then
-        expect(actualTargetProfileSummaries.length).to.equal(5);
+        expect(actualTargetProfileSummaries).to.have.lengthOf(5);
         expect(actualTargetProfileSummaries[0].outdated).to.be.false;
         expect(actualTargetProfileSummaries[1].outdated).to.be.false;
       });
@@ -83,7 +83,7 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
           });
 
         // then
-        expect(actualTargetProfileSummaries.length).to.equal(5);
+        expect(actualTargetProfileSummaries).to.have.lengthOf(5);
         expect(actualTargetProfileSummaries[0].name).to.equal('TPA');
         expect(actualTargetProfileSummaries[1].name).to.equal('TPC');
       });
@@ -112,7 +112,7 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
 
         // then
         const expectedMeta = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 3 };
-        expect(actualTargetProfileSummaries.length).to.equal(3);
+        expect(actualTargetProfileSummaries).to.have.lengthOf(3);
         expect(meta).to.deep.equal(expectedMeta);
       });
     });
@@ -142,7 +142,7 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
 
         // then
         const expectedMeta = { page: page.number, pageSize: page.size, pageCount: 2, rowCount: 5 };
-        expect(actualTargetProfileSummaries.length).to.equal(2);
+        expect(actualTargetProfileSummaries).to.have.lengthOf(2);
         expect(meta).to.deep.equal(expectedMeta);
       });
     });

--- a/api/tests/prescription/target-profile/unit/application/api/target-profile-api_test.js
+++ b/api/tests/prescription/target-profile/unit/application/api/target-profile-api_test.js
@@ -82,7 +82,7 @@ describe('Unit | API | TargetProfile', function () {
       const result = await targetProfileApi.getByOrganizationId(notExistingOrganizationId);
 
       // then
-      expect(result.length).to.equal(0);
+      expect(result).to.have.lengthOf(0);
     });
   });
 });

--- a/api/tests/profile/integration/infrastructure/repositories/profile-reward-repository_test.js
+++ b/api/tests/profile/integration/infrastructure/repositories/profile-reward-repository_test.js
@@ -27,7 +27,7 @@ describe('Profile | Integration | Repository | profile-reward', function () {
       // then
       const result = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId: userId });
 
-      expect(result.length).to.equal(1);
+      expect(result).to.have.lengthOf(1);
       expect(result[0].userId).to.equal(userId);
       expect(result[0].rewardId).to.equal(rewardId);
       expect(result[0].rewardType).to.equal(REWARD_TYPES.ATTESTATION);
@@ -73,7 +73,7 @@ describe('Profile | Integration | Repository | profile-reward', function () {
       const result = await getByUserId({ userId });
 
       // then
-      expect(result.length).to.equal(2);
+      expect(result).to.have.lengthOf(2);
       expect(result[0].rewardId).to.equal(firstRewardId);
       expect(result[0]).to.be.an.instanceof(ProfileReward);
       expect(result[1].rewardId).to.equal(secondRewardId);
@@ -105,7 +105,7 @@ describe('Profile | Integration | Repository | profile-reward', function () {
       const result = await getByAttestationKeyAndUserIds({ attestationKey: attestation.key, userIds: [user.id] });
 
       // then
-      expect(result.length).to.equal(0);
+      expect(result).to.have.lengthOf(0);
     });
 
     it('should return all attestations for users', async function () {
@@ -201,7 +201,7 @@ describe('Profile | Integration | Repository | profile-reward', function () {
       });
 
       // then
-      expect(result.length).to.equal(0);
+      expect(result).to.have.lengthOf(0);
     });
   });
 });

--- a/api/tests/quest/integration/infrastructure/repositories/quest-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/quest-repository_test.js
@@ -35,7 +35,7 @@ describe('Quest | Integration | Repository | quest', function () {
 
       // then
       expect(quests[0]).to.be.an.instanceof(Quest);
-      expect(quests.length).to.equal(3);
+      expect(quests).to.have.lengthOf(3);
     });
   });
 });

--- a/api/tests/quest/unit/domain/usecases/get-quest-results-for-campaign-participation_test.js
+++ b/api/tests/quest/unit/domain/usecases/get-quest-results-for-campaign-participation_test.js
@@ -28,7 +28,7 @@ describe('Quest | Unit | Domain | Usecases | getQuestResultsForCampaignParticipa
     });
 
     // then
-    expect(result.length).to.equal(0);
+    expect(result).to.have.lengthOf(0);
   });
 
   it('should return empty array when there is no eligibility', async function () {
@@ -60,7 +60,7 @@ describe('Quest | Unit | Domain | Usecases | getQuestResultsForCampaignParticipa
     });
 
     // then
-    expect(result.length).to.equal(0);
+    expect(result).to.have.lengthOf(0);
   });
 
   it('should return empty array when there is no eligible quests', async function () {
@@ -94,6 +94,6 @@ describe('Quest | Unit | Domain | Usecases | getQuestResultsForCampaignParticipa
     });
 
     // then
-    expect(result.length).to.equal(0);
+    expect(result).to.have.lengthOf(0);
   });
 });

--- a/api/tests/school/integration/domain/services/update-current-activity_test.js
+++ b/api/tests/school/integration/domain/services/update-current-activity_test.js
@@ -60,7 +60,7 @@ describe('Integration | UseCase | update current activity', function () {
           });
 
           const activities = await knex('activities').where({ assessmentId });
-          expect(activities.length).to.equal(1);
+          expect(activities).to.have.lengthOf(1);
           expect(activities[0].status).to.equal(Activity.status.STARTED);
           expect(currentActivity.status).equals(Activity.status.STARTED);
         }),
@@ -122,7 +122,7 @@ describe('Integration | UseCase | update current activity', function () {
           });
 
           const activities = await knex('activities').where({ assessmentId });
-          expect(activities.length).to.equal(1);
+          expect(activities).to.have.lengthOf(1);
           expect(activities[0].status).to.equal(Activity.status.SUCCEEDED);
           expect(currentActivity.status).equals(Activity.status.SUCCEEDED);
         }),
@@ -171,7 +171,7 @@ describe('Integration | UseCase | update current activity', function () {
         });
 
         const activities = await knex('activities').where({ assessmentId });
-        expect(activities.length).to.equal(1);
+        expect(activities).to.have.lengthOf(1);
         expect(activities[0].status).to.equal(Activity.status.FAILED);
         expect(currentActivity.status).equals(Activity.status.FAILED);
       });
@@ -218,7 +218,7 @@ describe('Integration | UseCase | update current activity', function () {
           });
 
           const activities = await knex('activities').where({ assessmentId });
-          expect(activities.length).to.equal(1);
+          expect(activities).to.have.lengthOf(1);
           expect(activities[0].status).to.equal(Activity.status.STARTED);
           expect(currentActivity.status).equals(Activity.status.STARTED);
         });
@@ -270,7 +270,7 @@ describe('Integration | UseCase | update current activity', function () {
           });
 
           const activities = await knex('activities').where({ assessmentId });
-          expect(activities.length).to.equal(1);
+          expect(activities).to.have.lengthOf(1);
           expect(activities[0].status).to.equal(Activity.status.SUCCEEDED);
           expect(currentActivity.status).equals(Activity.status.SUCCEEDED);
         });
@@ -316,7 +316,7 @@ describe('Integration | UseCase | update current activity', function () {
         });
 
         const activities = await knex('activities').where({ assessmentId });
-        expect(activities.length).to.equal(1);
+        expect(activities).to.have.lengthOf(1);
         expect(activities[0].status).to.equal(Activity.status.SKIPPED);
         expect(currentActivity.status).equals(Activity.status.SKIPPED);
       });

--- a/api/tests/shared/integration/infrastructure/repositories/admin-member.repository.test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/admin-member.repository.test.js
@@ -23,7 +23,7 @@ describe('Integration | Shared | Infrastructure | Repositories | adminMember', f
       const members = await adminMemberRepository.findAll();
 
       // then
-      expect(members.length).to.equal(2);
+      expect(members).to.have.lengthOf(2);
       expect(members).to.have.deep.members([
         new AdminMember({
           id: userWithPixAdminRole.id,
@@ -54,7 +54,7 @@ describe('Integration | Shared | Infrastructure | Repositories | adminMember', f
       const members = await adminMemberRepository.findAll();
 
       // then
-      expect(members.length).to.equal(1);
+      expect(members).to.have.lengthOf(1);
       expect(members[0].id).to.not.equal(userWithoutPixAdminRole.id);
     });
 

--- a/api/tests/shared/integration/infrastructure/repositories/answer-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/answer-repository_test.js
@@ -418,8 +418,8 @@ describe('Integration | Repository | answerRepository', function () {
         // then
         const answerInDB = await knex('answers');
         const knowledgeElementsInDB = await knex('knowledge-elements');
-        expect(answerInDB).to.have.length(0);
-        expect(knowledgeElementsInDB).to.have.length(0);
+        expect(answerInDB).to.have.lengthOf(0);
+        expect(knowledgeElementsInDB).to.have.lengthOf(0);
       });
     });
 
@@ -452,9 +452,9 @@ describe('Integration | Repository | answerRepository', function () {
         expect(error).to.be.instanceOf(ChallengeAlreadyAnsweredError);
         const answerInDB = await knex('answers');
         const knowledgeElementsInDB = await knex('knowledge-elements');
-        expect(answerInDB).to.have.length(1);
+        expect(answerInDB).to.have.lengthOf(1);
         expect(answerInDB[0].id).to.be.equal(alreadyCreatedAnswerId);
-        expect(knowledgeElementsInDB).to.have.length(0);
+        expect(knowledgeElementsInDB).to.have.lengthOf(0);
       });
     });
   });

--- a/api/tests/shared/integration/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/assessment-repository_test.js
@@ -419,7 +419,7 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
       const assessmentsReturned = await assessmentRepository.findNotAbortedCampaignAssessmentsByUserId(userId);
 
       // then
-      expect(assessmentsReturned.length).to.equal(1);
+      expect(assessmentsReturned).to.have.lengthOf(1);
       expect(assessmentsReturned[0]).to.be.an.instanceOf(Assessment);
       expect(assessmentsReturned[0].id).to.equal(assessmentId);
     });

--- a/api/tests/shared/integration/infrastructure/utils/knex-utils_test.js
+++ b/api/tests/shared/integration/infrastructure/utils/knex-utils_test.js
@@ -127,7 +127,7 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
         const { results, pagination } = await fetchPage(query, { number: pageNumber, size: pageSize });
 
         // then
-        expect(results).to.have.length(pageSize);
+        expect(results).to.have.lengthOf(pageSize);
         expect(pagination.pageSize).to.equal(pageSize);
       });
 
@@ -144,7 +144,7 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
         const { results, pagination } = await fetchPage(query, { number: pageNumber, size: pageSize });
 
         // then
-        expect(results).to.have.length(total);
+        expect(results).to.have.lengthOf(total);
         expect(pagination.pageSize).to.equal(pageSize);
       });
 
@@ -177,7 +177,7 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
         const { results, pagination } = await fetchPage(query, { number: pageNumber });
 
         // then
-        expect(results).to.have.length(pagination.pageSize);
+        expect(results).to.have.lengthOf(pagination.pageSize);
         expect(pagination.pageSize).to.equal(DEFAULT_PAGINATION.PAGE_SIZE);
       });
     });

--- a/api/tests/shared/unit/infrastructure/helpers/csv.js
+++ b/api/tests/shared/unit/infrastructure/helpers/csv.js
@@ -70,7 +70,7 @@ describe('Unit | Infrastructure | Helpers | csv.js', function () {
       const items = await parseCsvWithHeader(withHeaderFilePath);
 
       // then
-      expect(items.length).to.equal(3);
+      expect(items).to.have.lengthOf(3);
       expect(items).to.have.deep.members(expectedItems);
     });
 

--- a/api/tests/shared/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -1326,7 +1326,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
           const [result] = csvSerializer.deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true });
 
           // then
-          expect(result.candidates).to.have.length(6);
+          expect(result.candidates).to.have.lengthOf(6);
         });
       });
 

--- a/api/tests/shared/unit/infrastructure/serializers/jsonapi/membership-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/jsonapi/membership-serializer_test.js
@@ -145,7 +145,7 @@ describe('Unit | Serializer | JSONAPI | membership-serializer', function () {
 
       // then
       expect(json.data.relationships.organization).to.be.undefined;
-      expect(json.included.length).to.equal(1);
+      expect(json.included).to.have.lengthOf(1);
       expect(json.included[0].type).to.not.equal('organization');
     });
 
@@ -159,7 +159,7 @@ describe('Unit | Serializer | JSONAPI | membership-serializer', function () {
 
       // then
       expect(json.data.relationships.user).to.be.undefined;
-      expect(json.included.length).to.equal(1);
+      expect(json.included).to.have.lengthOf(1);
       expect(json.included[0].type).to.not.equal('users');
     });
   });

--- a/api/tests/shared/unit/infrastructure/temporary-storage/InMemoryTemporaryStorage_test.js
+++ b/api/tests/shared/unit/infrastructure/temporary-storage/InMemoryTemporaryStorage_test.js
@@ -248,7 +248,7 @@ describe('Unit | Infrastructure | temporary-storage | InMemoryTemporaryStorage',
       const values = await inMemoryTemporaryStorage.lrange(key);
 
       // then
-      expect(values.length).to.equal(3);
+      expect(values).to.have.lengthOf(3);
       expect(values).to.deep.equal(['value3', 'value2', 'value1']);
     });
   });

--- a/api/tests/team/acceptance/application/certification-center-invitation/certification-center-invitation.admin.route.test.js
+++ b/api/tests/team/acceptance/application/certification-center-invitation/certification-center-invitation.admin.route.test.js
@@ -50,7 +50,7 @@ describe('Acceptance | Team | Application | Route | Admin | Certification Center
 
       // then
       expect(response.statusCode).to.equal(200);
-      expect(response.result.data.length).to.equal(2);
+      expect(response.result.data).to.have.lengthOf(2);
       expect(response.result.data).to.deep.have.members([
         {
           type: 'certification-center-invitations',

--- a/api/tests/team/acceptance/application/certification-center-invitation/certification-center-invitation.route.test.js
+++ b/api/tests/team/acceptance/application/certification-center-invitation/certification-center-invitation.route.test.js
@@ -80,7 +80,7 @@ describe('Acceptance | Team | Application | Route | Certification Center Invitat
           .where({ certificationCenterId })
           .whereIn('email', emails);
         expect(response.statusCode).to.equal(204);
-        expect(certificationCenterInvitations.length).to.equal(2);
+        expect(certificationCenterInvitations).to.have.lengthOf(2);
       });
     });
   });

--- a/api/tests/team/integration/domain/usecases/create-or-update-certification-center-invitation-for-admin_test.js
+++ b/api/tests/team/integration/domain/usecases/create-or-update-certification-center-invitation-for-admin_test.js
@@ -54,7 +54,7 @@ describe('Integration | Team | UseCase | create-or-update-certification-center-i
 
     // then
     const allInvitations = await knex('certification-center-invitations').select('*');
-    expect(allInvitations).to.have.length(3);
+    expect(allInvitations).to.have.lengthOf(3);
 
     expect(result.isInvitationCreated).to.be.true;
     expect(result.certificationCenterInvitation).to.be.instanceOf(CertificationCenterInvitation);
@@ -98,7 +98,7 @@ describe('Integration | Team | UseCase | create-or-update-certification-center-i
 
     // then
     const allInvitations = await knex('certification-center-invitations').select('*');
-    expect(allInvitations).to.have.length(1);
+    expect(allInvitations).to.have.lengthOf(1);
 
     expect(result.isInvitationCreated).to.be.false;
     expect(result.certificationCenterInvitation).to.be.instanceOf(CertificationCenterInvitation);

--- a/api/tests/team/integration/domain/usecases/find-pending-certification-center-invitations.usecase.test.js
+++ b/api/tests/team/integration/domain/usecases/find-pending-certification-center-invitations.usecase.test.js
@@ -38,7 +38,7 @@ describe('Integration | Team | Domain | UseCase | find-pending-certification-cen
     });
 
     // then
-    expect(certificationCenterInvitations.length).to.equal(2);
+    expect(certificationCenterInvitations).to.have.lengthOf(2);
     expect(certificationCenterInvitations[0]).to.be.instanceOf(CertificationCenterInvitation);
     expect(certificationCenterInvitations[0]).to.deep.include({
       id: certificationCenterInvitation1.id,

--- a/api/tests/team/integration/infrastructure/repositories/certification-center-membership.repository.test.js
+++ b/api/tests/team/integration/infrastructure/repositories/certification-center-membership.repository.test.js
@@ -276,7 +276,7 @@ describe('Integration | Team | Infrastructure | Repository | Certification Cente
         const certificationCenterMemberships = await certificationCenterMembershipRepository.findByUserId(userId);
 
         // then
-        expect(certificationCenterMemberships.length).to.equal(1);
+        expect(certificationCenterMemberships).to.have.lengthOf(1);
         expect(certificationCenterMemberships[0].id).to.equal(notDisabledMembership.id);
       });
     });
@@ -321,7 +321,7 @@ describe('Integration | Team | Infrastructure | Repository | Certification Cente
         await certificationCenterMembershipRepository.findActiveAdminsByCertificationCenterId(certificationCenterId);
 
       // then
-      expect(certificationCenterMemberships.length).to.equal(2);
+      expect(certificationCenterMemberships).to.have.lengthOf(2);
       expect(certificationCenterMemberships[0].user.email).to.equal('admin1@example.net');
       expect(certificationCenterMemberships[1].user.email).to.equal('admin2@example.net');
     });
@@ -419,7 +419,7 @@ describe('Integration | Team | Infrastructure | Repository | Certification Cente
         });
 
       // then
-      expect(foundCertificationCenterMemberships.length).to.equal(4);
+      expect(foundCertificationCenterMemberships).to.have.lengthOf(4);
       expect(foundCertificationCenterMemberships[0].role).to.equal('ADMIN');
       expect(foundCertificationCenterMemberships[1].role).to.equal('MEMBER');
       expect(foundCertificationCenterMemberships[2].role).to.equal('MEMBER');
@@ -455,7 +455,7 @@ describe('Integration | Team | Infrastructure | Repository | Certification Cente
         });
 
       // then
-      expect(foundCertificationCenterMemberships.length).to.equal(1);
+      expect(foundCertificationCenterMemberships).to.have.lengthOf(1);
       expect(foundCertificationCenterMemberships[0].id).to.equal(7);
     });
   });
@@ -888,7 +888,7 @@ describe('Integration | Team | Infrastructure | Repository | Certification Cente
           .returning('*')
           .whereNotNull('disabledAt')
           .where({ userId });
-        expect(disabledMemberships.length).to.equal(2);
+        expect(disabledMemberships).to.have.lengthOf(2);
         expect(disabledMemberships).to.deep.include.members(expectedMemberships);
       });
 
@@ -936,7 +936,7 @@ describe('Integration | Team | Infrastructure | Repository | Certification Cente
           .returning('*')
           .whereNotNull('disabledAt')
           .andWhere({ userId });
-        expect(disabledMemberships.length).to.equal(2);
+        expect(disabledMemberships).to.have.lengthOf(2);
         expect(disabledMemberships).to.deep.include.members(expectedMemberships);
       });
     });
@@ -978,7 +978,7 @@ describe('Integration | Team | Infrastructure | Repository | Certification Cente
           .returning('*')
           .whereNotNull('disabledAt')
           .andWhere({ userId });
-        expect(disabledMemberships.length).to.equal(2);
+        expect(disabledMemberships).to.have.lengthOf(2);
       });
     });
   });

--- a/api/tests/team/integration/infrastructure/repositories/membership-repository.test.js
+++ b/api/tests/team/integration/infrastructure/repositories/membership-repository.test.js
@@ -771,7 +771,7 @@ describe('Integration | Team | Infrastructure | Repository | membership-reposito
 
         // then
         const disabledMemberships = await knex('memberships').returning('*').where({ userId });
-        expect(disabledMemberships.length).to.equal(2);
+        expect(disabledMemberships).to.have.lengthOf(2);
         expect(disabledMemberships).to.deep.include.members(expectedMemberships);
       });
     });
@@ -795,7 +795,7 @@ describe('Integration | Team | Infrastructure | Repository | membership-reposito
 
         // then
         const disabledMemberships = await knex('memberships').where({ userId });
-        expect(disabledMemberships.length).to.equal(0);
+        expect(disabledMemberships).to.have.lengthOf(0);
       });
     });
   });

--- a/api/tests/team/integration/infrastructure/repositories/organization-invitation.repository.test.js
+++ b/api/tests/team/integration/infrastructure/repositories/organization-invitation.repository.test.js
@@ -255,7 +255,7 @@ describe('Integration | Team | Infrastructure | Repository | organization-invita
       });
 
       // then
-      expect(foundOrganizationInvitations.length).to.equal(2);
+      expect(foundOrganizationInvitations).to.have.lengthOf(2);
     });
 
     it('should return organization-invitations from most recent to oldest', async function () {

--- a/api/tests/tooling/learning-content-builder/build-learning-content_test.js
+++ b/api/tests/tooling/learning-content-builder/build-learning-content_test.js
@@ -58,7 +58,7 @@ describe('Integration | buildLearningContent', function () {
     expect(areas[1].id).to.equal('recArea2');
     expect(areas[1].title_i18n.fr).to.equal('domaine2_Titre');
     expect(areas[1].title_i18n.en).to.equal('area2_Title');
-    expect(frameworks.length).to.equal(2);
+    expect(frameworks).to.have.lengthOf(2);
     expect(frameworks[0].id).to.deep.equal('recFramework1');
     expect(frameworks[0].name).to.deep.equal('monFramework 1');
     expect(frameworks[1].id).to.deep.equal('recFramework2');

--- a/api/tests/unit/domain/services/certification-challenges-service_test.js
+++ b/api/tests/unit/domain/services/certification-challenges-service_test.js
@@ -481,7 +481,7 @@ describe('Unit | Service | Certification Challenge Service', function () {
 
         // then
         const skillsForChallenges = _.uniq(_.map(certificationChallenges, 'associatedSkillName'));
-        expect(skillsForChallenges.length).to.equal(expectedSkills.length);
+        expect(skillsForChallenges).to.have.lengthOf(expectedSkills.length);
       });
     });
 

--- a/api/tests/unit/domain/services/certification-challenges-service_test.js
+++ b/api/tests/unit/domain/services/certification-challenges-service_test.js
@@ -1286,7 +1286,7 @@ describe('Unit | Service | Certification Challenge Service', function () {
         ),
       );
       expect(certificationChallengesForPlus).to.deep.include.members(expectedCertificationChallenges);
-      expect(certificationChallengesForPlus).to.have.length(8);
+      expect(certificationChallengesForPlus).to.have.lengthOf(8);
     });
 
     it('should preferably pick non answered challenges', async function () {
@@ -1471,7 +1471,7 @@ describe('Unit | Service | Certification Challenge Service', function () {
         ),
       );
       expect(certificationChallengesForPlus).to.deep.include.members(expectedCertificationChallenges);
-      expect(certificationChallengesForPlus).to.have.length(8);
+      expect(certificationChallengesForPlus).to.have.lengthOf(8);
     });
 
     it('should prioritize on hardest skill per area', async function () {
@@ -1812,7 +1812,7 @@ describe('Unit | Service | Certification Challenge Service', function () {
         ),
       );
       expect(certificationChallengesForPlus).to.deep.include.members(expectedCertificationChallenges);
-      expect(certificationChallengesForPlus).to.have.length(4);
+      expect(certificationChallengesForPlus).to.have.lengthOf(4);
     });
 
     it('should return an empty array when there is only challenges from origin Pix', async function () {
@@ -2089,7 +2089,7 @@ describe('Unit | Service | Certification Challenge Service', function () {
         ),
       );
       expect(certificationChallengesForPlus).to.deep.include.members(expectedCertificationChallenges);
-      expect(certificationChallengesForPlus).to.have.length(7);
+      expect(certificationChallengesForPlus).to.have.lengthOf(7);
     });
 
     it('should only consider directly validated skill', async function () {
@@ -2252,7 +2252,7 @@ describe('Unit | Service | Certification Challenge Service', function () {
         ),
       );
       expect(certificationChallengesForPlus).to.deep.include.members(expectedCertificationChallenges);
-      expect(certificationChallengesForPlus).to.have.length(6);
+      expect(certificationChallengesForPlus).to.have.lengthOf(6);
     });
 
     context('when there is no specific referential', function () {
@@ -2443,7 +2443,7 @@ describe('Unit | Service | Certification Challenge Service', function () {
           ),
         );
         expect(certificationChallengesForPlus).to.deep.include.members(expectedCertificationChallenges);
-        expect(certificationChallengesForPlus).to.have.length(8);
+        expect(certificationChallengesForPlus).to.have.lengthOf(8);
       });
     });
   });

--- a/api/tests/unit/domain/services/code-generator_test.js
+++ b/api/tests/unit/domain/services/code-generator_test.js
@@ -20,7 +20,7 @@ describe('Unit | Domain | Services | code generator', function () {
 
       // then
       return promise.then((code) => {
-        expect(code.length).to.equal(9);
+        expect(code).to.have.lengthOf(9);
       });
     });
 

--- a/api/tests/unit/domain/services/password-generator_test.js
+++ b/api/tests/unit/domain/services/password-generator_test.js
@@ -12,7 +12,7 @@ describe('Unit | Service | password-generator', function () {
       generatedPassword = service.generateSimplePassword();
 
       // then
-      expect(generatedPassword.length).to.equal(8);
+      expect(generatedPassword).to.have.lengthOf(8);
     });
 
     it('should not contains hard to read characters', function () {

--- a/api/tests/unit/domain/validators/certification-center-creation-validator_test.js
+++ b/api/tests/unit/domain/validators/certification-center-creation-validator_test.js
@@ -92,7 +92,7 @@ describe('Unit | Domain | Validators | certification-center-validator', function
             expect.fail('should have thrown an error');
           } catch (errors) {
             // then
-            expect(errors.invalidAttributes).to.have.length(2);
+            expect(errors.invalidAttributes).to.have.lengthOf(2);
             expect(errors.invalidAttributes).to.have.deep.equal(expectedError);
           }
         });
@@ -150,7 +150,7 @@ describe('Unit | Domain | Validators | certification-center-validator', function
             expect.fail('should have thrown an error');
           } catch (errors) {
             // then
-            expect(errors.invalidAttributes).to.have.length(1);
+            expect(errors.invalidAttributes).to.have.lengthOf(1);
             expect(errors.invalidAttributes).to.have.deep.equal(expectedError);
           }
         });

--- a/api/tests/unit/domain/validators/organization-creation-validator_test.js
+++ b/api/tests/unit/domain/validators/organization-creation-validator_test.js
@@ -65,7 +65,7 @@ describe('Unit | Domain | Validators | organization-validator', function () {
             expect.fail('should have thrown an error');
           } catch (errors) {
             // then
-            expect(errors.invalidAttributes).to.have.length(2);
+            expect(errors.invalidAttributes).to.have.lengthOf(2);
             expect(errors.invalidAttributes).to.have.deep.equal(expectedError);
           }
         });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-orga-settings-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-orga-settings-serializer_test.js
@@ -154,7 +154,7 @@ describe('Unit | Serializer | JSONAPI | user-orga-settings-serializer', function
 
       // then
       expect(json.data.relationships.user).to.be.undefined;
-      expect(json.included.length).to.equal(1);
+      expect(json.included).to.have.lengthOf(1);
       expect(json.included[0].type).to.not.equal('users');
     });
   });

--- a/api/tests/unit/infrastructure/utils/code-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/code-utils_test.js
@@ -8,7 +8,7 @@ describe('Unit | Utils | code-utils', function () {
       const result = generateNumericalString(6);
 
       // then
-      expect(result).to.have.length(6);
+      expect(result).to.have.lengthOf(6);
     });
   });
 });

--- a/api/tests/unit/scripts/helpers/csvHelpers_test.js
+++ b/api/tests/unit/scripts/helpers/csvHelpers_test.js
@@ -50,7 +50,7 @@ describe('Unit | Scripts | Helpers | csvHelpers.js', function () {
       const data = await parseCsv(validFilePath, options);
 
       // then
-      expect(data.length).to.equal(3);
+      expect(data).to.have.lengthOf(3);
       expect(data[0][2]).to.equal('david.herault@pix.fr');
     });
 
@@ -59,7 +59,7 @@ describe('Unit | Scripts | Helpers | csvHelpers.js', function () {
       const data = await parseCsv(utf8FilePath);
 
       // then
-      expect(data.length).to.equal(4);
+      expect(data).to.have.lengthOf(4);
     });
   });
 
@@ -76,7 +76,7 @@ describe('Unit | Scripts | Helpers | csvHelpers.js', function () {
       const items = await parseCsvWithHeader(withHeaderFilePath);
 
       // then
-      expect(items.length).to.equal(3);
+      expect(items).to.have.lengthOf(3);
       expect(items).to.have.deep.members(expectedItems);
     });
 
@@ -237,7 +237,7 @@ describe('Unit | Scripts | Helpers | csvHelpers.js', function () {
       });
 
       // then
-      expect(data.length).to.equal(3);
+      expect(data).to.have.lengthOf(3);
       expect(data).to.have.deep.members(expectedItems);
     });
   });

--- a/api/tests/unit/scripts/import-certification-cpf-cities_test.js
+++ b/api/tests/unit/scripts/import-certification-cpf-cities_test.js
@@ -200,9 +200,9 @@ describe('Unit | Scripts | import-certification-cpf-cities.js', function () {
       const cities = getCitiesWithDistricts();
 
       // then
-      expect(cities.filter(({ name }) => name === 'PARIS').length).to.equal(21);
-      expect(cities.filter(({ name }) => name === 'LYON').length).to.equal(10);
-      expect(cities.filter(({ name }) => name === 'MARSEILLE').length).to.equal(17);
+      expect(cities.filter(({ name }) => name === 'PARIS')).to.have.lengthOf(21);
+      expect(cities.filter(({ name }) => name === 'LYON')).to.have.lengthOf(10);
+      expect(cities.filter(({ name }) => name === 'MARSEILLE')).to.have.lengthOf(17);
       expect(cities).to.deep.equal([
         {
           name: 'PARIS',


### PR DESCRIPTION
## :fallen_leaf: Problème

On a beaucoup d'assertions dans les tests de l'API vérifiant le nombre d'éléments d'une liste écrits comme ceci : 
```javascript
expect(result.length).to.equal(3);
```

... alors qu'il existe une assertion dédiée `lengthOf` qui est plus sémantique et aussi qui affiche de manière efficace les éléments de la liste si le nombre d'éléments attendus n'est pas celui obtenus : 
```javascript
expect(result).to.have.lengthOf(3);
```

De plus dans le code on a un mélange d'assertions `.to.have.lengthOf(xxx)` et `.to.have.length(xxx)` alors que cette dernière n'est pas recommandée : 

> Due to a compatibility issue, the alias .length can’t be chained directly off of an uninvoked method such as .a. Therefore, .length can’t be used interchangeably with .lengthOf in every situation. It’s recommended to always use .lengthOf instead of .length.

cf. https://www.chaijs.com/api/bdd/#method_lengthof 

## :chestnut: Proposition

Utiliser de manière uniforme `.to.have.lengthOf(xxx)` partout où c'est possible : 


## :jack_o_lantern: Remarques

RAS

## :wood: Pour tester

Vérifier que la CI passe.