### PR TITLE
[BUGFIX] Mission: alt des illustrations (PIX-15601)

### DIFF
--- a/api/src/school/infrastructure/repositories/mission-repository.js
+++ b/api/src/school/infrastructure/repositories/mission-repository.js
@@ -5,13 +5,15 @@ import { Mission, MissionContent, MissionStep } from '../../domain/models/Missio
 import { MissionNotFoundError } from '../../domain/school-errors.js';
 import { missionDatasource } from '../datasources/learning-content/mission-datasource.js';
 
-const { FRENCH_FRANCE } = LOCALE;
+const { FRENCH_SPOKEN } = LOCALE;
 
 function _toDomain(data, locale) {
   const translatedName = getTranslatedKey(data.name_i18n, locale);
   const translatedLearningObjectives = getTranslatedKey(data.learningObjectives_i18n, locale);
   const translatedValidatedObjectives = getTranslatedKey(data.validatedObjectives_i18n, locale);
+  const translatedIntroductionMediaAlt = getTranslatedKey(data.introductionMediaAlt_i18n, locale);
   const translatedContent = getTranslatedContent(data.content, locale);
+
   return new Mission({
     id: data.id,
     name: translatedName,
@@ -22,13 +24,13 @@ function _toDomain(data, locale) {
     validatedObjectives: translatedValidatedObjectives,
     introductionMediaUrl: data.introductionMediaUrl,
     introductionMediaType: data.introductionMediaType,
-    introductionMediaAlt: data.introductionMediaAlt,
+    introductionMediaAlt: translatedIntroductionMediaAlt,
     documentationUrl: data.documentationUrl,
     content: translatedContent,
   });
 }
 
-async function get(id, locale = { locale: FRENCH_FRANCE }) {
+async function get(id, locale = FRENCH_SPOKEN) {
   try {
     const missionData = await missionDatasource.get(parseInt(id, 10));
     return _toDomain(missionData, locale);
@@ -37,7 +39,7 @@ async function get(id, locale = { locale: FRENCH_FRANCE }) {
   }
 }
 
-async function findAllActiveMissions(locale = { locale: FRENCH_FRANCE }) {
+async function findAllActiveMissions(locale = FRENCH_SPOKEN) {
   const allMissions = await missionDatasource.list();
   const allActiveMissions = allMissions.filter((mission) => {
     return (

--- a/api/tests/school/integration/infrastructure/repositories/mission-repository_test.js
+++ b/api/tests/school/integration/infrastructure/repositories/mission-repository_test.js
@@ -39,7 +39,7 @@ describe('Integration | Repository | mission-repository', function () {
               validatedObjectives_i18n: { fr: 'validatedObjectivesi18n' },
               introductionMediaUrl: 'http://monimage.pix.fr',
               introductionMediaType: 'image',
-              introductionMediaAlt: "Alt à l'image",
+              introductionMediaAlt_i18n: { fr: "Alt à l'image" },
               documentationUrl: 'http://madoc.pix.fr',
               content: {
                 steps: [
@@ -56,9 +56,10 @@ describe('Integration | Repository | mission-repository', function () {
         const mission = await missionRepository.get('1');
 
         // then
-        expect({ ...mission }).to.deep.equal(expectedMission);
+        expect(mission).to.deep.equal(expectedMission);
       });
     });
+
     context('when there is no mission for the given id', function () {
       it('should return the not found error', async function () {
         // given
@@ -114,7 +115,7 @@ describe('Integration | Repository | mission-repository', function () {
               validatedObjectives_i18n: { fr: 'validatedObjectivesi18n' },
               introductionMediaUrl: 'http://monimage.pix.fr',
               introductionMediaType: 'image',
-              introductionMediaAlt: "Alt à l'image",
+              introductionMediaAlt_i18n: { fr: "Alt à l'image" },
               documentationUrl: 'http://madoc.pix.fr',
               content: {
                 steps: [
@@ -135,7 +136,7 @@ describe('Integration | Repository | mission-repository', function () {
               validatedObjectives_i18n: { fr: 'validatedObjectivesi18n' },
               introductionMediaUrl: 'http://monimage.pix.fr',
               introductionMediaType: 'image',
-              introductionMediaAlt: "Alt à l'image",
+              introductionMediaAlt_i18n: { fr: "Alt à l'image" },
               documentationUrl: 'http://madoc.pix.fr',
               content: {
                 steps: [

--- a/junior/app/templates/identified/missions/mission/introduction.hbs
+++ b/junior/app/templates/identified/missions/mission/introduction.hbs
@@ -11,7 +11,7 @@
     <div class="mission-introduction__media">
       <Challenge::ChallengeMedia
         @src={{@model.mission.introductionMediaUrl}}
-        @alt={{@challenge.introductionMediaAlt}}
+        @alt={{@model.mission.introductionMediaAlt}}
         @type={{@model.mission.introductionMediaType}}
       />
     </div>


### PR DESCRIPTION
## :christmas_tree: Problème

Le mission repository ne lit pas correctement le référentiel pour le champ alt de l’illustration.

## :gift: Proposition

Lire le champ traduisible.

## :socks: Remarques

Les valeurs par défaut pour `locale` était incorrectes également, un objet avec fr-fr : `{ locale: 'fr-fr' }`.
Le référentiel contient uniquement du fr, ça fonctionnait grâce au fallback dans `getTranslatedKey()` qui prend du fr par défaut.

## :santa: Pour tester

Vérifier que les illustrations de mission ont un alt correct ?!