### PR TITLE
[FEATURE] Traduction des e-mails ES & NL suppr compte (PIX-15787)

### DIFF
--- a/api/translations/es.json
+++ b/api/translations/es.json
@@ -301,7 +301,9 @@
     "template-name": "modelo de importación"
   },
   "email-sender-name": {
-    "pix-app": "PIX - No contestar"
+    "pix-app": "PIX - No contestar",
+    "pix-certif": "Pix Certif - No responder",
+    "pix-orga": "Pix Orga - No responder"
   },
   "entity-validation-errors": {
     "ACCEPT_CGU": "Debes aceptar las condiciones de uso de Pix para crear una cuenta.",
@@ -376,6 +378,7 @@
       "moreOn": "Más información sobre",
       "pixPresentation": "Pix es el servicio público en línea para evaluar, desarrollar y certificar las competencias digitales.",
       "subtitle": "Ya puedes empezar las pruebas.",
+      "subtitleDescription": "Es muy sencillo, sólo tienes que hacer clic en el botón de abajo e iniciar sesión en tu cuenta Pix.",
       "title": "¡Tu cuenta Pix ha sido creada correctamente!"
     },
     "subject": "tu cuenta Pix ha sido creada correctamente"

--- a/api/translations/es.json
+++ b/api/translations/es.json
@@ -227,6 +227,14 @@
       "REJECTED_AUTOMATICALLY_COMMENT": "El candidato respondió incorrectamente a más del 50% de las preguntas, lo que invalidó toda su certificación y le supuso una puntuación de 0 píxeles."
     }
   },
+  "common": {
+    "email": {
+      "contactUs": "Contáctanos.",
+      "doNotAnswer": "Este es un correo electrónico automático, por favor, no respondas directamente.",
+      "moreOn": "Más información sobre",
+      "pixPresentation": "Pix es el servicio público en línea para evaluar, desarrollar y certificar tus competencias digitales."
+    }
+  },
   "csv-import-values": {
     "sup-organization-learner": {
       "diplomas": {

--- a/api/translations/es.json
+++ b/api/translations/es.json
@@ -53,13 +53,13 @@
       "is-shared": "Compartir (sí/no)",
       "mastery-percentage-target-profile": "% de dominio de todas las competencias del perfil",
       "progress": "% de aumento",
-      "shared-on": "Fecha y hora del reparto (Europa/París)",
+      "shared-on": "Fecha de separación",
       "skill": {
         "items-successfully-completed": "Habilidades dominadas en la competencia {nombre}.",
         "mastery-percentage": "% dominio de las habilidades adquiridas {nombre}",
         "total-items": "Número de logros del perfil de destino en la habilidad {nombre}."
       },
-      "started-on": "Fecha y hora de inicio (Europa/París)",
+      "started-on": "Fecha de inicio",
       "status": {
         "ko": "KB",
         "not-tested": "No probado",
@@ -89,7 +89,7 @@
       "is-certifiable": "Certificable (sí/no)",
       "is-sent": "Enviar (sí/no)",
       "pix-score": "Número total de píxeles",
-      "sent-on": "Fecha y ora de expedición (Europa/París)",
+      "sent-on": "Fecha de expedición",
       "skill-level": "Nivel de la habilidad {nombre}",
       "skill-ranking": "Número de píxeles de la habilidad {nombre}"
     }
@@ -225,14 +225,6 @@
       "COMPLEMENTARY_CERTIFICATION_REJECTED": "Rechazado",
       "COMPLEMENTARY_CERTIFICATION_VALIDATED": "Validado",
       "REJECTED_AUTOMATICALLY_COMMENT": "El candidato respondió incorrectamente a más del 50% de las preguntas, lo que invalidó toda su certificación y le supuso una puntuación de 0 píxeles."
-    }
-  },
-  "common": {
-    "email": {
-      "contactUs": "contact us here",
-      "doNotAnswer": "This is an automated email message, please do not reply.",
-      "moreOn": "More on",
-      "pixPresentation": "Pix is the online service to assess, develop and certify your digital skills."
     }
   },
   "csv-import-values": {
@@ -371,13 +363,12 @@
       "askForHelp": "¿Necesitas ayuda? Ponte en contacto con nosotros",
       "disclaimer": "Si no has creado tú la cuenta, puedes pedir que se elimine",
       "doNotAnswer": "Este es un correo electrónico automático, por favor, no respondas directamente.",
-      "goToPix": "Confirmo mi dirección de correo electrónico",
+      "goToPix": "Empezar las pruebas",
       "helpdeskLinkLabel": "aquí",
       "moreOn": "Más información sobre",
       "pixPresentation": "Pix es el servicio público en línea para evaluar, desarrollar y certificar las competencias digitales.",
-      "subtitle": "Gracias por crear su cuenta. Queda un paso para asegurar tu cuenta validando tu dirección de correo electrónico.",
-      "subtitleDescription": "Es muy sencillo, sólo tiene que hacer clic en el botón de abajo e iniciar sesión en su cuenta Pix.",
-      "title": "Hola {firstName},"
+      "subtitle": "Ya puedes empezar las pruebas.",
+      "title": "¡Tu cuenta Pix ha sido creada correctamente!"
     },
     "subject": "tu cuenta Pix ha sido creada correctamente"
   },
