### PR TITLE
[FEATURE] Rendre asynchrone l'import à format sur PixOrga (Pix-15437)

### DIFF
--- a/api/src/prescription/learner-management/application/jobs/import-common-organization-learners-job-controller.js
+++ b/api/src/prescription/learner-management/application/jobs/import-common-organization-learners-job-controller.js
@@ -1,0 +1,34 @@
+import { JobController } from '../../../../shared/application/jobs/job-controller.js';
+import { config } from '../../../../shared/config.js';
+import { DomainError } from '../../../../shared/domain/errors.js';
+import { logger as l } from '../../../../shared/infrastructure/utils/logger.js';
+import { ImportCommonOrganizationLearnersJob } from '../../domain/models/ImportCommonOrganizationLearnersJob.js';
+import { usecases } from '../../domain/usecases/index.js';
+
+class ImportCommonOrganizationLearnersJobController extends JobController {
+  #logger;
+
+  constructor({ logger = l } = {}) {
+    super(ImportCommonOrganizationLearnersJob.name);
+    this.#logger = logger;
+  }
+
+  get isJobEnabled() {
+    return config.pgBoss.importFileJobEnabled;
+  }
+
+  async handle({ data }) {
+    const { organizationImportId } = data;
+
+    try {
+      return await usecases.saveOrganizationLearnersFile({ organizationImportId });
+    } catch (err) {
+      if (!(err instanceof DomainError)) {
+        throw err;
+      }
+      this.#logger.error(err);
+    }
+  }
+}
+
+export { ImportCommonOrganizationLearnersJobController };

--- a/api/src/prescription/learner-management/application/jobs/validate-common-organization-learners-import-file-job-controller.js
+++ b/api/src/prescription/learner-management/application/jobs/validate-common-organization-learners-import-file-job-controller.js
@@ -1,0 +1,33 @@
+import { JobController } from '../../../../shared/application/jobs/job-controller.js';
+import { config } from '../../../../shared/config.js';
+import { DomainError } from '../../../../shared/domain/errors.js';
+import { logger as l } from '../../../../shared/infrastructure/utils/logger.js';
+import { ValidateCommonOrganizationImportFileJob } from '../../domain/models/ValidateCommonOrganizationImportFileJob.js';
+import { usecases } from '../../domain/usecases/index.js';
+
+class ValidateCommonOrganizationLearnersImportFileJobController extends JobController {
+  #logger;
+
+  constructor({ logger = l } = {}) {
+    super(ValidateCommonOrganizationImportFileJob.name);
+    this.#logger = logger;
+  }
+
+  get isJobEnabled() {
+    return config.pgBoss.validationFileJobEnabled;
+  }
+
+  async handle({ data }) {
+    const { organizationImportId } = data;
+    try {
+      await usecases.validateOrganizationLearnersFile({ organizationImportId });
+    } catch (err) {
+      if (!(err instanceof DomainError)) {
+        throw err;
+      }
+      this.#logger.warn(err);
+    }
+  }
+}
+
+export { ValidateCommonOrganizationLearnersImportFileJobController };

--- a/api/src/prescription/learner-management/application/organization-learners-controller.js
+++ b/api/src/prescription/learner-management/application/organization-learners-controller.js
@@ -1,5 +1,4 @@
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
-import { ApplicationTransaction } from '../../shared/infrastructure/ApplicationTransaction.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as scoOrganizationLearnerSerializer from '../infrastructure/serializers/jsonapi/sco-organization-learner-serializer.js';
 
@@ -22,12 +21,7 @@ const importOrganizationLearnerFromFeature = async function (request, h) {
   const organizationId = request.params.organizationId;
   const userId = request.auth.credentials.userId;
 
-  await ApplicationTransaction.execute(async () => {
-    await usecases.sendOrganizationLearnersFile({ payload: request.payload, organizationId, userId });
-  });
-  await ApplicationTransaction.execute(async () => {
-    await usecases.validateOrganizationLearnersFile({ organizationId });
-  });
+  await usecases.sendOrganizationLearnersFile({ payload: request.payload, organizationId, userId });
 
   return h.response().code(204);
 };

