### PR TITLE
[FEATURE] Rendre la documentation d’installation de Companion traduisible (PIX-15812)

### DIFF
--- a/mon-pix/app/components/companion/blocker.gjs
+++ b/mon-pix/app/components/companion/blocker.gjs
@@ -48,7 +48,7 @@ export default class CompanionBlocker extends Component {
 
         <ul class="companion-blocker__list">
           <li>
-            <PixButtonLink @href="https://cloud.pix.fr/s/KocingDC4mFJ3R6" target="_blank">{{t
+            <PixButtonLink @href={{t "common.companion.install-documentation-url"}} target="_blank">{{t
                 "common.companion.not-detected.link"
               }}</PixButtonLink>
           </li>

--- a/mon-pix/app/components/companion/check.gjs
+++ b/mon-pix/app/components/companion/check.gjs
@@ -34,7 +34,7 @@ export default class CompanionCheck extends Component {
         </h1>
 
         <PixButtonLink
-          @href="https://cloud.pix.fr/s/KocingDC4mFJ3R6"
+          @href={{t "common.companion.install-documentation-url"}}
           target="_blank"
           class="companion-check__link"
           @variant="primary-bis"

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -79,6 +79,7 @@
           "link": "Go to documentation"
         }
       },
+      "install-documentation-url": "https://cloud.pix.fr/s/KocingDC4mFJ3R6",
       "not-detected": {
         "description": " The extension may not be installed or enabled. Read the following documentation in order to resume your certification session.  If necessary ask your invigilator.",
         "link": "Go to documentation",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -80,6 +80,7 @@
           "link": "Acceder a la documentación"
         }
       },
+      "install-documentation-url": "https://cloud.pix.fr/s/KocingDC4mFJ3R6",
       "not-detected": {
         "description": "Es posible que la extensión no esté instalada o activada. Consulte el siguiente documento para reanudar la sesión de certificación.  Si es necesario, póngase en contacto con el supervisor.",
         "link": "Acceder a la documentación",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -79,6 +79,7 @@
           "link": "Accéder à la documentation"
         }
       },
+      "install-documentation-url": "https://cloud.pix.fr/s/KocingDC4mFJ3R6",
       "not-detected": {
         "description": "L’extension n’est peut-être pas installée ou activée. Consultez le document suivant afin de reprendre votre session de certification. Si besoin contactez le surveillant.",
         "link": "Accéder à la documentation",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -80,6 +80,7 @@
           "link": "Toegang tot de documentatie"
         }
       },
+      "install-documentation-url": "https://cloud.pix.fr/s/KocingDC4mFJ3R6",
       "not-detected": {
         "description": "De extensie is mogelijk niet geïnstalleerd of geactiveerd. Raadpleeg het volgende document om uw certificeringssessie te hervatten.  Neem indien nodig contact op met de supervisor.",
         "link": "Toegang tot de documentatie",


### PR DESCRIPTION
## :christmas_tree: Problème

L’URL de la documentation d’installation de Companion est en dur dans le code.

## :gift: Proposition

Mettre cette URL dans une clé de traduction.

## :socks: Remarques

N/A

## :santa: Pour tester

Vérifier que le lien de documentation fonctionne : https://app-pr10857.review.pix.fr/verification-extension-certification