### PR TITLE
[FEATURE] Ajouter l'entrée `Statistiques` pour les organisations ayant la feature sur PixOrga (PIX-15453)

### DIFF
--- a/orga/app/components/layout/sidebar.hbs
+++ b/orga/app/components/layout/sidebar.hbs
@@ -80,6 +80,13 @@
         {{t "navigation.main.support"}}
       </a>
     {{/if}}
-
+    {{#if this.shouldDisplayStatisticsEntry}}
+      <LinkTo @route="authenticated.statistics" class="sidebar-nav__item">
+        <span class="sidebar-nav__item-icon">
+          <PixIcon @name="monitoring" role="none" />
+        </span>
+        {{t "navigation.main.statistics"}}
+      </LinkTo>
+    {{/if}}
   </nav>
 </aside>

--- a/orga/app/components/layout/sidebar.js
+++ b/orga/app/components/layout/sidebar.js
@@ -37,6 +37,10 @@ export default class SidebarMenu extends Component {
     return this.currentUser.canAccessCampaignsPage;
   }
 
+  get shouldDisplayStatisticsEntry() {
+    return this.currentUser.canAccessStatisticsPage;
+  }
+
   get organizationLearnersList() {
     if (this.currentUser.isSCOManagingStudents) {
       return {

--- a/orga/app/models/prescriber.js
+++ b/orga/app/models/prescriber.js
@@ -20,8 +20,10 @@ export default class Prescriber extends Model {
       MISSIONS_MANAGEMENT: 'MISSIONS_MANAGEMENT',
       LEARNER_IMPORT: 'LEARNER_IMPORT',
       ORALIZATION: 'ORALIZATION',
+      COVER_RATE: 'COVER_RATE',
     };
   }
+
   get fullName() {
     return `${this.firstName} ${this.lastName}`;
   }
@@ -70,5 +72,9 @@ export default class Prescriber extends Model {
 
   get hasParticipants() {
     return Boolean(this.participantCount);
+  }
+
+  get hasCoverRateFeature() {
+    return this.features[Prescriber.featureList.COVER_RATE];
   }
 }

--- a/orga/app/router.js
+++ b/orga/app/router.js
@@ -87,6 +87,7 @@ Router.map(function () {
         this.route('results');
       });
     });
+    this.route('statistics', { path: '/statistiques' });
   });
 
   this.route('logout');

--- a/orga/app/routes/authenticated/statistics.js
+++ b/orga/app/routes/authenticated/statistics.js
@@ -1,0 +1,13 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class AuthenticatedStatisticsRoute extends Route {
+  @service currentUser;
+  @service router;
+
+  beforeModel() {
+    if (!this.currentUser.canAccessStatisticsPage) {
+      this.router.replaceWith('application');
+    }
+  }
+}

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -14,6 +14,48 @@ export default class CurrentUserService extends Service {
   @tracked isAgriculture;
   @tracked isGarAuthenticationMethod;
 
+  get homePage() {
+    if (this.canAccessMissionsPage) {
+      return 'authenticated.missions';
+    }
+    return 'authenticated.campaigns';
+  }
+
+  get canAccessImportPage() {
+    return Boolean(
+      (this.isSCOManagingStudents || this.isSUPManagingStudents || this.hasLearnerImportFeature) &&
+        this.isAdminInOrganization,
+    );
+  }
+
+  get canAccessAttestationsPage() {
+    return this.prescriber.attestationsManagement;
+  }
+
+  get canAccessPlacesPage() {
+    return this.isAdminInOrganization && this.prescriber.placesManagement;
+  }
+
+  get canAccessMissionsPage() {
+    return this.prescriber.missionsManagement;
+  }
+
+  get canAccessCampaignsPage() {
+    return !this.prescriber.missionsManagement;
+  }
+
+  get hasLearnerImportFeature() {
+    return this.prescriber.hasOrganizationLearnerImport;
+  }
+
+  get canActivateOralizationLearner() {
+    return this.prescriber.hasOralizationFeature;
+  }
+
+  get canAccessStatisticsPage() {
+    return this.isAdminInOrganization && this.prescriber.hasCoverRateFeature;
+  }
+
   async load() {
     if (this.session.isAuthenticated) {
       try {
@@ -56,43 +98,5 @@ export default class CurrentUserService extends Service {
     this.isGarAuthenticationMethod = organization.identityProviderForCampaigns === 'GAR';
     this.isAgriculture = organization.isAgriculture;
     this.organization = organization;
-  }
-
-  get homePage() {
-    if (this.canAccessMissionsPage) {
-      return 'authenticated.missions';
-    }
-    return 'authenticated.campaigns';
-  }
-
-  get canAccessImportPage() {
-    return Boolean(
-      (this.isSCOManagingStudents || this.isSUPManagingStudents || this.hasLearnerImportFeature) &&
-        this.isAdminInOrganization,
-    );
-  }
-
-  get canAccessAttestationsPage() {
-    return this.prescriber.attestationsManagement;
-  }
-
-  get canAccessPlacesPage() {
-    return this.isAdminInOrganization && this.prescriber.placesManagement;
-  }
-
-  get canAccessMissionsPage() {
-    return this.prescriber.missionsManagement;
-  }
-
-  get canAccessCampaignsPage() {
-    return !this.prescriber.missionsManagement;
-  }
-
-  get hasLearnerImportFeature() {
-    return this.prescriber.hasOrganizationLearnerImport;
-  }
-
-  get canActivateOralizationLearner() {
-    return this.prescriber.hasOralizationFeature;
   }
 }

--- a/orga/tests/integration/components/layout/sidebar-test.js
+++ b/orga/tests/integration/components/layout/sidebar-test.js
@@ -331,6 +331,21 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
     });
   });
 
