### PR TITLE
[FEATURE] Ajouter les filtres par domaines sur la page statistiques (PIX-15725)

### DIFF
--- a/orga/app/components/attestations/sixth-grade.gjs
+++ b/orga/app/components/attestations/sixth-grade.gjs
@@ -38,7 +38,7 @@ export default class AttestationsSixthGrade extends Component {
         @options={{@divisions}}
         @values={{this.selectedDivisions}}
         @onChange={{this.onSelectDivision}}
-        @placeholder={{t "pages.attestations.placeholder"}}
+        @placeholder={{t "common.filters.placeholder"}}
       >
         <:label>{{t "pages.attestations.select-label"}}</:label>
         <:default as |option|>{{option.label}}</:default>

--- a/orga/app/styles/components/statistics.scss
+++ b/orga/app/styles/components/statistics.scss
@@ -16,3 +16,10 @@
     }
   }
 }
+
+.statistics-page__filter {
+  display: flex;
+  gap: var(--pix-spacing-4x);
+  align-items: end;
+  margin-bottom: var(--pix-spacing-8x);
+}

--- a/orga/tests/integration/components/attestations/sixth-grade-test.gjs
+++ b/orga/tests/integration/components/attestations/sixth-grade-test.gjs
@@ -21,7 +21,7 @@ module('Integration | Component | Attestations | Sixth-grade', function (hooks) 
     assert.ok(screen.getByRole('heading', { name: t('pages.attestations.title') }));
     assert.ok(screen.getByText(t('pages.attestations.description')));
     assert.ok(screen.getByRole('textbox', { name: t('pages.attestations.select-label') }));
-    assert.ok(screen.getByPlaceholderText(t('pages.attestations.placeholder')));
+    assert.ok(screen.getByPlaceholderText(t('common.filters.placeholder')));
     assert.ok(screen.getByRole('button', { name: t('pages.attestations.download-attestations-button') }));
   });
 

