### PR TITLE
[FEATURE] Mise à jour du message en cas d'incident technique non bloquant sur Pix Certif (PIX-15391).

### DIFF
--- a/certif/tests/integration/components/issue-report-modal/non-blocking-technical-issue-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/issue-report-modal/non-blocking-technical-issue-certification-issue-report-fields-test.js
@@ -1,6 +1,7 @@
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -73,9 +74,7 @@ module(
       // then
       assert
         .dom(
-          screen.getByText(
-            "Signalement à titre informatif, le problème rencontré n'a pas empêché le candidat de continuer à répondre aux questions. En cas d’incident sur une question focus, merci de vous reporter à la catégorie E10.",
-          ),
+          screen.getByText(t('pages.session-finalization.add-issue-modal.non-blocking-issues.technical-information')),
         )
         .exists();
     });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -360,7 +360,7 @@
           "candidate-examples": "Left temporarily, under invigilation, the exam room, arrived late, encountered difficulties to connect to the session, had to reconnect to the session, had forgotten their password…",
           "candidate-information": "Reporting on an indicative basis, the problem encountered didn’t prevent the candidate from continuing to answer the questions.",
           "technical-examples": "The computer switched off, significant slowness of the network and/or of the machine etc…",
-          "technical-information": "Reporting on an indicative basis, the problem encountered didn’t prevent the candidate from continuing to answer the questions. In case of an incident during a focus mode question, please refer to the E10 category."
+          "technical-information": "Reporting on an indicative basis, the problem encountered didn’t prevent the candidate from continuing to answer the questions. As a reminder, any technical incident with a question must be reported live during the session, using the Invigilator’s Portal."
         },
         "subcategory-labels": {
           "accessibility-issue": "Problem with the accessibility of the question (ex : colour blindness)",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -360,7 +360,7 @@
           "candidate-examples": "a quitté temporairement, sous surveillance, la salle d’examen, est arrivé en retard, a rencontré des difficultés pour se connecter à la session, a dû se reconnecter à la session, avait oublié son mot de passe...",
           "candidate-information": "Signalement à titre informatif, le problème rencontré n'a pas empêché le candidat de continuer à répondre aux questions. ",
           "technical-examples": "L’ordinateur s’est éteint, lenteur significative du réseau et/ou de l’appareil etc.",
-          "technical-information": "Signalement à titre informatif, le problème rencontré n'a pas empêché le candidat de continuer à répondre aux questions. En cas d’incident sur une question focus, merci de vous reporter à la catégorie E10."
+          "technical-information": "Signalement à titre informatif, le problème rencontré n'a pas empêché le candidat de continuer à répondre aux questions. Pour rappel, un incident technique sur une question doit être signalé en direct pendant la session, depuis l'espace surveillant."
         },
         "subcategory-labels": {
           "accessibility-issue": "Problème avec l’accessibilité de la question (ex : daltonisme)",


### PR DESCRIPTION
## :christmas_tree: Problème

Lorsqu’un utilisateur Pix Certif finalise une session sur Pix Certif, il peut remonter des signalements après la session, notamment des “incidents techniques non bloquants”. 

Pour la v2, cette catégorie de signalement était utilisée à tort pour signaler des problèmes avec une question focus.
Un message avait donc été ajouté pour préciser l’utilité de cette catégorie.

Maintenant que nous sommes passés en V3, le message est caduc.

## :gift: Proposition

Indiquer, qu'avec la nouvelle certif, ce type de signalement ne se fait plus a posteriori via la page de finalisation, mais pendant le test.

## :santa: Pour tester

- Se connecter avec certif-pro
- https://certif-pr10761.review.pix.fr/sessions/7405/finalisation
- Signaler sur un élève au choix
- Sélectionner C7
- Constater que le message à changé

<img width="1055" alt="Capture d’écran 2024-12-10 à 09 53 44" src="https://github.com/user-attachments/assets/5c68f440-f6e8-40e7-8002-fb6c3539c5c7">

