### PR TITLE
[BUGFIX] Baisser la tailles des colonnes du tableau(PIX-14545)

### DIFF
--- a/orga/app/components/mission/activity-table.gjs
+++ b/orga/app/components/mission/activity-table.gjs
@@ -15,7 +15,7 @@ function statusColor(status) {
 <template>
   {{#if @missionLearners}}
     <div class="panel">
-      <table class="table content-text content-text--small participation-list__table">
+      <table class="table content-text content-text--small participation-list__table mission-table">
         <caption class="screen-reader-only">{{t
             "pages.missions.mission.table.activities.caption"
             missionName=@mission.name

--- a/orga/app/components/mission/result-table.gjs
+++ b/orga/app/components/mission/result-table.gjs
@@ -28,7 +28,7 @@ function getMissionResultColor(result) {
 <template>
   {{#if @missionLearners}}
     <div class="panel">
-      <table class="table content-text content-text--small participation-list__table">
+      <table class="table content-text content-text--small participation-list__table mission-table">
         <caption class="screen-reader-only">{{t
             "pages.missions.mission.table.result.caption"
             missionName=@mission.name

--- a/orga/app/styles/components/organization-learner/activity/participation-list.scss
+++ b/orga/app/styles/components/organization-learner/activity/participation-list.scss
@@ -5,6 +5,12 @@
       font-weight: 700;
     }
 
+    &.mission-table {
+      th:last-child {
+        width: 250px;
+      }
+    }
+
     td {
       color: var(--pix-neutral-900);
     }


### PR DESCRIPTION
## :christmas_tree: Problème

![image](https://github.com/user-attachments/assets/f4a381b8-fe76-4279-b55c-560d672d7892)

## :gift: Proposition
![image](https://github.com/user-attachments/assets/5a4ea80f-5c8b-42c9-9558-7f87d7574f74)

## :socks: Remarques

## :santa: Pour tester
Aller sur la page /activities ou /results d'une mission et réduire la taille de sa fenêtre. Il faut observer que les label ne sortent pas de la colonne.