### PR TITLE
[TECH] Migrer les participation avec un statut TO_SHARE et une date de participation (PIX-15647).

### DIFF
--- a/api/db/migrations/20241210103623_delete-shared-when-participation-is-to-share.js
+++ b/api/db/migrations/20241210103623_delete-shared-when-participation-is-to-share.js
@@ -1,0 +1,14 @@
+import { CampaignParticipationStatuses } from '../../src/prescription/shared/domain/constants.js';
+
+const up = async function (knex) {
+  await knex('campaign-participations')
+    .update({ sharedAt: null })
+    .where({ status: CampaignParticipationStatuses.TO_SHARE })
+    .whereNotNull('sharedAt');
+};
+
+const down = function () {
+  return;
+};
+
+export { down, up };

--- a/api/tests/integration/migration/20241210103623_delete-shared-when-participation-is-to-share_test.js
+++ b/api/tests/integration/migration/20241210103623_delete-shared-when-participation-is-to-share_test.js
@@ -1,0 +1,56 @@
+import { up as migrationToTest } from '../../../db/migrations/20241210103623_delete-shared-when-participation-is-to-share.js';
+import { CampaignParticipationStatuses } from '../../../src/prescription/shared/domain/constants.js';
+import { databaseBuilder, expect, knex } from '../../test-helper.js';
+
+describe('Integration | Migration | delete-shared-when-participation-is-to-share', function () {
+  let buggyParticipation, sharedParticipation, sharedAt;
+
+  beforeEach(async function () {
+    sharedAt = new Date(2024, 10, 1);
+    const user = databaseBuilder.factory.buildUser();
+    const learner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+      userId: user.id,
+    });
+    const user2 = databaseBuilder.factory.buildUser();
+    const learner2 = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+      userId: user2.id,
+    });
+    const campaign = databaseBuilder.factory.buildCampaign();
+    buggyParticipation = databaseBuilder.factory.buildCampaignParticipation({
+      campaignId: campaign.id,
+      organizationLearnerId: learner.id,
+      userId: user.id,
+      status: CampaignParticipationStatuses.TO_SHARE,
+      sharedAt,
+    });
+
+    sharedParticipation = databaseBuilder.factory.buildCampaignParticipation({
+      campaignId: campaign.id,
+      organizationLearnerId: learner2.id,
+      userId: user2.id,
+      status: CampaignParticipationStatuses.SHARED,
+      sharedAt,
+    });
+
+    await databaseBuilder.commit();
+  });
+
+  it('should set sharedAt at null for participation with sharedAt and status is TO_SHARE', async function () {
+    // when
+    await migrationToTest(knex);
+    // then
+    const patchedParticipation = await knex('campaign-participations').where('id', buggyParticipation.id).first();
+
+    expect(patchedParticipation.sharedAt).is.null;
+  });
+
+  it('should not update SHARED participation', async function () {
+    // when
+    await migrationToTest(knex);
+
+    // then
+    const participation = await knex('campaign-participations').where('id', sharedParticipation.id).first();
+
+    expect(participation.sharedAt).deep.equal(sharedAt);
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème

Certaines participations sont dans un état impossible (une date de partage mais un status TO_SHARE) ce qui bloque l'utilisateur si il souhaite partager sa participation dans PixApp. On suspecte le fait que les usecase d'envoi de resultat et de Retenter soient lancé en parallèlle.

## :gift: Proposition

On ajoute une migration pour réparer les données.

## :socks: Remarques
Un premier fix sur mon pix à bloquer l'utilisation simultanée des 2 boutons.
On va modifier mon-pix pour permettre de partager ses résultats en se basant seulement sur le statut et non pas si la date existe.
Il faudrait enfin s'assurer coté back que si les 2 usecases sont appellés, la concurrence soit gérer (peut être avec l'utilisation de .forUpdate() au moment du select de la participation.)

## :santa: Pour tester

Modifier une participation en la passant a TO_SHARE avec sharedAT
Lancer un migrate:down puis un migrate:up
