### PR TITLE
[FEATURE] Pouvoir faire une recherche exacte d'utilisateurs dans Pix Admin (PIX-9567)

### DIFF
--- a/admin/app/controllers/authenticated/users/list.js
+++ b/admin/app/controllers/authenticated/users/list.js
@@ -3,11 +3,18 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 const DEFAULT_PAGE_NUMBER = 1;
+const DEFAULT_QUERY_TYPE = 'CONTAINS';
 
 export default class ListController extends Controller {
-  queryParams = ['pageNumber', 'pageSize', 'id', 'firstName', 'lastName', 'email', 'username'];
+  queryParams = ['pageNumber', 'pageSize', 'id', 'firstName', 'lastName', 'email', 'username', 'queryType'];
+
+  queryTypes = [
+    { value: 'CONTAINS', label: 'Contient' },
+    { value: 'EXACT_QUERY', label: 'Exacte' },
+  ];
 
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
+  @tracked queryType = DEFAULT_QUERY_TYPE;
   @tracked pageSize = 10;
   @tracked id = null;
   @tracked firstName = null;
@@ -20,6 +27,7 @@ export default class ListController extends Controller {
   @tracked lastNameForm = null;
   @tracked emailForm = null;
   @tracked usernameForm = null;
+  @tracked queryTypeForm = DEFAULT_QUERY_TYPE;
 
   @action
   async refreshModel(event) {
@@ -29,6 +37,7 @@ export default class ListController extends Controller {
     this.lastName = this.lastNameForm;
     this.email = this.emailForm;
     this.username = this.usernameForm;
+    this.queryType = this.queryTypeForm;
     this.pageNumber = DEFAULT_PAGE_NUMBER;
   }
 
@@ -56,6 +65,10 @@ export default class ListController extends Controller {
   onChangeUsername(event) {
     this.usernameForm = event.target.value;
   }
+  @action
+  onChangeQueryType(event) {
+    this.queryTypeForm = event;
+  }
 
   @action
   clearSearchFields() {
@@ -64,11 +77,13 @@ export default class ListController extends Controller {
     this.lastName = null;
     this.email = null;
     this.username = null;
+    this.queryType = DEFAULT_QUERY_TYPE;
 
     this.idForm = null;
     this.firstNameForm = null;
     this.lastNameForm = null;
     this.emailForm = null;
     this.usernameForm = null;
+    this.queryTypeForm = DEFAULT_QUERY_TYPE;
   }
 }

--- a/admin/app/controllers/authenticated/users/list.js
+++ b/admin/app/controllers/authenticated/users/list.js
@@ -1,17 +1,22 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 const DEFAULT_PAGE_NUMBER = 1;
 const DEFAULT_QUERY_TYPE = 'CONTAINS';
 
 export default class ListController extends Controller {
+  @service intl;
+
   queryParams = ['pageNumber', 'pageSize', 'id', 'firstName', 'lastName', 'email', 'username', 'queryType'];
 
-  queryTypes = [
-    { value: 'CONTAINS', label: 'Contient' },
-    { value: 'EXACT_QUERY', label: 'Exacte' },
-  ];
+  get queryTypes() {
+    return [
+      { value: 'CONTAINS', label: this.intl.t('pages.users-list.query.contains') },
+      { value: 'EXACT_QUERY', label: this.intl.t('pages.users-list.query.exact') },
+    ];
+  }
 
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
   @tracked queryType = DEFAULT_QUERY_TYPE;
@@ -66,8 +71,8 @@ export default class ListController extends Controller {
     this.usernameForm = event.target.value;
   }
   @action
-  onChangeQueryType(event) {
-    this.queryTypeForm = event;
+  onChangeQueryType(value) {
+    this.queryTypeForm = value;
   }
 
   @action

--- a/admin/app/routes/authenticated/users/list.js
+++ b/admin/app/routes/authenticated/users/list.js
@@ -7,6 +7,7 @@ export default class ListRoute extends Route {
   queryParams = {
     pageNumber: { refreshModel: true },
     pageSize: { refreshModel: true },
+    queryType: { refreshModel: true },
     id: { refreshModel: true },
     firstName: { refreshModel: true },
     lastName: { refreshModel: true },
@@ -30,6 +31,7 @@ export default class ListRoute extends Route {
           number: params.pageNumber,
           size: params.pageSize,
         },
+        queryType: params.queryType,
       });
       return users;
     } catch (error) {
@@ -46,6 +48,7 @@ export default class ListRoute extends Route {
       controller.lastName = null;
       controller.email = null;
       controller.username = null;
+      controller.queryType = 'CONTAINS';
     }
   }
 }

--- a/admin/app/styles/authenticated/users/list.scss
+++ b/admin/app/styles/authenticated/users/list.scss
@@ -1,3 +1,13 @@
+.pix-select {
+  min-width: 110px;
+  margin-right: 16px;
+}
+
+.pix-select .pix-icon {
+  width: 1.35rem;
+  height: 1.35rem;
+}
+
 .user-list-form {
   display: flex;
   flex-wrap: wrap;
@@ -5,7 +15,7 @@
   justify-content: flex-end;
 
   &__input--small {
-    max-width: 190px;
+    max-width: 150px;
   }
 
   &__actions {

--- a/admin/app/styles/authenticated/users/list.scss
+++ b/admin/app/styles/authenticated/users/list.scss
@@ -1,25 +1,26 @@
-.pix-select {
-  min-width: 110px;
-  margin-right: 16px;
-}
-
-.pix-select .pix-icon {
-  width: 1.35rem;
-  height: 1.35rem;
-}
-
 .user-list-form {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--pix-spacing-2x);
   justify-content: flex-end;
 
+  .pix-select {
+    min-width: 7.5rem;
+    margin-right: var(--pix-spacing-2x);
+  }
+
+  .pix-select .pix-icon {
+    width: 1.315rem;
+    height: 1.315rem;
+
+  }
+
   &__input--small {
-    max-width: 150px;
+    max-width: 9.35rem;
   }
 
   &__actions {
     display: flex;
-    gap: 8px;
+    gap: var(--pix-spacing-2x);
   }
 }

--- a/admin/app/templates/authenticated/users/list.hbs
+++ b/admin/app/templates/authenticated/users/list.hbs
@@ -4,6 +4,14 @@
   <h1 class="page-title">Rechercher un(des) utilisateur(s)</h1>
   <div class="page-actions">
     <form class="user-list-form" {{on "submit" this.refreshModel}}>
+      <PixSelect
+        @id="query-type-selector"
+        @onChange={{this.onChangeQueryType}}
+        @value={{this.queryTypeForm}}
+        @options={{this.queryTypes}}
+      >
+        <:default>Contient</:default>
+      </PixSelect>
       <PixInput
         @id="userId"
         {{on "change" this.onChangeUserId}}

--- a/admin/app/templates/authenticated/users/list.hbs
+++ b/admin/app/templates/authenticated/users/list.hbs
@@ -9,9 +9,8 @@
         @onChange={{this.onChangeQueryType}}
         @value={{this.queryTypeForm}}
         @options={{this.queryTypes}}
-      >
-        <:default>Contient</:default>
-      </PixSelect>
+        @hideDefaultOption={{true}}
+      />
       <PixInput
         @id="userId"
         {{on "change" this.onChangeUserId}}

--- a/admin/tests/acceptance/authenticated/users/list-test.js
+++ b/admin/tests/acceptance/authenticated/users/list-test.js
@@ -171,7 +171,7 @@ module('Acceptance | authenticated/users | list', function (hooks) {
           assert.strictEqual(currentURL(), '/users/list');
         });
 
-        test('should empty all search fields', async function (assert) {
+        test('empties all search fields and resets query type to "Contains"', async function (assert) {
           // given
           await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
@@ -182,6 +182,9 @@ module('Acceptance | authenticated/users | list', function (hooks) {
             identifiant: 'emma123',
           });
           const screen = await visit('/users/list');
+          await click(screen.getByRole('button', { name: 'Contient' }));
+          await screen.findByRole('listbox');
+          await click(screen.getByRole('option', { name: 'Exacte' }));
           await fillIn(screen.getByRole('textbox', { name: 'Nom' }), 'sardine');
           await fillIn(screen.getByRole('textbox', { name: 'Adresse e-mail' }), 'emma@example.net');
           await fillIn(screen.getByRole('textbox', { name: 'Identifiant' }), 'emma123');
@@ -194,6 +197,8 @@ module('Acceptance | authenticated/users | list', function (hooks) {
           assert.dom(screen.getByRole('textbox', { name: 'Nom' })).hasNoValue();
           assert.dom(screen.getByRole('textbox', { name: 'Adresse e-mail' })).hasNoValue();
           assert.dom(screen.getByRole('textbox', { name: 'Identifiant' })).hasNoValue();
+          assert.dom(screen.getByRole('button', { name: 'Contient' })).exists();
+          assert.dom(screen.queryByRole('button', { name: 'Exacte' })).doesNotExist();
         });
 
         test('should let empty fields on search', async function (assert) {

--- a/admin/tests/acceptance/authenticated/users/list-test.js
+++ b/admin/tests/acceptance/authenticated/users/list-test.js
@@ -5,9 +5,12 @@ import { setupApplicationTest } from 'ember-qunit';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 import { module, test } from 'qunit';
 
+import setupIntl from '../../../helpers/setup-intl';
+
 module('Acceptance | authenticated/users | list', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks);
 
   module('When user is not logged in', function () {
     test('it should not be accessible by an unauthenticated user', async function (assert) {

--- a/admin/tests/unit/routes/authenticated/users/list-test.js
+++ b/admin/tests/unit/routes/authenticated/users/list-test.js
@@ -23,6 +23,8 @@ module('Unit | Route | authenticated/users/list', function (hooks) {
         number: 'somePageNumber',
         size: 'somePageSize',
       };
+      params.queryType = 'CONTAINS';
+      expectedQueryArgs.queryType = 'CONTAINS';
     });
 
     module('when queryParams filters are falsy', function () {
@@ -36,6 +38,7 @@ module('Unit | Route | authenticated/users/list', function (hooks) {
           email: '',
           username: '',
         };
+        expectedQueryArgs.queryType = 'CONTAINS';
 
         // then
         sinon.assert.notCalled(route.store.query);
@@ -96,6 +99,7 @@ module('Unit | Route | authenticated/users/list', function (hooks) {
         lastName: 'someLastName',
         email: 'someEmail',
         username: 'someUsername',
+        queryType: 'EXACT_QUERY',
       };
     });
 
@@ -112,6 +116,7 @@ module('Unit | Route | authenticated/users/list', function (hooks) {
         assert.deepEqual(controller.lastName, null);
         assert.deepEqual(controller.email, null);
         assert.deepEqual(controller.username, null);
+        assert.deepEqual(controller.queryType, 'CONTAINS');
       });
     });
 
@@ -128,6 +133,7 @@ module('Unit | Route | authenticated/users/list', function (hooks) {
         assert.deepEqual(controller.lastName, 'someLastName');
         assert.deepEqual(controller.email, 'someEmail');
         assert.deepEqual(controller.username, 'someUsername');
+        assert.deepEqual(controller.queryType, 'EXACT_QUERY');
       });
     });
   });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -740,6 +740,12 @@
           "update-certification-center-membership-role": "Le rôle du membre a été modifié."
         }
       }
+    },
+    "users-list": {
+      "query":  {
+        "contains": "Contient",
+        "exact": "Exacte"
+      }
     }
   }
 }

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -764,6 +764,12 @@
           "update-certification-center-membership-role": "Le rôle du membre a été modifié."
         }
       }
+    },
+    "users-list": {
+      "query":  {
+        "contains": "Contient",
+        "exact": "Exacte"
+      }
     }
   }
 }

