### PR TITLE
[BUGFIX] Impossible de seeder en RA (PIX-15448)

### DIFF
--- a/api/db/database-builder/factory/learning-content/build.js
+++ b/api/db/database-builder/factory/learning-content/build.js
@@ -1,5 +1,3 @@
-import nock from 'nock';
-
 import { buildArea } from './build-area.js';
 import { buildChallenge } from './build-challenge.js';
 import { buildCompetence } from './build-competence.js';
@@ -10,6 +8,8 @@ import { buildSkill } from './build-skill.js';
 import { buildThematic } from './build-thematic.js';
 import { buildTube } from './build-tube.js';
 import { buildTutorial } from './build-tutorial.js';
+
+let nock;
 
 export function build(learningContent) {
   learningContent.frameworks?.forEach(buildFramework);
@@ -23,8 +23,12 @@ export function build(learningContent) {
   learningContent.tutorials?.forEach(buildTutorial);
   learningContent.missions?.forEach(buildMission);
 
-  return nock('https://lcms-test.pix.fr/api')
+  return nock?.('https://lcms-test.pix.fr/api')
     .get('/releases/latest')
     .matchHeader('Authorization', 'Bearer test-api-key')
     .reply(200, { content: learningContent });
+}
+
+export function injectNock(value) {
+  nock = value;
 }

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -56,6 +56,9 @@ const databaseBuilder = await DatabaseBuilder.create({
   },
 });
 
+// TEMPORARY WORKAROUND
+databaseBuilder.factory.learningContent.injectNock(nock);
+
 nock.disableNetConnect();
 nock.enableNetConnect('localhost:9090');
 const EMPTY_BLANK_AND_NULL = ['', '\t \n', null];


### PR DESCRIPTION
## :fallen_leaf: Problème
Les seeds en RA crashent à cause d’une dépendance sur `nock` qui est une dépendance de dev.

## :chestnut: Proposition
Solution de contournement temporaire : injecter nock dans le database  builder learningContent pour les tests.

## :jack_o_lantern: Remarques
N/A

## :wood: Pour tester
Vérifier que la RA de cette PR est seedée correctement.