### PR TITLE
[TECH] Ajout d'un format compact de log pour le dev

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -400,6 +400,16 @@ LOG_ENDING_EVENT_DISPATCH=true
 # type: String
 LOG_FOR_HUMANS=true
 
+
+# Logs for humans format
+#
+# "compact": Always display logs on a single line with key information.
+#
+# presence: optional
+# type: String
+# LOG_FOR_HUMANS_FORMAT=compact
+
+
 # Trace email sending in the mailer
 # DEBUG="pix:mailer:email"
 

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -252,6 +252,7 @@ const configuration = (function () {
       enabled: toBoolean(process.env.LOG_ENABLED),
       logLevel: process.env.LOG_LEVEL || 'info',
       logForHumans: _getLogForHumans(),
+      logForHumansCompactFormat: process.env.LOG_FOR_HUMANS_FORMAT === 'compact',
       enableKnexPerformanceMonitoring: toBoolean(process.env.ENABLE_KNEX_PERFORMANCE_MONITORING),
       enableLogStartingEventDispatch: toBoolean(process.env.LOG_STARTING_EVENT_DISPATCH),
       enableLogEndingEventDispatch: toBoolean(process.env.LOG_ENDING_EVENT_DISPATCH),

--- a/api/src/shared/infrastructure/utils/logger.js
+++ b/api/src/shared/infrastructure/utils/logger.js
@@ -1,3 +1,5 @@
+import isEmpty from 'lodash/isEmpty.js';
+import omit from 'lodash/omit.js';
 import pino from 'pino';
 import pretty from 'pino-pretty';
 
@@ -13,6 +15,8 @@ if (logging.logForHumans) {
     colorize: true,
     translateTime: omitDay,
     ignore: 'pid,hostname',
+    messageFormat: logging.logForHumansCompactFormat ? messageFormatCompact : undefined,
+    hideObject: logging.logForHumansCompactFormat,
   });
 }
 
@@ -24,5 +28,48 @@ const logger = pino(
   },
   prettyPrint,
 );
+
+function messageFormatCompact(log, messageKey, _logLevel, { colors }) {
+  const message = log[messageKey];
+  const { err, req, res, responseTime } = log;
+
+  // compact log for errors
+  if (err) {
+    const stack = colors.red(err.stack);
+    return `${message}\n${stack}`;
+  }
+
+  // compact log for HTTP requests
+  if (req && res) {
+    const method = req.method?.toUpperCase();
+
+    const queries = req.metrics?.knexQueryCount ? `sql:${req.metrics.knexQueryCount}` : '';
+    const queriesTime = req.metrics?.knexTotalTimeSpent ? `sql-time:${req.metrics.knexTotalTimeSpent}` : '';
+
+    const statusCode = res.statusCode >= 400 ? colors.red(res.statusCode) : colors.greenBright(res.statusCode);
+    const request = colors.magentaBright([method, req.url].filter(Boolean).join(' '));
+    const details = colors.yellow([queries, queriesTime].filter(Boolean).join(' '));
+    const time = colors.gray(`(${responseTime}ms)`);
+
+    return [statusCode, request, details, time].filter(Boolean).join(' - ');
+  }
+
+  // compact log by default
+  const compactLog = omit(log, [
+    messageKey,
+    'id',
+    'level',
+    'time',
+    'pid',
+    'hostname',
+    'uri',
+    'address',
+    'event',
+    'started',
+    'created',
+  ]);
+  const details = !isEmpty(compactLog) ? colors.gray(JSON.stringify(compactLog)) : '';
+  return `${message} ${details}`;
+}
 
 export { logger };


### PR DESCRIPTION
## :fallen_leaf: Problème

En local, les logs de l'API sont difficiles à lire et suivre. (`LOG_FOR_HUMANS=true`)

## :chestnut: Proposition

Ajout d'un mode "compact" pour l'affichage des logs, désactivé par défaut, et activable via la variable d'environnement `LOG_FOR_HUMANS_FORMAT=compact`.

Ce format de log permet:
- d'avoir les logs toujours sur une seule ligne (avec les infos les plus pertinentes).
- d'afficher les informations de base des requêtes HTTP. (le status, la méthode http, l'url, le nombre de requêtes sql exécutées, le temps) 
- de mettre en évidence les stacks traces des erreurs.
- une coloration syntaxique en fonction des différentes informations.

**Exemple (log compacte):**
![SCR-20241126-lgxz](https://github.com/user-attachments/assets/6d383a59-7688-44b8-897b-f3dddb8b197f)

## :wood: Pour tester

1. En local, ajouter dans votre fichier `.env` la variable d'environnement `LOG_FOR_HUMANS_FORMAT=compact`.
2. Lancer le server de l'api: `npm run dev:api`