### PR TITLE
[BUGFIX] Afficher l'onglet Récompenses de fin de parcours uniquement sous condition (PIX-15052).

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/index.gjs
@@ -11,7 +11,9 @@ export default class EvaluationResultsTabs extends Component {
   @service tabManager;
 
   get showRewardsTab() {
-    return this.args.campaignParticipationResult.campaignParticipationBadges.length > 0;
+    const badges = this.args.campaignParticipationResult.campaignParticipationBadges;
+
+    return badges.some((badge) => badge.isAcquired || badge.isAlwaysVisible);
   }
 
   get initialTabIndex() {

--- a/mon-pix/tests/unit/components/campaigns/assessment/results/evaluation-results-tabs/index-test.js
+++ b/mon-pix/tests/unit/components/campaigns/assessment/results/evaluation-results-tabs/index-test.js
@@ -1,0 +1,88 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import createGlimmerComponent from '../../../../../../helpers/create-glimmer-component';
+
+module(
+  'Unit | Component | Campaigns | Assessment | Results | EvaluationResultsTabs | ResultsDetails | CompetenceRow',
+  function (hooks) {
+    setupTest(hooks);
+
+    module('#showRewardsTab', function () {
+      module('when there is no badge', function () {
+        test('should return false', async function (assert) {
+          // given
+          const component = createGlimmerComponent('campaigns/assessment/results/evaluation-results-tabs/index');
+
+          component.args.campaignParticipationResult = {
+            campaignParticipationBadges: [],
+          };
+
+          // then
+          assert.false(component.showRewardsTab);
+        });
+      });
+
+      module('when there is badges', function () {
+        module('when there is only not-acquired and no always visible badge', function () {
+          test('should return false', async function (assert) {
+            // given
+            const store = this.owner.lookup('service:store');
+            const notAlwaysVisibledBadge = store.createRecord('campaign-participation-badge', {
+              isAcquired: false,
+              isAlwaysVisible: false,
+            });
+
+            const component = createGlimmerComponent('campaigns/assessment/results/evaluation-results-tabs/index');
+
+            component.args.campaignParticipationResult = {
+              campaignParticipationBadges: [notAlwaysVisibledBadge],
+            };
+
+            // then
+            assert.false(component.showRewardsTab);
+          });
+        });
+
+        module('when there is at least a not-acquired but always visible badge', function () {
+          test('should return true', async function (assert) {
+            // given
+            const store = this.owner.lookup('service:store');
+            const alwaysVisibledBadge = store.createRecord('campaign-participation-badge', {
+              isAcquired: false,
+              isAlwaysVisible: true,
+            });
+
+            const component = createGlimmerComponent('campaigns/assessment/results/evaluation-results-tabs/index');
+
+            component.args.campaignParticipationResult = {
+              campaignParticipationBadges: [alwaysVisibledBadge],
+            };
+
+            // then
+            assert.true(component.showRewardsTab);
+          });
+        });
+
+        module('when there is at least one acquired badge', function () {
+          test('should return true', async function (assert) {
+            // given
+            const store = this.owner.lookup('service:store');
+            const acquiredBadge = store.createRecord('campaign-participation-badge', {
+              isAcquired: true,
+            });
+
+            const component = createGlimmerComponent('campaigns/assessment/results/evaluation-results-tabs/index');
+
+            component.args.campaignParticipationResult = {
+              campaignParticipationBadges: [acquiredBadge],
+            };
+
+            // then
+            assert.true(component.showRewardsTab);
+          });
+        });
+      });
+    });
+  },
+);


### PR DESCRIPTION
## :fallen_leaf: Problème

L'onglet Récompenses de la fin de parcours s'affiche alors qu'il n'y a pas de RT à montrer.

## :chestnut: Proposition

L'onglet ne doit s'afficher que s'il y a au moins un RT acquis ou non-acquis + en lacune.

## :wood: Pour tester

1. Sans être connecté, après avoir passé toutes les épreuves de [cette campagne](https://app-pr10592.review.pix.fr/campagnes/UNEVNK662/presentation) n'a pas l'onglet Récompenses alors qu'un RT (non-acquis et pas en lacune) existe

2. Se connecter avec `eval-campaign-with-badges@example.net`. [Cette campagne](https://app-pr10592.review.pix.fr/campagnes/EVALBADGE/evaluation/resultats) a bien l'onglet Récompenses, rempli comme souhaité
