### PR TITLE
[BUGFIX] Corriger la mention "Terminé" sur la dernière flashcard (PIX-15735)

### DIFF
--- a/mon-pix/app/components/module/element/flashcards/_flashcards-card.scss
+++ b/mon-pix/app/components/module/element/flashcards/_flashcards-card.scss
@@ -111,7 +111,6 @@
     @extend %pix-title-xs;
 
     padding: var(--pix-spacing-1x) var(--pix-spacing-4x);
-    color: var(--pix-neutral-0);
   }
 
   &__title {


### PR DESCRIPTION
## :christmas_tree: Problème

Lors de l’affichage de la dernière flashcard, la mention “terminé” apparaît sur fond blanc 😅 

Après investigation, c'est causé par l'ajout d'une propriété css `color: var(--pix-neutral-0)`

## :gift: Proposition

Enlever cette ligne.

## :socks: Remarques
Régression due à une montée en version pix-ui. 
A voir pourquoi cette ligne a été ajouté précédemment 🤔 


## :santa: Pour tester

- Aller sur le [didacticiel modulix](https://app-pr10824.review.pix.fr/modules/didacticiel-modulix/passage)
- Faire l'exercice des flashcards jusqu'à la fin 🐱 
- Vérifier que la mention Terminé n'apparaît plus sur fond blanc.