+  module('When the user has the cover rate feature', function () {
+    test('should display Statistiques entry with link to statistics page', async function (assert) {
+      class CurrentUserStub extends Service {
+        organization = { id: 5 };
+        canAccessStatisticsPage = true;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      const screen = await render(hbs`<Layout::Sidebar />`);
+
+      const statisticsLink = screen.getByRole('link', { name: t('navigation.main.statistics') });
+      assert.dom(statisticsLink).hasAttribute('href', '/statistiques');
+    });
+  });
+
   test('[a11y] it should contain accessibility aria-label nav', async function (assert) {
     // given
     class CurrentUserStub extends Service {

--- a/orga/tests/unit/models/prescriber-test.js
+++ b/orga/tests/unit/models/prescriber-test.js
@@ -247,4 +247,34 @@ module('Unit | Model | prescriber', function (hooks) {
       assert.false(hasOrganizationLearnerImport);
     });
   });
+
+  module('#hasCoverRateFeature', function () {
+    test('it return true when feature is enabled', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const model = store.createRecord('prescriber', {
+        features: { ['COVER_RATE']: true },
+      });
+
+      // when
+      const { hasCoverRateFeature } = model;
+
+      // then
+      assert.true(hasCoverRateFeature);
+    });
+
+    test('it return false when feature is disabled', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const model = store.createRecord('prescriber', {
+        features: { ['COVER_RATE']: false },
+      });
+
+      // when
+      const { hasCoverRateFeature } = model;
+
+      // then
+      assert.false(hasCoverRateFeature);
+    });
+  });
 });

--- a/orga/tests/unit/routes/authenticated/statistics-test.js
+++ b/orga/tests/unit/routes/authenticated/statistics-test.js
@@ -1,0 +1,46 @@
+import Service from '@ember/service';
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/statistics', function (hooks) {
+  setupTest(hooks);
+
+  module('beforeModel', function () {
+    test('should not redirect to application when canAccessStatisticsPage is true', function (assert) {
+      // given
+      class CurrentUserStub extends Service {
+        canAccessStatisticsPage = true;
+      }
+
+      this.owner.register('service:current-user', CurrentUserStub);
+      const route = this.owner.lookup('route:authenticated/statistics');
+      sinon.stub(route.router, 'replaceWith');
+
+      const expectedRedirection = 'application';
+      // when
+      route.beforeModel();
+
+      // then
+      assert.notOk(route.router.replaceWith.calledWith(expectedRedirection));
+    });
+
+    test('should redirect to application when canAccessStatisticsPage is false', function (assert) {
+      // given
+      class CurrentUserStub extends Service {
+        canAccessStatisticsPage = false;
+      }
+
+      this.owner.register('service:current-user', CurrentUserStub);
+      const route = this.owner.lookup('route:authenticated/statistics');
+      sinon.stub(route.router, 'replaceWith');
+
+      const expectedRedirection = 'application';
+      // when
+      route.beforeModel();
+
+      // then
+      assert.ok(route.router.replaceWith.calledWith(expectedRedirection));
+    });
+  });
+});

