### PR TITLE
[FEATURE] Pouvoir logger en debug sur un scope réduit (PIX-15534)

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -410,6 +410,15 @@ LOG_FOR_HUMANS=true
 # LOG_FOR_HUMANS_FORMAT=compact
 
 
+# Enables debug log level for a list of sections.
+# Sections must be given separated by commas.
+# micromatch syntax may be used to match several sections.
+# presence: optional
+# type: string
+# default: none
+# LOG_DEBUG=learningcontent:*,foo,bar
+
+
 # Trace email sending in the mailer
 # DEBUG="pix:mailer:email"
 

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -265,6 +265,7 @@ const configuration = (function () {
       enableLogStartingEventDispatch: toBoolean(process.env.LOG_STARTING_EVENT_DISPATCH),
       enableLogEndingEventDispatch: toBoolean(process.env.LOG_ENDING_EVENT_DISPATCH),
       opsEventIntervalInSeconds: process.env.OPS_EVENT_INTERVAL_IN_SECONDS || 15,
+      debugSections: process.env.LOG_DEBUG?.split(',') ?? [],
     },
     login: {
       temporaryBlockingThresholdFailureCount: _getNumber(


### PR DESCRIPTION
## :christmas_tree: Problème

En prod, on aimerait avoir des logs de niveau debug pour un ou des scopes particuliers.

## :gift: Proposition

Permettre la création de loggers enfants appartenants à une section, et pouvoir activer les logs de niveau debug pour une ou plusieurs sections.

## :socks: Remarques

Voir le commit https://github.com/1024pix/pix/pull/10679/commits/ac426a556fbf061d274fc96dddce97af6bee61dd pour l’utilisation.

## :santa: Pour tester

Sur la RA #10679, vérifier que le niveau de log est info, mais qu’on a bien des logs de niveau debug (20) pour la section "learngingcontent".
Pour faire apparaitre ces logs, faire un rafraichissement du cache sur Pix Admin.
Des logs de debug avec le message "'clearing cache" doivent apparaitre.
Puis sur Pix App passer des compétences ou une certif...
Des logs de debug avec le message "loading from PG" doivent apparaitre.