### PR TITLE
[FEATURE] Partager l'attestation au partage du résultat de la campagne (PIX-15365).

### DIFF
--- a/api/db/seeds/data/team-prescription/build-quests.js
+++ b/api/db/seeds/data/team-prescription/build-quests.js
@@ -192,15 +192,12 @@ const buildTargetProfile = (databaseBuilder, organization) => {
 
 export const buildQuests = async (databaseBuilder) => {
   // Create USERS
-
   const [successUser, successSharedUser, failedUser, pendingUser, blankUser] = buildUsers(databaseBuilder);
 
   // Create organization
-
   const organization = buildOrganization(databaseBuilder);
 
   // Add admin-orga@example.net as Admin in organization
-
   databaseBuilder.factory.buildMembership({
     organizationId: organization.id,
     organizationRole: 'ADMIN',
@@ -208,18 +205,15 @@ export const buildQuests = async (databaseBuilder) => {
   });
 
   // Associate attestation feature to organization
-
   databaseBuilder.factory.buildOrganizationFeature({
     organizationId: organization.id,
     featureId: FEATURE_ATTESTATIONS_MANAGEMENT_ID,
   });
 
   // Associate tag to organization
-
   databaseBuilder.factory.buildOrganizationTag({ organizationId: organization.id, tagId: AEFE_TAG.id });
 
   // Create organizationLearners
-
   const organizationLearnersData = [
     { userId: successUser.id, division: '6emeA', firstName: 'attestation-success', lastName: 'attestation-success' },
     {
@@ -241,11 +235,9 @@ export const buildQuests = async (databaseBuilder) => {
   ] = buildOrganizationLearners(databaseBuilder, organization, organizationLearnersData);
 
   // Create target profile
-
   const targetProfile = buildTargetProfile(databaseBuilder, organization);
 
   // Create campaigns
-
   const { id: campaignId } = databaseBuilder.factory.buildCampaign({
     ...CAMPAIGN,
     targetProfileId: targetProfile.id,
@@ -260,11 +252,8 @@ export const buildQuests = async (databaseBuilder) => {
   );
 
   // Create campaignParticipations
-
-  const [successParticipation, failedParticipation, pendingParticipation] = buildCampaignParticipations(
-    databaseBuilder,
-    campaignId,
-    [
+  const [successParticipation, successSharedParticipation, failedParticipation, pendingParticipation] =
+    buildCampaignParticipations(databaseBuilder, campaignId, [
       {
         user: successUser,
         organizationLearner: successOrganizationLearner,
@@ -283,15 +272,18 @@ export const buildQuests = async (databaseBuilder) => {
         user: pendingUser,
         organizationLearner: pendingOrganizationLearner,
       },
-    ],
-  );
+    ]);
 
   // Create assessments
-
   databaseBuilder.factory.buildAssessment({
     userId: successUser.id,
     type: Assessment.types.CAMPAIGN,
     campaignParticipationId: successParticipation.id,
+  });
+  databaseBuilder.factory.buildAssessment({
+    userId: successSharedUser.id,
+    type: Assessment.types.CAMPAIGN,
+    campaignParticipationId: successSharedParticipation.id,
   });
   databaseBuilder.factory.buildAssessment({
     userId: failedUser.id,
@@ -305,7 +297,6 @@ export const buildQuests = async (databaseBuilder) => {
   });
 
   // Create first stage
-
   await buildFirstStages(
     databaseBuilder,
     successUser,
@@ -317,18 +308,15 @@ export const buildQuests = async (databaseBuilder) => {
   );
 
   // Create attestation quest
-
   const { id: rewardId } = databaseBuilder.factory.buildAttestation({
     templateName: 'sixth-grade-attestation-template',
     key: ATTESTATIONS.SIXTH_GRADE,
   });
 
   // Create quest
-
   buildQuest(databaseBuilder, rewardId, targetProfile.id);
 
   // Create reward for success user
-
   databaseBuilder.factory.buildProfileReward({
     userId: successUser.id,
     rewardType: REWARD_TYPES.ATTESTATION,
@@ -342,13 +330,11 @@ export const buildQuests = async (databaseBuilder) => {
   });
 
   // Create link between profile reward and organization
-
   databaseBuilder.factory.buildOrganizationsProfileRewards({
     organizationId: organization.id,
     profileRewardId: sharedProfileRewardId,
   });
 
   // Insert job count in temporary storage for pending user
-
   await profileRewardTemporaryStorage.increment(pendingUser.id);
 };

--- a/mon-pix/app/adapters/campaign-participation-result.js
+++ b/mon-pix/app/adapters/campaign-participation-result.js
@@ -1,6 +1,10 @@
+import { service } from '@ember/service';
+
 import ApplicationAdapter from './application';
 
 export default class CampaignParticipationResult extends ApplicationAdapter {
+  @service currentUser;
+
   urlForQueryRecord(query) {
     if (query.userId && query.campaignId) {
       const url = `${this.host}/${this.namespace}/users/${query.userId}/campaigns/${query.campaignId}/assessment-result`;
@@ -14,6 +18,12 @@ export default class CampaignParticipationResult extends ApplicationAdapter {
   share(id) {
     const url = `${this.host}/${this.namespace}/campaign-participations/${id}`;
     return this.ajax(url, 'PATCH');
+  }
+
+  shareProfileReward(campaignParticipationId, profileRewardId) {
+    const payload = { data: { data: { attributes: { profileRewardId, campaignParticipationId } } } };
+    const url = `${this.host}/${this.namespace}/users/${this.currentUser.user.id}/profile/share-reward`;
+    return this.ajax(url, 'POST', payload);
   }
 
   beginImprovement(id) {

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
@@ -89,6 +89,11 @@ export default class EvaluationResultsHero extends Component {
 
       const campaignParticipationResult = this.args.campaignParticipationResult;
       const adapter = this.store.adapterFor('campaign-participation-result');
+
+      if (this.hasQuestResults && this.args.questResults[0].obtained) {
+        await adapter.shareProfileReward(campaignParticipationResult.id, this.args.questResults[0].profileRewardId);
+      }
+
       await adapter.share(campaignParticipationResult.id);
 
       campaignParticipationResult.isShared = true;

--- a/mon-pix/app/models/quest-result.js
+++ b/mon-pix/app/models/quest-result.js
@@ -4,4 +4,5 @@ export default class QuestResult extends Model {
   // attributes
   @attr obtained;
   @attr reward;
+  @attr('number') profileRewardId;
 }

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/hero/evaluation-results-hero-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/hero/evaluation-results-hero-test.js
@@ -147,6 +147,88 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
           assert.dom(screen.getByText(t('pages.skill-review.hero.explanations.improve'))).exists();
           assert.dom(screen.getByRole('button', { name: t('pages.skill-review.actions.improve') })).exists();
         });
+
+        module('when there are quest results', function (hooks) {
+          let shareProfileReward;
+
+          hooks.beforeEach(async function () {
+            const store = this.owner.lookup('service:store');
+            const adapter = store.adapterFor('campaign-participation-result');
+            shareProfileReward = sinon.stub(adapter, 'shareProfileReward');
+            shareProfileReward.resolves();
+          });
+
+          test('it should call the shareProfileReward adapter method', async function (assert) {
+            // given
+            const profileRewardId = 12;
+            this.set('questResults', [
+              {
+                obtained: true,
+                profileRewardId,
+                reward: { key: 'sixth-grade-attestation-template' },
+              },
+            ]);
+
+            // when
+            screen = await render(
+              hbs`<Campaigns::Assessment::Results::EvaluationResultsHero
+  @campaign={{this.campaign}}
+  @questResults={{this.questResults}}
+  @campaignParticipationResult={{this.campaignParticipationResult}}
+/>`,
+            );
+            await click(screen.getByRole('button', { name: t('pages.skill-review.actions.send') }));
+
+            // then
+            assert.ok(shareProfileReward.calledOnce);
+            sinon.assert.calledWithExactly(shareProfileReward, campaignParticipationResult.id, profileRewardId);
+          });
+
+          test('it should not call the shareProfileReward adapter method if quest result is not obtained', async function (assert) {
+            // given
+            this.set('questResults', [
+              {
+                obtained: false,
+                profileRewardId: null,
+                reward: { key: 'sixth-grade-attestation-template' },
+              },
+            ]);
+
+            // when
+            screen = await render(
+              hbs`<Campaigns::Assessment::Results::EvaluationResultsHero
+  @campaign={{this.campaign}}
+  @questResults={{this.questResults}}
+  @campaignParticipationResult={{this.campaignParticipationResult}}
+/>`,
+            );
+            await click(screen.getByRole('button', { name: t('pages.skill-review.actions.send') }));
+
+            // then
+            assert.ok(shareProfileReward.notCalled);
+          });
+        });
+
+        module('when there are no quest results', function () {
+          test('it should not call the shareProfileReward adapter method', async function (assert) {
+            // given
+            const store = this.owner.lookup('service:store');
+            const adapter = store.adapterFor('campaign-participation-result');
+            const shareProfileReward = sinon.stub(adapter, 'shareProfileReward');
+
+            // when
+            const screen = await render(
+              hbs`<Campaigns::Assessment::Results::EvaluationResultsHero
+  @campaign={{this.campaign}}
+  @campaignParticipationResult={{this.campaignParticipationResult}}
+/>`,
+            );
+            await click(screen.getByRole('button', { name: t('pages.skill-review.actions.send') }));
+
+            // then
+            assert.ok(shareProfileReward.notCalled);
+          });
+        });
       });
     });
 


### PR DESCRIPTION
## :fallen_leaf: Problème
L'utlisateur n'a pas de moyen de partager l'obtention de son attestation avec son organisation.

## :chestnut: Proposition
Partager l'attestation en meme temps que les resultats en fin de parcours

## :jack_o_lantern: Remarques
On a corrige les seeds.

## :wood: Pour tester

- acceder a orga "admin-orga@example.net"
- aller sur l'organisation attestation
- tenter de telecharger toutes les attestations 
- attester que seul l'attestation de "attestion-success-shared"  est presente
- se connecter sur pix app avec "attestation-success@example.net" et acceder a la page de fin de parcours ATESTTEST
- partager ses resultats
- retourner sur orga et attester que desormais l'attestation de "attestation-success" est egalement presente dans le zip
