### PR TITLE
[FEATURE] Mettre à jour le wording du bandeau Pix Certif pour les centres SCO sur Pix Certif (PIX-15652). 

### DIFF
--- a/certif/app/components/layout/banners.gjs
+++ b/certif/app/components/layout/banners.gjs
@@ -5,8 +5,6 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
-const ACTION_URL_FOR_INFORMATION_BANNER = 'https://cloud.pix.fr/s/GqwW6dFDDrHezfS';
-
 export default class Banners extends Component {
   @tracked isBannerVisible = true;
   @service session;
@@ -38,13 +36,8 @@ export default class Banners extends Component {
 
   <template>
     {{#if this.shouldDisplaySCOInformationBanner}}
-      <PixBannerAlert
-        @actionLabel={{t 'pages.sco.banner.url-label'}}
-        @actionUrl={{ACTION_URL_FOR_INFORMATION_BANNER}}
-        @canCloseBanner='true'
-        class='banners'
-      >
-        {{t 'pages.sco.banner.information'}}
+      <PixBannerAlert @canCloseBanner='true' class='banners'>
+        {{t 'pages.sco.banner.information' htmlSafe=true}}
       </PixBannerAlert>
     {{/if}}
 

--- a/certif/tests/acceptance/authenticated-test.js
+++ b/certif/tests/acceptance/authenticated-test.js
@@ -16,7 +16,7 @@ module('Acceptance | authenticated', function (hooks) {
   setupMirage(hooks);
   setupIntl(hooks, 'fr');
 
-  module('Sibebar', function () {
+  module('Sidebar', function () {
     module('When user clicks the sidebar logo', function () {
       test('it should redirect to the sessions list page', async function (assert) {
         // given
@@ -276,11 +276,12 @@ module('Acceptance | authenticated', function (hooks) {
           assert
             .dom(
               screen.getByText(
-                'La certification Pix se déroulera du 7 novembre 2024 au 7 mars 2025 pour les lycées et du 17 mars au 13 juin 2025 pour les collèges. Pensez à consulter la',
+                (content) =>
+                  content.startsWith('La Certification Pix se déroulera du 7 novembre 2024 au 7 mars 2025 ') &&
+                  content.endsWith('Collèges : du 17 mars au 13 juin 2025.'),
               ),
             )
             .exists();
-          assert.dom(screen.getByRole('link', { name: 'documentation pour voir les nouveautés.' })).exists();
         });
       });
 
@@ -294,10 +295,15 @@ module('Acceptance | authenticated', function (hooks) {
           const screen = await visit('/sessions');
 
           // then
-          const certificationBannerMessage = screen.queryByText(
-            'La certification Pix se déroulera du 7 novembre 2024 au 7 mars 2025 pour les lycées et du 17 mars au 13 juin 2025 pour les collèges. Pensez à consulter la',
-          );
-          assert.dom(certificationBannerMessage).doesNotExist();
+          assert
+            .dom(
+              screen.queryByText(
+                (content) =>
+                  content.startsWith('La Certification Pix se déroulera du 7 novembre 2024 au 7 mars 2025 ') &&
+                  content.endsWith('Collèges : du 17 mars au 13 juin 2025.'),
+              ),
+            )
+            .doesNotExist();
         });
       });
     });

--- a/certif/tests/acceptance/session-list-test.js
+++ b/certif/tests/acceptance/session-list-test.js
@@ -4,11 +4,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-import {
-  authenticateSession,
-  createAllowedCertificationCenterAccess,
-  createCertificationPointOfContactWithCustomCenters,
-} from '../helpers/test-init';
+import { authenticateSession } from '../helpers/test-init';
 
 module('Acceptance | Session List', function (hooks) {
   setupApplicationTest(hooks);
@@ -137,58 +133,6 @@ module('Acceptance | Session List', function (hooks) {
 
         // then
         assert.strictEqual(currentURL(), '/sessions/123');
-      });
-
-      test('it should update message display when selected certif center changes', async function (assert) {
-        // given
-        const centerManagingStudents = createAllowedCertificationCenterAccess({
-          certificationCenterName: 'Centre SCO isM',
-          certificationCenterType: 'SCO',
-          isRelatedOrganizationManagingStudents: true,
-        });
-        const centerNotManagingStudents = createAllowedCertificationCenterAccess({
-          certificationCenterName: 'Centre SCO isNotM',
-          certificationCenterType: 'SCO',
-          isRelatedOrganizationManagingStudents: false,
-        });
-        certificationPointOfContact = createCertificationPointOfContactWithCustomCenters({
-          pixCertifTermsOfServiceAccepted: true,
-          allowedCertificationCenterAccesses: [centerNotManagingStudents, centerManagingStudents],
-        });
-        await authenticateSession(certificationPointOfContact.id);
-        server.create('session-summary', { certificationCenterId: centerManagingStudents.id });
-
-        // when
-        const screen = await visit('/sessions');
-
-        assert
-          .dom(
-            screen.queryByText(
-              'La certification Pix se déroulera du 7 novembre 2024 au 7 mars 2025 pour les lycées et du 17 mars au 13 juin 2025 pour les collèges. Pensez à consulter la',
-            ),
-          )
-          .doesNotExist();
-
-        await click(
-          screen.getByRole('button', {
-            name: 'Changer de centre',
-          }),
-        );
-        await screen.findByRole('listbox');
-        await click(
-          screen.getByRole('option', {
-            name: 'Centre SCO isM (ABC123)',
-          }),
-        );
-
-        // then
-        assert
-          .dom(
-            screen.getByText(
-              'La certification Pix se déroulera du 7 novembre 2024 au 7 mars 2025 pour les lycées et du 17 mars au 13 juin 2025 pour les collèges. Pensez à consulter la',
-            ),
-          )
-          .exists();
       });
 
       test('it should delete the session of clicked session-summary', async function (assert) {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -288,8 +288,7 @@
     },
     "sco": {
       "banner": {
-        "information": "La certification Pix se déroulera du 7 novembre 2024 au 7 mars 2025 pour les lycées et du 17 mars au 13 juin 2025 pour les collèges. Pensez à consulter la",
-        "url-label": "documentation pour voir les nouveautés."
+        "information": "The Pix Certification will take place between 7 November 2024 until 7 March 2025 for students in Terminale. '<strong>'You must not schedule any certification session after 7 March.'</strong>' Finalisation until 31 March. '<br>'Colleges: from 17 March to 13 June 2025."
       },
       "enrol-candidates-in-session": {
         "title": "Inscrire des candidats",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -288,8 +288,7 @@
     },
     "sco": {
       "banner": {
-        "information": "La certification Pix se déroulera du 7 novembre 2024 au 7 mars 2025 pour les lycées et du 17 mars au 13 juin 2025 pour les collèges. Pensez à consulter la",
-        "url-label": "documentation pour voir les nouveautés."
+        "information": "La Certification Pix se déroulera du 7 novembre 2024 au 7 mars 2025 pour les élèves de Terminale. '<strong>'Aucune session de certification ne devra être programmée au-delà du 7 mars.'</strong>' Finalisation jusqu’au 31 mars. '<br>'Collèges : du 17 mars au 13 juin 2025."
       },
       "enrol-candidates-in-session": {
         "title": "Inscrire des candidats",


### PR DESCRIPTION
## :christmas_tree: Problème

Les centres de certif SCO ont un calendrier spécifiques à respecter pour l’organisation de leur sessions de certification Pix, élaborer en accord avec les ministères concernés. Un bandeau d’information leur est donc mis à disposition dans Pix Certif afin de les informer de ces dates de certif.

Avec la remontée des résultats de certif Pix dans Parcoursup pour les élèves de Terminales, il y a une date limite pour l’organisation, puis la finalisation des sessions afin de laisser le temps suffisant pour traiter les sessions et les publier. Le message actuel ne prend pas en compte cette contrainte.


## :gift: Proposition

Dans Pix Certif pour les centres de certif de type SCO, mettre à jour le texte du bandeau.

## :socks: Remarques

Suppression d'un test doublon

## :santa: Pour tester

Se connecter avec certif-sco-v3 sur Pix Certif
<img width="1728" alt="Capture d’écran 2024-12-13 à 16 15 41" src="https://github.com/user-attachments/assets/fb476add-2e90-4f37-9767-c7783bccce09" />

