### PR TITLE
[FEATURE] formater les date dans les export de résultats en utilisant le fuseau Europe/Paris (PIX-15742)

### DIFF
--- a/api/src/prescription/campaign/infrastructure/exports/campaigns/campaign-profiles-collection-result-line.js
+++ b/api/src/prescription/campaign/infrastructure/exports/campaigns/campaign-profiles-collection-result-line.js
@@ -1,6 +1,10 @@
 import dayjs from 'dayjs';
+import timezone from 'dayjs/plugin/timezone.js';
 import utc from 'dayjs/plugin/utc.js';
+
 dayjs.extend(utc);
+dayjs.extend(timezone);
+
 import * as csvSerializer from '../../../../../shared/infrastructure/serializers/csv/csv-serializer.js';
 
 const EMPTY_ARRAY = [];
@@ -92,7 +96,7 @@ class CampaignProfilesCollectionResultLine {
 
   _getSharedAtColumn() {
     return this.campaignParticipationResult.isShared
-      ? dayjs.utc(this.campaignParticipationResult.sharedAt).format()
+      ? dayjs.utc(this.campaignParticipationResult.sharedAt).tz('Europe/Paris').format('DD/MM/YYYY HH:mm')
       : this.notShared;
   }
 

--- a/api/src/prescription/campaign/infrastructure/utils/CampaignAssessmentCsvLine.js
+++ b/api/src/prescription/campaign/infrastructure/utils/CampaignAssessmentCsvLine.js
@@ -1,6 +1,10 @@
 import dayjs from 'dayjs';
+import timezone from 'dayjs/plugin/timezone.js';
 import utc from 'dayjs/plugin/utc.js';
+
 dayjs.extend(utc);
+dayjs.extend(timezone);
+
 import _ from 'lodash';
 
 const STATS_COLUMNS_COUNT = 3;
@@ -111,10 +115,10 @@ class CampaignAssessmentCsvLine {
         this.targetedKnowledgeElementsCount,
         this.learningContent.skills.length,
       ),
-      dayjs.utc(this.campaignParticipationInfo.createdAt).format(),
+      dayjs.utc(this.campaignParticipationInfo.createdAt).tz('Europe/Paris').format('DD/MM/YYYY HH:mm'),
       this._makeYesNoColumns(this.campaignParticipationInfo.isShared),
       this.campaignParticipationInfo.isShared
-        ? dayjs.utc(this.campaignParticipationInfo.sharedAt).format()
+        ? dayjs.utc(this.campaignParticipationInfo.sharedAt).tz('Europe/Paris').format('DD/MM/YYYY HH:mm')
         : this.emptyContent,
       ...(this.stageCollection.hasStage ? [this._getReachedStage()] : []),
       ...(this.campaignParticipationInfo.isShared

--- a/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -1,7 +1,5 @@
 import stream from 'node:stream';
 
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc.js';
 const { PassThrough } = stream;
 
 import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
@@ -11,7 +9,6 @@ import { Assessment } from '../../../../../../src/shared/domain/models/Assessmen
 import { CampaignParticipationStatuses, KnowledgeElement } from '../../../../../../src/shared/domain/models/index.js';
 import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { databaseBuilder, expect, mockLearningContent, streamToPromise } from '../../../../../test-helper.js';
-dayjs.extend(utc);
 
 describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-results-to-stream', function () {
   describe('#startWritingCampaignAssessmentResultsToStream', function () {
@@ -24,7 +21,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
     let writableStream;
     let csvPromise;
     let i18n;
-    let createdAt, sharedAt;
+    let createdAt, sharedAt, createdAtFormated, sharedAtFormated;
 
     beforeEach(async function () {
       i18n = getI18n();
@@ -47,9 +44,12 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
       });
 
       // participation
-      createdAt = new Date('2019-02-25');
-      sharedAt = new Date('2019-03-01');
-
+      // heure d'hiver UTC+1
+      createdAt = new Date('2019-02-25T10:20:00Z');
+      createdAtFormated = '25/02/2019 11:20';
+      // heure d'été UTC+2
+      sharedAt = new Date('2019-06-01T09:05:00Z');
+      sharedAtFormated = '01/06/2019 11:05';
       const learningContent = {
         frameworks: [{ id: 'frameworkId', name: 'frameworkName' }],
         areas: [{ id: 'recArea1', frameworkId: 'frameworkId', competenceIds: ['recCompetence1'] }],
@@ -158,9 +158,9 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
           `"'${organizationLearner.firstName}";` +
           `"${campaignParticipation.participantExternalId}";` +
           '1;' +
-          `"${dayjs.utc(createdAt).format()}";` +
+          `"${createdAtFormated}";` +
           '"Oui";' +
-          `"${dayjs.utc(sharedAt).format()}";` +
+          `"${sharedAtFormated}";` +
           '1;' +
           '"Non";' +
           '0,67;' +
@@ -298,9 +298,9 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
           `"'${organizationLearner.firstName}";` +
           `"${organizationLearner.attributes.hobby}";` +
           '1;' +
-          `"${dayjs.utc(createdAt).format()}";` +
+          `"${createdAtFormated}";` +
           '"Oui";' +
-          `"${dayjs.utc(sharedAt).format()}";` +
+          `"${sharedAtFormated}";` +
           '1;' +
           '"Non";' +
           '0,67;' +
@@ -407,9 +407,9 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
           `"'${organizationLearner.lastName}";` +
           `"'${organizationLearner.firstName}";` +
           '1;' +
-          `"${dayjs.utc(createdAt).format()}";` +
+          `"${createdAtFormated}";` +
           '"Oui";' +
-          `"${dayjs.utc(sharedAt).format()}";` +
+          `"${sharedAtFormated}";` +
           '1;' +
           '"Non";' +
           '0,67;' +
@@ -495,7 +495,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
           `"'${organizationLearner.lastName}";` +
           `"'${organizationLearner.firstName}";` +
           '0,333;' +
-          `"${dayjs.utc(createdAt).format()}";` +
+          `"${createdAtFormated}";` +
           '"Non";' +
           `"NA";` +
           '"NA";' +
@@ -529,9 +529,10 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
     });
 
     context('multiple participations', function () {
-      let secondParticipationDateCreatedAt;
+      let secondParticipationDateCreatedAt, secondParticipationCreatedFormated;
       beforeEach(async function () {
-        secondParticipationDateCreatedAt = new Date('2019-03-05');
+        secondParticipationDateCreatedAt = new Date('2019-03-05T11:23:00Z');
+        secondParticipationCreatedFormated = '05/03/2019 12:23';
         // on utilise un nouveau learner
         participant = databaseBuilder.factory.buildUser();
 
@@ -633,7 +634,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
           `"'${organizationLearner.lastName}";` +
           `"'${organizationLearner.firstName}";` +
           '0,667;' +
-          `"${dayjs.utc(secondParticipationDateCreatedAt).format()}";` +
+          `"${secondParticipationCreatedFormated}";` +
           '"Non";' +
           `"NA";` +
           '"NA";' +
@@ -658,9 +659,9 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
           `"'${organizationLearner.lastName}";` +
           `"'${organizationLearner.firstName}";` +
           '1;' +
-          `"${dayjs.utc(createdAt).format()}";` +
+          `"${createdAtFormated}";` +
           '"Oui";' +
-          `"${dayjs.utc(sharedAt).format()}";` +
+          `"${sharedAtFormated}";` +
           '1;' +
           '"Non";' +
           '0,67;' +

--- a/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -1,7 +1,4 @@
 import stream from 'node:stream';
-
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc.js';
 const { PassThrough } = stream;
 
 import * as campaignRepository from '../../../../../../lib/infrastructure/repositories/campaign-repository.js';
@@ -25,7 +22,6 @@ import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.j
 import * as competenceRepository from '../../../../../../src/shared/infrastructure/repositories/competence-repository.js';
 import * as organizationRepository from '../../../../../../src/shared/infrastructure/repositories/organization-repository.js';
 import { databaseBuilder, expect, streamToPromise } from '../../../../../test-helper.js';
-dayjs.extend(utc);
 
 describe('Integration | Domain | Use Cases | start-writing-profiles-collection-campaign-results-to-stream', function () {
   describe('#startWritingCampaignProfilesCollectionResultsToStream', function () {
@@ -39,6 +35,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
 
     const createdAt = new Date('2019-02-25T10:00:00Z');
     const sharedAt = new Date('2019-03-01T23:04:05Z');
+    const sharedAtFormated = '02/03/2019 00:04';
 
     beforeEach(async function () {
       i18n = getI18n();
@@ -200,10 +197,10 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
         const cells = csv.split('\n');
 
         expect(cells[0]).to.be.equals(
-          '\uFEFF"Nom de l\'organisation";"ID Campagne";"Code";"Nom de la campagne";"Nom du Participant";"Prénom du Participant";"Envoi (O/N)";"Date de l\'envoi";"Nombre de pix total";"Certifiable (O/N)";"Nombre de compétences certifiables";"Niveau pour la compétence nom en français recCompetence1";"Nombre de pix pour la compétence nom en français recCompetence1";"Niveau pour la compétence nom en français recCompetence2";"Nombre de pix pour la compétence nom en français recCompetence2"',
+          '\uFEFF"Nom de l\'organisation";"ID Campagne";"Code";"Nom de la campagne";"Nom du Participant";"Prénom du Participant";"Envoi (O/N)";"Date et heure de l\'envoi (Europe/Paris)";"Nombre de pix total";"Certifiable (O/N)";"Nombre de compétences certifiables";"Niveau pour la compétence nom en français recCompetence1";"Nombre de pix pour la compétence nom en français recCompetence1";"Niveau pour la compétence nom en français recCompetence2";"Nombre de pix pour la compétence nom en français recCompetence2"',
         );
         expect(cells[1]).to.be.equals(
-          `"Observatoire de Pix";${campaign.id};"QWERTY456";"'@Campagne de Test N°2";"'=Bono";"'@Jean";"Oui";"${dayjs.utc(sharedAt).format()}";52;"Non";2;1;12;5;40`,
+          `"Observatoire de Pix";${campaign.id};"QWERTY456";"'@Campagne de Test N°2";"'=Bono";"'@Jean";"Oui";"${sharedAtFormated}";52;"Non";2;1;12;5;40`,
         );
         expect(cells[2]).to.be.equals(
           `"Observatoire de Pix";${campaign.id};"QWERTY456";"'@Campagne de Test N°2";"'=Bono";"'@Jean";"Non";"NA";"NA";"NA";"NA";"NA";"NA";"NA";"NA"`,
@@ -263,10 +260,10 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
         const cells = csv.split('\n');
 
         expect(cells[0]).to.be.equals(
-          '\uFEFF"Nom de l\'organisation";"ID Campagne";"Code";"Nom de la campagne";"Nom du Participant";"Prénom du Participant";"Mail Perso";"Envoi (O/N)";"Date de l\'envoi";"Nombre de pix total";"Certifiable (O/N)";"Nombre de compétences certifiables";"Niveau pour la compétence nom en français recCompetence1";"Nombre de pix pour la compétence nom en français recCompetence1";"Niveau pour la compétence nom en français recCompetence2";"Nombre de pix pour la compétence nom en français recCompetence2"',
+          '\uFEFF"Nom de l\'organisation";"ID Campagne";"Code";"Nom de la campagne";"Nom du Participant";"Prénom du Participant";"Mail Perso";"Envoi (O/N)";"Date et heure de l\'envoi (Europe/Paris)";"Nombre de pix total";"Certifiable (O/N)";"Nombre de compétences certifiables";"Niveau pour la compétence nom en français recCompetence1";"Nombre de pix pour la compétence nom en français recCompetence1";"Niveau pour la compétence nom en français recCompetence2";"Nombre de pix pour la compétence nom en français recCompetence2"',
         );
         expect(cells[1]).to.be.equals(
-          `"Observatoire de Pix";${campaign.id};"QWERTY456";"'@Campagne de Test N°2";"'=Bono";"'@Jean";"'+Mon mail pro";"Oui";"${dayjs.utc(sharedAt).format()}";52;"Non";2;1;12;5;40`,
+          `"Observatoire de Pix";${campaign.id};"QWERTY456";"'@Campagne de Test N°2";"'=Bono";"'@Jean";"'+Mon mail pro";"Oui";"${sharedAtFormated}";52;"Non";2;1;12;5;40`,
         );
       });
     });
@@ -396,7 +393,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           `"'${organizationLearner.lastName}";` +
           `"'${organizationLearner.firstName}";` +
           '"Oui";' +
-          `"${dayjs.utc(sharedAt).format()}";` +
+          `"${sharedAtFormated}";` +
           '52;' +
           '"Non";' +
           '2;' +
@@ -474,7 +471,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           `"'${organizationLearner.firstName}";` +
           `"${organizationLearner.division}";` +
           '"Oui";' +
-          `"${dayjs.utc(sharedAt).format()}";` +
+          `"${sharedAtFormated}";` +
           '52;' +
           '"Non";' +
           '2;' +
@@ -554,7 +551,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           `"'${organizationLearner.group}";` +
           `"${organizationLearner.studentNumber}";` +
           '"Oui";' +
-          `"${dayjs.utc(sharedAt).format()}";` +
+          `"${sharedAtFormated}";` +
           '52;' +
           '"Non";' +
           '2;' +

--- a/api/tests/prescription/campaign/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -2,16 +2,12 @@ import stream from 'node:stream';
 
 const { PassThrough } = stream;
 
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc.js';
-
 import * as campaignCsvExportService from '../../../../../../src/prescription/campaign/domain/services/campaign-csv-export-service.js';
 import { startWritingCampaignAssessmentResultsToStream } from '../../../../../../src/prescription/campaign/domain/usecases/start-writing-campaign-assessment-results-to-stream.js';
 import { CampaignTypeError } from '../../../../../../src/shared/domain/errors.js';
 import { StageCollection } from '../../../../../../src/shared/domain/models/user-campaign-results/StageCollection.js';
 import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { catchErr, domainBuilder, expect, sinon, streamToPromise } from '../../../../../test-helper.js';
-dayjs.extend(utc);
 
 describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-to-stream', function () {
   let campaignRepository,
@@ -112,9 +108,9 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       '"Nom du Participant";' +
       '"Prénom du Participant";' +
       '"% de progression";' +
-      '"Date de début";' +
+      '"Date et heure de début (Europe/Paris)";' +
       '"Partage (O/N)";' +
-      '"Date du partage";' +
+      '"Date et heure du partage (Europe/Paris)";' +
       '"% maitrise de l\'ensemble des acquis du profil";' +
       `"% de maitrise des acquis de la compétence ${competence1_1.name}";` +
       `"Nombre d'acquis du profil cible dans la compétence ${competence1_1.name}";` +
@@ -172,9 +168,9 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       '"Prénom du Participant";' +
       `"${idPixLabel}";` +
       '"% de progression";' +
-      '"Date de début";' +
+      '"Date et heure de début (Europe/Paris)";' +
       '"Partage (O/N)";' +
-      '"Date du partage";' +
+      '"Date et heure du partage (Europe/Paris)";' +
       '"% maitrise de l\'ensemble des acquis du profil";' +
       `"% de maitrise des acquis de la compétence ${learningContent.competences[0].name}";` +
       `"Nombre d'acquis du profil cible dans la compétence ${learningContent.competences[0].name}";` +
@@ -226,9 +222,9 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       '"Nom du Participant";' +
       '"Prénom du Participant";' +
       '"% de progression";' +
-      '"Date de début";' +
+      '"Date et heure de début (Europe/Paris)";' +
       '"Partage (O/N)";' +
-      '"Date du partage";' +
+      '"Date et heure du partage (Europe/Paris)";' +
       `"${badge1.title} obtenu (O/N)";` +
       `"${badge2.title} obtenu (O/N)";` +
       '"% maitrise de l\'ensemble des acquis du profil";' +
@@ -280,9 +276,9 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       '"Nom du Participant";' +
       '"Prénom du Participant";' +
       '"% de progression";' +
-      '"Date de début";' +
+      '"Date et heure de début (Europe/Paris)";' +
       '"Partage (O/N)";' +
-      '"Date du partage";' +
+      '"Date et heure du partage (Europe/Paris)";' +
       '"% maitrise de l\'ensemble des acquis du profil";' +
       `"% de maitrise des acquis de la compétence ${learningContent.competences[0].name}";` +
       `"Nombre d'acquis du profil cible dans la compétence ${learningContent.competences[0].name}";` +
@@ -343,9 +339,9 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       '"Nom du Participant";' +
       '"Prénom du Participant";' +
       '"% de progression";' +
-      '"Date de début";' +
+      '"Date et heure de début (Europe/Paris)";' +
       '"Partage (O/N)";' +
-      '"Date du partage";' +
+      '"Date et heure du partage (Europe/Paris)";' +
       '"% maitrise de l\'ensemble des acquis du profil";' +
       `"% de maitrise des acquis de la compétence ${competence1_1.name}";` +
       `"Nombre d'acquis du profil cible dans la compétence ${competence1_1.name}";` +
@@ -404,9 +400,9 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       '"Nom du Participant";' +
       '"Prénom du Participant";' +
       '"% de progression";' +
-      '"Date de début";' +
+      '"Date et heure de début (Europe/Paris)";' +
       '"Partage (O/N)";' +
-      '"Date du partage";' +
+      '"Date et heure du partage (Europe/Paris)";' +
       '"Palier obtenu (/2)";' +
       '"% maitrise de l\'ensemble des acquis du profil";' +
       `"% de maitrise des acquis de la compétence ${learningContent.competences[0].name}";` +
@@ -462,9 +458,9 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
         '"Groupe";' +
         '"Numéro Étudiant";' +
         '"% de progression";' +
-        '"Date de début";' +
+        '"Date et heure de début (Europe/Paris)";' +
         '"Partage (O/N)";' +
-        '"Date du partage";' +
+        '"Date et heure du partage (Europe/Paris)";' +
         '"% maitrise de l\'ensemble des acquis du profil";' +
         `"% de maitrise des acquis de la compétence ${learningContent.competences[0].name}";` +
         `"Nombre d'acquis du profil cible dans la compétence ${learningContent.competences[0].name}";` +
@@ -519,9 +515,9 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
         '"Prénom du Participant";' +
         '"Classe";' +
         '"% de progression";' +
-        '"Date de début";' +
+        '"Date et heure de début (Europe/Paris)";' +
         '"Partage (O/N)";' +
-        '"Date du partage";' +
+        '"Date et heure du partage (Europe/Paris)";' +
         '"% maitrise de l\'ensemble des acquis du profil";' +
         `"% de maitrise des acquis de la compétence ${learningContent.competences[0].name}";` +
         `"Nombre d'acquis du profil cible dans la compétence ${learningContent.competences[0].name}";` +
@@ -547,8 +543,10 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
 
   it('should process result for each participation and add it to csv', async function () {
     // given
-    const createdAt = new Date('2020-01-01');
-    const sharedAt = new Date('2020-02-01');
+    const createdAt = new Date('2020-02-01T10:30:00Z');
+    const createdAtFormated = '01/02/2020 11:30';
+    const sharedAt = new Date('2020-02-01T15:20:00Z');
+    const sharedAtFormated = '01/02/2020 16:20';
     const { user: admin, campaign, organization } = _buildOrganizationAndUserWithMembershipAndCampaign();
     const badge = domainBuilder.buildBadge({ title: 'badge sup' });
     const targetProfile = domainBuilder.buildTargetProfile({
@@ -596,9 +594,9 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       '"Nom du Participant";' +
       '"Prénom du Participant";' +
       '"% de progression";' +
-      '"Date de début";' +
+      '"Date et heure de début (Europe/Paris)";' +
       '"Partage (O/N)";' +
-      '"Date du partage";' +
+      '"Date et heure du partage (Europe/Paris)";' +
       `"${badge.title} obtenu (O/N)";` +
       '"% maitrise de l\'ensemble des acquis du profil";' +
       `"% de maitrise des acquis de la compétence ${learningContent.competences[0].name}";` +
@@ -617,9 +615,9 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       `"${participantInfo.participantLastName}";` +
       `"${participantInfo.participantFirstName}";` +
       '1;' +
-      `"${dayjs.utc(createdAt).format()}";` +
+      `"${createdAtFormated}";` +
       '"Oui";' +
-      `"${dayjs.utc(sharedAt).format()}";` +
+      `"${sharedAtFormated}";` +
       '"Oui";' +
       '1;' +
       '1;' +

--- a/api/tests/prescription/campaign/unit/infrastructure/exports/campaigns/campaign-profiles-collection-result-line_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/exports/campaigns/campaign-profiles-collection-result-line_test.js
@@ -1,15 +1,11 @@
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc.js';
-
 import { CampaignProfilesCollectionResultLine } from '../../../../../../../src/prescription/campaign/infrastructure/exports/campaigns/campaign-profiles-collection-result-line.js';
 import { PlacementProfile } from '../../../../../../../src/shared/domain/models/index.js';
 import { getI18n } from '../../../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { domainBuilder, expect, sinon } from '../../../../../../test-helper.js';
-dayjs.extend(utc);
 
 describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', function () {
   describe('#toCsvLine', function () {
-    let organization, campaign, competences, createdAt, sharedAt;
+    let organization, campaign, competences, createdAt, sharedAt, sharedAtFormated;
 
     // TODO: Fix this the next time the file is edited.
     // eslint-disable-next-line mocha/no-setup-in-describe
@@ -33,8 +29,9 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
 
     beforeEach(function () {
       createdAt = new Date('2019-02-25T10:00:00Z');
-      sharedAt = new Date('2019-03-01T23:04:05Z');
 
+      sharedAt = new Date('2019-03-01T23:04:05Z');
+      sharedAtFormated = '02/03/2019 00:04';
       const listSkills1 = domainBuilder.buildSkillCollection({ name: '@web', minLevel: 1, maxLevel: 5 });
       const listSkills2 = domainBuilder.buildSkillCollection({ name: '@url', minLevel: 1, maxLevel: 2 });
 
@@ -88,7 +85,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           `"${campaignParticipationResultData.participantFirstName}";` +
           `"${campaignParticipationResultData.additionalInfos.hobby}";` +
           '"Oui";' +
-          `"${dayjs.utc(sharedAt).format()}";` +
+          `"${sharedAtFormated}";` +
           '13;' +
           '"Non";' +
           '0;' +
@@ -183,7 +180,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           `"${campaignParticipationResultData.participantLastName}";` +
           `"${campaignParticipationResultData.participantFirstName}";` +
           '"Oui";' +
-          `"${dayjs.utc(sharedAt).format()}";` +
+          `"${sharedAtFormated}";` +
           '13;' +
           '"Non";' +
           '0;' +
@@ -238,7 +235,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           `"${campaignParticipationResultData.participantLastName}";` +
           `"${campaignParticipationResultData.participantFirstName}";` +
           '"Oui";' +
-          `"${dayjs.utc(sharedAt).format()}";` +
+          `"${sharedAtFormated}";` +
           '13;' +
           '"Oui";' +
           '5;' +
@@ -421,7 +418,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           `"${campaignParticipationResultData.participantLastName}";` +
           `"${campaignParticipationResultData.participantFirstName}";` +
           '"Oui";' +
-          `"${dayjs.utc(sharedAt).format()}";` +
+          `"${sharedAtFormated}";` +
           '13;' +
           '"Non";' +
           '0;' +
@@ -486,7 +483,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
             `"${campaignParticipationResultData.participantFirstName}";` +
             '"";' +
             '"Oui";' +
-            `"${dayjs.utc(sharedAt).format()}";` +
+            `"${sharedAtFormated}";` +
             '13;' +
             '"Non";' +
             '0;' +
@@ -545,7 +542,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
             `"${campaignParticipationResultData.participantFirstName}";` +
             `"${campaignParticipationResultData.division}";` +
             '"Oui";' +
-            `"${dayjs.utc(sharedAt).format()}";` +
+            `"${sharedAtFormated}";` +
             '13;' +
             '"Non";' +
             '0;' +
@@ -678,7 +675,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
             `"${campaignParticipationResultData.group}";` +
             '"";' +
             '"Oui";' +
-            `"${dayjs.utc(sharedAt).format()}";` +
+            `"${sharedAtFormated}";` +
             '13;' +
             '"Non";' +
             '0;' +
@@ -739,7 +736,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
             `"${campaignParticipationResultData.group}";` +
             `"${campaignParticipationResultData.studentNumber}";` +
             '"Oui";' +
-            `"${dayjs.utc(sharedAt).format()}";` +
+            `"${sharedAtFormated}";` +
             '13;' +
             '"Non";' +
             '0;' +
@@ -800,7 +797,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
             `"${campaignParticipationResultData.group}";` +
             `"${campaignParticipationResultData.studentNumber}";` +
             '"Oui";' +
-            `"${dayjs.utc(sharedAt).format()}";` +
+            `"${sharedAtFormated}";` +
             '13;' +
             '"Non";' +
             '0;' +

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/csv/campaign-profiles-collection-export_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/csv/campaign-profiles-collection-export_test.js
@@ -130,7 +130,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-export', functi
         '"Nom du Participant";' +
         '"Prénom du Participant";' +
         '"Envoi (O/N)";' +
-        '"Date de l\'envoi";' +
+        '"Date et heure de l\'envoi (Europe/Paris)";' +
         '"Nombre de pix total";' +
         '"Certifiable (O/N)";' +
         '"Nombre de compétences certifiables";' +
@@ -171,7 +171,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-export', functi
         '"Prénom du Participant";' +
         '"Classe";' +
         '"Envoi (O/N)";' +
-        '"Date de l\'envoi";' +
+        '"Date et heure de l\'envoi (Europe/Paris)";' +
         '"Nombre de pix total";' +
         '"Certifiable (O/N)";' +
         '"Nombre de compétences certifiables";' +
@@ -213,7 +213,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-export', functi
         '"Groupe";' +
         '"Numéro Étudiant";' +
         '"Envoi (O/N)";' +
-        '"Date de l\'envoi";' +
+        '"Date et heure de l\'envoi (Europe/Paris)";' +
         '"Nombre de pix total";' +
         '"Certifiable (O/N)";' +
         '"Nombre de compétences certifiables";' +
@@ -252,7 +252,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-export', functi
         '"Prénom du Participant";' +
         '"email";' +
         '"Envoi (O/N)";' +
-        '"Date de l\'envoi";' +
+        '"Date et heure de l\'envoi (Europe/Paris)";' +
         '"Nombre de pix total";' +
         '"Certifiable (O/N)";' +
         '"Nombre de compétences certifiables";' +

--- a/api/tests/prescription/campaign/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
@@ -1,13 +1,8 @@
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc.js';
-
 import * as campaignParticipationService from '../../../../../../lib/domain/services/campaign-participation-service.js';
 import { CampaignAssessmentCsvLine } from '../../../../../../src/prescription/campaign/infrastructure/utils/CampaignAssessmentCsvLine.js';
 import { KnowledgeElement } from '../../../../../../src/shared/domain/models/index.js';
 import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { domainBuilder, expect } from '../../../../../test-helper.js';
-
-dayjs.extend(utc);
 
 function _computeExpectedColumnsIndex(campaign, organization, badges = [], stages = [], additionalHeaders = []) {
   const studentNumberPresenceModifier = organization.type === 'SUP' && organization.isManagingStudents ? 1 : 0;
@@ -92,7 +87,8 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', function (
   describe('#toCsvLine', function () {
     it('should return common info', function () {
       // given
-      const createdAt = new Date('2020-01-01');
+      const createdAt = new Date('2020-03-01T10:00:00Z');
+      const createdAtFormated = '01/03/2020 11:00';
       const organization = domainBuilder.buildOrganization({ isManagingStudents: false });
       const campaign = domainBuilder.buildCampaign({ idPixLabel: null });
       const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({
@@ -135,7 +131,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', function (
       expect(csvLine[cols.PARTICIPANT_FIRST_NAME], 'participant first name').to.equal(
         campaignParticipationInfo.participantFirstName,
       );
-      expect(csvLine[cols.PARTICIPATION_CREATED_AT], 'participant created at').to.equal(dayjs.utc(createdAt).format());
+      expect(csvLine[cols.PARTICIPATION_CREATED_AT], 'participant created at').to.equal(createdAtFormated);
       expect(csvLine[cols.PARTICIPATION_PROGRESSION], 'participation progression').to.equal(0);
     });
 
@@ -333,7 +329,8 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', function (
     context('when participation is shared', function () {
       it('should show informations regarding a shared participation', function () {
         // given
-        const sharedAt = new Date('2020-01-01T10:10:25Z');
+        const sharedAt = new Date('2020-03-01T10:10:25Z');
+        const sharedAtFormated = '01/03/2020 11:10';
         const organization = domainBuilder.buildOrganization();
         const campaign = domainBuilder.buildCampaign({ idPixLabel: null });
         const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({
@@ -371,7 +368,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', function (
         // then
         const cols = _computeExpectedColumnsIndex(campaign, organization);
         expect(csvLine[cols.PARTICIPATION_IS_SHARED], 'is shared').to.equal('Oui');
-        expect(csvLine[cols.PARTICIPATION_SHARED_AT], 'shared at').to.equal(dayjs.utc(sharedAt).format());
+        expect(csvLine[cols.PARTICIPATION_SHARED_AT], 'shared at').to.equal(sharedAtFormated);
         expect(csvLine[cols.PARTICIPATION_PERCENTAGE], 'participation percentage').to.equal(1);
       });
     });

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -41,13 +41,13 @@
       "is-shared": "Shared (Y/N)",
       "mastery-percentage-target-profile": "% of items successfully completed in the target profile",
       "progress": "% of progression",
-      "shared-on": "Shared on",
+      "shared-on": "Shared on (Europe/Paris)",
       "skill": {
         "items-successfully-completed": "Items of the target profile successfully completed in the competence {name}",
         "mastery-percentage": "% of items successfully completed in the competence {name}",
         "total-items": "Number of items of the target profile in the competence {name}"
       },
-      "started-on": "Started on",
+      "started-on": "Started on (Europe/Paris)",
       "status": {
         "ko": "KO",
         "not-tested": "Not tested",
@@ -77,7 +77,7 @@
       "is-certifiable": "Eligible for certification (Y/N)",
       "is-sent": "Sent (Y/N)",
       "pix-score": "Total pix score",
-      "sent-on": "Sent on",
+      "sent-on": "Sent on (Europe/Paris)",
       "skill-level": "Level reached in the competence {name}",
       "skill-ranking": "Pix score for the competence {name}"
     }

--- a/api/translations/es.json
+++ b/api/translations/es.json
@@ -53,13 +53,13 @@
       "is-shared": "Compartir (sí/no)",
       "mastery-percentage-target-profile": "% de dominio de todas las competencias del perfil",
       "progress": "% de aumento",
-      "shared-on": "Fecha de separación",
+      "shared-on": "Fecha y hora del reparto (Europa/París)",
       "skill": {
         "items-successfully-completed": "Habilidades dominadas en la competencia {nombre}.",
         "mastery-percentage": "% dominio de las habilidades adquiridas {nombre}",
         "total-items": "Número de logros del perfil de destino en la habilidad {nombre}."
       },
-      "started-on": "Fecha de inicio",
+      "started-on": "Fecha y hora de inicio (Europa/París)",
       "status": {
         "ko": "KB",
         "not-tested": "No probado",
@@ -89,7 +89,7 @@
       "is-certifiable": "Certificable (sí/no)",
       "is-sent": "Enviar (sí/no)",
       "pix-score": "Número total de píxeles",
-      "sent-on": "Fecha de expedición",
+      "sent-on": "Fecha y ora de expedición (Europa/París)",
       "skill-level": "Nivel de la habilidad {nombre}",
       "skill-ranking": "Número de píxeles de la habilidad {nombre}"
     }

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -53,13 +53,13 @@
       "is-shared": "Partage (O/N)",
       "mastery-percentage-target-profile": "% maitrise de l'ensemble des acquis du profil",
       "progress": "% de progression",
-      "shared-on": "Date du partage",
+      "shared-on": "Date et heure du partage (Europe/Paris)",
       "skill": {
         "items-successfully-completed": "Acquis maitrisés dans la compétence {name}",
         "mastery-percentage": "% de maitrise des acquis de la compétence {name}",
         "total-items": "Nombre d'acquis du profil cible dans la compétence {name}"
       },
-      "started-on": "Date de début",
+      "started-on": "Date et heure de début (Europe/Paris)",
       "status": {
         "ko": "KO",
         "not-tested": "Non testé",
@@ -89,7 +89,7 @@
       "is-certifiable": "Certifiable (O/N)",
       "is-sent": "Envoi (O/N)",
       "pix-score": "Nombre de pix total",
-      "sent-on": "Date de l'envoi",
+      "sent-on": "Date et heure de l'envoi (Europe/Paris)",
       "skill-level": "Niveau pour la compétence {name}",
       "skill-ranking": "Nombre de pix pour la compétence {name}"
     }

--- a/api/translations/nl.json
+++ b/api/translations/nl.json
@@ -53,13 +53,13 @@
       "is-shared": "Delen (J/N)",
       "mastery-percentage-target-profile": "% beheersing van alle vaardigheden in het profiel",
       "progress": "% toename",
-      "shared-on": "Datum van splitsing",
+      "shared-on": "Gedeelde datum en tijd (Europa/Parijs)",
       "skill": {
         "items-successfully-completed": "Vaardigheden beheerst in de {naam} competentie",
         "mastery-percentage": "% beheersing van verworven vaardigheden {naam}",
         "total-items": "Aantal prestaties van het doelprofiel in de vaardigheid {naam}"
       },
-      "started-on": "Startdatum",
+      "started-on": "Startdatum en tijd (Europa/Parijs)",
       "status": {
         "ko": "KO",
         "not-tested": "Niet getest",
@@ -89,7 +89,7 @@
       "is-certifiable": "Certificeerbaar (J/N)",
       "is-sent": "Verzenden (J/N)",
       "pix-score": "Totaal aantal pix",
-      "sent-on": "Datum van verzending",
+      "sent-on": "Datum en tijd van verzending (Europa/Parijs)",
       "skill-level": "Niveau voor vaardigheid {naam}",
       "skill-ranking": "Aantal pix voor vaardigheid {naam}"
     }


### PR DESCRIPTION
## :christmas_tree: Problème

Les dates sont formatées en utilisant un format technique moins accessible qui n'est pas très connu des utilisateurs (sauf pour ceux qui sont chauds sur la compétences 1.3)

## :gift: Proposition

On formate les dates sur le fuseau Europe/Paris

## :socks: Remarques

RAS

## :santa: Pour tester

- Faire des export de campagne (évaluation / collecte de profil)
- Voir les dates bien formatées