### PR TITLE
[BUGFIX] Améliorer la gestion des cas d'erreurs lors de la création d'un utilisateur (PIX-15393)

### DIFF
--- a/api/src/identity-access-management/infrastructure/repositories/user-to-create.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user-to-create.repository.js
@@ -47,6 +47,8 @@ async function _createWithUsername({ knexConnection, user }) {
     if (error.constraint === 'users_username_unique' && error.code === PGSQL_UNIQUE_CONSTRAINT_VIOLATION_ERROR) {
       throw new OrganizationLearnerAlreadyLinkedToUserError(detail, error.code, meta);
     }
+
+    throw error;
   }
 }
 
@@ -65,6 +67,8 @@ async function _createWithoutUsername({ knexConnection, user }) {
     if (error.constraint === 'users_email_unique' && error.code === PGSQL_UNIQUE_CONSTRAINT_VIOLATION_ERROR) {
       throw new AlreadyRegisteredEmailError();
     }
+
+    throw error;
   }
 }
 

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/user-to-create.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/user-to-create.repository.test.js
@@ -57,6 +57,24 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
           expect(error).to.be.instanceOf(OrganizationLearnerAlreadyLinkedToUserError);
         });
       });
+      context('when firstName field is not defined', function () {
+        it('throws an error', async function () {
+          // given
+          const user = new UserToCreate({
+            lastName: 'lastName',
+            username: 'lastName12',
+            cgu: true,
+            locale: 'fr-FR',
+          });
+          user.firstName = undefined;
+
+          // when
+          const error = await catchErr(userToCreateRepository.create)({ user });
+
+          // then
+          expect(error).to.be.instanceOf(Error);
+        });
+      });
     });
 
     context('when no username is given', function () {
@@ -105,6 +123,24 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
 
           // then
           expect(error).to.be.instanceOf(AlreadyRegisteredEmailError);
+        });
+      });
+      context('when firstName field is not defined', function () {
+        it('throws an error', async function () {
+          // given
+          const user = new UserToCreate({
+            lastName: 'lastName',
+            email: 'email@example.net',
+            cgu: true,
+            locale: 'fr-FR',
+          });
+          user.firstName = undefined;
+
+          // when
+          const error = await catchErr(userToCreateRepository.create)({ user });
+
+          // then
+          expect(error).to.be.instanceOf(Error);
         });
       });
     });


### PR DESCRIPTION
## :fallen_leaf: Problème
Actuellement, en cas d'erreur autre qu'un username ou email existant lors de la création d'un utilisateur dans la méthode [userToCreateRepository.create](https://github.com/1024pix/pix/blob/dev/api/src/identity-access-management/infrastructure/repositories/user-to-create.repository.js#L64), cette erreur n'est pas `throw` ce qui complexifie le débug.

## :chestnut: Proposition
Ajouter un `throw error` pour permettre de continuer l'investigation dessus.

## :jack_o_lantern: Remarques
RAS.

## :wood: Pour tester
- Vérifier que la CI passe.
