### PR TITLE
[FEATURE] Renvoyer le nombre de challenges possibles dans le simulateur (PIX-15216).

### DIFF
--- a/api/src/certification/flash-certification/application/scenario-simulator-controller.js
+++ b/api/src/certification/flash-certification/application/scenario-simulator-controller.js
@@ -64,6 +64,7 @@ async function simulateFlashAssessmentScenario(
           errorRate: answer.errorRate,
           answerStatus: answer.answerStatus,
           capacity: answer.capacity,
+          numberOfAvailableChallenges: answer.numberOfAvailableChallenges,
         })),
       }) + '\n';
     }

--- a/api/src/certification/flash-certification/domain/models/AssessmentSimulatorSingleMeasureStrategy.js
+++ b/api/src/certification/flash-certification/domain/models/AssessmentSimulatorSingleMeasureStrategy.js
@@ -60,6 +60,7 @@ export class AssessmentSimulatorSingleMeasureStrategy {
           capacity,
           reward,
           answerStatus,
+          numberOfAvailableChallenges: possibleChallenges.length,
         },
       ],
       challengeAnswers: [newAnswer],

--- a/api/tests/acceptance/application/scenario-simulator/scenario-simulator-controller_test.js
+++ b/api/tests/acceptance/application/scenario-simulator/scenario-simulator-controller_test.js
@@ -165,6 +165,7 @@ describe('Acceptance | Controller | scenario-simulator-controller', function () 
       expect(parsedResponse[0].simulationReport[0].reward).to.exist;
       expect(parsedResponse[0].simulationReport[0].errorRate).to.exist;
       expect(parsedResponse[0].simulationReport[0].answerStatus).to.exist;
+      expect(parsedResponse[0].simulationReport[0].numberOfAvailableChallenges).to.exist;
     });
 
     describe('when there is no connected user', function () {

--- a/api/tests/certification/flash-certification/integration/application/scenario-simulator-controller_test.js
+++ b/api/tests/certification/flash-certification/integration/application/scenario-simulator-controller_test.js
@@ -21,19 +21,6 @@ describe('Integration | Application | scenario-simulator-controller', function (
     sinon.stub(pickAnswerStatusService, 'pickAnswerStatusForCapacity');
     sinon.stub(pickChallengeService, 'chooseNextChallenge');
 
-    challenge1 = domainBuilder.buildChallenge({ id: 'chall1', successProbabilityThreshold: 0.65 });
-    reward1 = 0.2;
-    errorRate1 = 0.3;
-    capacity1 = 0.4;
-    simulationResults = [
-      {
-        challenge: challenge1,
-        reward: reward1,
-        errorRate: errorRate1,
-        capacity: capacity1,
-      },
-    ];
-
     httpTestServer = new HttpTestServer();
     await httpTestServer.register(moduleUnderTest);
   });
@@ -52,9 +39,11 @@ describe('Integration | Application | scenario-simulator-controller', function (
             errorRate: errorRate1,
             capacity: capacity1,
             answerStatus: 'ok',
+            numberOfAvailableChallenges: 1,
           },
         ];
       });
+
       context('When configuring the challenge pick probability', function () {
         it('should call simulateFlashAssessmentScenario usecase with correct arguments', async function () {
           // given
@@ -108,6 +97,7 @@ describe('Integration | Application | scenario-simulator-controller', function (
                   reward: reward1,
                   difficulty: challenge1.difficulty,
                   discriminant: challenge1.discriminant,
+                  numberOfAvailableChallenges: 1,
                 },
               ],
             },
@@ -164,6 +154,7 @@ describe('Integration | Application | scenario-simulator-controller', function (
                     reward: reward1,
                     difficulty: challenge1.difficulty,
                     discriminant: challenge1.discriminant,
+                    numberOfAvailableChallenges: 1,
                   },
                 ],
               },
@@ -221,6 +212,7 @@ describe('Integration | Application | scenario-simulator-controller', function (
                     reward: reward1,
                     difficulty: challenge1.difficulty,
                     discriminant: challenge1.discriminant,
+                    numberOfAvailableChallenges: 1,
                   },
                 ],
               },

--- a/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorSingleMeasureStrategy_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorSingleMeasureStrategy_test.js
@@ -111,6 +111,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorSingleMeasureStrategy', fu
                 errorRate: expectedErrorRate,
                 reward: expectedReward,
                 answerStatus: answerForSimulator,
+                numberOfAvailableChallenges: 2,
               },
             ],
             challengeAnswers: [
@@ -248,6 +249,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorSingleMeasureStrategy', fu
                 errorRate: expectedErrorRate,
                 reward: expectedReward,
                 answerStatus: answerForSimulator,
+                numberOfAvailableChallenges: 2,
               },
             ],
             challengeAnswers: [


### PR DESCRIPTION
## :fallen_leaf: Problème

Le simulateur sélectionne des épreuves via une probabilité (challengePickProbability), le souci c’est que cela dépend aussi du nombre de challenges dispos (en principe toujours supérieur à 5 mais non garanti).

Afin de valider les résultats, l'équipe Data demande à avoir l’info pour chaque sélection de challenges de combien de challenges etaient disponibles a ce moment la (par exemple il est possible que a la question 32 pour une capacite 3, que il ne reste pas au moins 5 challenges disponibles pour la fonction `pick-challenge`, surtout avec des filtres comme accessibilité ou une langue autre que le français)

## :chestnut: Proposition

Ajout du paramètre dans le retour du simulateur 

## :jack_o_lantern: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :wood: Pour tester

Vérifier que l'on obtient toujours 5 challenges possibles pour chacune des questions dans le retour du simulateur pour une capacité faible.
Réitérer l'opération avec une capacité élevée et vérifier que le nombre de challenges n'est pas forcément de 5 dans le retour du simulateur.

```
TOKEN=$(curl 'https://api-pr10639.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr10639.review.pix.fr/api/scenario-simulator \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "capacity": 1.5 }' | jq '.'
```