### PR TITLE
[TECH] Revoir l'injection des dépendances du model User (PIX-15712)

### DIFF
--- a/api/src/identity-access-management/domain/models/User.js
+++ b/api/src/identity-access-management/domain/models/User.js
@@ -45,7 +45,7 @@ class User {
       hasBeenAnonymised,
       hasBeenAnonymisedBy,
     } = {},
-    dependencies = { config, localeService, languageService },
+    dependencies = { localeService, languageService },
   ) {
     if (locale) {
       locale = dependencies.localeService.getCanonicalLocale(locale);
@@ -86,7 +86,6 @@ class User {
     this.authenticationMethods = authenticationMethods;
     this.hasBeenAnonymised = hasBeenAnonymised;
     this.hasBeenAnonymisedBy = hasBeenAnonymisedBy;
-    this.dependencies = dependencies;
   }
 
   get shouldChangePassword() {
@@ -108,16 +107,13 @@ class User {
   get shouldSeeDataProtectionPolicyInformationBanner() {
     const isNotOrganizationLearner = this.cgu === true;
     const parsedDate = new Date(this.lastDataProtectionPolicySeenAt);
-    return (
-      dayjs(parsedDate).isBefore(dayjs(this.dependencies.config.dataProtectionPolicy.updateDate)) &&
-      isNotOrganizationLearner
-    );
+    return dayjs(parsedDate).isBefore(dayjs(config.dataProtectionPolicy.updateDate)) && isNotOrganizationLearner;
   }
 
-  setLocaleIfNotAlreadySet(newLocale) {
+  setLocaleIfNotAlreadySet(newLocale, dependencies = { localeService }) {
     this.hasBeenModified = false;
     if (newLocale && !this.locale) {
-      const canonicalLocale = this.dependencies.localeService.getCanonicalLocale(newLocale);
+      const canonicalLocale = dependencies.localeService.getCanonicalLocale(newLocale);
       this.locale = canonicalLocale;
       this.hasBeenModified = true;
     }

--- a/api/tests/identity-access-management/unit/domain/models/User.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/User.test.js
@@ -1,18 +1,15 @@
 import { User } from '../../../../../src/identity-access-management/domain/models/User.js';
+import { config } from '../../../../../src/shared/config.js';
 import { domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Domain | Model | User', function () {
-  let config;
   let languageService;
   let localeService;
   let dependencies;
 
   beforeEach(function () {
-    config = {
-      dataProtectionPolicy: {
-        updateDate: '2020-01-01',
-      },
-    };
+    sinon.stub(config.dataProtectionPolicy, 'updateDate').value('2020-01-01');
+
     languageService = {
       assertLanguageAvailability: sinon.stub(),
       LANGUAGES_CODE: { FRENCH: 'fr' },
@@ -20,7 +17,7 @@ describe('Unit | Identity Access Management | Domain | Model | User', function (
     localeService = {
       getCanonicalLocale: sinon.stub(),
     };
-    dependencies = { config, localeService, languageService };
+    dependencies = { localeService, languageService };
   });
 
   describe('constructor', function () {
@@ -110,7 +107,7 @@ describe('Unit | Identity Access Management | Domain | Model | User', function (
       const user = new User(undefined, dependencies);
 
       // when
-      user.setLocaleIfNotAlreadySet(null);
+      user.setLocaleIfNotAlreadySet(null, { localeService });
 
       // then
       expect(localeService.getCanonicalLocale).to.not.have.been.called;
@@ -125,7 +122,7 @@ describe('Unit | Identity Access Management | Domain | Model | User', function (
         localeService.getCanonicalLocale.returns('fr-FR');
 
         // when
-        user.setLocaleIfNotAlreadySet('fr-fr');
+        user.setLocaleIfNotAlreadySet('fr-fr', { localeService });
 
         // then
         expect(localeService.getCanonicalLocale).to.have.been.calledWithExactly('fr-fr');


### PR DESCRIPTION
## :christmas_tree: Problème

Les dépendances du modèle User sont directement mises dans les propriétés de la classe et les exposent (dont l'objet `config`). Ce qui peut potentiellement être dangereux.

## :gift: Proposition

1. Ne plus injecter la config.
2. Ne plus mettre les dependences injectées en propriété de la classe User.

