### PR TITLE
[FEATURE] Empecher l'affichage des resultats d'une attestation si elle est liee a plusieurs profils cible (PIX-13828)

### DIFF
--- a/api/src/profile/domain/models/Campaign.js
+++ b/api/src/profile/domain/models/Campaign.js
@@ -1,6 +1,7 @@
 export class Campaign {
-  constructor({ id, organizationId }) {
+  constructor({ id, organizationId, targetProfileId }) {
     this.id = id;
     this.organizationId = organizationId;
+    this.targetProfileId = targetProfileId;
   }
 }

--- a/api/src/profile/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/profile/infrastructure/repositories/campaign-participation-repository.js
@@ -4,7 +4,7 @@ import { Campaign } from '../../domain/models/Campaign.js';
 export async function getCampaignByParticipationId({ campaignParticipationId }) {
   const knexConnection = DomainTransaction.getConnection();
   const campaign = await knexConnection('campaign-participations')
-    .select('campaigns.id', 'campaigns.organizationId')
+    .select('campaigns.id', 'campaigns.organizationId', 'campaigns.targetProfileId')
     .innerJoin('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
     .where({ 'campaign-participations.id': campaignParticipationId })
     .first();

--- a/api/src/quest/domain/models/Eligibility.js
+++ b/api/src/quest/domain/models/Eligibility.js
@@ -15,10 +15,22 @@ export class Eligibility {
     };
   }
 
+  set campaignParticipations(campaignParticipations) {
+    this.#campaignParticipations = campaignParticipations;
+  }
+
   hasCampaignParticipation(campaignParticipationId) {
     return Boolean(
       this.#campaignParticipations.find(
         (campaignParticipation) => campaignParticipation.id === campaignParticipationId,
+      ),
+    );
+  }
+
+  hasCampaignParticipationForTargetProfileId(targetProfileId) {
+    return Boolean(
+      this.#campaignParticipations.find(
+        (campaignParticipation) => campaignParticipation.targetProfileId === targetProfileId,
       ),
     );
   }

