### PR TITLE
[FEATURE] Traduction en ES & NL de l'e-mail de suppression du compte (PIX-15805)

### DIFF
--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -94,7 +94,7 @@ describe('Unit | Service | MailService', function () {
           from,
           to,
           template,
-          fromName: 'PIX - No contestar',
+          fromName: 'PIX - No responder',
           subject: mainTranslationsMapping.es['reset-password-demand-email'].subject,
           variables: {
             locale: SPANISH_SPOKEN,
@@ -689,7 +689,7 @@ describe('Unit | Service | MailService', function () {
       expect(options.subject).to.equal(
         translate({ phrase: 'verification-code-email.subject', locale: 'es' }, { code }),
       );
-      expect(options.fromName).to.equal('PIX - No contestar');
+      expect(options.fromName).to.equal('PIX - No responder');
       expect(options.template).to.equal('test-email-verification-code-template-id');
       expect(options.variables).to.include({
         homeName: 'pix.org',

--- a/api/translations/es.json
+++ b/api/translations/es.json
@@ -229,10 +229,10 @@
   },
   "common": {
     "email": {
-      "contactUs": "contact us here",
-      "doNotAnswer": "This is an automated email message, please do not reply.",
-      "moreOn": "More on",
-      "pixPresentation": "Pix is the online service to assess, develop and certify your digital skills."
+      "contactUs": "contáctanos aquí",
+      "doNotAnswer": "Este es un correo electrónico automático, por favor, no respondas directamente.",
+      "moreOn": "Más información sobre",
+      "pixPresentation": "Pix es el servicio público en línea para evaluar, desarrollar y certificar tus competencias digitales."
     }
   },
   "csv-import-values": {
@@ -301,7 +301,7 @@
     "template-name": "modelo de importación"
   },
   "email-sender-name": {
-    "pix-app": "PIX - No contestar"
+    "pix-app": "PIX - No responder"
   },
   "entity-validation-errors": {
     "ACCEPT_CGU": "Debes aceptar las condiciones de uso de Pix para crear una cuenta.",
@@ -397,14 +397,14 @@
   },
   "self-account-deletion-email": {
     "params": {
-      "hello": "Hello {firstName},",
-      "requestConfirmation": "Following your request, we can confirm that your Pix account and personal data have been deleted.",
-      "seeYouSoon": "We hope to see you soon for new digital adventures.",
-      "signing": "The Pix team",
-      "title": "Deleting your account",
-      "warning": "If you are not the source of this request, please contact support."
+      "hello": "Hola {firstName},",
+      "requestConfirmation": "Tras su solicitud, le confirmaremos la eliminación de su cuenta Pix y de sus datos personales.",
+      "seeYouSoon": "Esperamos verte pronto en nuevas aventuras digitales.",
+      "signing": "El equipo Pix",
+      "title": "Eliminar su cuenta",
+      "warning": "Si usted no es la fuente de esta solicitud, póngase en contacto con el servicio de asistencia."
     },
-    "subject": "Deleting your account"
+    "subject": "Eliminar su cuenta"
   },
   "verification-code-email": {
     "body": {

--- a/api/translations/nl.json
+++ b/api/translations/nl.json
@@ -229,10 +229,10 @@
   },
   "common": {
     "email": {
-      "contactUs": "contact us here",
-      "doNotAnswer": "This is an automated email message, please do not reply.",
-      "moreOn": "More on",
-      "pixPresentation": "Pix is the online service to assess, develop and certify your digital skills."
+      "contactUs": "neem hier contact met ons op",
+      "doNotAnswer": "Dit is een automatische e-mail, antwoord niet.",
+      "moreOn": "Ontdek meer over",
+      "pixPresentation": "Pix is de openbare online service voor het beoordelen, ontwikkelen en certificeren van je digitale vaardigheden."
     }
   },
   "csv-import-values": {
@@ -389,14 +389,14 @@
   },
   "self-account-deletion-email": {
     "params": {
-      "hello": "Hello {firstName},",
-      "requestConfirmation": "Following your request, we can confirm that your Pix account and personal data have been deleted.",
-      "seeYouSoon": "We hope to see you soon for new digital adventures.",
-      "signing": "The Pix team",
-      "title": "Deleting your account",
-      "warning": "If you are not the source of this request, please contact support."
+      "hello": "Hallo {firstName},",
+      "requestConfirmation": "Na je verzoek zullen we de verwijdering van je Pix-account en je persoonlijke gegevens bevestigen.",
+      "seeYouSoon": "We hopen je snel te zien voor nieuwe digitale avonturen.",
+      "signing": "Het Pix team",
+      "title": "Je account verwijderen",
+      "warning": "Als u niet de bron van dit verzoek bent, neem dan contact op met ondersteuning."
     },
-    "subject": "Deleting your account"
+    "subject": "Je account verwijderen"
   },
   "verification-code-email": {
     "body": {


### PR DESCRIPTION
## :christmas_tree: Problème

Les utilisateurs espagnols et néerlandais recevaient l'e-mail de confirmation de suppression du compte en anglais.

## :gift: Proposition

Traduire les différentes clés de l'anglais à la bonne langue : espagnol ou néerlandais .

## :socks: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :santa: Pour tester

* Si l'utilisateur a pour langue l'espagnol alors il recevra l'e-mail de suppression du compte en espagnol
* Idem mais en néerlandais 