### PR TITLE
[FEATURE] Afficher les statistiques dans Pix Orga (PIX-15455)

### DIFF
--- a/api/src/prescription/organization-learner/application/organization-learners-controller.js
+++ b/api/src/prescription/organization-learner/application/organization-learners-controller.js
@@ -1,5 +1,6 @@
 import { NoProfileRewardsFoundError } from '../../../profile/domain/errors.js';
 import { usecases } from '../domain/usecases/index.js';
+import * as analysisByTubesSerializer from '../infrastructure/serializers/jsonapi/analysis-by-tubes-serializer.js';
 
 const getAttestationZipForDivisions = async function (request, h) {
   const organizationId = request.params.organizationId;
@@ -17,10 +18,11 @@ const getAttestationZipForDivisions = async function (request, h) {
   }
 };
 
-const getAnalysisByTubes = async function (request, h) {
+const getAnalysisByTubes = async function (request, h, dependencies = { analysisByTubesSerializer }) {
   const organizationId = request.params.organizationId;
   const result = await usecases.getAnalysisByTubes({ organizationId });
-  return h.response(result).code(200);
+  const serializedResult = dependencies.analysisByTubesSerializer.serialize(result);
+  return h.response(serializedResult).code(200);
 };
 
 const organizationLearnersController = {

--- a/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/analysis-by-tubes-serializer.js
+++ b/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/analysis-by-tubes-serializer.js
@@ -1,0 +1,19 @@
+import { randomUUID } from 'node:crypto';
+
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (analysisByTubes) {
+  return new Serializer('analysis-by-tubes', {
+    transform(analysisByTubes) {
+      return {
+        id: randomUUID(),
+        ...analysisByTubes,
+      };
+    },
+    attributes: ['data'],
+  }).serialize(analysisByTubes);
+};
+
+export { serialize };

--- a/api/tests/prescription/organization-learner/acceptance/application/organization-learner-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/application/organization-learner-route_test.js
@@ -109,11 +109,16 @@ describe('Prescription | Organization Learner | Acceptance | Application | Organ
         const response = await server.inject(options);
 
         // then
+        const expectedResult = {
+          data: {
+            attributes: {
+              data: 'expected-data',
+            },
+            type: 'analysis-by-tubes',
+          },
+        };
         expect(response.statusCode).to.equal(200);
-        expect(response.result).to.deep.equal({
-          data: expectedData,
-          status: 'success',
-        });
+        expect(response.result.data).to.deep.includes(expectedResult.data);
       });
     });
   });

--- a/api/tests/prescription/organization-learner/unit/application/organization-learners-controller_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/organization-learners-controller_test.js
@@ -98,13 +98,19 @@ describe('Unit | Application | Organization-Learner | organization-learners-cont
     });
   });
 
