### PR TITLE
[BUGFIX] Afficher les données de campagnes supprimées non anonymisé (PIX-15613)

### DIFF
--- a/api/src/prescription/campaign-participation/domain/models/CampaignParticipationForUserManagement.js
+++ b/api/src/prescription/campaign-participation/domain/models/CampaignParticipationForUserManagement.js
@@ -22,18 +22,15 @@ class CampaignParticipationForUserManagement {
     this.campaignCode = null;
     this.sharedAt = null;
     this.deletedAt = null;
+
     if (campaignParticipationId) {
-      if (!deletedAt) {
-        this.organizationLearnerFullName = `${organizationLearnerFirstName} ${organizationLearnerLastName}`;
-        this.participantExternalId = participantExternalId;
-        this.status = status;
-        this.campaignId = campaignId;
-        this.campaignCode = campaignCode;
-        this.sharedAt = sharedAt;
-      } else {
-        this.organizationLearnerFullName = '-';
-        this.deletedAt = deletedAt;
-      }
+      this.organizationLearnerFullName = `${organizationLearnerFirstName} ${organizationLearnerLastName}`;
+      this.participantExternalId = participantExternalId;
+      this.status = status;
+      this.campaignId = campaignId;
+      this.campaignCode = campaignCode;
+      this.sharedAt = sharedAt;
+      this.deletedAt = deletedAt;
     } else {
       this.organizationLearnerFullName = '-';
       this.deletedAt = updatedAt;

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/participations-for-user-management-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/participations-for-user-management-repository_test.js
@@ -146,16 +146,17 @@ describe('Integration | Repository | Participations-For-User-Management', functi
           expect(participationsForUserManagement[0]).to.deep.includes({
             id: assessment.id,
             campaignParticipationId: campaignParticipation.id,
-            participantExternalId: null,
-            status: null,
+            participantExternalId: campaignParticipation.participantExternalId,
+            status: SHARED,
             createdAt: assessment.createdAt,
-            sharedAt: null,
-            campaignId: null,
-            campaignCode: null,
+            sharedAt: campaignParticipation.sharedAt,
+            campaignId: campaign.id,
+            campaignCode: campaign.code,
             deletedAt: campaignParticipation.deletedAt,
-            organizationLearnerFullName: '-',
+            organizationLearnerFullName: `${organizationLearner.firstName} ${organizationLearner.lastName}`,
           });
         });
+
         it('should return participation is deleted and anonymized', async function () {
           // given
           const assessment = databaseBuilder.factory.buildAssessment({

--- a/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipationForUserManagement_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipationForUserManagement_test.js
@@ -1,0 +1,67 @@
+import { CampaignParticipationForUserManagement } from '../../../../../../src/prescription/campaign-participation/domain/models/CampaignParticipationForUserManagement.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | Domain | Models | CampaignParticipationForUserManagement', function () {
+  describe('#constructor', function () {
+    it('should not return campaign participation informations when campaignParticipationId is missing', function () {
+      // given
+      const campaignParticipation = new CampaignParticipationForUserManagement({
+        id: 1,
+        campaignParticipationId: null,
+        participantExternalId: 'externalId',
+        status: 'TOTO',
+        campaignId: 3,
+        campaignCode: 'AZERTY',
+        createdAt: new Date('2020-01-01'),
+        sharedAt: new Date('2022-01-01'),
+        updatedAt: new Date('2022-01-01'),
+        deletedAt: new Date('2023-01-01'),
+        organizationLearnerFirstName: 'Jean',
+        organizationLearnerLastName: 'Meuh',
+      });
+
+      // then
+      expect(campaignParticipation.id).to.be.deep.equals(1);
+      expect(campaignParticipation.createdAt).to.be.deep.equals(new Date('2020-01-01'));
+      expect(campaignParticipation.deletedAt).to.be.deep.equals(new Date('2022-01-01'));
+      expect(campaignParticipation.organizationLearnerFullName).to.be.equals('-');
+
+      expect(campaignParticipation.campaignParticipationId).to.be.null;
+      expect(campaignParticipation.participantExternalId).to.be.null;
+      expect(campaignParticipation.status).to.be.null;
+      expect(campaignParticipation.campaignId).to.be.null;
+      expect(campaignParticipation.campaignCode).to.be.null;
+      expect(campaignParticipation.sharedAt).to.be.null;
+      expect(campaignParticipation.status).to.be.null;
+    });
+
+    it('should campaign participation informations when campaignParticipationId existing', function () {
+      // given
+      const campaignParticipation = new CampaignParticipationForUserManagement({
+        id: 1,
+        campaignParticipationId: 18,
+        participantExternalId: 'externalId',
+        status: 'TOTO',
+        campaignId: 3,
+        campaignCode: 'AZERTY',
+        createdAt: new Date('2020-01-01'),
+        sharedAt: new Date('2022-01-01'),
+        updatedAt: new Date('2022-01-01'),
+        deletedAt: new Date('2023-01-01'),
+        organizationLearnerFirstName: 'Jean',
+        organizationLearnerLastName: 'Meuh',
+      });
+
+      // thenid: 1,
+      expect(campaignParticipation.campaignParticipationId).to.be.equals(18);
+      expect(campaignParticipation.participantExternalId).to.be.equals('externalId');
+      expect(campaignParticipation.status).to.be.equals('TOTO');
+      expect(campaignParticipation.campaignId).to.be.equals(3);
+      expect(campaignParticipation.campaignCode).to.be.equals('AZERTY');
+      expect(campaignParticipation.createdAt).to.be.deep.equals(new Date('2020-01-01'));
+      expect(campaignParticipation.sharedAt).to.be.deep.equals(new Date('2022-01-01'));
+      expect(campaignParticipation.deletedAt).to.be.deep.equals(new Date('2023-01-01'));
+      expect(campaignParticipation.organizationLearnerFullName).to.be.equals('Jean Meuh');
+    });
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème

Nous sommes allée un peu vite en besogne, il n'est pas encore demandé de ne pas afficher les données d'une campagne supprimé tant qu'elle ne sont pas anonymisé afin de pouvoir faire la distinction des deux

## :gift: Proposition

Afficher les données de la campagne participation tant qu'elle sont accessible

## :socks: Remarques
RAS

## :santa: Pour tester
Supprimer une participation non anonymiser et vérifier qu'elle est toujours disponible
CI au vert