### PR TITLE
[FEATURE] Utiliser PixIcon dans Pix App - Partie 1 (PIX-14775).

### DIFF
--- a/high-level-tests/e2e/cypress/support/step_definitions/assessment.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/assessment.js
@@ -35,20 +35,17 @@ Then(`je vois la page de résultats`, () => {
 Then(`j'ai passé à {string}`, (challenge) => {
   cy.contains(".result-item", challenge)
     .find(".result-item__icon svg")
-    .should("have.class", "fa-circle-xmark")
-    .and("have.class", "result-item__icon--grey");
+    .should("have.class", "result-item__icon--grey");
 });
 
 Then(`j'ai mal répondu à {string}`, (challenge) => {
   cy.contains(".result-item", challenge)
     .find(".result-item__icon svg")
-    .should("have.class", "fa-circle-xmark")
-    .and("have.class", "result-item__icon--red");
+    .should("have.class", "result-item__icon--red");
 });
 
 Then(`j'ai bien répondu à {string}`, (challenge) => {
   cy.contains(".result-item", challenge)
     .find(".result-item__icon svg")
-    .should("have.class", "fa-circle-check")
-    .and("have.class", "result-item__icon--green");
+    .should("have.class", "result-item__icon--green");
 });

--- a/mon-pix/app/components/account-recovery/student-information-form.hbs
+++ b/mon-pix/app/components/account-recovery/student-information-form.hbs
@@ -25,7 +25,7 @@
           aria-label={{t "pages.account-recovery.find-sco-record.student-information.form.tooltip" htmlSafe=true}}
         >
           <:triggerElement>
-            <FaIcon @icon="circle-question" tabindex="0" />
+            <PixIcon @name="help" @plainIcon={{true}} @ariaHidden={{true}} tabindex="0" />
           </:triggerElement>
           <:tooltip>
             {{t "pages.account-recovery.find-sco-record.student-information.form.tooltip" htmlSafe=true}}

--- a/mon-pix/app/components/assessment-banner.hbs
+++ b/mon-pix/app/components/assessment-banner.hbs
@@ -24,7 +24,7 @@
       {{#if @displayHomeLink}}
         <button type="button" class="assessment-banner__home-link" onclick={{this.toggleClosingModal}}>
           {{t "common.actions.quit"}}
-          <FaIcon @icon="right-from-bracket" />
+          <PixIcon @name="logout" @ariaHidden={{true}} />
         </button>
         <PixModal
           class="assessment-banner__closing-modal"

--- a/mon-pix/app/components/authentication/new-password-input/password-rule.gjs
+++ b/mon-pix/app/components/authentication/new-password-input/password-rule.gjs
@@ -1,13 +1,13 @@
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import Component from '@glimmer/component';
 
 const RULE_STYLES = {
   VALID: {
-    iconClass: 'circle-check',
+    iconClass: 'checkCircle',
     listItemClass: 'password-rule',
   },
   INVALID: {
-    iconClass: 'circle-xmark',
+    iconClass: 'cancel',
     listItemClass: 'password-rule password-rule--error',
   },
 };
@@ -19,7 +19,7 @@ export default class PasswordRule extends Component {
 
   <template>
     <li class="{{this.classes.listItemClass}}" aria-label="{{@description}}.">
-      <FaIcon @icon="{{this.classes.iconClass}}" />
+      <PixIcon @name={{this.classes.iconClass}} @plainIcon={{true}} @ariaHidden={{true}} />
       <p aria-live="polite"> {{@description}} </p>
     </li>
   </template>

--- a/mon-pix/app/components/authentication/new-password-input/password-rule.scss
+++ b/mon-pix/app/components/authentication/new-password-input/password-rule.scss
@@ -3,15 +3,19 @@
   gap: var(--pix-spacing-2x);
   align-items: center;
 
-  path {
-    fill: var(--pix-success-500);
+  svg {
+    width: 1rem;
+    height: 1rem;
+    color: var(--pix-success-500);
   }
 
   &--error {
     font-weight: var(--pix-font-bold);
 
-    path {
-      fill: var(--pix-error-500);
+    svg {
+      width: 1rem;
+      height: 1rem;
+      color: var(--pix-error-500);
     }
   }
 }

--- a/mon-pix/app/components/certification-banners/congratulations-certification-banner.hbs
+++ b/mon-pix/app/components/certification-banners/congratulations-certification-banner.hbs
@@ -1,12 +1,11 @@
 <div class="congratulations-banner">
-  <button
-    aria-label={{t "common.actions.close"}}
+  <PixIconButton
+    @iconName="close"
+    @ariaLabel={{t "common.actions.close"}}
+    @triggerAction={{@closeBanner}}
+    @withBackground={{true}}
     class="icon-button congratulations-banner__icon"
-    {{on "click" @closeBanner}}
-    type="button"
-  >
-    <FaIcon @icon="xmark" />
-  </button>
+  />
   <p class="congratulations-banner__message">
     {{t "pages.certification-joiner.congratulation-banner.message" fullName=@fullName htmlSafe=true}}
   </p>
@@ -19,12 +18,12 @@
       rel="noopener noreferrer"
     >
       {{t "pages.certification-joiner.congratulation-banner.link.text"}}
-      <FaIcon @icon="up-right-from-square" class="congratulations-banner-links__link--icon" />
+      <PixIcon @name="openNew" @plainIcon={{true}} @title={{t "navigation.external-link-title"}} />
     </a>
     <LinkTo @route="authenticated.user-certifications" class="congratulations-banner-links__link">{{t
         "pages.certification-start.link-to-user-certification"
       }}
-      <FaIcon @icon="eye" class="congratulations-banner-links__link--icon" />
+      <PixIcon @name="eye" @plainIcon={{true}} @ariaHidden={{true}} />
     </LinkTo>
   </div>
 </div>

--- a/mon-pix/app/components/certification-joiner.hbs
+++ b/mon-pix/app/components/certification-joiner.hbs
@@ -86,13 +86,11 @@
             </ul>
           {{/if}}
           {{#if this.errorMessageLink}}
-            <a
-              rel="noopener noreferrer"
-              target="_blank"
-              href={{this.errorMessageLink.url}}
-            >{{this.errorMessageLink.label}}
+            <a rel="noopener noreferrer" target="_blank" href={{this.errorMessageLink.url}}>
+              {{this.errorMessageLink.label}}
+              <PixIcon @name="openNew" @title={{t "navigation.external-link-title"}} />
             </a>
-            <FaIcon @icon="up-right-from-square" />
+
           {{/if}}
         </PixMessage>
       </div>

--- a/mon-pix/app/components/certification-starter.hbs
+++ b/mon-pix/app/components/certification-starter.hbs
@@ -12,16 +12,20 @@
 
             {{#if (gt @certificationCandidateSubscription.eligibleSubscriptions.length 0)}}
               <span class="certification-starter-subscriptions-container-items__eligible-item">
-                <FaIcon
-                  @icon="circle-check"
+                <PixIcon
+                  @name="checkCircle"
+                  @plainIcon={{true}}
+                  @ariaHidden={{true}}
                   class="certification-starter-subscriptions-container-items__eligible-icon"
                 />
                 {{this.complementarySubscriptionLabel}}
               </span>
             {{else}}
               <span class="certification-starter-subscriptions-container-items__non-eligible-item">
-                <FaIcon
-                  @icon="circle-check"
+                <PixIcon
+                  @name="checkCircle"
+                  @plainIcon={{true}}
+                  @ariaHidden={{true}}
                   class="certification-starter-subscriptions-container-items__non-eligible-icon"
                 />
                 {{@certificationCandidateSubscription.nonEligibleSubscription.label}}
@@ -31,7 +35,12 @@
         </div>
         {{#if @certificationCandidateSubscription.nonEligibleSubscription}}
           <div class="certification-starter-subscriptions-container__non-eligible">
-            <FaIcon @icon="circle-exclamation" class="certification-starter-subscriptions-container__info-icon" />
+            <PixIcon
+              @name="error"
+              @plainIcon={{true}}
+              @ariaHidden={{true}}
+              class="certification-starter-subscriptions-container__info-icon"
+            />
             <span>
               {{t
                 "pages.certification-start.non-eligible-subscription"

--- a/mon-pix/app/components/certifications/certification-ender.hbs
+++ b/mon-pix/app/components/certifications/certification-ender.hbs
@@ -5,10 +5,10 @@
   <div class="certification-ender__finished-test">
     <img src="/images/illustrations/certification-ender/test-completed.svg" alt="" class="certification-ender__image" />
     <div class="certification-ender__candidate">
-      <div class="certification-ender__candidate-name">
-        <span><FaIcon @icon="circle-user" /></span>
+      <p class="certification-ender__candidate-name">
+        <PixIcon @name="userCircle" @plainIcon={{true}} @ariaHidden={{true}} />
         {{this.currentUser.user.fullName}}
-      </div>
+      </p>
       <h1 class="certification-ender__candidate-title">{{t "pages.certification-ender.candidate.title"}}</h1>
       {{#if @isEndedBySupervisor}}
         <div class="certification-ender__candidate-message">

--- a/mon-pix/app/components/challenge-actions.hbs
+++ b/mon-pix/app/components/challenge-actions.hbs
@@ -19,7 +19,7 @@
 
   {{else if @hasChallengeTimedOut}}
     <div class="challenge-actions__alert-message" role="alert" aria-live="assertive">
-      <FaIcon @icon="circle-info" class="challenge-actions-alert-message__icon" />
+      <PixIcon @name="info" @plainIcon={{true}} @ariaHidden={{true}} class="challenge-actions-alert-message__icon" />
       {{t "pages.challenge.timed.cannot-answer"}}
     </div>
     <PixButton
@@ -41,7 +41,7 @@
         role="alert"
         aria-live="assertive"
       >
-        <FaIcon @icon="circle-info" class="challenge-actions-alert-message__icon" />
+        <PixIcon @name="info" @plainIcon={{true}} @ariaHidden={{true}} class="challenge-actions-alert-message__icon" />
         {{#if this.isNotCertification}}
           <span data-test="default-focused-out-error-message">{{t
               "pages.challenge.has-focused-out-of-window.default"

--- a/mon-pix/app/components/challenge-embed-simulator.hbs
+++ b/mon-pix/app/components/challenge-embed-simulator.hbs
@@ -2,7 +2,7 @@
 <div class="challenge-embed-simulator">
   {{#if this.isLoadingEmbed}}
     <div class="embed placeholder blurred" aria-label="{{t 'pages.challenge.embed-simulator.placeholder'}}">
-      <FaIcon @icon="image" />
+      <PixIcon @name="image" />
     </div>
   {{/if}}
 
@@ -41,7 +41,7 @@
           aria-label={{t "pages.challenge.embed-simulator.actions.reset-label"}}
           {{on "click" this.rebootSimulator}}
         >
-          <FaIcon @icon="rotate-right" class="embed-reboot-content__icon" />
+          <PixIcon @name="refresh" @ariaHidden={{true}} class="embed-reboot-content__icon" />
           {{t "pages.challenge.embed-simulator.actions.reset"}}
         </button>
       </div>

--- a/mon-pix/app/components/challenge-illustration.hbs
+++ b/mon-pix/app/components/challenge-illustration.hbs
@@ -1,7 +1,7 @@
 <div data-test-id="challenge-illustration">
   {{#if this.displayPlaceholder}}
     <div class="challenge-illustration__placeholder" aria-label="{{t 'pages.challenge.illustration.placeholder'}}">
-      <FaIcon @icon="image" />
+      <PixIcon @name="image" />
     </div>
   {{/if}}
 

--- a/mon-pix/app/components/challenge-item/challenge-item-qcm.hbs
+++ b/mon-pix/app/components/challenge-item/challenge-item-qcm.hbs
@@ -17,7 +17,7 @@
 
     {{#if @answer}}
       <div class="challenge-response__locked-overlay">
-        <FaIcon @icon="lock" class="challenge-response-locked__icon" />
+        <PixIcon @name="lock" @plainIcon={{true}} @ariaHidden={{true}} class="challenge-response-locked__icon" />
       </div>
     {{/if}}
 

--- a/mon-pix/app/components/challenge-item/challenge-item-qcu.hbs
+++ b/mon-pix/app/components/challenge-item/challenge-item-qcu.hbs
@@ -17,7 +17,7 @@
 
     {{#if @answer}}
       <div class="challenge-response__locked-overlay">
-        <FaIcon @icon="lock" class="challenge-response-locked__icon" />
+        <PixIcon @name="lock" @plainIcon={{true}} @ariaHidden={{true}} class="challenge-response-locked__icon" />
       </div>
     {{/if}}
 

--- a/mon-pix/app/components/challenge-item/challenge-item-qroc.hbs
+++ b/mon-pix/app/components/challenge-item/challenge-item-qroc.hbs
@@ -99,7 +99,7 @@
 
       {{#if @answer}}
         <div class="challenge-response__locked-overlay">
-          <FaIcon @icon="lock" class="challenge-response-locked__icon" />
+          <PixIcon @name="lock" @plainIcon={{true}} @ariaHidden={{true}} class="challenge-response-locked__icon" />
         </div>
       {{/if}}
 

--- a/mon-pix/app/components/challenge-item/challenge-item-qrocm.hbs
+++ b/mon-pix/app/components/challenge-item/challenge-item-qrocm.hbs
@@ -16,7 +16,7 @@
 
     {{#if @answer}}
       <div class="challenge-response__locked-overlay">
-        <FaIcon @icon="lock" class="challenge-response-locked__icon" />
+        <PixIcon @name="lock" @plainIcon={{true}} @ariaHidden={{true}} class="challenge-response-locked__icon" />
       </div>
     {{/if}}
 

--- a/mon-pix/app/components/challenge-statement.hbs
+++ b/mon-pix/app/components/challenge-statement.hbs
@@ -65,7 +65,7 @@
               "pages.challenge.statement.file-download.actions.choose-type"
             }}</span>
           <div class="challenge-statement__help-icon">
-            <FaIcon @icon="circle-info" />
+            <PixIcon @name="info" @plainIcon={{true}} @ariaHidden={{true}} />
             <div class="challenge-statement__help-tooltip">
               <span class="challenge-statement__help-text">{{t
                   "pages.challenge.statement.file-download.description"

--- a/mon-pix/app/components/feedback-panel-v3.hbs
+++ b/mon-pix/app/components/feedback-panel-v3.hbs
@@ -11,7 +11,8 @@
       aria-expanded={{this.isAriaExpanded}}
       type="button"
     >
-      <FaIcon @icon="flag" />{{t "pages.challenge.feedback-panel-v3.actions.open-close"}}
+      <PixIcon @name="flag" @plainIcon={{true}} @ariaHidden={{true}} />
+      {{t "pages.challenge.feedback-panel-v3.actions.open-close"}}
     </button>
 
     {{#if this.shouldBeExpanded}}

--- a/mon-pix/app/components/feedback-panel.hbs
+++ b/mon-pix/app/components/feedback-panel.hbs
@@ -10,7 +10,7 @@
       aria-controls={{this.feedbackPanelId}}
       type="button"
     >
-      <FaIcon @icon="flag" />
+      <PixIcon @name="flag" @plainIcon={{true}} @ariaHidden={{true}} />
       {{t "pages.challenge.feedback-panel.actions.open-close"}}
     </button>
   </div>
@@ -56,7 +56,7 @@
                   {{/if}}
                   {{#if this.quickHelpInstructions}}
                     <div class="feedback-panel__quick-help">
-                      <FaIcon @icon="circle-exclamation" class="tuto-icon__warning" />
+                      <PixIcon @name="error" @plainIcon={{true}} @ariaHidden={{true}} class="tuto-icon__warning" />
                       <p>{{t this.quickHelpInstructions htmlSafe=true}}</p>
                     </div>
                   {{/if}}
@@ -65,7 +65,7 @@
               {{#if this.displayTextBox}}
                 {{#if this.displayAddCommentButton}}
                   <button type="button" class="feedback-panel__comment" onClick={{this.addComment}}>
-                    <FaIcon @icon="pen" class="feedback-panel-comment__icon" />
+                    <PixIcon @name="edit" @ariaHidden={{true}} class="feedback-panel-comment__icon" />
                     {{t "pages.challenge.feedback-panel.form.fields.detail-selection.add-comment"}}
                   </button>
                 {{else}}

--- a/mon-pix/app/components/hexagon-score.hbs
+++ b/mon-pix/app/components/hexagon-score.hbs
@@ -12,7 +12,12 @@
             class="hexagon-score-content-pix-total__icon"
             aria-describedby="hexagon-score-tooltip"
           >
-            <FaIcon @icon="circle-info" aria-label={{t "pages.profile.total-score-helper.icon"}} />
+            <PixIcon
+              @name="info"
+              @plainIcon={{true}}
+              @ariaHidden={{true}}
+              @title={{t "pages.profile.total-score-helper.icon"}}
+            />
           </button>
         </:triggerElement>
         <:tooltip>

--- a/mon-pix/app/components/inaccessible-campaign.hbs
+++ b/mon-pix/app/components/inaccessible-campaign.hbs
@@ -17,9 +17,9 @@
     </div>
     <div class="campaign-landing-page-error">
       <h1 class="campaign-landing-page-error__title">{{yield}}</h1>
-      <LinkTo @route="authenticated" class="button button--extra-big button--link campaign-landing-page__error-button">
+      <PixButtonLink @route="authenticated" class="campaign-landing-page__error-button">
         {{t "navigation.back-to-profile"}}
-      </LinkTo>
+      </PixButtonLink>
     </div>
   </div>
 </div>

--- a/mon-pix/app/components/module/_recap.scss
+++ b/mon-pix/app/components/module/_recap.scss
@@ -42,6 +42,8 @@
 
 .module-recap-header {
   &__icon {
+    width: 3rem;
+    height: 3rem;
     color: var(--pix-primary-300);
   }
 }

--- a/mon-pix/app/components/module/element/_download.scss
+++ b/mon-pix/app/components/module/element/_download.scss
@@ -27,6 +27,11 @@
 
     display: block;
     color: var(--pix-info-700);
+
+    svg {
+      width: 1rem;
+      height: 1rem;
+    }
   }
 }
 

--- a/mon-pix/app/components/module/element/download.gjs
+++ b/mon-pix/app/components/module/element/download.gjs
@@ -1,8 +1,8 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import { t } from 'ember-intl';
 import ResponsiveListWideWrap from 'mon-pix/components/common/responsive-ul-wide-wrap';
 
@@ -47,7 +47,7 @@ export default class ModulixDownload extends ModuleElement {
         target="_blank"
       >
         {{t "pages.modulix.download.documentationLinkLabel"}}
-        <FaIcon @icon="arrow-up-right-from-square" />
+        <PixIcon @name="openNew" @title={{t "navigation.external-link-title"}} />
       </a>
     </div>
   </template>

--- a/mon-pix/app/components/module/recap.gjs
+++ b/mon-pix/app/components/module/recap.gjs
@@ -1,5 +1,5 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import { t } from 'ember-intl';
 import ModuleBetaBanner from 'mon-pix/components/module/beta-banner';
 import ModuleObjectives from 'mon-pix/components/module/objectives';
@@ -11,7 +11,7 @@ import ModuleObjectives from 'mon-pix/components/module/objectives';
 
   <main class="module-recap">
     <div class="module-recap__header">
-      <FaIcon @icon="circle-check" class="module-recap-header__icon fa-3x" />
+      <PixIcon @name="checkCircle" @plainIcon={{true}} @ariaHidden={{true}} class="module-recap-header__icon" />
     </div>
     <h1 class="module-recap__title">{{t "pages.modulix.recap.title"}}</h1>
 

--- a/mon-pix/app/components/navbar-burger-menu.hbs
+++ b/mon-pix/app/components/navbar-burger-menu.hbs
@@ -75,7 +75,7 @@
             @route="logout"
             class="navbar-burger-menu-footer-item__link navbar-burger-menu-footer-item__link--logout"
           >
-            <FaIcon @icon="power-off" class="navbar-burger-menu-footer-list-item-logout__icon" />
+            <PixIcon @name="power" @ariaHidden={{true}} class="navbar-burger-menu-footer-list-item-logout__icon" />
             {{t "navigation.user.sign-out"}}
           </LinkTo>
         </li>

--- a/mon-pix/app/components/navbar-mobile-header.hbs
+++ b/mon-pix/app/components/navbar-mobile-header.hbs
@@ -11,7 +11,7 @@
           aria-controls="principale-menu"
         >
           <span id="nav-mobile-button" class="sr-only">{{t "navigation.mobile-button-title"}}</span>
-          <FaIcon @icon="bars" />
+          <PixIcon @name="menu" @ariaHidden={{true}} />
         </button>
 
         <NavbarBurgerMenu @showSidebar={{this.isMenuOpen}} @onClose={{this.closeMenu}} />

--- a/mon-pix/app/components/new-information.hbs
+++ b/mon-pix/app/components/new-information.hbs
@@ -27,7 +27,8 @@
             rel="noopener noreferrer"
             class="new-information-content-text__link {{@textColorClass}}"
           >
-            <FaIcon @icon="arrow-right" /><span>{{@linkText}}</span>
+            <PixIcon @name="arrowRight" @ariaHidden={{true}} />
+            <span>{{@linkText}}</span>
           </a>
         {{/if}}
       {{/if}}

--- a/mon-pix/app/components/result-item.hbs
+++ b/mon-pix/app/components/result-item.hbs
@@ -1,7 +1,12 @@
 <div class="result-item">
   {{#if this.resultItem}}
     <div class="result-item__icon" title="{{this.resultTooltip}}">
-      <FaIcon @icon={{this.resultItem.icon}} class={{concat "result-item__icon--" this.resultItem.color}} />
+      <PixIcon
+        @name={{this.resultItem.icon}}
+        @plainIcon={{true}}
+        @ariaHidden={{true}}
+        class={{concat "result-item__icon--" this.resultItem.color}}
+      />
     </div>
 
     <div class="result-item__instruction">

--- a/mon-pix/app/components/routes/register-form.hbs
+++ b/mon-pix/app/components/routes/register-form.hbs
@@ -133,8 +133,12 @@
         </PixButton>
       </div>
 
-      <PixButton @triggerAction={{this.resetForm}} @variant="secondary" class="register-form__reset-form-button">
-        <FaIcon @icon="arrow-left" />
+      <PixButton
+        @triggerAction={{this.resetForm}}
+        @variant="secondary"
+        @iconBefore="arrowLeft"
+        class="register-form__reset-form-button"
+      >
         {{t "pages.login-or-register.register-form.not-me"}}
       </PixButton>
 

--- a/mon-pix/app/components/sitemap/content.hbs
+++ b/mon-pix/app/components/sitemap/content.hbs
@@ -86,7 +86,7 @@
         <h2>
           <a href="{{this.supportHomeUrl}}" target="_blank" rel="noopener noreferrer">
             {{t "navigation.main.help"}}
-            <FaIcon @icon="up-right-from-square" aria-hidden="true" />
+            <PixIcon @name="openNew" @ariaHidden={{true}} />
             <span class="sr-only">{{t "navigation.external-link-title"}}</span>
           </a>
         </h2>
@@ -98,43 +98,37 @@
           <li class="sitemap-content-items-link-resources__resource">
             <a href={{this.accessibilityUrl}} target="_blank" rel="noopener noreferrer">
               {{t "pages.sitemap.accessibility.title"}}
-              <FaIcon @icon="up-right-from-square" aria-hidden="true" />
+              <PixIcon @name="openNew" @ariaHidden={{true}} />
               <span class="sr-only">{{t "navigation.external-link-title"}}</span>
             </a>
-            <ul>
-              <li>
-                <a href={{this.accessibilityHelpUrl}} target="_blank" rel="noopener noreferrer">
-                  {{t "pages.sitemap.accessibility.help"}}
-                  <FaIcon @icon="up-right-from-square" aria-hidden="true" />
-                  <span class="sr-only">{{t "navigation.external-link-title"}}</span>
-                </a>
-              </li>
-            </ul>
           </li>
-
+          <li class="sitemap-content-items-link-resources__resource">
+            <a href={{this.accessibilityHelpUrl}} target="_blank" rel="noopener noreferrer">
+              {{t "pages.sitemap.accessibility.help"}}
+              <PixIcon @name="openNew" @ariaHidden={{true}} />
+              <span class="sr-only">{{t "navigation.external-link-title"}}</span>
+            </a>
+          </li>
           <li class="sitemap-content-items-link-resources__resource">
             <a href={{this.cguUrl}} target="_blank" rel="noopener noreferrer">
               {{t "navigation.footer.eula"}}
-              <FaIcon @icon="up-right-from-square" aria-hidden="true" />
+              <PixIcon @name="openNew" @ariaHidden={{true}} />
               <span class="sr-only">{{t "navigation.external-link-title"}}</span>
             </a>
           </li>
-
           <li class="sitemap-content-items-link-resources__resource">
             <a href={{this.dataProtectionPolicyUrl}} target="_blank" rel="noopener noreferrer">
               {{t "pages.sitemap.cgu.policy"}}
-              <FaIcon @icon="up-right-from-square" aria-hidden="true" />
+              <PixIcon @name="openNew" @ariaHidden={{true}} />
               <span class="sr-only">{{t "navigation.external-link-title"}}</span>
             </a>
-            <ul>
-              <li>
-                <a href={{this.dataProtectionPolicyUrl}} target="_blank" rel="noopener noreferrer">
-                  {{t "pages.sitemap.cgu.subcontractors"}}
-                  <FaIcon @icon="up-right-from-square" aria-hidden="true" />
-                  <span class="sr-only">{{t "navigation.external-link-title"}}</span>
-                </a>
-              </li>
-            </ul>
+          </li>
+          <li class="sitemap-content-items-link-resources__resource">
+            <a href={{this.dataProtectionPolicyUrl}} target="_blank" rel="noopener noreferrer">
+              {{t "pages.sitemap.cgu.subcontractors"}}
+              <PixIcon @name="openNew" @ariaHidden={{true}} />
+              <span class="sr-only">{{t "navigation.external-link-title"}}</span>
+            </a>
           </li>
         </ul>
       </li>

--- a/mon-pix/app/components/user-certifications-detail-header.hbs
+++ b/mon-pix/app/components/user-certifications-detail-header.hbs
@@ -66,11 +66,10 @@
                   class="icon-button"
                   aria-describedby="verification-code-copy-button-tooltip"
                 >
-                  <FaIcon
+                  <PixIcon
                     class="verification-code__copy-button"
-                    @icon="copy"
-                    @prefix="far"
-                    alt={{t "pages.certificate.verification-code.alt"}}
+                    @name="copy"
+                    @title={{t "pages.certificate.verification-code.alt"}}
                   />
                 </CopyButton>
               </:triggerElement>

--- a/mon-pix/app/components/user-certifications-detail-result.hbs
+++ b/mon-pix/app/components/user-certifications-detail-result.hbs
@@ -6,7 +6,7 @@
         {{@certification.commentForCandidate}}
       </p>
       <p class="user-certifications-detail-result__jury__info">
-        <FaIcon @icon="circle-info" />
+        <PixIcon @name="info" @plainIcon={{true}} @ariaHidden={{true}} />
         {{t "pages.certificate.jury-info"}}
       </p>
     </PixBlock>

--- a/mon-pix/app/components/user-logged-menu.hbs
+++ b/mon-pix/app/components/user-logged-menu.hbs
@@ -52,7 +52,7 @@
           </li>
           <li>
             <LinkTo @route="logout" class="logged-user-menu__link">
-              <FaIcon @icon="power-off" class="logged-user-menu__icon" />
+              <PixIcon @name="power" @ariaHidden={{true}} class="logged-user-menu__icon" />
               {{t "navigation.user.sign-out"}}
             </LinkTo>
           </li>

--- a/mon-pix/app/styles/components/_assessment-banner.scss
+++ b/mon-pix/app/styles/components/_assessment-banner.scss
@@ -63,12 +63,20 @@
   @extend %pix-body-m;
 
   z-index: 1;
+  display: flex;
+  gap: var(--pix-spacing-1x);
+  align-items: center;
   height: 1.5rem;
   color: var(--pix-neutral-0);
   text-align: right;
 
   &:hover {
     color: rgb(var(--pix-neutral-0) 0.8);
+  }
+
+  svg {
+    width: 1rem;
+    height: 1rem;
   }
 }
 

--- a/mon-pix/app/styles/components/_certification-joiner.scss
+++ b/mon-pix/app/styles/components/_certification-joiner.scss
@@ -58,6 +58,17 @@
         }
       }
 
+      a {
+        display: flex;
+        gap: var(--pix-spacing-1x);
+        align-items: center;
+
+        svg {
+          width: 1rem;
+          height: 1rem;
+        }
+      }
+
       a,
       a:visited {
         color: var(--pix-error-500);

--- a/mon-pix/app/styles/components/_certification-starter.scss
+++ b/mon-pix/app/styles/components/_certification-starter.scss
@@ -84,16 +84,28 @@
 
       &__eligible-item,
       &__non-eligible-item {
+        display: flex;
+        gap: var(--pix-spacing-1x);
+        align-items: center;
         font-weight: 500;
       }
 
       &__eligible-icon {
+        width: 1rem;
+        height: 1rem;
         color: var(--pix-success-700);
       }
 
       &__non-eligible-item,
       &__non-eligible-icon {
         color: var(--pix-neutral-500);
+      }
+
+      &__info-icon,
+      &__non-eligible-icon,
+      &__eligible-icon {
+        width: 1rem;
+        height: 1rem;
       }
     }
 
@@ -103,10 +115,6 @@
       padding: 10px 16px;
       color: var(--pix-warning-700);
       background-color: var(--pix-warning-50);
-    }
-
-    &__info-icon {
-      margin-right: 10px;
     }
   }
 }

--- a/mon-pix/app/styles/components/_challenge-embed-simulator.scss
+++ b/mon-pix/app/styles/components/_challenge-embed-simulator.scss
@@ -78,5 +78,5 @@
 }
 
 .embed-reboot-content__icon {
-  margin-right: 10px;
+  margin-right: var(--pix-spacing-2x);
 }

--- a/mon-pix/app/styles/components/_challenge-item.scss
+++ b/mon-pix/app/styles/components/_challenge-item.scss
@@ -149,8 +149,8 @@ form .challenge-response.challenge-response--locked {
 
 form .challenge-response-locked {
   &__icon {
-    font-size: 3.125rem;
-    opacity: 1;
+    width: 3.125rem;
+    height: 3.125rem;
 
     &:hover {
       opacity: 1;

--- a/mon-pix/app/styles/components/_congratulations-certification-banner.scss
+++ b/mon-pix/app/styles/components/_congratulations-certification-banner.scss
@@ -17,42 +17,27 @@
   }
 }
 
-.congratulations-banner p {
-  text-align: center;
-}
-
 .congratulations-banner__icon {
   position: absolute;
-  top: 12px;
-  right: 12px;
-  bottom: auto;
-  left: auto;
-  display: flex;
+  top: var(--pix-spacing-2x);
+  right: var(--pix-spacing-2x);
   color: var(--pix-neutral-0);
-  font-size: 1.25rem;
-  cursor: pointer;
-  opacity: 0.5;
 
   &:hover,
   &:active {
-    color: var(--pix-neutral-500);
+    color: var(--pix-certif-500);
   }
 }
 
-@mixin textBannerStyle {
-  color: var(--pix-neutral-0);
-  font-weight: var(--pix-font-normal);
-  font-family: $font-open-sans;
-  line-height: 2rem;
-  text-align: center;
-}
-
 .congratulations-banner__message {
-  @include textBannerStyle;
+  margin: var(--pix-spacing-6x) 0;
+  text-align: center;
 
-  margin: 0 0 24px;
-  padding: 0 8px;
-  font-size: 1.5rem;
+  @extend %pix-title-s;
+
+  @include device-is('tablet') {
+    margin: var(--pix-spacing-1x) 0 var(--pix-spacing-6x) 0;
+  }
 }
 
 .congratulations-banner__complementary-certifications {
@@ -121,29 +106,29 @@
 }
 
 .congratulations-banner-links__link {
-  @include textBannerStyle;
-
+  display: flex;
+  gap: var(--pix-spacing-2x);
+  align-items: center;
+  justify-content: center;
   width: 100%;
   margin-bottom: 12px;
-  padding: 4px 16px;
-  font-weight: 500;
-  font-size: 0.875rem;
-  font-family: $font-roboto;
+  padding: var(--pix-spacing-1x) var(--pix-spacing-4x);
+  font-weight: var(--pix-font-medium);
+  line-height: 2rem;
   border: 1px solid var(--pix-neutral-20);
   border-radius: 4px;
 
-  &:last-child {
-    margin-bottom: 0;
-  }
+  @extend %pix-body-s;
 
   @include device-is('tablet') {
     width: 45%;
     margin-bottom: 0;
   }
-}
 
-.congratulations-banner-links__link--icon {
-  margin: auto 5px;
+  svg {
+    width: 1rem;
+    height: 1rem;
+  }
 }
 
 .oudated-complementary-certification-banner {

--- a/mon-pix/app/styles/components/_feedback-panel-v3.scss
+++ b/mon-pix/app/styles/components/_feedback-panel-v3.scss
@@ -41,7 +41,8 @@
   text-decoration: underline;
 
   svg {
-    margin-right: var(--pix-spacing-1x);
+    width: 1rem;
+    height: 1rem;
   }
 
   &[aria-expanded='true'] {

--- a/mon-pix/app/styles/components/_feedback-panel.scss
+++ b/mon-pix/app/styles/components/_feedback-panel.scss
@@ -9,22 +9,19 @@
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 
 .feedback-panel__open-button {
+  display: flex;
   gap: var(--pix-spacing-1x);
+  align-items: center;
   width: 100%;
   padding: 0.75rem 0;
-  color: var(--pix-neutral-800);
-  font-weight: var(--pix-font-normal);
-  font-size: 0.875rem;
-  font-family: $font-roboto;
-  line-height: 20px;
-  text-align: left;
   text-decoration: underline;
   background-color: transparent;
-  border: none;
-  cursor: pointer;
+
+  @extend %pix-body-s;
 
   svg {
-    margin-right: var(--pix-spacing-1x);
+    width: 1rem;
+    height: 1rem;
   }
 
   &[aria-expanded='true'] {

--- a/mon-pix/app/styles/components/_hexagon-score.scss
+++ b/mon-pix/app/styles/components/_hexagon-score.scss
@@ -59,7 +59,7 @@
     align-items: center;
     justify-content: space-around;
     width: 70px;
-    padding: 3px 8px 0;
+    padding: 0 var(--pix-spacing-2x);
 
     .pix-tooltip__content {
       max-width: 19rem;
@@ -112,6 +112,12 @@
   background: none;
   border: none;
   cursor: pointer;
+
+  svg {
+    width: 1rem;
+    height: 1rem;
+    margin-top: 0.2rem;
+  }
 
   &:hover,
   &:focus {

--- a/mon-pix/app/styles/components/_learning-more-tutorial-panel.scss
+++ b/mon-pix/app/styles/components/_learning-more-tutorial-panel.scss
@@ -17,7 +17,7 @@
 
 .learning-more-panel__tutorial-info {
   margin: 5px;
-  color: var(--pix-neutral-100);
+  color: var(--pix-neutral-500);
   font-size: 0.813rem;
   line-height: 1.25rem;
 }

--- a/mon-pix/app/styles/components/_navbar-burger-menu.scss
+++ b/mon-pix/app/styles/components/_navbar-burger-menu.scss
@@ -95,7 +95,17 @@
     }
 
     &--logout {
+      display: flex;
+      align-items: center;
       margin-top: var(--pix-spacing-2x);
     }
+  }
+}
+
+.navbar-burger-menu-footer-list-item-logout {
+  &__icon {
+    width: 1rem;
+    height: 1rem;
+    margin-right: var(--pix-spacing-1x);
   }
 }

--- a/mon-pix/app/styles/components/_navbar-mobile-header.scss
+++ b/mon-pix/app/styles/components/_navbar-mobile-header.scss
@@ -16,6 +16,11 @@
     background: none;
     border: none;
     cursor: pointer;
+
+    svg {
+      width: 2rem;
+      height: 2rem;
+    }
   }
 
   &__logo {

--- a/mon-pix/app/styles/components/_new-information.scss
+++ b/mon-pix/app/styles/components/_new-information.scss
@@ -121,12 +121,15 @@
     line-height: 1.375rem;
     letter-spacing: 0.009rem;
 
-    .fa-arrow-right {
-      margin-right: 5px;
+    svg {
+      width: 1rem;
+      height: 1rem;
+      margin-right: var(--pix-spacing-1x);
     }
 
     @include device-is('desktop') {
-      display: inline-table;
+      display: flex;
+      align-items: center;
     }
 
     &:focus span,

--- a/mon-pix/app/styles/components/_user-certifications-detail-header.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-header.scss
@@ -14,7 +14,8 @@
   display: flex;
   flex-direction: row;
   padding: 32px 0;
-  font-family: $font-open-sans;
+
+  @extend %pix-body-m;
 
   &__info-certificate {
     align-self: center;
@@ -26,8 +27,7 @@
     }
 
     h1 {
-      font-weight: lighter;
-      font-size: 2rem;
+      @extend %pix-title-m;
     }
 
     p:nth-child(4) {
@@ -102,20 +102,18 @@
     max-width: 250px;
     margin: auto;
     color: var(--pix-neutral-900);
-    font-family: $font-open-sans;
     letter-spacing: 0;
+
+    @extend %pix-body-m;
 
     &__title {
       display: flex;
-      padding: 0;
-      padding-bottom: 8px;
-      font-weight: initial;
-      font-size: 1rem;
+      padding: 0 0 var(--pix-spacing-2x) 0;
     }
 
     &__box {
       display: flex;
-      align-items: baseline;
+      align-items: center;
       justify-content: center;
       padding: 10px 20px;
       background-color: var(--pix-neutral-20);
@@ -123,8 +121,7 @@
       border-radius: 4px;
 
       .verification-code__code {
-        margin: 0;
-        margin-right: 6px;
+        margin: 0 var(--pix-spacing-2x) 0 0;
         padding: 0;
         font-weight: bold;
         font-size: 1.25rem;
@@ -146,8 +143,7 @@
     }
 
     &__informations {
-      margin: 0;
-      margin-top: 8px;
+      margin: var(--pix-spacing-2x) 0 0 0;
       font-size: 0.8125rem;
       line-height: 20px;
     }

--- a/mon-pix/app/styles/components/_user-certifications-detail-result.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-result.scss
@@ -48,6 +48,11 @@
 
     &__info {
       font-size: 0.75rem;
+
+      svg {
+        width: 1rem;
+        height: 1rem;
+      }
     }
 
     &__comment {

--- a/mon-pix/app/styles/components/_user-logged-menu.scss
+++ b/mon-pix/app/styles/components/_user-logged-menu.scss
@@ -86,6 +86,12 @@
       list-style: none;
     }
   }
+
+  &__icon {
+    width: 1rem;
+    height: 1rem;
+    margin-right: var(--pix-spacing-2x);
+  }
 }
 
 .logged-user-menu-details__fullname {
@@ -110,9 +116,5 @@
     color: var(--pix-neutral-800);
     text-decoration: none;
     background-color: var(--pix-neutral-20);
-  }
-
-  & > svg {
-    margin-right: 5px;
   }
 }

--- a/mon-pix/app/styles/components/certifications/certification-ender.scss
+++ b/mon-pix/app/styles/components/certifications/certification-ender.scss
@@ -25,40 +25,36 @@
   &__candidate-name {
     display: block;
     color: var(--pix-neutral-500);
-    font-weight: normal;
-    font-size: 1.25rem;
-    font-family: $font-open-sans;
-    line-height: 45px;
+
+    @extend %pix-body-l;
+
+    @include device-is('tablet') {
+      display: flex;
+      gap: var(--pix-spacing-1x);
+      align-items: center;
+    }
   }
 
   &__candidate-title {
-    display: block;
     color: var(--pix-success-700);
-    font-size: 2rem;
-    font-family: $font-open-sans;
-    line-height: 64px;
+
+    @extend %pix-title-m;
   }
 
   &__candidate-message {
-    display: block;
     width: 272px;
     margin: 16px auto auto;
     color: var(--pix-neutral-100);
-    font-size: 1rem;
-    font-family: $font-roboto;
-    line-height: 22px;
+
+    @extend %pix-body-l;
   }
 
   &__remote-certification {
     margin-top: 16px;
 
     .pix-message {
-
       &__content {
-        margin-left: 16px;
         color: var(--pix-neutral-500);
-        font-size: 14px;
-        line-height: 20px;
       }
     }
   }
@@ -76,9 +72,8 @@
     width: 272px;
     margin: auto;
     color: var(--pix-neutral-500);
-    font-size: 0.875rem;
-    font-family: $font-roboto;
-    line-height: 22px;
+
+    @extend %pix-body-s;
   }
 
   &__results {
@@ -92,27 +87,23 @@
   &__results-disclaimer {
     margin-bottom: 8px;
     color: var(--pix-success-700);
-    font-weight: 600;
-    font-size: 0.875rem;
-    font-family: $font-open-sans;
-    line-height: 23px;
+    font-weight: var(--pix-font-bold);
     text-transform: uppercase;
+
+    @extend %pix-body-s;
   }
 
   &__results-title {
-    display: block;
     margin-bottom: 6px;
     color: var(--pix-neutral-900);
-    font-size: 1.25rem;
-    font-family: $font-open-sans;
+
+    @extend %pix-body-l;
   }
 
   &__results-steps {
-    display: block;
     color: var(--pix-neutral-500);
-    font-size: 0.875rem;
-    font-family: $font-roboto;
-    line-height: 22px;
+
+    @extend %pix-body-s;
   }
 }
 
@@ -149,10 +140,6 @@
 
     &__candidate-disconnect-tip {
       width: auto;
-    }
-
-    &__candidate-name {
-      font-size: 1.5rem;
     }
 
     &__candidate-title {

--- a/mon-pix/app/styles/components/sitemap/_content.scss
+++ b/mon-pix/app/styles/components/sitemap/_content.scss
@@ -9,6 +9,8 @@
     list-style: none;
 
     a {
+      display: inline-flex;
+      gap: var(--pix-spacing-1x);
       color: var(--pix-primary-700);
     }
   }

--- a/mon-pix/app/styles/pages/_campaign-landing-page.scss
+++ b/mon-pix/app/styles/pages/_campaign-landing-page.scss
@@ -179,10 +179,12 @@
   &__title {
     @extend %pix-title-xs;
 
+    margin-bottom: var(--pix-spacing-6x);
     text-align: center;
   }
 }
 
 .campaign-landing-page__error-button {
+  width: fit-content;
   margin: auto;
 }

--- a/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
@@ -2,11 +2,23 @@
   max-width: max-content;
   margin: 0 auto 32px;
   padding: 48px 24px;
-  font-family: $font-roboto;
   text-align: center;
+
+  @extend %pix-body-m;
 
   @include device-is('tablet') {
     padding: 48px 60px;
+  }
+
+  &__title {
+    @extend %pix-title-m;
+  }
+
+  &__description {
+    max-width: 500px;
+    margin: var(--pix-spacing-6x) 0;
+    color: var(--pix-neutral-500);
+    line-height: 22px;
   }
 
   &__form {
@@ -14,32 +26,17 @@
     flex-direction: column;
     align-items: center;
 
-    .form__title {
-      margin-bottom: 16px;
-      color: var(--pix-neutral-800);
-      font-size: 2rem;
-      font-family: $font-open-sans;
-    }
-
-    .form__description {
-      max-width: 500px;
-      margin-bottom: 32px;
-      color: var(--pix-neutral-500);
-      line-height: 22px;
-    }
-
     .form__input-and-label {
       display: flex;
       flex-direction: column;
 
       label {
         margin-bottom: 6px;
-        color: var(--pix-neutral-900);
-        font-weight: var(--pix-font-normal);
-        font-size: 0.875rem;
         line-height: 22px;
         letter-spacing: 0.15px;
         text-align: left;
+
+        @extend %pix-body-s;
       }
 
       input {
@@ -54,24 +51,13 @@
     }
 
     .form__actions {
-      width: calc(276px + 4px + 0.5ch + 1px);
-      margin-top: 24px;
-      padding: 14px 20px;
+      margin: var(--pix-spacing-6x) 0;
     }
 
     .form__error--validation {
-      margin: 16px 10px 0;
       color: var(--pix-error-700);
-      font-size: 0.875rem;
-    }
 
-    .form__error--not-found {
-      margin: 0;
-      margin-top: 16px;
-
-      svg {
-        margin-right: 4px;
-      }
+      @extend %pix-body-s;
     }
   }
 }

--- a/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
+++ b/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
@@ -8,16 +8,15 @@
 <main role="main">
   <PixBackgroundHeader id="main">
     <PixBlock class="fill-in-certificate-verification-code">
+      <h1 class="fill-in-certificate-verification-code__title">
+        {{t "pages.fill-in-certificate-verification-code.first-title"}}
+      </h1>
+
+      <p class="fill-in-certificate-verification-code__description">
+        {{t "pages.fill-in-certificate-verification-code.description"}}
+      </p>
+
       <form class="fill-in-certificate-verification-code__form" autocomplete="off">
-
-        <h1 class="form__title">
-          {{t "pages.fill-in-certificate-verification-code.first-title"}}
-        </h1>
-
-        <p class="form__description">
-          {{t "pages.fill-in-certificate-verification-code.description"}}
-        </p>
-
         <div class="form__input-and-label">
           <label for="certificate-verification-code">
             {{t "pages.fill-in-certificate-verification-code.label"}}
@@ -33,20 +32,19 @@
           />
         </div>
 
+        <PixButton @type="submit" @triggerAction={{this.checkCertificate}} class="form__actions">
+          {{t "pages.fill-in-certificate-verification-code.verify"}}
+        </PixButton>
+
         {{#if this.errorMessage}}
           <div class="form__error--validation" aria-live="polite">
             {{this.errorMessage}}
           </div>
         {{/if}}
 
-        <PixButton @type="submit" @triggerAction={{this.checkCertificate}} class="form__actions">
-          {{t "pages.fill-in-certificate-verification-code.verify"}}
-        </PixButton>
-
         {{#if this.showNotFoundCertificationErrorMessage}}
-          <PixMessage @type="alert" class="form__error--not-found">
-            <FaIcon @icon="triangle-exclamation" />
-            <span>{{t "pages.fill-in-certificate-verification-code.errors.not-found"}}</span>
+          <PixMessage @type="error" @withIcon={{true}}>
+            {{t "pages.fill-in-certificate-verification-code.errors.not-found"}}
           </PixMessage>
         {{/if}}
       </form>

--- a/mon-pix/app/utils/result-icon.js
+++ b/mon-pix/app/utils/result-icon.js
@@ -1,22 +1,22 @@
 const resultIcons = {
   ok: {
-    icon: 'circle-check',
+    icon: 'checkCircle',
     color: 'green',
   },
   ko: {
-    icon: 'circle-xmark',
+    icon: 'cancel',
     color: 'red',
   },
   focusedOut: {
-    icon: 'circle-xmark',
+    icon: 'cancel',
     color: 'red',
   },
   aband: {
-    icon: 'circle-xmark',
+    icon: 'cancel',
     color: 'grey',
   },
   timedout: {
-    icon: 'circle-xmark',
+    icon: 'cancel',
     color: 'red',
   },
 };

--- a/mon-pix/tests/integration/components/certification-banners/congratulations-certification-banner-test.js
+++ b/mon-pix/tests/integration/components/certification-banners/congratulations-certification-banner-test.js
@@ -46,7 +46,7 @@ module('Integration | Component | Certification Banners | Congratulations Certif
     );
 
     // when
-    await click(screen.getByLabelText('Fermer'));
+    await click(screen.getByRole('button', { name: 'Fermer' }));
 
     // then
     sinon.assert.calledOnce(closeBannerStub);

--- a/mon-pix/tests/integration/components/module/download-test.gjs
+++ b/mon-pix/tests/integration/components/module/download-test.gjs
@@ -67,7 +67,7 @@ module('Integration | Component | Module | Element | Download', function (hooks)
 
     // then
     const documentationLink = screen.getByRole('link', {
-      name: t('pages.modulix.download.documentationLinkLabel'),
+      name: `${t('pages.modulix.download.documentationLinkLabel')} ${t('navigation.external-link-title')}`,
     });
     assert.dom(documentationLink).hasAttribute('href', t('pages.modulix.download.documentationLinkHref'));
   });

--- a/mon-pix/tests/unit/components/result-item-test.js
+++ b/mon-pix/tests/unit/components/result-item-test.js
@@ -44,10 +44,10 @@ module('Unit | Component | result-item-component', function (hooks) {
 
   module('#resultItem Computed property - defined case', function () {
     [
-      { result: 'ok', expectedColor: 'green', expectedIcon: 'circle-check' },
-      { result: 'ko', expectedColor: 'red', expectedIcon: 'circle-xmark' },
-      { result: 'timedout', expectedColor: 'red', expectedIcon: 'circle-xmark' },
-      { result: 'aband', expectedColor: 'grey', expectedIcon: 'circle-xmark' },
+      { result: 'ok', expectedColor: 'green', expectedIcon: 'checkCircle' },
+      { result: 'ko', expectedColor: 'red', expectedIcon: 'cancel' },
+      { result: 'timedout', expectedColor: 'red', expectedIcon: 'cancel' },
+      { result: 'aband', expectedColor: 'grey', expectedIcon: 'cancel' },
     ].forEach((data) => {
       test(`should return a ${data.expectedColor} ${data.expectedIcon} icon when answer provided has a ${data.result} result`, function (assert) {
         // given


### PR DESCRIPTION
## :fallen_leaf: Problème
Le composant PixIcon existe et les FaIcon peuvent désormais être remplacés.

## :chestnut: Proposition
Utiliser PixIcon

## :jack_o_lantern: Remarques
Lorsque arrive à une page de step lors d'un passage d'épreuve, une phrase présentait un contraste trop faible, c'est corrigé

<img width="572" alt="ok" src="https://github.com/user-attachments/assets/1402e46c-a7ef-4b34-8a8e-6535fd6dcc16">

J'ai aussi fixé la page oups avec son bouton carré (https://app-pr10632.review.pix.fr//campagnes/EVALBADGE/evaluation/resultats)

| ![Capture d’écran 2024-11-25 à 19 29 29](https://github.com/user-attachments/assets/6cdff10f-bb89-44cd-bb5e-bc7b28dc6025) | ![Capture d’écran 2024-11-25 à 19 31 16](https://github.com/user-attachments/assets/58a4006e-821f-4c94-98a2-7734e6ae7643) |
|--------|--------|


## :wood: Pour tester

- Se connecter avec certif-success@example.net

> [!NOTE]
>  **Coté épreuves :** 

| Étapes | Screens |
|--------|--------|
| Signaler une épreuve (voir screen) et constater que les icônes warning et flag apparaîssent | ![Capture d’écran 2024-11-25 à 18 08 42](https://github.com/user-attachments/assets/0e1d2acc-8814-4393-a41b-8ce3250a5318) |
| Signaler une épreuve (voir screen) et constater que les icônes stylo apparaît | ![Capture d’écran 2024-11-26 à 17 20 49](https://github.com/user-attachments/assets/1ccfb944-adc0-426e-9e4a-b59b8f973886) |
| Sur une épreuve avec embed, constater que l'icône refresh apparaît | <img width="372" alt="ok" src="https://github.com/user-attachments/assets/ff902112-dbde-4185-9933-e4a3e82ea393"> |
| Sur une épreuve avec focus, défocus la question et constater que l'icône info apparaît | ![Capture d’écran 2024-11-25 à 18 20 15](https://github.com/user-attachments/assets/83d4fef6-2647-499a-9609-80ae5edfa448) |
| (Je ne sais pas reproduire celui-ci hors local, mais cette icône s'affiche lorsqu'une image ou un embed n'apparaît pas) | ![Capture d’écran 2024-11-25 à 18 25 05](https://github.com/user-attachments/assets/35c00b93-aa1b-4a9e-bca7-3745bed7c311) |
| Dans une épreuve, revenir à l'épreuve précédente et constater que l'icône lock apparaît | ![Capture d’écran 2024-11-26 à 18 22 47](https://github.com/user-attachments/assets/6dfb9d9a-2252-4d8f-aa7a-6d41e06d1730) | 
| Dans un checkpoint, constater que les icônes de succès ou d'erreur s'affichent ainsi que l'icône pour quitter le passage des questions | ![Capture d’écran 2024-11-26 à 18 25 07](https://github.com/user-attachments/assets/36f88ad3-f3f7-4e4a-b05b-69d48ea24f76) | 
| Tester avec une épreuve timé | - | 


---

> [!NOTE]
>  **Coté Accès :** 

| https://app-pr10632.review.pix.fr/recuperer-mon-compte Constater que l'icône info apparaît sur le champ | <img width="572" alt="ok" src="https://github.com/user-attachments/assets/70f0c417-e7d1-429f-b142-bd61852d15ad"> |
|--------|--------|
| Dans le menu utilisateur (desktop) constater que l'icône power apparaît | ![Capture d’écran 2024-11-25 à 15 21 42](https://github.com/user-attachments/assets/0b6396e2-ee57-4ab9-9adb-a5804fb190c9) |
| Dans la sidebar (mobile) constater que l'icône power apparaît | - |
| Lors d'une inscription à Pix App, constater que les icône de validation et d'erreur pour le mot de passe apparaîssent | ![Capture d’écran 2024-11-26 à 18 29 15](https://github.com/user-attachments/assets/00dbf2cf-caa7-428f-a0ef-f39129234645) |

---

> [!NOTE]
>  **Coté modulix :** 

| Sur un module avec un bouton de téléchargement, constater la présence de l'icône fenêtre | ![Capture d’écran 2024-11-26 à 18 01 44](https://github.com/user-attachments/assets/73326774-3941-413f-9921-e0582c7f6810) |
|--------|--------|
| Sur le récap, constater la présence de l'icône de validation | ![Capture d’écran 2024-11-26 à 18 01 14](https://github.com/user-attachments/assets/30ce9c29-4706-4030-afcd-7d7080a02ba7) |

---

| https://app-pr10632.review.pix.fr/plan-du-site Constater que les icônes externe s'affichent | <img width="572" alt="ok" src="https://github.com/user-attachments/assets/0b37d62f-9b54-4962-a268-6d165279c401"> |
|--------|--------|