--- a/api/src/quest/domain/usecases/get-quest-results-for-campaign-participation.js
+++ b/api/src/quest/domain/usecases/get-quest-results-for-campaign-participation.js
@@ -1,9 +1,73 @@
+const getEligibilityForThisCampaignParticipation = async (eligibilityRepository, userId, campaignParticipationId) => {
+  const eligibilities = await eligibilityRepository.find({ userId });
+  return eligibilities.find((e) => e.hasCampaignParticipation(campaignParticipationId));
+};
+
+const getTargetProfileRequirementsPerQuest = (quests) =>
+  quests
+    .map((quest) => {
+      const campaignParticipationsRequirement = quest.eligibilityRequirements.find(
+        (requirement) => requirement.type === 'campaignParticipations',
+      );
+      if (campaignParticipationsRequirement && campaignParticipationsRequirement.data.targetProfileIds)
+        return campaignParticipationsRequirement.data.targetProfileIds;
+    })
+    .filter(Boolean);
+
+/**
+ * This function retrieves the target profiles we should use for the current participation.
+ * It first retrieves the target profile for the current campaign participation.
+ * Then it retrieves the target profile requirements for each quest.
+ * It filters the target profile requirements to only keep the ones that contain the target profile for the current participation.
+ * It checks if the user has participated in campaigns linked to all the target profiles present in the quest requirements.
+ * If the user has participated in campaigns linked to all the target profiles present in the quest requirements, it returns the target profile requirements containing the target profile for the current participation.
+ * If not, it returns the target profile for the current participation.
+ *
+ * @param campaignParticipationRepository
+ * @param {number} campaignParticipationId
+ * @param {[Quest]} quests
+ * @param {Eligibility} eligibility
+ * @returns {Promise<[number]>}
+ */
+const getTargetProfilesForThisCampaignParticipation = async ({
+  campaignParticipationRepository,
+  campaignParticipationId,
+  quests,
+  eligibility,
+}) => {
+  const { targetProfileId: targetProfileForThisParticipation } =
+    await campaignParticipationRepository.getCampaignByParticipationId({
+      campaignParticipationId,
+    });
+
+  const targetProfileRequirementsPerQuest = getTargetProfileRequirementsPerQuest(quests);
+
+  const targetProfileRequirementsContainingTargetProfileForCurrentParticipation =
+    targetProfileRequirementsPerQuest.filter((targetProfileIds) =>
+      targetProfileIds.includes(targetProfileForThisParticipation),
+    );
+
+  const targetProfileRequirementContainingTargetProfileForCurrentParticipationWithParticipationForEveryTargetProfile =
+    targetProfileRequirementsContainingTargetProfileForCurrentParticipation.find((targetProfileRequirement) =>
+      targetProfileRequirement.every((targetProfileId) =>
+        eligibility.hasCampaignParticipationForTargetProfileId(targetProfileId),
+      ),
+    );
+
+  return (
+    targetProfileRequirementContainingTargetProfileForCurrentParticipationWithParticipationForEveryTargetProfile ?? [
+      targetProfileForThisParticipation,
+    ]
+  );
+};
+
 export const getQuestResultsForCampaignParticipation = async ({
   userId,
   campaignParticipationId,
   questRepository,
   eligibilityRepository,
   rewardRepository,
+  campaignParticipationRepository,
 }) => {
   const quests = await questRepository.findAll();
 
@@ -11,18 +75,24 @@ export const getQuestResultsForCampaignParticipation = async ({
     return [];
   }
 
-  const eligibilities = await eligibilityRepository.find({ userId });
-  const eligibility = eligibilities.find((e) => e.hasCampaignParticipation(campaignParticipationId));
+  const eligibility = await getEligibilityForThisCampaignParticipation(
+    eligibilityRepository,
+    userId,
+    campaignParticipationId,
+  );
 
   if (!eligibility) return [];
 
-  /*
-  This effectively overrides the existing campaignParticipations property with a new getter that always returns the updated targetProfileIds array based on the provided campaignParticipationId.
-  We can't just reassign the getter with the new value, because the getter will still be called and the new value would be ignored
-  */
-  Object.defineProperty(eligibility, 'campaignParticipations', {
-    get: () => ({ targetProfileIds: [eligibility.getTargetProfileForCampaignParticipation(campaignParticipationId)] }),
+  const targetProfileIdsForThisCampaignParticipation = await getTargetProfilesForThisCampaignParticipation({
+    campaignParticipationRepository,
+    campaignParticipationId,
+    quests,
+    eligibility,
   });
+
+  eligibility.campaignParticipations = targetProfileIdsForThisCampaignParticipation.map((targetProfileId) => ({
+    targetProfileId,
+  }));
 
   const questResults = [];
   for (const quest of quests) {

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -1,6 +1,7 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import * as campaignParticipationRepository from '../../../profile/infrastructure/repositories/campaign-participation-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import { repositories } from '../../infrastructure/repositories/index.js';
@@ -17,6 +18,7 @@ const dependencies = {
   rewardRepository: repositories.rewardRepository,
   successRepository: repositories.successRepository,
   questRepository,
+  campaignParticipationRepository,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/tests/profile/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/profile/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -19,6 +19,7 @@ describe('Profile | Integration | Infrastructure | Repository | campaign-partici
       expect(result).to.be.an.instanceOf(Campaign);
       expect(result.id).to.equal(campaign.id);
       expect(result.organizationId).to.equal(campaign.organizationId);
+      expect(result.targetProfileId).to.equal(campaign.targetProfileId);
     });
 
     it('return null if campaignParticipation does not exist', async function () {

--- a/api/tests/quest/integration/domain/usecases/get-quest-results-for-campaign-participation_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-quest-results-for-campaign-participation_test.js
@@ -4,6 +4,167 @@ import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { databaseBuilder, expect } from '../../../../test-helper.js';
 
 describe('Quest | Integration | Domain | Usecases | getQuestResultsForCampaignParticipation', function () {
+  describe('when there are multiple target profiles in the quest requirements', function () {
+    it('should get quest results for campaign participation belonging to one of the target profiles', async function () {
+      const organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO' }).id;
+      const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId,
+      });
+
+      // build target profiles
+
+      const firstTargetProfile = databaseBuilder.factory.buildTargetProfile({
+        ownerOrganizationId: organizationId,
+      });
+      const secondTargetProfile = databaseBuilder.factory.buildTargetProfile({
+        ownerOrganizationId: organizationId,
+      });
+
+      // build campaigns
+
+      const firstCampaign = databaseBuilder.factory.buildCampaign({
+        organizationId,
+        targetProfileId: firstTargetProfile.id,
+      });
+
+      const secondCampaign = databaseBuilder.factory.buildCampaign({
+        organizationId,
+        targetProfileId: secondTargetProfile.id,
+      });
+
+      // build campaign participations
+
+      databaseBuilder.factory.buildCampaignParticipation({
+        organizationLearnerId,
+        campaignId: firstCampaign.id,
+        userId,
+      });
+
+      const { id: secondCampaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
+        organizationLearnerId,
+        campaignId: secondCampaign.id,
+        userId,
+      });
+
+      const rewardId = databaseBuilder.factory.buildAttestation().id;
+      const questId = databaseBuilder.factory.buildQuest({
+        rewardType: 'attestations',
+        rewardId,
+        eligibilityRequirements: [
+          {
+            type: 'organization',
+            data: {
+              type: 'SCO',
+            },
+            comparison: COMPARISON.ALL,
+          },
+          {
+            type: 'campaignParticipations',
+            data: {
+              targetProfileIds: [firstTargetProfile.id, secondTargetProfile.id],
+            },
+            comparison: COMPARISON.ALL,
+          },
+        ],
+        successRequirements: [],
+      }).id;
+
+      await databaseBuilder.commit();
+
+      const result = await usecases.getQuestResultsForCampaignParticipation({
+        userId,
+        campaignParticipationId: secondCampaignParticipationId,
+      });
+
+      expect(result[0]).to.be.instanceOf(QuestResult);
+      expect(result[0].id).to.equal(questId);
+      expect(result[0].reward.id).to.equal(rewardId);
+    });
+
+    it('should not return quest results for campaign participation if user has not participated to campaigns linked to all profiles target in quest requirement', async function () {
+      const organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO' }).id;
+      const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId,
+      });
+
+      // build target profiles
+
+      const firstTargetProfile = databaseBuilder.factory.buildTargetProfile({
+        ownerOrganizationId: organizationId,
+      });
+      const secondTargetProfile = databaseBuilder.factory.buildTargetProfile({
+        ownerOrganizationId: organizationId,
+      });
+      const thirdTargetProfile = databaseBuilder.factory.buildTargetProfile({
+        ownerOrganizationId: organizationId,
+      });
+
+      // build campaigns
+
+      const firstCampaign = databaseBuilder.factory.buildCampaign({
+        organizationId,
+        targetProfileId: firstTargetProfile.id,
+      });
+
+      const secondCampaign = databaseBuilder.factory.buildCampaign({
+        organizationId,
+        targetProfileId: secondTargetProfile.id,
+      });
+
+      databaseBuilder.factory.buildCampaign({
+        organizationId,
+        targetProfileId: thirdTargetProfile.id,
+      });
+
+      // build campaign participations
+
+      databaseBuilder.factory.buildCampaignParticipation({
+        organizationLearnerId,
+        campaignId: firstCampaign.id,
+        userId,
+      });
+
+      const { id: secondCampaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
+        organizationLearnerId,
+        campaignId: secondCampaign.id,
+        userId,
+      });
+
+      const rewardId = databaseBuilder.factory.buildAttestation().id;
+
+      databaseBuilder.factory.buildQuest({
+        rewardType: 'attestations',
+        rewardId,
+        eligibilityRequirements: [
+          {
+            type: 'organization',
+            data: {
+              type: 'SCO',
+            },
+            comparison: COMPARISON.ALL,
+          },
+          {
+            type: 'campaignParticipations',
+            data: {
+              targetProfileIds: [firstTargetProfile.id, secondTargetProfile.id, thirdTargetProfile.id],
+            },
+            comparison: COMPARISON.ALL,
+          },
+        ],
+        successRequirements: [],
+      }).id;
+
+      await databaseBuilder.commit();
+
+      const result = await usecases.getQuestResultsForCampaignParticipation({
+        userId,
+        campaignParticipationId: secondCampaignParticipationId,
+      });
+
+      expect(result).to.be.empty;
+    });
+  });
+
   it('should get quest results for campaign participation', async function () {
     const organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO' }).id;
     const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
@@ -33,6 +194,7 @@ describe('Quest | Integration | Domain | Usecases | getQuestResultsForCampaignPa
 
     expect(result[0]).to.be.instanceOf(QuestResult);
     expect(result[0].id).to.equal(questId);
+    expect(result[0].obtained).to.equal(false);
     expect(result[0].reward.id).to.equal(rewardId);
   });
 

--- a/api/tests/quest/unit/domain/models/Eligibility_test.js
+++ b/api/tests/quest/unit/domain/models/Eligibility_test.js
@@ -79,4 +79,36 @@ describe('Quest | Unit | Domain | Models | Eligibility ', function () {
       expect(result).to.be.null;
     });
   });
+
+  describe('#hasCampaignParticipationForTargetProfileId', function () {
+    it('should return true if has campaign participation for given target profile', function () {
+      // given
+      const campaignParticipations = [
+        { id: 1, targetProfileId: 10 },
+        { id: 2, targetProfileId: 20 },
+      ];
+      const eligiblity = new Eligibility({ campaignParticipations });
+
+      // when
+      const result = eligiblity.hasCampaignParticipationForTargetProfileId(10);
+
+      // then
+      expect(result).to.be.true;
+    });
+
+    it('should return false if there are no campaign participation for given target profile', function () {
+      // given
+      const campaignParticipations = [
+        { id: 1, targetProfileId: 10 },
+        { id: 2, targetProfileId: 20 },
+      ];
+      const eligiblity = new Eligibility({ campaignParticipations });
+
+      // when
+      const result = eligiblity.hasCampaignParticipationForTargetProfileId(1);
+
+      // then
+      expect(result).to.be.false;
+    });
+  });
 });

