### PR TITLE
[FEATURE] Création des tables legal documents (PIX-15578)

### DIFF
--- a/api/db/migrations/20241206094819_create-legal-document-versions-table.js
+++ b/api/db/migrations/20241206094819_create-legal-document-versions-table.js
@@ -1,0 +1,17 @@
+const TABLE_NAME = 'legal-document-versions';
+
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.increments().primary();
+    table.string('type').notNullable().comment("Legal document type ('TOS', 'PDP',...)");
+    table.string('service').notNullable().comment("Service related to the document ('pix-app', ...)");
+    table.dateTime('versionAt').notNullable().comment('Document version date');
+    table.comment('Legal document versions by services');
+  });
+};
+
+const down = async function (knex) {
+  return knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };

--- a/api/db/migrations/20241206100509_create-legal-document-version-user-acceptances.js
+++ b/api/db/migrations/20241206100509_create-legal-document-version-user-acceptances.js
@@ -1,0 +1,27 @@
+const TABLE_NAME = 'legal-document-version-user-acceptances';
+
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table
+      .integer('legalDocumentVersionId')
+      .references('id')
+      .inTable('legal-document-versions')
+      .notNullable()
+      .comment('Accepted legal document version id');
+    table
+      .integer('userId')
+      .references('id')
+      .inTable('users')
+      .notNullable()
+      .comment('User who has accepted the document');
+    table.dateTime('acceptedAt').notNullable().defaultTo(knex.fn.now()).comment('Document version acceptance date');
+    table.unique(['userId', 'legalDocumentVersionId']);
+    table.comment('Legal document versions user acceptances');
+  });
+};
+
+const down = async function (knex) {
+  return knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };


### PR DESCRIPTION
## :christmas_tree: Problème

Dans le cadre de la nouvelle gestion du versioning des CGUs pour Pix Orga, nous avons besoin de tables dédiées pour stocker les version.


## :gift: Proposition

Créer les tables (voir ticket Jira)


## :santa: Pour tester

Vérifier en base de données si les 2 tables et leurs colonnes associées sont correctes.
