### PR TITLE
[FEATURE] Ajout d'un bouton reload pour les embed (PIX-15418)

### DIFF
--- a/junior/app/components/challenge/challenge-embed-simulator/component.js
+++ b/junior/app/components/challenge/challenge-embed-simulator/component.js
@@ -1,3 +1,4 @@
+import { action } from '@ember/object';
 import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
 
@@ -7,5 +8,31 @@ export default class ChallengeEmbedSimulator extends Component {
     const itemMedia = document.getElementsByClassName('challenge-item__media ')[0];
     const height = this.args.isMediaWithForm ? (baseHeight * itemMedia.offsetWidth) / 710 : baseHeight;
     return htmlSafe(`height: ${height}px; max-height: ${baseHeight}px`);
+  }
+
+  @action
+  setIframeHtmlElement(htmlElement) {
+    this.iframe = htmlElement;
+  }
+
+  @action
+  rebootSimulator() {
+    const iframe = this.iframe;
+    const tmpSrc = iframe.src;
+
+    const loadListener = () => {
+      if (iframe.src === 'about:blank') {
+        // First onload: when we reset the iframe
+        iframe.src = tmpSrc;
+      } else {
+        // Second onload: when we re-assign the iframe's src to its original value
+        iframe.focus();
+        iframe.removeEventListener('load', loadListener);
+      }
+    };
+
+    iframe.addEventListener('load', loadListener);
+
+    iframe.src = 'about:blank';
   }
 }

--- a/junior/app/components/challenge/challenge-embed-simulator/template.hbs
+++ b/junior/app/components/challenge/challenge-embed-simulator/template.hbs
@@ -15,15 +15,15 @@
   </iframe>
   {{#if @shouldDisplayRebootButton}}
     <div class="reboot-container">
-      <button
-        type="button"
+      <PixButton
         class="link link--grey reboot-container__content"
         aria-label={{t "pages.challenge.embed-simulator.actions.reset-label"}}
-        {{on "click" this.rebootSimulator}}
+        @iconBefore="refresh"
+        @variant="tertiary"
+        @triggerAction={{this.rebootSimulator}}
       >
-        <PixIcon @name="refresh" @ariaHidden={{true}} class="embed-reboot-content__icon" />
         {{t "components.challenge.embed-simulator.actions.reset"}}
-      </button>
+      </PixButton>
     </div>
   {{/if}}
 </div>

--- a/junior/app/components/challenge/challenge-embed-simulator/template.hbs
+++ b/junior/app/components/challenge/challenge-embed-simulator/template.hbs
@@ -10,6 +10,20 @@
     src="{{@url}}"
     title="{{@title}}"
     style="{{this.embedDocumentHeightStyle}}"
+    {{did-render this.setIframeHtmlElement}}
   >
   </iframe>
+  {{#if @shouldDisplayRebootButton}}
+    <div class="reboot-container">
+      <button
+        type="button"
+        class="link link--grey reboot-container__content"
+        aria-label={{t "pages.challenge.embed-simulator.actions.reset-label"}}
+        {{on "click" this.rebootSimulator}}
+      >
+        <PixIcon @name="refresh" @ariaHidden={{true}} class="embed-reboot-content__icon" />
+        {{t "components.challenge.embed-simulator.actions.reset"}}
+      </button>
+    </div>
+  {{/if}}
 </div>

--- a/junior/app/components/challenge/item/component.js
+++ b/junior/app/components/challenge/item/component.js
@@ -1,6 +1,17 @@
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 
 export default class Item extends Component {
+  @tracked isRebootable = false;
+
+  constructor() {
+    super(...arguments);
+    window.addEventListener('message', ({ data }) => {
+      if (data?.from === 'pix' && data?.type === 'init') {
+        this.isRebootable = !!data.rebootable;
+      }
+    });
+  }
   get isMediaWithForm() {
     return this.args.challenge.hasForm && this.hasMedia && this.args.challenge.type !== undefined;
   }
@@ -11,5 +22,9 @@ export default class Item extends Component {
       this.args.challenge.hasValidEmbedDocument ||
       this.args.challenge.hasWebComponent
     );
+  }
+
+  get shouldDisplayRebootButton() {
+    return this.isRebootable && !this.args.isDisabled;
   }
 }

--- a/junior/app/components/challenge/item/template.hbs
+++ b/junior/app/components/challenge/item/template.hbs
@@ -14,6 +14,7 @@
             @height={{@challenge.embedHeight}}
             @hideSimulator={{@isDisabled}}
             @isMediaWithForm={{this.isMediaWithForm}}
+            @shouldDisplayRebootButton={{this.shouldDisplayRebootButton}}
           />
         </div>
       {{/if}}

--- a/junior/app/styles/components/challenge/challenge-embed-simulator.scss
+++ b/junior/app/styles/components/challenge/challenge-embed-simulator.scss
@@ -20,7 +20,11 @@
   .reboot-container {
     display: flex;
     justify-content: flex-end;
-    color: var(--pix-neutral-500);
+
+    .pix-button--tertiary {
+      color: var(--pix-neutral-500);
+      text-decoration: none;
+    }
 
     &__content {
       display: flex;

--- a/junior/app/styles/components/challenge/challenge-embed-simulator.scss
+++ b/junior/app/styles/components/challenge/challenge-embed-simulator.scss
@@ -16,6 +16,17 @@
     width: 100%;
     height: 100%;
   }
+
+  .reboot-container {
+    display: flex;
+    justify-content: flex-end;
+    color: var(--pix-neutral-500);
+
+    &__content {
+      display: flex;
+      align-items: center;
+    }
+  }
 }
 
 

--- a/junior/translations/fr.json
+++ b/junior/translations/fr.json
@@ -13,6 +13,13 @@
       "play": "J'écoute",
       "stop": "Stop",
       "label": "Lire la consigne à haute voix"
+    },
+    "challenge": {
+      "embed-simulator": {
+        "actions": {
+          "reset": "Recommencer"
+        }
+      }
     }
   },
   "pages": {


### PR DESCRIPTION
## :christmas_tree: Problème

Les utilisateurs ne peuvent pas reload l'embed sans recharger la page.
## :gift: Proposition

Ajout d'un bouton "Recommencer" en dessous des embeds avant validation.

## :socks: Remarques

RAS

## :santa: Pour tester

Ce boutton ne doit pas s'afficher sur des carrousel / QCU_Image / etc... 

Possible de tester avec un simulateur qui doit avoir le bouton de reload => https://junior-pr10784.review.pix.fr/challenges/challenge1JkmTl7OQTiW4z/preview

Lors de la validation il faut que le boutton soit caché