### PR TITLE
[FEATURE] Modifier le lien pour l'interprétation des résultats en anglais sur Pix Orga (PIX-15679).

### DIFF
--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -813,7 +813,7 @@
     "certifications": {
       "title": "Certification results",
       "description": "Please select the class for which you would like to export the certification results (.csv) or download certificates (.pdf).",
-      "documentation-link": "https://cloud.pix.fr/s/8pJqgNNntwDtsDY",
+      "documentation-link": "https://cloud.pix.fr/s/dqCoeH8q4fjWZjq",
       "documentation-link-label": "Interpreting the results",
       "documentation-link-notice": "Follow this link to find indications on how to interpret the results: ",
       "download-attestations-button": "Download attestations",


### PR DESCRIPTION
## :christmas_tree: Problème

Sur Pix Orga, dans l'onglet certifications, le lien de la documentation présent dans le bandeau d'information en anglais mène sur le fichier tandis qu'en français il mène vers la liste des dossiers.

## :gift: Proposition

On souhaite être iso avec le lien en français

## :santa: Pour tester

Se connecter à Pix Orga sur .ORG avec allorga@example.net
Aller dans l'onglet certification
Constater que l'on est correctement redirigé vers la documentation en anglais

<img width="1024" alt="Capture d’écran 2024-12-04 à 18 07 26" src="https://github.com/user-attachments/assets/2d1f01e9-e238-4def-bdda-b120a2e0cd7b">

