### PR TITLE
[BUGFIX] Ignorer les réponses envoyés par les autres simulateurs auto (PIX-15256)

### DIFF
--- a/mon-pix/app/components/module/element/embed.gjs
+++ b/mon-pix/app/components/module/element/embed.gjs
@@ -40,6 +40,7 @@ export default class ModulixEmbed extends ModuleElement {
   }
 
   _receiveEmbedMessage(event) {
+    if (!this._messageIsFromCurrentElementSimulator(event)) return;
     if (!isEmbedAllowedOrigin(event.origin)) return;
     const message = this._getMessageFromEventData(event);
     if (message && message.answer && message.from === 'pix') {
@@ -48,6 +49,10 @@ export default class ModulixEmbed extends ModuleElement {
         element: this.args.embed,
       });
     }
+  }
+
+  _messageIsFromCurrentElementSimulator(event) {
+    return event.source === this.iframe.contentWindow;
   }
 
   _getMessageFromEventData(event) {

--- a/mon-pix/app/components/module/element/embed.gjs
+++ b/mon-pix/app/components/module/element/embed.gjs
@@ -36,7 +36,9 @@ export default class ModulixEmbed extends ModuleElement {
     this.iframe.focus();
 
     this.messageHandler = this._receiveEmbedMessage.bind(this);
-    window.addEventListener('message', this.messageHandler);
+    if (this.args.embed.isCompletionRequired) {
+      window.addEventListener('message', this.messageHandler);
+    }
   }
 
   _receiveEmbedMessage(event) {

--- a/mon-pix/tests/integration/components/module/embed_test.gjs
+++ b/mon-pix/tests/integration/components/module/embed_test.gjs
@@ -186,6 +186,36 @@ module('Integration | Component | Module | Embed', function (hooks) {
         });
       });
 
