### PR TITLE
[TECH] Export de la liste blanche SCO

### DIFF
--- a/admin/app/components/administration/certification/sco-whitelist-configuration.gjs
+++ b/admin/app/components/administration/certification/sco-whitelist-configuration.gjs
@@ -14,7 +14,6 @@ export default class ScoWhitelistConfiguration extends Component {
   @service intl;
   @service session;
   @service pixToast;
-  @service notifications;
   @service fileSaver;
 
   @tracked isExportLoading = false;
@@ -59,7 +58,9 @@ export default class ScoWhitelistConfiguration extends Component {
       const token = this.session.data.authenticated.access_token;
       await this.fileSaver.save({ url, fileName, token });
     } catch (error) {
-      this.pixToast.sendErrorNotification(this.intl.t('pages.administration.certification.sco-whitelist.export.error'));
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t('pages.administration.certification.sco-whitelist.export.error')
+      });
     } finally {
       this.isExportLoading = false;
     }

--- a/admin/app/components/administration/certification/sco-whitelist-configuration.gjs
+++ b/admin/app/components/administration/certification/sco-whitelist-configuration.gjs
@@ -38,8 +38,11 @@ export default class ScoWhitelistConfiguration extends Component {
           message: this.intl.t('pages.administration.certification.sco-whitelist.import.success'),
         });
       } else {
+        const responseJson = await response.json();
+        const errorKey = responseJson?.errors[0]?.code || 'error';
+
         this.pixToast.sendErrorNotification({
-          message: this.intl.t('pages.administration.certification.sco-whitelist.import.error'),
+          message: this.intl.t(`pages.administration.certification.sco-whitelist.import.${errorKey}`),
         });
       }
     } catch (error) {
@@ -59,7 +62,7 @@ export default class ScoWhitelistConfiguration extends Component {
       await this.fileSaver.save({ url, fileName, token });
     } catch (error) {
       this.pixToast.sendErrorNotification({
-        message: this.intl.t('pages.administration.certification.sco-whitelist.export.error')
+        message: this.intl.t('pages.administration.certification.sco-whitelist.export.error'),
       });
     } finally {
       this.isExportLoading = false;

--- a/admin/app/components/administration/certification/sco-whitelist-configuration.gjs
+++ b/admin/app/components/administration/certification/sco-whitelist-configuration.gjs
@@ -70,7 +70,6 @@ export default class ScoWhitelistConfiguration extends Component {
       @title={{t "pages.administration.certification.sco-whitelist.title"}}
       class="sco-whitelist-configuration"
     >
-      <PixMessage @type="warning">Feature en cours de construction</PixMessage>
       <PixMessage @type="info">{{t "pages.administration.certification.sco-whitelist.instructions"}}</PixMessage>
 
       <div class="sco-whitelist-configuration__actions">

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -32,6 +32,7 @@
 @import 'components/administration/certification/certification-scoring-configuration';
 @import 'components/administration/certification/competence-scoring-configuration';
 @import 'components/administration/certification/flash-algorithm-configuration-form';
+@import 'components/administration/certification/sco-whitelist-configuration';
 @import 'components/administration/certification/scoring-simulator';
 @import 'components/autonomous-courses/details';
 @import 'components/autonomous-courses/form';

--- a/admin/app/styles/components/administration/certification/sco-whitelist-configuration.scss
+++ b/admin/app/styles/components/administration/certification/sco-whitelist-configuration.scss
@@ -1,0 +1,8 @@
+.sco-whitelist-configuration {
+  &__actions {
+    display: flex;
+    flex-direction: row;
+    gap: var(--pix-spacing-6x);
+    margin-top: var(--pix-spacing-6x);
+  }
+}

--- a/admin/tests/integration/components/administration/certification/sco-whitelist-configuration-test.gjs
+++ b/admin/tests/integration/components/administration/certification/sco-whitelist-configuration-test.gjs
@@ -59,26 +59,58 @@ module('Integration | Component | administration/certification/sco-whitelist-con
   });
 
   module('when import fails', function () {
-    test('it displays an error notification', async function (assert) {
-      // given
-      fetchStub
-        .withArgs(`${ENV.APP.API_HOST}/api/admin/sco-whitelist`, {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            'Content-Type': 'text/csv',
-            Accept: 'application/json',
-          },
-          method: 'POST',
-          body: file,
-        })
-        .rejects();
-      // when
-      const screen = await render(<template><ScoWhitelistConfiguration /><PixToastContainer /></template>);
-      const input = await screen.findByLabelText(t('pages.administration.certification.sco-whitelist.import.button'));
-      await triggerEvent(input, 'change', { files: [file] });
+    module('when it is a generic error', function () {
+      test('it displays an error notification', async function (assert) {
+        // given
+        fetchStub
+          .withArgs(`${ENV.APP.API_HOST}/api/admin/sco-whitelist`, {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              'Content-Type': 'text/csv',
+              Accept: 'application/json',
+            },
+            method: 'POST',
+            body: file,
+          })
+          .rejects();
+        // when
+        const screen = await render(<template><ScoWhitelistConfiguration /><PixToastContainer /></template>);
+        const input = await screen.findByLabelText(t('pages.administration.certification.sco-whitelist.import.button'));
+        await triggerEvent(input, 'change', { files: [file] });
 
-      // then
-      assert.ok(await screen.findByText(t('pages.administration.certification.sco-whitelist.import.error')));
+        // then
+        assert.ok(await screen.findByText(t('pages.administration.certification.sco-whitelist.import.error')));
+      });
+    });
+
+    module('when it is a CERTIFICATION_INVALID_SCO_WHITELIST_ERROR', function () {
+      test('it displays an error notification', async function (assert) {
+        // given
+        fetchStub
+          .withArgs(`${ENV.APP.API_HOST}/api/admin/sco-whitelist`, {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              'Content-Type': 'text/csv',
+              Accept: 'application/json',
+            },
+            method: 'POST',
+            body: file,
+          })
+          .resolves(
+            fetchResponse({ body: { errors: [{ code: 'CERTIFICATION_INVALID_SCO_WHITELIST_ERROR' }] }, status: 422 }),
+          );
+        // when
+        const screen = await render(<template><ScoWhitelistConfiguration /><PixToastContainer /></template>);
+        const input = await screen.findByLabelText(t('pages.administration.certification.sco-whitelist.import.button'));
+        await triggerEvent(input, 'change', { files: [file] });
+
+        // then
+        assert.ok(
+          await screen.findByText(
+            t('pages.administration.certification.sco-whitelist.import.CERTIFICATION_INVALID_SCO_WHITELIST_ERROR'),
+          ),
+        );
+      });
     });
   });
 });

