### PR TITLE
[BUGFIX] :recycle: remaniement de la vérification des valeurs contenues dans le fichier CSV d'import de session en masse (PIX-15719)

### DIFF
--- a/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
@@ -46,10 +46,9 @@ function deserializeForSessionsImport({
 
   const csvBillingModeKey = headers.billingMode;
   const csvPrepaymentCodeKey = headers.prepaymentCode;
-  const firstCsvLine = parsedCsvData?.[0];
 
   _verifiyFileIntegrity({
-    firstCsvLine,
+    parsedCsvData,
     hasBillingMode,
     csvBillingModeKey,
     csvPrepaymentCodeKey,
@@ -311,15 +310,14 @@ function _validateComplementaryCertificationHeaders(headers, certificationCenter
 }
 
 function _verifiyFileIntegrity({
-  firstCsvLine,
+  parsedCsvData,
   hasBillingMode,
   csvBillingModeKey,
   csvPrepaymentCodeKey,
-  expectedHeadersKeys,
   certificationCenterHabilitations,
 }) {
+  const firstCsvLine = parsedCsvData[0];
   if (
-    _isCsvEmpty(firstCsvLine) ||
     _isScoAndHasBillingModeColumnsInCsv({
       hasBillingMode,
       firstCsvLine,
@@ -335,21 +333,20 @@ function _verifiyFileIntegrity({
     _validateComplementaryCertificationHeaders(complementaryCertificationHeaders, certificationCenterHabilitations);
   }
 
-  _verifyHeaders({ expectedHeadersKeys, headers, firstCsvLine, hasBillingMode });
+  verifyColumnsValueAgainstConstraints({ csvLines: parsedCsvData, headers, hasBillingMode });
 }
 
-function _verifyHeaders({ expectedHeadersKeys, firstCsvLine, headers, hasBillingMode }) {
-  expectedHeadersKeys.forEach((key) => {
-    const matchingCsvColumnValue = firstCsvLine[headers[key]];
+function verifyColumnsValueAgainstConstraints({ csvLines, headers, hasBillingMode }) {
+  for (const key in headers) {
+    if (!hasBillingMode && (key === 'billingMode' || key === 'prepaymentCode')) {
+      break;
+    }
 
-    if (_missingCsvColumn(matchingCsvColumnValue)) {
-      if (_isBillingModeOptionalAndAssociatedColumnsMissing(key, hasBillingMode)) {
-        return;
-      }
-
+    if (csvLines.map((line) => line[headers[key]]).some((e) => e === undefined)) {
+      // TODO change error code here and in certif front
       throw new FileValidationError('CSV_HEADERS_NOT_VALID');
     }
-  });
+  }
 }
 
 function _isScoAndHasBillingModeColumnsInCsv({
@@ -359,14 +356,6 @@ function _isScoAndHasBillingModeColumnsInCsv({
   csvPrepaymentCodeKey,
 }) {
   return !hasBillingMode && (csvBillingModeKey in firstCsvLine || csvPrepaymentCodeKey in firstCsvLine);
-}
-
-function _missingCsvColumn(matchingCsvColumnValue) {
-  return matchingCsvColumnValue === undefined;
-}
-
-function _isBillingModeOptionalAndAssociatedColumnsMissing(key, hasBillingMode) {
-  return (key === 'billingMode' || key === 'prepaymentCode') && !hasBillingMode;
 }
 
 function _hasSessionInformation({ address, room, date, time, examiner }) {
@@ -456,10 +445,6 @@ function _generateUniqueKey({ address, room, date, time }) {
   return address + room + date + time;
 }
 
-function _isCsvEmpty(firstCsvLine) {
-  return !firstCsvLine;
-}
-
 function serializeLine(lineArray) {
   return lineArray.map(_csvSerializeValue).join(';') + '\n';
 }
@@ -470,4 +455,5 @@ export {
   deserializeForSessionsImport,
   parseForCampaignsImport,
   serializeLine,
+  verifyColumnsValueAgainstConstraints,
 };

--- a/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
@@ -343,8 +343,7 @@ function verifyColumnsValueAgainstConstraints({ csvLines, headers, hasBillingMod
     }
 
     if (csvLines.map((line) => line[headers[key]]).some((e) => e === undefined)) {
-      // TODO change error code here and in certif front
-      throw new FileValidationError('CSV_HEADERS_NOT_VALID');
+      throw new FileValidationError('CSV_DATA_REQUIRED');
     }
   }
 }

--- a/api/tests/shared/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -96,7 +96,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
         // then
         expect(error).to.be.instanceOf(FileValidationError);
-        expect(error.code).to.equal('CSV_HEADERS_NOT_VALID');
+        expect(error.code).to.equal('CSV_DATA_REQUIRED');
       });
 
       context('when billing mode header is missing', function () {
@@ -134,7 +134,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
             // then
             expect(error).to.be.instanceOf(FileValidationError);
-            expect(error.code).to.equal('CSV_HEADERS_NOT_VALID');
+            expect(error.code).to.equal('CSV_DATA_REQUIRED');
           });
         });
 
@@ -1422,7 +1422,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
         });
 
         expect(error).to.be.instanceOf(FileValidationError);
-        expect(error.code).to.equal('CSV_HEADERS_NOT_VALID');
+        expect(error.code).to.equal('CSV_DATA_REQUIRED');
       });
     });
   });
@@ -1732,7 +1732,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
       const error = await catchErr(csvSerializer.verifyColumnsValueAgainstConstraints)({ csvLines, headers });
 
       expect(error).to.be.instanceOf(FileValidationError);
-      expect(error.code).to.equal('CSV_HEADERS_NOT_VALID');
+      expect(error.code).to.equal('CSV_DATA_REQUIRED');
     });
 
     context('no billing mode', function () {


### PR DESCRIPTION
## :christmas_tree: Problème

Nous nous sommes retrouvés avec une valeur `undefined` à un endroit inattendu lors d'un import de session en masse (voir https://1024pix.atlassian.net/wiki/spaces/DC/blog/2024/12/13/4806377475/Erreur+500+sur+l+import+en+masse+de+session).

## :gift: Proposition

Vérifier l'ensemble des valeurs du fichier pour lever une erreur s'il y en a une en `undefined`.
Ça ne devrait pas arriver.


## :socks: Remarques

1. Il y a des exceptions autour du mode de paiement.
2. Nous n'avons pas trouvé comment cette valeur a pu être transmise par la librairie [PapaCsvParser](https://www.papaparse.com/) que nous utilisons...

## :santa: Pour tester

Impossible de reproduire l'erreur. Cependant, il serait bien de tester que l'import de session en masse continue de fonctionner.