--- a/api/tests/quest/unit/domain/usecases/get-quest-results-for-campaign-participation_test.js
+++ b/api/tests/quest/unit/domain/usecases/get-quest-results-for-campaign-participation_test.js
@@ -4,6 +4,8 @@ import { getQuestResultsForCampaignParticipation } from '../../../../../src/ques
 import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Domain | Usecases | getQuestResultsForCampaignParticipation', function () {
+  let campaignParticipationRepository;
+
   let questRepository, eligibilityRepository, rewardRepository, campaignParticipationId, userId;
 
   beforeEach(function () {
@@ -11,6 +13,7 @@ describe('Quest | Unit | Domain | Usecases | getQuestResultsForCampaignParticipa
     campaignParticipationId = 2;
     questRepository = { findAll: sinon.stub() };
     eligibilityRepository = { find: sinon.stub() };
+    campaignParticipationRepository = { getCampaignByParticipationId: sinon.stub() };
     rewardRepository = { getByQuestAndUserId: sinon.stub() };
   });
 
@@ -56,6 +59,7 @@ describe('Quest | Unit | Domain | Usecases | getQuestResultsForCampaignParticipa
       userId,
       questRepository,
       eligibilityRepository,
+      campaignParticipationRepository,
       rewardRepository,
     });
 