--- a/admin/tests/integration/components/administration/certification/sco-whitelist-configuration_test.gjs
+++ b/admin/tests/integration/components/administration/certification/sco-whitelist-configuration_test.gjs
@@ -1,4 +1,4 @@
-import NotificationContainer from '@1024pix/ember-cli-notifications/components/notification-container';
+import PixToastContainer from '@1024pix/pix-ui/components/pix-toast-container';
 import { render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import { triggerEvent } from '@ember/test-helpers';
@@ -45,7 +45,7 @@ module('Integration | Component | administration/certification/sco-whitelist-con
         // given
         fileSaverStub.resolves();
         // when
-        const screen = await render(<template><ScoWhitelistConfiguration /><NotificationContainer /></template>);
+        const screen = await render(<template><ScoWhitelistConfiguration /><PixToastContainer /></template>);
         const input = await screen.findByText(t('pages.administration.certification.sco-whitelist.export.button'));
         await triggerEvent(input, 'click');
 
@@ -61,7 +61,7 @@ module('Integration | Component | administration/certification/sco-whitelist-con
         // given
         fileSaverStub.rejects();
         // when
-        const screen = await render(<template><ScoWhitelistConfiguration /><NotificationContainer /></template>);
+        const screen = await render(<template><ScoWhitelistConfiguration /><PixToastContainer /></template>);
         const input = await screen.findByText(t('pages.administration.certification.sco-whitelist.export.button'));
         await triggerEvent(input, 'click');
 
@@ -89,7 +89,7 @@ module('Integration | Component | administration/certification/sco-whitelist-con
 
       test('it displays a success notification', async function (assert) {
         // when
-        const screen = await render(<template><ScoWhitelistConfiguration /><NotificationContainer /></template>);
+        const screen = await render(<template><ScoWhitelistConfiguration /><PixToastContainer /></template>);
         const input = await screen.getByLabelText(t('pages.administration.certification.sco-whitelist.import.button'));
         await triggerEvent(input, 'change', { files: [file] });
 
@@ -115,7 +115,7 @@ module('Integration | Component | administration/certification/sco-whitelist-con
           })
           .rejects();
         // when
-        const screen = await render(<template><ScoWhitelistConfiguration /><NotificationContainer /></template>);
+        const screen = await render(<template><ScoWhitelistConfiguration /><PixToastContainer /></template>);
         const input = await screen.findByLabelText(t('pages.administration.certification.sco-whitelist.import.button'));
         await triggerEvent(input, 'change', { files: [file] });
 

--- a/admin/tests/integration/components/administration/certification/sco-whitelist-configuration_test.gjs
+++ b/admin/tests/integration/components/administration/certification/sco-whitelist-configuration_test.gjs
@@ -1,5 +1,5 @@
-import PixToastContainer from '@1024pix/pix-ui/components/pix-toast-container';
 import { render } from '@1024pix/ember-testing-library';
+import PixToastContainer from '@1024pix/pix-ui/components/pix-toast-container';
 import Service from '@ember/service';
 import { triggerEvent } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';

--- a/admin/tests/integration/components/administration/certification/sco-whitelist-configuration_test.gjs
+++ b/admin/tests/integration/components/administration/certification/sco-whitelist-configuration_test.gjs
@@ -1,0 +1,138 @@
+import NotificationContainer from '@1024pix/ember-cli-notifications/components/notification-container';
+import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import { triggerEvent } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import ScoWhitelistConfiguration from 'pix-admin/components/administration/certification/sco-whitelist-configuration';
+import ENV from 'pix-admin/config/environment';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+const accessToken = 'An access token';
+const fileContent = 'foo';
+const file = new Blob([fileContent], { type: `valid-file` });
+
+module('Integration | Component | administration/certification/sco-whitelist-configuration', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  let fetchStub, fileSaverStub;
+
+  hooks.beforeEach(function () {
+    class SessionService extends Service {
+      data = { authenticated: { access_token: accessToken } };
+    }
+    this.owner.register('service:session', SessionService);
+
+    class FileSaver extends Service {
+      save = fileSaverStub;
+    }
+
+    this.owner.register('service:file-saver', FileSaver);
+
+    fetchStub = sinon.stub(window, 'fetch');
+    fileSaverStub = sinon.stub();
+  });
+
+  hooks.afterEach(function () {
+    window.fetch.restore();
+  });
+
+  module('Export', function () {
+    module('when export succeeds', function () {
+      test('it succeeds', async function (assert) {
+        // given
+        fileSaverStub.resolves();
+        // when
+        const screen = await render(<template><ScoWhitelistConfiguration /><NotificationContainer /></template>);
+        const input = await screen.findByText(t('pages.administration.certification.sco-whitelist.export.button'));
+        await triggerEvent(input, 'click');
+
+        // then
+        assert
+          .dom(await screen.queryByText(t('pages.administration.certification.sco-whitelist.export.error')))
+          .doesNotExist();
+      });
+    });
+
+    module('when export fails', function () {
+      test('it displays an error notification', async function (assert) {
+        // given
+        fileSaverStub.rejects();
+        // when
+        const screen = await render(<template><ScoWhitelistConfiguration /><NotificationContainer /></template>);
+        const input = await screen.findByText(t('pages.administration.certification.sco-whitelist.export.button'));
+        await triggerEvent(input, 'click');
+
+        // then
+        assert.dom(await screen.getByText(t('pages.administration.certification.sco-whitelist.export.error'))).exists();
+      });
+    });
+  });
+
+  module('Import', function () {
+    module('when import succeeds', function (hooks) {
+      hooks.beforeEach(function () {
+        fetchStub
+          .withArgs(`${ENV.APP.API_HOST}/api/admin/sco-whitelist`, {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              'Content-Type': 'text/csv',
+              Accept: 'application/json',
+            },
+            method: 'POST',
+            body: file,
+          })
+          .resolves(fetchResponse({ status: 201 }));
+      });
+
+      test('it displays a success notification', async function (assert) {
+        // when
+        const screen = await render(<template><ScoWhitelistConfiguration /><NotificationContainer /></template>);
+        const input = await screen.getByLabelText(t('pages.administration.certification.sco-whitelist.import.button'));
+        await triggerEvent(input, 'change', { files: [file] });
+
+        // then
+        assert
+          .dom(await screen.getByText(t('pages.administration.certification.sco-whitelist.import.success')))
+          .exists();
+      });
+    });
+
+    module('when import fails', function () {
+      test('it displays an error notification', async function (assert) {
+        // given
+        fetchStub
+          .withArgs(`${ENV.APP.API_HOST}/api/admin/sco-whitelist`, {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              'Content-Type': 'text/csv',
+              Accept: 'application/json',
+            },
+            method: 'POST',
+            body: file,
+          })
+          .rejects();
+        // when
+        const screen = await render(<template><ScoWhitelistConfiguration /><NotificationContainer /></template>);
+        const input = await screen.findByLabelText(t('pages.administration.certification.sco-whitelist.import.button'));
+        await triggerEvent(input, 'change', { files: [file] });
+
+        // then
+        assert.dom(await screen.getByText(t('pages.administration.certification.sco-whitelist.import.error'))).exists();
+      });
+    });
+  });
+});
+
+function fetchResponse({ body, status }) {
+  const mockResponse = new window.Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-type': 'application/json',
+    },
+  });
+
+  return mockResponse;
+}

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -413,11 +413,16 @@
         },
         "sco-whitelist": {
           "title": "SCO whitelist",
+          "export": {
+            "button": "Export whitelist (CSV)",
+            "error": "Could not download SCO whitelist."
+          },
           "import": {
-            "button": "Import new CSV file as whitelist",
+            "button": "Import file as whitelist (CSV)",
             "error": "Could not save SCO whitelist",
-            "success": "SCO whitelist saved"
-          }
+            "success": "SCO whitelist saved."
+          },
+          "instructions": "Recommended: make an export, modify the export, and import the modified version."
         },
         "scoring-simulator": {
           "title": "Scoring simulator",

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -418,6 +418,7 @@
             "error": "Could not download SCO whitelist."
           },
           "import": {
+            "CERTIFICATION_INVALID_SCO_WHITELIST_ERROR": "An error has occurred. Please verify externalIds in csv.",
             "button": "Import file as whitelist (CSV)",
             "error": "Could not save SCO whitelist",
             "success": "SCO whitelist saved."

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -423,11 +423,16 @@
         },
         "sco-whitelist": {
           "title": "Liste blanche centres SCO",
+          "export": {
+            "button": "Exporter la liste blanche (format CSV)",
+            "error": "Échec de la récupération de la liste blanche."
+          },
           "import": {
-            "button": "Importer une nouvelle liste blanche au format CSV",
+            "button": "Importer une nouvelle liste blanche (format CSV)",
             "error": "Échec de l'enregistrement de la liste blanche",
-            "success": "Liste blanche enregistrée"
-          }
+            "success": "Liste blanche enregistrée."
+          },
+          "instructions": "Recommandation: exporter la liste, modifier l'export, et envoyer la version modifiée."
         },
         "scoring-simulator": {
           "title": "Simulateur de scoring",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -428,6 +428,7 @@
             "error": "Échec de la récupération de la liste blanche."
           },
           "import": {
+            "CERTIFICATION_INVALID_SCO_WHITELIST_ERROR": "Une erreur est survenue. Veuillez vérifier les externalId renseignés.",
             "button": "Importer une nouvelle liste blanche (format CSV)",
             "error": "Échec de l'enregistrement de la liste blanche",
             "success": "Liste blanche enregistrée."

--- a/api/src/certification/configuration/application/http-error-mapper-configuration.js
+++ b/api/src/certification/configuration/application/http-error-mapper-configuration.js
@@ -1,0 +1,10 @@
+import { HttpErrors } from '../../../shared/application/http-errors.js';
+import { DomainErrorMappingConfiguration } from '../../../shared/application/models/domain-error-mapping-configuration.js';
+import { InvalidScoWhitelistError } from '../domain/errors.js';
+
+export const configurationDomainErrorMappingConfiguration = [
+  {
+    name: InvalidScoWhitelistError.name,
+    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+  },
+].map((domainErrorMappingConfiguration) => new DomainErrorMappingConfiguration(domainErrorMappingConfiguration));

--- a/api/src/certification/configuration/application/sco-whitelist-controller.js
+++ b/api/src/certification/configuration/application/sco-whitelist-controller.js
@@ -1,5 +1,6 @@
 import { usecases } from '../domain/usecases/index.js';
 import { extractExternalIds } from '../infrastructure/serializers/csv/sco-whitelist-csv-parser.js';
+import { serialize } from '../infrastructure/serializers/csv/sco-whitelist-csv-serializer.js';
 
 const importScoWhitelist = async function (request, h, dependencies = { extractExternalIds }) {
   const externalIds = await dependencies.extractExternalIds(request.payload.path);
@@ -8,8 +9,10 @@ const importScoWhitelist = async function (request, h, dependencies = { extractE
 };
 
 const exportScoWhitelist = async function (request, h) {
+  const whitelist = await usecases.exportScoWhitelist();
+
   return h
-    .response()
+    .response(await serialize({ centers: whitelist }))
     .header('Content-Type', 'text/csv; charset=utf-8')
     .header('content-disposition', 'filename=sco-whitelist')
     .code(200);

--- a/api/src/certification/configuration/application/sco-whitelist-controller.js
+++ b/api/src/certification/configuration/application/sco-whitelist-controller.js
@@ -7,6 +7,15 @@ const importScoWhitelist = async function (request, h, dependencies = { extractE
   return h.response().created();
 };
 
+const exportScoWhitelist = async function (request, h) {
+  return h
+    .response()
+    .header('Content-Type', 'text/csv; charset=utf-8')
+    .header('content-disposition', 'filename=sco-whitelist')
+    .code(200);
+};
+
 export const scoWhitelistController = {
   importScoWhitelist,
+  exportScoWhitelist,
 };

--- a/api/src/certification/configuration/application/sco-whitelist-route.js
+++ b/api/src/certification/configuration/application/sco-whitelist-route.js
@@ -40,6 +40,24 @@ const register = async function (server) {
         ],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/admin/sco-whitelist',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+            assign: 'hasRoleSuperAdmin',
+          },
+        ],
+        handler: scoWhitelistController.exportScoWhitelist,
+        tags: ['api', 'admin'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs authentifiés avec le rôle Super Admin',
+          'Elle permet de récupérer la liste blanche des centres SCO.',
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/src/certification/configuration/domain/errors.js
+++ b/api/src/certification/configuration/domain/errors.js
@@ -1,0 +1,7 @@
+import { DomainError } from '../../../shared/domain/errors.js';
+
+export class InvalidScoWhitelistError extends DomainError {
+  constructor(meta) {
+    super('La liste blanche contient des données invalides.', 'CERTIFICATION_INVALID_SCO_WHITELIST_ERROR', meta);
+  }
+}

--- a/api/src/certification/configuration/domain/usecases/export-sco-whitelist.js
+++ b/api/src/certification/configuration/domain/usecases/export-sco-whitelist.js
@@ -1,0 +1,13 @@
+/**
+ * @typedef {import ('./index.js').CenterRepository} CenterRepository
+ * @typedef {import ('../models/Center.js').Center} Center
+ */
+
+/**
+ * @param {Object} params
+ * @param {CenterRepository} params.centerRepository
+ * @returns {Promise<Array<Center>>}
+ */
+export const exportScoWhitelist = async ({ centerRepository }) => {
+  return centerRepository.getWhitelist();
+};

--- a/api/src/certification/configuration/domain/usecases/import-sco-whitelist.js
+++ b/api/src/certification/configuration/domain/usecases/import-sco-whitelist.js
@@ -3,6 +3,7 @@
  */
 
 import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { InvalidScoWhitelistError } from '../errors.js';
 
 export const importScoWhitelist = withTransaction(
   /**
@@ -14,7 +15,10 @@ export const importScoWhitelist = withTransaction(
     const numberOfUpdatedLines = await centerRepository.addToWhitelistByExternalIds({ externalIds });
 
     if (externalIds.length !== numberOfUpdatedLines) {
-      throw new RangeError('Some externalIds are not valid, please verify whitelist');
+      throw new InvalidScoWhitelistError({
+        numberOfExternalIdsInInput: externalIds.length,
+        numberOfValidExternalIds: numberOfUpdatedLines,
+      });
     }
   },
 );

--- a/api/src/certification/configuration/domain/usecases/import-sco-whitelist.js
+++ b/api/src/certification/configuration/domain/usecases/import-sco-whitelist.js
@@ -11,6 +11,10 @@ export const importScoWhitelist = withTransaction(
    */
   async ({ externalIds = [], centerRepository }) => {
     await centerRepository.resetWhitelist();
-    return centerRepository.addToWhitelistByExternalIds({ externalIds });
+    const numberOfUpdatedLines = await centerRepository.addToWhitelistByExternalIds({ externalIds });
+
+    if (externalIds.length !== numberOfUpdatedLines) {
+      throw new RangeError('Some externalIds are not valid, please verify whitelist');
+    }
   },
 );

--- a/api/src/certification/configuration/domain/usecases/index.js
+++ b/api/src/certification/configuration/domain/usecases/index.js
@@ -16,7 +16,7 @@ import * as centerRepository from '../../infrastructure/repositories/center-repo
  * @typedef {complementaryCertificationRepository} ComplementaryCertificationRepository
  * @typedef {attachableTargetProfileRepository} AttachableTargetProfileRepository
  * @typedef {centerPilotFeaturesRepository} CenterPilotFeaturesRepository
- * @typedef {centerRepository} CentersRepository
+ * @typedef {centerRepository} CenterRepository
  * @typedef {candidateRepository} CandidateRepository
  **/
 const dependencies = {

--- a/api/src/certification/configuration/infrastructure/repositories/center-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/center-repository.js
@@ -5,14 +5,16 @@ import { CenterTypes } from '../../domain/models/CenterTypes.js';
 /**
  * @param {Object} params
  * @param {Array<number>} params.externalIds
- * @returns {Promise<void>}
+ * @returns {Promise<number>} - number of rows affected
  */
 export const addToWhitelistByExternalIds = async ({ externalIds }) => {
   const knexConn = DomainTransaction.getConnection();
-  return knexConn('certification-centers')
+  const numberOfUpdatedLines = knexConn('certification-centers')
     .update({ isScoBlockedAccessWhitelist: true, updatedAt: knexConn.fn.now() })
     .where({ type: CenterTypes.SCO })
     .whereIn('externalId', externalIds);
+
+  return numberOfUpdatedLines || 0;
 };
 
 /**

--- a/api/src/certification/configuration/infrastructure/repositories/center-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/center-repository.js
@@ -1,4 +1,5 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { Center } from '../../domain/models/Center.js';
 import { CenterTypes } from '../../domain/models/CenterTypes.js';
 
 /**
@@ -22,4 +23,20 @@ export const resetWhitelist = async () => {
   return knexConn('certification-centers')
     .update({ isScoBlockedAccessWhitelist: false, updatedAt: knexConn.fn.now() })
     .where({ type: CenterTypes.SCO });
+};
+
+/**
+ * @returns {Promise<Array<Center>>}
+ */
+export const getWhitelist = async () => {
+  const knexConn = DomainTransaction.getConnection();
+  const data = await knexConn('certification-centers')
+    .select('id', 'type', 'externalId')
+    .where({ isScoBlockedAccessWhitelist: true });
+
+  return data.map(_toDomain);
+};
+
+const _toDomain = ({ id, externalId, type }) => {
+  return new Center({ id, externalId, type });
 };

--- a/api/src/certification/configuration/infrastructure/serializers/csv/sco-whitelist-csv-parser.js
+++ b/api/src/certification/configuration/infrastructure/serializers/csv/sco-whitelist-csv-parser.js
@@ -1,12 +1,20 @@
+import { createReadStream } from 'node:fs';
 import * as fs from 'node:fs/promises';
 
+import { FileValidationError } from '../../../../../shared/domain/errors.js';
 import { CsvParser } from '../../../../../shared/infrastructure/serializers/csv/csv-parser.js';
+import { getDataBuffer } from '../../../../../shared/infrastructure/utils/buffer.js';
+import { logger } from '../../../../../shared/infrastructure/utils/logger.js';
 import { ScoWhitelistCsvHeader } from './sco-whitelist-csv-header.js';
 
 export const extractExternalIds = async (file) => {
-  const buffer = await fs.readFile(file);
+  const stream = createReadStream(file);
+  const buffer = await getDataBuffer(stream);
   try {
     return _extractIds(buffer).map(({ externalId }) => externalId.trim());
+  } catch (error) {
+    logger.error(error);
+    throw new FileValidationError();
   } finally {
     fs.unlink(file);
   }

--- a/api/src/certification/configuration/infrastructure/serializers/csv/sco-whitelist-csv-serializer.js
+++ b/api/src/certification/configuration/infrastructure/serializers/csv/sco-whitelist-csv-serializer.js
@@ -1,0 +1,10 @@
+import { getCsvContent } from '../../../../../shared/infrastructure/utils/csv/write-csv-utils.js';
+
+/**
+ * @param {Object} params
+ * @param {Array<Center>} params.centers
+ * @returns {Promise<string>}
+ */
+export const serialize = async ({ centers }) => {
+  return getCsvContent({ data: centers, fileHeaders: [{ label: 'externalId', value: 'externalId' }] });
+};

--- a/api/src/certification/shared/application/http-error-mapper-configuration.js
+++ b/api/src/certification/shared/application/http-error-mapper-configuration.js
@@ -1,5 +1,6 @@
 import { HttpErrors } from '../../../shared/application/http-errors.js';
 import { DomainErrorMappingConfiguration } from '../../../shared/application/models/domain-error-mapping-configuration.js';
+import { configurationDomainErrorMappingConfiguration } from '../../configuration/application/http-error-mapper-configuration.js';
 import { enrolmentDomainErrorMappingConfiguration } from '../../enrolment/application/http-error-mapper-configuration.js';
 import { resultsDomainErrorMappingConfiguration } from '../../results/application/http-error-mapper-configuration.js';
 import { sessionDomainErrorMappingConfiguration } from '../../session-management/application/http-error-mapper-configuration.js';
@@ -22,5 +23,6 @@ certificationDomainErrorMappingConfiguration.push(
   ...resultsDomainErrorMappingConfiguration,
   ...enrolmentDomainErrorMappingConfiguration,
   ...sessionDomainErrorMappingConfiguration,
+  ...configurationDomainErrorMappingConfiguration,
 );
 export { certificationDomainErrorMappingConfiguration };

--- a/api/tests/certification/configuration/acceptance/application/sco-whitelist-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/sco-whitelist-route_test.js
@@ -16,7 +16,7 @@ describe('Certification | Configuration | Acceptance | API | sco-whitelist-route
   });
 
   describe('POST /api/admin/sco-whitelist', function () {
-    it('should return 200 HTTP status code', async function () {
+    it('should return 201 HTTP status code', async function () {
       // given
       const superAdmin = await insertUserWithRoleSuperAdmin();
       const buffer = 'externalId\next1\next2';
@@ -57,6 +57,26 @@ describe('Certification | Configuration | Acceptance | API | sco-whitelist-route
         .where({ isScoBlockedAccessWhitelist: true })
         .pluck('externalId');
       expect(whitelist).to.deep.equal(['ext1', 'ext2']);
+    });
+  });
+
+  describe('GET /api/admin/sco-whitelist', function () {
+    it('should return 200 HTTP status code', async function () {
+      // given
+      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const options = {
+        method: 'GET',
+        url: '/api/admin/sco-whitelist',
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(superAdmin.id),
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
     });
   });
 });

--- a/api/tests/certification/configuration/acceptance/application/sco-whitelist-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/sco-whitelist-route_test.js
@@ -97,7 +97,17 @@ describe('Certification | Configuration | Acceptance | API | sco-whitelist-route
       const response = await server.inject(options);
 
       // then
-      expect(response.statusCode).to.equal(500);
+      expect(response.statusCode).to.equal(422);
+      expect(response.result.errors[0]).to.deep.equal({
+        status: '422',
+        code: 'CERTIFICATION_INVALID_SCO_WHITELIST_ERROR',
+        title: 'Unprocessable entity',
+        detail: 'La liste blanche contient des données invalides.',
+        meta: {
+          numberOfExternalIdsInInput: 2,
+          numberOfValidExternalIds: 1,
+        },
+      });
       const whitelist = await knex('certification-centers')
         .where({ isScoBlockedAccessWhitelist: true })
         .pluck('externalId');

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/center-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/center-repository_test.js
@@ -23,11 +23,12 @@ describe('Certification | Configuration | Integration | Repository | center-repo
       await databaseBuilder.commit();
 
       // when
-      await centerRepository.addToWhitelistByExternalIds({
+      const numberOfUpdatedLines = await centerRepository.addToWhitelistByExternalIds({
         externalIds: [whitelistedExternalId1, whitelistedExternalId2],
       });
 
       // then
+      expect(numberOfUpdatedLines).to.equal(2);
       const updatedCenter1 = await knex('certification-centers').where({ id: center1BeforeUpdate.id }).first();
       expect(updatedCenter1.isScoBlockedAccessWhitelist).to.be.true;
       expect(updatedCenter1.updatedAt).to.be.above(center1BeforeUpdate.updatedAt);

--- a/api/tests/certification/configuration/unit/application/sco-whitelist-route_test.js
+++ b/api/tests/certification/configuration/unit/application/sco-whitelist-route_test.js
@@ -24,4 +24,25 @@ describe('Certification | Configuration | Unit | Application | Router | sco-whit
       });
     });
   });
+
+  describe('GET /api/admin/sco-whitelist', function () {
+    describe('when the user authenticated has no role', function () {
+      it('should return 403 HTTP status code', async function () {
+        // given
+        sinon
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
+          .returns((request, h) => h.response().code(403).takeover());
+        sinon.stub(scoWhitelistController, 'exportScoWhitelist').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('GET', '/api/admin/sco-whitelist');
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(scoWhitelistController.exportScoWhitelist);
+      });
+    });
+  });
 });

--- a/api/tests/certification/configuration/unit/domain/usecases/export-sco-whitelist_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/export-sco-whitelist_test.js
@@ -1,0 +1,29 @@
+import { CenterTypes } from '../../../../../../src/certification/configuration/domain/models/CenterTypes.js';
+import { exportScoWhitelist } from '../../../../../../src/certification/configuration/domain/usecases/export-sco-whitelist.js';
+import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+
+describe('Certification | Configuration | Unit | UseCase | export-sco-whitelist', function () {
+  let centerRepository;
+
+  beforeEach(function () {
+    centerRepository = {
+      getWhitelist: sinon.stub().throws(new Error('bad arguments')),
+    };
+  });
+
+  it('should whitelist a center', async function () {
+    // given
+    const whitelistedCenter = domainBuilder.certification.configuration.buildCenter({
+      type: CenterTypes.SCO,
+      externalId: 'IN_WHITELIST',
+    });
+    centerRepository.getWhitelist.resolves([whitelistedCenter]);
+
+    // when
+    const results = await exportScoWhitelist({ centerRepository });
+
+    // then
+    expect(centerRepository.getWhitelist).to.have.been.calledOnce;
+    expect(results).to.deep.equal([whitelistedCenter]);
+  });
+});

--- a/api/tests/certification/configuration/unit/domain/usecases/import-sco-whitelist_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/import-sco-whitelist_test.js
@@ -1,4 +1,5 @@
 import { DomainTransaction } from '../../../../../../lib/infrastructure/DomainTransaction.js';
+import { InvalidScoWhitelistError } from '../../../../../../src/certification/configuration/domain/errors.js';
 import { importScoWhitelist } from '../../../../../../src/certification/configuration/domain/usecases/import-sco-whitelist.js';
 import { catchErr, expect, sinon } from '../../../../../test-helper.js';
 
@@ -46,7 +47,7 @@ describe('Certification | Configuration | Unit | UseCase | import-sco-whitelist'
     )([11, 12]);
 
     // then
-    expect(error).to.be.instanceOf(RangeError);
-    expect(error.message).to.equal('Some externalIds are not valid, please verify whitelist');
+    expect(error).to.be.instanceOf(InvalidScoWhitelistError);
+    expect(error.message).to.equal('La liste blanche contient des données invalides.');
   });
 });

