### PR TITLE
[TECH] Retirer les imports directs en dehors des repositories autorisés aux fichiers "datasources/learning-content/*" (PIX-15474)

### DIFF
--- a/api/db/seeds/data/common/tooling/learning-content.js
+++ b/api/db/seeds/data/common/tooling/learning-content.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 
-import { skillDatasource } from '../../../../../src/shared/infrastructure/datasources/learning-content/skill-datasource.js';
 import * as challengeRepository from '../../../../../src/shared/infrastructure/repositories/challenge-repository.js';
 import * as competenceRepository from '../../../../../src/shared/infrastructure/repositories/competence-repository.js';
+import * as skillRepository from '../../../../../src/shared/infrastructure/repositories/skill-repository.js';
 import { logger } from '../../../../../src/shared/infrastructure/utils/logger.js';
 
 let ALL_COMPETENCES, ALL_ACTIVE_SKILLS, ALL_CHALLENGES, ACTIVE_SKILLS_BY_COMPETENCE, ACTIVE_SKILLS_BY_TUBE;
@@ -35,7 +35,7 @@ async function getCoreCompetences() {
 
 async function getAllActiveSkills() {
   if (!ALL_ACTIVE_SKILLS) {
-    ALL_ACTIVE_SKILLS = await skillDatasource.findActive();
+    ALL_ACTIVE_SKILLS = (await skillRepository.list()).filter((skill) => skill.status === 'actif');
   }
   return ALL_ACTIVE_SKILLS;
 }

--- a/api/lib/infrastructure/repositories/campaign-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-repository.js
@@ -1,8 +1,8 @@
 import { knex } from '../../../db/knex-database-connection.js';
+import * as tubeRepository from '../../../lib/infrastructure/repositories/tube-repository.js';
 import { CAMPAIGN_FEATURES } from '../../../src/shared/domain/constants.js';
 import { NotFoundError } from '../../../src/shared/domain/errors.js';
 import { Campaign } from '../../../src/shared/domain/models/Campaign.js';
-import { tubeDatasource } from '../../../src/shared/infrastructure/datasources/learning-content/tube-datasource.js';
 import * as skillRepository from '../../../src/shared/infrastructure/repositories/skill-repository.js';
 import { DomainTransaction } from '../DomainTransaction.js';
 
@@ -127,7 +127,7 @@ const findTubes = async function ({ campaignId }) {
 
 const findAllSkills = async function ({ campaignId }) {
   const tubeIds = await findTubes({ campaignId });
-  const tubes = await tubeDatasource.findByRecordIds(tubeIds);
+  const tubes = await tubeRepository.findByRecordIds(tubeIds);
   const skillIds = tubes.flatMap((tube) => tube.skillIds);
   return skillRepository.findByRecordIds(skillIds);
 };

--- a/api/lib/infrastructure/repositories/correction-repository.js
+++ b/api/lib/infrastructure/repositories/correction-repository.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 
+// TODO modifier les dépendances avec datasource en meme temps que la PR de lecture, pour des considérations de perf
 import { Answer } from '../../../src/evaluation/domain/models/Answer.js';
 import { Challenge } from '../../../src/shared/domain/models/Challenge.js';
 import { Correction } from '../../../src/shared/domain/models/Correction.js';

--- a/api/scripts/data-generation/generate-certifications-for-organization.js
+++ b/api/scripts/data-generation/generate-certifications-for-organization.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import yargs from 'yargs';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
-import { competenceDatasource } from '../../src/shared/infrastructure/datasources/learning-content/competence-datasource.js';
+import * as competenceRepository from '../../src/shared/infrastructure/repositories/competence-repository.js';
 
 const CERTIF_ERROR_RATE = 0.05;
 const CERTIF_REJECTED_RATE = 0.15;
@@ -79,7 +79,7 @@ async function _do({ organizationId, certificationCenterId }) {
     await _createCertificationResultsInError({ assessmentIds: errorAssessmentIds, transaction });
     console.log('\tOK');
 
-    const competences = await competenceDatasource.list();
+    const competences = await competenceRepository.list();
     const pixCompetences = competences.filter((competence) => competence.origin === 'Pix');
     const rejectedCount = parseInt(allAssessmentIds.length * CERTIF_REJECTED_RATE);
     const rejectedAssessmentIds = _.sampleSize(allAssessmentIds, rejectedCount);

--- a/api/src/certification/results/infrastructure/repositories/certified-profile-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certified-profile-repository.js
@@ -5,6 +5,7 @@ import { LOCALE } from '../../../../shared/domain/constants.js';
 const { FRENCH_SPOKEN } = LOCALE;
 import { knex } from '../../../../../db/knex-database-connection.js';
 import * as knowledgeElementRepository from '../../../../../lib/infrastructure/repositories/knowledge-element-repository.js';
+import * as tubeRepository from '../../../../../lib/infrastructure/repositories/tube-repository.js';
 import * as areaRepository from '../../../../../src/shared/infrastructure/repositories/area-repository.js';
 import * as competenceRepository from '../../../../../src/shared/infrastructure/repositories/competence-repository.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
@@ -15,10 +16,7 @@ import {
   CertifiedSkill,
   CertifiedTube,
 } from '../../../../shared/domain/read-models/CertifiedProfile.js';
-import {
-  skillDatasource,
-  tubeDatasource,
-} from '../../../../shared/infrastructure/datasources/learning-content/index.js';
+import { skillDatasource } from '../../../../shared/infrastructure/datasources/learning-content/index.js';
 
 const get = async function (certificationCourseId) {
   const certificationDatas = await knex
@@ -80,13 +78,13 @@ async function _createCertifiedSkills(skillIds, askedSkillIds) {
 
 async function _createCertifiedTubes(certifiedSkills) {
   const certifiedSkillsByTube = _.groupBy(certifiedSkills, 'tubeId');
-  const learningContentTubes = await tubeDatasource.findByRecordIds(Object.keys(certifiedSkillsByTube));
-  return learningContentTubes.map((learningContentTube) => {
-    const name = learningContentTube.practicalTitle_i18n.fr;
+  const tubes = await tubeRepository.findByRecordIds(Object.keys(certifiedSkillsByTube), FRENCH_SPOKEN);
+  return tubes.map((tube) => {
+    const name = tube.practicalTitle;
     return new CertifiedTube({
-      id: learningContentTube.id,
+      id: tube.id,
       name,
-      competenceId: learningContentTube.competenceId,
+      competenceId: tube.competenceId,
     });
   });
 }

--- a/api/src/certification/results/infrastructure/repositories/certified-profile-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certified-profile-repository.js
@@ -6,6 +6,7 @@ const { FRENCH_SPOKEN } = LOCALE;
 import { knex } from '../../../../../db/knex-database-connection.js';
 import * as knowledgeElementRepository from '../../../../../lib/infrastructure/repositories/knowledge-element-repository.js';
 import * as areaRepository from '../../../../../src/shared/infrastructure/repositories/area-repository.js';
+import * as competenceRepository from '../../../../../src/shared/infrastructure/repositories/competence-repository.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import {
   CertifiedArea,
@@ -15,7 +16,6 @@ import {
   CertifiedTube,
 } from '../../../../shared/domain/read-models/CertifiedProfile.js';
 import {
-  competenceDatasource,
   skillDatasource,
   tubeDatasource,
 } from '../../../../shared/infrastructure/datasources/learning-content/index.js';
@@ -93,16 +93,17 @@ async function _createCertifiedTubes(certifiedSkills) {
 
 async function _createCertifiedCompetences(certifiedTubes) {
   const certifiedTubesByCompetence = _.groupBy(certifiedTubes, 'competenceId');
-  const learningContentCompetences = await competenceDatasource.findByRecordIds(
-    Object.keys(certifiedTubesByCompetence),
-  );
-  return learningContentCompetences.map((learningContentCompetence) => {
-    const name = learningContentCompetence.name_i18n.fr;
+  const competences = await competenceRepository.findByRecordIds({
+    competenceIds: Object.keys(certifiedTubesByCompetence),
+    locale: FRENCH_SPOKEN,
+  });
+  return competences.map((competence) => {
+    const name = competence.name;
     return new CertifiedCompetence({
-      id: learningContentCompetence.id,
+      id: competence.id,
       name,
-      areaId: learningContentCompetence.areaId,
-      origin: learningContentCompetence.origin,
+      areaId: competence.areaId,
+      origin: competence.origin,
     });
   });
 }

--- a/api/src/certification/results/infrastructure/repositories/certified-profile-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certified-profile-repository.js
@@ -1,21 +1,24 @@
 import _ from 'lodash';
 
+import { LOCALE } from '../../../../shared/domain/constants.js';
+
+const { FRENCH_SPOKEN } = LOCALE;
 import { knex } from '../../../../../db/knex-database-connection.js';
 import * as knowledgeElementRepository from '../../../../../lib/infrastructure/repositories/knowledge-element-repository.js';
-import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import * as areaRepository from '../../../../../src/shared/infrastructure/repositories/area-repository.js';
+import { NotFoundError } from '../../../../shared/domain/errors.js';
 import {
   CertifiedArea,
   CertifiedCompetence,
   CertifiedProfile,
   CertifiedSkill,
   CertifiedTube,
-} from '../../../../../src/shared/domain/read-models/CertifiedProfile.js';
+} from '../../../../shared/domain/read-models/CertifiedProfile.js';
 import {
-  areaDatasource,
   competenceDatasource,
   skillDatasource,
   tubeDatasource,
-} from '../../../../../src/shared/infrastructure/datasources/learning-content/index.js';
+} from '../../../../shared/infrastructure/datasources/learning-content/index.js';
 
 const get = async function (certificationCourseId) {
   const certificationDatas = await knex
@@ -106,13 +109,16 @@ async function _createCertifiedCompetences(certifiedTubes) {
 
 async function _createCertifiedAreas(certifiedCompetences) {
   const certifiedCompetencesByArea = _.groupBy(certifiedCompetences, 'areaId');
-  const learningContentAreas = await areaDatasource.findByRecordIds(Object.keys(certifiedCompetencesByArea));
-  return learningContentAreas.map((learningContentArea) => {
-    const name = learningContentArea.title_i18n.fr;
+  const areas = await areaRepository.findByRecordIds({
+    areaIds: Object.keys(certifiedCompetencesByArea),
+    locale: FRENCH_SPOKEN,
+  });
+  return areas.map((area) => {
+    const name = area.title;
     return new CertifiedArea({
-      id: learningContentArea.id,
+      id: area.id,
       name,
-      color: learningContentArea.color,
+      color: area.color,
     });
   });
 }

--- a/api/src/certification/results/infrastructure/repositories/certified-profile-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certified-profile-repository.js
@@ -8,6 +8,7 @@ import * as knowledgeElementRepository from '../../../../../lib/infrastructure/r
 import * as tubeRepository from '../../../../../lib/infrastructure/repositories/tube-repository.js';
 import * as areaRepository from '../../../../../src/shared/infrastructure/repositories/area-repository.js';
 import * as competenceRepository from '../../../../../src/shared/infrastructure/repositories/competence-repository.js';
+import * as skillRepository from '../../../../../src/shared/infrastructure/repositories/skill-repository.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import {
   CertifiedArea,
@@ -16,7 +17,6 @@ import {
   CertifiedSkill,
   CertifiedTube,
 } from '../../../../shared/domain/read-models/CertifiedProfile.js';
-import { skillDatasource } from '../../../../shared/infrastructure/datasources/learning-content/index.js';
 
 const get = async function (certificationCourseId) {
   const certificationDatas = await knex
@@ -64,14 +64,14 @@ const get = async function (certificationCourseId) {
 export { get };
 
 async function _createCertifiedSkills(skillIds, askedSkillIds) {
-  const learningContentSkills = await skillDatasource.findByRecordIds(skillIds);
-  return learningContentSkills.map((learningContentSkill) => {
+  const skills = await skillRepository.findByRecordIds(skillIds);
+  return skills.map((skill) => {
     return new CertifiedSkill({
-      id: learningContentSkill.id,
-      name: learningContentSkill.name,
-      hasBeenAskedInCertif: askedSkillIds.includes(learningContentSkill.id),
-      tubeId: learningContentSkill.tubeId,
-      difficulty: learningContentSkill.level,
+      id: skill.id,
+      name: skill.name,
+      hasBeenAskedInCertif: askedSkillIds.includes(skill.id),
+      tubeId: skill.tubeId,
+      difficulty: skill.difficulty,
     });
   });
 }

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/certified-profile-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/certified-profile-repository_test.js
@@ -1,6 +1,6 @@
 import * as certifiedProfileRepository from '../../../../../../src/certification/results/infrastructure/repositories/certified-profile-repository.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
-import { KnowledgeElement } from '../../../../../../src/shared/domain/models/KnowledgeElement.js';
+import { KnowledgeElement } from '../../../../../../src/shared/domain/models/index.js';
 import { CertifiedProfile } from '../../../../../../src/shared/domain/read-models/CertifiedProfile.js';
 import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
 

--- a/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
@@ -6,13 +6,15 @@ import { CAMPAIGN_FEATURES } from '../../../../src/shared/domain/constants.js';
 import { NotFoundError } from '../../../../src/shared/domain/errors.js';
 import { Campaign } from '../../../../src/shared/domain/models/Campaign.js';
 import { databaseBuilder, domainBuilder, expect, mockLearningContent } from '../../../test-helper.js';
-import { buildArea } from '../../../tooling/domain-builder/factory/build-area.js';
-import { buildCompetence } from '../../../tooling/domain-builder/factory/build-competence.js';
-import { buildFramework } from '../../../tooling/domain-builder/factory/build-framework.js';
-import { buildSkill } from '../../../tooling/domain-builder/factory/build-skill.js';
-import { buildThematic } from '../../../tooling/domain-builder/factory/build-thematic.js';
-import { buildTube } from '../../../tooling/domain-builder/factory/build-tube.js';
-import { buildLearningContent } from '../../../tooling/learning-content-builder/build-learning-content.js';
+import {
+  buildArea,
+  buildCompetence,
+  buildFramework,
+  buildSkill,
+  buildThematic,
+  buildTube,
+} from '../../../tooling/domain-builder/factory/index.js';
+import { buildLearningContent } from '../../../tooling/learning-content-builder/index.js';
 
 describe('Integration | Repository | Campaign', function () {
   describe('#areKnowledgeElementsResettable', function () {

--- a/api/tests/tooling/learning-content-builder/build-skill.js
+++ b/api/tests/tooling/learning-content-builder/build-skill.js
@@ -1,5 +1,3 @@
-import * as skillDatasource from '../../../src/shared/infrastructure/datasources/learning-content/skill-datasource.js';
-
 const buildSkill = function buildSkill({
   id = 'recSK123',
   name = '@sau6',
@@ -10,7 +8,7 @@ const buildSkill = function buildSkill({
   tubeId = 'recTUB123',
   version = 1,
   level = 6,
-  status = skillDatasource.ACTIVE_STATUS,
+  status = 'actif',
 } = {}) {
   return {
     id,


### PR DESCRIPTION
## :fallen_leaf: Problème
On va dégommer les datasources dans peu de temps

## :chestnut: Proposition
Essayer de centraliser les appels aux datasources que depuis le repository correspondant. Exemple : areaDatasource doit être utilisé uniquement dans areaRepository.

## :jack_o_lantern: Remarques
Dans le correction repository, il y a des appels directs au challengeDatasource et skillDatasource. Les remplacer maintenant risque de poser des problèmes de perf. On prévoit leur remplacement durant la PR de changement de paradigme concernant la gestion du cache référentiel (qui ne saurait tarder)

## :wood: Pour tester
tests au vert
