### PR TITLE
[BUGFIX] Mélange des options QCM à tort (PIX-15655)

### DIFF
--- a/mon-pix/app/components/challenge-item/challenge-item-qcm.hbs
+++ b/mon-pix/app/components/challenge-item/challenge-item-qcm.hbs
@@ -11,7 +11,7 @@
         @answerChanged={{this.answerChanged}}
         @shuffleSeed={{@assessment.id}}
         @isAnswerFieldDisabled={{this.isAnswerFieldDisabled}}
-        @shuffled="{{@challenge.shuffled}}"
+        @shuffled={{@challenge.shuffled}}
       />
     </div>
 


### PR DESCRIPTION
## :christmas_tree: Problème

Avec le nouveau learning content, l’API renvoie des challenges avec une propriété `shuffled` null`, et cela provoque un mélange des propositions à tort.

## :gift: Proposition

Corriger PixApp pour éviter que le propositions soient mélangées quand `shuffled` est `null`.

## :socks: Remarques

N/A

## :santa: Pour tester

Vérifier que ce challenge ne se mélange pas :
https://app-pr10770.review.pix.fr/challenges/recYmb097nI7ZZVB/preview
