### PR TITLE
[TECH] Mise à jour des icônes dans admnistration de PixAdmin (PIX-15604)

### DIFF
--- a/admin/app/components/administration/common/learning-content.gjs
+++ b/admin/app/components/administration/common/learning-content.gjs
@@ -48,7 +48,7 @@ export default class LearningContent extends Component {
         </PixNotificationAlert>
         <PixNotificationAlert @type="info">Durée de l’opération : <strong>≈10s</strong>.</PixNotificationAlert>
 
-        <PixButton class="btn-refresh-cache" @triggerAction={{this.refreshLearningContent}} @iconBefore="reload">
+        <PixButton class="btn-refresh-cache" @triggerAction={{this.refreshLearningContent}} @iconBefore="refresh">
           Recharger le cache
         </PixButton>
         <br /><br />
@@ -58,7 +58,7 @@ export default class LearningContent extends Component {
         <PixButton
           @triggerAction={{this.createLearningContentReleaseAndRefreshCache}}
           @variant="primary-bis"
-          @iconBefore="reload"
+          @iconBefore="refresh"
         >
           Créer une nouvelle version du référentiel et recharger le cache
         </PixButton>

--- a/admin/app/components/organizations/places.gjs
+++ b/admin/app/components/organizations/places.gjs
@@ -40,7 +40,7 @@ export default class Places extends Component {
             @variant="primary"
             @route="authenticated.organizations.get.places.new"
             @model={{@model}}
-            @iconBefore="plus"
+            @iconBefore="add"
           >
             Ajouter des places
           </PixButtonLink>

--- a/admin/app/components/target-profiles/badge-form/criteria.gjs
+++ b/admin/app/components/target-profiles/badge-form/criteria.gjs
@@ -1,8 +1,7 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
 import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
-import { fn } from '@ember/helper';
-import { concat } from '@ember/helper';
+import { concat, fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
@@ -111,7 +110,7 @@ export default class Criteria extends Component {
           @variant="primary"
           @size="small"
           @triggerAction={{this.addCappedTubeCriterion}}
-          @iconBefore="plus"
+          @iconBefore="add"
         >
           Ajouter une nouvelle sélection de sujets
         </PixButton>

--- a/admin/app/components/target-profiles/insights.gjs
+++ b/admin/app/components/target-profiles/insights.gjs
@@ -14,7 +14,7 @@ import Stages from './stages';
           @variant="secondary"
           @route="authenticated.target-profiles.target-profile.badges.new"
           @model={{@targetProfile.id}}
-          @iconBefore="plus"
+          @iconBefore="add"
         >
           Nouveau résultat thématique
         </PixButtonLink>

--- a/admin/app/components/target-profiles/stages.gjs
+++ b/admin/app/components/target-profiles/stages.gjs
@@ -256,7 +256,7 @@ export default class Stages extends Component {
               @variant="secondary"
               @triggerAction={{this.addStage}}
               @isDisabled={{this.isAddStageDisabled}}
-              @iconBefore="plus"
+              @iconBefore="add"
             >
               Nouveau palier
             </PixButton>
@@ -268,7 +268,7 @@ export default class Stages extends Component {
                     @variant="secondary"
                     @triggerAction={{this.addFirstSkillStage}}
                     @isDisabled={{this.isAddFirstSkillStageDisabled}}
-                    @iconBefore="plus"
+                    @iconBefore="add"
                   >
                     Nouveau palier "1er acquis"
                   </PixButton>

--- a/admin/app/components/trainings/create-training-triggers.gjs
+++ b/admin/app/components/trainings/create-training-triggers.gjs
@@ -28,7 +28,7 @@ import Details from './trigger/details';
         @query={{hash type="prerequisite"}}
         @variant="secondary"
         aria-label={{t "pages.trainings.training.triggers.prerequisite.alternative-title"}}
-        @iconBefore="plus"
+        @iconBefore="add"
       >
         {{t "pages.trainings.training.triggers.prerequisite.title"}}
       </PixButtonLink>
@@ -56,7 +56,7 @@ import Details from './trigger/details';
         @query={{hash type="goal"}}
         @variant="secondary"
         aria-label={{t "pages.trainings.training.triggers.goal.alternative-title"}}
-        @iconBefore="plus"
+        @iconBefore="add"
       >
         {{t "pages.trainings.training.triggers.goal.title"}}
       </PixButtonLink>

--- a/admin/app/templates/authenticated/certification-centers/list.hbs
+++ b/admin/app/templates/authenticated/certification-centers/list.hbs
@@ -2,7 +2,7 @@
 <header class="page-header">
   <h1 class="page-title">Tous les centres de certification</h1>
   <div class="page-actions">
-    <PixButtonLink @route="authenticated.certification-centers.new" @variant="secondary" @iconBefore="plus">
+    <PixButtonLink @route="authenticated.certification-centers.new" @variant="secondary" @iconBefore="add">
       Nouveau centre de certif
     </PixButtonLink>
   </div>

--- a/admin/app/templates/authenticated/organizations/list.hbs
+++ b/admin/app/templates/authenticated/organizations/list.hbs
@@ -3,7 +3,7 @@
   <h1 class="page-title">Toutes les organisations</h1>
   {{#if this.accessControl.hasAccessToOrganizationActionsScope}}
     <div class="page-actions">
-      <PixButtonLink @route="authenticated.organizations.new" @variant="secondary" @iconBefore="plus">
+      <PixButtonLink @route="authenticated.organizations.new" @variant="secondary" @iconBefore="add">
         Nouvelle organisation
       </PixButtonLink>
     </div>

--- a/admin/app/templates/authenticated/target-profiles/list.hbs
+++ b/admin/app/templates/authenticated/target-profiles/list.hbs
@@ -1,8 +1,9 @@
 <header class="page-header">
   <h1 class="page-title">Tous les profils cibles</h1>
   <div class="page-actions">
-    <LinkTo @route="authenticated.smart-random-simulator" class="page-actions__link">Accéder au simulateur Smart Random</LinkTo>
-    <PixButtonLink @route="authenticated.target-profiles.new" @variant="secondary" @iconBefore="plus">
+    <LinkTo @route="authenticated.smart-random-simulator" class="page-actions__link">Accéder au simulateur Smart Random
+    </LinkTo>
+    <PixButtonLink @route="authenticated.target-profiles.new" @variant="secondary" @iconBefore="add">
       Nouveau profil cible
     </PixButtonLink>
   </div>

--- a/admin/app/templates/authenticated/trainings/list.hbs
+++ b/admin/app/templates/authenticated/trainings/list.hbs
@@ -12,7 +12,7 @@
         <FaIcon @icon="arrow-up-right-from-square" />
         <span>Consulter la documentation</span>
       </a>
-      <PixButtonLink @route="authenticated.trainings.new" @variant="secondary" @iconBefore="plus">
+      <PixButtonLink @route="authenticated.trainings.new" @variant="secondary" @iconBefore="add">
         Nouveau contenu formatif
       </PixButtonLink>
     </div>


### PR DESCRIPTION
## :christmas_tree: Problème

Les icônes n'apparaissent plus sur les boutons de PixAdmin > Administration > Commun

## :gift: Proposition

Mettre les noms des icônes à jour

## :santa: Pour tester

Aller dans PixAdmin > Administration > Commun
Vérifier que les icônes apparaissent

| Avant   |  Après      | 
|----------|-------------|
| <img width="286" alt="Capture d’écran 2024-12-05 à 14 46 23" src="https://github.com/user-attachments/assets/8223dc2c-ef7c-465e-8ccc-6d2e0ccf6bdb"> | <img width="286" alt="Capture d’écran 2024-12-05 à 14 46 09" src="https://github.com/user-attachments/assets/1e8bd60f-40ee-449a-b5b2-933186b27cb1"> |