--- a/api/src/prescription/learner-management/application/organization-learners-controller.js
+++ b/api/src/prescription/learner-management/application/organization-learners-controller.js
@@ -28,9 +28,6 @@ const importOrganizationLearnerFromFeature = async function (request, h) {
   await ApplicationTransaction.execute(async () => {
     await usecases.validateOrganizationLearnersFile({ organizationId });
   });
-  await ApplicationTransaction.execute(async () => {
-    await usecases.saveOrganizationLearnersFile({ organizationId });
-  });
 
   return h.response().code(204);
 };

--- a/api/src/prescription/learner-management/domain/models/ImportCommonOrganizationLearnersJob.js
+++ b/api/src/prescription/learner-management/domain/models/ImportCommonOrganizationLearnersJob.js
@@ -1,0 +1,5 @@
+export class ImportCommonOrganizationLearnersJob {
+  constructor({ organizationImportId }) {
+    this.organizationImportId = organizationImportId;
+  }
+}

--- a/api/src/prescription/learner-management/domain/models/ValidateCommonOrganizationImportFileJob.js
+++ b/api/src/prescription/learner-management/domain/models/ValidateCommonOrganizationImportFileJob.js
@@ -1,0 +1,5 @@
+export class ValidateCommonOrganizationImportFileJob {
+  constructor({ organizationImportId }) {
+    this.organizationImportId = organizationImportId;
+  }
+}

