### PR TITLE
[BUGFIX] Réparer l'envoi des résultats d'une campagne à accès simplifié (PIX-15440).

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
@@ -43,13 +43,11 @@ export default class EvaluationResultsHero extends Component {
     };
   }
 
-  get isSharableCampaign() {
-    return !this.args.campaign.isSimplifiedAccess;
-  }
-
   get showCustomOrganizationBlock() {
     const hasCustomContent = this.args.campaign.customResultPageText || this.args.campaign.hasCustomResultPageButton;
-    return hasCustomContent && (!this.isSharableCampaign || this.args.campaignParticipationResult.isShared);
+    return (
+      hasCustomContent && (this.args.campaign.isSimplifiedAccess || this.args.campaignParticipationResult.isShared)
+    );
   }
 
   get hasQuestResults() {
@@ -192,7 +190,7 @@ export default class EvaluationResultsHero extends Component {
           </div>
         {{/if}}
 
-        {{#if this.isSharableCampaign}}
+        {{#if @isSharableCampaign}}
           {{#if @campaignParticipationResult.isShared}}
             <PixMessage class="evaluation-results-hero-results__shared-message" @type="success" @withIcon={{true}}>
               {{t "pages.skill-review.hero.shared-message"}}
@@ -215,7 +213,7 @@ export default class EvaluationResultsHero extends Component {
         {{/if}}
 
         <div class="evaluation-results-hero-details__actions">
-          {{#if this.isSharableCampaign}}
+          {{#if @isSharableCampaign}}
             {{#if @campaignParticipationResult.isShared}}
               {{#if @hasTrainings}}
                 <PixButton @triggerAction={{this.handleSeeTrainingsClick}} @size="large">

--- a/mon-pix/app/components/campaigns/assessment/results/quit-results.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/quit-results.gjs
@@ -11,45 +11,48 @@ import { t } from 'ember-intl';
 export default class QuitResults extends Component {
   @tracked showModal = false;
 
+  get shouldShareCampaignResults() {
+    return this.args.isSharableCampaign && !this.args.isCampaignShared;
+  }
+
   @action
   toggleModal() {
     this.showModal = !this.showModal;
   }
 
   <template>
-    {{#if @isCampaignShared}}
-      <LinkTo @route="authenticated" class="evaluation-results-header__back-link">
-        {{t "common.actions.quit"}}
-      </LinkTo>
-    {{else}}
+    {{#if this.shouldShareCampaignResults}}
       <button class="evaluation-results-header__back-link" type="button" {{on "click" this.toggleModal}}>
         {{t "common.actions.quit"}}
       </button>
+      <PixModal
+        @title={{t "pages.evaluation-results.quit-results.modal.title"}}
+        @onCloseButtonClick={{this.toggleModal}}
+        @showModal={{this.showModal}}
+      >
+        <:content>
+          <p class="quit-results__first-paragraph">{{t
+              "pages.evaluation-results.quit-results.modal.content-information"
+            }}</p>
+          <p><strong>{{t "pages.evaluation-results.quit-results.modal.content-instruction"}}</strong></p>
+        </:content>
+
+        <:footer>
+          <div class="quit-results__footer">
+            <PixButton @variant="secondary" @triggerAction={{this.toggleModal}}>
+              {{t "pages.evaluation-results.quit-results.modal.actions.cancel-to-share"}}
+            </PixButton>
+
+            <PixButtonLink @href="authenticated" @variant="primary">
+              {{t "pages.evaluation-results.quit-results.modal.actions.quit-without-sharing"}}
+            </PixButtonLink>
+          </div>
+        </:footer>
+      </PixModal>
+    {{else}}
+      <LinkTo @route="authenticated" class="evaluation-results-header__back-link">
+        {{t "common.actions.quit"}}
+      </LinkTo>
     {{/if}}
-
-    <PixModal
-      @title={{t "pages.evaluation-results.quit-results.modal.title"}}
-      @onCloseButtonClick={{this.toggleModal}}
-      @showModal={{this.showModal}}
-    >
-      <:content>
-        <p class="quit-results__first-paragraph">{{t
-            "pages.evaluation-results.quit-results.modal.content-information"
-          }}</p>
-        <p><strong>{{t "pages.evaluation-results.quit-results.modal.content-instruction"}}</strong></p>
-      </:content>
-
-      <:footer>
-        <div class="quit-results__footer">
-          <PixButton @variant="secondary" @triggerAction={{this.toggleModal}}>
-            {{t "pages.evaluation-results.quit-results.modal.actions.cancel-to-share"}}
-          </PixButton>
-
-          <PixButtonLink @href="authenticated" @variant="primary">
-            {{t "pages.evaluation-results.quit-results.modal.actions.quit-without-sharing"}}
-          </PixButtonLink>
-        </div>
-      </:footer>
-    </PixModal>
   </template>
 }

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results.gjs
@@ -2,6 +2,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
+import ENV from 'mon-pix/config/environment';
 
 import EvaluationResultsHero from '../../../campaigns/assessment/results/evaluation-results-hero';
 import EvaluationResultsTabs from '../../../campaigns/assessment/results/evaluation-results-tabs';
@@ -12,6 +13,11 @@ export default class EvaluationResults extends Component {
 
   get hasTrainings() {
     return Boolean(this.args.model.trainings.length);
+  }
+
+  get isSharableCampaign() {
+    const isAutonomousCourse = this.args.model.campaign.organizationId === ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID;
+    return !isAutonomousCourse && !this.args.model.campaign.isForAbsoluteNovice;
   }
 
   @action
@@ -35,7 +41,10 @@ export default class EvaluationResults extends Component {
           <span>{{@model.campaign.title}}</span>
           <span class="sr-only">{{t "pages.skill-review.abstract-title"}}</span>
         </h1>
-        <QuitResults @isCampaignShared={{@model.campaignParticipationResult.isShared}} />
+        <QuitResults
+          @isCampaignShared={{@model.campaignParticipationResult.isShared}}
+          @isSharableCampaign={{this.isSharableCampaign}}
+        />
       </header>
       <EvaluationResultsHero
         @campaign={{@model.campaign}}
@@ -43,6 +52,7 @@ export default class EvaluationResults extends Component {
         @questResults={{@model.questResults}}
         @hasTrainings={{this.hasTrainings}}
         @showTrainings={{this.showTrainings}}
+        @isSharableCampaign={{this.isSharableCampaign}}
       />
       <EvaluationResultsTabs
         @campaign={{@model.campaign}}

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/hero/evaluation-results-hero-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/hero/evaluation-results-hero-test.js
@@ -32,6 +32,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
         hbs`<Campaigns::Assessment::Results::EvaluationResultsHero
   @campaign={{this.campaign}}
   @campaignParticipationResult={{this.campaignParticipationResult}}
+  @isSharableCampaign={{true}}
 />`,
       );
     });
@@ -75,6 +76,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
           hbs`<Campaigns::Assessment::Results::EvaluationResultsHero
   @campaign={{this.campaign}}
   @campaignParticipationResult={{this.campaignParticipationResult}}
+  @isSharableCampaign={{true}}
 />`,
         );
 
@@ -112,6 +114,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
             hbs`<Campaigns::Assessment::Results::EvaluationResultsHero
   @campaign={{this.campaign}}
   @campaignParticipationResult={{this.campaignParticipationResult}}
+  @isSharableCampaign={{true}}
 />`,
           );
         });
@@ -175,6 +178,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
   @campaign={{this.campaign}}
   @questResults={{this.questResults}}
   @campaignParticipationResult={{this.campaignParticipationResult}}
+  @isSharableCampaign={{true}}
 />`,
             );
             await click(screen.getByRole('button', { name: t('pages.skill-review.actions.send') }));
@@ -200,6 +204,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
   @campaign={{this.campaign}}
   @questResults={{this.questResults}}
   @campaignParticipationResult={{this.campaignParticipationResult}}
+  @isSharableCampaign={{true}}
 />`,
             );
             await click(screen.getByRole('button', { name: t('pages.skill-review.actions.send') }));
@@ -221,6 +226,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
               hbs`<Campaigns::Assessment::Results::EvaluationResultsHero
   @campaign={{this.campaign}}
   @campaignParticipationResult={{this.campaignParticipationResult}}
+  @isSharableCampaign={{true}}
 />`,
             );
             await click(screen.getByRole('button', { name: t('pages.skill-review.actions.send') }));
@@ -244,6 +250,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
             hbs`<Campaigns::Assessment::Results::EvaluationResultsHero
   @campaign={{this.campaign}}
   @campaignParticipationResult={{this.campaignParticipationResult}}
+  @isSharableCampaign={{true}}
 />`,
           );
 
@@ -267,6 +274,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
             hbs`<Campaigns::Assessment::Results::EvaluationResultsHero
   @campaign={{this.campaign}}
   @campaignParticipationResult={{this.campaignParticipationResult}}
+  @isSharableCampaign={{true}}
 />`,
           );
 
@@ -296,6 +304,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
   @showTrainings={{this.showTrainings}}
   @campaign={{this.campaign}}
   @campaignParticipationResult={{this.campaignParticipationResult}}
+  @isSharableCampaign={{true}}
 />`,
           );
         });
@@ -317,7 +326,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
     });
   });
 
-  module('when campaign is simplified access', function () {
+  module('when campaign results should not be shared', function () {
     module('when there is no custom link', function () {
       module('when user is anonymous', function () {
         test('it should display only a connection link', async function (assert) {
@@ -327,10 +336,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
           }
           this.owner.register('service:current-user', currentUserService);
 
-          this.set('campaign', {
-            isSimplifiedAccess: true,
-            hasCustomResultPageButton: false,
-          });
+          this.set('campaign', { hasCustomResultPageButton: false });
           this.set('campaignParticipationResult', { masteryRate: 0.75 });
 
           // when
@@ -338,6 +344,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
             hbs`<Campaigns::Assessment::Results::EvaluationResultsHero
   @campaign={{this.campaign}}
   @campaignParticipationResult={{this.campaignParticipationResult}}
+  @isSharableCampaign={{false}}
 />`,
           );
 
@@ -360,10 +367,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
           }
           this.owner.register('service:currentUser', currentUserService);
 
-          this.set('campaign', {
-            isSimplifiedAccess: true,
-            hasCustomResultPageButton: false,
-          });
+          this.set('campaign', { hasCustomResultPageButton: false });
           this.set('campaignParticipationResult', { masteryRate: 0.75 });
 
           // when
@@ -371,6 +375,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
             hbs`<Campaigns::Assessment::Results::EvaluationResultsHero
   @campaign={{this.campaign}}
   @campaignParticipationResult={{this.campaignParticipationResult}}
+  @isSharableCampaign={{false}}
 />`,
           );
 
@@ -387,10 +392,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
     module('when there is a custom link', function () {
       test('it should not display a homepage link', async function (assert) {
         // given
-        this.set('campaign', {
-          isSimplifiedAccess: true,
-          hasCustomResultPageButton: true,
-        });
+        this.set('campaign', { hasCustomResultPageButton: true });
         this.set('campaignParticipationResult', { masteryRate: 0.75 });
 
         // when
@@ -398,6 +400,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
           hbs`<Campaigns::Assessment::Results::EvaluationResultsHero
   @campaign={{this.campaign}}
   @campaignParticipationResult={{this.campaignParticipationResult}}
+  @isSharableCampaign={{false}}
 />`,
         );
 
@@ -440,6 +443,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
           hbs`<Campaigns::Assessment::Results::EvaluationResultsHero
   @campaign={{this.campaign}}
   @campaignParticipationResult={{this.campaignParticipationResult}}
+  @isSharableCampaign={{true}}
 />`,
         );
       });
@@ -454,6 +458,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
           hbs`<Campaigns::Assessment::Results::EvaluationResultsHero
   @campaign={{this.campaign}}
   @campaignParticipationResult={{this.campaignParticipationResult}}
+  @isSharableCampaign={{true}}
 />`,
         );
 

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/quit-results-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/quit-results-test.js
@@ -9,10 +9,31 @@ import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering'
 module('Integration | Components | Campaigns | Assessment | Results | Quit Results', function (hooks) {
   setupIntlRenderingTest(hooks);
 
+  module('when the campaign results are not sharable', function () {
+    test('it should display a quit button link', async function (assert) {
+      // when
+      const screen = await render(
+        hbs`<Campaigns::Assessment::Results::QuitResults @isCampaignShared={{true}} @isSharableCampaign={{false}} />`,
+      );
+
+      // then
+      assert.ok(
+        screen
+          .getByRole('link', {
+            name: 'Quitter',
+          })
+          .getAttribute('href')
+          .includes('/'),
+      );
+    });
+  });
+
   module('when the evaluation results have been shared', function () {
     test('it should display a quit button link', async function (assert) {
       // when
-      const screen = await render(hbs`<Campaigns::Assessment::Results::QuitResults @isCampaignShared={{true}} />`);
+      const screen = await render(
+        hbs`<Campaigns::Assessment::Results::QuitResults @isCampaignShared={{true}} @isSharableCampaign={{true}} />`,
+      );
 
       // then
       assert.ok(
@@ -29,7 +50,9 @@ module('Integration | Components | Campaigns | Assessment | Results | Quit Resul
   module('when the evaluation results have not been shared yet', function () {
     test('it should display a quit button', async function (assert) {
       // when
-      const screen = await render(hbs`<Campaigns::Assessment::Results::QuitResults @isCampaignShared={{false}} />`);
+      const screen = await render(
+        hbs`<Campaigns::Assessment::Results::QuitResults @isCampaignShared={{false}} @isSharableCampaign={{true}} />`,
+      );
 
       // then
       assert.dom(screen.getByRole('button', { name: 'Quitter' })).exists();
@@ -38,7 +61,9 @@ module('Integration | Components | Campaigns | Assessment | Results | Quit Resul
     module('when the quit button is clicked', function () {
       test('it should display a modal', async function (assert) {
         // given
-        const screen = await render(hbs`<Campaigns::Assessment::Results::QuitResults @isCampaignShared={{false}} />`);
+        const screen = await render(
+          hbs`<Campaigns::Assessment::Results::QuitResults @isCampaignShared={{false}} @isSharableCampaign={{true}} />`,
+        );
 
         // when
         await click(screen.getByRole('button', { name: 'Quitter' }));

--- a/mon-pix/tests/unit/components/routes/campaigns/assessment/evaluation-results-test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/assessment/evaluation-results-test.js
@@ -1,0 +1,68 @@
+import { setupTest } from 'ember-qunit';
+import ENV from 'mon-pix/config/environment';
+import { module, test } from 'qunit';
+
+import createGlimmerComponent from '../../../../../helpers/create-glimmer-component';
+
+module('Unit | Component | Routes | Campaigns | Assessment | EvaluationResults', function (hooks) {
+  setupTest(hooks);
+
+  module('#isSharableCampaign', function () {
+    module('when campaign is not an autonomous course and not for absolute novice', function () {
+      test('should return true', async function (assert) {
+        // given
+        ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID = 9999;
+
+        const component = createGlimmerComponent('routes/campaigns/assessment/evaluation-results');
+
+        component.args.model = {
+          campaign: {
+            organizationId: 1,
+            isForAbsoluteNovice: false,
+          },
+        };
+
+        // then
+        assert.true(component.isSharableCampaign);
+      });
+    });
+
+    module('when campaign is an autonomous course', function () {
+      test('should return false', async function (assert) {
+        // given
+        ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID = 1;
+
+        const component = createGlimmerComponent('routes/campaigns/assessment/evaluation-results');
+
+        component.args.model = {
+          campaign: {
+            organizationId: 1,
+            isForAbsoluteNovice: false,
+          },
+        };
+
+        // then
+        assert.false(component.isSharableCampaign);
+      });
+    });
+
+    module('when campaign is for absolute novice', function () {
+      test('should return false', async function (assert) {
+        // given
+        ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID = 9999;
+
+        const component = createGlimmerComponent('routes/campaigns/assessment/evaluation-results');
+
+        component.args.model = {
+          campaign: {
+            organizationId: 1,
+            isForAbsoluteNovice: true,
+          },
+        };
+
+        // then
+        assert.false(component.isSharableCampaign);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :fallen_leaf: Problème

On ne pouvait plus envoyer les résultats d'un parcours à accès simplifié.

## :chestnut: Proposition

On veut pouvoir envoyer les résultats d'une campagne sauf dans ces 2 cas :
- si la campagne est `isForAbsoluteNovice`
- si c'est un parcours autonome

La correction impacte aussi l'action du bouton `Quitter` dans l'en-tête : on ne souhaite pas ouvrir une modale demandant le partage de résultat dans les cas cités précédemment.

## :wood: Pour tester

- [TECH] Vérifier les tests
- [FUNC] Faire des tests en RA (parcours autonome VS accès simplifié VS isForAbsoluteNovice VS campagne normale)
