### PR TITLE
[TECH] Montée de version vers PixUI 52 (PIX-15817)

### DIFF
--- a/junior/app/components/banner/communication/template.hbs
+++ b/junior/app/components/banner/communication/template.hbs
@@ -1,5 +1,5 @@
 {{#if this.isEnabled}}
-  <PixBanner @type={{this.bannerType}} class="sticker-banner">
+  <PixBannerAlert @type={{this.bannerType}} class="sticker-banner">
     {{this.bannerContent}}
-  </PixBanner>
+  </PixBannerAlert>
 {{/if}}

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -13,7 +13,7 @@
         "@1024pix/ember-matomo-tag-manager": "^2.4.3",
         "@1024pix/ember-testing-library": "^3.0.6",
         "@1024pix/eslint-plugin": "^2.0.1",
-        "@1024pix/pix-ui": "^48.9.0",
+        "@1024pix/pix-ui": "^52.0.3",
         "@1024pix/stylelint-config": "^5.1.25",
         "@1024pix/web-components": "^0.2.6",
         "@babel/eslint-parser": "^7.25.9",
@@ -130,9 +130,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "48.9.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-48.9.0.tgz",
-      "integrity": "sha512-YzXZWdw6rdCDl7tfOHxjcUiEw9uhG1gVdK3m83nSlcVh+XOnF5RfkTS38+F95tB29/DGgNb3ePjIL8l3j0FnPg==",
+      "version": "52.0.3",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-52.0.3.tgz",
+      "integrity": "sha512-LIF09XMn0UPH/3GsyfQrJOr25dJTPdapro7BUjARhMqkaox6wmHXXC2Rmh+8QeRqL2Xfne96EgxL3s+rWJ4u6A==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/junior/package.json
+++ b/junior/package.json
@@ -40,7 +40,7 @@
     "@1024pix/ember-matomo-tag-manager": "^2.4.3",
     "@1024pix/ember-testing-library": "^3.0.6",
     "@1024pix/eslint-plugin": "^2.0.1",
-    "@1024pix/pix-ui": "^48.9.0",
+    "@1024pix/pix-ui": "^52.0.3",
     "@1024pix/stylelint-config": "^5.1.25",
     "@1024pix/web-components": "^0.2.6",
     "@babel/eslint-parser": "^7.25.9",


### PR DESCRIPTION
## :christmas_tree: Problème

Nous avons trois versions de retard sur PixUI, avec un 💥 breaking changes impactant pour nous

## :gift: Proposition

- Mettre à jour PixUI
- Renommer PixBanner en PixBannerAlert

## :santa: Pour tester

Vérifier que la bannière apparaît sur l'écran d'accueil
Aller sur quelques écrans, vérifier que tout est OK
