### PR TITLE
[TECH] Isoler le contexte du GAR dans le session service via des fonctions dédiés

### DIFF
--- a/mon-pix/app/components/navbar-desktop-header.js
+++ b/mon-pix/app/components/navbar-desktop-header.js
@@ -27,7 +27,7 @@ export default class NavbarDesktopHeader extends Component {
   }
 
   get _isExternalUser() {
-    return this.session.get('data.externalUser');
+    return this.session.isAuthenticatedByGar;
   }
 
   get showHeaderMenuItem() {

--- a/mon-pix/app/components/routes/campaigns/invited/associate-sco-student-form.js
+++ b/mon-pix/app/components/routes/campaigns/invited/associate-sco-student-form.js
@@ -76,7 +76,7 @@ export default class AssociateScoStudentForm extends Component {
         } else {
           this.reconciliationError = error;
           this.displayInformationModal = true;
-          this.session.set('data.expectedUserId', error.meta.userId);
+          this.session.userIdForLearnerAssociation = error.meta.userId;
         }
       } else if (error.status === '422' && error.code === 'ACCOUNT_SEEMS_TO_BELONGS_TO_ANOTHER_USER') {
         this.reconciliationError = error;

--- a/mon-pix/app/components/routes/campaigns/join/associate-sco-student-with-mediacentre-form.js
+++ b/mon-pix/app/components/routes/campaigns/join/associate-sco-student-with-mediacentre-form.js
@@ -23,7 +23,7 @@ export default class AssociateScoStudentWithMediacentreForm extends Component {
   constructor() {
     super(...arguments);
 
-    const tokenIdForExternalUser = this.session.data.externalUser;
+    const tokenIdForExternalUser = this.session.externalUserTokenFromGar;
     if (tokenIdForExternalUser) {
       const userFirstNameAndLastName = decodeToken(tokenIdForExternalUser);
       this.firstName = userFirstNameAndLastName['first_name'];
@@ -53,7 +53,7 @@ export default class AssociateScoStudentWithMediacentreForm extends Component {
   }
 
   _createExternalUserRecord() {
-    const externalUserToken = this.session.get('data.externalUser');
+    const externalUserToken = this.session.externalUserTokenFromGar;
     return this.store.createRecord('external-user', {
       birthdate: this.attributes.birthdate,
       campaignCode: this.args.campaignCode,
@@ -70,7 +70,7 @@ export default class AssociateScoStudentWithMediacentreForm extends Component {
         } else {
           this.reconciliationError = error;
           this.displayInformationModal = true;
-          this.session.set('data.expectedUserId', error.meta.userId);
+          this.session.userIdForLearnerAssociation = error.meta.userId;
         }
       } else if (error.status === '404') {
         this.errorMessage = this.intl.t('pages.join.sco.error-not-found', { htmlSafe: true });

--- a/mon-pix/app/components/routes/login-form.js
+++ b/mon-pix/app/components/routes/login-form.js
@@ -1,16 +1,16 @@
 import { action } from '@ember/object';
-import { inject } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import get from 'lodash/get';
 import ENV from 'mon-pix/config/environment';
 
 export default class LoginForm extends Component {
-  @inject session;
-  @inject store;
-  @inject router;
-  @inject currentUser;
-  @inject intl;
+  @service session;
+  @service store;
+  @service router;
+  @service currentUser;
+  @service intl;
 
   @tracked login = null;
   @tracked password = null;
@@ -28,8 +28,8 @@ export default class LoginForm extends Component {
     this.isErrorMessagePresent = false;
     this.hasUpdateUserError = false;
 
-    this.externalUserToken = this.session.get('data.externalUser');
-    this.expectedUserId = this.session.get('data.expectedUserId');
+    this.externalUserToken = this.session.externalUserTokenFromGar;
+    this.expectedUserId = this.session.userIdForLearnerAssociation;
 
     if (this.externalUserToken) {
       await this._authenticateExternalUser(this.password, this.login);

--- a/mon-pix/app/controllers/campaigns/campaign-landing-page.js
+++ b/mon-pix/app/controllers/campaigns/campaign-landing-page.js
@@ -26,7 +26,7 @@ export default class CampaignLandingPageController extends Controller {
   }
 
   get isUserAuthenticatedByGAR() {
-    return !!this.session.get('data.externalUser');
+    return this.session.isAuthenticatedByGar;
   }
 
   get isUserAuthenticatedByPix() {

--- a/mon-pix/app/controllers/campaigns/join/sco-mediacentre.js
+++ b/mon-pix/app/controllers/campaigns/join/sco-mediacentre.js
@@ -11,7 +11,7 @@ export default class ScoMediacentreController extends Controller {
   async createAndReconcile(externalUser) {
     const response = await externalUser.save();
 
-    this.session.set('data.externalUser', null);
+    this.session.revokeGarExternalUserToken();
 
     await this.session.authenticate('authenticator:oauth2', { token: response.accessToken });
     await this.currentUser.load();

--- a/mon-pix/app/controllers/campaigns/join/student-sco.js
+++ b/mon-pix/app/controllers/campaigns/join/student-sco.js
@@ -22,7 +22,7 @@ export default class StudentScoController extends Controller {
 
     await this.session.authenticate('authenticator:oauth2', { token: externalUserAuthenticationRequest.accessToken });
 
-    await this._clearExternalUserContext();
+    this.session.revokeGarAuthenticationContext();
 
     await this.currentUser.load();
     await this._reconcileUser();
@@ -37,10 +37,5 @@ export default class StudentScoController extends Controller {
         campaignCode: this.model.code,
       })
       .save({ adapterOptions: { tryReconciliation: true } });
-  }
-
-  _clearExternalUserContext() {
-    this.session.set('data.externalUser', null);
-    this.session.set('data.expectedUserId', null);
   }
 }

--- a/mon-pix/app/controllers/fill-in-campaign-code.js
+++ b/mon-pix/app/controllers/fill-in-campaign-code.js
@@ -26,7 +26,7 @@ export default class FillInCampaignCodeController extends Controller {
   }
 
   get isUserAuthenticatedByGAR() {
-    return !!this.session.get('data.externalUser');
+    return this.session.isAuthenticatedByGar;
   }
 
   get firstTitle() {
@@ -74,8 +74,7 @@ export default class FillInCampaignCodeController extends Controller {
         filter: { code: campaignCode },
       });
       const isGARCampaign = this.campaign.identityProvider === IDENTITY_PROVIDER_ID_GAR;
-      const isUserAuthenticatedByGAR = this.session.get('data.externalUser');
-      if (_shouldShowGARModal(isGARCampaign, isUserAuthenticatedByGAR, this.isUserAuthenticatedByPix)) {
+      if (_shouldShowGARModal(isGARCampaign, this.isUserAuthenticatedByGAR, this.isUserAuthenticatedByPix)) {
         this.showGARModal = true;
         return;
       }

--- a/mon-pix/app/routes/campaigns/access.js
+++ b/mon-pix/app/routes/campaigns/access.js
@@ -58,20 +58,20 @@ export default class AccessRoute extends Route {
   }
 
   _shouldLoginToAccessSCORestrictedCampaign(campaign) {
-    const isUserExternal = get(this.session, 'data.externalUser');
+    const isAuthenticatedByGar = this.session.isAuthenticatedByGar;
     const hasUserSeenJoinPage = this.campaignStorage.get(campaign.code, 'hasUserSeenJoinPage');
     return (
       campaign.isRestricted &&
       campaign.organizationType === 'SCO' &&
       !campaign.isReconciliationRequired &&
       !this.session.isAuthenticated &&
-      (!isUserExternal || hasUserSeenJoinPage)
+      (!isAuthenticatedByGar || hasUserSeenJoinPage)
     );
   }
 
   _shouldJoinFromMediacentre(campaign) {
-    const isUserExternal = get(this.session, 'data.externalUser');
-    return campaign.isRestricted && isUserExternal;
+    const isAuthenticatedByGar = this.session.isAuthenticatedByGar;
+    return campaign.isRestricted && isAuthenticatedByGar;
   }
 
   _shouldJoinSimplifiedCampaignAsAnonymous(campaign) {

--- a/mon-pix/app/routes/fill-in-campaign-code.js
+++ b/mon-pix/app/routes/fill-in-campaign-code.js
@@ -6,7 +6,7 @@ export default class FillInCampaignCodeRoute extends Route {
 
   beforeModel(transition) {
     if (transition.to.queryParams.externalUser) {
-      this.session.data.externalUser = transition.to.queryParams.externalUser;
+      this.session.externalUserTokenFromGar = transition.to.queryParams.externalUser;
     }
   }
 

--- a/mon-pix/app/routes/logout.js
+++ b/mon-pix/app/routes/logout.js
@@ -11,7 +11,7 @@ export default class LogoutRoute extends Route {
   @service router;
 
   beforeModel() {
-    delete this.session.data.externalUser;
+    this.session.revokeGarExternalUserToken();
     this.campaignStorage.clearAll();
 
     if (this.session.isAuthenticated) {

--- a/mon-pix/app/routes/terms-of-service.js
+++ b/mon-pix/app/routes/terms-of-service.js
@@ -7,8 +7,7 @@ export default class TermsOfServiceRoute extends Route {
   @service router;
 
   beforeModel(transition) {
-    const isUserExternal = Boolean(this.session.data.externalUser);
-    if (isUserExternal || !this.currentUser.user.mustValidateTermsOfService) {
+    if (this.session.isAuthenticatedByGar || !this.currentUser.user.mustValidateTermsOfService) {
       if (this.session.attemptedTransition) {
         this.session.attemptedTransition.retry();
       } else {

--- a/mon-pix/tests/helpers/service-stubs.js
+++ b/mon-pix/tests/helpers/service-stubs.js
@@ -1,0 +1,103 @@
+import Service from '@ember/service';
+import sinon from 'sinon';
+
+/**
+ * Stub the session service.
+ *
+ * @param {Object} owner - The owner object.
+ * @param {Object} [sessionData={}] - The session object.
+ * @param {boolean} [sessionData.isAuthenticated=false] - Indicates if the user is authenticated.
+ * @param {boolean} [sessionData.isAuthenticatedByGar=false] - Indicates if the user is authenticated by GAR.
+ * @param {string} [sessionData.externalUserTokenFromGar='external-user-token'] - The external user token from GAR.
+ * @param {string} [sessionData.userIdForLearnerAssociation='expected-user-id'] - The expected user ID from GAR.
+ * @param {string} [sessionData.source='pix'] - The source of authentication.
+ * @returns {Service} The stubbed session service.
+ */
+export function stubSessionService(owner, sessionData = {}) {
+  const isAuthenticated = sessionData.isAuthenticated || false;
+  const isAuthenticatedByGar = sessionData.isAuthenticatedByGar || false;
+  const externalUserTokenFromGar = sessionData.externalUserTokenFromGar || 'external-user-token';
+  const userIdForLearnerAssociation = sessionData.userIdForLearnerAssociation;
+  const source = isAuthenticated ? sessionData.source || 'pix' : null;
+
+  /**
+   * Stub class for the session service.
+   */
+  class SessionStub extends Service {
+    constructor() {
+      super();
+      this.isAuthenticated = isAuthenticated;
+      this.isAuthenticatedByGar = isAuthenticatedByGar;
+      this.userIdForLearnerAssociation = userIdForLearnerAssociation;
+
+      if (isAuthenticated) {
+        this.data = { authenticated: { source } };
+      } else {
+        this.data = {};
+      }
+
+      if (isAuthenticatedByGar) {
+        this.externalUserTokenFromGar = externalUserTokenFromGar;
+      }
+
+      this.authenticate = sinon.stub();
+      this.authenticateUser = sinon.stub();
+      this.requireAuthentication = sinon.stub();
+      this.invalidate = sinon.stub();
+      this.revokeGarExternalUserToken = sinon.stub();
+      this.revokeGarAuthenticationContext = sinon.stub();
+      this.requireAuthenticationAndApprovedTermsOfService = sinon.stub();
+      this.setAttemptedTransition = sinon.stub();
+    }
+  }
+
+  owner.register('service:session', SessionStub);
+  return owner.lookup('service:session');
+}
+
+/**
+ * Stub the current user service.
+ *
+ * @param {Object} owner - The owner object.
+ * @param {Object} [userData={}] - The user object.
+ * @param {boolean} [userData.isAnonymous=false] - Indicates if the user is anonymous.
+ * @param {string} [userData.firstName='John'] - The first name of the user.
+ * @param {string} [userData.lastName='Doe'] - The last name of the user.
+ * @param {boolean} [userData.mustValidateTermsOfService=false] - Indicates if the user must validate terms of service.
+ * @param {boolean} [userData.hasRecommendedTrainings=false] - Indicates if the user has recommended trainings.
+ * @returns {Service} The stubbed current user service.
+ */
+export function stubCurrentUserService(owner, userData = {}) {
+  const isAnonymous = userData.isAnonymous || false;
+  const firstName = userData.firstName || 'John';
+  const lastName = userData.lastName || 'Doe';
+  const fullName = `${firstName} ${lastName}`;
+  const mustValidateTermsOfService = userData.mustValidateTermsOfService || false;
+  const hasRecommendedTrainings = userData.hasRecommendedTrainings || false;
+
+  /**
+   * Stub class for the current user service.
+   */
+  class CurrentUserStub extends Service {
+    constructor() {
+      super();
+      if (isAnonymous) {
+        this.user = { isAnonymous: true };
+      } else {
+        this.user = {
+          isAnonymous: false,
+          firstName,
+          lastName,
+          fullName,
+          hasRecommendedTrainings,
+          mustValidateTermsOfService,
+        };
+      }
+
+      this.load = sinon.stub();
+    }
+  }
+
+  owner.register('service:current-user', CurrentUserStub);
+  return owner.lookup('service:current-user');
+}

--- a/mon-pix/tests/integration/components/navbar-desktop-header-test.js
+++ b/mon-pix/tests/integration/components/navbar-desktop-header-test.js
@@ -1,10 +1,10 @@
 import { render } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { setBreakpoint } from 'ember-responsive/test-support';
 import { module, test } from 'qunit';
 
+import { stubCurrentUserService, stubSessionService } from '../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | navbar-desktop-header', function (hooks) {
@@ -13,10 +13,7 @@ module('Integration | Component | navbar-desktop-header', function (hooks) {
   module('when user is not logged', function (hooks) {
     hooks.beforeEach(function () {
       // given
-      class sessionService extends Service {
-        isAuthenticated = false;
-      }
-      this.owner.register('service:session', sessionService);
+      stubSessionService(this.owner, { isAuthenticated: false });
       setBreakpoint('desktop');
     });
 
@@ -65,21 +62,8 @@ module('Integration | Component | navbar-desktop-header', function (hooks) {
   module('When user is logged', function (hooks) {
     hooks.beforeEach(function () {
       // given
-      class sessionService extends Service {
-        isAuthenticated = true;
-        data = {
-          authenticated: {
-            token: 'access_token',
-            userId: 1,
-            source: 'pix',
-          },
-        };
-      }
-      this.owner.register('service:session', sessionService);
-      class currentUserService extends Service {
-        user = { isAnonymous: false, firstName: 'Judy' };
-      }
-      this.owner.register('service:currentUser', currentUserService);
+      stubSessionService(this.owner, { isAuthenticated: true });
+      stubCurrentUserService(this.owner, { firstName: 'Judy' });
       setBreakpoint('desktop');
     });
 
@@ -142,24 +126,8 @@ module('Integration | Component | navbar-desktop-header', function (hooks) {
   module('when user has recommended trainings', function (hooks) {
     hooks.beforeEach(function () {
       // given
-      class sessionService extends Service {
-        isAuthenticated = true;
-        data = {
-          authenticated: {
-            token: 'access_token',
-            userId: 1,
-            source: 'pix',
-          },
-        };
-      }
-      this.owner.register('service:session', sessionService);
-      class currentUser extends Service {
-        user = {
-          isAnonymous: false,
-          hasRecommendedTrainings: true,
-        };
-      }
-      this.owner.register('service:currentUser', currentUser);
+      stubSessionService(this.owner, { isAuthenticated: true });
+      stubCurrentUserService(this.owner, { hasRecommendedTrainings: true });
       setBreakpoint('desktop');
     });
 
@@ -175,13 +143,7 @@ module('Integration | Component | navbar-desktop-header', function (hooks) {
   module('when user comes from external platform', function (hooks) {
     hooks.beforeEach(function () {
       // given
-      class sessionService extends Service {
-        isAuthenticated = false;
-        data = {
-          externalUser: 'externalUserToken',
-        };
-      }
-      this.owner.register('service:session', sessionService);
+      stubSessionService(this.owner, { isAuthenticatedByGar: true });
       setBreakpoint('desktop');
     });
 
@@ -230,15 +192,8 @@ module('Integration | Component | navbar-desktop-header', function (hooks) {
   module('when logged user is anonymous', function (hooks) {
     hooks.beforeEach(async function () {
       // given
-      class sessionService extends Service {
-        isAuthenticated = true;
-      }
-      this.owner.register('service:session', sessionService);
-      class currentUserService extends Service {
-        user = { isAnonymous: true };
-      }
-      this.owner.register('service:currentUser', currentUserService);
-
+      stubSessionService(this.owner, { isAuthenticated: true });
+      stubCurrentUserService(this.owner, { isAnonymous: true });
       setBreakpoint('desktop');
     });
 

--- a/mon-pix/tests/integration/components/routes/login-form-test.js
+++ b/mon-pix/tests/integration/components/routes/login-form-test.js
@@ -6,6 +6,7 @@ import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import { stubSessionService } from '../../../helpers/service-stubs.js';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | routes/login-form', function (hooks) {
@@ -29,10 +30,8 @@ module('Integration | Component | routes/login-form', function (hooks) {
       },
     };
 
-    class SessionStub extends Service {
-      authenticate = sinon.stub().rejects(errorResponse);
-    }
-    this.owner.register('service:session', SessionStub);
+    const sessionStub = stubSessionService(this.owner);
+    sessionStub.authenticate.rejects(errorResponse);
 
     const screen = await render(hbs`<Routes::LoginForm />`);
     await fillByLabel('Adresse e-mail ou identifiant', 'pix@example.net');
@@ -61,11 +60,8 @@ module('Integration | Component | routes/login-form', function (hooks) {
   module('when there is no invitation', function () {
     test('should call authentication service with appropriate parameters', async function (assert) {
       // given
-      class SessionStub extends Service {
-        authenticate = sinon.stub().resolves();
-      }
-      this.owner.register('service:session', SessionStub);
-      const sessionServiceObserver = this.owner.lookup('service:session');
+      const sessionStub = stubSessionService(this.owner);
+      sessionStub.authenticate.resolves();
 
       // when
       const screen = await render(hbs`<Routes::LoginForm />`);
@@ -74,7 +70,7 @@ module('Integration | Component | routes/login-form', function (hooks) {
       await click(screen.getByRole('button', { name: t('pages.login-or-register.login-form.button') }));
 
       // then
-      sinon.assert.calledWith(sessionServiceObserver.authenticate, 'authenticator:oauth2', {
+      sinon.assert.calledWith(sessionStub.authenticate, 'authenticator:oauth2', {
         login: 'pix@example.net',
         password: 'JeMeLoggue1024',
         scope: 'mon-pix',
@@ -86,12 +82,8 @@ module('Integration | Component | routes/login-form', function (hooks) {
   module('when there is an invitation', function () {
     test('should be ok and call authentication service with appropriate parameters', async function (assert) {
       // given
-      class SessionStub extends Service {
-        authenticate = sinon.stub().resolves();
-      }
-      this.owner.register('service:session', SessionStub);
-
-      const sessionServiceObserver = this.owner.lookup('service:session');
+      const sessionStub = stubSessionService(this.owner);
+      sessionStub.authenticate.resolves();
 
       //  when
       const screen = await render(hbs`<Routes::LoginForm />`);
@@ -100,7 +92,7 @@ module('Integration | Component | routes/login-form', function (hooks) {
       await click(screen.getByRole('button', { name: t('pages.login-or-register.login-form.button') }));
 
       // then
-      sinon.assert.calledWith(sessionServiceObserver.authenticate, 'authenticator:oauth2', {
+      sinon.assert.calledWith(sessionStub.authenticate, 'authenticator:oauth2', {
         login: 'pix@example.net',
         password: 'JeMeLoggue1024',
         scope: 'mon-pix',
@@ -128,10 +120,8 @@ module('Integration | Component | routes/login-form', function (hooks) {
         },
       };
 
-      class SessionStub extends Service {
-        authenticate = sinon.stub().rejects(response);
-      }
-      this.owner.register('service:session', SessionStub);
+      const sessionStub = stubSessionService(this.owner);
+      sessionStub.authenticate.rejects(response);
 
       const routerObserver = this.owner.lookup('service:router');
       routerObserver.replaceWith = sinon.stub();
@@ -159,13 +149,12 @@ module('Integration | Component | routes/login-form', function (hooks) {
       }
       this.owner.register('service:store', StoreStub);
 
-      class SessionStub extends Service {
-        authenticate = sinon.stub().resolves();
-        isAuthenticated = sinon.stub().returns(true);
-        get = sinon.stub().returns(externalUserToken);
-        invalidate = sinon.stub().resolves();
-      }
-      this.owner.register('service:session', SessionStub);
+      const sessionStub = stubSessionService(this.owner, {
+        isAuthenticated: true,
+        isAuthenticatedByGar: true,
+        externalUserTokenFromGar: externalUserToken,
+      });
+      sessionStub.authenticate.resolves();
 
       addGarAuthenticationMethodToUserStub = sinon.stub();
     });

--- a/mon-pix/tests/unit/components/navbar-desktop-header-test.js
+++ b/mon-pix/tests/unit/components/navbar-desktop-header-test.js
@@ -95,9 +95,8 @@ module('Unit | Component | Navbar Desktop Header Component', function (hooks) {
       component = createGlimmerComponent('navbar-desktop-header');
       component.session = Service.create({
         isAuthenticated: false,
-        data: {
-          externalUser: 'externalUserToken',
-        },
+        isAuthenticatedByGar: true,
+        externalUserTokenFromGar: 'externalUserToken',
       });
     });
 

--- a/mon-pix/tests/unit/components/routes/campaigns/join/associate-sco-student-with-mediacentre-form-test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/join/associate-sco-student-with-mediacentre-form-test.js
@@ -19,7 +19,7 @@ module('Unit | Component | routes/campaigns/join/associate-sco-student-with-medi
   hooks.beforeEach(function () {
     record = { unloadRecord: sinon.stub() };
     storeStub = { createRecord: sinon.stub().returns(record) };
-    sessionStub = { data: {}, get: sinon.stub(), set: sinon.stub() };
+    sessionStub = { externalUserTokenFromGar: null };
     onSubmitStub = sinon.stub();
     component = createComponent('routes/campaigns/join/associate-sco-student-with-mediacentre-form', {
       onSubmit: onSubmitStub,
@@ -39,7 +39,7 @@ module('Unit | Component | routes/campaigns/join/associate-sco-student-with-medi
         birthdate: '2000-10-10',
       };
 
-      sessionStub.get.withArgs('data.externalUser').returns(externalUserToken);
+      sessionStub.externalUserTokenFromGar = externalUserToken;
     });
 
     test('should create an external-user', async function (assert) {
@@ -123,7 +123,7 @@ module('Unit | Component | routes/campaigns/join/associate-sco-student-with-medi
           sinon.assert.calledOnce(record.unloadRecord);
           assert.true(component.displayInformationModal);
           assert.strictEqual(component.reconciliationError, error);
-          sinon.assert.calledWith(sessionStub.set, 'data.expectedUserId', error.meta.userId);
+          assert.strictEqual(sessionStub.userIdForLearnerAssociation, error.meta.userId);
           assert.ok(true);
         });
       });

--- a/mon-pix/tests/unit/components/routes/login-form-test.js
+++ b/mon-pix/tests/unit/components/routes/login-form-test.js
@@ -25,7 +25,9 @@ module('Unit | Component | routes/login-form', function (hooks) {
     sessionStub = {
       authenticate: sinon.stub().resolves(),
       isAuthenticated: sinon.stub().returns(true),
-      get: sinon.stub(),
+      isAuthenticatedByGar: false,
+      externalUserTokenFromGar: null,
+      userIdForLearnerAssociation: null,
       invalidate: sinon.stub(),
     };
     routerStub = {
@@ -174,8 +176,9 @@ module('Unit | Component | routes/login-form', function (hooks) {
       const expectedUserId = 1;
 
       hooks.beforeEach(() => {
-        sessionStub.get.withArgs('data.externalUser').returns(externalUserToken);
-        sessionStub.get.withArgs('data.expectedUserId').returns(expectedUserId);
+        sessionStub.isAuthenticatedByGar = false;
+        sessionStub.externalUserTokenFromGar = externalUserToken;
+        sessionStub.userIdForLearnerAssociation = expectedUserId;
       });
 
       test('should display an error message when update user authentication method fails', async function (assert) {

--- a/mon-pix/tests/unit/components/update-expired-password-form-test.js
+++ b/mon-pix/tests/unit/components/update-expired-password-form-test.js
@@ -65,11 +65,10 @@ module('Unit | Component | Update Expired Password Form', function (hooks) {
   module('#handleUpdatePasswordAndAuthenticate', function (hooks) {
     const login = 'beth.rave1203';
     const newPassword = 'Pix67890';
-    const scope = 'mon-pix';
 
     hooks.beforeEach(() => {
       const sessionStub = Service.create({
-        authenticate: sinon.stub().resolves(),
+        authenticateUser: sinon.stub().resolves(),
       });
 
       const resetExpiredPasswordDemand = {
@@ -101,19 +100,11 @@ module('Unit | Component | Update Expired Password Form', function (hooks) {
       });
 
       test('should authenticate with username and newPassword', async function (assert) {
-        // given
-        const expectedAuthenticator = 'authenticator:oauth2';
-        const expectedParameters = {
-          login,
-          password: newPassword,
-          scope,
-        };
-
         // when
         await component.actions.handleUpdatePasswordAndAuthenticate.call(component);
 
         // then
-        sinon.assert.calledWith(component.session.authenticate, expectedAuthenticator, expectedParameters);
+        sinon.assert.calledWith(component.session.authenticateUser, login, newPassword);
         assert.ok(true);
       });
     });
@@ -162,7 +153,7 @@ module('Unit | Component | Update Expired Password Form', function (hooks) {
     module('When authentication after update fails', function () {
       test('should set authenticationHasFailed to true', async function (assert) {
         // given
-        component.session.authenticate.rejects();
+        component.session.authenticateUser.rejects();
 
         // when
         await component.actions.handleUpdatePasswordAndAuthenticate.call(component);

--- a/mon-pix/tests/unit/controllers/campaigns/join/sco-mediacentre-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/join/sco-mediacentre-test.js
@@ -2,6 +2,8 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import { stubCurrentUserService, stubSessionService } from '../../../../helpers/service-stubs.js';
+
 module('Unit | Controller | campaigns | join | sco-mediacentre', function (hooks) {
   setupTest(hooks);
 
@@ -12,37 +14,24 @@ module('Unit | Controller | campaigns | join | sco-mediacentre', function (hooks
     controller.set('model', { code: 'AZERTY999' });
   });
 
-  module('#createAndReconcile', function (hooks) {
-    let externalUser;
-    let sessionStub;
-    let currentUserStub;
-
-    hooks.beforeEach(function () {
-      externalUser = { save: sinon.stub() };
-      sessionStub = {
-        set: sinon.stub(),
-        authenticate: sinon.stub(),
-      };
-      currentUserStub = { load: sinon.stub() };
-      controller.set('session', sessionStub);
-      controller.set('currentUser', currentUserStub);
-    });
-
+  module('#createAndReconcile', function () {
     test('should authenticate the user', async function (assert) {
       // given
       const accessToken = 'access-token';
-      externalUser.save.resolves({ accessToken });
-      sessionStub.set.resolves();
-      sessionStub.authenticate.resolves();
-      currentUserStub.load.resolves();
+      const externalUser = { save: sinon.stub().resolves({ accessToken }) };
+
+      const sessionService = stubSessionService(this.owner);
+      const currentUserService = stubCurrentUserService(this.owner);
+      sessionService.authenticate.resolves();
+      currentUserService.load.resolves();
 
       // when
       await controller.actions.createAndReconcile.call(controller, externalUser);
 
       // then
       sinon.assert.calledOnce(externalUser.save);
-      sinon.assert.calledWith(sessionStub.set, 'data.externalUser', null);
-      sinon.assert.calledWith(sessionStub.authenticate, 'authenticator:oauth2', { token: accessToken });
+      sinon.assert.calledOnce(sessionService.revokeGarExternalUserToken);
+      sinon.assert.calledWith(sessionService.authenticate, 'authenticator:oauth2', { token: accessToken });
       assert.ok(true);
     });
   });

--- a/mon-pix/tests/unit/controllers/campaigns/join/student-sco-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/join/student-sco-test.js
@@ -2,6 +2,8 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import { stubSessionService } from '../../../../helpers/service-stubs.js';
+
 module('Unit | Controller | campaigns | join | student-sco', function (hooks) {
   setupTest(hooks);
 
@@ -13,11 +15,10 @@ module('Unit | Controller | campaigns | join | student-sco', function (hooks) {
 
   hooks.beforeEach(function () {
     controller = this.owner.lookup('controller:campaigns.join.student-sco');
-
-    sessionStub = {
-      set: sinon.stub(),
-      authenticate: sinon.stub(),
-    };
+    sessionStub = stubSessionService(this.owner, {
+      isAuthenticatedByGar: true,
+      userIdForLearnerAssociation: expectedUserId,
+    });
     currentUserStub = {
       load: sinon.stub().resolves(),
       user: {
@@ -56,8 +57,7 @@ module('Unit | Controller | campaigns | join | student-sco', function (hooks) {
 
       // then
       sinon.assert.calledOnce(expectedExternalUserAuthenticationRequest.save);
-      sinon.assert.calledWith(sessionStub.set, 'data.externalUser', null);
-      sinon.assert.calledWith(sessionStub.set, 'data.expectedUserId', null);
+      sinon.assert.calledOnce(sessionStub.revokeGarAuthenticationContext);
       assert.ok(true);
     });
 

--- a/mon-pix/tests/unit/routes/campaigns/access-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/access-test.js
@@ -3,27 +3,23 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import { stubSessionService } from '../../../helpers/service-stubs.js';
+
 module('Unit | Route | Access', function (hooks) {
   setupTest(hooks);
 
-  let route, campaign, sessionStub;
+  let route, campaign;
 
   hooks.beforeEach(function () {
     campaign = {
       code: 'NEW_CODE',
       isRestrictedByIdentityProvider: sinon.stub(),
     };
-    sessionStub = {
-      requireAuthenticationAndApprovedTermsOfService: sinon.stub(),
-      setAttemptedTransition: sinon.stub(),
-      data: { externalUser: null, authenticated: {} },
-    };
+
     route = this.owner.lookup('route:campaigns.access');
     route.modelFor = sinon.stub().returns(campaign);
     route.campaignStorage = { get: sinon.stub() };
-
     route.router = { replaceWith: sinon.stub(), transitionTo: sinon.stub() };
-    route.session = sessionStub;
     class OidcIdentityProvidersStub extends Service {
       list = [];
     }
@@ -31,102 +27,109 @@ module('Unit | Route | Access', function (hooks) {
   });
 
   module('#beforeModel', function () {
-    test('should redirect to entry point when /access is directly set in the url', async function (assert) {
-      //when
-      await route.beforeModel({ from: null });
+    module('when user is authenticated from Pix', function (hooks) {
+      let sessionStub;
 
-      //then
-      sinon.assert.calledWith(route.router.replaceWith, 'campaigns.entry-point');
-      assert.ok(true);
-    });
-
-    test('should continue on access route when from is set', async function (assert) {
-      //when
-      await route.beforeModel({ from: 'campaigns.campaign-landing-page' });
-
-      //then
-      sinon.assert.notCalled(route.router.replaceWith);
-      assert.ok(true);
-    });
-
-    test('should override authentication route', async function (assert) {
-      // when
-      await route.beforeModel({ from: 'campaigns.campaign-landing-page' });
-
-      // then
-
-      assert.strictEqual(route.authenticationRoute, 'inscription');
-    });
-
-    test("should call parent's beforeModel and transition to authenticationRoute", async function (assert) {
-      // when
-      await route.beforeModel({ from: 'campaigns.campaign-landing-page' });
-
-      // then
-      sinon.assert.calledWith(
-        sessionStub.requireAuthenticationAndApprovedTermsOfService,
-        { from: 'campaigns.campaign-landing-page' },
-        'inscription',
-      );
-      assert.ok(true);
-    });
-
-    module('when campaign belongs to an oidc provider', function (hooks) {
       hooks.beforeEach(function () {
-        const oidcPartner = {
-          id: 'oidc-partner',
-          code: 'OIDC_PARTNER',
-        };
-        class OidcIdentityProvidersStub extends Service {
-          'oidc-partner' = oidcPartner;
-          list = [oidcPartner];
-        }
-        this.owner.register('service:oidcIdentityProviders', OidcIdentityProvidersStub);
+        sessionStub = stubSessionService(this.owner, { isAuthenticated: true });
+        route.session = sessionStub;
       });
 
-      module('and user is not connected with that provider', function () {
-        test('should use provider route', async function (assert) {
-          // given
-          route.session.data.externalUser = 'some external user';
-          campaign.isRestrictedByIdentityProvider.withArgs('OIDC_PARTNER').returns(true);
+      test('should redirect to entry point when /access is directly set in the url', async function (assert) {
+        //when
+        await route.beforeModel({ from: null });
 
-          // when
-          await route.beforeModel({ from: 'campaigns.campaign-landing-page' });
+        //then
+        sinon.assert.calledWith(route.router.replaceWith, 'campaigns.entry-point');
+        assert.ok(true);
+      });
 
-          // then
-          sinon.assert.calledWith(route.router.replaceWith, 'authentication.login-oidc', 'oidc-partner');
-          assert.ok(true);
+      test('should continue on access route when from is set', async function (assert) {
+        //when
+        await route.beforeModel({ from: 'campaigns.campaign-landing-page' });
+
+        //then
+        sinon.assert.notCalled(route.router.replaceWith);
+        assert.ok(true);
+      });
+
+      test('should override authentication route', async function (assert) {
+        // when
+        await route.beforeModel({ from: 'campaigns.campaign-landing-page' });
+
+        // then
+
+        assert.strictEqual(route.authenticationRoute, 'inscription');
+      });
+
+      test("should call parent's beforeModel and transition to authenticationRoute", async function (assert) {
+        // when
+        await route.beforeModel({ from: 'campaigns.campaign-landing-page' });
+
+        // then
+        sinon.assert.calledWith(
+          sessionStub.requireAuthenticationAndApprovedTermsOfService,
+          { from: 'campaigns.campaign-landing-page' },
+          'inscription',
+        );
+        assert.ok(true);
+      });
+
+      module('when campaign belongs to an oidc provider', function (hooks) {
+        hooks.beforeEach(function () {
+          const oidcProviderService = this.owner.lookup('service:oidcIdentityProviders');
+          const oidcPartner = { id: 'oidc-partner', code: 'OIDC_PARTNER' };
+          oidcProviderService['oidc-partner'] = oidcPartner;
+          oidcProviderService.list = [oidcPartner];
         });
-      });
 
-      module('and user is connected with that provider', function () {
-        test('should not use provider route', async function (assert) {
-          // given
-          route.session.data.externalUser = 'some external user';
-          const OIDC_PARTNER = 'OIDC_PARTNER';
-          route.session.data.authenticated.identityProviderCode = OIDC_PARTNER;
-          campaign.isRestrictedByIdentityProvider.withArgs(OIDC_PARTNER).returns(true);
+        module('and user is not connected with that provider', function () {
+          test('should use provider route', async function (assert) {
+            // given
+            campaign.isRestrictedByIdentityProvider.withArgs('OIDC_PARTNER').returns(true);
 
-          // when
-          await route.beforeModel({ from: 'campaigns.campaign-landing-page' });
+            // when
+            await route.beforeModel({ from: 'campaigns.campaign-landing-page' });
 
-          // then
-          sinon.assert.neverCalledWith(route.router.replaceWith, 'authentication.login-oidc', 'oidc-partner');
-          assert.ok(true);
+            // then
+            sinon.assert.calledWith(route.router.replaceWith, 'authentication.login-oidc', 'oidc-partner');
+            assert.ok(true);
+          });
+        });
+
+        module('and user is connected with that provider', function () {
+          test('should not use provider route', async function (assert) {
+            // given
+            const OIDC_PARTNER = 'OIDC_PARTNER';
+            route.session.data.authenticated.identityProviderCode = OIDC_PARTNER;
+            campaign.isRestrictedByIdentityProvider.withArgs(OIDC_PARTNER).returns(true);
+
+            // when
+            await route.beforeModel({ from: 'campaigns.campaign-landing-page' });
+
+            // then
+            sinon.assert.neverCalledWith(route.router.replaceWith, 'authentication.login-oidc', 'oidc-partner');
+            assert.ok(true);
+          });
         });
       });
     });
 
     module(
       'when campaign is SCO restricted and user is neither authenticated from Pix nor a user from an external platform',
-      function () {
+      function (hooks) {
+        let sessionStub;
+
+        hooks.beforeEach(function () {
+          sessionStub = stubSessionService(this.owner, { isAuthenticated: false });
+          route.session = sessionStub;
+          campaign.isRestricted = true;
+          campaign.organizationType = 'SCO';
+        });
+
         test('should override authentication route with student-sco', async function (assert) {
           // given
-          route.session.isAuthenticated = false;
-          campaign.isRestricted = true;
           campaign.isReconciliationRequired = false;
-          campaign.organizationType = 'SCO';
-          route.session.data.externalUser = undefined;
 
           // when
           await route.beforeModel({ from: 'campaigns.campaign-landing-page' });
@@ -137,11 +140,7 @@ module('Unit | Route | Access', function (hooks) {
 
         test('should not override authentication route when campaign reconciliationRequired', async function (assert) {
           // given
-          route.session.isAuthenticated = false;
-          campaign.isRestricted = true;
           campaign.isReconciliationRequired = true;
-          campaign.organizationType = 'SCO';
-          route.session.data.externalUser = undefined;
 
           // when
           await route.beforeModel({ from: 'campaigns.campaign-landing-page' });
@@ -155,10 +154,10 @@ module('Unit | Route | Access', function (hooks) {
     module('when campaign is SCO restricted and user has been disconnected from sco form', function () {
       test('should override authentication route with student-sco', async function (assert) {
         // given
-        route.session.isAuthenticated = false;
+        const sessionStub = stubSessionService(this.owner, { isAuthenticated: false, isAuthenticatedByGar: true });
+        route.session = sessionStub;
         campaign.isRestricted = true;
         campaign.organizationType = 'SCO';
-        route.session.data.externalUser = 'some external user';
         route.campaignStorage.get.withArgs(campaign.code, 'hasUserSeenJoinPage').returns(true);
 
         // when
@@ -172,8 +171,9 @@ module('Unit | Route | Access', function (hooks) {
     module('when campaign is restricted and user is from an external platform', function () {
       test('should override authentication route with sco-mediacentre', async function (assert) {
         // given
+        const sessionStub = stubSessionService(this.owner, { isAuthenticated: false, isAuthenticatedByGar: true });
+        route.session = sessionStub;
         campaign.isRestricted = true;
-        route.session.data.externalUser = 'some external user';
 
         // when
         await route.beforeModel({ from: 'campaigns.campaign-landing-page' });
@@ -186,6 +186,8 @@ module('Unit | Route | Access', function (hooks) {
     module('when campaign is simplified access and user is not authenticated', function () {
       test('should override authentication route with anonymous', async function (assert) {
         // given
+        const sessionStub = stubSessionService(this.owner, { isAuthenticated: false });
+        route.session = sessionStub;
         campaign.isSimplifiedAccess = true;
         route.session.isAuthenticated = false;
 

--- a/mon-pix/tests/unit/routes/fill-in-campaign-code-test.js
+++ b/mon-pix/tests/unit/routes/fill-in-campaign-code-test.js
@@ -1,6 +1,7 @@
-import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
+
+import { stubSessionService } from '../../helpers/service-stubs.js';
 
 module('Unit | Route | fill-in-campaign-code', function (hooks) {
   setupTest(hooks);
@@ -11,9 +12,7 @@ module('Unit | Route | fill-in-campaign-code', function (hooks) {
       const externalUser = 'external-user-token';
       const route = this.owner.lookup('route:fill-in-campaign-code');
 
-      const sessionStub = Service.create({
-        data: { externalUser: null },
-      });
+      const sessionStub = stubSessionService(this.owner);
       route.set('session', sessionStub);
 
       const transition = { to: { queryParams: { externalUser } } };
@@ -22,7 +21,7 @@ module('Unit | Route | fill-in-campaign-code', function (hooks) {
       route.beforeModel(transition);
 
       // then
-      assert.strictEqual(sessionStub.data.externalUser, externalUser);
+      assert.strictEqual(sessionStub.externalUserTokenFromGar, externalUser);
     });
   });
 });

--- a/mon-pix/tests/unit/routes/terms-of-service-test.js
+++ b/mon-pix/tests/unit/routes/terms-of-service-test.js
@@ -2,22 +2,22 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import { stubCurrentUserService, stubSessionService } from '../../helpers/service-stubs.js';
+
 module('Unit | Route | Terms-of-service', function (hooks) {
   setupTest(hooks);
 
   let route;
 
-  hooks.beforeEach(function () {
-    route = this.owner.lookup('route:terms-of-service');
-    route.router = { replaceWith: sinon.stub() };
-    route.currentUser = { user: { mustValidateTermsOfService: true } };
-    route.session = { attemptedTransition: null, data: {}, requireAuthentication: sinon.stub().returns() };
-  });
-
   module('#beforeModel', function () {
     module('when user is external', function (hooks) {
       hooks.beforeEach(function () {
-        route.session.data.externalUser = 'some external user';
+        const sessionStub = stubSessionService(this.owner, { isAuthenticatedByGar: true });
+        const currentUser = stubCurrentUserService(this.owner, { mustValidateTermsOfService: true });
+        route = this.owner.lookup('route:terms-of-service');
+        route.router = { replaceWith: sinon.stub() };
+        route.session = sessionStub;
+        route.currentUser = currentUser;
       });
 
       test('should redirect to default page if there is no attempted transition', async function (assert) {
@@ -43,7 +43,12 @@ module('Unit | Route | Terms-of-service', function (hooks) {
 
     module('when user must not validate terms of service', function (hooks) {
       hooks.beforeEach(function () {
-        route.currentUser.user.mustValidateTermsOfService = false;
+        const sessionStub = stubSessionService(this.owner, { isAuthenticatedByGar: true });
+        const currentUser = stubCurrentUserService(this.owner, { mustValidateTermsOfService: false });
+        route = this.owner.lookup('route:terms-of-service');
+        route.router = { replaceWith: sinon.stub() };
+        route.session = sessionStub;
+        route.currentUser = currentUser;
       });
 
       test('should transition to default page if there is no attempted transition', async function (assert) {

--- a/mon-pix/tests/unit/services/session-test.js
+++ b/mon-pix/tests/unit/services/session-test.js
@@ -25,7 +25,6 @@ module('Unit | Services | session', function (hooks) {
       setLocale: sinon.stub(),
     };
     sessionService._getRouteAfterInvalidation = sinon.stub();
-    sessionService._logoutUser = sinon.stub();
 
     routerService = this.owner.lookup('service:router');
     routerService.transitionTo = sinon.stub();


### PR DESCRIPTION
## :christmas_tree: Problème

Nous souhaitons gérer le contexte d'authentification du GAR en session storage, or actuellement il est manipulé de différentes manières dans les routes, controllers et composants. Ce qui rend difficile la mise en place du session storage pour le contexte d'authentification du GAR.

## :gift: Proposition

Isoler et créer des fonctions helper de session utilisateur dédiées au GAR.
- Création d'un utilitaire de stub des services de `session` et `currentUser`
- Utilisation des fonctions helpers dédiées au GAR dans les routes, controllers et composants
- Utilisation des stubs sur les routes, controllers et composants impactés.

## :socks: Remarques

L'utilisation globale des `stubSessionService` et `stubCurrentUser` sur l'ensemble de `mon-pix` sera faite dans une PR dédiée.

## :santa: Pour tester

**Le connexion via le GAR doit correctement fonctionner:**

Se connecter avec le SSO GAR (faux GAR)  
 - Indiquer un samlId aléatoire, le prénom `Hermione` et le nom `Granger`  
 - Se connecter avec le bouton _« Sign in »_
1. Sur la page _« Saisissez votre code »_ indiquer le code campagne `SCOBADGE1`
2. Cliquer sur le bouton _« Accéder au parcours »_
3. Cliquer sur le bouton _« Je commence »_
4. Indiquer la date de naissance `05-05-2013`
5. Cliquer sur le bouton _« C'est parti ! »_
6. Cliquer sur le bouton _« Continuer avec mon compte Pix »_
7. Sur le formulaire _« J’ai déjà un compte Pix »_ indiquer l'adresse email `hermione@school.net` et son mdp
8. Faire et envoyer le parcours
9. Se déconnecter
10. Se connecter à nouveau avec le SSO GAR (faux GAR)  
> L'utilisateur est connecté directement
