### PR TITLE
[FEATURE] Ajouter la date d'extraction à la page statistiques sur Pix Orga (PIX-15458).

### DIFF
--- a/orga/app/components/statistics/index.gjs
+++ b/orga/app/components/statistics/index.gjs
@@ -1,6 +1,7 @@
 import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import dayjs from 'dayjs';
 import { t } from 'ember-intl';
 
 import Header from '../table/header';
@@ -39,9 +40,15 @@ export default class Statistics extends Component {
     return this.analysisByTubes.slice(start, end);
   }
 
+  get extractedDate() {
+    return dayjs(this.analysisByTubes[0]?.extraction_date).format('D MMM YYYY');
+  }
+
   <template>
     <div class="statistics-page__header">
       <h1 class="page-title">{{t "pages.statistics.title"}}</h1>
+      <span class="statistics-page-header__date">{{t "pages.statistics.before-date"}}
+        {{this.extractedDate}}</span>
     </div>
 
     <section class="statistics-page__section">

--- a/orga/app/styles/components/statistics.scss
+++ b/orga/app/styles/components/statistics.scss
@@ -5,6 +5,10 @@
   margin-bottom: var(--pix-spacing-8x);
 }
 
+.statistics-page-header__date {
+  @extend %pix-body-xs;
+}
+
 .statistics-page__section {
   tbody > tr {
     &:nth-child(odd) {

--- a/orga/tests/integration/components/statistics/index-test.gjs
+++ b/orga/tests/integration/components/statistics/index-test.gjs
@@ -1,5 +1,6 @@
 import { render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
+import dayjs from 'dayjs';
 import { t } from 'ember-intl/test-support';
 import Statistics from 'pix-orga/components/statistics/index';
 import { module, test } from 'qunit';
@@ -9,10 +10,20 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | Statistics | Index', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it should display title', async function (assert) {
+  test('it should display title and extracted date', async function (assert) {
     //given
+    const extractionDate = '2024-12-08';
     const model = {
-      data: [],
+      data: [
+        {
+          competence_code: '2.1',
+          competence: 'Interagir',
+          sujet: 'Gérer ses contacts',
+          niveau_par_user: '1.30',
+          niveau_par_sujet: '1.50',
+          extraction_date: extractionDate,
+        },
+      ],
     };
 
     //when
@@ -20,6 +31,7 @@ module('Integration | Component | Statistics | Index', function (hooks) {
 
     //then
     assert.ok(screen.getByRole('heading', { name: t('pages.statistics.title'), level: 1 }));
+    assert.ok(screen.getByText(dayjs(extractionDate).format('D MMM YYYY'), { exact: false }));
   });
 
   test('it should display table headers', async function (assert) {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1463,6 +1463,7 @@
     },
     "statistics": {
       "title": "Statistics",
+      "before-date": "on",
       "gauge": {
         "label": "On the topic, your participants achieved a level of {userLevel} out of a maximum reachable level of {tubeLevel}."
       },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1469,6 +1469,7 @@
     },
     "statistics": {
       "title": "Statistiques",
+      "before-date": "au",
       "gauge": {
         "label": "Sur le sujet vos participants ont obtenu un niveau de {userLevel} sur un niveau maximum atteignable de {tubeLevel}."
       },

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1463,6 +1463,7 @@
     },
     "statistics": {
       "title": "Statistieken",
+      "before-date": "op",
       "gauge": {
         "label": "Je deelnemers behaalden een {userLevel} op een maximaal haalbaar niveau van {tubeLevel}."
       },


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, nous ne savons pas de quand datent les données. C'est triste, car cela peut générer du support inutile.

## :gift: Proposition
Ajouter la date d'extraction, des bisous.

## :socks: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :santa: Pour tester

- Se connecter en tant qu'Admin sur Pix Orga
- Aller sur l'orga PRO Classic
- Aller sur la page statistiques
- Constater la date d'extraction dans le titre de la page 