### PR TITLE
[TECH] Ajouter les traductions manquantes pour la page de sélection SSO (PIX-15609)

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -486,10 +486,11 @@
       },
       "sso-selection": {
         "signin": {
-          "link": "Log in",
+          "button": "Log in",
           "message": "You will be redirected to the “{providerName}” connection page in order to identify yourself on Pix."
         },
         "signup": {
+          "button": "Sign up",
           "link": "Sign up",
           "title": "Don't have an account?"
         },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -494,10 +494,11 @@
       },
       "sso-selection": {
         "signin": {
-          "link": "Me conecto",
+          "button": "Log in",
           "message": "{providerName} Será redirigido a la página de acceso \" \" para identificarse en Pix."
         },
         "signup": {
+          "button": "Sign up",
           "link": "Inscríbete",
           "title": "¿No tiene una cuenta?"
         },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -490,10 +490,11 @@
       },
       "sso-selection": {
         "signin": {
-          "link": "Ik log in",
+          "button": "Log in",
           "message": "{providerName} Je wordt doorgestuurd naar de \" \" inlogpagina om je te identificeren op Pix."
         },
         "signup": {
+          "button": "Sign up",
           "link": "Aanmelden",
           "title": "Heb je geen account?"
         },


### PR DESCRIPTION
## :christmas_tree: Problème

Les clés de traductions `pages.authentication.sso-selection.*` sont différentes entre les fichiers de traduction sur mon-pix.

## :gift: Proposition

Aligner les fichiers de traductions

## :socks: Remarques

- Ne peut pas être testé fonctionnellement car cette page s'affiche uniquement sur le domaine .fr.

## :santa: Pour tester

Vérifier que les structures des traductions `pages.authentication.sso-selection.*` sont identiques entre les 4 fichiers.