@@ -397,14 +388,14 @@
   },
   "self-account-deletion-email": {
     "params": {
-      "hello": "Hello {firstName},",
-      "requestConfirmation": "Following your request, we can confirm that your Pix account and personal data have been deleted.",
-      "seeYouSoon": "We hope to see you soon for new digital adventures.",
-      "signing": "The Pix team",
-      "title": "Deleting your account",
-      "warning": "If you are not the source of this request, please contact support."
+      "hello": "Hola {nombre},",
+      "requestConfirmation": "Tras su solicitud, le confirmaremos la eliminación de su cuenta Pix y de sus datos personales.",
+      "seeYouSoon": "Esperamos verte pronto en nuevas aventuras digitales.",
+      "signing": "El equipo Pix",
+      "title": "Eliminar su cuenta",
+      "warning": "Si usted no es la fuente de esta solicitud, póngase en contacto con el servicio de asistencia."
     },
-    "subject": "Deleting your account"
+    "subject": "Eliminar su cuenta"
   },
   "verification-code-email": {
     "body": {

--- a/api/translations/nl.json
+++ b/api/translations/nl.json
@@ -227,6 +227,14 @@
       "REJECTED_AUTOMATICALLY_COMMENT": "De kandidaat beantwoordde meer dan 50% van de vragen fout, waardoor zijn hele certificering ongeldig werd en hij een score van 0 pix kreeg."
     }
   },
+  "common": {
+    "email": {
+      "contactUs": "neem hier contact met ons op",
+      "doNotAnswer": "Dit is een automatische e-mail, antwoord niet.",
+      "moreOn": "Ontdek meer over",
+      "pixPresentation": "Pix is de openbare online service voor het beoordelen, ontwikkelen en certificeren van je digitale vaardigheden."
+    }
+  },
   "csv-import-values": {
     "sup-organization-learner": {
       "diplomas": {

--- a/api/translations/nl.json
+++ b/api/translations/nl.json
@@ -301,7 +301,9 @@
     "template-name": "importmodel"
   },
   "email-sender-name": {
-    "pix-app": "PIX - Niet beantwoorden"
+    "pix-app": "PIX - Niet beantwoorden",
+    "pix-certif": "PIX - Niet beantwoorden",
+    "pix-orga": "Pix Orga - Niet beantwoorden"
   },
   "entity-validation-errors": {
     "ACCEPT_CGU": "Je moet de gebruiksvoorwaarden van Pix accepteren om een account aan te maken.",
@@ -368,6 +370,7 @@
       "moreOn": "Ontdek meer over",
       "pixPresentation": "Pix is de online overheidsdienst voor het beoordelen, ontwikkelen en certificeren van je digitale vaardigheden.",
       "subtitle": "Je kunt nu beginnen met de tests.",
+      "subtitleDescription": "Het is heel eenvoudig, klik op de knop hieronder en log in op je Pix-account.",
       "title": "Je Pix-account is aangemaakt!"
     },
     "subject": "Je Pix-account is aangemaakt"

--- a/api/translations/nl.json
+++ b/api/translations/nl.json
@@ -53,13 +53,13 @@
       "is-shared": "Delen (J/N)",
       "mastery-percentage-target-profile": "% beheersing van alle vaardigheden in het profiel",
       "progress": "% toename",
-      "shared-on": "Gedeelde datum en tijd (Europa/Parijs)",
+      "shared-on": "Datum van splitsing",
       "skill": {
         "items-successfully-completed": "Vaardigheden beheerst in de {naam} competentie",
         "mastery-percentage": "% beheersing van verworven vaardigheden {naam}",
         "total-items": "Aantal prestaties van het doelprofiel in de vaardigheid {naam}"
       },
-      "started-on": "Startdatum en tijd (Europa/Parijs)",
+      "started-on": "Startdatum",
       "status": {
         "ko": "KO",
         "not-tested": "Niet getest",
@@ -89,7 +89,7 @@
       "is-certifiable": "Certificeerbaar (J/N)",
       "is-sent": "Verzenden (J/N)",
       "pix-score": "Totaal aantal pix",
-      "sent-on": "Datum en tijd van verzending (Europa/Parijs)",
+      "sent-on": "Datum van verzending",
       "skill-level": "Niveau voor vaardigheid {naam}",
       "skill-ranking": "Aantal pix voor vaardigheid {naam}"
     }
@@ -227,14 +227,6 @@
       "REJECTED_AUTOMATICALLY_COMMENT": "De kandidaat beantwoordde meer dan 50% van de vragen fout, waardoor zijn hele certificering ongeldig werd en hij een score van 0 pix kreeg."
     }
   },
