### PR TITLE
[FEATURE] Pouvoir créer un élément Expand dans le contenu d'un Module (PIX-15772)

### DIFF
--- a/api/src/devcomp/domain/models/element/Expand.js
+++ b/api/src/devcomp/domain/models/element/Expand.js
@@ -1,0 +1,20 @@
+import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { Element } from './Element.js';
+
+class Expand extends Element {
+  /**
+   *
+   * @param{string} id
+   * @param{string} title
+   * @param{string} content
+   */
+  constructor({ id, title, content } = {}) {
+    super({ id, type: 'expand' });
+    assertNotNullOrUndefined(title, 'The title is required for an Expand element');
+    assertNotNullOrUndefined(content, 'The content is required for an Expand element');
+    this.title = title;
+    this.content = content;
+  }
+}
+
+export { Expand };

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -96,6 +96,13 @@
             ]
           }
         },
+        {"type":  "element", "element":  {
+          "id": "5c468891-6b50-41c6-bb30-8639b52c5bca",
+          "type": "expand",
+          "title": "Voici un indice pour répondre à la magnifique flashcard",
+          "content": "<p> Souvent, pour s’amuser, les hommes d’équipage\nPrennent des albatros, vastes oiseaux des mers,\nQui suivent, indolents compagnons de voyage,\nLe navire glissant sur les gouffres amers.\n\nÀ peine les ont-ils déposés sur les planches,\nQue ces rois de l’azur, maladroits et honteux,\nLaissent piteusement leurs grandes ailes blanches\nComme des avirons traîner à côté d’eux.\n\nCe voyageur ailé, comme il est gauche et veule !\nLui, naguère si beau, qu’il est comique et laid !\nL’un agace son bec avec un brûle-gueule,\nL’autre mime, en boitant, l’infirme qui volait !\n\nLe Poète est semblable au prince des nuées\nQui hante la tempête et se rit de l’archer ;\nExilé sur le sol au milieu des huées,\nSes ailes de géant l’empêchent de marcher. </p>"
+
+        }},
         {
           "type": "element",
           "element": {

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -9,6 +9,7 @@ import { ComponentStepper } from '../../domain/models/component/ComponentStepper
 import { Step } from '../../domain/models/component/Step.js';
 import { Download } from '../../domain/models/element/Download.js';
 import { Embed } from '../../domain/models/element/Embed.js';
+import { Expand } from '../../domain/models/element/Expand.js';
 import { Card } from '../../domain/models/element/flashcards/Card.js';
 import { Flashcards } from '../../domain/models/element/flashcards/Flashcards.js';
 import { Image } from '../../domain/models/element/Image.js';
@@ -91,6 +92,8 @@ export class ModuleFactory {
         return ModuleFactory.#buildDownload(element);
       case 'embed':
         return ModuleFactory.#buildEmbed(element);
+      case 'expand':
+        return ModuleFactory.#buildExpand(element);
       case 'image':
         return ModuleFactory.#buildImage(element);
       case 'separator':
@@ -115,6 +118,7 @@ export class ModuleFactory {
         return undefined;
     }
   }
+
   static #buildDownload(element) {
     return new Download({
       id: element.id,
@@ -130,6 +134,14 @@ export class ModuleFactory {
       url: element.url,
       instruction: element.instruction,
       height: element.height,
+    });
+  }
+
+  static #buildExpand(element) {
+    return new Expand({
+      id: element.id,
+      title: element.title,
+      content: element.content,
     });
   }
 

--- a/api/tests/devcomp/unit/domain/models/element/Expand_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Expand_test.js
@@ -1,0 +1,54 @@
+import { Expand } from '../../../../../../src/devcomp/domain/models/element/Expand.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | Element | Expand', function () {
+  describe('#constructor', function () {
+    it('should create a valid Expand object', function () {
+      // given
+      const attributes = {
+        id: '39f28a81-290c-440c-b8b9-1762112fbde3',
+        content: '<p> My Content </p>',
+        title: 'Expand title',
+      };
+
+      // when
+      const result = new Expand(attributes);
+
+      // then
+      expect(result.id).to.equal(attributes.id);
+      expect(result.content).to.equal(attributes.content);
+      expect(result.title).to.equal(attributes.title);
+      expect(result.type).to.equal('expand');
+    });
+  });
+
+  describe('An expand without a title', function () {
+    it('should throw an error', function () {
+      const attributes = {
+        id: '39f28a81-290c-440c-b8b9-1762112fbde3',
+      };
+      // when
+      const error = catchErrSync(() => new Expand(attributes))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The title is required for an Expand element');
+    });
+  });
+
+  describe('An expand without a content', function () {
+    it('should throw an error', function () {
+      const attributes = {
+        id: '39f28a81-290c-440c-b8b9-1762112fbde3',
+        title: 'A title',
+      };
+      // when
+      const error = catchErrSync(() => new Expand(attributes))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The content is required for an Expand element');
+    });
+  });
+});

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/expand-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/expand-schema.js
@@ -1,0 +1,12 @@
+import Joi from 'joi';
+
+import { htmlSchema, uuidSchema } from '../utils.js';
+
+const expandElementSchema = Joi.object({
+  id: uuidSchema,
+  type: Joi.string().valid('expand').required(),
+  title: Joi.string().required(),
+  content: htmlSchema.required(),
+}).required();
+
+export { expandElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
@@ -2,6 +2,7 @@ import Joi from 'joi';
 
 import { downloadElementSchema } from './element/download-schema.js';
 import { embedElementSchema } from './element/embed-schema.js';
+import { expandElementSchema } from './element/expand-schema.js';
 import { flashcardsElementSchema } from './element/flashcards-schema.js';
 import { imageElementSchema } from './element/image-schema.js';
 import { qcmElementSchema } from './element/qcm-schema.js';
@@ -30,6 +31,7 @@ const elementSchema = Joi.alternatives().conditional('.type', {
   switch: [
     { is: 'download', then: downloadElementSchema },
     { is: 'embed', then: embedElementSchema },
+    { is: 'expand', then: expandElementSchema },
     { is: 'flashcards', then: flashcardsElementSchema },
     { is: 'image', then: imageElementSchema },
     { is: 'qcu', then: qcuElementSchema },
@@ -44,6 +46,7 @@ const elementSchema = Joi.alternatives().conditional('.type', {
 const stepperElementSchema = Joi.alternatives().conditional('.type', {
   switch: [
     { is: 'download', then: downloadElementSchema },
+    { is: 'expand', then: expandElementSchema },
     { is: 'image', then: imageElementSchema },
     { is: 'qcu', then: qcuElementSchema },
     { is: 'qcm', then: qcmElementSchema },

--- a/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
@@ -877,6 +877,53 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const expectedFlashcards = moduleData.grains[0].components[0].element;
         validateFlashcards(flashcards, expectedFlashcards);
       });
+
+      it('should instantiate a Module with a ComponentElement which contains a Expand Element', function () {
+        // given
+        const givenData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          isBeta: true,
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            tabletSupport: 'comfortable',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              components: [
+                {
+                  type: 'element',
+                  element: {
+                    id: '71de6394-ff88-4de3-8834-a40057a50ff4',
+                    type: 'expand',
+                    title: "Plus d'info sur la poésie",
+                    content: '<p>La poésie c’est cool</p>',
+                  },
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = ModuleFactory.build(givenData);
+
+        // then
+        const expand = module.grains[0].components[0].element;
+        const expectedExpand = givenData.grains[0].components[0].element;
+        expect(expand.id).to.equal(expectedExpand.id);
+        expect(expand.content).to.equal(expectedExpand.content);
+        expect(expand.title).to.equal(expectedExpand.title);
+        expect(expand.type).to.equal(expectedExpand.type);
+      });
     });
 
     describe('With ComponentStepper', function () {


### PR DESCRIPTION
## :christmas_tree: Problème
On veut pouvoir retourner un élément expand contenu dans un module.

## :gift: Proposition
Créer l'élément Expand pour un Module

## :socks: Remarques
RAS

## :santa: Pour tester
- Ouvrir Pix App. ouvrir l'onglet Network de la console dev du navigateur.
- Accéder au module didacticiel https://app-pr10858.review.pix.fr/modules/didacticiel-modulix/details
- Vérifier dans les appels réseau la réponse pour didacticiel.json : un élément de type expand doit être présent dans le fichier