### PR TITLE
[BUGFIX] MAJ l'interface lors de l'import JSON d'un profil-cible (PIX-15548).

### DIFF
--- a/admin/app/components/common/tubes-selection.gjs
+++ b/admin/app/components/common/tubes-selection.gjs
@@ -172,6 +172,7 @@ export default class TubesSelection extends Component {
         throw new Error("Le format du fichier n'est pas reconnu.");
       }
 
+      this.refreshAreas();
       this._triggerOnChange();
       this.pixToast.sendSuccessNotification({ message: 'Fichier bien importé.' });
     } catch (error) {


### PR DESCRIPTION
## :christmas_tree: Problème

Dans la création d'un profil-cible, lors de l'import JSON, la liste et le nombre de sujets n'est pas mis à jour sans rechargement de la page.

## :gift: Proposition

Rendre l'écran réactif lors de l'import.

## :santa: Pour tester

Tester la création de profil cible sur [Admin en RA](https://admin-pr10728.review.pix.fr/) (un fichier JSON est dispo sur le ticket pour essayer)
