### PR TITLE
[FEATURE] Telecharger via Pix les resultats de sessions via POST (PIX-15514)

### DIFF
--- a/api/src/certification/results/application/certification-results-controller.js
+++ b/api/src/certification/results/application/certification-results-controller.js
@@ -71,6 +71,26 @@ const getSessionResultsToDownload = async function (
     .header('Content-Disposition', `attachment; filename=${csvResult.filename}`);
 };
 
+const postSessionResultsToDownload = async function (
+  request,
+  h,
+  dependencies = { tokenService, getSessionCertificationResultsCsv },
+) {
+  const { sessionId } = dependencies.tokenService.extractCertificationResultsLink(request.payload.token);
+  const { session, certificationResults } = await usecases.getSessionResults({ sessionId });
+
+  const csvResult = await dependencies.getSessionCertificationResultsCsv({
+    session,
+    certificationResults,
+    i18n: request.i18n,
+  });
+
+  return h
+    .response(csvResult.content)
+    .header('Content-Type', 'text/csv;charset=utf-8')
+    .header('Content-Disposition', `attachment; filename=${csvResult.filename}`);
+};
+
 const getCertifiedProfile = async function (
   request,
   h,
@@ -86,6 +106,7 @@ const certificationResultsController = {
   getCleaCertifiedCandidateDataCsv,
   getSessionResultsByRecipientEmail,
   getSessionResultsToDownload,
+  postSessionResultsToDownload,
   getCertifiedProfile,
 };
 

--- a/api/src/certification/results/application/certification-results-route.js
+++ b/api/src/certification/results/application/certification-results-route.js
@@ -1,6 +1,7 @@
 import Joi from 'joi';
 
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
+import { LOCALE } from '../../../shared/domain/constants.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { authorization } from '../../shared/application/pre-handlers/authorization.js';
 import { certificationResultsController } from './certification-results-controller.js';
@@ -83,6 +84,27 @@ const register = async function (server) {
           }),
         },
         handler: certificationResultsController.getSessionResultsToDownload,
+        tags: ['api', 'sessions', 'results'],
+        notes: [
+          'Cette route est accessible via un token généré par un utilisateur ayant le rôle SUPERADMIN',
+          "Elle retourne tous les résultats de certifications d'une session, sous format CSV",
+        ],
+      },
+    },
+    {
+      method: 'POST',
+      path: '/api/sessions/download-all-results',
+      config: {
+        auth: false,
+        validate: {
+          query: Joi.object({
+            lang: Joi.string().optional().valid(LOCALE.FRENCH_SPOKEN, LOCALE.ENGLISH_SPOKEN),
+          }),
+          payload: Joi.object({
+            token: Joi.string().required(),
+          }),
+        },
+        handler: certificationResultsController.postSessionResultsToDownload,
         tags: ['api', 'sessions', 'results'],
         notes: [
           'Cette route est accessible via un token généré par un utilisateur ayant le rôle SUPERADMIN',

--- a/api/tests/certification/results/acceptance/application/certification-results-route_test.js
+++ b/api/tests/certification/results/acceptance/application/certification-results-route_test.js
@@ -197,4 +197,74 @@ describe('Certification | Results | Acceptance | Application | Routes | certific
       });
     });
   });
