### PR TITLE
[TECH] attend la deconnexion dans le hook After (Pix-15599)

### DIFF
--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -74,8 +74,8 @@ afterEach(function () {
   return databaseBuilder.clean();
 });
 
-after(function () {
-  return disconnect();
+after(async function () {
+  return await disconnect();
 });
 
 /* eslint-enable mocha/no-top-level-hooks */


### PR DESCRIPTION
## :christmas_tree: Problème

Il semblerait qu'on ait un flaky. 

## :gift: Proposition
Le message parle du hook AfterAll sur un fichier.
En regardant le fichier, on voit qu'il utilise fakeTimers mais après investigation, l'utilisation de fakeTimers semble ok (similaire à beaucoup d'autre fichier. Prochain candidat le hook after definit dans la config de test. celui ci retourne un promesse mais la fonction n'est pas marquée comme `async` ce qui semble correspondre à notre erreur.

## :socks: Remarques

En chemin, on est tombé sur un flaky (mais pas réussi à la reproduire en lançant seulement le fichier :'(
Le problème vient de l'ordre d'insertion qui n'est pas garanti
```
  1) Integration | Application | stage-collection-controller
       update
         should modify stage collection according to the request:

      AssertionError: expected [ { id: 9, level: 2, …(6) }, …(3) ] to have the same members as [ { id: 10, level: 2, …(6) }, …(3) ]
      + expected - actual

       [
         {
      -    "id": 9
      +    "id": 10
           "isFirstSkill": false
           "level": 2
           "message": "Palier niveau 2 message"
           "prescriberDescription": "Palier niveau 2 description prescripteur"
--
           "threshold": [null]
           "title": "Palier niveau 2 titre"
         }
         {
      -    "id": 10
      +    "id": 9
           "isFirstSkill": true
           "level": [null]
           "message": "Palier premier acquis message"
           "prescriberDescription": "Palier premier acquis description prescripteur"
      
      at Context.<anonymous> (file:///Users/breduillieardlionel/code/pix/api/tests/evaluation/integration/application/stage-collections/stage-collection-controller_test.js:120:49)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```
 

## :santa: Pour tester
RAS
