### PR TITLE
[TECH] Création des tables de contenu pédagogique dans la base de données de l'API (PIX-15355)

### DIFF
--- a/api/db/migrations/20241120132349_create-learningcontent-schema-and-tables.js
+++ b/api/db/migrations/20241120132349_create-learningcontent-schema-and-tables.js
@@ -115,6 +115,20 @@ const up = async function (knex) {
     table.text('link');
     table.string('locale');
   });
+  await knex.schema.withSchema(SCHEMA_NAME).createTable('missions', function (table) {
+    table.string('id').primary();
+    table.string('status');
+    table.jsonb('name_i18n');
+    table.jsonb('content');
+    table.jsonb('learningObjectives_i18n');
+    table.jsonb('validatedObjectives_i18n');
+    table.string('introductionMediaType');
+    table.text('introductionMediaUrl');
+    table.jsonb('introductionMediaAlt_i18n');
+    table.text('documentationUrl');
+    table.text('cardImageUrl');
+    table.string('competenceId').references('id').inTable(`${SCHEMA_NAME}.competences`);
+  });
 };
 
 const down = function (knex) {

--- a/api/db/migrations/20241120132349_create-learningcontent-schema-and-tables.js
+++ b/api/db/migrations/20241120132349_create-learningcontent-schema-and-tables.js
@@ -106,6 +106,15 @@ const up = async function (knex) {
     table.specificType('competences', 'string[]');
     table.specificType('challenges', 'string[]');
   });
+  await knex.schema.withSchema(SCHEMA_NAME).createTable('tutorials', function (table) {
+    table.string('id').primary();
+    table.string('duration');
+    table.text('format');
+    table.text('title');
+    table.text('source');
+    table.text('link');
+    table.string('locale');
+  });
 };
 
 const down = function (knex) {

--- a/api/db/migrations/20241120132349_create-learningcontent-schema-and-tables.js
+++ b/api/db/migrations/20241120132349_create-learningcontent-schema-and-tables.js
@@ -45,6 +45,20 @@ const up = async function (knex) {
     table.boolean('isMobileCompliant');
     table.boolean('isTabletCompliant');
   });
+  await knex.schema.withSchema(SCHEMA_NAME).createTable('skills', function (table) {
+    table.string('id').primary();
+    table.text('name');
+    table.string('status');
+    table.float('pixValue');
+    table.integer('version');
+    table.integer('level');
+    table.string('hintStatus');
+    table.jsonb('hint_i18n');
+    table.string('competenceId').references('id').inTable(`${SCHEMA_NAME}.competences`);
+    table.string('tubeId').references('id').inTable(`${SCHEMA_NAME}.tubes`);
+    table.specificType('tutorialIds', 'string[]');
+    table.specificType('learningMoreTutorialIds', 'string[]');
+  });
 };
 
 const down = function (knex) {

--- a/api/db/migrations/20241120132349_create-learningcontent-schema-and-tables.js
+++ b/api/db/migrations/20241120132349_create-learningcontent-schema-and-tables.js
@@ -59,6 +59,46 @@ const up = async function (knex) {
     table.specificType('tutorialIds', 'string[]');
     table.specificType('learningMoreTutorialIds', 'string[]');
   });
+
+  await knex.schema.withSchema(SCHEMA_NAME).createTable('challenges', function (table) {
+    table.string('id').primary();
+    table.text('instruction');
+    table.text('alternativeInstruction');
+    table.text('proposals');
+    table.string('type');
+    table.text('solution');
+    table.text('solutionToDisplay');
+    table.boolean('t1Status');
+    table.boolean('t2Status');
+    table.boolean('t3Status');
+    table.string('status');
+    table.string('genealogy');
+    table.string('accessibility1');
+    table.string('accessibility2');
+    table.boolean('requireGafamWebsiteAccess');
+    table.boolean('isIncompatibleIpadCertif');
+    table.string('deafAndHardOfHearing');
+    table.boolean('isAwarenessChallenge');
+    table.boolean('toRephrase');
+    table.integer('alternativeVersion');
+    table.boolean('shuffled');
+    table.text('illustrationAlt');
+    table.text('illustrationUrl');
+    table.specificType('attachments', 'string[]');
+    table.string('responsive');
+    table.float('alpha');
+    table.float('delta');
+    table.boolean('autoReply');
+    table.boolean('focusable');
+    table.string('format');
+    table.integer('timer');
+    table.integer('embedHeight');
+    table.text('embedUrl');
+    table.text('embedTitle');
+    table.specificType('locales', 'string[]');
+    table.string('competenceId').references('id').inTable(`${SCHEMA_NAME}.competences`);
+    table.string('skillId').references('id').inTable(`${SCHEMA_NAME}.skills`);
+  });
 };
 
 const down = function (knex) {

--- a/api/db/migrations/20241120132349_create-learningcontent-schema-and-tables.js
+++ b/api/db/migrations/20241120132349_create-learningcontent-schema-and-tables.js
@@ -6,6 +6,15 @@ const up = async function (knex) {
     table.string('id').primary();
     table.text('name');
   });
