### PR TITLE
[BUGFIX] Ne pas créer plusieurs récompenses de quêtes (PIX-15804)

### DIFF
--- a/api/src/quest/domain/usecases/reward-user.js
+++ b/api/src/quest/domain/usecases/reward-user.js
@@ -16,8 +16,8 @@ export const rewardUser = async ({
   }
 
   const eligibilities = await eligibilityRepository.find({ userId });
-
   const rewards = await rewardRepository.getByUserId({ userId });
+
   const rewardIds = rewards.map((reward) => reward.rewardId);
 
   for (const quest of quests) {
@@ -36,6 +36,7 @@ export const rewardUser = async ({
 
     if (userHasSucceedQuest) {
       await rewardRepository.reward({ userId, rewardId: quest.rewardId });
+      rewardIds.push(quest.rewardId);
     }
   }
 };

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -4,4 +4,5 @@ export default class FeatureToggle extends Model {
   @attr('boolean') isTextToSpeechButtonEnabled;
   @attr('boolean') showNewCampaignPresentationPage;
   @attr('boolean') isPixCompanionEnabled;
+  @attr('boolean') isQuestEnabled;
 }


### PR DESCRIPTION
## :christmas_tree: Problème
Si un utilisateur réussissait une quête et était en même temps éligible à plusieurs autres, on pouvait écrire plusieurs fois sa ligne dans la table `profile-rewards`

## :gift: Proposition
Aller chercher ses récompenses a chaque quête disponible, plutôt qu'une fois au début et ensuite boucler sur les quêtes

## :socks: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :santa: Pour tester
- Mettre la variable `FT_ENABLE_QUESTS` à `False`
- Participer avec `attestation-blank@example.net` aux parcours `ATTEST001`, `ATTEST002` et `ATTEST003` en les réussissant
- Mettre la variable `FT_ENABLE_QUESTS` à `True`
- Répondre a n'importe quelle question sur Pix App
- Vérifier en Base que l'utilisateur n'a qu'une seule fois la ligne dans `profile-rewards`