+
+  describe('POST /api/sessions/download-all-results', function () {
+    context('when a valid token is given', function () {
+      it('should return 200 HTTP status code', async function () {
+        // given
+        const server = await createServer();
+
+        const dbf = databaseBuilder.factory;
+
+        const session = dbf.buildSession({ date: '2020/01/01', time: '12:00' });
+        const sessionId = session.id;
+
+        const candidate1 = dbf.buildCertificationCandidate({
+          sessionId,
+          resultRecipientEmail: 'recipientEmail@example.net',
+        });
+        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidate1.id });
+        const candidate2 = dbf.buildCertificationCandidate({
+          sessionId,
+          resultRecipientEmail: 'recipientEmail@example.net',
+        });
+        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidate2.id });
+
+        const certif1 = dbf.buildCertificationCourse({
+          sessionId: candidate1.sessionId,
+          userId: candidate1.userId,
+          lastName: candidate1.lastName,
+          birthdate: candidate1.birthdate,
+          createdAt: candidate1.createdAt,
+        });
+        const certif2 = dbf.buildCertificationCourse({
+          sessionId: candidate2.sessionId,
+          userId: candidate2.userId,
+          lastName: candidate2.lastName,
+          birthdate: candidate2.birthdate,
+          createdAt: candidate2.createdAt,
+        });
+
+        const assessmentId1 = dbf.buildAssessment({ certificationCourseId: certif1.id }).id;
+        dbf.buildAssessment({
+          certificationCourseId: certif2.id,
+          commentByAutoJury: AutoJuryCommentKeys.CANCELLED_DUE_TO_NEUTRALIZATION,
+        });
+
+        dbf.buildAssessmentResult({ assessmentId: assessmentId1, createdAt: new Date('2018-04-15T00:00:00Z') });
+
+        const token = jsonwebtoken.sign(
+          {
+            session_id: sessionId,
+          },
+          settings.authentication.secret,
+          { expiresIn: '30d' },
+        );
+
+        const request = {
+          method: 'POST',
+          url: `/api/sessions/download-all-results`,
+          payload: { token },
+        };
+
+        await databaseBuilder.commit();
+
+        // when
+        const response = await server.inject(request);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+  });
 });

--- a/api/tests/certification/results/unit/application/certification-results-controller_test.js
+++ b/api/tests/certification/results/unit/application/certification-results-controller_test.js
@@ -131,6 +131,48 @@ describe('Certification | Results | Unit | Controller | certification results', 
     });
   });
 
+  describe('#postSessionResultsToDownload ', function () {
+    it('should return results to download', async function () {
+      // given
+      const userId = 274939274;
+      const i18n = getI18n();
+      const session = { id: 1, date: '2020/01/01', time: '12:00' };
+      const sessionId = session.id;
+      const fileName = `20200101_1200_resultats_session_${sessionId}.csv`;
+      const certificationResults = [];
+      const token = Symbol('a beautiful token');
+      const request = {
+        i18n,
+        payload: { token },
+        auth: {
+          credentials: { userId },
+        },
+      };
+      const dependencies = {
+        getSessionCertificationResultsCsv: sinon.stub(),
+        tokenService: {
+          extractCertificationResultsLink: sinon.stub(),
+        },
+      };
+      dependencies.tokenService.extractCertificationResultsLink.withArgs(token).returns({ sessionId });
+      dependencies.getSessionCertificationResultsCsv
+        .withArgs({
+          session,
+          certificationResults,
+          i18n: request.i18n,
+        })
+        .returns({ content: 'csv-string', filename: fileName });
+      sinon.stub(usecases, 'getSessionResults').withArgs({ sessionId }).resolves({ session, certificationResults });
+
+      // when
+      const response = await certificationResultsController.postSessionResultsToDownload(request, hFake, dependencies);
+
+      // then
+      expect(response.source).to.deep.equal('csv-string');
+      expect(response.headers['Content-Disposition']).to.equal(`attachment; filename=${fileName}`);
+    });
+  });
+
   describe('#getCertifiedProfile', function () {
     it('should fetch the associated certified profile serialized as JSONAPI', async function () {
       const certifiedProfileSerializer = {

--- a/api/tests/certification/results/unit/application/certification-results-route_test.js
+++ b/api/tests/certification/results/unit/application/certification-results-route_test.js
@@ -36,4 +36,25 @@ describe('Certification | Results | Unit | Application | Certification Results R
       expect(response.statusCode).to.equal(200);
     });
   });
+
+  describe('POST /api/sessions/download-all-results', function () {
+    describe('when payload is invalid', function () {
+      it('should return 400', async function () {
+        // given
+        sinon.stub(certificationResultsController, 'postSessionResultsToDownload').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/sessions/download-all-results', {
+          not: 'aValidPayload',
+        });
+
+        // then
+        expect(response.statusCode).to.equal(400);
+        const { errors } = JSON.parse(response.payload);
+        expect(errors[0].detail).to.equals('"token" is required');
+      });
+    });
+  });
 });

