### PR TITLE
[FEATURE] Création du feature toggle FT_NEW_LEGAL_DOCUMENTS_VERSIONING (PIX-15567)

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -846,6 +846,11 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: false
 # FT_SELF_ACCOUNT_DELETION=false
 
+# Enable legal documents versioning
+# type: boolean
+# default: false
+# FT_NEW_LEGAL_DOCUMENTS_VERSIONING=false
+
 # =====
 # CPF
 # =====

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -219,6 +219,7 @@ const configuration = (function () {
       isSelfAccountDeletionEnabled: toBoolean(process.env.FT_SELF_ACCOUNT_DELETION),
       isQuestEnabled: toBoolean(process.env.FT_ENABLE_QUESTS),
       isTextToSpeechButtonEnabled: toBoolean(process.env.FT_ENABLE_TEXT_TO_SPEECH_BUTTON),
+      isLegalDocumentsVersioningEnabled: toBoolean(process.env.FT_NEW_LEGAL_DOCUMENTS_VERSIONING),
       setupEcosystemBeforeStart: toBoolean(process.env.FT_SETUP_ECOSYSTEM_BEFORE_START) || false,
       showExperimentalMissions: toBoolean(process.env.FT_SHOW_EXPERIMENTAL_MISSIONS),
       showNewCampaignPresentationPage: toBoolean(process.env.FT_SHOW_NEW_CAMPAIGN_PRESENTATION_PAGE),
@@ -443,6 +444,7 @@ const configuration = (function () {
     config.featureToggles.isQuestEnabled = false;
     config.featureToggles.isAsyncQuestRewardingCalculationEnabled = false;
     config.featureToggles.isTextToSpeechButtonEnabled = false;
+    config.featureToggles.isLegalDocumentsVersioningEnabled = false;
     config.featureToggles.showNewResultPage = false;
     config.featureToggles.showExperimentalMissions = false;
 

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -29,6 +29,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-quest-enabled': false,
             'is-self-account-deletion-enabled': false,
             'is-text-to-speech-button-enabled': false,
+            'is-legal-documents-versioning-enabled': false,
             'setup-ecosystem-before-start': false,
             'show-experimental-missions': false,
             'show-new-campaign-presentation-page': false,

--- a/orga/app/models/feature-toggle.js
+++ b/orga/app/models/feature-toggle.js
@@ -1,3 +1,5 @@
-import Model from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 
-export default class FeatureToggle extends Model {}
+export default class FeatureToggle extends Model {
+  @attr('boolean') isLegalDocumentsVersioningEnabled;
+}


### PR DESCRIPTION
## :christmas_tree: Problème

Dans le cadre de la nouvelle gestion du versioning des CGUs pour Pix Orga, il est nécessaire d’avoir un Feature Toggle dédié.

## :gift: Proposition

Création du feature toggle FT_NEW_LEGAL_DOCUMENTS_VERSIONING


## :santa: Pour tester

Sur Pix Orga, vérifier que l’appel sur /api/feature-toggles retourne le nouveau feature toggle.
![image](https://github.com/user-attachments/assets/fecd76e1-080a-4e94-ac81-d130aad9b7e6)
