### PR TITLE
[TECH] Appliquer le nouveau shade aux composants PixReturnTo sur Pix App (PIX-15685).

### DIFF
--- a/mon-pix/app/styles/pages/_user-certifications-get.scss
+++ b/mon-pix/app/styles/pages/_user-certifications-get.scss
@@ -1,13 +1,6 @@
 .user-certifications-page-get {
   position: relative;
 
-  &__return-to {
-    position: absolute;
-    top: calc(-0.813rem - 20px);
-    align-self: flex-start;
-    margin-left: -30px;
-  }
-
   &__details-body {
     display: flex;
     width: 100%;
@@ -60,10 +53,6 @@
 
 @include device-is('mobile') {
   @include contentInColumn;
-
-  .user-certifications-page-get__return-to {
-    margin-left: -22px;
-  }
 }
 
 @include device-is('tablet') {

--- a/mon-pix/app/templates/authenticated/user-certifications/get.hbs
+++ b/mon-pix/app/templates/authenticated/user-certifications/get.hbs
@@ -1,13 +1,9 @@
 <PixBackgroundHeader class="user-certifications-page-get">
 
+  <PixReturnTo @route="authenticated.user-certifications" @shade="neutral-light">
+    {{t "pages.certificate.back-link"}}
+  </PixReturnTo>
   <PixBlock class="user-certifications-page-get__header">
-    <PixReturnTo
-      @route="authenticated.user-certifications"
-      @shade="white"
-      class="user-certifications-page-get__return-to"
-    >
-      {{t "pages.certificate.back-link"}}
-    </PixReturnTo>
     <UserCertificationsDetailHeader @certification={{@model}} />
   </PixBlock>
 

--- a/mon-pix/app/templates/shared-certification.hbs
+++ b/mon-pix/app/templates/shared-certification.hbs
@@ -2,14 +2,11 @@
 
 <PixBackgroundHeader class="user-certifications-page-get">
 
+  <PixReturnTo @route="fill-in-certificate-verification-code" @shade="neutral-light">
+    {{t "pages.shared-certification.back-link"}}
+  </PixReturnTo>
+
   <PixBlock class="user-certifications-page-get__header">
-    <PixReturnTo
-      @route="fill-in-certificate-verification-code"
-      @shade="white"
-      class="user-certifications-page-get__return-to"
-    >
-      {{t "pages.shared-certification.back-link"}}
-    </PixReturnTo>
     <UserCertificationsDetailHeader @certification={{this.model}} />
   </PixBlock>
 


### PR DESCRIPTION
## :christmas_tree: Problème
Depuis la [v.50](https://ui.pix.fr/?path=/docs/changelog--docs#5010httpsgithubcom1024pixpix-uicomparev5000v5010-2024-12-09) le shade blanc du PixReturnTo se nomme `neutral-light`. 
Une montée de version de Pix UI a été réalisé récemment mais sans embarquer cette modification

## :gift: Proposition

Appliquer le `neutral-light` aux `@shade="white"`

## :socks: Remarques

On déplace les composants et on se débarasse du css inutile 

## :santa: Pour tester

- se connecter a pix app avec certif-success
- Aller dans ses certifications https://app-pr10791.review.pix.fr/mes-certifications/129301
- en sélectionner une
- constater que le bouton pour revenir à la page précédente est en blanc et que le hover montre une flèche noire sur fond blanc
- Copier le code de vérification de ce certificat
- Aller dans l'url [/verification-certificat](https://app-pr10791.review.pix.fr/verification-certificat) et coller le code 
- constater que le bouton pour revenir a aussi ce comportement