-  describe('#getLearnersLevelsByTubes', function () {
+  describe('#getAnalysisByTubes', function () {
     it('should return data', async function () {
       // given
       const organizationId = 123;
 
+      const useCaseResult = Symbol('use-case-result');
       sinon.stub(usecases, 'getAnalysisByTubes');
-      usecases.getAnalysisByTubes.withArgs({ organizationId }).resolves();
+      usecases.getAnalysisByTubes.withArgs({ organizationId }).resolves(useCaseResult);
+      const analysisByTubesSerializer = {
+        serialize: sinon.stub(),
+      };
+      const expectedResult = Symbol('expected-result');
+      analysisByTubesSerializer.serialize.withArgs(useCaseResult).returns(expectedResult);
 
       const request = {
         params: {
@@ -113,9 +119,12 @@ describe('Unit | Application | Organization-Learner | organization-learners-cont
       };
 
       // when
-      const response = await organizationLearnersController.getAnalysisByTubes(request, hFake);
+      const response = await organizationLearnersController.getAnalysisByTubes(request, hFake, {
+        analysisByTubesSerializer,
+      });
 
       // then
+      expect(response.source).to.equal(expectedResult);
       expect(response.statusCode).to.equal(200);
     });
   });

--- a/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/analysis-by-tubes-serializer_test.js
+++ b/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/analysis-by-tubes-serializer_test.js
@@ -1,0 +1,21 @@
+import * as serializer from '../../../../../../../src/prescription/organization-learner/infrastructure/serializers/jsonapi/analysis-by-tubes-serializer.js';
+import { expect } from '../../../../../../test-helper.js';
+
+describe('Unit | Serializer | JSONAPI | analysis-by-tubes-serializer', function () {
+  describe('#serialize', function () {
+    it('should convert an analysis-by-tubes object into JSON API data', function () {
+      // given
+      const analysisByTubes = { data: [{}] };
+      const expectedType = 'analysis-by-tubes';
+      const expectedData = analysisByTubes.data;
+
+      // when
+      const json = serializer.serialize(analysisByTubes);
+
+      // then
+      expect(json.data.type).to.equal(expectedType);
+      expect(json.data.attributes.data).to.deep.equal(expectedData);
+      expect(json.data.id).to.exist;
+    });
+  });
+});

--- a/orga/app/adapters/analysis-by-tube.js
+++ b/orga/app/adapters/analysis-by-tube.js
@@ -1,0 +1,10 @@
+import ApplicationAdapter from './application';
+
+export default class AnalysisByTubeAdapter extends ApplicationAdapter {
+  urlForQueryRecord(query) {
+    const { organizationId } = query;
+    delete query.organizationId;
+
+    return `${this.host}/${this.namespace}/organizations/${organizationId}/organization-learners-level-by-tubes`;
+  }
+}

--- a/orga/app/components/layout/sidebar.gjs
+++ b/orga/app/components/layout/sidebar.gjs
@@ -122,15 +122,15 @@ export default class SidebarMenu extends Component {
           {{t "navigation.main.team"}}
         </PixNavigationButton>
 
-        {{#if this.shouldDisplayStatisticsEntry}}
-          <PixNavigationButton @route="authenticated.statistics" @icon="monitoring">
-            {{t "navigation.main.statistics"}}
-          </PixNavigationButton>
-        {{/if}}
-
         {{#if this.shouldDisplayPlacesEntry}}
           <PixNavigationButton @route="authenticated.places" @icon="seat">
             {{t "navigation.main.places"}}
+          </PixNavigationButton>
+        {{/if}}
+
+        {{#if this.shouldDisplayStatisticsEntry}}
+          <PixNavigationButton @route="authenticated.statistics" @icon="monitoring">
+            {{t "navigation.main.statistics"}}
           </PixNavigationButton>
         {{/if}}
 

--- a/orga/app/components/statistics/cover-rate-gauge.gjs
+++ b/orga/app/components/statistics/cover-rate-gauge.gjs
@@ -1,0 +1,69 @@
+import { guidFor } from '@ember/object/internals';
+import { htmlSafe } from '@ember/template';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+
+const MAX_REACHABLE_LEVEL = 7;
+
+export default class CoverRateGauge extends Component {
+  get id() {
+    return guidFor(this);
+  }
+
+  get userLevel() {
+    return this.formatNumber(this.args.userLevel);
+  }
+
+  get tubeLevel() {
+    return this.formatNumber(this.args.tubeLevel);
+  }
+
+  formatNumber = (str) => {
+    const num = Number(str);
+    const oneDigitNum = num.toFixed(1);
+    if (oneDigitNum.toString().endsWith('0')) {
+      return Math.ceil(num);
+    }
+    return oneDigitNum;
+  };
+
+  getGaugeSizeStyle = (level, { withExtraPercentage }) => {
+    const gaugeSize = (level / MAX_REACHABLE_LEVEL) * 100;
+    return htmlSafe(`width: calc(${gaugeSize}% + ${withExtraPercentage ? 5 : 0}%)`);
+  };
+
+  <template>
+    <div class="cover-rate-gauge">
+      <div class="cover-rate-gauge__container">
+        <div
+          class="cover-rate-gauge__level cover-rate-gauge__level--tube-level"
+          style={{this.getGaugeSizeStyle this.tubeLevel withExtraPercentage=true}}
+        >
+          {{this.tubeLevel}}
+        </div>
+        <div class="cover-rate-gauge__background">
+          <label for={{this.id}} class="screen-reader-only">{{t
+              "pages.statistics.gauge.label"
+              userLevel=this.userLevel
+              tubeLevel=this.tubeLevel
+            }}</label>
+          <progress
+            class="cover-rate-gauge__progress"
+            id={{this.id}}
+            max={{this.tubeLevel}}
+            value={{this.userLevel}}
+            style={{this.getGaugeSizeStyle this.tubeLevel withExtraPercentage=false}}
+          >
+            {{this.userLevel}}
+          </progress>
+        </div>
+        <div
+          class="cover-rate-gauge__level cover-rate-gauge__level--user-level"
+          style={{this.getGaugeSizeStyle this.userLevel withExtraPercentage=true}}
+        >
+          {{this.userLevel}}
+        </div>
+      </div>
+    </div>
+  </template>
+}

--- a/orga/app/components/statistics/index.gjs
+++ b/orga/app/components/statistics/index.gjs
@@ -1,0 +1,47 @@
+import { t } from 'ember-intl';
+
+import Header from '../table/header';
+import CoverRateGauge from './cover-rate-gauge';
+import TagLevel from './tag-level';
+
+const analysisByTubes = (model) => {
+  return model.data.sort(
+    (a, b) => a.competence_code.localeCompare(b.competence_code) || a.sujet.localeCompare(b.sujet),
+  );
+};
+
+<template>
+  <div class="statistics-page__header">
+    <h1 class="page-title">{{t "pages.statistics.title"}}</h1>
+  </div>
+
+  <section class="statistics-page__section">
+    <table class="panel">
+      <caption class="screen-reader-only">{{t "pages.statistics.table.caption"}}</caption>
+      <thead>
+        <tr>
+          <Header @size="wide" scope="col">{{t "pages.statistics.table.headers.skills"}}</Header>
+          <Header @size="medium" scope="col">{{t "pages.statistics.table.headers.topics"}}</Header>
+          <Header @size="medium" @align="center" scope="col">{{t "pages.statistics.table.headers.positioning"}}</Header>
+          <Header @align="center" @size="medium" scope="col">{{t
+              "pages.statistics.table.headers.reached-level"
+            }}</Header>
+        </tr>
+      </thead>
+      <tbody>
+        {{#each (analysisByTubes @model) as |line|}}
+          <tr>
+            <td>{{line.competence_code}} {{line.competence}}</td>
+            <td>{{line.sujet}}</td>
+            <td>
+              <CoverRateGauge @userLevel={{line.niveau_par_user}} @tubeLevel={{line.niveau_par_sujet}} />
+            </td>
+            <td class="table__column--center">
+              <TagLevel @level={{line.niveau_par_user}} />
+            </td>
+          </tr>
+        {{/each}}
+      </tbody>
+    </table>
+  </section>
+</template>

--- a/orga/app/components/statistics/tag-level.gjs
+++ b/orga/app/components/statistics/tag-level.gjs
@@ -1,0 +1,23 @@
+import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+
+const MAX_LEVEL = {
+  novice: 3,
+  independent: 4,
+  advanced: 6,
+};
+
+export default class TagLevel extends Component {
+  get category() {
+    const parsedLevel = Math.ceil(parseFloat(this.args.level));
+    if (parsedLevel < MAX_LEVEL.novice) return 'pages.statistics.level.novice';
+    if (parsedLevel < MAX_LEVEL.independent) return 'pages.statistics.level.independent';
+    if (parsedLevel < MAX_LEVEL.advanced) return 'pages.statistics.level.advanced';
+    return 'pages.statistics.level.expert';
+  }
+
+  <template>
+    <PixTag>{{t this.category}}</PixTag>
+  </template>
+}

--- a/orga/app/models/analysis-by-tube.js
+++ b/orga/app/models/analysis-by-tube.js
@@ -1,0 +1,5 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class AnalysisByTube extends Model {
+  @attr() data;
+}

--- a/orga/app/routes/authenticated/statistics.js
+++ b/orga/app/routes/authenticated/statistics.js
@@ -4,10 +4,15 @@ import { service } from '@ember/service';
 export default class AuthenticatedStatisticsRoute extends Route {
   @service currentUser;
   @service router;
+  @service store;
 
   beforeModel() {
     if (!this.currentUser.canAccessStatisticsPage) {
       this.router.replaceWith('application');
     }
+  }
+
+  model() {
+    return this.store.queryRecord('analysis-by-tube', { organizationId: this.currentUser.organization.id });
   }
 }

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -51,6 +51,7 @@
 @import 'components/sup-organization-participant/replace-students-modal';
 @import 'components/import-banner';
 @import 'components/import-information-banner';
+@import 'components/statistics/cover-rate-gauge';
 
 // pages
 @import 'pages/login';

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -51,6 +51,7 @@
 @import 'components/sup-organization-participant/replace-students-modal';
 @import 'components/import-banner';
 @import 'components/import-information-banner';
+@import 'components/statistics';
 @import 'components/statistics/cover-rate-gauge';
 
 // pages

--- a/orga/app/styles/components/statistics.scss
+++ b/orga/app/styles/components/statistics.scss
@@ -1,0 +1,13 @@
+.statistics-page__header {
+  display: flex;
+  gap: var(--pix-spacing-2x);
+  align-items: baseline;
+}
+
+.statistics-page__section {
+  tbody > tr {
+    &:nth-child(odd) {
+      background-color: var(--pix-neutral-20);
+    }
+  }
+}

--- a/orga/app/styles/components/statistics/cover-rate-gauge.scss
+++ b/orga/app/styles/components/statistics/cover-rate-gauge.scss
@@ -1,0 +1,83 @@
+.cover-rate-gauge {
+  display: grid;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 3.5rem;
+}
+
+.cover-rate-gauge__container {
+  position: relative;
+  width: 8.875rem;
+
+  --gauge-height: 0.875rem;
+
+  height: var(--gauge-height);
+  color: var(--pix-neutral-500);
+  font-weight: var(--pix-font-medium);
+}
+
+.cover-rate-gauge__background {
+  display: grid;
+  align-items: center;
+  height: var(--gauge-height);
+  padding: 0 2px;
+  line-height: 20px;
+  background-color: rgba(var(--pix-neutral-900-inline), 0.1);
+  border-radius: 3.125rem;
+
+  --level-text-spacing-from-gauge: -12px;
+
+  &:before {
+    position: absolute;
+    left: var(--level-text-spacing-from-gauge);
+    content: '0';
+  }
+
+  &:after {
+    position: absolute;
+    right: var(--level-text-spacing-from-gauge);
+    content: '7';
+  }
+}
+
+.cover-rate-gauge__progress {
+  width: 100%;
+  height: 10px;
+  color: var(--pix-primary-300);
+  background-color: var(--pix-neutral-0);
+  border: none;
+
+  --gauge-border-radius: 1.625rem;
+
+  border-radius: var(--gauge-border-radius);
+
+  &::-webkit-progress-value {
+    background-color: var(--pix-primary-300);
+    border-radius: var(--gauge-border-radius);
+  }
+
+  &::-moz-progress-bar {
+    background-color: var(--pix-primary-300);
+    border-radius: var(--gauge-border-radius);
+  }
+
+  &::-webkit-progress-bar {
+    background-color: var(--pix-neutral-0);
+    border-radius: var(--gauge-border-radius);
+  }
+}
+
+.cover-rate-gauge__level {
+  position: absolute;
+  text-align: right;
+
+  &--user-level {
+    color: var(--pix-primary-500);
+  }
+
+  &--tube-level {
+    top: -20px;
+    color: var(--pix-neutral-800);
+  }
+}

--- a/orga/app/templates/authenticated/statistics.hbs
+++ b/orga/app/templates/authenticated/statistics.hbs
@@ -1,0 +1,3 @@
+{{page-title (t "pages.statistics.title")}}
+
+<Statistics @model={{this.model}} />

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -276,6 +276,20 @@ function routes() {
 
   this.get('/organizations/:id/participants', findFilteredPaginatedOrganizationParticipants);
 
+  this.get('/organizations/:id/organization-learners-level-by-tubes', (schema) => {
+    return schema.analysisByTubes.create({
+      data: [
+        {
+          competence_code: '2.1',
+          competence: 'Interagir',
+          sujet: 'Gérer ses contacts',
+          niveau_par_user: '1.30',
+          niveau_par_sujet: '1.50',
+        },
+      ],
+    });
+  });
+
   this.get('/organization-learners/:id', (schema, request) => {
     const participantId = request.params.id;
 

--- a/orga/tests/acceptance/statistics-test.js
+++ b/orga/tests/acceptance/statistics-test.js
@@ -1,0 +1,44 @@
+import { visit } from '@1024pix/ember-testing-library';
+import { currentURL } from '@ember/test-helpers';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { t } from 'ember-intl/test-support';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import authenticateSession from '../helpers/authenticate-session';
+import setupIntl from '../helpers/setup-intl';
+import { createPrescriberForOrganization } from '../helpers/test-init';
+
+module('Acceptance | Statistics', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks);
+
+  module('When prescriber is not logged in', function () {
+    test('it should not be accessible by an unauthenticated prescriber', async function (assert) {
+      // when
+      await visit('/statistiques');
+
+      // then
+      assert.deepEqual(currentURL(), '/connexion');
+    });
+  });
+
+  module('When prescriber is logged in and has cover rate feature', function () {
+    test('user should access to page', async function (assert) {
+      // given
+      const user = createPrescriberForOrganization({ lang: 'fr', pixOrgaTermsOfServiceAccepted: true }, {}, 'ADMIN', {
+        COVER_RATE: true,
+      });
+      await authenticateSession(user.id);
+
+      // when
+      const screen = await visit('/statistiques');
+
+      // then
+      assert.ok(screen.getByRole('heading', { level: 1, name: t('pages.statistics.title') }));
+      assert.ok(screen.getByRole('table'));
+      assert.ok(screen.getAllByRole('cell'));
+    });
+  });
+});

--- a/orga/tests/integration/components/statistics/index-test.gjs
+++ b/orga/tests/integration/components/statistics/index-test.gjs
@@ -1,0 +1,62 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import Statistics from 'pix-orga/components/statistics/index';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Statistics | Index', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display title', async function (assert) {
+    //given
+    const model = {
+      data: [],
+    };
+
+    //when
+    const screen = await render(<template><Statistics @model={{model}} /></template>);
+
+    //then
+    assert.ok(screen.getByRole('heading', { name: t('pages.statistics.title'), level: 1 }));
+  });
+
+  test('it should display table headers', async function (assert) {
+    //given
+    const model = {
+      data: [],
+    };
+
+    //when
+    const screen = await render(<template><Statistics @model={{model}} /></template>);
+
+    //then
+    assert.ok(screen.getByRole('columnheader', { name: t('pages.statistics.table.headers.skills') }));
+    assert.ok(screen.getByRole('columnheader', { name: t('pages.statistics.table.headers.topics') }));
+    assert.ok(screen.getByRole('columnheader', { name: t('pages.statistics.table.headers.reached-level') }));
+    assert.ok(screen.getByRole('columnheader', { name: t('pages.statistics.table.headers.positioning') }));
+  });
+
+  test('it should display rows data', async function (assert) {
+    //given
+    const model = {
+      data: [
+        {
+          competence_code: '2.1',
+          competence: 'Interagir',
+          sujet: 'Gérer ses contacts',
+          niveau_par_user: '1.30',
+          niveau_par_sujet: '1.50',
+        },
+      ],
+    };
+
+    //when
+    const screen = await render(<template><Statistics @model={{model}} /></template>);
+
+    //then
+    assert.ok(screen.getByRole('cell', { name: '2.1 Interagir' }));
+    assert.ok(screen.getByRole('cell', { name: 'Gérer ses contacts' }));
+    assert.ok(screen.getByRole('cell', { name: t('pages.statistics.level.novice') }));
+  });
+});

--- a/orga/tests/integration/components/statistics/tag-level-test.gjs
+++ b/orga/tests/integration/components/statistics/tag-level-test.gjs
@@ -1,0 +1,53 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import TagLevel from 'pix-orga/components/statistics/tag-level';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Statistics | TagLevel', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('#get category', function () {
+    test('when level is lower than 3 it should return novice', async function (assert) {
+      //given
+      const level = 2;
+
+      //when
+      const screen = await render(<template><TagLevel @level={{level}} /></template>);
+
+      //then
+      assert.ok(screen.getByText(t('pages.statistics.level.novice')));
+    });
+    test('when level is lower than 4 it should return independent', async function (assert) {
+      //given
+      const level = 3;
+
+      //when
+      const screen = await render(<template><TagLevel @level={{level}} /></template>);
+
+      //then
+      assert.ok(screen.getByText(t('pages.statistics.level.independent')));
+    });
+    test('when level is lower than 6 it should return advanced', async function (assert) {
+      //given
+      const level = 5;
+
+      //when
+      const screen = await render(<template><TagLevel @level={{level}} /></template>);
+
+      //then
+      assert.ok(screen.getByText(t('pages.statistics.level.advanced')));
+    });
+    test('when level is upper than 6 it should return expert', async function (assert) {
+      //given
+      const level = 7;
+
+      //when
+      const screen = await render(<template><TagLevel @level={{level}} /></template>);
+
+      //then
+      assert.ok(screen.getByText(t('pages.statistics.level.expert')));
+    });
+  });
+});

--- a/orga/tests/unit/adapters/analysis-by-tube-test.js
+++ b/orga/tests/unit/adapters/analysis-by-tube-test.js
@@ -1,0 +1,25 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Adapters | analysis-by-tube', function (hooks) {
+  setupTest(hooks);
+
+  let adapter;
+
+  hooks.beforeEach(function () {
+    adapter = this.owner.lookup('adapter:analysis-by-tube');
+    adapter.ajax = sinon.stub().resolves();
+  });
+
+  module('#urlForQueryRecord', () => {
+    test('should build query url from organizationId', async function (assert) {
+      const organizationId = 'organizationId';
+      const query = { organizationId };
+      const url = await adapter.urlForQueryRecord(query);
+
+      assert.ok(url.endsWith(`api/organizations/${organizationId}/organization-learners-level-by-tubes`));
+      assert.strictEqual(query.organizationId, undefined);
+    });
+  });
+});

--- a/orga/tests/unit/routes/authenticated/statistics-test.js
+++ b/orga/tests/unit/routes/authenticated/statistics-test.js
@@ -43,4 +43,27 @@ module('Unit | Route | authenticated/statistics', function (hooks) {
       assert.ok(route.router.replaceWith.calledWith(expectedRedirection));
     });
   });
+
+  module('model', function () {
+    test('fetch analysis by tubes data', async function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/statistics');
+      const store = this.owner.lookup('service:store');
+
+      const organizationId = Symbol('organization-id');
+      const analysisByTubes = Symbol('analysis-by-tubes');
+
+      route.currentUser = { organization: { id: organizationId } };
+
+      const queryRecord = sinon.stub(store, 'queryRecord');
+
+      queryRecord.withArgs('analysis-by-tube', { organizationId }).resolves(analysisByTubes);
+
+      // when
+      const result = await route.model();
+
+      // then
+      assert.deepEqual(result, analysisByTubes);
+    });
+  });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1461,6 +1461,14 @@
         "row-title": "Student"
       }
     },
