### PR TITLE
[FEATURE] Utiliser des PixIcon au lieu de FaIcon dans la page détails de Modulix (PIX-15729)

### DIFF
--- a/mon-pix/app/components/module/_details.scss
+++ b/mon-pix/app/components/module/_details.scss
@@ -85,15 +85,16 @@
   &__title {
     @extend %pix-body-xs;
 
+    display: flex;
+    align-items: center;
     color: var(--pix-neutral-800);
-    text-align: center;
     text-transform: uppercase;
   }
 }
 
 .module-details-infos-indications-category-title {
   &__icon {
-    margin-right: var(--pix-spacing-2x);
+    margin-right: var(--pix-spacing-1x);
   }
 }
 

--- a/mon-pix/app/components/module/details.gjs
+++ b/mon-pix/app/components/module/details.gjs
@@ -1,8 +1,8 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
@@ -135,17 +135,21 @@ export default class ModulixDetails extends Component {
         <div class="module-details-infos__indications">
           <div class="module-details-infos-indications__category">
             <div class="module-details-infos-indications-category__title">
-              <FaIcon @icon="stopwatch" class="module-details-infos-indications-category-title__icon" />{{t
-                "pages.modulix.details.duration"
-              }}
+              <PixIcon
+                @name="stopwatch"
+                class="module-details-infos-indications-category-title__icon"
+                @ariaHidden="true"
+              />{{t "pages.modulix.details.duration"}}
             </div>
             <p>{{t "pages.modulix.details.durationValue" htmlSafe=true duration=@module.details.duration}}</p>
           </div>
           <div class="module-details-infos-indications__category">
             <div class="module-details-infos-indications-category__title">
-              <FaIcon @icon="signal" class="module-details-infos-indications-category-title__icon" />{{t
-                "pages.modulix.details.level"
-              }}
+              <PixIcon
+                @name="barsUp"
+                class="module-details-infos-indications-category-title__icon"
+                @ariaHidden="true"
+              />{{t "pages.modulix.details.level"}}
             </div>
             <p>{{@module.details.level}}</p>
           </div>


### PR DESCRIPTION
## :christmas_tree: Problème
On utilise encore des FaIcon dans la page de détails d'un module.

## :gift: Proposition
Maintenant que les icônes concernées ont été ajoutées dans PixUI, utiliser PixIcon pour stopwatch et burnsUp

## :socks: Remarques
RAS

## :santa: Pour tester
- Aller dans Modulix
- Ouvrir la page détails d'un module
- Regarder les labels durée et niveau et voir si ça s'affiche bien avec les icônes
