### PR TITLE
[FEATURE] Calculer l'obtention de l'attestation a la fin du parcours (PIX-15498)

### DIFF
--- a/api/src/shared/application/assessments/assessment-controller.js
+++ b/api/src/shared/application/assessments/assessment-controller.js
@@ -10,6 +10,7 @@ import { usecases as devcompUsecases } from '../../../devcomp/domain/usecases/in
 import { Answer } from '../../../evaluation/domain/models/Answer.js';
 import { ValidatorAlwaysOK } from '../../../evaluation/domain/models/ValidatorAlwaysOK.js';
 import * as competenceEvaluationSerializer from '../../../evaluation/infrastructure/serializers/jsonapi/competence-evaluation-serializer.js';
+import { usecases as questUsecases } from '../../../quest/domain/usecases/index.js';
 import {
   extractLocaleFromRequest,
   extractUserIdFromRequest,
@@ -98,6 +99,7 @@ const completeAssessment = async function (request) {
     const assessment = await usecases.completeAssessment({ assessmentId, locale });
     await usecases.handleBadgeAcquisition({ assessment });
     await usecases.handleStageAcquisition({ assessment });
+    if (assessment.userId) await questUsecases.rewardUser({ userId: assessment.userId });
     await devcompUsecases.handleTrainingRecommendation({ assessment, locale });
   });
 

--- a/api/tests/shared/unit/application/assessments/assessment-controller_test.js
+++ b/api/tests/shared/unit/application/assessments/assessment-controller_test.js
@@ -3,6 +3,7 @@ import { usecases } from '../../../../../lib/domain/usecases/index.js';
 import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';
 import { usecases as certificationUsecases } from '../../../../../src/certification/session-management/domain/usecases/index.js';
 import { usecases as devcompUsecases } from '../../../../../src/devcomp/domain/usecases/index.js';
+import { usecases as questUsecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { assessmentController } from '../../../../../src/shared/application/assessments/assessment-controller.js';
 import { domainBuilder, expect, hFake, sinon } from '../../../../test-helper.js';
 
@@ -74,6 +75,7 @@ describe('Unit | Controller | assessment-controller', function () {
       sinon.stub(usecases, 'handleBadgeAcquisition');
       sinon.stub(devcompUsecases, 'handleTrainingRecommendation');
       sinon.stub(usecases, 'handleStageAcquisition');
+      sinon.stub(questUsecases, 'rewardUser');
       usecases.completeAssessment.resolves(assessment);
       usecases.handleBadgeAcquisition.resolves();
       sinon.stub(events.eventDispatcher, 'dispatch');
@@ -107,6 +109,30 @@ describe('Unit | Controller | assessment-controller', function () {
         assessment,
         locale,
       });
+    });
+
+    it('should call the rewardUser use case if there is a userId', async function () {
+      // given
+      usecases.completeAssessment.resolves({ userId: 12 });
+
+      // when
+      await assessmentController.completeAssessment({ params: { id: assessmentId } });
+
+      // then
+      expect(questUsecases.rewardUser).to.have.been.calledWithExactly({
+        userId: 12,
+      });
+    });
+
+    it('should not call the rewardUser use case if there is no userId', async function () {
+      // given
+      usecases.completeAssessment.resolves({ userId: null });
+
+      // when
+      await assessmentController.completeAssessment({ params: { id: assessmentId } });
+
+      // then
+      expect(questUsecases.rewardUser).to.be.not.called;
     });
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème
Si un utilisateur lance une campagne qui ne contient que des acquis précédemment joués, on ne va pas calculer l'obtention de son attestation qui se produit pour l'instant uniquement a chaque réponse de l'utilisateur. 

## :gift: Proposition
Brancher le usecase de l'obtention sur la route "complete-assessment".

## :santa: Pour tester
se connecter avec l'utilisateur "perfect"
le réconcilier a l'organisation "attestation"
lancer un parcours attestation avec cet utilisateur
constater qu'on a obtenu l'attestation
