### PR TITLE
[BUGFIX] Perte des infos GAR quand la page est rafraichie (PIX-12534)

### DIFF
--- a/mon-pix/app/authenticators/gar.js
+++ b/mon-pix/app/authenticators/gar.js
@@ -1,3 +1,4 @@
+import { isEmpty } from '@ember/utils';
 import BaseAuthenticator from 'ember-simple-auth/authenticators/base';
 import { decodeToken } from 'mon-pix/helpers/jwt';
 import RSVP from 'rsvp';
@@ -11,6 +12,15 @@ export default class GarAuthenticator extends BaseAuthenticator {
       access_token: token,
       user_id,
       source,
+    });
+  }
+
+  restore(data) {
+    return new RSVP.Promise((resolve, reject) => {
+      if (!isEmpty(data['access_token'])) {
+        resolve(data);
+      }
+      reject();
     });
   }
 }

--- a/mon-pix/app/services/session.js
+++ b/mon-pix/app/services/session.js
@@ -3,8 +3,12 @@ import SessionService from 'ember-simple-auth/services/session';
 import get from 'lodash/get';
 import ENV from 'mon-pix/config/environment';
 import { FRENCH_FRANCE_LOCALE, FRENCH_INTERNATIONAL_LOCALE } from 'mon-pix/services/locale';
+import { SessionStorageEntry } from 'mon-pix/utils/session-storage-entry.js';
 
 const FRANCE_TLD = 'fr';
