### PR TITLE
[BUGFIX] Problème d'affichage sur les leçons (PIX-15767)

### DIFF
--- a/junior/app/components/challenge/item/component.js
+++ b/junior/app/components/challenge/item/component.js
@@ -12,8 +12,10 @@ export default class Item extends Component {
       }
     });
   }
+
   get isMediaWithForm() {
-    return this.args.challenge.hasForm && this.hasMedia && this.args.challenge.type !== undefined;
+    const challenge = this.args.challenge;
+    return challenge.hasForm && this.hasMedia && challenge.hasType;
   }
 
   get hasMedia() {

--- a/junior/app/models/challenge.js
+++ b/junior/app/models/challenge.js
@@ -67,4 +67,8 @@ export default class Challenge extends Model {
   get hasForm() {
     return this.autoReply === false;
   }
+
+  get hasType() {
+    return !!this.type;
+  }
 }

--- a/junior/tests/unit/models/challenge-test.js
+++ b/junior/tests/unit/models/challenge-test.js
@@ -182,4 +182,25 @@ module('Unit | Model | Challenge', function (hooks) {
       assert.false(challenge.isQCM);
     });
   });
+
+  module('#hasType', function () {
+    test('should be true if type is set', async function (assert) {
+      const challenge = store.createRecord('challenge', {
+        type: 'QCM',
+      });
+      assert.true(challenge.hasType);
+    });
+    test('should be false if type is null', async function (assert) {
+      const challenge = store.createRecord('challenge', {
+        type: null,
+      });
+      assert.false(challenge.hasType);
+    });
+    test('should be false if type is undefined', async function (assert) {
+      const challenge = store.createRecord('challenge', {
+        type: undefined,
+      });
+      assert.false(challenge.hasType);
+    });
+  });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Quand un challenge est une leçon, celle-ci n'a pas de type.
Elle s'affiche alors mal dans Pix Junior : 

![image](https://github.com/user-attachments/assets/f6dddd10-9044-4cc9-ab02-3b9c2b38074a)

## :gift: Proposition

Le code coté junior n'est pas assez robuste. Considérer un type `null` ou `undefined` de la même manière.

## :santa: Pour tester
Accéder à un challenge leçon. Exemple : https://junior-pr10843.review.pix.fr/challenges/challenge2bcxkQe0i5r9J8/preview
et observer que le bouton "Je continue" est bien placé sous l'image.
![image](https://github.com/user-attachments/assets/38c944b4-4033-49e4-aea4-12a651e0139c)
