### PR TITLE
[FEATURE] Ajout d'une description à Pix Certif et autorisation du passage des google Bots (PIX-15321).

### DIFF
--- a/certif/app/index.html
+++ b/certif/app/index.html
@@ -3,8 +3,6 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Pix Certif</title>
-    <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-pix_certif.png">

--- a/certif/app/routes/application.js
+++ b/certif/app/routes/application.js
@@ -16,4 +16,11 @@ export default class ApplicationRoute extends Route {
     const userLocale = this.currentUser.certificationPointOfContact?.lang;
     await this.session.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
   }
+
+  model() {
+    return {
+      title: this.currentDomain.isFranceDomain ? 'Pix Certif (France)' : 'Pix Certif (hors France)',
+      headElement: document.querySelector('head'),
+    };
+  }
 }

--- a/certif/app/templates/application.hbs
+++ b/certif/app/templates/application.hbs
@@ -1,4 +1,9 @@
-{{page-title "Pix Certif"}}
+{{page-title this.model.title}}
+{{#in-element this.model.headElement insertBefore=null}}
+  {{! template-lint-disable no-forbidden-elements }}
+  <meta name="description" content={{t "application.description"}} />
+{{/in-element}}
+
 <CommunicationBanner />
 {{outlet}}
 <PixToastContainer @closeButtonAriaLabel={{t "common.notifications.close-button.extra-information"}} />

--- a/certif/public/robots.txt
+++ b/certif/public/robots.txt
@@ -1,4 +1,3 @@
 # http://www.robotstxt.org
 User-agent: *
-Disallow: /
-Noindex: /
+Allow: /

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -1,4 +1,7 @@
 {
+  "application": {
+    "description": "The platform dedicated to the organisation of Pix Certification sessions. Pix Certif allows you to create and manage certification sessions."
+  },
   "banners": {
     "language-availability": {
       "message": "Your language is not yet available on Pix Certif. For your convenience, the application will be presented in English. The entire Pix team is working to add your language."

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -1,4 +1,7 @@
 {
+  "application": {
+    "description": "La plateforme dédiée à l'organisation de sessions de Certification Pix. Votre espace Pix Certif vous permet de créer et administrer des sessions de certification."
+  },
   "banners": {
     "language-availability": {
       "message": "Votre langue n'est pas encore disponible sur Pix Certif. Pour votre confort, l'application sera présentée en anglais. Toute l'équipe de Pix travaille à l'ajout de votre langue."


### PR DESCRIPTION
## :fallen_leaf: Problème
Lorsqu’on cherche Pix Certif sur google on tombe sur ça : 

<img width="400" src="https://github.com/user-attachments/assets/5e7bcf55-a6d9-4a0a-970d-6a831d382b6a" />
<img width="400" src="https://github.com/user-attachments/assets/e86dc518-e0b5-40ea-90bf-06c85622d6f1" />


## :chestnut: Proposition

- Pour certif.pix.fr

Pix Certif (France)
La plateforme dédiée à l'organisation de sessions de Certification Pix. Votre espace Pix Certif vous permet de créer et administrer des sessions de certification.

- Pour certif.pix.org

Pix Certif (hors France)
La plateforme dédiée à l'organisation de sessions de Certification Pix. Votre espace Pix Certif vous permet de créer et administrer des sessions de certification.

🇬🇧  
The platform dedicated to the organisation of Pix Certification sessions. Pix Certif allows you to create and manage certification sessions.