--- a/api/src/prescription/learner-management/domain/usecases/import-from-feature/save-organization-learners-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-from-feature/save-organization-learners-file.js
@@ -4,7 +4,7 @@ import { AggregateImportError } from '../../errors.js';
 import { ImportOrganizationLearnerSet } from '../../models/ImportOrganizationLearnerSet.js';
 
 const saveOrganizationLearnersFile = async function ({
-  organizationId,
+  organizationImportId,
   organizationLearnerImportFormatRepository,
   organizationLearnerRepository,
   organizationImportRepository,
@@ -12,9 +12,10 @@ const saveOrganizationLearnersFile = async function ({
   dependencies = { getDataBuffer },
 }) {
   const errors = [];
-  const organizationImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
+  const organizationImport = await organizationImportRepository.get(organizationImportId);
 
   try {
+    const organizationId = organizationImport.organizationId;
     const importFormat = await organizationLearnerImportFormatRepository.get(organizationId);
 
     const readableStream = await importStorage.readFile({ filename: organizationImport.filename });

--- a/api/src/prescription/learner-management/domain/usecases/import-from-feature/validate-organization-learners-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-from-feature/validate-organization-learners-file.js
@@ -1,19 +1,22 @@
 import { CommonCsvLearnerParser } from '../../../infrastructure/serializers/csv/common-csv-learner-parser.js';
 import { getDataBuffer } from '../../../infrastructure/utils/bufferize/get-data-buffer.js';
 import { AggregateImportError } from '../../errors.js';
+import { ImportCommonOrganizationLearnersJob } from '../../models/ImportCommonOrganizationLearnersJob.js';
 import { ImportOrganizationLearnerSet } from '../../models/ImportOrganizationLearnerSet.js';
 
 const validateOrganizationLearnersFile = async function ({
-  organizationId,
+  organizationImportId,
   organizationLearnerImportFormatRepository,
+  importCommonOrganizationLearnersJobRepository,
   organizationImportRepository,
   importStorage,
   dependencies = { getDataBuffer },
 }) {
   const errors = [];
 
-  const organizationImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
+  const organizationImport = await organizationImportRepository.get(organizationImportId);
   try {
+    const organizationId = organizationImport.organizationId;
     const importFormat = await organizationLearnerImportFormatRepository.get(organizationId);
 
     const readableStream = await importStorage.readFile({ filename: organizationImport.filename });
@@ -29,6 +32,9 @@ const validateOrganizationLearnersFile = async function ({
     });
 
     learnerSet.addLearners(learners);
+    await importCommonOrganizationLearnersJobRepository.performAsync(
+      new ImportCommonOrganizationLearnersJob({ organizationImportId: organizationImport.id }),
+    );
   } catch (error) {
     if (Array.isArray(error)) {
       errors.push(...error);

--- a/api/src/prescription/learner-management/domain/usecases/import-from-feature/validate-organization-learners-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-from-feature/validate-organization-learners-file.js
@@ -33,7 +33,7 @@ const validateOrganizationLearnersFile = async function ({
 
     learnerSet.addLearners(learners);
     await importCommonOrganizationLearnersJobRepository.performAsync(
-      new ImportCommonOrganizationLearnersJob({ organizationImportId: organizationImport.id }),
+      new ImportCommonOrganizationLearnersJob({ organizationImportId }),
     );
   } catch (error) {
     if (Array.isArray(error)) {

--- a/api/src/prescription/learner-management/domain/usecases/index.js
+++ b/api/src/prescription/learner-management/domain/usecases/index.js
@@ -17,6 +17,7 @@ import * as membershipRepository from '../../../../team/infrastructure/repositor
 import * as registrationOrganizationLearnerRepository from '../../../organization-learner/infrastructure/repositories/registration-organization-learner-repository.js';
 import * as campaignParticipationRepository from '../../infrastructure/repositories/campaign-participation-repository.js';
 import { repositories } from '../../infrastructure/repositories/index.js';
+import { importCommonOrganizationLearnersJobRepository } from '../../infrastructure/repositories/jobs/import-common-organization-learners-job-repository.js';
 import { importOrganizationLearnersJobRepository } from '../../infrastructure/repositories/jobs/import-organization-learners-job-repository.js';
 import { importScoCsvOrganizationLearnersJobRepository } from '../../infrastructure/repositories/jobs/import-sco-csv-organization-learners-job-repository.js';
 import { importSupOrganizationLearnersJobRepository } from '../../infrastructure/repositories/jobs/import-sup-organization-learners-job-repository.js';
@@ -59,6 +60,7 @@ import { importStorage } from '../../infrastructure/storage/import-storage.js';
 const dependencies = {
   campaignParticipationRepository,
   campaignRepository,
+  importCommonOrganizationLearnersJobRepository,
   importOrganizationLearnersJobRepository,
   importScoCsvOrganizationLearnersJobRepository,
   importStorage,

--- a/api/src/prescription/learner-management/domain/usecases/index.js
+++ b/api/src/prescription/learner-management/domain/usecases/index.js
@@ -21,6 +21,7 @@ import { importCommonOrganizationLearnersJobRepository } from '../../infrastruct
 import { importOrganizationLearnersJobRepository } from '../../infrastructure/repositories/jobs/import-organization-learners-job-repository.js';
 import { importScoCsvOrganizationLearnersJobRepository } from '../../infrastructure/repositories/jobs/import-sco-csv-organization-learners-job-repository.js';
 import { importSupOrganizationLearnersJobRepository } from '../../infrastructure/repositories/jobs/import-sup-organization-learners-job-repository.js';
+import { validateCommonOrganizationImportFileJobRepository } from '../../infrastructure/repositories/jobs/validate-common-organization-learners-import-file-job-repository.js';
 import { validateCsvOrganizationImportFileJobRepository } from '../../infrastructure/repositories/jobs/validate-csv-organization-learners-import-file-job-repository.js';
 import { validateOrganizationImportFileJobRepository } from '../../infrastructure/repositories/jobs/validate-organization-learners-import-file-job-repository.js';
 import * as organizationImportRepository from '../../infrastructure/repositories/organization-import-repository.js';
@@ -82,6 +83,7 @@ const dependencies = {
   supOrganizationLearnerRepository,
   userReconciliationService,
   userRepository,
+  validateCommonOrganizationImportFileJobRepository,
   validateCsvOrganizationImportFileJobRepository,
   validateOrganizationImportFileJobRepository,
 };

--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-common-organization-learners-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-common-organization-learners-job-repository.js
@@ -1,0 +1,18 @@
+import {
+  JobExpireIn,
+  JobRepository,
+  JobRetry,
+} from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { ImportCommonOrganizationLearnersJob } from '../../../domain/models/ImportCommonOrganizationLearnersJob.js';
+
+class ImportCommonOrganizationLearnersJobRepository extends JobRepository {
+  constructor() {
+    super({
+      name: ImportCommonOrganizationLearnersJob.name,
+      expireIn: JobExpireIn.HIGH,
+      retry: JobRetry.FEW_RETRY,
+    });
+  }
+}
+
+export const importCommonOrganizationLearnersJobRepository = new ImportCommonOrganizationLearnersJobRepository();

--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/validate-common-organization-learners-import-file-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/validate-common-organization-learners-import-file-job-repository.js
@@ -1,0 +1,19 @@
+import {
+  JobExpireIn,
+  JobRepository,
+  JobRetry,
+} from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { ValidateCommonOrganizationImportFileJob } from '../../../domain/models/ValidateCommonOrganizationImportFileJob.js';
+
+class ValidateCommonOrganizationImportFileJobRepository extends JobRepository {
+  constructor() {
+    super({
+      name: ValidateCommonOrganizationImportFileJob.name,
+      expireIn: JobExpireIn.HIGH,
+      retry: JobRetry.FEW_RETRY,
+    });
+  }
+}
+
+export const validateCommonOrganizationImportFileJobRepository =
+  new ValidateCommonOrganizationImportFileJobRepository();

--- a/api/tests/prescription/learner-management/acceptance/application/organization-learners-route_test.js
+++ b/api/tests/prescription/learner-management/acceptance/application/organization-learners-route_test.js
@@ -1,4 +1,5 @@
 import { IMPORT_KEY_FIELD } from '../../../../../src/prescription/learner-management/domain/constants.js';
+import { getLastByOrganizationId } from '../../../../../src/prescription/learner-management/infrastructure/repositories/organization-import-repository.js';
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
 import {
@@ -7,7 +8,6 @@ import {
   expect,
   generateValidRequestAuthorizationHeader,
   insertUserWithRoleSuperAdmin,
-  knex,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | Prescription | learner management | Application | organization-learners-management', function () {
@@ -129,11 +129,11 @@ describe('Acceptance | Prescription | learner management | Application | organiz
       // when
       const response = await server.inject(options);
 
-      const organizationLearners = await knex('organization-learners').where({ organizationId });
+      const organizationImport = await getLastByOrganizationId(organizationId);
       // then
       expect(response.statusCode).to.equal(204);
 
-      expect(organizationLearners).lengthOf(1);
+      expect(organizationImport.status).to.equals('UPLOADED');
     });
   });
 

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-common-organization-learners-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-common-organization-learners-job-repository_test.js
@@ -1,0 +1,27 @@
+import { ImportCommonOrganizationLearnersJob } from '../../../../../../../src/prescription/learner-management/domain/models/ImportCommonOrganizationLearnersJob.js';
+import { importCommonOrganizationLearnersJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/import-common-organization-learners-job-repository.js';
+import {
+  JobExpireIn,
+  JobRetry,
+} from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import { expect } from '../../../../../../test-helper.js';
+
+describe('Integration | Prescription | Infrastructure | Repository | Jobs | importCommonOrganizationLearnersJobRepository', function () {
+  describe('#performAsync', function () {
+    it('publish a job', async function () {
+      // when
+      await importCommonOrganizationLearnersJobRepository.performAsync(
+        new ImportCommonOrganizationLearnersJob({ organizationImportId: 4123132 }),
+      );
+
+      // then
+      await expect(ImportCommonOrganizationLearnersJob.name).to.have.have.been.performed.withJob({
+        expirein: JobExpireIn.HIGH,
+        retrylimit: JobRetry.FEW_RETRY.retryLimit,
+        retrydelay: JobRetry.FEW_RETRY.retryDelay,
+        retrybackoff: JobRetry.FEW_RETRY.retryBackoff,
+        data: { organizationImportId: 4123132 },
+      });
+    });
+  });
+});

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-common-organization-learners-import-file-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-common-organization-learners-import-file-job-repository_test.js
@@ -1,0 +1,27 @@
+import { ValidateCommonOrganizationImportFileJob } from '../../../../../../../src/prescription/learner-management/domain/models/ValidateCommonOrganizationImportFileJob.js';
+import { validateCommonOrganizationImportFileJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/validate-common-organization-learners-import-file-job-repository.js';
+import {
+  JobExpireIn,
+  JobRetry,
+} from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import { expect } from '../../../../../../test-helper.js';
+
+describe('Integration | Prescription | Infrastructure | Repository | Jobs | validateCommonOrganizationImportFileJobRepository', function () {
+  describe('#performAsync', function () {
+    it('publish a job', async function () {
+      // when
+      await validateCommonOrganizationImportFileJobRepository.performAsync(
+        new ValidateCommonOrganizationImportFileJob({ organizationImportId: 4123132 }),
+      );
+
+      // then
+      await expect(ValidateCommonOrganizationImportFileJob.name).to.have.been.performed.withJob({
+        expirein: JobExpireIn.HIGH,
+        retrylimit: JobRetry.FEW_RETRY.retryLimit,
+        retrydelay: JobRetry.FEW_RETRY.retryDelay,
+        retrybackoff: JobRetry.FEW_RETRY.retryBackoff,
+        data: { organizationImportId: 4123132 },
+      });
+    });
+  });
+});

--- a/api/tests/prescription/learner-management/unit/application/jobs/import-common-organization-learners-job-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/jobs/import-common-organization-learners-job-controller_test.js
@@ -1,0 +1,78 @@
+import { ImportCommonOrganizationLearnersJobController } from '../../../../../../src/prescription/learner-management/application/jobs/import-common-organization-learners-job-controller.js';
+import { usecases } from '../../../../../../src/prescription/learner-management/domain/usecases/index.js';
+import { config } from '../../../../../../src/shared/config.js';
+import { OrganizationLearnersCouldNotBeSavedError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErr, expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | Prescription | Application | Jobs | importOrganizationLearnersJobController', function () {
+  describe('#isJobEnabled', function () {
+    it('return true when job is enabled', function () {
+      //given
+      sinon.stub(config.pgBoss, 'importFileJobEnabled').value(true);
+
+      // when
+      const handler = new ImportCommonOrganizationLearnersJobController();
+
+      // then
+      expect(handler.isJobEnabled).to.be.true;
+    });
+
+    it('return false when job is disabled', function () {
+      //given
+      sinon.stub(config.pgBoss, 'importFileJobEnabled').value(false);
+
+      //when
+      const handler = new ImportCommonOrganizationLearnersJobController();
+
+      //then
+      expect(handler.isJobEnabled).to.be.false;
+    });
+  });
+
+  describe('#handle', function () {
+    it('should call usecase', async function () {
+      sinon.stub(usecases, 'saveOrganizationLearnersFile');
+
+      // given
+      const handler = new ImportCommonOrganizationLearnersJobController();
+      const data = { organizationImportId: Symbol('organizationImportId') };
+
+      // when
+      await handler.handle({ data });
+
+      // then
+      expect(usecases.saveOrganizationLearnersFile).to.have.been.calledOnce;
+      expect(usecases.saveOrganizationLearnersFile).to.have.been.calledWithExactly(data);
+    });
+
+    it('should not throw when error is from domain', async function () {
+      const error = new OrganizationLearnersCouldNotBeSavedError();
+      sinon.stub(usecases, 'saveOrganizationLearnersFile').rejects(error);
+
+      // given
+      const errorStub = sinon.stub();
+      const handler = new ImportCommonOrganizationLearnersJobController({ logger: { error: errorStub } });
+      const data = { organizationImportId: Symbol('organizationImportId') };
+
+      // when & then
+      await handler.handle({ data });
+
+      expect(errorStub).to.have.been.calledWithExactly(error);
+    });
+
+    it('should throw when error is not from domain', async function () {
+      const error = new Error();
+      sinon.stub(usecases, 'saveOrganizationLearnersFile').rejects(error);
+
+      // given
+      const handler = new ImportCommonOrganizationLearnersJobController();
+      const data = { organizationImportId: Symbol('organizationImportId') };
+
+      // when
+      const result = await catchErr(handler.handle)({ data });
+
+      // then
+      expect(result).to.equal(error);
+    });
+  });
+});

--- a/api/tests/prescription/learner-management/unit/application/jobs/validate-common-organization-learners-import-file-job-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/jobs/validate-common-organization-learners-import-file-job-controller_test.js
@@ -1,0 +1,78 @@
+import { ValidateCommonOrganizationLearnersImportFileJobController } from '../../../../../../src/prescription/learner-management/application/jobs/validate-common-organization-learners-import-file-job-controller.js';
+import { usecases } from '../../../../../../src/prescription/learner-management/domain/usecases/index.js';
+import { S3FileDoesNotExistError } from '../../../../../../src/prescription/learner-management/infrastructure/storage/import-storage.js';
+import { config } from '../../../../../../src/shared/config.js';
+import { catchErr, expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | Prescription | Application | Jobs | validateOrganizationLearnersImportFileJobController', function () {
+  describe('#isJobEnabled', function () {
+    it('return true when job is enabled', function () {
+      //given
+      sinon.stub(config.pgBoss, 'validationFileJobEnabled').value(true);
+
+      // when
+      const handler = new ValidateCommonOrganizationLearnersImportFileJobController();
+
+      // then
+      expect(handler.isJobEnabled).to.be.true;
+    });
+
+    it('return false when job is disabled', function () {
+      //given
+      sinon.stub(config.pgBoss, 'validationFileJobEnabled').value(false);
+
+      //when
+      const handler = new ValidateCommonOrganizationLearnersImportFileJobController();
+
+      //then
+      expect(handler.isJobEnabled).to.be.false;
+    });
+  });
+
+  describe('#handle', function () {
+    it('should call usecase', async function () {
+      sinon.stub(usecases, 'validateOrganizationLearnersFile');
+      // given
+      const handler = new ValidateCommonOrganizationLearnersImportFileJobController();
+      const data = { organizationImportId: Symbol('organizationImportId') };
+
+      // when
+      await handler.handle({ data });
+
+      // then
+      expect(usecases.validateOrganizationLearnersFile).to.have.been.calledOnce;
+      expect(usecases.validateOrganizationLearnersFile).to.have.been.calledWithExactly(data);
+    });
+
+    it('should not throw when error is from domain', async function () {
+      const error = new S3FileDoesNotExistError();
+      sinon.stub(usecases, 'validateOrganizationLearnersFile').rejects(error);
+
+      // given
+      const warnStub = sinon.stub();
+      const handler = new ValidateCommonOrganizationLearnersImportFileJobController({ logger: { warn: warnStub } });
+      const data = { organizationImportId: Symbol('organizationImportId') };
+
+      // when
+      await handler.handle({ data });
+
+      // then
+      expect(warnStub).to.have.been.calledWithExactly(error);
+    });
+
+    it('should throw when error is not from domain', async function () {
+      const error = new Error();
+      sinon.stub(usecases, 'validateOrganizationLearnersFile').rejects(error);
+
+      // given
+      const handler = new ValidateCommonOrganizationLearnersImportFileJobController();
+      const data = { organizationImportId: Symbol('organizationImportId') };
+
+      // when
+      const result = await catchErr(handler.handle)({ data });
+
+      // then
+      expect(result).to.equal(error);
+    });
+  });
+});

--- a/api/tests/prescription/learner-management/unit/application/organization-learners-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/organization-learners-controller_test.js
@@ -5,12 +5,11 @@ import { expect, hFake, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Prescription | Learner Management | Application | organization-learner-controller', function () {
   describe('#importOrganizationLearnerFromFeature', function () {
-    let saveOrganizationLearnersFileStub, sendOrganizationLearnersFileStub, validateOrganizationLearnersFileStub;
+    let sendOrganizationLearnersFileStub, validateOrganizationLearnersFileStub;
 
     beforeEach(function () {
       sinon.stub(ApplicationTransaction, 'execute');
       ApplicationTransaction.execute.callsFake((callback) => callback());
-      saveOrganizationLearnersFileStub = sinon.stub(usecases, 'saveOrganizationLearnersFile');
       sendOrganizationLearnersFileStub = sinon.stub(usecases, 'sendOrganizationLearnersFile');
       validateOrganizationLearnersFileStub = sinon.stub(usecases, 'validateOrganizationLearnersFile');
     });
@@ -27,14 +26,9 @@ describe('Unit | Prescription | Learner Management | Application | organization-
 
       const response = await organizationLearnersController.importOrganizationLearnerFromFeature(request, hFake);
 
-      expect(ApplicationTransaction.execute.calledThrice, 'ApplicationTransaction.execute').to.be.true;
-      expect(
-        sinon.assert.callOrder(
-          sendOrganizationLearnersFileStub,
-          validateOrganizationLearnersFileStub,
-          saveOrganizationLearnersFileStub,
-        ),
-      ).to.not.throws;
+      expect(ApplicationTransaction.execute.calledTwice, 'ApplicationTransaction.execute').to.be.true;
+      expect(sinon.assert.callOrder(sendOrganizationLearnersFileStub, validateOrganizationLearnersFileStub)).to.not
+        .throws;
       expect(
         usecases.sendOrganizationLearnersFile.calledWithExactly({ payload, organizationId, userId }),
         'sendOrganizationLearnerFile',

--- a/api/tests/prescription/learner-management/unit/application/organization-learners-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/organization-learners-controller_test.js
@@ -1,17 +1,13 @@
 import { organizationLearnersController } from '../../../../../src/prescription/learner-management/application/organization-learners-controller.js';
 import { usecases } from '../../../../../src/prescription/learner-management/domain/usecases/index.js';
-import { ApplicationTransaction } from '../../../../../src/prescription/shared/infrastructure/ApplicationTransaction.js';
 import { expect, hFake, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Prescription | Learner Management | Application | organization-learner-controller', function () {
   describe('#importOrganizationLearnerFromFeature', function () {
-    let sendOrganizationLearnersFileStub, validateOrganizationLearnersFileStub;
+    let sendOrganizationLearnersFileStub;
 
     beforeEach(function () {
-      sinon.stub(ApplicationTransaction, 'execute');
-      ApplicationTransaction.execute.callsFake((callback) => callback());
       sendOrganizationLearnersFileStub = sinon.stub(usecases, 'sendOrganizationLearnersFile');
-      validateOrganizationLearnersFileStub = sinon.stub(usecases, 'validateOrganizationLearnersFile');
     });
 
     it('should call usecases in correct order', async function () {
@@ -26,19 +22,10 @@ describe('Unit | Prescription | Learner Management | Application | organization-
 
       const response = await organizationLearnersController.importOrganizationLearnerFromFeature(request, hFake);
 
-      expect(ApplicationTransaction.execute.calledTwice, 'ApplicationTransaction.execute').to.be.true;
-      expect(sinon.assert.callOrder(sendOrganizationLearnersFileStub, validateOrganizationLearnersFileStub)).to.not
-        .throws;
       expect(
-        usecases.sendOrganizationLearnersFile.calledWithExactly({ payload, organizationId, userId }),
+        sendOrganizationLearnersFileStub.calledWithExactly({ payload, organizationId, userId }),
         'sendOrganizationLearnerFile',
       ).to.be.true;
-      expect(
-        usecases.validateOrganizationLearnersFile.calledWithExactly({ organizationId }),
-        'validateOrganizationLearnerFile',
-      ).to.be.true;
-      expect(usecases.saveOrganizationLearnersFile.calledWithExactly({ organizationId }), 'saveOrganizationLearnerFile')
-        .to.be.true;
 
       expect(response.statusCode).to.be.equal(204);
     });

--- a/api/tests/prescription/learner-management/unit/domain/usecases/import-from-feature/save-organization-learners-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/import-from-feature/save-organization-learners-file_test.js
@@ -15,6 +15,7 @@ describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
     organizationImportStub,
     dataBuffer,
     fileEncoding,
+    organizationImportId,
     organizationId,
     dataStream,
     s3Filepath,
@@ -25,6 +26,7 @@ describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
     existingLearners;
 
   beforeEach(function () {
+    organizationImportId = Symbol('organizationImportId');
     organizationId = 1234;
     s3Filepath = Symbol('s3-path.csv');
     fileEncoding = Symbol('file encoding');
@@ -34,7 +36,7 @@ describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
     learnerToSave = Symbol('learner to save');
     learnerIds = Symbol('learner Ids');
 
-    importFormat = Symbol('importFormat');
+    importFormat = Symbol('OrganizationLearnerImportFormat');
 
     parsedLearners = Symbol('parsed learners');
 
@@ -49,7 +51,7 @@ describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
     };
 
     organizationImportRepositoryStub = {
-      getLastByOrganizationId: sinon.stub(),
+      get: sinon.stub(),
       save: sinon.stub(),
     };
 
@@ -81,10 +83,11 @@ describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
 
     // get latest organizationImport
     organizationImportStub = {
+      organizationId,
       process: sinon.stub(),
       filename: s3Filepath,
     };
-    organizationImportRepositoryStub.getLastByOrganizationId.withArgs(organizationId).resolves(organizationImportStub);
+    organizationImportRepositoryStub.get.withArgs(organizationImportId).resolves(organizationImportStub);
 
     // get config from feature import
     organizationLearnerImportFormatRepositoryStub.get.withArgs(organizationId).resolves(importFormat);
@@ -114,7 +117,7 @@ describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
     it('should process the file', async function () {
       // when
       await saveOrganizationLearnersFile({
-        organizationId,
+        organizationImportId,
         importStorage: importStorageStub,
         organizationImportRepository: organizationImportRepositoryStub,
         organizationLearnerRepository: organizationLearnerRepositoryStub,
@@ -159,7 +162,7 @@ describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
 
       // when
       const saveError = await catchErr(saveOrganizationLearnersFile)({
-        organizationId,
+        organizationImportId,
         importStorage: importStorageStub,
         organizationImportRepository: organizationImportRepositoryStub,
         organizationLearnerRepository: organizationLearnerRepositoryStub,
@@ -189,15 +192,13 @@ describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
       it('should save the error', async function () {
         // given
         const error = new Error('Error Happened');
-        organizationImportRepositoryStub.getLastByOrganizationId
-          .withArgs(organizationId)
-          .resolves(organizationImportStub);
+        organizationImportRepositoryStub.get.withArgs(organizationImportId).resolves(organizationImportStub);
 
         organizationLearnerImportFormatRepositoryStub.get.withArgs(organizationId).rejects(error);
 
         // when
         await catchErr(saveOrganizationLearnersFile)({
-          organizationId,
+          organizationImportId,
           importStorage: importStorageStub,
           organizationImportRepository: organizationImportRepositoryStub,
           organizationLearnerRepository: organizationLearnerRepositoryStub,
@@ -212,15 +213,13 @@ describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
       it('should save the errors', async function () {
         // given
         const error = new Error('Error Happened');
-        organizationImportRepositoryStub.getLastByOrganizationId
-          .withArgs(organizationId)
-          .resolves(organizationImportStub);
+        organizationImportRepositoryStub.get.withArgs(organizationImportId).resolves(organizationImportStub);
 
         organizationLearnerImportFormatRepositoryStub.get.withArgs(organizationId).rejects([error, error]);
 
         // when
         await catchErr(saveOrganizationLearnersFile)({
-          organizationId,
+          organizationImportId,
           importStorage: importStorageStub,
           organizationImportRepository: organizationImportRepositoryStub,
           organizationLearnerRepository: organizationLearnerRepositoryStub,


### PR DESCRIPTION
## :christmas_tree: Problème

Un village d'irréductible usecases sont toujours en synchrone ne permettant pas au captains de pouvoir mettre en pause TOUS les imports lors de la montée en charge de l'Application

## :gift: Proposition

Tout le monde passe à l'asynchronie, même ces 2 derniers usecase d'import à format générique

## :socks: Remarques

RAS

## :santa: Pour tester

Faire un import à format Generic. et vérifier que l'import est réalisé.
Vérifier que nous avons bien les jobs dans pgboss