### PR TITLE
[BUGFIX] Ne pas afficher « Autres moyens de connexion » quand aucun SSO n'est disponible (PIX-15494)

### DIFF
--- a/mon-pix/app/components/authentication/other-authentication-providers.gjs
+++ b/mon-pix/app/components/authentication/other-authentication-providers.gjs
@@ -13,52 +13,54 @@ export default class OtherAuthenticationProviders extends Component {
   }
 
   <template>
-    <section class="authentication-other-authentication-providers-section">
-      <h2 class="authentication-other-authentication-providers-section__heading">
-        {{#if @isForSignup}}
-          {{t "components.authentication.other-authentication-providers.signup.heading"}}
-        {{else}}
-          {{t "components.authentication.other-authentication-providers.login.heading"}}
-        {{/if}}
-      </h2>
-
-      {{#if this.oidcIdentityProviders.featuredIdentityProvider}}
-        <PixButtonLink
-          @route="authentication.login-oidc"
-          @model="{{this.oidcIdentityProviders.featuredIdentityProvider.slug}}"
-          @variant="secondary"
-          class="authentication-other-authentication-providers-section__button-link"
-        >
-          <img
-            src="/images/logo/identity-providers/{{this.oidcIdentityProviders.featuredIdentityProvider.slug}}.svg"
-            alt=""
-            class="authentication-other-authentication-providers-section__featured-identity-provider-logo"
-          />
+    {{#if this.oidcIdentityProviders.hasIdentityProviders}}
+      <section class="authentication-other-authentication-providers-section">
+        <h2 class="authentication-other-authentication-providers-section__heading">
           {{#if @isForSignup}}
-            {{t
-              "components.authentication.other-authentication-providers.signup.signup-with-featured-identity-provider-link"
-              featuredIdentityProvider=this.oidcIdentityProviders.featuredIdentityProvider.organizationName
-            }}
+            {{t "components.authentication.other-authentication-providers.signup.heading"}}
           {{else}}
-            {{t
-              "components.authentication.other-authentication-providers.login.login-with-featured-identity-provider-link"
-              featuredIdentityProvider=this.oidcIdentityProviders.featuredIdentityProvider.organizationName
-            }}
+            {{t "components.authentication.other-authentication-providers.login.heading"}}
           {{/if}}
-        </PixButtonLink>
-      {{/if}}
+        </h2>
 
-      {{#if this.oidcIdentityProviders.hasOtherIdentityProviders}}
-        <PixButtonLink
-          @route={{this.ssoSelectionRoute}}
-          @variant="secondary"
-          class="authentication-other-authentication-providers-section__button-link"
-        >
-          {{t "components.authentication.other-authentication-providers.select-another-organization-link"}}
+        {{#if this.oidcIdentityProviders.featuredIdentityProvider}}
+          <PixButtonLink
+            @route="authentication.login-oidc"
+            @model="{{this.oidcIdentityProviders.featuredIdentityProvider.slug}}"
+            @variant="secondary"
+            class="authentication-other-authentication-providers-section__button-link"
+          >
+            <img
+              src="/images/logo/identity-providers/{{this.oidcIdentityProviders.featuredIdentityProvider.slug}}.svg"
+              alt=""
+              class="authentication-other-authentication-providers-section__featured-identity-provider-logo"
+            />
+            {{#if @isForSignup}}
+              {{t
+                "components.authentication.other-authentication-providers.signup.signup-with-featured-identity-provider-link"
+                featuredIdentityProvider=this.oidcIdentityProviders.featuredIdentityProvider.organizationName
+              }}
+            {{else}}
+              {{t
+                "components.authentication.other-authentication-providers.login.login-with-featured-identity-provider-link"
+                featuredIdentityProvider=this.oidcIdentityProviders.featuredIdentityProvider.organizationName
+              }}
+            {{/if}}
+          </PixButtonLink>
+        {{/if}}
 
-          <span class="authentication-other-authentication-providers-section__chevron-right"></span>
-        </PixButtonLink>
-      {{/if}}
-    </section>
+        {{#if this.oidcIdentityProviders.hasOtherIdentityProviders}}
+          <PixButtonLink
+            @route={{this.ssoSelectionRoute}}
+            @variant="secondary"
+            class="authentication-other-authentication-providers-section__button-link"
+          >
+            {{t "components.authentication.other-authentication-providers.select-another-organization-link"}}
+
+            <span class="authentication-other-authentication-providers-section__chevron-right"></span>
+          </PixButtonLink>
+        {{/if}}
+      </section>
+    {{/if}}
   </template>
 }

--- a/mon-pix/app/services/oidc-identity-providers.js
+++ b/mon-pix/app/services/oidc-identity-providers.js
@@ -21,6 +21,10 @@ export default class OidcIdentityProviders extends Service {
       .map((provider) => provider.organizationName);
   }
 
+  get hasIdentityProviders() {
+    return this.list.length > 0;
+  }
+
   // TODO: Manage this through the API
   get featuredIdentityProvider() {
     return this.list.find((identityProvider) => {

--- a/mon-pix/tests/unit/services/oidc-identity-providers-test.js
+++ b/mon-pix/tests/unit/services/oidc-identity-providers-test.js
@@ -78,6 +78,51 @@ module('Unit | Service | oidc-identity-providers', function (hooks) {
     });
   });
 
+  module('hasIdentityProviders', function () {
+    module('when there is some identity providers', function () {
+      test('returns true', async function () {
+        // given
+        const oidcPartner = {
+          id: 'oidc-partner',
+          code: 'OIDC_PARTNER',
+          organizationName: 'Partenaire OIDC',
+          slug: 'partenaire-oidc',
+          shouldCloseSession: false,
+          source: 'oidc-externe',
+        };
+        const oidcPartnerObject = Object.create(oidcPartner);
+        const storeStub = Service.create({
+          peekAll: sinon.stub().returns([oidcPartnerObject]),
+        });
+        const oidcIdentityProvidersService = this.owner.lookup('service:oidcIdentityProviders');
+        oidcIdentityProvidersService.set('store', storeStub);
+
+        // when
+        const hasIdentityProviders = await oidcIdentityProvidersService.hasIdentityProviders;
+
+        // then
+        assert.strictEqual(hasIdentityProviders, true);
+      });
+    });
+
+    module('when there is no identity providers', function () {
+      test('returns false', async function () {
+        // given
+        const storeStub = Service.create({
+          peekAll: sinon.stub().returns([]),
+        });
+        const oidcIdentityProvidersService = this.owner.lookup('service:oidcIdentityProviders');
+        oidcIdentityProvidersService.set('store', storeStub);
+
+        // when
+        const hasIdentityProviders = await oidcIdentityProvidersService.hasIdentityProviders;
+
+        // then
+        assert.strictEqual(hasIdentityProviders, false);
+      });
+    });
+  });
+
   module('featuredIdentityProvider', function () {
     module('when there is some identity providers containing a featured one', function () {
       test('returns the featured identity provider', async function () {


### PR DESCRIPTION
## :fallen_leaf: Problème

Lorsqu'aucun SSO n'est configuré/disponible, sur la page de connexion _« Autres moyens de connexion »_ et _« Autres moyens d’inscription »_ ne devraient pas s’afficher quand il n’y a pas de SSO disponible.

![Screenshot_2024-11-27_at_17-52-20_Connexion_Pix-bug](https://github.com/user-attachments/assets/59d4b30e-dc61-4bce-aeae-cfbf48813d90)

![Screenshot_2024-11-27_at_17-52-36_Inscription_Pix-bug](https://github.com/user-attachments/assets/7c8b913c-6473-422e-aa39-44072904d860)

## :chestnut: Proposition

Conditionner l'affichage du titre _« Autres moyens de connexion »_ à la disponibilité de SSO.

![Screenshot_2024-11-27_at_17-51-47_Connexion_Pix](https://github.com/user-attachments/assets/6d09711c-c950-442f-84a0-ba5b3739ea7a)

![Screenshot_2024-11-27_at_17-52-52_Inscription_Pix](https://github.com/user-attachments/assets/78a1ae94-f562-4b80-8fa8-2194dbb84ff0)

## :jack_o_lantern: Remarques

RAS

## :wood: Pour tester

* Vérifier que dans les RA  _« Autres moyens de connexion »_ et _« Autres moyens d’inscription »_ ne s'affichent pas
* Vérifier en local, en recette, que lorsque au moins 1 SSO est disponible  _« Autres moyens de connexion »_ et _« Autres moyens d’inscription »_ s'affichent bien