--- a/orga/tests/unit/services/current-user-test.js
+++ b/orga/tests/unit/services/current-user-test.js
@@ -453,6 +453,34 @@ module('Unit | Service | current-user', function (hooks) {
         assert.false(currentUserService.hasLearnerImportFeature);
       });
     });
+
+    module('#canAccessStatisticsPage', function () {
+      test('should return true if user is admin and organization has feature activated', function (assert) {
+        currentUserService.isAdminInOrganization = true;
+        currentUserService.prescriber = {
+          hasCoverRateFeature: true,
+        };
+
+        assert.true(currentUserService.canAccessStatisticsPage);
+      });
+
+      test('should return false if user is admin and organization does not have feature activated', function (assert) {
+        currentUserService.isAdminInOrganization = true;
+        currentUserService.prescriber = {
+          hasCoverRateFeature: false,
+        };
+
+        assert.false(currentUserService.canAccessStatisticsPage);
+      });
+      test('should return false if user is not admin', function (assert) {
+        currentUserService.isAdminInOrganization = false;
+        currentUserService.prescriber = {
+          hasCoverRateFeature: true,
+        };
+
+        assert.false(currentUserService.canAccessStatisticsPage);
+      });
+    });
   });
 
   module('user is not authenticated', function () {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -358,6 +358,7 @@
       "organization-participants": "Participants",
       "places": "Seats",
       "sco-organization-participants": "Students",
+      "statistics": "Statistics",
       "sup-organization-participants": "Students",
       "support": "Help desk",
       "team": "Team"
@@ -516,7 +517,7 @@
       },
       "landing-page-text": {
         "label": "Text to display on the starting page",
-        "sublabel":"This field will be displayed to campaign participants."
+        "sublabel": "This field will be displayed to campaign participants."
       },
       "legal-warning": "*In accordance with the French law governing computer technology and freedoms (“Informatique et Libertés”), and as data controller, please be careful not to ask for significant or identifying personal data unless it is absolutely necessary. Asking for social security numbers, as well as any sensitive data, is strictly prohibited.",
       "multiple-sendings": {
@@ -569,8 +570,7 @@
       "target-profiles-search-placeholder": "Search by name",
       "test-title": {
         "label": "Title of the customised test",
-        "sublabel":"This field will be displayed to campaign participants."
-
+        "sublabel": "This field will be displayed to campaign participants."
       },
       "yes": "Yes"
     },
@@ -589,8 +589,8 @@
       "campaign-modification-success-message": "The changes have been successfully saved.",
       "campaign-name": "Name of the campaign",
       "landing-page-text": {
-         "label": "Text to display on the starting page",
-         "sublabel":"This field will be displayed to campaign participants."
+        "label": "Text to display on the starting page",
+        "sublabel": "This field will be displayed to campaign participants."
       },
       "owner": {
         "title": "Owner of the campaign",
@@ -599,8 +599,8 @@
         "placeholder": "Owner’s first and last name"
       },
       "personalised-test-title": {
-        "label":"Title of the personalised test",
-        "sublabel":"This field will be displayed to campaign participants."
+        "label": "Title of the personalised test",
+        "sublabel": "This field will be displayed to campaign participants."
       }
     },
     "campaign-results": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -364,6 +364,7 @@
       "organization-participants": "Participants",
       "places": "Places",
       "sco-organization-participants": "Élèves",
+      "statistics": "Statistiques",
       "sup-organization-participants": "Étudiants",
       "support": "Centre d'aide",
       "team": "Équipe"
@@ -575,8 +576,7 @@
       "target-profiles-search-placeholder": "Rechercher par nom",
       "test-title": {
         "label": "Titre du parcours",
-        "sublabel":"Ce champs sera affiché aux participants de la campagne."
-
+        "sublabel": "Ce champs sera affiché aux participants de la campagne."
       },
       "yes": "Oui"
     },
