### PR TITLE
[BUGFIX] Lire la variable d’env START_JOB_IN_WEB_PROCESS comme booléen

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -67,7 +67,7 @@ process.on('SIGINT', () => {
 (async () => {
   try {
     await start();
-    if (process.env.START_JOB_IN_WEB_PROCESS) {
+    if (config.infra.startJobInWebProcess) {
       import('./worker.js');
     }
   } catch (error) {

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -237,6 +237,7 @@ const configuration = (function () {
         process.env.INFRA_CHUNK_SIZE_ORGANIZATION_LEARNER_DATA_PROCESSING,
         1000,
       ),
+      startJobInWebProcess: toBoolean(process.env.START_JOB_IN_WEB_PROCESS),
     },
     jwtConfig: {
       livretScolaire: {


### PR DESCRIPTION
## :christmas_tree: Problème

La variable d’env START_JOB_IN_WEB_PROCESS n’est pas lue comme un booléean, si on la met à "false", elle est considérée comme true.

## :gift: Proposition

Lire la variable comme un booléen.

## :socks: Remarques

N/A

## :santa: Pour tester

Vérifier que le conteneur web de la RA n’est pas un worker, on ne doit pas voir de log info "Starting pg-boss".