### PR TITLE
[TECH] Améliorer la gestion d'erreurs lors du téléchargement des résultats de session sur Pix App (PIX-15587).

### DIFF
--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -492,6 +492,10 @@ function _mapToHttpError(error) {
     return new HttpErrors.BadRequestError(error.message, 'SENDING_EMAIL_TO_INVALID_EMAIL_ADDRESS', error.meta);
   }
 
+  if (error instanceof DomainErrors.InvalidSessionResultTokenError) {
+    return new HttpErrors.BadRequestError(error.message, error.code);
+  }
+
   return new HttpErrors.BaseHttpError(error.message);
 }
 

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -394,8 +394,11 @@ class InvalidResultRecipientTokenError extends DomainError {
 }
 
 class InvalidSessionResultTokenError extends DomainError {
-  constructor(message = 'Le token de récupération des résultats de la session de certification est invalide.') {
-    super(message);
+  constructor(
+    message = 'The token used to retrieve the results of the certification session is invalid.',
+    code = 'INVALID_SESSION_RESULT_TOKEN',
+  ) {
+    super(message, code);
   }
 }
 

--- a/api/tests/shared/integration/application/error-manager_test.js
+++ b/api/tests/shared/integration/application/error-manager_test.js
@@ -89,6 +89,17 @@ describe('Integration | API | Controller Error', function () {
       );
       expect(responseCode(response)).to.equal('SESSION_WITHOUT_STARTED_CERTIFICATION');
     });
