### PR TITLE
[FEATURE] Ajouter la validation des imports SUP dans un job PgBoss (Pix-13793)

### DIFF
--- a/api/src/prescription/learner-management/application/jobs/validate-csv-organization-learners-import-file-job-controller.js
+++ b/api/src/prescription/learner-management/application/jobs/validate-csv-organization-learners-import-file-job-controller.js
@@ -1,0 +1,39 @@
+import { JobController } from '../../../../shared/application/jobs/job-controller.js';
+import { config } from '../../../../shared/config.js';
+import { DomainError } from '../../../../shared/domain/errors.js';
+import { getI18n } from '../../../../shared/infrastructure/i18n/i18n.js';
+import { logger as l } from '../../../../shared/infrastructure/utils/logger.js';
+import { ValidateCsvOrganizationImportFileJob } from '../../domain/models/ValidateCsvOrganizationImportFileJob.js';
+import { usecases } from '../../domain/usecases/index.js';
+import { SupOrganizationLearnerParser } from '../../infrastructure/serializers/csv/sup-organization-learner-parser.js';
+
+class ValidateCsvOrganizationLearnersImportFileJobController extends JobController {
+  #logger;
+
+  constructor({ logger = l } = {}) {
+    super(ValidateCsvOrganizationImportFileJob.name);
+    this.#logger = logger;
+  }
+
+  get isJobEnabled() {
+    return config.pgBoss.validationFileJobEnabled;
+  }
+
+  async handle({ data }) {
+    const { organizationImportId, locale, type } = data;
+
+    const Parser = SupOrganizationLearnerParser;
+    const i18n = getI18n(locale);
+
+    try {
+      await usecases.validateCsvFile({ organizationImportId, i18n, type, Parser });
+    } catch (err) {
+      if (!(err instanceof DomainError)) {
+        throw err;
+      }
+      this.#logger.warn(err);
+    }
+  }
+}
+
+export { ValidateCsvOrganizationLearnersImportFileJobController };

