### PR TITLE
[FEATURE] Ajout de l'API getLegalDocumentStatusByUserId dans legal-document context (PIX-15581)

### DIFF
--- a/api/db/database-builder/factory/build-legal-document-version.js
+++ b/api/db/database-builder/factory/build-legal-document-version.js
@@ -2,13 +2,13 @@ import { databaseBuffer } from '../database-buffer.js';
 
 const buildLegalDocumentVersion = function ({
   id = databaseBuffer.getNextId(),
-  type,
   service,
+  type,
   versionAt = new Date(),
 } = {}) {
   return databaseBuffer.pushInsertable({
     tableName: 'legal-document-versions',
-    values: { id, type, service, versionAt },
+    values: { id, service, type, versionAt },
   });
 };
 

--- a/api/src/legal-documents/application/api/legal-documents-api.js
+++ b/api/src/legal-documents/application/api/legal-documents-api.js
@@ -1,16 +1,29 @@
 import { usecases } from '../../domain/usecases/index.js';
 
 /**
- * Accept legal document by user id.
+ * Accepts a legal document for a user by their ID.
  *
- * @param{string} params.service
- * @param{string} params.type
- * @param{string} params.userId
- *
- * @returns {Promise<void>}
+ * @param {Object} params - The parameters.
+ * @param {string} params.userId - The ID of the user.
+ * @param {string} params.service - The service associated with the legal document. (e.g. 'pix-orga')
+ * @param {string} params.type - The type of the legal document. (e.g. 'TOS')
+ * @returns {Promise<void>} - A promise that resolves when the legal document is accepted.
  */
