### PR TITLE
[BUGFIX]  Bloquer l'entrée en certification de candidats cléa sans RT (PIX-15497)

### DIFF
--- a/api/src/certification/enrolment/domain/usecases/verify-candidate-subscriptions.js
+++ b/api/src/certification/enrolment/domain/usecases/verify-candidate-subscriptions.js
@@ -48,18 +48,22 @@ export async function verifyCandidateSubscriptions({
   }
 
   if (_doesNeedEligibilityCheck(session, candidate)) {
-    const userPixCertifications = await pixCertificationRepository.findByUserId({ userId: candidate.userId });
-
-    if (!_hasValidCoreCertification(userPixCertifications)) {
-      throw new CertificationCandidateEligibilityError();
-    }
-
     const subscribedHighestBadgeAcquisition = await _findHighestBadgeAcquisitionForCandidateSubscription({
       candidate,
       certificationBadgesService,
     });
 
     if (!subscribedHighestBadgeAcquisition || _isSubscribedUserBadgeOutDated(subscribedHighestBadgeAcquisition)) {
+      throw new CertificationCandidateEligibilityError();
+    }
+
+    if (_hasCoreAndComplementarSubscriptions(candidate)) {
+      return;
+    }
+
+    const userPixCertifications = await pixCertificationRepository.findByUserId({ userId: candidate.userId });
+
+    if (!_hasValidCoreCertification(userPixCertifications)) {
       throw new CertificationCandidateEligibilityError();
     }
 
@@ -87,6 +91,14 @@ export async function verifyCandidateSubscriptions({
       throw new CertificationCandidateEligibilityError();
     }
   }
+}
+
+function _hasCoreAndComplementarSubscriptions(candidate) {
+  return (
+    candidate.subscriptions.length === 2 &&
+    candidate.subscriptions.some((subscription) => subscription.isComplementary()) &&
+    candidate.subscriptions.some((subscription) => !subscription.isComplementary())
+  );
 }
 
 /**
@@ -118,8 +130,7 @@ function _isSubscribedUserBadgeOutDated(subscribedBadgeAcquisition) {
 function _doesNeedEligibilityCheck(session, candidate) {
   return (
     SessionVersion.isV3(session.version) &&
-    candidate.subscriptions.length === 1 &&
-    candidate.subscriptions[0]?.isComplementary()
+    candidate.subscriptions.some((subscription) => subscription.isComplementary())
   );
 }
 
@@ -157,7 +168,8 @@ function _getSubscribedHighestBadgeAcquisition({ userAcquiredBadgeAcquisitions, 
   return _.find(
     userAcquiredBadgeAcquisitions,
     ({ complementaryCertificationId }) =>
-      candidate.subscriptions[0].complementaryCertificationId === complementaryCertificationId,
+      candidate.subscriptions.find((subscription) => subscription.isComplementary()).complementaryCertificationId ===
+      complementaryCertificationId,
   );
 }
 

--- a/api/src/certification/enrolment/domain/usecases/verify-candidate-subscriptions.js
+++ b/api/src/certification/enrolment/domain/usecases/verify-candidate-subscriptions.js
@@ -57,7 +57,7 @@ export async function verifyCandidateSubscriptions({
       throw new CertificationCandidateEligibilityError();
     }
 
-    if (_hasCoreAndComplementarSubscriptions(candidate)) {
+    if (_hasCoreAndComplementarySubscriptions(candidate)) {
       return;
     }
 

--- a/api/tests/certification/enrolment/unit/domain/usecases/verify-candidate-subscriptions_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/verify-candidate-subscriptions_test.js
@@ -124,33 +124,77 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | verify-candidate
     });
 
     context('when candidate has a core and complementary subscriptions', function () {
-      it('should resolve', async function () {
-        // given
-        const certificationCandidateId = 456;
-        const complementaryCertificationId = 123;
-        const candidate = domainBuilder.certification.enrolment.buildCandidate({
-          id: certificationCandidateId,
-          userId: 1234,
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildCoreSubscription({
-              certificationCandidateId,
-            }),
-            domainBuilder.certification.enrolment.buildComplementarySubscription({
-              certificationCandidateId,
-              complementaryCertificationId,
-            }),
-          ],
-        });
+      context('when candidate has a badge acquisiton', function () {
+        it('should resolve', async function () {
+          // given
+          const certificationCandidateId = 456;
+          const complementaryCertificationId = 123;
+          const complementaryCertificationBadgeId = 4568;
+          const candidate = domainBuilder.certification.enrolment.buildCandidate({
+            id: certificationCandidateId,
+            userId: 1234,
+            subscriptions: [
+              domainBuilder.certification.enrolment.buildCoreSubscription({
+                certificationCandidateId,
+              }),
+              domainBuilder.certification.enrolment.buildComplementarySubscription({
+                certificationCandidateId,
+                complementaryCertificationId,
+              }),
+            ],
+          });
 
-        // when
-        //then
-        return expect(
-          verifyCandidateSubscriptions({
-            userId: 2,
+          dependencies.certificationBadgesService.findLatestBadgeAcquisitions.resolves([
+            domainBuilder.buildCertifiableBadgeAcquisition({
+              complementaryCertificationId,
+              complementaryCertificationBadgeId,
+            }),
+          ]);
+
+          // when
+          //then
+          return expect(
+            verifyCandidateSubscriptions({
+              userId: 2,
+              candidate,
+              ...dependencies,
+            }),
+          ).to.be.fulfilled;
+        });
+      });
+
+      context('when candidate has no badge acquisiton', function () {
+        it('should throw', async function () {
+          // given
+          const certificationCandidateId = 456;
+          const complementaryCertificationId = 123;
+          const candidate = domainBuilder.certification.enrolment.buildCandidate({
+            id: certificationCandidateId,
+            userId: 1234,
+            subscriptions: [
+              domainBuilder.certification.enrolment.buildCoreSubscription({
+                certificationCandidateId,
+              }),
+              domainBuilder.certification.enrolment.buildComplementarySubscription({
+                certificationCandidateId,
+                complementaryCertificationId,
+              }),
+            ],
+          });
+
+          dependencies.certificationBadgesService.findLatestBadgeAcquisitions.resolves([]);
+
+          // when
+          const error = await catchErr(verifyCandidateSubscriptions)({
+            userId: candidate.userId,
             candidate,
+            limitDate: Date.now(),
             ...dependencies,
-          }),
-        ).to.be.fulfilled;
+          });
+
+          //then
+          expect(error).to.be.instanceOf(CertificationCandidateEligibilityError);
+        });
       });
     });
 

--- a/mon-pix/tests/acceptance/certification-course-test.js
+++ b/mon-pix/tests/acceptance/certification-course-test.js
@@ -181,7 +181,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
             assert
               .dom(
                 screen.getByText(
-                  'Les informations saisies correspondent à un candidat inscrit à la session en certification complémentaire seule.',
+                  'Les informations saisies correspondent à un candidat inscrit à une certification complémentaire.',
                   { exact: false },
                 ),
               )
@@ -190,7 +190,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
             assert
               .dom(
                 screen.getByText(
-                  'Vérifiez que vous êtes connecté au compte éligible pour le passage de la certification complémentaire seule.',
+                  'Vérifiez que vous êtes connecté au compte éligible pour le passage de cette certification complémentaire.',
                   { exact: false },
                 ),
               )

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -722,7 +722,7 @@
         "message": "Well done, {fullName}, your Pix profile can now be certified."
       },
       "error-messages": {
-        "candidate-not-eligible": "<strong>The account with which you are currently logged in isn’t eligible for this session of certification.</strong> '<br>' The information entered matches a candidate enrolled in the session for taking a complementary certification on it’s own. '<br>' Please check that you are logged with an account that is eligible to taking the complementary certification alone.",
+        "candidate-not-eligible": "<strong>The account with which you are currently logged in isn’t eligible for this session of certification.</strong> '<br>' The information entered matches a candidate enrolled in the session for taking a complementary certification. '<br>' Please check that you are logged with an account that is eligible to taking this complementary certification.",
         "generic": {
           "check-personal-info": "Check with the invigilator that your personal information matches the sign-in sheet.",
           "check-session-number": "Check the session number.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -723,7 +723,7 @@
         "message": "Bravo {fullName}, votre profil Pix est certifiable."
       },
       "error-messages": {
-        "candidate-not-eligible": "<strong>Le compte avec lequel vous êtes actuellement connecté n’est pas éligible à cette session de certification.</strong> '<br>' Les informations saisies correspondent à un candidat inscrit à la session en certification complémentaire seule. '<br>' Vérifiez que vous êtes connecté au compte éligible pour le passage de la certification complémentaire seule.",
+        "candidate-not-eligible": "<strong>Le compte avec lequel vous êtes actuellement connecté n’est pas éligible à cette session de certification.</strong> '<br>' Les informations saisies correspondent à un candidat inscrit à une certification complémentaire. '<br>' Vérifiez que vous êtes connecté au compte éligible pour le passage de cette certification complémentaire.",
         "generic": {
           "check-personal-info": "Vérifiez auprès du surveillant la correspondance de vos informations personnelles avec la feuille d'émargement.",
           "check-session-number": "Vérifiez le numéro de session.",


### PR DESCRIPTION
## :fallen_leaf: Problème
La vérification d'élibilité à la réconciliation n'est actuellement faite que pour les candidats inscrits en Pix+ seule.

## :chestnut: Proposition
Vérifier que le candidat a aquis le RT certifiant avant lors de la réconciliation


## :wood: Pour tester
- Inscrire un candidat en session pour une certification Pix + Clea
- tenter de rejoindre la session avec un user n'ayant PAS le badge
- constater l'affichage suivant

![image](https://github.com/user-attachments/assets/ac078584-7280-443d-a0ad-9898356361d8)

- tenter de rejoindre la session avec un user ayant le badge
- constater que l'entrée en session se passe correctement
