### PR TITLE
[TECH] Migrer la route PATCH /api/admin/certification-centers/{id} dans src (PIX-15539)

### DIFF
--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -68,30 +68,6 @@ const register = async function (server) {
         tags: ['api', 'certification-center-membership'],
       },
     },
-    {
-      method: 'PATCH',
-      path: '/api/admin/certification-centers/{id}',
-      config: {
-        handler: certificationCenterController.update,
-        pre: [
-          {
-            method: (request, h) =>
-              securityPreHandlers.hasAtLeastOneAccessOf([
-                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-                securityPreHandlers.checkAdminMemberHasRoleCertif,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-                securityPreHandlers.checkAdminMemberHasRoleMetier,
-              ])(request, h),
-            assign: 'hasAuthorizationToAccessAdminScope',
-          },
-        ],
-        notes: [
-          "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès**\n" +
-            '- Elle met à jour les informations d‘un centre de certification\n',
-        ],
-        tags: ['api', 'admin', 'certification-center'],
-      },
-    },
   ];
   const certifRoutes = [
     {

--- a/api/src/organizational-entities/application/certification-center/certification-center.admin.controller.js
+++ b/api/src/organizational-entities/application/certification-center/certification-center.admin.controller.js
@@ -1,4 +1,3 @@
-import { usecases as libUsecases } from '../../../../lib/domain/usecases/index.js';
 import { usecases as certificationConfigurationUsecases } from '../../../certification/configuration/domain/usecases/index.js';
 import { usecases as certificationUsecases } from '../../../certification/enrolment/domain/usecases/index.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
@@ -51,7 +50,7 @@ const update = async function (request) {
 
   const { updatedCertificationCenter, certificationCenterPilotFeatures } = await DomainTransaction.execute(
     async () => {
-      const updatedCertificationCenter = await libUsecases.updateCertificationCenter({
+      const updatedCertificationCenter = await usecases.updateCertificationCenter({
         certificationCenterId,
         certificationCenterInformation,
         complementaryCertificationIds,

--- a/api/src/organizational-entities/application/certification-center/certification-center.admin.route.js
+++ b/api/src/organizational-entities/application/certification-center/certification-center.admin.route.js
@@ -1,6 +1,5 @@
 import Joi from 'joi';
 
-import { certificationCenterController } from '../../../../lib/application/certification-centers/certification-center-controller.js';
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType, optionalIdentifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { certificationCenterAdminController } from './certification-center.admin.controller.js';
@@ -102,7 +101,7 @@ const register = async function (server) {
       method: 'PATCH',
       path: '/api/admin/certification-centers/{id}',
       config: {
-        handler: (request, h) => certificationCenterController.update(request, h),
+        handler: (request, h) => certificationCenterAdminController.update(request, h),
         pre: [
           {
             method: (request, h) =>

--- a/api/src/organizational-entities/application/certification-center/certification-center.admin.route.js
+++ b/api/src/organizational-entities/application/certification-center/certification-center.admin.route.js
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 
+import { certificationCenterController } from '../../../../lib/application/certification-centers/certification-center-controller.js';
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType, optionalIdentifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { certificationCenterAdminController } from './certification-center.admin.controller.js';
@@ -95,6 +96,30 @@ const register = async function (server) {
             "- Récupération d'un centre de certification\n",
         ],
         tags: ['api', 'organizational-entities', 'certification-center'],
+      },
+    },
+    {
+      method: 'PATCH',
+      path: '/api/admin/certification-centers/{id}',
+      config: {
+        handler: (request, h) => certificationCenterController.update(request, h),
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès**\n" +
+            '- Elle met à jour les informations d‘un centre de certification\n',
+        ],
+        tags: ['api', 'admin', 'certification-center'],
       },
     },
   ]);

--- a/api/src/organizational-entities/domain/usecases/create-certification-center.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/create-certification-center.usecase.js
@@ -1,5 +1,5 @@
-import * as certificationCenterCreationValidator from '../../../../lib/domain/validators/certification-center-creation-validator.js';
 import { ComplementaryCertificationHabilitation } from '../../../shared/domain/models/ComplementaryCertificationHabilitation.js';
+import * as certificationCenterCreationValidator from '../validators/certification-center-creation.validator.js';
 
 /**
  *

--- a/api/src/organizational-entities/domain/usecases/index.js
+++ b/api/src/organizational-entities/domain/usecases/index.js
@@ -2,6 +2,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import * as organizationTagRepository from '../../../../lib/infrastructure/repositories/organization-tag-repository.js';
+import * as centerRepository from '../../../certification/enrolment/infrastructure/repositories/center-repository.js';
 import * as learnersApi from '../../../prescription/learner-management/application/api/learners-api.js';
 import * as schoolRepository from '../../../school/infrastructure/repositories/school-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
@@ -13,11 +14,13 @@ import * as dataProtectionOfficerRepository from '../../infrastructure/repositor
 import * as organizationFeatureRepository from '../../infrastructure/repositories/organization-feature-repository.js';
 import { organizationForAdminRepository } from '../../infrastructure/repositories/organization-for-admin.repository.js';
 import { tagRepository } from '../../infrastructure/repositories/tag.repository.js';
+
 const path = dirname(fileURLToPath(import.meta.url));
 
 /**
  * @typedef {import ('../../../prescription/learner-management/application/api/learners-api.js')} learnersApi
  * @typedef {import ('../../infrastructure/repositories/certification-center.repository.js')} CertificationCenterRepository
+ * @typedef {import ('../../../certification/enrolment/infrastructure/repositories/center-repository.js')} CenterRepository
  * @typedef {import ('../../infrastructure/repositories/certification-center-for-admin-repository.js')} CertificationCenterForAdminRepository
  * @typedef {import ('../../infrastructure/repositories/complementary-certification-habilitation-repository.js')} ComplementaryCertificationHabilitationRepository
  * @typedef {import ('../../infrastructure/repositories/data-protection-officer-repository.js')} DataProtectionOfficerRepository
@@ -28,6 +31,7 @@ const path = dirname(fileURLToPath(import.meta.url));
  */
 
 const repositories = {
+  centerRepository,
   certificationCenterRepository,
   certificationCenterForAdminRepository,
   dataProtectionOfficerRepository,

--- a/api/src/organizational-entities/domain/usecases/update-certification-center.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/update-certification-center.usecase.js
@@ -4,9 +4,9 @@
  * @typedef {import('./index.js').ComplementaryCertificationHabilitationRepository} ComplementaryCertificationHabilitationRepository
  * @typedef {import('./index.js').DataProtectionOfficerRepository} DataProtectionOfficerRepository
  */
-import * as certificationCenterCreationValidator from '../../../../lib/domain/validators/certification-center-creation-validator.js';
 import { CenterForAdminFactory } from '../../../certification/enrolment/domain/models/factories/CenterForAdminFactory.js';
 import { ComplementaryCertificationHabilitation, DataProtectionOfficer } from '../../../shared/domain/models/index.js';
+import * as certificationCenterCreationValidator from '../validators/certification-center-creation.validator.js';
 
 /**
  * @param {Object} params

--- a/api/src/organizational-entities/domain/usecases/update-certification-center.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/update-certification-center.usecase.js
@@ -4,12 +4,9 @@
  * @typedef {import('./index.js').ComplementaryCertificationHabilitationRepository} ComplementaryCertificationHabilitationRepository
  * @typedef {import('./index.js').DataProtectionOfficerRepository} DataProtectionOfficerRepository
  */
-import { CenterForAdminFactory } from '../../../src/certification/enrolment/domain/models/factories/CenterForAdminFactory.js';
-import {
-  ComplementaryCertificationHabilitation,
-  DataProtectionOfficer,
-} from '../../../src/shared/domain/models/index.js';
-import * as certificationCenterCreationValidator from '../validators/certification-center-creation-validator.js';
+import * as certificationCenterCreationValidator from '../../../../lib/domain/validators/certification-center-creation-validator.js';
+import { CenterForAdminFactory } from '../../../certification/enrolment/domain/models/factories/CenterForAdminFactory.js';
+import { ComplementaryCertificationHabilitation, DataProtectionOfficer } from '../../../shared/domain/models/index.js';
 
 /**
  * @param {Object} params
@@ -18,7 +15,7 @@ import * as certificationCenterCreationValidator from '../validators/certificati
  * @param {Array<number>} params.complementaryCertificationIds
  * @param {CenterRepository} params.centerRepository
  * @param {CertificationCenterForAdminRepository} params.certificationCenterForAdminRepository
- * @param {ComplementaryCertificationHabilitationRepository} params.ComplementaryCertificationHabilitationRepository
+ * @param {ComplementaryCertificationHabilitationRepository} params.complementaryCertificationHabilitationRepository
  * @param {DataProtectionOfficerRepository} params.dataProtectionOfficerRepository
  */
 const updateCertificationCenter = async function ({

--- a/api/src/organizational-entities/domain/validators/certification-center-creation.validator.js
+++ b/api/src/organizational-entities/domain/validators/certification-center-creation.validator.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 
-import { EntityValidationError } from '../../../src/shared/domain/errors.js';
+import { EntityValidationError } from '../../../shared/domain/errors.js';
 
 const validationConfiguration = { abortEarly: false, allowUnknown: true };
 

--- a/api/tests/acceptance/application/certification-centers/index_test.js
+++ b/api/tests/acceptance/application/certification-centers/index_test.js
@@ -3,7 +3,6 @@ import {
   databaseBuilder,
   expect,
   generateValidRequestAuthorizationHeader,
-  insertUserWithRoleSuperAdmin,
 } from '../../../test-helper.js';
 
 describe('Acceptance | Route | Certification Centers', function () {
@@ -11,48 +10,6 @@ describe('Acceptance | Route | Certification Centers', function () {
 
   beforeEach(async function () {
     server = await createServer();
-  });
-
-  describe('PATCH /api/admin/certification-centers/{id}', function () {
-    context('when an admin member updates a certification center information', function () {
-      it('it should return an HTTP code 200 with the updated data', async function () {
-        // given
-        const adminMember = await insertUserWithRoleSuperAdmin();
-        const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
-
-        await databaseBuilder.commit();
-
-        // when
-        const { result, statusCode } = await server.inject({
-          headers: {
-            authorization: generateValidRequestAuthorizationHeader(adminMember.id),
-          },
-          method: 'PATCH',
-          payload: {
-            data: {
-              id: certificationCenter.id,
-              attributes: {
-                'data-protection-officer-first-name': 'Justin',
-                'data-protection-officer-last-name': 'Ptipeu',
-                'data-protection-officer-email': 'justin.ptipeu@example.net',
-                'is-v3-pilot': true,
-                name: 'Justin Ptipeu Orga',
-                type: 'PRO',
-              },
-            },
-          },
-          url: `/api/admin/certification-centers/${certificationCenter.id}`,
-        });
-
-        // then
-        expect(statusCode).to.equal(200);
-        expect(result.data.attributes['data-protection-officer-first-name']).to.equal('Justin');
-        expect(result.data.attributes['data-protection-officer-last-name']).to.equal('Ptipeu');
-        expect(result.data.attributes['data-protection-officer-email']).to.equal('justin.ptipeu@example.net');
-        expect(result.data.attributes['is-v3-pilot']).to.equal(true);
-        expect(result.data.attributes.name).to.equal('Justin Ptipeu Orga');
-      });
-    });
   });
 
   describe('GET /api/certification-centers/{certificationCenterId}/divisions', function () {

--- a/api/tests/organizational-entities/acceptance/application/certification-center/certification-center.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/certification-center/certification-center.admin.route.test.js
@@ -6,12 +6,12 @@ import {
   insertUserWithRoleSuperAdmin,
 } from '../../../../test-helper.js';
 
-describe('Acceptance | Organization Entities | Route | Certification Centers', function () {
-  let server, request;
+describe('Acceptance | Organization Entities | Admin | Route | Certification Centers', function () {
+  let adminMember, request, server;
 
   beforeEach(async function () {
     server = await createServer();
-    await insertUserWithRoleSuperAdmin();
+    adminMember = await insertUserWithRoleSuperAdmin();
   });
 
   describe('GET /api/admin/certification-centers', function () {
@@ -356,6 +356,47 @@ describe('Acceptance | Organization Entities | Route | Certification Centers', f
 
         // then
         expect(response.statusCode).to.equal(401);
+      });
+    });
+  });
+
+  describe('PATCH /api/admin/certification-centers/{id}', function () {
+    context('when an admin member updates a certification center information', function () {
+      it('returns an HTTP code 200 with the updated data', async function () {
+        // given
+        const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+
+        await databaseBuilder.commit();
+
+        // when
+        const { result, statusCode } = await server.inject({
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(adminMember.id),
+          },
+          method: 'PATCH',
+          payload: {
+            data: {
+              id: certificationCenter.id,
+              attributes: {
+                'data-protection-officer-first-name': 'Justin',
+                'data-protection-officer-last-name': 'Ptipeu',
+                'data-protection-officer-email': 'justin.ptipeu@example.net',
+                'is-v3-pilot': true,
+                name: 'Justin Ptipeu Orga',
+                type: 'PRO',
+              },
+            },
+          },
+          url: `/api/admin/certification-centers/${certificationCenter.id}`,
+        });
+
+        // then
+        expect(statusCode).to.equal(200);
+        expect(result.data.attributes['data-protection-officer-first-name']).to.equal('Justin');
+        expect(result.data.attributes['data-protection-officer-last-name']).to.equal('Ptipeu');
+        expect(result.data.attributes['data-protection-officer-email']).to.equal('justin.ptipeu@example.net');
+        expect(result.data.attributes['is-v3-pilot']).to.equal(true);
+        expect(result.data.attributes.name).to.equal('Justin Ptipeu Orga');
       });
     });
   });

--- a/api/tests/organizational-entities/integration/domain/usecases/update-certification-center.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/update-certification-center.usecase.test.js
@@ -1,13 +1,13 @@
-import { updateCertificationCenter } from '../../../../lib/domain/usecases/update-certification-center.js';
-import { CenterForAdmin } from '../../../../src/certification/enrolment/domain/models/CenterForAdmin.js';
-import * as centerRepository from '../../../../src/certification/enrolment/infrastructure/repositories/center-repository.js';
-import * as certificationCenterForAdminRepository from '../../../../src/organizational-entities/infrastructure/repositories/certification-center-for-admin.repository.js';
-import * as complementaryCertificationHabilitationRepository from '../../../../src/organizational-entities/infrastructure/repositories/complementary-certification-habilitation.repository.js';
-import * as dataProtectionOfficerRepository from '../../../../src/organizational-entities/infrastructure/repositories/data-protection-officer.repository.js';
-import { databaseBuilder, domainBuilder, expect } from '../../../test-helper.js';
+import { CenterForAdmin } from '../../../../../src/certification/enrolment/domain/models/CenterForAdmin.js';
+import * as centerRepository from '../../../../../src/certification/enrolment/infrastructure/repositories/center-repository.js';
+import { updateCertificationCenter } from '../../../../../src/organizational-entities/domain/usecases/update-certification-center.usecase.js';
+import * as certificationCenterForAdminRepository from '../../../../../src/organizational-entities/infrastructure/repositories/certification-center-for-admin.repository.js';
+import * as complementaryCertificationHabilitationRepository from '../../../../../src/organizational-entities/infrastructure/repositories/complementary-certification-habilitation.repository.js';
+import * as dataProtectionOfficerRepository from '../../../../../src/organizational-entities/infrastructure/repositories/data-protection-officer.repository.js';
+import { databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
 
-describe('Integration | UseCases | update-certification-center', function () {
-  it('should update certification center and his data protection officer information', async function () {
+describe('Integration | Organizational Entities | Domain | UseCases | update-certification-center', function () {
+  it('updates certification center and its data protection officer information', async function () {
     // given
     const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
     databaseBuilder.factory.buildDataProtectionOfficer.withCertificationCenterId({

--- a/api/tests/organizational-entities/unit/domain/validators/certification-center-creation.validator.test.js
+++ b/api/tests/organizational-entities/unit/domain/validators/certification-center-creation.validator.test.js
@@ -1,6 +1,6 @@
-import * as certificationCenterCreationValidator from '../../../../lib/domain/validators/certification-center-creation-validator.js';
-import { EntityValidationError } from '../../../../src/shared/domain/errors.js';
-import { expect } from '../../../test-helper.js';
+import * as certificationCenterCreationValidator from '../../../../../src/organizational-entities/domain/validators/certification-center-creation.validator.js';
+import { EntityValidationError } from '../../../../../src/shared/domain/errors.js';
+import { expect } from '../../../../test-helper.js';
 
 const MISSING_VALUE = '';
 
@@ -10,10 +10,10 @@ function _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedErro
   expect(entityValidationErrors.invalidAttributes[0]).to.deep.equal(expectedError);
 }
 
-describe('Unit | Domain | Validators | certification-center-validator', function () {
+describe('Unit | Organizational Entities | Domain | Validators | certification-center-validator', function () {
   describe('#validate', function () {
     context('when validation is successful', function () {
-      it('should not throw any error', function () {
+      it('does not throw any error', function () {
         // given
         const certificationCenterCreationParams = { name: 'ACME', type: 'PRO' };
 
@@ -24,7 +24,7 @@ describe('Unit | Domain | Validators | certification-center-validator', function
 
     context('when certification-center data validation fails', function () {
       context('on name attribute', function () {
-        it('should reject with error when name is missing', function () {
+        it('rejects with error when name is missing', function () {
           // given
           const expectedError = {
             attribute: 'name',
@@ -45,7 +45,7 @@ describe('Unit | Domain | Validators | certification-center-validator', function
           }
         });
 
-        it('should reject with error when name is longer than 255 characters', function () {
+        it('rejects with error when name is longer than 255 characters', function () {
           // given
           const expectedError = {
             attribute: 'name',
@@ -68,7 +68,7 @@ describe('Unit | Domain | Validators | certification-center-validator', function
       });
 
       context('on type attribute', function () {
-        it('should reject with error when type is missing', function () {
+        it('rejects with error when type is missing', function () {
           // given
           const expectedError = [
             {
@@ -97,7 +97,7 @@ describe('Unit | Domain | Validators | certification-center-validator', function
           }
         });
 
-        it('should reject with error when type value is not SUP, SCO or PRO', function () {
+        it('rejects with error when type value is not SUP, SCO or PRO', function () {
           // given
           const expectedError = {
             attribute: 'type',
@@ -117,7 +117,7 @@ describe('Unit | Domain | Validators | certification-center-validator', function
 
         // eslint-disable-next-line mocha/no-setup-in-describe
         ['SUP', 'SCO', 'PRO'].forEach((type) => {
-          it(`should not throw with ${type} as type`, function () {
+          it(`does not throw with ${type} as type`, function () {
             // given
             const certificationCenterCreationParams = { name: 'ACME', type };
 
@@ -129,7 +129,7 @@ describe('Unit | Domain | Validators | certification-center-validator', function
       });
 
       context('on externalId attribute', function () {
-        it('should reject with error when externalId is longer than 255 characters', function () {
+        it('rejects with error when externalId is longer than 255 characters', function () {
           // given
           const expectedError = [
             {
@@ -156,7 +156,7 @@ describe('Unit | Domain | Validators | certification-center-validator', function
         });
       });
 
-      it('should reject with errors on all fields (but only once by field) when all fields are missing', function () {
+      it('rejects with errors on all fields (but only once by field) when all fields are missing', function () {
         // given
         const certificationCenterCreationParams = {
           name: MISSING_VALUE,


### PR DESCRIPTION
## :christmas_tree: Problème
Le code de l'API PATCH /api/admin/certification-centers/{id} est encore dans lib.

## :gift: Proposition
Le migrer dans src/organizational-entities.

## :socks: Remarques
RAS

## :santa: Pour tester
- Se connecter à la RA de Pix Admin avec le compte superadmin https://admin-pr10705.review.pix.fr
- Aller sur la page de détail d'un centre de certif (ex: [Accèssorium](https://admin-pr10705.review.pix.fr/certification-centers/8000)
- Cliquer sur le bouton `Modifier`
- Modifier les informations du centre dans le formulaire correspondant
- Ouvrir la console navigateur
- Vérifier que l'appel PATCH /api/admin/certification-centers/${id} renvoie bien une 200
