### PR TITLE
[FEATURE] Faire remonter le nombre de clics sur le bouton "Exporter les résultats de campagne" dans Matomo

### DIFF
--- a/orga/app/components/campaign/header/tabs.gjs
+++ b/orga/app/components/campaign/header/tabs.gjs
@@ -10,12 +10,19 @@ export default class CampaignTabs extends Component {
   @service notifications;
   @service fileSaver;
   @service session;
+  @service metrics;
 
   @action
   async exportData() {
     try {
       const token = this.session.data.authenticated.access_token;
       await this.fileSaver.save({ url: this.args.campaign.urlToResult, token });
+      this.metrics.add({
+        event: 'custom-event',
+        'pix-event-category': 'Campagnes',
+        'pix-event-action': "Cliquer sur le bouton d'export des résultats d'une campagne",
+        'pix-event-name': "Clic sur le bouton d'export",
+      });
     } catch (err) {
       this.notifications.sendError(this.intl.t('api-error-messages.global'));
     }

--- a/orga/app/routes/application.js
+++ b/orga/app/routes/application.js
@@ -7,8 +7,10 @@ export default class ApplicationRoute extends Route {
   @service currentUser;
   @service session;
   @service intl;
+  @service metrics;
 
   async beforeModel(transition) {
+    this.metrics.initialize();
     await this.session.setup();
     await this.featureToggles.load();
     const isFranceDomain = this.currentDomain.isFranceDomain;

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -105,8 +105,6 @@ module.exports = function (environment) {
       warnIfNoIconsIncluded: false,
     },
 
-    matomo: {},
-
     'ember-cli-notifications': {
       autoClear: true,
       clearDuration: 5000,
@@ -120,6 +118,11 @@ module.exports = function (environment) {
     'ember-cli-mirage': {
       usingProxy: true,
     },
+
+    metrics: {
+      enabled: analyticsEnabled,
+      matomoUrl: process.env.WEB_ANALYTICS_URL,
+    },
   };
 
   if (environment === 'development') {
@@ -132,10 +135,6 @@ module.exports = function (environment) {
     // ENV.APP.LOG_TRANSITIONS = true;
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
-    if (analyticsEnabled) {
-      ENV.matomo.url = process.env.WEB_ANALYTICS_URL;
-      ENV.matomo.debug = true;
-    }
   }
 
   if (environment === 'test') {
@@ -157,16 +156,12 @@ module.exports = function (environment) {
       autoClear: null,
       clearDuration: null,
     };
-
+    ENV.metrics.enabled = false;
     ENV.pagination.debounce = 0;
   }
 
   if (environment === 'production') {
     // here you can enable a production-specific feature
-
-    if (analyticsEnabled) {
-      ENV.matomo.url = process.env.WEB_ANALYTICS_URL;
-    }
   }
 
   return ENV;

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -11,6 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-cli-notifications": "^8.0.2",
+        "@1024pix/ember-matomo-tag-manager": "^2.4.3",
         "@1024pix/ember-testing-library": "^3.0.6",
         "@1024pix/eslint-config": "^1.3.8",
         "@1024pix/pix-ui": "^49.4.1",
@@ -862,6 +863,16 @@
         "@babel/core": "^7.3.4",
         "object-assign": "4.1.1",
         "rsvp": "^4.8.4"
+      }
+    },
+    "node_modules/@1024pix/ember-matomo-tag-manager": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@1024pix/ember-matomo-tag-manager/-/ember-matomo-tag-manager-2.4.3.tgz",
+      "integrity": "sha512-gsoFCZxMXO5purZh92WwgWyydRS/PftFr7+HRF9bRAHbPrqkd6NCmLEHvFZ9ETXKPB3SkF79Qh28SaljXTkb5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@embroider/addon-shim": "^1.0.0"
       }
     },
     "node_modules/@1024pix/ember-testing-library": {

--- a/orga/package.json
+++ b/orga/package.json
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-cli-notifications": "^8.0.2",
+    "@1024pix/ember-matomo-tag-manager": "^2.4.3",
     "@1024pix/ember-testing-library": "^3.0.6",
     "@1024pix/eslint-config": "^1.3.8",
     "@1024pix/pix-ui": "^49.4.1",
@@ -80,7 +81,6 @@
     "ember-cli-dependency-checker": "^3.3.2",
     "ember-cli-htmlbars": "^6.3.0",
     "ember-cli-inject-live-reload": "^2.1.0",
-    "ember-cli-matomo-tag-manager": "^1.3.1",
     "ember-cli-mirage": "^3.0.4",
     "ember-cli-sass": "^11.0.1",
     "ember-click-outside": "^6.1.1",

--- a/orga/tests/integration/components/campaign/header/tabs-test.js
+++ b/orga/tests/integration/components/campaign/header/tabs-test.js
@@ -143,5 +143,27 @@ module('Integration | Component | Campaign::Header::Tabs', function (hooks) {
         }),
       );
     });
+
+    test('it should push matomo event when user clicks on export button', async function (assert) {
+      const add = sinon.stub();
+
+      class MetricsStubService extends Service {
+        add = add;
+      }
+      this.owner.register('service:metrics', MetricsStubService);
+
+      const screen = await render(hbs`<Campaign::Header::Tabs @campaign={{this.campaign}} />`);
+
+      // when
+      await click(screen.getByRole('button', { name: t('pages.campaign.actions.export-results') }));
+
+      sinon.assert.calledWithExactly(add, {
+        event: 'custom-event',
+        'pix-event-category': 'Campagnes',
+        'pix-event-action': "Cliquer sur le bouton d'export des résultats d'une campagne",
+        'pix-event-name': "Clic sur le bouton d'export",
+      });
+      assert.ok(true);
+    });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème

On aimerait pouvoir suivre l’usage de l’export des résultats de campagne. 

## :gift: Proposition

- Ajout de la configuration Matomo la plus récente dans orga

## :socks: Remarques

Les métriques supplémentaires demandées dans le ticket Jira (infos à garder sur les users, orgas et nb de résultats dans le fichier) seraient à renseigner à l'aide des custom dimensions de Matomo. Pas d'exemple précédent de leur implémentation chez Pix.

## :santa: Pour tester

CI au vert
Le clic sur le bouton "Exporter les résultats de campagne" fonctionne.
En renseignant les variables d'environnement nécessaires dans Scalingo, on voit bien les requêtes Matomo partir dans la console.