### PR TITLE
[FEATURE] Affiche les participations anonymisées (Pix-15517)

### DIFF
--- a/admin/app/components/campaigns/participation-row.gjs
+++ b/admin/app/components/campaigns/participation-row.gjs
@@ -53,9 +53,13 @@ export default class ParticipationRow extends Component {
   <template>
     <td>{{@participation.firstName}} {{@participation.lastName}}</td>
     <td>
-      <LinkTo @route="authenticated.users.get" @model={{@participation.userId}}>
+      {{#if @participation.userId}}
+        <LinkTo @route="authenticated.users.get" @model={{@participation.userId}}>
+          {{@participation.userFullName}}
+        </LinkTo>
+      {{else}}
         {{@participation.userFullName}}
-      </LinkTo>
+      {{/if}}
     </td>
     {{#if @idPixLabel}}
       <td class="table__column table__column--break-word">

--- a/admin/tests/integration/components/campaigns/participation-row-test.gjs
+++ b/admin/tests/integration/components/campaigns/participation-row-test.gjs
@@ -24,6 +24,7 @@ module('Integration | Component | Campaigns | participation-row', function (hook
       const participation = EmberObject.create({
         firstName: 'Jean',
         lastName: 'Claude',
+        userId: 123,
         userFullName: 'Jean-Claude Gangan',
         createdAt: new Date('2020-01-01'),
       });
@@ -35,6 +36,22 @@ module('Integration | Component | Campaigns | participation-row', function (hook
       assert.dom(screen.getByText('Jean Claude')).exists();
       assert.dom(screen.getByRole('link', { name: 'Jean-Claude Gangan' })).exists();
       assert.dom(screen.getByText('01/01/2020')).exists();
+    });
+    test('it should display name without link when there is no userId', async function (assert) {
+      // given
+      const participation = EmberObject.create({
+        firstName: '',
+        lastName: '',
+        userFullName: '(Anonymised)',
+        createdAt: new Date('2020-01-01'),
+      });
+
+      // when
+      const screen = await render(<template><ParticipationRow @participation={{participation}} /></template>);
+
+      // then
+      assert.ok(screen.getByText('(Anonymised)'));
+      assert.notOk(screen.queryByRole('link', { name: '(Anonymised)' }));
     });
 
     test('it should not display participantExternalId if idPixLabel is null', async function (assert) {

--- a/api/src/prescription/campaign-participation/domain/models/ParticipationForCampaignManagement.js
+++ b/api/src/prescription/campaign-participation/domain/models/ParticipationForCampaignManagement.js
@@ -19,7 +19,11 @@ class ParticipationForCampaignManagement {
     this.lastName = lastName;
     this.firstName = firstName;
     this.userId = userId;
-    this.userFullName = userFirstName + ' ' + userLastName;
+    if (userFirstName && userLastName) {
+      this.userFullName = `${userFirstName} ${userLastName}`;
+    } else {
+      this.userFullName = '(Anonymised)';
+    }
     this.participantExternalId = participantExternalId;
     this.status = status;
     this.createdAt = createdAt;

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/participations-for-campaign-management-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/participations-for-campaign-management-repository.js
@@ -31,13 +31,13 @@ const findPaginatedParticipationsForCampaignManagement = async function ({ campa
       deletedByFirstName: 'deletedByUsers.firstName',
       deletedByLastName: 'deletedByUsers.lastName',
     })
-    .join(
+    .leftJoin(
       'view-active-organization-learners',
       'view-active-organization-learners.id',
       'campaign-participations.organizationLearnerId',
     )
     .leftJoin('users as deletedByUsers', 'deletedByUsers.id', 'campaign-participations.deletedBy')
-    .innerJoin('users', 'users.id', 'campaign-participations.userId')
+    .leftJoin('users', 'users.id', 'campaign-participations.userId')
     .where('campaignId', campaignId)
     .orderBy(['lastName', 'firstName'], ['asc', 'asc']);
 

--- a/api/tests/prescription/campaign-participation/unit/domain/models/ParticipationForCampaignManagement_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/models/ParticipationForCampaignManagement_test.js
@@ -13,6 +13,16 @@ describe('Unit | Domain | Models | ParticipationForCampaignManagement', function
       // then
       expect(participationForCampaignManagement.userFullName).to.equal('Jacques Ouche');
     });
+    it('is empty if no userFirstName or userLastname', function () {
+      // when
+      const participationForCampaignManagement = new ParticipationForCampaignManagement({
+        userFirstName: '',
+        userLastName: '',
+      });
+
+      // then
+      expect(participationForCampaignManagement.userFullName).to.equal('(Anonymised)');
+    });
   });
 
   context('#deletedByFullName', function () {


### PR DESCRIPTION
## :christmas_tree: Problème

Actuellement, une fois qu'un prescrit et anonymiser, ses participations à la campagne ne s'affiche plus,  or on souhaite quand même permettre au support de voir que des participations ont été supprimées / anonymisées

## :gift: Proposition

Afficher les participations anonymisées à une campagne

## :socks: Remarques
RAS

## :santa: Pour tester

- Se connecter sur admin et afficher les participations à la campagne PROASSMUL
- se connecter à la RA avec pgsql-console et afficher les participation à la campagne PROASSMUL
- récupérer le organizationLearnerId de Alex Terrieur 
- Lancer le script d'anonymisation des prescrits avec l'organizationLearnerId d'alex terrieur
- Rafraichir la page admin et voir qu'on remonte toujours le meme nombre de participation mais sans les infos du prescrits / user
