### PR TITLE
[FEATURE] améliore les messages d'erreur d'import de prescrits

### DIFF
--- a/api/src/prescription/learner-management/domain/read-models/OrganizationImportDetail.js
+++ b/api/src/prescription/learner-management/domain/read-models/OrganizationImportDetail.js
@@ -1,13 +1,23 @@
+import omit from 'lodash/omit.js';
+
 export class OrganizationImportDetail {
+  #errors;
   constructor({ id, status, errors, createdAt, updatedAt, firstName, lastName }) {
     this.id = id;
     this.status = status;
-    this.errors = errors;
+    this.#errors = errors;
     this.updatedAt = updatedAt;
     this.createdAt = createdAt;
     this.createdBy = {
       firstName,
       lastName,
     };
+  }
+  get hasFixableErrors() {
+    return this.#errors?.some((error) => error.code || error.name === 'AggregateImportError') === true;
+  }
+
+  get errors() {
+    return this.#errors?.map((error) => omit(error, 'stack')) ?? null;
   }
 }

--- a/api/src/prescription/learner-management/infrastructure/serializers/jsonapi/organization-import-detail-serializer.js
+++ b/api/src/prescription/learner-management/infrastructure/serializers/jsonapi/organization-import-detail-serializer.js
@@ -4,7 +4,7 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (organizationImportDetail, meta) {
   return new Serializer('organization-import-detail', {
-    attributes: ['id', 'status', 'errors', 'createdBy', 'createdAt', 'updatedAt'],
+    attributes: ['id', 'status', 'errors', 'hasFixableErrors', 'createdBy', 'createdAt', 'updatedAt'],
     meta,
   }).serialize(organizationImportDetail);
 };

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-import-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-import-repository_test.js
@@ -161,14 +161,12 @@ describe('Integration | Repository | Organization Learner Management | Organizat
       const result = await organizationImportRepository.getLastImportDetailForOrganization(
         expectedResult.organizationId,
       );
-
       expect(result).to.eql({
         id: expectedResult.id,
         status: expectedResult.status,
         updatedAt: expectedResult.updatedAt,
         createdAt: expectedResult.createdAt,
         createdBy: { firstName: user.firstName, lastName: user.lastName },
-        errors: null,
       });
     });
   });

--- a/api/tests/prescription/learner-management/unit/domain/read-models/OrganizationImportDetail_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/read-models/OrganizationImportDetail_test.js
@@ -1,4 +1,8 @@
 import { IMPORT_STATUSES } from '../../../../../../src/prescription/learner-management/domain/constants.js';
+import {
+  AggregateImportError,
+  SiecleXmlImportError,
+} from '../../../../../../src/prescription/learner-management/domain/errors.js';
 import { OrganizationImportDetail } from '../../../../../../src/prescription/learner-management/domain/read-models/OrganizationImportDetail.js';
 import { expect } from '../../../../../test-helper.js';
 