+    "statistics": {
+      "level": {
+        "advanced": "advanced",
+        "expert": "expert",
+        "independent": "independent",
+        "novice": "novice"
+      }
+    },
     "sup-organization-participant-activity": {
       "title": "Student activity"
     },

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1462,6 +1462,9 @@
       }
     },
     "statistics": {
+      "gauge": {
+        "label": "On the topic, your participants achieved a level of {userLevel} out of a maximum reachable level of {tubeLevel}."
+      },
       "level": {
         "advanced": "advanced",
         "expert": "expert",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1462,6 +1462,7 @@
       }
     },
     "statistics": {
+      "title": "Statistics",
       "gauge": {
         "label": "On the topic, your participants achieved a level of {userLevel} out of a maximum reachable level of {tubeLevel}."
       },
@@ -1470,6 +1471,15 @@
         "expert": "expert",
         "independent": "independent",
         "novice": "novice"
+      },
+      "table": {
+        "caption": "This table displays the analysis of all participants' results by topic. For each line, it shows the skill, the topic, the coverage rate and the level achieved.",
+        "headers": {
+          "positioning": "Positioning",
+          "reached-level": "Reached level",
+          "skills": "Skills",
+          "topics": "Topics"
+        }
       }
     },
     "sup-organization-participant-activity": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1468,6 +1468,9 @@
       }
     },
     "statistics": {
+      "gauge": {
+        "label": "Sur le sujet vos participants ont obtenu un niveau de {userLevel} sur un niveau maximum atteignable de {tubeLevel}."
+      },
       "level": {
         "advanced": "avancé",
         "expert": "expert",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1468,6 +1468,7 @@
       }
     },
     "statistics": {
+      "title": "Statistiques",
       "gauge": {
         "label": "Sur le sujet vos participants ont obtenu un niveau de {userLevel} sur un niveau maximum atteignable de {tubeLevel}."
       },
@@ -1476,6 +1477,15 @@
         "expert": "expert",
         "independent": "indépendant",
         "novice": "novice"
+      },
+      "table": {
+        "caption": "Ce tableau affiche l'analyse des résultats de tous les participants par sujets. Il indique pour chaque ligne la compétence, le sujet, le taux de couverture ainsi que le niveau atteint",
+        "headers": {
+          "positioning": "Positionnement",
+          "reached-level": "Niveau atteint",
+          "skills": "Compétences",
+          "topics": "Sujets"
+        }
       }
     },
     "sup-organization-participant-activity": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1467,6 +1467,14 @@
         "row-title": "Élève"
       }
     },
