### PR TITLE
[FEATURE] API - statut béta (PIX-15350)

### DIFF
--- a/api/src/devcomp/domain/models/module/Module.js
+++ b/api/src/devcomp/domain/models/module/Module.js
@@ -2,10 +2,11 @@ import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asser
 import { ModuleInstantiationError } from '../../errors.js';
 
 class Module {
-  constructor({ id, slug, title, grains, details, transitionTexts = [] }) {
+  constructor({ id, slug, title, isBeta, grains, details, transitionTexts = [] }) {
     assertNotNullOrUndefined(id, 'The id is required for a module');
-    assertNotNullOrUndefined(title, 'The title is required for a module');
     assertNotNullOrUndefined(slug, 'The slug is required for a module');
+    assertNotNullOrUndefined(title, 'The title is required for a module');
+    assertNotNullOrUndefined(isBeta, 'isBeta value is required for a module');
     assertNotNullOrUndefined(grains, 'A list of grains is required for a module');
     this.#assertGrainsIsAnArray(grains);
     assertNotNullOrUndefined(details, 'The details are required for a module');
@@ -14,6 +15,7 @@ class Module {
     this.id = id;
     this.slug = slug;
     this.title = title;
+    this.isBeta = isBeta;
     this.grains = grains;
     this.transitionTexts = transitionTexts;
     this.details = details;

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
@@ -2,6 +2,7 @@
   "id": "6282925d-4775-4bca-b513-4c3009ec5886",
   "slug": "adresse-ip-publique-et-vous",
   "title": "L'adresse IP publique : ce qu'elle révèle sur vous !",
+  "isBeta": true,
   "details": {
     "image": "https://images.pix.fr/modulix/placeholder-details.svg",
     "description": "<p>Quand vous naviguez sur internet, vous partagez des informations et laissez ainsi de nombreuses traces : adresse IP, cookies, historique, etc. Dans ce module, découvrez ce qu'est une adresse IP publique et ce qu’elle dévoile sur vous.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -2,6 +2,7 @@
   "id": "f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d",
   "slug": "bien-ecrire-son-adresse-mail",
   "title": "Bien écrire son adresse mail",
+  "isBeta": true,
   "details": {
     "image": "https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg",
     "description": "Bien écrire son adresse mail est important. Dans ce module, vous allez apprendre à écrire correctement une adresse e-mail pour mieux communiquer et éviter les erreurs courantes.",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-parle-francais.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-parle-francais.json
@@ -2,6 +2,7 @@
   "id": "01151659-77c1-41cc-8724-89091357af3d",
   "slug": "chatgpt-parle-francais",
   "title": "ChatGPT parle-t-il vraiment français ?",
+  "isBeta": true,
   "details": {
     "image": "https://images.pix.fr/modulix/placeholder-details.svg",
     "description": "<p>Les Large Language Models (LLM) sont des systèmes d'intelligence artificielle générative. Ils donnent l'impression de parler toutes les langues mais, du fait de leurs biais, leurs productions sont parfois stéréotypées ou discriminantes. Dans ce module, vous allez découvrir les origines de ces biais et interroger directement des LLM pour les repérer !</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -2,6 +2,7 @@
   "id": "6282925d-4775-4bca-b513-4c3009ec5886",
   "slug": "didacticiel-modulix",
   "title": "Didacticiel Modulix",
+  "isBeta": true,
   "details": {
     "image": "https://images.pix.fr/modulix/placeholder-details.svg",
     "description": "<p>Découvrez avec ce didacticiel comment fonctionne Modulix !</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
@@ -2,6 +2,7 @@
   "id": "65b761ab-3ebd-44a9-84b7-8b5e151aee76",
   "slug": "distinguer-vrai-faux-sur-internet",
   "title": "Les informations sur internet : distinguer le vrai du faux",
+  "isBeta": true,
   "details": {
     "image": "https://images.pix.fr/modulix/placeholder-details.svg",
     "description": "Sur internet, de nombreuses informations circulent. Certaines sont vraies, d'autres sont fausses. Dans ce module, vous allez découvrir une méthode pour analyser l'information et aiguiser votre esprit critique !",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
@@ -2,6 +2,7 @@
   "id": "8bdec793-7508-41b4-9df2-e1cf96969680",
   "slug": "mots-de-passe-securises",
   "title": "Des mots de passe solides",
+  "isBeta": true,
   "details": {
     "image": "https://images.pix.fr/modulix/placeholder-details.svg",
     "description": "Aujourd'hui, on utilise des mots de passe pour tout : son téléphone, son adresse mail, ses réseaux sociaux. Dans ce module, vous allez découvrir pourquoi et comment créer des mots de passe solides.",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
@@ -2,6 +2,7 @@
   "id": "6282925d-4775-4bca-b513-4c3009ec5886",
   "slug": "ports-connexions-essentiels",
   "title": "Les ports de connexion d’un ordinateur",
+  "isBeta": true,
   "details": {
     "image": "https://images.pix.fr/modulix/placeholder-details.svg",
     "description": "Pour savoir ce qu'on peut brancher ou non à un ordinateur, il faut bien connaître les principaux ports de connexion !",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
@@ -2,6 +2,7 @@
   "id": "a64d1ca8-5222-464a-ae0c-e8bbdf949e18",
   "slug": "principes-fondateurs-wikipedia",
   "title": "Les principes fondateurs de Wikipédia",
+  "isBeta": true,
   "details": {
     "image": "https://images.pix.fr/modulix/placeholder-details.svg",
     "description": "Wikipédia est un site très connu, que vous avez sans doute déjà utilisé. Dans ce module, vous trouverez des explications sur les principes de Wikipédia. Vous découvrirez aussi des méthodes pour l'utiliser.",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
@@ -2,6 +2,7 @@
   "id": "68f92c57-9e66-4258-a2f4-b71fad7ab004",
   "slug": "sources-informations",
   "title": "Les sources d'information",
+  "isBeta": true,
   "details": {
     "image": "https://images.pix.fr/modulix/placeholder-details.svg",
     "description": "Sur internet et les réseaux sociaux, il est parfois difficile de savoir si une information est vraie ou fausse. Dans ce module, vous allez découvrir pourquoi il est important de s’intéresser à la source d’une information pour démêler le vrai du faux.",

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -32,6 +32,7 @@ export class ModuleFactory {
         id: moduleData.id,
         slug: moduleData.slug,
         title: moduleData.title,
+        isBeta: moduleData.isBeta,
         transitionTexts: moduleData.transitionTexts?.map((transitionText) => new TransitionText(transitionText)) ?? [],
         details: new Details(moduleData.details),
         grains: moduleData.grains.map((grain) => {

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
@@ -8,6 +8,7 @@ function serialize(module) {
       return {
         id: module.slug,
         title: module.title,
+        isBeta: module.isBeta,
         transitionTexts: module.transitionTexts,
         details: module.details,
         grains: module.grains.map((grain) => {
@@ -20,7 +21,7 @@ function serialize(module) {
         }),
       };
     },
-    attributes: ['title', 'grains', 'transitionTexts', 'details'],
+    attributes: ['title', 'isBeta', 'grains', 'transitionTexts', 'details'],
     grains: {
       ref: 'id',
       includes: true,

--- a/api/tests/devcomp/integration/domain/models/Module_test.js
+++ b/api/tests/devcomp/integration/domain/models/Module_test.js
@@ -16,6 +16,7 @@ describe('Integration | Devcomp | Domain | Models | Module', function () {
       const id = '1';
       const slug = 'les-adresses-email';
       const title = 'Les adresses email';
+      const isBeta = true;
       const grains = [grain];
       const transitionTexts = [
         {
@@ -30,7 +31,7 @@ describe('Integration | Devcomp | Domain | Models | Module', function () {
       const details = Symbol('details');
 
       // when
-      const error = catchErrSync(() => new Module({ id, slug, title, grains, transitionTexts, details }))();
+      const error = catchErrSync(() => new Module({ id, slug, title, isBeta, grains, transitionTexts, details }))();
 
       // then
       expect(error).to.be.instanceOf(ModuleInstantiationError);

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -48,6 +48,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
         id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
         slug: existingModuleSlug,
         title: 'Bien écrire son adresse mail',
+        isBeta: true,
         details: {
           image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
           description:

--- a/api/tests/devcomp/unit/domain/models/module/Module_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/Module_test.js
@@ -10,17 +10,19 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
       const id = 1;
       const slug = 'les-adresses-email';
       const title = 'Les adresses email';
+      const isBeta = false;
       const grains = [Symbol('text')];
       const transitionTexts = [];
       const details = Symbol('details');
 
       // when
-      const module = new Module({ id, slug, title, grains, details, transitionTexts });
+      const module = new Module({ id, slug, title, isBeta, grains, details, transitionTexts });
 
       // then
       expect(module.id).to.equal(id);
       expect(module.slug).to.equal(slug);
       expect(module.title).to.equal(title);
+      expect(module.isBeta).to.equal(isBeta);
       expect(module.transitionTexts).to.equal(transitionTexts);
       expect(module.grains).to.have.lengthOf(grains.length);
       expect(module.details).to.deep.equal(details);
@@ -37,10 +39,21 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
       });
     });
 
-    describe('if a module does not have a title', function () {
+    describe('if a module does not have a slug', function () {
       it('should throw an error', function () {
         // when
         const error = catchErrSync(() => new Module({ id: 1 }))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The slug is required for a module');
+      });
+    });
+
+    describe('if a module does not have a title', function () {
+      it('should throw an error', function () {
+        // when
+        const error = catchErrSync(() => new Module({ id: 1, slug: 'my-slug' }))();
 
         // then
         expect(error).to.be.instanceOf(DomainError);
@@ -48,14 +61,21 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
       });
     });
 
-    describe('if a module does not have a slug', function () {
+    describe('if a module does not have isBeta value', function () {
       it('should throw an error', function () {
         // when
-        const error = catchErrSync(() => new Module({ id: 1, title: '' }))();
+        const error = catchErrSync(
+          () =>
+            new Module({
+              id: 'id_module_1',
+              slug: 'bien-ecrire-son-adresse-mail',
+              title: 'Bien écrire son adresse mail',
+            }),
+        )();
 
         // then
         expect(error).to.be.instanceOf(DomainError);
-        expect(error.message).to.equal('The slug is required for a module');
+        expect(error.message).to.equal('isBeta value is required for a module');
       });
     });
 
@@ -68,6 +88,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               id: 'id_module_1',
               slug: 'bien-ecrire-son-adresse-mail',
               title: 'Bien écrire son adresse mail',
+              isBeta: true,
             }),
         )();
 
@@ -86,6 +107,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               id: 'id_module_1',
               slug: 'bien-ecrire-son-adresse-mail',
               title: 'Bien écrire son adresse mail',
+              isBeta: true,
               grains: 'elements',
             }),
         )();
@@ -105,6 +127,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               id: 'id_module_1',
               slug: 'bien-ecrire-son-adresse-mail',
               title: 'Bien écrire son adresse mail',
+              isBeta: true,
               grains: [],
             }),
         )();

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
@@ -112,6 +112,7 @@ const moduleSchema = Joi.object({
     .regex(/^[a-z0-9-]+$/)
     .required(),
   title: htmlNotAllowedSchema.required(),
+  isBeta: Joi.boolean().required(),
   details: moduleDetailsSchema.required(),
   transitionTexts: Joi.array().items(transitionTextSchema),
   grains: Joi.array().items(grainSchema).required(),

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -219,6 +219,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
         slug: 'didacticiel-modulix',
         title: '<h1>Didacticiel Modulix</h1>',
+        isBeta: true,
         details: {
           image: 'https://images.pix.fr/modulix/placeholder-details.svg',
           description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',

--- a/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
@@ -28,6 +28,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
           title: 'title',
+          isBeta: true,
           details: {
             image: 'https://images.pix.fr/modulix/placeholder-details.svg',
             description: 'Description',
@@ -78,6 +79,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             id: '6282925d-4775-4bca-b513-4c3009ec5886',
             slug: 'title',
             title: 'title',
+            isBeta: true,
             details: {
               image: 'https://images.pix.fr/modulix/placeholder-details.svg',
               description: 'Description',
@@ -126,6 +128,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             id: '6282925d-4775-4bca-b513-4c3009ec5886',
             slug: 'title',
             title: 'title',
+            isBeta: true,
             details: {
               image: 'https://images.pix.fr/modulix/placeholder-details.svg',
               description: 'Description',
@@ -174,6 +177,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             id: '6282925d-4775-4bca-b513-4c3009ec5886',
             slug: 'title',
             title: 'title',
+            isBeta: true,
             details: {
               image: 'https://images.pix.fr/modulix/placeholder-details.svg',
               description: 'Description',
@@ -229,6 +233,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
         slug: 'title',
         title: 'title',
+        isBeta: true,
         details: {
           image: 'https://images.pix.fr/modulix/placeholder-details.svg',
           description: 'Description',
@@ -276,6 +281,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
         slug: 'title',
         title: 'title',
+        isBeta: true,
         details: {
           image: 'https://images.pix.fr/modulix/placeholder-details.svg',
           description: 'Description',
@@ -333,6 +339,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
           title: 'title',
+          isBeta: true,
           details: {
             image: 'https://images.pix.fr/modulix/placeholder-details.svg',
             description: 'Description',
@@ -375,6 +382,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
           title: 'title',
+          isBeta: true,
           details: {
             image: 'https://images.pix.fr/modulix/placeholder-details.svg',
             description: 'Description',
@@ -419,6 +427,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
           title: 'title',
+          isBeta: true,
           details: {
             image: 'https://images.pix.fr/modulix/placeholder-details.svg',
             description: 'Description',
@@ -459,6 +468,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
           title: 'title',
+          isBeta: true,
           details: {
             image: 'https://images.pix.fr/modulix/placeholder-details.svg',
             description: 'Description',
@@ -513,6 +523,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
           title: 'title',
+          isBeta: true,
           details: {
             image: 'https://images.pix.fr/modulix/placeholder-details.svg',
             description: 'Description',
@@ -553,6 +564,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
           title: 'title',
+          isBeta: true,
           details: {
             image: 'https://images.pix.fr/modulix/placeholder-details.svg',
             description: 'Description',
@@ -596,6 +608,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
           title: 'title',
+          isBeta: true,
           details: {
             image: 'https://images.pix.fr/modulix/placeholder-details.svg',
             description: 'Description',
@@ -655,6 +668,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
           title: 'title',
+          isBeta: true,
           details: {
             image: 'https://images.pix.fr/modulix/placeholder-details.svg',
             description: 'Description',
@@ -722,6 +736,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
           title: 'title',
+          isBeta: true,
           details: {
             image: 'https://images.pix.fr/modulix/placeholder-details.svg',
             description: 'Description',
@@ -805,6 +820,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
           title: 'title',
+          isBeta: true,
           details: {
             image: 'https://images.pix.fr/modulix/placeholder-details.svg',
             description: 'Description',
@@ -870,6 +886,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
           title: 'title',
+          isBeta: true,
           details: {
             image: 'https://images.pix.fr/modulix/placeholder-details.svg',
             description: 'Description',
@@ -920,6 +937,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
           title: 'title',
+          isBeta: true,
           details: {
             image: 'https://images.pix.fr/modulix/placeholder-details.svg',
             description: 'Description',
@@ -967,6 +985,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
           title: 'title',
+          isBeta: true,
           details: {
             image: 'https://images.pix.fr/modulix/placeholder-details.svg',
             description: 'Description',
@@ -1015,6 +1034,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
           title: 'title',
+          isBeta: true,
           details: {
             image: 'https://images.pix.fr/modulix/placeholder-details.svg',
             description: 'Description',
@@ -1067,6 +1087,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
           title: 'title',
+          isBeta: true,
           details: {
             image: 'https://images.pix.fr/modulix/placeholder-details.svg',
             description: 'Description',
@@ -1115,6 +1136,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
           title: 'title',
+          isBeta: true,
           details: {
             image: 'https://images.pix.fr/modulix/placeholder-details.svg',
             description: 'Description',
@@ -1167,6 +1189,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
           title: 'title',
+          isBeta: true,
           details: {
             image: 'https://images.pix.fr/modulix/placeholder-details.svg',
             description: 'Description',
@@ -1233,6 +1256,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
           title: 'title',
+          isBeta: true,
           details: {
             image: 'https://images.pix.fr/modulix/placeholder-details.svg',
             description: 'Description',
@@ -1309,6 +1333,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
           title: 'title',
+          isBeta: true,
           details: {
             image: 'https://images.pix.fr/modulix/placeholder-details.svg',
             description: 'Description',
@@ -1396,6 +1421,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
           title: 'title',
+          isBeta: true,
           details: {
             image: 'https://images.pix.fr/modulix/placeholder-details.svg',
             description: 'Description',
@@ -1465,6 +1491,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
           title: 'title',
+          isBeta: true,
           details: {
             image: 'https://images.pix.fr/modulix/placeholder-details.svg',
             description: 'Description',
@@ -1519,6 +1546,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
           title: 'title',
+          isBeta: true,
           details: {
             image: 'https://images.pix.fr/modulix/placeholder-details.svg',
             description: 'Description',
@@ -1575,6 +1603,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
           title: 'title',
+          isBeta: true,
           details: {
             image: 'https://images.pix.fr/modulix/placeholder-details.svg',
             description: 'Description',
@@ -1623,6 +1652,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
         slug: 'title',
         title: 'title',
+        isBeta: true,
         details: {
           image: 'https://images.pix.fr/modulix/placeholder-details.svg',
           description: 'Description',
@@ -1674,6 +1704,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
         slug: 'title',
         title: 'title',
+        isBeta: true,
         details: {
           image: 'https://images.pix.fr/modulix/placeholder-details.svg',
           description: 'Description',

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -26,6 +26,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
       const id = 'id';
       const slug = 'bien-ecrire-son-adresse-mail';
       const title = 'Bien écrire son adresse mail';
+      const isBeta = true;
       const details = {
         image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
         description:
@@ -38,13 +39,14 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
           'Comprendre les fonctions des parties d’une adresse mail',
         ],
       };
-      const moduleFromDomain = new Module({ id, details, slug, title, grains: [] });
+      const moduleFromDomain = new Module({ id, details, slug, title, grains: [], isBeta });
       const expectedJson = {
         data: {
           type: 'modules',
           id: slug,
           attributes: {
             title,
+            'is-beta': isBeta,
             'transition-texts': [],
             details,
           },
@@ -68,6 +70,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
       const id = 'id';
       const slug = 'bien-ecrire-son-adresse-mail';
       const title = 'Bien écrire son adresse mail';
+      const isBeta = true;
       const details = {
         image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
         description:
@@ -90,6 +93,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
         id,
         slug,
         title,
+        isBeta,
         details,
         transitionTexts,
         grains: [
@@ -105,6 +109,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
         data: {
           attributes: {
             title: 'Bien écrire son adresse mail',
+            'is-beta': isBeta,
             'transition-texts': transitionTexts,
             details,
           },


### PR DESCRIPTION
## :fallen_leaf: Problème
Pas de champ isBeta

## :chestnut: Proposition
Dans les modules, permettre d’ajouter un champ isBeta booléen obligatoire. Le placer sur tous les modules existants à date avec la valeur true, pour rester iso avec le comportement actuel.

## :jack_o_lantern: Remarques
Attention à l'ordre de merge par rapport au Front: merger l'api avant le front.

## :wood: Pour tester
Utiliser endpoint d'appel au Module sur la RA : `/api/modules/bien-ecrire-son-adresse-mail`.
Vérifier que le champ `is-beta` apparaît bien.
