### PR TITLE
[TECH] Suppression de l'utilisation de la dependency RSVP partout où on peut immédiatement la remplacer par Promise (PIX-15814)

### DIFF
--- a/admin/app/authenticators/oidc.js
+++ b/admin/app/authenticators/oidc.js
@@ -4,7 +4,6 @@ import BaseAuthenticator from 'ember-simple-auth/authenticators/base';
 import fetch from 'fetch';
 import ENV from 'pix-admin/config/environment';
 import { decodeToken } from 'pix-admin/helpers/jwt';
-import RSVP from 'rsvp';
 
 export default class OidcAuthenticator extends BaseAuthenticator {
   @service session;
@@ -47,7 +46,7 @@ export default class OidcAuthenticator extends BaseAuthenticator {
 
     const data = await response.json();
     if (!response.ok) {
-      return RSVP.reject(data);
+      return Promise.reject(data);
     }
 
     const decodedAccessToken = decodeToken(data.access_token);
@@ -61,7 +60,7 @@ export default class OidcAuthenticator extends BaseAuthenticator {
   }
 
   restore(data) {
-    return new RSVP.Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       if (!isEmpty(data['access_token'])) {
         resolve(data);
       }

--- a/mon-pix/app/authenticators/anonymous.js
+++ b/mon-pix/app/authenticators/anonymous.js
@@ -4,7 +4,6 @@ import BaseAuthenticator from 'ember-simple-auth/authenticators/base';
 import fetch from 'fetch';
 import ENV from 'mon-pix/config/environment';
 import { decodeToken } from 'mon-pix/helpers/jwt';
-import RSVP from 'rsvp';
 
 export default BaseAuthenticator.extend({
   intl: service(),
@@ -31,7 +30,7 @@ export default BaseAuthenticator.extend({
 
     const data = await response.json();
     if (!response.ok) {
-      return RSVP.reject(data);
+      return Promise.reject(data);
     }
 
     const decodedAccessToken = decodeToken(data.access_token);
@@ -43,7 +42,7 @@ export default BaseAuthenticator.extend({
   },
 
   restore(data) {
-    return new RSVP.Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       if (!isEmpty(data['access_token'])) {
         resolve(data);
       }

--- a/mon-pix/app/authenticators/gar.js
+++ b/mon-pix/app/authenticators/gar.js
@@ -1,13 +1,12 @@
 import { isEmpty } from '@ember/utils';
 import BaseAuthenticator from 'ember-simple-auth/authenticators/base';
 import { decodeToken } from 'mon-pix/helpers/jwt';
-import RSVP from 'rsvp';
 
 export default class GarAuthenticator extends BaseAuthenticator {
   authenticate(token, tokenDecoder = decodeToken) {
     const token_type = 'bearer';
     const { user_id, source } = tokenDecoder(token);
-    return RSVP.resolve({
+    return Promise.resolve({
       token_type,
       access_token: token,
       user_id,
@@ -16,7 +15,7 @@ export default class GarAuthenticator extends BaseAuthenticator {
   }
 
   restore(data) {
-    return new RSVP.Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       if (!isEmpty(data['access_token'])) {
         resolve(data);
       }

--- a/mon-pix/app/authenticators/oauth2.js
+++ b/mon-pix/app/authenticators/oauth2.js
@@ -1,7 +1,6 @@
 import OAuth2PasswordGrant from 'ember-simple-auth/authenticators/oauth2-password-grant';
 import ENV from 'mon-pix/config/environment';
 import { decodeToken } from 'mon-pix/helpers/jwt';
-import RSVP from 'rsvp';
 
 export default class OAuth2 extends OAuth2PasswordGrant {
   serverTokenEndpoint = `${ENV.APP.API_HOST}/api/token`;
@@ -14,7 +13,7 @@ export default class OAuth2 extends OAuth2PasswordGrant {
       const decodedAccessToken = decodeToken(token);
       const user_id = decodedAccessToken.user_id;
       const source = decodedAccessToken.source;
-      return RSVP.resolve({
+      return Promise.resolve({
         token_type,
         access_token: token,
         user_id,

--- a/mon-pix/app/authenticators/oidc.js
+++ b/mon-pix/app/authenticators/oidc.js
@@ -4,7 +4,6 @@ import BaseAuthenticator from 'ember-simple-auth/authenticators/base';
 import fetch from 'fetch';
 import ENV from 'mon-pix/config/environment';
 import { decodeToken } from 'mon-pix/helpers/jwt';
-import RSVP from 'rsvp';
 
 export default class OidcAuthenticator extends BaseAuthenticator {
   @service intl;
@@ -49,7 +48,7 @@ export default class OidcAuthenticator extends BaseAuthenticator {
 
     const data = await response.json();
     if (!response.ok) {
-      return RSVP.reject(data);
+      return Promise.reject(data);
     }
 
     const decodedAccessToken = decodeToken(data.access_token);
@@ -65,7 +64,7 @@ export default class OidcAuthenticator extends BaseAuthenticator {
   }
 
   restore(data) {
-    return new RSVP.Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       if (!isEmpty(data['access_token'])) {
         resolve(data);
       }


### PR DESCRIPTION
## :christmas_tree: Problème

Le code de Pix des applications Front utilise la [dependency obsolète _RSVP_](https://discuss.emberjs.com/t/should-we-still-use-rsvp-instead-of-native-promises/19243) pour des usages qui peuvent être immédiatement remplacés par l'utilisation des _Promises_ natives. On cherche à se débarrasser de la [dependency obsolète _RSVP_.

## :gift: Proposition

Remplacer l'utilisation de _RSVP_ par l'utilisation de  _Promises_ natives partout où le remplacement est immédiat.

On s'occupera de remplacer `RSVP.hash` dans une autre PR.

## :socks: Remarques

RAS

## :santa: Pour tester

### Tests de non-régression sur la RA

* Se connecter avec un identifiant/email et un mot de passe à Pix App et constater qu'il n'y a pas de régression
* Se déconnecter de Pix App et constater qu'il n'y a pas de régression

### Tests de non-régression en local

Sur Pix App avec un SSO OIDC : 
* Se connecter à Pix App avec un SSO OIDC et constater qu'il n'y a pas de régression
* Se déconnecter de Pix App et constater qu'il n'y a pas de régression

Sur Pix App avec le Gar : 
* Se connecter à Pix App avec le Gar et constater qu'il n'y a pas de régression
* Se déconnecter de Pix App et constater qu'il n'y a pas de régression

Sur Pix Admin avec un SSO OIDC : 
* Se connecter à Pix Admin avec un SSO OIDC et constater qu'il n'y a pas de régression
* Se déconnecter de Pix Admin et constater qu'il n'y a pas de régression
