### PR TITLE
[BUGFIX] Ne pas appeler le usecase "reward user" si l'utlilisateur n'est pas connecte (PIX-15528)

### DIFF
--- a/api/src/evaluation/application/answers/answer-controller.js
+++ b/api/src/evaluation/application/answers/answer-controller.js
@@ -11,7 +11,11 @@ const save = async function (request, h, dependencies = { answerSerializer, requ
   const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
   const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
   const createdAnswer = await usecases.correctAnswerThenUpdateAssessment({ answer, userId, locale });
-  if (!config.featureToggles.isAsyncQuestRewardingCalculationEnabled && config.featureToggles.isQuestEnabled) {
+  if (
+    userId &&
+    !config.featureToggles.isAsyncQuestRewardingCalculationEnabled &&
+    config.featureToggles.isQuestEnabled
+  ) {
     await questUsecases.rewardUser({ userId });
   }
 

--- a/api/src/prescription/organization-learner/domain/usecases/find-organization-learners-with-participations.js
+++ b/api/src/prescription/organization-learner/domain/usecases/find-organization-learners-with-participations.js
@@ -1,4 +1,8 @@
+import Joi from 'joi';
+
 import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
+
+const userIdsSchema = Joi.array().items(Joi.number());
 
 const findOrganizationLearnersWithParticipations = withTransaction(async function ({
   userIds,
@@ -7,6 +11,12 @@ const findOrganizationLearnersWithParticipations = withTransaction(async functio
   libOrganizationLearnerRepository,
   tagRepository,
 }) {
+  const validationResult = userIdsSchema.validate(userIds);
+
+  if (validationResult.error) {
+    return [];
+  }
+
   const organizationLearners = (
     await Promise.all(
       userIds.map((userId) => {

--- a/api/src/quest/domain/usecases/reward-user.js
+++ b/api/src/quest/domain/usecases/reward-user.js
@@ -5,6 +5,10 @@ export const rewardUser = async ({
   successRepository,
   rewardRepository,
 }) => {
+  if (!userId) {
+    return;
+  }
+
   const quests = await questRepository.findAll();
 
   if (quests.length === 0) {

--- a/api/tests/prescription/organization-learner/unit/domain/usecases/find-organization-learners-with-participations_test.js
+++ b/api/tests/prescription/organization-learner/unit/domain/usecases/find-organization-learners-with-participations_test.js
@@ -1,7 +1,30 @@
-import { _getCampaignParticipationOverviewsWithoutPagination } from '../../../../../../src/prescription/organization-learner/domain/usecases/find-organization-learners-with-participations.js';
+import {
+  _getCampaignParticipationOverviewsWithoutPagination,
+  findOrganizationLearnersWithParticipations,
+} from '../../../../../../src/prescription/organization-learner/domain/usecases/find-organization-learners-with-participations.js';
+import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | find-organization-learners-with-participations', function () {
+  context('#findOrganizationLearnersWithParticipations', function () {
+    it('should not call libOrganizationLearnerRepository if userIds does not have the expected format', async function () {
+      // given
+      sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
+      const libOrganizationLearnerRepository = {
+        findByUserId: sinon.stub(),
+      };
+
+      // when
+      await findOrganizationLearnersWithParticipations({
+        userIds: [null],
+        libOrganizationLearnerRepository,
+      });
+
+      // then
+      expect(libOrganizationLearnerRepository.findByUserId).to.not.have.been.called;
+    });
+  });
+
   context('#_getCampaignParticipationOverviewsWithoutPagination', function () {
     it('should return all campaign participations', async function () {
       // given

--- a/api/tests/quest/unit/domain/usecases/reward-user_test.js
+++ b/api/tests/quest/unit/domain/usecases/reward-user_test.js
@@ -8,6 +8,8 @@ describe('Quest | Unit | Domain | Usecases | RewardUser', function () {
   let successRepository;
   let rewardRepository;
 
+  let dependencies;
+
   beforeEach(function () {
     userId = 1;
 
@@ -22,6 +24,13 @@ describe('Quest | Unit | Domain | Usecases | RewardUser', function () {
     successRepository = { find: sinon.stub() };
 
     rewardRepository = { save: sinon.stub(), getByUserId: sinon.stub() };
+
+    dependencies = {
+      questRepository,
+      eligibilityRepository,
+      successRepository,
+      rewardRepository,
+    };
   });
 
   context('when there are no quests available', function () {
@@ -30,7 +39,21 @@ describe('Quest | Unit | Domain | Usecases | RewardUser', function () {
       questRepository.findAll.resolves([]);
 
       // when
-      await rewardUser({ userId, questRepository, eligibilityRepository });
+      await rewardUser({ userId, ...dependencies });
+      expect(eligibilityRepository.find).to.not.have.been.called;
+    });
+  });
+
+  context('when user id is not provided', function () {
+    it('should not call eligibility repository', async function () {
+      // given
+      const quest = { isEligible: () => false };
+      questRepository.findAll.resolves([quest]);
+      rewardRepository.getByUserId.resolves([]);
+      eligibilityRepository.find.resolves([]);
+
+      // when
+      await rewardUser({ userId: null, ...dependencies });
       expect(eligibilityRepository.find).to.not.have.been.called;
     });
   });
@@ -46,10 +69,7 @@ describe('Quest | Unit | Domain | Usecases | RewardUser', function () {
       // when
       await rewardUser({
         userId,
-        questRepository,
-        eligibilityRepository,
-        successRepository,
-        rewardRepository,
+        ...dependencies,
       });
       expect(successRepository.find).to.not.have.been.called;
     });
@@ -72,10 +92,7 @@ describe('Quest | Unit | Domain | Usecases | RewardUser', function () {
       // when
       await rewardUser({
         userId,
-        questRepository,
-        eligibilityRepository,
-        successRepository,
-        rewardRepository,
+        ...dependencies,
       });
 
       // then
@@ -99,10 +116,7 @@ describe('Quest | Unit | Domain | Usecases | RewardUser', function () {
       // when
       await rewardUser({
         userId,
-        questRepository,
-        eligibilityRepository,
-        successRepository,
-        rewardRepository,
+        ...dependencies,
       });
       expect(successRepository.find).to.not.have.been.called;
     });


### PR DESCRIPTION
## :christmas_tree: Problème
Si un utilisateur non identifie repond a une question, on declenche le calcul de son attestation. Cela donne des requetes incoherentes et des problemes de charge. En effet au lieu de chercher les informations de l'utilisateur en cours, on parcourt les donnees de tous les utilisateurs non reconcilies.

## :gift: Proposition
Mettre des verifications aux differentes etapes pour eviter ce cas de figure.

## :santa: Pour tester
Tests au vert.
Le deploiement ne doit plus crasher la recette. 
[Essayer le parcours statique avec un utilisateur non connecte](https://app-pr10697.review.pix.fr/courses/recif2CZqh4EQvGX8)