### PR TITLE
[BUGFIX] Empêcher de lever une alerte sur un challenge déjà répondu (PIX-15388).

### DIFF
--- a/api/src/certification/evaluation/domain/errors.js
+++ b/api/src/certification/evaluation/domain/errors.js
@@ -1,0 +1,9 @@
+import { DomainError } from '../../../shared/domain/errors.js';
+
+class ChallengeAlreadyAnsweredError extends DomainError {
+  constructor(message) {
+    super(message);
+  }
+}
+
+export { ChallengeAlreadyAnsweredError };

--- a/api/src/certification/session-management/domain/usecases/create-certification-challenge-live-alert.js
+++ b/api/src/certification/session-management/domain/usecases/create-certification-challenge-live-alert.js
@@ -1,3 +1,4 @@
+import { ChallengeAlreadyAnsweredError } from '../../../evaluation/domain/errors.js';
 import { CertificationChallengeLiveAlert } from '../../../shared/domain/models/CertificationChallengeLiveAlert.js';
 
 const createCertificationChallengeLiveAlert = async function ({
@@ -18,6 +19,14 @@ const createCertificationChallengeLiveAlert = async function ({
   }
 
   const answers = await answerRepository.findByAssessment(assessmentId);
+
+  const isCurrentChallengeAlreadyAnswered = Boolean(
+    answers.find(({ challengeId: currentChallengeId }) => currentChallengeId === challengeId),
+  );
+
+  if (isCurrentChallengeAlreadyAnswered) {
+    throw new ChallengeAlreadyAnsweredError();
+  }
 
   const questionNumber = _getCurrentQuestionNumber(answers);
 


### PR DESCRIPTION
## :fallen_leaf: Problème

Il est possible pour un candidat de lever une alerte à un challenge auquel il vient de répondre (à cause d’un ralentissement réseau par exemple) générant une erreur 500 lors de la suite du test de certification

Il ne devrait pas être possible de lever d’alerte à un challenge qui a déjà une réponse. 

## :chestnut: Proposition

Empêcher la création d'une alerte si le challenge courant a déjà une réponse

## :jack_o_lantern: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :wood: Pour tester

- Créer une session V3
- Ajouter un candidat et commencer le test
- Passer en réseau très lent
- Tenter de répondre à la question et avant que le chargement de la question suivante ne se termine, essayer de lever une alerte.
- Vérifier que cela n'est pas possible
