### PR TITLE
[BUGFIX] Centrer la description du formulaire d'activation d'espace Pix Orga (PIX-11564)

### DIFF
--- a/orga/app/styles/pages/join-request.scss
+++ b/orga/app/styles/pages/join-request.scss
@@ -33,6 +33,7 @@
 
   &__description {
     max-width: 497px;
+    margin: auto;
     font-weight: 400;
     font-size: 0.875rem;
     font-family: $font-roboto;


### PR DESCRIPTION
## :fallen_leaf: Problème
Le texte sur la page `/demande-administration-sco` n'est pas centré.

## :chestnut: Proposition
Le centrer.

## :jack_o_lantern: Remarques
RAS

## :wood: Pour tester
- Aller sur la page https://orga-pr10633.review.pix.fr/demande-administration-sco
- Vérifier que le texte _A l'attention des personnels...de l'espace Pix Orga_ est bien centré sur la page 😃 