+      module('when message is not coming from current element’s iframe', function () {
+        test('should not call the onAnswer method', async function (assert) {
+          // given
+          const embed = {
+            id: 'id',
+            title: 'Simulateur',
+            isCompletionRequired: true,
+            url: 'https://example.org',
+            height: 800,
+          };
+          const onElementAnswerStub = sinon.stub();
+          await render(<template><ModulixEmbed @embed={{embed}} @onAnswer={{onElementAnswerStub}} /></template>);
+          await clickByName(t('pages.modulix.buttons.embed.start.ariaLabel'));
+          const otheriFrame = document.createElement('iframe');
+          otheriFrame.src = 'https://example.org';
+
+          // when
+          const event = new MessageEvent('message', {
+            data: { answer: 'toto', from: 'pix' },
+            origin: 'https://epreuves.pix.fr',
+            source: otheriFrame.contentWindow,
+          });
+          window.dispatchEvent(event);
+
+          // then
+          sinon.assert.notCalled(onElementAnswerStub);
+          assert.ok(true);
+        });
+      });
+
       module('otherwise when everything is ok', function () {
         test('should call the onAnswer method', async function (assert) {
           // given

--- a/mon-pix/tests/integration/components/module/embed_test.gjs
+++ b/mon-pix/tests/integration/components/module/embed_test.gjs
@@ -93,6 +93,37 @@ module('Integration | Component | Module | Embed', function (hooks) {
     });
 
     module('when a message is received', function () {
+      module('when embed does not require completion', function () {
+        test('should not call the onAnswer method', async function (assert) {
+          // given
+          const embed = {
+            id: 'id',
+            title: 'Simulateur',
+            isCompletionRequired: false,
+            url: 'https://example.org',
+            height: 800,
+          };
+          const onElementAnswerStub = sinon.stub();
+          const screen = await render(
+            <template><ModulixEmbed @embed={{embed}} @onAnswer={{onElementAnswerStub}} /></template>,
+          );
+          await clickByName(t('pages.modulix.buttons.embed.start.ariaLabel'));
+
+          // when
+          const iframe = screen.getByTitle('Simulateur');
+          const event = new MessageEvent('message', {
+            data: { answer: 'toto', from: 'pix' },
+            origin: 'https://epreuves.pix.fr',
+            source: iframe.contentWindow,
+          });
+          window.dispatchEvent(event);
+
+          // then
+          sinon.assert.notCalled(onElementAnswerStub);
+          assert.ok(true);
+        });
+      });
+
       module('when message is not from pix', function () {
         test('should not call the onAnswer method', async function (assert) {
           // given

--- a/mon-pix/tests/integration/components/module/embed_test.gjs
+++ b/mon-pix/tests/integration/components/module/embed_test.gjs
@@ -98,19 +98,23 @@ module('Integration | Component | Module | Embed', function (hooks) {
           // given
           const embed = {
             id: 'id',
-            title: 'title',
+            title: 'Simulateur',
             isCompletionRequired: true,
             url: 'https://example.org',
             height: 800,
           };
           const onElementAnswerStub = sinon.stub();
-          await render(<template><ModulixEmbed @embed={{embed}} @onAnswer={{onElementAnswerStub}} /></template>);
+          const screen = await render(
+            <template><ModulixEmbed @embed={{embed}} @onAnswer={{onElementAnswerStub}} /></template>,
+          );
           await clickByName(t('pages.modulix.buttons.embed.start.ariaLabel'));
 
           // when
+          const iframe = screen.getByTitle('Simulateur');
           const event = new MessageEvent('message', {
             data: { answer: 'toto', from: 'nsa' },
             origin: 'https://epreuves.pix.fr',
+            source: iframe.contentWindow,
           });
           window.dispatchEvent(event);
 
@@ -125,19 +129,23 @@ module('Integration | Component | Module | Embed', function (hooks) {
           // given
           const embed = {
             id: 'id',
-            title: 'title',
+            title: 'Simulateur',
             isCompletionRequired: true,
             url: 'https://example.org',
             height: 800,
           };
           const onElementAnswerStub = sinon.stub();
-          await render(<template><ModulixEmbed @embed={{embed}} @onAnswer={{onElementAnswerStub}} /></template>);
+          const screen = await render(
+            <template><ModulixEmbed @embed={{embed}} @onAnswer={{onElementAnswerStub}} /></template>,
+          );
           await clickByName(t('pages.modulix.buttons.embed.start.ariaLabel'));
 
           // when
+          const iframe = screen.getByTitle('Simulateur');
           const event = new MessageEvent('message', {
             data: { start: 'true', from: 'pix' },
             origin: 'https://epreuves.pix.fr',
+            source: iframe.contentWindow,
           });
           window.dispatchEvent(event);
 
@@ -152,19 +160,23 @@ module('Integration | Component | Module | Embed', function (hooks) {
           // given
           const embed = {
             id: 'id',
-            title: 'title',
+            title: 'Simulateur',
             isCompletionRequired: true,
             url: 'https://example.org',
             height: 800,
           };
           const onElementAnswerStub = sinon.stub();
-          await render(<template><ModulixEmbed @embed={{embed}} @onAnswer={{onElementAnswerStub}} /></template>);
+          const screen = await render(
+            <template><ModulixEmbed @embed={{embed}} @onAnswer={{onElementAnswerStub}} /></template>,
+          );
           await clickByName(t('pages.modulix.buttons.embed.start.ariaLabel'));
 
           // when
+          const iframe = screen.getByTitle('Simulateur');
           const event = new MessageEvent('message', {
             data: { answer: 'toto', from: 'pix' },
             origin: 'https://example.org',
+            source: iframe.contentWindow,
           });
           window.dispatchEvent(event);
 
@@ -179,19 +191,23 @@ module('Integration | Component | Module | Embed', function (hooks) {
           // given
           const embed = {
             id: 'id',
-            title: 'title',
+            title: 'Simulateur',
             isCompletionRequired: true,
             url: 'https://example.org',
             height: 800,
           };
           const onElementAnswerStub = sinon.stub();
-          await render(<template><ModulixEmbed @embed={{embed}} @onAnswer={{onElementAnswerStub}} /></template>);
+          const screen = await render(
+            <template><ModulixEmbed @embed={{embed}} @onAnswer={{onElementAnswerStub}} /></template>,
+          );
           await clickByName(t('pages.modulix.buttons.embed.start.ariaLabel'));
 
           // when
+          const iframe = screen.getByTitle('Simulateur');
           const event = new MessageEvent('message', {
             data: { answer: 'toto', from: 'pix' },
             origin: 'https://epreuves.pix.fr',
+            source: iframe.contentWindow,
           });
           window.dispatchEvent(event);
 


### PR DESCRIPTION
## :christmas_tree: Problème

Dans un module, on peut insérer plusieurs éléments `Embed` et donc instancier simultanément autant de simulateurs. Or, pour les simulateurs auto, on écoute un évènement `message` global à la fenêtre mais on ne sait pas quel simulateur l'a envoyé. Si plusieurs élément `Embed` écoutent en même temps, ils vont tous recevoir l'évènement `message` et tous appeler l'API pour enregistrer la réponse, même si elle n'a pas été émise par leur `iframe`.

## :gift: Proposition

- À la réception de l'évènement `message`, vérifier qu'il a bien été émis par l'`iframe` de l'élément qui l'a reçu.

## :socks: Remarques

- Amélioration des tests dans un premier commit : auparavant, le faux évènement était envoyé sans source, à présent on simule le fait qu'il soit envoyé par l'iframe, ce qui est plus proche de la réalité.
- 🌟 Bonus 🌟 : à présent, seuls les éléments `Embed` pour lesquels `isCompletionRequired` est `true` écoutent l'évènement envoyé par le simulateur. Cela aurait suffit à corriger le problème dans le didacticiel où ne cohabitent qu'un embed auto et un non-auto, mais pas un module où deux embed auto aurait cohabité. C'est quand même plus propre de n'écouter l'évènement que si on en a besoin.

## :santa: Pour tester

1. Se rendre sur le [didacticiel modulix](https://app-pr10734.review.pix.fr/modules/didacticiel-modulix)
1. Passer les grains jusqu'au premier embed, cliquer sur **Commencer**
1. **Continuer**, puis **Commencer** le deuxième embed
1. Ouvrir le devtool "Réseau"
1. Résoudre le simulateur en coupant le micro
1. Constater qu'un seul appel est fait à l'API et que le statut de la réponse est 201
