### PR TITLE
[TECH] Migrer l'envoi de résultats de participations "completed" à Pôle Emploi vers le contexte Prescription (Pix-15340)

### DIFF
--- a/api/src/prescription/campaign-participation/application/jobs/participation-completed-job-controller.js
+++ b/api/src/prescription/campaign-participation/application/jobs/participation-completed-job-controller.js
@@ -1,6 +1,6 @@
-import { usecases } from '../../../../../lib/domain/usecases/index.js';
 import { JobController } from '../../../../shared/application/jobs/job-controller.js';
 import { ParticipationCompletedJob } from '../../domain/models/ParticipationCompletedJob.js';
+import { usecases } from '../../domain/usecases/index.js';
 export class ParticipationCompletedJobController extends JobController {
   constructor() {
     super(ParticipationCompletedJob.name);

--- a/api/src/prescription/campaign-participation/domain/usecases/send-completed-participation-results-to-pole-emploi.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/send-completed-participation-results-to-pole-emploi.js
@@ -1,8 +1,8 @@
-import { PoleEmploiSending } from '../../../src/prescription/campaign-participation/domain/models/PoleEmploiSending.js';
-import { PoleEmploiPayload } from '../../../src/prescription/campaign-participation/infrastructure/externals/pole-emploi/PoleEmploiPayload.js';
-import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
-import * as httpErrorsHelper from '../../infrastructure/http/errors-helper.js';
-import { httpAgent } from '../../infrastructure/http/http-agent.js';
+import * as httpErrorsHelper from '../../../../../lib/infrastructure/http/errors-helper.js';
+import { httpAgent } from '../../../../../lib/infrastructure/http/http-agent.js';
+import { logger } from '../../../../shared/infrastructure/utils/logger.js';
+import { PoleEmploiPayload } from '../../infrastructure/externals/pole-emploi/PoleEmploiPayload.js';
+import { PoleEmploiSending } from '../models/PoleEmploiSending.js';
 
 const sendCompletedParticipationResultsToPoleEmploi = async ({
   campaignParticipationId,

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/send-completed-participation-results-to-pole-emploi_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/send-completed-participation-results-to-pole-emploi_test.js
@@ -1,5 +1,5 @@
-import { usecases } from '../../../../lib/domain/usecases/index.js';
-import * as poleEmploiNotifier from '../../../../src/prescription/campaign-participation/infrastructure/externals/pole-emploi/pole-emploi-notifier.js';
+import { usecases } from '../../../../../../lib/domain/usecases/index.js';
+import * as poleEmploiNotifier from '../../../../../../src/prescription/campaign-participation/infrastructure/externals/pole-emploi/pole-emploi-notifier.js';
 import {
   databaseBuilder,
   expect,
@@ -7,7 +7,7 @@ import {
   learningContentBuilder,
   mockLearningContent,
   sinon,
-} from '../../../test-helper.js';
+} from '../../../../../test-helper.js';
 
 describe('Integration | Domain | UseCases | send-completed-participation-results-to-pole-emploi', function () {
   let campaignParticipationId, userId, responseCode;

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/send-completed-participation-results-to-pole-emploi_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/send-completed-participation-results-to-pole-emploi_test.js
@@ -1,4 +1,4 @@
-import { usecases } from '../../../../../../lib/domain/usecases/index.js';
+import { usecases } from '../../../../../../src/prescription/campaign-participation/domain/usecases/index.js';
 import * as poleEmploiNotifier from '../../../../../../src/prescription/campaign-participation/infrastructure/externals/pole-emploi/pole-emploi-notifier.js';
 import {
   databaseBuilder,

--- a/api/tests/prescription/campaign-participation/unit/application/jobs/participation-completed-job-controller_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/jobs/participation-completed-job-controller_test.js
@@ -1,5 +1,5 @@
-import { usecases } from '../../../../../../lib/domain/usecases/index.js';
 import { ParticipationCompletedJobController } from '../../../../../../src/prescription/campaign-participation/application/jobs/participation-completed-job-controller.js';
+import { usecases } from '../../../../../../src/prescription/campaign-participation/domain/usecases/index.js';
 import { expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | Prescription | Application | Jobs | participationCompletedJobController', function () {


### PR DESCRIPTION
## :christmas_tree: Problème

On doit déplacer le usecase send-completed-results-to-pole-emploi vers le contexte Prescription. 

## :gift: Proposition

On déplace les fichiers du usecase ainsi que ceux des tests et on modifie les imports.

## :socks: Remarques

- Cette MR est à merger dans shared-results-to-PE avant d'être mergée sur dev : on peut donc se dispenser de la func review 
