### PR TITLE
[TECH] Support du format CSV pour le script de rescoring de certification (PIX-15366).

### DIFF
--- a/api/scripts/certification/rescore-certifications.js
+++ b/api/scripts/certification/rescore-certifications.js
@@ -1,72 +1,61 @@
 import 'dotenv/config';
 
-import * as url from 'node:url';
+import Joi from 'joi';
 
-import { disconnect } from '../../db/knex-database-connection.js';
 import { CertificationRescoringByScriptJob } from '../../src/certification/session-management/domain/models/CertificationRescoringByScriptJob.js';
 import { certificationRescoringByScriptJobRepository } from '../../src/certification/session-management/infrastructure/repositories/jobs/certification-rescoring-by-script-job-repository.js';
-import { logger } from '../../src/shared/infrastructure/utils/logger.js';
-import { parseCsv } from '../helpers/csvHelpers.js';
+import { csvFileParser } from '../../src/shared/application/scripts/parsers.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
 
-const modulePath = url.fileURLToPath(import.meta.url);
-const isLaunchedFromCommandLine = process.argv[1] === modulePath;
+const columnsSchemas = [{ name: 'certificationCourseId', schema: Joi.number() }];
 
-/**
- * Usage: node scripts/certification/rescore-certifications.js path/file.csv
- * File has only one column of certification-courses.id (integer), no header
- **/
-async function main(filePath) {
-  logger.info('Reading and parsing csv data file... ');
-  const certificationCourseIds = await extractCsvData(filePath);
-
-  logger.info(`Publishing ${certificationCourseIds.length} rescoring jobs`);
-  const jobs = await _scheduleRescoringJobs(certificationCourseIds);
-
-  const errors = jobs.filter((result) => result.status === 'rejected');
-  if (errors.length) {
-    errors.forEach((result) => logger.error(result.reason, 'Some jobs could not be published'));
-    return 1;
+export class RescoreCertificationScript extends Script {
+  constructor() {
+    super({
+      description: 'Rescore all certification given by CSV file. This script will schedule job to rescore',
+      permanent: true,
+      options: {
+        file: {
+          type: 'string',
+          describe:
+            'CSV File with only one column with certification-courses.id (integer) to process. Need `certificationCourseId`',
+          demandOption: true,
+          coerce: csvFileParser(columnsSchemas),
+        },
+      },
+    });
   }
 
-  logger.info(`${jobs.length} jobs successfully published`);
-  return 0;
-}
+  async handle({ options, logger }) {
+    const { file: certificationCourses } = options;
+    const certificationCourseIds = certificationCourses.map(({ certificationCourseId }) => certificationCourseId);
 
-async function extractCsvData(filePath) {
-  const dataRows = await parseCsv(filePath, { header: false, skipEmptyLines: true });
-  return dataRows.reduce((certificationCourseIds, dataRow) => {
-    const certificationCenterId = parseInt(dataRow[0]);
-    certificationCourseIds.push(certificationCenterId);
-    return certificationCourseIds;
-  }, []);
-}
+    logger.info(`Publishing ${certificationCourseIds.length} rescoring jobs`);
+    const jobs = await this.#scheduleRescoringJobs(certificationCourseIds);
 
-const _scheduleRescoringJobs = async (certificationCourseIds) => {
-  const promisefiedJobs = certificationCourseIds.map(async (certificationCourseId) => {
-    try {
-      await certificationRescoringByScriptJobRepository.performAsync(
-        new CertificationRescoringByScriptJob({ certificationCourseId }),
-      );
-    } catch (error) {
-      throw new Error(`Error for certificationCourseId: [${certificationCourseId}]`, { cause: error });
+    const errors = jobs.filter((result) => result.status === 'rejected');
+    if (errors.length) {
+      errors.forEach((result) => logger.error(result.reason, 'Some jobs could not be published'));
+      return 1;
     }
-  });
-  return Promise.allSettled(promisefiedJobs);
-};
 
-(async () => {
-  if (isLaunchedFromCommandLine) {
-    try {
-      const filePath = process.argv[2];
-      const exitCode = await main(filePath);
-      return exitCode;
-    } catch (error) {
-      logger.error(error);
-      process.exitCode = 1;
-    } finally {
-      await disconnect();
-    }
+    logger.info(`${jobs.length} jobs successfully published`);
+    return 0;
   }
-})();
 
-export { main };
+  async #scheduleRescoringJobs(certificationCourseIds) {
+    const promisefiedJobs = certificationCourseIds.map(async (certificationCourseId) => {
+      try {
+        await certificationRescoringByScriptJobRepository.performAsync(
+          new CertificationRescoringByScriptJob({ certificationCourseId }),
+        );
+      } catch (error) {
+        throw new Error(`Error for certificationCourseId: [${certificationCourseId}]`, { cause: error });
+      }
+    });
+    return Promise.allSettled(promisefiedJobs);
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, RescoreCertificationScript);

--- a/api/tests/integration/scripts/certification/rescore-certifications_test.js
+++ b/api/tests/integration/scripts/certification/rescore-certifications_test.js
@@ -1,15 +1,31 @@
-import { main } from '../../../../scripts/certification/rescore-certifications.js';
-import { createTempFile, expect, knex } from '../../../test-helper.js';
+import { RescoreCertificationScript } from '../../../../scripts/certification/rescore-certifications.js';
+import { createTempFile, expect, knex, sinon } from '../../../test-helper.js';
 
 describe('Integration | Scripts | Certification | rescore-certfication', function () {
-  it('should save pg boss jobs for each certification course ids', async function () {
-    // given
+  it('should parse input file', async function () {
+    const script = new RescoreCertificationScript();
+    const { options } = script.metaInfo;
     const file = 'certification-courses-ids-to-rescore.csv';
-    const data = '1\n2\n';
+    const data = 'certificationCourseId\n1\n2\n3\n';
     const csvFilePath = await createTempFile(file, data);
 
+    const parsedData = await options.file.coerce(csvFilePath);
+
+    expect(parsedData).to.deep.equals([
+      { certificationCourseId: 1 },
+      { certificationCourseId: 2 },
+      { certificationCourseId: 3 },
+    ]);
+  });
+
+  it('should save pg boss jobs for each certification course ids', async function () {
+    // given
+    const file = [{ certificationCourseId: 1 }, { certificationCourseId: 2 }];
+    const logger = { info: sinon.spy(), error: sinon.spy() };
+    const script = new RescoreCertificationScript();
+
     // when
-    await main(csvFilePath);
+    await script.handle({ logger, options: { file } });
 
     // then
     const [job1, job2] = await knex('pgboss.job')

--- a/api/tests/integration/scripts/certification/rescore-certifications_test.js
+++ b/api/tests/integration/scripts/certification/rescore-certifications_test.js
@@ -1,13 +1,15 @@
 import { main } from '../../../../scripts/certification/rescore-certifications.js';
-import { expect, knex } from '../../../test-helper.js';
+import { createTempFile, expect, knex } from '../../../test-helper.js';
 
 describe('Integration | Scripts | Certification | rescore-certfication', function () {
   it('should save pg boss jobs for each certification course ids', async function () {
     // given
-    const certificationsCourseIdList = [1, 2];
+    const file = 'certification-courses-ids-to-rescore.csv';
+    const data = '1\n2\n';
+    const csvFilePath = await createTempFile(file, data);
 
     // when
-    await main(certificationsCourseIdList);
+    await main(csvFilePath);
 
     // then
     const [job1, job2] = await knex('pgboss.job')


### PR DESCRIPTION
## :fallen_leaf: Problème

On veut rescorer pas mal de certifications. Dans l'etat actuel ca ferait une grosse ligne de commande, engrendrant illisibilite, risques de tailles de terminal, et risques erreurs humaines.

## :chestnut: Proposition

Tranformer le format d'input du script de rescoring avec un fichier CSV pour plus de confort et de capacite de faire de la volumetrie

## :jack_o_lantern: Remarques
La procedure operationnelle a ete mise a jour en consequence

## :wood: Pour tester

_Je recommande de suivre la procedure operationnelle interne, histoire de suivre le meme format que les captains_

* Creer un fichier CSV avec des certification-courses.id , pas de header, pas de separateur, des sauts de lignes (format classique pour un CSV simple a une colonne)
* Lancer la commande `node scripts/certification/rescore-certifications.js --file <PATH_TO_CSV>`
* Verifier que votre table pgboss.job contient les ordres de rescoring CertificationReescoringByScriptJob avec les bons identifiants
* Eventuellement : lancer l'API et voir le rescoring se faire (aucun changement sur cette partie la)
