### PR TITLE
[TECH] Ajouter une API interne permettant de vérifier si un utilisateur a été un prescrit (PIX-14983)

### DIFF
--- a/api/src/prescription/learner-management/application/api/learners-api.js
+++ b/api/src/prescription/learner-management/application/api/learners-api.js
@@ -1,0 +1,19 @@
+import { usecases } from '../../domain/usecases/index.js';
+
+/**
+ * Check if user has been a learner of an organization
+ *
+ * @param {object} params
+ * @param {number} params.userId - The ID of the user to check
+ * @returns {Promise<boolean>}
+ * @throws TypeError - Throw when params.userId is not defined
+ */
+export const hasBeenLearner = async ({ userId }) => {
+  if (!userId) {
+    throw new TypeError('userId is required');
+  }
+
+  const isLearner = await usecases.hasBeenLearner({ userId });
+
+  return isLearner;
+};

--- a/api/src/prescription/learner-management/domain/usecases/has-been-learner.js
+++ b/api/src/prescription/learner-management/domain/usecases/has-been-learner.js
@@ -1,0 +1,16 @@
+/**
+ * @typedef {import('./index.js').OrganizationLearnerRepository} OrganizationLearnerRepository
+ */
+
+/**
+ * @param{number} userId
+ * @param{OrganizationLearnerRepository} organizationLearnerRepository
+ * @returns {Promise<boolean>}
+ */
+const hasBeenLearner = async function ({ userId, organizationLearnerRepository }) {
+  const countOrganizationLearner = await organizationLearnerRepository.countByUserId(userId);
+
+  return countOrganizationLearner > 0;
+};
+
+export { hasBeenLearner };

--- a/api/src/prescription/learner-management/domain/usecases/index.js
+++ b/api/src/prescription/learner-management/domain/usecases/index.js
@@ -101,6 +101,7 @@ const usecasesWithoutInjectedDependencies = {
  * @property {handlePayloadTooLargeError} handlePayloadTooLargeError
  * @property {importOrganizationLearnersFromSIECLECSVFormat} importOrganizationLearnersFromSIECLECSVFormat
  * @property {importSupOrganizationLearners} importSupOrganizationLearners
+ * @property {hasBeenLearner} hasBeenLearner
  * @property {reconcileCommonOrganizationLearner} reconcileCommonOrganizationLearner
  * @property {reconcileScoOrganizationLearnerAutomatically} reconcileScoOrganizationLearnerAutomatically
  * @property {replaceSupOrganizationLearners} replaceSupOrganizationLearners

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
@@ -264,6 +264,13 @@ const reconcileUserByNationalStudentIdAndOrganizationId = async function ({
   }
 };
 
+const countByUserId = async function (userId) {
+  const knexConn = DomainTransaction.getConnection();
+  const { count } = await knexConn('organization-learners').count('id').where({ userId }).first();
+
+  return count;
+};
+
 // copied from api/lib/repositories/organization-learner-repository-test.js-
 const findByUserId = async function ({ userId }) {
   const knexConn = DomainTransaction.getConnection();
@@ -298,6 +305,7 @@ const reconcileUserToOrganizationLearner = async function ({ userId, organizatio
 
 export {
   addOrUpdateOrganizationOfOrganizationLearners,
+  countByUserId,
   disableAllOrganizationLearnersInOrganization,
   disableCommonOrganizationLearnersFromOrganizationId,
   dissociateUserFromOrganizationLearner,

--- a/api/tests/prescription/learner-management/integration/domain/usecases/has-been-learner_test.js
+++ b/api/tests/prescription/learner-management/integration/domain/usecases/has-been-learner_test.js
@@ -1,0 +1,43 @@
+import { usecases } from '../../../../../../src/prescription/learner-management/domain/usecases/index.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Integration | Prescription | Learner Management | UseCase | has-been-learner', function () {
+  let userId;
+
+  beforeEach(async function () {
+    const organizationId = databaseBuilder.factory.buildOrganization().id;
+    const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+
+    userId = databaseBuilder.factory.buildUser().id;
+    const otherUserId = databaseBuilder.factory.buildUser().id;
+
+    databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId });
+    databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId: otherUserId });
+    databaseBuilder.factory.buildOrganizationLearner({ organizationId: otherOrganizationId, userId });
+
+    await databaseBuilder.commit();
+  });
+
+  context('when organization learner exist for given userId', function () {
+    it('should return true', async function () {
+      // when
+      const result = await usecases.hasBeenLearner({ userId });
+
+      // then
+      expect(result).to.be.true;
+    });
+  });
+
+  context('when no organization learner exist for given userId', function () {
+    it('should return false', async function () {
+      // given
+      const notExistingUserId = 0;
+
+      // when
+      const result = await usecases.hasBeenLearner({ userId: notExistingUserId });
+
+      // then
+      expect(result).to.be.false;
+    });
+  });
+});

