### PR TITLE
[FEATURE] Modifier les couleurs de l'espace surveillant sur Pix Certif (PIX-15549).

### DIFF
--- a/certif/app/components/login-session-supervisor/footer.scss
+++ b/certif/app/components/login-session-supervisor/footer.scss
@@ -1,4 +1,4 @@
-#login-session-supervisor-page > main > footer {
+.login-session-supervisor-page > main > footer {
   border-radius: 0 0 10px 10px;
   background: var(--pix-neutral-20);
   display: flex;

--- a/certif/app/components/login-session-supervisor/form.scss
+++ b/certif/app/components/login-session-supervisor/form.scss
@@ -1,4 +1,4 @@
-#login-session-supervisor-page > main > section {
+.login-session-supervisor-page > main > section {
   p.error-message {
     margin-bottom: 10px;
     text-align: center;

--- a/certif/app/components/login-session-supervisor/header.scss
+++ b/certif/app/components/login-session-supervisor/header.scss
@@ -1,4 +1,4 @@
-#login-session-supervisor-page > main > section {
+.login-session-supervisor-page > main > section {
   header {
     text-align: center;
 

--- a/certif/app/components/login-session-supervisor/index.gjs
+++ b/certif/app/components/login-session-supervisor/index.gjs
@@ -55,7 +55,7 @@ export default class LoginSessionSupervisor extends Component {
   }
 
   <template>
-    <div id='login-session-supervisor-page'>
+    <div id='login-session-supervisor-page' class='login-session-supervisor-page'>
       <main>
         <section>
           <LoginSessionSupervisorHeader @errorMessage={{this.errorMessage}} />

--- a/certif/app/components/login-session-supervisor/index.scss
+++ b/certif/app/components/login-session-supervisor/index.scss
@@ -1,7 +1,6 @@
-#login-session-supervisor-page {
+.login-session-supervisor-page {
   align-items: center;
-  background: $pix-primary-certif-gradient;
-  box-shadow: 0 2px 8px 0 rgb(0 0 0 / 10%);
+  background: var(--pix-certif-500);
   display: flex;
   flex-direction: column;
   height: 100px;

--- a/certif/app/styles/components/session-supervising/candidate-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-list.scss
@@ -1,5 +1,5 @@
 .session-supervising-candidate-list-background {
-  background: var(--pix-neutral-900);
+  background: var(--pix-certif-500);
   border-radius: 18px 18px 0 0;
   flex-grow: 1;
   padding: 32px 16px;
@@ -18,7 +18,7 @@
     &__description {
       display: flex;
       justify-content: flex-start;
-      color: var(--pix-neutral-20);
+      color: var(--pix-neutral-0);
       font-size: 0.875rem;
       font-weight: normal;
       min-height: 14px;
@@ -30,7 +30,7 @@
       @extend %pix-title-xs;
       font-weight: 600;
       margin: 0 0 8px;
-      color: var(--pix-neutral-20);
+      color: var(--pix-neutral-0);
     }
 
     &__candidates {
@@ -38,7 +38,7 @@
       padding: 0;
 
       > li {
-        background: var(--pix-neutral-800);
+        background: rgb(var(--pix-neutral-900-inline), 40%);
       }
     }
 
@@ -60,7 +60,6 @@
     &__search {
       align-items: center;
       background-color: var(--pix-neutral-0);
-      border: 1px solid #7A869A;
       border-radius: 4px;
       box-sizing: border-box;
       display: flex;
@@ -73,7 +72,7 @@
     &__candidates-count {
       display: flex;
       justify-content: flex-start;
-      color: var(--pix-neutral-20);
+      color: var(--pix-neutral-0);
       font-size: 0.875rem;
       font-weight: normal;
       height: 14px;


### PR DESCRIPTION
## :christmas_tree: Problème

Avec la mise en place de la nouvelle navigation, l'espace surveillant doit s'aligner en terme de couleur

## :gift: Proposition

Changer quelques couleurs de fond

## :santa: Pour tester

| <img width="1727" alt="Capture d’écran 2024-12-03 à 18 44 48" src="https://github.com/user-attachments/assets/66518114-d324-4d8c-b1ef-8545a84417ff"> | <img width="1727" alt="Capture d’écran 2024-12-03 à 18 44 41" src="https://github.com/user-attachments/assets/c8faba04-a6da-4175-9e58-ad766d8be03f"> |
|--------|--------|
| <img width="1728" alt="Capture d’écran 2024-12-03 à 18 44 20" src="https://github.com/user-attachments/assets/d18619c9-525f-48b4-9670-b25b815a4672"> | <img width="1728" alt="Capture d’écran 2024-12-03 à 18 43 59" src="https://github.com/user-attachments/assets/5993c861-cbab-42d0-92ca-0386d58815d8"> |