@@ -77,6 +81,9 @@ describe('Quest | Unit | Domain | Usecases | getQuestResultsForCampaignParticipa
         rewardId: 20,
       }),
     ]);
+    campaignParticipationRepository.getCampaignByParticipationId
+      .withArgs({ campaignParticipationId })
+      .resolves([{ targetProfileId: 40 }]);
 
     eligibilityRepository.find.withArgs({ userId }).resolves([
       new Eligibility({
@@ -90,6 +97,7 @@ describe('Quest | Unit | Domain | Usecases | getQuestResultsForCampaignParticipa
       userId,
       questRepository,
       eligibilityRepository,
+      campaignParticipationRepository,
       rewardRepository,
     });
 


### PR DESCRIPTION
## :fallen_leaf: Problème
Si les prerequis d'une quete se composent de plusieurs profils cible on affiche le resultat alors meme que l'utilisateur n'a pas complete toutes les campagnes liees aux differents profils cible.
Cela a pour consequence d'afficher a l'utilisateur qu'il n'a pas obtenu la quete alors meme qu'il n'a pas rempli tous les criteres pour l'obtenir. 

## :chestnut: Proposition
Avant de retourner la quete a afficher prendre en compte les profils cibles presents dans la quete et verifier la participation de l'utilisateur a des campagnes liees a ces profils cible.

## :jack_o_lantern: Remarques
Le nom de la branche n'a plus rien a voir avec la PR.

## :wood: Pour tester
- Avec l'utilisateur attestation-blank@example.net
reussir la campagne ATTEST002
- Verifier qu'a la fin de la campagne on n'affiche pas le resultat de l'attestation
- Reussir la campagne ATTEST003
- Verifier que le resultat de l'attestation s'affiche en fin de parcours

