### PR TITLE
[TECH] Modifier le type de la colonne "id" de la table "learningcontent.missions" (PIX-15481)

### DIFF
--- a/api/db/database-builder/factory/learning-content/build-mission.js
+++ b/api/db/database-builder/factory/learning-content/build-mission.js
@@ -1,7 +1,7 @@
 import { databaseBuffer } from '../../database-buffer.js';
 
 export function buildMission({
-  id = 'missionIdA',
+  id = 1,
   status = 'status Mission A',
   name_i18n = { fr: 'name FR Mission A', en: 'name EN Mission A' },
   content = { some: 'content' },

--- a/api/db/migrations/20241127142253_alter-table-column-id-missions-to-integer.js
+++ b/api/db/migrations/20241127142253_alter-table-column-id-missions-to-integer.js
@@ -1,0 +1,30 @@
+const TABLE_NAME = 'missions';
+const SCHEMA_NAME = 'learningcontent';
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.withSchema(SCHEMA_NAME).dropTable(TABLE_NAME);
+  await knex.schema.withSchema(SCHEMA_NAME).createTable('missions', function (table) {
+    table.integer('id').primary();
+    table.string('status');
+    table.jsonb('name_i18n');
+    table.jsonb('content');
+    table.jsonb('learningObjectives_i18n');
+    table.jsonb('validatedObjectives_i18n');
+    table.string('introductionMediaType');
+    table.text('introductionMediaUrl');
+    table.jsonb('introductionMediaAlt_i18n');
+    table.text('documentationUrl');
+    table.text('cardImageUrl');
+    table.string('competenceId');
+  });
+}
+
+/**
+ * @returns { Promise<void> }
+ */
+export async function down() {
+  // non
+}


### PR DESCRIPTION
## :fallen_leaf: Problème
Pour être iso avec la release, en fait les ids de mission sont des integers.

## :chestnut: Proposition
Drop la table et la recréer dans la mesure où il n'y a, pour le moment, aucune donnée dedans. Car quand on veut faire des altérations sur la colonne primary d'une table il faut le faire en deux migrations, une pour drop la contrainte primary et l'autre pour faire les modifs et remettre la contrainte.

## :jack_o_lantern: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :wood: Pour tester
Tests au vert