+  await knex.schema.withSchema(SCHEMA_NAME).createTable('areas', function (table) {
+    table.string('id').primary();
+    table.string('code');
+    table.text('name');
+    table.jsonb('title_i18n');
+    table.string('color');
+    table.string('frameworkId').references('id').inTable(`${SCHEMA_NAME}.frameworks`);
+    table.specificType('competenceIds', 'string[]');
+  });
 };
 
 const down = function (knex) {

--- a/api/db/migrations/20241120132349_create-learningcontent-schema-and-tables.js
+++ b/api/db/migrations/20241120132349_create-learningcontent-schema-and-tables.js
@@ -13,7 +13,7 @@ const up = async function (knex) {
     table.jsonb('title_i18n');
     table.string('color');
     table.string('frameworkId').references('id').inTable(`${SCHEMA_NAME}.frameworks`);
-    table.specificType('competenceIds', 'string[]');
+    table.specificType('competenceIds', 'text[]');
   });
   await knex.schema.withSchema(SCHEMA_NAME).createTable('competences', function (table) {
     table.string('id').primary();
@@ -22,15 +22,15 @@ const up = async function (knex) {
     table.string('index');
     table.text('origin');
     table.string('areaId').references('id').inTable(`${SCHEMA_NAME}.areas`);
-    table.specificType('skillIds', 'string[]');
-    table.specificType('thematicIds', 'string[]');
+    table.specificType('skillIds', 'text[]');
+    table.specificType('thematicIds', 'text[]');
   });
   await knex.schema.withSchema(SCHEMA_NAME).createTable('thematics', function (table) {
     table.string('id').primary();
     table.jsonb('name_i18n');
     table.integer('index');
     table.string('competenceId').references('id').inTable(`${SCHEMA_NAME}.competences`);
-    table.specificType('tubeIds', 'string[]');
+    table.specificType('tubeIds', 'text[]');
   });
   await knex.schema.withSchema(SCHEMA_NAME).createTable('tubes', function (table) {
     table.string('id').primary();
@@ -41,7 +41,7 @@ const up = async function (knex) {
     table.jsonb('practicalDescription_i18n');
     table.string('competenceId').references('id').inTable(`${SCHEMA_NAME}.competences`);
     table.string('thematicId').references('id').inTable(`${SCHEMA_NAME}.thematics`);
-    table.specificType('skillIds', 'string[]');
+    table.specificType('skillIds', 'text[]');
     table.boolean('isMobileCompliant');
     table.boolean('isTabletCompliant');
   });
@@ -56,8 +56,8 @@ const up = async function (knex) {
     table.jsonb('hint_i18n');
     table.string('competenceId').references('id').inTable(`${SCHEMA_NAME}.competences`);
     table.string('tubeId').references('id').inTable(`${SCHEMA_NAME}.tubes`);
-    table.specificType('tutorialIds', 'string[]');
-    table.specificType('learningMoreTutorialIds', 'string[]');
+    table.specificType('tutorialIds', 'text[]');
+    table.specificType('learningMoreTutorialIds', 'text[]');
   });
   await knex.schema.withSchema(SCHEMA_NAME).createTable('challenges', function (table) {
     table.string('id').primary();
@@ -83,7 +83,7 @@ const up = async function (knex) {
     table.boolean('shuffled');
     table.text('illustrationAlt');
     table.text('illustrationUrl');
-    table.specificType('attachments', 'string[]');
+    table.specificType('attachments', 'text[]');
     table.string('responsive');
     table.float('alpha');
     table.float('delta');
@@ -94,7 +94,7 @@ const up = async function (knex) {
     table.integer('embedHeight');
     table.text('embedUrl');
     table.text('embedTitle');
-    table.specificType('locales', 'string[]');
+    table.specificType('locales', 'text[]');
     table.string('competenceId').references('id').inTable(`${SCHEMA_NAME}.competences`);
     table.string('skillId').references('id').inTable(`${SCHEMA_NAME}.skills`);
   });
@@ -103,8 +103,8 @@ const up = async function (knex) {
     table.text('name');
     table.text('description');
     table.boolean('isActive');
-    table.specificType('competences', 'string[]');
-    table.specificType('challenges', 'string[]');
+    table.specificType('competences', 'text[]');
+    table.specificType('challenges', 'text[]');
   });
   await knex.schema.withSchema(SCHEMA_NAME).createTable('tutorials', function (table) {
     table.string('id').primary();

--- a/api/db/migrations/20241120132349_create-learningcontent-schema-and-tables.js
+++ b/api/db/migrations/20241120132349_create-learningcontent-schema-and-tables.js
@@ -1,0 +1,15 @@
+const SCHEMA_NAME = 'learningcontent';
+
+const up = async function (knex) {
+  await knex.raw(`CREATE SCHEMA ??`, [SCHEMA_NAME]);
+  await knex.schema.withSchema(SCHEMA_NAME).createTable('frameworks', function (table) {
+    table.string('id').primary();
+    table.text('name');
+  });
+};
+
+const down = function (knex) {
+  return knex.schema.dropSchema(SCHEMA_NAME, true);
+};
+
+export { down, up };

--- a/api/db/migrations/20241120132349_create-learningcontent-schema-and-tables.js
+++ b/api/db/migrations/20241120132349_create-learningcontent-schema-and-tables.js
@@ -59,7 +59,6 @@ const up = async function (knex) {
     table.specificType('tutorialIds', 'string[]');
     table.specificType('learningMoreTutorialIds', 'string[]');
   });
-
   await knex.schema.withSchema(SCHEMA_NAME).createTable('challenges', function (table) {
     table.string('id').primary();
     table.text('instruction');
@@ -98,6 +97,14 @@ const up = async function (knex) {
     table.specificType('locales', 'string[]');
     table.string('competenceId').references('id').inTable(`${SCHEMA_NAME}.competences`);
     table.string('skillId').references('id').inTable(`${SCHEMA_NAME}.skills`);
+  });
+  await knex.schema.withSchema(SCHEMA_NAME).createTable('courses', function (table) {
+    table.string('id').primary();
+    table.text('name');
+    table.text('description');
+    table.boolean('isActive');
+    table.specificType('competences', 'string[]');
+    table.specificType('challenges', 'string[]');
   });
 };
 

--- a/api/db/migrations/20241120132349_create-learningcontent-schema-and-tables.js
+++ b/api/db/migrations/20241120132349_create-learningcontent-schema-and-tables.js
@@ -15,6 +15,16 @@ const up = async function (knex) {
     table.string('frameworkId').references('id').inTable(`${SCHEMA_NAME}.frameworks`);
     table.specificType('competenceIds', 'string[]');
   });
+  await knex.schema.withSchema(SCHEMA_NAME).createTable('competences', function (table) {
+    table.string('id').primary();
+    table.jsonb('name_i18n');
+    table.jsonb('description_i18n');
+    table.string('index');
+    table.text('origin');
+    table.string('areaId').references('id').inTable(`${SCHEMA_NAME}.areas`);
+    table.specificType('skillIds', 'string[]');
+    table.specificType('thematicIds', 'string[]');
+  });
 };
 
 const down = function (knex) {

--- a/api/db/migrations/20241120132349_create-learningcontent-schema-and-tables.js
+++ b/api/db/migrations/20241120132349_create-learningcontent-schema-and-tables.js
@@ -25,6 +25,13 @@ const up = async function (knex) {
     table.specificType('skillIds', 'string[]');
     table.specificType('thematicIds', 'string[]');
   });
+  await knex.schema.withSchema(SCHEMA_NAME).createTable('thematics', function (table) {
+    table.string('id').primary();
+    table.jsonb('name_i18n');
+    table.integer('index');
+    table.string('competenceId').references('id').inTable(`${SCHEMA_NAME}.competences`);
+    table.specificType('tubeIds', 'string[]');
+  });
 };
 
 const down = function (knex) {

--- a/api/db/migrations/20241120132349_create-learningcontent-schema-and-tables.js
+++ b/api/db/migrations/20241120132349_create-learningcontent-schema-and-tables.js
@@ -32,6 +32,19 @@ const up = async function (knex) {
     table.string('competenceId').references('id').inTable(`${SCHEMA_NAME}.competences`);
     table.specificType('tubeIds', 'string[]');
   });
