### PR TITLE
[BUGFIX] Rajouter un fond derrière le bloc d'alerte d'une épreuve focus (PIX-15545).

### DIFF
--- a/mon-pix/app/styles/pages/_challenge.scss
+++ b/mon-pix/app/styles/pages/_challenge.scss
@@ -53,14 +53,24 @@
   }
 
   &__info-alert {
+    position: relative;
     z-index: 1;
     display: flex;
     flex-direction: column;
     align-items: center;
-    color: var(--pix-primary-700);
-    background-color: rgb(var(--pix-primary-100) 0.9);
+    overflow: hidden;
+    color: var(--pix-primary-900);
     border-radius: 51px;
-    box-shadow: 0 10px 20px 0 rgb(var(--pix-content-dark) 0.06);
+    box-shadow: 0 10px 20px 0 var(--pix-primary-700);
+
+    &::before {
+      position: absolute;
+      z-index: -1;
+      background-color: var(--pix-primary-100);
+      opacity: 0.95;
+      content: '';
+      inset: 0;
+    }
 
     &.challenge__info-alert--hide {
       height: 0;


### PR DESCRIPTION
## :christmas_tree: Problème

![image](https://github.com/user-attachments/assets/3c680e11-dc6c-4a38-9474-e7a7d2dae79a)

Le bloc d'alerte des épreuves focus n'est plus lisible.

## :gift: Proposition

- Remettre un fond
- Augmenter le contraste avec le texte

## :santa: Pour tester

Visualiser sur [cette épreuve focus](https://app-pr10722.review.pix.fr/challenges/rec2dRKsI4aBIsayz/preview) en RA.
