### PR TITLE
[BUGFIX] Fix mission title in list display (PIX-15395)

### DIFF
--- a/junior/app/styles/components/mission-card/card.scss
+++ b/junior/app/styles/components/mission-card/card.scss
@@ -91,7 +91,10 @@
         font-size: 22.38px;
         line-height: normal;
         text-align: center;
-        text-wrap: wrap;
+
+        p {
+          white-space: break-spaces;
+        }
       }
 
       .fake-button {


### PR DESCRIPTION
## :fallen_leaf: Problème
Sur iPad (iPadOS 16.7) Safari 16, il y a un problème d'affichage des titres sur la page avec les cartes des missions. Le titre sort de la carte.

![24-11-18 18-16-09 0132](https://github.com/user-attachments/assets/8b305102-8d1b-44c1-9318-e3bedc0bf7e4)

## :chestnut: Proposition
Remplacer `text-wrap` par un `white-space: break-spaces`

## :jack_o_lantern: Remarques
`text-wrap` n'est pas supporté par les anciennes versions de Safari. Nous devons assurer une rétrocompatibilité.

## :wood: Pour tester
- Aller sur l'environnement de RA avec Safari 16.4
- Vérifier que le titre ne sort pas de la carte