@@ -19,7 +23,6 @@ describe('Unit | Models | OrganizationImportDetail', function () {
     const expected = {
       id: 1,
       status: IMPORT_STATUSES.VALIDATION_ERROR,
-      errors: [{ message: 'Oups' }],
       updatedAt: new Date('2023-01-02'),
       createdAt: new Date('2023-01-01'),
       createdBy: {
@@ -30,6 +33,78 @@ describe('Unit | Models | OrganizationImportDetail', function () {
 
     const organizationImportDetail = new OrganizationImportDetail(attributes);
 
-    expect(organizationImportDetail).to.eql(expected);
+    expect(organizationImportDetail).to.deep.equal(expected);
+    expect(organizationImportDetail.errors).to.deep.equal([{ message: 'Oups' }]);
+    expect(organizationImportDetail.hasFixableErrors).to.equal(false);
+  });
+
+  describe('hasFixableErrors', function () {
+    let data;
+
+    beforeEach(function () {
+      data = {
+        id: 1,
+        status: IMPORT_STATUSES.VALIDATION_ERROR,
+        updatedAt: new Date('2023-01-02'),
+        firstName: 'Tomie',
+        lastName: 'Katana',
+        organizationId: 1,
+        createdBy: 12,
+        createdAt: new Date('2023-01-01'),
+      };
+    });
+
+    it('should return true if error is AggregateImportError', function () {
+      const organizationImportDetail = new OrganizationImportDetail({
+        ...data,
+        errors: [new AggregateImportError([new Error('oups')])],
+      });
+      expect(organizationImportDetail.hasFixableErrors).to.be.true;
+    });
+
+    it('should return true if error has a code property', function () {
+      const organizationImportDetail = new OrganizationImportDetail({
+        ...data,
+        errors: [new SiecleXmlImportError('oups')],
+      });
+      expect(organizationImportDetail.hasFixableErrors).to.be.true;
+    });
+
+    it('should return false if there is no error', function () {
+      const organizationImportDetail = new OrganizationImportDetail({
+        ...data,
+        errors: undefined,
+      });
+      expect(organizationImportDetail.hasFixableErrors).to.be.false;
+    });
+
+    it("should return false if errors doesn't contains DomainError", function () {
+      const organizationImportDetail = new OrganizationImportDetail({
+        ...data,
+        errors: [new Error('oups')],
+      });
+
+      expect(organizationImportDetail.hasFixableErrors).to.be.false;
+    });
+  });
+
+  describe('errors', function () {
+    it('should remove stack trace informations from errors', function () {
+      // given
+      const updatedAt = new Date();
+      const createdAt = new Date();
+
+      const organizationImport = new OrganizationImportDetail({
+        id: 1,
+        status: IMPORT_STATUSES.VALIDATION_ERROR,
+        firstName: 'Richard',
+        lastName: 'Aldana',
+        // use object spread to mimic what is saved in db
+        errors: [{ ...new SiecleXmlImportError('plop', 'line 2'), stack: 'Error stack' }],
+        updatedAt,
+        createdAt,
+      });
+      expect(organizationImport.errors).to.deep.equal([{ code: 'plop', meta: 'line 2', name: 'SiecleXmlImportError' }]);
+    });
   });
 });

--- a/api/tests/prescription/learner-management/unit/infrastructure/serializers/jsonapi/organization-import-detail-serializer_test.js
+++ b/api/tests/prescription/learner-management/unit/infrastructure/serializers/jsonapi/organization-import-detail-serializer_test.js
@@ -31,6 +31,7 @@ describe('Unit | Serializer | JSONAPI | organization-import-detail-serializer', 
             'created-at': createdAt,
             'created-by': { firstName: 'Richard', lastName: 'Aldana' },
             errors: [{ code: 'header', name: 'CsvImportError', meta: { line: 3 } }],
+            'has-fixable-errors': true,
           },
         },
       });