-  "common": {
-    "email": {
-      "contactUs": "contact us here",
-      "doNotAnswer": "This is an automated email message, please do not reply.",
-      "moreOn": "More on",
-      "pixPresentation": "Pix is the online service to assess, develop and certify your digital skills."
-    }
-  },
   "csv-import-values": {
     "sup-organization-learner": {
       "diplomas": {
@@ -363,13 +355,12 @@
       "askForHelp": "Hulp nodig? Neem contact met ons op",
       "disclaimer": "Als je de account niet hebt aangemaakt, kun je vragen om deze te verwijderen.",
       "doNotAnswer": "Dit is een automatische e-mail, antwoord niet.",
-      "goToPix": "Ik bevestig mijn e-mailadres",
+      "goToPix": "Beginnen met de tests",
       "helpdeskLinkLabel": "hier",
       "moreOn": "Ontdek meer over",
       "pixPresentation": "Pix is de online overheidsdienst voor het beoordelen, ontwikkelen en certificeren van je digitale vaardigheden.",
-      "subtitle": "Bedankt voor het aanmaken van je account. Er is nog één stap over om je account te beveiligen door je e-mailadres te valideren.",
-      "subtitleDescription": "Het is heel eenvoudig, klik op de knop hieronder en log in op je Pix-account.",
-      "title": "Hallo {firstName},"
+      "subtitle": "Je kunt nu beginnen met de tests.",
+      "title": "Je Pix-account is aangemaakt!"
     },
     "subject": "Je Pix-account is aangemaakt"
   },
@@ -389,14 +380,14 @@
   },
   "self-account-deletion-email": {
     "params": {
-      "hello": "Hello {firstName},",
-      "requestConfirmation": "Following your request, we can confirm that your Pix account and personal data have been deleted.",
-      "seeYouSoon": "We hope to see you soon for new digital adventures.",
-      "signing": "The Pix team",
-      "title": "Deleting your account",
-      "warning": "If you are not the source of this request, please contact support."
+      "hello": "Hallo {voornaam},",
+      "requestConfirmation": "Na je verzoek zullen we de verwijdering van je Pix-account en je persoonlijke gegevens bevestigen.",
+      "seeYouSoon": "We hopen je snel te zien voor nieuwe digitale avonturen.",
+      "signing": "Het Pix-team",
+      "title": "Je account verwijderen",
+      "warning": "Als u niet de bron van dit verzoek bent, neem dan contact op met ondersteuning."
     },
-    "subject": "Deleting your account"
+    "subject": "Je account verwijderen"
   },
   "verification-code-email": {
     "body": {


### PR DESCRIPTION
- L'e-mail de suppression du compte est bien reçu en espagnol 
- L'e-mail de suppression du compte est bien reçu en néerlandais 