--- a/api/tests/prescription/learner-management/unit/application/api/learners-api_test.js
+++ b/api/tests/prescription/learner-management/unit/application/api/learners-api_test.js
@@ -1,0 +1,32 @@
+import { hasBeenLearner } from '../../../../../../src/prescription/learner-management/application/api/learners-api.js';
+import { usecases } from '../../../../../../src/prescription/learner-management/domain/usecases/index.js';
+import { catchErr, expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | Prescription | learner management | Api | learners', function () {
+  describe('#hasBeenLearner', function () {
+    it('should throw a "TypeError" when "userId" is not defined', async function () {
+      // given
+      const hasBeenLearnerStub = sinon.stub(usecases, 'hasBeenLearner');
+
+      // when
+      const error = await catchErr(hasBeenLearner)({ userId: undefined });
+
+      // then
+      expect(error).to.be.instanceOf(TypeError);
+      expect(hasBeenLearnerStub).to.not.have.been.called;
+    });
+
+    it('should check if "userId" in param has been a learner', async function () {
+      // given
+      const hasBeenLearnerStub = sinon.stub(usecases, 'hasBeenLearner').resolves(true);
+      const userId = 1;
+
+      // when
+      const result = await hasBeenLearner({ userId });
+
+      // then
+      expect(result).to.be.true;
+      expect(hasBeenLearnerStub).to.have.been.calledOnceWith({ userId });
+    });
+  });
+});

--- a/api/tests/prescription/learner-management/unit/domain/usecases/has-been-learner_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/has-been-learner_test.js
@@ -1,0 +1,43 @@
+import { hasBeenLearner } from '../../../../../../src/prescription/learner-management/domain/usecases/has-been-learner.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | Prescription | Learner Management | UseCase | has-been-learner', function () {
+  let organizationLearnerRepository, userId;
+
+  beforeEach(function () {
+    organizationLearnerRepository = {
+      countByUserId: sinon.stub(),
+    };
+    userId = 1;
+  });
+
+  context('when user has been linked to at least one organization learner', function () {
+    beforeEach(function () {
+      organizationLearnerRepository.countByUserId.resolves(1);
+    });
+
+    it('should return true', async function () {
+      // when
+      const result = await hasBeenLearner({ userId, organizationLearnerRepository });
+
+      // then
+      expect(result).to.be.true;
+      expect(organizationLearnerRepository.countByUserId).to.have.been.calledOnceWith(userId);
+    });
+  });
+
+  context('when user has not been linked to an organization learner', function () {
+    beforeEach(function () {
+      organizationLearnerRepository.countByUserId.resolves(0);
+    });
+
+    it('should return false', async function () {
+      // when
+      const result = await hasBeenLearner({ userId, organizationLearnerRepository });
+
+      // then
+      expect(result).to.be.false;
+      expect(organizationLearnerRepository.countByUserId).to.have.been.calledOnceWith(userId);
+    });
+  });
+});


### PR DESCRIPTION
## :fallen_leaf: Problème
Afin de réaliser la fonctionnalité permettant à un utilisateur de supprimer son compte en autonomie, nous avons besoin de savoir s'il a été / est un prescrit dans une organisation

## :chestnut: Proposition
Réaliser une API interne afin de pouvoir déterminer ça dans le contexte `Prescription/learner-management` : 
- `learners-api.js` contenant une API `hasBeenLearner`
- `has-been-learner.js` qui est un usecase renvoie cette vérification
- Une fonction `countByUserId`dans le repository `organization-learner-repository.js` pour compter le nombre de fois où il a été prescrit dans une organisation.

## :jack_o_lantern: Remarques
RAS

## :wood: Pour tester
- Vérifier que la CI est au vert
