### PR TITLE
[BUGFIX] Impossible de patcher les acquis en recette (PIX-15533)

### DIFF
--- a/api/src/learning-content/infrastructure/repositories/area-repository.js
+++ b/api/src/learning-content/infrastructure/repositories/area-repository.js
@@ -1,3 +1,21 @@
 import { LearningContentRepository } from './learning-content-repository.js';
 
-export const areaRepository = new LearningContentRepository({ tableName: 'learningcontent.areas' });
+class AreaRepository extends LearningContentRepository {
+  constructor() {
+    super({ tableName: 'learningcontent.areas' });
+  }
+
+  toDto({ id, code, name, title_i18n, color, frameworkId, competenceIds }) {
+    return {
+      id,
+      code,
+      name,
+      title_i18n,
+      color,
+      frameworkId,
+      competenceIds,
+    };
+  }
+}
+
+export const areaRepository = new AreaRepository();

--- a/api/src/learning-content/infrastructure/repositories/challenge-repository.js
+++ b/api/src/learning-content/infrastructure/repositories/challenge-repository.js
@@ -1,6 +1,92 @@
 import { LearningContentRepository } from './learning-content-repository.js';
 
-export const challengeRepository = new LearningContentRepository({
-  tableName: 'learningcontent.challenges',
-  chunkSize: 500,
-});
+class ChallengeRepository extends LearningContentRepository {
+  constructor() {
+    super({
+      tableName: 'learningcontent.challenges',
+      chunkSize: 500,
+    });
+  }
+
+  toDto({
+    id,
+    instruction,
+    alternativeInstruction,
+    proposals,
+    type,
+    solution,
+    solutionToDisplay,
+    t1Status,
+    t2Status,
+    t3Status,
+    status,
+    genealogy,
+    accessibility1,
+    accessibility2,
+    requireGafamWebsiteAccess,
+    isIncompatibleIpadCertif,
+    deafAndHardOfHearing,
+    isAwarenessChallenge,
+    toRephrase,
+    alternativeVersion,
+    shuffled,
+    illustrationAlt,
+    illustrationUrl,
+    attachments,
+    responsive,
+    alpha,
+    delta,
+    autoReply,
+    focusable,
+    format,
+    timer,
+    embedHeight,
+    embedUrl,
+    embedTitle,
+    locales,
+    competenceId,
+    skillId,
+  }) {
+    return {
+      id,
+      instruction,
+      alternativeInstruction,
+      proposals,
+      type,
+      solution,
+      solutionToDisplay,
+      t1Status,
+      t2Status,
+      t3Status,
+      status,
+      genealogy,
+      accessibility1,
+      accessibility2,
+      requireGafamWebsiteAccess,
+      isIncompatibleIpadCertif,
+      deafAndHardOfHearing,
+      isAwarenessChallenge,
+      toRephrase,
+      alternativeVersion,
+      shuffled,
+      illustrationAlt,
+      illustrationUrl,
+      attachments,
+      responsive,
+      alpha,
+      delta,
+      autoReply,
+      focusable,
+      format,
+      timer,
+      embedHeight,
+      embedUrl,
+      embedTitle,
+      locales,
+      competenceId,
+      skillId,
+    };
+  }
+}
+
+export const challengeRepository = new ChallengeRepository();

--- a/api/src/learning-content/infrastructure/repositories/competence-repository.js
+++ b/api/src/learning-content/infrastructure/repositories/competence-repository.js
@@ -1,3 +1,22 @@
 import { LearningContentRepository } from './learning-content-repository.js';
 
-export const competenceRepository = new LearningContentRepository({ tableName: 'learningcontent.competences' });
+class CompetenceRepository extends LearningContentRepository {
+  constructor() {
+    super({ tableName: 'learningcontent.competences' });
+  }
+
+  toDto({ id, name_i18n, description_i18n, index, origin, areaId, skillIds, thematicIds }) {
+    return {
+      id,
+      name_i18n,
+      description_i18n,
+      index,
+      origin,
+      areaId,
+      skillIds,
+      thematicIds,
+    };
+  }
+}
+
+export const competenceRepository = new CompetenceRepository();

--- a/api/src/learning-content/infrastructure/repositories/course-repository.js
+++ b/api/src/learning-content/infrastructure/repositories/course-repository.js
@@ -1,3 +1,20 @@
 import { LearningContentRepository } from './learning-content-repository.js';
 
