### PR TITLE
[TECH] Modifier le type de la colonne reward ID de la table Profile Rewards (PIX-15546).

### DIFF
--- a/api/db/migrations/20240820101213_add-profile-rewards-table.js
+++ b/api/db/migrations/20240820101213_add-profile-rewards-table.js
@@ -1,4 +1,3 @@
-import { REWARD_TYPES } from '../../src/quest/domain/constants.js';
 export const PROFILE_REWARDS_TABLE_NAME = 'profile-rewards';
 
 const up = async function (knex) {
@@ -6,8 +5,8 @@ const up = async function (knex) {
     table.increments('id').primary();
     table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
     table.bigInteger('userId').index().references('users.id');
-    table.enum('rewardType', [REWARD_TYPES.ATTESTATION]).defaultTo(REWARD_TYPES.ATTESTATION);
-    table.bigInteger('rewardId').notNullable();
+    table.string('rewardType').notNullable();
+    table.string('rewardId').notNullable();
   });
 };
 

--- a/api/db/migrations/20241204091429_alter-profile-rewards-columns.js
+++ b/api/db/migrations/20241204091429_alter-profile-rewards-columns.js
@@ -1,0 +1,19 @@
+import { REWARD_TYPES } from '../../src/quest/domain/constants.js';
+
+const TABLE_NAME = 'profile-rewards';
+
+const up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.text('rewardType').defaultTo(REWARD_TYPES.ATTESTATION).alter();
+    table.bigInteger('rewardId').notNullable().alter();
+  });
+};
+
+const down = async function (knex) {
+  await knex.raw('ALTER TABLE "profile-rewards" ALTER COLUMN "rewardType" DROP DEFAULT;');
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.string('rewardId').notNullable().alter();
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## :christmas_tree: Problème
Une migration qui avait déjà été jouée sur certains environnements a été modifiée a posteriori, donc les modifications de cette migration n'ont pas été prises en compte (on ne rejoue pas les migrations sur les environnements autres que le local).

## :gift: Proposition
On remet la migration modifiée précédemment à son état initial puis on ajoute une nouvelle migration qui va modifier la table Profile-Rewards pour modifier les types des colonnes Reward Type et Reward Id.  


## :socks: Remarques
On a remplacé le type Enum de la colonne Reward Type par un type String car d'après la doc PGSQL il n'est pas possible de rajouter des éléments à une Enum a posteriori. Or c'est une option qu'on veut garder possible, donc ça aurait été relou. 

## :santa: Pour tester
Les applications doivent continuer à fonctionner et l'acquisition des Attestations doit toujours être possible.