### PR TITLE
[BUGFIX] Ne plus retourner de 500 lors de la consultation de learner d'organization ayant l'import à format (Pix-15610)

### DIFF
--- a/api/src/prescription/learner-management/domain/read-models/OrganizationLearnerForAdmin.js
+++ b/api/src/prescription/learner-management/domain/read-models/OrganizationLearnerForAdmin.js
@@ -58,13 +58,15 @@ class OrganizationLearnerForAdmin {
   }
 
   updateDivisionAndBirthdate({ additionalInformations, additionalColumns }) {
-    const dateOfBirthColumn = additionalColumns.find((column) => column.name === IMPORT_KEY_FIELD.COMMON_BIRTHDATE);
-    if (dateOfBirthColumn) {
-      this.birthdate = additionalInformations[dateOfBirthColumn.key];
-    }
-    const divisionColumn = additionalColumns.find((column) => column.name === IMPORT_KEY_FIELD.COMMON_DIVISION);
-    if (divisionColumn) {
-      this.division = additionalInformations[divisionColumn.key];
+    if (additionalInformations) {
+      const dateOfBirthColumn = additionalColumns.find((column) => column.name === IMPORT_KEY_FIELD.COMMON_BIRTHDATE);
+      if (dateOfBirthColumn) {
+        this.birthdate = additionalInformations[dateOfBirthColumn.key];
+      }
+      const divisionColumn = additionalColumns.find((column) => column.name === IMPORT_KEY_FIELD.COMMON_DIVISION);
+      if (divisionColumn) {
+        this.division = additionalInformations[divisionColumn.key];
+      }
     }
   }
 }

--- a/api/tests/prescription/learner-management/unit/domain/read-models/OrganizationLearnerForAdmin_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/read-models/OrganizationLearnerForAdmin_test.js
@@ -29,23 +29,41 @@ describe('Unit | Domain | Read-models | OrganizationLearnerForAdmin', function (
       expect(() => new OrganizationLearnerForAdmin(validArguments)).not.to.throw(ObjectValidationError);
     });
 
-    it('should overide birthdate and division if additionalColumns and additionalInfos are given', function () {
-      const learner = new OrganizationLearnerForAdmin({
-        ...validArguments,
-        additionalColumns: [
-          {
-            name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE,
-            key: 'dateofbirth',
-          },
-          { name: IMPORT_KEY_FIELD.COMMON_DIVISION, key: 'groupe' },
-        ],
-        additionalInformations: {
-          groupe: 'CP',
-          dateofbirth: '2020-02-01',
-        },
+    describe('additionalColumns', function () {
+      it('should not throw when addtionalInformations is not defined', function () {
+        const learner = new OrganizationLearnerForAdmin({
+          ...validArguments,
+          additionalColumns: [
+            {
+              name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE,
+              key: 'dateofbirth',
+            },
+            { name: IMPORT_KEY_FIELD.COMMON_DIVISION, key: 'groupe' },
+          ],
+          additionalInformations: null,
+        });
+        expect(learner.division).to.equal('3A');
+        expect(learner.birthdate).to.deep.equal('2000-10-15');
       });
-      expect(learner.division).to.equal('CP');
-      expect(learner.birthdate).to.deep.equal('2020-02-01');
+
+      it('should overide birthdate and division if additionalColumns and additionalInfos are given', function () {
+        const learner = new OrganizationLearnerForAdmin({
+          ...validArguments,
+          additionalColumns: [
+            {
+              name: IMPORT_KEY_FIELD.COMMON_BIRTHDATE,
+              key: 'dateofbirth',
+            },
+            { name: IMPORT_KEY_FIELD.COMMON_DIVISION, key: 'groupe' },
+          ],
+          additionalInformations: {
+            groupe: 'CP',
+            dateofbirth: '2020-02-01',
+          },
+        });
+        expect(learner.division).to.equal('CP');
+        expect(learner.birthdate).to.deep.equal('2020-02-01');
+      });
     });
 
     it('should throw an ObjectValidationError when id is not valid', function () {


### PR DESCRIPTION
## :christmas_tree: Problème

Si une organization détient récupère l'import à format en court de vie. il est possible que des learners de cette organization n'ait donc aucune valeur spécial. ce qui pourrait engendrer des 500 sur les API côté Admin

## :gift: Proposition

Vérifier que l'on a des additionalInformations à mapper

## :socks: Remarques

RAS

## :santa: Pour tester

Participer à une campagne sur une orga sans import à format. lui ajouter l'import à format . Et vérifier que dans PixAdmin sur l'ancien compte réconcilié. nous avons bien la page qui s'affiche avec sa participation