### PR TITLE
[BUGFIX] Le scroll auto ne descend pas assez bas (PIX-15476)

### DIFF
--- a/mon-pix/app/components/module/navbar.gjs
+++ b/mon-pix/app/components/module/navbar.gjs
@@ -52,6 +52,7 @@ export default class ModulixNavbar extends Component {
 
   <template>
     <nav
+      id="module-navbar"
       class="module-navbar"
       aria-label={{t "pages.modulix.flashcards.navigation.currentStep" current=@currentStep total=@totalSteps}}
     >

--- a/mon-pix/app/services/modulix-auto-scroll.js
+++ b/mon-pix/app/services/modulix-auto-scroll.js
@@ -13,10 +13,11 @@ export default class ModulixAutoScroll extends Service {
 
   focusAndScroll(
     htmlElement,
-    { scroll, userPrefersReducedMotion, getWindowScrollY } = {
+    { scroll, userPrefersReducedMotion, getWindowScrollY, getNavbar } = {
       scroll: this.#scroll,
       userPrefersReducedMotion: this.#userPrefersReducedMotion,
       getWindowScrollY: this.#getWindowScrollY,
+      getNavbar: this.#getNavbar,
     },
   ) {
     if (this.modulixPreviewMode.isEnabled) {
@@ -27,7 +28,7 @@ export default class ModulixAutoScroll extends Service {
 
     const elementY = htmlElement.getBoundingClientRect().top + getWindowScrollY();
     scroll({
-      top: elementY - this.#SCROLL_OFFSET_PX,
+      top: elementY - this.#getScrollOffset({ getNavbar }),
       behavior: userPrefersReducedMotion() ? 'instant' : 'smooth',
     });
   }
@@ -43,5 +44,9 @@ export default class ModulixAutoScroll extends Service {
 
   #getWindowScrollY() {
     return window.scrollY;
+  }
+
+  #getNavbar() {
+    return document.getElementById('module-navbar');
   }
 }

--- a/mon-pix/app/services/modulix-auto-scroll.js
+++ b/mon-pix/app/services/modulix-auto-scroll.js
@@ -4,11 +4,18 @@ import Service, { service } from '@ember/service';
 export default class ModulixAutoScroll extends Service {
   @service modulixPreviewMode;
 
-  #SCROLL_OFFSET_PX = 70;
+  #DISTANCE_BETWEEN_GRAIN_AND_NAVBAR_PX = 70;
 
   @action
   setHTMLElementScrollOffsetCssProperty(htmlElement) {
-    htmlElement.style.setProperty('--scroll-offset', `${this.#SCROLL_OFFSET_PX}px`);
+    htmlElement.style.setProperty('--scroll-offset', `${this.#getScrollOffset()}px`);
+  }
+
+  #getScrollOffset({ getNavbar } = { getNavbar: this.#getNavbar }) {
+    const navbarElement = getNavbar();
+    const navbarHeight = navbarElement ? navbarElement.getBoundingClientRect().height : 0;
+
+    return this.#DISTANCE_BETWEEN_GRAIN_AND_NAVBAR_PX + navbarHeight;
   }
 
   focusAndScroll(

--- a/mon-pix/tests/unit/services/modulix-auto-scroll-test.js
+++ b/mon-pix/tests/unit/services/modulix-auto-scroll-test.js
@@ -36,6 +36,39 @@ module('Unit | Services | Module | ModulixAutoScroll', function (hooks) {
         assert.ok(true);
       });
 
+      test('should scroll to given html element', function (assert) {
+        // given
+        const scrollOffsetPx = 70;
+        const topOfGivenElement = 150;
+        const navbarHeight = 72;
+        const windowScrollY = 12;
+
+        const modulixAutoScrollService = this.owner.lookup('service:modulix-auto-scroll');
+        const htmlElement = document.createElement('div');
+        htmlElement.getBoundingClientRect = sinon.stub().returns({ top: topOfGivenElement });
+        const navbarElement = document.createElement('nav');
+        navbarElement.getBoundingClientRect = sinon.stub().returns({ height: navbarHeight });
+        const scroll = sinon.stub();
+        const getNavbar = sinon.stub().returns(navbarElement);
+        const getWindowScrollY = sinon.stub().returns(windowScrollY);
+        const userPrefersReducedMotion = sinon.stub().returns(false);
+
+        // when
+        modulixAutoScrollService.focusAndScroll(htmlElement, {
+          scroll,
+          userPrefersReducedMotion,
+          getWindowScrollY,
+          getNavbar,
+        });
+
+        // then
+        sinon.assert.calledWithExactly(scroll, {
+          top: topOfGivenElement + windowScrollY - (scrollOffsetPx + navbarHeight),
+          behavior: 'smooth',
+        });
+        assert.ok(true);
+      });
+
       module('according to user preferences', function (hooks) {
         let modulixAutoScrollService;
         let htmlElement;
@@ -64,6 +97,7 @@ module('Unit | Services | Module | ModulixAutoScroll', function (hooks) {
             scroll: scrollStub,
             userPrefersReducedMotion: userPrefersReducedMotionStub,
             getWindowScrollY: getWindowScrollYStub,
+            getNavbar: sinon.stub(),
           });
         }
 
@@ -110,9 +144,11 @@ module('Unit | Services | Module | ModulixAutoScroll', function (hooks) {
         const modulixAutoScrollService = this.owner.lookup('service:modulix-auto-scroll');
         const htmlElement = document.createElement('div');
         htmlElement.focus = sinon.stub();
+
         class PreviewModeServiceStub extends Service {
           isEnabled = true;
         }
+
         this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
 
         // when


### PR DESCRIPTION
## :fallen_leaf: Problème
La barre de navigation n’est pas prise en compte dans le calcul du scroll, il faudrait inclure sa hauteur pour éviter de tomber au milieu d’un texte

## :chestnut: Proposition
Utiliser un document.getelementById pour récupérer l'élément Navbar, le passer à la fonction focusAndScroll() et calculer la hauteur à laquelle afficher l'écran en fonction de l'épaisseur de la Navbar.

## :jack_o_lantern: Remarques
- Solution alternative suite à la PR créée sur le même sujet [ici](https://github.com/1024pix/pix/pull/10657)
- Dans la fonction focusAndScroll, on a dû ajouter en paramètre la fonction getNavbar qui permet de récupérer l'élement Navbar sur la page du module. Cela permet notamment d'avoir un test unitaire fonctionnel

## :wood: Pour tester
- Ouvrir un module
- Cliquer sur "Continuer" ou "Passer" sur des grains et voir comment se comporte le scroll
- Zoomer la page sur le navigateur
- Cliquer sur "Continuer" ou "Passer" sur des grains et voir comment se comporte le scroll
