### PR TITLE
[TECH] Appliquer le nouveau nommage des composants sur Pix Admin (PIX-14606)

### DIFF
--- a/admin/app/components/administration/certification/sco-whitelist-configuration.gjs
+++ b/admin/app/components/administration/certification/sco-whitelist-configuration.gjs
@@ -1,6 +1,6 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
-import PixMessage from '@1024pix/pix-ui/components/pix-message';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -74,7 +74,9 @@ export default class ScoWhitelistConfiguration extends Component {
       @title={{t "pages.administration.certification.sco-whitelist.title"}}
       class="sco-whitelist-configuration"
     >
-      <PixMessage @type="info">{{t "pages.administration.certification.sco-whitelist.instructions"}}</PixMessage>
+      <PixNotificationAlert @type="info">{{t
+          "pages.administration.certification.sco-whitelist.instructions"
+        }}</PixNotificationAlert>
 
       <div class="sco-whitelist-configuration__actions">
         <PixButton @triggerAction={{this.exportWhitelist}} @isLoading={{this.isExportLoading}}>

--- a/admin/app/components/administration/certification/scoring-simulator.gjs
+++ b/admin/app/components/administration/certification/scoring-simulator.gjs
@@ -1,7 +1,7 @@
 import PixBlock from '@1024pix/pix-ui/components/pix-block';
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixMessage from '@1024pix/pix-ui/components/pix-message';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
@@ -95,7 +95,10 @@ export default class ScoringSimulator extends Component {
       </form>
 
       {{#each this.errors as |error|}}
-        <PixMessage class="scoring-simulator-form__error-message" @type="error">{{error}}</PixMessage>
+        <PixNotificationAlert
+          class="scoring-simulator-form__error-message"
+          @type="error"
+        >{{error}}</PixNotificationAlert>
       {{/each}}
 
       <dl class="scoring-simulator__data">

--- a/admin/app/components/administration/common/learning-content.gjs
+++ b/admin/app/components/administration/common/learning-content.gjs
@@ -1,5 +1,5 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixMessage from '@1024pix/pix-ui/components/pix-message';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -41,12 +41,12 @@ export default class LearningContent extends Component {
         <p>Une version du référentiel de données pédagogique est créée quotidiennement (vers 4h00) et le référentiel
           utilisé par l'application est mis à jour (vers 6h00).</p>
         <p>Si le cache a été vidé, il peut s’avérer utile ou nécessaire de recharger le référentiel.</p>
-        <PixMessage @type="alert" @withIcon={{true}}>
+        <PixNotificationAlert @type="alert" @withIcon={{true}}>
           <strong>Attention !</strong>
           Le rechargement du référentiel est une opération risquée. Il est recommandé de ne l’effectuer qu’en cas de
           force majeure, accompagné d’un développeur ou d'une développeuse.
-        </PixMessage>
-        <PixMessage @type="info">Durée de l’opération : <strong>≈10s</strong>.</PixMessage>
+        </PixNotificationAlert>
+        <PixNotificationAlert @type="info">Durée de l’opération : <strong>≈10s</strong>.</PixNotificationAlert>
 
         <PixButton class="btn-refresh-cache" @triggerAction={{this.refreshLearningContent}} @iconBefore="reload">
           Recharger le cache
@@ -54,7 +54,7 @@ export default class LearningContent extends Component {
         <br /><br />
         <p>Si quelque chose a été changé dans le référentiel et qu'il faut appliquer ces changements dans l'application,
           il faut créer une nouvelle version et mettre à jour le cache.</p>
-        <PixMessage @type="info">Durée de l’opération : <strong>≈1mn</strong>.</PixMessage>
+        <PixNotificationAlert @type="info">Durée de l’opération : <strong>≈1mn</strong>.</PixNotificationAlert>
         <PixButton
           @triggerAction={{this.createLearningContentReleaseAndRefreshCache}}
           @variant="primary-bis"

--- a/admin/app/components/campaigns/update.gjs
+++ b/admin/app/components/campaigns/update.gjs
@@ -1,4 +1,4 @@
-import PixBanner from '@1024pix/pix-ui/components/pix-banner';
+import PixBannerAlert from '@1024pix/pix-ui/components/pix-banner-alert';
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
@@ -263,7 +263,7 @@ export default class Update extends Component {
             </PixFieldset>
 
             {{#if this.displayIsForAbsoluteNoviceWarning}}
-              <PixBanner @type="warning">
+              <PixBannerAlert @type="warning">
                 <div class="is-for-absolute-novice-warning">
                   <p>Les campagnes
                     <strong><i>isForAbsoluteNovice</i></strong>
@@ -275,7 +275,7 @@ export default class Update extends Component {
                     <li>Envoi de résultats</li>
                   </ul>
                 </div>
-              </PixBanner>
+              </PixBannerAlert>
             {{/if}}
           {{/if}}
         </div>

--- a/admin/app/components/common/tubes-details/area.gjs
+++ b/admin/app/components/common/tubes-details/area.gjs
@@ -1,11 +1,11 @@
-import PixCollapsible from '@1024pix/pix-ui/components/pix-collapsible';
+import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
 
 import Competence from '../tubes-details/competence';
 
 <template>
   <div class="area-border-container">
     <div class="area-border {{@color}}"></div>
-    <PixCollapsible class="{{@color}} list-competences">
+    <PixAccordions class="{{@color}} list-competences">
       <:title>{{@title}}</:title>
       <:content>
         {{#each @competences as |competence|}}
@@ -17,6 +17,6 @@ import Competence from '../tubes-details/competence';
           />
         {{/each}}
       </:content>
-    </PixCollapsible>
+    </PixAccordions>
   </div>
 </template>

--- a/admin/app/components/common/tubes-details/competence.gjs
+++ b/admin/app/components/common/tubes-details/competence.gjs
@@ -1,4 +1,4 @@
-import PixCollapsible from '@1024pix/pix-ui/components/pix-collapsible';
+import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
 import { eq } from 'ember-truth-helpers';
 
 import Header from '../../table/header';
@@ -7,7 +7,7 @@ import Tube from '../tubes-details/tube';
 
 <template>
   <div class="competence-container">
-    <PixCollapsible>
+    <PixAccordions>
       <:title>{{@title}}</:title>
       <:content>
         <div class="panel">
@@ -56,6 +56,6 @@ import Tube from '../tubes-details/tube';
           </table>
         </div>
       </:content>
-    </PixCollapsible>
+    </PixAccordions>
   </div>
 </template>

--- a/admin/app/components/common/tubes-selection/areas.gjs
+++ b/admin/app/components/common/tubes-selection/areas.gjs
@@ -1,4 +1,4 @@
-import PixCollapsible from '@1024pix/pix-ui/components/pix-collapsible';
+import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
 
 import Competence from './competence';
 
@@ -6,7 +6,7 @@ import Competence from './competence';
   {{#each @areas as |area|}}
     <div class="area-border-container">
       <div class="area-border {{area.color}}"></div>
-      <PixCollapsible class="{{area.color}} list-competences">
+      <PixAccordions class="{{area.color}} list-competences">
         <:title>{{area.code}} · {{area.title}}</:title>
         <:content>
           {{#each area.sortedCompetences as |competence|}}
@@ -22,7 +22,7 @@ import Competence from './competence';
             />
           {{/each}}
         </:content>
-      </PixCollapsible>
+      </PixAccordions>
     </div>
   {{/each}}
 </template>

--- a/admin/app/components/common/tubes-selection/competence.gjs
+++ b/admin/app/components/common/tubes-selection/competence.gjs
@@ -1,5 +1,5 @@
+import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
 import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
-import PixCollapsible from '@1024pix/pix-ui/components/pix-collapsible';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
@@ -47,7 +47,7 @@ export default class Competence extends Component {
 
   <template>
     <div class="competence-container">
-      <PixCollapsible>
+      <PixAccordions>
         <:title>{{@competence.index}} {{@competence.name}}</:title>
         <:content>
           <div class="panel">
@@ -110,7 +110,7 @@ export default class Competence extends Component {
             </table>
           </div>
         </:content>
-      </PixCollapsible>
+      </PixAccordions>
     </div>
   </template>
 }

--- a/admin/app/components/complementary-certifications/attach-badges/badges/list.gjs
+++ b/admin/app/components/complementary-certifications/attach-badges/badges/list.gjs
@@ -1,4 +1,4 @@
-import PixMessage from '@1024pix/pix-ui/components/pix-message';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
@@ -19,14 +19,14 @@ export default class List extends Component {
   <template>
     <div class="complementary-certification-attach-badges">
       {{#if @error}}
-        <PixMessage
+        <PixNotificationAlert
           role="alert"
           @type="error"
           @withIcon={{true}}
           class="complementary-certification-attach-badges__error"
         >
           {{@error}}
-        </PixMessage>
+        </PixNotificationAlert>
       {{/if}}
 
       <section class="complementary-certification-attach-badges__section">

--- a/admin/app/components/complementary-certifications/target-profiles/information.gjs
+++ b/admin/app/components/complementary-certifications/target-profiles/information.gjs
@@ -1,5 +1,5 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixToggle from '@1024pix/pix-ui/components/pix-toggle';
+import PixToggleButton from '@1024pix/pix-ui/components/pix-toggle-button';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
@@ -26,11 +26,11 @@ export default class Information extends Component {
           <LinkToCurrentTargetProfile @model={{@currentTargetProfile}} />
         {{/if}}
         {{#if this.isMultipleCurrentTargetProfiles}}
-          <PixToggle @toggled={{@switchToggle}} @onChange={{@switchTargetProfile}} @screenReaderOnly={{true}}>
+          <PixToggleButton @toggled={{@switchToggle}} @onChange={{@switchTargetProfile}} @screenReaderOnly={{true}}>
             <:label>Accéder aux détails des profils cibles courants</:label>
             <:on>Profil 1</:on>
             <:off>Profil 2</:off>
-          </PixToggle>
+          </PixToggleButton>
         {{/if}}
         {{#if this.hasAccessToAttachNewTargetProfile}}
           <div class="complementary-certification-details-target-profile__attach-button">

--- a/admin/app/components/login-form.gjs
+++ b/admin/app/components/login-form.gjs
@@ -1,6 +1,6 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixMessage from '@1024pix/pix-ui/components/pix-message';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
@@ -94,22 +94,22 @@ export default class LoginForm extends Component {
           </LinkTo>
 
           {{#if @userShouldCreateAnAccount}}
-            <PixMessage @type="alert">
+            <PixNotificationAlert @type="alert">
               Vous n'avez pas de compte Pix.
-            </PixMessage>
+            </PixNotificationAlert>
           {{/if}}
 
           {{#if @unknownErrorHasOccured}}
-            <PixMessage @type="alert">
+            <PixNotificationAlert @type="alert">
               Une erreur est survenue. Veuillez recommencer ou contacter les administrateurs de la plateforme.
-            </PixMessage>
+            </PixNotificationAlert>
           {{/if}}
 
           {{#if @userShouldRequestAccess}}
-            <PixMessage @type="alert">
+            <PixNotificationAlert @type="alert">
               Vous n'avez pas les droits pour vous connecter. Veuillez demander un accès aux administrateurs de la
               plateforme.
-            </PixMessage>
+            </PixNotificationAlert>
           {{/if}}
         {{else}}
           <PixInput

--- a/admin/app/components/organizations/information-section-view.gjs
+++ b/admin/app/components/organizations/information-section-view.gjs
@@ -1,6 +1,6 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixMessage from '@1024pix/pix-ui/components/pix-message';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
@@ -72,9 +72,9 @@ export default class OrganizationInformationSection extends Component {
           {{/each}}
         </ul>
       {{else}}
-        <PixMessage class="organization-information-section__missing-tags-message" @type="information">Cette
+        <PixNotificationAlert class="organization-information-section__missing-tags-message" @type="information">Cette
           organisation n'a pas de tags.
-        </PixMessage>
+        </PixNotificationAlert>
       {{/if}}
       <div class="organization__network-label">
         {{#if this.hasOrganizationChildren}}
@@ -100,12 +100,12 @@ export default class OrganizationInformationSection extends Component {
         {{/if}}
       </div>
       {{#if @organization.isArchived}}
-        <PixMessage class="organization-information-section__archived-message" @type="warning">
+        <PixNotificationAlert class="organization-information-section__archived-message" @type="warning">
           Archivée le
           {{@organization.archivedFormattedDate}}
           par
           {{@organization.archivistFullName}}.
-        </PixMessage>
+        </PixNotificationAlert>
       {{/if}}
 
       <div class="organization-information-section__content">

--- a/admin/app/components/target-profiles/badge-form/criteria.gjs
+++ b/admin/app/components/target-profiles/badge-form/criteria.gjs
@@ -1,6 +1,6 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
-import PixMessage from '@1024pix/pix-ui/components/pix-message';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import { fn } from '@ember/helper';
 import { concat } from '@ember/helper';
 import { on } from '@ember/modifier';
@@ -68,13 +68,13 @@ export default class Criteria extends Component {
 
   <template>
     <Card @title="Critères d'obtention du résultat thématique">
-      <PixMessage @type="info" @withIcon={{true}}>
+      <PixNotificationAlert @type="info" @withIcon={{true}}>
         Vous pouvez définir des critères de réussite du résultat thématique
         <strong>sur une liste de sujets ET/OU sur l’ensemble du profil cible</strong>.
         <br />
         <strong>Toutes les conditions devront être remplies</strong>
         pour obtenir le résultat thématique.
-      </PixMessage>
+      </PixNotificationAlert>
       <div class="badge-form-criteria-choice">
         <p>Définir un critère d'obtention&nbsp;:</p>
         <PixCheckbox

--- a/admin/app/components/target-profiles/edit-target-profile-form.gjs
+++ b/admin/app/components/target-profiles/edit-target-profile-form.gjs
@@ -1,7 +1,7 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixMessage from '@1024pix/pix-ui/components/pix-message';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
 import { fn } from '@ember/helper';
@@ -115,9 +115,9 @@ export default class CreateTargetProfileForm extends Component {
         </Card>
 
         {{#if @targetProfile.hasLinkedCampaign}}
-          <PixMessage @withIcon={{true}}>
+          <PixNotificationAlert @withIcon={{true}}>
             Le référentiel n'est pas modifiable car le profil cible est déjà relié à une campagne.
-          </PixMessage>
+          </PixNotificationAlert>
         {{else}}
           <TubesSelection
             @frameworks={{@frameworks}}

--- a/admin/app/components/target-profiles/insights.gjs
+++ b/admin/app/components/target-profiles/insights.gjs
@@ -1,4 +1,4 @@
-import PixBanner from '@1024pix/pix-ui/components/pix-banner';
+import PixBannerAlert from '@1024pix/pix-ui/components/pix-banner-alert';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 
 import Badges from './badges';
@@ -25,7 +25,7 @@ import Stages from './stages';
       <h2 class="insights-section__title">Paliers</h2>
 
       {{#if @targetProfile.hasLinkedCampaign}}
-        <PixBanner
+        <PixBannerAlert
           @type={{this.type}}
           @actionLabel={{this.actionLabel}}
           @actionUrl={{this.actionUrl}}
@@ -37,7 +37,7 @@ import Stages from './stages';
             <li>supprimer un palier existant</li>
             <li>modifier les seuils ou niveaux des paliers existants</li>
           </ul>
-        </PixBanner>
+        </PixBannerAlert>
       {{/if}}
 
       <Stages

--- a/admin/app/components/users/user-overview.gjs
+++ b/admin/app/components/users/user-overview.gjs
@@ -1,7 +1,7 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
-import PixMessage from '@1024pix/pix-ui/components/pix-message';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { fn } from '@ember/helper';
@@ -275,9 +275,12 @@ export default class UserOverview extends Component {
         {{else}}
           <div>
             {{#if @user.hasBeenAnonymised}}
-              <PixMessage @type="warning" class="user-detail-personal-information-section__anonymisation-message">
+              <PixNotificationAlert
+                @type="warning"
+                class="user-detail-personal-information-section__anonymisation-message"
+              >
                 {{this.anonymisationMessage}}
-              </PixMessage>
+              </PixNotificationAlert>
             {{/if}}
           </div>
           <div class="user-detail-personal-information-section__content">

--- a/admin/app/styles/components/common/tubes-selection.scss
+++ b/admin/app/styles/components/common/tubes-selection.scss
@@ -134,12 +134,12 @@
   }
 }
 
-.pix-collapsible__content {
+.pix-accordions__content {
   padding: 0;
 }
 
 .list-competences {
-  &.pix-collapsible__title {
+  &.pix-accordions__title {
     position: relative;
     align-items: center;
     padding-left: 2rem;
@@ -153,14 +153,14 @@
     }
   }
 
-  & + .pix-collapsible__content {
+  & + .pix-accordions__content {
     padding: 0 0 1rem 2rem;
     cursor: auto;
   }
 }
 
 .competence-container {
-  .pix-collapsible {
+  .pix-accordions {
     border-radius: 0;
     box-shadow: none;
   }

--- a/admin/app/styles/components/target-profiles/insights.scss
+++ b/admin/app/styles/components/target-profiles/insights.scss
@@ -23,7 +23,7 @@
   }
 }
 
-.insights__section > .pix-banner {
+.insights__section > .pix-banner-alert {
   margin-bottom: $pix-spacing-m;
 
   ul,

--- a/admin/app/templates/authenticated/tools.hbs
+++ b/admin/app/templates/authenticated/tools.hbs
@@ -11,12 +11,12 @@
       <header class="page-section__header">
         <h2 class="page-section__title">Archiver des campagnes en masse</h2>
       </header>
-      <PixMessage class="tools__warning" @type="warning" @withIcon={{true}}>
+      <PixNotificationAlert class="tools__warning" @type="warning" @withIcon={{true}}>
         L'envoi du fichier .csv via le bouton ci-dessous va archiver toutes campagnes renseignées.<br />
         Le fichier ne doit comporter qu'une seule colonne, correspondant aux id des campagnes, et avoir comme en-tête
         <strong>“campaignId”</strong>
         dans la première cellule de la colonne.
-      </PixMessage>
+      </PixNotificationAlert>
       <PixButtonUpload @id="file-upload" @onChange={{this.archiveCampaigns}} accept=".csv">
         Envoyer le fichier des campagnes à archiver
       </PixButtonUpload>
@@ -25,12 +25,12 @@
       <header class="page-section__header">
         <h2 class="page-section__title">Afficher un arbre de passage de missions Pix Junior</h2>
       </header>
-      <PixMessage class="tools__warning" @type="warning" @withIcon={{true}}>
+      <PixNotificationAlert class="tools__warning" @type="warning" @withIcon={{true}}>
         Cette fonctionnalité est un POC destiné à l'analyse des résultats de passage Pix Junior.<br />
         Elle permet de visualiser les résultats d'une question Metabase sous la forme d'un arbre sur le site
         <a href="https://mermaid.live/">https://mermaid.live/</a>
-      </PixMessage>
-      <PixMessage class="tools__info" @type="info" @withIcon={{true}}>
+      </PixNotificationAlert>
+      <PixNotificationAlert class="tools__info" @type="info" @withIcon={{true}}>
         <strong>Mode d'emploi</strong>
         <ol>
           <li>1. Exécuter la question Metabase
@@ -45,7 +45,7 @@
           <li>3. Envoyer le fichier json grace au bouton ci-dessous.</li>
           <li>4. À l'aide du lien généré, accéder à la représentation graphique de l'arbre de résultats.</li>
         </ol>
-      </PixMessage>
+      </PixNotificationAlert>
       <PixButtonUpload @id="json-file-upload" @onChange={{this.displayTree}} accept=".json">
         Envoyer le fichier des chemins Pix Junior
       </PixButtonUpload>

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.6",
         "@1024pix/eslint-config": "^1.3.8",
-        "@1024pix/pix-ui": "^48.9.0",
+        "@1024pix/pix-ui": "^49.2.0",
         "@1024pix/stylelint-config": "^5.1.24",
         "@babel/eslint-parser": "^7.19.1",
         "@ember/optional-features": "^2.0.0",
@@ -147,9 +147,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "48.9.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-48.9.0.tgz",
-      "integrity": "sha512-YzXZWdw6rdCDl7tfOHxjcUiEw9uhG1gVdK3m83nSlcVh+XOnF5RfkTS38+F95tB29/DGgNb3ePjIL8l3j0FnPg==",
+      "version": "49.2.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-49.2.0.tgz",
+      "integrity": "sha512-GHX9aNsxGXK+f18ki21AVjxkigRLQnkaAY/UGyvaw+nFaisXeVgS13kcfn1LzM5tsO6Q92IR7I0D3ffV9qvG4A==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/admin/package.json
+++ b/admin/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.6",
     "@1024pix/eslint-config": "^1.3.8",
-    "@1024pix/pix-ui": "^48.9.0",
+    "@1024pix/pix-ui": "^49.2.0",
     "@1024pix/stylelint-config": "^5.1.24",
     "@babel/eslint-parser": "^7.19.1",
     "@ember/optional-features": "^2.0.0",
@@ -112,8 +112,8 @@
     "loader.js": "^4.7.0",
     "lodash": "^4.17.21",
     "npm-run-all2": "^6.0.0",
-    "pako": "^2.1.0",
     "p-queue": "^8.0.0",
+    "pako": "^2.1.0",
     "prettier": "^3.3.2",
     "prettier-plugin-ember-template-tag": "^2.0.2",
     "query-string": "^9.0.0",


### PR DESCRIPTION
## :fallen_leaf: Problème
La mise à jour 49.0.0 de pix-ui a entrainé un renommage de certains composants.

- `PixProgressGauge` devient `PixProgressBar`
- `PixMessage` devient `PixNotificationAlert`
- `PixBanner` devient `PixBannerAlert`
- `PixToggle` devient `PixToggleButton`
- `PixCollapsible` devient `PixAccordions`

## :chestnut: Proposition
Utiliser le nouveau nommage sur ces composants

## :jack_o_lantern: Remarques
RAS

## :wood: Pour tester
- Vérifier qu'il n'y a pas de régressions sur les pages qui utilisent ces composants.
