### PR TITLE
[BUGFIX] Réparer le style du pied de page de la mire de connexion (PIX-15363).

### DIFF
--- a/mon-pix/app/components/authentication-layout/index.scss
+++ b/mon-pix/app/components/authentication-layout/index.scss
@@ -83,15 +83,25 @@
   width: 100%;
   margin-top: var(--pix-spacing-12x);
 
-  .footer-container-content__navigation {
-    margin-top: var(--pix-spacing-2x);
+  nav {
+    @extend %pix-body-xs;
+
+    margin-top: var(--pix-spacing-4x);
     margin-left: 0;
-    line-height: 1rem;
+
+    ul {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--pix-spacing-2x) var(--pix-spacing-3x);
+    }
 
     a {
-      @extend %pix-body-xs;
-
+      color: var(--pix-neutral-500);
       text-decoration: underline;
+
+      &:hover, &:focus {
+        color: var(--pix-primary-500);
+      }
     }
 
     .footer-navigation__item {

--- a/mon-pix/app/components/footer/footer-links.gjs
+++ b/mon-pix/app/components/footer/footer-links.gjs
@@ -6,6 +6,7 @@ import { t } from 'ember-intl';
 export default class FooterLinks extends Component {
   @service url;
   @service currentDomain;
+  @service currentUser;
 
   get shouldDisplayStudentDataProtectionPolicyLink() {
     return this.currentDomain.isFranceDomain;
@@ -56,11 +57,13 @@ export default class FooterLinks extends Component {
           </a>
         </li>
 
-        <li>
-          <LinkTo @route="authenticated.sitemap">
-            {{t "navigation.footer.sitemap"}}
-          </LinkTo>
-        </li>
+        {{#if this.currentUser.user}}
+          <li>
+            <LinkTo @route="authenticated.sitemap">
+              {{t "navigation.footer.sitemap"}}
+            </LinkTo>
+          </li>
+        {{/if}}
 
         <li>
           <a href="{{this.cguUrl}}" target="_blank" rel="noopener noreferrer">

--- a/mon-pix/app/styles/components/_footer.scss
+++ b/mon-pix/app/styles/components/_footer.scss
@@ -32,7 +32,7 @@
 }
 
 // Footer links
-.footer-links__list {
+#footer .footer-links__list {
   text-align: right;
   text-wrap: pretty;
 

--- a/mon-pix/tests/integration/components/footer/footer-links-test.js
+++ b/mon-pix/tests/integration/components/footer/footer-links-test.js
@@ -1,0 +1,86 @@
+import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import { hbs } from 'ember-cli-htmlbars';
+import { t } from 'ember-intl/test-support';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Footer', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('displays a navigation with a list of links', async function (assert) {
+    // when
+    const screen = await render(hbs`<Footer::FooterLinks />`);
+
+    // then
+    assert.dom(screen.getByRole('navigation')).hasAttribute('aria-label', t('navigation.footer.label'));
+
+    assert.ok(screen.getByRole('link', { name: t('navigation.footer.help-center') }));
+    assert.ok(screen.getByRole('link', { name: t('navigation.footer.a11y') }));
+    assert.ok(screen.getByRole('link', { name: t('navigation.footer.server-status') }));
+    assert.ok(screen.getByRole('link', { name: t('navigation.footer.eula') }));
+    assert.ok(screen.getByRole('link', { name: t('navigation.footer.legal-notice') }));
+    assert.ok(screen.getByRole('link', { name: t('navigation.footer.data-protection-policy') }));
+  });
+
+  module('when user is connected', function (hooks) {
+    hooks.beforeEach(function () {
+      class CurrentUserStub extends Service {
+        user = { fullName: 'John Doe' };
+      }
+
+      this.owner.register('service:currentUser', CurrentUserStub);
+    });
+
+    test('displays the sitemap link', async function (assert) {
+      // when
+      const screen = await render(hbs`<Footer::FooterLinks />`);
+
+      // then
+      assert.ok(screen.getByRole('link', { name: t('navigation.footer.sitemap') }));
+    });
+  });
+
+  module('when url does not have frenchDomainExtension', function (hooks) {
+    hooks.beforeEach(function () {
+      class CurrentDomainServiceStub extends Service {
+        get isFranceDomain() {
+          return false;
+        }
+      }
+
+      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+    });
+
+    test('does not display the student data policy', async function (assert) {
+      // when
+      const screen = await render(hbs`<Footer />}`);
+
+      // then
+      assert
+        .dom(screen.queryByRole('link', { name: t('navigation.footer.student-data-protection-policy') }))
+        .doesNotExist();
+    });
+  });
+
+  module('when url has frenchDomainExtension', function (hooks) {
+    hooks.beforeEach(function () {
+      class CurrentDomainServiceStub extends Service {
+        get isFranceDomain() {
+          return true;
+        }
+      }
+
+      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+    });
+
+    test('displays the student data policy', async function (assert) {
+      // when
+      const screen = await render(hbs`<Footer />}`);
+
+      // then
+      assert.dom(screen.getByRole('link', { name: t('navigation.footer.student-data-protection-policy') })).exists();
+    });
+  });
+});

--- a/mon-pix/tests/integration/components/footer/footer-test.js
+++ b/mon-pix/tests/integration/components/footer/footer-test.js
@@ -26,14 +26,6 @@ module('Integration | Component | Footer', function (hooks) {
 
     assert.dom(screen.getByAltText(t('common.pix'))).exists();
     assert.dom(screen.getByText(`${t('navigation.copyrights')} ${new Date().getFullYear()} Pix`)).exists();
-
-    assert.ok(screen.getByRole('link', { name: t('navigation.footer.help-center') }));
-    assert.ok(screen.getByRole('link', { name: t('navigation.footer.a11y') }));
-    assert.ok(screen.getByRole('link', { name: t('navigation.footer.server-status') }));
-    assert.ok(screen.getByRole('link', { name: t('navigation.footer.sitemap') }));
-    assert.ok(screen.getByRole('link', { name: t('navigation.footer.eula') }));
-    assert.ok(screen.getByRole('link', { name: t('navigation.footer.legal-notice') }));
-    assert.ok(screen.getByRole('link', { name: t('navigation.footer.data-protection-policy') }));
   });
 
   module('when url does not have frenchDomainExtension', function (hooks) {
@@ -54,16 +46,6 @@ module('Integration | Component | Footer', function (hooks) {
       // then
       assert.dom(screen.queryByAltText(t('common.french-republic'))).doesNotExist();
     });
-
-    test('does not display the student data policy', async function (assert) {
-      // when
-      const screen = await render(hbs`<Footer />}`);
-
-      // then
-      assert
-        .dom(screen.queryByRole('link', { name: t('navigation.footer.student-data-protection-policy') }))
-        .doesNotExist();
-    });
   });
 
   module('when url does have frenchDomainExtension', function (hooks) {
@@ -83,14 +65,6 @@ module('Integration | Component | Footer', function (hooks) {
 
       // then
       assert.dom(screen.getByAltText(t('common.french-republic'))).exists();
-    });
-
-    test('displays the student data policy', async function (assert) {
-      // when
-      const screen = await render(hbs`<Footer />}`);
-
-      // then
-      assert.dom(screen.getByRole('link', { name: t('navigation.footer.student-data-protection-policy') })).exists();
     });
   });
 });


### PR DESCRIPTION
## :fallen_leaf: Problème

Suite à [cette PR](https://github.com/1024pix/pix/pull/10601), le footer de la nouvelle mire de connexion n'a plus le bon style.

## :chestnut: Proposition

Respecter le design initial.

## :wood: Pour tester

Voir en RA (.fr et .org)