-export const courseRepository = new LearningContentRepository({ tableName: 'learningcontent.courses' });
+class CourseRepository extends LearningContentRepository {
+  constructor() {
+    super({ tableName: 'learningcontent.courses' });
+  }
+
+  toDto({ id, name, description, isActive, competences, challenges }) {
+    return {
+      id,
+      name,
+      description,
+      isActive,
+      competences,
+      challenges,
+    };
+  }
+}
+
+export const courseRepository = new CourseRepository();

--- a/api/src/learning-content/infrastructure/repositories/framework-repository.js
+++ b/api/src/learning-content/infrastructure/repositories/framework-repository.js
@@ -1,3 +1,16 @@
 import { LearningContentRepository } from './learning-content-repository.js';
 
-export const frameworkRepository = new LearningContentRepository({ tableName: 'learningcontent.frameworks' });
+class FrameworkRepository extends LearningContentRepository {
+  constructor() {
+    super({ tableName: 'learningcontent.frameworks' });
+  }
+
+  toDto({ id, name }) {
+    return {
+      id,
+      name,
+    };
+  }
+}
+
+export const frameworkRepository = new FrameworkRepository();

--- a/api/src/learning-content/infrastructure/repositories/learning-content-repository.js
+++ b/api/src/learning-content/infrastructure/repositories/learning-content-repository.js
@@ -19,14 +19,24 @@ export class LearningContentRepository {
   }
 
   /**
-   * @param {object[]} dtos
+   * @param {object[]} objects
    */
-  async save(dtos) {
-    if (!dtos) return;
+  async save(objects) {
+    if (!objects) return;
+    const dtos = objects.map(this.toDto);
     const knex = DomainTransaction.getConnection();
     for (const chunk of chunks(dtos, this.#chunkSize)) {
       await knex.insert(chunk).into(this.#tableName).onConflict('id').merge();
     }
+  }
+
+  /**
+   * Maps an object to a DTO before insertion.
+   * @param {object} object
+   * @returns {object}
+   */
+  toDto(_object) {
+    // must be overridden
   }
 }
 

--- a/api/src/learning-content/infrastructure/repositories/mission-repository.js
+++ b/api/src/learning-content/infrastructure/repositories/mission-repository.js
@@ -1,3 +1,39 @@
 import { LearningContentRepository } from './learning-content-repository.js';
 
-export const missionRepository = new LearningContentRepository({ tableName: 'learningcontent.missions' });
+class MissionRepository extends LearningContentRepository {
+  constructor() {
+    super({ tableName: 'learningcontent.missions' });
+  }
+
+  toDto({
+    id,
+    status,
+    name_i18n,
+    content,
+    learningObjectives_i18n,
+    validatedObjectives_i18n,
+    introductionMediaType,
+    introductionMediaUrl,
+    introductionMediaAlt_i18n,
+    documentationUrl,
+    cardImageUrl,
+    competenceId,
+  }) {
+    return {
+      id,
+      status,
+      name_i18n,
+      content,
+      learningObjectives_i18n,
+      validatedObjectives_i18n,
+      introductionMediaType,
+      introductionMediaUrl,
+      introductionMediaAlt_i18n,
+      documentationUrl,
+      cardImageUrl,
+      competenceId,
+    };
+  }
+}
+
+export const missionRepository = new MissionRepository();

--- a/api/src/learning-content/infrastructure/repositories/skill-repository.js
+++ b/api/src/learning-content/infrastructure/repositories/skill-repository.js
@@ -1,3 +1,39 @@
 import { LearningContentRepository } from './learning-content-repository.js';
 
-export const skillRepository = new LearningContentRepository({ tableName: 'learningcontent.skills' });
+class SkillRepository extends LearningContentRepository {
+  constructor() {
+    super({ tableName: 'learningcontent.skills' });
+  }
+
+  toDto({
+    id,
+    name,
+    status,
+    pixValue,
+    version,
+    level,
+    hintStatus,
+    hint_i18n,
+    competenceId,
+    tubeId,
+    tutorialIds,
+    learningMoreTutorialIds,
+  }) {
+    return {
+      id,
+      name,
+      status,
+      pixValue,
+      version,
+      level,
+      hintStatus,
+      hint_i18n,
+      competenceId,
+      tubeId,
+      tutorialIds,
+      learningMoreTutorialIds,
+    };
+  }
+}
+
+export const skillRepository = new SkillRepository();

--- a/api/src/learning-content/infrastructure/repositories/thematic-repository.js
+++ b/api/src/learning-content/infrastructure/repositories/thematic-repository.js
@@ -1,3 +1,19 @@
 import { LearningContentRepository } from './learning-content-repository.js';
 
-export const thematicRepository = new LearningContentRepository({ tableName: 'learningcontent.thematics' });
+class ThematicRepository extends LearningContentRepository {
+  constructor() {
+    super({ tableName: 'learningcontent.thematics' });
+  }
+
+  toDto({ id, name_i18n, index, competenceId, tubeIds }) {
+    return {
+      id,
+      name_i18n,
+      index,
+      competenceId,
+      tubeIds,
+    };
+  }
+}
+
+export const thematicRepository = new ThematicRepository();

--- a/api/src/learning-content/infrastructure/repositories/tube-repository.js
+++ b/api/src/learning-content/infrastructure/repositories/tube-repository.js
@@ -1,3 +1,37 @@
 import { LearningContentRepository } from './learning-content-repository.js';
 
-export const tubeRepository = new LearningContentRepository({ tableName: 'learningcontent.tubes' });
+class TubeRepository extends LearningContentRepository {
+  constructor() {
+    super({ tableName: 'learningcontent.tubes' });
+  }
+
+  toDto({
+    id,
+    name,
+    title,
+    description,
+    practicalTitle_i18n,
+    practicalDescription_i18n,
+    competenceId,
+    thematicId,
+    skillIds,
+    isMobileCompliant,
+    isTabletCompliant,
+  }) {
+    return {
+      id,
+      name,
+      title,
+      description,
+      practicalTitle_i18n,
+      practicalDescription_i18n,
+      competenceId,
+      thematicId,
+      skillIds,
+      isMobileCompliant,
+      isTabletCompliant,
+    };
+  }
+}
+
+export const tubeRepository = new TubeRepository();

--- a/api/src/learning-content/infrastructure/repositories/tutorial-repository.js
+++ b/api/src/learning-content/infrastructure/repositories/tutorial-repository.js
@@ -1,3 +1,21 @@
 import { LearningContentRepository } from './learning-content-repository.js';
 
-export const tutorialRepository = new LearningContentRepository({ tableName: 'learningcontent.tutorials' });
+class TutorialRepository extends LearningContentRepository {
+  constructor() {
+    super({ tableName: 'learningcontent.tutorials' });
+  }
+
+  toDto({ id, duration, format, title, source, link, locale }) {
+    return {
+      id,
+      duration,
+      format,
+      title,
+      source,
+      link,
+      locale,
+    };
+  }
+}
+
+export const tutorialRepository = new TutorialRepository();

--- a/api/tests/learning-content/integration/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/learning-content/integration/infrastructure/repositories/skill-repository_test.js
@@ -329,4 +329,61 @@ describe('Learning Content | Integration | Repositories | Skill', function () {
       ]);
     });
   });
