### PR TITLE
[BUGFIX] Suppression des doublons de réponses lors de l'appel à /next (PIX-15561).

### DIFF
--- a/api/src/shared/infrastructure/repositories/answer-repository.js
+++ b/api/src/shared/infrastructure/repositories/answer-repository.js
@@ -83,10 +83,16 @@ const findByAssessment = async function (assessmentId) {
 
 const findByAssessmentExcludingChallengeIds = async function ({ assessmentId, excludedChallengeIds = [] }) {
   const answerDTOs = await knex
-    .select(COLUMNS)
-    .from('answers')
-    .where({ assessmentId })
-    .whereNotIn('challengeId', excludedChallengeIds);
+    .with('all-first-answers', (qb) => {
+      qb.select('*')
+        .distinctOn('challengeId', 'assessmentId')
+        .from('answers')
+        .where({ assessmentId })
+        .whereNotIn('challengeId', excludedChallengeIds)
+        .orderBy(['challengeId', 'assessmentId', 'createdAt']);
+    })
+    .from('all-first-answers')
+    .orderBy('all-first-answers.createdAt');
 
   return _toDomainArray(answerDTOs);
 };


### PR DESCRIPTION
## :christmas_tree: Problème

La PR #10673 a introduit une régression.
En effet, une suppression des doublons de réponses existant en BDD a été retirée de la requête de recherche de réponses.
Cette suppression a entraîné des erreurs en production à cause d'un nombre trop important de réponses par rapport au nombre de questions posées au candidat.

## :gift: Proposition

On réintroduit cette recherche de réponses uniques, non plus à l'aide de lodash comme cela était le cas, mais en SQL

## :socks: Remarques

Pour verifier le plan d'execution de la nouvelle requete SQL 

```sql
EXPLAIN ANALYZE with "all-first-answers" as (
select distinct on ("challengeId", "assessmentId") * 
from "answers" 
where "assessmentId" = 139227 
order by "challengeId" asc, "assessmentId" asc, "createdAt" asc
) select * from "all-first-answers" order by "all-first-answers"."createdAt" asc;
```


## :santa: Pour tester

- Créer une session V3
- dès la première question, récupérer l'id du challenge
- En BDD, créer deux nouvelles ligne dans la table answers avec le couple `assessmentId` - `challengeId` correspondant
- Actualiser la page du challenge (question 1 normalement)
- Un nouvelle question devrait apparaitre sans erreur, et le test peut s'enchainer.