### PR TITLE
[FEATURE] Changement du titre du module IA avancé LLM ChatGPT MODC-176

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-parle-francais.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-parle-francais.json
@@ -44,7 +44,7 @@
   "grains": [
     {
       "id": "0bfa08bd-7052-49bb-89e8-150efa589926",
-      "type": "activity",
+      "type": "discovery",
       "title": "Pris dans le filet !",
       "components": [
         {
@@ -310,7 +310,7 @@
     },
     {
       "id": "256e2ddc-3ffc-4906-8c52-3026f353c0a0",
-      "type": "lesson",
+      "type": "summary",
       "title": "Les biais des LLM : à retenir",
       "components": [
         {
@@ -325,7 +325,7 @@
     },
     {
       "id": "e52da884-2233-4101-96a5-befd5c7d7975",
-      "type": "activity",
+      "type": "discovery",
       "title": "Découverte du comparateur",
       "components": [
         {
@@ -460,7 +460,7 @@
     },
     {
       "id": "91b54b81-5b7c-4daa-9e2f-67b7a714fd9e",
-      "type": "activity",
+      "type": "challenge",
       "title": "Utilisation du comparateur",
       "components": [
         {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-parle-francais.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-parle-francais.json
@@ -1,11 +1,11 @@
 {
   "id": "01151659-77c1-41cc-8724-89091357af3d",
-  "slug": "chatgpt-parle-francais",
-  "title": "ChatGPT parle-t-il vraiment français ?",
+  "slug": "chatgpt-vraiment-neutre",
+  "title": "ChatGPT est-il vraiment neutre ?",
   "isBeta": true,
   "details": {
     "image": "https://images.pix.fr/modulix/placeholder-details.svg",
-    "description": "<p>Les <i lang=\"en\">Large Language Models</i> (LLM) sont des systèmes d'intelligence artificielle générative. Ils donnent l'impression de parler toutes les langues mais, du fait de leurs biais, leurs productions sont parfois stéréotypées ou discriminantes. Dans ce module, vous allez découvrir les origines de ces biais et interroger directement des LLM pour les repérer !</p>",
+    "description": "<p>Les <i lang=\"en\">Large Language Models</i> (LLM) sont des systèmes d'intelligence artificielle générative. Ils donnent l'impression d’avoir réponse à tout mais, du fait de leurs biais, leurs productions sont parfois stéréotypées ou discriminantes. Dans ce module, vous allez découvrir les origines de ces biais et interroger directement des LLM pour les repérer !</p>",
     "duration": 10,
     "level": "Avancé",
     "objectives": [


### PR DESCRIPTION
## :christmas_tree: Problème

Les retours de panels nous apprennent que le titre du module manque de cohérence avec le contenu effectif du module.

## :gift: Proposition

Changer le titre du module pour qu'il corresponde davantage au contenu. Modification du descriptif pour conserver une cohérence du contenu.

## :socks: Remarques

Prendre soin de lister les utilisateurs à prévenir du changement de lien.

## :santa: Pour tester

Accéder à la page `details` du module https://app-pr10837.review.pix.fr/modules/chatgpt-vraiment-neutre/details .