### PR TITLE
[FEATURE] campaign participation id in ke snapshots (Pix-15753)

### DIFF
--- a/api/db/database-builder/factory/build-knowledge-element-snapshot.js
+++ b/api/db/database-builder/factory/build-knowledge-element-snapshot.js
@@ -9,6 +9,7 @@ const buildKnowledgeElementSnapshot = function ({
   userId,
   snappedAt = new Date('2020-01-01'),
   snapshot,
+  campaignParticipationId,
 } = {}) {
   const dateMinusOneDay = new Date(snappedAt.getTime() - 1000 * 60 * 60 * 24 * 7);
   userId = _.isUndefined(userId) ? buildUser().id : userId;
@@ -24,6 +25,7 @@ const buildKnowledgeElementSnapshot = function ({
     userId,
     snappedAt,
     snapshot,
+    campaignParticipationId,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/db/database-builder/factory/knowledge-elements-snapshot-factory.js
+++ b/api/db/database-builder/factory/knowledge-elements-snapshot-factory.js
@@ -1,7 +1,7 @@
 import { databaseBuffer } from '../database-buffer.js';
 import { buildKnowledgeElement } from './build-knowledge-element.js';
 
-function buildSnapshot({ id, userId, snappedAt, knowledgeElementsAttributes }) {
+function buildSnapshot({ id, userId, snappedAt, knowledgeElementsAttributes, campaignParticipationId }) {
   const knowledgeElements = knowledgeElementsAttributes.map((attributes) => buildKnowledgeElement(attributes));
 
   const values = {
@@ -9,6 +9,7 @@ function buildSnapshot({ id, userId, snappedAt, knowledgeElementsAttributes }) {
     userId,
     snappedAt,
     snapshot: JSON.stringify(knowledgeElements),
+    campaignParticipationId,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/db/migrations/20241218140743_create-campaignparticipationid-column-in-ke-snaphots.js
+++ b/api/db/migrations/20241218140743_create-campaignparticipationid-column-in-ke-snaphots.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'knowledge-element-snapshots';
+const COLUMN_NAME = 'campaignParticipationId';
+
+const up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table
+      .integer(COLUMN_NAME)
+      .unsigned()
+      .nullable()
+      .references('campaign-participations.id')
+      .index()
+      .comment('Added this column as part of the anonymization process');
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/db/seeds/data/common/tooling/campaign-tooling.js
+++ b/api/db/seeds/data/common/tooling/campaign-tooling.js
@@ -241,6 +241,7 @@ async function createAssessmentCampaign({
           userId,
           snappedAt: sharedAt,
           snapshot: JSON.stringify(keDataForSnapshot),
+          campaignParticipationId,
         });
 
         if (configCampaign.recommendedTrainingsIds?.length > 0) {
@@ -404,6 +405,7 @@ async function createProfilesCollectionCampaign({
         userId,
         snappedAt: sharedAt,
         snapshot: JSON.stringify(keDataForSnapshot),
+        campaignParticipationId,
       });
 
       await databaseBuilder.commit();

--- a/api/lib/infrastructure/repositories/knowledge-element-snapshot-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-snapshot-repository.js
@@ -18,13 +18,14 @@ function _toKnowledgeElementCollection({ snapshot } = {}) {
   );
 }
 
-const save = async function ({ userId, snappedAt, knowledgeElements }) {
+const save = async function ({ userId, snappedAt, knowledgeElements, campaignParticipationId }) {
   try {
     const knexConn = DomainTransaction.getConnection();
     return await knexConn('knowledge-element-snapshots').insert({
       userId,
       snappedAt,
       snapshot: JSON.stringify(knowledgeElements),
+      campaignParticipationId,
     });
   } catch (error) {
     if (knexUtils.isUniqConstraintViolated(error)) {
@@ -78,7 +79,7 @@ const findMultipleUsersFromUserIdsAndSnappedAtDates = async function (userIdsAnd
   });
 
   const results = await knex
-    .select('userId', 'snapshot', 'snappedAt')
+    .select('userId', 'snapshot', 'snappedAt', 'campaignParticipationId')
     .from('knowledge-element-snapshots')
     .whereIn(['knowledge-element-snapshots.userId', 'snappedAt'], params);
 
@@ -89,6 +90,7 @@ const findMultipleUsersFromUserIdsAndSnappedAtDates = async function (userIdsAnd
       userId: result.userId,
       snappedAt: result.snappedAt,
       knowledgeElements: mappedKnowledgeElements,
+      campaignParticipationId: result.campaignParticipationId,
     });
   });
 };

--- a/api/scripts/prod/generate-knowledge-element-snapshots-for-campaigns.js
+++ b/api/scripts/prod/generate-knowledge-element-snapshots-for-campaigns.js
@@ -77,7 +77,12 @@ async function generateKnowledgeElementSnapshots(
         limitDate: sharedAt,
       });
       try {
-        await dependencies.knowledgeElementSnapshotRepository.save({ userId, snappedAt: sharedAt, knowledgeElements });
+        await dependencies.knowledgeElementSnapshotRepository.save({
+          userId,
+          snappedAt: sharedAt,
+          knowledgeElements,
+          campaignParticipationId: campaignParticipation.id,
+        });
       } catch (err) {
         if (!(err instanceof AlreadyExistingEntityError)) {
           throw err;

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
@@ -37,6 +37,7 @@ const updateWithSnapshot = async function (campaignParticipation) {
     userId: campaignParticipation.userId,
     snappedAt: campaignParticipation.sharedAt,
     knowledgeElements,
+    campaignParticipationId: campaignParticipation.id,
   });
 };
 

--- a/api/src/prescription/shared/domain/read-models/CampaignParticipationKnowledgeElementSnapshots.js
+++ b/api/src/prescription/shared/domain/read-models/CampaignParticipationKnowledgeElementSnapshots.js
@@ -1,8 +1,9 @@
 class CampaignParticipationKnowledgeElementSnapshots {
-  constructor({ userId, snappedAt, knowledgeElements } = {}) {
+  constructor({ userId, snappedAt, knowledgeElements, campaignParticipationId } = {}) {
     this.userId = userId;
     this.snappedAt = snappedAt;
     this.knowledgeElements = knowledgeElements;
+    this.campaignParticipationId = campaignParticipationId;
   }
 }
 

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -313,12 +313,13 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
   });
 
   describe('#findSnapshotGroupedByCompetencesForUsers', function () {
-    let userId1, userId2, sandbox;
+    let userId1, userId2, campaignParticipationId, sandbox;
 
     beforeEach(function () {
       sandbox = sinon.createSandbox();
       userId1 = databaseBuilder.factory.buildUser().id;
       userId2 = databaseBuilder.factory.buildUser().id;
+      campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation().id;
       return databaseBuilder.commit();
     });
 
@@ -399,6 +400,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
           userId: userId1,
           snappedAt: dateUserId1,
           snapshot: JSON.stringify([knowledgeElement]),
+          campaignParticipationId,
         });
         await databaseBuilder.commit();
 
@@ -416,11 +418,14 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
     context('when user does not have a snapshot for this date', function () {
       context('when no date is provided along with the user', function () {
         let expectedKnowledgeElement;
+        let campaignParticipationId;
 
         beforeEach(function () {
+          campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation().id;
           expectedKnowledgeElement = databaseBuilder.factory.buildKnowledgeElement({
             userId: userId1,
             createdAt: new Date('2018-01-01'),
+            campaignParticipationId,
           });
           return databaseBuilder.commit();
         });
@@ -1010,6 +1015,8 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
     it('should return the knowledge elements in the snapshot when user has a snapshot for this date', async function () {
       // given
       const learningContent = domainBuilder.buildCampaignLearningContent.withSimpleContent();
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation().id;
+
       const userId = databaseBuilder.factory.buildUser().id;
       const dateUserId = new Date('2020-01-03');
       const knowledgeElement = databaseBuilder.factory.buildKnowledgeElement({
@@ -1020,6 +1027,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
         userId,
         snappedAt: dateUserId,
         snapshot: JSON.stringify([knowledgeElement]),
+        campaignParticipationId,
       });
       await databaseBuilder.commit();
 

--- a/api/tests/integration/scripts/prod/generate-knowledge-element-snapshots-for-campaigns_test.js
+++ b/api/tests/integration/scripts/prod/generate-knowledge-element-snapshots-for-campaigns_test.js
@@ -131,10 +131,13 @@ describe('Integration | Scripts | generate-knowledge-element-snapshots-for-campa
     it('should save snapshots', async function () {
       // given
       const concurrency = 1;
-      const campaignParticipationData = [{ userId: 1, sharedAt: new Date('2020-01-01') }];
+      const campaignParticipationData = [{ id: 1, userId: 1, sharedAt: new Date('2020-01-01') }];
       const expectedKnowledgeElements = ['someKnowledgeElements'];
       knowledgeElementRepositoryStub.findUniqByUserId
-        .withArgs({ userId: campaignParticipationData[0].userId, limitDate: campaignParticipationData[0].sharedAt })
+        .withArgs({
+          userId: campaignParticipationData[0].userId,
+          limitDate: campaignParticipationData[0].sharedAt,
+        })
         .resolves(expectedKnowledgeElements);
 
       // when
@@ -148,6 +151,7 @@ describe('Integration | Scripts | generate-knowledge-element-snapshots-for-campa
         userId: campaignParticipationData[0].userId,
         snappedAt: campaignParticipationData[0].sharedAt,
         knowledgeElements: expectedKnowledgeElements,
+        campaignParticipationId: campaignParticipationData[0].id,
       });
     });
   });


### PR DESCRIPTION
## :christmas_tree: Problème

Dans le cadre de l'anonymisation, on veut pouvoir rattacher les enregistrements de la table knowledge-element-snapshots aux campaign participations qui leur correspondent.

## :gift: Proposition

Pour cela, on ajoute une colonne campaign participation id à la table ke snapshots. On enregistre également le campaign participation id au moment de l'insertion d'un snapshot en base de données.

## :santa: Pour tester
On fait un parcours sur le PixApp de la RA et on partage ses résultats. 
Puis on se connecte au scalingo de la RA. On vérifie que la table ke-snapshots a bien la colonne "campaignParticipationId" remplie pour notre utilisateur.
