### PR TITLE
[FEATURE] Informer les prescripteurs des informations de leurs campagnes que leurs prescrits voient [PIX-191]

### DIFF
--- a/orga/app/components/campaign/create-form.gjs
+++ b/orga/app/components/campaign/create-form.gjs
@@ -436,6 +436,7 @@ export default class CreateForm extends Component {
           <PixInput
             @id="campaign-title"
             @name="campaign-title"
+            @subLabel={{t "pages.campaign-creation.test-title.sublabel"}}
             maxlength="50"
             {{on "change" (fn this.onChangeCampaignValue "title")}}
             @value={{@campaign.title}}
@@ -449,6 +450,7 @@ export default class CreateForm extends Component {
           @id="custom-landing-page-text"
           @maxlength="5000"
           @value={{@campaign.customLandingPageText}}
+          @subLabel={{t "pages.campaign-creation.landing-page-text.sublabel"}}
           {{on "change" this.onChangeCampaignCustomLandingPageText}}
           rows="8"
         >

--- a/orga/app/components/campaign/update-form.gjs
+++ b/orga/app/components/campaign/update-form.gjs
@@ -145,12 +145,13 @@ export default class UpdateForm extends Component {
           <PixInput
             @id="campaign-title"
             @name="campaign-title"
+            @subLabel={{t "pages.campaign-modification.personalised-test-title.sublabel"}}
             class="form-control"
             maxlength="50"
             @value={{this.title}}
             {{on "change" this.onChangeCampaignTitle}}
           >
-            <:label>{{t "pages.campaign-modification.personalised-test-title"}}</:label>
+            <:label>{{t "pages.campaign-modification.personalised-test-title.label"}}</:label>
           </PixInput>
           {{#if @campaign.errors.title}}
             <div class="form__error error-message">
@@ -166,10 +167,11 @@ export default class UpdateForm extends Component {
           class="form-control"
           @maxlength={{5000}}
           @value={{this.customLandingPageText}}
+          @subLabel={{t "pages.campaign-modification.landing-page-text.sublabel"}}
           {{on "change" this.onChangeCampaignCustomLandingPageText}}
           rows={{8}}
         >
-          <:label>{{t "pages.campaign-modification.landing-page-text"}}</:label>
+          <:label>{{t "pages.campaign-modification.landing-page-text.label"}}</:label>
         </PixTextarea>
         {{#if @campaign.errors.customLandingPageText}}
           <div class="form__error error-message">

--- a/orga/tests/acceptance/campaign-creation-test.js
+++ b/orga/tests/acceptance/campaign-creation-test.js
@@ -107,11 +107,14 @@ module('Acceptance | Campaign Creation', function (hooks) {
       await clickByName('Évaluer les participants');
       await click(screen.getByLabelText(`${t('pages.campaign-creation.target-profiles-list-label')} *`));
       await click(await screen.findByRole('option', { name: expectedTargetProfileName }));
-      await fillByLabel('Titre du parcours', 'Savoir rechercher');
+
+      const title = `${t('pages.campaign-creation.test-title.label')} ${t('pages.campaign-creation.test-title.sublabel')}`;
+
+      await fillByLabel(title, 'Savoir rechercher');
       await clickByName('Non');
 
       // when
-      await clickByName('Créer la campagne');
+      await clickByName(t('pages.campaign-creation.actions.create'));
 
       // then
       assert.strictEqual(server.db.campaigns[0].name, 'Ma Campagne');

--- a/orga/tests/acceptance/campaign-update-test.js
+++ b/orga/tests/acceptance/campaign-update-test.js
@@ -1,15 +1,18 @@
 import { clickByName, fillByLabel, visit as visitScreen } from '@1024pix/ember-testing-library';
-import { currentURL } from '@ember/test-helpers';
+import { currentURL, fillIn } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 import authenticateSession from '../helpers/authenticate-session';
+import setupIntl from '../helpers/setup-intl';
 import { createPrescriberByUser, createUserManagingStudents } from '../helpers/test-init';
 
 module('Acceptance | Campaign Update', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks);
   let user;
 
   module('when user is ADMIN', function (hooks) {
@@ -35,9 +38,15 @@ module('Acceptance | Campaign Update', function (hooks) {
       const newName = 'New Name';
       const newText = 'New text';
 
-      await visitScreen(`/campagnes/${campaign.id}/modification`);
+      const screen = await visitScreen(`/campagnes/${campaign.id}/modification`);
       await fillByLabel('Nom de la campagne *', newName);
-      await fillByLabel("Texte de la page d'accueil", newText);
+
+      const landingPageTextInput = screen.getByLabelText(
+        `${t('pages.campaign-modification.landing-page-text.label')}`,
+        { exact: false },
+      );
+
+      await fillIn(landingPageTextInput, newText);
 
       // when
       await clickByName('Modifier');

--- a/orga/tests/integration/components/campaign/create-form-test.js
+++ b/orga/tests/integration/components/campaign/create-form-test.js
@@ -4,7 +4,7 @@ import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
-import { module, test } from 'qunit';
+import { assert, module, test } from 'qunit';
 import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
@@ -220,6 +220,34 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         name: t('pages.campaign-creation.multiple-sendings.assessments.question-label'),
       });
       assert.dom(within(radiogroup).getByLabelText(t('pages.campaign-creation.yes'))).isChecked();
+    });
+
+    test('it should explain which informations will be visible to organization-learners', async function () {
+      // given
+      this.campaign.type = 'ASSESSMENT';
+
+      // when
+      const screen = await render(
+        hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
+  @onSubmit={{this.createCampaignSpy}}
+  @onCancel={{this.cancelSpy}}
+  @errors={{this.errors}}
+  @targetProfiles={{this.targetProfiles}}
+  @membersSortedByFullName={{this.defaultMembers}}
+/>`,
+      );
+
+      // then
+      const testTitleSublabel = screen.getAllByLabelText(t('pages.campaign-creation.landing-page-text.sublabel'), {
+        exact: false,
+      })[0];
+      const landingPageSublabel = screen.getAllByLabelText(t('pages.campaign-creation.landing-page-text.sublabel'), {
+        exact: false,
+      })[1];
+
+      assert.ok(testTitleSublabel);
+      assert.ok(landingPageSublabel);
     });
   });
 
@@ -957,7 +985,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     );
 
     assert
-      .dom(screen.getByRole('textbox', { name: t('pages.campaign-creation.test-title.label') }))
+      .dom(screen.getByLabelText(t('pages.campaign-creation.test-title.label'), { exact: false }))
       .hasValue('Mon titre de parcours');
   });
 
@@ -978,7 +1006,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     );
 
     assert
-      .dom(screen.getByRole('textbox', { name: t('pages.campaign-creation.landing-page-text.label') }))
+      .dom(screen.getByLabelText(t('pages.campaign-creation.landing-page-text.label'), { exact: false }))
       .hasValue('Mon texte de landing page');
   });
 

--- a/orga/tests/integration/components/campaign/update-form-test.js
+++ b/orga/tests/integration/components/campaign/update-form-test.js
@@ -1,5 +1,6 @@
 import { clickByName, fillByLabel, render as renderScreen } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
+import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -36,11 +37,11 @@ module('Integration | Component | Campaign::UpdateForm', function (hooks) {
       );
 
       // then
-      assert.dom(screen.getByLabelText('Titre du parcours')).exists();
-      assert.dom(screen.getByLabelText('Titre du parcours')).hasAttribute('maxLength', '50');
+      assert.dom(screen.getByLabelText('Titre du parcours', { exact: false })).exists();
+      assert.dom(screen.getByLabelText('Titre du parcours', { exact: false })).hasAttribute('maxLength', '50');
     });
 
-    test('it should contain inputs, attributes, information block,validation and cancel buttons', async function (assert) {
+    test('it should contain inputs, attributes, information block, validation and cancel buttons', async function (assert) {
       // when
       const screen = await renderScreen(
         hbs`<Campaign::UpdateForm @campaign={{this.campaign}} @onSubmit={{this.updateCampaignSpy}} @onCancel={{this.cancelSpy}} />`,
@@ -49,8 +50,8 @@ module('Integration | Component | Campaign::UpdateForm', function (hooks) {
       // then
       assert.dom(screen.getByLabelText('Nom de la campagne *')).exists();
       assert.dom(screen.getByLabelText('Propriétaire de la campagne *')).exists();
-      assert.dom(screen.getByLabelText("Texte de la page d'accueil")).exists();
-      assert.dom(screen.getByLabelText('Titre du parcours')).exists();
+      assert.dom(screen.getByLabelText("Texte de la page d'accueil", { exact: false })).exists();
+      assert.dom(screen.getByLabelText('Titre du parcours', { exact: false })).exists();
       assert.dom(screen.getByText('Modifier')).exists();
       assert.dom(screen.getByText('Annuler')).exists();
     });
@@ -87,7 +88,33 @@ module('Integration | Component | Campaign::UpdateForm', function (hooks) {
       );
 
       //then
-      assert.dom(screen.getByLabelText("Texte de la page d'accueil")).hasAttribute('maxLength', '5000');
+      assert
+        .dom(screen.getByLabelText("Texte de la page d'accueil", { exact: false }))
+        .hasAttribute('maxLength', '5000');
+    });
+
+    test('it should explain which informations will be visible to organization-learners', async function (assert) {
+      //when
+      const screen = await renderScreen(
+        hbs`<Campaign::UpdateForm @campaign={{this.campaign}} @onSubmit={{this.updateCampaignSpy}} @onCancel={{this.cancelSpy}} />`,
+      );
+
+      //then
+      const testTitleSublabel = screen.getAllByLabelText(
+        t('pages.campaign-modification.personalised-test-title.sublabel'),
+        {
+          exact: false,
+        },
+      )[0];
+      const landingPageSublabel = screen.getAllByLabelText(
+        t('pages.campaign-modification.landing-page-text.sublabel'),
+        {
+          exact: false,
+        },
+      )[1];
+
+      assert.ok(testTitleSublabel);
+      assert.ok(landingPageSublabel);
     });
   });
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -514,7 +514,8 @@
         "question-label": "What is the type of the external ID ?"
       },
       "landing-page-text": {
-        "label": "Text to display on the starting page"
+        "label": "Text to display on the starting page",
+        "sublabel":"This field will be displayed to campaign participants."
       },
       "legal-warning": "*In accordance with the French law governing computer technology and freedoms (“Informatique et Libertés”), and as data controller, please be careful not to ask for significant or identifying personal data unless it is absolutely necessary. Asking for social security numbers, as well as any sensitive data, is strictly prohibited.",
       "multiple-sendings": {
@@ -566,7 +567,9 @@
       "target-profiles-list-label": "What would you like to test?",
       "target-profiles-search-placeholder": "Search by name",
       "test-title": {
-        "label": "Title of the customised test"
+        "label": "Title of the customised test",
+        "sublabel":"This field will be displayed to campaign participants."
+
       },
       "yes": "Yes"
     },
@@ -584,14 +587,20 @@
       },
       "campaign-modification-success-message": "The changes have been successfully saved.",
       "campaign-name": "Name of the campaign",
-      "landing-page-text": "Text to display on the starting page",
+      "landing-page-text": {
+         "label": "Text to display on the starting page",
+         "sublabel":"This field will be displayed to campaign participants."
+      },
       "owner": {
         "title": "Owner of the campaign",
         "info": "The campaign owner, along with the organisation administrators, are the only ones who can modify or archive this campaign.",
         "label": "Owner of the campaign",
         "placeholder": "Owner’s first and last name"
       },
-      "personalised-test-title": "Title of the personalised test"
+      "personalised-test-title": {
+        "label":"Title of the personalised test",
+        "sublabel":"This field will be displayed to campaign participants."
+      }
     },
     "campaign-results": {
       "title": "Results",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -520,7 +520,8 @@
         "question-label": "Quel est le type de l'identifiant externe ?"
       },
       "landing-page-text": {
-        "label": "Texte de la page d'accueil"
+        "label": "Texte de la page d'accueil",
+        "sublabel": "Ce champs sera affiché aux participants de la campagne."
       },
       "legal-warning": "* En vertu de la loi Informatique et libertés, et en tant que responsable de traitement, soyez attentifs à ne pas demander de donnée particulièrement identifiante ou signifiante si ce n’est pas absolument indispensable. Le numéro de sécurité sociale (NIR) est à proscrire ainsi que toute donnée sensible.",
       "multiple-sendings": {
@@ -572,7 +573,9 @@
       "target-profiles-list-label": "Que souhaitez-vous tester ?",
       "target-profiles-search-placeholder": "Rechercher par nom",
       "test-title": {
-        "label": "Titre du parcours"
+        "label": "Titre du parcours",
+        "sublabel":"Ce champs sera affiché aux participants de la campagne."
+
       },
       "yes": "Oui"
     },
@@ -590,14 +593,20 @@
       },
       "campaign-modification-success-message": "Les modifications ont bien été enregistrées.",
       "campaign-name": "Nom de la campagne",
-      "landing-page-text": "Texte de la page d'accueil",
+      "landing-page-text": {
+        "label": "Texte de la page d'accueil",
+        "sublabel":"Ce champs sera affiché aux participants de la campagne."
+     },
       "owner": {
         "title": "Propriétaire de la campagne",
         "info": "Le propriétaire de la campagne ainsi que les administrateurs de cette organisation, sont les seules personnes qui peuvent modifier et archiver cette campagne.",
         "label": "Propriétaire de la campagne",
         "placeholder": "Nom et prénom du propriétaire"
       },
-      "personalised-test-title": "Titre du parcours"
+      "personalised-test-title": {
+        "label":"Titre du parcours",
+        "sublabel":"Ce champs sera affiché aux participants de la campagne."
+      }
     },
     "campaign-results": {
       "title": "Résultats",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -477,7 +477,8 @@
         "question-label": "Wat is het type externe identifier?"
       },
       "landing-page-text": {
-        "label": "Tekst op de startpagina"
+        "label": "Tekst op de startpagina",
+        "sublabel":"Dit veld wordt weergegeven voor deelnemers aan de campagne."
       },
       "legal-warning": "* In overeenstemming met de Franse wet op gegevensbescherming en als verantwoordelijke voor de verwerking van de gegevens, vragen we niet naar bijzonder identificerende of belangrijke gegevens, tenzij dit absoluut noodzakelijk is. Het burgerservicenummer (BSN) moet worden vermeden, net als gevoelige gegevens.",
       "multiple-sendings": {
@@ -529,7 +530,8 @@
       "target-profiles-list-label": "Wat wil je testen?",
       "target-profiles-search-placeholder": "Zoeken op naam",
       "test-title": {
-        "label": "Titel test"
+        "label": "Titel test",
+        "sublabel":"Dit veld wordt weergegeven voor deelnemers aan de campagne."
       },
       "title": "Een campagne maken",
       "yes": "Ja"
@@ -547,14 +549,20 @@
       },
       "campaign-modification-success-message": "De wijzigingen zijn opgeslagen.",
       "campaign-name": "Naam Campagne",
-      "landing-page-text": "Tekst op de startpagina",
+      "landing-page-text": {
+         "label": "Tekst op de startpagina",
+         "sublabel":"Dit veld wordt weergegeven voor deelnemers aan de campagne."
+      },
       "owner": {
         "info": "De eigenaar van de campagne en de beheerders van deze organisatie zijn de enige personen die deze campagne kunnen wijzigen en archiveren.",
         "label": "Eigenaar van de campagne",
         "placeholder": "Naam en voornaam eigenaar",
         "title": "Eigenaar van de campagne"
       },
-      "personalised-test-title": "Titel test",
+      "personalised-test-title": {
+        "label":"Titel test",
+        "sublabel":"Dit veld wordt weergegeven voor deelnemers aan de campagne."
+      },
       "title": "Een campagne wijzigen"
     },
     "campaign-results": {


### PR DESCRIPTION
## :fallen_leaf: Problème
Il arrive que des prescripteurs, ne sachant pas que ce sont des informations visibles par le prescrit, mettent des noms et descriptions complexes.

## :chestnut: Proposition
Rajouter l'information lors de la création et modification d'une campagne

## :jack_o_lantern: Remarques
je n'ai pas eu le courage de refacto les tests pour qu'ils s'appuient sur les clées de trad

## :wood: Pour tester
- se connecter à Pix Orga
- aller sur la  page de création de campagne et vérifier la présence des sous-labels
- aller sur la page de modification de campagne et vérifier la présence des sous-labels