### PR TITLE
[FEATURE] déplace le footer d'orga en base de la page (pix-15615)

### DIFF
--- a/orga/app/styles/components/layout/footer.scss
+++ b/orga/app/styles/components/layout/footer.scss
@@ -4,12 +4,12 @@
   flex-shrink: 0;
   align-items: center;
   justify-content: space-between;
-  margin: 0 var(--pix-spacing-6x);
-  border-top: 1px solid var(--pix-neutral-20);
 
   @include device-is('desktop') {
     flex-direction: row;
   }
+
+  line-height: 1;
 
   &__navigation {
     display: flex;
@@ -33,7 +33,6 @@
   }
 
   &__copyrights {
-    padding: 16px 0;
     color: var(--pix-neutral-20)0;
     font-size: 0.75rem;
     font-family: $font-roboto;

--- a/orga/app/styles/components/ui/action-bar.scss
+++ b/orga/app/styles/components/ui/action-bar.scss
@@ -30,7 +30,3 @@
     }
   }
 }
-
-footer {
-  padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
-}

--- a/orga/app/templates/authenticated.hbs
+++ b/orga/app/templates/authenticated.hbs
@@ -1,11 +1,17 @@
 <PixAppLayout @variant="orga" class="app">
-  <Layout::Sidebar @placesCount={{@model.available}} @onChangeOrganization={{this.onChangeOrganization}} />
+  <:navigation>
 
-  <main class="main-content__body page">
-    <Banner::TopBanners />
-    {{outlet}}
+    <Layout::Sidebar @placesCount={{@model.available}} @onChangeOrganization={{this.onChangeOrganization}} />
+  </:navigation>
+  <:main>
+
+    <main class="main-content__body page">
+      <Banner::TopBanners />
+      {{outlet}}
+    </main>
+  </:main>
+  <:footer>
     <Layout::Footer />
-  </main>
-
+  </:footer>
 </PixAppLayout>
 <NotificationContainer @position="bottom-right" />

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -14,7 +14,7 @@
         "@1024pix/ember-matomo-tag-manager": "^2.4.3",
         "@1024pix/ember-testing-library": "^3.0.6",
         "@1024pix/eslint-config": "^1.3.8",
-        "@1024pix/pix-ui": "^51.2.0",
+        "@1024pix/pix-ui": "^52.0.0",
         "@1024pix/stylelint-config": "^5.1.24",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.13",
@@ -922,9 +922,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "51.2.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-51.2.0.tgz",
-      "integrity": "sha512-SYiCwxizS2dgAbQ4w2SrrBFUyIdRxPLAywDCArzFjpG5Dlruz7x0Gehz729wI5gUGObaslUGokHr3bNKU7tPyw==",
+      "version": "52.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-52.0.0.tgz",
+      "integrity": "sha512-mwkYcEOAgLS/MSK3hFAu4ZO2kHSGDDybvoOZSKsT/Y1Z3VtprosSvN9jdLzCn2U649BzfDeaRx9mNRfS7zF8wg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/orga/package.json
+++ b/orga/package.json
@@ -55,7 +55,7 @@
     "@1024pix/ember-matomo-tag-manager": "^2.4.3",
     "@1024pix/ember-testing-library": "^3.0.6",
     "@1024pix/eslint-config": "^1.3.8",
-    "@1024pix/pix-ui": "^51.2.0",
+    "@1024pix/pix-ui": "^52.0.0",
     "@1024pix/stylelint-config": "^5.1.24",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.13",


### PR DESCRIPTION
## :christmas_tree: Problème

le footer n'est pas collé en bas de la page

## :gift: Proposition

on utilise la nouvelle version de pix-ui pour avoir le footer en base de la page 

## :socks: Remarques

ras

## :santa: Pour tester

- Se connecter à pix-orga et se déplacer dans les pages.
- Vérifier que le footer est toujours bien aligné en bas de page.