-const acceptLegalDocumentByUserId = async ({ type, service, userId }) => {
+const acceptLegalDocumentByUserId = async ({ userId, service, type }) => {
   return usecases.acceptLegalDocumentByUserId({ type, service, userId });
 };
 
-export { acceptLegalDocumentByUserId };
+/**
+ * Gets the status of a legal document for a user by their ID.
+ *
+ * @param {Object} params - The parameters.
+ * @param {string} params.userId - The ID of the user.
+ * @param {string} params.service - The service associated with the legal document. (e.g. 'pix-orga')
+ * @param {string} params.type - The type of the legal document. (e.g. 'TOS')
+ * @returns {Promise<LegalDocumentStatus>} - A promise that resolves with the status of the legal document.
+ */
+const getLegalDocumentStatusByUserId = async ({ userId, service, type }) => {
+  return usecases.getLegalDocumentStatusByUserId({ type, service, userId });
+};
+
+export { acceptLegalDocumentByUserId, getLegalDocumentStatusByUserId };

--- a/api/src/legal-documents/application/api/legal-documents-api.js
+++ b/api/src/legal-documents/application/api/legal-documents-api.js
@@ -10,7 +10,7 @@ import { usecases } from '../../domain/usecases/index.js';
  * @returns {Promise<void>} - A promise that resolves when the legal document is accepted.
  */
 const acceptLegalDocumentByUserId = async ({ userId, service, type }) => {
-  return usecases.acceptLegalDocumentByUserId({ type, service, userId });
+  return usecases.acceptLegalDocumentByUserId({ userId, service, type });
 };
 
 /**
@@ -23,7 +23,7 @@ const acceptLegalDocumentByUserId = async ({ userId, service, type }) => {
  * @returns {Promise<LegalDocumentStatus>} - A promise that resolves with the status of the legal document.
  */
 const getLegalDocumentStatusByUserId = async ({ userId, service, type }) => {
-  return usecases.getLegalDocumentStatusByUserId({ type, service, userId });
+  return usecases.getLegalDocumentStatusByUserId({ userId, service, type });
 };
 
 export { acceptLegalDocumentByUserId, getLegalDocumentStatusByUserId };

--- a/api/src/legal-documents/domain/errors.js
+++ b/api/src/legal-documents/domain/errors.js
@@ -1,13 +1,18 @@
 import { DomainError } from '../../shared/domain/errors.js';
 
 class LegalDocumentInvalidDateError extends DomainError {
-  constructor({
-    code = 'LEGAL_DOCUMENT_INVALID_DATE',
-    message = 'Document version must not be before or equal to same document type and service',
-  } = {}) {
-    super(message);
-    this.code = code;
+  constructor() {
+    super(
+      'Document version must not be before or equal to same document service and type',
+      'LEGAL_DOCUMENT_INVALID_DATE',
+    );
   }
 }
 
-export { LegalDocumentInvalidDateError };
+class LegalDocumentVersionNotFoundError extends DomainError {
+  constructor() {
+    super('No legal document version found for service and type', 'LEGAL_DOCUMENT_VERSION_NOT_FOUND');
+  }
+}
+
+export { LegalDocumentInvalidDateError, LegalDocumentVersionNotFoundError };

--- a/api/src/legal-documents/domain/models/LegalDocument.js
+++ b/api/src/legal-documents/domain/models/LegalDocument.js
@@ -1,10 +1,10 @@
 import dayjs from 'dayjs';
 
 export class LegalDocument {
-  constructor({ id, type, service, versionAt }) {
+  constructor({ id, service, type, versionAt }) {
     this.id = id;
-    this.type = type;
     this.service = service;
+    this.type = type;
     this.versionAt = versionAt;
   }
 

--- a/api/src/legal-documents/domain/models/LegalDocument.js
+++ b/api/src/legal-documents/domain/models/LegalDocument.js
@@ -1,8 +1,17 @@
+import dayjs from 'dayjs';
+
 export class LegalDocument {
   constructor({ id, type, service, versionAt }) {
     this.id = id;
     this.type = type;
     this.service = service;
     this.versionAt = versionAt;
+  }
+
+  buildDocumentPath() {
+    const service = this.service.toLowerCase();
+    const type = this.type.toLowerCase();
+    const versionAt = dayjs(this.versionAt).format('YYYY-MM-DD');
+    return `${service}-${type}-${versionAt}`;
   }
 }

--- a/api/src/legal-documents/domain/models/LegalDocumentStatus.js
+++ b/api/src/legal-documents/domain/models/LegalDocumentStatus.js
@@ -1,0 +1,57 @@
+export const STATUS = {
+  ACCEPTED: 'accepted',
+  REQUESTED: 'requested',
+  UPDATE_REQUESTED: 'update-requested',
+};
+
+export class LegalDocumentStatus {
+  constructor({ status, acceptedAt, documentPath }) {
+    this.status = status;
+    this.acceptedAt = acceptedAt;
+    this.documentPath = documentPath;
+  }
+
+  /**
+   * Builds a LegalDocumentStatus based on legacy PixOrga CGU.
+   *
+   * @param {Object} userPixOrgaCgu - The user object.
+   * @param {boolean} userPixOrgaCgu.pixOrgaTermsOfServiceAccepted - Indicates if the PixOrga terms of service are accepted.
+   * @param {Date} userPixOrgaCgu.lastPixOrgaTermsOfServiceValidatedAt - The date when the PixOrga terms of service were last validated.
+   * @returns {LegalDocumentStatus} The legal document status.
+   */
+  static buildForLegacyPixOrgaCgu(userPixOrgaCgu) {
+    const LEGACY_PIXORGA_TOS_PATH = 'pix-orga-tos-2024-01-02';
+    const { pixOrgaTermsOfServiceAccepted, lastPixOrgaTermsOfServiceValidatedAt } = userPixOrgaCgu;
+
+    return new LegalDocumentStatus({
+      status: pixOrgaTermsOfServiceAccepted ? STATUS.ACCEPTED : STATUS.REQUESTED,
+      acceptedAt: lastPixOrgaTermsOfServiceValidatedAt,
+      documentPath: LEGACY_PIXORGA_TOS_PATH,
+    });
+  }
+
+  /**
+   * Builds a LegalDocumentStatus based on the last document version and user acceptance.
+   *
+   * @param {Object} lastDocumentVersion - The last document version object.
+   * @param {string} lastDocumentVersion.id - The ID of the last document version.
+   * @param {Object} lastUserAcceptance - The last user acceptance object.
+   * @param {string} lastUserAcceptance.legalDocumentVersionId - The ID of the accepted legal document version.
+   * @param {Date} lastUserAcceptance.acceptedAt - The date when the document was accepted.
+   * @returns {LegalDocumentStatus} The legal document status.
+   */
+  static build(lastDocumentVersion, lastUserAcceptance) {
+    const documentPath = lastDocumentVersion.buildDocumentPath();
+
+    if (!lastUserAcceptance) {
+      return new LegalDocumentStatus({ status: STATUS.REQUESTED, acceptedAt: null, documentPath });
+    }
+
+    const { legalDocumentVersionId, acceptedAt } = lastUserAcceptance;
+    if (lastDocumentVersion.id === legalDocumentVersionId) {
+      return new LegalDocumentStatus({ status: STATUS.ACCEPTED, acceptedAt, documentPath });
+    }
+
+    return new LegalDocumentStatus({ status: STATUS.UPDATE_REQUESTED, acceptedAt: null, documentPath });
+  }
+}

--- a/api/src/legal-documents/domain/usecases/accept-legal-document-by-user-id.usecase.js
+++ b/api/src/legal-documents/domain/usecases/accept-legal-document-by-user-id.usecase.js
@@ -1,22 +1,22 @@
 import { LegalDocumentService } from '../models/LegalDocumentService.js';
 import { LegalDocumentType } from '../models/LegalDocumentType.js';
 
-const { TOS } = LegalDocumentType.VALUES;
 const { PIX_ORGA } = LegalDocumentService.VALUES;
+const { TOS } = LegalDocumentType.VALUES;
 
 /**
  * Accepts a legal document by user ID.
  *
  * @param {Object} params - The parameters.
- * @param {string} params.type - The type of the legal document.
- * @param {string} params.service - The service of the legal document.
  * @param {string} params.userId - The ID of the user.
+ * @param {string} params.service - The service of the legal document.
+ * @param {string} params.type - The type of the legal document.
  * @returns {Promise<void>} A promise that resolves when the operation is complete.
  */
 const acceptLegalDocumentByUserId = async ({
-  type,
-  service,
   userId,
+  service,
+  type,
   userRepository,
   legalDocumentRepository,
   userAcceptanceRepository,
@@ -31,9 +31,9 @@ const acceptLegalDocumentByUserId = async ({
   }
 
   // new document acceptance
-  const legalDocument = await legalDocumentRepository.findLastVersionByTypeAndService({ type, service });
+  const legalDocument = await legalDocumentRepository.findLastVersionByTypeAndService({ service, type });
   if (!legalDocument) {
-    logger.warn(`No legal document found for type: ${type} and service: ${service}`);
+    logger.warn(`No legal document found for service: ${service} and type: ${type}`);
     return;
   }
 

--- a/api/src/legal-documents/domain/usecases/accept-legal-document-by-user-id.usecase.js
+++ b/api/src/legal-documents/domain/usecases/accept-legal-document-by-user-id.usecase.js
@@ -22,6 +22,9 @@ const acceptLegalDocumentByUserId = async ({
   userAcceptanceRepository,
   logger,
 }) => {
+  LegalDocumentType.assert(type);
+  LegalDocumentService.assert(service);
+
   // legacy document acceptance
   if (type === TOS && service === PIX_ORGA) {
     await userRepository.setPixOrgaCguByUserId(userId);

--- a/api/src/legal-documents/domain/usecases/create-legal-document.usecase.js
+++ b/api/src/legal-documents/domain/usecases/create-legal-document.usecase.js
@@ -6,22 +6,22 @@ import { LegalDocumentType } from '../models/LegalDocumentType.js';
  * Creates a new legal document.
  *
  * @param {Object} params - The parameters.
- * @param {string} params.type - The type of the legal document.
  * @param {string} params.service - The service of the legal document.
+ * @param {string} params.type - The type of the legal document.
  * @param {string} params.versionAt - Version date of the new legal document.
  * @returns {Promise<LegalDocument>} A promise that resolves the new legal document.
  */
-const createLegalDocument = async ({ type, service, versionAt, legalDocumentRepository }) => {
-  LegalDocumentType.assert(type);
+const createLegalDocument = async ({ service, type, versionAt, legalDocumentRepository }) => {
   LegalDocumentService.assert(service);
+  LegalDocumentType.assert(type);
 
-  const lastDocument = await legalDocumentRepository.findLastVersionByTypeAndService({ type, service });
+  const lastDocument = await legalDocumentRepository.findLastVersionByTypeAndService({ service, type });
 
   if (lastDocument && lastDocument.versionAt >= versionAt) {
     throw new LegalDocumentInvalidDateError();
   }
 
-  return legalDocumentRepository.create({ type, service, versionAt });
+  return legalDocumentRepository.create({ service, type, versionAt });
 };
 
 export { createLegalDocument };

--- a/api/src/legal-documents/domain/usecases/get-legal-document-status-by-user-id.usecase.js
+++ b/api/src/legal-documents/domain/usecases/get-legal-document-status-by-user-id.usecase.js
@@ -1,0 +1,45 @@
+import { config } from '../../../shared/config.js';
+import { LegalDocumentVersionNotFoundError } from '../errors.js';
+import { LegalDocumentService } from '../models/LegalDocumentService.js';
+import { LegalDocumentStatus } from '../models/LegalDocumentStatus.js';
+import { LegalDocumentType } from '../models/LegalDocumentType.js';
+
+/**
+ * Gets the legal document status by user ID.
+ *
+ * @param {Object} params - The parameters.
+ * @param {string} params.userId - The user ID.
+ * @param {string} params.service - The service associated with the legal document.
+ * @param {string} params.type - The type of the legal document.
+ * @returns {Promise<LegalDocumentStatus>} The legal document status.
+ * @throws {Error} If no legal document version is found for the type and service.
+ */
+const getLegalDocumentStatusByUserId = async ({
+  userId,
+  service,
+  type,
+  userRepository,
+  legalDocumentRepository,
+  userAcceptanceRepository,
+  featureToggles = config.featureToggles,
+}) => {
+  LegalDocumentService.assert(service);
+  LegalDocumentType.assert(type);
+
+  const { isLegalDocumentsVersioningEnabled } = featureToggles;
+
+  if (!isLegalDocumentsVersioningEnabled) {
+    const user = await userRepository.findPixOrgaCgusByUserId(userId);
+    return LegalDocumentStatus.buildForLegacyPixOrgaCgu(user);
+  }
+
+  const lastLegalDocument = await legalDocumentRepository.findLastVersionByTypeAndService({ service, type });
+
+  if (!lastLegalDocument) throw new LegalDocumentVersionNotFoundError();
+
+  const lastUserAcceptance = await userAcceptanceRepository.findLastForLegalDocument({ userId, service, type });
+
+  return LegalDocumentStatus.build(lastLegalDocument, lastUserAcceptance);
+};
+
+export { getLegalDocumentStatusByUserId };

--- a/api/src/legal-documents/domain/usecases/index.js
+++ b/api/src/legal-documents/domain/usecases/index.js
@@ -1,7 +1,6 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { config } from '../../../shared/config.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
@@ -17,7 +16,7 @@ const repositories = {
   userRepository,
 };
 
-const dependencies = Object.assign({ config, logger }, repositories);
+const dependencies = Object.assign({ logger }, repositories);
 
 const usecasesWithoutInjectedDependencies = {
   ...(await importNamedExportsFromDirectory({ path: join(path, './'), ignoredFileNames: ['index.js'] })),

--- a/api/src/legal-documents/infrastructure/repositories/legal-document.repository.js
+++ b/api/src/legal-documents/infrastructure/repositories/legal-document.repository.js
@@ -7,14 +7,14 @@ const TABLE_NAME = 'legal-document-versions';
  * Retrieves the latest version of a legal document by type and service.
  *
  * @param {Object} params - The parameters.
- * @param {string} params.type - The type of the legal document.
  * @param {string} params.service - The service associated with the legal document.
+ * @param {string} params.type - The type of the legal document.
  * @returns {Promise<LegalDocument|null>} The latest version of the legal document or null if not found.
  */
-const findLastVersionByTypeAndService = async ({ type, service }) => {
+const findLastVersionByTypeAndService = async ({ service, type }) => {
   const knexConnection = DomainTransaction.getConnection();
   const documentVersionDto = await knexConnection(TABLE_NAME)
-    .where({ type, service })
+    .where({ service, type })
     .orderBy('versionAt', 'desc')
     .first();
 
@@ -27,15 +27,15 @@ const findLastVersionByTypeAndService = async ({ type, service }) => {
  * Creates a new legal document in the database.
  *
  * @param {Object} params - The parameters.
- * @param {string} params.type - The type of the legal document.
  * @param {string} params.service - The service associated with the legal document.
+ * @param {string} params.type - The type of the legal document.
  * @param {Date} params.versionAt - The date of the legal document version.
  * @returns {Promise<LegalDocument>} The newly created legal document.
  */
-const create = async ({ type, service, versionAt }) => {
+const create = async ({ service, type, versionAt }) => {
   const knexConnection = DomainTransaction.getConnection();
 
-  const [documentVersionDto] = await knexConnection(TABLE_NAME).insert({ type, service, versionAt }).returning('*');
+  const [documentVersionDto] = await knexConnection(TABLE_NAME).insert({ service, type, versionAt }).returning('*');
 
   return new LegalDocument(documentVersionDto);
 };

--- a/api/src/legal-documents/infrastructure/repositories/user-acceptance.repository.js
+++ b/api/src/legal-documents/infrastructure/repositories/user-acceptance.repository.js
@@ -1,5 +1,7 @@
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 
+const TABLE_NAME = 'legal-document-version-user-acceptances';
+
 /**
  * Creates a new user acceptance record for a legal document version.
  *
@@ -10,7 +12,34 @@ import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
  */
 const create = async ({ userId, legalDocumentVersionId }) => {
   const knexConnection = DomainTransaction.getConnection();
-  await knexConnection('legal-document-version-user-acceptances').insert({ userId, legalDocumentVersionId });
+  await knexConnection(TABLE_NAME).insert({ userId, legalDocumentVersionId });
 };
 
-export { create };
+/**
+ * Finds the last user acceptance record for a specific legal document type and service.
+ *
+ * @param {Object} params - The parameters for finding the user acceptance.
+ * @param {string} params.userId - The ID of the user.
+ * @param {string} params.type - The type of the legal document.
+ * @param {string} params.service - The service associated with the legal document.
+ * @returns {Promise<Object|null>} A promise that resolves to the user acceptance record or null if not found.
+ */
+const findLastForLegalDocument = async ({ userId, type, service }) => {
+  const knexConnection = DomainTransaction.getConnection();
+  const userAcceptanceDto = await knexConnection(TABLE_NAME)
+    .select('userId', 'legalDocumentVersionId', 'acceptedAt')
+    .join(
+      'legal-document-versions',
+      'legal-document-version-user-acceptances.legalDocumentVersionId',
+      'legal-document-versions.id',
+    )
+    .where({ userId, type, service })
+    .orderBy('versionAt', 'desc')
+    .first();
+
+  if (!userAcceptanceDto) return null;
+
+  return userAcceptanceDto;
+};
+
+export { create, findLastForLegalDocument };

--- a/api/src/legal-documents/infrastructure/repositories/user-acceptance.repository.js
+++ b/api/src/legal-documents/infrastructure/repositories/user-acceptance.repository.js
@@ -20,11 +20,11 @@ const create = async ({ userId, legalDocumentVersionId }) => {
  *
  * @param {Object} params - The parameters for finding the user acceptance.
  * @param {string} params.userId - The ID of the user.
- * @param {string} params.type - The type of the legal document.
  * @param {string} params.service - The service associated with the legal document.
+ * @param {string} params.type - The type of the legal document.
  * @returns {Promise<Object|null>} A promise that resolves to the user acceptance record or null if not found.
  */
-const findLastForLegalDocument = async ({ userId, type, service }) => {
+const findLastForLegalDocument = async ({ userId, service, type }) => {
   const knexConnection = DomainTransaction.getConnection();
   const userAcceptanceDto = await knexConnection(TABLE_NAME)
     .select('userId', 'legalDocumentVersionId', 'acceptedAt')
@@ -33,7 +33,7 @@ const findLastForLegalDocument = async ({ userId, type, service }) => {
       'legal-document-version-user-acceptances.legalDocumentVersionId',
       'legal-document-versions.id',
     )
-    .where({ userId, type, service })
+    .where({ userId, service, type })
     .orderBy('versionAt', 'desc')
     .first();
 

--- a/api/src/legal-documents/infrastructure/repositories/user.repository.js
+++ b/api/src/legal-documents/infrastructure/repositories/user.repository.js
@@ -14,4 +14,22 @@ const setPixOrgaCguByUserId = async (userId) => {
   });
 };
 
-export { setPixOrgaCguByUserId };
+/**
+ * Retrieves the Pix terms of service acceptance status for a user.
+ *
+ * @param {string} userId - The ID of the user to retrieve.
+ * @returns {Promise<Object | null>} A promise that resolves to an object containing the acceptance status and the date of validation.
+ */
+const findPixOrgaCgusByUserId = async (userId) => {
+  const knexConnection = DomainTransaction.getConnection();
+  const userPixOrgaCgus = await knexConnection('users')
+    .select('pixOrgaTermsOfServiceAccepted', 'lastPixOrgaTermsOfServiceValidatedAt')
+    .where('id', userId)
+    .first();
+
+  if (!userPixOrgaCgus) return null;
+
+  return userPixOrgaCgus;
+};
+
+export { findPixOrgaCgusByUserId, setPixOrgaCguByUserId };

--- a/api/src/legal-documents/scripts/add-new-legal-document-version.js
+++ b/api/src/legal-documents/scripts/add-new-legal-document-version.js
@@ -33,7 +33,7 @@ export class AddNewLegalDocumentVersion extends Script {
   }
 
   async handle({ options, logger }) {
-    let { type, service } = options;
+    let { service, type } = options;
     const { versionAt } = options;
 
     type = type.trim();
@@ -41,7 +41,7 @@ export class AddNewLegalDocumentVersion extends Script {
 
     logger.info(`Adding new legal document for type:${type}, service:${service}, versionAt:${versionAt}`);
 
-    await usecases.createLegalDocument({ type, service, versionAt });
+    await usecases.createLegalDocument({ service, type, versionAt });
     logger.info(`New legal document for type:${type}, service:${service}, versionAt:${versionAt} added successfully.`);
   }
 }

--- a/api/tests/legal-documents/integration/application/api/legal-documents-api.test.js
+++ b/api/tests/legal-documents/integration/application/api/legal-documents-api.test.js
@@ -1,21 +1,23 @@
 import * as legalDocumentsApi from '../../../../../src/legal-documents/application/api/legal-documents-api.js';
 import { LegalDocumentService } from '../../../../../src/legal-documents/domain/models/LegalDocumentService.js';
+import { LegalDocumentStatus, STATUS } from '../../../../../src/legal-documents/domain/models/LegalDocumentStatus.js';
 import { LegalDocumentType } from '../../../../../src/legal-documents/domain/models/LegalDocumentType.js';
-import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
+import { config } from '../../../../../src/shared/config.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
 
-const { TOS } = LegalDocumentType.VALUES;
 const { PIX_ORGA } = LegalDocumentService.VALUES;
+const { TOS } = LegalDocumentType.VALUES;
 
 describe('Integration | Privacy | Application | Api | legal documents', function () {
   describe('#acceptLegalDocumentByUserId', function () {
     it('accepts the latest legal document version by user id ', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
-      const latestDocument = databaseBuilder.factory.buildLegalDocumentVersion({ type: TOS, service: PIX_ORGA });
+      const latestDocument = databaseBuilder.factory.buildLegalDocumentVersion({ service: PIX_ORGA, type: TOS });
       await databaseBuilder.commit();
 
       // when
-      await legalDocumentsApi.acceptLegalDocumentByUserId({ userId, type: TOS, service: PIX_ORGA });
+      await legalDocumentsApi.acceptLegalDocumentByUserId({ service: PIX_ORGA, userId, type: TOS });
 
       // then
       const userAcceptance = await knex('legal-document-version-user-acceptances')
@@ -24,6 +26,42 @@ describe('Integration | Privacy | Application | Api | legal documents', function
         .first();
 
       expect(userAcceptance).to.exist;
+    });
+  });
+
+  describe('#getLegalDocumentStatusByUserId', function () {
+    it('returns the legal document status for a user', async function () {
+      // given
+      sinon.stub(config, 'featureToggles').value({ isLegalDocumentsVersioningEnabled: true });
+      const service = PIX_ORGA;
+      const type = TOS;
+      const user = databaseBuilder.factory.buildUser();
+      const documentVersion = databaseBuilder.factory.buildLegalDocumentVersion({
+        service,
+        type,
+        versionAt: new Date('2024-02-01'),
+      });
+      databaseBuilder.factory.buildLegalDocumentVersionUserAcceptance({
+        userId: user.id,
+        legalDocumentVersionId: documentVersion.id,
+        acceptedAt: new Date('2024-03-01'),
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const legalDocumentStatus = await legalDocumentsApi.getLegalDocumentStatusByUserId({
+        userId: user.id,
+        service,
+        type,
+      });
+
+      // then
+      expect(legalDocumentStatus).to.be.an.instanceOf(LegalDocumentStatus);
+      expect(legalDocumentStatus).to.deep.equal({
+        status: STATUS.ACCEPTED,
+        acceptedAt: new Date('2024-03-01'),
+        documentPath: 'pix-orga-tos-2024-02-01',
+      });
     });
   });
 });

--- a/api/tests/legal-documents/integration/domain/usecases/accept-legal-document-by-user-id.usecase.test.js
+++ b/api/tests/legal-documents/integration/domain/usecases/accept-legal-document-by-user-id.usecase.test.js
@@ -3,8 +3,8 @@ import { LegalDocumentType } from '../../../../../src/legal-documents/domain/mod
 import { usecases } from '../../../../../src/legal-documents/domain/usecases/index.js';
 import { databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
 
-const { TOS } = LegalDocumentType.VALUES;
 const { PIX_ORGA } = LegalDocumentService.VALUES;
+const { TOS } = LegalDocumentType.VALUES;
 
 describe('Integration | Legal documents | Domain | Use case | accept-legal-document-by-user-id', function () {
   it('accepts the lastest legal document version for a user', async function () {
@@ -15,11 +15,11 @@ describe('Integration | Legal documents | Domain | Use case | accept-legal-docum
       service: PIX_ORGA,
       versionAt: new Date('2021-01-01'),
     });
-    const document = databaseBuilder.factory.buildLegalDocumentVersion({ type: TOS, service: PIX_ORGA });
+    const document = databaseBuilder.factory.buildLegalDocumentVersion({ service: PIX_ORGA, type: TOS });
     await databaseBuilder.commit();
 
     // when
-    await usecases.acceptLegalDocumentByUserId({ userId: user.id, type: TOS, service: PIX_ORGA });
+    await usecases.acceptLegalDocumentByUserId({ userId: user.id, service: PIX_ORGA, type: TOS });
 
     // then
     const userAcceptance = await knex('legal-document-version-user-acceptances')
@@ -33,12 +33,12 @@ describe('Integration | Legal documents | Domain | Use case | accept-legal-docum
     it('accepts the Pix Orga CGUs in the legacy and legal document model', async function () {
       // given
       const user = databaseBuilder.factory.buildUser({ pixOrgaTermsOfServiceAccepted: false });
-      databaseBuilder.factory.buildLegalDocumentVersion({ type: TOS, service: PIX_ORGA });
+      databaseBuilder.factory.buildLegalDocumentVersion({ service: PIX_ORGA, type: TOS });
 
       await databaseBuilder.commit();
 
       // when
-      await usecases.acceptLegalDocumentByUserId({ userId: user.id, type: TOS, service: PIX_ORGA });
+      await usecases.acceptLegalDocumentByUserId({ userId: user.id, service: PIX_ORGA, type: TOS });
 
       // then
       const updatedUser = await knex('users').where('id', user.id).first();
@@ -52,11 +52,11 @@ describe('Integration | Legal documents | Domain | Use case | accept-legal-docum
       await databaseBuilder.commit();
 
       // when
-      await usecases.acceptLegalDocumentByUserId({ userId: user.id, type: TOS, service: PIX_ORGA, logger: loggerStub });
+      await usecases.acceptLegalDocumentByUserId({ userId: user.id, service: PIX_ORGA, type: TOS, logger: loggerStub });
 
       // then
       expect(loggerStub.warn).to.have.been.calledWith(
-        `No legal document found for type: ${TOS} and service: ${PIX_ORGA}`,
+        `No legal document found for service: ${PIX_ORGA} and type: ${TOS}`,
       );
     });
   });

--- a/api/tests/legal-documents/integration/domain/usecases/create-legal-document.usecase.test.js
+++ b/api/tests/legal-documents/integration/domain/usecases/create-legal-document.usecase.test.js
@@ -4,8 +4,8 @@ import { LegalDocumentType } from '../../../../../src/legal-documents/domain/mod
 import { usecases } from '../../../../../src/legal-documents/domain/usecases/index.js';
 import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
 
-const { TOS } = LegalDocumentType.VALUES;
 const { PIX_ORGA } = LegalDocumentService.VALUES;
+const { TOS } = LegalDocumentType.VALUES;
 
 describe('Integration | Legal documents | Domain | Use case | create-legal-document', function () {
   it('creates a new legal document when there is no previous version', async function () {
@@ -13,10 +13,10 @@ describe('Integration | Legal documents | Domain | Use case | create-legal-docum
     const type = TOS;
     const service = PIX_ORGA;
     const versionAt = new Date('2024-12-01');
-    const expectedDocument = domainBuilder.buildLegalDocument({ type, service, versionAt });
+    const expectedDocument = domainBuilder.buildLegalDocument({ service, type, versionAt });
 
     // when
-    const document = await usecases.createLegalDocument({ type, service, versionAt });
+    const document = await usecases.createLegalDocument({ service, type, versionAt });
 
     // then
     expect(document).to.deepEqualInstanceOmitting(expectedDocument, 'id');
@@ -30,11 +30,11 @@ describe('Integration | Legal documents | Domain | Use case | create-legal-docum
       const existingVersionAt = new Date('2024-12-01');
       const newVersionAt = new Date('2024-11-30');
 
-      databaseBuilder.factory.buildLegalDocumentVersion({ type, service, versionAt: existingVersionAt });
+      databaseBuilder.factory.buildLegalDocumentVersion({ service, type, versionAt: existingVersionAt });
       await databaseBuilder.commit();
 
       // when
-      const error = await catchErr(usecases.createLegalDocument)({ type, service, versionAt: newVersionAt });
+      const error = await catchErr(usecases.createLegalDocument)({ service, type, versionAt: newVersionAt });
 
       //then
       expect(error).to.be.instanceOf(LegalDocumentInvalidDateError);
@@ -49,13 +49,13 @@ describe('Integration | Legal documents | Domain | Use case | create-legal-docum
       const service = PIX_ORGA;
       const existingVersionAt = new Date('2024-12-01');
       const newVersionAt = new Date('2024-12-02');
-      const expectedDocument = domainBuilder.buildLegalDocument({ type, service, versionAt: newVersionAt });
+      const expectedDocument = domainBuilder.buildLegalDocument({ service, type, versionAt: newVersionAt });
 
-      databaseBuilder.factory.buildLegalDocumentVersion({ type, service, versionAt: existingVersionAt });
+      databaseBuilder.factory.buildLegalDocumentVersion({ service, type, versionAt: existingVersionAt });
       await databaseBuilder.commit();
 
       // when
-      const document = await usecases.createLegalDocument({ type, service, versionAt: newVersionAt });
+      const document = await usecases.createLegalDocument({ service, type, versionAt: newVersionAt });
 
       // then
       expect(document).to.deepEqualInstanceOmitting(expectedDocument, 'id');

--- a/api/tests/legal-documents/integration/domain/usecases/create-legal-document.usecase.test.js
+++ b/api/tests/legal-documents/integration/domain/usecases/create-legal-document.usecase.test.js
@@ -39,7 +39,7 @@ describe('Integration | Legal documents | Domain | Use case | create-legal-docum
       //then
       expect(error).to.be.instanceOf(LegalDocumentInvalidDateError);
       expect(error.message).to.be.equal(
-        'Document version must not be before or equal to same document type and service',
+        'Document version must not be before or equal to same document service and type',
       );
     });
 

--- a/api/tests/legal-documents/integration/domain/usecases/get-legal-document-status-by-user-id.usecase.test.js
+++ b/api/tests/legal-documents/integration/domain/usecases/get-legal-document-status-by-user-id.usecase.test.js
@@ -6,8 +6,8 @@ import { usecases } from '../../../../../src/legal-documents/domain/usecases/ind
 import { config } from '../../../../../src/shared/config.js';
 import { databaseBuilder, expect, sinon } from '../../../../test-helper.js';
 
-const { TOS } = LegalDocumentType.VALUES;
 const { PIX_ORGA } = LegalDocumentService.VALUES;
+const { TOS } = LegalDocumentType.VALUES;
 
 describe('Integration | Legal documents | Domain | Use case | get-legal-document-status-by-user-id', function () {
   beforeEach(async function () {
@@ -16,8 +16,8 @@ describe('Integration | Legal documents | Domain | Use case | get-legal-document
 
   it('returns the legal document status for a user', async function () {
     // given
-    const type = TOS;
     const service = PIX_ORGA;
+    const type = TOS;
     const user = databaseBuilder.factory.buildUser();
     const documentVersion = databaseBuilder.factory.buildLegalDocumentVersion({
       type,
@@ -32,7 +32,7 @@ describe('Integration | Legal documents | Domain | Use case | get-legal-document
     await databaseBuilder.commit();
 
     // when
-    const legalDocumentStatus = await usecases.getLegalDocumentStatusByUserId({ type, service, userId: user.id });
+    const legalDocumentStatus = await usecases.getLegalDocumentStatusByUserId({ userId: user.id, service, type });
 
     // then
     expect(legalDocumentStatus).to.be.an.instanceOf(LegalDocumentStatus);
@@ -46,13 +46,13 @@ describe('Integration | Legal documents | Domain | Use case | get-legal-document
   context('when the legal document version does not exist', function () {
     it('throws an error', async function () {
       // given
-      const type = TOS;
       const service = PIX_ORGA;
+      const type = TOS;
       const user = databaseBuilder.factory.buildUser();
       await databaseBuilder.commit();
 
       // when / then
-      await expect(usecases.getLegalDocumentStatusByUserId({ type, service, userId: user.id })).to.be.rejectedWith(
+      await expect(usecases.getLegalDocumentStatusByUserId({ userId: user.id, service, type })).to.be.rejectedWith(
         LegalDocumentVersionNotFoundError,
       );
     });
@@ -65,8 +65,8 @@ describe('Integration | Legal documents | Domain | Use case | get-legal-document
 
     it('returns the legal document status for a user based on PixOrga CGU', async function () {
       // given
-      const type = TOS;
       const service = PIX_ORGA;
+      const type = TOS;
       const user = databaseBuilder.factory.buildUser({
         pixOrgaTermsOfServiceAccepted: true,
         lastPixOrgaTermsOfServiceValidatedAt: new Date('2024-03-01'),
@@ -74,7 +74,7 @@ describe('Integration | Legal documents | Domain | Use case | get-legal-document
       await databaseBuilder.commit();
 
       // when
-      const legalDocumentStatus = await usecases.getLegalDocumentStatusByUserId({ type, service, userId: user.id });
+      const legalDocumentStatus = await usecases.getLegalDocumentStatusByUserId({ userId: user.id, service, type });
 
       // then
       expect(legalDocumentStatus).to.be.an.instanceOf(LegalDocumentStatus);

--- a/api/tests/legal-documents/integration/domain/usecases/get-legal-document-status-by-user-id.usecase.test.js
+++ b/api/tests/legal-documents/integration/domain/usecases/get-legal-document-status-by-user-id.usecase.test.js
@@ -1,0 +1,88 @@
+import { LegalDocumentVersionNotFoundError } from '../../../../../src/legal-documents/domain/errors.js';
+import { LegalDocumentService } from '../../../../../src/legal-documents/domain/models/LegalDocumentService.js';
+import { LegalDocumentStatus, STATUS } from '../../../../../src/legal-documents/domain/models/LegalDocumentStatus.js';
+import { LegalDocumentType } from '../../../../../src/legal-documents/domain/models/LegalDocumentType.js';
+import { usecases } from '../../../../../src/legal-documents/domain/usecases/index.js';
+import { config } from '../../../../../src/shared/config.js';
+import { databaseBuilder, expect, sinon } from '../../../../test-helper.js';
+
+const { TOS } = LegalDocumentType.VALUES;
+const { PIX_ORGA } = LegalDocumentService.VALUES;
+
+describe('Integration | Legal documents | Domain | Use case | get-legal-document-status-by-user-id', function () {
+  beforeEach(async function () {
+    sinon.stub(config, 'featureToggles').value({ isLegalDocumentsVersioningEnabled: true });
+  });
+
+  it('returns the legal document status for a user', async function () {
+    // given
+    const type = TOS;
+    const service = PIX_ORGA;
+    const user = databaseBuilder.factory.buildUser();
+    const documentVersion = databaseBuilder.factory.buildLegalDocumentVersion({
+      type,
+      service,
+      versionAt: new Date('2024-02-01'),
+    });
+    databaseBuilder.factory.buildLegalDocumentVersionUserAcceptance({
+      userId: user.id,
+      legalDocumentVersionId: documentVersion.id,
+      acceptedAt: new Date('2024-03-01'),
+    });
+    await databaseBuilder.commit();
+
+    // when
+    const legalDocumentStatus = await usecases.getLegalDocumentStatusByUserId({ type, service, userId: user.id });
+
+    // then
+    expect(legalDocumentStatus).to.be.an.instanceOf(LegalDocumentStatus);
+    expect(legalDocumentStatus).to.deep.equal({
+      status: STATUS.ACCEPTED,
+      acceptedAt: new Date('2024-03-01'),
+      documentPath: 'pix-orga-tos-2024-02-01',
+    });
+  });
+
+  context('when the legal document version does not exist', function () {
+    it('throws an error', async function () {
+      // given
+      const type = TOS;
+      const service = PIX_ORGA;
+      const user = databaseBuilder.factory.buildUser();
+      await databaseBuilder.commit();
+
+      // when / then
+      await expect(usecases.getLegalDocumentStatusByUserId({ type, service, userId: user.id })).to.be.rejectedWith(
+        LegalDocumentVersionNotFoundError,
+      );
+    });
+  });
+
+  context('when the feature toggle isLegalDocumentsVersioningEnabled is false', function () {
+    beforeEach(async function () {
+      sinon.stub(config, 'featureToggles').value({ isLegalDocumentsVersioningEnabled: false });
+    });
+
+    it('returns the legal document status for a user based on PixOrga CGU', async function () {
+      // given
+      const type = TOS;
+      const service = PIX_ORGA;
+      const user = databaseBuilder.factory.buildUser({
+        pixOrgaTermsOfServiceAccepted: true,
+        lastPixOrgaTermsOfServiceValidatedAt: new Date('2024-03-01'),
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const legalDocumentStatus = await usecases.getLegalDocumentStatusByUserId({ type, service, userId: user.id });
+
+      // then
+      expect(legalDocumentStatus).to.be.an.instanceOf(LegalDocumentStatus);
+      expect(legalDocumentStatus).to.deep.equal({
+        status: STATUS.ACCEPTED,
+        acceptedAt: new Date('2024-03-01'),
+        documentPath: 'pix-orga-tos-2024-01-02',
+      });
+    });
+  });
+});

--- a/api/tests/legal-documents/integration/infrastructure/repositories/legal-document.repository.test.js
+++ b/api/tests/legal-documents/integration/infrastructure/repositories/legal-document.repository.test.js
@@ -4,8 +4,8 @@ import { LegalDocumentType } from '../../../../../src/legal-documents/domain/mod
 import * as legalDocumentRepository from '../../../../../src/legal-documents/infrastructure/repositories/legal-document.repository.js';
 import { databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
 
-const { TOS } = LegalDocumentType.VALUES;
 const { PIX_ORGA, PIX_APP } = LegalDocumentService.VALUES;
+const { TOS } = LegalDocumentType.VALUES;
 
 describe('Integration | Legal document | Infrastructure | Repository | legal-document', function () {
   describe('#findLastVersionByTypeAndService', function () {
@@ -32,7 +32,7 @@ describe('Integration | Legal document | Infrastructure | Repository | legal-doc
       await databaseBuilder.commit();
 
       // when
-      const lastDocument = await legalDocumentRepository.findLastVersionByTypeAndService({ type, service });
+      const lastDocument = await legalDocumentRepository.findLastVersionByTypeAndService({ service, type });
 
       // then
       expect(lastDocument).to.deepEqualInstance(domainBuilder.buildLegalDocument(expectedDocument));
@@ -58,11 +58,11 @@ describe('Integration | Legal document | Infrastructure | Repository | legal-doc
       const versionAt = new Date('2024-12-01');
 
       // when
-      const createdDocument = await legalDocumentRepository.create({ type, service, versionAt });
+      const createdDocument = await legalDocumentRepository.create({ service, type, versionAt });
 
       // then
       expect(createdDocument).to.be.instanceOf(LegalDocument);
-      expect(createdDocument).to.deep.include({ type, service, versionAt });
+      expect(createdDocument).to.deep.include({ service, type, versionAt });
     });
   });
 });

--- a/api/tests/legal-documents/integration/infrastructure/repositories/user-acceptance.repository.test.js
+++ b/api/tests/legal-documents/integration/infrastructure/repositories/user-acceptance.repository.test.js
@@ -25,4 +25,99 @@ describe('Integration | Legal document | Infrastructure | Repository | user-acce
       expect(userAcceptance.acceptedAt).to.be.a('date');
     });
   });
+
+  describe('#findLastForLegalDocument', function () {
+    it('finds the last user acceptance record for a legal document type and service.', async function () {
+      // given
+      const user = databaseBuilder.factory.buildUser();
+      const oldDocumentVersion = databaseBuilder.factory.buildLegalDocumentVersion({
+        type: TOS,
+        service: PIX_ORGA,
+        versionAt: new Date('2023-01-01'),
+      });
+      databaseBuilder.factory.buildLegalDocumentVersionUserAcceptance({
+        userId: user.id,
+        legalDocumentVersionId: oldDocumentVersion.id,
+        acceptedAt: new Date('2023-02-01'),
+      });
+      const newDocumentVersion = databaseBuilder.factory.buildLegalDocumentVersion({
+        type: TOS,
+        service: PIX_ORGA,
+        versionAt: new Date('2024-02-01'),
+      });
+      databaseBuilder.factory.buildLegalDocumentVersionUserAcceptance({
+        userId: user.id,
+        legalDocumentVersionId: newDocumentVersion.id,
+        acceptedAt: new Date('2024-03-01'),
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const userAcceptance = await userAcceptanceRepository.findLastForLegalDocument({
+        userId: user.id,
+        type: TOS,
+        service: PIX_ORGA,
+      });
+
+      // then
+      expect(userAcceptance.legalDocumentVersionId).to.equal(newDocumentVersion.id);
+      expect(userAcceptance.userId).to.equal(user.id);
+      expect(userAcceptance.acceptedAt).to.deep.equal(new Date('2024-03-01'));
+    });
+
+    context('when user has not accepted the document', function () {
+      it('returns null', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser();
+        databaseBuilder.factory.buildLegalDocumentVersion({ type: TOS, service: PIX_ORGA });
+        await databaseBuilder.commit();
+
+        // when
+        const userAcceptance = await userAcceptanceRepository.findLastForLegalDocument({
+          userId: user.id,
+          type: TOS,
+          service: PIX_ORGA,
+        });
+
+        // then
+        expect(userAcceptance).to.be.null;
+      });
+    });
+
+    context('when the document does not exist', function () {
+      it('returns null', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser();
+        await databaseBuilder.commit();
+
+        // when
+        const userAcceptance = await userAcceptanceRepository.findLastForLegalDocument({
+          userId: user.id,
+          type: TOS,
+          service: PIX_ORGA,
+        });
+
+        // then
+        expect(userAcceptance).to.be.null;
+      });
+    });
+
+    context('when the user does not exist', function () {
+      it('returns null', async function () {
+        // given
+        databaseBuilder.factory.buildLegalDocumentVersion({ type: TOS, service: PIX_ORGA });
+        await databaseBuilder.commit();
+
+        // when
+        const userAcceptance = await userAcceptanceRepository.findLastForLegalDocument({
+          userId: 123,
+          type: TOS,
+          service: PIX_ORGA,
+        });
+
+        // then
+        expect(userAcceptance).to.be.null;
+      });
+    });
+  });
 });

--- a/api/tests/legal-documents/integration/infrastructure/repositories/user-acceptance.repository.test.js
+++ b/api/tests/legal-documents/integration/infrastructure/repositories/user-acceptance.repository.test.js
@@ -3,8 +3,8 @@ import { LegalDocumentType } from '../../../../../src/legal-documents/domain/mod
 import * as userAcceptanceRepository from '../../../../../src/legal-documents/infrastructure/repositories/user-acceptance.repository.js';
 import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
 
-const { TOS } = LegalDocumentType.VALUES;
 const { PIX_ORGA } = LegalDocumentService.VALUES;
+const { TOS } = LegalDocumentType.VALUES;
 
 describe('Integration | Legal document | Infrastructure | Repository | user-acceptance', function () {
   describe('#create', function () {

--- a/api/tests/legal-documents/integration/infrastructure/repositories/user.repository.test.js
+++ b/api/tests/legal-documents/integration/infrastructure/repositories/user.repository.test.js
@@ -20,4 +20,32 @@ describe('Integration | Legal document | Infrastructure | Repository | user', fu
       expect(updatedUser.lastPixOrgaTermsOfServiceValidatedAt).to.be.a('date');
     });
   });
+
+  describe('#findPixOrgaCgusByUserId', function () {
+    it('returns the Pix Orga CGU for a user id', async function () {
+      // given
+      const user = databaseBuilder.factory.buildUser({
+        pixOrgaTermsOfServiceAccepted: true,
+        lastPixOrgaTermsOfServiceValidatedAt: new Date('2024-01-01'),
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const userPixOrgaCgu = await userRepository.findPixOrgaCgusByUserId(user.id);
+
+      // then
+      expect(userPixOrgaCgu.pixOrgaTermsOfServiceAccepted).to.equal(true);
+      expect(userPixOrgaCgu.lastPixOrgaTermsOfServiceValidatedAt).to.deep.equal(new Date('2024-01-01'));
+    });
+
+    context('when the user does not exist', function () {
+      it('returns null', async function () {
+        // when
+        const userPixOrgaCgu = await userRepository.findPixOrgaCgusByUserId(123);
+
+        // then
+        expect(userPixOrgaCgu).to.be.null;
+      });
+    });
+  });
 });

--- a/api/tests/legal-documents/unit/domain/models/LegalDocument.test.js
+++ b/api/tests/legal-documents/unit/domain/models/LegalDocument.test.js
@@ -1,0 +1,22 @@
+import { LegalDocument } from '../../../../../src/legal-documents/domain/models/LegalDocument.js';
+import { LegalDocumentService } from '../../../../../src/legal-documents/domain/models/LegalDocumentService.js';
+import { LegalDocumentType } from '../../../../../src/legal-documents/domain/models/LegalDocumentType.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Legal documents | Domain | Model | LegalDocument', function () {
+  describe('#buildDocumentPath', function () {
+    it('builds the document path', function () {
+      // given
+      const service = LegalDocumentService.VALUES.PIX_ORGA;
+      const type = LegalDocumentType.VALUES.TOS;
+      const versionAt = new Date('2024-01-01');
+
+      // when
+      const legalDocumentStatus = new LegalDocument({ service, type, versionAt });
+      const documentPath = legalDocumentStatus.buildDocumentPath();
+
+      // then
+      expect(documentPath).to.be.equal(`pix-orga-tos-2024-01-01`);
+    });
+  });
+});

--- a/api/tests/legal-documents/unit/domain/models/LegalDocumentStatus.test.js
+++ b/api/tests/legal-documents/unit/domain/models/LegalDocumentStatus.test.js
@@ -4,8 +4,8 @@ import { LegalDocumentStatus, STATUS } from '../../../../../src/legal-documents/
 import { LegalDocumentType } from '../../../../../src/legal-documents/domain/models/LegalDocumentType.js';
 import { expect } from '../../../../test-helper.js';
 
-const { TOS } = LegalDocumentType.VALUES;
 const { PIX_ORGA } = LegalDocumentService.VALUES;
+const { TOS } = LegalDocumentType.VALUES;
 
 describe('Unit | Legal documents | Domain | Model | LegalDocumentStatus', function () {
   describe('#LegalDocumentStatus.buildForLegacyPixOrgaCgu', function () {

--- a/api/tests/legal-documents/unit/domain/models/LegalDocumentStatus.test.js
+++ b/api/tests/legal-documents/unit/domain/models/LegalDocumentStatus.test.js
@@ -1,0 +1,131 @@
+import { LegalDocument } from '../../../../../src/legal-documents/domain/models/LegalDocument.js';
+import { LegalDocumentService } from '../../../../../src/legal-documents/domain/models/LegalDocumentService.js';
+import { LegalDocumentStatus, STATUS } from '../../../../../src/legal-documents/domain/models/LegalDocumentStatus.js';
+import { LegalDocumentType } from '../../../../../src/legal-documents/domain/models/LegalDocumentType.js';
+import { expect } from '../../../../test-helper.js';
+
+const { TOS } = LegalDocumentType.VALUES;
+const { PIX_ORGA } = LegalDocumentService.VALUES;
+
+describe('Unit | Legal documents | Domain | Model | LegalDocumentStatus', function () {
+  describe('#LegalDocumentStatus.buildForLegacyPixOrgaCgu', function () {
+    context('when the user has accepted the Pix Orga CGU', function () {
+      it('returns an "accepted" legal document status', function () {
+        // given
+        const acceptedAt = new Date('2024-01-01');
+        const userPixOrgaCgu = {
+          pixOrgaTermsOfServiceAccepted: true,
+          lastPixOrgaTermsOfServiceValidatedAt: acceptedAt,
+        };
+
+        // when
+        const legalDocumentStatus = LegalDocumentStatus.buildForLegacyPixOrgaCgu(userPixOrgaCgu);
+
+        // then
+        expect(legalDocumentStatus).to.be.instanceof(LegalDocumentStatus);
+        expect(legalDocumentStatus).to.deep.equal({
+          status: STATUS.ACCEPTED,
+          acceptedAt: acceptedAt,
+          documentPath: 'pix-orga-tos-2024-01-02',
+        });
+      });
+    });
+
+    context('when the user has not accepted the Pix Orga CGU', function () {
+      it('returns a "requested" legal document status', function () {
+        // given
+        const userPixOrgaCgu = {
+          pixOrgaTermsOfServiceAccepted: false,
+          lastPixOrgaTermsOfServiceValidatedAt: null,
+        };
+
+        // when
+        const legalDocumentStatus = LegalDocumentStatus.buildForLegacyPixOrgaCgu(userPixOrgaCgu);
+
+        // then
+        expect(legalDocumentStatus).to.be.instanceof(LegalDocumentStatus);
+        expect(legalDocumentStatus).to.deep.equal({
+          status: STATUS.REQUESTED,
+          acceptedAt: null,
+          documentPath: 'pix-orga-tos-2024-01-02',
+        });
+      });
+    });
+  });
+
+  describe('#LegalDocumentStatus.build', function () {
+    context('when the user has accepted the last document version', function () {
+      it('returns an "accepted" legal document status', function () {
+        // given
+        const lastDocumentVersion = new LegalDocument({
+          id: 'last-document-version-id',
+          type: TOS,
+          service: PIX_ORGA,
+          versionAt: new Date('2024-01-01'),
+        });
+        const acceptedAt = new Date('2024-01-01');
+        const lastUserAcceptance = { legalDocumentVersionId: lastDocumentVersion.id, acceptedAt };
+
+        // when
+        const legalDocumentStatus = LegalDocumentStatus.build(lastDocumentVersion, lastUserAcceptance);
+
+        // then
+        expect(legalDocumentStatus).to.be.instanceof(LegalDocumentStatus);
+        expect(legalDocumentStatus).to.deep.equal({
+          status: STATUS.ACCEPTED,
+          acceptedAt,
+          documentPath: 'pix-orga-tos-2024-01-01',
+        });
+      });
+    });
+
+    context('when the user has not accepted the current document version', function () {
+      it('returns a "requested" legal document status', function () {
+        // given
+        const lastDocumentVersion = new LegalDocument({
+          id: 'last-document-version-id',
+          type: TOS,
+          service: PIX_ORGA,
+          versionAt: new Date('2024-01-01'),
+        });
+        const lastUserAcceptance = null;
+
+        // when
+        const legalDocumentStatus = LegalDocumentStatus.build(lastDocumentVersion, lastUserAcceptance);
+
+        // then
+        expect(legalDocumentStatus).to.be.instanceof(LegalDocumentStatus);
+        expect(legalDocumentStatus).to.deep.equal({
+          status: STATUS.REQUESTED,
+          acceptedAt: null,
+          documentPath: 'pix-orga-tos-2024-01-01',
+        });
+      });
+    });
+
+    context('when the user has accepted a previous document version', function () {
+      it('returns an "update-requested" legal document status', function () {
+        // given
+        const lastDocumentVersion = new LegalDocument({
+          id: 'last-document-version-id',
+          type: TOS,
+          service: PIX_ORGA,
+          versionAt: new Date('2024-01-01'),
+        });
+        const acceptedAt = new Date('2024-01-01');
+        const lastUserAcceptance = { legalDocumentVersionId: 'previous-document-version-id', acceptedAt };
+
+        // when
+        const legalDocumentStatus = LegalDocumentStatus.build(lastDocumentVersion, lastUserAcceptance);
+
+        // then
+        expect(legalDocumentStatus).to.be.instanceof(LegalDocumentStatus);
+        expect(legalDocumentStatus).to.deep.equal({
+          status: STATUS.UPDATE_REQUESTED,
+          acceptedAt: null,
+          documentPath: 'pix-orga-tos-2024-01-01',
+        });
+      });
+    });
+  });
+});

--- a/api/tests/legal-documents/unit/domain/usecase/accept-legal-document-by-user-id.usecase.test.js
+++ b/api/tests/legal-documents/unit/domain/usecase/accept-legal-document-by-user-id.usecase.test.js
@@ -5,19 +5,19 @@ import { LegalDocumentType } from '../../../../../src/legal-documents/domain/mod
 import { usecases } from '../../../../../src/legal-documents/domain/usecases/index.js';
 import { expect } from '../../../../test-helper.js';
 
-const { TOS } = LegalDocumentType.VALUES;
 const { PIX_ORGA } = LegalDocumentService.VALUES;
+const { TOS } = LegalDocumentType.VALUES;
 
 describe('Unit | Legal documents | Domain | Use case | accept-legal-document-by-user-id', function () {
   context('when the legal document type is invalid', function () {
     it('throws an error', async function () {
       // given
-      const type = 'invalid-type';
-      const service = PIX_ORGA;
       const userId = 123;
+      const service = PIX_ORGA;
+      const type = 'invalid-type';
 
       // when / then
-      await expect(usecases.acceptLegalDocumentByUserId({ type, service, userId })).to.have.been.rejectedWith(
+      await expect(usecases.acceptLegalDocumentByUserId({ userId, service, type })).to.have.been.rejectedWith(
         Joi.ValidationError,
       );
     });
@@ -26,12 +26,12 @@ describe('Unit | Legal documents | Domain | Use case | accept-legal-document-by-
   context('when the legal document service is invalid', function () {
     it('throws an error', async function () {
       // given
-      const type = TOS;
-      const service = 'invalid-service';
       const userId = 123;
+      const service = 'invalid-service';
+      const type = TOS;
 
       // when / then
-      await expect(usecases.acceptLegalDocumentByUserId({ type, service, userId })).to.have.been.rejectedWith(
+      await expect(usecases.acceptLegalDocumentByUserId({ userId, service, type })).to.have.been.rejectedWith(
         Joi.ValidationError,
       );
     });

--- a/api/tests/legal-documents/unit/domain/usecase/accept-legal-document-by-user-id.usecase.test.js
+++ b/api/tests/legal-documents/unit/domain/usecase/accept-legal-document-by-user-id.usecase.test.js
@@ -1,0 +1,39 @@
+import Joi from 'joi';
+
+import { LegalDocumentService } from '../../../../../src/legal-documents/domain/models/LegalDocumentService.js';
+import { LegalDocumentType } from '../../../../../src/legal-documents/domain/models/LegalDocumentType.js';
+import { usecases } from '../../../../../src/legal-documents/domain/usecases/index.js';
+import { expect } from '../../../../test-helper.js';
+
+const { TOS } = LegalDocumentType.VALUES;
+const { PIX_ORGA } = LegalDocumentService.VALUES;
+
+describe('Unit | Legal documents | Domain | Use case | accept-legal-document-by-user-id', function () {
+  context('when the legal document type is invalid', function () {
+    it('throws an error', async function () {
+      // given
+      const type = 'invalid-type';
+      const service = PIX_ORGA;
+      const userId = 123;
+
+      // when / then
+      await expect(usecases.acceptLegalDocumentByUserId({ type, service, userId })).to.have.been.rejectedWith(
+        Joi.ValidationError,
+      );
+    });
+  });
+
+  context('when the legal document service is invalid', function () {
+    it('throws an error', async function () {
+      // given
+      const type = TOS;
+      const service = 'invalid-service';
+      const userId = 123;
+
+      // when / then
+      await expect(usecases.acceptLegalDocumentByUserId({ type, service, userId })).to.have.been.rejectedWith(
+        Joi.ValidationError,
+      );
+    });
+  });
+});

--- a/api/tests/legal-documents/unit/domain/usecase/create-legal-document.usecase.test.js
+++ b/api/tests/legal-documents/unit/domain/usecase/create-legal-document.usecase.test.js
@@ -5,8 +5,8 @@ import { LegalDocumentType } from '../../../../../src/legal-documents/domain/mod
 import { usecases } from '../../../../../src/legal-documents/domain/usecases/index.js';
 import { expect } from '../../../../test-helper.js';
 
-const { TOS } = LegalDocumentType.VALUES;
 const { PIX_ORGA } = LegalDocumentService.VALUES;
+const { TOS } = LegalDocumentType.VALUES;
 
 describe('Unit | Legal documents | Domain | Use case | create-legal-document', function () {
   context('when the legal document type is invalid', function () {
@@ -17,7 +17,7 @@ describe('Unit | Legal documents | Domain | Use case | create-legal-document', f
       const versionAt = new Date('2024-12-01');
 
       // when / then
-      await expect(usecases.createLegalDocument({ type, service, versionAt })).to.have.been.rejectedWith(
+      await expect(usecases.createLegalDocument({ service, type, versionAt })).to.have.been.rejectedWith(
         Joi.ValidationError,
       );
     });
@@ -31,7 +31,7 @@ describe('Unit | Legal documents | Domain | Use case | create-legal-document', f
       const versionAt = new Date('2024-12-01');
 
       // when / then
-      await expect(usecases.createLegalDocument({ type, service, versionAt })).to.have.been.rejectedWith(
+      await expect(usecases.createLegalDocument({ service, type, versionAt })).to.have.been.rejectedWith(
         Joi.ValidationError,
       );
     });

--- a/api/tests/legal-documents/unit/domain/usecase/get-legal-document-status-by-user-id.usecase.test.js
+++ b/api/tests/legal-documents/unit/domain/usecase/get-legal-document-status-by-user-id.usecase.test.js
@@ -1,0 +1,39 @@
+import Joi from 'joi';
+
+import { LegalDocumentService } from '../../../../../src/legal-documents/domain/models/LegalDocumentService.js';
+import { LegalDocumentType } from '../../../../../src/legal-documents/domain/models/LegalDocumentType.js';
+import { usecases } from '../../../../../src/legal-documents/domain/usecases/index.js';
+import { expect } from '../../../../test-helper.js';
+
+const { TOS } = LegalDocumentType.VALUES;
+const { PIX_ORGA } = LegalDocumentService.VALUES;
+
+describe('Unit | Legal documents | Domain | Use case | get-legal-document-status-by-user-id', function () {
+  context('when the legal document type is invalid', function () {
+    it('throws an error', async function () {
+      // given
+      const type = 'invalid-type';
+      const service = PIX_ORGA;
+      const userId = 123;
+
+      // when / then
+      await expect(usecases.getLegalDocumentStatusByUserId({ type, service, userId })).to.have.been.rejectedWith(
+        Joi.ValidationError,
+      );
+    });
+  });
+
+  context('when the legal document service is invalid', function () {
+    it('throws an error', async function () {
+      // given
+      const type = TOS;
+      const service = 'invalid-service';
+      const userId = 123;
+
+      // when / then
+      await expect(usecases.getLegalDocumentStatusByUserId({ type, service, userId })).to.have.been.rejectedWith(
+        Joi.ValidationError,
+      );
+    });
+  });
+});

--- a/api/tests/legal-documents/unit/domain/usecase/get-legal-document-status-by-user-id.usecase.test.js
+++ b/api/tests/legal-documents/unit/domain/usecase/get-legal-document-status-by-user-id.usecase.test.js
@@ -5,8 +5,8 @@ import { LegalDocumentType } from '../../../../../src/legal-documents/domain/mod
 import { usecases } from '../../../../../src/legal-documents/domain/usecases/index.js';
 import { expect } from '../../../../test-helper.js';
 
-const { TOS } = LegalDocumentType.VALUES;
 const { PIX_ORGA } = LegalDocumentService.VALUES;
+const { TOS } = LegalDocumentType.VALUES;
 
 describe('Unit | Legal documents | Domain | Use case | get-legal-document-status-by-user-id', function () {
   context('when the legal document type is invalid', function () {
@@ -17,7 +17,7 @@ describe('Unit | Legal documents | Domain | Use case | get-legal-document-status
       const userId = 123;
 
       // when / then
-      await expect(usecases.getLegalDocumentStatusByUserId({ type, service, userId })).to.have.been.rejectedWith(
+      await expect(usecases.getLegalDocumentStatusByUserId({ service, type, userId })).to.have.been.rejectedWith(
         Joi.ValidationError,
       );
     });
@@ -31,7 +31,7 @@ describe('Unit | Legal documents | Domain | Use case | get-legal-document-status
       const userId = 123;
 
       // when / then
-      await expect(usecases.getLegalDocumentStatusByUserId({ type, service, userId })).to.have.been.rejectedWith(
+      await expect(usecases.getLegalDocumentStatusByUserId({ service, type, userId })).to.have.been.rejectedWith(
         Joi.ValidationError,
       );
     });


### PR DESCRIPTION
## :christmas_tree: Problème

Dans le cadre de la nouvelle gestion du versioning des CGUs pour Pix Orga, nous avons besoin d’une API permettant de récupérer l'état d’acceptation d’un document légal pour un utilisateur.

## :gift: Proposition

Ajouter une API getLegalDocumentStatusByUserId permettant récupérer le status d'un document légal pour un utilisateur
- Si le feature toggle `newLegalDocumentsVersioning` est **activé**: calculer le status à partir du nouveau modèle de gestion de documents légaux.
- Si le feature toggle `newLegalDocumentsVersioning` est **désactivé**: calculer le status à partir des attributs Pix Orga CGU de la table `users`.

Retour de l'API avec un modèle `LegalDocumentStatus`:
- `status`: `accepted`, `requested` ou `update-requested`
- `acceptedAt`: date d’acceptation (uniquement si accepted)
- `documentPath`: chemin du document (pour pointer vers la page pix-site du document)

## :socks: Remarques

- Ajout d'une factory `databaseBuilder` pour `legal-document-version-user-acceptances`
- Ajout de la vérification des attributs `type` et `service` dans le use case `accept-legal-document-by-user-id`
- Changement d'ordre des propriétés des arguments pour que le code des legal documents soit plus logique à utiliser

## :santa: Pour tester

- L'API n'est pas encore utilisée, s'appuyer sur les tests d'intégration et unitaire.
- Un série de test fonctionnels sera réalisée lors de son intégration.
