### PR TITLE
[TECH] corrige le type des paramètres du script d'anonymisation d'un learner  (PIX-15360)

### DIFF
--- a/api/scripts/prod/delete-and-anonymise-organization-learners.js
+++ b/api/scripts/prod/delete-and-anonymise-organization-learners.js
@@ -12,7 +12,7 @@ export class DeleteAndAnonymiseOrgnizationLearnerScript extends Script {
       permanent: true,
       options: {
         organizationLearnerIds: {
-          type: '<array>number',
+          type: 'string',
           describe: 'a list of comma separated organization learner ids',
           demandOption: true,
           coerce: commaSeparatedNumberParser(),
@@ -28,7 +28,6 @@ export class DeleteAndAnonymiseOrgnizationLearnerScript extends Script {
     organizationLearnerRepository = { removeByIds },
   }) {
     const engineeringUserId = process.env.ENGINEERING_USER_ID;
-
     logger.info(`Anonymise ${options.organizationLearnerIds.length} learners`);
     await DomainTransaction.execute(async () => {
       await campaignParticipationRepository.removeByOrganizationLearnerIds({

--- a/api/tests/integration/scripts/prod/delete-and-anonymise-organization-learners_test.js
+++ b/api/tests/integration/scripts/prod/delete-and-anonymise-organization-learners_test.js
@@ -11,11 +11,10 @@ describe('DeleteAndAnonymiseOrgnizationLearnerScript', function () {
       const { options } = script.metaInfo;
 
       expect(options.organizationLearnerIds).to.deep.include({
-        type: '<array>number',
+        type: 'string',
         describe: 'a list of comma separated organization learner ids',
         demandOption: true,
       });
-      expect(options.organizationLearnerIds.coerce).to.be.a('function');
     });
 
     it('parses list of organizationLearnerIds', async function () {


### PR DESCRIPTION
## :fallen_leaf: Problème
le script d'anonymisation ne supporte pas un seul id car on avait mis `<array>number` qui n'est pas supporté

## :chestnut: Proposition
On change le type du param pour qu'il soit supporté par yargs

## :jack_o_lantern: Remarques
 

## :wood: Pour tester
lancer le script avec 1 ou 1,2 
ne pas voir d'erreur
