### PR TITLE
[FEATURE] Ajout des règles métier pour canSelfDeleteAccount (PIX-15333)

### DIFF
--- a/api/src/privacy/domain/usecases/can-self-delete-account.usecase.js
+++ b/api/src/privacy/domain/usecases/can-self-delete-account.usecase.js
@@ -5,13 +5,32 @@ import { config } from '../../../shared/config.js';
  *
  * @param {Object} params - The parameters for the use case.
  * @param {number} params.userId - The ID of the user.
- * @param {Object} [params.featureToggles] - The feature toggles configuration.
+ * @param {Object} params.featureToggles - The feature toggles configuration.
+ * @param {Object} params.candidatesApiRepository - The repository for candidate-related operations.
+ * @param {Object} params.learnersApiRepository - The repository for learner-related operations.
+ * @param {Object} params.userTeamsApiRepository - The repository for user team access operations.
  * @returns {Promise<boolean>} - A promise that resolves to a boolean indicating if self-account deletion is enabled.
  */
-const canSelfDeleteAccount = async ({ featureToggles = config.featureToggles }) => {
+const canSelfDeleteAccount = async ({
+  userId,
+  featureToggles = config.featureToggles,
+  candidatesApiRepository,
+  learnersApiRepository,
+  userTeamsApiRepository,
+}) => {
   const { isSelfAccountDeletionEnabled } = featureToggles;
-
   if (!isSelfAccountDeletionEnabled) return false;
+
+  const hasBeenLearner = await learnersApiRepository.hasBeenLearner({ userId });
+  if (hasBeenLearner) return false;
+
+  const hasBeenCandidate = await candidatesApiRepository.hasBeenCandidate({ userId });
+  if (hasBeenCandidate) return false;
+
+  const userTeamsInfo = await userTeamsApiRepository.getUserTeamsInfo({ userId });
+  if (userTeamsInfo.isPixAgent) return false;
+  if (userTeamsInfo.isOrganizationMember) return false;
+  if (userTeamsInfo.isCertificationCenterMember) return false;
 
   return true;
 };

--- a/api/src/privacy/domain/usecases/index.js
+++ b/api/src/privacy/domain/usecases/index.js
@@ -3,6 +3,9 @@ import { fileURLToPath } from 'node:url';
 
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
+import * as candidatesApiRepository from '../../infrastructure/repositories/candidates-api.repository.js';
+import * as learnersApiRepository from '../../infrastructure/repositories/learners-api.repository.js';
+import * as userTeamsApiRepository from '../../infrastructure/repositories/user-teams-api.repository.js';
 
 const path = dirname(fileURLToPath(import.meta.url));
 
@@ -10,7 +13,11 @@ const usecasesWithoutInjectedDependencies = {
   ...(await importNamedExportsFromDirectory({ path: join(path, './'), ignoredFileNames: ['index.js'] })),
 };
 
-const dependencies = {};
+const dependencies = {
+  candidatesApiRepository,
+  learnersApiRepository,
+  userTeamsApiRepository,
+};
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
 

--- a/api/src/privacy/infrastructure/repositories/candidates-api.repository.js
+++ b/api/src/privacy/infrastructure/repositories/candidates-api.repository.js
@@ -1,0 +1,16 @@
+import * as candidatesApi from '../../../certification/enrolment/application/api/candidates-api.js';
+
+/**
+ * Checks if the user has been a candidate.
+ *
+ * @param {Object} params - The parameters.
+ * @param {string} params.userId - The ID of the user.
+ * @param {Object} [params.dependencies] - The dependencies.
+ * @param {Object} [params.dependencies.candidatesApi] - The candidates API.
+ * @returns {Promise<boolean>} - A promise that resolves to a boolean indicating if the user has been a candidate.
+ */
+const hasBeenCandidate = async ({ userId, dependencies = { candidatesApi } }) => {
+  return dependencies.candidatesApi.hasBeenCandidate({ userId });
+};
+
+export { hasBeenCandidate };

--- a/api/src/privacy/infrastructure/repositories/learners-api.repository.js
+++ b/api/src/privacy/infrastructure/repositories/learners-api.repository.js
@@ -1,0 +1,16 @@
+import * as learnersApi from '../../../prescription/learner-management/application/api/learners-api.js';
+
+/**
+ * Checks if the user has been a learner.
+ *
+ * @param {Object} params - The parameters.
+ * @param {string} params.userId - The ID of the user.
+ * @param {Object} [params.dependencies] - The dependencies.
+ * @param {Object} [params.dependencies.learnersApi] - The learners API.
+ * @returns {Promise<boolean>} - A promise that resolves to a boolean indicating if the user has been a learner.
+ */
+const hasBeenLearner = async ({ userId, dependencies = { learnersApi } }) => {
+  return dependencies.learnersApi.hasBeenLearner({ userId });
+};
+
+export { hasBeenLearner };

--- a/api/src/privacy/infrastructure/repositories/user-teams-api.repository.js
+++ b/api/src/privacy/infrastructure/repositories/user-teams-api.repository.js
@@ -1,0 +1,16 @@
+import * as userTeamsApi from '../../../team/application/api/user-teams.js';
+
+/**
+ * Get user teams info.
+ *
+ * @param {Object} params - The parameters.
+ * @param {string} params.userId - The ID of the user.
+ * @param {Object} [params.dependencies] - The dependencies.
+ * @param {Object} [params.dependencies.userTeamsApi] - The user teams API.
+ * @returns {Promise<UserTeamsInfo>} The user teams info.
+ */
+const getUserTeamsInfo = async ({ userId, dependencies = { userTeamsApi } }) => {
+  return dependencies.userTeamsApi.getUserTeamsInfo(userId);
+};
+
+export { getUserTeamsInfo };

--- a/api/src/team/application/api/models/user-teams-info.js
+++ b/api/src/team/application/api/models/user-teams-info.js
@@ -1,0 +1,11 @@
+/**
+ * @class
+ * @classdesc Model representing a user teams info.
+ */
+export class UserTeamsInfo {
+  constructor({ isPixAgent, isOrganizationMember, isCertificationCenterMember } = {}) {
+    this.isPixAgent = isPixAgent;
+    this.isOrganizationMember = isOrganizationMember;
+    this.isCertificationCenterMember = isCertificationCenterMember;
+  }
+}

--- a/api/src/team/application/api/user-teams.js
+++ b/api/src/team/application/api/user-teams.js
@@ -1,0 +1,22 @@
+import { usecases } from '../../domain/usecases/index.js';
+import { UserTeamsInfo } from './models/user-teams-info.js';
+
+/**
+ * @module UserTeamsApi
+ */
+
+/**
+ * Retrieves information user's teams.
+ *
+ * @param {string} userId - The ID of the user.
+ * @returns {Promise<UserTeamsInfo>} A promise that resolves to an instance of UserTeamsInfo.
+ * @throws {TypeError} preconditions failed
+ */
+export async function getUserTeamsInfo(userId) {
+  if (!userId) {
+    throw new TypeError('userId is required');
+  }
+
+  const userTeamsInfo = await usecases.getUserTeamsInfo({ userId });
+  return new UserTeamsInfo(userTeamsInfo);
+}

--- a/api/src/team/domain/usecases/get-user-teams-info.usecase.js
+++ b/api/src/team/domain/usecases/get-user-teams-info.usecase.js
@@ -1,0 +1,26 @@
+/**
+ * Get the user's team information.
+ *
+ * @param {Object} params - The parameters.
+ * @param {string} params.userId - The ID of the user.
+ * @param {Object} params.adminMemberRepository - The repository for Pix Admin membership.
+ * @param {Object} params.certificationCenterMembershipRepository - The repository for certification center memberships.
+ * @param {Object} params.membershipRepository - The repository for organization memberships.
+ * @returns {Promise<Object>} The user's team information.
+ */
+export const getUserTeamsInfo = async function ({
+  userId,
+  adminMemberRepository,
+  certificationCenterMembershipRepository,
+  membershipRepository,
+}) {
+  const pixAdminMembership = await adminMemberRepository.get({ userId });
+  const organizationMembershipsCount = await membershipRepository.countByUserId(userId);
+  const certificationCenterMembershipsCount = await certificationCenterMembershipRepository.countByUserId(userId);
+
+  return {
+    isPixAgent: pixAdminMembership?.hasAccessToAdminScope ?? false,
+    isOrganizationMember: organizationMembershipsCount > 0,
+    isCertificationCenterMember: certificationCenterMembershipsCount > 0,
+  };
+};

--- a/api/src/team/infrastructure/repositories/certification-center-membership.repository.js
+++ b/api/src/team/infrastructure/repositories/certification-center-membership.repository.js
@@ -61,6 +61,21 @@ const countActiveMembersForCertificationCenter = async function (certificationCe
   return count;
 };
 
+/**
+ * Get the number of active memberships for a user
+ *
+ * @param {string} userId - The ID of the user
+ * @returns {Promise<number>} - The number of active memberships
+ */
+const countByUserId = async function (userId) {
+  const knexConnection = DomainTransaction.getConnection();
+  const { count } = await knexConnection(CERTIFICATION_CENTER_MEMBERSHIP_TABLE_NAME)
+    .where({ userId, disabledAt: null })
+    .count('id')
+    .first();
+  return count;
+};
+
 const create = async function ({ certificationCenterId, role, userId }) {
   await knex(CERTIFICATION_CENTER_MEMBERSHIP_TABLE_NAME).insert({ certificationCenterId, role, userId });
 };
@@ -297,7 +312,7 @@ const findById = async function (certificationCenterMembershipId) {
 };
 
 const findOneWithCertificationCenterIdAndUserId = async function ({ certificationCenterId, userId }) {
-  const certificationCenterMembership = await knex('certification-center-memberships')
+  const certificationCenterMembership = await knex(CERTIFICATION_CENTER_MEMBERSHIP_TABLE_NAME)
     .where({ certificationCenterId, userId })
     .first();
 
@@ -332,6 +347,7 @@ async function findActiveAdminsByCertificationCenterId(certificationCenterId) {
 
 const certificationCenterMembershipRepository = {
   countActiveMembersForCertificationCenter,
+  countByUserId,
   create,
   disableById,
   disableMembershipsByUserId,

--- a/api/src/team/infrastructure/repositories/membership.repository.js
+++ b/api/src/team/infrastructure/repositories/membership.repository.js
@@ -14,6 +14,18 @@ const ORGANIZATIONS_TABLE = 'organizations';
 const MEMBERSHIPS_TABLE = 'memberships';
 const USERS_TABLE = 'users';
 
+/**
+ * Get the number of active memberships for a user
+ *
+ * @param {string} userId - The ID of the user
+ * @returns {Promise<number>} - The number of active memberships
+ */
+export const countByUserId = async function (userId) {
+  const knexConnection = DomainTransaction.getConnection();
+  const { count } = await knexConnection(MEMBERSHIPS_TABLE).where({ userId, disabledAt: null }).count('id').first();
+  return count;
+};
+
 export const create = async (userId, organizationId, organizationRole) => {
   const knexConnection = DomainTransaction.getConnection();
   try {

--- a/api/tests/privacy/integration/domain/usecases/can-self-delete-account.usecase.test.js
+++ b/api/tests/privacy/integration/domain/usecases/can-self-delete-account.usecase.test.js
@@ -2,22 +2,7 @@ import { usecases } from '../../../../../src/privacy/domain/usecases/index.js';
 import { databaseBuilder, expect } from '../../../../test-helper.js';
 
 describe('Integration | Privacy | Domain | UseCase | can-self-delete-account', function () {
-  context('Feature flag is disabled', function () {
-    it('returns false', async function () {
-      // given
-      const featureToggles = { isSelfAccountDeletionEnabled: false };
-      const user = databaseBuilder.factory.buildUser();
-      await databaseBuilder.commit();
-
-      // when
-      const result = await usecases.canSelfDeleteAccount({ userId: user.id, featureToggles });
-
-      // then
-      expect(result).to.be.false;
-    });
-  });
-
-  context('Feature flag is enabled', function () {
+  context('When user is eligible', function () {
     it('returns true', async function () {
       // given
       const featureToggles = { isSelfAccountDeletionEnabled: true };

--- a/api/tests/privacy/unit/domain/usecases/can-self-delete-account.usecase.test.js
+++ b/api/tests/privacy/unit/domain/usecases/can-self-delete-account.usecase.test.js
@@ -1,0 +1,130 @@
+import { usecases } from '../../../../../src/privacy/domain/usecases/index.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Privacy | Domain | UseCase | can-self-delete-account', function () {
+  const userId = '123';
+  let dependencies;
+
+  beforeEach(function () {
+    dependencies = {
+      featureToggles: { isSelfAccountDeletionEnabled: false },
+      learnersApiRepository: { hasBeenLearner: sinon.stub().resolves(false) },
+      candidatesApiRepository: { hasBeenCandidate: sinon.stub().resolves(false) },
+      userTeamsApiRepository: {
+        getUserTeamsInfo: sinon.stub().resolves({
+          isPixAgent: false,
+          isOrganizationMember: false,
+          isCertificationCenterMember: false,
+        }),
+      },
+    };
+  });
+
+  context('When feature flag is enabled', function () {
+    beforeEach(function () {
+      sinon.stub(dependencies.featureToggles, 'isSelfAccountDeletionEnabled').value(true);
+    });
+
+    context('When user is eligible', function () {
+      it('returns true', async function () {
+        // when
+        const result = await usecases.canSelfDeleteAccount({ userId, ...dependencies });
+
+        // then
+        expect(result).to.be.true;
+      });
+    });
+
+    context('When user has been a learner', function () {
+      it('returns false', async function () {
+        // given
+        dependencies.learnersApiRepository.hasBeenLearner.withArgs({ userId }).resolves(true);
+
+        // when
+        const result = await usecases.canSelfDeleteAccount({ userId, ...dependencies });
+
+        // then
+        expect(result).to.be.false;
+      });
+    });
+
+    context('User has been a candidate to certification', function () {
+      it('returns false', async function () {
+        // given
+        dependencies.candidatesApiRepository.hasBeenCandidate.withArgs({ userId }).resolves(true);
+
+        // when
+        const result = await usecases.canSelfDeleteAccount({ userId, ...dependencies });
+
+        // then
+        expect(result).to.be.false;
+      });
+    });
+
+    context('User if user is a Pix agent', function () {
+      it('returns false', async function () {
+        // given
+        dependencies.userTeamsApiRepository.getUserTeamsInfo.withArgs({ userId }).resolves({
+          isPixAgent: true,
+          isOrganizationMember: false,
+          isCertificationCenterMember: false,
+        });
+
+        // when
+        const result = await usecases.canSelfDeleteAccount({ userId, ...dependencies });
+
+        // then
+        expect(result).to.be.false;
+      });
+    });
+
+    context('User if user is member of an organization', function () {
+      it('returns false', async function () {
+        // given
+        dependencies.userTeamsApiRepository.getUserTeamsInfo.withArgs({ userId }).resolves({
+          isPixAgent: false,
+          isOrganizationMember: true,
+          isCertificationCenterMember: false,
+        });
+
+        // when
+        const result = await usecases.canSelfDeleteAccount({ userId, ...dependencies });
+
+        // then
+        expect(result).to.be.false;
+      });
+    });
+
+    context('User if user is member of a certification center', function () {
+      it('returns false', async function () {
+        // given
+        dependencies.userTeamsApiRepository.getUserTeamsInfo.withArgs({ userId }).resolves({
+          isPixAgent: false,
+          isOrganizationMember: false,
+          isCertificationCenterMember: true,
+        });
+
+        // when
+        const result = await usecases.canSelfDeleteAccount({ userId, ...dependencies });
+
+        // then
+        expect(result).to.be.false;
+      });
+    });
+  });
+
+  context('Feature flag is disabled', function () {
+    context('When user is eligible', function () {
+      it('returns false', async function () {
+        // given
+        sinon.stub(dependencies.featureToggles, 'isSelfAccountDeletionEnabled').value(false);
+
+        // when
+        const result = await usecases.canSelfDeleteAccount({ userId: '123', ...dependencies });
+
+        // then
+        expect(result).to.be.false;
+      });
+    });
+  });
+});

--- a/api/tests/privacy/unit/infrastructure/repositories/candidates-api.repository.test.js
+++ b/api/tests/privacy/unit/infrastructure/repositories/candidates-api.repository.test.js
@@ -1,0 +1,21 @@
+import { hasBeenCandidate } from '../../../../../src/privacy/infrastructure/repositories/candidates-api.repository.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Privacy | Infrastructure | Repositories | candidates-api', function () {
+  describe('#hasBeenCandidate', function () {
+    it('indicates if user has been a candidate to certification', async function () {
+      // given
+      const dependencies = {
+        candidatesApi: {
+          hasBeenCandidate: async () => true,
+        },
+      };
+
+      // when
+      const result = await hasBeenCandidate({ userId: '123', dependencies });
+
+      // then
+      expect(result).to.be.true;
+    });
+  });
+});

--- a/api/tests/privacy/unit/infrastructure/repositories/learners-api.repository.test.js
+++ b/api/tests/privacy/unit/infrastructure/repositories/learners-api.repository.test.js
@@ -1,0 +1,21 @@
+import { hasBeenLearner } from '../../../../../src/privacy/infrastructure/repositories/learners-api.repository.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Privacy | Infrastructure | Repositories | learners-api', function () {
+  describe('#hasBeenLearner', function () {
+    it('indicates if user has been a learner', async function () {
+      // given
+      const dependencies = {
+        learnersApi: {
+          hasBeenLearner: async () => true,
+        },
+      };
+
+      // when
+      const result = await hasBeenLearner({ userId: '123', dependencies });
+
+      // then
+      expect(result).to.be.true;
+    });
+  });
+});

--- a/api/tests/privacy/unit/infrastructure/repositories/user-teams-api.repository.test.js
+++ b/api/tests/privacy/unit/infrastructure/repositories/user-teams-api.repository.test.js
@@ -1,0 +1,27 @@
+import { getUserTeamsInfo } from '../../../../../src/privacy/infrastructure/repositories/user-teams-api.repository.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Privacy | Infrastructure | Repositories | user-teams-api', function () {
+  describe('#getUserTeamsInfo', function () {
+    it('returns user teams information', async function () {
+      // given
+      const userTeamsInfo = {
+        isPixAgent: false,
+        isOrganizationMember: false,
+        isCertificationCenterMember: false,
+      };
+
+      const dependencies = {
+        userTeamsApi: {
+          getUserTeamsInfo: async () => userTeamsInfo,
+        },
+      };
+
+      // when
+      const result = await getUserTeamsInfo({ userId: '123', dependencies });
+
+      // then
+      expect(result).to.be.deep.equal(userTeamsInfo);
+    });
+  });
+});

--- a/api/tests/team/integration/application/api/user-teams.test.js
+++ b/api/tests/team/integration/application/api/user-teams.test.js
@@ -1,0 +1,21 @@
+import { UserTeamsInfo } from '../../../../../src/team/application/api/models/user-teams-info.js';
+import { getUserTeamsInfo } from '../../../../../src/team/application/api/user-teams.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Team | Integration | Application | API | user-teams', function () {
+  describe('#getUserTeamsInfo', function () {
+    it("returns user's teams info", async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      await databaseBuilder.commit();
+
+      // when
+      const result = await getUserTeamsInfo(userId);
+
+      // then
+      expect(result).to.deep.equal(
+        new UserTeamsInfo({ isPixAgent: false, isOrganizationMember: false, isCertificationCenterMember: false }),
+      );
+    });
+  });
+});

--- a/api/tests/team/integration/domain/usecases/get-user-teams-info.usecase.test.js
+++ b/api/tests/team/integration/domain/usecases/get-user-teams-info.usecase.test.js
@@ -1,0 +1,44 @@
+import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
+import { usecases } from '../../../../../src/team/domain/usecases/index.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Integration | Team | Domain | Usecases | getUserTeamsInfo', function () {
+  context('when user is a Pix agent, organization member, and certification center member', function () {
+    it('returns correct user teams information', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      await databaseBuilder.factory.buildPixAdminRole({ userId, role: PIX_ADMIN.ROLES.SUPER_ADMIN });
+      await databaseBuilder.factory.buildMembership({ userId });
+      await databaseBuilder.factory.buildCertificationCenterMembership({ userId });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await usecases.getUserTeamsInfo({ userId });
+
+      // then
+      expect(result).to.deep.equal({
+        isPixAgent: true,
+        isOrganizationMember: true,
+        isCertificationCenterMember: true,
+      });
+    });
+  });
+
+  context('when user does not belong to any team', function () {
+    it('returns correct user teams information', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      await databaseBuilder.commit();
+
+      // when
+      const result = await usecases.getUserTeamsInfo({ userId });
+
+      // then
+      expect(result).to.deep.equal({
+        isPixAgent: false,
+        isOrganizationMember: false,
+        isCertificationCenterMember: false,
+      });
+    });
+  });
+});

--- a/api/tests/team/integration/infrastructure/repositories/certification-center-membership.repository.test.js
+++ b/api/tests/team/integration/infrastructure/repositories/certification-center-membership.repository.test.js
@@ -48,6 +48,35 @@ describe('Integration | Team | Infrastructure | Repository | Certification Cente
     });
   });
 
+  describe('#countByUserId', function () {
+    it("counts all the user's memberships in certification centers", async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildCertificationCenterMembership({ userId });
+      databaseBuilder.factory.buildCertificationCenterMembership({ userId });
+      databaseBuilder.factory.buildCertificationCenterMembership();
+      await databaseBuilder.commit();
+
+      // when
+      const membershipCount = await certificationCenterMembershipRepository.countByUserId(userId);
+
+      // then
+      expect(membershipCount).to.equal(2);
+    });
+
+    it('does not count disabled memberships', async function () {
+      // given
+      const { userId } = databaseBuilder.factory.buildCertificationCenterMembership({ disabledAt: new Date() });
+      await databaseBuilder.commit();
+
+      // when
+      const membershipCount = await certificationCenterMembershipRepository.countByUserId(userId);
+
+      // then
+      expect(membershipCount).to.equal(0);
+    });
+  });
+
   describe('#create', function () {
     afterEach(async function () {
       await knex('certification-center-memberships').delete();

--- a/api/tests/team/integration/infrastructure/repositories/membership-repository.test.js
+++ b/api/tests/team/integration/infrastructure/repositories/membership-repository.test.js
@@ -70,6 +70,35 @@ describe('Integration | Team | Infrastructure | Repository | membership-reposito
     });
   });
 
+  describe('#countByUserId', function () {
+    it("counts all the user's memberships in organizations", async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildMembership({ userId });
+      databaseBuilder.factory.buildMembership({ userId });
+      databaseBuilder.factory.buildMembership();
+      await databaseBuilder.commit();
+
+      // when
+      const membershipCount = await membershipRepository.countByUserId(userId);
+
+      // then
+      expect(membershipCount).to.equal(2);
+    });
+
+    it('does not count disabled memberships', async function () {
+      // given
+      const { userId } = databaseBuilder.factory.buildMembership({ disabledAt: new Date() });
+      await databaseBuilder.commit();
+
+      // when
+      const membershipCount = await membershipRepository.countByUserId(userId);
+
+      // then
+      expect(membershipCount).to.equal(0);
+    });
+  });
+
   describe('#get', function () {
     let existingMembershipId;
 

--- a/api/tests/team/unit/application/api/user-teams.test.js
+++ b/api/tests/team/unit/application/api/user-teams.test.js
@@ -1,0 +1,34 @@
+import { UserTeamsInfo } from '../../../../../src/team/application/api/models/user-teams-info.js';
+import { getUserTeamsInfo } from '../../../../../src/team/application/api/user-teams.js';
+import { usecases } from '../../../../../src/team/domain/usecases/index.js';
+import { catchErr, expect, sinon } from '../../../../test-helper.js';
+
+describe('Team | Unit | Application | API | user-teams', function () {
+  describe('#getUserTeamsInfo', function () {
+    it("returns user's teams access", async function () {
+      // given
+      const userId = 1;
+      const userTeamsInfo = { isPixAgent: true, isOrganizationMember: true, isCertificationCenterMember: true };
+      const getUserTeamsInfoStub = sinon.stub(usecases, 'getUserTeamsInfo').resolves(userTeamsInfo);
+
+      // when
+      const result = await getUserTeamsInfo(userId);
+
+      // then
+      expect(result).to.deep.equal(new UserTeamsInfo(userTeamsInfo));
+      expect(getUserTeamsInfoStub).to.have.been.calledOnceWith({ userId });
+    });
+
+    it('throws a "TypeError" when "userId" is not defined', async function () {
+      // given
+      const getUserTeamsInfoStub = sinon.stub(usecases, 'getUserTeamsInfo');
+
+      // when
+      const error = await catchErr(getUserTeamsInfo)(undefined);
+
+      // then
+      expect(error).to.be.instanceOf(TypeError);
+      expect(getUserTeamsInfoStub).to.not.have.been.called;
+    });
+  });
+});


### PR DESCRIPTION
## :fallen_leaf: Problème

Le use case `canSelfDeleteAccount` du contexte `privacy` n'implémente pas toutes les règles métiers.

## :chestnut: Proposition

Implémenter toutes les règles métier pour `canSelfDeleteAccount` du contexte `privacy`:
- L'utilisateur n'a jamais été un élève (via la `learnersApi`)
- L'utilisateur n'a jamais été candidat à une certification (via la `candidatesApi`)
- L'utilisateur n'est pas un agent Pix
- L'utilisateur n'est pas membre d'une organisation
- L'utilisateur n'est pas membre d'un centre de certification

## :jack_o_lantern: Remarques

Ajout d'une API dans le contexte `team` qui retourne les accès des équipes d'un utilisateur (4 premiers commits)
```js
const access = userTeamsApi.getUserTeamsAccess(userId);

console.log(access); // { isPixAgent: false, isOrganizationMember: false, isCertificationCenterMember: false }

```

## :wood: Pour tester

### Étape préalable
- Créer un nouveau compte utilisateur

### Avec le feature flag est désactivé

`FT_SELF_ACCOUNT_DELETION=false`

**Test: L'utilisateur est éligible**
- Se connecter avec le nouveau compte utilisateur
- Aller sur "Mon compte"
- _Vérifier que le menu "Supprimer mon compte" **n'est pas** présent_

### Avec le feature flag est activé

`FT_SELF_ACCOUNT_DELETION=true`

**Test: L'utilisateur est éligible**
- Se connecter avec le nouveau compte utilisateur
- Aller sur "Mon compte"
- _Vérifier que le menu "Supprimer mon compte" **est** présent_

**Test: L'utilisateur est un élève**
- Se connecter avec le compte: bart@school.net
- Aller sur "Mon compte"
- _Vérifier que le menu "Supprimer mon compte" **n'est pas** présent_

**Test: L'utilisateur est candidat à une certification**
- Se connecter avec le compte: user-0-7403@example.net
- Aller sur "Mon compte"
- _Vérifier que le menu "Supprimer mon compte" **n'est pas** présent_

**Test: L'utilisateur est un agent Pix**
- Se connecter avec le compte: superadmin@example.net
- Aller sur "Mon compte"
- _Vérifier que le menu "Supprimer mon compte" **n'est pas** présent_

**Test: L'utilisateur est un member d'une organisation**
- Se connecter avec le compte: admin.leaving@example.net
- Aller sur "Mon compte"
- _Vérifier que le menu "Supprimer mon compte" **n'est pas** présent_

**Test: L'utilisateur est un member d'un centre de certification**
- Se connecter avec le compte: james-paledroits@example.net
- Aller sur "Mon compte"
- _Vérifier que le menu "Supprimer mon compte" **n'est pas** présent_