### PR TITLE
[FEATURE] Script d'ajout d'un document legal (PIX-15582)

### DIFF
--- a/api/scripts/legal-documents/add-new-legal-document-version.js
+++ b/api/scripts/legal-documents/add-new-legal-document-version.js
@@ -1,0 +1,61 @@
+import 'dotenv/config';
+
+import Joi from 'joi';
+
+import { usecases } from '../../src/legal-documents/domain/usecases/index.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+
+export class AddNewLegalDocumentVersion extends Script {
+  constructor() {
+    super({
+      description: 'Adds a new legal document version.',
+      permanent: true,
+      options: {
+        type: {
+          type: 'string',
+          describe: 'Type of document (ex: "TOS", "PDP")',
+          demandOption: true,
+          requiresArg: true,
+        },
+        service: {
+          type: 'string',
+          describe: 'Associated service (ex: "pix-app", "pix-orga",...)',
+          demandOption: true,
+          requiresArg: true,
+        },
+        versionAt: {
+          type: 'string',
+          describe: 'Version date of the legal document, format "YYYY-MM-DD", (ex: "2020-02-27")',
+          demandOption: true,
+          requiresArg: true,
+          coerce: (value) => {
+            const schema = Joi.string()
+              .pattern(/^\d{4}-\d{2}-\d{2}$/)
+              .message('Invalid date format. Expected "YYYY-MM-DD".');
+            const { error, value: validatedDate } = schema.validate(value);
+            if (error) {
+              throw new Error(error.message);
+            }
+            return new Date(validatedDate);
+          },
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    let { type, service } = options;
+    const { versionAt } = options;
+
+    type = type.trim();
+    service = service.trim();
+
+    logger.info(`Adding new legal document for type:${type}, service:${service}, versionAt:${versionAt}`);
+
+    await usecases.createLegalDocument({ type, service, versionAt });
+    logger.info(`New legal document for type:${type}, service:${service}, versionAt:${versionAt} added successfully.`);
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, AddNewLegalDocumentVersion);

--- a/api/scripts/legal-documents/add-new-legal-document-version.js
+++ b/api/scripts/legal-documents/add-new-legal-document-version.js
@@ -1,8 +1,7 @@
 import 'dotenv/config';
 
-import Joi from 'joi';
-
 import { usecases } from '../../src/legal-documents/domain/usecases/index.js';
+import { isoDateParser } from '../../src/shared/application/scripts/parsers.js';
 import { Script } from '../../src/shared/application/scripts/script.js';
 import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
 
@@ -29,16 +28,7 @@ export class AddNewLegalDocumentVersion extends Script {
           describe: 'Version date of the legal document, format "YYYY-MM-DD", (ex: "2020-02-27")',
           demandOption: true,
           requiresArg: true,
-          coerce: (value) => {
-            const schema = Joi.string()
-              .pattern(/^\d{4}-\d{2}-\d{2}$/)
-              .message('Invalid date format. Expected "YYYY-MM-DD".');
-            const { error, value: validatedDate } = schema.validate(value);
-            if (error) {
-              throw new Error(error.message);
-            }
-            return new Date(validatedDate);
-          },
+          coerce: isoDateParser(),
         },
       },
     });

--- a/api/src/legal-documents/domain/errors.js
+++ b/api/src/legal-documents/domain/errors.js
@@ -1,0 +1,13 @@
+import { DomainError } from '../../shared/domain/errors.js';
+
+class LegalDocumentInvalidDateError extends DomainError {
+  constructor({
+    code = 'LEGAL_DOCUMENT_INVALID_DATE',
+    message = 'Document version must not be before or equal to same document type and service',
+  } = {}) {
+    super(message);
+    this.code = code;
+  }
+}
+
+export { LegalDocumentInvalidDateError };

--- a/api/src/legal-documents/domain/models/LegalDocument.js
+++ b/api/src/legal-documents/domain/models/LegalDocument.js
@@ -1,14 +1,4 @@
 export class LegalDocument {
-  static TYPES = {
-    TOS: 'TOS',
-  };
-
-  static SERVICES = {
-    PIX_APP: 'pix-app',
-    PIX_ORGA: 'pix-orga',
-    PIX_CERTIF: 'pix-certif',
-  };
-
   constructor({ id, type, service, versionAt }) {
     this.id = id;
     this.type = type;

--- a/api/src/legal-documents/domain/models/LegalDocumentService.js
+++ b/api/src/legal-documents/domain/models/LegalDocumentService.js
@@ -1,0 +1,13 @@
+import Joi from 'joi';
+
+const VALUES = {
+  PIX_APP: 'pix-app',
+  PIX_ORGA: 'pix-orga',
+  PIX_CERTIF: 'pix-certif',
+};
+
+const assert = (value) => {
+  Joi.assert(value, Joi.string().valid(...Object.values(VALUES)));
+};
+
+export const LegalDocumentService = { VALUES, assert };

--- a/api/src/legal-documents/domain/models/LegalDocumentType.js
+++ b/api/src/legal-documents/domain/models/LegalDocumentType.js
@@ -1,0 +1,11 @@
+import Joi from 'joi';
+
+const VALUES = {
+  TOS: 'TOS',
+};
+
+const assert = (value) => {
+  Joi.assert(value, Joi.string().valid(...Object.values(VALUES)));
+};
+
+export const LegalDocumentType = { VALUES, assert };

--- a/api/src/legal-documents/domain/usecases/accept-legal-document-by-user-id.usecase.js
+++ b/api/src/legal-documents/domain/usecases/accept-legal-document-by-user-id.usecase.js
@@ -1,7 +1,8 @@
-import { LegalDocument } from '../models/LegalDocument.js';
+import { LegalDocumentService } from '../models/LegalDocumentService.js';
+import { LegalDocumentType } from '../models/LegalDocumentType.js';
 
-const { TOS } = LegalDocument.TYPES;
-const { PIX_ORGA } = LegalDocument.SERVICES;
+const { TOS } = LegalDocumentType.VALUES;
+const { PIX_ORGA } = LegalDocumentService.VALUES;
 
 /**
  * Accepts a legal document by user ID.

--- a/api/src/legal-documents/domain/usecases/create-legal-document.usecase.js
+++ b/api/src/legal-documents/domain/usecases/create-legal-document.usecase.js
@@ -1,0 +1,27 @@
+import { LegalDocumentInvalidDateError } from '../errors.js';
+import { LegalDocumentService } from '../models/LegalDocumentService.js';
+import { LegalDocumentType } from '../models/LegalDocumentType.js';
+
+/**
+ * Creates a new legal document.
+ *
+ * @param {Object} params - The parameters.
+ * @param {string} params.type - The type of the legal document.
+ * @param {string} params.service - The service of the legal document.
+ * @param {string} params.versionAt - Version date of the new legal document.
+ * @returns {Promise<LegalDocument>} A promise that resolves the new legal document.
+ */
+const createLegalDocument = async ({ type, service, versionAt, legalDocumentRepository }) => {
+  LegalDocumentType.assert(type);
+  LegalDocumentService.assert(service);
+
+  const lastDocument = await legalDocumentRepository.findLastVersionByTypeAndService({ type, service });
+
+  if (lastDocument && lastDocument.versionAt >= versionAt) {
+    throw new LegalDocumentInvalidDateError();
+  }
+
+  return legalDocumentRepository.create({ type, service, versionAt });
+};
+
+export { createLegalDocument };

--- a/api/src/legal-documents/infrastructure/repositories/legal-document.repository.js
+++ b/api/src/legal-documents/infrastructure/repositories/legal-document.repository.js
@@ -1,6 +1,8 @@
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { LegalDocument } from '../../domain/models/LegalDocument.js';
 
+const TABLE_NAME = 'legal-document-versions';
+
 /**
  * Retrieves the latest version of a legal document by type and service.
  *
@@ -11,7 +13,7 @@ import { LegalDocument } from '../../domain/models/LegalDocument.js';
  */
 const findLastVersionByTypeAndService = async ({ type, service }) => {
   const knexConnection = DomainTransaction.getConnection();
-  const documentVersionDto = await knexConnection('legal-document-versions')
+  const documentVersionDto = await knexConnection(TABLE_NAME)
     .where({ type, service })
     .orderBy('versionAt', 'desc')
     .first();
@@ -21,4 +23,21 @@ const findLastVersionByTypeAndService = async ({ type, service }) => {
   return new LegalDocument(documentVersionDto);
 };
 
-export { findLastVersionByTypeAndService };
+/**
+ * Creates a new legal document in the database.
+ *
+ * @param {Object} params - The parameters.
+ * @param {string} params.type - The type of the legal document.
+ * @param {string} params.service - The service associated with the legal document.
+ * @param {Date} params.versionAt - The date of the legal document version.
+ * @returns {Promise<LegalDocument>} The newly created legal document.
+ */
+const create = async ({ type, service, versionAt }) => {
+  const knexConnection = DomainTransaction.getConnection();
+
+  const [documentVersionDto] = await knexConnection(TABLE_NAME).insert({ type, service, versionAt }).returning('*');
+
+  return new LegalDocument(documentVersionDto);
+};
+
+export { create, findLastVersionByTypeAndService };

--- a/api/src/shared/application/scripts/parsers.js
+++ b/api/src/shared/application/scripts/parsers.js
@@ -50,3 +50,21 @@ export function commaSeparatedNumberParser(separator = ',') {
     return Joi.attempt(data, Joi.array().items(Joi.number()));
   };
 }
+
+/**
+ * Create a parser for date strings in the format "YYYY-MM-DD"
+ * @returns {Date}
+ */
+export function isoDateParser() {
+  return (date) => {
+    const schema = Joi.string()
+      .pattern(/^\d{4}-\d{2}-\d{2}$/)
+      .message('Invalid date format. Expected "YYYY-MM-DD".');
+
+    const { error, value: validatedDate } = schema.validate(date);
+    if (error) {
+      throw new Error(error.message);
+    }
+    return new Date(validatedDate);
+  };
+}

--- a/api/tests/legal-documents/integration/application/api/legal-documents-api.test.js
+++ b/api/tests/legal-documents/integration/application/api/legal-documents-api.test.js
@@ -1,9 +1,10 @@
 import * as legalDocumentsApi from '../../../../../src/legal-documents/application/api/legal-documents-api.js';
-import { LegalDocument } from '../../../../../src/legal-documents/domain/models/LegalDocument.js';
+import { LegalDocumentService } from '../../../../../src/legal-documents/domain/models/LegalDocumentService.js';
+import { LegalDocumentType } from '../../../../../src/legal-documents/domain/models/LegalDocumentType.js';
 import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
 
-const { TOS } = LegalDocument.TYPES;
-const { PIX_ORGA } = LegalDocument.SERVICES;
+const { TOS } = LegalDocumentType.VALUES;
+const { PIX_ORGA } = LegalDocumentService.VALUES;
 
 describe('Integration | Privacy | Application | Api | legal documents', function () {
   describe('#acceptLegalDocumentByUserId', function () {

--- a/api/tests/legal-documents/integration/domain/usecases/accept-legal-document-by-user-id.usecase.test.js
+++ b/api/tests/legal-documents/integration/domain/usecases/accept-legal-document-by-user-id.usecase.test.js
@@ -1,9 +1,10 @@
-import { LegalDocument } from '../../../../../src/legal-documents/domain/models/LegalDocument.js';
+import { LegalDocumentService } from '../../../../../src/legal-documents/domain/models/LegalDocumentService.js';
+import { LegalDocumentType } from '../../../../../src/legal-documents/domain/models/LegalDocumentType.js';
 import { usecases } from '../../../../../src/legal-documents/domain/usecases/index.js';
 import { databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
 
-const { TOS } = LegalDocument.TYPES;
-const { PIX_ORGA } = LegalDocument.SERVICES;
+const { TOS } = LegalDocumentType.VALUES;
+const { PIX_ORGA } = LegalDocumentService.VALUES;
 
 describe('Integration | Legal documents | Domain | Use case | accept-legal-document-by-user-id', function () {
   it('accepts the lastest legal document version for a user', async function () {

--- a/api/tests/legal-documents/integration/domain/usecases/create-legal-document.usecase.test.js
+++ b/api/tests/legal-documents/integration/domain/usecases/create-legal-document.usecase.test.js
@@ -1,0 +1,64 @@
+import { LegalDocumentInvalidDateError } from '../../../../../src/legal-documents/domain/errors.js';
+import { LegalDocumentService } from '../../../../../src/legal-documents/domain/models/LegalDocumentService.js';
+import { LegalDocumentType } from '../../../../../src/legal-documents/domain/models/LegalDocumentType.js';
+import { usecases } from '../../../../../src/legal-documents/domain/usecases/index.js';
+import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
+
+const { TOS } = LegalDocumentType.VALUES;
+const { PIX_ORGA } = LegalDocumentService.VALUES;
+
+describe('Integration | Legal documents | Domain | Use case | create-legal-document', function () {
+  it('creates a new legal document when there is no previous version', async function () {
+    // given
+    const type = TOS;
+    const service = PIX_ORGA;
+    const versionAt = new Date('2024-12-01');
+    const expectedDocument = domainBuilder.buildLegalDocument({ type, service, versionAt });
+
+    // when
+    const document = await usecases.createLegalDocument({ type, service, versionAt });
+
+    // then
+    expect(document).to.deepEqualInstanceOmitting(expectedDocument, 'id');
+  });
+
+  context('when a previous version exists', function () {
+    it('throws an error if the new version date is before or equal to the existing version date', async function () {
+      // given
+      const type = TOS;
+      const service = PIX_ORGA;
+      const existingVersionAt = new Date('2024-12-01');
+      const newVersionAt = new Date('2024-11-30');
+
+      databaseBuilder.factory.buildLegalDocumentVersion({ type, service, versionAt: existingVersionAt });
+      await databaseBuilder.commit();
+
+      // when
+      const error = await catchErr(usecases.createLegalDocument)({ type, service, versionAt: newVersionAt });
+
+      //then
+      expect(error).to.be.instanceOf(LegalDocumentInvalidDateError);
+      expect(error.message).to.be.equal(
+        'Document version must not be before or equal to same document type and service',
+      );
+    });
+
+    it('creates a new document if the new version date is after the existing version date', async function () {
+      // given
+      const type = TOS;
+      const service = PIX_ORGA;
+      const existingVersionAt = new Date('2024-12-01');
+      const newVersionAt = new Date('2024-12-02');
+      const expectedDocument = domainBuilder.buildLegalDocument({ type, service, versionAt: newVersionAt });
+
+      databaseBuilder.factory.buildLegalDocumentVersion({ type, service, versionAt: existingVersionAt });
+      await databaseBuilder.commit();
+
+      // when
+      const document = await usecases.createLegalDocument({ type, service, versionAt: newVersionAt });
+
+      // then
+      expect(document).to.deepEqualInstanceOmitting(expectedDocument, 'id');
+    });
+  });
+});

--- a/api/tests/legal-documents/integration/infrastructure/repositories/legal-document.repository.test.js
+++ b/api/tests/legal-documents/integration/infrastructure/repositories/legal-document.repository.test.js
@@ -49,4 +49,20 @@ describe('Integration | Legal document | Infrastructure | Repository | legal-doc
       expect(lastDocument).to.be.null;
     });
   });
+
+  describe('#create', function () {
+    it('creates a new legal document in the database', async function () {
+      // given
+      const type = TOS;
+      const service = PIX_ORGA;
+      const versionAt = new Date('2024-12-01');
+
+      // when
+      const createdDocument = await legalDocumentRepository.create({ type, service, versionAt });
+
+      // then
+      expect(createdDocument).to.be.instanceOf(LegalDocument);
+      expect(createdDocument).to.deep.include({ type, service, versionAt });
+    });
+  });
 });

--- a/api/tests/legal-documents/integration/infrastructure/repositories/legal-document.repository.test.js
+++ b/api/tests/legal-documents/integration/infrastructure/repositories/legal-document.repository.test.js
@@ -1,9 +1,11 @@
 import { LegalDocument } from '../../../../../src/legal-documents/domain/models/LegalDocument.js';
+import { LegalDocumentService } from '../../../../../src/legal-documents/domain/models/LegalDocumentService.js';
+import { LegalDocumentType } from '../../../../../src/legal-documents/domain/models/LegalDocumentType.js';
 import * as legalDocumentRepository from '../../../../../src/legal-documents/infrastructure/repositories/legal-document.repository.js';
 import { databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
 
-const { TOS } = LegalDocument.TYPES;
-const { PIX_ORGA, PIX_APP } = LegalDocument.SERVICES;
+const { TOS } = LegalDocumentType.VALUES;
+const { PIX_ORGA, PIX_APP } = LegalDocumentService.VALUES;
 
 describe('Integration | Legal document | Infrastructure | Repository | legal-document', function () {
   describe('#findLastVersionByTypeAndService', function () {

--- a/api/tests/legal-documents/integration/infrastructure/repositories/user-acceptance.repository.test.js
+++ b/api/tests/legal-documents/integration/infrastructure/repositories/user-acceptance.repository.test.js
@@ -1,9 +1,10 @@
-import { LegalDocument } from '../../../../../src/legal-documents/domain/models/LegalDocument.js';
+import { LegalDocumentService } from '../../../../../src/legal-documents/domain/models/LegalDocumentService.js';
+import { LegalDocumentType } from '../../../../../src/legal-documents/domain/models/LegalDocumentType.js';
 import * as userAcceptanceRepository from '../../../../../src/legal-documents/infrastructure/repositories/user-acceptance.repository.js';
 import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
 
-const { TOS } = LegalDocument.TYPES;
-const { PIX_ORGA } = LegalDocument.SERVICES;
+const { TOS } = LegalDocumentType.VALUES;
+const { PIX_ORGA } = LegalDocumentService.VALUES;
 
 describe('Integration | Legal document | Infrastructure | Repository | user-acceptance', function () {
   describe('#create', function () {

--- a/api/tests/legal-documents/unit/domain/models/LegalDocumentService.test.js
+++ b/api/tests/legal-documents/unit/domain/models/LegalDocumentService.test.js
@@ -1,0 +1,26 @@
+import Joi from 'joi';
+
+import { LegalDocumentService } from '../../../../../src/legal-documents/domain/models/LegalDocumentService.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Legal documents | Domain | Model | LegalDocumentService', function () {
+  describe('VALUES', function () {
+    it('has correct values', function () {
+      expect(LegalDocumentService.VALUES.PIX_APP).to.equal('pix-app');
+      expect(LegalDocumentService.VALUES.PIX_ORGA).to.equal('pix-orga');
+      expect(LegalDocumentService.VALUES.PIX_CERTIF).to.equal('pix-certif');
+    });
+  });
+
+  describe('#assert', function () {
+    it('does not throw an error for valid values', function () {
+      expect(() => LegalDocumentService.assert('pix-app')).to.not.throw();
+      expect(() => LegalDocumentService.assert('pix-orga')).to.not.throw();
+      expect(() => LegalDocumentService.assert('pix-certif')).to.not.throw();
+    });
+
+    it('throws an error for invalid values', function () {
+      expect(() => LegalDocumentService.assert('invalid-value')).to.throw(Joi.ValidationError);
+    });
+  });
+});

--- a/api/tests/legal-documents/unit/domain/models/LegalDocumentType.test.js
+++ b/api/tests/legal-documents/unit/domain/models/LegalDocumentType.test.js
@@ -1,0 +1,22 @@
+import Joi from 'joi';
+
+import { LegalDocumentType } from '../../../../../src/legal-documents/domain/models/LegalDocumentType.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Legal documents | Domain | Model | LegalDocumentType', function () {
+  describe('VALUES', function () {
+    it('has correct values', function () {
+      expect(LegalDocumentType.VALUES.TOS).to.equal('TOS');
+    });
+  });
+
+  describe('assert', function () {
+    it('does not throw an error for valid value', function () {
+      expect(() => LegalDocumentType.assert('TOS')).to.not.throw();
+    });
+
+    it('throws an error for invalid value', function () {
+      expect(() => LegalDocumentType.assert('INVALID')).to.throw(Joi.ValidationError);
+    });
+  });
+});

--- a/api/tests/legal-documents/unit/domain/usecase/create-legal-document.usecase.test.js
+++ b/api/tests/legal-documents/unit/domain/usecase/create-legal-document.usecase.test.js
@@ -1,0 +1,39 @@
+import Joi from 'joi';
+
+import { LegalDocumentService } from '../../../../../src/legal-documents/domain/models/LegalDocumentService.js';
+import { LegalDocumentType } from '../../../../../src/legal-documents/domain/models/LegalDocumentType.js';
+import { usecases } from '../../../../../src/legal-documents/domain/usecases/index.js';
+import { expect } from '../../../../test-helper.js';
+
+const { TOS } = LegalDocumentType.VALUES;
+const { PIX_ORGA } = LegalDocumentService.VALUES;
+
+describe('Unit | Legal documents | Domain | Use case | create-legal-document', function () {
+  context('when the legal document type is invalid', function () {
+    it('throws an error', async function () {
+      // given
+      const type = 'invalid-type';
+      const service = PIX_ORGA;
+      const versionAt = new Date('2024-12-01');
+
+      // when / then
+      await expect(usecases.createLegalDocument({ type, service, versionAt })).to.have.been.rejectedWith(
+        Joi.ValidationError,
+      );
+    });
+  });
+
+  context('when the legal document service is invalid', function () {
+    it('throws an error', async function () {
+      // given
+      const type = TOS;
+      const service = 'invalid-service';
+      const versionAt = new Date('2024-12-01');
+
+      // when / then
+      await expect(usecases.createLegalDocument({ type, service, versionAt })).to.have.been.rejectedWith(
+        Joi.ValidationError,
+      );
+    });
+  });
+});

--- a/api/tests/shared/unit/application/scripts/parsers_test.js
+++ b/api/tests/shared/unit/application/scripts/parsers_test.js
@@ -6,6 +6,7 @@ import {
   commaSeparatedNumberParser,
   commaSeparatedStringParser,
   csvFileParser,
+  isoDateParser,
 } from '../../../../../src/shared/application/scripts/parsers.js';
 import { catchErr, expect } from '../../../../test-helper.js';
 
@@ -106,6 +107,47 @@ describe('Shared | Unit | Application | Parsers', function () {
 
       // then
       expect(() => parser(input)).to.throw('"[1]" must be a number');
+    });
+  });
+
+  describe('isoDateParser', function () {
+    it('parses a valid date string in YYYY-MM-DD format', function () {
+      // given
+      const input = '2023-12-25';
+
+      // when
+      const parser = isoDateParser();
+      const result = parser(input);
+
+      // then
+      expect(result).to.be.instanceOf(Date);
+      expect(result.toISOString().startsWith('2023-12-25')).to.be.true;
+    });
+
+    it('throws an error for an invalid date format', async function () {
+      // given
+      const input = '12-25-2023';
+
+      // when
+      const parser = isoDateParser();
+      const error = await catchErr(parser)(input);
+
+      // then
+      expect(error).to.be.instanceOf(Error);
+      expect(error.message).to.equal('Invalid date format. Expected "YYYY-MM-DD".');
+    });
+
+    it('throws an error for non-date strings', async function () {
+      // given
+      const input = 'not-a-date';
+
+      // when
+      const parser = isoDateParser();
+      const error = await catchErr(parser)(input);
+
+      // then
+      expect(error).to.be.instanceOf(Error);
+      expect(error.message).to.equal('Invalid date format. Expected "YYYY-MM-DD".');
     });
   });
 });

--- a/api/tests/tooling/domain-builder/factory/build-legal-document.js
+++ b/api/tests/tooling/domain-builder/factory/build-legal-document.js
@@ -1,9 +1,11 @@
 import { LegalDocument } from '../../../../src/legal-documents/domain/models/LegalDocument.js';
+import { LegalDocumentService } from '../../../../src/legal-documents/domain/models/LegalDocumentService.js';
+import { LegalDocumentType } from '../../../../src/legal-documents/domain/models/LegalDocumentType.js';
 
 const buildLegalDocument = function ({
   id = 123,
-  type = LegalDocument.TYPES.TOS,
-  service = LegalDocument.SERVICES.PIX_APP,
+  type = LegalDocumentType.VALUES.TOS,
+  service = LegalDocumentService.VALUES.PIX_ORGA,
   versionAt = new Date(),
 } = {}) {
   return new LegalDocument({


### PR DESCRIPTION
## :christmas_tree: Problème

Avec la nouvelle table legal-document-versions, nous avons besoin d’ajouter de nouveaux documents. Dans un premier temps, nous allons utiliser un script pour en insérer dans cette table.

## :gift: Proposition

Créer un script


## :santa: Pour tester

En local:
 - cd `api`

 - Lancer la commande `node scripts/legal-documents/add-new-legal-document-version.js --type 'TOS' --service 'pix-orga' --versionAt '2020-01-01'`

- Constater en base que l'écriture s'est faite correctement dans la table 'legal-document-versions'

- Essayer d'introduire un nouveau document avec les même paramètres ou une date antérieur
- Constater la non écriture en base