### PR TITLE
[FEATURE] Ajout de la route GET /api/users/my-account (PIX-14903)

### DIFF
--- a/api/src/identity-access-management/application/user/user.controller.js
+++ b/api/src/identity-access-management/application/user/user.controller.js
@@ -5,6 +5,7 @@ import { usecases } from '../../domain/usecases/index.js';
 import { authenticationMethodsSerializer } from '../../infrastructure/serializers/jsonapi/authentication-methods.serializer.js';
 import { emailVerificationSerializer } from '../../infrastructure/serializers/jsonapi/email-verification.serializer.js';
 import * as updateEmailSerializer from '../../infrastructure/serializers/jsonapi/update-email.serializer.js';
+import { userAccountInfoSerializer } from '../../infrastructure/serializers/jsonapi/user-account-info.serializer.js';
 import { userWithActivitySerializer } from '../../infrastructure/serializers/jsonapi/user-with-activity.serializer.js';
 
 const acceptPixCertifTermsOfService = async function (request, h) {
@@ -86,6 +87,22 @@ const getCurrentUser = async function (request, h, dependencies = { userWithActi
   const result = await usecases.getCurrentUser({ authenticatedUserId });
 
   return dependencies.userWithActivitySerializer.serialize(result);
+};
+
+/**
+ * @param request
+ * @param h
+ * @param {{
+ *   userAccountInfoSerializer: UserAccountInfoSerializer
+ * }} dependencies
+ * @return {Promise<*>}
+ */
+const getCurrentUserAccountInfo = async function (request, h, dependencies = { userAccountInfoSerializer }) {
+  const authenticatedUserId = request.auth.credentials.userId;
+
+  const userAccountInfo = await usecases.getUserAccountInfo({ userId: authenticatedUserId });
+
+  return dependencies.userAccountInfoSerializer.serialize(userAccountInfo);
 };
 
 /**
@@ -214,6 +231,7 @@ export const userController = {
   acceptPixOrgaTermsOfService,
   changeUserLanguage,
   getCurrentUser,
+  getCurrentUserAccountInfo,
   getUserAuthenticationMethods,
   rememberUserHasSeenLastDataProtectionPolicyInformation,
   createUser,

--- a/api/src/identity-access-management/application/user/user.route.js
+++ b/api/src/identity-access-management/application/user/user.route.js
@@ -82,6 +82,18 @@ export const userRoutes = [
   },
   {
     method: 'GET',
+    path: '/api/users/my-account',
+    config: {
+      handler: (request, h) => userController.getCurrentUserAccountInfo(request, h),
+      notes: [
+        '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+          '- Récupération des information de compte utilisateur\n',
+      ],
+      tags: ['identity-access-management', 'api', 'user', 'my-account'],
+    },
+  },
+  {
+    method: 'GET',
     path: '/api/users/{id}/authentication-methods',
     config: {
       validate: {

--- a/api/src/identity-access-management/application/user/user.route.js
+++ b/api/src/identity-access-management/application/user/user.route.js
@@ -87,7 +87,7 @@ export const userRoutes = [
       handler: (request, h) => userController.getCurrentUserAccountInfo(request, h),
       notes: [
         '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
-          '- Récupération des information de compte utilisateur\n',
+          '- Récupération des informations du compte utilisateur authentifié\n',
       ],
       tags: ['identity-access-management', 'api', 'user', 'my-account'],
     },

--- a/api/src/identity-access-management/domain/models/UserAccountInfo.js
+++ b/api/src/identity-access-management/domain/models/UserAccountInfo.js
@@ -1,0 +1,8 @@
+export class UserAccountInfo {
+  constructor({ id, email, username, canSelfDeleteAccount } = {}) {
+    this.id = id;
+    this.email = email;
+    this.username = username;
+    this.canSelfDeleteAccount = canSelfDeleteAccount;
+  }
+}

--- a/api/src/identity-access-management/domain/usecases/get-user-account-info.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/get-user-account-info.usecase.js
@@ -1,0 +1,16 @@
+import { UserAccountInfo } from '../models/UserAccountInfo.js';
+
+const getUserAccountInfo = async ({ userId, userRepository, privacyUsersApiRepository }) => {
+  const user = await userRepository.get(userId);
+
+  const canSelfDeleteAccount = await privacyUsersApiRepository.canSelfDeleteAccount({ userId });
+
+  return new UserAccountInfo({
+    id: user.id,
+    email: user.email,
+    username: user.username,
+    canSelfDeleteAccount,
+  });
+};
+
+export { getUserAccountInfo };

--- a/api/src/identity-access-management/domain/usecases/index.js
+++ b/api/src/identity-access-management/domain/usecases/index.js
@@ -31,6 +31,7 @@ import { eventLoggingJobRepository } from '../../infrastructure/repositories/job
 import { garAnonymizedBatchEventsLoggingJobRepository } from '../../infrastructure/repositories/jobs/gar-anonymized-batch-events-logging-job-repository.js';
 import { userAnonymizedEventLoggingJobRepository } from '../../infrastructure/repositories/jobs/user-anonymized-event-logging-job-repository.js';
 import { oidcProviderRepository } from '../../infrastructure/repositories/oidc-provider-repository.js';
+import * as privacyUsersApiRepository from '../../infrastructure/repositories/privacy-users-api.repository.js';
 import { refreshTokenRepository } from '../../infrastructure/repositories/refresh-token.repository.js';
 import { resetPasswordDemandRepository } from '../../infrastructure/repositories/reset-password-demand.repository.js';
 import * as userRepository from '../../infrastructure/repositories/user.repository.js';
@@ -58,6 +59,7 @@ const repositories = {
   membershipRepository,
   oidcProviderRepository,
   organizationLearnerRepository,
+  privacyUsersApiRepository,
   refreshTokenRepository,
   resetPasswordDemandRepository,
   userAnonymizedEventLoggingJobRepository,

--- a/api/src/identity-access-management/infrastructure/repositories/privacy-users-api.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/privacy-users-api.repository.js
@@ -1,0 +1,7 @@
+import * as privacyUsersApi from '../../../privacy/application/api/users-api.js';
+
+const canSelfDeleteAccount = async ({ userId, dependencies = { privacyUsersApi } }) => {
+  return dependencies.privacyUsersApi.canSelfDeleteAccount({ userId });
+};
+
+export { canSelfDeleteAccount };

--- a/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-account-info.serializer.js
+++ b/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-account-info.serializer.js
@@ -1,0 +1,12 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (userAccountInfo, meta) {
+  return new Serializer('account-info', {
+    attributes: ['email', 'username', 'canSelfDeleteAccount'],
+    meta,
+  }).serialize(userAccountInfo);
+};
+
+export const userAccountInfoSerializer = { serialize };

--- a/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-with-activity.serializer.js
+++ b/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-with-activity.serializer.js
@@ -18,6 +18,7 @@ const serialize = function (users, meta) {
       'pixCertifTermsOfServiceAccepted',
       'lang',
       'isAnonymous',
+      'accountInfo',
       'profile',
       'hasSeenAssessmentInstructions',
       'isCertifiable',
@@ -59,6 +60,12 @@ const serialize = function (users, meta) {
           return `/api/users/${parent.id}/trainings`;
         },
       },
+    },
+    accountInfo: {
+      ref: 'id',
+      ignoreRelationshipData: true,
+      nullIfMissing: true,
+      relationshipLinks: { related: () => '/api/users/my-account' },
     },
     meta,
   }).serialize(users);

--- a/api/tests/identity-access-management/acceptance/application/user/user.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/user/user.route.test.js
@@ -232,6 +232,11 @@ describe('Acceptance | Identity Access Management | Application | Route | User',
             'last-data-protection-policy-seen-at': null,
           },
           relationships: {
+            'account-info': {
+              links: {
+                related: '/api/users/my-account',
+              },
+            },
             profile: {
               links: {
                 related: `/api/users/${user.id}/profile`,
@@ -277,7 +282,7 @@ describe('Acceptance | Identity Access Management | Application | Route | User',
       expect(response.statusCode).to.equal(200);
       expect(response.result).to.deep.equal({
         data: {
-          type: 'my-accounts',
+          type: 'account-infos',
           id: user.id.toString(),
           attributes: {
             'can-self-delete-account': false,

--- a/api/tests/identity-access-management/acceptance/application/user/user.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/user/user.route.test.js
@@ -260,6 +260,35 @@ describe('Acceptance | Identity Access Management | Application | Route | User',
     });
   });
 
+  describe('GET /api/users/my-account', function () {
+    it('returns 200 HTTP status code', async function () {
+      // given
+      const user = databaseBuilder.factory.buildUser();
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/users/my-account',
+        headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result).to.deep.equal({
+        data: {
+          type: 'my-accounts',
+          id: user.id.toString(),
+          attributes: {
+            'can-self-delete-account': false,
+            email: user.email,
+            username: user.username,
+          },
+        },
+      });
+    });
+  });
+
   describe('GET /api/users/{id}/authentication-methods', function () {
     it('returns 200 HTTP status code', async function () {
       // given

--- a/api/tests/identity-access-management/integration/domain/usecases/get-user-account-info.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/get-user-account-info.usecase.test.js
@@ -1,0 +1,21 @@
+import { usecases } from '../../../../../src/identity-access-management/domain/usecases/index.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Integration | Identity Access Management  | Domain | Usecases | get-user-account-info', function () {
+  it('returns user account info', async function () {
+    // given
+    const user = databaseBuilder.factory.buildUser();
+    await databaseBuilder.commit();
+
+    // when
+    const userAccountInfo = await usecases.getUserAccountInfo({ userId: user.id });
+
+    // then
+    expect(userAccountInfo).to.deep.equal({
+      id: user.id,
+      email: user.email,
+      username: user.username,
+      canSelfDeleteAccount: false,
+    });
+  });
+});

--- a/api/tests/identity-access-management/unit/infrastructure/repositories/privacy-users-api.repository.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/repositories/privacy-users-api.repository.test.js
@@ -1,0 +1,21 @@
+import { canSelfDeleteAccount } from '../../../../../src/identity-access-management/infrastructure/repositories/privacy-users-api.repository.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Identity Access Management | Infrastructure | Repositories | privacy-users-api', function () {
+  describe('#canSelfDeleteAccount', function () {
+    it('indicates if user can self delete their account', async function () {
+      // given
+      const dependencies = {
+        privacyUsersApi: {
+          canSelfDeleteAccount: async () => true,
+        },
+      };
+
+      // when
+      const result = await canSelfDeleteAccount({ userId: '123', dependencies });
+
+      // then
+      expect(result).to.be.true;
+    });
+  });
+});

--- a/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-account-info.serializer.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-account-info.serializer.test.js
@@ -1,0 +1,30 @@
+import { userAccountInfoSerializer } from '../../../../../../src/identity-access-management/infrastructure/serializers/jsonapi/user-account-info.serializer.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | Identity Access Management | Infrastructure | Serializer | JSONAPI | user-account-info', function () {
+  describe('#serialize', function () {
+    it('serializes user account information', function () {
+      // given
+      const userAccountInfo = {
+        email: 'user@email.com',
+        username: 'my-username',
+        canSelfDeleteAccount: true,
+      };
+
+      // when
+      const json = userAccountInfoSerializer.serialize(userAccountInfo);
+
+      // then
+      expect(json).to.be.deep.equal({
+        data: {
+          type: 'account-infos',
+          attributes: {
+            email: 'user@email.com',
+            username: 'my-username',
+            'can-self-delete-account': true,
+          },
+        },
+      });
+    });
+  });
+});

--- a/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-with-activity.serializer.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-with-activity.serializer.test.js
@@ -65,6 +65,11 @@ describe('Unit | Identity Access Management | Infrastructure | Serializer | JSON
                 userModelObject.shouldSeeDataProtectionPolicyInformationBanner,
             },
             relationships: {
+              'account-info': {
+                links: {
+                  related: '/api/users/my-account',
+                },
+              },
               profile: {
                 links: {
                   related: `/api/users/${userModelObject.id}/profile`,

--- a/mon-pix/app/models/account-info.js
+++ b/mon-pix/app/models/account-info.js
@@ -1,0 +1,7 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class AccountInfo extends Model {
+  @attr('string') email;
+  @attr('string') username;
+  @attr('boolean') canSelfDeleteAccount;
+}

--- a/mon-pix/app/models/user.js
+++ b/mon-pix/app/models/user.js
@@ -26,6 +26,7 @@ export default class User extends Model {
   // includes
   @belongsTo('is-certifiable', { async: true, inverse: null }) isCertifiable;
   @belongsTo('profile', { async: true, inverse: null }) profile;
+  @belongsTo('account-info', { async: true, inverse: null }) accountInfo;
   @hasMany('certification', { async: true, inverse: 'user' }) certifications;
   @hasMany('scorecard', { async: true, inverse: null }) scorecards;
   @hasMany('training', { async: true, inverse: null }) trainings;

--- a/mon-pix/app/templates/authenticated/user-account.hbs
+++ b/mon-pix/app/templates/authenticated/user-account.hbs
@@ -32,6 +32,11 @@
                 </LinkTo>
               </li>
             {{/if}}
+            {{#if @model.accountInfo.canSelfDeleteAccount}}
+              <li>
+                {{! ADD DELETE ACCOUNT LINK HERE }}
+              </li>
+            {{/if}}
           </ul>
         </nav>
       </PixBlock>


### PR DESCRIPTION
## :fallen_leaf: Problème

Dans le cadre de la fonctionnalité de suppression de compte en autonomie, nous avons besoin d'une API permettant de récupérer des informations du compte utilisateur, dont la propriété: `canSelfDeleteAccount`

## :chestnut: Proposition

1. **Création d'un endpoint `GET /api/users/my-account`**
> Récupère les informations utilisateurs suivantes:
> - `email`: Email de l'utilisateur
> - `username`: Username de l'utilisateur
> - `canSelfDeleteAccount`: indique si l'utilisateur peut supprimer son compte en autonomie (récupérer via l'API user sur contexte "privacy")

2. **Appeler l'API `GET /api/users/my-account` sur la page "Mon compte"**

## :wood: Pour tester

_Avec le feature toggle `FT_SELF_ACCOUNT_DELETION=false`_
1. Se connection sur Pix App avec un compte existant
2. Aller sur la page "Mon compte"
> Vérifier qu'un appel est réalisé: `GET /users/my-account` avec l'`email`, le `username` et `canSelfDeleteAccount=false`

_Avec le feature toggle `FT_SELF_ACCOUNT_DELETION=true`_
1. Se connection sur Pix App avec un compte existant
2. Aller sur la page "Mon compte"
> Vérifier qu'un appel est réalisé: `GET /users/my-account` avec l'`email`, le `username` et `canSelfDeleteAccount=true`
