### PR TITLE
[FEATURE] Envoyer l'email de confirmation de suppression de compte en autonomie (PIX-14917)

### DIFF
--- a/api/src/identity-access-management/application/user/user.controller.js
+++ b/api/src/identity-access-management/application/user/user.controller.js
@@ -203,10 +203,11 @@ const rememberUserHasSeenLastDataProtectionPolicyInformation = async function (
   return dependencies.userSerializer.serialize(updatedUser);
 };
 
-const selfDeleteUserAccount = async function (request, h) {
+const selfDeleteUserAccount = async function (request, h, dependencies = { requestResponseUtils }) {
   const authenticatedUserId = request.auth.credentials.userId;
+  const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
 
-  await usecases.selfDeleteUserAccount({ userId: authenticatedUserId });
+  await usecases.selfDeleteUserAccount({ userId: authenticatedUserId, locale });
 
   return h.response().code(204);
 };

--- a/api/src/identity-access-management/domain/emails/create-self-delete-user-account.email.js
+++ b/api/src/identity-access-management/domain/emails/create-self-delete-user-account.email.js
@@ -1,0 +1,29 @@
+import { EmailFactory } from '../../../shared/mail/domain/models/EmailFactory.js';
+import { mailer } from '../../../shared/mail/infrastructure/services/mailer.js';
+
+export function createSelfDeleteUserAccountEmail({ locale, email, firstName }) {
+  const factory = new EmailFactory({ app: 'pix-app', locale });
+
+  const { i18n, defaultVariables } = factory;
+
+  return factory.buildEmail({
+    template: mailer.selfAccountDeletionTemplateId,
+    subject: i18n.__('self-account-deletion-email.subject'),
+    to: email,
+    variables: {
+      homeName: defaultVariables.homeName,
+      homeUrl: defaultVariables.homeUrl,
+      helpdeskUrl: defaultVariables.helpdeskUrl,
+      displayNationalLogo: defaultVariables.displayNationalLogo,
+      doNotAnswer: i18n.__('common.email.doNotAnswer'),
+      moreOn: i18n.__('common.email.moreOn'),
+      pixPresentation: i18n.__('common.email.pixPresentation'),
+      title: i18n.__('self-account-deletion-email.params.title'),
+      hello: i18n.__('self-account-deletion-email.params.hello', { firstName }),
+      requestConfirmation: i18n.__('self-account-deletion-email.params.requestConfirmation'),
+      seeYouSoon: i18n.__('self-account-deletion-email.params.seeYouSoon'),
+      signing: i18n.__('self-account-deletion-email.params.signing'),
+      warning: i18n.__('self-account-deletion-email.params.warning'),
+    },
+  });
+}

--- a/api/src/identity-access-management/domain/usecases/self-delete-user-account.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/self-delete-user-account.usecase.js
@@ -1,4 +1,5 @@
 import { ForbiddenAccess } from '../../../shared/domain/errors.js';
+import { createSelfDeleteUserAccountEmail } from '../emails/create-self-delete-user-account.email.js';
 
 /**
  * @typedef {import('../../infrastructure/repositories/privacy-users-api.repository.js')} PrivacyUsersApiRepository
@@ -10,15 +11,33 @@ import { ForbiddenAccess } from '../../../shared/domain/errors.js';
  * @param{PrivacyUsersApiRepository} privacyUsersApiRepository
  * @returns {Promise<boolean>}
  */
-export const selfDeleteUserAccount = async function ({ userId, privacyUsersApiRepository }) {
+export const selfDeleteUserAccount = async function ({
+  userId,
+  locale,
+  userRepository,
+  privacyUsersApiRepository,
+  emailRepository,
+}) {
   const canSelfDeleteAccount = await privacyUsersApiRepository.canSelfDeleteAccount({ userId });
 
   if (!canSelfDeleteAccount) {
     throw new ForbiddenAccess();
   }
 
+  const user = await userRepository.get(userId);
+
   const anonymizedByUserId = userId;
   const anonymizedByUserRole = 'USER';
   const client = 'PIX_APP';
   await privacyUsersApiRepository.anonymizeUser({ userId, anonymizedByUserId, anonymizedByUserRole, client });
+
+  if (user.email) {
+    await emailRepository.sendEmailAsync(
+      createSelfDeleteUserAccountEmail({
+        locale: locale,
+        email: user.email,
+        firstName: user.firstName,
+      }),
+    );
+  }
 };

--- a/api/src/shared/mail/infrastructure/services/mailer.js
+++ b/api/src/shared/mail/infrastructure/services/mailer.js
@@ -103,6 +103,10 @@ class Mailer {
   get targetProfileNotCertifiableTemplateId() {
     return mailing[this._providerName].templates.targetProfileNotCertifiableTemplateId;
   }
+
+  get selfAccountDeletionTemplateId() {
+    return mailing[this._providerName].templates.selfAccountDeletionTemplateId;
+  }
 }
 
 const mailer = new Mailer();

--- a/api/tests/identity-access-management/integration/domain/usecases/self-delete-user-account.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/self-delete-user-account.usecase.test.js
@@ -5,15 +5,34 @@ import { databaseBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Identity Access Management | Domain | UseCase | self-delete-user-account', function () {
   context('when user can self delete their account', function () {
-    it('doesn’t throw ForbiddenError', async function () {
-      // given
-      const userId = databaseBuilder.factory.buildUser().id;
-      await databaseBuilder.commit();
+    context('when user has an email', function () {
+      it('doesn’t throw ForbiddenError and creates a SendEmailJob', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        await databaseBuilder.commit();
 
-      sinon.stub(config.featureToggles, 'isSelfAccountDeletionEnabled').value(true);
+        sinon.stub(config.featureToggles, 'isSelfAccountDeletionEnabled').value(true);
 
-      // when & then
-      await expect(usecases.selfDeleteUserAccount({ userId })).to.not.be.rejectedWith(ForbiddenAccess);
+        // when & then
+        await expect(usecases.selfDeleteUserAccount({ userId })).to.not.be.rejectedWith(ForbiddenAccess);
+
+        await expect('SendEmailJob').to.have.been.performed.withJobsCount(1);
+      });
+    });
+
+    context('when user doesn’t have an email', function () {
+      it('doesn’t throw ForbiddenError and doesn’t create a SendEmailJob', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser.withoutPixAuthenticationMethod().id;
+        await databaseBuilder.commit();
+
+        sinon.stub(config.featureToggles, 'isSelfAccountDeletionEnabled').value(true);
+
+        // when & then
+        await expect(usecases.selfDeleteUserAccount({ userId })).to.not.be.rejectedWith(ForbiddenAccess);
+
+        await expect('SendEmailJob').to.have.been.performed.withJobsCount(0);
+      });
     });
   });
 

--- a/api/tests/identity-access-management/unit/domain/emails/create-account-creation.email_test.js
+++ b/api/tests/identity-access-management/unit/domain/emails/create-account-creation.email_test.js
@@ -3,7 +3,7 @@ import { Email } from '../../../../../src/shared/mail/domain/models/Email.js';
 import { mailer } from '../../../../../src/shared/mail/infrastructure/services/mailer.js';
 import { expect } from '../../../../test-helper.js';
 
-describe('Unit | Identity Access Management | Domain | Emails | create-account-creation', function () {
+describe('Unit | Identity Access Management | Domain | Email | create-account-creation', function () {
   it('creates account creation email with correct parameters', function () {
     const emailParams = {
       locale: 'fr',

--- a/api/tests/identity-access-management/unit/domain/emails/create-self-delete-user-account.email_test.js
+++ b/api/tests/identity-access-management/unit/domain/emails/create-self-delete-user-account.email_test.js
@@ -1,0 +1,36 @@
+import { createSelfDeleteUserAccountEmail } from '../../../../../src/identity-access-management/domain/emails/create-self-delete-user-account.email.js';
+import { Email } from '../../../../../src/shared/mail/domain/models/Email.js';
+import { mailer } from '../../../../../src/shared/mail/infrastructure/services/mailer.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Identity Access Management | Domain | Email | create-self-delete-user-account', function () {
+  it('creates self delete user account email with correct parameters', function () {
+    const emailParams = {
+      locale: 'fr',
+      email: 'test@example.com',
+      firstName: 'John',
+    };
+
+    const email = createSelfDeleteUserAccountEmail(emailParams);
+
+    expect(email).to.be.instanceof(Email);
+    expect(email).to.have.property('subject').that.is.a('string');
+    expect(email.to).to.equal(emailParams.email);
+    expect(email.template).to.equal(mailer.selfAccountDeletionTemplateId);
+
+    const variables = email.variables;
+    expect(variables).to.have.property('displayNationalLogo').that.is.a('boolean');
+    expect(variables).to.have.property('doNotAnswer').that.is.a('string');
+    expect(variables).to.have.property('helpdeskUrl').that.is.a('string');
+    expect(variables).to.have.property('homeName').that.is.a('string');
+    expect(variables).to.have.property('homeUrl').that.is.a('string');
+    expect(variables).to.have.property('moreOn').that.is.a('string');
+    expect(variables).to.have.property('pixPresentation').that.is.a('string');
+    expect(variables).to.have.property('title').that.is.a('string');
+    expect(variables).to.have.property('hello').that.is.a('string');
+    expect(variables).to.have.property('requestConfirmation').that.is.a('string');
+    expect(variables).to.have.property('seeYouSoon').that.is.a('string');
+    expect(variables).to.have.property('signing').that.is.a('string');
+    expect(variables).to.have.property('warning').that.is.a('string');
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème

Nous avons besoin d'envoyer un email de confirmation de suppression de compte en autonomie.

## :gift: Proposition

Utiliser :
* un job d'envoi d'email pour envoyer en asynchrone et dans une job queue (emailRepository.sendEmailAsync)
* utiliser le template et les traductions créés dans #10530

<img width="429" alt="self-delete-user-account-email" src="https://github.com/user-attachments/assets/bf37f4cf-0d75-4667-8c6b-a9da5b0562ec">

## :socks: Remarques

Vu en équipe : par rapport au modèle de template initial, un lien a été placé sur tout le texte _« Si vous n'êtes pas à l’origine de cette demande, merci de contacter le support. »_ / _« If you are not the source of this request, please contact support. »_ .

Le lien a été placé sur tout l'ensemble du texte : 
* pour une déclinaison parfaite dans toutes les langues, compte tenu du fait que toutes les langues ne peuvent pas avoir les mêmes structures de phrase
* pour s'assurer que le processus de traduction soit cohérent compte tenu du fait que les personnes en charge des traductions n'ont pas toujours accès à la fonctionnalité à traduire

## :santa: Pour tester

### Test du courriel de notification en français

1. Créer un compte en _français_
2. Supprimer son compte
3. Vérifier la réception du courriel de notification de suppression de compte en français
4. Vérifier tous les textes et liens de ce courriel
5. Constater que la Marianne apparait _bien_ dans le pied de page du courriel

### Test du courriel de notification en anglais

1. Aller sur Pix App sur le domaine `.org` pour pouvoir disposer du LanguageSwitcher
2. Dans le LanguageSwitcher, choisir la langue `English`
3. Créer un compte en _anglais_
4. Supprimer son compte
6. Vérifier la réception du courriel de notification de suppression de compte en anglais
7. Vérifier tous les textes et liens de ce courriel
8. Constater que la Marianne n’apparait _pas_ dans le pied de page du courriel

### Test de non-régression avec les utilisateurs sans adresse email

Tester que la suppression de compte fonctionne toujours bien, sans régression, avec les utilisateurs sans adresse email enregistrée (connexion uniquement par identifiant et ou SSO).

--- 

Pour tester en local il y a des actions à réaliser au préalable :

Lancer les jobs, sinon l'envoi d'email par la job queue ne pourra pas avoir lieu : 

```shell
cd api/
npm run start:job
```