@@ -596,8 +596,8 @@
       "campaign-name": "Nom de la campagne",
       "landing-page-text": {
         "label": "Texte de la page d'accueil",
-        "sublabel":"Ce champs sera affiché aux participants de la campagne."
-     },
+        "sublabel": "Ce champs sera affiché aux participants de la campagne."
+      },
       "owner": {
         "title": "Propriétaire de la campagne",
         "info": "Le propriétaire de la campagne ainsi que les administrateurs de cette organisation, sont les seules personnes qui peuvent modifier et archiver cette campagne.",
@@ -605,8 +605,8 @@
         "placeholder": "Nom et prénom du propriétaire"
       },
       "personalised-test-title": {
-        "label":"Titre du parcours",
-        "sublabel":"Ce champs sera affiché aux participants de la campagne."
+        "label": "Titre du parcours",
+        "sublabel": "Ce champs sera affiché aux participants de la campagne."
       }
     },
     "campaign-results": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -358,6 +358,7 @@
       "organization-participants": "Deelnemers",
       "places": "Plaatsen",
       "sco-organization-participants": "Leerlingen",
+      "statistics": "Statistieken",
       "sup-organization-participants": "Studenten",
       "support": "Helpcentrum",
       "team": "Team"
@@ -479,7 +480,7 @@
       },
       "landing-page-text": {
         "label": "Tekst op de startpagina",
-        "sublabel":"Dit veld wordt weergegeven voor deelnemers aan de campagne."
+        "sublabel": "Dit veld wordt weergegeven voor deelnemers aan de campagne."
       },
       "legal-warning": "* In overeenstemming met de Franse wet op gegevensbescherming en als verantwoordelijke voor de verwerking van de gegevens, vragen we niet naar bijzonder identificerende of belangrijke gegevens, tenzij dit absoluut noodzakelijk is. Het burgerservicenummer (BSN) moet worden vermeden, net als gevoelige gegevens.",
       "multiple-sendings": {
@@ -532,7 +533,7 @@
       "target-profiles-search-placeholder": "Zoeken op naam",
       "test-title": {
         "label": "Titel test",
-        "sublabel":"Dit veld wordt weergegeven voor deelnemers aan de campagne."
+        "sublabel": "Dit veld wordt weergegeven voor deelnemers aan de campagne."
       },
       "title": "Een campagne maken",
       "yes": "Ja"
@@ -551,8 +552,8 @@
       "campaign-modification-success-message": "De wijzigingen zijn opgeslagen.",
       "campaign-name": "Naam Campagne",
       "landing-page-text": {
-         "label": "Tekst op de startpagina",
-         "sublabel":"Dit veld wordt weergegeven voor deelnemers aan de campagne."
+        "label": "Tekst op de startpagina",
+        "sublabel": "Dit veld wordt weergegeven voor deelnemers aan de campagne."
       },
       "owner": {
         "info": "De eigenaar van de campagne en de beheerders van deze organisatie zijn de enige personen die deze campagne kunnen wijzigen en archiveren.",
@@ -561,8 +562,8 @@
         "title": "Eigenaar van de campagne"
       },
       "personalised-test-title": {
-        "label":"Titel test",
-        "sublabel":"Dit veld wordt weergegeven voor deelnemers aan de campagne."
+        "label": "Titel test",
+        "sublabel": "Dit veld wordt weergegeven voor deelnemers aan de campagne."
       },
       "title": "Een campagne wijzigen"
     },


### PR DESCRIPTION
## :christmas_tree: Problème
Nous avons précedemment crée la feature `cover rate` pour mettre a disposition les statistiques au grain d'une orga.
On doit maintenant donner la possibilité de voir cette nouvelle page pour les orgas ayant cette feature

## :gift: Proposition
Ajouter une entrée dans la barre de navigation dans PixOrga 

## :socks: Remarques
Celle ci ne sera visible que pour les ADMINS des organisations ayant la feature d'activée

## :santa: Pour tester
- Se connecter avec `admin-orga@example.net`
- Aller sur l'orga `PRO Classic`
- Vérifier que l'entrée apparait bien dans le menu et qu'on est bien dirigé vers la nouvelle page
- Faire la même chose avec une autre orga
- Vérifier que l'entrée n'est pas présente
- Se connecter avec `member-orga@example.net`
- Aller sur l'orga `PRO Classic`
- Vérifier que l'entrée n'est pas présente non plus