### PR TITLE
[BUGFIX] retirer un scroll non utils sur la page d'accueil (PIX-13917)

### DIFF
--- a/junior/app/styles/app.scss
+++ b/junior/app/styles/app.scss
@@ -62,7 +62,7 @@ b {
   main {
     display: flex;
     flex-direction: column;
-    min-height: 95vh;
+    min-height: 92vh;
   }
 }
 

--- a/junior/app/styles/pages/organization-code.scss
+++ b/junior/app/styles/pages/organization-code.scss
@@ -1,7 +1,7 @@
 .school-code {
   display: flex;
   flex-direction: column;
-  margin-top: 100px;
+  margin-top: 2rem;
 
   p, label {
     width: fit-content;
@@ -72,15 +72,17 @@
     width: 149px;
     height: 80px;
     margin-top: 130px;
+    margin-bottom: 20px;
   }
 
   @include device-is('desktop') {
-    margin-top: 62px;
+    margin-top: 30px;
 
     .logo {
       width: 209px;
       height: 112px;
       margin-top: 130px;
+      margin-bottom: 16px;
     }
   }
 


### PR DESCRIPTION
## :fallen_leaf: Problème
Un scroll inutile est présent sur la page de connexion

## :chestnut: Proposition
Ajuster les marge pour retirer le scroll

## :wood: Pour tester
Se connecter sur l'application Junior et certifier l'écran non-scrollabe !