### PR TITLE
[FEATURE] Adjust self delete account (PIX-15713)

### DIFF
--- a/admin/app/components/users/user-overview.gjs
+++ b/admin/app/components/users/user-overview.gjs
@@ -47,9 +47,14 @@ export default class UserOverview extends Component {
   }
 
   get anonymisationMessage() {
-    return this.args.user.anonymisedByFullName
-      ? `Utilisateur anonymisé par ${this.args.user.anonymisedByFullName}.`
-      : 'Utilisateur anonymisé.';
+    if (this.args.user.id === String(this.args.user.hasBeenAnonymisedBy)) {
+      return this.intl.t('pages.user-details.overview.anonymisation.self-anonymisation-message');
+    }
+    if (this.args.user.anonymisedByFullName) {
+      const fullName = this.args.user.anonymisedByFullName;
+      return this.intl.t('pages.user-details.overview.anonymisation.user-anonymised-by-admin-message', { fullName });
+    }
+    return this.intl.t('pages.user-details.overview.anonymisation.default-anonymised-user-message');
   }
 
   get canModifyEmail() {

--- a/admin/app/models/user.js
+++ b/admin/app/models/user.js
@@ -19,6 +19,7 @@ export default class User extends Model {
   @attr() lastLoggedAt;
   @attr() emailConfirmedAt;
   @attr() hasBeenAnonymised;
+  @attr() hasBeenAnonymisedBy;
   @attr() anonymisedByFullName;
   @attr() isPixAgent;
 

--- a/admin/tests/integration/components/users/user-overview-test.gjs
+++ b/admin/tests/integration/components/users/user-overview-test.gjs
@@ -22,6 +22,65 @@ module('Integration | Component | users | user-overview', function (hooks) {
     });
 
     module('when the admin look at user details', function () {
+      module('when the user is anonymised', function () {
+        module('when the user has self deleted his account', function () {
+          test('displays the dedicated deletion message', async function (assert) {
+            // given
+
+            const store = this.owner.lookup('service:store');
+            const user = store.createRecord('user', {
+              id: '123',
+              firstName: '(anonymised)',
+              lastName: '(anonymised)',
+              email: null,
+              username: null,
+              hasBeenAnonymised: true,
+              hasBeenAnonymisedBy: 123,
+              anonymisedByFullName: '(anonymised) (anonymised)',
+            });
+
+            // when
+            const screen = await render(<template><UserOverview @user={{user}} /></template>);
+
+            // then
+            assert
+              .dom(screen.getByText(t('pages.user-details.overview.anonymisation.self-anonymisation-message')))
+              .exists();
+          });
+        });
+
+        module("when the user's account has been deleted by an admin member", function () {
+          test("displays the deletion message with the admin member's full name", async function (assert) {
+            // given
+            const store = this.owner.lookup('service:store');
+            const fullName = 'Laurent Bobine';
+            const user = store.createRecord('user', {
+              id: '123',
+              firstName: '(anonymised)',
+              lastName: '(anonymised)',
+              email: null,
+              username: null,
+              hasBeenAnonymised: true,
+              hasBeenAnonymisedBy: 456,
+              anonymisedByFullName: fullName,
+            });
+
+            // when
+            const screen = await render(<template><UserOverview @user={{user}} /></template>);
+
+            // then
+
+            assert
+              .dom(
+                screen.getByText(
+                  t('pages.user-details.overview.anonymisation.user-anonymised-by-admin-message', { fullName }),
+                ),
+              )
+              .exists();
+          });
+        });
+      });
+
       test('displays the update button', async function (assert) {
         // given
         const user = {
@@ -545,19 +604,27 @@ module('Integration | Component | users | user-overview', function (hooks) {
       test('displays an anonymisation message with the full name of the admin member', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
-        const user = store.createRecord('user', { hasBeenAnonymised: true, anonymisedByFullName: 'Laurent Gina' });
+        const fullName = 'Laurent Gina';
+        const user = store.createRecord('user', { hasBeenAnonymised: true, anonymisedByFullName: fullName });
 
         // when
         const screen = await render(<template><UserOverview @user={{user}} /></template>);
 
         // then
-        assert.dom(screen.getByText('Utilisateur anonymisé par Laurent Gina.')).exists();
+        assert
+          .dom(
+            screen.getByText(
+              t('pages.user-details.overview.anonymisation.user-anonymised-by-admin-message', { fullName }),
+            ),
+          )
+          .exists();
       });
 
       test('disables action buttons "Modifier" and "Anonymiser cet utilisateur"', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
-        const user = store.createRecord('user', { hasBeenAnonymised: true, anonymisedByFullName: 'Laurent Gina' });
+        const fullName = 'Laurent Gina';
+        const user = store.createRecord('user', { hasBeenAnonymised: true, anonymisedByFullName: fullName });
 
         // when
         const screen = await render(<template><UserOverview @user={{user}} /></template>);
@@ -577,7 +644,9 @@ module('Integration | Component | users | user-overview', function (hooks) {
           const screen = await render(<template><UserOverview @user={{user}} /></template>);
 
           // then
-          assert.dom(screen.getByText('Utilisateur anonymisé.')).exists();
+          assert
+            .dom(screen.getByText(t('pages.user-details.overview.anonymisation.default-anonymised-user-message')))
+            .exists();
         });
       });
     });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -738,7 +738,7 @@
         "authentication-methods": "Méthodes de connexion",
         "certification-centers-list": "Pix Certif",
         "cgu": "Terms of service",
-        "cgu-aria-label" : "Terms of service",
+        "cgu-aria-label": "Terms of service",
         "details": "Informations prescrit",
         "organizations-list": "Pix Orga",
         "participations-list": "Participations",
@@ -752,6 +752,13 @@
         "success": {
           "deactivate-certification-center-membership": "Le membre a correctement été désactivé.",
           "update-certification-center-membership-role": "Le rôle du membre a été modifié."
+        }
+      },
+      "overview": {
+        "anonymisation": {
+          "default-anonymised-user-message": "Anonymised user.",
+          "self-anonymisation-message": "User anonymised by themself.",
+          "user-anonymised-by-admin-message": "User anonymised by {fullName}."
         }
       }
     },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -762,7 +762,7 @@
         "authentication-methods": "Méthodes de connexion",
         "certification-centers-list": "Pix Certif",
         "cgu": "CGU",
-        "cgu-aria-label" : "Conditions générales d'utilisation",
+        "cgu-aria-label": "Conditions générales d'utilisation",
         "details": "Informations prescrit",
         "organizations-list": "Pix Orga",
         "participations-list": "Participations",
@@ -776,6 +776,13 @@
         "success": {
           "deactivate-certification-center-membership": "Le membre a correctement été désactivé.",
           "update-certification-center-membership-role": "Le rôle du membre a été modifié."
+        }
+      },
+      "overview": {
+        "anonymisation": {
+          "default-anonymised-user-message": "Utilisateur anonymisé.",
+          "self-anonymisation-message": "Utilisateur anonymisé par lui-même.",
+          "user-anonymised-by-admin-message": "Utilisateur anonymisé par {fullName}."
         }
       }
     },

--- a/api/src/identity-access-management/domain/models/UserDetailsForAdmin.js
+++ b/api/src/identity-access-management/domain/models/UserDetailsForAdmin.js
@@ -24,6 +24,7 @@ class UserDetailsForAdmin {
       emailConfirmedAt,
       userLogin,
       hasBeenAnonymised,
+      hasBeenAnonymisedBy,
       anonymisedByFirstName,
       anonymisedByLastName,
       isPixAgent,
@@ -54,6 +55,7 @@ class UserDetailsForAdmin {
     this.emailConfirmedAt = emailConfirmedAt;
     this.userLogin = userLogin;
     this.hasBeenAnonymised = hasBeenAnonymised;
+    this.hasBeenAnonymisedBy = hasBeenAnonymisedBy;
     this.updatedAt = updatedAt;
     this.anonymisedByFirstName = anonymisedByFirstName;
     this.anonymisedByLastName = anonymisedByLastName;

--- a/api/src/identity-access-management/infrastructure/repositories/user.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user.repository.js
@@ -557,6 +557,7 @@ function _fromKnexDTOToUserDetailsForAdmin({
     authenticationMethods,
     userLogin,
     hasBeenAnonymised: userDTO.hasBeenAnonymised,
+    hasBeenAnonymisedBy: userDTO.hasBeenAnonymisedBy,
     updatedAt: userDTO.updatedAt,
     createdAt: userDTO.createdAt,
     anonymisedByFirstName: userDTO.anonymisedByFirstName,

--- a/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-details-for-admin.serializer.js
+++ b/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-details-for-admin.serializer.js
@@ -30,6 +30,7 @@ const serialize = function (usersDetailsForAdmin) {
       'lastLoggedAt',
       'emailConfirmedAt',
       'hasBeenAnonymised',
+      'hasBeenAnonymisedBy',
       'anonymisedByFullName',
       'organizationLearners',
       'authenticationMethods',

--- a/api/tests/identity-access-management/acceptance/application/user/user.admin.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/user/user.admin.route.test.js
@@ -288,6 +288,7 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
           'pix-orga-terms-of-service-accepted': false,
           username: user.username,
           'has-been-anonymised': false,
+          'has-been-anonymised-by': null,
           'anonymised-by-full-name': null,
           'is-pix-agent': false,
         });

--- a/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-details-for-admin.serializer.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-details-for-admin.serializer.test.js
@@ -47,6 +47,7 @@ describe('Unit | Serializer | JSONAPI | user-details-for-admin-serializer', func
             'last-logged-at': now,
             'email-confirmed-at': now,
             'has-been-anonymised': false,
+            'has-been-anonymised-by': null,
             'anonymised-by-full-name': null,
             'is-pix-agent': false,
           },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2162,8 +2162,8 @@
         "more-information": "Para más información,",
         "more-information-contact-support": "puede ponerse en contacto con el servicio de asistencia.",
         "title": "Eliminar mi cuenta definitivamente",
-        "warning-email": "Esta acción es irreversible. {pixScore} Todas las habilidades, cursos y píxeles que haya obtenido se eliminarán de forma permanente para la cuenta PIX que utilice la dirección de correo electrónico<strong>{email}</strong>.",
-        "warning-other": "Esta acción es irreversible. {pixScore} Todas las habilidades, cursos y píxeles que haya obtenido se eliminarán permanentemente de la cuenta PIX.<strong>{firstName} {lastName}</strong>."
+        "warning-email": "Esta acción es irreversible. {pixScore} Todas las habilidades, cursos y píxeles que haya obtenido se eliminarán de forma permanente para la cuenta PIX que utilice la dirección de correo electrónico <strong>{email}</strong>.",
+        "warning-other": "Esta acción es irreversible. {pixScore} Todas las habilidades, cursos y píxeles que haya obtenido se eliminarán permanentemente de la cuenta PIX <strong>{firstName} {lastName}</strong>."
       },
       "email-confirmed": "Dirección de correo electrónico verificada.",
       "email-verification": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2162,8 +2162,8 @@
         "more-information": "Voor meer informatie,",
         "more-information-contact-support": "kunt u contact opnemen met ondersteuning.",
         "title": "Mijn account permanent verwijderen",
-        "warning-email": "Deze actie is onomkeerbaar. {pixScore} Alle vaardigheden, cursussen en pix die je hebt verkregen worden permanent verwijderd voor het PIX-account met het e-mailadres<strong>{email}</strong>.",
-        "warning-other": "Deze actie is onomkeerbaar. {pixScore} Alle vaardigheden, cursussen en pix die je hebt behaald, worden permanent verwijderd van het PIX-account.<strong>{firstName} {lastName}</strong>."
+        "warning-email": "Deze actie is onomkeerbaar. {pixScore} Alle vaardigheden, cursussen en pix die je hebt verkregen worden permanent verwijderd voor het PIX-account met het e-mailadres <strong>{email}</strong>.",
+        "warning-other": "Deze actie is onomkeerbaar. {pixScore} Alle vaardigheden, cursussen en pix die je hebt behaald, worden permanent verwijderd van het PIX-account <strong>{firstName} {lastName}</strong>."
       },
       "email-confirmed": "Geverifieerd e-mailadres.",
       "email-verification": {


### PR DESCRIPTION
## :christmas_tree: Problème

Quelques ajustements doivent être faits pour la suppression de compte en autonomie.
- Sur Pix App : En NL et ES, l’e-mail est collé au texte de la page de suppression du compte
- Dans Pix Admin:
Sur la page de détail d'un utilisateur (user overview), s'il a supprimé lui-même son compte, le message doit être "utilisateur anonymisé par lui-même" et non "utilisateur anonymisé par (anonymised) (anonymised").

## :gift: Proposition
Faire les modifications nécessaires pour régler les problèmes ci-dessus.

## :socks: Remarques


## :santa: Pour tester

Reprendre les points listés plus haut.
En particulier, tester les trois messages d'anonymisation (avec un utilisateur qui a lui-même supprimé son compte, un utilisateur dont un admin a supprimé le compte, un utilisateur dont le compte est supprimé mais sans nom d'administrateur correspondant en base.)