--- a/api/tests/certification/configuration/unit/domain/usecases/import-sco-whitelist_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/import-sco-whitelist_test.js
@@ -1,6 +1,6 @@
 import { DomainTransaction } from '../../../../../../lib/infrastructure/DomainTransaction.js';
 import { importScoWhitelist } from '../../../../../../src/certification/configuration/domain/usecases/import-sco-whitelist.js';
-import { expect, sinon } from '../../../../../test-helper.js';
+import { catchErr, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Certification | Configuration | Unit | UseCase | import-sco-whitelist', function () {
   let centerRepository;
@@ -19,7 +19,7 @@ describe('Certification | Configuration | Unit | UseCase | import-sco-whitelist'
   it('should whitelist a center', async function () {
     // given
     centerRepository.resetWhitelist.resolves();
-    centerRepository.addToWhitelistByExternalIds.resolves();
+    centerRepository.addToWhitelistByExternalIds.resolves(1);
 
     // when
     await importScoWhitelist({
@@ -30,5 +30,23 @@ describe('Certification | Configuration | Unit | UseCase | import-sco-whitelist'
     // then
     expect(centerRepository.resetWhitelist).to.have.been.calledOnce;
     expect(centerRepository.addToWhitelistByExternalIds).to.have.been.calledOnceWithExactly({ externalIds: [12] });
+  });
+
+  it('should reject new whitelist when not valid', async function () {
+    // given
+    centerRepository.resetWhitelist.resolves();
+    centerRepository.addToWhitelistByExternalIds.resolves(1);
+
+    // when
+    const error = await catchErr((externalIds) =>
+      importScoWhitelist({
+        externalIds,
+        centerRepository,
+      }),
+    )([11, 12]);
+
+    // then
+    expect(error).to.be.instanceOf(RangeError);
+    expect(error.message).to.equal('Some externalIds are not valid, please verify whitelist');
   });
 });

--- a/api/tests/certification/configuration/unit/infrastructure/serializers/csv/sco-whitelist-csv-parser_test.js
+++ b/api/tests/certification/configuration/unit/infrastructure/serializers/csv/sco-whitelist-csv-parser_test.js
@@ -1,5 +1,5 @@
 import { extractExternalIds } from '../../../../../../../src/certification/configuration/infrastructure/serializers/csv/sco-whitelist-csv-parser.js';
-import { CsvImportError } from '../../../../../../../src/shared/domain/errors.js';
+import { FileValidationError } from '../../../../../../../src/shared/domain/errors.js';
 import { catchErr, createTempFile, expect, removeTempFile } from '../../../../../../test-helper.js';
 
 describe('Integration | Serializer | CSV | Certification | Configuration | sco-whitelist-csv-parser', function () {
@@ -26,8 +26,7 @@ describe('Integration | Serializer | CSV | Certification | Configuration | sco-w
         const data = 'RendLesDonnées\n1';
         const filePath = await createTempFile(file, data);
         const error = await catchErr(extractExternalIds)(filePath);
-        expect(error).to.be.an.instanceOf(CsvImportError);
-        expect(error.code).to.equal('ENCODING_NOT_SUPPORTED');
+        expect(error).to.be.an.instanceOf(FileValidationError);
       });
     });
   });