--- a/orga/app/components/import/banner.gjs
+++ b/orga/app/components/import/banner.gjs
@@ -63,7 +63,7 @@ export default class ImportBanner extends Component {
   }
 
   get anchorMessage() {
-    if (this.args.organizationImportDetail?.hasError) {
+    if (this.args.organizationImportDetail?.hasFixableErrors) {
       return this.intl.t('pages.organization-participants-import.banner.anchor-error');
     }
     return null;
@@ -87,7 +87,9 @@ export default class ImportBanner extends Component {
 
   get actionMessage() {
     if (this.args.organizationImportDetail?.hasError)
-      return this.intl.t('pages.organization-participants-import.banner.error-text');
+      if (this.args.organizationImportDetail?.hasFixableErrors)
+        return this.intl.t('pages.organization-participants-import.banner.fix-error-text');
+      else return this.intl.t('pages.organization-participants-import.banner.retry-error-text');
     return this.intl.t('pages.organization-participants-import.banner.in-progress-text');
   }
 

--- a/orga/app/models/organization-import-detail.js
+++ b/orga/app/models/organization-import-detail.js
@@ -5,6 +5,7 @@ export default class OrganizationImportDetail extends Model {
   @attr('date') createdAt;
   @attr('date') updatedAt;
   @attr() errors;
+  @attr() hasFixableErrors;
   @attr() createdBy;
 
   get hasError() {

--- a/orga/tests/unit/models/organization-import-detail-test.js
+++ b/orga/tests/unit/models/organization-import-detail-test.js
@@ -50,7 +50,7 @@ module('Unit | Model | organization-import-detail', function (hooks) {
       assert.ok(model.isDone);
     });
     ['UPLOADED', 'VALIDATED', 'UPLOAD_ERROR', 'VALIDATION_ERROR', 'IMPORT_ERROR'].forEach((status) => {
-      test('it should return false', function (assert) {
+      test(`it should return false ${status}`, function (assert) {
         const store = this.owner.lookup('service:store');
         const model = store.createRecord('organization-import-detail', {
           status,
@@ -61,7 +61,7 @@ module('Unit | Model | organization-import-detail', function (hooks) {
   });
   module('inProgress', function () {
     ['UPLOADED', 'VALIDATED'].forEach((status) => {
-      test('it should return true', function (assert) {
+      test(`it should return true - ${status}`, function (assert) {
         const store = this.owner.lookup('service:store');
         const model = store.createRecord('organization-import-detail', {
           status,
@@ -70,7 +70,7 @@ module('Unit | Model | organization-import-detail', function (hooks) {
       });
     });
     ['UPLOAD_ERROR', 'VALIDATION_ERROR', 'IMPORT_ERROR', 'IMPORTED'].forEach((status) => {
-      test('it should return false', function (assert) {
+      test(`it should return false - ${status}`, function (assert) {
         const store = this.owner.lookup('service:store');
         const model = store.createRecord('organization-import-detail', {
           status,

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1184,10 +1184,11 @@
       },
       "banner": {
         "anchor-error": "See the list of errors",
-        "error-text": "Please correct them and import the file again.",
+        "fix-error-text": "Please correct them and import the file again.",
         "import-error": "The import of participants has failed.",
         "import-in-progress": "The content of the file has been validated and the participants are now being imported in PixOrga.",
         "in-progress-text": "Please refresh this page in a few moments to see the status of the file.",
+        "retry-error-text": "An error has occurred, please import later or write to Pix support",
         "upload-completed": "The file was imported on {date} by {firstName} {lastName}.",
         "upload-error": "The file could not be imported.",
         "upload-in-progress": "It may take a few minutes to import the file. Please do not leave this page.",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1190,10 +1190,11 @@
       },
       "banner": {
         "anchor-error": "Voir la liste des erreurs",
-        "error-text": "Merci de corriger les erreurs et d’importer à nouveau le fichier.",
+        "fix-error-text": "Merci de corriger les erreurs et d’importer à nouveau le fichier.",
         "import-error": "L'import des participants a échoué.",
         "import-in-progress": "Le contenu du fichier est validé, l’import des participants est en cours.",
         "in-progress-text": "Merci de rafraîchir cette page dans quelques instants pour connaitre l’état de traitement du fichier.",
+        "retry-error-text": "Une erreur est survenue, merci d'importer plus tard ou d'écrire au support Pix",
         "upload-completed": "Le fichier a été importé le {date} par {firstName} {lastName}.",
         "upload-error": "Le fichier n'a pas pu être importé.",
         "upload-in-progress": "L’import du fichier peut prendre quelques minutes. Merci de ne pas quitter cette page.",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1104,7 +1104,8 @@
       },
       "banner": {
         "anchor-error": "De lijst met foutmeldingen bekijken",
-        "error-text": "Corrigeer de fouten en importeer het bestand opnieuw.",
+        "fix-error-text": "Corrigeer de fouten en importeer het bestand opnieuw.",
+        "retry-error-text": "Er is een fout opgetreden, importeer later of schrijf naar Pix support.",
         "import-error": "De import van deelnemers is mislukt.",
         "import-in-progress": "De inhoud van het bestand is gevalideerd en de deelnemers worden geïmporteerd.",
         "in-progress-text": "Vernieuw deze pagina over enkele ogenblikken om de status van het bestand te controleren.",


### PR DESCRIPTION
## :christmas_tree: Problème
Lorsqu'une erreur d'import survient, actuellement on a : “Merci de corriger les erreurs et d’importer à nouveau le fichier”
mais il existe des cas ou il n'y pas d'erreurs à corriger

## :gift: Proposition

Dans les cas où il n'y a pas d'erreurs à corriger, on affiche “Une erreur est survenue, merci d'importer plus tard ou d'écrire au support Pix”

## :socks: Remarques
ras 

## :santa: Pour tester
- (non régression) Faire un import. de prescrit avec un fichier pourri
- voir les erreur à corriger (et le lien qui mène aux erreurs)
- Modifier les variable d'env pour mettre en pause les imports
- Faire un import de prescrit sur orga
- Se connecter sur S3 et supprimer le fichier (bucket de dev)
- Modifier les variable d'env pour relancer les imports
 (et peut être lancer start:job)
- recharger la page coté orga 
- voir le bon fichier d'erreur (sans le lien)