### PR TITLE
[FEATURE] Ne recuperer que les attestations partagées pour le prescripteur (PIX-15336)

### DIFF
--- a/api/db/seeds/data/team-prescription/build-quests.js
+++ b/api/db/seeds/data/team-prescription/build-quests.js
@@ -3,7 +3,7 @@ import { REWARD_TYPES } from '../../../../src/quest/domain/constants.js';
 import { COMPARISON } from '../../../../src/quest/domain/models/Quest.js';
 import { Assessment, CampaignParticipationStatuses } from '../../../../src/shared/domain/models/index.js';
 import { temporaryStorage } from '../../../../src/shared/infrastructure/temporary-storage/index.js';
-import { AEFE_TAG, FEATURE_ATTESTATIONS_MANAGEMENT_ID } from '../common/constants.js';
+import { AEFE_TAG, FEATURE_ATTESTATIONS_MANAGEMENT_ID, USER_ID_ADMIN_ORGANIZATION } from '../common/constants.js';
 import { TARGET_PROFILE_BADGES_STAGES_ID } from './constants.js';
 
 const profileRewardTemporaryStorage = temporaryStorage.withPrefix('profile-rewards:');
@@ -81,7 +81,7 @@ const buildOrganization = (databaseBuilder) => databaseBuilder.factory.buildOrga
 const buildOrganizationLearners = (databaseBuilder, organization, users) =>
   users.map((user) =>
     databaseBuilder.factory.buildOrganizationLearner({
-      userId: user.id,
+      ...user,
       organizationId: organization.id,
     }),
   );