--- a/api/tests/certification/configuration/unit/infrastructure/serializers/csv/sco-whitelist-csv-serializer_test.js
+++ b/api/tests/certification/configuration/unit/infrastructure/serializers/csv/sco-whitelist-csv-serializer_test.js
@@ -1,0 +1,20 @@
+import { CenterTypes } from '../../../../../../../src/certification/configuration/domain/models/CenterTypes.js';
+import { serialize } from '../../../../../../../src/certification/configuration/infrastructure/serializers/csv/sco-whitelist-csv-serializer.js';
+import { domainBuilder, expect } from '../../../../../../test-helper.js';
+
+describe('Integration | Serializer | CSV | Certification | Configuration | sco-whitelist-csv-serializer', function () {
+  it('returns all external ids as a string', async function () {
+    // given
+    const center = domainBuilder.certification.configuration.buildCenter({
+      type: CenterTypes.SCO,
+      externalId: 'SERIALIZED_EXTERNAL_ID',
+    });
+
+    // when
+    const results = await serialize({ centers: [center] });
+
+    // then
+    const expectedResult = '\uFEFF' + '"externalId"\n' + '"SERIALIZED_EXTERNAL_ID"';
+    expect(results).to.equal(expectedResult);
+  });
+});


### PR DESCRIPTION
## :fallen_leaf: Problème

