### PR TITLE
[TECH] Utilisation des session et currentUser service stubs dans Pix App (PIX-15677)

### DIFF
--- a/mon-pix/app/components/data-protection-policy-information-banner.js
+++ b/mon-pix/app/components/data-protection-policy-information-banner.js
@@ -5,6 +5,7 @@ import isEmpty from 'lodash/isEmpty';
 import ENV from 'mon-pix/config/environment';
 
 export default class DataProtectionPolicyInformationBanner extends Component {
+  @service session;
   @service currentUser;
   @service currentDomain;
   @service intl;
@@ -14,8 +15,7 @@ export default class DataProtectionPolicyInformationBanner extends Component {
   _rawBannerContent = ENV.APP.BANNER_CONTENT;
 
   get shouldDisplayDataProtectionPolicyInformation() {
-    const isUserLoggedIn = typeof this.currentUser.user !== 'undefined';
-    if (!isUserLoggedIn) {
+    if (!this.session.isAuthenticated) {
       return false;
     }
 

--- a/mon-pix/tests/integration/components/authentication/login-form-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/login-form-test.gjs
@@ -4,6 +4,7 @@ import LoginForm from 'mon-pix/components/authentication/login-form';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import { stubSessionService } from '../../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 const I18N_KEYS = {
@@ -26,8 +27,7 @@ module('Integration | Component | Authentication | LoginForm', function (hooks) 
   hooks.beforeEach(async function () {
     storeService = this.owner.lookup('service:store');
     routerService = this.owner.lookup('service:router');
-    sessionService = this.owner.lookup('service:session');
-    sinon.stub(sessionService, 'authenticateUser');
+    sessionService = stubSessionService(this.owner, { isAuthenticated: false });
 
     screen = await render(<template><LoginForm /></template>);
   });

--- a/mon-pix/tests/integration/components/authentication/signup-form/index-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/signup-form/index-test.gjs
@@ -4,6 +4,7 @@ import SignupForm from 'mon-pix/components/authentication/signup-form';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import { stubSessionService } from '../../../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 const I18N_KEYS = {
@@ -21,8 +22,7 @@ module('Integration | Component | Authentication | SignupForm | index', function
   let sessionService;
 
   hooks.beforeEach(async function () {
-    sessionService = this.owner.lookup('service:session');
-    sinon.stub(sessionService, 'authenticateUser');
+    sessionService = stubSessionService(this.owner, { isAuthenticated: false });
   });
 
   test('it signs up successfully', async function (assert) {

--- a/mon-pix/tests/integration/components/autonomous-course/landing-page-start-block-test.js
+++ b/mon-pix/tests/integration/components/autonomous-course/landing-page-start-block-test.js
@@ -1,11 +1,11 @@
 import { render } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import { stubSessionService } from '../../../helpers/service-stubs.js';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Autonomous Course | Landing page start block', function (hooks) {
@@ -28,7 +28,13 @@ module('Integration | Component | Autonomous Course | Landing page start block',
     assert.dom(screen.getByText('dummy landing page text')).exists();
   });
 
-  module('when user is anonymous', function () {
+  module('when user is anonymous', function (hooks) {
+    let sessionService;
+
+    hooks.beforeEach(function () {
+      sessionService = stubSessionService(this.owner, { isAuthenticated: false });
+    });
+
     test('should display the launcher block', async function (assert) {
       // when
       const screen = await render(hbs`<AutonomousCourse::LandingPageStartBlock />`);
@@ -63,7 +69,6 @@ module('Integration | Component | Autonomous Course | Landing page start block',
     });
 
     test('should redirect to log-in form on specific button click', async function (assert) {
-      const sessionService = this.owner.lookup('service:session');
       sessionService.requireAuthenticationAndApprovedTermsOfService = sinon.stub().resolves();
 
       this.set('startCampaignParticipation', sinon.stub());
@@ -88,11 +93,7 @@ module('Integration | Component | Autonomous Course | Landing page start block',
   module('when user is logged', function () {
     test('should start campaign participation on main button click', async function (assert) {
       // given
-      class SessionStub extends Service {
-        isAuthenticated = true;
-      }
-
-      this.owner.register('service:session', SessionStub);
+      stubSessionService(this.owner, { isAuthenticated: true });
       this.set('startCampaignParticipation', sinon.stub());
 
       // when

--- a/mon-pix/tests/integration/components/campaign-start-block-test.js
+++ b/mon-pix/tests/integration/components/campaign-start-block-test.js
@@ -1,12 +1,11 @@
 import { render } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-import { stubCurrentUserService } from '../../helpers/service-stubs';
+import { stubCurrentUserService, stubSessionService } from '../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | campaign-start-block', function (hooks) {
@@ -46,14 +45,8 @@ module('Integration | Component | campaign-start-block', function (hooks) {
 
     hooks.beforeEach(function () {
       stubCurrentUserService(this.owner, { firstName: 'Izuku', lastName: 'Midorya' });
+      session = stubSessionService(this.owner, { isAuthenticated: true });
 
-      class SessionStub extends Service {
-        isAuthenticated = true;
-        invalidate = sinon.stub();
-      }
-
-      this.owner.register('service:session', SessionStub);
-      session = this.owner.lookup('service:session', SessionStub);
       this.set('campaign', {});
       this.set('startCampaignParticipation', sinon.stub());
     });
@@ -181,13 +174,7 @@ module('Integration | Component | campaign-start-block', function (hooks) {
   module('When the user is not authenticated', function (hooks) {
     hooks.beforeEach(function () {
       stubCurrentUserService(this.owner, { firstName: 'Izuku', lastName: 'Midorya' });
-
-      class SessionStub extends Service {
-        isAuthenticated = false;
-        invalidate = sinon.stub();
-      }
-
-      this.owner.register('service:session', SessionStub);
+      stubSessionService(this.owner, { isAuthenticated: false });
       this.set('campaign', {});
       this.set('startCampaignParticipation', sinon.stub());
     });
@@ -258,14 +245,9 @@ module('Integration | Component | campaign-start-block', function (hooks) {
 
   module('When the user has isAnonymous', function (hooks) {
     hooks.beforeEach(function () {
-      stubCurrentUserService(this.owner, { firstName: 'Izuku', lastName: 'Midorya', isAnonymous: true });
+      stubCurrentUserService(this.owner, { isAnonymous: true });
+      stubSessionService(this.owner, { isAuthenticated: true });
 
-      class SessionStub extends Service {
-        isAuthenticated = true;
-        invalidate = sinon.stub();
-      }
-
-      this.owner.register('service:session', SessionStub);
       this.set('campaign', {});
       this.set('startCampaignParticipation', sinon.stub());
     });

--- a/mon-pix/tests/integration/components/campaign-start-block-test.js
+++ b/mon-pix/tests/integration/components/campaign-start-block-test.js
@@ -6,6 +6,7 @@ import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import { stubCurrentUserService } from '../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | campaign-start-block', function (hooks) {
@@ -44,15 +45,7 @@ module('Integration | Component | campaign-start-block', function (hooks) {
     let session;
 
     hooks.beforeEach(function () {
-      class currentUser extends Service {
-        user = {
-          firstName: 'Izuku',
-          lastName: 'Midorya',
-          isAnonymous: false,
-        };
-      }
-
-      this.owner.register('service:currentUser', currentUser);
+      stubCurrentUserService(this.owner, { firstName: 'Izuku', lastName: 'Midorya' });
 
       class SessionStub extends Service {
         isAuthenticated = true;
@@ -187,15 +180,7 @@ module('Integration | Component | campaign-start-block', function (hooks) {
 
   module('When the user is not authenticated', function (hooks) {
     hooks.beforeEach(function () {
-      class currentUser extends Service {
-        user = {
-          firstName: 'Izuku',
-          lastName: 'Midorya',
-          isAnonymous: false,
-        };
-      }
-
-      this.owner.register('service:currentUser', currentUser);
+      stubCurrentUserService(this.owner, { firstName: 'Izuku', lastName: 'Midorya' });
 
       class SessionStub extends Service {
         isAuthenticated = false;
@@ -273,15 +258,7 @@ module('Integration | Component | campaign-start-block', function (hooks) {
 
   module('When the user has isAnonymous', function (hooks) {
     hooks.beforeEach(function () {
-      class currentUser extends Service {
-        user = {
-          firstName: 'Izuku',
-          lastName: 'Midorya',
-          isAnonymous: true,
-        };
-      }
-
-      this.owner.register('service:currentUser', currentUser);
+      stubCurrentUserService(this.owner, { firstName: 'Izuku', lastName: 'Midorya', isAnonymous: true });
 
       class SessionStub extends Service {
         isAuthenticated = true;

--- a/mon-pix/tests/integration/components/campaign/skill-review/attestation-result-test.gjs
+++ b/mon-pix/tests/integration/components/campaign/skill-review/attestation-result-test.gjs
@@ -6,6 +6,7 @@ import AttestationResult from 'mon-pix/components/campaigns/assessment/results/e
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import { stubSessionService } from '../../../../helpers/service-stubs.js';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Campaign | Skill Review | attestation-result', function (hooks) {
@@ -59,22 +60,13 @@ module('Integration | Component | Campaign | Skill Review | attestation-result',
           obtained: true,
         },
       ];
-      class sessionService extends Service {
-        isAuthenticated = true;
-        data = {
-          authenticated: {
-            access_token: 'access_token',
-            user_id: 1,
-            source: 'pix',
-          },
-        };
-      }
+      stubSessionService(this.owner, { isAuthenticated: true });
+
       const fileSaverSaveStub = sinon.stub();
       class FileSaverStub extends Service {
         save = fileSaverSaveStub;
       }
 
-      this.owner.register('service:session', sessionService);
       this.owner.register('service:fileSaver', FileSaverStub);
 
       // when
@@ -84,9 +76,9 @@ module('Integration | Component | Campaign | Skill Review | attestation-result',
       // then
       assert.ok(
         fileSaverSaveStub.calledWithExactly({
-          url: '/api/users/1/attestations/SIXTH_GRADE',
+          url: '/api/users/123/attestations/SIXTH_GRADE',
           fileName: 'sensibilisation-au-numerique',
-          token: 'access_token',
+          token: 'access_token!',
         }),
       );
     });
@@ -99,23 +91,14 @@ module('Integration | Component | Campaign | Skill Review | attestation-result',
           obtained: true,
         },
       ];
-      class sessionService extends Service {
-        isAuthenticated = true;
-        data = {
-          authenticated: {
-            access_token: 'access_token',
-            user_id: 1,
-            source: 'pix',
-          },
-        };
-      }
+      stubSessionService(this.owner, { isAuthenticated: true });
+
       const onErrorStub = sinon.stub();
       const fileSaverSaveStub = sinon.stub().throws();
       class FileSaverStub extends Service {
         save = fileSaverSaveStub;
       }
 
-      this.owner.register('service:session', sessionService);
       this.owner.register('service:fileSaver', FileSaverStub);
 
       // when
@@ -127,9 +110,9 @@ module('Integration | Component | Campaign | Skill Review | attestation-result',
       // then
       assert.ok(
         fileSaverSaveStub.calledWithExactly({
-          url: '/api/users/1/attestations/SIXTH_GRADE',
+          url: '/api/users/123/attestations/SIXTH_GRADE',
           fileName: 'sensibilisation-au-numerique',
-          token: 'access_token',
+          token: 'access_token!',
         }),
       );
       assert.ok(onErrorStub.calledOnce);

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/hero/evaluation-results-hero-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/hero/evaluation-results-hero-test.js
@@ -1,11 +1,11 @@
 import { render } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import { stubCurrentUserService } from '../../../../../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-rendering';
 
 module('Integration | Components | Campaigns | Assessment | Results | Evaluation Results Hero', function (hooks) {
@@ -16,13 +16,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
 
     hooks.beforeEach(async function () {
       // given
-      class currentUserService extends Service {
-        user = {
-          firstName: 'Hermione',
-        };
-      }
-
-      this.owner.register('service:currentUser', currentUserService);
+      stubCurrentUserService(this.owner, { firstName: 'Hermione' });
 
       this.set('campaign', { organizationId: 1 });
       this.set('campaignParticipationResult', { masteryRate: 0.755 });
@@ -331,10 +325,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
       module('when user is anonymous', function () {
         test('it should display only a connection link', async function (assert) {
           // given
-          class currentUserService extends Service {
-            user = { isAnonymous: true };
-          }
-          this.owner.register('service:current-user', currentUserService);
+          stubCurrentUserService(this.owner, { isAnonymous: true });
 
           this.set('campaign', { hasCustomResultPageButton: false });
           this.set('campaignParticipationResult', { masteryRate: 0.75 });
@@ -360,12 +351,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
       module('when user is connected', function () {
         test('it should display only a connection link', async function (assert) {
           // given
-          class currentUserService extends Service {
-            user = {
-              firstName: 'Hermione',
-            };
-          }
-          this.owner.register('service:currentUser', currentUserService);
+          stubCurrentUserService(this.owner, { firstName: 'Hermione' });
 
           this.set('campaign', { hasCustomResultPageButton: false });
           this.set('campaignParticipationResult', { masteryRate: 0.75 });

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/tabs/trainings-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/tabs/trainings-test.js
@@ -5,6 +5,7 @@ import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import { stubCurrentUserService } from '../../../../../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-rendering';
 
 module('Integration | Components | Campaigns | Assessment | Evaluation Results Tabs | Trainings', function (hooks) {
@@ -87,7 +88,7 @@ module('Integration | Components | Campaigns | Assessment | Evaluation Results T
       let adapter, storeService;
 
       hooks.beforeEach(function () {
-        sinon.stub(this.owner.lookup('service:currentUser'), 'user').value({ id: 1 });
+        stubCurrentUserService(this.owner, { id: 1 });
 
         storeService = this.owner.lookup('service:store');
         adapter = storeService.adapterFor('campaign-participation-result');

--- a/mon-pix/tests/integration/components/certifications/certification-ender-test.js
+++ b/mon-pix/tests/integration/components/certifications/certification-ender-test.js
@@ -1,9 +1,9 @@
 import { render as renderScreen } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 
+import { stubCurrentUserService } from '../../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Certifications | CertificationEnder', function (hooks) {
@@ -32,13 +32,7 @@ module('Integration | Component | Certifications | CertificationEnder', function
 
   test('should display the current user name', async function (assert) {
     // given
-    class currentUser extends Service {
-      user = {
-        fullName: 'Jim Halpert',
-      };
-    }
-
-    this.owner.register('service:currentUser', currentUser);
+    stubCurrentUserService(this.owner, { firstName: 'Jim', lastName: 'Halpert' });
 
     // when
     const screen = await renderScreen(
@@ -62,13 +56,7 @@ module('Integration | Component | Certifications | CertificationEnder', function
   module('when the assessment status is not ended by supervisor', function () {
     test('should not display the ended by supervisor text', async function (assert) {
       // given
-      class currentUser extends Service {
-        user = {
-          fullName: 'Jim Halpert',
-        };
-      }
-
-      this.owner.register('service:currentUser', currentUser);
+      stubCurrentUserService(this.owner, { firstName: 'Jim', lastName: 'Halpert' });
 
       // when
       const screen = await renderScreen(
@@ -83,13 +71,7 @@ module('Integration | Component | Certifications | CertificationEnder', function
   module('when the assessment status is ended by supervisor', function () {
     test('should display the ended by supervisor text', async function (assert) {
       // given
-      class currentUser extends Service {
-        user = {
-          fullName: 'Jim Halpert',
-        };
-      }
-
-      this.owner.register('service:currentUser', currentUser);
+      stubCurrentUserService(this.owner, { firstName: 'Jim', lastName: 'Halpert' });
 
       // when
       const screen = await renderScreen(
@@ -104,13 +86,7 @@ module('Integration | Component | Certifications | CertificationEnder', function
   module('when the assessment status is ended by finalization', function () {
     test('should display the ended by finalization text', async function (assert) {
       // given
-      class currentUser extends Service {
-        user = {
-          fullName: 'Jim Halpert',
-        };
-      }
-
-      this.owner.register('service:currentUser', currentUser);
+      stubCurrentUserService(this.owner, { firstName: 'Jim', lastName: 'Halpert' });
 
       // when
       const screen = await renderScreen(hbs`<Certifications::CertificationEnder

--- a/mon-pix/tests/integration/components/challenge-statement-test.js
+++ b/mon-pix/tests/integration/components/challenge-statement-test.js
@@ -7,6 +7,7 @@ import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import { stubCurrentUserService } from '../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | ChallengeStatement', function (hooks) {
@@ -25,14 +26,7 @@ module('Integration | Component | ChallengeStatement', function (hooks) {
   }
 
   hooks.beforeEach(function () {
-    class currentUser extends Service {
-      user = {
-        hasSeenFocusedChallengeTooltip: false,
-      };
-    }
-
-    this.owner.unregister('service:currentUser');
-    this.owner.register('service:currentUser', currentUser);
+    stubCurrentUserService(this.owner);
   });
 
   /*

--- a/mon-pix/tests/integration/components/challenge/statement/tooltip-test.js
+++ b/mon-pix/tests/integration/components/challenge/statement/tooltip-test.js
@@ -1,9 +1,9 @@
 import { render } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { click, triggerEvent, triggerKeyEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 
+import { stubCurrentUserService } from '../../../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Tooltip', function (hooks) {
@@ -17,14 +17,7 @@ module('Integration | Component | Tooltip', function (hooks) {
     module('when user has not seen the tooltip yet', function (hooks) {
       hooks.beforeEach(async function () {
         // given
-        class currentUser extends Service {
-          user = {
-            hasSeenFocusedChallengeTooltip: false,
-            save: () => {},
-          };
-        }
-        this.owner.unregister('service:currentUser');
-        this.owner.register('service:currentUser', currentUser);
+        stubCurrentUserService(this.owner, { hasSeenFocusedChallengeTooltip: false });
 
         this.set('challenge', {
           instruction: 'La consigne de mon test',
@@ -53,14 +46,7 @@ module('Integration | Component | Tooltip', function (hooks) {
     module('when user has seen the tooltip', function (hooks) {
       hooks.beforeEach(async function () {
         // given
-        class currentUser extends Service {
-          user = {
-            hasSeenFocusedChallengeTooltip: true,
-          };
-        }
-
-        this.owner.unregister('service:currentUser');
-        this.owner.register('service:currentUser', currentUser);
+        stubCurrentUserService(this.owner, { hasSeenFocusedChallengeTooltip: true });
 
         this.set('challenge', {
           instruction: 'La consigne de mon test',
@@ -133,14 +119,7 @@ module('Integration | Component | Tooltip', function (hooks) {
     module('when user has not seen the tooltip yet', function (hooks) {
       hooks.beforeEach(async function () {
         // given
-        class currentUser extends Service {
-          user = {
-            hasSeenOtherChallengesTooltip: false,
-            save: () => {},
-          };
-        }
-        this.owner.unregister('service:currentUser');
-        this.owner.register('service:currentUser', currentUser);
+        stubCurrentUserService(this.owner, { hasSeenOtherChallengesTooltip: false });
 
         this.set('challenge', {
           instruction: 'La consigne de mon test',
@@ -169,14 +148,7 @@ module('Integration | Component | Tooltip', function (hooks) {
     module('when user has seen the tooltip', function (hooks) {
       hooks.beforeEach(async function () {
         // given
-        class currentUser extends Service {
-          user = {
-            hasSeenOtherChallengesTooltip: true,
-          };
-        }
-
-        this.owner.unregister('service:currentUser');
-        this.owner.register('service:currentUser', currentUser);
+        stubCurrentUserService(this.owner, { hasSeenOtherChallengesTooltip: true });
 
         this.set('challenge', {
           instruction: 'La consigne de mon test',

--- a/mon-pix/tests/integration/components/dashboard/content-test.js
+++ b/mon-pix/tests/integration/components/dashboard/content-test.js
@@ -5,33 +5,28 @@ import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 
+import { stubCurrentUserService } from '../../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Dashboard | Content', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   const pixScore = 105;
-  let store;
-
-  hooks.beforeEach(function () {
-    store = this.owner.lookup('service:store');
-  });
 
   test('should render component', async function (assert) {
     // given
-    class CurrentUserStub extends Service {
-      user = store.createRecord('user', {
+    stubCurrentUserService(
+      this.owner,
+      {
         firstName: 'Banana',
         lastName: 'Split',
         email: 'banana.split@example.net',
-        profile: store.createRecord('profile', {
-          pixScore,
-        }),
         hasSeenNewDashboardInfo: false,
-      });
-    }
+        profile: { pixScore },
+      },
+      { withStoreStubbed: false },
+    );
 
-    this.owner.register('service:currentUser', CurrentUserStub);
     this.set('model', {
       campaignParticipationOverviews: [],
       campaignParticipations: [],
@@ -47,19 +42,17 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
 
   module('campaign-participation-overview rendering', function (hooks) {
     hooks.beforeEach(function () {
-      class CurrentUserStub extends Service {
-        user = store.createRecord('user', {
+      stubCurrentUserService(
+        this.owner,
+        {
           firstName: 'Banana',
           lastName: 'Split',
           email: 'banana.split@example.net',
-          profile: store.createRecord('profile', {
-            pixScore,
-          }),
           hasSeenNewDashboardInfo: false,
-        });
-      }
-
-      this.owner.register('service:currentUser', CurrentUserStub);
+          profile: { pixScore },
+        },
+        { withStoreStubbed: false },
+      );
     });
 
     test('should render campaign participation when there is at least one campaign participation overviews', async function (assert) {
@@ -104,19 +97,17 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
 
   module('recommended competence-card rendering', function (hooks) {
     hooks.beforeEach(function () {
-      class CurrentUserStub extends Service {
-        user = store.createRecord('user', {
+      stubCurrentUserService(
+        this.owner,
+        {
           firstName: 'Banana',
           lastName: 'Split',
           email: 'banana.split@example.net',
-          profile: store.createRecord('profile', {
-            pixScore,
-          }),
           hasSeenNewDashboardInfo: false,
-        });
-      }
-
-      this.owner.register('service:currentUser', CurrentUserStub);
+          profile: { pixScore },
+        },
+        { withStoreStubbed: false },
+      );
     });
 
     test('should render competence-card when there is at least one competence-card not started', async function (assert) {
@@ -188,19 +179,17 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
 
   module('improvable competence-card rendering', function (hooks) {
     hooks.beforeEach(function () {
-      class CurrentUserStub extends Service {
-        user = store.createRecord('user', {
+      stubCurrentUserService(
+        this.owner,
+        {
           firstName: 'Banana',
           lastName: 'Split',
           email: 'banana.split@example.net',
-          profile: store.createRecord('profile', {
-            pixScore,
-          }),
           hasSeenNewDashboardInfo: false,
-        });
-      }
-
-      this.owner.register('service:currentUser', CurrentUserStub);
+          profile: { pixScore },
+        },
+        { withStoreStubbed: false },
+      );
     });
 
     test('should render competence-card when there is at least one competence-card not started', async function (assert) {
@@ -272,19 +261,17 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
 
   module('started competence-card rendering', function (hooks) {
     hooks.beforeEach(function () {
-      class CurrentUserStub extends Service {
-        user = store.createRecord('user', {
+      stubCurrentUserService(
+        this.owner,
+        {
           firstName: 'Banana',
           lastName: 'Split',
           email: 'banana.split@example.net',
-          profile: store.createRecord('profile', {
-            pixScore,
-          }),
           hasSeenNewDashboardInfo: false,
-        });
-      }
-
-      this.owner.register('service:currentUser', CurrentUserStub);
+          profile: { pixScore },
+        },
+        { withStoreStubbed: false },
+      );
     });
 
     test('should render competence-card when there is at least one competence-card started', async function (assert) {
@@ -360,19 +347,18 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
   module('new dashboard info rendering', function () {
     test('should display NewInformation on dashboard if user has not close it before', async function (assert) {
       // given
-      class CurrentUserStub extends Service {
-        user = store.createRecord('user', {
+      stubCurrentUserService(
+        this.owner,
+        {
           firstName: 'Banana',
           lastName: 'Split',
           email: 'banana.split@example.net',
-          profile: store.createRecord('profile', {
-            pixScore,
-          }),
           hasSeenNewDashboardInfo: false,
-        });
-      }
+          profile: { pixScore },
+        },
+        { withStoreStubbed: false },
+      );
 
-      this.owner.register('service:currentUser', CurrentUserStub);
       this.set('model', {
         campaignParticipationOverviews: [],
         campaignParticipations: [],
@@ -388,19 +374,18 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
 
     test('should not display NewInformation on dashboard if user has close it before', async function (assert) {
       // given
-      class HasSeenNewDashboardInformationCurrentUserStub extends Service {
-        user = store.createRecord('user', {
+      stubCurrentUserService(
+        this.owner,
+        {
           firstName: 'Banana',
           lastName: 'Split',
           email: 'banana.split@example.net',
-          profile: store.createRecord('profile', {
-            pixScore,
-          }),
           hasSeenNewDashboardInfo: true,
-        });
-      }
+          profile: { pixScore },
+        },
+        { withStoreStubbed: false },
+      );
 
-      this.owner.register('service:currentUser', HasSeenNewDashboardInformationCurrentUserStub);
       this.set('model', {
         campaignParticipationOverviews: [],
         campaignParticipations: [],
@@ -424,19 +409,18 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
         }
       }
 
-      class CurrentUserStub extends Service {
-        user = store.createRecord('user', {
+      stubCurrentUserService(
+        this.owner,
+        {
           firstName: 'Banana',
           lastName: 'Split',
           email: 'banana.split@example.net',
-          profile: store.createRecord('profile', {
-            pixScore,
-          }),
           hasSeenNewDashboardInfo: false,
-        });
-      }
+          profile: { pixScore },
+        },
+        { withStoreStubbed: false },
+      );
 
-      this.owner.register('service:currentUser', CurrentUserStub);
       this.owner.register('service:currentDomain', CurrentDomainServiceStub);
       this.set('model', {
         campaignParticipationOverviews: [],
@@ -460,19 +444,19 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
           return false;
         }
       }
-      class CurrentUserStub extends Service {
-        user = store.createRecord('user', {
+
+      stubCurrentUserService(
+        this.owner,
+        {
           firstName: 'Banana',
           lastName: 'Split',
           email: 'banana.split@example.net',
-          profile: store.createRecord('profile', {
-            pixScore,
-          }),
           hasSeenNewDashboardInfo: false,
-        });
-      }
+          profile: { pixScore },
+        },
+        { withStoreStubbed: false },
+      );
 
-      this.owner.register('service:currentUser', CurrentUserStub);
       this.owner.register('service:currentDomain', CurrentDomainServiceStub);
       this.set('model', {
         campaignParticipationOverviews: [],
@@ -492,19 +476,18 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
   module('empty dashboard info rendering', function () {
     test('should display Empty Dashboard Information if user has nothing to do', async function (assert) {
       // given
-      class CurrentUserStub extends Service {
-        user = store.createRecord('user', {
+      stubCurrentUserService(
+        this.owner,
+        {
           firstName: 'Banana',
           lastName: 'Split',
           email: 'banana.split@example.net',
-          profile: store.createRecord('profile', {
-            pixScore,
-          }),
           hasSeenNewDashboardInfo: false,
-        });
-      }
+          profile: { pixScore },
+        },
+        { withStoreStubbed: false },
+      );
 
-      this.owner.register('service:currentUser', CurrentUserStub);
       this.set('model', {
         campaignParticipationOverviews: [],
         campaignParticipations: [],
@@ -522,19 +505,18 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
 
     test('should not display Empty Dashboard Information on dashboard if user has competence to continue', async function (assert) {
       // given
-      class HasSeenNewDashboardInformationCurrentUserStub extends Service {
-        user = store.createRecord('user', {
+      stubCurrentUserService(
+        this.owner,
+        {
           firstName: 'Banana',
           lastName: 'Split',
           email: 'banana.split@example.net',
-          profile: store.createRecord('profile', {
-            pixScore,
-          }),
           hasSeenNewDashboardInfo: true,
-        });
-      }
+          profile: { pixScore },
+        },
+        { withStoreStubbed: false },
+      );
 
-      this.owner.register('service:currentUser', HasSeenNewDashboardInformationCurrentUserStub);
       this.set('model', {
         campaignParticipationOverviews: [],
         campaignParticipations: [],
@@ -560,19 +542,18 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
   module('user pix score rendering', function () {
     test('should display user score', async function (assert) {
       // given
-      class CurrentUserStub extends Service {
-        user = store.createRecord('user', {
+      stubCurrentUserService(
+        this.owner,
+        {
           firstName: 'Banana',
           lastName: 'Split',
           email: 'banana.split@example.net',
-          profile: store.createRecord('profile', {
-            pixScore,
-          }),
           hasSeenNewDashboardInfo: false,
-        });
-      }
+          profile: { pixScore },
+        },
+        { withStoreStubbed: false },
+      );
 
-      this.owner.register('service:currentUser', CurrentUserStub);
       this.set('model', {
         campaignParticipationOverviews: [],
         campaignParticipations: [],
@@ -591,20 +572,19 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
   module('participation to a profile collection campaign to resume', function () {
     test('should display the banner to resume participation', async function (assert) {
       // given
-      class CurrentUserWithCodeStub extends Service {
-        user = store.createRecord('user', {
+      stubCurrentUserService(
+        this.owner,
+        {
           firstName: 'Banana',
           lastName: 'Split',
           email: 'banana.split@example.net',
-          profile: store.createRecord('profile', {
-            pixScore,
-          }),
           hasSeenNewDashboardInfo: false,
           codeForLastProfileToShare: 'SNAP1234',
-        });
-      }
+          profile: { pixScore },
+        },
+        { withStoreStubbed: false },
+      );
 
-      this.owner.register('service:currentUser', CurrentUserWithCodeStub);
       this.set('model', {
         campaignParticipationOverviews: [],
         campaignParticipations: [],
@@ -620,19 +600,18 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
 
     test('should not display the banner when there is no code', async function (assert) {
       // given
-      class CurrentUserStub extends Service {
-        user = store.createRecord('user', {
+      stubCurrentUserService(
+        this.owner,
+        {
           firstName: 'Banana',
           lastName: 'Split',
           email: 'banana.split@example.net',
-          profile: store.createRecord('profile', {
-            pixScore,
-          }),
           hasSeenNewDashboardInfo: false,
-        });
-      }
+          profile: { pixScore },
+        },
+        { withStoreStubbed: false },
+      );
 
-      this.owner.register('service:currentUser', CurrentUserStub);
       this.set('model', {
         campaignParticipationOverviews: [],
         campaignParticipations: [],

--- a/mon-pix/tests/integration/components/footer/footer-links-test.js
+++ b/mon-pix/tests/integration/components/footer/footer-links-test.js
@@ -4,6 +4,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 
+import { stubCurrentUserService } from '../../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Footer', function (hooks) {
@@ -26,11 +27,7 @@ module('Integration | Component | Footer', function (hooks) {
 
   module('when user is connected', function (hooks) {
     hooks.beforeEach(function () {
-      class CurrentUserStub extends Service {
-        user = { fullName: 'John Doe' };
-      }
-
-      this.owner.register('service:currentUser', CurrentUserStub);
+      stubCurrentUserService(this.owner);
     });
 
     test('displays the sitemap link', async function (assert) {

--- a/mon-pix/tests/integration/components/navbar-burger-menu-test.js
+++ b/mon-pix/tests/integration/components/navbar-burger-menu-test.js
@@ -1,22 +1,16 @@
 import { render } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 
+import { stubCurrentUserService } from '../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | navbar-burger-menu', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   hooks.beforeEach(async function () {
-    class currentUser extends Service {
-      user = {
-        fullName: 'Bobby Carotte',
-      };
-    }
-
-    this.owner.register('service:currentUser', currentUser);
+    stubCurrentUserService(this.owner, { firstName: 'Bobby', lastName: 'Carotte' });
   });
 
   test("should display the user's fullname", async function (assert) {
@@ -52,15 +46,11 @@ module('Integration | Component | navbar-burger-menu', function (hooks) {
 
   module('when user has participations', function (hooks) {
     hooks.beforeEach(async function () {
-      class currentUser extends Service {
-        user = {
-          fullName: 'Bobby Carotte',
-          hasAssessmentParticipations: true,
-        };
-      }
-
-      this.owner.unregister('service:currentUser');
-      this.owner.register('service:currentUser', currentUser);
+      stubCurrentUserService(this.owner, {
+        firstName: 'Bobby',
+        lastName: 'Carotte',
+        hasAssessmentParticipations: true,
+      });
     });
 
     test('should display "My tests" link', async function (assert) {
@@ -74,15 +64,11 @@ module('Integration | Component | navbar-burger-menu', function (hooks) {
 
   module('when user has no participations', function (hooks) {
     hooks.beforeEach(async function () {
-      class currentUser extends Service {
-        user = {
-          fullName: 'John Doe',
-          hasAssessmentParticipations: false,
-        };
-      }
-
-      this.owner.unregister('service:currentUser');
-      this.owner.register('service:currentUser', currentUser);
+      stubCurrentUserService(this.owner, {
+        firstName: 'Bobby',
+        lastName: 'Carotte',
+        hasAssessmentParticipations: false,
+      });
     });
 
     test('should not display "My tests" link', async function (assert) {
@@ -95,15 +81,11 @@ module('Integration | Component | navbar-burger-menu', function (hooks) {
   });
   module('when user has recommended trainings', function (hooks) {
     hooks.beforeEach(async function () {
-      class currentUser extends Service {
-        user = {
-          fullName: 'John Doe',
-          hasRecommendedTrainings: true,
-        };
-      }
-
-      this.owner.unregister('service:currentUser');
-      this.owner.register('service:currentUser', currentUser);
+      stubCurrentUserService(this.owner, {
+        firstName: 'Bobby',
+        lastName: 'Carotte',
+        hasRecommendedTrainings: true,
+      });
     });
 
     test('should not display "My trainings" link', async function (assert) {

--- a/mon-pix/tests/integration/components/navbar-desktop-nav-menu-test.js
+++ b/mon-pix/tests/integration/components/navbar-desktop-nav-menu-test.js
@@ -1,9 +1,9 @@
 import { render } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 
+import { stubSessionService } from '../../helpers/service-stubs.js';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | navbar desktop menu', function (hooks) {
@@ -11,10 +11,8 @@ module('Integration | Component | navbar desktop menu', function (hooks) {
 
   test('should render links', async function (assert) {
     // given
-    class SessionStub extends Service {
-      isAuthenticated = true;
-    }
-    this.owner.register('service:session', SessionStub);
+    stubSessionService(this.owner, { isAuthenticated: true });
+
     this.set('menu', [
       {
         name: t('navigation.not-logged.sign-in'),

--- a/mon-pix/tests/integration/components/navbar-header-test.js
+++ b/mon-pix/tests/integration/components/navbar-header-test.js
@@ -1,10 +1,10 @@
 import { render } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { setBreakpoint } from 'ember-responsive/test-support';
 import { module, test } from 'qunit';
 
+import { stubCurrentUserService, stubSessionService } from '../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | navbar-header', function (hooks) {
@@ -28,14 +28,8 @@ module('Integration | Component | navbar-header', function (hooks) {
     test('should be rendered in mobile/tablet mode with a burger', async function (assert) {
       // given
       setBreakpoint('tablet');
-      class SessionStub extends Service {
-        isAuthenticated = true;
-      }
-      this.owner.register('service:session', SessionStub);
-      class CurrentUserStub extends Service {
-        user = { fullName: 'John Doe' };
-      }
-      this.owner.register('service:current-user', CurrentUserStub);
+      stubSessionService(this.owner, { isAuthenticated: true });
+      stubCurrentUserService(this.owner, { firstName: 'John', lastName: 'Doe' });
 
       // when
       const screen = await render(hbs`<NavbarHeader />`);
@@ -48,10 +42,7 @@ module('Integration | Component | navbar-header', function (hooks) {
     test('should be rendered in mobile/tablet mode without burger', async function (assert) {
       // given
       setBreakpoint('tablet');
-      class SessionStub extends Service {
-        isAuthenticated = false;
-      }
-      this.owner.register('service:session', SessionStub);
+      stubSessionService(this.owner, { isAuthenticated: false });
 
       // when
       const screen = await render(hbs`<NavbarHeader />`);

--- a/mon-pix/tests/integration/components/navbar-mobile-header-test.js
+++ b/mon-pix/tests/integration/components/navbar-mobile-header-test.js
@@ -1,11 +1,10 @@
 import { render } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { setBreakpoint } from 'ember-responsive/test-support';
 import { module, test } from 'qunit';
 
-import { stubCurrentUserService } from '../../helpers/service-stubs';
+import { stubCurrentUserService, stubSessionService } from '../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | navbar-mobile-header', function (hooks) {
@@ -14,10 +13,7 @@ module('Integration | Component | navbar-mobile-header', function (hooks) {
   module('when user is not logged', function (hooks) {
     hooks.beforeEach(async function () {
       // given & when
-      class SessionStub extends Service {
-        isAuthenticated = false;
-      }
-      this.owner.register('service:session', SessionStub);
+      stubSessionService(this.owner, { isAuthenticated: false });
       setBreakpoint('tablet');
     });
 
@@ -41,10 +37,7 @@ module('Integration | Component | navbar-mobile-header', function (hooks) {
 
   module('When user is logged', function (hooks) {
     hooks.beforeEach(function () {
-      class SessionStub extends Service {
-        isAuthenticated = true;
-      }
-      this.owner.register('service:session', SessionStub);
+      stubSessionService(this.owner, { isAuthenticated: true });
       stubCurrentUserService(this.owner, { firstName: 'John', lastName: 'Doe' });
       setBreakpoint('tablet');
     });

--- a/mon-pix/tests/integration/components/navbar-mobile-header-test.js
+++ b/mon-pix/tests/integration/components/navbar-mobile-header-test.js
@@ -5,6 +5,7 @@ import { t } from 'ember-intl/test-support';
 import { setBreakpoint } from 'ember-responsive/test-support';
 import { module, test } from 'qunit';
 
+import { stubCurrentUserService } from '../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | navbar-mobile-header', function (hooks) {
@@ -44,10 +45,7 @@ module('Integration | Component | navbar-mobile-header', function (hooks) {
         isAuthenticated = true;
       }
       this.owner.register('service:session', SessionStub);
-      class CurrentUserStub extends Service {
-        user = { fullName: 'John Doe' };
-      }
-      this.owner.register('service:currentUser', CurrentUserStub);
+      stubCurrentUserService(this.owner, { firstName: 'John', lastName: 'Doe' });
       setBreakpoint('tablet');
     });
 

--- a/mon-pix/tests/integration/components/profile-content-test.js
+++ b/mon-pix/tests/integration/components/profile-content-test.js
@@ -2,11 +2,11 @@
 /* eslint ember/require-tagless-components: 0 */
 
 import { render } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
 import { setBreakpoint } from 'ember-responsive/test-support';
 import { module, test } from 'qunit';
 
+import { stubSessionService } from '../../helpers/service-stubs.js';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Profile-content', function (hooks) {
@@ -16,16 +16,7 @@ module('Integration | Component | Profile-content', function (hooks) {
     let model;
 
     hooks.beforeEach(function () {
-      this.owner.register(
-        'service:session',
-        Service.extend({
-          data: {
-            authenticated: {
-              access_token: 'VALID-TOKEN',
-            },
-          },
-        }),
-      );
+      stubSessionService(this.owner, { isAuthenticated: true });
 
       model = {
         profile: {
@@ -65,7 +56,6 @@ module('Integration | Component | Profile-content', function (hooks) {
         // when
         setBreakpoint('tablet');
         this.set('model', model);
-        this.owner.register('service:session', Service.extend({ isAuthenticated: true }));
         await render(hbs`<ProfileContent @model={{this.model}} @media={{this.media}} />`);
 
         // then
@@ -80,7 +70,6 @@ module('Integration | Component | Profile-content', function (hooks) {
         // when
         setBreakpoint('mobile');
         this.set('model', model);
-        this.owner.register('service:session', Service.extend({ isAuthenticated: true }));
         await render(hbs`<ProfileContent @model={{this.model}} @media={{this.media}} />`);
 
         // then

--- a/mon-pix/tests/integration/components/routes/campaigns/invited/associate-sup-student-form-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/invited/associate-sup-student-form-test.js
@@ -5,28 +5,27 @@ import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import { stubSessionService } from '../../../../../helpers/service-stubs.js';
 import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | routes/campaigns/invited/associate-sup-student-form', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  let sessionStub;
   let storeStub;
   let saveStub;
   let routerObserver;
 
   hooks.beforeEach(function () {
+    stubSessionService(this.owner, { isAuthenticated: false });
     routerObserver = this.owner.lookup('service:router');
     routerObserver.transitionTo = sinon.stub();
     saveStub = sinon.stub();
-    sessionStub = class StoreStub extends Service {};
     storeStub = class StoreStub extends Service {
       createRecord = () => ({
         save: saveStub,
         unloadRecord: () => sinon.stub(),
       });
     };
-    this.owner.register('service:session', sessionStub);
     this.owner.register('service:store', storeStub);
   });
 

--- a/mon-pix/tests/integration/components/routes/register-form-test.js
+++ b/mon-pix/tests/integration/components/routes/register-form-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 
 import ENV from '../../../../config/environment';
+import { stubSessionService } from '../../../helpers/service-stubs.js';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 const EMAIL_INPUT_LABEL = '* Adresse e-mail (ex: nom@exemple.fr)';
@@ -35,16 +36,13 @@ const USERNAME_ERROR_MESSAGE =
 module('Integration | Component | routes/register-form', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  let authenticateStub;
+  let sessionService;
   let saveUserAssociationStub;
   let saveDependentUserStub;
 
   hooks.beforeEach(function () {
-    authenticateStub = sinon.stub();
-    class sessionStub extends Service {
-      authenticate = authenticateStub;
-    }
-    authenticateStub.resolves();
+    sessionService = stubSessionService(this.owner, { isAuthenticated: false });
+    sessionService.authenticate.resolves();
 
     saveUserAssociationStub = sinon.stub();
     saveDependentUserStub = sinon.stub();
@@ -66,7 +64,6 @@ module('Integration | Component | routes/register-form', function (hooks) {
     saveUserAssociationStub.resolves({ username: 'pix.pix1010' });
     saveDependentUserStub.resolves();
 
-    this.owner.register('service:session', sessionStub);
     this.owner.register('service:store', storeStub);
   });
 
@@ -87,7 +84,7 @@ module('Integration | Component | routes/register-form', function (hooks) {
       await click(screen.getByRole('button', { name: t('pages.login-or-register.register-form.button-form') }));
 
       // then
-      sinon.assert.calledWith(authenticateStub, 'authenticator:oauth2', {
+      sinon.assert.calledWith(sessionService.authenticate, 'authenticator:oauth2', {
         login: 'shi@fu.me',
         password: 'Mypassword1',
         scope: 'mon-pix',
@@ -107,7 +104,7 @@ module('Integration | Component | routes/register-form', function (hooks) {
       await click(screen.getByRole('button', { name: t('pages.login-or-register.register-form.button-form') }));
 
       // then
-      sinon.assert.calledWith(authenticateStub, 'authenticator:oauth2', {
+      sinon.assert.calledWith(sessionService.authenticate, 'authenticator:oauth2', {
         login: 'pix.pix1010',
         password: 'Mypassword1',
         scope: 'mon-pix',

--- a/mon-pix/tests/integration/components/tutorial-panel-test.js
+++ b/mon-pix/tests/integration/components/tutorial-panel-test.js
@@ -1,10 +1,10 @@
 import { render } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 // eslint-disable-next-line no-restricted-imports
 import { find } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 
+import { stubCurrentUserService } from '../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Tutorial Panel', function (hooks) {
@@ -47,14 +47,7 @@ module('Integration | Component | Tutorial Panel', function (hooks) {
       module('when the user is logged in', function () {
         test('should render the tutorial with actions', async function (assert) {
           // given
-          class CurrentUserStub extends Service {
-            user = {
-              firstName: 'Banana',
-              email: 'banana.split@example.net',
-              fullName: 'Banana Split',
-            };
-          }
-          this.owner.register('service:currentUser', CurrentUserStub);
+          stubCurrentUserService(this.owner, { firstName: 'Banana', lastName: 'Split' });
 
           // when
           await render(hbs`<TutorialPanel @hint={{this.hint}} @tutorials={{this.tutorials}} />`);
@@ -73,10 +66,7 @@ module('Integration | Component | Tutorial Panel', function (hooks) {
       module('when the user is not logged in', function () {
         test('should render the tutorial without actions', async function (assert) {
           // given
-          class CurrentUserStub extends Service {
-            user = null;
-          }
-          this.owner.register('service:currentUser', CurrentUserStub);
+          stubCurrentUserService(this.owner, { isAuthenticated: false });
 
           // when
           await render(hbs`<TutorialPanel @hint={{this.hint}} @tutorials={{this.tutorials}} />`);

--- a/mon-pix/tests/integration/components/tutorials/card-test.js
+++ b/mon-pix/tests/integration/components/tutorials/card-test.js
@@ -1,10 +1,10 @@
 import { render } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 // eslint-disable-next-line no-restricted-imports
 import { find } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 
+import { stubCurrentUserService } from '../../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Tutorials | Card', function (hooks) {
@@ -13,12 +13,9 @@ module('Integration | Component | Tutorials | Card', function (hooks) {
   module('when user is logged', function () {
     test('should render the component with actions', async function (assert) {
       // given
-      class CurrentUserStub extends Service {
-        user = { firstName: 'John' };
-      }
+      stubCurrentUserService(this.owner);
 
       const store = this.owner.lookup('service:store');
-      this.owner.register('service:currentUser', CurrentUserStub);
       this.set(
         'tutorial',
         store.createRecord('tutorial', {
@@ -51,12 +48,9 @@ module('Integration | Component | Tutorials | Card', function (hooks) {
   module('when user is not logged', function () {
     test('should render the component without actions', async function (assert) {
       // given
-      class CurrentUserStub extends Service {
-        user = null;
-      }
+      stubCurrentUserService(this.owner, { isAuthenticated: false });
 
       const store = this.owner.lookup('service:store');
-      this.owner.register('service:currentUser', CurrentUserStub);
       this.set(
         'tutorial',
         store.createRecord('tutorial', {

--- a/mon-pix/tests/integration/components/user-logged-menu-test.js
+++ b/mon-pix/tests/integration/components/user-logged-menu-test.js
@@ -1,10 +1,10 @@
 import { render } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { click, triggerKeyEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 
+import { stubCurrentUserService } from '../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | user logged menu', function (hooks) {
@@ -13,14 +13,7 @@ module('Integration | Component | user logged menu', function (hooks) {
   module('when rendering for logged user', function (hooks) {
     hooks.beforeEach(async function () {
       // given
-      class currentUserService extends Service {
-        user = {
-          firstName: 'Hermione',
-          fullName: 'Hermione Granger',
-        };
-      }
-
-      this.owner.register('service:currentUser', currentUserService);
+      stubCurrentUserService(this.owner, { firstName: 'Hermione', lastName: 'Granger' });
     });
 
     test('should display logged user name with a11y guidance', async function (assert) {
@@ -177,14 +170,12 @@ module('Integration | Component | user logged menu', function (hooks) {
     module('Link to "My tests"', function () {
       module('when user has at least one participation', function (hooks) {
         hooks.beforeEach(function () {
-          class currentUserService extends Service {
-            user = {
-              firstName: 'Hermione',
-              hasAssessmentParticipations: true,
-            };
-          }
-          this.owner.unregister('service:currentUser');
-          this.owner.register('service:currentUser', currentUserService);
+          stubCurrentUserService(this.owner, {
+            id: 456,
+            firstName: 'Hermione',
+            lastName: 'Granger',
+            hasAssessmentParticipations: true,
+          });
         });
 
         test('should display link to user tests', async function (assert) {
@@ -220,10 +211,7 @@ module('Integration | Component | user logged menu', function (hooks) {
 
   module('when user is unlogged or not found', function (hooks) {
     hooks.beforeEach(function () {
-      class currentUserService extends Service {
-        user = null;
-      }
-      this.owner.register('service:currentUser', currentUserService);
+      stubCurrentUserService(this.owner, { isAuthenticated: false });
     });
 
     test('should not display user information, for unlogged', async function (assert) {

--- a/mon-pix/tests/unit/adapters/application-test.js
+++ b/mon-pix/tests/unit/adapters/application-test.js
@@ -3,6 +3,8 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import { stubSessionService } from '../../helpers/service-stubs.js';
+
 const FRENCH_INTERNATIONAL_LOCALE = 'fr';
 const FRANCE_TLD = 'fr';
 const ENGLISH_INTERNATIONAL_LOCALE = 'en';
@@ -132,16 +134,15 @@ module('Unit | Adapters | ApplicationAdapter', function (hooks) {
     module('when the HTTP status code received is different from 401', function () {
       test('should not invalidate the current session', function (assert) {
         // given
+        const sessionService = stubSessionService(this.owner, { isAuthenticated: true });
         const applicationAdapter = this.owner.lookup('adapter:application');
-        const session = this.owner.lookup('service:session');
         sinon.stub(REST.prototype, 'handleResponse');
-        sinon.stub(session, 'invalidate');
 
         // when
         applicationAdapter.handleResponse(302);
 
         // then
-        sinon.assert.notCalled(session.invalidate);
+        sinon.assert.notCalled(sessionService.invalidate);
         sinon.assert.calledOnce(REST.prototype.handleResponse);
         sinon.restore();
         assert.ok(true);

--- a/mon-pix/tests/unit/adapters/email-verification-code-test.js
+++ b/mon-pix/tests/unit/adapters/email-verification-code-test.js
@@ -1,7 +1,7 @@
-import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import sinon from 'sinon';
+
+import { stubCurrentUserService } from '../../helpers/service-stubs';
 
 module('Unit | Adapter | Email-Verification-Code', function (hooks) {
   setupTest(hooks);
@@ -9,14 +9,11 @@ module('Unit | Adapter | Email-Verification-Code', function (hooks) {
   module('#buildURL', function () {
     test('should call API to send email verification code', async function (assert) {
       // given
-      const adapter = this.owner.lookup('adapter:email-verification-code');
-      const getStub = sinon.stub();
-      class CurrentUserStub extends Service {
-        user = { get: getStub.returns(123) };
-      }
-      this.owner.register('service:current-user', CurrentUserStub);
+      const currentUserService = stubCurrentUserService(this.owner, { id: 123 });
+      currentUserService.user.get.returns(123);
 
       // when
+      const adapter = this.owner.lookup('adapter:email-verification-code');
       const url = await adapter.buildURL();
 
       // then

--- a/mon-pix/tests/unit/components/authentication/login-or-register-oidc-test.js
+++ b/mon-pix/tests/unit/components/authentication/login-or-register-oidc-test.js
@@ -5,6 +5,7 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 
 import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+import { stubSessionService } from '../../../helpers/service-stubs.js';
 import setupIntl from '../../../helpers/setup-intl';
 
 module('Unit | Component | authentication | login-or-register-oidc', function (hooks) {
@@ -16,13 +17,8 @@ module('Unit | Component | authentication | login-or-register-oidc', function (h
       test('creates session', async function (assert) {
         // given
         const component = createGlimmerComponent('authentication/login-or-register-oidc');
-        const authenticateStub = sinon.stub();
+        const sessionService = stubSessionService(this.owner, { isAuthenticated: false });
 
-        class SessionStub extends Service {
-          authenticate = authenticateStub;
-        }
-
-        this.owner.register('service:session', SessionStub);
         component.args.identityProviderSlug = 'super-idp';
         component.args.authenticationKey = 'super-key';
         component.isTermsOfServiceValidated = true;
@@ -31,7 +27,7 @@ module('Unit | Component | authentication | login-or-register-oidc', function (h
         await component.register();
 
         // then
-        sinon.assert.calledWith(authenticateStub, 'authenticator:oidc', {
+        sinon.assert.calledWith(sessionService.authenticate, 'authenticator:oidc', {
           authenticationKey: 'super-key',
           identityProviderSlug: 'super-idp',
           hostSlug: 'users',
@@ -45,13 +41,10 @@ module('Unit | Component | authentication | login-or-register-oidc', function (h
         test('displays error', async function (assert) {
           // given
           const component = createGlimmerComponent('authentication/login-or-register-oidc');
-          const authenticateStub = sinon.stub().rejects({ errors: [{ status: '401' }] });
 
-          class SessionStub extends Service {
-            authenticate = authenticateStub;
-          }
+          const sessionService = stubSessionService(this.owner, { isAuthenticated: false });
+          sessionService.authenticate.rejects({ errors: [{ status: '401' }] });
 
-          this.owner.register('service:session', SessionStub);
           component.args.identityProviderSlug = 'super-idp';
           component.args.authenticationKey = 'super-key';
           component.isTermsOfServiceValidated = true;
@@ -86,15 +79,12 @@ module('Unit | Component | authentication | login-or-register-oidc', function (h
           test('it displays the invalid locale error message', async function (assert) {
             // given
             const component = createGlimmerComponent('authentication/login-or-register-oidc');
-            const authenticateStub = sinon
-              .stub()
-              .rejects({ errors: [{ status: '400', code: 'INVALID_LOCALE_FORMAT', meta: { locale: 'zzzz' } }] });
 
-            class SessionStub extends Service {
-              authenticate = authenticateStub;
-            }
+            const sessionService = stubSessionService(this.owner, { isAuthenticated: false });
+            sessionService.authenticate.rejects({
+              errors: [{ status: '400', code: 'INVALID_LOCALE_FORMAT', meta: { locale: 'zzzz' } }],
+            });
 
-            this.owner.register('service:session', SessionStub);
             component.args.identityProviderSlug = 'super-idp';
             component.args.authenticationKey = 'super-key';
             component.isTermsOfServiceValidated = true;
@@ -114,15 +104,12 @@ module('Unit | Component | authentication | login-or-register-oidc', function (h
           test('it displays the unsupported locale error message', async function (assert) {
             // given
             const component = createGlimmerComponent('authentication/login-or-register-oidc');
-            const authenticateStub = sinon
-              .stub()
-              .rejects({ errors: [{ status: '400', code: 'LOCALE_NOT_SUPPORTED', meta: { locale: 'jp' } }] });
 
-            class SessionStub extends Service {
-              authenticate = authenticateStub;
-            }
+            const sessionService = stubSessionService(this.owner, { isAuthenticated: false });
+            sessionService.authenticate.rejects({
+              errors: [{ status: '400', code: 'LOCALE_NOT_SUPPORTED', meta: { locale: 'jp' } }],
+            });
 
-            this.owner.register('service:session', SessionStub);
             component.args.identityProviderSlug = 'super-idp';
             component.args.authenticationKey = 'super-key';
             component.isTermsOfServiceValidated = true;
@@ -142,13 +129,9 @@ module('Unit | Component | authentication | login-or-register-oidc', function (h
       test('displays error message with details', async function (assert) {
         // given
         const component = createGlimmerComponent('authentication/login-or-register-oidc');
-        const authenticateStub = sinon.stub().rejects({ errors: [{ status: '500', detail: 'some detail' }] });
+        const sessionService = stubSessionService(this.owner, { isAuthenticated: false });
+        sessionService.authenticate.rejects({ errors: [{ status: '500', detail: 'some detail' }] });
 
-        class SessionStub extends Service {
-          authenticate = authenticateStub;
-        }
-
-        this.owner.register('service:session', SessionStub);
         component.args.identityProviderSlug = 'super-idp';
         component.args.authenticationKey = 'super-key';
         component.isTermsOfServiceValidated = true;
@@ -163,13 +146,9 @@ module('Unit | Component | authentication | login-or-register-oidc', function (h
       test('displays default error message', async function (assert) {
         // given
         const component = createGlimmerComponent('authentication/login-or-register-oidc');
-        const authenticateStub = sinon.stub().rejects({ errors: [{ status: '500' }] });
+        const sessionService = stubSessionService(this.owner, { isAuthenticated: false });
+        sessionService.authenticate.rejects({ errors: [{ status: '500' }] });
 
-        class SessionStub extends Service {
-          authenticate = authenticateStub;
-        }
-
-        this.owner.register('service:session', SessionStub);
         component.args.identityProviderSlug = 'super-idp';
         component.args.authenticationKey = 'super-key';
         component.isTermsOfServiceValidated = true;
@@ -188,15 +167,12 @@ module('Unit | Component | authentication | login-or-register-oidc', function (h
         // given
         let inflightLoading;
         const component = createGlimmerComponent('authentication/login-or-register-oidc');
-        const authenticateStub = function () {
+        const sessionService = stubSessionService(this.owner, { isAuthenticated: false });
+        sessionService.authenticate = function () {
           inflightLoading = component.isRegisterLoading;
           return Promise.resolve();
         };
-        class SessionStub extends Service {
-          authenticate = authenticateStub;
-        }
 
-        this.owner.register('service:session', SessionStub);
         component.args.identityProviderSlug = 'super-idp';
         component.args.authenticationKey = 'super-key';
         component.isTermsOfServiceValidated = true;

--- a/mon-pix/tests/unit/components/authentication/oidc-reconciliation-test.js
+++ b/mon-pix/tests/unit/components/authentication/oidc-reconciliation-test.js
@@ -6,6 +6,7 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 
 import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+import { stubSessionService } from '../../../helpers/service-stubs.js';
 import setupIntl from '../../../helpers/setup-intl';
 
 module('Unit | Component | authentication | oidc-reconciliation', function (hooks) {
@@ -144,13 +145,8 @@ module('Unit | Component | authentication | oidc-reconciliation', function (hook
       test('user authenticates with reconciliation', async function (assert) {
         // given
         const component = createGlimmerComponent('authentication/oidc-reconciliation');
-        const authenticateStub = sinon.stub();
+        const sessionService = stubSessionService(this.owner, { isAuthenticated: false });
 
-        class SessionStub extends Service {
-          authenticate = authenticateStub;
-        }
-
-        this.owner.register('service:session', SessionStub);
         component.args.identityProviderSlug = 'super-idp';
         component.args.authenticationKey = 'super-key';
         component.isTermsOfServiceValidated = true;
@@ -159,7 +155,7 @@ module('Unit | Component | authentication | oidc-reconciliation', function (hook
         await component.reconcile();
 
         // then
-        sinon.assert.calledWith(authenticateStub, 'authenticator:oidc', {
+        sinon.assert.calledWith(sessionService.authenticate, 'authenticator:oidc', {
           authenticationKey: 'super-key',
           identityProviderSlug: 'super-idp',
           hostSlug: 'user/reconcile',
@@ -172,13 +168,9 @@ module('Unit | Component | authentication | oidc-reconciliation', function (hook
         test('should display error', async function (assert) {
           // given
           const component = createGlimmerComponent('authentication/oidc-reconciliation');
-          const authenticateStub = sinon.stub().rejects({ errors: [{ status: '401' }] });
+          const sessionService = stubSessionService(this.owner, { isAuthenticated: false });
+          sessionService.authenticate.rejects({ errors: [{ status: '401' }] });
 
-          class SessionStub extends Service {
-            authenticate = authenticateStub;
-          }
-
-          this.owner.register('service:session', SessionStub);
           component.args.identityProviderSlug = 'super-idp';
           component.args.authenticationKey = 'super-key';
           component.isTermsOfServiceValidated = true;
@@ -199,13 +191,9 @@ module('Unit | Component | authentication | oidc-reconciliation', function (hook
         test('should display generic error message', async function (assert) {
           // given
           const component = createGlimmerComponent('authentication/oidc-reconciliation');
-          const authenticateStub = sinon.stub().rejects({ errors: [{ status: '400' }] });
+          const sessionService = stubSessionService(this.owner, { isAuthenticated: false });
+          sessionService.authenticate.rejects({ errors: [{ status: '400' }] });
 
-          class SessionStub extends Service {
-            authenticate = authenticateStub;
-          }
-
-          this.owner.register('service:session', SessionStub);
           component.args.identityProviderSlug = 'super-idp';
           component.args.authenticationKey = 'super-key';
           component.isTermsOfServiceValidated = true;
@@ -224,15 +212,11 @@ module('Unit | Component | authentication | oidc-reconciliation', function (hook
         // given
         let inflightLoading;
         const component = createGlimmerComponent('authentication/oidc-reconciliation');
-        const authenticateStub = function () {
+        const sessionService = stubSessionService(this.owner, { isAuthenticated: false });
+        sessionService.authenticate = function () {
           inflightLoading = component.isLoading;
           return Promise.resolve();
         };
-
-        class SessionStub extends Service {
-          authenticate = authenticateStub;
-        }
-        this.owner.register('service:session', SessionStub);
 
         // when
         await component.reconcile();

--- a/mon-pix/tests/unit/components/autonomous-courses/landing-page-start-block-test.js
+++ b/mon-pix/tests/unit/components/autonomous-courses/landing-page-start-block-test.js
@@ -1,9 +1,9 @@
-import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
 import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+import { stubSessionService } from '../../../helpers/service-stubs.js';
 
 module('Unit | Component | Autonomous Course | Landing page start block', function (hooks) {
   setupTest(hooks);
@@ -21,22 +21,14 @@ module('Unit | Component | Autonomous Course | Landing page start block', functi
     module('when user is anonymous', function () {
       test('should redirect to sign-in page on click', async function (assert) {
         // given
-        const event = {
-          preventDefault: () => {},
-        };
-
-        class SessionStub extends Service {
-          isAuthenticated = false;
-          requireAuthenticationAndApprovedTermsOfService = sinon.stub();
-        }
-        this.owner.register('service:session', SessionStub);
-        const session = this.owner.lookup('service:session');
+        const sessionService = stubSessionService(this.owner, { isAuthenticated: false });
+        const event = { preventDefault: () => {} };
 
         // when
         await component.actions.redirectToSigninIfUserIsAnonymous.call(component, event);
 
         // then
-        sinon.assert.calledWith(session.requireAuthenticationAndApprovedTermsOfService, 'stubbed-transition');
+        sinon.assert.calledWith(sessionService.requireAuthenticationAndApprovedTermsOfService, 'stubbed-transition');
         assert.ok(true);
       });
     });
@@ -44,15 +36,8 @@ module('Unit | Component | Autonomous Course | Landing page start block', functi
     module('when user is authenticated', function () {
       test('should redirect to next page', async function (assert) {
         // given
-        const event = {
-          preventDefault: () => {},
-        };
-
-        class SessionStub extends Service {
-          isAuthenticated = true;
-        }
-        this.owner.register('service:session', SessionStub);
-        this.owner.lookup('service:session');
+        stubSessionService(this.owner, { isAuthenticated: true });
+        const event = { preventDefault: () => {} };
 
         // when
         await component.actions.redirectToSigninIfUserIsAnonymous.call(component, event);

--- a/mon-pix/tests/unit/components/navbar-mobile-header-test.js
+++ b/mon-pix/tests/unit/components/navbar-mobile-header-test.js
@@ -1,22 +1,16 @@
-/* eslint ember/no-classic-classes: 0 */
-/* eslint ember/require-tagless-components: 0 */
-
-import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
+import { stubSessionService } from '../../helpers/service-stubs.js';
 
 module('Unit | Component | Navbar Mobile Header Component', function (hooks) {
   setupTest(hooks);
-  const sessionStubResolve = Service.extend({ isAuthenticated: true });
-  const sessionStubReject = Service.extend({ isAuthenticated: false });
-
   let component;
 
   module('When user is logged', function (hooks) {
     hooks.beforeEach(function () {
-      this.owner.register('service:session', sessionStubResolve);
+      stubSessionService(this.owner, { isAuthenticated: true });
       component = createGlimmerComponent('navbar-mobile-header');
     });
 
@@ -30,7 +24,7 @@ module('Unit | Component | Navbar Mobile Header Component', function (hooks) {
 
   module('When user is not logged', function (hooks) {
     hooks.beforeEach(function () {
-      this.owner.register('service:session', sessionStubReject);
+      stubSessionService(this.owner, { isAuthenticated: false });
       component = createGlimmerComponent('navbar-mobile-header');
     });
 

--- a/mon-pix/tests/unit/components/register-form-test.js
+++ b/mon-pix/tests/unit/components/register-form-test.js
@@ -5,6 +5,7 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
+import { stubSessionService } from '../../helpers/service-stubs.js';
 import setupIntl from '../../helpers/setup-intl';
 
 module('Unit | Component | register-form', function (hooks) {
@@ -144,6 +145,7 @@ module('Unit | Component | register-form', function (hooks) {
     module('completes successfully', function () {
       test('registers and authenticates user with username', async function (assert) {
         // given
+        const sessionService = stubSessionService(this.owner, { isAuthenticated: false });
         const eventStub = { preventDefault: sinon.stub() };
         const store = this.owner.lookup('service:store');
         const createdDependentUser = store.createRecord('dependent-user', {
@@ -156,18 +158,11 @@ module('Unit | Component | register-form', function (hooks) {
         component.password = 'Password12345!';
         component.username = 'lilicoptere0205';
 
-        const authenticateStub = sinon.stub();
-
-        class SessionStub extends Service {
-          authenticate = authenticateStub;
-        }
-        this.owner.register('service:session', SessionStub);
-
         // when
         await component.register(eventStub);
 
         // then
-        sinon.assert.calledWith(authenticateStub, 'authenticator:oauth2', {
+        sinon.assert.calledWith(sessionService.authenticate, 'authenticator:oauth2', {
           login: component.username,
           password: component.password,
           scope: 'mon-pix',
@@ -185,6 +180,7 @@ module('Unit | Component | register-form', function (hooks) {
     module('completes with error', function () {
       test('displays error message', async function (assert) {
         // given
+        const sessionService = stubSessionService(this.owner, { isAuthenticated: false });
         const eventStub = { preventDefault: sinon.stub() };
         const store = this.owner.lookup('service:store');
         const createdDependentUser = store.createRecord('dependent-user', {
@@ -199,18 +195,11 @@ module('Unit | Component | register-form', function (hooks) {
         component.password = 'Password12345!';
         component.username = 'lilicoptere0205';
 
-        const authenticateStub = sinon.stub();
-
-        class SessionStub extends Service {
-          authenticate = authenticateStub;
-        }
-        this.owner.register('service:session', SessionStub);
-
         // when
         await component.register(eventStub);
 
         // then
-        sinon.assert.notCalled(authenticateStub);
+        sinon.assert.notCalled(sessionService.authenticate);
 
         assert.false(component.isCreationFormNotValid);
         assert.false(component.isLoading);
@@ -235,15 +224,11 @@ module('Unit | Component | register-form', function (hooks) {
         component.password = 'Password12345!';
         component.username = 'lilicoptere0205';
 
-        const authenticateStub = function () {
+        const sessionService = stubSessionService(this.owner, { isAuthenticated: false });
+        sessionService.authenticate = function () {
           inflightLoading = component.isLoading;
           return Promise.resolve();
         };
-
-        class SessionStub extends Service {
-          authenticate = authenticateStub;
-        }
-        this.owner.register('service:session', SessionStub);
 
         // when
         await component.register(eventStub);

--- a/mon-pix/tests/unit/components/routes/campaigns/join-sco-information-modal-test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/join-sco-information-modal-test.js
@@ -5,6 +5,7 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 
 import createComponent from '../../../../helpers/create-glimmer-component';
+import { stubSessionService } from '../../../../helpers/service-stubs.js';
 import setupIntl from '../../../../helpers/setup-intl';
 
 module('Unit | Component | routes/campaigns/join-sco-information-modal', function (hooks) {
@@ -163,15 +164,8 @@ module('Unit | Component | routes/campaigns/join-sco-information-modal', functio
     test('should not redirect user to login page when session is invalidated', function (assert) {
       // given
       const component = createComponent('routes/campaigns/join-sco-information-modal');
-      const invalidateStub = sinon.stub().resolves();
-      const setStub = sinon.stub();
 
-      class SessionStub extends Service {
-        invalidate = invalidateStub;
-        set = setStub;
-      }
-
-      this.owner.register('service:session', SessionStub);
+      const sessionStub = stubSessionService(this.owner);
 
       class CampaignStorageStub extends Service {
         set = sinon.stub();
@@ -186,8 +180,8 @@ module('Unit | Component | routes/campaigns/join-sco-information-modal', functio
       component.goToCampaignConnectionForm();
 
       // then
-      sinon.assert.calledOnce(invalidateStub);
-      sinon.assert.calledWith(setStub, 'skipRedirectAfterSessionInvalidation', true);
+      sinon.assert.calledOnce(sessionStub.invalidate);
+      assert.true(sessionStub.skipRedirectAfterSessionInvalidation);
       assert.ok(true);
     });
   });

--- a/mon-pix/tests/unit/components/routes/login-form-test.js
+++ b/mon-pix/tests/unit/components/routes/login-form-test.js
@@ -1,4 +1,3 @@
-import Service from '@ember/service';
 import { t } from 'ember-intl/test-support';
 import { setupTest } from 'ember-qunit';
 import ENV from 'mon-pix/config/environment';
@@ -6,6 +5,7 @@ import createGlimmerComponent from 'mon-pix/tests/helpers/create-glimmer-compone
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import { stubSessionService } from '../../../helpers/service-stubs.js';
 import setupIntl from '../../../helpers/setup-intl';
 
 module('Unit | Component | routes/login-form', function (hooks) {
@@ -150,17 +150,12 @@ module('Unit | Component | routes/login-form', function (hooks) {
         test('isLoading is true', async function (assert) {
           // given
           let inflightLoading;
-
           const component = createGlimmerComponent('routes/login-form');
-          const authenticateStub = function () {
+          const sessionService = stubSessionService(this.owner, { isAuthenticated: false });
+          sessionService.authenticate = function () {
             inflightLoading = component.isLoading;
             return Promise.resolve();
           };
-          class SessionStub extends Service {
-            authenticate = authenticateStub;
-          }
-
-          this.owner.register('service:session', SessionStub);
 
           // when
           await component.authenticate(eventStub);


### PR DESCRIPTION
## :christmas_tree: Problème

Actuellement, la déclaration des stubs des services `session` et `current-user` dans les tests est fastidieuse et souvent sujette à des erreurs car elle nécessite parfois de connaître l'implémentation exacte de ces classes et des données qu'elles manipulent.

## :gift: Proposition

Mise à disposition des fonctions utilitaires `stubSessionService()` et `stubCurrentUserService()` permettant de faciliter le stubbing de ces services sur les tests d'intégration et unitaire de Pix App : 
- les services sont automatiquement enregistrés sur le `owner`
- les données des services sont pré-remplies avec des valeurs par défaut et sont surchargeables
- toutes les fonctions des services sont pré-stubbées avec `sinon`
- le service créé est retourné par la fonction

**stubSessionService**
```js
import { stubSessionService } from '../../helpers/service-stubs';

// stub d'une session non authentifiée
stubSessionService(this.owner, { isAuthenticated: false });

// stub d'une session authentifiée
const sessionService = stubSessionService(this.owner, { isAuthenticated: true });

// les fonctions du service sont pré-stubbées par sinon
sessionService.authenticate.resolves()
sinon.assert.called(sessionService.authenticate)
```

**stubCurrentUserService**
```js
import { stubCurrentUserService } from '../../helpers/service-stubs';

// stub du current user avec informations prédéfinies et surchargeables
const currentUserService = stubCurrentUserService(this.owner);
console.log(currentUserService.user) // { id: 123, email: 'john.doe@example.net', firstName: 'John', ... }

// informations surchargées
const currentUserService = stubCurrentUserService(this.owner, { firstName: 'Jane' });
console.log(currentUserService.user) // { id: 123, email: 'jane.doe@example.net', firstName: 'Jane', ... }

// utilisateur anonyme
const currentUserService = stubCurrentUserService(this.owner, { isAnonymous: true });
console.log(currentUserService.user) // { isAnonymous: true }
```