@@ -199,6 +199,14 @@ export const buildQuests = async (databaseBuilder) => {
 
   const organization = buildOrganization(databaseBuilder);
 
+  // Add admin-orga@example.net as Admin in organization
+
+  databaseBuilder.factory.buildMembership({
+    organizationId: organization.id,
+    organizationRole: 'ADMIN',
+    userId: USER_ID_ADMIN_ORGANIZATION,
+  });
+
   // Associate attestation feature to organization
 
   databaseBuilder.factory.buildOrganizationFeature({
@@ -212,18 +220,25 @@ export const buildQuests = async (databaseBuilder) => {
 
   // Create organizationLearners
 
+  const organizationLearnersData = [
+    { userId: successUser.id, division: '6emeA', firstName: 'attestation-success', lastName: 'attestation-success' },
+    {
+      userId: successSharedUser.id,
+      division: '6emeA',
+      firstName: 'attestation-success-shared',
+      lastName: 'attestation-success-shared',
+    },
+    { userId: failedUser.id, division: '6emeA', firstName: 'attestation-failed', lastName: 'attestation-failed' },
+    { userId: pendingUser.id, division: '6emeB', firstName: 'attestation-pending', lastName: 'attestation-pending' },
+    { userId: blankUser.id, division: '6emeB', firstName: 'attestation-blank', lastName: 'attestation-blank' },
+  ];
+
   const [
     successOrganizationLearner,
     successSharedOrganizationLearner,
     failedOrganizationLearner,
     pendingOrganizationLearner,
-  ] = buildOrganizationLearners(databaseBuilder, organization, [
-    successUser,
-    successSharedUser,
-    failedUser,
-    pendingUser,
-    blankUser,
-  ]);
+  ] = buildOrganizationLearners(databaseBuilder, organization, organizationLearnersData);
 
   // Create target profile
 

--- a/api/src/prescription/organization-learner/application/organization-learners-controller.js
+++ b/api/src/prescription/organization-learner/application/organization-learners-controller.js
@@ -1,3 +1,4 @@
+import { NoProfileRewardsFoundError } from '../../../profile/domain/errors.js';
 import { usecases } from '../domain/usecases/index.js';
 
 const getAttestationZipForDivisions = async function (request, h) {
@@ -5,9 +6,15 @@ const getAttestationZipForDivisions = async function (request, h) {
   const attestationKey = request.params.attestationKey;
   const divisions = request.query.divisions;
 
-  const buffer = await usecases.getAttestationZipForDivisions({ attestationKey, organizationId, divisions });
-
-  return h.response(buffer).header('Content-Type', 'application/zip');
+  try {
+    const buffer = await usecases.getAttestationZipForDivisions({ attestationKey, organizationId, divisions });
+    return h.response(buffer).header('Content-Type', 'application/zip');
+  } catch (error) {
+    if (error instanceof NoProfileRewardsFoundError) {
+      return h.response().code(204);
+    }
+    throw error;
+  }
 };
 
 const organizationLearnersController = {

--- a/api/src/prescription/organization-learner/domain/usecases/get-attestation-zip-for-divisions.js
+++ b/api/src/prescription/organization-learner/domain/usecases/get-attestation-zip-for-divisions.js
@@ -12,5 +12,6 @@ export const getAttestationZipForDivisions = async ({
   return organizationLearnerRepository.getAttestationsForOrganizationLearnersAndKey({
     attestationKey,
     organizationLearners,
+    organizationId,
   });
 };

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
@@ -122,11 +122,17 @@ async function findOrganizationLearnersByDivisions({ organizationId, divisions }
   return organizationLearners.map((organizationLearner) => new OrganizationLearner(organizationLearner));
 }
 
-async function getAttestationsForOrganizationLearnersAndKey({ attestationKey, organizationLearners, attestationsApi }) {
+async function getAttestationsForOrganizationLearnersAndKey({
+  attestationKey,
+  organizationLearners,
+  organizationId,
+  attestationsApi,
+}) {
   const userIds = organizationLearners.map((learner) => learner.userId);
   return attestationsApi.generateAttestations({
     attestationKey,
     userIds,
+    organizationId,
   });
 }
 

--- a/api/src/profile/application/api/attestations-api.js
+++ b/api/src/profile/application/api/attestations-api.js
@@ -1,6 +1,7 @@
 import * as path from 'node:path';
 import * as url from 'node:url';
 
+import { LOCALE } from '../../../shared/domain/constants.js';
 import { usecases } from '../../domain/usecases/index.js';
 import * as pdfWithFormSerializer from '../../infrastructure/serializers/pdf/pdf-with-form-serializer.js';
 
@@ -9,9 +10,16 @@ const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 export const generateAttestations = async function ({
   attestationKey,
   userIds,
+  organizationId,
   dependencies = { pdfWithFormSerializer },
 }) {
-  const { data, templateName } = await usecases.getAttestationDataForUsers({ attestationKey, userIds });
+  const locale = LOCALE.FRENCH_FRANCE;
+  const { data, templateName } = await usecases.getSharedAttestationsForOrganizationByUserIds({
+    attestationKey,
+    userIds,
+    organizationId,
+    locale,
+  });
 
   const templatePath = path.join(__dirname, `../../infrastructure/serializers/pdf/templates/${templateName}.pdf`);
 

--- a/api/src/profile/domain/errors.js
+++ b/api/src/profile/domain/errors.js
@@ -18,4 +18,15 @@ class ProfileRewardCantBeSharedError extends DomainError {
   }
 }
 
-export { AttestationNotFoundError, ProfileRewardCantBeSharedError, RewardTypeDoesNotExistError };
+class NoProfileRewardsFoundError extends DomainError {
+  constructor(message = 'No profile rewards found') {
+    super(message);
+  }
+}
+
+export {
+  AttestationNotFoundError,
+  NoProfileRewardsFoundError,
+  ProfileRewardCantBeSharedError,
+  RewardTypeDoesNotExistError,
+};

--- a/api/src/profile/domain/models/OrganizationProfileReward.js
+++ b/api/src/profile/domain/models/OrganizationProfileReward.js
@@ -1,0 +1,8 @@
+class OrganizationProfileReward {
+  constructor({ organizationId, profileRewardId }) {
+    this.profileRewardId = profileRewardId;
+    this.organizationId = organizationId;
+  }
+}
+
+export { OrganizationProfileReward };

--- a/api/src/profile/domain/usecases/get-attestation-data-for-users.js
+++ b/api/src/profile/domain/usecases/get-attestation-data-for-users.js
@@ -8,14 +8,14 @@ export async function getAttestationDataForUsers({
   profileRewardRepository,
   attestationRepository,
 }) {
-  const users = await userRepository.getByIds({ userIds });
-  const profileRewards = await profileRewardRepository.getByAttestationKeyAndUserIds({ attestationKey, userIds });
-
   const attestationData = await attestationRepository.getByKey({ attestationKey });
 
   if (!attestationData) {
     throw new AttestationNotFoundError();
   }
+  const users = await userRepository.getByIds({ userIds });
+
+  const profileRewards = await profileRewardRepository.getByAttestationKeyAndUserIds({ attestationKey, userIds });
 
   return {
     data: profileRewards.map(({ userId, createdAt }) => {

--- a/api/src/profile/domain/usecases/get-shared-attestations-for-organization-by-user-ids.js
+++ b/api/src/profile/domain/usecases/get-shared-attestations-for-organization-by-user-ids.js
@@ -1,0 +1,38 @@
+import { AttestationNotFoundError, NoProfileRewardsFoundError } from '../errors.js';
+
+export async function getSharedAttestationsForOrganizationByUserIds({
+  attestationKey,
+  userIds,
+  organizationId,
+  locale,
+  userRepository,
+  profileRewardRepository,
+  attestationRepository,
+  organizationProfileRewardRepository,
+}) {
+  const attestationData = await attestationRepository.getByKey({ attestationKey });
+
+  if (!attestationData) {
+    throw new AttestationNotFoundError();
+  }
+
+  const users = await userRepository.getByIds({ userIds });
+
+  const sharedProfileRewards = await organizationProfileRewardRepository.getByOrganizationId({ organizationId });
+  const profileRewardIds = sharedProfileRewards.map((sharedProfileReward) => sharedProfileReward.profileRewardId);
+
+  const profileRewards = await profileRewardRepository.getByIds({ profileRewardIds });
+  const filteredProfileRewards = profileRewards.filter((profileReward) => userIds.includes(profileReward.userId));
+
+  if (filteredProfileRewards.length === 0) {
+    throw new NoProfileRewardsFoundError();
+  }
+
+  return {
+    data: filteredProfileRewards.map(({ userId, createdAt }) => {
+      const user = users.find((user) => user.id === userId);
+      return user.toForm(createdAt, locale);
+    }),
+    templateName: attestationData.templateName,
+  };
+}

--- a/api/src/profile/infrastructure/repositories/organization-profile-reward-repository.js
+++ b/api/src/profile/infrastructure/repositories/organization-profile-reward-repository.js
@@ -1,5 +1,6 @@
 import { ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME } from '../../../../db/migrations/20241118134739_create-organizations-profile-rewards-table.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { OrganizationProfileReward } from '../../domain/models/OrganizationProfileReward.js';
 
 export const save = async ({ organizationId, profileRewardId }) => {
   const knexConn = DomainTransaction.getConnection();
@@ -10,4 +11,12 @@ export const save = async ({ organizationId, profileRewardId }) => {
     })
     .onConflict()
     .ignore();
+};
+
+export const getByOrganizationId = async ({ organizationId }) => {
+  const knexConn = DomainTransaction.getConnection();
+  const organizationProfileRewards = await knexConn(ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME).where({ organizationId });
+  return organizationProfileRewards.map(
+    (organizationProfileReward) => new OrganizationProfileReward(organizationProfileReward),
+  );
 };

--- a/api/src/profile/infrastructure/repositories/profile-reward-repository.js
+++ b/api/src/profile/infrastructure/repositories/profile-reward-repository.js
@@ -46,6 +46,18 @@ export const getById = async ({ profileRewardId }) => {
 
 /**
  * @param {Object} args
+ * @param {number} args.profileRewardIds
+ * @returns {Promise<Array<ProfileReward>>}
+ */
+export const getByIds = async ({ profileRewardIds }) => {
+  const knexConnection = await DomainTransaction.getConnection();
+  const profileRewards = await knexConnection(PROFILE_REWARDS_TABLE_NAME).whereIn('id', profileRewardIds);
+
+  return profileRewards.map(toDomain);
+};
+
+/**
+ * @param {Object} args
  * @param {string} args.attestationKey
  * @param {Array<number>} args.userIds
  * @returns {Promise<Array<ProfileReward>>}

--- a/api/tests/prescription/learner-management/unit/infrastructure/organization-learner-repository_test.js
+++ b/api/tests/prescription/learner-management/unit/infrastructure/organization-learner-repository_test.js
@@ -9,18 +9,20 @@ describe('Prescription | Learner-Management | Unit | Infrastructure | organizati
       const attestationKey = Symbol('attestation');
       const userId1 = 1;
       const userId2 = 2;
+      const organizationId = Symbol('organizationId');
       const organizationLearners = [{ userId: userId1 }, { userId: userId2 }];
 
       const expectedResult = Symbol('expectedResult');
 
       attestationApiStub.generateAttestations
-        .withArgs({ attestationKey, userIds: [userId1, userId2] })
+        .withArgs({ attestationKey, userIds: [userId1, userId2], organizationId })
         .resolves(expectedResult);
 
       //when
       const result = await getAttestationsForOrganizationLearnersAndKey({
         attestationKey,
         organizationLearners,
+        organizationId,
         attestationsApi: attestationApiStub,
       });
 

--- a/api/tests/prescription/organization-learner/acceptance/application/organization-learner-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/application/organization-learner-route_test.js
@@ -33,11 +33,12 @@ describe('Prescription | Organization Learner | Acceptance | Application | Organ
         organizationId,
         division: '6emeA',
       });
-      databaseBuilder.factory.buildProfileReward({
+      const profileRewardId = databaseBuilder.factory.buildProfileReward({
         userId: organizationLearner.userId,
         rewardId: attestation.id,
         rewardType: REWARD_TYPES.ATTESTATION,
-      });
+      }).id;
+      databaseBuilder.factory.buildOrganizationsProfileRewards({ organizationId, profileRewardId });
 
       await databaseBuilder.commit();
 

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/get-attestation-zip-for-divisions_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/get-attestation-zip-for-divisions_test.js
@@ -6,11 +6,17 @@ import { databaseBuilder, expect } from '../../../../../test-helper.js';
 describe('Integration | Prescription | Learner Management | Domain | UseCase | get-attestation-zip-for-divisions', function () {
   it('returns a zip attestation', async function () {
     // given
+    const templateName = 'sixth-grade-attestation-template';
     const organizationId = databaseBuilder.factory.buildOrganization().id;
-    databaseBuilder.factory.buildOrganizationLearner({ organizationId, division: '6eme A' });
-    databaseBuilder.factory.buildOrganizationLearner({ organizationId, division: '6eme B' });
-    const attestation = databaseBuilder.factory.buildAttestation();
-
+    const firstLearner = databaseBuilder.factory.buildOrganizationLearner({ organizationId, division: '6eme A' });
+    const secondLearner = databaseBuilder.factory.buildOrganizationLearner({ organizationId, division: '6eme B' });
+    const attestation = databaseBuilder.factory.buildAttestation({ templateName });
+    const firstRewardId = databaseBuilder.factory.buildProfileReward({
+      rewardId: attestation.id,
+      userId: firstLearner.userId,
+    });
+    databaseBuilder.factory.buildProfileReward({ rewardId: attestation.id, userId: secondLearner.userId });
+    databaseBuilder.factory.buildOrganizationsProfileRewards({ organizationId, profileRewardId: firstRewardId.id });
     await databaseBuilder.commit();
 
     // when

--- a/api/tests/prescription/organization-learner/unit/application/organization-learners-controller_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/organization-learners-controller_test.js
@@ -1,0 +1,100 @@
+import { organizationLearnersController } from '../../../../../src/prescription/organization-learner/application/organization-learners-controller.js';
+import { usecases } from '../../../../../src/prescription/organization-learner/domain/usecases/index.js';
+import { NoProfileRewardsFoundError } from '../../../../../src/profile/domain/errors.js';
+import { catchErr, expect, hFake, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Application | Organization-Learner | organization-learners-controller', function () {
+  describe('#getAttestationZipForDivisions', function () {
+    describe('success case', function () {
+      it('should return buffer', async function () {
+        // given
+        const organizationId = 123;
+        const attestationKey = Symbol('attestationKey');
+        const divisions = Symbol('divisions');
+        const expectedBuffer = Symbol('buffer');
+
+        sinon.stub(usecases, 'getAttestationZipForDivisions');
+
+        usecases.getAttestationZipForDivisions
+          .withArgs({ organizationId, attestationKey, divisions })
+          .resolves(expectedBuffer);
+
+        const request = {
+          params: {
+            organizationId,
+            attestationKey,
+          },
+          query: {
+            divisions,
+          },
+        };
+
+        // when
+        const response = await organizationLearnersController.getAttestationZipForDivisions(request, hFake);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+
+    describe('errors case', function () {
+      it('should return 204 if usecase return NoProfileRewardsFoundError', async function () {
+        // given
+        const organizationId = 123;
+        const attestationKey = Symbol('attestationKey');
+        const divisions = Symbol('divisions');
+
+        sinon.stub(usecases, 'getAttestationZipForDivisions');
+
+        usecases.getAttestationZipForDivisions
+          .withArgs({ organizationId, attestationKey, divisions })
+          .rejects(new NoProfileRewardsFoundError());
+
+        const request = {
+          params: {
+            organizationId,
+            attestationKey,
+          },
+          query: {
+            divisions,
+          },
+        };
+
+        // when
+        const response = await organizationLearnersController.getAttestationZipForDivisions(request, hFake);
+
+        // then
+        expect(response.statusCode).to.equal(204);
+      });
+
+      it('should throw another error', async function () {
+        // given
+        const organizationId = 123;
+        const attestationKey = Symbol('attestationKey');
+        const divisions = Symbol('divisions');
+        const expectedError = Symbol('error');
+        sinon.stub(usecases, 'getAttestationZipForDivisions');
+
+        usecases.getAttestationZipForDivisions
+          .withArgs({ organizationId, attestationKey, divisions })
+          .rejects(expectedError);
+
+        const request = {
+          params: {
+            organizationId,
+            attestationKey,
+          },
+          query: {
+            divisions,
+          },
+        };
+
+        // when
+        const error = await catchErr(organizationLearnersController.getAttestationZipForDivisions)(request, hFake);
+
+        // then
+        expect(error).to.equal(expectedError);
+      });
+    });
+  });
+});

--- a/api/tests/profile/integration/domain/usecases/get-shared-attestations-for-organization-by-user-ids_test.js
+++ b/api/tests/profile/integration/domain/usecases/get-shared-attestations-for-organization-by-user-ids_test.js
@@ -1,0 +1,111 @@
+import { AttestationNotFoundError, NoProfileRewardsFoundError } from '../../../../../src/profile/domain/errors.js';
+import { User } from '../../../../../src/profile/domain/models/User.js';
+import { usecases } from '../../../../../src/profile/domain/usecases/index.js';
+import { catchErr, databaseBuilder, expect, sinon } from '../../../../test-helper.js';
+
+describe('Profile | Integration | Domain | get-shared-attestations-for-organization-by-user-ids', function () {
+  let clock;
+  const now = new Date('2022-12-25');
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers({
+      now,
+      toFake: ['Date'],
+    });
+  });
+
+  afterEach(async function () {
+    clock.restore();
+  });
+
+  describe('#getAttestationDataForUsers', function () {
+    it('should return profile rewards for given userIds', async function () {
+      const locale = 'FR-fr';
+      const attestation = databaseBuilder.factory.buildAttestation();
+      const firstUser = new User(databaseBuilder.factory.buildUser({ firstName: 'Alex', lastName: 'Terieur' }));
+      const secondUser = new User(databaseBuilder.factory.buildUser({ firstName: 'Theo', lastName: 'Courant' }));
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId: firstUser.id });
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId: secondUser.id });
+
+      const firstProfileReward = databaseBuilder.factory.buildProfileReward({
+        rewardId: attestation.id,
+        userId: firstUser.id,
+      });
+      databaseBuilder.factory.buildOrganizationsProfileRewards({
+        organizationId,
+        profileRewardId: firstProfileReward.id,
+      });
+      const secondProfileReward = databaseBuilder.factory.buildProfileReward({
+        rewardId: attestation.id,
+        userId: secondUser.id,
+      });
+      databaseBuilder.factory.buildOrganizationsProfileRewards({
+        organizationId,
+        profileRewardId: secondProfileReward.id,
+      });
+
+      await databaseBuilder.commit();
+
+      const results = await usecases.getSharedAttestationsForOrganizationByUserIds({
+        attestationKey: attestation.key,
+        organizationId,
+        userIds: [firstUser.id],
+        locale,
+      });
+
+      expect(results).to.deep.equal({
+        data: [firstUser.toForm(firstProfileReward.createdAt, locale)],
+        templateName: attestation.templateName,
+      });
+      expect(results.data[0].get('fullName')).to.equal('Alex TERIEUR');
+    });
+
+    it('should return AttestationNotFound error if attestation does not exist', async function () {
+      //given
+      const locale = 'FR-fr';
+      const firstUser = new User(databaseBuilder.factory.buildUser());
+
+      databaseBuilder.factory.buildProfileReward({
+        userId: firstUser.id,
+      });
+      await databaseBuilder.commit();
+
+      //when
+      const error = await catchErr(usecases.getSharedAttestationsForOrganizationByUserIds)({
+        attestationKey: 'NOT_EXISTING_ATTESTATION',
+        userIds: [firstUser.id],
+        organizationId: 1,
+        locale,
+      });
+
+      //then
+      expect(error).to.be.an.instanceof(AttestationNotFoundError);
+    });
+
+    it('should return NoProfileRewardsFoundError error if there is no profile rewards', async function () {
+      //given
+      const locale = 'FR-fr';
+      const attestation = databaseBuilder.factory.buildAttestation();
+      const firstUser = new User(databaseBuilder.factory.buildUser({ firstName: 'Alex', lastName: 'Terieur' }));
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildProfileReward({
+        rewardId: attestation.id,
+        userId: firstUser.id,
+      });
+
+      await databaseBuilder.commit();
+
+      //when
+      const error = await catchErr(usecases.getSharedAttestationsForOrganizationByUserIds)({
+        attestationKey: attestation.key,
+        userIds: [firstUser.id],
+        organizationId,
+        locale,
+      });
+
+      //then
+      expect(error).to.be.an.instanceOf(NoProfileRewardsFoundError);
+    });
+  });
+});

--- a/api/tests/profile/integration/infrastructure/repositories/organizations-profile-rewards-repository_test.js
+++ b/api/tests/profile/integration/infrastructure/repositories/organizations-profile-rewards-repository_test.js
@@ -1,5 +1,9 @@
 import { ORGANIZATIONS_PROFILE_REWARDS_TABLE_NAME } from '../../../../../db/migrations/20241118134739_create-organizations-profile-rewards-table.js';
-import { save } from '../../../../../src/profile/infrastructure/repositories/organization-profile-reward-repository.js';
+import { OrganizationProfileReward } from '../../../../../src/profile/domain/models/OrganizationProfileReward.js';
+import {
+  getByOrganizationId,
+  save,
+} from '../../../../../src/profile/infrastructure/repositories/organization-profile-reward-repository.js';
 import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
 
 describe('Profile | Integration | Infrastructure | Repository | organizations-profile-rewards-repository', function () {
@@ -68,6 +72,76 @@ describe('Profile | Integration | Infrastructure | Repository | organizations-pr
         profileRewardId: profileReward.id,
       });
       expect(organizationProfileReward).to.have.lengthOf(1);
+    });
+  });
+
+  describe('#getByOrganizationIds', function () {
+    it('should return empty array if profile rewards does not exist for given organizationId', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+      await databaseBuilder.commit();
+
+      // when
+      const results = await getByOrganizationId({ organizationId });
+
+      // then
+      expect(results).to.be.empty;
+    });
+
+    it('should return profile rewards for given organizationId', async function () {
+      // given
+      const firstProfileReward = databaseBuilder.factory.buildProfileReward({ rewardId: 1 });
+      const secondProfileReward = databaseBuilder.factory.buildProfileReward({ rewardId: 2 });
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildOrganizationsProfileRewards({
+        organizationId,
+        profileRewardId: firstProfileReward.id,
+      });
+      databaseBuilder.factory.buildOrganizationsProfileRewards({
+        organizationId,
+        profileRewardId: secondProfileReward.id,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const results = await getByOrganizationId({ organizationId });
+
+      // then
+      const expectedResults = [
+        { profileRewardId: firstProfileReward.id, organizationId },
+        { profileRewardId: secondProfileReward.id, organizationId },
+      ];
+
+      expect(results).to.have.lengthOf(2);
+      expect(results).to.have.deep.members(expectedResults);
+    });
+
+    it('should not return profile rewards for other organizationId', async function () {
+      // given
+      const profileReward = databaseBuilder.factory.buildProfileReward();
+      const otherProfileReward = databaseBuilder.factory.buildProfileReward({ rewardId: 11 });
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      const expectedProfileReward = new OrganizationProfileReward(
+        databaseBuilder.factory.buildOrganizationsProfileRewards({
+          organizationId,
+          profileRewardId: profileReward.id,
+        }),
+      );
+      databaseBuilder.factory.buildOrganizationsProfileRewards({
+        organizationId: otherOrganizationId,
+        profileRewardId: otherProfileReward.id,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const results = await getByOrganizationId({ organizationId });
+
+      // then
+      expect(results).to.have.lengthOf(1);
+      expect(results[0]).to.deep.equal(expectedProfileReward);
     });
   });
 });

--- a/api/tests/profile/integration/infrastructure/repositories/profile-reward-repository_test.js
+++ b/api/tests/profile/integration/infrastructure/repositories/profile-reward-repository_test.js
@@ -4,6 +4,7 @@ import { ProfileReward } from '../../../../../src/profile/domain/models/ProfileR
 import {
   getByAttestationKeyAndUserIds,
   getById,
+  getByIds,
   getByUserId,
   save,
 } from '../../../../../src/profile/infrastructure/repositories/profile-reward-repository.js';
@@ -63,6 +64,38 @@ describe('Profile | Integration | Repository | profile-reward', function () {
       // then
       expect(result).to.be.an.instanceof(ProfileReward);
       expect(result.id).to.equal(expectedProfileReward.id);
+    });
+  });
+
+  describe('#getByIds', function () {
+    it('should return empty array if the profile rewards does not exist', async function () {
+      // given
+      const notExistingProfileRewardId = 12;
+
+      // when
+      const result = await getByIds({ profileRewardIds: [notExistingProfileRewardId] });
+
+      // then
+      expect(result).to.be.empty;
+    });
+
+    it('should return the profile rewards for given ids', async function () {
+      // given
+      const attestation = databaseBuilder.factory.buildAttestation({ key: 'key' });
+      const firstProfileReward = databaseBuilder.factory.buildProfileReward({ rewardId: attestation.id });
+      const secondProfileReward = databaseBuilder.factory.buildProfileReward({ rewardId: attestation.id });
+      const expectedProfileReward = [firstProfileReward.id, secondProfileReward.id];
+
+      databaseBuilder.factory.buildProfileReward();
+
+      await databaseBuilder.commit();
+
+      // when
+      const results = await getByIds({ profileRewardIds: expectedProfileReward });
+
+      // then
+      expect(results).to.have.lengthOf(2);
+      expect(results).to.have.deep.members([firstProfileReward, secondProfileReward]);
     });
   });
 

--- a/api/tests/profile/unit/application/api/attestations-api_test.js
+++ b/api/tests/profile/unit/application/api/attestations-api_test.js
@@ -1,5 +1,6 @@
 import { generateAttestations } from '../../../../../src/profile/application/api/attestations-api.js';
 import { usecases } from '../../../../../src/profile/domain/usecases/index.js';
+import { LOCALE } from '../../../../../src/shared/domain/constants.js';
 import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Profile | Unit | Application | Api | attestations', function () {
@@ -7,7 +8,9 @@ describe('Profile | Unit | Application | Api | attestations', function () {
     it('should return a zip archive with users attestations', async function () {
       const attestationKey = Symbol('attestationKey');
       const userIds = Symbol('userIds');
+      const organizationId = Symbol('organizationId');
       const data = Symbol('data');
+      const locale = LOCALE.FRENCH_FRANCE;
       const expectedBuffer = Symbol('expectedBuffer');
 
       const dependencies = {
@@ -16,16 +19,20 @@ describe('Profile | Unit | Application | Api | attestations', function () {
         },
       };
 
-      sinon.stub(usecases, 'getAttestationDataForUsers');
+      sinon.stub(usecases, 'getSharedAttestationsForOrganizationByUserIds');
 
-      usecases.getAttestationDataForUsers
-        .withArgs({ attestationKey, userIds })
-        .resolves({ data, templateName: 'sixth-grade-attestation-template' });
+      usecases.getSharedAttestationsForOrganizationByUserIds
+        .withArgs({ attestationKey, userIds, organizationId, locale })
+        .resolves({
+          data,
+          templateName: 'sixth-grade-attestation-template',
+        });
 
       dependencies.pdfWithFormSerializer.serialize
         .withArgs(sinon.match(/(\w*\/)*sixth-grade-attestation-template.pdf/), data)
         .resolves(expectedBuffer);
-      const result = await generateAttestations({ attestationKey, userIds, dependencies });
+
+      const result = await generateAttestations({ attestationKey, userIds, organizationId, dependencies });
 
       expect(result).to.equal(expectedBuffer);
     });


### PR DESCRIPTION
## :fallen_leaf: Problème
Actuellement le prescripteur peut télécharger les attestations de tous les learners ayant obtenu leur attestation pour les classes demandées.
Or, il ne doit pas pouvoir voir celles liées à des participations non partagées.

## :chestnut: Proposition
Utiliser le mécanisme fait dans cette PR : https://github.com/1024pix/pix/pull/10576
Et mettre en place le fonctionnement pour ne retourner que celles partagées.

## :jack_o_lantern: Remarques
On en profite pour gérer l'erreur dans le cas où pour les classes demandées, il n'y a pas d'attestations disponibles

## :wood: Pour tester

Se connecter à PixOrga avec `admin-orga@example.net`
Aller sur l'organisation `attestation`
Aller sur la page `Attestation`
Selectionner la classe `6emeA`
Telecharger les attestations, 
Verifier qu'une seule attestation est présente dans le zip : celui de `attestation-success-shared``

Refaire la même manip avec la classe `6emeB` 
Verifier que rien n'est télécharger et que le code réponse est 204
🐈‍⬛ 