### PR TITLE
[FEATURE] Afficher dans les exports les dates aux formats UTC afin de faciliter le traitement avec l'heure (PIX-13289)

### DIFF
--- a/api/src/prescription/campaign/infrastructure/exports/campaigns/campaign-profiles-collection-result-line.js
+++ b/api/src/prescription/campaign/infrastructure/exports/campaigns/campaign-profiles-collection-result-line.js
@@ -92,7 +92,7 @@ class CampaignProfilesCollectionResultLine {
 
   _getSharedAtColumn() {
     return this.campaignParticipationResult.isShared
-      ? dayjs.utc(this.campaignParticipationResult.sharedAt).format('YYYY-MM-DD')
+      ? dayjs.utc(this.campaignParticipationResult.sharedAt).format()
       : this.notShared;
   }
 

--- a/api/src/prescription/campaign/infrastructure/utils/CampaignAssessmentCsvLine.js
+++ b/api/src/prescription/campaign/infrastructure/utils/CampaignAssessmentCsvLine.js
@@ -111,10 +111,10 @@ class CampaignAssessmentCsvLine {
         this.targetedKnowledgeElementsCount,
         this.learningContent.skills.length,
       ),
-      dayjs.utc(this.campaignParticipationInfo.createdAt).format('YYYY-MM-DD'),
+      dayjs.utc(this.campaignParticipationInfo.createdAt).format(),
       this._makeYesNoColumns(this.campaignParticipationInfo.isShared),
       this.campaignParticipationInfo.isShared
-        ? dayjs.utc(this.campaignParticipationInfo.sharedAt).format('YYYY-MM-DD')
+        ? dayjs.utc(this.campaignParticipationInfo.sharedAt).format()
         : this.emptyContent,
       ...(this.stageCollection.hasStage ? [this._getReachedStage()] : []),
       ...(this.campaignParticipationInfo.isShared

--- a/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -1,5 +1,7 @@
 import stream from 'node:stream';
 
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc.js';
 const { PassThrough } = stream;
 
 import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
@@ -9,6 +11,7 @@ import { Assessment } from '../../../../../../src/shared/domain/models/Assessmen
 import { CampaignParticipationStatuses, KnowledgeElement } from '../../../../../../src/shared/domain/models/index.js';
 import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { databaseBuilder, expect, mockLearningContent, streamToPromise } from '../../../../../test-helper.js';
+dayjs.extend(utc);
 
 describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-results-to-stream', function () {
   describe('#startWritingCampaignAssessmentResultsToStream', function () {
@@ -155,9 +158,9 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
           `"'${organizationLearner.firstName}";` +
           `"${campaignParticipation.participantExternalId}";` +
           '1;' +
-          '2019-02-25;' +
+          `"${dayjs.utc(createdAt).format()}";` +
           '"Oui";' +
-          '2019-03-01;' +
+          `"${dayjs.utc(sharedAt).format()}";` +
           '1;' +
           '"Non";' +
           '0,67;' +
@@ -295,9 +298,9 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
           `"'${organizationLearner.firstName}";` +
           `"${organizationLearner.attributes.hobby}";` +
           '1;' +
-          '2019-02-25;' +
+          `"${dayjs.utc(createdAt).format()}";` +
           '"Oui";' +
-          '2019-03-01;' +
+          `"${dayjs.utc(sharedAt).format()}";` +
           '1;' +
           '"Non";' +
           '0,67;' +
@@ -404,9 +407,9 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
           `"'${organizationLearner.lastName}";` +
           `"'${organizationLearner.firstName}";` +
           '1;' +
-          '2019-02-25;' +
+          `"${dayjs.utc(createdAt).format()}";` +
           '"Oui";' +
-          '2019-03-01;' +
+          `"${dayjs.utc(sharedAt).format()}";` +
           '1;' +
           '"Non";' +
           '0,67;' +
@@ -492,7 +495,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
           `"'${organizationLearner.lastName}";` +
           `"'${organizationLearner.firstName}";` +
           '0,333;' +
-          `2019-02-25;` +
+          `"${dayjs.utc(createdAt).format()}";` +
           '"Non";' +
           `"NA";` +
           '"NA";' +
@@ -630,7 +633,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
           `"'${organizationLearner.lastName}";` +
           `"'${organizationLearner.firstName}";` +
           '0,667;' +
-          `2019-03-05;` +
+          `"${dayjs.utc(secondParticipationDateCreatedAt).format()}";` +
           '"Non";' +
           `"NA";` +
           '"NA";' +
@@ -655,9 +658,9 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
           `"'${organizationLearner.lastName}";` +
           `"'${organizationLearner.firstName}";` +
           '1;' +
-          '2019-02-25;' +
+          `"${dayjs.utc(createdAt).format()}";` +
           '"Oui";' +
-          '2019-03-01;' +
+          `"${dayjs.utc(sharedAt).format()}";` +
           '1;' +
           '"Non";' +
           '0,67;' +

--- a/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -1,5 +1,7 @@
 import stream from 'node:stream';
 
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc.js';
 const { PassThrough } = stream;
 
 import * as campaignRepository from '../../../../../../lib/infrastructure/repositories/campaign-repository.js';
@@ -23,6 +25,7 @@ import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.j
 import * as competenceRepository from '../../../../../../src/shared/infrastructure/repositories/competence-repository.js';
 import * as organizationRepository from '../../../../../../src/shared/infrastructure/repositories/organization-repository.js';
 import { databaseBuilder, expect, streamToPromise } from '../../../../../test-helper.js';
+dayjs.extend(utc);
 
 describe('Integration | Domain | Use Cases | start-writing-profiles-collection-campaign-results-to-stream', function () {
   describe('#startWritingCampaignProfilesCollectionResultsToStream', function () {
@@ -200,7 +203,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           '\uFEFF"Nom de l\'organisation";"ID Campagne";"Code";"Nom de la campagne";"Nom du Participant";"Prénom du Participant";"Envoi (O/N)";"Date de l\'envoi";"Nombre de pix total";"Certifiable (O/N)";"Nombre de compétences certifiables";"Niveau pour la compétence nom en français recCompetence1";"Nombre de pix pour la compétence nom en français recCompetence1";"Niveau pour la compétence nom en français recCompetence2";"Nombre de pix pour la compétence nom en français recCompetence2"',
         );
         expect(cells[1]).to.be.equals(
-          `"Observatoire de Pix";${campaign.id};"QWERTY456";"'@Campagne de Test N°2";"'=Bono";"'@Jean";"Oui";2019-03-01;52;"Non";2;1;12;5;40`,
+          `"Observatoire de Pix";${campaign.id};"QWERTY456";"'@Campagne de Test N°2";"'=Bono";"'@Jean";"Oui";"${dayjs.utc(sharedAt).format()}";52;"Non";2;1;12;5;40`,
         );
         expect(cells[2]).to.be.equals(
           `"Observatoire de Pix";${campaign.id};"QWERTY456";"'@Campagne de Test N°2";"'=Bono";"'@Jean";"Non";"NA";"NA";"NA";"NA";"NA";"NA";"NA";"NA"`,
@@ -263,7 +266,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           '\uFEFF"Nom de l\'organisation";"ID Campagne";"Code";"Nom de la campagne";"Nom du Participant";"Prénom du Participant";"Mail Perso";"Envoi (O/N)";"Date de l\'envoi";"Nombre de pix total";"Certifiable (O/N)";"Nombre de compétences certifiables";"Niveau pour la compétence nom en français recCompetence1";"Nombre de pix pour la compétence nom en français recCompetence1";"Niveau pour la compétence nom en français recCompetence2";"Nombre de pix pour la compétence nom en français recCompetence2"',
         );
         expect(cells[1]).to.be.equals(
-          `"Observatoire de Pix";${campaign.id};"QWERTY456";"'@Campagne de Test N°2";"'=Bono";"'@Jean";"'+Mon mail pro";"Oui";2019-03-01;52;"Non";2;1;12;5;40`,
+          `"Observatoire de Pix";${campaign.id};"QWERTY456";"'@Campagne de Test N°2";"'=Bono";"'@Jean";"'+Mon mail pro";"Oui";"${dayjs.utc(sharedAt).format()}";52;"Non";2;1;12;5;40`,
         );
       });
     });
@@ -393,7 +396,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           `"'${organizationLearner.lastName}";` +
           `"'${organizationLearner.firstName}";` +
           '"Oui";' +
-          '2019-03-01;' +
+          `"${dayjs.utc(sharedAt).format()}";` +
           '52;' +
           '"Non";' +
           '2;' +
@@ -471,7 +474,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           `"'${organizationLearner.firstName}";` +
           `"${organizationLearner.division}";` +
           '"Oui";' +
-          '2019-03-01;' +
+          `"${dayjs.utc(sharedAt).format()}";` +
           '52;' +
           '"Non";' +
           '2;' +
@@ -551,7 +554,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           `"'${organizationLearner.group}";` +
           `"${organizationLearner.studentNumber}";` +
           '"Oui";' +
-          '2019-03-01;' +
+          `"${dayjs.utc(sharedAt).format()}";` +
           '52;' +
           '"Non";' +
           '2;' +

--- a/api/tests/prescription/campaign/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -2,12 +2,16 @@ import stream from 'node:stream';
 
 const { PassThrough } = stream;
 
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc.js';
+
 import * as campaignCsvExportService from '../../../../../../src/prescription/campaign/domain/services/campaign-csv-export-service.js';
 import { startWritingCampaignAssessmentResultsToStream } from '../../../../../../src/prescription/campaign/domain/usecases/start-writing-campaign-assessment-results-to-stream.js';
 import { CampaignTypeError } from '../../../../../../src/shared/domain/errors.js';
 import { StageCollection } from '../../../../../../src/shared/domain/models/user-campaign-results/StageCollection.js';
 import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { catchErr, domainBuilder, expect, sinon, streamToPromise } from '../../../../../test-helper.js';
+dayjs.extend(utc);
 
 describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-to-stream', function () {
   let campaignRepository,
@@ -543,6 +547,8 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
 
   it('should process result for each participation and add it to csv', async function () {
     // given
+    const createdAt = new Date('2020-01-01');
+    const sharedAt = new Date('2020-02-01');
     const { user: admin, campaign, organization } = _buildOrganizationAndUserWithMembershipAndCampaign();
     const badge = domainBuilder.buildBadge({ title: 'badge sup' });
     const targetProfile = domainBuilder.buildTargetProfile({
@@ -551,8 +557,8 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
     const learningContent = domainBuilder.buildLearningContent.withSimpleContent();
     const participantInfo = domainBuilder.buildCampaignParticipationInfo({
       campaignParticipationId: 12,
-      createdAt: new Date('2020-01-01'),
-      sharedAt: new Date('2020-02-01'),
+      createdAt,
+      sharedAt,
     });
     const knowledgeElement = domainBuilder.buildKnowledgeElement({
       status: 'validated',
@@ -611,9 +617,9 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       `"${participantInfo.participantLastName}";` +
       `"${participantInfo.participantFirstName}";` +
       '1;' +
-      '2020-01-01;' +
+      `"${dayjs.utc(createdAt).format()}";` +
       '"Oui";' +
-      '2020-02-01;' +
+      `"${dayjs.utc(sharedAt).format()}";` +
       '"Oui";' +
       '1;' +
       '1;' +

--- a/api/tests/prescription/campaign/unit/infrastructure/exports/campaigns/campaign-profiles-collection-result-line_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/exports/campaigns/campaign-profiles-collection-result-line_test.js
@@ -1,11 +1,15 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc.js';
+
 import { CampaignProfilesCollectionResultLine } from '../../../../../../../src/prescription/campaign/infrastructure/exports/campaigns/campaign-profiles-collection-result-line.js';
 import { PlacementProfile } from '../../../../../../../src/shared/domain/models/index.js';
 import { getI18n } from '../../../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { domainBuilder, expect, sinon } from '../../../../../../test-helper.js';
+dayjs.extend(utc);
 
 describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', function () {
   describe('#toCsvLine', function () {
-    let organization, campaign, competences;
+    let organization, campaign, competences, createdAt, sharedAt;
 
     // TODO: Fix this the next time the file is edited.
     // eslint-disable-next-line mocha/no-setup-in-describe
@@ -28,6 +32,9 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
     });
 
     beforeEach(function () {
+      createdAt = new Date('2019-02-25T10:00:00Z');
+      sharedAt = new Date('2019-03-01T23:04:05Z');
+
       const listSkills1 = domainBuilder.buildSkillCollection({ name: '@web', minLevel: 1, maxLevel: 5 });
       const listSkills2 = domainBuilder.buildSkillCollection({ name: '@url', minLevel: 1, maxLevel: 2 });
 
@@ -63,8 +70,8 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           id: 1,
           isShared: true,
           isCompleted: true,
-          createdAt: new Date('2019-02-25T10:00:00Z'),
-          sharedAt: new Date('2019-03-01T23:04:05Z'),
+          createdAt,
+          sharedAt,
           userId: 123,
           participantFirstName: 'Juan',
           participantLastName: 'Carlitos',
@@ -81,7 +88,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           `"${campaignParticipationResultData.participantFirstName}";` +
           `"${campaignParticipationResultData.additionalInfos.hobby}";` +
           '"Oui";' +
-          '2019-03-01;' +
+          `"${dayjs.utc(sharedAt).format()}";` +
           '13;' +
           '"Non";' +
           '0;' +
@@ -120,8 +127,8 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           id: 1,
           isShared: true,
           isCompleted: true,
-          createdAt: new Date('2019-02-25T10:00:00Z'),
-          sharedAt: new Date('2019-03-01T23:04:05Z'),
+          createdAt,
+          sharedAt,
           userId: 123,
           participantFirstName: 'Juan',
           participantLastName: 'Carlitos',
@@ -160,8 +167,8 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           id: 1,
           isShared: true,
           isCompleted: true,
-          createdAt: new Date('2019-02-25T10:00:00Z'),
-          sharedAt: new Date('2019-03-01T23:04:05Z'),
+          createdAt,
+          sharedAt,
           userId: 123,
           participantFirstName: 'Juan',
           participantLastName: 'Carlitos',
@@ -176,7 +183,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           `"${campaignParticipationResultData.participantLastName}";` +
           `"${campaignParticipationResultData.participantFirstName}";` +
           '"Oui";' +
-          '2019-03-01;' +
+          `"${dayjs.utc(sharedAt).format()}";` +
           '13;' +
           '"Non";' +
           '0;' +
@@ -215,8 +222,8 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           id: 1,
           isShared: true,
           isCompleted: true,
-          createdAt: new Date('2019-02-25T10:00:00Z'),
-          sharedAt: new Date('2019-03-01T23:04:05Z'),
+          createdAt,
+          sharedAt,
           userId: 123,
           participantFirstName: 'Juan',
           participantLastName: 'Carlitos',
@@ -231,7 +238,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           `"${campaignParticipationResultData.participantLastName}";` +
           `"${campaignParticipationResultData.participantFirstName}";` +
           '"Oui";' +
-          '2019-03-01;' +
+          `"${dayjs.utc(sharedAt).format()}";` +
           '13;' +
           '"Oui";' +
           '5;' +
@@ -272,8 +279,8 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           id: 1,
           isShared: false,
           isCompleted: true,
-          createdAt: new Date('2019-02-25T10:00:00Z'),
-          sharedAt: new Date('2019-03-01T23:04:05Z'),
+          createdAt,
+          sharedAt,
           participantExternalId: '-Mon mail pro',
           userId: 123,
           participantFirstName: 'Juan',
@@ -333,8 +340,8 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           id: 1,
           isShared: false,
           isCompleted: true,
-          createdAt: new Date('2019-02-25T10:00:00Z'),
-          sharedAt: new Date('2019-03-01T23:04:05Z'),
+          createdAt,
+          sharedAt,
           participantExternalId: 'mailpro@pro.net',
           userId: 123,
           participantFirstName: 'Juan',
@@ -396,8 +403,8 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           id: 1,
           isShared: true,
           isCompleted: true,
-          createdAt: new Date('2019-02-25T10:00:00Z'),
-          sharedAt: new Date('2019-03-01T23:04:05Z'),
+          createdAt,
+          sharedAt,
           userId: 123,
           participantFirstName: 'Juan',
           participantLastName: 'Carlitos',
@@ -414,7 +421,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           `"${campaignParticipationResultData.participantLastName}";` +
           `"${campaignParticipationResultData.participantFirstName}";` +
           '"Oui";' +
-          '2019-03-01;' +
+          `"${dayjs.utc(sharedAt).format()}";` +
           '13;' +
           '"Non";' +
           '0;' +
@@ -461,8 +468,8 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
             id: 1,
             isShared: true,
             isCompleted: true,
-            createdAt: new Date('2019-02-25T10:00:00Z'),
-            sharedAt: new Date('2019-03-01T23:04:05Z'),
+            createdAt,
+            sharedAt,
             userId: 123,
             participantFirstName: 'Juan',
             participantLastName: 'Carlitos',
@@ -479,7 +486,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
             `"${campaignParticipationResultData.participantFirstName}";` +
             '"";' +
             '"Oui";' +
-            '2019-03-01;' +
+            `"${dayjs.utc(sharedAt).format()}";` +
             '13;' +
             '"Non";' +
             '0;' +
@@ -520,8 +527,8 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
             id: 1,
             isShared: true,
             isCompleted: true,
-            createdAt: new Date('2019-02-25T10:00:00Z'),
-            sharedAt: new Date('2019-03-01T23:04:05Z'),
+            createdAt,
+            sharedAt,
             userId: 123,
             participantFirstName: 'Juan',
             participantLastName: 'Carlitos',
@@ -538,7 +545,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
             `"${campaignParticipationResultData.participantFirstName}";` +
             `"${campaignParticipationResultData.division}";` +
             '"Oui";' +
-            '2019-03-01;' +
+            `"${dayjs.utc(sharedAt).format()}";` +
             '13;' +
             '"Non";' +
             '0;' +
@@ -586,8 +593,8 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
             id: 1,
             isShared: false,
             isCompleted: true,
-            createdAt: new Date('2019-02-25T10:00:00Z'),
-            sharedAt: new Date('2019-03-01T23:04:05Z'),
+            createdAt,
+            sharedAt,
             participantExternalId: '-Mon mail pro',
             userId: 123,
             participantFirstName: 'Juan',
@@ -651,8 +658,8 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
             id: 1,
             isShared: true,
             isCompleted: true,
-            createdAt: new Date('2019-02-25T10:00:00Z'),
-            sharedAt: new Date('2019-03-01T23:04:05Z'),
+            createdAt,
+            sharedAt,
             userId: 123,
             participantFirstName: 'Juan',
             participantLastName: 'Carlitos',
@@ -671,7 +678,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
             `"${campaignParticipationResultData.group}";` +
             '"";' +
             '"Oui";' +
-            '2019-03-01;' +
+            `"${dayjs.utc(sharedAt).format()}";` +
             '13;' +
             '"Non";' +
             '0;' +
@@ -712,8 +719,8 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
             id: 1,
             isShared: true,
             isCompleted: true,
-            createdAt: new Date('2019-02-25T10:00:00Z'),
-            sharedAt: new Date('2019-03-01T23:04:05Z'),
+            createdAt,
+            sharedAt,
             userId: 123,
             participantFirstName: 'Juan',
             participantLastName: 'Carlitos',
@@ -732,7 +739,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
             `"${campaignParticipationResultData.group}";` +
             `"${campaignParticipationResultData.studentNumber}";` +
             '"Oui";' +
-            '2019-03-01;' +
+            `"${dayjs.utc(sharedAt).format()}";` +
             '13;' +
             '"Non";' +
             '0;' +
@@ -773,8 +780,8 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
             id: 1,
             isShared: true,
             isCompleted: true,
-            createdAt: new Date('2019-02-25T10:00:00Z'),
-            sharedAt: new Date('2019-03-01T23:04:05Z'),
+            createdAt,
+            sharedAt,
             userId: 123,
             participantFirstName: 'Juan',
             participantLastName: 'Carlitos',
@@ -793,7 +800,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
             `"${campaignParticipationResultData.group}";` +
             `"${campaignParticipationResultData.studentNumber}";` +
             '"Oui";' +
-            '2019-03-01;' +
+            `"${dayjs.utc(sharedAt).format()}";` +
             '13;' +
             '"Non";' +
             '0;' +
@@ -841,8 +848,8 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
             id: 1,
             isShared: false,
             isCompleted: true,
-            createdAt: new Date('2019-02-25T10:00:00Z'),
-            sharedAt: new Date('2019-03-01T23:04:05Z'),
+            createdAt,
+            sharedAt,
             participantExternalId: '-Mon mail pro',
             userId: 123,
             participantFirstName: 'Juan',

--- a/api/tests/prescription/campaign/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
@@ -1,8 +1,13 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc.js';
+
 import * as campaignParticipationService from '../../../../../../lib/domain/services/campaign-participation-service.js';
 import { CampaignAssessmentCsvLine } from '../../../../../../src/prescription/campaign/infrastructure/utils/CampaignAssessmentCsvLine.js';
 import { KnowledgeElement } from '../../../../../../src/shared/domain/models/index.js';
 import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { domainBuilder, expect } from '../../../../../test-helper.js';
+
+dayjs.extend(utc);
 
 function _computeExpectedColumnsIndex(campaign, organization, badges = [], stages = [], additionalHeaders = []) {
   const studentNumberPresenceModifier = organization.type === 'SUP' && organization.isManagingStudents ? 1 : 0;
@@ -87,10 +92,11 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', function (
   describe('#toCsvLine', function () {
     it('should return common info', function () {
       // given
+      const createdAt = new Date('2020-01-01');
       const organization = domainBuilder.buildOrganization({ isManagingStudents: false });
       const campaign = domainBuilder.buildCampaign({ idPixLabel: null });
       const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({
-        createdAt: new Date('2020-01-01'),
+        createdAt,
         isCompleted: false,
       });
       const targetProfile = domainBuilder.buildTargetProfile();
@@ -129,7 +135,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', function (
       expect(csvLine[cols.PARTICIPANT_FIRST_NAME], 'participant first name').to.equal(
         campaignParticipationInfo.participantFirstName,
       );
-      expect(csvLine[cols.PARTICIPATION_CREATED_AT], 'participant created at').to.equal('2020-01-01');
+      expect(csvLine[cols.PARTICIPATION_CREATED_AT], 'participant created at').to.equal(dayjs.utc(createdAt).format());
       expect(csvLine[cols.PARTICIPATION_PROGRESSION], 'participation progression').to.equal(0);
     });
 
@@ -327,10 +333,11 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', function (
     context('when participation is shared', function () {
       it('should show informations regarding a shared participation', function () {
         // given
+        const sharedAt = new Date('2020-01-01T10:10:25Z');
         const organization = domainBuilder.buildOrganization();
         const campaign = domainBuilder.buildCampaign({ idPixLabel: null });
         const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({
-          sharedAt: new Date('2020-01-01'),
+          sharedAt,
         });
         const targetProfile = domainBuilder.buildTargetProfile();
         const learningContent = domainBuilder.buildLearningContent.withSimpleContent();
@@ -364,7 +371,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', function (
         // then
         const cols = _computeExpectedColumnsIndex(campaign, organization);
         expect(csvLine[cols.PARTICIPATION_IS_SHARED], 'is shared').to.equal('Oui');
-        expect(csvLine[cols.PARTICIPATION_SHARED_AT], 'shared at').to.equal('2020-01-01');
+        expect(csvLine[cols.PARTICIPATION_SHARED_AT], 'shared at').to.equal(dayjs.utc(sharedAt).format());
         expect(csvLine[cols.PARTICIPATION_PERCENTAGE], 'participation percentage').to.equal(1);
       });
     });


### PR DESCRIPTION
## :christmas_tree: Problème

Il n'y a pas d'heure pour permettre d'affiner le tri sur les exports.

## :gift: Proposition

Afficher l'heure aux format UTC laissant libre court à l'utilisateur pour retraiter cette donnée dans le format qui l'intéresse. étant un export CSV technique. cela ne semble pas incohérent de donner une date au format UTC ( vous savez i18n )

## :socks: Remarques

RAS

## :santa: Pour tester
Télécharger deux export ( Assessement / Collecte de profil ) . Et vérifier que le format est bien en UTC