+
+const externalUserTokenFromGarStorage = new SessionStorageEntry('externalUserTokenFromGar');
+const userIdForLearnerAssociationStorage = new SessionStorageEntry('userIdForLearnerAssociation');
 
 export default class CurrentSessionService extends SessionService {
   @service currentUser;
@@ -79,34 +83,28 @@ export default class CurrentSessionService extends SessionService {
   }
 
   get externalUserTokenFromGar() {
-    return this.data.externalUser;
+    return externalUserTokenFromGarStorage.get();
   }
 
   set externalUserTokenFromGar(token) {
-    this.data.externalUser = token;
+    externalUserTokenFromGarStorage.set(token);
   }
 
   get userIdForLearnerAssociation() {
-    return this.data.expectedUserId;
+    return userIdForLearnerAssociationStorage.get();
   }
 
   set userIdForLearnerAssociation(userId) {
-    this.data.expectedUserId = userId;
+    userIdForLearnerAssociationStorage.set(userId);
   }
 
   revokeGarExternalUserToken() {
-    if (this.externalUserTokenFromGar) {
-      delete this.data.externalUser;
-    }
+    externalUserTokenFromGarStorage.remove();
   }
 
   revokeGarAuthenticationContext() {
-    if (this.userIdForLearnerAssociation) {
-      delete this.data.expectedUserId;
-    }
-    if (this.externalUserTokenFromGar) {
-      delete this.data.externalUser;
-    }
+    externalUserTokenFromGarStorage.remove();
+    userIdForLearnerAssociationStorage.remove();
   }
 
   async _loadCurrentUserAndSetLocale(locale = null) {

--- a/mon-pix/app/utils/session-storage-entry.js
+++ b/mon-pix/app/utils/session-storage-entry.js
@@ -1,0 +1,18 @@
+export class SessionStorageEntry {
+  constructor(key) {
+    this.key = key;
+  }
+
+  set(value) {
+    sessionStorage.setItem(this.key, JSON.stringify({ value }));
+  }
+
+  get() {
+    const result = JSON.parse(sessionStorage.getItem(this.key)) || {};
+    return result.value;
+  }
+
+  remove() {
+    sessionStorage.removeItem(this.key);
+  }
+}

--- a/mon-pix/tests/unit/utils/session-storage-entry-test.js
+++ b/mon-pix/tests/unit/utils/session-storage-entry-test.js
@@ -1,0 +1,76 @@
+import { SessionStorageEntry } from 'mon-pix/utils/session-storage-entry';
+import { module, test } from 'qunit';
+
+module('Unit | Utilities | SessionStorageEntry', function () {
+  test('sets and gets a string value', function (assert) {
+    // given
+    const entry = new SessionStorageEntry('testKey');
+    const value = 'testValue';
+
+    // when
+    entry.set(value);
+
+    // then
+    assert.strictEqual(entry.get(), value);
+  });
+
+  test('sets and gets a number value', function (assert) {
+    // given
+    const entry = new SessionStorageEntry('numberKey');
+    const value = 123;
+
+    // when
+    entry.set(value);
+
+    // then
+    assert.strictEqual(entry.get(), value);
+  });
+
+  test('sets and gets a boolean value', function (assert) {
+    // given
+    const entry = new SessionStorageEntry('booleanKey');
+    const value = true;
+
+    // when
+    entry.set(value);
+
+    // then
+    assert.strictEqual(entry.get(), value);
+  });
+
+  test('sets and gets a null value', function (assert) {
+    // given
+    const entry = new SessionStorageEntry('nullKey');
+    const value = null;
+
+    // when
+    entry.set(value);
+
+    // then
+    assert.strictEqual(entry.get(), value);
+  });
+
+  test('returns undefined for a non-existing key', function (assert) {
+    // given
+    const entry = new SessionStorageEntry('nonExistingKey');
+
+    // when
+    const result = entry.get();
+
+    // then
+    assert.strictEqual(result, undefined);
+  });
+
+  test('removes a key', function (assert) {
+    // given
+    const entry = new SessionStorageEntry('testKey');
+    const value = 'testValue';
+    entry.set(value);
+
+    // when
+    entry.remove();
+
+    // then
+    assert.strictEqual(entry.get(), undefined);
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème

Lors du parcours utilisateur GAR, 2 bugs ont été identifiés:
- **BUG 1:** Quand l'utilisateur rafraîchit sa page avant la réconcialisation (sur l'écran de landing page et de réconciliation), les informations du GAR sont perdues et on le redirige directement vers la connexion.
- **BUG 2:** Quand un utilisateur est déjà réconcilié et qu'il se connecte directement à Pix via le GAR, quand il rafraîchit la page, il est déconnecté

## :gift: Proposition

- Pour le **BUG 1**, les informations de contexte du GAR vont être stockées en session storage.
- Pour le **BUG 2**, il faut restaurer l'authentification GAR quand l'utilisateur recharge la page (comme c'est fait actuellement pour les connexions OIDC).

## :socks: Remarques

Un utilitaire `SessionStorageKey` a été ajouté, il permet de stocker des clés dans le session storage en s'assurant que les valeurs soient correctement parsées quand elles sont lues:
```js
const myKeyStorage = new SessionStorageKey('mykey')

myKeyStorage.set('hello')
myKeyStorage.get() // 'hello'

myKeyStorage.set(123)
myKeyStorage.get() // 123

myKeyStorage.set(undefined)
myKeyStorage.get() // undefined
```

## :santa: Pour tester

Se connecter avec le SSO GAR (faux GAR)  
 - Indiquer un samlId aléatoire, le prénom `Hermione` et le nom `Granger`  
 - Se connecter avec le bouton _« Sign in »_

**BUG 1**
1. Sur la page _« Saisissez votre code »_ indiquer le code campagne `SCOBADGE1`
2. Cliquer sur le bouton _« Accéder au parcours »_
3. **Rafraichir la page** 
> on doit pouvoir faire les étapes suivantes sans souci
4. Cliquer sur le bouton _« Je commence »_
5. Indiquer la date de naissance `05-05-2013`
6. Cliquer sur le bouton _« C'est parti ! »_
7. Cliquer sur le bouton _« Continuer avec mon compte Pix »_
8. Sur le formulaire _« J’ai déjà un compte Pix »_ indiquer l'adresse email `hermione@school.net` et son mdp
9. Faire et envoyer le parcours
10. Se déconnecter

**BUG 2**
1. Se connecter à nouveau avec le SSO GAR (faux GAR), normalement l'utilisateur est déjà réconcilié et se connecte directement. 
2. **Rafraîchir la page**
> L'utilisateur n'est pas déconnecté

