### PR TITLE
[BUGFIX] Nouveaux repositories learning content : résultats en doublon (PIX-15640)

### DIFF
--- a/api/lib/infrastructure/repositories/framework-repository.js
+++ b/api/lib/infrastructure/repositories/framework-repository.js
@@ -27,7 +27,7 @@ export async function getByName(name) {
 
 export async function findByRecordIds(ids) {
   if (!config.featureToggles.useNewLearningContent) return oldFrameworkRepository.findByRecordIds(ids);
-  const frameworkDtos = await getInstance().loadMany(ids);
+  const frameworkDtos = await getInstance().getMany(ids);
   return frameworkDtos
     .filter((frameworkDto) => frameworkDto)
     .sort(byName)

--- a/api/lib/infrastructure/repositories/thematic-repository.js
+++ b/api/lib/infrastructure/repositories/thematic-repository.js
@@ -27,7 +27,7 @@ export async function findByCompetenceIds(competenceIds, locale) {
 
 export async function findByRecordIds(ids, locale) {
   if (!config.featureToggles.useNewLearningContent) return oldThematicRepository.findByRecordIds(ids, locale);
-  const thematicDtos = await getInstance().loadMany(ids);
+  const thematicDtos = await getInstance().getMany(ids);
   return thematicDtos
     .filter((thematic) => thematic)
     .map((thematicDto) => toDomain(thematicDto, locale))

--- a/api/lib/infrastructure/repositories/tube-repository.js
+++ b/api/lib/infrastructure/repositories/tube-repository.js
@@ -10,6 +10,7 @@ const TABLE_NAME = 'learningcontent.tubes';
 const ACTIVE_STATUS = 'actif';
 
 export async function get(id) {
+  if (!config.featureToggles.useNewLearningContent) return oldTubeRepository.get(id);
   const tubeDto = await getInstance().load(id);
   if (!tubeDto) {
     throw new LearningContentResourceNotFound();

--- a/api/lib/infrastructure/repositories/tube-repository.js
+++ b/api/lib/infrastructure/repositories/tube-repository.js
@@ -34,7 +34,7 @@ export async function findByNames({ tubeNames, locale }) {
 
 export async function findByRecordIds(ids, locale) {
   if (!config.featureToggles.useNewLearningContent) return oldTubeRepository.findByRecordIds(ids, locale);
-  const tubeDtos = await getInstance().loadMany(ids);
+  const tubeDtos = await getInstance().getMany(ids);
   return toDomainList(
     tubeDtos.filter((tubeDto) => tubeDto),
     locale,

--- a/api/src/devcomp/infrastructure/repositories/tutorial-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/tutorial-repository.js
@@ -19,7 +19,7 @@ const TABLE_NAME = 'learningcontent.tutorials';
 export async function findByRecordIdsForCurrentUser({ ids, userId, locale }) {
   if (!config.featureToggles.useNewLearningContent)
     return oldTutorialRepository.findByRecordIdsForCurrentUser({ ids, userId, locale });
-  let tutorialDtos = await getInstance().loadMany(ids);
+  let tutorialDtos = await getInstance().getMany(ids);
   tutorialDtos = tutorialDtos.filter((tutorialDto) => tutorialDto);
   if (locale) {
     const lang = extractLangFromLocale(locale);

--- a/api/src/shared/infrastructure/repositories/area-repository.js
+++ b/api/src/shared/infrastructure/repositories/area-repository.js
@@ -48,7 +48,7 @@ export async function findByFrameworkId({ frameworkId, locale }) {
 
 export async function findByRecordIds({ areaIds, locale }) {
   if (!config.featureToggles.useNewLearningContent) return oldAreaRepository.findByRecordIds({ areaIds, locale });
-  const areaDtos = await getInstance().loadMany(areaIds);
+  const areaDtos = await getInstance().getMany(areaIds);
   return areaDtos
     .filter((areaDto) => areaDto)
     .sort(byId)

--- a/api/src/shared/infrastructure/repositories/challenge-repository_old.js
+++ b/api/src/shared/infrastructure/repositories/challenge-repository_old.js
@@ -135,8 +135,15 @@ const findValidatedBySkillId = async function (skillId, locale) {
 };
 
 export async function getManyTypes(ids) {
-  const challenges = await challengeDatasource.getMany(ids);
-  return Object.fromEntries(challenges.map(({ id, type }) => [id, type]));
+  try {
+    const challenges = await challengeDatasource.getMany(ids);
+    return Object.fromEntries(challenges.map(({ id, type }) => [id, type]));
+  } catch (err) {
+    if (err instanceof LearningContentResourceNotFound) {
+      throw new NotFoundError();
+    }
+    throw err;
+  }
 }
 
 function byId(challenge1, challenge2) {

--- a/api/src/shared/infrastructure/repositories/competence-repository.js
+++ b/api/src/shared/infrastructure/repositories/competence-repository.js
@@ -43,7 +43,7 @@ export async function getCompetenceName({ id, locale }) {
 export async function findByRecordIds({ competenceIds, locale }) {
   if (!config.featureToggles.useNewLearningContent)
     return oldCompetenceRepository.findByRecordIds({ competenceIds, locale });
-  const competenceDtos = await getInstance().loadMany(competenceIds);
+  const competenceDtos = await getInstance().getMany(competenceIds);
   return competenceDtos
     .filter((competenceDto) => competenceDto)
     .sort(byId)

--- a/api/src/shared/infrastructure/repositories/learning-content-repository.js
+++ b/api/src/shared/infrastructure/repositories/learning-content-repository.js
@@ -137,7 +137,7 @@ export class LearningContentRepository {
    * @param {string|number|undefined} id
    */
   clearCache(id) {
-    logger.debug({ tableName: this.#tableName, id }, 'trigerring cache clear');
+    logger.debug({ tableName: this.#tableName, id }, 'triggering cache clear');
 
     if (id) {
       this.#dataloader.clear(id);

--- a/api/src/shared/infrastructure/repositories/learning-content-repository.js
+++ b/api/src/shared/infrastructure/repositories/learning-content-repository.js
@@ -66,21 +66,35 @@ export class LearningContentRepository {
   /**
    * Loads one entity by ID.
    * @param {string|number} id
-   * @returns {Promise<object>}
+   * @returns {Promise<object|null>}
    */
   async load(id) {
-    if (!id) return null;
     return this.#dataloader.load(id);
+  }
+
+  /**
+   * Gets several entities by ID.
+   * Deduplicates ids and removes nullish ids before loading.
+   * @param {string[]|number[]} ids
+   * @returns {Promise<(object|null)[]>}
+   */
+  async getMany(ids) {
+    const idsToLoad = new Set(ids);
+    idsToLoad.delete(undefined);
+    idsToLoad.delete(null);
+
+    const dtos = await this.loadMany(Array.from(idsToLoad));
+
+    return dtos;
   }
 
   /**
    * Loads several entities by ID.
    * @param {string[]|number[]} ids
-   * @returns {Promise<object[]>}
+   * @returns {Promise<(object|null)[]>}
    */
   async loadMany(ids) {
-    const notNullIds = ids.filter((id) => id);
-    return this.#dataloader.loadMany(notNullIds);
+    return this.#dataloader.loadMany(ids);
   }
 
   /**

--- a/api/src/shared/infrastructure/repositories/skill-repository.js
+++ b/api/src/shared/infrastructure/repositories/skill-repository.js
@@ -1,3 +1,4 @@
+import { knex } from '../../../../db/knex-database-connection.js';
 import { config } from '../../config.js';
 import { NotFoundError } from '../../domain/errors.js';
 import { Skill } from '../../domain/models/Skill.js';
@@ -64,17 +65,19 @@ export async function findOperativeByCompetenceId(competenceId) {
 export async function findOperativeByCompetenceIds(competenceIds) {
   if (!config.featureToggles.useNewLearningContent)
     return oldSkillRepository.findOperativeByCompetenceIds(competenceIds);
-  const skills = [];
-  for (const competenceId of competenceIds) {
-    const skillsForCompetence = await findOperativeByCompetenceId(competenceId);
-    skills.push(...skillsForCompetence);
-  }
-  return skills.sort(byId);
+  const ids = await knex
+    .pluck('id')
+    .from(TABLE_NAME)
+    .whereIn('competenceId', competenceIds)
+    .whereIn('status', OPERATIVE_STATUSES)
+    .orderBy('id');
+  const skillDtos = await getInstance().loadMany(ids);
+  return skillDtos.map(toDomain);
 }
 
 export async function findOperativeByIds(ids) {
   if (!config.featureToggles.useNewLearningContent) return oldSkillRepository.findOperativeByIds(ids);
-  const skillDtos = await getInstance().loadMany(ids);
+  const skillDtos = await getInstance().getMany(ids);
   return skillDtos
     .filter((skillDto) => skillDto && OPERATIVE_STATUSES.includes(skillDto.status))
     .sort(byId)
@@ -83,7 +86,7 @@ export async function findOperativeByIds(ids) {
 
 export async function findByRecordIds(ids) {
   if (!config.featureToggles.useNewLearningContent) return oldSkillRepository.findByRecordIds(ids);
-  const skillDtos = await getInstance().loadMany(ids);
+  const skillDtos = await getInstance().getMany(ids);
   return skillDtos
     .filter((skillDto) => skillDto)
     .sort(byId)
@@ -92,7 +95,7 @@ export async function findByRecordIds(ids) {
 
 export async function findActiveByRecordIds(ids) {
   if (!config.featureToggles.useNewLearningContent) return oldSkillRepository.findActiveByRecordIds(ids);
-  const skillDtos = await getInstance().loadMany(ids);
+  const skillDtos = await getInstance().getMany(ids);
   return skillDtos
     .filter((skillDto) => skillDto && skillDto.status === ACTIVE_STATUS)
     .sort(byId)

--- a/api/tests/integration/infrastructure/repositories/area-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/area-repository_test.js
@@ -438,6 +438,27 @@ describe('Integration | Repository | area-repository', function () {
             ]);
           });
         });
+
+        it('should ignore null and duplicates', async function () {
+          // when
+          const areas = await areaRepository.findByRecordIds({
+            areaIds: ['recArea2', 'recArea0', 'recCOUCOUMAMAN', 'recArea0'],
+          });
+
+          // then
+          expect(areas).to.deepEqualArray([
+            domainBuilder.buildArea({
+              ...areaData0,
+              title: areaData0.title_i18n.fr,
+              competences: [],
+            }),
+            domainBuilder.buildArea({
+              ...areaData2,
+              title: areaData2.title_i18n.fr,
+              competences: [],
+            }),
+          ]);
+        });
       });
 
       context('when no areas found for given ids', function () {

--- a/api/tests/integration/infrastructure/repositories/framework-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/framework-repository_test.js
@@ -99,9 +99,9 @@ describe('Integration | Repository | framework-repository', function () {
         expect(frameworks).to.deepEqualArray([expectedFramework0, expectedFramework2]);
       });
 
-      it('should return frameworks it managed to find', async function () {
+      it('should return frameworks it managed to find once', async function () {
         // when
-        const frameworks = await frameworkRepository.findByRecordIds(['recId2', 'recIdCAVA']);
+        const frameworks = await frameworkRepository.findByRecordIds(['recId2', 'recIdCAVA', 'recId2']);
 
         // then
         const expectedFramework2 = domainBuilder.buildFramework({ ...frameworkData2, areas: [] });

--- a/api/tests/integration/infrastructure/repositories/thematic-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/thematic-repository_test.js
@@ -157,6 +157,32 @@ describe('Integration | Repository | thematic-repository', function () {
             ]);
           });
         });
+
+        it('should ignore null and duplicates', async function () {
+          // when
+          const thematics = await thematicRepository.findByCompetenceIds([
+            'competenceIdB',
+            'competenceIdA',
+            'competenceCOUCOUMAMAN',
+            'competenceIdB',
+          ]);
+
+          // then
+          expect(thematics).to.deepEqualArray([
+            domainBuilder.buildThematic({
+              ...thematicData0,
+              name: thematicData0.name_i18n.fr,
+            }),
+            domainBuilder.buildThematic({
+              ...thematicData1,
+              name: thematicData1.name_i18n.fr,
+            }),
+            domainBuilder.buildThematic({
+              ...thematicData2,
+              name: thematicData2.name_i18n.fr,
+            }),
+          ]);
+        });
       });
 
       context('when no thematics found for given competence ids', function () {
@@ -208,6 +234,27 @@ describe('Integration | Repository | thematic-repository', function () {
               }),
             ]);
           });
+        });
+        it('should ignore nulls and duplicates', async function () {
+          // when
+          const thematics = await thematicRepository.findByRecordIds([
+            'thematicId3',
+            'thematicId0',
+            'thematicCOUCOUPAPA',
+            'thematicId3',
+          ]);
+
+          // then
+          expect(thematics).to.deepEqualArray([
+            domainBuilder.buildThematic({
+              ...thematicData0,
+              name: thematicData0.name_i18n.fr,
+            }),
+            domainBuilder.buildThematic({
+              ...thematicData3,
+              name: thematicData3.name_i18n.fr,
+            }),
+          ]);
         });
       });
 

--- a/api/tests/integration/infrastructure/repositories/tube-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tube-repository_test.js
@@ -193,6 +193,29 @@ describe('Integration | Repository | tube-repository', function () {
             ]);
           });
         });
+
+        it('should ingore dupes and nulls', async function () {
+          // when
+          const tubes = await tubeRepository.findByNames({
+            tubeNames: ['name Tube 2', 'name Tube 0', 'non existant mais on sen fiche', 'name Tube 0'],
+          });
+
+          // then
+          expect(tubes).to.deepEqualArray([
+            domainBuilder.buildTube({
+              ...tubeData0,
+              practicalTitle: tubeData0.practicalTitle_i18n.fr,
+              practicalDescription: tubeData0.practicalDescription_i18n.fr,
+              skills: [],
+            }),
+            domainBuilder.buildTube({
+              ...tubeData2,
+              practicalTitle: tubeData2.practicalTitle_i18n.fr,
+              practicalDescription: tubeData2.practicalDescription_i18n.fr,
+              skills: [],
+            }),
+          ]);
+        });
       });
 
       context('when no tubes found for given names', function () {
@@ -259,6 +282,31 @@ describe('Integration | Repository | tube-repository', function () {
               }),
             ]);
           });
+        });
+        it('should ignore dupes and nulls', async function () {
+          // when
+          const tubes = await tubeRepository.findByRecordIds([
+            'tubeId2',
+            'tubeId0',
+            'non existant mais on sen fiche',
+            'tubeId0',
+          ]);
+
+          // then
+          expect(tubes).to.deepEqualArray([
+            domainBuilder.buildTube({
+              ...tubeData0,
+              practicalTitle: tubeData0.practicalTitle_i18n.fr,
+              practicalDescription: tubeData0.practicalDescription_i18n.fr,
+              skills: [],
+            }),
+            domainBuilder.buildTube({
+              ...tubeData2,
+              practicalTitle: tubeData2.practicalTitle_i18n.fr,
+              practicalDescription: tubeData2.practicalDescription_i18n.fr,
+              skills: [],
+            }),
+          ]);
         });
       });
 
@@ -327,6 +375,32 @@ describe('Integration | Repository | tube-repository', function () {
               }),
             ]);
           });
+        });
+        it('should ignore duplicates and nulls', async function () {
+          // when
+          const tubes = await tubeRepository.findActiveByRecordIds([
+            'tubeId2',
+            'tubeId0',
+            'tubeId1',
+            'non existant mais on sen fiche',
+            'tubeId0',
+          ]);
+
+          // then
+          expect(tubes).to.deepEqualArray([
+            domainBuilder.buildTube({
+              ...tubeData0,
+              practicalTitle: tubeData0.practicalTitle_i18n.fr,
+              practicalDescription: tubeData0.practicalDescription_i18n.fr,
+              skills: [],
+            }),
+            domainBuilder.buildTube({
+              ...tubeData2,
+              practicalTitle: tubeData2.practicalTitle_i18n.fr,
+              practicalDescription: tubeData2.practicalDescription_i18n.fr,
+              skills: [],
+            }),
+          ]);
         });
       });
 

--- a/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
@@ -697,6 +697,92 @@ describe('Integration | Repository | challenge-repository', function () {
               }),
             ]);
           });
+          it('should allow duplicates', async function () {
+            // when
+            const challenges = await challengeRepository.getMany(['challengeId02', 'challengeId00', 'challengeId02']);
+
+            // then
+            expect(challenges).to.deepEqualArray([
+              domainBuilder.buildChallenge({
+                ...challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson,
+                blindnessCompatibility:
+                  challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.accessibility1,
+                colorBlindnessCompatibility:
+                  challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.accessibility2,
+                focused: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.focusable,
+                discriminant: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.alpha,
+                difficulty: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.delta,
+                validator: new ValidatorQCU({
+                  solution: domainBuilder.buildSolution({
+                    id: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.id,
+                    type: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.type,
+                    value: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.solution,
+                    isT1Enabled: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t1Status,
+                    isT2Enabled: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t2Status,
+                    isT3Enabled: challengeData00_skill00_qcu_valide_flashCompatible_frnl_noEmbedJson.t3Status,
+                    qrocBlocksTypes: {},
+                  }),
+                }),
+                skill: domainBuilder.buildSkill({
+                  ...skillData00_tube00competence00_actif,
+                  difficulty: skillData00_tube00competence00_actif.level,
+                  hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+                }),
+              }),
+              domainBuilder.buildChallenge({
+                ...challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson,
+                blindnessCompatibility:
+                  challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility1,
+                colorBlindnessCompatibility:
+                  challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility2,
+                focused: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.focusable,
+                discriminant: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.alpha,
+                difficulty: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.delta,
+                validator: new ValidatorQCM({
+                  solution: domainBuilder.buildSolution({
+                    id: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.id,
+                    type: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.type,
+                    value: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.solution,
+                    isT1Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t1Status,
+                    isT2Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t2Status,
+                    isT3Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t3Status,
+                    qrocBlocksTypes: {},
+                  }),
+                }),
+                skill: domainBuilder.buildSkill({
+                  ...skillData00_tube00competence00_actif,
+                  difficulty: skillData00_tube00competence00_actif.level,
+                  hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+                }),
+              }),
+              domainBuilder.buildChallenge({
+                ...challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson,
+                blindnessCompatibility:
+                  challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility1,
+                colorBlindnessCompatibility:
+                  challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility2,
+                focused: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.focusable,
+                discriminant: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.alpha,
+                difficulty: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.delta,
+                validator: new ValidatorQCM({
+                  solution: domainBuilder.buildSolution({
+                    id: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.id,
+                    type: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.type,
+                    value: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.solution,
+                    isT1Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t1Status,
+                    isT2Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t2Status,
+                    isT3Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t3Status,
+                    qrocBlocksTypes: {},
+                  }),
+                }),
+                skill: domainBuilder.buildSkill({
+                  ...skillData00_tube00competence00_actif,
+                  difficulty: skillData00_tube00competence00_actif.level,
+                  hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+                }),
+              }),
+            ]);
+          });
         });
       });
       context('when locale is provided', function () {
@@ -1407,6 +1493,116 @@ describe('Integration | Repository | challenge-repository', function () {
               }),
             ]);
           });
+          it('should avoid duplicates', async function () {
+            // given
+            const skills = [
+              domainBuilder.buildSkill({
+                ...skillData00_tube00competence00_actif,
+                difficulty: skillData00_tube00competence00_actif.level,
+                hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+              }),
+              domainBuilder.buildSkill({
+                ...skillData02_tube02competence01_perime,
+                difficulty: skillData02_tube02competence01_perime.level,
+                hint: skillData02_tube02competence01_perime.hint_i18n.fr,
+              }),
+              domainBuilder.buildSkill({
+                ...skillData01_tube01competence00_actif,
+                difficulty: skillData01_tube01competence00_actif.level,
+                hint: skillData01_tube01competence00_actif.hint_i18n.fr,
+              }),
+              domainBuilder.buildSkill({
+                ...skillData00_tube00competence00_actif,
+                difficulty: skillData00_tube00competence00_actif.level,
+                hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+              }),
+            ];
+
+            // when
+            const challenges = await challengeRepository.findOperativeBySkills(skills, 'en');
+
+            // then
+            expect(challenges).to.deep.equal([
+              domainBuilder.buildChallenge({
+                ...challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson,
+                blindnessCompatibility:
+                  challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility1,
+                colorBlindnessCompatibility:
+                  challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility2,
+                focused: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.focusable,
+                discriminant: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.alpha,
+                difficulty: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.delta,
+                validator: new ValidatorQCU({
+                  solution: domainBuilder.buildSolution({
+                    id: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.id,
+                    type: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.type,
+                    value: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.solution,
+                    isT1Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t1Status,
+                    isT2Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t2Status,
+                    isT3Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t3Status,
+                    qrocBlocksTypes: {},
+                  }),
+                }),
+                skill: domainBuilder.buildSkill({
+                  ...skillData00_tube00competence00_actif,
+                  difficulty: skillData00_tube00competence00_actif.level,
+                  hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+                }),
+              }),
+              domainBuilder.buildChallenge({
+                ...challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson,
+                blindnessCompatibility:
+                  challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility1,
+                colorBlindnessCompatibility:
+                  challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.accessibility2,
+                focused: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.focusable,
+                discriminant: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.alpha,
+                difficulty: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.delta,
+                validator: new ValidatorQCM({
+                  solution: domainBuilder.buildSolution({
+                    id: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.id,
+                    type: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.type,
+                    value: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.solution,
+                    isT1Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t1Status,
+                    isT2Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t2Status,
+                    isT3Enabled: challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson.t3Status,
+                    qrocBlocksTypes: {},
+                  }),
+                }),
+                skill: domainBuilder.buildSkill({
+                  ...skillData00_tube00competence00_actif,
+                  difficulty: skillData00_tube00competence00_actif.level,
+                  hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+                }),
+              }),
+              domainBuilder.buildChallenge({
+                ...challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson,
+                blindnessCompatibility:
+                  challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility1,
+                colorBlindnessCompatibility:
+                  challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility2,
+                focused: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.focusable,
+                discriminant: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.alpha,
+                difficulty: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.delta,
+                validator: new ValidatorQCU({
+                  solution: domainBuilder.buildSolution({
+                    id: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.id,
+                    type: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.type,
+                    value: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.solution,
+                    isT1Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t1Status,
+                    isT2Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t2Status,
+                    isT3Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t3Status,
+                    qrocBlocksTypes: {},
+                  }),
+                }),
+                skill: domainBuilder.buildSkill({
+                  ...skillData01_tube01competence00_actif,
+                  difficulty: skillData01_tube01competence00_actif.level,
+                  hint: skillData01_tube01competence00_actif.hint_i18n.fr,
+                }),
+              }),
+            ]);
+          });
         });
       });
     });
@@ -1949,6 +2145,20 @@ describe('Integration | Repository | challenge-repository', function () {
           challengeId07: 'QCM',
           challengeId09: 'QCU',
         });
+      });
+
+      it('should throw NotFoundError when some ids are not found', async function () {
+        // when
+        const err = await catchErr(challengeRepository.getManyTypes)([
+          'challengeId09',
+          'challengeId04',
+          'challengeId666',
+          'challengeId02',
+          'challengeId01',
+        ]);
+
+        // then
+        expect(err).to.be.instanceOf(NotFoundError);
       });
     });
   }

--- a/api/tests/shared/integration/infrastructure/repositories/competence-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/competence-repository_test.js
@@ -293,6 +293,26 @@ describe('Integration | Repository | competence-repository', function () {
             ]);
           });
         });
+        it('should ignore null and duplicates', async function () {
+          // when
+          const competences = await competenceRepository.findByRecordIds({
+            competenceIds: ['recCompetence3_pix', 'recCompetence2_pasPix', 'recCouCouMaman', 'recCompetence2_pasPix'],
+          });
+
+          // then
+          expect(competences).to.deepEqualArray([
+            domainBuilder.buildCompetence({
+              ...competenceData2,
+              name: competenceData2.name_i18n.fr,
+              description: competenceData2.description_i18n.fr,
+            }),
+            domainBuilder.buildCompetence({
+              ...competenceData3,
+              name: competenceData3.name_i18n.fr,
+              description: competenceData3.description_i18n.fr,
+            }),
+          ]);
+        });
       });
 
       context('when no competences found for given ids', function () {

--- a/api/tests/shared/integration/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/skill-repository_test.js
@@ -430,6 +430,59 @@ describe('Integration | Repository | skill-repository', function () {
             }),
           ]);
         });
+        it('should avoid returning duplicates', async function () {
+          // when
+          const skills = await skillRepository.findOperativeByCompetenceIds([
+            'competenceIdA',
+            'competenceIdB',
+            'competenceInconnue',
+            'competenceIdB',
+          ]);
+
+          // then
+          expect(skills).to.deepEqualArray([
+            domainBuilder.buildSkill({
+              ...skillData00_tubeAcompetenceA_actif,
+              difficulty: skillData00_tubeAcompetenceA_actif.level,
+              hint: skillData00_tubeAcompetenceA_actif.hint_i18n.fr,
+            }),
+            domainBuilder.buildSkill({
+              ...skillData01_tubeAcompetenceA_archive,
+              difficulty: skillData01_tubeAcompetenceA_archive.level,
+              hint: skillData01_tubeAcompetenceA_archive.hint_i18n.fr,
+            }),
+            domainBuilder.buildSkill({
+              ...skillData03_tubeBcompetenceA_actif,
+              difficulty: skillData03_tubeBcompetenceA_actif.level,
+              hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
+            }),
+            domainBuilder.buildSkill({
+              ...skillData04_tubeBcompetenceA_archive,
+              difficulty: skillData04_tubeBcompetenceA_archive.level,
+              hint: skillData04_tubeBcompetenceA_archive.hint_i18n.fr,
+            }),
+            domainBuilder.buildSkill({
+              ...skillData06_tubeCcompetenceB_actif,
+              difficulty: skillData06_tubeCcompetenceB_actif.level,
+              hint: skillData06_tubeCcompetenceB_actif.hint_i18n.fr,
+            }),
+            domainBuilder.buildSkill({
+              ...skillData07_tubeCcompetenceB_archive,
+              difficulty: skillData07_tubeCcompetenceB_archive.level,
+              hint: skillData07_tubeCcompetenceB_archive.hint_i18n.fr,
+            }),
+            domainBuilder.buildSkill({
+              ...skillData09_tubeDcompetenceB_actif,
+              difficulty: skillData09_tubeDcompetenceB_actif.level,
+              hint: skillData09_tubeDcompetenceB_actif.hint_i18n.fr,
+            }),
+            domainBuilder.buildSkill({
+              ...skillData10_tubeDcompetenceB_archive,
+              difficulty: skillData10_tubeDcompetenceB_archive.level,
+              hint: skillData10_tubeDcompetenceB_archive.hint_i18n.fr,
+            }),
+          ]);
+        });
       });
 
       context('when no operative skills find for competence ids', function () {
@@ -523,6 +576,30 @@ describe('Integration | Repository | skill-repository', function () {
             'skillId03',
             'skillId01',
             'skillIdCoucou',
+          ]);
+
+          // then
+          expect(skills).to.deepEqualArray([
+            domainBuilder.buildSkill({
+              ...skillData01_tubeAcompetenceA_archive,
+              difficulty: skillData01_tubeAcompetenceA_archive.level,
+              hint: skillData01_tubeAcompetenceA_archive.hint_i18n.fr,
+            }),
+            domainBuilder.buildSkill({
+              ...skillData03_tubeBcompetenceA_actif,
+              difficulty: skillData03_tubeBcompetenceA_actif.level,
+              hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
+            }),
+          ]);
+        });
+        it('should avoid returning duplicates', async function () {
+          // when
+          const skills = await skillRepository.findOperativeByIds([
+            'skillId02',
+            'skillId03',
+            'skillId01',
+            'skillIdCoucou',
+            'skillId01',
           ]);
 
           // then
@@ -658,6 +735,31 @@ describe('Integration | Repository | skill-repository', function () {
             }),
           ]);
         });
+        it('should avoid returning duplicates', async function () {
+          // when
+          const skills = await skillRepository.findActiveByRecordIds([
+            'skillId02',
+            'skillId03',
+            'skillId01',
+            'skillId00',
+            'skillIdCoucou',
+            'skillId00',
+          ]);
+
+          // then
+          expect(skills).to.deepEqualArray([
+            domainBuilder.buildSkill({
+              ...skillData00_tubeAcompetenceA_actif,
+              difficulty: skillData00_tubeAcompetenceA_actif.level,
+              hint: skillData00_tubeAcompetenceA_actif.hint_i18n.fr,
+            }),
+            domainBuilder.buildSkill({
+              ...skillData03_tubeBcompetenceA_actif,
+              difficulty: skillData03_tubeBcompetenceA_actif.level,
+              hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
+            }),
+          ]);
+        });
       });
     });
 
@@ -681,6 +783,42 @@ describe('Integration | Repository | skill-repository', function () {
             'skillId01',
             'skillId00',
             'skillIdCoucou',
+          ]);
+
+          // then
+          expect(skills).to.deepEqualArray([
+            domainBuilder.buildSkill({
+              ...skillData00_tubeAcompetenceA_actif,
+              difficulty: skillData00_tubeAcompetenceA_actif.level,
+              hint: skillData00_tubeAcompetenceA_actif.hint_i18n.fr,
+            }),
+            domainBuilder.buildSkill({
+              ...skillData01_tubeAcompetenceA_archive,
+              difficulty: skillData01_tubeAcompetenceA_archive.level,
+              hint: skillData01_tubeAcompetenceA_archive.hint_i18n.fr,
+            }),
+            domainBuilder.buildSkill({
+              ...skillData02_tubeAcompetenceA_perime,
+              difficulty: skillData02_tubeAcompetenceA_perime.level,
+              hint: skillData02_tubeAcompetenceA_perime.hint_i18n.fr,
+            }),
+            domainBuilder.buildSkill({
+              ...skillData03_tubeBcompetenceA_actif,
+              difficulty: skillData03_tubeBcompetenceA_actif.level,
+              hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
+            }),
+          ]);
+        });
+
+        it('should avoid returning duplicates', async function () {
+          // when
+          const skills = await skillRepository.findByRecordIds([
+            'skillId02',
+            'skillId03',
+            'skillId01',
+            'skillId00',
+            'skillIdCoucou',
+            'skillId00',
           ]);
 
           // then


### PR DESCRIPTION
## :christmas_tree: Problème

Certaines méthodes des nouveaux repositories de learning content retournent des doublons là où les anciennes n’en retournaient pas.

## :gift: Proposition

Modifier l’implémentation des nouveaux repositories pour éviter les doublons.

## :socks: Remarques

N/A

## :santa: Pour tester

Aller sur la page des tutos de l’utilisateur et vérifier que le nombre de résultats en bas reste cohérent.