+
+  describe('when giving additionnal fields', function () {
+    it('should ignore these', async function () {
+      // given
+      const skillDtos = [
+        {
+          id: 'skill1',
+          name: '@cuiredespates2',
+          hintStatus: 'pré-validé',
+          tutorialIds: ['tuto1', 'tuto2'],
+          learningMoreTutorialIds: ['tutoMore1'],
+          pixValue: 10000,
+          competenceId: 'competence1',
+          status: 'périmé',
+          tubeId: 'tube1',
+          version: 1,
+          level: 2,
+          hint_i18n: {
+            fr: 'Il faut une casserolle d’eau chaude',
+            en: 'A casserolle of hot water is needed',
+            nl: 'Aflugeublik',
+          },
+          // additionnal fields
+          airtableId: 'recSkill1',
+          foo: 'foo',
+          bar: 'bar',
+        },
+      ];
+
+      // when
+      await skillRepository.save(skillDtos);
+
+      // then
+      const savedSkills = await knex.select('*').from('learningcontent.skills').orderBy('name');
+
+      expect(savedSkills).to.deep.equal([
+        {
+          id: 'skill1',
+          name: '@cuiredespates2',
+          hintStatus: 'pré-validé',
+          tutorialIds: ['tuto1', 'tuto2'],
+          learningMoreTutorialIds: ['tutoMore1'],
+          pixValue: 10000,
+          competenceId: 'competence1',
+          status: 'périmé',
+          tubeId: 'tube1',
+          version: 1,
+          level: 2,
+          hint_i18n: {
+            fr: 'Il faut une casserolle d’eau chaude',
+            en: 'A casserolle of hot water is needed',
+            nl: 'Aflugeublik',
+          },
+        },
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
## :christmas_tree: Problème

Les patchs envoyés par l’API LCMS contiennent des champs inconnus (comme `airtableId` pour les acquis).

## :gift: Proposition

Filtrer les champs à écrire en BDD.

## :socks: Remarques

N/A

## :santa: Pour tester

Faire un curl pour patcher une entité sur la RA en donnant des champs inconnus, et vérifier que le patch est bien pris en compte.