### PR TITLE
[BUGFIX] Permettre la finalisation des sessions ayant à la fois des certifications complétés et une raison d'abandon (PIX-15524).

### DIFF
--- a/api/src/certification/session-management/domain/usecases/finalize-session.js
+++ b/api/src/certification/session-management/domain/usecases/finalize-session.js
@@ -119,7 +119,10 @@ async function _removeAbortReasonFromCompletedCertificationCourses({
         sessionCertificationCourse.isCompleted()
       ) {
         sessionCertificationCourse.unabort();
-        await certificationCourseRepository.update({ certificationCourse: sessionCertificationCourse });
+        // do not use transaction so throwing error will not revert the session unabort
+        await certificationCourseRepository.updateWithoutTransaction({
+          certificationCourse: sessionCertificationCourse,
+        });
       }
     }
   }

--- a/api/src/certification/session-management/domain/usecases/finalize-session.js
+++ b/api/src/certification/session-management/domain/usecases/finalize-session.js
@@ -120,8 +120,9 @@ async function _removeAbortReasonFromCompletedCertificationCourses({
       ) {
         sessionCertificationCourse.unabort();
         // do not use transaction so throwing error will not revert the session unabort
-        await certificationCourseRepository.updateWithoutTransaction({
+        await certificationCourseRepository.update({
           certificationCourse: sessionCertificationCourse,
+          noTransaction: true,
         });
       }
     }

--- a/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
@@ -1,14 +1,14 @@
 import _ from 'lodash';
 
 import { knex } from '../../../../../db/knex-database-connection.js';
-import {
-  logErrorWithCorrelationIds,
-  logInfoWithCorrelationIds,
-} from '../../../../../src/shared/infrastructure/monitoring-tools.js';
 import { config } from '../../../../shared/config.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { Assessment } from '../../../../shared/domain/models/index.js';
+import {
+  logErrorWithCorrelationIds,
+  logInfoWithCorrelationIds,
+} from '../../../../shared/infrastructure/monitoring-tools.js';
 import { ComplementaryCertificationCourse } from '../../../session-management/domain/models/ComplementaryCertificationCourse.js';
 import { CertificationCourse } from '../../domain/models/CertificationCourse.js';
 import { CertificationIssueReport } from '../../domain/models/CertificationIssueReport.js';
@@ -202,17 +202,13 @@ async function findOneCertificationCourseByUserIdAndSessionId({ userId, sessionI
   });
 }
 
-async function updateWithoutTransaction({ certificationCourse }) {
-  return update({ certificationCourse, noTransaction: true });
-}
-
 async function update({ certificationCourse, noTransaction = false }) {
   const knexConn = noTransaction ? knex : DomainTransaction.getConnection();
 
   const certificationCourseData = _pickUpdatableProperties(certificationCourse);
 
   const nbOfUpdatedCertificationCourses = await knexConn('certification-courses')
-    .update(certificationCourseData)
+    .update({ ...certificationCourseData, updatedAt: new Date() })
     .where({ id: certificationCourseData.id });
 
   if (nbOfUpdatedCertificationCourses === 0) {
@@ -249,7 +245,6 @@ export {
   isVerificationCodeAvailable,
   save,
   update,
-  updateWithoutTransaction,
 };
 
 function _adaptModelToDb(certificationCourse) {

--- a/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
@@ -202,8 +202,12 @@ async function findOneCertificationCourseByUserIdAndSessionId({ userId, sessionI
   });
 }
 
-async function update({ certificationCourse }) {
-  const knexConn = DomainTransaction.getConnection();
+async function updateWithoutTransaction({ certificationCourse }) {
+  return update({ certificationCourse, noTransaction: true });
+}
+
+async function update({ certificationCourse, noTransaction = false }) {
+  const knexConn = noTransaction ? knex : DomainTransaction.getConnection();
 
   const certificationCourseData = _pickUpdatableProperties(certificationCourse);
 
@@ -245,6 +249,7 @@ export {
   isVerificationCodeAvailable,
   save,
   update,
+  updateWithoutTransaction,
 };
 
 function _adaptModelToDb(certificationCourse) {

--- a/api/tests/certification/session-management/integration/domain/usecases/finalize-session_test.js
+++ b/api/tests/certification/session-management/integration/domain/usecases/finalize-session_test.js
@@ -1,0 +1,30 @@
+import { SessionWithAbortReasonOnCompletedCertificationCourseError } from '../../../../../../src/certification/session-management/domain/errors.js';
+import { usecases } from '../../../../../../src/certification/session-management/domain/usecases/index.js';
+import { ABORT_REASONS } from '../../../../../../src/certification/shared/domain/models/CertificationCourse.js';
+import { catchErr, databaseBuilder, expect, knex } from '../../../../../test-helper.js';
+
+describe('Certification | Session Management | Integration | Domain | UseCase | Finalize Session ', function () {
+  context('When there is an abort reason for completed certification course', function () {
+    it('should throw an SessionWithAbortReasonOnCompletedCertificationCourseError error', async function () {
+      const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+        abortReason: ABORT_REASONS.CANDIDATE,
+        completedAt: new Date(),
+      });
+      await databaseBuilder.commit();
+      const certificationReports = [
+        { certificationCourseId: certificationCourse.id, abortReason: ABORT_REASONS.CANDIDATE },
+      ];
+
+      const err = await catchErr(usecases.finalizeSession)({
+        sessionId: certificationCourse.sessionId,
+        certificationReports,
+      });
+
+      expect(err).to.be.instanceOf(SessionWithAbortReasonOnCompletedCertificationCourseError);
+      const updatedCertificationCourse = await knex('certification-courses')
+        .where('id', certificationCourse.id)
+        .first();
+      expect(updatedCertificationCourse.abortReason).to.be.null;
+    });
+  });
+});

--- a/api/tests/certification/session-management/unit/domain/usecases/finalize-session_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/finalize-session_test.js
@@ -1,6 +1,5 @@
 import {
   SessionAlreadyFinalizedError,
-  SessionWithAbortReasonOnCompletedCertificationCourseError,
   SessionWithMissingAbortReasonError,
   SessionWithoutStartedCertificationError,
 } from '../../../../../../src/certification/session-management/domain/errors.js';
@@ -105,44 +104,6 @@ describe('Unit | UseCase | finalize-session', function () {
 
         // then
         expect(err).to.be.instanceOf(InvalidCertificationReportForFinalization);
-      });
-    });
-
-    context('When there is an abort reason for completed certification course', function () {
-      it('should throw an SessionWithAbortReasonOnCompletedCertificationCourseError error', async function () {
-        // given
-        const reportWithAbortReason = domainBuilder.buildCertificationReport({
-          abortReason: 'candidate',
-          certificationCourseId: 1234,
-        });
-        const certificationReports = [reportWithAbortReason];
-        const completedCertificationCourse = domainBuilder.buildCertificationCourse({
-          id: 1234,
-          abortReason: 'candidate',
-          completedAt: '2022-01-01',
-        });
-        sessionRepository.countUncompletedCertificationsAssessment.withArgs({ id: sessionId }).resolves(0);
-        certificationCourseRepository.findCertificationCoursesBySessionId
-          .withArgs({ sessionId })
-          .resolves([completedCertificationCourse]);
-
-        certificationCourseRepository.update.resolves(
-          domainBuilder.buildCertificationCourse({ ...completedCertificationCourse, abortReason: null }),
-        );
-
-        // when
-        const err = await catchErr(finalizeSession)({
-          sessionId,
-          examinerGlobalComment,
-          sessionRepository,
-          certificationReports,
-          certificationReportRepository,
-          certificationCourseRepository,
-        });
-
-        // then
-        expect(certificationCourseRepository.update).to.have.been.calledOnce;
-        expect(err).to.be.instanceOf(SessionWithAbortReasonOnCompletedCertificationCourseError);
       });
     });
 

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -361,14 +361,15 @@ describe('Integration | Repository | Certification Course', function () {
   });
 
   describe('#update', function () {
-    let certificationCourse;
+    let certificationCourse, certificationCourseData;
 
     beforeEach(async function () {
       // given
       const userId = databaseBuilder.factory.buildUser({}).id;
-      const certificationCourseData = databaseBuilder.factory.buildCertificationCourse({
+      certificationCourseData = databaseBuilder.factory.buildCertificationCourse({
         userId,
         isCancelled: false,
+        updatedAt: new Date('2020-12-01'),
       });
       certificationCourse = domainBuilder.buildCertificationCourse(certificationCourseData);
       await databaseBuilder.commit();
@@ -408,36 +409,26 @@ describe('Integration | Repository | Certification Course', function () {
 
       // then
       const unpersistedUpdatedCertificationCourseDTO = unpersistedUpdatedCertificationCourse.toDTO();
-      const persistedUpdatedCertificationCourse = await certificationCourseRepository.get({
-        id: unpersistedUpdatedCertificationCourseDTO.id,
-      });
-      const persistedUpdatedCertificationCourseDTO = persistedUpdatedCertificationCourse.toDTO();
-      expect(persistedUpdatedCertificationCourse.getId()).to.equal(unpersistedUpdatedCertificationCourse.getId());
-      expect(persistedUpdatedCertificationCourseDTO.firstName).to.equal(
-        unpersistedUpdatedCertificationCourseDTO.firstName,
-      );
-      expect(persistedUpdatedCertificationCourseDTO.lastName).to.equal(
-        unpersistedUpdatedCertificationCourseDTO.lastName,
-      );
-      expect(persistedUpdatedCertificationCourseDTO.birthdate).to.equal(
-        unpersistedUpdatedCertificationCourseDTO.birthdate,
-      );
-      expect(persistedUpdatedCertificationCourseDTO.birthplace).to.equal(
-        unpersistedUpdatedCertificationCourseDTO.birthplace,
-      );
-      expect(persistedUpdatedCertificationCourseDTO.birthPostalCode).to.equal(
+      const updatedCertificationCourse = await knex('certification-courses')
+        .where('id', unpersistedUpdatedCertificationCourse.getId())
+        .first();
+      expect(updatedCertificationCourse.id).to.equal(unpersistedUpdatedCertificationCourse.getId());
+      expect(updatedCertificationCourse.firstName).to.equal(unpersistedUpdatedCertificationCourseDTO.firstName);
+      expect(updatedCertificationCourse.lastName).to.equal(unpersistedUpdatedCertificationCourseDTO.lastName);
+      expect(updatedCertificationCourse.birthdate).to.equal(unpersistedUpdatedCertificationCourseDTO.birthdate);
+      expect(updatedCertificationCourse.birthplace).to.equal(unpersistedUpdatedCertificationCourseDTO.birthplace);
+      expect(updatedCertificationCourse.birthPostalCode).to.equal(
         unpersistedUpdatedCertificationCourseDTO.birthPostalCode,
       );
-      expect(persistedUpdatedCertificationCourseDTO.birthINSEECode).to.equal(
+      expect(updatedCertificationCourse.birthINSEECode).to.equal(
         unpersistedUpdatedCertificationCourseDTO.birthINSEECode,
       );
-      expect(persistedUpdatedCertificationCourseDTO.birthCountry).to.equal(
-        unpersistedUpdatedCertificationCourseDTO.birthCountry,
-      );
-      expect(persistedUpdatedCertificationCourseDTO.sex).to.equal(unpersistedUpdatedCertificationCourseDTO.sex);
-      expect(persistedUpdatedCertificationCourseDTO.isCancelled).to.be.true;
-      expect(persistedUpdatedCertificationCourseDTO.completedAt).to.deep.equal(new Date('1999-12-31'));
-      expect(persistedUpdatedCertificationCourseDTO.isRejectedForFraud).to.be.true;
+      expect(updatedCertificationCourse.birthCountry).to.equal(unpersistedUpdatedCertificationCourseDTO.birthCountry);
+      expect(updatedCertificationCourse.sex).to.equal(unpersistedUpdatedCertificationCourseDTO.sex);
+      expect(updatedCertificationCourse.isCancelled).to.be.true;
+      expect(updatedCertificationCourse.completedAt).to.deep.equal(new Date('1999-12-31'));
+      expect(updatedCertificationCourse.isRejectedForFraud).to.be.true;
+      expect(updatedCertificationCourse.updatedAt).to.be.greaterThan(certificationCourseData.updatedAt);
     });
 
     it('should prevent other values to be updated', async function () {


### PR DESCRIPTION
## :christmas_tree: Problème

Actuellement plusieurs sessions se retrouvent bloqué lors de la finalisation avec le message suivant :

Le champ “Raison de l’abandon” a été renseigné pour un candidat qui a terminé son test de certification entre temps. La session ne peut donc pas être finalisée. Merci de rafraîchir la page avant de finaliser.

## :gift: Proposition

Une transaction dans le code revenait en arrière sur la mise à jour de la certification, car une erreur était jeté juste après.
On a fait le choix d'inclure un paramètre withTransaction pour ne pas l'appliquer dans notre cas de figure.

## :socks: Remarques

On a ajouté la mise à jour de l'updatedAt de la table certification-courses. Bookshelf le faisait automatiquement. Désormais il faut le faire à la main.

## :santa: Pour tester
Pix Certif : 
- Se connecter avec certifmemberv3
- Créer une session
- Inscrire un candidat
- Aller dans l'espace surveillant et permettre à ce dernier de démarrer 

Sur Pix App : 
 
- Se connecter avec certif-success
- Démarrer la certification


Sur Certif : 

- Faire un F5 et aller sur le détails de la session, le bouton pour finaliser devrait apparaître
- Une ligne concernant le candidat doit apparaître avec un sélecteur de raison d'abandon, mettre une des deux (ça entraîne un enregistrement BDD d'un abort reason sur la certif course)

Sur Pix App : 

- Terminer la certification

Sur Pix Certif : 

- Finaliser la session
- Constater que l'on reçoit un message d'erreur : `Le champ “Raison de l’abandon” a été renseigné pour un candidat qui a terminé son...`
- Vérifier en BDD que l'abort reason du candidat n'existe plus (+ updatedAt mis à jour)
- Faire un F5 comme demandé, le candidat n'apparaît plus dans la ligne en warning
- Re-finaliser la session et constater que ça fonctionne