--- a/api/src/identity-access-management/application/user/user.admin.controller.js
+++ b/api/src/identity-access-management/application/user/user.admin.controller.js
@@ -14,9 +14,9 @@ import * as userLoginSerializer from '../../infrastructure/serializers/jsonapi/u
  * @returns {Promise<*>}
  */
 const findPaginatedFilteredUsers = async function (request, h, dependencies = { userForAdminSerializer }) {
-  const { filter, page } = request.query;
+  const { filter, page, queryType } = request.query;
 
-  const { models: users, pagination } = await usecases.findPaginatedFilteredUsers({ filter, page });
+  const { models: users, pagination } = await usecases.findPaginatedFilteredUsers({ filter, page, queryType });
   return dependencies.userForAdminSerializer.serialize(users, pagination);
 };
 

--- a/api/src/identity-access-management/application/user/user.admin.route.js
+++ b/api/src/identity-access-management/application/user/user.admin.route.js
@@ -62,6 +62,7 @@ export const userAdminRoutes = [
             number: Joi.number().integer().empty('').allow(null).optional(),
             size: Joi.number().integer().empty('').allow(null).optional(),
           }).default({}),
+          queryType: Joi.string().valid('CONTAINS', 'EXACT_QUERY').empty('').allow(null).default('CONTAINS').optional(),
         }),
       },
       handler: (request, h) => userAdminController.findPaginatedFilteredUsers(request, h),

--- a/api/src/identity-access-management/application/user/user.admin.route.js
+++ b/api/src/identity-access-management/application/user/user.admin.route.js
@@ -5,6 +5,7 @@ import { securityPreHandlers } from '../../../shared/application/security-pre-ha
 import { SUPPORTED_LOCALES } from '../../../shared/domain/constants.js';
 import { AVAILABLE_LANGUAGES } from '../../../shared/domain/services/language-service.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { QUERY_TYPES } from '../../domain/constants/user-query.js';
 import { userAdminController } from './user.admin.controller.js';
 
 export const userAdminRoutes = [
@@ -62,7 +63,10 @@ export const userAdminRoutes = [
             number: Joi.number().integer().empty('').allow(null).optional(),
             size: Joi.number().integer().empty('').allow(null).optional(),
           }).default({}),
-          queryType: Joi.string().valid('CONTAINS', 'EXACT_QUERY').empty('').allow(null).default('CONTAINS').optional(),
+          queryType: Joi.string()
+            .valid(QUERY_TYPES.CONTAINS, QUERY_TYPES.EXACT_QUERY)
+            .default(QUERY_TYPES.CONTAINS)
+            .optional(),
         }),
       },
       handler: (request, h) => userAdminController.findPaginatedFilteredUsers(request, h),

--- a/api/src/identity-access-management/domain/constants/user-query.js
+++ b/api/src/identity-access-management/domain/constants/user-query.js
@@ -1,0 +1,4 @@
+export const QUERY_TYPES = {
+  CONTAINS: 'CONTAINS',
+  EXACT_QUERY: 'EXACT_QUERY',
+};

--- a/api/src/identity-access-management/domain/usecases/find-paginated-filtered-users.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/find-paginated-filtered-users.usecase.js
@@ -1,5 +1,5 @@
-const findPaginatedFilteredUsers = function ({ filter, page, userRepository }) {
-  return userRepository.findPaginatedFiltered({ filter, page });
+const findPaginatedFilteredUsers = function ({ filter, page, queryType, userRepository }) {
+  return userRepository.findPaginatedFiltered({ filter, page, queryType });
 };
 
 export { findPaginatedFilteredUsers };

--- a/api/src/identity-access-management/infrastructure/repositories/user.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user.repository.js
@@ -159,9 +159,9 @@ const getUserDetailsForAdmin = async function (userId) {
   });
 };
 
