### PR TITLE
[TECH] Corrige la conjugaison de "was" en "were" dans le script de configuration.

### DIFF
--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -100,39 +100,39 @@ function setup_and_run_infrastructure() {
   # Install dependencies for  admin
   echo "Installing dependencies for admin"
   (cd admin && npm ci)
-  echo "✅ Dependencies for admin was installed"
+  echo "✅ Dependencies for admin were installed"
   echo ""
 
   # Install dependencies for audit-logger
   echo "Installing dependencies for audit-logger"
   (cd audit-logger && npm ci)
-  echo "✅ Dependencies for audit-logger was installed"
+  echo "✅ Dependencies for audit-logger were installed"
   echo ""
 
   # Install dependencies for "certif"
   echo "Installing dependencies for certif"
   (cd certif && npm ci)
-  echo "✅ Dependencies for certif was installed"
+  echo "✅ Dependencies for certif were installed"
   echo ""
 
   # Install dependencies for "junior"
   echo "Installing dependencies for junior"
   (cd junior && npm ci)
-  echo "✅ Dependencies for junior was installed"
+  echo "✅ Dependencies for junior were installed"
   echo ""
 
   # Install dependencies for "mon-pix"
   echo "Installing dependencies for mon-pix"
   (cd mon-pix && npm ci)
-  echo "✅ Dependencies for mon-pix was installed"
+  echo "✅ Dependencies for mon-pix were installed"
   echo ""
 
   # Install dependencies for orga
   echo "Installing dependencies for orga"
   (cd orga && npm ci)
-  echo "✅ Dependencies for orga was installed"
+  echo "✅ Dependencies for orga were installed"
   echo "-----------"
-  echo "✔ All dependencies was downloaded and installed"
+  echo "✔ All dependencies were downloaded and installed"
 
 }
 


### PR DESCRIPTION
## :christmas_tree: Problème

Comme justement remarqué et corrigé par @MathiasDPX dans la PR #10440, la conjugaison du verbe "to be" au passé n'est pas correcte dans le script de configuration.

> J'ai changé was en were
> was: I, he/she/it
> were: you, we, they

## :gift: Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

On récupère le commit de @MathiasDPX :smile:

## :socks: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

Merci :pray: @MathiasDPX.

## :santa: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

Vérifier que le verbe "to be" est correctement conjugué dans les messages du script de configuration.
