### PR TITLE
[TECH] Améliorer les logs de la route /api/token (PIX-15710)

### DIFF
--- a/api/src/identity-access-management/application/monitor-pre-handlers.js
+++ b/api/src/identity-access-management/application/monitor-pre-handlers.js
@@ -1,17 +1,30 @@
-import { logger } from '../../shared/infrastructure/utils/logger.js';
+import { monitoringTools } from '../../shared/infrastructure/monitoring-tools.js';
 import { generateHash } from '../infrastructure/utils/crypto.js';
 
-async function monitorApiTokenRoute(request, h, dependencies = { logger }) {
+async function monitorApiTokenRoute(request, h, dependencies = { monitoringTools }) {
   const { username, refresh_token, grant_type, scope } = request.payload;
 
   if (grant_type === 'password') {
     const hash = generateHash(username);
-    dependencies.logger.warn({ hash, grant_type, scope }, 'Authentication attempt');
+    dependencies.monitoringTools.logWarnWithCorrelationIds({
+      message: 'Authentication attempt',
+      hash,
+      grant_type,
+      scope,
+    });
   } else if (grant_type === 'refresh_token') {
     const hash = generateHash(refresh_token);
-    dependencies.logger.warn({ hash, grant_type, scope }, 'Authentication attempt');
+    dependencies.monitoringTools.logWarnWithCorrelationIds({
+      message: 'Authentication attempt',
+      hash,
+      grant_type,
+      scope,
+    });
   } else {
-    dependencies.logger.warn(request.payload, 'Authentication attempt with unknown method');
+    dependencies.monitoringTools.logWarnWithCorrelationIds({
+      message: 'Authentication attempt with unknown method',
+      ...request.payload,
+    });
   }
 
   return true;

--- a/api/src/shared/infrastructure/monitoring-tools.js
+++ b/api/src/shared/infrastructure/monitoring-tools.js
@@ -140,6 +140,7 @@ const monitoringTools = {
   incrementInContext,
   installHapiHook,
   logErrorWithCorrelationIds,
+  logWarnWithCorrelationIds,
   logInfoWithCorrelationIds,
   pushInContext,
   setInContext,

--- a/api/tests/identity-access-management/unit/application/monitor-pre-handlers.test.js
+++ b/api/tests/identity-access-management/unit/application/monitor-pre-handlers.test.js
@@ -10,14 +10,19 @@ describe('Unit | Identity Access Management | Application | monitor-pre-handlers
       const grant_type = 'password';
       const scope = 'pix-app';
       const hash = generateHash(username);
-      const logger = { warn: sinon.stub() };
+      const monitoringTools = { logWarnWithCorrelationIds: sinon.stub() };
       const request = { payload: { grant_type, username, scope } };
 
       // when
-      monitorPreHandlers.monitorApiTokenRoute(request, hFake, { logger });
+      monitorPreHandlers.monitorApiTokenRoute(request, hFake, { monitoringTools });
 
       // then
-      expect(logger.warn).to.have.been.calledWith({ hash, grant_type, scope }, 'Authentication attempt');
+      expect(monitoringTools.logWarnWithCorrelationIds).to.have.been.calledWith({
+        message: 'Authentication attempt',
+        hash,
+        grant_type,
+        scope,
+      });
     });
 
     it('logs authentication attempt with grant type refresh token', async function () {
@@ -26,27 +31,35 @@ describe('Unit | Identity Access Management | Application | monitor-pre-handlers
       const grant_type = 'refresh_token';
       const scope = 'pix-app';
       const hash = generateHash(refresh_token);
-      const logger = { warn: sinon.stub() };
+      const monitoringTools = { logWarnWithCorrelationIds: sinon.stub() };
       const request = { payload: { grant_type, refresh_token, scope } };
 
       // when
-      monitorPreHandlers.monitorApiTokenRoute(request, hFake, { logger });
+      monitorPreHandlers.monitorApiTokenRoute(request, hFake, { monitoringTools });
 
       // then
-      expect(logger.warn).to.have.been.calledWith({ hash, grant_type, scope }, 'Authentication attempt');
+      expect(monitoringTools.logWarnWithCorrelationIds).to.have.been.calledWith({
+        message: 'Authentication attempt',
+        hash,
+        grant_type,
+        scope,
+      });
     });
 
     it('logs authentication attempt with grant type unknown', async function () {
       // given
       const grant_type = 'unknown';
-      const logger = { warn: sinon.stub() };
+      const monitoringTools = { logWarnWithCorrelationIds: sinon.stub() };
       const request = { payload: { foo: 'bar', grant_type } };
 
       // when
-      monitorPreHandlers.monitorApiTokenRoute(request, hFake, { logger });
+      monitorPreHandlers.monitorApiTokenRoute(request, hFake, { monitoringTools });
 
       // then
-      expect(logger.warn).to.have.been.calledWith(request.payload, 'Authentication attempt with unknown method');
+      expect(monitoringTools.logWarnWithCorrelationIds).to.have.been.calledWith({
+        message: 'Authentication attempt with unknown method',
+        ...request.payload,
+      });
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème

Les logs de monitoring de la route /api/token sont difficilement exploitables.

## :gift: Proposition

2 améliorations du monitoring ont été effectuées:
- **Monitor 1:** Utiliser le log avec ID de corrélation, pour faire le lien avec la requête.
- **Monitor 2:** Ajout d'information dans la log spécifique à la requête `/api/token` (déjà présent actuellement)

## :socks: Remarques

Nous allons tester le rendu des 2 monitorings et voir lequel est le plus exploitable. Celui le moins utile sera supprimé par la suite.

## :santa: Pour tester

1. Se connecter avec login/mdp.
2. Observer les logs dans la console (avec `LOG_FOR_HUMANS_FORMAT=full`) avec les informations:
- `user_id` (pour Monitor 1)
- `request_id` (pour Monitor 1)
- `grant_type` (pour Monitor 1 et 2)
- `scope` (pour Monitor 1 et 2)
- `hash` (pour Monitor 1)
- `usernameHash` (pour Monitor 2)
- `refreshTokenHash` (pour Monitor 2)

**Pour "Monitor 1":**
```
[14:41:32] WARN: Authentication attempt
    user_id: "-"
    request_id: "-"
    id: "XXXXXXXX"
    hash: "YYYYYYYYY"
    grant_type: "password"
    scope: "mon-pix"
```

**Pour "Monitor 2":**
```
[14:41:33] INFO: request completed
    queryParams: {}
    req: {
      "id": "XXXXXXXX",
      ...
      "grantType": "password",
      "scope": "mon-pix",
      "usernameHash": "YYYYYYYYY",
      "refreshTokenHash": "-",
      "user_id": "-",
      ...
    }
```
