### PR TITLE
[BUGFIX] :bug: Plus d'erreur 500 si une épreuve est à la fois répondue et signalée (PIX-15484)

### DIFF
--- a/api/src/certification/evaluation/domain/usecases/get-next-challenge.js
+++ b/api/src/certification/evaluation/domain/usecases/get-next-challenge.js
@@ -44,16 +44,19 @@ const getNextChallenge = async function ({
 }) {
   const certificationCourse = await certificationCourseRepository.get({ id: assessment.certificationCourseId });
 
-  const allAnswers = await answerRepository.findByAssessment(assessment.id);
-  const alreadyAnsweredChallengeIds = allAnswers.map(({ challengeId }) => challengeId);
-
   const validatedLiveAlertChallengeIds = await _getValidatedLiveAlertChallengeIds({
     assessmentId: assessment.id,
     certificationChallengeLiveAlertRepository,
   });
 
-  const excludedChallengeIds = [...alreadyAnsweredChallengeIds, ...validatedLiveAlertChallengeIds];
+  const allAnswers = await answerRepository.findByAssessmentExcludingChallengeIds({
+    assessmentId: assessment.id,
+    excludedChallengeIds: validatedLiveAlertChallengeIds,
+  });
 
+  const alreadyAnsweredChallengeIds = allAnswers.map(({ challengeId }) => challengeId);
+
+  const excludedChallengeIds = [...alreadyAnsweredChallengeIds, ...validatedLiveAlertChallengeIds];
   const lastNonAnsweredCertificationChallenge =
     await sessionManagementCertificationChallengeRepository.getNextChallengeByCourseIdForV3(
       assessment.certificationCourseId,

--- a/api/src/shared/infrastructure/repositories/answer-repository.js
+++ b/api/src/shared/infrastructure/repositories/answer-repository.js
@@ -81,6 +81,16 @@ const findByAssessment = async function (assessmentId) {
   return _toDomainArray(answerDTOsWithoutDuplicate);
 };
 
+const findByAssessmentExcludingChallengeIds = async function ({ assessmentId, excludedChallengeIds = [] }) {
+  const answerDTOs = await knex
+    .select(COLUMNS)
+    .from('answers')
+    .where({ assessmentId })
+    .whereNotIn('challengeId', excludedChallengeIds);
+
+  return _toDomainArray(answerDTOs);
+};
+
 const findChallengeIdsFromAnswerIds = async function (ids) {
   return knex.distinct().pluck('challengeId').from('answers').whereInArray('id', ids);
 };
@@ -108,6 +118,7 @@ const saveWithKnowledgeElements = async function (answer, knowledgeElements) {
 };
 export {
   findByAssessment,
+  findByAssessmentExcludingChallengeIds,
   findByChallengeAndAssessment,
   findChallengeIdsFromAnswerIds,
   get,

--- a/api/tests/certification/evaluation/unit/domain/usecases/get-next-challenge_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/get-next-challenge_test.js
@@ -26,7 +26,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
         getMostRecentBeforeDate: sinon.stub(),
       };
       answerRepository = {
-        findByAssessment: sinon.stub(),
+        findByAssessmentExcludingChallengeIds: sinon.stub(),
       };
       challengeRepository = {
         get: sinon.stub(),
@@ -79,7 +79,9 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           .withArgs(v3CertificationCourse.getStartDate())
           .resolves(flashAlgorithmConfiguration);
 
-        answerRepository.findByAssessment.withArgs(assessment.id).resolves([]);
+        answerRepository.findByAssessmentExcludingChallengeIds
+          .withArgs({ assessmentId: assessment.id, excludedChallengeIds: [] })
+          .resolves([]);
         certificationChallengeLiveAlertRepository.getLiveAlertValidatedChallengeIdsByAssessmentId
           .withArgs({ assessmentId: assessment.id })
           .resolves([]);
@@ -170,7 +172,9 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
             .withArgs(v3CertificationCourse.getStartDate())
             .resolves(flashAlgorithmConfiguration);
 
-          answerRepository.findByAssessment.withArgs(assessment.id).resolves([]);
+          answerRepository.findByAssessmentExcludingChallengeIds
+            .withArgs({ assessmentId: assessment.id, excludedChallengeIds: [] })
+            .resolves([]);
           certificationChallengeLiveAlertRepository.getLiveAlertValidatedChallengeIdsByAssessmentId
             .withArgs({ assessmentId: assessment.id })
             .resolves([]);
@@ -259,7 +263,9 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
             id: nonAnsweredCertificationChallenge.challengeId,
           });
 
-          answerRepository.findByAssessment.withArgs(assessment.id).resolves([]);
+          answerRepository.findByAssessmentExcludingChallengeIds
+            .withArgs({ assessmentId: assessment.id, excludedChallengeIds: [] })
+            .resolves([]);
           certificationChallengeLiveAlertRepository.getLiveAlertValidatedChallengeIdsByAssessmentId
             .withArgs({ assessmentId: assessment.id })
             .resolves([]);
@@ -319,8 +325,8 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
 
         const answerStillValid = domainBuilder.buildAnswer({ challengeId: alreadyAnsweredChallenge.id });
         const answerWithOutdatedChallenge = domainBuilder.buildAnswer({ challengeId: outdatedChallenge.id });
-        answerRepository.findByAssessment
-          .withArgs(assessment.id)
+        answerRepository.findByAssessmentExcludingChallengeIds
+          .withArgs({ assessmentId: assessment.id, excludedChallengeIds: [] })
           .resolves([answerStillValid, answerWithOutdatedChallenge]);
 
         certificationChallengeLiveAlertRepository.getLiveAlertValidatedChallengeIdsByAssessmentId
@@ -418,7 +424,12 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           .withArgs(v3CertificationCourse.getStartDate())
           .resolves(flashAlgorithmConfiguration);
 
-        answerRepository.findByAssessment.withArgs(assessment.id).resolves([]);
+        answerRepository.findByAssessmentExcludingChallengeIds
+          .withArgs({
+            assessmentId: assessment.id,
+            excludedChallengeIds: [nonAnsweredCertificationChallenge.challengeId],
+          })
+          .resolves([]);
         challengeRepository.findActiveFlashCompatible.withArgs({ locale }).resolves([nextChallenge, lastSeenChallenge]);
         challengeRepository.getMany.withArgs([]).resolves([]);
 
@@ -514,7 +525,12 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           .withArgs(v3CertificationCourse.getStartDate())
           .resolves(flashAlgorithmConfiguration);
 
-        answerRepository.findByAssessment.withArgs(assessment.id).resolves([]);
+        answerRepository.findByAssessmentExcludingChallengeIds
+          .withArgs({
+            assessmentId: assessment.id,
+            excludedChallengeIds: [nonAnsweredCertificationChallenge.challengeId],
+          })
+          .resolves([]);
         challengeRepository.findActiveFlashCompatible
           .withArgs()
           .resolves([challengeWithLiveAlert, challengeWithOtherSkill, challengeWithLiveAlertedSkill]);
@@ -600,7 +616,9 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           .withArgs(v3CertificationCourse.getStartDate())
           .resolves(flashAlgorithmConfiguration);
 
-        answerRepository.findByAssessment.withArgs(assessment.id).resolves([answer]);
+        answerRepository.findByAssessmentExcludingChallengeIds
+          .withArgs({ assessmentId: assessment.id, excludedChallengeIds: [] })
+          .resolves([answer]);
         certificationChallengeLiveAlertRepository.getLiveAlertValidatedChallengeIdsByAssessmentId
           .withArgs({ assessmentId: assessment.id })
           .resolves([]);
@@ -679,7 +697,9 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
             const assessment = domainBuilder.buildAssessment();
             const locale = 'fr-FR';
 
-            answerRepository.findByAssessment.withArgs(assessment.id).resolves([]);
+            answerRepository.findByAssessmentExcludingChallengeIds
+              .withArgs({ assessmentId: assessment.id, excludedChallengeIds: [] })
+              .resolves([]);
             certificationChallengeLiveAlertRepository.getLiveAlertValidatedChallengeIdsByAssessmentId
               .withArgs({ assessmentId: assessment.id })
               .resolves([]);


### PR DESCRIPTION
## :fallen_leaf: Problème

Une certification peut être bloquée parce qu'un signalement ET une réponse sont associées à la même épreuve.

## :chestnut: Proposition

Exclure les réponses liées à un signalement validé lors de la sélection de la prochaine épreuve

## :jack_o_lantern: Remarques

## :wood: Pour tester

- Démarrer une session de certification ;
- En arrivant sur une page d'épreuves, insérer en base de donnée un signalement validée associé
- Répondre à l'épreuve

Aucun problème ne devrait survenir.

