### PR TITLE
[FEATURE] Voir dans une Sidebar les grains accessibles (PIX-15396)

### DIFF
--- a/mon-pix/app/components/module/_navbar.scss
+++ b/mon-pix/app/components/module/_navbar.scss
@@ -9,16 +9,33 @@
 
   &__content {
     display: flex;
-    flex-wrap: wrap;
     gap: var(--pix-spacing-3x);
+    align-items: center;
     max-width: var(--modulix-max-content-width);
     margin: 0 auto;
+  }
+}
 
-    &__current-step {
-      padding: var(--pix-spacing-1x) var(--pix-spacing-2x);
+.module-sidebar-list-item {
+  &__link {
+    @extend %pix-body-l;
+
+    display: inline-block;
+    width: 100%;
+    padding: var(--pix-spacing-3x) var(--pix-spacing-8x);
+    color: var(--pix-neutral-800);
+
+    &.current-grain {
+      --border-width: 5px;
+
+      padding-left: calc(var(--pix-spacing-8x) - var(--border-width));
+      color: var(--pix-primary-500);
+      border-left: var(--border-width) solid var(--pix-primary-500);
+    }
+
+    &:hover {
       color: var(--pix-primary-700);
-      background-color: var(--pix-primary-100);
-      border-radius: var(--modulix-radius-xs);
+      background-color: var(--pix-neutral-20);
     }
   }
 }

--- a/mon-pix/app/components/module/navbar.gjs
+++ b/mon-pix/app/components/module/navbar.gjs
@@ -1,13 +1,42 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixProgressGauge from '@1024pix/pix-ui/components/pix-progress-gauge';
+import PixSidebar from '@1024pix/pix-ui/components/pix-sidebar';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
+import { eq } from 'ember-truth-helpers';
 
 export default class ModulixNavbar extends Component {
+  @service intl;
+
   get progressValue() {
     if (this.args.totalSteps <= 1) {
       return 100;
     }
     return ((this.args.currentStep - 1) / (this.args.totalSteps - 1)) * 100;
+  }
+
+  @tracked
+  sidebarOpened = false;
+
+  @action
+  openSidebar() {
+    this.sidebarOpened = true;
+  }
+
+  @action
+  closeSidebar() {
+    this.sidebarOpened = false;
+  }
+
+  get grainTypeTexts() {
+    return this.args.grainsToDisplay.map((grain) => this.intl.t(`pages.modulix.grain.tag.${grain.type}`));
+  }
+
+  get currentGrainIndex() {
+    return this.grainTypeTexts.length - 1;
   }
 
   <template>
@@ -16,12 +45,33 @@ export default class ModulixNavbar extends Component {
       aria-label={{t "pages.modulix.flashcards.navigation.currentStep" current=@currentStep total=@totalSteps}}
     >
       <div class="module-navbar__content">
-        <div class="module-navbar__content__current-step">
-          {{@currentStep}}/{{@totalSteps}}
-        </div>
+        <PixButton
+          @variant="tertiary"
+          @triggerAction={{this.openSidebar}}
+          aria-label={{t "pages.modulix.sidebar.button"}}
+        >
+          {{t "pages.modulix.flashcards.navigation.currentStep" current=@currentStep total=@totalSteps}}
+        </PixButton>
 
         <PixProgressGauge @hidePercentage={{true}} @isDecorative={{true}} @value={{this.progressValue}} />
       </div>
     </nav>
+
+    <PixSidebar @title={{@module.title}} @showSidebar={{this.sidebarOpened}} @onClose={{this.closeSidebar}}>
+      <:content>
+        <nav>
+          <ul>
+            {{#each this.grainTypeTexts as |type index|}}
+              <li
+                class="module-sidebar-list-item__link {{if (eq index this.currentGrainIndex) 'current-grain'}}"
+                aria-current={{if (eq index this.currentGrainIndex) "step"}}
+              >
+                {{type}}
+              </li>
+            {{/each}}
+          </ul>
+        </nav>
+      </:content>
+    </PixSidebar>
   </template>
 }

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -198,7 +198,12 @@ export default class ModulePassage extends Component {
 
   <template>
     {{pageTitle @module.title}}
-    <ModuleNavbar @currentStep={{this.currentPassageStep}} @totalSteps={{this.displayableGrains.length}} />
+    <ModuleNavbar
+      @currentStep={{this.currentPassageStep}}
+      @totalSteps={{this.displayableGrains.length}}
+      @module={{@module}}
+      @grainsToDisplay={{this.grainsToDisplay}}
+    />
 
     <main class="module-passage">
       {{#if @module.isBeta}}

--- a/mon-pix/app/styles/components/_navbar-burger-menu.scss
+++ b/mon-pix/app/styles/components/_navbar-burger-menu.scss
@@ -13,7 +13,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding-right: 32px;
+    padding-right: var(--pix-spacing-8x);
   }
 
   &__content {
@@ -25,7 +25,7 @@
     flex-direction: column;
     margin-top: auto;
     margin-bottom: 21px;
-    padding: 10px 32px;
+    padding: 10px var(--pix-spacing-8x);
   }
 
   &__footer {
@@ -36,17 +36,19 @@
 
 .navbar-burger-menu-list-item {
   &__link {
+    @extend %pix-body-l;
+
     display: inline-block;
     width: 100%;
-    padding: 12px 32px;
+    padding: var(--pix-spacing-3x) var(--pix-spacing-8x);
     color: var(--pix-neutral-800);
-    font-size: 1.125rem;
-    font-family: $font-roboto;
 
     &.active {
-      padding-left: calc(32px - 5px);
+      --border-width: 5px;
+
+      padding-left: calc(var(--pix-spacing-8x) - var(--border-width));
       color: var(--pix-primary-500);
-      border-left: 5px solid var(--pix-primary-500);
+      border-left: var(--border-width) solid var(--pix-primary-500);
     }
 
     &:hover {
@@ -74,12 +76,14 @@
 
     display: inline-block;
     width: 100%;
-    padding: 10px 32px;
+    padding: 10px var(--pix-spacing-8x);
     color: var(--pix-neutral-0);
 
     &.active {
-      padding-left: calc(32px - 5px);
-      border-left: 5px solid var(--pix-neutral-0);
+      --border-width: 5px;
+
+      padding-left: calc(var(--pix-spacing-8x) - var(--border-width));
+      border-left: var(--border-width) solid var(--pix-neutral-0);
     }
 
     &:hover {

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -73,7 +73,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // then
       assert.dom(find('.grain-card--activity')).exists();
-      assert.dom(screen.getByText('activité')).exists();
+      assert.dom(screen.getByText('Activité')).exists();
     });
 
     test('should have the "lesson" color and tag if grain is of type lesson', async function (assert) {
@@ -88,7 +88,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // then
       assert.dom(find('.grain-card--lesson')).exists();
-      assert.dom(screen.getByText('leçon')).exists();
+      assert.dom(screen.getByText('Leçon')).exists();
     });
 
     test('should have the "lesson" color and tag if grain is of undefined type', async function (assert) {
@@ -103,7 +103,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // then
       assert.dom(find('.grain-card--lesson')).exists();
-      assert.dom(screen.getByText('leçon')).exists();
+      assert.dom(screen.getByText('Leçon')).exists();
     });
 
     test('should have the "lesson" color and tag if grain is of unknown type', async function (assert) {
@@ -118,7 +118,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // then
       assert.dom(find('.grain-card--lesson')).exists();
-      assert.dom(screen.getByText('leçon')).exists();
+      assert.dom(screen.getByText('Leçon')).exists();
     });
 
     test('should have the "discovery" color and tag if grain is of type discovery', async function (assert) {
@@ -133,7 +133,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // then
       assert.dom(find('.grain-card--discovery')).exists();
-      assert.dom(screen.getByText('découverte')).exists();
+      assert.dom(screen.getByText('Découverte')).exists();
     });
 
     test('should have the "challenge" color and tag if grain is of type challenge', async function (assert) {
@@ -148,7 +148,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // then
       assert.dom(find('.grain-card--challenge')).exists();
-      assert.dom(screen.getByText('défi')).exists();
+      assert.dom(screen.getByText('Défi')).exists();
     });
 
     test('should have the "summary" color and tag if grain is of type summary', async function (assert) {
@@ -163,7 +163,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // then
       assert.dom(find('.grain-card--summary')).exists();
-      assert.dom(screen.getByText("récap'")).exists();
+      assert.dom(screen.getByText("Récap'")).exists();
     });
   });
 

--- a/mon-pix/tests/integration/components/module/navbar_test.gjs
+++ b/mon-pix/tests/integration/components/module/navbar_test.gjs
@@ -1,16 +1,26 @@
-import { render } from '@1024pix/ember-testing-library';
+import { clickByName, render, within } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
 import ModulixNavbar from 'mon-pix/components/module/navbar';
 import { module, test } from 'qunit';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import { waitForDialog } from '../../../helpers/wait-for';
 
 module('Integration | Component | Module | Navbar', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   module('when at first step', function () {
     test('should display step 1 with empty progress bar', async function (assert) {
+      // given
+      const module = createModule(this.owner);
+
       //  when
-      const screen = await render(<template><ModulixNavbar @currentStep={{1}} @totalSteps={{3}} /></template>);
+      const screen = await render(
+        <template>
+          <ModulixNavbar @currentStep={{1}} @totalSteps={{3}} @module={{module}} @grainsToDisplay={{module.grains}} />
+        </template>,
+      );
 
       // then
       assert.ok(screen);
@@ -21,8 +31,15 @@ module('Integration | Component | Module | Navbar', function (hooks) {
 
   module('when at step 2 of 3', function () {
     test('should display step 2 with half-filled progress bar', async function (assert) {
+      // given
+      const module = createModule(this.owner);
+
       //  when
-      const screen = await render(<template><ModulixNavbar @currentStep={{2}} @totalSteps={{3}} /></template>);
+      const screen = await render(
+        <template>
+          <ModulixNavbar @currentStep={{2}} @totalSteps={{3}} @module={{module}} @grainsToDisplay={{module.grains}} />
+        </template>,
+      );
 
       // then
       assert.ok(screen);
@@ -33,8 +50,15 @@ module('Integration | Component | Module | Navbar', function (hooks) {
 
   module('when at last step', function () {
     test('should display step 3 with full-filled progress bar', async function (assert) {
+      // given
+      const module = createModule(this.owner);
+
       //  when
-      const screen = await render(<template><ModulixNavbar @currentStep={{3}} @totalSteps={{3}} /></template>);
+      const screen = await render(
+        <template>
+          <ModulixNavbar @currentStep={{3}} @totalSteps={{3}} @module={{module}} @grainsToDisplay={{module.grains}} />
+        </template>,
+      );
 
       // then
       assert.ok(screen);
@@ -45,8 +69,15 @@ module('Integration | Component | Module | Navbar', function (hooks) {
 
   module('when there is only one step', function () {
     test('should display step 1/1 and a full-filled progress bar', async function (assert) {
+      // given
+      const module = createModule(this.owner);
+
       //  when
-      const screen = await render(<template><ModulixNavbar @currentStep={{1}} @totalSteps={{1}} /></template>);
+      const screen = await render(
+        <template>
+          <ModulixNavbar @currentStep={{1}} @totalSteps={{1}} @module={{module}} @grainsToDisplay={{module.grains}} />
+        </template>,
+      );
 
       // then
       assert.ok(screen);
@@ -54,4 +85,70 @@ module('Integration | Component | Module | Navbar', function (hooks) {
       assert.dom('.progress-gauge__bar').hasValue(100);
     });
   });
+
+  module('when user opens sidebar', function () {
+    test('should display sidebar', async function (assert) {
+      // given
+      const module = createModule(this.owner);
+
+      //  when
+      const screen = await render(
+        <template>
+          <ModulixNavbar @currentStep={{1}} @totalSteps={{3}} @module={{module}} @grainsToDisplay={{module.grains}} />
+        </template>,
+      );
+      const sidebarOpenButton = screen.getByRole('button', { name: 'Afficher les étapes du module' });
+      await click(sidebarOpenButton);
+      await waitForDialog();
+
+      // then
+      assert.ok(screen);
+      assert.dom(screen.getByRole('dialog', { name: module.title })).exists();
+    });
+
+    test('should display steps list in sidebar', async function (assert) {
+      // given
+      const module = createModule(this.owner);
+      const threeFirstGrains = module.grains.slice(0, -1);
+
+      //  when
+      const screen = await render(
+        <template>
+          <ModulixNavbar
+            @currentStep={{3}}
+            @totalSteps={{4}}
+            @module={{module}}
+            @grainsToDisplay={{threeFirstGrains}}
+          />
+        </template>,
+      );
+      await clickByName('Afficher les étapes du module');
+      await waitForDialog();
+
+      // then
+      assert.ok(screen);
+      const list = screen.getByRole('list');
+      assert.dom(list).exists();
+      const items = within(list).getAllByRole('listitem');
+      assert.strictEqual(items.length, 3);
+      assert.strictEqual(items[0].textContent.trim(), t('pages.modulix.grain.tag.discovery'));
+      assert.strictEqual(items[1].textContent.trim(), t('pages.modulix.grain.tag.activity'));
+      assert.strictEqual(items[2].textContent.trim(), t('pages.modulix.grain.tag.lesson'));
+      assert.dom(items[2]).hasAria('current', 'step');
+      assert.dom(screen.queryByRole('listitem', { name: t('pages.modulix.grain.tag.summary') })).doesNotExist();
+    });
+  });
 });
+
+function createModule(owner) {
+  const store = owner.lookup('service:store');
+  const grain1 = store.createRecord('grain', { title: 'Grain title', type: 'discovery' });
+  const grain2 = store.createRecord('grain', { title: 'Grain title', type: 'activity' });
+  const grain3 = store.createRecord('grain', { title: 'Grain title', type: 'lesson' });
+  const grain4 = store.createRecord('grain', { title: 'Grain title', type: 'summary' });
+  return store.createRecord('module', {
+    title: 'Didacticiel',
+    grains: [grain1, grain2, grain3, grain4],
+    transitionTexts: [],
+  });
+}

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1594,11 +1594,11 @@
       },
       "grain": {
         "tag": {
-          "activity": "activity",
-          "challenge": "challenge",
-          "discovery": "discovery",
-          "lesson": "lesson",
-          "summary": "summary"
+          "activity": "Activity",
+          "challenge": "Challenge",
+          "discovery": "Discovery",
+          "lesson": "Lesson",
+          "summary": "Summary"
         }
       },
       "modals": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1627,6 +1627,9 @@
         "subtitle": "You have achieved the following objectives:",
         "title": "Congratulations! Module completed"
       },
+      "sidebar": {
+        "button": "Display the steps of the module"
+      },
       "stepper": {
         "step": {
           "position": "Step {currentStep} of {totalSteps}"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1638,6 +1638,9 @@
         "subtitle": "Has alcanzado los siguientes objetivos:",
         "title": "¡Enhorabuena! Módulo completado"
       },
+      "sidebar": {
+        "button": "Mostrar los pasos del módulo"
+      },
       "stepper": {
         "step": {
           "position": "{currentStep} Paso a paso {totalSteps}"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1606,10 +1606,10 @@
       "grain": {
         "tag": {
           "activity": "Actividad",
-          "challenge": "desafío",
-          "discovery": "descubrimiento",
-          "lesson": "lección",
-          "summary": "recapitular"
+          "challenge": "Desafío",
+          "discovery": "Descubrimiento",
+          "lesson": "Lección",
+          "summary": "Recapitular"
         }
       },
       "modals": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1628,6 +1628,9 @@
         "subtitle": "Vous avez atteint les objectifs suivants :",
         "title": "Bravo ! Module terminé"
       },
+      "sidebar": {
+        "button": "Afficher les étapes du module"
+      },
       "stepper": {
         "step": {
           "position": "Étape {currentStep} sur {totalSteps}"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1595,11 +1595,11 @@
       },
       "grain": {
         "tag": {
-          "activity": "activité",
-          "challenge": "défi",
-          "discovery": "découverte",
-          "lesson": "leçon",
-          "summary": "récap'"
+          "activity": "Activité",
+          "challenge": "Défi",
+          "discovery": "Découverte",
+          "lesson": "Leçon",
+          "summary": "Récap'"
         }
       },
       "modals": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1601,11 +1601,11 @@
       },
       "grain": {
         "tag": {
-          "activity": "activiteit",
+          "activity": "Activiteit",
           "challenge": "Uitdaging",
-          "discovery": "ontdekking",
-          "lesson": "les",
-          "summary": "recap"
+          "discovery": "Ontdekking",
+          "lesson": "Les",
+          "summary": "Recap"
         }
       },
       "modals": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1634,6 +1634,9 @@
         "subtitle": "Je hebt de volgende doelen bereikt:",
         "title": "Gefeliciteerd! Module voltooid"
       },
+      "sidebar": {
+        "button": "De stappen van de module "
+      },
       "stepper": {
         "step": {
           "position": "{currentStep} Stap op {totalSteps}"


### PR DESCRIPTION
## :fallen_leaf: Problème
Dans Modulix, la barre de navigation est un peu vide.

## :chestnut: Proposition
Ajouter le lien “voir les étapes” , au clic le menu apparaît avec : 
- le titre du module,
- la catégorie de grain de chacun des grains.

## :jack_o_lantern: Remarques
On a copié les styles de la navbar Pix App mobile et réutilisé des tokens sur cette navbar (petit impact sur la typo)

## :wood: Pour tester
Vérifier que l’affichage est OK vs les maquettes
