### PR TITLE
[FEATURE] Ajouter un prehandler pour la route de récupération d'une liste d'attestations (PIX-15593)

### DIFF
--- a/api/src/prescription/organization-learner/application/organization-learners-route.js
+++ b/api/src/prescription/organization-learner/application/organization-learners-route.js
@@ -45,6 +45,12 @@ const register = async function (server) {
             method: securityPreHandlers.checkUserBelongsToOrganization,
             assign: 'checkUserBelongsToOrganization',
           },
+          {
+            method: securityPreHandlers.makeCheckOrganizationHasFeature(
+              ORGANIZATION_FEATURE.ATTESTATIONS_MANAGEMENT.key,
+            ),
+            assign: 'makeCheckOrganizationHasFeature',
+          },
         ],
         validate: {
           params: Joi.object({

--- a/api/tests/prescription/organization-learner/acceptance/application/organization-learner-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/application/organization-learner-route_test.js
@@ -22,8 +22,12 @@ describe('Prescription | Organization Learner | Acceptance | Application | Organ
   describe('GET /api/organizations/{organizationId}/attestations/{attestationKey}', function () {
     it('should return 200 status code and right content type', async function () {
       // given
+      const attestationFeatureId = databaseBuilder.factory.buildFeature(
+        ORGANIZATION_FEATURE.ATTESTATIONS_MANAGEMENT,
+      ).id;
       const userId = databaseBuilder.factory.buildUser().id;
       const organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildOrganizationFeature({ organizationId, featureId: attestationFeatureId });
       databaseBuilder.factory.buildMembership({
         userId,
         organizationId,


### PR DESCRIPTION
## :christmas_tree: Problème
Nous avons mis à disposition une route pour récupérer une liste d'attestations sur PixOrga. Cette fonctionnalitée est restreinte aux organisations ayant la feature `ATTESTATION_MANAGEMENT`d'activée. Or nous ne faisions aucun check sur la route a ce niveau

## :gift: Proposition
Ajout d'un prehandler qui vérifie que la feature est bien activée pour l'organisation 


## :santa: Pour tester
Soyez créatifs 😇 
🐈‍⬛ 