+
+    it('responds Bad Request when a InvalidSessionResultTokenError error occurs', async function () {
+      routeHandler.throws(new DomainErrors.InvalidSessionResultTokenError());
+      const response = await server.requestObject(request);
+
+      expect(response.statusCode).to.equal(BAD_REQUEST_ERROR);
+      expect(responseDetail(response)).to.equal(
+        'The token used to retrieve the results of the certification session is invalid.',
+      );
+      expect(responseCode(response)).to.equal('INVALID_SESSION_RESULT_TOKEN');
+    });
   });
 
   context('403 Forbidden', function () {

--- a/mon-pix/app/components/download-session-results.gjs
+++ b/mon-pix/app/components/download-session-results.gjs
@@ -11,13 +11,14 @@ import ENV from 'mon-pix/config/environment';
 import PixWindow from 'mon-pix/utils/pix-window';
 
 export default class DownloadSessionResults extends Component {
-  @tracked showErrorMessage = false;
+  @tracked errorMessage = null;
   @service fileSaver;
+  @service intl;
 
   @action
   async downloadSessionResults(event) {
     event.preventDefault();
-    this.showErrorMessage = false;
+    this.errorMessage = null;
 
     try {
       const token = decodeURIComponent(PixWindow.getLocationHash().slice(1));
@@ -28,8 +29,12 @@ export default class DownloadSessionResults extends Component {
           body: { token },
         },
       });
-    } catch {
-      this.showErrorMessage = true;
+    } catch (error) {
+      if (error.code === 'INVALID_SESSION_RESULT_TOKEN') {
+        this.errorMessage = this.intl.t('pages.download-session-results.errors.invalid-token');
+      } else {
+        this.errorMessage = this.intl.t('common.error');
+      }
     }
   }
 
@@ -46,9 +51,9 @@ export default class DownloadSessionResults extends Component {
             {{t "pages.download-session-results.button.label"}}
           </PixButton>
 
-          {{#if this.showErrorMessage}}
+          {{#if this.errorMessage}}
             <PixMessage @type="error" class="form__error">
-              {{t "pages.download-session-results.errors.expiration"}}
+              {{this.errorMessage}}
             </PixMessage>
           {{/if}}
         </form>

--- a/mon-pix/app/components/user-certifications-detail-header.hbs
+++ b/mon-pix/app/components/user-certifications-detail-header.hbs
@@ -49,7 +49,6 @@
           <p class="attestation__error-message">{{this.attestationDownloadErrorMessage}}</p>
         {{/if}}
       </div>
-      <hr />
       <div class="verification-code">
         <h2 class="verification-code__title">
           {{t "pages.certificate.verification-code.title"}}

--- a/mon-pix/app/components/user-certifications-detail-header.js
+++ b/mon-pix/app/components/user-certifications-detail-header.js
@@ -34,8 +34,8 @@ export default class UserCertificationsDetailHeader extends Component {
     const token = this.session.data.authenticated.access_token;
     try {
       await this.fileSaver.save({ url, token });
-    } catch (error) {
-      this.attestationDownloadErrorMessage = error.message;
+    } catch (_) {
+      this.attestationDownloadErrorMessage = this.intl.t('common.error');
     }
   }
 }

--- a/mon-pix/app/services/file-saver.js
+++ b/mon-pix/app/services/file-saver.js
@@ -45,7 +45,7 @@ export default class FileSaver extends Service {
 
     if (!response.ok) {
       const payload = await response.json();
-      throw new Error(payload?.errors[0]?.detail);
+      throw payload?.errors[0];
     }
 
     if (response.headers && response.headers.get('Content-Disposition')) {

--- a/mon-pix/app/styles/components/_user-certifications-detail-header.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-header.scss
@@ -72,34 +72,31 @@
 }
 
 .attestation-and-verification-code {
-  padding: 16px 20px;
+  max-width: 100%;
+  padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
   background-color: var(--pix-neutral-20);
   border-radius: 8px;
 
+  @include device-is('desktop') {
+    max-width: calc(var(--pix-spacing-12x) * 6);
+  }
+
   .attestation {
-    margin: auto;
-    font-size: 0.875rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-bottom: var(--pix-spacing-6x);
     text-align: center;
 
-    button {
-      max-width: 250px;
-      padding: 14px 20px;
-    }
-
     &__error-message {
-      max-width: 250px;
-      margin-top: 15px;
+      @extend %pix-body-s;
+
+      margin-top: var(--pix-spacing-4x);
       color: var(--pix-error-500);
     }
   }
 
-  hr {
-    margin: 24px 0;
-    border: 1px solid var(--pix-neutral-20);
-  }
-
   .verification-code {
-    max-width: 250px;
     margin: auto;
     color: var(--pix-neutral-900);
     letter-spacing: 0;
@@ -157,10 +154,5 @@
   @include device-is('desktop') {
     flex-grow: 0;
     margin-left: auto;
-
-    .verification-code,
-    .attestation {
-      margin: 0;
-    }
   }
 }

--- a/mon-pix/tests/integration/components/download-session-results-test.gjs
+++ b/mon-pix/tests/integration/components/download-session-results-test.gjs
@@ -34,9 +34,9 @@ module('Integration | Component | download-session-results', function (hooks) {
     assert.dom(screen.getByRole('button', { name: t('pages.download-session-results.button.label') })).exists();
   });
 
-  test('should display the expiration error message', async function (assert) {
+  test('should display the invalid token error message', async function (assert) {
     // given
-    fileSaver.save.rejects();
+    fileSaver.save.rejects({ status: '400', code: 'INVALID_SESSION_RESULT_TOKEN' });
 
     // when
     const screen = await render(hbs`<DownloadSessionResults />`);
@@ -44,7 +44,7 @@ module('Integration | Component | download-session-results', function (hooks) {
     await click(downloadButton);
 
     // then
-    assert.dom(screen.getByText(t('pages.download-session-results.errors.expiration'))).exists();
+    assert.dom(screen.getByText(t('pages.download-session-results.errors.invalid-token'))).exists();
   });
 
   test('should trigger the download', async function (assert) {

--- a/mon-pix/tests/integration/components/user-certifications-detail-header-test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-header-test.js
@@ -330,7 +330,7 @@ module('Integration | Component | user certifications detail header', function (
   });
 
   module('when there is an error during the download of the attestation', function () {
-    test('should show the error message', async function (assert) {
+    test('should show the common error message', async function (assert) {
       // given
       const fileSaverSaveStub = sinon.stub();
 
@@ -366,7 +366,7 @@ module('Integration | Component | user certifications detail header', function (
       await click(screen.getByRole('button', { name: 'Télécharger mon attestation' }));
 
       // then
-      assert.ok(screen.getByText('an error message'));
+      assert.ok(screen.getByText('Une erreur est survenue. Veuillez recommencer ou contacter le support.'));
     });
   });
 });

--- a/mon-pix/tests/unit/services/file-saver-test.js
+++ b/mon-pix/tests/unit/services/file-saver-test.js
@@ -155,25 +155,24 @@ module('Unit | Service | file-saver', function (hooks) {
     });
 
     module('when the response is an error', function () {
-      test('should throw an error with the response error detail as message', async function (assert) {
+      test('should throw', async function (assert) {
         // given
         jsonStub.resolves({ errors: [{ detail: 'the error message' }] });
         const response = { ok: false, json: jsonStub };
         fetchStub = sinon.stub().resolves(response);
 
         // when
-        try {
-          await fileSaver.save({
-            url,
-            fileName: defaultFileName,
-            token,
-            fetcher: fetchStub,
-            downloadFileForIEBrowser: downloadFileForIEBrowserStub,
-            downloadFileForModernBrowsers: downloadFileForModernBrowsersStub,
-          });
-        } catch (error) {
-          assert.strictEqual(error.message, 'the error message');
-        }
+        const promise = fileSaver.save({
+          url,
+          fileName: defaultFileName,
+          token,
+          fetcher: fetchStub,
+          downloadFileForIEBrowser: downloadFileForIEBrowserStub,
+          downloadFileForModernBrowsers: downloadFileForModernBrowsersStub,
+        });
+
+        // then
+        assert.rejects(promise);
       });
     });
   });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1267,7 +1267,7 @@
         "label": "Download results"
       },
       "errors": {
-        "expiration": "The session results download link has expired."
+        "invalid-token": "The session results download link is invalid."
       },
       "title": "Download session results"
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1267,7 +1267,7 @@
         "label": "Télécharger les résultats"
       },
       "errors": {
-        "expiration": "Le lien de téléchargement des résultats de session a expiré."
+        "invalid-token": "Le lien de téléchargement des résultats de session est invalide."
       },
       "title": "Télécharger les résultats de session"
     },


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, un seul message d'erreur était affiché en cas d'erreur lors du téléchargement.
Or on veut pouvoir distinguer un problème interne d'un problème de token erroné ou périmé.

## :gift: Proposition

Améliorer la gestion d'erreur

## :socks: Remarques
La gestion du decode token ne permet pas de distinguer un token invalide (tronqué ou faux) d'un token périmé (expiration dépassé) on garde donc un seul message d'erreur pour les deux cas de figure.

Le `fileSaver` jetait une `Error` avec le détails de l'erreur,  un besoin spécifique lorsqu'il a été implémenté pour le téléchargement de l'attestation PDF de la certification.
Or il y a deux problèmes : 
- Dépendre du `details` de l'erreur API n'est pas idéal. Le message n'est pas traduit et il peut évoquer des détails techniques que l'utilisateur ne va pas comprendre.
- Retourner le détail est très spécifique, si on veut rendre l'usage du fileSaver plus générique, il faut à minima que l'on retourne toute l'erreur et les fonctionnalités traiteront de leur coté leurs besoin.

Le fileSave est actuellement utilisé par 3 fonctionnalités : 
- Coté Evaluation (1) et coté Certif (2 => attestation PDF et CSV des résultats).

Coté Evaluation, on ne fait rien de ce qui est jeté par l'API lors d'une erreur => notre modification n'a donc pas d'impact pour eux.

Coté Certif, sur l'attestation PDF, on affichait directement le détails jeté par l'API (ou le navigateur !) => on doit modifier la gestion d'erreur.

## :santa: Pour tester


Non régression pour l'attestation PDF : 

- Se connecter sur Pix App avec certif-success@example.net
- https://app-pr10743.review.pix.fr/mes-certifications/153005

| AVANT | APRÈS | 
|--------|--------|
| <img width="815" alt="Capture d’écran 2024-12-06 à 12 55 06" src="https://github.com/user-attachments/assets/9a302b2c-80f6-46a3-bf4d-e1c3882592d2"> | <img width="815" alt="Capture d’écran 2024-12-06 à 12 54 08" src="https://github.com/user-attachments/assets/c1c49342-e922-4501-9b68-432654da6c51"> |


Non régression pour le téléchargement : 

https://app-pr10743.review.pix.fr/resultats-session