### PR TITLE
[FEATURE] Modifier le lien pour l'interprétation des résultats sur Pix Orga (PIX-15555).

### DIFF
--- a/orga/app/styles/pages/authenticated/certifications.scss
+++ b/orga/app/styles/pages/authenticated/certifications.scss
@@ -39,3 +39,15 @@
     margin-left: auto;
   }
 }
+
+.certifications-page-action {
+  &__link {
+    display: inline-flex;
+    align-items: center;
+
+    svg {
+      width: 1rem;
+      height: 1rem;
+    }
+  }
+}

--- a/orga/app/templates/authenticated/certifications.hbs
+++ b/orga/app/templates/authenticated/certifications.hbs
@@ -30,9 +30,15 @@
 
     <PixNotificationAlert @withIcon={{true}}>
       {{t "pages.certifications.documentation-link-notice"}}
-      <a href={{t "pages.certifications.documentation-link"}} target="_blank" rel="noopener noreferrer">{{t
-          "pages.certifications.documentation-link-label"
-        }}</a>
+      <a
+        class="link--underlined certifications-page-action__link"
+        href={{t "pages.certifications.documentation-link"}}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {{t "pages.certifications.documentation-link-label"}}
+        <PixIcon @name="openNew" @title={{t "navigation.external-link-title"}} />
+      </a>
     </PixNotificationAlert>
   {{else}}
     <p class="certifications-page__text">

--- a/orga/tests/acceptance/certifications-test.js
+++ b/orga/tests/acceptance/certifications-test.js
@@ -86,10 +86,12 @@ module('Acceptance | Certifications page', function (hooks) {
 
       test('should show documentation about certification results link', async function (assert) {
         // given / when
-        await visit('/certifications');
+        const screen = await visit('/certifications');
 
         // then
-        assert.ok('a[href="https://cloud.pix.fr/s/cRaeKT4ErrXs4X8"]');
+        assert
+          .dom(screen.getByRole('link', { name: 'Interprétation des résultats Ouverture dans une nouvelle fenêtre' }))
+          .hasAttribute('href', 'https://cloud.pix.fr/s/8pJqgNNntwDtsDY');
       });
 
       test('should display attestation download button', async function (assert) {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -339,6 +339,7 @@
       "number": "{count, plural, =0 {0 credits} =1 {1 credit} other {{count, number} credits}}",
       "tooltip-text": "The number of credits displayed is the number of credits acquired by the organisation and currently valid (regardless of their activation). For more information, please contact us at the following address: '<a href=mailto:pro@pix.fr>'pro@pix.fr'</a>'"
     },
+    "external-link-title": "Open in a new window",
     "footer": {
       "a11y": "Accessibility",
       "aria-label": "Footer navigation",
@@ -811,8 +812,8 @@
     "certifications": {
       "title": "Certification results",
       "description": "Please select the class for which you would like to export the certification results (.csv) or download certificates (.pdf).",
-      "documentation-link": "https://cloud.pix.fr/s/cRaeKT4ErrXs4X8",
-      "documentation-link-label": "Interpreting the results.",
+      "documentation-link": "https://cloud.pix.fr/s/8pJqgNNntwDtsDY",
+      "documentation-link-label": "Interpreting the results",
       "documentation-link-notice": "Follow this link to find indications on how to interpret the results: ",
       "download-attestations-button": "Download attestations",
       "download-button": "Export the results",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -345,6 +345,7 @@
       "number": "{count, plural, =0 {0 crédit} =1 {1 crédit} other {{count, number} crédits}}",
       "tooltip-text": "Le nombre de crédits affichés correspond au nombre de crédits acquis par l’organisation et en cours de validité (indépendamment de leur activation). Pour plus d’information contactez-nous à l’adresse '<a href=mailto:pro@pix.fr>'pro@pix.fr'</a>'"
     },
+    "external-link-title": "Ouverture dans une nouvelle fenêtre",
     "footer": {
       "a11y": "Accessibilité : partiellement conforme",
       "aria-label": "Navigation de pied de page",
@@ -817,8 +818,8 @@
     "certifications": {
       "title": "Résultats de certification",
       "description": "Sélectionnez la classe pour laquelle vous souhaitez exporter les résultats de certification (.csv) ou télécharger les attestations (.pdf).'<br>' Vous pouvez filtrer cette liste en renseignant le nom de la classe directement dans le champ.",
-      "documentation-link": "https://cloud.pix.fr/s/cRaeKT4ErrXs4X8",
-      "documentation-link-label": "Interprétation des résultats.",
+      "documentation-link": "https://cloud.pix.fr/s/8pJqgNNntwDtsDY",
+      "documentation-link-label": "Interprétation des résultats",
       "documentation-link-notice": "Vous trouverez en suivant ce lien quelques éléments pour interpréter les résultats : ",
       "download-attestations-button": "Télécharger les attestations",
       "download-button": "Exporter les résultats",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -329,6 +329,7 @@
     }
   },
   "navigation": {
+    "external-link-title": "Open in a new window",
     "assessment-individual-results": {
       "aria-label": "Navigatie door het deel met individuele beoordelingsresultaten"
     },
@@ -809,7 +810,7 @@
     },
     "certifications": {
       "description": "Selecteer de klas waarvoor je de certificeringsresultaten wilt exporteren (.csv) of de certificaten wilt downloaden (.pdf).'<br>' Je kunt deze lijst filteren door de naam van de klas direct in het veld in te voeren.",
-      "documentation-link": "https://cloud.pix.fr/s/cRaeKT4ErrXs4X8",
+      "documentation-link": "https://cloud.pix.fr/s/8pJqgNNntwDtsDY",
       "documentation-link-label": "Interpretatie van de resultaten.",
       "documentation-link-notice": "Volg deze link voor meer informatie over de interpretatie van de resultaten:",
       "download-attestations-button": "Getuigschriften downloaden",


### PR DESCRIPTION
## :christmas_tree: Problème

Sur Pix Orga, dans l'onglet certifications, le lien de la documentation présent dans le bandeau d'information ne fonctionne plus.

## :gift: Proposition

Le modifier.

## :socks: Remarques
Ajout d'une icône indiquant un changement de page au clic avec indication pour le lecteur d'écran.

## :santa: Pour tester

Se connecter à Pix Orga avec allorga@example.net
Aller dans l'onglet certification
Constater que l'on est correctement redirigé vers la documentation

<img width="1024" alt="Capture d’écran 2024-12-04 à 18 07 26" src="https://github.com/user-attachments/assets/2d1f01e9-e238-4def-bdda-b120a2e0cd7b">