--- a/api/src/prescription/learner-management/application/sco-organization-management-controller.js
+++ b/api/src/prescription/learner-management/application/sco-organization-management-controller.js
@@ -31,18 +31,20 @@ const importOrganizationLearnersFromSIECLE = async function (
         payload: request.payload,
       });
     } else if (format === 'csv') {
-      await usecases.uploadCsvFile({
+      const organizationImportId = await usecases.uploadCsvFile({
         Parser: OrganizationLearnerParser,
         payload: request.payload,
         organizationId,
         userId,
         i18n: request.i18n,
       });
+
       await usecases.validateCsvFile({
         Parser: OrganizationLearnerParser,
-        organizationId,
+        organizationImportId,
         i18n: request.i18n,
       });
+
       await usecases.importOrganizationLearnersFromSIECLECSVFormat({
         userId: authenticatedUserId,
         organizationId,

--- a/api/src/prescription/learner-management/application/sup-organization-management-controller.js
+++ b/api/src/prescription/learner-management/application/sup-organization-management-controller.js
@@ -23,14 +23,12 @@ const importSupOrganizationLearners = async function (
       organizationId,
       userId,
       i18n: request.i18n,
-    });
-    await usecases.validateCsvFile({
-      Parser: SupOrganizationLearnerParser,
-      organizationId,
-      i18n: request.i18n,
       type: 'ADDITIONAL_STUDENT',
-      performJob: true,
     });
+  } catch (error) {
+    dependencies.logWarnWithCorrelationIds(error);
+
+    throw error;
   } finally {
     try {
       dependencies.unlink(request.payload.path);
@@ -60,14 +58,12 @@ const replaceSupOrganizationLearners = async function (
       organizationId,
       userId,
       i18n: request.i18n,
-    });
-    await usecases.validateCsvFile({
-      Parser: SupOrganizationLearnerParser,
-      organizationId,
-      i18n: request.i18n,
       type: 'REPLACE_STUDENT',
-      performJob: true,
     });
+  } catch (error) {
+    dependencies.logWarnWithCorrelationIds(error);
+
+    throw error;
   } finally {
     // see https://hapi.dev/api/?v=21.3.3#-routeoptionspayloadoutput
     // add a catch to avoid an error if unlink fails

--- a/api/src/prescription/learner-management/domain/models/ValidateCsvOrganizationImportFileJob.js
+++ b/api/src/prescription/learner-management/domain/models/ValidateCsvOrganizationImportFileJob.js
@@ -1,0 +1,7 @@
+export class ValidateCsvOrganizationImportFileJob {
+  constructor({ organizationImportId, type, locale }) {
+    this.organizationImportId = organizationImportId;
+    this.type = type;
+    this.locale = locale;
+  }
+}

--- a/api/src/prescription/learner-management/domain/usecases/index.js
+++ b/api/src/prescription/learner-management/domain/usecases/index.js
@@ -18,6 +18,7 @@ import * as campaignParticipationRepository from '../../infrastructure/repositor
 import { repositories } from '../../infrastructure/repositories/index.js';
 import { importOrganizationLearnersJobRepository } from '../../infrastructure/repositories/jobs/import-organization-learners-job-repository.js';
 import { importSupOrganizationLearnersJobRepository } from '../../infrastructure/repositories/jobs/import-sup-organization-learners-job-repository.js';
+import { validateCsvOrganizationImportFileJobRepository } from '../../infrastructure/repositories/jobs/validate-csv-organization-learners-import-file-job-repository.js';
 import { validateOrganizationImportFileJobRepository } from '../../infrastructure/repositories/jobs/validate-organization-learners-import-file-job-repository.js';
 import * as organizationImportRepository from '../../infrastructure/repositories/organization-import-repository.js';
 import * as organizationLearnerImportFormatRepository from '../../infrastructure/repositories/organization-learner-import-format-repository.js';
@@ -48,6 +49,7 @@ import { importStorage } from '../../infrastructure/storage/import-storage.js';
  * @typedef {import ('../../infrastructure/repositories/sup-organization-learner-repository.js')} SupOrganizationLearnerRepository
  * @typedef {import ('../../../../../lib/domain/services/user-reconciliation-service.js')} UserReconciliationService
  * @typedef {import('../../../../identity-access-management/infrastructure/repositories/user.repository.js')} userRepository
+ * @typedef {import('../../infrastructure/repositories/jobs/validate-csv-organization-learners-import-file-job-repository.js')} validateCsvOrganizationImportFileJobRepository
  * @typedef {import ('../../infrastructure/repositories/jobs/validate-organization-learners-import-file-job-repository.js')} ValidateOrganizationImportFileJobRepository
  */
 const dependencies = {
@@ -72,6 +74,7 @@ const dependencies = {
   supOrganizationLearnerRepository,
   userReconciliationService,
   userRepository,
+  validateCsvOrganizationImportFileJobRepository,
   validateOrganizationImportFileJobRepository,
 };
 

--- a/api/src/prescription/learner-management/domain/usecases/validate-csv-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/validate-csv-file.js
@@ -3,22 +3,21 @@ import { ImportSupOrganizationLearnersJob } from '../models/ImportSupOrganizatio
 
 const validateCsvFile = async function ({
   Parser,
-  organizationId,
+  organizationImportId,
   i18n,
   type,
-  performJob,
   importSupOrganizationLearnersJobRepository,
   organizationImportRepository,
   importStorage,
 }) {
-  const organizationImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
+  const organizationImport = await organizationImportRepository.get(organizationImportId);
   const errors = [];
   let warningsData;
 
   try {
     const parser = await importStorage.getParser(
       { Parser, filename: organizationImport.filename },
-      organizationId,
+      organizationImport.organizationId,
       i18n,
     );
 
@@ -26,7 +25,7 @@ const validateCsvFile = async function ({
 
     warningsData = warnings;
 
-    if (performJob) {
+    if (type) {
       await importSupOrganizationLearnersJobRepository.performAsync(
         new ImportSupOrganizationLearnersJob({
           organizationImportId: organizationImport.id,

--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/validate-csv-organization-learners-import-file-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/validate-csv-organization-learners-import-file-job-repository.js
@@ -1,0 +1,18 @@
+import {
+  JobExpireIn,
+  JobRepository,
+  JobRetry,
+} from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { ValidateCsvOrganizationImportFileJob } from '../../../domain/models/ValidateCsvOrganizationImportFileJob.js';
+
+class ValidateCsvOrganizationImportFileJobRepository extends JobRepository {
+  constructor() {
+    super({
+      name: ValidateCsvOrganizationImportFileJob.name,
+      expireIn: JobExpireIn.HIGH,
+      retry: JobRetry.FEW_RETRY,
+    });
+  }
+}
+
+export const validateCsvOrganizationImportFileJobRepository = new ValidateCsvOrganizationImportFileJobRepository();

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-csv-organization-learners-import-file-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-csv-organization-learners-import-file-job-repository_test.js
@@ -1,0 +1,27 @@
+import { ValidateCsvOrganizationImportFileJob } from '../../../../../../../src/prescription/learner-management/domain/models/ValidateCsvOrganizationImportFileJob.js';
+import { validateCsvOrganizationImportFileJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/validate-csv-organization-learners-import-file-job-repository.js';
+import {
+  JobExpireIn,
+  JobRetry,
+} from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import { expect } from '../../../../../../test-helper.js';
+
+describe('Integration | Prescription | Infrastructure | Repository | Jobs | validateCsvOrganizationImportFileJobRepository', function () {
+  describe('#performAsync', function () {
+    it('publish a job', async function () {
+      // when
+      await validateCsvOrganizationImportFileJobRepository.performAsync(
+        new ValidateCsvOrganizationImportFileJob({ organizationImportId: 4123132, type: 'REPLACE', locale: 'fr' }),
+      );
+
+      // then
+      await expect(ValidateCsvOrganizationImportFileJob.name).to.have.been.performed.withJob({
+        expirein: JobExpireIn.HIGH,
+        retrylimit: JobRetry.FEW_RETRY.retryLimit,
+        retrydelay: JobRetry.FEW_RETRY.retryDelay,
+        retrybackoff: JobRetry.FEW_RETRY.retryBackoff,
+        data: { organizationImportId: 4123132, type: 'REPLACE', locale: 'fr' },
+      });
+    });
+  });
+});

--- a/api/tests/prescription/learner-management/unit/application/jobs/validate-csv-organization-learners-import-file-job-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/jobs/validate-csv-organization-learners-import-file-job-controller_test.js
@@ -1,0 +1,85 @@
+import { ValidateCsvOrganizationLearnersImportFileJobController } from '../../../../../../src/prescription/learner-management/application/jobs/validate-csv-organization-learners-import-file-job-controller.js';
+import { usecases } from '../../../../../../src/prescription/learner-management/domain/usecases/index.js';
+import { SupOrganizationLearnerParser } from '../../../../../../src/prescription/learner-management/infrastructure/serializers/csv/sup-organization-learner-parser.js';
+import { S3FileDoesNotExistError } from '../../../../../../src/prescription/learner-management/infrastructure/storage/import-storage.js';
+import { config } from '../../../../../../src/shared/config.js';
+import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
+import { catchErr, expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | Prescription | Application | Jobs | validateCsvOrganizationLearnersImportFileJobController', function () {
+  describe('#isJobEnabled', function () {
+    it('return true when job is enabled', function () {
+      //given
+      sinon.stub(config.pgBoss, 'validationFileJobEnabled').value(true);
+
+      // when
+      const handler = new ValidateCsvOrganizationLearnersImportFileJobController();
+
+      // then
+      expect(handler.isJobEnabled).to.be.true;
+    });
+
+    it('return false when job is disabled', function () {
+      //given
+      sinon.stub(config.pgBoss, 'validationFileJobEnabled').value(false);
+
+      //when
+      const handler = new ValidateCsvOrganizationLearnersImportFileJobController();
+
+      //then
+      expect(handler.isJobEnabled).to.be.false;
+    });
+  });
+
+  describe('#handle', function () {
+    it('should call usecase', async function () {
+      sinon.stub(usecases, 'validateCsvFile');
+      // given
+      const handler = new ValidateCsvOrganizationLearnersImportFileJobController();
+      const data = { organizationImportId: Symbol('organizationImportId'), locale: 'en', type: 'ADDITIONAL_STUDENT' };
+
+      // when
+      await handler.handle({ data });
+
+      // then
+      expect(usecases.validateCsvFile).to.have.been.calledOnce;
+      expect(usecases.validateCsvFile).to.have.been.calledWithExactly({
+        organizationImportId: data.organizationImportId,
+        i18n: getI18n(data.locale),
+        type: data.type,
+        Parser: SupOrganizationLearnerParser,
+      });
+    });
+
+    it('should not throw when error is from domain', async function () {
+      const error = new S3FileDoesNotExistError();
+      sinon.stub(usecases, 'validateCsvFile').rejects(error);
+
+      // given
+      const warnStub = sinon.stub();
+      const handler = new ValidateCsvOrganizationLearnersImportFileJobController({ logger: { warn: warnStub } });
+      const data = { organizationImportId: Symbol('organizationImportId') };
+
+      // when
+      await handler.handle({ data });
+
+      // then
+      expect(warnStub).to.have.been.calledWithExactly(error);
+    });
+
+    it('should throw when error is not from domain', async function () {
+      const error = new Error();
+      sinon.stub(usecases, 'validateCsvFile').rejects(error);
+
+      // given
+      const handler = new ValidateCsvOrganizationLearnersImportFileJobController();
+      const data = { organizationImportId: Symbol('organizationImportId') };
+
+      // when
+      const result = await catchErr(handler.handle)({ data });
+
+      // then
+      expect(result).to.equal(error);
+    });
+  });
+});

--- a/api/tests/prescription/learner-management/unit/application/sup-organization-management-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/sup-organization-management-controller_test.js
@@ -7,11 +7,8 @@ describe('Unit | Controller | sup-organization-management-controller', function 
   let organizationId;
   let path;
   let i18n;
-  let warnings;
-  let serializedResponse;
   let userId;
 
-  let supOrganizationLearnerWarningSerializerStub;
   let logErrorWithCorrelationIdsStub;
   let unlinkStub;
 
@@ -22,14 +19,12 @@ describe('Unit | Controller | sup-organization-management-controller', function 
     userId = Symbol('userId');
 
     sinon.stub(usecases, 'uploadCsvFile');
-    sinon.stub(usecases, 'validateCsvFile');
-    supOrganizationLearnerWarningSerializerStub = { serialize: sinon.stub() };
     logErrorWithCorrelationIdsStub = sinon.stub();
     unlinkStub = sinon.stub();
   });
 
   context('#importSupOrganizationLearners', function () {
-    it('should call uploadCsvFile, validateCsvFile and importSupOrganizationLearners usecase and return 200', async function () {
+    it('should call uploadCsvFile usecase and return 200', async function () {
       const params = { id: organizationId };
       const request = {
         auth: { credentials: { userId } },
@@ -37,22 +32,17 @@ describe('Unit | Controller | sup-organization-management-controller', function 
         params,
         i18n,
       };
-      usecases.uploadCsvFile.withArgs({ userId, organizationId, payload: request.payload, i18n }).resolves();
-      usecases.validateCsvFile.withArgs({ organizationId, i18n }).resolves();
-
-      supOrganizationLearnerWarningSerializerStub.serialize
-        .withArgs({ id: organizationId, warnings })
-        .returns(serializedResponse);
+      usecases.uploadCsvFile
+        .withArgs({ userId, organizationId, payload: request.payload, i18n, type: 'ADDITIONAL_STUDENT' })
+        .resolves();
 
       // when
       const response = await supOrganizationManagementController.importSupOrganizationLearners(request, hFake, {
-        supOrganizationLearnerWarningSerializer: supOrganizationLearnerWarningSerializerStub,
         logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub,
         unlink: unlinkStub,
       });
 
       // then
-      expect(sinon.assert.callOrder(usecases.uploadCsvFile, usecases.validateCsvFile)).to.not.throws;
       expect(response.statusCode).to.be.equal(204);
 
       expect(unlinkStub).to.have.been.calledWith(path);
@@ -70,7 +60,6 @@ describe('Unit | Controller | sup-organization-management-controller', function 
 
       // when
       await catchErr(supOrganizationManagementController.importSupOrganizationLearners)(request, hFake, {
-        supOrganizationLearnerWarningSerializer: supOrganizationLearnerWarningSerializerStub,
         logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub,
         unlink: unlinkStub,
       });
@@ -111,23 +100,17 @@ describe('Unit | Controller | sup-organization-management-controller', function 
         params,
         i18n,
       };
-      usecases.uploadCsvFile.withArgs({ userId, organizationId, payload: request.payload, i18n }).resolves();
-      usecases.validateCsvFile.withArgs({ organizationId, i18n }).resolves();
-
-      supOrganizationLearnerWarningSerializerStub.serialize
-        .withArgs({ id: organizationId, warnings })
-        .returns(serializedResponse);
+      usecases.uploadCsvFile
+        .withArgs({ userId, organizationId, payload: request.payload, i18n, type: 'REPLACE_STUDENT' })
+        .resolves();
 
       // when
       const response = await supOrganizationManagementController.replaceSupOrganizationLearners(request, hFake, {
-        supOrganizationLearnerWarningSerializer: supOrganizationLearnerWarningSerializerStub,
         logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub,
         unlink: unlinkStub,
       });
 
       // then
-      // then
-      expect(sinon.assert.callOrder(usecases.uploadCsvFile, usecases.validateCsvFile)).to.not.throws;
       expect(response.statusCode).to.be.equal(204);
 
       expect(unlinkStub).to.have.been.calledWith(path);
@@ -166,7 +149,6 @@ describe('Unit | Controller | sup-organization-management-controller', function 
 
       // when
       const response = await supOrganizationManagementController.replaceSupOrganizationLearners(request, hFake, {
-        supOrganizationLearnerWarningSerializer: supOrganizationLearnerWarningSerializerStub,
         logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub,
         unlink: unlinkStub,
       });

--- a/api/tests/prescription/learner-management/unit/domain/usecases/upload-csv-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/upload-csv-file_test.js
@@ -1,8 +1,8 @@
-import { IMPORT_STATUSES } from '../../../../../../src/prescription/learner-management/domain/constants.js';
 import { OrganizationImport } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationImport.js';
 import { uploadCsvFile } from '../../../../../../src/prescription/learner-management/domain/usecases/upload-csv-file.js';
 import { SupOrganizationLearnerImportHeader } from '../../../../../../src/prescription/learner-management/infrastructure/serializers/csv/sup-organization-learner-import-header.js';
 import { SupOrganizationLearnerParser } from '../../../../../../src/prescription/learner-management/infrastructure/serializers/csv/sup-organization-learner-parser.js';
+import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { catchErr, createTempFile, expect, removeTempFile, sinon } from '../../../../../test-helper.js';
 
@@ -12,12 +12,29 @@ const supOrganizationLearnerImportHeader = new SupOrganizationLearnerImportHeade
   .map((column) => column.name)
   .join(';');
 
-describe('Unit | UseCase | ImportSupOrganizationLearner', function () {
+describe('Unit | UseCase | uploadCsvFile', function () {
   const organizationId = 1;
   const userId = 2;
-  let timer, fakeDate, organizationImportRepositoryStub, importStorageStub, payload, filepath, s3Filename, csvContent;
+  let timer,
+    fakeDate,
+    organizationImportRepositoryStub,
+    validateCsvOrganizationImportFileJobRepositoryStub,
+    importStorageStub,
+    payload,
+    filepath,
+    s3Filename,
+    csvContent,
+    organizationImportStub,
+    organizationImportSavedStub,
+    organizationImportId;
 
   beforeEach(async function () {
+    sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
+      return callback();
+    });
+
+    organizationImportId = Symbol('organizationImportId');
+
     s3Filename = Symbol('filename');
     csvContent = `${supOrganizationLearnerImportHeader}
     Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;12346;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;
@@ -35,9 +52,24 @@ describe('Unit | UseCase | ImportSupOrganizationLearner', function () {
       getParser: sinon.stub(),
     };
 
+    validateCsvOrganizationImportFileJobRepositoryStub = { performAsync: sinon.stub() };
+
+    organizationImportStub = { upload: sinon.stub() };
+
+    organizationImportSavedStub = { id: organizationImportId, upload: sinon.stub() };
+
+    sinon
+      .stub(OrganizationImport, 'create')
+      .withArgs({ createdBy: userId, organizationId })
+      .returns(organizationImportStub);
+
     organizationImportRepositoryStub = {
       save: sinon.stub(),
+      getLastByOrganizationId: sinon.stub(),
     };
+    organizationImportRepositoryStub.getLastByOrganizationId
+      .withArgs(organizationId)
+      .resolves(organizationImportSavedStub);
   });
 
   afterEach(async function () {
@@ -55,7 +87,7 @@ describe('Unit | UseCase | ImportSupOrganizationLearner', function () {
         .resolves(SupOrganizationLearnerParser.buildParser(csvContent, organizationId, i18n));
 
       // when
-      await uploadCsvFile({
+      const result = await uploadCsvFile({
         Parser: SupOrganizationLearnerParser,
         payload,
         userId,
@@ -66,31 +98,26 @@ describe('Unit | UseCase | ImportSupOrganizationLearner', function () {
       });
 
       // then
-      expect(organizationImportRepositoryStub.save).to.have.been.calledOnce;
-      expect(organizationImportRepositoryStub.save.firstCall.args[0]).to.deep.equals(
-        new OrganizationImport({
-          organizationId,
-          createdBy: userId,
-          createdAt: fakeDate,
-          updatedAt: fakeDate,
-          encoding: 'win1252',
-          filename: s3Filename,
-          status: IMPORT_STATUSES.UPLOADED,
-        }),
+      expect(organizationImportRepositoryStub.save.getCall(0)).to.have.been.calledWithExactly(organizationImportStub);
+      expect(organizationImportRepositoryStub.save.getCall(1)).to.have.been.calledWithExactly(
+        organizationImportSavedStub,
       );
+      expect(result).to.be.equals(organizationImportId);
     });
   });
+
   context('when there is an upload error', function () {
     it('save UPLOAD_ERROR state in database', async function () {
       // given
-      importStorageStub.sendFile.withArgs({ filepath: payload.path }).rejects();
+      const errorS3 = new Error('s3ErrorUpload');
+      importStorageStub.sendFile.withArgs({ filepath: payload.path }).rejects(errorS3);
 
       importStorageStub.getParser
         .withArgs({ Parser: SupOrganizationLearnerParser, filename: s3Filename }, organizationId, i18n)
         .resolves(SupOrganizationLearnerParser.buildParser(csvContent, organizationId, i18n));
 
       // when
-      const error = await catchErr(uploadCsvFile)({
+      await catchErr(uploadCsvFile)({
         Parser: SupOrganizationLearnerParser,
         payload,
         userId,
@@ -101,17 +128,48 @@ describe('Unit | UseCase | ImportSupOrganizationLearner', function () {
       });
 
       // then
-      expect(organizationImportRepositoryStub.save).to.have.been.calledOnce;
-      expect(organizationImportRepositoryStub.save.firstCall.args[0]).to.deep.equals(
-        new OrganizationImport({
-          organizationId,
-          createdBy: userId,
-          createdAt: fakeDate,
-          errors: [error],
-          status: IMPORT_STATUSES.UPLOAD_ERROR,
-          updatedAt: fakeDate,
-        }),
-      );
+      expect(organizationImportSavedStub.upload).to.have.been.calledWithExactly({
+        filename: undefined,
+        encoding: undefined,
+        errors: [errorS3],
+      });
+    });
+
+    it('should save organization import with error when save job fails', async function () {
+      //given
+      const expectedError = new Error('jobFails');
+      const parserStub = { getFileEncoding: sinon.stub() };
+      const encoding = Symbol('encoding');
+
+      validateCsvOrganizationImportFileJobRepositoryStub.performAsync.rejects(expectedError);
+
+      importStorageStub.sendFile.withArgs({ filepath: payload.path }).resolves(s3Filename);
+      importStorageStub.getParser
+        .withArgs({ Parser: SupOrganizationLearnerParser, filename: s3Filename }, organizationId, i18n)
+        .resolves(parserStub);
+
+      parserStub.getFileEncoding.returns(encoding);
+
+      // when
+      await catchErr(uploadCsvFile)({
+        Parser: SupOrganizationLearnerParser,
+        payload,
+        userId,
+        organizationId,
+        i18n,
+        type: Symbol('type'),
+        organizationImportRepository: organizationImportRepositoryStub,
+        importStorage: importStorageStub,
+        validateCsvOrganizationImportFileJobRepository: validateCsvOrganizationImportFileJobRepositoryStub,
+      });
+
+      //then
+      expect(organizationImportSavedStub.upload).to.have.been.calledWithExactly({
+        filename: s3Filename,
+        encoding,
+        errors: [expectedError],
+      });
+      expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(organizationImportSavedStub);
     });
   });
 });


### PR DESCRIPTION
## :fallen_leaf: Problème
Nous n'avons pas encore toutes les routes permettant de faire des imports en asynchrone, ce qui pourrait surcharger certains container web lors de forte charge

## :chestnut: Proposition
Déplacer les imports SUP dans des job PgBoss

## :jack_o_lantern: Remarques
RAS

## :wood: Pour tester
Faire un import SUP ajouter et remplacer. et vérifier que tout est OKAY

Faire un import Fregate aussi et vérifier que celui ci est toujours OK