### PR TITLE
[FEATURE] Modifier le comportement du bouton de rafraîchissement lors d'un signalement (PIX-15726)

### DIFF
--- a/mon-pix/app/components/assessments/live-alert.gjs
+++ b/mon-pix/app/components/assessments/live-alert.gjs
@@ -5,13 +5,14 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
+import PixWindow from 'mon-pix/utils/pix-window';
 
 export default class LiveAlert extends Component {
   @service router;
 
   @action
   refreshPage() {
-    this.router.refresh();
+    PixWindow.reload();
   }
 
   <template>

--- a/mon-pix/app/components/companion/blocker.gjs
+++ b/mon-pix/app/components/companion/blocker.gjs
@@ -5,6 +5,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
+import PixWindow from 'mon-pix/utils/pix-window';
 
 import ShieldIcon from './shield-icon';
 
@@ -33,7 +34,7 @@ export default class CompanionBlocker extends Component {
 
   @action
   refreshPage() {
-    window.location.reload(true);
+    PixWindow.reload();
   }
 
   <template>

--- a/mon-pix/app/utils/pix-window.js
+++ b/mon-pix/app/utils/pix-window.js
@@ -10,10 +10,15 @@ function getLocationHref() {
   return window.location.href;
 }
 
+function reload() {
+  window.location.reload(true);
+}
+
 const PixWindow = {
   getLocationHash,
   getLocationHostname,
   getLocationHref,
+  reload,
 };
 
 export default PixWindow;

--- a/mon-pix/tests/acceptance/certification-course-test.js
+++ b/mon-pix/tests/acceptance/certification-course-test.js
@@ -688,63 +688,6 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
               .exists();
           });
         });
-
-        module('when refreshing the page', function () {
-          test('it should keep challenge action buttons disabled', async function (assert) {
-            assert.timeout(5000);
-            // given
-            user = server.create('user', 'withEmail', 'certifiable', { hasSeenOtherChallengesTooltip: true });
-
-            server.create('challenge', 'forCertification');
-
-            this.server.create('certification-course', {
-              accessCode: 'ABCD12',
-              sessionId: 1,
-              nbChallenges: 1,
-              firstName: 'Laura',
-              lastName: 'Bravo',
-              version: 3,
-            });
-
-            this.server.create('certification-candidate-subscription', {
-              id: 2,
-              sessionId: 1,
-              eligibleSubscriptions: null,
-              nonEligibleSubscription: null,
-            });
-
-            await authenticate(user);
-            const screen = await visit('/certifications');
-            await fillCertificationJoiner({
-              sessionId: '1',
-              firstName: 'Laura',
-              lastName: 'Bravo',
-              dayOfBirth: '04',
-              monthOfBirth: '01',
-              yearOfBirth: '1990',
-              t,
-            });
-            await fillCertificationStarter({ accessCode: 'ABCD12', t });
-            await click(screen.getByRole('button', { name: 'Signaler un problème avec la question' }));
-            await click(screen.getByRole('button', { name: 'Oui, je suis sûr(e)' }));
-            // eslint-disable-next-line ember/no-settled-after-test-helper
-            await settled();
-
-            // when
-            await click(screen.getByRole('button', { name: 'Rafraîchir la page' }));
-            // eslint-disable-next-line ember/no-settled-after-test-helper
-            await settled();
-
-            // then
-            assert.dom(screen.queryByRole('button', { name: 'Signaler un problème avec la question' })).doesNotExist();
-            assert
-              .dom(screen.getByRole('button', { name: 'Je passe et je vais à la prochaine question' }))
-              .hasAttribute('disabled');
-            assert
-              .dom(screen.getByRole('button', { name: 'Je valide et je vais à la prochaine question' }))
-              .hasAttribute('disabled');
-          });
-        });
       });
     });
   });

--- a/mon-pix/tests/unit/components/assessments/live-alert-test.js
+++ b/mon-pix/tests/unit/components/assessments/live-alert-test.js
@@ -1,23 +1,32 @@
 import { setupTest } from 'ember-qunit';
 import createGlimmerComponent from 'mon-pix/tests/helpers/create-glimmer-component';
+import PixWindow from 'mon-pix/utils/pix-window';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
 module('Unit | Component | Assessments | Live alert', function (hooks) {
   setupTest(hooks);
 
+  let reloadStub;
+
+  hooks.beforeEach(function () {
+    reloadStub = sinon.stub(PixWindow, 'reload');
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
   module('#refreshPage', function () {
     test('should refresh page', async function (assert) {
       // given
-      const routerService = this.owner.lookup('service:router');
-      sinon.stub(routerService, 'refresh');
       const component = createGlimmerComponent('assessments/live-alert');
 
       // when
       await component.refreshPage();
 
       // then
-      sinon.assert.calledOnce(component.router.refresh);
+      sinon.assert.calledOnce(reloadStub);
       assert.ok(true);
     });
   });

--- a/mon-pix/tests/unit/components/companion/blocker-test.js
+++ b/mon-pix/tests/unit/components/companion/blocker-test.js
@@ -1,6 +1,7 @@
 import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
 import createGlimmerComponent from 'mon-pix/tests/helpers/create-glimmer-component';
+import PixWindow from 'mon-pix/utils/pix-window';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -141,6 +142,36 @@ module('Unit | Component | Companion | Blocker', function (hooks) {
         sinon.assert.calledWith(removeEventListenerStub, 'block', onBlock);
         assert.ok(true);
       });
+    });
+  });
+
+  module('#refreshPage', function (hooks) {
+    let reloadStub;
+
+    hooks.beforeEach(function () {
+      reloadStub = sinon.stub(PixWindow, 'reload');
+    });
+
+    hooks.afterEach(function () {
+      sinon.restore();
+    });
+
+    test('should refresh the page', async function (assert) {
+      // given
+      const startCheckingExtensionIsEnabledStub = sinon.stub();
+      class PixCompanionStub extends Service {
+        startCheckingExtensionIsEnabled = startCheckingExtensionIsEnabledStub;
+        isExtensionEnabled = true;
+      }
+      this.owner.register('service:pix-companion', PixCompanionStub);
+      const component = createGlimmerComponent('companion/blocker');
+
+      // when
+      await component.refreshPage();
+
+      // then
+      sinon.assert.calledOnce(reloadStub);
+      assert.ok(true);
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème

Contexte : 
- Avec une connexion ENT expirée,
- suite à une reconnexion
- après rafraîchissement d'une épreuve,
- si cette épreuve est en état de signalement

Alors : 
Les boutons de soumission d'épreuve restent désactivés.

## :gift: Proposition

Avoir un vrai rafraîchissement navigateur pour bien renouveler le cookie de session.

## :socks: Remarques

Le comportement ne change pas pour l'utilisateur.
D'autres questions ont été soulevées suite à ça sur des épreuves timées.

## :santa: Pour tester

- En RA, se connecter avec un utilisateur certifiable (`certif-success@example.net`)
- Lancer un test de certif
- Pendant le test, signaler une question
- Le surveiller doit valider le signalement
- Le candidat utilise le bouton "rafraîchir la page"
- ✅ Constater que les boutons de soumission de réponse sont toujours bien désactivés
