### PR TITLE
[BUGFIX] Inclure la hauteur de la navbar dans le calcul du scroll auto (PIX-15476)

### DIFF
--- a/mon-pix/app/components/module/navbar.gjs
+++ b/mon-pix/app/components/module/navbar.gjs
@@ -11,6 +11,20 @@ import { eq } from 'ember-truth-helpers';
 export default class ModulixNavbar extends Component {
   @service intl;
 
+  static #padding = 2 * ModulixNavbar.#getCssVarValue('--pix-spacing-4x');
+  static #buttonBorderWidth = 2 * 2;
+  static #buttonPadding = 2 * ModulixNavbar.#getCssVarValue('--pix-spacing-2x');
+  static #textFontSize = 14; // 1rem in mobile
+  static HEIGHT =
+    ModulixNavbar.#padding +
+    ModulixNavbar.#buttonBorderWidth +
+    ModulixNavbar.#buttonPadding +
+    ModulixNavbar.#textFontSize;
+
+  static #getCssVarValue(varName) {
+    return getComputedStyle(document.documentElement).getPropertyValue(varName).slice(0, -2);
+  }
+
   get progressValue() {
     if (this.args.totalSteps <= 1) {
       return 100;

--- a/mon-pix/app/services/modulix-auto-scroll.js
+++ b/mon-pix/app/services/modulix-auto-scroll.js
@@ -1,10 +1,11 @@
 import { action } from '@ember/object';
 import Service, { service } from '@ember/service';
+import ModulixNavbar from 'mon-pix/components/module/navbar';
 
 export default class ModulixAutoScroll extends Service {
   @service modulixPreviewMode;
 
-  #SCROLL_OFFSET_PX = 70;
+  #SCROLL_OFFSET_PX = 70 + ModulixNavbar.HEIGHT;
 
   @action
   setHTMLElementScrollOffsetCssProperty(htmlElement) {

--- a/mon-pix/tests/integration/components/module/navbar_test.gjs
+++ b/mon-pix/tests/integration/components/module/navbar_test.gjs
@@ -10,6 +10,16 @@ import { waitForDialog } from '../../../helpers/wait-for';
 module('Integration | Component | Module | Navbar', function (hooks) {
   setupIntlRenderingTest(hooks);
 
+  module('HEIGHT', function () {
+    test('should return the approximate height of the navbar', function (assert) {
+      // when
+      const height = ModulixNavbar.HEIGHT;
+
+      // then
+      assert.strictEqual(height, 66);
+    });
+  });
+
   module('when at first step', function () {
     test('should display step 1 with empty progress bar', async function (assert) {
       // given

--- a/mon-pix/tests/unit/services/modulix-auto-scroll-test.js
+++ b/mon-pix/tests/unit/services/modulix-auto-scroll-test.js
@@ -1,5 +1,6 @@
 import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
+import ModulixNavbar from 'mon-pix/components/module/navbar';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -16,7 +17,7 @@ module('Unit | Services | Module | ModulixAutoScroll', function (hooks) {
       modulixAutoScrollService.setHTMLElementScrollOffsetCssProperty(htmlElement);
 
       // then
-      assert.strictEqual(htmlElement.style.getPropertyValue('--scroll-offset'), '70px');
+      assert.strictEqual(htmlElement.style.getPropertyValue('--scroll-offset'), `${70 + ModulixNavbar.HEIGHT}px`);
     });
   });
 
@@ -68,7 +69,7 @@ module('Unit | Services | Module | ModulixAutoScroll', function (hooks) {
         }
 
         function expectScrollCalledWith(expectedBehavior) {
-          const expectedScrollToTop = -45;
+          const expectedScrollToTop = -45 - ModulixNavbar.HEIGHT;
           sinon.assert.calledWith(scrollStub, { top: expectedScrollToTop, behavior: expectedBehavior });
         }
 

--- a/mon-pix/tests/unit/services/modulix-auto-scroll-test.js
+++ b/mon-pix/tests/unit/services/modulix-auto-scroll-test.js
@@ -70,7 +70,7 @@ module('Unit | Services | Module | ModulixAutoScroll', function (hooks) {
 
         function expectScrollCalledWith(expectedBehavior) {
           const expectedScrollToTop = -45 - ModulixNavbar.HEIGHT;
-          sinon.assert.calledWith(scrollStub, { top: expectedScrollToTop, behavior: expectedBehavior });
+          sinon.assert.calledWithExactly(scrollStub, { top: expectedScrollToTop, behavior: expectedBehavior });
         }
 
         module('when user prefers reduced motions', function () {


### PR DESCRIPTION
## :fallen_leaf: Problème
La barre de navigation n’est pas prise en compte dans le calcul du scroll. On se retrouve parfois avec du texte coupé.

## :chestnut: Proposition
Inclure au mieux la hauteur de la navbar dans le calcul du scroll auto.

Malheureusement, la hauteur est dynamique donc ça ne sera pas toujours parfait. Par exemple en desktop le token de typographie body L inclue une font-size de 1.125rem alors qu'on a précisé ici 1rem (c'est sa valeur en mobile). Un autre exemple est si l'utilisateur zoome.

## :jack_o_lantern: Remarques
RAS

## :wood: Pour tester
Vérifier que le scroll auto de grain à grain fait en sorte de voir un tout petit bout du grain précédant.
