### PR TITLE
[TECH] Utiliser le type error sur les PixNotificationAlert.

### DIFF
--- a/admin/app/components/administration/common/learning-content.gjs
+++ b/admin/app/components/administration/common/learning-content.gjs
@@ -41,7 +41,7 @@ export default class LearningContent extends Component {
         <p>Une version du référentiel de données pédagogique est créée quotidiennement (vers 4h00) et le référentiel
           utilisé par l'application est mis à jour (vers 6h00).</p>
         <p>Si le cache a été vidé, il peut s’avérer utile ou nécessaire de recharger le référentiel.</p>
-        <PixNotificationAlert @type="alert" @withIcon={{true}}>
+        <PixNotificationAlert @type="error" @withIcon={{true}}>
           <strong>Attention !</strong>
           Le rechargement du référentiel est une opération risquée. Il est recommandé de ne l’effectuer qu’en cas de
           force majeure, accompagné d’un développeur ou d'une développeuse.

--- a/admin/app/components/login-form.gjs
+++ b/admin/app/components/login-form.gjs
@@ -94,19 +94,19 @@ export default class LoginForm extends Component {
           </LinkTo>
 
           {{#if @userShouldCreateAnAccount}}
-            <PixNotificationAlert @type="alert">
+            <PixNotificationAlert @type="error">
               Vous n'avez pas de compte Pix.
             </PixNotificationAlert>
           {{/if}}
 
           {{#if @unknownErrorHasOccured}}
-            <PixNotificationAlert @type="alert">
+            <PixNotificationAlert @type="error">
               Une erreur est survenue. Veuillez recommencer ou contacter les administrateurs de la plateforme.
             </PixNotificationAlert>
           {{/if}}
 
           {{#if @userShouldRequestAccess}}
-            <PixNotificationAlert @type="alert">
+            <PixNotificationAlert @type="error">
               Vous n'avez pas les droits pour vous connecter. Veuillez demander un accès aux administrateurs de la
               plateforme.
             </PixNotificationAlert>

--- a/orga/app/components/auth/register-form.hbs
+++ b/orga/app/components/auth/register-form.hbs
@@ -100,7 +100,7 @@
     </div>
 
     {{#if this.errorMessage}}
-      <PixNotificationAlert @type="alert">
+      <PixNotificationAlert @type="error">
         {{this.errorMessage}}
       </PixNotificationAlert>
     {{/if}}


### PR DESCRIPTION
## :christmas_tree: Problème
Le type, `alert`, a été déprécié sur Pix UI au profit de `error`. Depuis octobre, le type a été supprimé sur Pix UI mais des composants utilisent encore ce type.

## :gift: Proposition

Utiliser le type `error`.

## :socks: Remarques

Quel impact sur les `PixNotificationAlert` en type `alert` ?

L'impact est visuel, au lieu d'avoir une notification rouge, on a eu des notifications bleues car le type `info` (bleu) prend le relais quand le type indiqué est inconnu.

---

Deux PixMessage dans Pix App utilisent aussi le type alert mais c'est corrigé dans la PR de MAJ de Pix UI actuellement en review.

## :santa: Pour tester

Se rendre sur les pages concernées

Pix Orga : Message d'erreur sur le double mire de connexion suite à une invitation dans le formulaire de gauche _« Je m’inscris »_

Pix Admin : 

- Message d'erreur sur la page de connexion (avec la connexion Google !)
- Page du référentiel
