### PR TITLE
[FEATURE] Rendre la page attestations visible seulement aux admins de l'organisation (PIX-15611)

### DIFF
--- a/api/db/seeds/data/team-prescription/build-quests.js
+++ b/api/db/seeds/data/team-prescription/build-quests.js
@@ -1,9 +1,14 @@
 import { ATTESTATIONS } from '../../../../src/profile/domain/constants.js';
 import { REWARD_TYPES } from '../../../../src/quest/domain/constants.js';
 import { COMPARISON } from '../../../../src/quest/domain/models/Quest.js';
-import { Assessment, CampaignParticipationStatuses } from '../../../../src/shared/domain/models/index.js';
+import { Assessment, CampaignParticipationStatuses, Membership } from '../../../../src/shared/domain/models/index.js';
 import { temporaryStorage } from '../../../../src/shared/infrastructure/temporary-storage/index.js';
-import { AEFE_TAG, FEATURE_ATTESTATIONS_MANAGEMENT_ID, USER_ID_ADMIN_ORGANIZATION } from '../common/constants.js';
+import {
+  AEFE_TAG,
+  FEATURE_ATTESTATIONS_MANAGEMENT_ID,
+  USER_ID_ADMIN_ORGANIZATION,
+  USER_ID_MEMBER_ORGANIZATION,
+} from '../common/constants.js';
 import { TARGET_PROFILE_BADGES_STAGES_ID } from './constants.js';
 
 const profileRewardTemporaryStorage = temporaryStorage.withPrefix('profile-rewards:');
@@ -35,7 +40,7 @@ const USERS = [
     email: 'attestation-blank@example.net',
   },
 ];
-const ORGANIZATION = { name: 'attestation', type: 'SCO', isManagingStudents: true };
+const ORGANIZATION = { name: 'Attestation', type: 'SCO', isManagingStudents: true };
 const CAMPAIGN = [
   { code: 'ATTEST001', multipleSendings: true, name: 'campagne attestation 1' },
   { code: 'ATTEST002', multipleSendings: true, name: 'campagne attestation 2' },
@@ -276,8 +281,15 @@ export const buildQuests = async (databaseBuilder) => {
   // Add admin-orga@example.net as Admin in organization
   databaseBuilder.factory.buildMembership({
     organizationId: organization.id,
-    organizationRole: 'ADMIN',
+    organizationRole: Membership.roles.ADMIN,
     userId: USER_ID_ADMIN_ORGANIZATION,
+  });
+
+  // Add member-orga@example.net as Member in organization
+  databaseBuilder.factory.buildMembership({
+    organizationId: organization.id,
+    organizationRole: Membership.roles.MEMBER,
+    userId: USER_ID_MEMBER_ORGANIZATION,
   });
 
   // Associate attestation feature to organization

--- a/api/src/prescription/organization-learner/application/organization-learners-route.js
+++ b/api/src/prescription/organization-learner/application/organization-learners-route.js
@@ -42,8 +42,8 @@ const register = async function (server) {
       config: {
         pre: [
           {
-            method: securityPreHandlers.checkUserBelongsToOrganization,
-            assign: 'checkUserBelongsToOrganization',
+            method: securityPreHandlers.checkUserIsAdminInOrganization,
+            assign: 'checkUserIsAdminInOrganization',
           },
           {
             method: securityPreHandlers.makeCheckOrganizationHasFeature(

--- a/api/tests/prescription/organization-learner/acceptance/application/organization-learner-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/application/organization-learner-route_test.js
@@ -31,7 +31,7 @@ describe('Prescription | Organization Learner | Acceptance | Application | Organ
       databaseBuilder.factory.buildMembership({
         userId,
         organizationId,
-        organizationRole: Membership.roles.MEMBER,
+        organizationRole: Membership.roles.ADMIN,
       });
       const attestation = databaseBuilder.factory.buildAttestation({
         templateName: 'sixth-grade-attestation-template',

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -29,7 +29,7 @@ export default class CurrentUserService extends Service {
   }
 
   get canAccessAttestationsPage() {
-    return this.prescriber.attestationsManagement;
+    return this.prescriber.attestationsManagement && this.isAdminInOrganization;
   }
 
   get canAccessPlacesPage() {

--- a/orga/tests/unit/services/current-user-test.js
+++ b/orga/tests/unit/services/current-user-test.js
@@ -303,7 +303,8 @@ module('Unit | Service | current-user', function (hooks) {
     });
 
     module('#canAccessAttestationsPage', function () {
-      test('should return true if organization has feature activated', function (assert) {
+      test('should return true if user is admin and organization has feature activated', function (assert) {
+        currentUserService.isAdminInOrganization = true;
         currentUserService.prescriber = {
           attestationsManagement: true,
         };
@@ -311,9 +312,19 @@ module('Unit | Service | current-user', function (hooks) {
         assert.true(currentUserService.canAccessAttestationsPage);
       });
 
-      test('should return false if organization does not have feature activated', function (assert) {
+      test('should return false if user is admin and organization does not have feature activated', function (assert) {
+        currentUserService.isAdminInOrganization = true;
         currentUserService.prescriber = {
           attestationsManagement: false,
+        };
+
+        assert.false(currentUserService.canAccessAttestationsPage);
+      });
+
+      test('should return false if user is not admin and organization has feature activated', function (assert) {
+        currentUserService.isAdminInOrganization = false;
+        currentUserService.prescriber = {
+          attestationsManagement: true,
         };
 
         assert.false(currentUserService.canAccessAttestationsPage);


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement la nouvelle page attestations dans Pix Orga est visible pour les membres & admins des organisations ayant la feature d'activée
Or, on ne voudrait afficher cette page seulement aux admins des organisations ayant la feature

## :gift: Proposition
Ajouter une condition pour vérifier que l'utilisateur est admin de l'organisation (en plus d'avoir la feature activée)

## :socks: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :santa: Pour tester
- Se connecter a Pix Orga avec `admin-orga@example.net`
- Aller sur l'organisation `attestations`
- Vérifier l'affichage de la page `attestations` ainsi que son accès
- Se connecter a Pix Orga avec `member-orga@example.net`
- Aller sur l'organisation `attestations`
- Vérifier que la page `attestations` n'apparait plus dans la nav bar
- Aller sur `/attestations`
- Vérifier qu'on n'accède pas a la page et qu'on est bien redirigé