### PR TITLE
[TECH] Remettre l'usage de skillDatasource dans les seeds

### DIFF
--- a/api/db/seeds/data/common/tooling/learning-content.js
+++ b/api/db/seeds/data/common/tooling/learning-content.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 
+import { skillDatasource } from '../../../../../src/shared/infrastructure/datasources/learning-content/index.js';
 import * as challengeRepository from '../../../../../src/shared/infrastructure/repositories/challenge-repository.js';
 import * as competenceRepository from '../../../../../src/shared/infrastructure/repositories/competence-repository.js';
-import * as skillRepository from '../../../../../src/shared/infrastructure/repositories/skill-repository.js';
 import { logger } from '../../../../../src/shared/infrastructure/utils/logger.js';
 
 let ALL_COMPETENCES, ALL_ACTIVE_SKILLS, ALL_CHALLENGES, ACTIVE_SKILLS_BY_COMPETENCE, ACTIVE_SKILLS_BY_TUBE;
@@ -35,7 +35,7 @@ async function getCoreCompetences() {
 
 async function getAllActiveSkills() {
   if (!ALL_ACTIVE_SKILLS) {
-    ALL_ACTIVE_SKILLS = (await skillRepository.list()).filter((skill) => skill.status === 'actif');
+    ALL_ACTIVE_SKILLS = await skillDatasource.findActive();
   }
   return ALL_ACTIVE_SKILLS;
 }


### PR DESCRIPTION
## :fallen_leaf: Problème
Les seeds ne marchent plus depuis qu'on a remplacé l'usage de skillDatasource par skillRepository

## :chestnut: Proposition
On rétablit pour ne pas bloquer le flux, on se débarrassera proprement du datasource dans la PR de lecture dans PG du réf.

## :jack_o_lantern: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :wood: Pour tester
Seeds OK