+  await knex.schema.withSchema(SCHEMA_NAME).createTable('tubes', function (table) {
+    table.string('id').primary();
+    table.text('name');
+    table.text('title');
+    table.text('description');
+    table.jsonb('practicalTitle_i18n');
+    table.jsonb('practicalDescription_i18n');
+    table.string('competenceId').references('id').inTable(`${SCHEMA_NAME}.competences`);
+    table.string('thematicId').references('id').inTable(`${SCHEMA_NAME}.thematics`);
+    table.specificType('skillIds', 'string[]');
+    table.boolean('isMobileCompliant');
+    table.boolean('isTabletCompliant');
+  });
 };
 
 const down = function (knex) {


### PR DESCRIPTION
## :fallen_leaf: Problème
Dans le cadre du chantier de refacto du cache référentiel dans le but de résoudre le problème des dépassements mémoire, on va remplacer la couche de second niveau de cache. Plus précisément, on va remplacer l'usage de Redis par PG, et enregistrer la release récupérée depuis l'API LCMS dans différentes tables PG, une table par entité

## :chestnut: Proposition
On crée d'abord les tables qu'on laisse vide.

## :jack_o_lantern: Remarques
En parallèle, on fait en sorte d'ignorer ces tables lors de la réplication. Côté réplication la release est aussi répliquée à sa manière depuis bien longtemps, on ne veut pas téléscoper ce fonctionnement.

Aussi, penser à invisibiliser le schéma "learningcontent" dans metabase pour tout le monde toutes les bases sauf les admins.

En attente du retour de l'équipe pix-junior concernant les missions, certains champs étaient récupérés côté API pix mais semblent inexistants dans la release et vice-versa, donc j'ai demandé une petite clarification

## :wood: Pour tester
Jouer les migrations et constater l'apparition du schéma et des tables.