+    "statistics": {
+      "level": {
+        "advanced": "avancé",
+        "expert": "expert",
+        "independent": "indépendant",
+        "novice": "novice"
+      }
+    },
     "sup-organization-participant-activity": {
       "title": "Activité de l'étudiant"
     },

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1461,6 +1461,14 @@
       },
       "title": "{count, plural, =0 {Studenten} =1 {Studenten ({count})} other {studenten ({count})}}"
     },
+    "statistics": {
+      "level": {
+        "advanced": "geavanceerd",
+        "expert": "expert",
+        "independent": "onafhankelijk",
+        "novice": "beginnende"
+      }
+    },
     "sup-organization-participant-activity": {
       "title": "Activiteit van de student"
     },

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1462,6 +1462,9 @@
       "title": "{count, plural, =0 {Studenten} =1 {Studenten ({count})} other {studenten ({count})}}"
     },
     "statistics": {
+      "gauge": {
+        "label": "Je deelnemers behaalden een {userLevel} op een maximaal haalbaar niveau van {tubeLevel}."
+      },
       "level": {
         "advanced": "geavanceerd",
         "expert": "expert",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1462,6 +1462,7 @@
       "title": "{count, plural, =0 {Studenten} =1 {Studenten ({count})} other {studenten ({count})}}"
     },
     "statistics": {
+      "title": "Statistieken",
       "gauge": {
         "label": "Je deelnemers behaalden een {userLevel} op een maximaal haalbaar niveau van {tubeLevel}."
       },
@@ -1470,6 +1471,15 @@
         "expert": "expert",
         "independent": "onafhankelijk",
         "novice": "beginnende"
+      },
+      "table": {
+        "caption": "Deze tabel toont de resultaten van alle deelnemers per onderwerp. Voor elke regel wordt de vaardigheid, het onderwerp, het dekkingspercentage en het behaalde niveau aangegeven.",
+        "headers": {
+          "positioning": "positionering",
+          "reached-level": "Bereikt niveau",
+          "skills": "Vaardigheden",
+          "topics": "Onderwerpen"
+        }
       }
     },
     "sup-organization-participant-activity": {


### PR DESCRIPTION
## :christmas_tree: Problème
Nous avons créé précédemment la page statistiques, mais elle ne comporte aucune info

## :gift: Proposition
Afficher un titre, ainsi qu'un tableau avec les données que nous récupérons dans cette page

## :socks: Remarques
On a fait le choix pour l'instant de laisser la même couleur pour les fonds des tags. A voir ultérieurement avec le design ce qu'on peut en faire

## :santa: Pour tester
- Se connecter avec `admin-orga@example.net`
- Aller sur l'organisation Pro Classic
- Aller sur la page "Statistiques"
- Vérifier l'afffichage du titre
- Vérifier l'affichage du tableau ( headers + contenu )