### PR TITLE
[BUGFIX] Crash du rafraichissement du cache en recette (PIX-15642)

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -40,6 +40,15 @@ REDIS_URL=redis://localhost:6379
 # default: none
 # sample (everyday at 06:30 UTC): CACHE_RELOAD_TIME=30 6 * * *
 
+# Cache reload container size
+#
+# If not present, a default size is chosen by Scalingo
+#
+# present: optional
+# type: string (S,M,L,XL,2XL)
+# default: none
+# CACHE_RELOAD_CONTAINER_SIZE=M
+
 # =========
 # DATABASES
 # =========

--- a/api/scripts/generate-cron.js
+++ b/api/scripts/generate-cron.js
@@ -3,8 +3,13 @@ const cronContent = {
 };
 
 if (process.env.CACHE_RELOAD_TIME) {
-  cronContent.jobs.push({
+  const cacheReloadJob = {
     command: `${process.env.CACHE_RELOAD_TIME} npm run cache:refresh`,
-  });
+  };
+  if (process.env.CACHE_RELOAD_CONTAINER_SIZE) {
+    cacheReloadJob.size = process.env.CACHE_RELOAD_CONTAINER_SIZE;
+  }
+  cronContent.jobs.push(cacheReloadJob);
 }
+
 console.log(JSON.stringify(cronContent));


### PR DESCRIPTION
## :christmas_tree: Problème

La taille par défaut des containers one-off utilisés pour les tâches planifiées est M (voir [la documentation de Scalingo](https://doc.scalingo.com/platform/app/task-scheduling/scalingo-scheduler#defining-tasks)), il semblerait que cette taille commence à être insuffisante et que régulièrement le one-off crash par manque de mémoire, exemple [en recette ce 10 décembre](https://app.datadoghq.eu/logs?query=service%3Apix-api-recette%20host%3Aone-off-6077&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1733798011850&to_ts=1733812411850&live=false).

Le crash a pu être reproduit en démarrant manuellement un one-off, cf capture d’écran.

![Screenshot from 2024-12-10 07-51-40](https://github.com/user-attachments/assets/cdb44990-50c4-4d6e-aaef-a084f884e8d5)

## :gift: Proposition

Pouvoir choisir la taille du container utilisé pour la tâche planifiée de rafraîchissement du cache.

## :socks: Remarques

N/A

## :santa: Pour tester

La variable d’environnement `CACHE_RELOAD_CONTAINER_SIZE` a été valorisée à `L` sur la RA.

Démarrer un one-off sur la RA, et vérifier le contenu du fichier `cron.json` :

```sh
scalingo -a pix-api-review-pr10762 run bash
cat cron.json
```