### PR TITLE
[BUGFIX] Garantir un comportement ISO entre l'ancienne version et la nouvelle version du repository lorsqu'on passe des valeurs invalides en guise de collection (PIX-15696)

### DIFF
--- a/api/lib/infrastructure/repositories/tube-repository.js
+++ b/api/lib/infrastructure/repositories/tube-repository.js
@@ -28,6 +28,9 @@ export async function list() {
 
 export async function findByNames({ tubeNames, locale }) {
   if (!config.featureToggles.useNewLearningContent) return oldTubeRepository.findByNames({ tubeNames, locale });
+  if (!tubeNames) {
+    return [];
+  }
   const ids = await knex.pluck('id').from(TABLE_NAME).whereIn('name', tubeNames).orderBy('name');
   const tubeDtos = await getInstance().loadMany(ids);
   return toDomainList(tubeDtos, locale);

--- a/api/tests/devcomp/integration/infrastructure/repositories/tutorial-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/tutorial-repository_test.js
@@ -170,6 +170,57 @@ describe('Integration | Repository | tutorial-repository', function () {
         expect(tutorials).to.have.lengthOf(1);
         expect(tutorials[0].tutorialEvaluation).to.deep.equal(tutorialEvaluation);
       });
+
+      it('should return empty array when invalid argument given for ids', async function () {
+        // given
+        const tutorialsList = [
+          {
+            duration: '00:00:54',
+            format: 'video',
+            link: 'https://tuto.fr',
+            source: 'tuto.fr',
+            title: 'tuto0',
+            id: 'recTutorial0',
+            skillId: undefined,
+            userSavedTutorial: undefined,
+            tutorialEvaluation: undefined,
+          },
+          {
+            duration: '00:01:54',
+            format: 'page',
+            link: 'https://tuto.com',
+            source: 'tuto.com',
+            title: 'tuto1',
+            id: 'recTutorial1',
+            skillId: undefined,
+            userSavedTutorial: undefined,
+            tutorialEvaluation: undefined,
+          },
+        ];
+
+        await mockLearningContent({
+          tutorials: tutorialsList,
+        });
+
+        // when
+        const tutorials1 = await tutorialRepository.findByRecordIdsForCurrentUser({
+          ids: [],
+          userId: null,
+        });
+        const tutorials2 = await tutorialRepository.findByRecordIdsForCurrentUser({
+          ids: null,
+          userId: null,
+        });
+        const tutorials3 = await tutorialRepository.findByRecordIdsForCurrentUser({
+          ids: undefined,
+          userId: null,
+        });
+
+        // then
+        expect(tutorials1).to.deep.equal([]);
+        expect(tutorials2).to.deep.equal([]);
+        expect(tutorials3).to.deep.equal([]);
+      });
     });
 
     describe('#findPaginatedFilteredForCurrentUser', function () {

--- a/api/tests/integration/infrastructure/repositories/tube-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tube-repository_test.js
@@ -227,6 +227,20 @@ describe('Integration | Repository | tube-repository', function () {
           expect(tubes).to.deep.equal([]);
         });
       });
+
+      context('when invalid value provided for tubeNames argument', function () {
+        it('should return an empty array', async function () {
+          // when
+          const tubes1 = await tubeRepository.findByNames({ tubeNames: null });
+          const tubes2 = await tubeRepository.findByNames({ tubeNames: undefined });
+          const tubes3 = await tubeRepository.findByNames({ tubeNames: [] });
+
+          // then
+          expect(tubes1).to.deep.equal([]);
+          expect(tubes2).to.deep.equal([]);
+          expect(tubes3).to.deep.equal([]);
+        });
+      });
     });
 
     describe('#findByRecordIds', function () {

--- a/api/tests/shared/integration/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/skill-repository_test.js
@@ -617,6 +617,20 @@ describe('Integration | Repository | skill-repository', function () {
           ]);
         });
       });
+
+      context('when invalid value given for ids argument', function () {
+        it('should return an empty array', async function () {
+          // when
+          const skills1 = await skillRepository.findOperativeByIds(null);
+          const skills2 = await skillRepository.findOperativeByIds(undefined);
+          const skills3 = await skillRepository.findOperativeByIds([]);
+
+          // then
+          expect(skills1).to.deep.equal([]);
+          expect(skills2).to.deep.equal([]);
+          expect(skills3).to.deep.equal([]);
+        });
+      });
     });
 
     describe('#get', function () {
@@ -761,6 +775,20 @@ describe('Integration | Repository | skill-repository', function () {
           ]);
         });
       });
+
+      context('when invalid value given for ids argument', function () {
+        it('should return an empty array', async function () {
+          // when
+          const skills1 = await skillRepository.findActiveByRecordIds(null);
+          const skills2 = await skillRepository.findActiveByRecordIds(undefined);
+          const skills3 = await skillRepository.findActiveByRecordIds([]);
+
+          // then
+          expect(skills1).to.deep.equal([]);
+          expect(skills2).to.deep.equal([]);
+          expect(skills3).to.deep.equal([]);
+        });
+      });
     });
 
     describe('#findByRecordIds', function () {
@@ -844,6 +872,20 @@ describe('Integration | Repository | skill-repository', function () {
               hint: skillData03_tubeBcompetenceA_actif.hint_i18n.fr,
             }),
           ]);
+        });
+      });
+
+      context('when invalid value given for ids argument', function () {
+        it('should return an empty array', async function () {
+          // when
+          const skills1 = await skillRepository.findByRecordIds(null);
+          const skills2 = await skillRepository.findByRecordIds(undefined);
+          const skills3 = await skillRepository.findByRecordIds([]);
+
+          // then
+          expect(skills1).to.deep.equal([]);
+          expect(skills2).to.deep.equal([]);
+          expect(skills3).to.deep.equal([]);
         });
       });
     });


### PR DESCRIPTION
## :christmas_tree: Problème
Concernant les repositories relevant de la gestion du contenu pédagogique, dans l'implémentation de certains méthodes des "anciens" repositories on remarque l'usage de lodash. Une de ses propriétés est de bien gérer lorsqu'on lui passe des "collections" qui n'en sont pas, exemple :
```
const foo = null;
const bar = undefined;
_.includes(foo, 'coucou'); // returns []
_.includes(bar, 'coucou'); // returns []
```

Dans l'implémentation des "nouveaux" repositories, cette tolérance n'est pas toujours respectée.

## :gift: Proposition
Chercher les anciennes méthodes dont les parcours de collection se font via lodash, puis dans leur équivalent "nouveau" :
- Ajouter un test pour vérifier la tolérance aux valeurs invalides
- Si besoin (si test rouge), ajouter une garde dans le code du "nouveau" repository correspondant

## :socks: Remarques

La nouvelle implémentation passant par le dataloader n'a pas eu besoin d'être modifiée, car les renforts étaient déjà présents dans le learning-content-repository.
En revanche, il y a un queryBuilder "callback" qui utilisait un `whereIn` qui a dû être renforcé.

## :santa: Pour tester

Non rég, tests verts