Dans la suite des episodes "on en peut plus de gerer la liste blanche par variable d'environnement", et pour pouvoir importer une liste blanche, il faut pouvoir aussi l'exporter.

## :chestnut: Proposition

* Creer un bouton d'export
* Compatibilite entre le fichier d'export et d'import

## :jack_o_lantern: Remarques

* J'ai ajoute aussi une petite securite sur l'import pour ne pas pouvoir importer une liste invalide

## :wood: Pour tester

* Sur Pix Admin, aller dans Administration > Certification > Liste blanche centres SCO
  * soit `/administration/certification`
* Cliquer sur le bouton d'export
  * Pas d'erreur, et recuperation d'un fichier CSV avec un en-tete "externalId"
* Reperer, ou creer, un centre SCO, et y mettre un externalId
  * Par exemple CERTIFICATION_SCO_MANAGING_STUDENTS_EXTERNAL_ID est un bon candidat
* Editer le fichier CSV export, y mettre l'externalId
* Cliquer sur le bouton d'import et importer le fichier sauvegarde
  * Pas d'erreur 
* Refaire un  export, et voir que le nouveau fichier d'export contient l'externalId
* Editer le fichier CSV export, y mettre un external id "faux", genre "PAS_MOI"
* Tenter d'exporter un fichier avec ce mauvais id
  * Constater un message d'erreur
  * Tenter un export et voir que la liste blanche n'a pas bouge (on a refuse la liste avec des data invalides)
