### PR TITLE
[FEATURE] Traiter les retours sur la flashcard (PIX-15324)

### DIFF
--- a/mon-pix/app/components/module/element/flashcards/_flashcards-card.scss
+++ b/mon-pix/app/components/module/element/flashcards/_flashcards-card.scss
@@ -7,7 +7,7 @@
   justify-content: space-between;
   max-width: 345px;
   height: 440px;
-  margin: auto auto var(--pix-spacing-4x);
+  margin: auto auto var(--pix-spacing-2x);
   padding: var(--pix-spacing-6x);
   background: var(--pix-neutral-0);
   border: 5px solid var(--pix-neutral-100);
@@ -70,7 +70,7 @@
     }
 
     &--verso {
-      justify-content: flex-end;
+      justify-content: flex-start;
     }
   }
 }
@@ -84,6 +84,10 @@
 
   &__title {
     @extend %pix-title-s;
+
+    width: 100%;
+    text-align: center;
+    text-wrap: balance;
   }
 }
 
@@ -111,6 +115,8 @@
   }
 
   &__title {
+    @extend %pix-title-xs;
+
     padding: 0 var(--pix-spacing-4x);
     color: var(--pix-neutral-0);
   }

--- a/mon-pix/app/components/module/element/flashcards/flashcards.gjs
+++ b/mon-pix/app/components/module/element/flashcards/flashcards.gjs
@@ -175,11 +175,11 @@ export default class ModulixFlashcards extends Component {
               <p class="element-flashcards__footer__question">{{t "pages.modulix.flashcards.answerDirection"}}</p>
               <div class="element-flashcards__footer__answer">
                 <button
-                  class="element-flashcards__footer__answer__button element-flashcards__footer__answer__button--no"
+                  class="element-flashcards__footer__answer__button element-flashcards__footer__answer__button--yes"
                   type="button"
-                  {{on "click" (fn this.onSelfAssessment "no")}}
+                  {{on "click" (fn this.onSelfAssessment "yes")}}
                 >
-                  {{t "pages.modulix.buttons.flashcards.answers.no"}}
+                  {{t "pages.modulix.buttons.flashcards.answers.yes"}}
                 </button>
                 <button
                   class="element-flashcards__footer__answer__button element-flashcards__footer__answer__button--almost"
@@ -189,11 +189,11 @@ export default class ModulixFlashcards extends Component {
                   {{t "pages.modulix.buttons.flashcards.answers.almost"}}
                 </button>
                 <button
-                  class="element-flashcards__footer__answer__button element-flashcards__footer__answer__button--yes"
+                  class="element-flashcards__footer__answer__button element-flashcards__footer__answer__button--no"
                   type="button"
-                  {{on "click" (fn this.onSelfAssessment "yes")}}
+                  {{on "click" (fn this.onSelfAssessment "no")}}
                 >
-                  {{t "pages.modulix.buttons.flashcards.answers.yes"}}
+                  {{t "pages.modulix.buttons.flashcards.answers.no"}}
                 </button>
               </div>
             {{/if}}


### PR DESCRIPTION
## :christmas_tree: Problème

La revue de la flashcard a été faite et il y a des retours à traiter.

## :gift: Proposition

Traiter ces retours

- Typo du titre de la fin de flashcards 
  * Réduire la taille (token inférieur)
  * Essayer du [text-wrap pretty](https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap) ?
- Réduire la marge avec la section sous la carte de 16px à 8px (où on affiche “Vous aviez la réponse”)
- aligner à gauche le "Revoir la question" plutôt qu'à droite pour coïncider avec un sens de nav
- ordonner Oui / Presque / Non plutôt que Non / Presque / Oui

## :socks: Remarques

RAS

## :santa: Pour tester

- Aller sur le didacticiel modulix /modules/didacticiel-modulix/passage
- Vérifier que les retours ont été traité 🎉 
