### PR TITLE
[FEATURE] Afficher une notification lorsque aucune attestation n'est disponible (PIX-15364)

### DIFF
--- a/orga/app/controllers/authenticated/attestations.js
+++ b/orga/app/controllers/authenticated/attestations.js
@@ -10,6 +10,7 @@ export default class AuthenticatedAttestationsController extends Controller {
   @service session;
   @service currentUser;
   @service notifications;
+  @service intl;
 
   @action
   async downloadSixthGradeAttestationsFile(selectedDivisions) {
@@ -23,7 +24,14 @@ export default class AuthenticatedAttestationsController extends Controller {
 
       const token = this.session.isAuthenticated ? this.session.data.authenticated.access_token : '';
 
-      await this.fileSaver.save({ url, token, fileName: SIXTH_GRADE_ATTESTATION_FILE_NAME });
+      const noAttestationMessageNotification = this.intl.t('pages.attestations.no-attestations');
+
+      await this.fileSaver.save({
+        url,
+        token,
+        fileName: SIXTH_GRADE_ATTESTATION_FILE_NAME,
+        noContentMessageNotification: noAttestationMessageNotification,
+      });
     } catch (error) {
       this.notifications.sendError(error.message, { autoClear: false });
     }

--- a/orga/app/services/file-saver.js
+++ b/orga/app/services/file-saver.js
@@ -1,7 +1,9 @@
 import Service from '@ember/service';
 import { service } from '@ember/service';
 import fetch from 'fetch';
+
 export default class FileSaverService extends Service {
+  @service notifications;
   @service intl;
 
   async save({
@@ -11,8 +13,14 @@ export default class FileSaverService extends Service {
     fetcher = _fetchData,
     downloadFileForIEBrowser = _downloadFileForIEBrowser,
     downloadFileForModernBrowsers = _downloadFileForModernBrowsers,
+    noContentMessageNotification = this.intl.t('common.no-content'),
   }) {
     const response = await fetcher({ url, token, locale: this.locale });
+
+    if (response.status === 204) {
+      this.notifications.sendWarning(noContentMessageNotification);
+      return;
+    }
 
     if (response.status !== 200) {
       const jsonResponse = await response.json();

--- a/orga/tests/unit/controllers/authenticated/attestations-test.js
+++ b/orga/tests/unit/controllers/authenticated/attestations-test.js
@@ -14,6 +14,7 @@ module('Unit | Controller | authenticated/attestations', function (hooks) {
   module('#downloadSixthGradeAttestationsFile', function () {
     test('should call the file-saver service with the right parameters', async function (assert) {
       // given
+      this.intl = this.owner.lookup('service:intl');
       const controller = this.owner.lookup('controller:authenticated/attestations');
 
       const token = 'a token';
@@ -52,6 +53,7 @@ module('Unit | Controller | authenticated/attestations', function (hooks) {
           token,
           url: `/api/organizations/${organizationId}/attestations/${SIXTH_GRADE_ATTESTATION_KEY}?divisions[]=${encodeURIComponent(selectedDivision)}`,
           fileName: SIXTH_GRADE_ATTESTATION_FILE_NAME,
+          noContentMessageNotification: this.intl.t('pages.attestations.no-attestations'),
         }),
       );
     });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -246,6 +246,7 @@
       }
     },
     "loading": "Loading",
+    "no-content": "No content available",
     "pagination": {
       "action": {
         "next": "Go to next page",
@@ -415,6 +416,7 @@
       "title": "Attestations",
       "description": "Select the class for which you wish to export attestations in PDF format.",
       "download-attestations-button": "Download",
+      "no-attestations": "No attestation available",
       "placeholder": "-- Select --",
       "select-label": "Select one or more classes"
     },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -246,6 +246,7 @@
       }
     },
     "loading": "Chargement en cours",
+    "no-content": "Aucun contenu",
     "pagination": {
       "action": {
         "next": "Aller à la page suivante",
@@ -421,6 +422,7 @@
       "title": "Attestations",
       "description": "Sélectionnez la classe pour laquelle vous souhaitez exporter les attestations au format PDF.",
       "download-attestations-button": "Télécharger",
+      "no-attestations": "Aucune attestation disponible pour votre sélection",
       "placeholder": "-- Sélectionner --",
       "select-label": "Sélectionnez une ou plusieurs classes"
     },

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -270,7 +270,8 @@
       },
       "subjects": "Onderwerpen: {value, number}",
       "thematic-results": "Thematische resultaten: {value, number}"
-    }
+    },
+    "no-content": "Geen inhoud"
   },
   "components": {
     "campaign": {
@@ -412,6 +413,7 @@
       "title": "Resultaten voor {firstName} {lastName}"
     },
     "attestations": {
+      "no-attestations": "Er zijn geen certificaten beschikbaar voor jouw selectie",
       "title": "Certificaten",
       "description": "Selecteer de klas waarvoor je de attesten in PDF-formaat wilt exporteren.",
       "download-attestations-button": "Downloaden",


### PR DESCRIPTION
## :fallen_leaf: Problème
Actuellement si aucune attestation n'est disponible ( non obtenue et/ou non partagée ) rien ne se passe ou s'affiche pour lui notifier

## :chestnut: Proposition
Afficher une notification type `warning` dans ce cas la

## :jack_o_lantern: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :wood: Pour tester

- Se connecter à PixOrga avec `admin-orga@example.net`
- Aller sur l'organisation `attestation` et sur l'onglet attestation
- Selectionner la classe 6emeB ( Aucun élève n'a d'attestation )
- Vérifier que la notification warning s'affiche bien