-const findPaginatedFiltered = async function ({ filter, page }) {
+const findPaginatedFiltered = async function ({ filter, page, queryType }) {
   const query = knex('users')
-    .where((qb) => _setSearchFiltersForQueryBuilder(filter, qb))
+    .where((qb) => _setSearchFiltersForQueryBuilder(filter, qb, queryType))
     .orderBy([{ column: 'firstName', order: 'asc' }, { column: 'lastName', order: 'asc' }, { column: 'id' }]);
   const { results, pagination } = await fetchPage(query, page);
 
@@ -625,22 +625,30 @@ function _toDomainFromDTO({
   });
 }
 
-function _setSearchFiltersForQueryBuilder(filter, qb) {
+function _applyQueryType(field, value, qb, queryType) {
+  if (queryType === 'EXACT_QUERY') {
+    qb.where(field, value);
+  } else {
+    qb.whereILike(field, `%${value}%`);
+  }
+}
+
+function _setSearchFiltersForQueryBuilder(filter, qb, queryType) {
   const { id, firstName, lastName, email, username } = filter;
 
   if (id) {
     qb.where({ id });
   }
   if (firstName) {
-    qb.whereILike('firstName', `%${firstName}%`);
+    _applyQueryType('firstName', firstName, qb, queryType);
   }
   if (lastName) {
-    qb.whereILike('lastName', `%${lastName}%`);
+    _applyQueryType('lastName', lastName, qb, queryType);
   }
   if (email) {
-    qb.whereILike('email', `%${email}%`);
+    _applyQueryType('email', email, qb, queryType);
   }
   if (username) {
-    qb.whereILike('username', `%${username}%`);
+    _applyQueryType('username', username, qb, queryType);
   }
 }

--- a/api/tests/identity-access-management/acceptance/application/user/user.admin.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/user/user.admin.route.test.js
@@ -1,3 +1,4 @@
+import { QUERY_TYPES } from '../../../../../src/identity-access-management/domain/constants/user-query.js';
 import {
   createServer,
   databaseBuilder,
@@ -50,6 +51,7 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
       await databaseBuilder.factory.buildUser({ firstName: 'Ann' });
       await databaseBuilder.factory.buildUser({ firstName: 'Anne' });
       await databaseBuilder.factory.buildUser({ firstName: 'Annie' });
+      await databaseBuilder.factory.buildUser({ firstName: 'Lisa' });
       await databaseBuilder.commit();
     });
 
@@ -58,7 +60,8 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
         it('retrieves this list of users', async function () {
           // given
           const user = await insertUserWithRoleSuperAdmin();
-          const params = '?filter[firstName]=Ann' + '&page[number]=1&page[size]=25' + '&queryType=EXACT_QUERY';
+          const params =
+            '?filter[firstName]=Ann' + '&page[number]=1&page[size]=25' + `&queryType=${QUERY_TYPES.EXACT_QUERY}`;
 
           requestOptions = {
             method: 'GET',
@@ -80,7 +83,8 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
         it('retrieves this list of users', async function () {
           // given
           const user = await insertUserWithRoleSuperAdmin();
-          const params = '?filter[firstName]=Ann' + '&page[number]=1&page[size]=25' + '&queryType=CONTAINS';
+          const params =
+            '?filter[firstName]=Ann' + '&page[number]=1&page[size]=25' + `&queryType=${QUERY_TYPES.CONTAINS}`;
 
           requestOptions = {
             method: 'GET',

--- a/api/tests/identity-access-management/acceptance/application/user/user.admin.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/user/user.admin.route.test.js
@@ -44,32 +44,56 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
   });
 
   describe('GET /api/admin/users', function () {
-    context('When filters match a list of users', function () {
-      let requestOptions;
+    let requestOptions;
 
-      beforeEach(async function () {
-        const user = await insertUserWithRoleSuperAdmin();
-        const params = '?filter[firstName]=Ann' + '&page[number]=1&page[size]=25';
+    beforeEach(async function () {
+      await databaseBuilder.factory.buildUser({ firstName: 'Ann' });
+      await databaseBuilder.factory.buildUser({ firstName: 'Anne' });
+      await databaseBuilder.factory.buildUser({ firstName: 'Annie' });
+      await databaseBuilder.commit();
+    });
 
-        requestOptions = {
-          method: 'GET',
-          url: `/api/admin/users${params}`,
-          headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
-        };
+    context('When EXACT_QUERY type is settled', function () {
+      context('When filters match a list of users', function () {
+        it('retrieves this list of users', async function () {
+          // given
+          const user = await insertUserWithRoleSuperAdmin();
+          const params = '?filter[firstName]=Ann' + '&page[number]=1&page[size]=25' + '&queryType=EXACT_QUERY';
 
-        await databaseBuilder.factory.buildUser({ firstName: 'Ann' });
-        await databaseBuilder.factory.buildUser({ firstName: 'Anne' });
-        await databaseBuilder.factory.buildUser({ firstName: 'Annie' });
-        await databaseBuilder.commit();
+          requestOptions = {
+            method: 'GET',
+            url: `/api/admin/users${params}`,
+            headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+          };
+          // when
+          const response = await server.inject(requestOptions);
+
+          // then
+          const { result, statusCode } = response;
+          expect(statusCode).to.equal(200);
+          expect(result.data).to.have.lengthOf(1);
+        });
       });
+    });
+    context('When CONTAINS type is settled', function () {
+      context('When filters match a list of users', function () {
+        it('retrieves this list of users', async function () {
+          // given
+          const user = await insertUserWithRoleSuperAdmin();
+          const params = '?filter[firstName]=Ann' + '&page[number]=1&page[size]=25' + '&queryType=CONTAINS';
 
-      it('retrieves this list of users', async function () {
-        // when
-        const response = await server.inject(requestOptions);
-        // then
-        const { result, statusCode } = response;
-        expect(statusCode).to.equal(200);
-        expect(result.data).to.have.lengthOf(3);
+          requestOptions = {
+            method: 'GET',
+            url: `/api/admin/users${params}`,
+            headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+          };
+          // when
+          const response = await server.inject(requestOptions);
+          // then
+          const { result, statusCode } = response;
+          expect(statusCode).to.equal(200);
+          expect(result.data).to.have.lengthOf(3);
+        });
       });
     });
   });

--- a/api/tests/identity-access-management/integration/application/user/user.admin.route.test.js
+++ b/api/tests/identity-access-management/integration/application/user/user.admin.route.test.js
@@ -22,7 +22,7 @@ describe('Integration | Identity Access Management | Application | Route | Admin
       // when
       const response = await httpTestServer.request(
         'GET',
-        '/api/admin/users?filter[firstName]=Bruce&filter[lastName]=Wayne&filter[email]=batman@gotham.city&page[number]=3&page[size]=25',
+        '/api/admin/users?filter[firstName]=Bruce&filter[lastName]=Wayne&filter[email]=batman@gotham.city&page[number]=3&page[size]=25&queryType=CONTAINS',
       );
 
       // then
@@ -43,7 +43,7 @@ describe('Integration | Identity Access Management | Application | Route | Admin
       // when
       const response = await httpTestServer.request(
         'GET',
-        '/api/admin/users?filter[firstName]=Bruce&filter[lastName]=Wayne&filter[email]=batman@gotham.city&page[number]=3&page[size]=25',
+        '/api/admin/users?filter[firstName]=Bruce&filter[lastName]=Wayne&filter[email]=batman@gotham.city&page[number]=3&page[size]=25&queryType=CONTAINS',
       );
 
       // then

--- a/api/tests/identity-access-management/integration/application/user/user.admin.route.test.js
+++ b/api/tests/identity-access-management/integration/application/user/user.admin.route.test.js
@@ -1,5 +1,6 @@
 import { identityAccessManagementRoutes } from '../../../../../src/identity-access-management/application/routes.js';
 import { userAdminController } from '../../../../../src/identity-access-management/application/user/user.admin.controller.js';
+import { QUERY_TYPES } from '../../../../../src/identity-access-management/domain/constants/user-query.js';
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
@@ -22,7 +23,7 @@ describe('Integration | Identity Access Management | Application | Route | Admin
       // when
       const response = await httpTestServer.request(
         'GET',
-        '/api/admin/users?filter[firstName]=Bruce&filter[lastName]=Wayne&filter[email]=batman@gotham.city&page[number]=3&page[size]=25&queryType=CONTAINS',
+        `/api/admin/users?filter[firstName]=Bruce&filter[lastName]=Wayne&filter[email]=batman@gotham.city&page[number]=3&page[size]=25&queryType=${QUERY_TYPES.CONTAINS}`,
       );
 
       // then
@@ -43,7 +44,7 @@ describe('Integration | Identity Access Management | Application | Route | Admin
       // when
       const response = await httpTestServer.request(
         'GET',
-        '/api/admin/users?filter[firstName]=Bruce&filter[lastName]=Wayne&filter[email]=batman@gotham.city&page[number]=3&page[size]=25&queryType=CONTAINS',
+        `/api/admin/users?filter[firstName]=Bruce&filter[lastName]=Wayne&filter[email]=batman@gotham.city&page[number]=3&page[size]=25&queryType=${QUERY_TYPES.CONTAINS}`,
       );
 
       // then

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
@@ -297,195 +297,41 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
           expect(pagination).to.deep.equal(expectedPagination);
         });
       });
+      context('when default/contains request type is settled', function () {
+        context('when there are multiple users matching the same "first name" search pattern', function () {
+          beforeEach(function () {
+            databaseBuilder.factory.buildUser({ firstName: 'Son Gohan' });
+            databaseBuilder.factory.buildUser({ firstName: 'Son Goku' });
+            databaseBuilder.factory.buildUser({ firstName: 'Son Goten' });
+            databaseBuilder.factory.buildUser({ firstName: 'Vegeta' });
+            databaseBuilder.factory.buildUser({ firstName: 'Piccolo' });
+            return databaseBuilder.commit();
+          });
 
-      context('when there are multiple users matching the same "first name" search pattern', function () {
-        beforeEach(function () {
-          databaseBuilder.factory.buildUser({ firstName: 'Son Gohan' });
-          databaseBuilder.factory.buildUser({ firstName: 'Son Goku' });
-          databaseBuilder.factory.buildUser({ firstName: 'Son Goten' });
-          databaseBuilder.factory.buildUser({ firstName: 'Vegeta' });
-          databaseBuilder.factory.buildUser({ firstName: 'Piccolo' });
-          return databaseBuilder.commit();
+          it('should return only users matching "first name" if given in filter', async function () {
+            // given
+            const filter = { firstName: 'Go' };
+            const page = { number: 1, size: 10 };
+            const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 3 };
+
+            // when
+            const { models: matchingUsers, pagination } = await userRepository.findPaginatedFiltered({ filter, page });
+
+            // then
+            expect(map(matchingUsers, 'firstName')).to.have.members(['Son Gohan', 'Son Goku', 'Son Goten']);
+            expect(pagination).to.deep.equal(expectedPagination);
+          });
         });
 
-        it('should return only users matching "first name" if given in filter', async function () {
-          // given
-          const filter = { firstName: 'Go' };
-          const page = { number: 1, size: 10 };
-          const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 3 };
-
-          // when
-          const { models: matchingUsers, pagination } = await userRepository.findPaginatedFiltered({ filter, page });
-
-          // then
-          expect(map(matchingUsers, 'firstName')).to.have.members(['Son Gohan', 'Son Goku', 'Son Goten']);
-          expect(pagination).to.deep.equal(expectedPagination);
-        });
-      });
-
-      context('when there are multiple users matching the same "last name" search pattern', function () {
-        beforeEach(async function () {
-          each(
-            [
-              { firstName: 'Anakin', lastName: 'Skywalker' },
-              { firstName: 'Luke', lastName: 'Skywalker' },
-              { firstName: 'Leia', lastName: 'Skywalker' },
-              { firstName: 'Han', lastName: 'Solo' },
-              { firstName: 'Ben', lastName: 'Solo' },
-            ],
-            (user) => {
-              databaseBuilder.factory.buildUser(user);
-            },
-          );
-
-          await databaseBuilder.commit();
-        });
-
-        it('should return only users matching "last name" if given in filter', async function () {
-          // given
-          const filter = { lastName: 'walk' };
-          const page = { number: 1, size: 10 };
-          const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 3 };
-
-          // when
-          const { models: matchingUsers, pagination } = await userRepository.findPaginatedFiltered({ filter, page });
-
-          // then
-          expect(map(matchingUsers, 'firstName')).to.have.members(['Anakin', 'Luke', 'Leia']);
-          expect(pagination).to.deep.equal(expectedPagination);
-        });
-      });
-
-      context('when there are multiple users matching the same "email" search pattern', function () {
-        beforeEach(async function () {
-          each(
-            [
-              { email: 'playpus@pix.fr' },
-              { email: 'panda@pix.fr' },
-              { email: 'otter@pix.fr' },
-              { email: 'playpus@example.net' },
-              { email: 'panda@example.net' },
-              { email: 'PANDA@example.net' },
-              { email: 'PANDA@PIX.be' },
-            ],
-            (user) => {
-              databaseBuilder.factory.buildUser(user);
-            },
-          );
-
-          await databaseBuilder.commit();
-        });
-
-        it('should return only users matching "email" if given in filter even if it is in uppercase in database', async function () {
-          // given
-          const filter = { email: 'panda' };
-          const page = { number: 1, size: 10 };
-          const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 4 };
-
-          // when
-          const { models: matchingUsers, pagination } = await userRepository.findPaginatedFiltered({ filter, page });
-
-          // then
-          expect(map(matchingUsers, 'email')).to.have.members([
-            'panda@pix.fr',
-            'panda@example.net',
-            'panda@example.net',
-            'panda@pix.be',
-          ]);
-          expect(pagination).to.deep.equal(expectedPagination);
-        });
-
-        it('should return only users matching "email" if given in filter', async function () {
-          // given
-          const filter = { email: 'pix.fr' };
-          const page = { number: 1, size: 10 };
-          const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 3 };
-
-          // when
-          const { models: matchingUsers, pagination } = await userRepository.findPaginatedFiltered({ filter, page });
-
-          // then
-          expect(map(matchingUsers, 'email')).to.have.members(['playpus@pix.fr', 'panda@pix.fr', 'otter@pix.fr']);
-          expect(pagination).to.deep.equal(expectedPagination);
-        });
-      });
-
-      context('when there are multiple users matching the same "username" search pattern', function () {
-        it('should return only users matching "username" if given in filter', async function () {
-          // given
-          each(
-            [
-              { username: 'alex.ception1011' },
-              { username: 'alex.terieur1011' },
-              { username: 'ella.danloss0101' },
-              { username: 'ella.bienhu1011' },
-              { username: 'ella.bienhu2312' },
-            ],
-            (user) => {
-              databaseBuilder.factory.buildUser(user);
-            },
-          );
-          await databaseBuilder.commit();
-          const filter = { username: '1011' };
-          const page = { number: 1, size: 10 };
-
-          // when
-          const { models: matchingUsers } = await userRepository.findPaginatedFiltered({ filter, page });
-
-          // then
-          expect(map(matchingUsers, 'username')).to.have.members([
-            'alex.ception1011',
-            'alex.terieur1011',
-            'ella.bienhu1011',
-          ]);
-        });
-      });
-
-      context(
-        'when there are multiple users matching the fields "first name", "last name" and "email" search pattern',
-        function () {
+        context('when there are multiple users matching the same "last name" search pattern', function () {
           beforeEach(async function () {
             each(
               [
-                // Matching users
-                {
-                  firstName: 'fn_ok_1',
-                  lastName: 'ln_ok_1',
-                  email: 'email_ok_1@mail.com',
-                  username: 'username_ok0210',
-                },
-                {
-                  firstName: 'fn_ok_2',
-                  lastName: 'ln_ok_2',
-                  email: 'email_ok_2@mail.com',
-                  username: 'username_ok1214',
-                },
-                {
-                  firstName: 'fn_ok_3',
-                  lastName: 'ln_ok_3',
-                  email: 'email_ok_3@mail.com',
-                  username: 'username_ok1010',
-                },
-
-                // Unmatching users
-                {
-                  firstName: 'fn_ko_4',
-                  lastName: 'ln_ok_4',
-                  email: 'email_ok_4@mail.com',
-                  username: 'username_ko1309',
-                },
-                {
-                  firstName: 'fn_ok_5',
-                  lastName: 'ln_ko_5',
-                  email: 'email_ok_5@mail.com',
-                  username: 'username_ok1911',
-                },
-                {
-                  firstName: 'fn_ok_6',
-                  lastName: 'ln_ok_6',
-                  email: 'email_ko_6@mail.com',
-                  username: 'username_ok2010',
-                },
+                { firstName: 'Anakin', lastName: 'Skywalker' },
+                { firstName: 'Luke', lastName: 'Skywalker' },
+                { firstName: 'Leia', lastName: 'Skywalker' },
+                { firstName: 'Han', lastName: 'Solo' },
+                { firstName: 'Ben', lastName: 'Solo' },
               ],
               (user) => {
                 databaseBuilder.factory.buildUser(user);
@@ -495,9 +341,67 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
             await databaseBuilder.commit();
           });
 
-          it('should return only users matching "first name" AND "last name" AND "email" AND "username" if given in filter', async function () {
+          it('should return only users matching "last name" if given in filter', async function () {
             // given
-            const filter = { firstName: 'fn_ok', lastName: 'ln_ok', email: 'email_ok', username: 'username_ok' };
+            const filter = { lastName: 'walk' };
+            const page = { number: 1, size: 10 };
+            const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 3 };
+
+            // when
+            const { models: matchingUsers, pagination } = await userRepository.findPaginatedFiltered({
+              filter,
+              page,
+              queryType: 'CONTAINS',
+            });
+
+            // then
+            expect(map(matchingUsers, 'firstName')).to.have.members(['Anakin', 'Luke', 'Leia']);
+            expect(pagination).to.deep.equal(expectedPagination);
+          });
+        });
+
+        context('when there are multiple users matching the same "email" search pattern', function () {
+          beforeEach(async function () {
+            each(
+              [
+                { email: 'playpus@pix.fr' },
+                { email: 'panda@pix.fr' },
+                { email: 'otter@pix.fr' },
+                { email: 'playpus@example.net' },
+                { email: 'panda@example.net' },
+                { email: 'PANDA@example.net' },
+                { email: 'PANDA@PIX.be' },
+              ],
+              (user) => {
+                databaseBuilder.factory.buildUser(user);
+              },
+            );
+
+            await databaseBuilder.commit();
+          });
+
+          it('should return only users matching "email" if given in filter even if it is in uppercase in database', async function () {
+            // given
+            const filter = { email: 'panda' };
+            const page = { number: 1, size: 10 };
+            const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 4 };
+
+            // when
+            const { models: matchingUsers, pagination } = await userRepository.findPaginatedFiltered({ filter, page });
+
+            // then
+            expect(map(matchingUsers, 'email')).to.have.members([
+              'panda@pix.fr',
+              'panda@example.net',
+              'panda@example.net',
+              'panda@pix.be',
+            ]);
+            expect(pagination).to.deep.equal(expectedPagination);
+          });
+
+          it('should return only users matching "email" if given in filter', async function () {
+            // given
+            const filter = { email: 'pix.fr' };
             const page = { number: 1, size: 10 };
             const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 3 };
 
@@ -505,22 +409,168 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
             const { models: matchingUsers, pagination } = await userRepository.findPaginatedFiltered({ filter, page });
 
             // then
-            expect(map(matchingUsers, 'firstName')).to.have.members(['fn_ok_1', 'fn_ok_2', 'fn_ok_3']);
-            expect(map(matchingUsers, 'lastName')).to.have.members(['ln_ok_1', 'ln_ok_2', 'ln_ok_3']);
-            expect(map(matchingUsers, 'email')).to.have.members([
-              'email_ok_1@mail.com',
-              'email_ok_2@mail.com',
-              'email_ok_3@mail.com',
-            ]);
-            expect(map(matchingUsers, 'username')).to.have.members([
-              'username_ok0210',
-              'username_ok1214',
-              'username_ok1010',
-            ]);
+            expect(map(matchingUsers, 'email')).to.have.members(['playpus@pix.fr', 'panda@pix.fr', 'otter@pix.fr']);
             expect(pagination).to.deep.equal(expectedPagination);
           });
-        },
-      );
+        });
+
+        context('when there are multiple users matching the same "username" search pattern', function () {
+          it('should return only users matching "username" if given in filter', async function () {
+            // given
+            each(
+              [
+                { username: 'alex.ception1011' },
+                { username: 'alex.terieur1011' },
+                { username: 'ella.danloss0101' },
+                { username: 'ella.bienhu1011' },
+                { username: 'ella.bienhu2312' },
+              ],
+              (user) => {
+                databaseBuilder.factory.buildUser(user);
+              },
+            );
+            await databaseBuilder.commit();
+            const filter = { username: '1011' };
+            const page = { number: 1, size: 10 };
+
+            // when
+            const { models: matchingUsers } = await userRepository.findPaginatedFiltered({ filter, page });
+
+            // then
+            expect(map(matchingUsers, 'username')).to.have.members([
+              'alex.ception1011',
+              'alex.terieur1011',
+              'ella.bienhu1011',
+            ]);
+          });
+        });
+
+        context(
+          'when there are multiple users matching the fields "first name", "last name" and "email" search pattern',
+          function () {
+            beforeEach(async function () {
+              each(
+                [
+                  // Matching users
+                  {
+                    firstName: 'fn_ok_1',
+                    lastName: 'ln_ok_1',
+                    email: 'email_ok_1@mail.com',
+                    username: 'username_ok0210',
+                  },
+                  {
+                    firstName: 'fn_ok_2',
+                    lastName: 'ln_ok_2',
+                    email: 'email_ok_2@mail.com',
+                    username: 'username_ok1214',
+                  },
+                  {
+                    firstName: 'fn_ok_3',
+                    lastName: 'ln_ok_3',
+                    email: 'email_ok_3@mail.com',
+                    username: 'username_ok1010',
+                  },
+
+                  // Unmatching users
+                  {
+                    firstName: 'fn_ko_4',
+                    lastName: 'ln_ok_4',
+                    email: 'email_ok_4@mail.com',
+                    username: 'username_ko1309',
+                  },
+                  {
+                    firstName: 'fn_ok_5',
+                    lastName: 'ln_ko_5',
+                    email: 'email_ok_5@mail.com',
+                    username: 'username_ok1911',
+                  },
+                  {
+                    firstName: 'fn_ok_6',
+                    lastName: 'ln_ok_6',
+                    email: 'email_ko_6@mail.com',
+                    username: 'username_ok2010',
+                  },
+                ],
+                (user) => {
+                  databaseBuilder.factory.buildUser(user);
+                },
+              );
+
+              await databaseBuilder.commit();
+            });
+
+            it('should return only users matching "first name" AND "last name" AND "email" AND "username" if given in filter', async function () {
+              // given
+              const filter = { firstName: 'fn_ok', lastName: 'ln_ok', email: 'email_ok', username: 'username_ok' };
+              const page = { number: 1, size: 10 };
+              const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 3 };
+
+              // when
+              const { models: matchingUsers, pagination } = await userRepository.findPaginatedFiltered({
+                filter,
+                page,
+              });
+
+              // then
+              expect(map(matchingUsers, 'firstName')).to.have.members(['fn_ok_1', 'fn_ok_2', 'fn_ok_3']);
+              expect(map(matchingUsers, 'lastName')).to.have.members(['ln_ok_1', 'ln_ok_2', 'ln_ok_3']);
+              expect(map(matchingUsers, 'email')).to.have.members([
+                'email_ok_1@mail.com',
+                'email_ok_2@mail.com',
+                'email_ok_3@mail.com',
+              ]);
+              expect(map(matchingUsers, 'username')).to.have.members([
+                'username_ok0210',
+                'username_ok1214',
+                'username_ok1010',
+              ]);
+              expect(pagination).to.deep.equal(expectedPagination);
+            });
+          },
+        );
+      });
+      context('when exact search is required', function () {
+        beforeEach(function () {
+          databaseBuilder.factory.buildUser({ firstName: 'Son Gohan' });
+          databaseBuilder.factory.buildUser({ firstName: 'Son Goku' });
+          databaseBuilder.factory.buildUser({ firstName: 'Son Goten' });
+          databaseBuilder.factory.buildUser({ firstName: 'Vegeta' });
+          databaseBuilder.factory.buildUser({ firstName: 'Piccolo' });
+          return databaseBuilder.commit();
+        });
+        it('should return only exact "first name" matching if given in filter', async function () {
+          // given
+          const filter = { firstName: 'Son Gohan' };
+          const page = { number: 1, size: 10 };
+
+          // when
+          const { models: matchingUsers } = await userRepository.findPaginatedFiltered({
+            filter,
+            page,
+            queryType: 'EXACT_QUERY',
+          });
+
+          // then
+          expect(map(matchingUsers, 'firstName')).to.have.members(['Son Gohan']);
+        });
+        it('should return no matching if matching is fuzzy', async function () {
+          // given
+          const filter = { firstName: 'Go' };
+          const page = { number: 1, size: 10 };
+          const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 0, rowCount: 0 };
+
+          // when
+          const { models: matchingUsers, pagination } = await userRepository.findPaginatedFiltered({
+            filter,
+            page,
+            queryType: 'EXACT_QUERY',
+          });
+
+          // then
+          expect(map(matchingUsers, 'firstName')).to.be.empty;
+          expect(pagination).to.deep.equal(expectedPagination);
+        });
+      });
     });
 
     describe('#findAnotherUserByEmail', function () {

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
@@ -101,7 +101,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
   describe('find user', function () {
     describe('#findByExternalIdentifier', function () {
       context('when identityProvider is generic', function () {
-        it('should return user informations for the given external identity id and identity provider', async function () {
+        it('returns user informations for the given external identity id and identity provider', async function () {
           // given
           const externalIdentityId = 'external-identity-id';
           const userId = databaseBuilder.factory.buildUser().id;
@@ -125,7 +125,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       });
 
       context('when identityProvider is POLE_EMPLOI', function () {
-        it('should return user informations for the given external identity id and identity provider', async function () {
+        it('returns user informations for the given external identity id and identity provider', async function () {
           // given
           const externalIdentityId = 'external-identity-id';
           const userId = databaseBuilder.factory.buildUser().id;
@@ -147,7 +147,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         });
       });
 
-      it('should return undefined when no user was found with this external identity id', async function () {
+      it('returns undefined when no user was found with this external identity id', async function () {
         // given
         const badId = 'not-exist-external-identity-id';
 
@@ -161,7 +161,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         return expect(foundUser).to.be.null;
       });
 
-      it('should return null when the identity provider provided is PIX', async function () {
+      it('returns null when the identity provider provided is PIX', async function () {
         // given
         const externalIdentityId = 'external-identity-id';
         const userId = databaseBuilder.factory.buildUser().id;
@@ -183,7 +183,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
 
     describe('#findPaginatedFiltered', function () {
       context('when there are users in the database', function () {
-        it('should return an array of users', async function () {
+        it('returns an array of users', async function () {
           // given
           const filter = {};
           const page = { number: 1, size: 10 };
@@ -281,7 +281,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       });
 
       context('when there are lots of users (> 10) in the database', function () {
-        it('should return paginated matching users', async function () {
+        it('returns paginated matching users', async function () {
           // given
           const filter = {};
           const page = { number: 1, size: 3 };
@@ -308,7 +308,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
             return databaseBuilder.commit();
           });
 
-          it('should return only users matching "first name" if given in filter', async function () {
+          it('returns only users matching "first name" if given in filter', async function () {
             // given
             const filter = { firstName: 'Go' };
             const page = { number: 1, size: 10 };
@@ -341,7 +341,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
             await databaseBuilder.commit();
           });
 
-          it('should return only users matching "last name" if given in filter', async function () {
+          it('returns only users matching "last name" if given in filter', async function () {
             // given
             const filter = { lastName: 'walk' };
             const page = { number: 1, size: 10 };
@@ -380,7 +380,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
             await databaseBuilder.commit();
           });
 
-          it('should return only users matching "email" if given in filter even if it is in uppercase in database', async function () {
+          it('returns only users matching "email" if given in filter even if it is in uppercase in database', async function () {
             // given
             const filter = { email: 'panda' };
             const page = { number: 1, size: 10 };
@@ -399,7 +399,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
             expect(pagination).to.deep.equal(expectedPagination);
           });
 
-          it('should return only users matching "email" if given in filter', async function () {
+          it('returns only users matching "email" if given in filter', async function () {
             // given
             const filter = { email: 'pix.fr' };
             const page = { number: 1, size: 10 };
@@ -415,7 +415,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         });
 
         context('when there are multiple users matching the same "username" search pattern', function () {
-          it('should return only users matching "username" if given in filter', async function () {
+          it('returns only users matching "username" if given in filter', async function () {
             // given
             each(
               [
@@ -499,7 +499,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
               await databaseBuilder.commit();
             });
 
-            it('should return only users matching "first name" AND "last name" AND "email" AND "username" if given in filter', async function () {
+            it('returns only users matching "first name" AND "last name" AND "email" AND "username" if given in filter', async function () {
               // given
               const filter = { firstName: 'fn_ok', lastName: 'ln_ok', email: 'email_ok', username: 'username_ok' };
               const page = { number: 1, size: 10 };
@@ -538,7 +538,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
           databaseBuilder.factory.buildUser({ firstName: 'Piccolo' });
           return databaseBuilder.commit();
         });
-        it('should return only exact "first name" matching if given in filter', async function () {
+        it('returns only exact "first name" matching if given in filter', async function () {
           // given
           const filter = { firstName: 'Son Gohan' };
           const page = { number: 1, size: 10 };
@@ -553,7 +553,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
           // then
           expect(map(matchingUsers, 'firstName')).to.have.members(['Son Gohan']);
         });
-        it('should return no matching if matching is fuzzy', async function () {
+        it('returns no matching if matching is fuzzy', async function () {
           // given
           const filter = { firstName: 'Go' };
           const page = { number: 1, size: 10 };
@@ -574,7 +574,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
     });
 
     describe('#findAnotherUserByEmail', function () {
-      it('should return a list of a single user if email already used', async function () {
+      it('returns a list of a single user if email already used', async function () {
         // given
         const currentUser = databaseBuilder.factory.buildUser({
           email: 'current.user@example.net',
@@ -593,7 +593,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         expect(foundUsers[0].email).to.equal(anotherUser.email);
       });
 
-      it('should return a list of a single user if email case insensitive already used', async function () {
+      it('returns a list of a single user if email case insensitive already used', async function () {
         // given
         const currentUser = databaseBuilder.factory.buildUser({
           email: 'current.user@example.net',
@@ -612,7 +612,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         expect(foundUsers[0].email).to.equal(anotherUser.email);
       });
 
-      it('should return an empty list if email is not used', async function () {
+      it('returns an empty list if email is not used', async function () {
         // given
         const currentUser = databaseBuilder.factory.buildUser({
           email: 'current.user@example.net',
@@ -628,7 +628,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
     });
 
     describe('#findAnotherUserByUsername', function () {
-      it('should return a list of a single user if username already used', async function () {
+      it('returns a list of a single user if username already used', async function () {
         // given
         const currentUser = databaseBuilder.factory.buildUser({
           username: 'current.user.name',
@@ -647,7 +647,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         expect(foundUsers[0].username).to.equal(anotherUser.username);
       });
 
-      it('should return an empty list if username is not used', async function () {
+      it('returns an empty list if username is not used', async function () {
         // given
         const currentUser = databaseBuilder.factory.buildUser({
           username: 'current.user.name',
@@ -665,7 +665,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
 
   describe('get user', function () {
     describe('#getByEmail', function () {
-      it('should handle a rejection, when user id is not found', async function () {
+      it('handles a rejection, when user id is not found', async function () {
         // given
         const emailThatDoesNotExist = '10093';
 
@@ -676,7 +676,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         expect(result).to.be.instanceOf(UserNotFoundError);
       });
 
-      it('should return the user with email case insensitive', async function () {
+      it('returns the user with email case insensitive', async function () {
         // given
         const mixCaseEmail = 'USER@example.net';
         const userInDb = databaseBuilder.factory.buildUser({ email: mixCaseEmail });
@@ -703,7 +703,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         await databaseBuilder.commit();
       });
 
-      it('should return user informations for the given SAML ID', async function () {
+      it('returns user informations for the given SAML ID', async function () {
         // when
         const user = await userRepository.getBySamlId('some-saml-id');
 
@@ -712,7 +712,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         expect(user.id).to.equal(userInDb.id);
       });
 
-      it('should return undefined when no user was found with this SAML ID', async function () {
+      it('returns undefined when no user was found with this SAML ID', async function () {
         // given
         const badSamlId = 'bad-saml-id';
 
@@ -725,7 +725,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
     });
 
     describe('#get', function () {
-      it('should return the found user', async function () {
+      it('returns the found user', async function () {
         // given
         const userInDb = databaseBuilder.factory.buildUser(userToInsert);
         await databaseBuilder.commit();
@@ -744,7 +744,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         expect(user.updatedAt.toISOString()).to.equal('2019-03-12T19:37:03.000Z');
       });
 
-      it('should return a UserNotFoundError if no user is found', async function () {
+      it('returns a UserNotFoundError if no user is found', async function () {
         // given
         const nonExistentUserId = 678;
 
@@ -784,7 +784,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         await _insertUserWithOrganizationsAndCertificationCenterAccesses();
       });
 
-      it('should return user informations for the given email', async function () {
+      it('returns user informations for the given email', async function () {
         // given
         const expectedUser = new User(userInDB);
 
@@ -802,7 +802,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         expect(foundUser.locale).to.equal(expectedUser.locale);
       });
 
-      it('should return user informations for the given email (case insensitive)', async function () {
+      it('returns user informations for the given email (case insensitive)', async function () {
         // given
         const expectedUser = new User(userInDB);
         const uppercaseEmailAlreadyInDb = userInDB.email.toUpperCase();
@@ -816,7 +816,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         expect(foundUser.email).to.equal(expectedUser.email);
       });
 
-      it('should return user informations for the given username (case insensitive)', async function () {
+      it('returns user informations for the given username (case insensitive)', async function () {
         // given
         const savedUser = databaseBuilder.factory.buildUser({
           username: 'thomas123',
@@ -839,7 +839,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         expect(foundUser.cgu).to.equal(savedUser.cgu);
       });
 
-      it('should return authenticationMethods associated to the user', async function () {
+      it('returns authenticationMethods associated to the user', async function () {
         // when
         const foundUser = await userRepository.getByUsernameOrEmailWithRolesAndPassword(userInDB.email);
 
@@ -856,7 +856,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         );
       });
 
-      it('should only return actives certification center membership associated to the user', async function () {
+      it('only returns actives certification center membership associated to the user', async function () {
         // given
         const email = 'lilou@example.net';
         const user = databaseBuilder.factory.buildUser({ email });
@@ -882,7 +882,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         expect(certificationCenterMembership.id).to.equal(activeCertificationCenterMembership.id);
       });
 
-      it('should return membership associated to the user', async function () {
+      it('returns membership associated to the user', async function () {
         // when
         const user = await userRepository.getByUsernameOrEmailWithRolesAndPassword(userInDB.email);
 
@@ -917,7 +917,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         });
       });
 
-      it('should return certification center membership associated to the user', async function () {
+      it('returns certification center membership associated to the user', async function () {
         // given
         const user = databaseBuilder.factory.buildUser({ email: 'super@example.net' });
         const certificationCenterMembershipId = databaseBuilder.factory.buildCertificationCenterMembership({
@@ -937,7 +937,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         expect(firstCertificationCenterMembership.id).to.equal(certificationCenterMembershipId);
       });
 
-      it('should reject with a UserNotFound error when no user was found with this email', async function () {
+      it('rejects with a UserNotFound error when no user was found with this email', async function () {
         // given
         const unusedEmail = 'kikou@pix.fr';
 
@@ -948,7 +948,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         expect(result).to.be.instanceOf(UserNotFoundError);
       });
 
-      it('should reject with a UserNotFound error when no user was found with this username', async function () {
+      it('rejects with a UserNotFound error when no user was found with this username', async function () {
         // given
         const unusedUsername = 'john.doe0909';
 
@@ -961,7 +961,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
     });
 
     describe('#getWithMemberships', function () {
-      it('should return user with his/her membership(s) for the given id', async function () {
+      it('returns user with his/her membership(s) for the given id', async function () {
         // given
         const user = databaseBuilder.factory.buildUser.withRawPassword({
           firstName: 'Sarah',
@@ -1010,7 +1010,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       });
 
       context('when the membership associated to the user has been disabled', function () {
-        it('should not return the membership', async function () {
+        it('does not return the membership', async function () {
           // given
           const userId = databaseBuilder.factory.buildUser().id;
           const organizationId = databaseBuilder.factory.buildOrganization().id;
@@ -1030,7 +1030,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         });
       });
 
-      it('should reject with a UserNotFound error when no user was found with the given id', async function () {
+      it('rejects with a UserNotFound error when no user was found with the given id', async function () {
         // given
         const unknownUserId = 666;
 
@@ -1043,7 +1043,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
     });
 
     describe('#getWithCertificationCenterMemberships', function () {
-      it('should return user for the given id', async function () {
+      it('returns user for the given id', async function () {
         // given
         await _insertUserWithOrganizationsAndCertificationCenterAccesses();
         const expectedUser = new User(userInDB);
@@ -1061,7 +1061,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         expect(user.cgu).to.equal(expectedUser.cgu);
       });
 
-      it('should return actives certification center membership associated to the user', async function () {
+      it('returns actives certification center membership associated to the user', async function () {
         // when
         const userInDB = databaseBuilder.factory.buildUser(userToInsert);
         const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
@@ -1094,7 +1094,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         expect(associatedCertificationCenter.name).to.equal(certificationCenter.name);
       });
 
-      it('should reject with a UserNotFound error when no user was found with the given id', async function () {
+      it('rejects with a UserNotFound error when no user was found with the given id', async function () {
         // given
         await _insertUserWithOrganizationsAndCertificationCenterAccesses();
         const unknownUserId = 666;
@@ -1108,7 +1108,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
     });
 
     describe('#getForObfuscation', function () {
-      it('should return a domain user with authentication methods only when found', async function () {
+      it('returns a domain user with authentication methods only when found', async function () {
         // given
         const userInDb = databaseBuilder.factory.buildUser(userToInsert);
         await databaseBuilder.commit();
@@ -1121,7 +1121,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         expect(user.email).to.equal(userInDb.email);
       });
 
-      it('should throw an error when user not found', async function () {
+      it('throws an error when user not found', async function () {
         // given
         const userIdThatDoesNotExist = '99999';
 
@@ -1134,7 +1134,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
     });
 
     describe('#getUserDetailsForAdmin', function () {
-      it('should return the found user', async function () {
+      it('returns the found user', async function () {
         // given
         const createdAt = new Date('2021-01-01');
         const emailConfirmedAt = new Date('2022-01-01');
@@ -1183,7 +1183,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         expect(userDetailsForAdmin.isPixAgent).to.be.false;
       });
 
-      it('should return a UserNotFoundError if no user is found', async function () {
+      it('returns a UserNotFoundError if no user is found', async function () {
         // given
         const nonExistentUserId = 678;
 
@@ -1195,7 +1195,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       });
 
       context('when user has organizationLearners', function () {
-        it('should return the user with his organizationLearner', async function () {
+        it('returns the user with his organizationLearner', async function () {
           // given
           const randomUser = databaseBuilder.factory.buildUser();
           const userInDB = databaseBuilder.factory.buildUser(userToInsert);
@@ -1287,7 +1287,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       });
 
       context("when user doesn't have organizationLearners", function () {
-        it('should return the user with an empty array', async function () {
+        it('returns the user with an empty array', async function () {
           // given
           const userInDB = databaseBuilder.factory.buildUser(userToInsert);
           await databaseBuilder.commit();
@@ -1330,7 +1330,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       });
 
       context('when user is anonymized', function () {
-        it('should return an empty array of authenticationMethods', async function () {
+        it('returns an empty array of authenticationMethods', async function () {
           // given
           const userInDB = databaseBuilder.factory.buildUser({
             ...userToInsert,
@@ -1350,7 +1350,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
           expect(hasBeenAnonymisedBy).to.equal(1);
         });
 
-        it("should return the anonymisedBy's first and last names", async function () {
+        it("returns the anonymisedBy's first and last names", async function () {
           // given
           const adminWhoAnonymisedUser = databaseBuilder.factory.buildUser({
             id: 1,
@@ -1375,7 +1375,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       });
 
       context('when user has login details', function () {
-        it('should return the user with his login details', async function () {
+        it('returns the user with his login details', async function () {
           // given
           const userInDB = databaseBuilder.factory.buildUser(userToInsert);
           databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
@@ -1438,7 +1438,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
     });
 
     describe('#updateEmail', function () {
-      it('should update the user email', async function () {
+      it('updates the user email', async function () {
         // given
         const newEmail = 'new_email@example.net';
         const userInDb = databaseBuilder.factory.buildUser({ ...userToInsert, email: 'old_email@example.net' });
@@ -1486,7 +1486,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         await databaseBuilder.commit();
       });
 
-      it('should update the user email', async function () {
+      it('updates the user email', async function () {
         // given
         const newEmail = 'new_email@example.net';
         const userAttributes = {
@@ -1506,7 +1506,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         expect(updatedUser.updatedAt).to.deep.equal(now);
       });
 
-      it('should rollback the user email in case of error in transaction', async function () {
+      it('rolls back the user email in case of error in transaction', async function () {
         // given
         const newEmail = 'new_email@example.net';
         const userAttributes = {
@@ -1631,7 +1631,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
     });
 
     describe('#updateUsername', function () {
-      it('should update the username', async function () {
+      it('updates the username', async function () {
         // given
         const username = 'blue.carter0701';
         const userId = databaseBuilder.factory.buildUser(userToInsert).id;
@@ -1649,7 +1649,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         expect(updatedUser.updatedAt).to.deep.equal(now);
       });
 
-      it('should throw UserNotFoundError when user id not found', async function () {
+      it('throws UserNotFoundError when user id not found', async function () {
         // given
         const wrongUserId = 0;
         const username = 'blue.carter0701';
@@ -1666,7 +1666,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
     });
 
     describe('#updatePixOrgaTermsOfServiceAcceptedToTrue', function () {
-      it('should return the model with pixOrgaTermsOfServiceAccepted flag updated to true', async function () {
+      it('returns the model with pixOrgaTermsOfServiceAccepted flag updated to true', async function () {
         // given
         const userId = databaseBuilder.factory.buildUser({ pixOrgaTermsOfServiceAccepted: false }).id;
         await databaseBuilder.commit();
@@ -1679,7 +1679,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         expect(result.pixOrgaTermsOfServiceAccepted).to.be.true;
       });
 
-      it('should update the lastPixOrgaTermsOfServiceValidatedAt', async function () {
+      it('updates the lastPixOrgaTermsOfServiceValidatedAt', async function () {
         // given
         const user = databaseBuilder.factory.buildUser({
           pixOrgaTermsOfServiceAccepted: true,
@@ -1697,7 +1697,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
     });
 
     describe('#updatePixCertifTermsOfServiceAcceptedToTrue', function () {
-      it('should return the model with pixCertifTermsOfServiceAccepted flag updated to true', async function () {
+      it('returns the model with pixCertifTermsOfServiceAccepted flag updated to true', async function () {
         // given
         const userId = databaseBuilder.factory.buildUser({ pixCertifTermsOfServiceAccepted: false }).id;
         await databaseBuilder.commit();
@@ -1710,7 +1710,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         expect(actualUser.pixCertifTermsOfServiceAccepted).to.be.true;
       });
 
-      it('should update the pixCertifTermsOfServiceValidatedAt', async function () {
+      it('updates the pixCertifTermsOfServiceValidatedAt', async function () {
         // given
         const user = databaseBuilder.factory.buildUser({
           pixCertifTermsOfServiceAccepted: true,
@@ -1728,7 +1728,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
     });
 
     describe('#updateHasSeenAssessmentInstructionsToTrue', function () {
-      it('should return the model with hasSeenAssessmentInstructions flag updated to true', async function () {
+      it('returns the model with hasSeenAssessmentInstructions flag updated to true', async function () {
         // given
         const userId = databaseBuilder.factory.buildUser({ hasSeenAssessmentInstructions: false }).id;
         await databaseBuilder.commit();
@@ -1743,7 +1743,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
     });
 
     describe('#updateHasSeenNewDashboardInfoToTrue', function () {
-      it('should return the model with hasSeenNewDashboardInfo flag updated to true', async function () {
+      it('returns the model with hasSeenNewDashboardInfo flag updated to true', async function () {
         // given
         const userId = databaseBuilder.factory.buildUser({ hasSeenNewDashboardInfo: false }).id;
         await databaseBuilder.commit();
@@ -1768,7 +1768,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         return databaseBuilder.commit();
       });
 
-      it('should return the model with hasSeenFocusedChallengeTooltip flag updated to true', async function () {
+      it('returns the model with hasSeenFocusedChallengeTooltip flag updated to true', async function () {
         // when
         const challengeType = 'focused';
         const actualUser = await userRepository.updateHasSeenChallengeTooltip({ userId, challengeType });
@@ -1778,7 +1778,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         expect(actualUser.updatedAt).to.deep.equal(now);
       });
 
-      it('should return the model with hasSeenOtherChallengesTooltip flag updated to true', async function () {
+      it('returns the model with hasSeenOtherChallengesTooltip flag updated to true', async function () {
         // when
         const challengeType = 'other';
         const actualUser = await userRepository.updateHasSeenChallengeTooltip({ userId, challengeType });
@@ -1791,7 +1791,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
   });
 
   describe('#checkIfEmailIsAvailable', function () {
-    it('should return the email when the email is not registered', async function () {
+    it('returns the email when the email is not registered', async function () {
       // when
       const email = await userRepository.checkIfEmailIsAvailable('email@example.net');
 
@@ -1835,12 +1835,12 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       return databaseBuilder.commit();
     });
 
-    it('should return true when the user exists by email', async function () {
+    it('returns true when the user exists by email', async function () {
       const userExists = await userRepository.isUserExistingByEmail(email);
       expect(userExists).to.be.true;
     });
 
-    it('should return true when the user exists by email (case insensitive)', async function () {
+    it('returns true when the user exists by email (case insensitive)', async function () {
       // given
       const uppercaseEmailAlreadyInDb = email.toUpperCase();
 
@@ -1851,14 +1851,14 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       expect(userExists).to.be.true;
     });
 
-    it('should throw an error when the user does not exist by email', async function () {
+    it('throws an error when the user does not exist by email', async function () {
       const err = await catchErr(userRepository.isUserExistingByEmail)('none');
       expect(err).to.be.instanceOf(UserNotFoundError);
     });
   });
 
   describe('#acceptPixLastTermsOfService', function () {
-    it('should validate the last terms of service and save the date of acceptance ', async function () {
+    it('validates the last terms of service and save the date of acceptance ', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser({
         mustValidateTermsOfService: true,
@@ -1880,7 +1880,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
   describe('#isUsernameAvailable', function () {
     const username = 'abc.def0101';
 
-    it("should return username when it doesn't exist", async function () {
+    it("returns username when it doesn't exist", async function () {
       // when
       const result = await userRepository.isUsernameAvailable(username);
 
@@ -1888,7 +1888,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       expect(result).to.equal(username);
     });
 
-    it('should throw AlreadyRegisteredUsernameError when username already exist', async function () {
+    it('throws AlreadyRegisteredUsernameError when username already exist', async function () {
       // given
       databaseBuilder.factory.buildUser({
         username,

--- a/api/tests/identity-access-management/unit/application/user/user.admin.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/user/user.admin.controller.test.js
@@ -49,7 +49,7 @@ describe('Unit | Identity Access Management | Application | Controller | Admin |
 
     it('allows to filter users by first name', async function () {
       // given
-      const query = { filter: { firstName: 'Alexia' }, page: {} };
+      const query = { filter: { firstName: 'Alexia' }, page: {}, queryType: 'CONTAINS' };
       const request = { query };
       usecases.findPaginatedFilteredUsers.resolves({ models: {}, pagination: {} });
 
@@ -62,7 +62,7 @@ describe('Unit | Identity Access Management | Application | Controller | Admin |
 
     it('allows to filter users by last name', async function () {
       // given
-      const query = { filter: { lastName: 'Granjean' }, page: {} };
+      const query = { filter: { lastName: 'Granjean' }, page: {}, queryType: 'CONTAINS' };
       const request = { query };
       usecases.findPaginatedFilteredUsers.resolves({ models: {}, pagination: {} });
 
@@ -75,7 +75,7 @@ describe('Unit | Identity Access Management | Application | Controller | Admin |
 
     it('allows to filter users by email', async function () {
       // given
-      const query = { filter: { email: 'alexiagranjean' }, page: {} };
+      const query = { filter: { email: 'alexiagranjean' }, page: {}, queryType: 'CONTAINS' };
       const request = { query };
       usecases.findPaginatedFilteredUsers.resolves({ models: {}, pagination: {} });
 
@@ -88,7 +88,7 @@ describe('Unit | Identity Access Management | Application | Controller | Admin |
 
     it('allows to paginate on a given page and page size', async function () {
       // given
-      const query = { filter: { email: 'alexiagranjean' }, page: { number: 2, size: 25 } };
+      const query = { filter: { email: 'alexiagranjean' }, page: { number: 2, size: 25 }, queryType: 'CONTAINS' };
       const request = { query };
       usecases.findPaginatedFilteredUsers.resolves({ models: {}, pagination: {} });
 

--- a/api/tests/identity-access-management/unit/application/user/user.admin.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/user/user.admin.controller.test.js
@@ -1,4 +1,5 @@
 import { userAdminController } from '../../../../../src/identity-access-management/application/user/user.admin.controller.js';
+import { QUERY_TYPES } from '../../../../../src/identity-access-management/domain/constants/user-query.js';
 import { User } from '../../../../../src/identity-access-management/domain/models/User.js';
 import { usecases } from '../../../../../src/identity-access-management/domain/usecases/index.js';
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
@@ -49,7 +50,7 @@ describe('Unit | Identity Access Management | Application | Controller | Admin |
 
     it('allows to filter users by first name', async function () {
       // given
-      const query = { filter: { firstName: 'Alexia' }, page: {}, queryType: 'CONTAINS' };
+      const query = { filter: { firstName: 'Alexia' }, page: {}, queryType: QUERY_TYPES.CONTAINS };
       const request = { query };
       usecases.findPaginatedFilteredUsers.resolves({ models: {}, pagination: {} });
 
@@ -62,7 +63,7 @@ describe('Unit | Identity Access Management | Application | Controller | Admin |
 
     it('allows to filter users by last name', async function () {
       // given
-      const query = { filter: { lastName: 'Granjean' }, page: {}, queryType: 'CONTAINS' };
+      const query = { filter: { lastName: 'Granjean' }, page: {}, queryType: QUERY_TYPES.CONTAINS };
       const request = { query };
       usecases.findPaginatedFilteredUsers.resolves({ models: {}, pagination: {} });
 
@@ -75,7 +76,7 @@ describe('Unit | Identity Access Management | Application | Controller | Admin |
 
     it('allows to filter users by email', async function () {
       // given
-      const query = { filter: { email: 'alexiagranjean' }, page: {}, queryType: 'CONTAINS' };
+      const query = { filter: { email: 'alexiagranjean' }, page: {}, queryType: QUERY_TYPES.CONTAINS };
       const request = { query };
       usecases.findPaginatedFilteredUsers.resolves({ models: {}, pagination: {} });
 
@@ -88,7 +89,11 @@ describe('Unit | Identity Access Management | Application | Controller | Admin |
 
     it('allows to paginate on a given page and page size', async function () {
       // given
-      const query = { filter: { email: 'alexiagranjean' }, page: { number: 2, size: 25 }, queryType: 'CONTAINS' };
+      const query = {
+        filter: { email: 'alexiagranjean' },
+        page: { number: 2, size: 25 },
+        queryType: QUERY_TYPES.CONTAINS,
+      };
       const request = { query };
       usecases.findPaginatedFilteredUsers.resolves({ models: {}, pagination: {} });
 

--- a/api/tests/identity-access-management/unit/domain/usecases/find-paginated-filtered-users.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/find-paginated-filtered-users.usecase.test.js
@@ -1,3 +1,4 @@
+import { QUERY_TYPES } from '../../../../../src/identity-access-management/domain/constants/user-query.js';
 import { User } from '../../../../../src/identity-access-management/domain/models/User.js';
 import { usecases } from '../../../../../src/identity-access-management/domain/usecases/index.js';
 import { expect, sinon } from '../../../../test-helper.js';
@@ -7,7 +8,7 @@ describe('Unit | Identity Access Management | UseCase | find-paginated-filtered-
     // given
     const filter = { email: 'gigi@example.net' };
     const page = { number: 1, size: 2 };
-    const queryType = 'CONTAINS';
+    const queryType = QUERY_TYPES.CONTAINS;
     const resolvedPagination = { page: 1, pageSize: 2, itemsCount: 3, pagesCount: 2 };
     const matchingUsers = [new User({ id: 1 }), new User({ id: 2 }), new User({ id: 3 })];
     const userRepository = {

--- a/api/tests/identity-access-management/unit/domain/usecases/find-paginated-filtered-users.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/find-paginated-filtered-users.usecase.test.js
@@ -7,18 +7,18 @@ describe('Unit | Identity Access Management | UseCase | find-paginated-filtered-
     // given
     const filter = { email: 'gigi@example.net' };
     const page = { number: 1, size: 2 };
-
+    const queryType = 'CONTAINS';
     const resolvedPagination = { page: 1, pageSize: 2, itemsCount: 3, pagesCount: 2 };
     const matchingUsers = [new User({ id: 1 }), new User({ id: 2 }), new User({ id: 3 })];
     const userRepository = {
       findPaginatedFiltered: sinon.stub(),
     };
     userRepository.findPaginatedFiltered
-      .withArgs({ filter, page })
+      .withArgs({ filter, page, queryType })
       .resolves({ models: matchingUsers, pagination: resolvedPagination });
 
     // when
-    const response = await usecases.findPaginatedFilteredUsers({ filter, page, userRepository });
+    const response = await usecases.findPaginatedFilteredUsers({ filter, page, queryType, userRepository });
 
     // then
     expect(response.models).to.equal(matchingUsers);


### PR DESCRIPTION
## :fallen_leaf: Problème

Actuellement la recherche d'utilisateurs sur Pix Admin sur `firstName`, `lastName`, `email`, `username` est réalisée avec l'opérateur PostgreSQL `ILIKE`.

En l'absence d'index adaptés sur ces champs, la recherche est parfois lente.

On veut donc avoir la possibilité de réaliser des recherches exactes qui sont plus rapides.

## :chestnut: Proposition

Ajouter une option pour faire une recherche exacte ou recherche floue/partielle (ex: orga archivée ou non)
Dans Pix Admin, sur la liste des utilisateurs:
- Ajouter un menu déroulant avec deux options : Exacte ou Contient
- Le menu déroulant est placé avant le champ “ID” (validé par le support)
- Par défaut : la valeur “Contient” (validé par le support = usage majoritaire)
- Si l’option “Contient” est choisie alors l’option s’applique pour les champs “prénom, nom, e-mail, identifiant” → faire une recherche de type LIKE en postgre SQL

## :jack_o_lantern: Remarques
ras

## :wood: Pour tester
Sur Pix Admin (onglet "utilisateurs") :
- constater que la recherche par défaut est de type "Contient"
- faire une recherche "Contient" avec le prénom Ad ; vérifier par une requête en base que les utilisateurs affichés sont corrects (7 utilisateurs)
- Constater que la même recherche en minuscules ("ad") renvoie la même liste
- Passer en requête "Exacte", avec le prénom "Ad" : constater que l'utilisateur (un seul) retourné est le même qu'en base
- Faire la même recherche avec le prénom "ad", constater qu'aucun utilisateur n'est affiché
- Nettoyer les champs de recherche (croix à droite), constater que par défaut la recherche est à nouveau de type "Contient"
- Passer la requête en mode "Exacte" et rafraîchir la page pour constater que par défaut la recherche est à nouveau de type "Contient"
- Faire une recherche exacte, changer de page puis revenir sur la page de recherche d'utilisateurs > le type de recherche "Exacte" est maintenu 