--- a/orga/tests/integration/components/statistics/index-test.gjs
+++ b/orga/tests/integration/components/statistics/index-test.gjs
@@ -1,5 +1,6 @@
-import { render } from '@1024pix/ember-testing-library';
+import { clickByName, render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
+import { click } from '@ember/test-helpers';
 import dayjs from 'dayjs';
 import { t } from 'ember-intl/test-support';
 import Statistics from 'pix-orga/components/statistics/index';
@@ -55,6 +56,7 @@ module('Integration | Component | Statistics | Index', function (hooks) {
     const model = {
       data: [
         {
+          domaine: '2. Communication et collaboration',
           competence_code: '2.1',
           competence: 'Interagir',
           sujet: 'Gérer ses contacts',
@@ -79,6 +81,7 @@ module('Integration | Component | Statistics | Index', function (hooks) {
       const model = {
         data: [
           {
+            domaine: '2. Communication et collaboration',
             competence_code: '2.1',
             competence: 'Interagir',
             sujet: 'Gérer ses contacts',
@@ -86,6 +89,7 @@ module('Integration | Component | Statistics | Index', function (hooks) {
             niveau_par_sujet: '1.50',
           },
           {
+            domaine: '2. Communication et collaboration',
             competence_code: '2.1',
             competence: 'Interagir',
             sujet: 'Gérer ses contacts',
@@ -117,6 +121,7 @@ module('Integration | Component | Statistics | Index', function (hooks) {
       const model = {
         data: [
           {
+            domaine: '2. Communication et collaboration',
             competence_code: '2.1',
             competence: 'Interagir',
             sujet: 'Gérer ses contacts',
@@ -124,6 +129,7 @@ module('Integration | Component | Statistics | Index', function (hooks) {
             niveau_par_sujet: '1.50',
           },
           {
+            domaine: '2. Communication et collaboration',
             competence_code: '2.1',
             competence: 'Interagir',
             sujet: 'Gérer ses contacts',
@@ -154,6 +160,7 @@ module('Integration | Component | Statistics | Index', function (hooks) {
       const model = {
         data: [
           {
+            domaine: '2. Communication et collaboration',
             competence_code: '2.1',
             competence: 'Foo',
             sujet: 'Gérer ses contacts',
@@ -161,6 +168,7 @@ module('Integration | Component | Statistics | Index', function (hooks) {
             niveau_par_sujet: '1.50',
           },
           {
+            domaine: '2. Communication et collaboration',
             competence_code: '2.1',
             competence: 'Interagir',
             sujet: 'Gérer ses contacts',
@@ -185,6 +193,56 @@ module('Integration | Component | Statistics | Index', function (hooks) {
       //then
       assert.ok(screen.getByRole('cell', { name: '2.1 Interagir' }));
       assert.ok(screen.getByRole('cell', { name: t('pages.statistics.level.novice') }));
+    });
+  });
+
+  module('filter', function () {
+    test('should filtered analysis', async function (assert) {
+      //given
+      const model = {
+        data: [
+          {
+            domaine: '1. Information et données',
+            competence_code: '1.1 ',
+            competence: 'Mener une recherche et une veille d’information',
+            sujet: "Indices de qualité d'une page web",
+            niveau_par_user: '1.30',
+            niveau_par_sujet: '1.50',
+          },
+          {
+            domaine: '2. Communication et collaboration',
+            competence_code: '2.1',
+            competence: 'Interagir',
+            sujet: 'Gérer ses contacts',
+            niveau_par_user: '1.30',
+            niveau_par_sujet: '1.50',
+          },
+        ],
+      };
+
+      //when
+      const screen = await render(<template><Statistics @model={{model}} /></template>);
+
+      //then
+      assert.ok(screen.getByText(t('common.pagination.page-results', { total: 2 })));
+
+      // when
+      const select = screen.getByRole('button', { name: t('pages.statistics.select-label') });
+      await click(select);
+      const option = await screen.findByRole('option', { name: '2. Communication et collaboration' });
+      await click(option);
+
+      // then
+      assert.ok(screen.getByText(t('common.pagination.page-results', { total: 1 })));
+      assert.ok(screen.getByRole('cell', { name: '2.1 Interagir' }));
+      assert.ok(screen.getByRole('cell', { name: 'Gérer ses contacts' }));
+      assert.ok(screen.getByRole('cell', { name: t('pages.statistics.level.novice') }));
+
+      // when
+      await clickByName(t('common.filters.actions.clear'));
+
+      // then
+      assert.ok(screen.getByText(t('common.pagination.page-results', { total: 2 })));
     });
   });
 });

--- a/orga/tests/integration/components/statistics/index-test.gjs
+++ b/orga/tests/integration/components/statistics/index-test.gjs
@@ -219,12 +219,24 @@ module('Integration | Component | Statistics | Index', function (hooks) {
           },
         ],
       };
+      class Router extends Service {
+        currentRoute = {
+          queryParams: {
+            pageSize: 1,
+            pageNumber: 2,
+          },
+        };
+        replaceWith = ({ queryParams }) => {
+          this.currentRoute.queryParams.pageNumber = queryParams.pageNumber;
+        };
+      }
+      this.owner.register('service:router', Router);
 
       //when
       const screen = await render(<template><Statistics @model={{model}} /></template>);
 
       //then
-      assert.ok(screen.getByText(t('common.pagination.page-results', { total: 2 })));
+      assert.ok(screen.getByText(t('common.pagination.page-info', { start: 2, end: 2, total: 2 })));
 
       // when
       const select = screen.getByRole('button', { name: t('pages.statistics.select-label') });
@@ -242,7 +254,7 @@ module('Integration | Component | Statistics | Index', function (hooks) {
       await clickByName(t('common.filters.actions.clear'));
 
       // then
-      assert.ok(screen.getByText(t('common.pagination.page-results', { total: 2 })));
+      assert.ok(screen.getByText(t('common.pagination.page-info', { start: 1, end: 1, total: 2 })));
     });
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -228,7 +228,8 @@
         "label": "Search by last name and first name",
         "placeholder": "Last name, first name"
       },
-      "loading": "Loading..."
+      "loading": "Loading...",
+      "placeholder": "-- Select --"
     },
     "form": {
       "mandatory-all-fields": "All fields are required.",
@@ -1473,6 +1474,7 @@
         "independent": "independent",
         "novice": "novice"
       },
+      "select-label": "Domain",
       "table": {
         "caption": "This table displays the analysis of all participants' results by topic. For each line, it shows the skill, the topic, the coverage rate and the level achieved.",
         "headers": {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -421,7 +421,6 @@
       "description": "Select the class for which you wish to export attestations in PDF format.",
       "download-attestations-button": "Download",
       "no-attestations": "No attestation available",
-      "placeholder": "-- Select --",
       "select-label": "Select one or more classes"
     },
     "campaign": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -228,7 +228,8 @@
         "label": "Recherche sur le nom et prénom",
         "placeholder": "Nom, prénom"
       },
-      "loading": "Chargement..."
+      "loading": "Chargement...",
+      "placeholder": "-- Sélectionner --"
     },
     "form": {
       "mandatory-all-fields": "Tous les champs sont obligatoires.",
@@ -1479,6 +1480,7 @@
         "independent": "indépendant",
         "novice": "novice"
       },
+      "select-label": "Domaine",
       "table": {
         "caption": "Ce tableau affiche l'analyse des résultats de tous les participants par sujets. Il indique pour chaque ligne la compétence, le sujet, le taux de couverture ainsi que le niveau atteint",
         "headers": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -427,7 +427,6 @@
       "description": "Sélectionnez la classe pour laquelle vous souhaitez exporter les attestations au format PDF.",
       "download-attestations-button": "Télécharger",
       "no-attestations": "Aucune attestation disponible pour votre sélection",
-      "placeholder": "-- Sélectionner --",
       "select-label": "Sélectionnez une ou plusieurs classes"
     },
     "campaign": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -421,7 +421,6 @@
       "title": "Certificaten",
       "description": "Selecteer de klas waarvoor je de attesten in PDF-formaat wilt exporteren.",
       "download-attestations-button": "Downloaden",
-      "placeholder": "-- Selecteer --",
       "select-label": "Selecteer een of meer klassen"
     },
     "campaign-activity": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -228,6 +228,7 @@
         "placeholder": "Achternaam, voornaam"
       },
       "loading": "Laden...",
+      "placeholder": "-- Selecteer --",
       "title": "Filters"
     },
     "form": {
@@ -1462,6 +1463,7 @@
       "title": "{count, plural, =0 {Studenten} =1 {Studenten ({count})} other {studenten ({count})}}"
     },
     "statistics": {
+      "select-label": "Domein",
       "title": "Statistieken",
       "before-date": "op",
       "gauge": {


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement il n'existe aucun moyen de filtrer pour afficher seulement un domaine dans la page statistiques

## :gift: Proposition
Ajouter une barre avec possibilitée de filtrer par les domaines présent dans la page

## :socks: Remarques
Tout comme la pagination, le filtre est fait uniquement côté front
Il serait peut être judicieux dans un futur proche de mutualiser ce composant car il existe dupliquer dans plusieurs page de l'application

## :santa: Pour tester
- Se connecter a Pix Orga avec `admin-orga@example.net`
- Aller sur l'organisation `Pro Classic`
- Aller sur la page statistiques
- Vérifier la présence de la barre de filtre
- Tester les différents filtres présent
- Tester également avec la pagination pour faire des combo filtre/page