### PR TITLE
[FEATURE] Modififier le texte anglais du tag d'éligibilité à la certification (PIX-15311)

### DIFF
--- a/orga/app/components/campaign/results/profile-list.gjs
+++ b/orga/app/components/campaign/results/profile-list.gjs
@@ -121,7 +121,7 @@ import ParticipationEvolutionIcon from './participation-evolution-icon';
                 {{/if}}
                 <td class="table__column--center hide-on-mobile">
                   {{#if profile.certifiable}}
-                    <PixTag @color="green-light">{{t "pages.profiles-list.table.column.certifiable"}}</PixTag>
+                    <PixTag @color="green-light">{{t "pages.profiles-list.table.column.certifiable-tag"}}</PixTag>
                   {{/if}}
                 </td>
                 <td class="table__column--center hide-on-mobile">

--- a/orga/tests/integration/components/campaign/results/profile-list-test.js
+++ b/orga/tests/integration/components/campaign/results/profile-list-test.js
@@ -387,7 +387,7 @@ module('Integration | Component | Campaign::Results::ProfileList', function (hoo
       // then
       assert.ok(screen.getByRole('cell', { name: '01/02/2020' }));
       assert.ok(screen.getByRole('cell', { name: '10' }));
-      assert.ok(screen.getByRole('cell', { name: 'Certifiable' }));
+      assert.ok(screen.getByRole('cell', { name: t('pages.profiles-list.table.column.certifiable-tag') }));
       assert.ok(screen.getByRole('cell', { name: '5' }));
     });
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1283,6 +1283,7 @@
         "column": {
           "ariaSharedProfileCount": "Number of profiles shared",
           "certifiable": "Eligible for certification",
+          "certifiable-tag": "Eligible",
           "competences-certifiables": "Competences eligible for certification",
           "evolution": "Evolution",
           "first-name": "First name",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1289,6 +1289,7 @@
         "column": {
           "ariaSharedProfileCount": "Nombre de partages de profil",
           "certifiable": "Certifiable",
+          "certifiable-tag": "Certifiable",
           "competences-certifiables": "Comp. certifiables",
           "evolution": "Évolution",
           "first-name": "Prénom",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1281,6 +1281,7 @@
         "column": {
           "ariaSharedProfileCount": "Aantal profielaandelen",
           "certifiable": "Certificeerbaar",
+          "certifiable-tag": "Certificeerbaar",
           "competences-certifiables": "Certificeerbare vaard.",
           "evolution": "Evolutie",
           "first-name": "Voornaam",


### PR DESCRIPTION
## :fallen_leaf: Problème
En anglais, le nom du tag est trop long et redondant avec le header de la colonne

## :chestnut: Proposition
le renommer en "Eligible"

## :jack_o_lantern: Remarques

## :wood: Pour tester
- se connecter sur Pix Orga
- aller sur l'analyse d'une campagne de collecte de profile
- vérifier le tag d'eligibilité