### PR TITLE
[BUGFIX] Ajouter blocage compte utilisateur sur 2 formulaires oubliés provoquant des user-logins.failureCount supérieurs à 50 (PIX-14229)

### DIFF
--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -16,44 +16,6 @@ import { buildPixAdminRole } from './build-pix-admin-role.js';
 const DEFAULT_PASSWORD = 'pix123';
 const { ROLES } = PIX_ADMIN;
 
-function _buildPixAuthenticationMethod({
-  id = databaseBuffer.getNextId(),
-  userId,
-  rawPassword = DEFAULT_PASSWORD,
-  shouldChangePassword,
-  createdAt,
-  updatedAt,
-} = {}) {
-  // eslint-disable-next-line no-sync
-  const hashedPassword = cryptoService.hashPasswordSync(rawPassword);
-
-  const values = {
-    id,
-    userId,
-    identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
-    authenticationComplement: new AuthenticationMethod.PixAuthenticationComplement({
-      password: hashedPassword,
-      shouldChangePassword,
-    }),
-    externalIdentifier: undefined,
-    createdAt,
-    updatedAt,
-  };
-
-  return databaseBuffer.pushInsertable({
-    tableName: 'authentication-methods',
-    values,
-  });
-}
-
-function _generateEmailIfUndefined(email, id, lastName, firstName) {
-  if (isUndefined(email)) {
-    return `${firstName}.${lastName}${id}@example.net`.replaceAll(/\s+/g, '_').toLowerCase();
-  }
-
-  return email;
-}
-
 /**
  * @typedef SeedUser
  * @type {object}
@@ -430,6 +392,44 @@ buildUser.withCertificationCenterMembership = function buildUserWithCertificatio
 
   return user;
 };
+
+function _buildPixAuthenticationMethod({
+  id = databaseBuffer.getNextId(),
+  userId,
+  rawPassword = DEFAULT_PASSWORD,
+  shouldChangePassword,
+  createdAt,
+  updatedAt,
+} = {}) {
+  // eslint-disable-next-line no-sync
+  const hashedPassword = cryptoService.hashPasswordSync(rawPassword);
+
+  const values = {
+    id,
+    userId,
+    identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
+    authenticationComplement: new AuthenticationMethod.PixAuthenticationComplement({
+      password: hashedPassword,
+      shouldChangePassword,
+    }),
+    externalIdentifier: undefined,
+    createdAt,
+    updatedAt,
+  };
+
+  return databaseBuffer.pushInsertable({
+    tableName: 'authentication-methods',
+    values,
+  });
+}
+
+function _generateEmailIfUndefined(email, id, lastName, firstName) {
+  if (isUndefined(email)) {
+    return `${firstName}.${lastName}${id}@example.net`.replaceAll(/\s+/g, '_').toLowerCase();
+  }
+
+  return email;
+}
 
 /**
  * @typedef {

--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -2,7 +2,7 @@ import Joi from 'joi';
 
 import { responseAuthenticationDoc } from '../../../src/shared/infrastructure/open-api-doc/authentication/response-authentication-doc.js';
 import { responseObjectErrorDoc } from '../../../src/shared/infrastructure/open-api-doc/response-object-error-doc.js';
-import { authenticationController as AuthenticationController } from './authentication-controller.js';
+import { authenticationController } from './authentication-controller.js';
 
 const register = async function (server) {
   server.route([
@@ -44,7 +44,7 @@ const register = async function (server) {
             403: responseObjectErrorDoc,
           },
         },
-        handler: AuthenticationController.authenticateApplication,
+        handler: authenticationController.authenticateApplication,
         tags: ['api', 'authorization-server'],
       },
     },
@@ -66,7 +66,7 @@ const register = async function (server) {
             },
           }),
         },
-        handler: AuthenticationController.authenticateExternalUser,
+        handler: authenticationController.authenticateExternalUser,
         tags: ['api'],
       },
     },

--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -67,6 +67,10 @@ const register = async function (server) {
           }),
         },
         handler: authenticationController.authenticateExternalUser,
+        notes: [
+          '- Cette route permet d’authentifier un utilisateur Pix provenant de la double mire GAR.\n' +
+            '- Elle renvoie un objet contenant un access token.',
+        ],
         tags: ['api'],
       },
     },

--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { responseAuthenticationDoc } from '../../../src/shared/infrastructure/open-api-doc/authentication/response-authentication-doc.js';
 import { responseObjectErrorDoc } from '../../../src/shared/infrastructure/open-api-doc/response-object-error-doc.js';
 import { authenticationController } from './authentication-controller.js';
@@ -66,6 +67,7 @@ const register = async function (server) {
             },
           }),
         },
+        pre: [{ method: securityPreHandlers.checkIfUserIsBlocked }],
         handler: authenticationController.authenticateExternalUser,
         notes: [
           '- Cette route permet d’authentifier un utilisateur Pix provenant de la double mire GAR.\n' +

--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.route.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.route.js
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { oidcProviderController } from './oidc-provider.controller.js';
 
 export const oidcProviderRoutes = [
@@ -125,6 +126,7 @@ export const oidcProviderRoutes = [
           }),
         }),
       },
+      pre: [{ method: securityPreHandlers.checkIfUserIsBlocked }],
       handler: (request, h) => oidcProviderController.findUserForReconciliation(request, h),
       notes: [
         "- Cette route permet d'identifier un utilisateur Pix provenant de la double mire OIDC.\n" +

--- a/api/src/identity-access-management/application/token/token.controller.js
+++ b/api/src/identity-access-management/application/token/token.controller.js
@@ -29,14 +29,7 @@ const createToken = async function (request, h, dependencies = { tokenService })
   const grantType = request.payload.grant_type;
   const scope = request.payload.scope;
 
-  if (grantType === 'refresh_token') {
-    refreshToken = request.payload.refresh_token;
-
-    const tokensInfo = await usecases.createAccessTokenFromRefreshToken({ refreshToken, scope });
-
-    accessToken = tokensInfo.accessToken;
-    expirationDelaySeconds = tokensInfo.expirationDelaySeconds;
-  } else if (grantType === 'password') {
+  if (grantType === 'password') {
     const { username, password, scope } = request.payload;
     const localeFromCookie = request.state?.locale;
     const source = 'pix';
@@ -45,6 +38,13 @@ const createToken = async function (request, h, dependencies = { tokenService })
 
     accessToken = tokensInfo.accessToken;
     refreshToken = tokensInfo.refreshToken;
+    expirationDelaySeconds = tokensInfo.expirationDelaySeconds;
+  } else if (grantType === 'refresh_token') {
+    refreshToken = request.payload.refresh_token;
+
+    const tokensInfo = await usecases.createAccessTokenFromRefreshToken({ refreshToken, scope });
+
+    accessToken = tokensInfo.accessToken;
     expirationDelaySeconds = tokensInfo.expirationDelaySeconds;
   } else {
     throw new BadRequestError('Invalid grant type');

--- a/api/src/identity-access-management/domain/models/UserLogin.js
+++ b/api/src/identity-access-management/domain/models/UserLogin.js
@@ -26,14 +26,8 @@ class UserLogin {
     this.failureCount++;
   }
 
-  isUserMarkedAsTemporaryBlocked() {
-    const now = new Date();
-    return !!this.temporaryBlockedUntil && this.temporaryBlockedUntil > now;
-  }
-
-  resetUserTemporaryBlocking() {
-    this.failureCount = 0;
-    this.temporaryBlockedUntil = null;
+  hasFailedAtLeastOnce() {
+    return this.failureCount > 0 || !!this.temporaryBlockedUntil;
   }
 
   shouldMarkUserAsTemporarilyBlocked() {
@@ -45,8 +39,14 @@ class UserLogin {
     this.temporaryBlockedUntil = new Date(Date.now() + config.login.temporaryBlockingBaseTimeMs * commonRatio);
   }
 
-  hasFailedAtLeastOnce() {
-    return this.failureCount > 0 || !!this.temporaryBlockedUntil;
+  isUserMarkedAsTemporaryBlocked() {
+    const now = new Date();
+    return !!this.temporaryBlockedUntil && this.temporaryBlockedUntil > now;
+  }
+
+  resetUserTemporaryBlocking() {
+    this.failureCount = 0;
+    this.temporaryBlockedUntil = null;
   }
 
   shouldMarkUserAsBlocked() {
@@ -57,14 +57,14 @@ class UserLogin {
     this.blockedAt = new Date();
   }
 
+  isUserMarkedAsBlocked() {
+    return !!this.blockedAt;
+  }
+
   resetUserBlocking() {
     this.failureCount = 0;
     this.temporaryBlockedUntil = null;
     this.blockedAt = null;
-  }
-
-  isUserMarkedAsBlocked() {
-    return !!this.blockedAt;
   }
 
   anonymize() {

--- a/api/src/identity-access-management/domain/models/UserLogin.js
+++ b/api/src/identity-access-management/domain/models/UserLogin.js
@@ -55,6 +55,7 @@ class UserLogin {
 
   markUserAsBlocked() {
     this.blockedAt = new Date();
+    this.temporaryBlockedUntil = null;
   }
 
   isUserMarkedAsBlocked() {

--- a/api/src/identity-access-management/domain/models/UserLogin.js
+++ b/api/src/identity-access-management/domain/models/UserLogin.js
@@ -27,7 +27,7 @@ class UserLogin {
   }
 
   hasFailedAtLeastOnce() {
-    return this.failureCount > 0 || !!this.temporaryBlockedUntil;
+    return this.failureCount > 0 || Boolean(this.temporaryBlockedUntil);
   }
 
   shouldMarkUserAsTemporarilyBlocked() {
@@ -41,7 +41,7 @@ class UserLogin {
 
   isUserMarkedAsTemporaryBlocked() {
     const now = new Date();
-    return !!this.temporaryBlockedUntil && this.temporaryBlockedUntil > now;
+    return this?.temporaryBlockedUntil > now;
   }
 
   resetUserTemporaryBlocking() {
@@ -58,7 +58,7 @@ class UserLogin {
   }
 
   isUserMarkedAsBlocked() {
-    return !!this.blockedAt;
+    return Boolean(this.blockedAt);
   }
 
   resetUserBlocking() {

--- a/api/src/identity-access-management/domain/usecases/authenticate-user.js
+++ b/api/src/identity-access-management/domain/usecases/authenticate-user.js
@@ -3,19 +3,6 @@ import { ForbiddenAccess, LocaleFormatError, LocaleNotSupportedError } from '../
 import { MissingOrInvalidCredentialsError, UserShouldChangePasswordError } from '../errors.js';
 import { RefreshToken } from '../models/RefreshToken.js';
 
-async function _checkUserAccessScope(scope, user, adminMemberRepository) {
-  if (scope === PIX_ORGA.SCOPE && !user.isLinkedToOrganizations()) {
-    throw new ForbiddenAccess(PIX_ORGA.NOT_LINKED_ORGANIZATION_MSG);
-  }
-
-  if (scope === PIX_ADMIN.SCOPE) {
-    const adminMember = await adminMemberRepository.get({ userId: user.id });
-    if (!adminMember?.hasAccessToAdminScope) {
-      throw new ForbiddenAccess(PIX_ADMIN.NOT_ALLOWED_MSG);
-    }
-  }
-}
-
 const authenticateUser = async function ({
   password,
   scope,
@@ -68,5 +55,18 @@ const authenticateUser = async function ({
     throw new MissingOrInvalidCredentialsError();
   }
 };
+
+async function _checkUserAccessScope(scope, user, adminMemberRepository) {
+  if (scope === PIX_ORGA.SCOPE && !user.isLinkedToOrganizations()) {
+    throw new ForbiddenAccess(PIX_ORGA.NOT_LINKED_ORGANIZATION_MSG);
+  }
+
+  if (scope === PIX_ADMIN.SCOPE) {
+    const adminMember = await adminMemberRepository.get({ userId: user.id });
+    if (!adminMember?.hasAccessToAdminScope) {
+      throw new ForbiddenAccess(PIX_ADMIN.NOT_ALLOWED_MSG);
+    }
+  }
+}
 
 export { authenticateUser };

--- a/api/src/shared/application/security-pre-handlers.js
+++ b/api/src/shared/application/security-pre-handlers.js
@@ -69,10 +69,17 @@ async function checkIfUserIsBlocked(
     checkIfUserIsBlockedUseCase,
   },
 ) {
-  const { username, grant_type: grantType } = request.payload;
+  const { username, grant_type: grantType, data } = request.payload;
 
+  let usernameOrEmailToCheck;
   if (grantType === 'password') {
-    await dependencies.checkIfUserIsBlockedUseCase.execute(username);
+    usernameOrEmailToCheck = username;
+  } else if (data?.attributes?.password) {
+    usernameOrEmailToCheck = data.attributes.email;
+  }
+
+  if (usernameOrEmailToCheck) {
+    await dependencies.checkIfUserIsBlockedUseCase.execute(usernameOrEmailToCheck);
   }
 
   return h.response(true);

--- a/api/src/shared/application/security-pre-handlers.js
+++ b/api/src/shared/application/security-pre-handlers.js
@@ -74,7 +74,9 @@ async function checkIfUserIsBlocked(
   let usernameOrEmailToCheck;
   if (grantType === 'password') {
     usernameOrEmailToCheck = username;
-  } else if (data?.attributes?.password) {
+  } else if (data?.attributes?.username) {
+    usernameOrEmailToCheck = data.attributes.username;
+  } else if (data?.attributes?.email) {
     usernameOrEmailToCheck = data.attributes.email;
   }
 

--- a/api/tests/identity-access-management/integration/application/oidc-provider.route.test.js
+++ b/api/tests/identity-access-management/integration/application/oidc-provider.route.test.js
@@ -1,11 +1,14 @@
+import jsonwebtoken from 'jsonwebtoken';
+
 import { oidcProviderController } from '../../../../src/identity-access-management/application/oidc-provider/oidc-provider.controller.js';
 import { identityAccessManagementRoutes } from '../../../../src/identity-access-management/application/routes.js';
 import {
   AuthenticationKeyExpired,
   DifferentExternalIdentifierError,
 } from '../../../../src/identity-access-management/domain/errors.js';
+import { authenticationSessionService } from '../../../../src/identity-access-management/domain/services/authentication-session.service.js';
 import { UserNotFoundError } from '../../../../src/shared/domain/errors.js';
-import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
+import { databaseBuilder, expect, HttpTestServer, sinon } from '../../../test-helper.js';
 
 const routesUnderTest = identityAccessManagementRoutes[0];
 
@@ -39,6 +42,51 @@ describe('Integration | Identity Access Management | Application | Route | oidc-
         // then
         expect(response.statusCode).to.equal(404);
         expect(response.result.errors[0].detail).to.equal('Ce compte est introuvable.');
+      });
+    });
+
+    context('when user is blocked', function () {
+      it('returns 403', async function () {
+        // given
+        const email = 'i.am.blocked@example.net';
+        const password = 'pix123';
+        const userId = databaseBuilder.factory.buildUser.withRawPassword({ email, rawPassword: password }).id;
+        databaseBuilder.factory.buildUserLogin({ userId, failureCount: 50, blockedAt: new Date() });
+        await databaseBuilder.commit();
+
+        const idToken = jsonwebtoken.sign(
+          {
+            given_name: 'Brice',
+            family_name: 'Glace',
+            nonce: 'nonce',
+            sub: 'some-user-unique-id',
+          },
+          'secret',
+        );
+        const userAuthenticationKey = await authenticationSessionService.save({
+          sessionContent: { idToken },
+          userInfo: {
+            firstName: 'Brice',
+            lastName: 'Glace',
+            nonce: 'nonce',
+            externalIdentityId: 'some-user-unique-id',
+          },
+        });
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/oidc/user/check-reconciliation', {
+          data: {
+            attributes: {
+              email,
+              password,
+              'identity-provider': 'OIDC_EXAMPLE_NET',
+              'authentication-key': userAuthenticationKey,
+            },
+          },
+        });
+
+        // then
+        expect(response.statusCode).to.equal(403);
       });
     });
 

--- a/api/tests/identity-access-management/integration/application/oidc-provider.route.test.js
+++ b/api/tests/identity-access-management/integration/application/oidc-provider.route.test.js
@@ -19,78 +19,74 @@ describe('Integration | Identity Access Management | Application | Route | oidc-
   });
 
   describe('POST /api/oidc/user/check-reconciliation', function () {
-    context('error cases', function () {
-      context('when user is not found', function () {
-        it('returns a response with HTTP status code 404', async function () {
-          // given
-          sinon.stub(oidcProviderController, 'findUserForReconciliation').rejects(new UserNotFoundError());
+    context('when user is not found', function () {
+      it('returns a response with HTTP status code 404', async function () {
+        // given
+        sinon.stub(oidcProviderController, 'findUserForReconciliation').rejects(new UserNotFoundError());
 
-          // when
-          const response = await httpTestServer.request('POST', '/api/oidc/user/check-reconciliation', {
-            data: {
-              attributes: {
-                email: 'eva.poree@example.net',
-                password: 'pix123',
-                'identity-provider': 'POLE_EMPLOI',
-                'authentication-key': '123abc',
-              },
+        // when
+        const response = await httpTestServer.request('POST', '/api/oidc/user/check-reconciliation', {
+          data: {
+            attributes: {
+              email: 'eva.poree@example.net',
+              password: 'pix123',
+              'identity-provider': 'POLE_EMPLOI',
+              'authentication-key': '123abc',
             },
-          });
-
-          // then
-          expect(response.statusCode).to.equal(404);
-          expect(response.result.errors[0].detail).to.equal('Ce compte est introuvable.');
+          },
         });
+
+        // then
+        expect(response.statusCode).to.equal(404);
+        expect(response.result.errors[0].detail).to.equal('Ce compte est introuvable.');
       });
+    });
 
-      context('when authentication key expired', function () {
-        it('returns a response with HTTP status code 401', async function () {
-          // given
-          sinon.stub(oidcProviderController, 'findUserForReconciliation').rejects(new AuthenticationKeyExpired());
+    context('when authentication key expired', function () {
+      it('returns a response with HTTP status code 401', async function () {
+        // given
+        sinon.stub(oidcProviderController, 'findUserForReconciliation').rejects(new AuthenticationKeyExpired());
 
-          // when
-          const response = await httpTestServer.request('POST', '/api/oidc/user/check-reconciliation', {
-            data: {
-              attributes: {
-                email: 'eva.poree@example.net',
-                password: 'pix123',
-                'identity-provider': 'POLE_EMPLOI',
-                'authentication-key': '123abc',
-              },
+        // when
+        const response = await httpTestServer.request('POST', '/api/oidc/user/check-reconciliation', {
+          data: {
+            attributes: {
+              email: 'eva.poree@example.net',
+              password: 'pix123',
+              'identity-provider': 'POLE_EMPLOI',
+              'authentication-key': '123abc',
             },
-          });
-
-          // then
-          expect(response.statusCode).to.equal(401);
-          expect(response.result.errors[0].detail).to.equal('This authentication key has expired.');
+          },
         });
+
+        // then
+        expect(response.statusCode).to.equal(401);
+        expect(response.result.errors[0].detail).to.equal('This authentication key has expired.');
       });
+    });
 
-      context('when external identity id and external identifier are different', function () {
-        it('returns a response with HTTP status code 412', async function () {
-          // given
-          sinon
-            .stub(oidcProviderController, 'findUserForReconciliation')
-            .rejects(new DifferentExternalIdentifierError());
+    context('when external identity id and external identifier are different', function () {
+      it('returns a response with HTTP status code 412', async function () {
+        // given
+        sinon.stub(oidcProviderController, 'findUserForReconciliation').rejects(new DifferentExternalIdentifierError());
 
-          // when
-          const response = await httpTestServer.request('POST', '/api/oidc/user/check-reconciliation', {
-            data: {
-              attributes: {
-                email: 'eva.poree@example.net',
-                password: 'pix123',
-                'identity-provider': 'POLE_EMPLOI',
-                'authentication-key': '123abc',
-              },
+        // when
+        const response = await httpTestServer.request('POST', '/api/oidc/user/check-reconciliation', {
+          data: {
+            attributes: {
+              email: 'eva.poree@example.net',
+              password: 'pix123',
+              'identity-provider': 'POLE_EMPLOI',
+              'authentication-key': '123abc',
             },
-          });
-
-          // then
-          expect(response.statusCode).to.equal(409);
-          expect(response.result.errors[0].detail).to.equal(
-            "La valeur de l'externalIdentifier de la méthode de connexion ne correspond pas à celui reçu par le partenaire.",
-          );
+          },
         });
+
+        // then
+        expect(response.statusCode).to.equal(409);
+        expect(response.result.errors[0].detail).to.equal(
+          "La valeur de l'externalIdentifier de la méthode de connexion ne correspond pas à celui reçu par le partenaire.",
+        );
       });
     });
   });

--- a/api/tests/shared/integration/application/security-pre-handlers_test.js
+++ b/api/tests/shared/integration/application/security-pre-handlers_test.js
@@ -399,6 +399,26 @@ describe('Integration | Application | SecurityPreHandlers', function () {
         // then
         expect(response.statusCode).to.equal(200);
       });
+
+      describe('when the application tries to refresh the access token', function () {
+        before(async function () {
+          // given
+          databaseBuilder.factory.buildUser({ username: 'refresh_token_user_1' });
+          await databaseBuilder.commit();
+        });
+
+        it('returns 200', async function () {
+          // when
+          const { statusCode } = await httpServerTest.requestObject({
+            method: 'POST',
+            url: '/api/token',
+            payload: { grant_type: 'refresh_token' },
+          });
+
+          // then
+          expect(statusCode).to.equal(200);
+        });
+      });
     });
 
     describe('when user is temporary blocked', function () {
@@ -424,26 +444,6 @@ describe('Integration | Application | SecurityPreHandlers', function () {
         // then
         expect(response.statusCode).to.equal(403);
         expect(response.result.errors[0].code).to.equal('USER_IS_TEMPORARY_BLOCKED');
-      });
-    });
-
-    describe('when the application tries to refresh the access token', function () {
-      before(async function () {
-        // given
-        databaseBuilder.factory.buildUser({ username: 'refresh_token_user_1' });
-        await databaseBuilder.commit();
-      });
-
-      it('returns 200', async function () {
-        // when
-        const { statusCode } = await httpServerTest.requestObject({
-          method: 'POST',
-          url: '/api/token',
-          payload: { grant_type: 'refresh_token' },
-        });
-
-        // then
-        expect(statusCode).to.equal(200);
       });
     });
 

--- a/api/tests/unit/domain/models/UserLogin_test.js
+++ b/api/tests/unit/domain/models/UserLogin_test.js
@@ -230,7 +230,8 @@ describe('Unit | Domain | Models | UserLogin', function () {
     context('when failure count equals failure count threshold', function () {
       it('returns true', function () {
         // given
-        const userLogin = new UserLogin({ failureCount: 20 });
+        const failureCountThreshold = 20;
+        const userLogin = new UserLogin({ failureCount: failureCountThreshold });
 
         // when
         const result = userLogin.shouldMarkUserAsTemporarilyBlocked();

--- a/api/tests/unit/domain/models/UserLogin_test.js
+++ b/api/tests/unit/domain/models/UserLogin_test.js
@@ -269,6 +269,20 @@ describe('Unit | Domain | Models | UserLogin', function () {
         expect(result).to.be.true;
       });
     });
+
+    context('when failure count is upper than the limit failure count', function () {
+      it('returns true', function () {
+        // given
+        const failureCount = config.login.blockingLimitFailureCount + 1;
+        const userLogin = new UserLogin({ failureCount });
+
+        // when
+        const result = userLogin.shouldMarkUserAsBlocked();
+
+        // then
+        expect(result).to.be.true;
+      });
+    });
   });
 
   describe('#resetUserBlocking', function () {

--- a/api/tests/unit/domain/models/UserLogin_test.js
+++ b/api/tests/unit/domain/models/UserLogin_test.js
@@ -1,4 +1,5 @@
 import { UserLogin } from '../../../../src/identity-access-management/domain/models/UserLogin.js';
+import { config } from '../../../../src/shared/config.js';
 import { expect, sinon } from '../../../test-helper.js';
 
 describe('Unit | Domain | Models | UserLogin', function () {
@@ -158,7 +159,8 @@ describe('Unit | Domain | Models | UserLogin', function () {
     context('when user reaches the limit failure count but is not yet blocked', function () {
       it('returns false', function () {
         // given
-        const userLogin = new UserLogin({ failureCount: 50, blockedAt: null });
+        const failureCount = config.login.blockingLimitFailureCount;
+        const userLogin = new UserLogin({ failureCount, blockedAt: null });
 
         // when
         const result = userLogin.isUserMarkedAsBlocked();
@@ -171,7 +173,8 @@ describe('Unit | Domain | Models | UserLogin', function () {
     context('when user has blockedAt date', function () {
       it('returns true', function () {
         // given
-        const userLogin = new UserLogin({ failureCount: 50, blockedAt: new Date('2022-11-29') });
+        const failureCount = config.login.blockingLimitFailureCount;
+        const userLogin = new UserLogin({ failureCount, blockedAt: new Date('2022-11-29') });
 
         // when
         const result = userLogin.isUserMarkedAsBlocked();
@@ -184,7 +187,8 @@ describe('Unit | Domain | Models | UserLogin', function () {
     context('when user has no failure count nor blockedAt date', function () {
       it('returns false', function () {
         // given
-        const userLogin = new UserLogin({ failureCount: 50, blockedAt: null });
+        const failureCount = config.login.blockingLimitFailureCount;
+        const userLogin = new UserLogin({ failureCount, blockedAt: null });
 
         // when
         const result = userLogin.isUserMarkedAsBlocked();
@@ -212,7 +216,8 @@ describe('Unit | Domain | Models | UserLogin', function () {
     context('when failure count is lower than failure count threshold', function () {
       it('returns false', function () {
         // given
-        const userLogin = new UserLogin({ failureCount: 5 });
+        const failureCount = config.login.blockingLimitFailureCount - 1;
+        const userLogin = new UserLogin({ failureCount });
 
         // when
         const result = userLogin.shouldMarkUserAsTemporarilyBlocked();
@@ -240,7 +245,8 @@ describe('Unit | Domain | Models | UserLogin', function () {
     context('when failure count is lower than the limit failure count', function () {
       it('returns false', function () {
         // given
-        const userLogin = new UserLogin({ failureCount: 49 });
+        const failureCount = config.login.blockingLimitFailureCount - 1;
+        const userLogin = new UserLogin({ failureCount });
 
         // when
         const result = userLogin.shouldMarkUserAsBlocked();
@@ -253,7 +259,8 @@ describe('Unit | Domain | Models | UserLogin', function () {
     context('when failure count equals the limit failure count', function () {
       it('returns true', function () {
         // given
-        const userLogin = new UserLogin({ failureCount: 50 });
+        const failureCount = config.login.blockingLimitFailureCount;
+        const userLogin = new UserLogin({ failureCount });
 
         // when
         const result = userLogin.shouldMarkUserAsBlocked();
@@ -267,9 +274,10 @@ describe('Unit | Domain | Models | UserLogin', function () {
   describe('#resetUserBlocking', function () {
     it('should reset failure count and reset temporary blocked until', function () {
       // given
+      const failureCount = config.login.blockingLimitFailureCount;
       const userLogin = new UserLogin({
         userId: 666,
-        failureCount: 50,
+        failureCount,
         temporaryBlockedUntil: new Date('2022-11-25'),
         blockedAt: new Date('2022-12-01'),
       });

--- a/api/tests/unit/domain/models/UserLogin_test.js
+++ b/api/tests/unit/domain/models/UserLogin_test.js
@@ -264,7 +264,7 @@ describe('Unit | Domain | Models | UserLogin', function () {
     });
   });
 
-  describe('#unblockUser', function () {
+  describe('#resetUserBlocking', function () {
     it('should reset failure count and reset temporary blocked until', function () {
       // given
       const userLogin = new UserLogin({

--- a/api/tests/unit/domain/models/UserLogin_test.js
+++ b/api/tests/unit/domain/models/UserLogin_test.js
@@ -209,6 +209,21 @@ describe('Unit | Domain | Models | UserLogin', function () {
 
       // then
       expect(userLogin.blockedAt).to.deepEqualInstance(new Date('2022-11-28T12:00:00Z'));
+      expect(userLogin.temporaryBlockedUntil).to.be.null;
+    });
+
+    context('when the user was temporarily blocked and must be blocked', function () {
+      it('blocks user and removes temporaryBlockedUntil', function () {
+        // given
+        const userLogin = new UserLogin({ temporaryBlockedUntil: new Date('2022-11-25') });
+
+        // when
+        userLogin.markUserAsBlocked();
+
+        // then
+        expect(userLogin.blockedAt).to.deepEqualInstance(new Date('2022-11-28T12:00:00Z'));
+        expect(userLogin.temporaryBlockedUntil).to.be.null;
+      });
     });
   });
 

--- a/mon-pix/app/adapters/user-oidc-authentication-request.js
+++ b/mon-pix/app/adapters/user-oidc-authentication-request.js
@@ -1,6 +1,6 @@
 import ApplicationAdapter from './application';
 
-export default class ExternalUserAuthenticationRequest extends ApplicationAdapter {
+export default class UserOidcAuthenticationRequest extends ApplicationAdapter {
   buildURL() {
     return `${this.host}/${this.namespace}/oidc/user/`;
   }


### PR DESCRIPTION
## :christmas_tree: Problème

L'authentification ne prend pas en compte le fait qu'un utilisateur puisse être bloqué dans 2 formulaires _« J’ai déjà un compte Pix »_ oubliés. Et ainsi lorsqu'un utilisateur ne réussit pas à s’authentifier avec succès sur ces formulaires il est susceptible de faire grimper le `"user-logins"."failureCount"` au-delà de la limite de blocage (actuellement `50`). 

### Formulaire d'association OIDC

Ce formulaire utilise la route `/api/oidc/user/check-reconciliation`

![api-oidc-user-check-reconciliation](https://github.com/user-attachments/assets/9ad233fd-1a39-4d9d-95a7-ea6a3108ed58)

On notera également que le message d'erreur `« Votre demande d'authentification a expiré. »` est incorrect.

### Formulaire GAR pour rejoindre une organisation

Ce formulaire utilise la route `/api/token-from-external-user`

![api-token-from-external-user](https://github.com/user-attachments/assets/02ca5a64-3d5f-4638-96c0-5ad2ed544840)

## :gift: Proposition

Ajouter aux 2 routes concernées, `/api/oidc/user/check-reconciliation` et `/api/token-from-external-user`, le _securityPreHandler_ `checkIfUserIsBlocked` manquant.

On corrigera dans une autre PR le mauvais message d'erreur _« Votre demande d'authentification a expiré. »_ (alors qu'on devrait avoir le message _« L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects. »_) dans le formulaire d'association OIDC. En effet c'est une erreur qui est déjà présente et qui n'est pas une régression apportée par cette PR. De plus il s'agit d'une autre problématique, la problématique du manque d'utilisation de code dans les erreurs.

## :socks: Remarques

Cette PR intègre dans son dernier commit `feat(api): removes UserLogin temporaryBlockedUntil when markUserAsBlocked` une modification lors du blocage d'un compte utilisateur : lors du blocage d'un compte, la date `temporaryBlockedUntil` est mise à `null`. En effet la date `temporaryBlockedUntil` ne sert plus à rien dès lors que le compte est bloqué et que la date `blockedAt` a été assignée. Ne plus avoir cette date `temporaryBlockedUntil` lorsqu'un compte est bloqué rend la consultation et la compréhension des données plus facile et plus intuitive :bulb: 

## :santa: Pour tester

### Test du formulaire d'association OIDC

1. Se connecter à un SSO
2. Sur le formulaire  _« J’ai déjà un compte Pix »_ indiquer l'adresse email `james-paledroits@example.net`
3. Entrer un mauvais mot de passe et vérifier que le `"user-logins"."failureCount"` ne va pas au-delà de la limite de blocage (actuellement `50`)

### Test du formulaire GAR pour rejoindre une organisation

1. Se connecter avec le SSO GAR (par exemple avec un faux GAR)
1.1 Sur le faux GAR indiquer un samlId aléatoire, le prénom `Hermione` et le nom `Granger`
1.2 Se connecter avec le bouton _« Sign in »_
2. Sur la page _«  Saisissez votre code »_ indiquer le code campagne `SCOBADGE1`
3. Cliquer sur le bouton _« Accéder au parcours »_
4. Cliquer sur le bouton _« Je commence »_
5. Indiquer la date de naissance `05-05-2013`
6. Cliquer sur le bouton _« C'est parti ! »_
7. Cliquer sur le bouton _« Continuer avec mon compte Pix »_
8. Sur le formulaire  _« J’ai déjà un compte Pix »_ indiquer l'adresse email `hermione@school.net`
9. Entrer un mauvais mot de passe et vérifier que le `"user-logins"."failureCount"` ne va pas au-delà de la limite de blocage (actuellement `50`)


