### PR TITLE
[FEATURE] Prendre en compte le feature toggle quest enabled (PIX-15789)

### DIFF
--- a/api/src/shared/application/assessments/assessment-controller.js
+++ b/api/src/shared/application/assessments/assessment-controller.js
@@ -15,6 +15,7 @@ import {
   extractLocaleFromRequest,
   extractUserIdFromRequest,
 } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { config } from '../../config.js';
 import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { AssessmentEndedError } from '../../domain/errors.js';
 import { Examiner } from '../../domain/models/Examiner.js';
@@ -99,7 +100,10 @@ const completeAssessment = async function (request) {
     const assessment = await usecases.completeAssessment({ assessmentId, locale });
     await usecases.handleBadgeAcquisition({ assessment });
     await usecases.handleStageAcquisition({ assessment });
-    if (assessment.userId) await questUsecases.rewardUser({ userId: assessment.userId });
+    if (assessment.userId && config.featureToggles.isQuestEnabled) {
+      await questUsecases.rewardUser({ userId: assessment.userId });
+    }
+
     await devcompUsecases.handleTrainingRecommendation({ assessment, locale });
   });
 

--- a/api/tests/shared/unit/application/assessments/assessment-controller_test.js
+++ b/api/tests/shared/unit/application/assessments/assessment-controller_test.js
@@ -5,6 +5,7 @@ import { usecases as certificationUsecases } from '../../../../../src/certificat
 import { usecases as devcompUsecases } from '../../../../../src/devcomp/domain/usecases/index.js';
 import { usecases as questUsecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { assessmentController } from '../../../../../src/shared/application/assessments/assessment-controller.js';
+import { config } from '../../../../../src/shared/config.js';
 import { domainBuilder, expect, hFake, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Controller | assessment-controller', function () {
@@ -111,8 +112,21 @@ describe('Unit | Controller | assessment-controller', function () {
       });
     });
 
+    it('should not call the rewardUser usecase if the questEnabled flag is false', async function () {
+      // given
+      config.featureToggles.isQuestEnabled = false;
+      usecases.completeAssessment.resolves({ userId: 12 });
+
+      // when
+      await assessmentController.completeAssessment({ params: { id: assessmentId } });
+
+      // then
+      expect(questUsecases.rewardUser).to.have.not.been.called;
+    });
+
     it('should call the rewardUser use case if there is a userId', async function () {
       // given
+      config.featureToggles.isQuestEnabled = true;
       usecases.completeAssessment.resolves({ userId: 12 });
 
       // when

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
@@ -21,6 +21,7 @@ export default class EvaluationResultsHero extends Component {
   @service router;
   @service store;
   @service tabManager;
+  @service featureToggles;
 
   @tracked hasGlobalError = false;
   @tracked isButtonLoading = false;
@@ -48,6 +49,10 @@ export default class EvaluationResultsHero extends Component {
     return (
       hasCustomContent && (this.args.campaign.isSimplifiedAccess || this.args.campaignParticipationResult.isShared)
     );
+  }
+
+  get displayQuestResult() {
+    return this.featureToggles.featureToggles?.isQuestEnabled && this.hasQuestResults;
   }
 
   get hasQuestResults() {
@@ -174,7 +179,7 @@ export default class EvaluationResultsHero extends Component {
           </div>
         {{/if}}
 
-        {{#if this.hasQuestResults}}
+        {{#if this.displayQuestResult}}
           <AttestationResult @results={{@questResults}} @onError={{(fn this.setGlobalError true)}} />
         {{/if}}
 


### PR DESCRIPTION
## :christmas_tree: Problème
Nous calculons et affichons la quete meme si le feature flag est a false.

## :gift: Proposition
Respecter le feature flag

## :santa: Pour tester
Desactiver le feature flag et se connecter avec attestation-success et verifier que l'attestation n'apparait pas.