--- a/mon-pix/app/components/download-session-results.gjs
+++ b/mon-pix/app/components/download-session-results.gjs
@@ -12,7 +12,7 @@ import PixWindow from 'mon-pix/utils/pix-window';
 
 export default class DownloadSessionResults extends Component {
   @tracked showErrorMessage = false;
-  @service requestManager;
+  @service fileSaver;
 
   @action
   async downloadSessionResults(event) {
@@ -21,10 +21,12 @@ export default class DownloadSessionResults extends Component {
 
     try {
       const token = decodeURIComponent(PixWindow.getLocationHash().slice(1));
-      await this.requestManager.request({
+      await this.fileSaver.save({
         url: `${ENV.APP.API_HOST}/api/sessions/download-all-results`,
-        method: 'POST',
-        body: JSON.stringify({ token }),
+        options: {
+          method: 'POST',
+          body: { token },
+        },
       });
     } catch {
       this.showErrorMessage = true;

--- a/mon-pix/app/services/file-saver.js
+++ b/mon-pix/app/services/file-saver.js
@@ -16,21 +16,32 @@ export default class FileSaver extends Service {
     document.body.removeChild(link);
   }
 
-  _fetchData({ url, token }) {
-    return fetch(url, {
-      headers: { Authorization: `Bearer ${token}` },
-    });
+  _fetchData({ url, token, options = {} }) {
+    const requestOptions = {
+      method: options.method ?? 'GET',
+      headers: {},
+    };
+
+    if (token) requestOptions.headers['Authorization'] = `Bearer ${token}`;
+
+    if (options.body) {
+      requestOptions.headers['Content-Type'] = 'application/json';
+      requestOptions.body = JSON.stringify(options.body);
+    }
+
+    return fetch(url, requestOptions);
   }
 
   async save({
     url,
     fileName,
     token,
+    options,
     fetcher = this._fetchData,
     downloadFileForIEBrowser = this._downloadFileForIEBrowser,
     downloadFileForModernBrowsers = this._downloadFileForModernBrowsers,
   }) {
-    const response = await fetcher({ url, token });
+    const response = await fetcher({ url, token, options });
 
     if (!response.ok) {
       const payload = await response.json();


### PR DESCRIPTION
## :christmas_tree: Problème

On a une page de telechargement de session, sur Pix App, page resultats-session mais elle ne permet pas encore de telecharger un fichier de résultats.

## :gift: Proposition

* Creer la version POST de l'API de telechargement actuelle
* Brancher cette nouvelle API a la page de telechargements

## :socks: Remarques

J'ai bascule sur le service fileSaver qui est utilise deja dans Pix. J'ai fais les adaptations pour notre usage mais je n'ai pas cherche a refactorer le fetch pour requestManager.

## :santa: Pour tester

### Nouvelle page

* Sur Pix Admin aller dans les sessions de certifications > selectionner une session > copier le lien de resultats
* Dans ce lien, il y a un token, ne garder **que** cette partie, que l'on appellera MON_TOKEN
* Sur Pix App aller sur la page `/resultats-session#MON_TOKEN` et cliquer sur Telecharger
* Verifier le contenu du fichier recu
* Ajouter le parametre `?lang=en` et verifier que le fichier est en anglais 
* Ajouter le parametre `?lang=fr` et verifier que le fichier est en francais

### Non regression

On a touche au file-saver du coup un peu de non reg

* Verifier le bon telechargement d'une attestation de certification

#### Verifier le bon telechargement d'une attestation de campagnes

Plutôt se connecter avec [attestation-blank@example.net](mailto:attestation-blank@example.net)
Et passer le parcours : ATTEST001
En ayant au moins 50% de bonnes réponses, et le téléchargement de l'attestation devrait être dispo en fin de parcours
