### PR TITLE
[FEATURE] Modification du background des mires sur Pix Orga et Pix Certif (PIX-15554)

### DIFF
--- a/certif/app/styles/pages/join.scss
+++ b/certif/app/styles/pages/join.scss
@@ -3,6 +3,6 @@
   justify-content: center;
   width: 100%;
   min-height: 100vh;
-  background: $pix-primary-certif-gradient;
+  background: var(--pix-certif-500);
   box-shadow: 0 2px 8px 0 rgb(var(--pix-neutral-900) 0.1);
 }

--- a/certif/app/styles/pages/login.scss
+++ b/certif/app/styles/pages/login.scss
@@ -5,5 +5,5 @@
   justify-content: center;
   width: 100%;
   min-height: 100vh;
-  background: $pix-primary-certif-gradient;
+  background: var(--pix-certif-500);
 }

--- a/certif/app/styles/pages/session-supervising-error.scss
+++ b/certif/app/styles/pages/session-supervising-error.scss
@@ -5,7 +5,7 @@
   width: 100%;
   height: 100px;
   min-height: 100vh;
-  background: $pix-primary-certif-gradient;
+  background: var(--pix-certif-500);
   box-shadow: 0 2px var(--pix-spacing-2x) 0 rgb(0 0 0 / 10%);
 }
 

--- a/certif/app/styles/pages/terms-of-service.scss
+++ b/certif/app/styles/pages/terms-of-service.scss
@@ -4,7 +4,7 @@
   align-items: center;
   width: 100%;
   min-height: 100vh;
-  background: $pix-primary-certif-gradient;
+  background: var(--pix-certif-500);
 }
 
 .terms-of-service-form {

--- a/orga/app/styles/pages/authenticated/terms-of-service.scss
+++ b/orga/app/styles/pages/authenticated/terms-of-service.scss
@@ -6,7 +6,7 @@
   width: 100%;
   height: 100%;
   min-height: 800px;
-  background: $pix-secondary-orga-gradient;
+  background: var(--pix-orga-500);
 }
 
 .terms-of-service-form {

--- a/orga/app/styles/pages/join-request.scss
+++ b/orga/app/styles/pages/join-request.scss
@@ -5,7 +5,7 @@
   justify-content: center;
   width: 100%;
   min-height: 100%;
-  background: $pix-secondary-orga-gradient;
+  background: var(--pix-orga-500);
 
   a {
     text-decoration: underline;

--- a/orga/app/styles/pages/join.scss
+++ b/orga/app/styles/pages/join.scss
@@ -5,5 +5,5 @@
   justify-content: center;
   width: 100%;
   min-height: 100vh;
-  background: $pix-secondary-orga-gradient;
+  background: var(--pix-orga-500);
 }

--- a/orga/app/styles/pages/login.scss
+++ b/orga/app/styles/pages/login.scss
@@ -5,7 +5,7 @@
   justify-content: center;
   width: 100%;
   min-height: 100vh;
-  background: $pix-secondary-orga-gradient;
+  background: var(--pix-orga-500);
 
   &__header {
     text-align: center;


### PR DESCRIPTION
## :christmas_tree: Problème

Le background n'était pas à jour avec les tokens couleurs

## :gift: Proposition

Modification du background pour supprimer le gradient

## :socks: Remarques

RAS

## :santa: Pour tester

* Aller sur les mires Pix Orga et Pix Certif et constater les modifications 
* Aller sur les doubles mires d'invitation de Pix Orga et Pix Certif et constater les modifications
* Aller sur la page d'erreur dans l'espace surveillant et constater la modification
* Aller sur les pages d'acceptation des CGU sur Pix Orga et Pix Certif et constater les modifications
* Vérifier que la modification a été effectuée sur la page des instructions pour la certification dans Pix App 
* Vérifier que la bannière de la certification a été modifiée dans Pix App 