### PR TITLE
[FEATURE] Prendre en compte la langue depuis la payload pour le simualtor flash (PIX-15218).

### DIFF
--- a/api/src/certification/flash-certification/application/scenario-simulator-controller.js
+++ b/api/src/certification/flash-certification/application/scenario-simulator-controller.js
@@ -4,7 +4,6 @@ import _ from 'lodash';
 
 import { pickChallengeService } from '../../../evaluation/domain/services/pick-challenge-service.js';
 import { random } from '../../../shared/infrastructure/utils/random.js';
-import { extractLocaleFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { pickAnswerStatusService } from '../../shared/domain/services/pick-answer-status-service.js';
 import { usecases } from '../domain/usecases/index.js';
 import { scenarioSimulatorBatchSerializer } from '../infrastructure/serializers/scenario-simulator-batch-serializer.js';
@@ -17,7 +16,6 @@ async function simulateFlashAssessmentScenario(
     random,
     pickAnswerStatusService,
     pickChallengeService,
-    extractLocaleFromRequest,
   },
 ) {
   const {
@@ -27,11 +25,10 @@ async function simulateFlashAssessmentScenario(
     variationPercent,
     capacity,
     accessibilityAdjustmentNeeded,
+    locale,
   } = request.payload;
 
   const pickAnswerStatus = dependencies.pickAnswerStatusService.pickAnswerStatusForCapacity(capacity);
-
-  const locale = dependencies.extractLocaleFromRequest(request);
 
   async function* generate() {
     const iterations = _.range(0, numberOfIterations);

--- a/api/src/certification/flash-certification/application/scenario-simulator-route.js
+++ b/api/src/certification/flash-certification/application/scenario-simulator-route.js
@@ -1,6 +1,7 @@
 import Joi from 'joi';
 
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
+import { LOCALE } from '../../../shared/domain/constants.js';
 import { scenarioSimulatorController } from './scenario-simulator-controller.js';
 
 const register = async (server) => {
@@ -27,6 +28,10 @@ const register = async (server) => {
               variationPercent: Joi.number().min(0).max(1),
               capacity: Joi.number().min(-8).max(8).required(),
               accessibilityAdjustmentNeeded: Joi.boolean(),
+              locale: Joi.string()
+                .valid(...Object.values(LOCALE))
+                .lowercase()
+                .required(),
             })
             .required(),
         },

--- a/api/tests/acceptance/application/scenario-simulator/scenario-simulator-controller_test.js
+++ b/api/tests/acceptance/application/scenario-simulator/scenario-simulator-controller_test.js
@@ -32,6 +32,7 @@ describe('Acceptance | Controller | scenario-simulator-controller', function () 
 
     validPayload = {
       capacity: 4.5,
+      locale: 'fr-fr',
     };
 
     const learningContent = {


### PR DESCRIPTION
## :fallen_leaf: Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

La langue est passe en header pour le simulateur aujourd’hui.
Ca serait bien de l’avoir avec tous les autres paramètres (la payload).

## :chestnut: Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

Ajout du paramètre `locale` à la payload acceptée.
Ce paramètre est obligatoire et ne peut valoir qu'une des valeurs de locale supportée par Pix.
Le header `accept-languages` n'est plus pris en compte.

## :jack_o_lantern: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :wood: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

```
TOKEN=$(curl 'https://api-pr10650.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr10650.review.pix.fr/api/scenario-simulator \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -X POST \
    -d '{ "capacity": 1.5, "locale": "fr" }' | jq '.'
