### PR TITLE
[FEATURE]: couper le lien entre les utilisateurs et leurs recommended trainings lors de l'anonymisation (PIX-15558)

### DIFF
--- a/api/tests/integration/scripts/prod/delete-and-anonymise-organization-learners_test.js
+++ b/api/tests/integration/scripts/prod/delete-and-anonymise-organization-learners_test.js
@@ -221,15 +221,15 @@ describe('DeleteAndAnonymiseOrgnizationLearnerScript', function () {
         const anonymizedRecommendedTrainingResults =
           await knex('user-recommended-trainings').whereNull('campaignParticipationId');
 
-        const otherRecommendedTrainingResults =
-          await knex('user-recommended-trainings').whereNotNull('campaignParticipationId');
+        const otherRecommendedTrainingResults = await knex('user-recommended-trainings').where({
+          campaignParticipationId: otherParticipation.id,
+        });
 
         expect(anonymizedRecommendedTrainingResults).lengthOf(1);
         expect(anonymizedRecommendedTrainingResults[0].campaignParticipationId).to.be.null;
         expect(anonymizedRecommendedTrainingResults[0].updatedAt).to.deep.equal(now);
 
         expect(otherRecommendedTrainingResults).lengthOf(1);
-        expect(otherRecommendedTrainingResults[1].campaignParticipationId).to.deep.equal(otherParticipation.id);
       });
     });
   });


### PR DESCRIPTION
## :christmas_tree: Problème

On doit couper le lien entre les utilisateurs anonymisés et leurs recommended trainings.

## :gift: Proposition

On passe le "campaignParticipationId" à null dans la table user-recommended-training pour les utilisateurs concernés.

## :socks: Remarques

On en a profité pour mettre à jour la colonne "updatedAt" de la table "assessments", juste avant d'anonymiser l'utilisateur.

## :santa: Pour tester

Se connecter sur le scalingo de la review app. 
Choisir un utilisateur avec des participations pour tester l'anonymisation (retenir son campaignPartcipationId). Faire une requête pour voir les assessments qui lui appartiennent. Regarder le "campaignParticipationId" ainsi que les "updatedAt" de ses assessments.
En parallèle, lancer le script d'anonymisation. Vérifier que les valeurs de "updatedAt" des assessments de l'utilisateur ont bien été modifiées au bon timestamp.