### PR TITLE
[FEATURE] Ajout de la page de suppression de compte (PIX-14904) (PIX-14905)

### DIFF
--- a/mon-pix/app/components/user-account/delete-account-section.gjs
+++ b/mon-pix/app/components/user-account/delete-account-section.gjs
@@ -1,0 +1,52 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+
+export default class DeleteAccountSection extends Component {
+  @service url;
+
+  get supportHomeUrl() {
+    return this.url.supportHomeUrl;
+  }
+
+  get hasEmail() {
+    return Boolean(this.args.user.email);
+  }
+
+  <template>
+    <section class="delete-account-section">
+      <h2>{{t "pages.user-account.delete-account.title"}}</h2>
+
+      <p>
+        {{#if this.hasEmail}}
+          {{t
+            "pages.user-account.delete-account.warning-email"
+            pixScore=@user.profile.pixScore
+            email=@user.email
+            htmlSafe=true
+          }}
+        {{else}}
+          {{t
+            "pages.user-account.delete-account.warning-other"
+            pixScore=@user.profile.pixScore
+            firstName=@user.firstName
+            lastName=@user.lastName
+            htmlSafe=true
+          }}
+        {{/if}}
+      </p>
+
+      <p>
+        {{t "pages.user-account.delete-account.more-information"}}
+        <a href="{{this.supportHomeUrl}}" target="_blank" rel="noopener noreferrer">
+          {{t "pages.user-account.delete-account.more-information-contact-support"}}
+        </a>
+      </p>
+
+      <PixButton @variant="error">
+        {{t "pages.user-account.delete-account.actions.delete"}}
+      </PixButton>
+    </section>
+  </template>
+}

--- a/mon-pix/app/components/user-account/delete-account-section.scss
+++ b/mon-pix/app/components/user-account/delete-account-section.scss
@@ -1,0 +1,23 @@
+.delete-account-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pix-spacing-6x);
+  align-items: start;
+
+  h2 {
+    @extend %pix-title-xs;
+  }
+
+  p {
+    color: var(--pix-neutral-500);
+  }
+
+  a {
+    text-decoration: underline;
+
+    &:focus
+    &:hover {
+      color: var(--pix-primary-500);
+    }
+  }
+}

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -38,6 +38,7 @@ Router.map(function () {
       this.route('personal-information', { path: '/informations-personnelles' });
       this.route('connection-methods', { path: '/methodes-de-connexion' });
       this.route('language', { path: '/langue' });
+      this.route('delete-account');
     });
 
     this.route('certifications', function () {

--- a/mon-pix/app/routes/authenticated/user-account/delete-account.js
+++ b/mon-pix/app/routes/authenticated/user-account/delete-account.js
@@ -1,0 +1,19 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class DeleteAccountRoute extends Route {
+  @service router;
+  @service store;
+
+  async model() {
+    const user = this.modelFor('authenticated.user-account');
+    return { user };
+  }
+
+  async redirect(model) {
+    const accountInfo = await model.user.accountInfo;
+    if (!accountInfo.canSelfDeleteAccount) {
+      this.router.transitionTo('authenticated.user-account.personal-information');
+    }
+  }
+}

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -148,6 +148,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @import 'authentication/login-form';
 @import 'authentication/signup-form';
 @import 'authentication/sso-selection-form';
+@import 'user-account/delete-account-section';
 
 /* pages */
 @import 'pages/assessment-results';

--- a/mon-pix/app/styles/components/_user-account.scss
+++ b/mon-pix/app/styles/components/_user-account.scss
@@ -1,20 +1,20 @@
 .user-account {
 
+  .pix-background-header__content {
+    max-width: 1280px;
+  }
+
   &__title {
     @extend %pix-title-l;
 
-    position: relative;
-    right: 0;
-    margin: 0 0 8px;
-    padding-bottom: 26px;
+    margin-bottom: var(--pix-spacing-8x);
     color: var(--pix-neutral-0);
-    text-align: center;
   }
 
   &__validation-title {
     @extend %pix-title-s;
 
-    padding-bottom: 16px;
+    padding-bottom: var(--pix-spacing-4x);
     color: var(--pix-neutral-900);
     text-align: center;
 
@@ -26,7 +26,7 @@
   &__menu-and-content {
     display: flex;
     flex-wrap: nowrap;
-    justify-content: center;
+    gap: var(--pix-spacing-6x);
 
     @include device-is('mobile') {
       flex-wrap: wrap;
@@ -40,7 +40,7 @@
 
   &__menu-block {
     height: max-content;
-    margin: 32px 26px;
+    border-radius: var(--pix-spacing-2x);
 
     .user-account-menu {
 
@@ -52,20 +52,23 @@
 
       ul li {
         border-bottom: 1.5px solid var(--pix-neutral-20);
-        border-radius: 4px;
+        border-radius: var(--pix-spacing-2x);
 
         &:first-child a {
-          border-radius: 4px 4px 0 0;
+          border-radius: var(--pix-spacing-2x) var(--pix-spacing-2x) 0 0;
         }
 
         &:last-child a {
           border-bottom: none;
-          border-radius: 0 0 4px 4px;
+          border-radius: 0 0 var(--pix-spacing-2x) var(--pix-spacing-2x);
         }
       }
 
       &__link {
-        display: block;
+        @extend %pix-body-m;
+
+        display: flex;
+        align-items: center;
         padding: var(--pix-spacing-4x);
         color: var(--pix-neutral-800);
 
@@ -82,24 +85,34 @@
         }
 
         &.active {
+          font-weight: var(--pix-font-medium);
           background-color: var(--pix-neutral-20);
         }
+
+        &--important {
+          color: var(--pix-error-500);
+        }
       }
+    }
+
+    @include device-is('mobile') {
+      flex-grow: 1;
     }
   }
 
   &__content.pix-block {
+    @extend %pix-body-m;
+
     flex-grow: 1;
-    max-width: 600px;
     height: max-content;
-    margin: 32px 0;
-    padding: 14px 24px;
+    padding: var(--pix-spacing-8x);
+    border-radius: var(--pix-spacing-2x);
 
     @include device-is('mobile') {
       min-width: 100%;
       max-width: 100%;
       margin: 0;
-      padding: 16px;
+      padding: var(--pix-spacing-4x);
     }
   }
 
@@ -108,10 +121,5 @@
       max-width: 520px;
       margin-bottom: 10px;
     }
-  }
-
-  &__connection-methods {
-    max-width: 980px;
-    padding: 10px 0;
   }
 }

--- a/mon-pix/app/styles/pages/_language.scss
+++ b/mon-pix/app/styles/pages/_language.scss
@@ -1,6 +1,4 @@
 .language {
-  padding: var(--pix-spacing-2x) 0;
-
   &__notification {
     margin-top: var(--pix-spacing-4x);
   }

--- a/mon-pix/app/styles/pages/_personal-information.scss
+++ b/mon-pix/app/styles/pages/_personal-information.scss
@@ -1,15 +1,12 @@
-.personal-information {
-  max-width: 980px;
-  margin: 0 auto;
-  padding: 0;
-}
-
 .personal-information-item {
   display: flex;
   align-content: flex-start;
-  margin: 20px 0;
-  padding-bottom: 1rem;
+  padding: var(--pix-spacing-4x) 0;
   border-bottom: var(--pix-neutral-20) 1px solid;
+
+  &:first-child {
+    padding-top: 0;
+  }
 
   &:last-child {
     padding-bottom: 0;

--- a/mon-pix/app/templates/authenticated/user-account.hbs
+++ b/mon-pix/app/templates/authenticated/user-account.hbs
@@ -5,36 +5,42 @@
 </header>
 
 <main id="main" class="main" role="main">
-  <PixBackgroundHeader>
-
+  <PixBackgroundHeader class="user-account">
     <h1 class="user-account__title">{{t "pages.user-account.title"}}</h1>
+
     <div class="user-account__menu-and-content">
       <PixBlock class="user-account__menu-block">
         <nav class="user-account-menu" role="navigation">
           <ul>
             <li>
               <LinkTo @route="authenticated.user-account.personal-information" class="user-account-menu__link">
-                <FaIcon @icon="user" />
+                <PixIcon @name="userCircle" @ariaHidden={{true}} />
                 {{t "pages.user-account.personal-information.menu-link-title"}}
               </LinkTo>
             </li>
             <li>
               <LinkTo @route="authenticated.user-account.connection-methods" class="user-account-menu__link">
-                <FaIcon @icon="link" />
+                <PixIcon @name="link" @ariaHidden={{true}} />
                 {{t "pages.user-account.connexion-methods.menu-link-title"}}
               </LinkTo>
             </li>
             {{#if this.isInternationalDomain}}
               <li>
                 <LinkTo @route="authenticated.user-account.language" class="user-account-menu__link">
-                  <FaIcon @icon="earth-europe" />
+                  <PixIcon @name="language" @ariaHidden={{true}} />
                   {{t "pages.user-account.language.menu-link-title"}}
                 </LinkTo>
               </li>
             {{/if}}
             {{#if @model.accountInfo.canSelfDeleteAccount}}
               <li>
-                {{! ADD DELETE ACCOUNT LINK HERE }}
+                <LinkTo
+                  @route="authenticated.user-account.delete-account"
+                  class="user-account-menu__link user-account-menu__link--important"
+                >
+                  <PixIcon @name="delete" @ariaHidden={{true}} />
+                  {{t "pages.user-account.delete-account.menu-link-title"}}
+                </LinkTo>
               </li>
             {{/if}}
           </ul>

--- a/mon-pix/app/templates/authenticated/user-account/delete-account.hbs
+++ b/mon-pix/app/templates/authenticated/user-account/delete-account.hbs
@@ -1,0 +1,1 @@
+<UserAccount::DeleteAccountSection @user={{@model.user}} />

--- a/mon-pix/mirage/factories/user.js
+++ b/mon-pix/mirage/factories/user.js
@@ -1,6 +1,18 @@
 import sumBy from 'lodash/sumBy';
 import { Factory, trait } from 'miragejs';
 
+function _addAccountInfo(user, server) {
+  if (!user.profile) {
+    user.update({
+      accountInfo: server.create('account-info', {
+        email: user.email,
+        username: user.username,
+        canSelfDeleteAccount: false,
+      }),
+    });
+  }
+}
+
 function _addDefaultProfile(user, server) {
   if (!user.profile) {
     const pixScoreValue = sumBy(user.scorecards.models, 'earnedPix');
@@ -384,9 +396,19 @@ export default Factory.extend({
       user.update({ trainings });
     },
   }),
+  withCanSelfDeleteAccount: trait({
+    afterCreate(user, server) {
+      user.update({
+        accountInfo: server.create('accountInfo', {
+          canSelfDeleteAccount: true,
+        }),
+      });
+    },
+  }),
   afterCreate(user, server) {
     _addDefaultIsCertifiable(user, server);
     _addDefaultScorecards(user, server);
     _addDefaultProfile(user, server);
+    _addAccountInfo(user, server);
   },
 });

--- a/mon-pix/mirage/routes/users/get-my-account.js
+++ b/mon-pix/mirage/routes/users/get-my-account.js
@@ -1,0 +1,17 @@
+import { decodeToken } from 'mon-pix/helpers/jwt';
+
+export default function getMyAccount(schema, request) {
+  const userToken = request.requestHeaders.Authorization.replace('Bearer ', '');
+  const userId = decodeToken(userToken).user_id;
+
+  const user = schema.users.find(userId);
+  if (!user.accountInfo) {
+    return schema.accountInfos.create({
+      email: user.email,
+      username: user.username,
+      canSelfDeleteAccount: false,
+    });
+  }
+
+  return user.accountInfo;
+}

--- a/mon-pix/mirage/routes/users/index.js
+++ b/mon-pix/mirage/routes/users/index.js
@@ -3,6 +3,7 @@ import { Response } from 'miragejs';
 import findPaginatedUserTrainings from './find-paginated-user-trainings';
 import getAuthenticatedUser from './get-authenticated-user';
 import getCampaignParticipationResult from './get-campaign-participation-result';
+import getMyAccount from './get-my-account.js';
 import getProfile from './get-profile';
 import getScorecards from './get-scorecards';
 import getUserCampaignParticipationOverviews from './get-user-campaign-participation-overviews';
@@ -17,6 +18,8 @@ import resetScorecard from './reset-scorecard';
 
 export default function index(config) {
   config.get('/users/me', getAuthenticatedUser);
+
+  config.get('/users/my-account', getMyAccount);
 
   config.post('/users', (schema, request) => {
     const params = JSON.parse(request.requestBody);

--- a/mon-pix/mirage/serializers/user.js
+++ b/mon-pix/mirage/serializers/user.js
@@ -19,6 +19,9 @@ export default ApplicationSerializer.extend({
   links(user) {
     const userBaseUrl = `/api/users/${user.id}`;
     return {
+      accountInfo: {
+        related: '/api/users/my-account',
+      },
       isCertifiable: {
         related: `${userBaseUrl}/is-certifiable`,
       },

--- a/mon-pix/tests/acceptance/user-account-test.js
+++ b/mon-pix/tests/acceptance/user-account-test.js
@@ -16,7 +16,7 @@ module('Acceptance | User account page', function (hooks) {
   setupIntl(hooks);
 
   module('When user is not connected', function () {
-    test('should be redirected to connection page', async function (assert) {
+    test('it is redirected to connection page', async function (assert) {
       // given / when
       await visit('/mon-compte');
 
@@ -34,7 +34,7 @@ module('Acceptance | User account page', function (hooks) {
       await authenticate(user);
     });
 
-    test('should display my account page', async function (assert) {
+    test('it displays my account page', async function (assert) {
       // when
       await visit('/mon-compte');
 
@@ -43,7 +43,7 @@ module('Acceptance | User account page', function (hooks) {
     });
 
     module('My account menu', function () {
-      test('should display my account menu', async function (assert) {
+      test('it displays my account menu', async function (assert) {
         // when
         const screen = await visit('/mon-compte');
 
@@ -51,9 +51,12 @@ module('Acceptance | User account page', function (hooks) {
         assert.ok(screen.getByRole('link', { name: t('pages.user-account.personal-information.menu-link-title') }));
         assert.ok(screen.getByRole('link', { name: t('pages.user-account.connexion-methods.menu-link-title') }));
         assert.ok(screen.getByRole('link', { name: t('pages.user-account.language.menu-link-title') }));
+        assert
+          .dom(screen.queryByRole('link', { name: t('pages.user-account.delete-account.menu-link-title') }))
+          .doesNotExist();
       });
 
-      test('should display personal information on click on "Informations personnelles"', async function (assert) {
+      test('it displays personal information on click on "Informations personnelles"', async function (assert) {
         // given
         const screen = await visit('/mon-compte');
 
@@ -64,7 +67,7 @@ module('Acceptance | User account page', function (hooks) {
         assert.strictEqual(currentURL(), '/mon-compte/informations-personnelles');
       });
 
-      test('should display connection methods on click on "Méthodes de connexion"', async function (assert) {
+      test('it displays connection methods on click on "Méthodes de connexion"', async function (assert) {
         // given
         const screen = await visit('/mon-compte');
 
@@ -75,8 +78,25 @@ module('Acceptance | User account page', function (hooks) {
         assert.strictEqual(currentURL(), '/mon-compte/methodes-de-connexion');
       });
 
+      module('When user can delete their account', () => {
+        test('it displays "Delete my account" menu', async function (assert) {
+          // given
+          const user = server.create('user', 'withEmail', 'withCanSelfDeleteAccount');
+          await authenticate(user);
+
+          // when
+          const screen = await visit('/mon-compte');
+
+          // then
+          assert.ok(screen.getByRole('link', { name: t('pages.user-account.personal-information.menu-link-title') }));
+          assert.ok(screen.getByRole('link', { name: t('pages.user-account.connexion-methods.menu-link-title') }));
+          assert.ok(screen.getByRole('link', { name: t('pages.user-account.language.menu-link-title') }));
+          assert.ok(screen.getByRole('link', { name: t('pages.user-account.delete-account.menu-link-title') }));
+        });
+      });
+
       module('When not in France domain', () => {
-        test('displays language switcher on click on "Choisir ma langue"', async function (assert) {
+        test('it displays language switcher on click on "Choisir ma langue"', async function (assert) {
           // given
           class CurrentDomainStubService extends Service {
             get isFranceDomain() {
@@ -102,7 +122,7 @@ module('Acceptance | User account page', function (hooks) {
       });
 
       module('When in France domain', () => {
-        test('does not display language menu link', async function (assert) {
+        test('it does not display language menu link', async function (assert) {
           // given
           class CurrentDomainStubService extends Service {
             get isFranceDomain() {

--- a/mon-pix/tests/acceptance/user-account/delete-account-test.js
+++ b/mon-pix/tests/acceptance/user-account/delete-account-test.js
@@ -1,0 +1,48 @@
+import { visit } from '@1024pix/ember-testing-library';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { t } from 'ember-intl/test-support';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import { authenticate } from '../../helpers/authentication';
+import setupIntl from '../../helpers/setup-intl';
+
+module('Acceptance | user-account | delete-account', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks);
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
+  module('when user can self-delete their account', function () {
+    test('it deletes their account', async function (assert) {
+      // given
+      const userDetails = { email: 'john.doe@example.net', username: 'john.doe0101' };
+      const user = server.create('user', 'withCanSelfDeleteAccount', userDetails);
+      await authenticate(user);
+
+      // when
+      const screen = await visit('/mon-compte/delete-account');
+
+      // then
+      assert.ok(screen.getByRole('heading', { name: t('pages.user-account.delete-account.title') }));
+    });
+  });
+
+  module('when user cannot self-delete their account', function () {
+    test('it is redirected to account personal information page', async function (assert) {
+      // given
+      const user = server.create('user');
+      await authenticate(user);
+
+      // when
+      const screen = await visit('/mon-compte/delete-account');
+
+      // then
+      assert.ok(screen.getByText(t('pages.user-account.personal-information.first-name')));
+    });
+  });
+});

--- a/mon-pix/tests/integration/components/user-account/delete-account-section-test.gjs
+++ b/mon-pix/tests/integration/components/user-account/delete-account-section-test.gjs
@@ -1,0 +1,72 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import DeleteAccountSection from 'mon-pix/components/user-account/delete-account-section';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+const I18N_KEYS = {
+  title: 'pages.user-account.delete-account.title',
+  contactSupport: 'pages.user-account.delete-account.more-information-contact-support',
+  buttonLabel: 'pages.user-account.delete-account.actions.delete',
+};
+
+module('Integration | Component | UserAccount | DeleteAccountSection', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('when user has an email', function () {
+    test('it displays the delete account section with account email', async function (assert) {
+      //given
+      const user = {
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'john.doe@email.com',
+        profile: { pixScore: 42 },
+      };
+
+      // when
+      const screen = await render(<template><DeleteAccountSection @user={{user}} /></template>);
+
+      // then
+      const title = await screen.findByRole('heading', { name: t(I18N_KEYS.title) });
+      assert.dom(title).exists();
+
+      const pixScore = screen.getByText(/42 pix/i);
+      assert.dom(pixScore).exists();
+
+      const email = screen.getByText(/john.doe@email.com/i);
+      assert.dom(email).exists();
+
+      const supportLink = screen.getByRole('link', { name: t(I18N_KEYS.contactSupport) });
+      assert.dom(supportLink).hasAttribute('href', 'https://pix.org/fr/support');
+
+      const button = screen.getByRole('button', { name: t(I18N_KEYS.buttonLabel) });
+      assert.dom(button).exists();
+    });
+  });
+
+  module('when user does not have an email', function () {
+    test('it displays the delete account section with account fullname', async function (assert) {
+      //given
+      const user = {
+        firstName: 'John',
+        lastName: 'Doe',
+        email: null,
+        profile: { pixScore: 42 },
+      };
+
+      // when
+      const screen = await render(<template><DeleteAccountSection @user={{user}} /></template>);
+
+      // then
+      const title = await screen.findByRole('heading', { name: t(I18N_KEYS.title) });
+      assert.dom(title).exists();
+
+      const pixScore = screen.getByText(/42 pix/i);
+      assert.dom(pixScore).exists();
+
+      const fullname = screen.getByText(/John Doe/i);
+      assert.dom(fullname).exists();
+    });
+  });
+});

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2123,6 +2123,17 @@
         "menu-link-title": "Log in methods",
         "username": "Username"
       },
+      "delete-account": {
+        "actions": {
+          "delete": "Delete my account"
+        },
+        "menu-link-title": "Delete my account",
+        "more-information": "For more information, ",
+        "more-information-contact-support": "please contact support.",
+        "title": "Delete my account permanently",
+        "warning-email": "This action is irreversible. All the skills, courses and {pixScore} pix you have obtained will be permanently deleted for the PIX account using <strong>{email}</strong>.",
+        "warning-other": "This action is irreversible. All the skills, courses and {pixScore} pix you have obtained will be permanently deleted for the PIX account <strong>{firstName} {lastName}</strong>."
+      },
       "email-confirmed": "Email address verified.",
       "email-verification": {
         "code-explanation-of-use": "To move from one field to another, use either the tabulation, or the left and right arrows of the keyboard. To fill in a field, type a number between 1 and 9, or use the up and down arrows of the keyboard.",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -264,7 +264,7 @@
         "obtained": "Certificado obtenido",
         "not-obtained": "Certificado no obtenido",
         "computing": "Certificado actualmente en cálculo",
-        "SIXTH_GRADE": {"title": "Conciencia digital"},
+        "SIXTH_GRADE": { "title": "Conciencia digital" },
         "computing-description": "Un problema técnico nos impide informarle sobre la obtención de su certificado. Vuelva a iniciar sesión mañana en Pix, sección 'Mi viaje', para ver sus resultados. Pedimos disculpas por las molestias ocasionadas."
       },
       "results-loader": {
@@ -2133,6 +2133,17 @@
         "email": "Dirección de correo electrónico",
         "menu-link-title": "Mis métodos de conexión",
         "username": "Nombre de usuario"
+      },
+      "delete-account": {
+        "actions": {
+          "delete": "Delete my account"
+        },
+        "menu-link-title": "Delete my account",
+        "more-information": "For more information, ",
+        "more-information-contact-support": "please contact support.",
+        "title": "Delete my account permanently",
+        "warning-email": "This action is irreversible. All the skills, courses and {pixScore} pix you have obtained will be permanently deleted for the PIX account using <strong>{email}</strong>.",
+        "warning-other": "This action is irreversible. All the skills, courses and {pixScore} pix you have obtained will be permanently deleted for the PIX account <strong>{firstName} {lastName}</strong>."
       },
       "email-confirmed": "Dirección de correo electrónico verificada.",
       "email-verification": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2124,6 +2124,17 @@
         "menu-link-title": "Mes méthodes de connexion",
         "username": "Identifiant"
       },
+      "delete-account": {
+        "actions": {
+          "delete": "Supprimer mon compte"
+        },
+        "menu-link-title": "Supprimer mon compte",
+        "more-information": "Pour plus d’informations, ",
+        "more-information-contact-support": "vous pouvez contacter le support.",
+        "title": "Supprimer mon compte définitivement",
+        "warning-email": "Cette action est irréversible. Toutes les compétences, parcours et {pixScore} pix que vous avez obtenus seront effacés de façon définitive pour le compte PIX utilisant l’adresse e-mail <strong>{email}</strong>.",
+        "warning-other": "Cette action est irréversible. Toutes les compétences, parcours et {pixScore} pix que vous avez obtenus seront effacés de façon définitive pour le compte PIX <strong>{firstName} {lastName}</strong>."
+      },
       "email-confirmed": "Adresse e-mail vérifiée.",
       "email-verification": {
         "code-explanation-of-use": "Pour se déplacer de champ en champ, utilisez soit la tabulation, soit les flèches gauche et droite du clavier. Pour remplir un champ, saisissez des chiffres de 1 à 9 ou bien utilisez les flèches haut et bas du clavier.",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -260,7 +260,7 @@
         "obtained": "Verkregen certificaat",
         "not-obtained": "Certificaat niet behaald",
         "computing": "Certificaat wordt momenteel berekend",
-        "SIXTH_GRADE": {"title": "Digitaal bewustzijn"},
+        "SIXTH_GRADE": { "title": "Digitaal bewustzijn" },
         "computing-description": "Door een technisch probleem kunnen wij u niet informeren over het verkrijgen van uw certificaat. Meld u morgen opnieuw aan bij Pix, 'Mijn reis', om uw resultaten te bekijken. Onze excuses voor het ongemak."
       },
       "results-loader": {
@@ -2129,6 +2129,17 @@
         "email": "E-mail adres",
         "menu-link-title": "Mijn verbindingsmethoden",
         "username": "Inloggen"
+      },
+      "delete-account": {
+        "actions": {
+          "delete": "Delete my account"
+        },
+        "menu-link-title": "Delete my account",
+        "more-information": "For more information, ",
+        "more-information-contact-support": "please contact support.",
+        "title": "Delete my account permanently",
+        "warning-email": "This action is irreversible. All the skills, courses and {pixScore} pix you have obtained will be permanently deleted for the PIX account using <strong>{email}</strong>.",
+        "warning-other": "This action is irreversible. All the skills, courses and {pixScore} pix you have obtained will be permanently deleted for the PIX account <strong>{firstName} {lastName}</strong>."
       },
       "email-confirmed": "Geverifieerd e-mailadres.",
       "email-verification": {


### PR DESCRIPTION
## :fallen_leaf: Problème

Dans le cadre de la fonctionnalité de suppression de compte en autonomie, nous avons besoin d'afficher la page de suppression de compte si l'utilisateur est éligible.

## :chestnut: Proposition

1. Ajout d'un menu "Supprimer mon compte" si l'utilisateur est éligible (`canSelfDeleteAccount`)
2. Ajout de la page de suppression de compte, accessible uniquement si l'utilisateur est éligible.

## :jack_o_lantern: Remarques

1. Modification du style des pages "Mon compte" pour être consistent avec les maquettes du design
2. Modification des icônes de menu "Mon compte" pour utiliser les icônes `PixIcon` du design system.

## :wood: Pour tester

**Test: Menu non affiché**
1. Avec le feature toggle `FT_SELF_ACCOUNT_DELETION=false`
2. Se connecter sur Pix App avec un compte existant (bart@school.net / pix123)
3. Aller sur la page "Mon compte"
- Vérifier que le menu "Supprimer mon compte" n'apparaît pas

**Test: Page non accessible**
1. Avec le feature toggle `FT_SELF_ACCOUNT_DELETION=false`
2. Se connecter sur Pix App avec un compte existant (bart@school.net / pix123)
3. Aller sur la page "Mon compte"
5. Aller directement sur l'url `/mon-compte/delete-account`
- Vérifier que vous êtes redirigé sur `/mon-compte/informations-personnelles`

**Test: Menu et page accessible sur Pix.fr et compte email**
1. Avec le feature toggle `FT_SELF_ACCOUNT_DELETION=true`
2. Se connecter sur **Pix App (FR)** avec un compte email (bart@school.net / pix123)
3. Aller sur la page "Mon compte"
4. Cliquer sur le menu "Supprimer mon compte"
- Vérifier que la page "Supprimer mon compte" apparaît.
- Vérifier que le message apparait avec le bon nombre de pix et l'adresse email
- Vérifier que le lien du support est correct en `pix.fr`

**Test: Menu et page accessible sur Pix.fr et compte sans email**
1. Avec le feature toggle `FT_SELF_ACCOUNT_DELETION=true`
2. Se connecter sur **Pix App (FR)** avec un compte **sans adresse email (bob.leponge.0202 / pix123)** 
3. Aller sur la page "Mon compte"
4. Cliquer sur le menu "Supprimer mon compte"
- Vérifier que le message apparait avec le bon nombre de pix et le nom et prénom

**Test: Lien support sur pix.org**
1. Avec le feature toggle `FT_SELF_ACCOUNT_DELETION=true`
1. Se connecter sur **Pix App (ORG)** avec un compte email (bart@school.net / pix123)
2. Aller sur la page "Mon compte"
3. Cliquer sur le menu "Supprimer mon compte"
- Vérifier que le lien du support est correct en `pix.org`