### PR TITLE
[TECH] :recycle:  Remaniement du filtre des compétence (récupération d'une PR ÉcriPlus)

### DIFF
--- a/api/src/evaluation/domain/services/algorithm-methods/skills-filter.js
+++ b/api/src/evaluation/domain/services/algorithm-methods/skills-filter.js
@@ -8,9 +8,9 @@ import { logPredictedLevel, logStep } from '../smart-random-log-service.js';
 
 const getPlayableSkills = (skills) => skills.filter(({ isPlayable }) => isPlayable);
 
-const notAlreadyTestedSkill = (knowledgeElements) => (skill) => {
+const notAlreadyTestedSkill = (knowledgeElements) => {
   const alreadyTestedSkillIds = knowledgeElements.map(({ skillId }) => skillId);
-  return !alreadyTestedSkillIds.includes(skill.id);
+  return (skill) => !alreadyTestedSkillIds.includes(skill.id);
 };
 const getUntestedSkills = (knowledgeElements, skills) => skills.filter(notAlreadyTestedSkill(knowledgeElements));
 


### PR DESCRIPTION
## :christmas_tree: Problème

C'est la reprise de la PR https://github.com/1024pix/pix/pull/8602 puisque je n'arrive pas à la faire passer (PB avec notre intégration continue il me semble)

## :gift: Proposition

## :socks: Remarques


## :santa: Pour tester
