### PR TITLE
[FEATURE] Ajouter une route API donnant accès au résultat de certif d'un élève (PIX-15799).

### DIFF
--- a/api/lib/application/sco-organization-learners/index.js
+++ b/api/lib/application/sco-organization-learners/index.js
@@ -11,13 +11,10 @@ import {
 } from '../../../src/shared/application/http-errors.js';
 import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { config } from '../../../src/shared/config.js';
-import { identifiersType } from '../../../src/shared/domain/types/identifiers-type.js';
+import { identifiersType, studentIdentifierType } from '../../../src/shared/domain/types/identifiers-type.js';
 import { scoOrganizationLearnerController } from './sco-organization-learner-controller.js';
 
 const { passwordValidationPattern } = config.account;
-
-const inePattern = new RegExp('^[0-9]{9}[a-zA-Z]{2}$');
-const inaPattern = new RegExp('^[0-9]{10}[a-zA-Z]{1}$');
 
 const register = async function (server) {
   server.route([
@@ -230,10 +227,7 @@ const register = async function (server) {
               attributes: {
                 'first-name': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
                 'last-name': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
-                'ine-ina': Joi.alternatives().try(
-                  Joi.string().regex(inePattern).required(),
-                  Joi.string().regex(inaPattern).required(),
-                ),
+                'ine-ina': studentIdentifierType,
                 birthdate: Joi.date().format('YYYY-MM-DD').required(),
               },
             },

--- a/api/server.js
+++ b/api/server.js
@@ -22,6 +22,7 @@ import { evaluationRoutes } from './src/evaluation/routes.js';
 import { identityAccessManagementRoutes } from './src/identity-access-management/application/routes.js';
 import { learningContentRoutes } from './src/learning-content/routes.js';
 import { organizationalEntitiesRoutes } from './src/organizational-entities/application/routes.js';
+import { parcoursupRoutes } from './src/parcoursup/application/routes.js';
 import { campaignRoutes } from './src/prescription/campaign/routes.js';
 import { campaignParticipationsRoutes } from './src/prescription/campaign-participation/routes.js';
 import { learnerManagementRoutes } from './src/prescription/learner-management/routes.js';
@@ -179,6 +180,7 @@ const setupRoutesAndPlugins = async function (server) {
     learningContentRoutes,
     ...certificationRoutes,
     ...prescriptionRoutes,
+    ...parcoursupRoutes,
   );
   await server.register(configuration);
 };

--- a/api/src/identity-access-management/application/account-recovery/account-recovery.route.js
+++ b/api/src/identity-access-management/application/account-recovery/account-recovery.route.js
@@ -3,12 +3,11 @@ import BaseJoi from 'joi';
 import XRegExp from 'xregexp';
 
 import { config } from '../../../shared/config.js';
+import { studentIdentifierType } from '../../../shared/domain/types/identifiers-type.js';
 import { accountRecoveryController } from './account-recovery.controller.js';
 
 const Joi = BaseJoi.extend(JoiDate);
 const { passwordValidationPattern } = config.account;
-const inePattern = new RegExp('^[0-9]{9}[a-zA-Z]{2}$');
-const inaPattern = new RegExp('^[0-9]{10}[a-zA-Z]{1}$');
 
 export const accountRecoveryRoutes = [
   {
@@ -64,10 +63,7 @@ export const accountRecoveryRoutes = [
             attributes: {
               'first-name': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
               'last-name': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
-              'ine-ina': Joi.alternatives().try(
-                Joi.string().regex(inePattern).required(),
-                Joi.string().regex(inaPattern).required(),
-              ),
+              'ine-ina': studentIdentifierType,
               birthdate: Joi.date().format('YYYY-MM-DD').required(),
               email: Joi.string().email().required(),
             },

--- a/api/src/parcoursup/application/certification-controller.js
+++ b/api/src/parcoursup/application/certification-controller.js
@@ -1,0 +1,11 @@
+import { usecases } from '../domain/usecases/index.js';
+
+const getCertificationResult = async function (request) {
+  const ine = request.params.ine;
+  return usecases.getCertificationResult({ ine });
+};
+
+const certificationController = {
+  getCertificationResult,
+};
+export { certificationController };

--- a/api/src/parcoursup/application/certification-route.js
+++ b/api/src/parcoursup/application/certification-route.js
@@ -1,0 +1,34 @@
+import Joi from 'joi';
+
+import { securityPreHandlers } from '../../shared/application/security-pre-handlers.js';
+import { studentIdentifierType } from '../../shared/domain/types/identifiers-type.js';
+import { certificationController } from './certification-controller.js';
+
+const register = async function (server) {
+  server.route({
+    method: 'GET',
+    path: '/api/parcoursup/students/{ine}/certification',
+    config: {
+      validate: {
+        params: Joi.object({
+          ine: studentIdentifierType,
+        }),
+      },
+      handler: certificationController.getCertificationResult,
+      pre: [
+        {
+          method: securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+          assign: 'hasAuthorizationToAccessAdminScope',
+        },
+      ],
+      tags: ['api', 'parcoursup'],
+      notes: [
+        '- **Cette route est accessible uniquement à Parcours Sup**\n' +
+          '- Récupère les informations de la dernière certification de l‘année en cours pour l‘élève identifié via son INE',
+      ],
+    },
+  });
+};
+
+const name = 'parcoursup-api';
+export { name, register };

--- a/api/src/parcoursup/application/routes.js
+++ b/api/src/parcoursup/application/routes.js
@@ -1,0 +1,3 @@
+import * as certificationRoute from './certification-route.js';
+
+export const parcoursupRoutes = [certificationRoute];

--- a/api/src/parcoursup/domain/read-models/CertificationResult.js
+++ b/api/src/parcoursup/domain/read-models/CertificationResult.js
@@ -1,0 +1,7 @@
+class CertificationResult {
+  constructor({ ine }) {
+    this.ine = ine;
+  }
+}
+
+export { CertificationResult };

--- a/api/src/parcoursup/domain/usecases/get-certification-result.js
+++ b/api/src/parcoursup/domain/usecases/get-certification-result.js
@@ -1,0 +1,5 @@
+const getCertificationResult = function ({ ine, certificationRepository }) {
+  return certificationRepository.get({ ine });
+};
+
+export { getCertificationResult };

--- a/api/src/parcoursup/domain/usecases/index.js
+++ b/api/src/parcoursup/domain/usecases/index.js
@@ -1,0 +1,32 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
+import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
+import * as certificationRepository from '../../infrastructure/repositories/certification-repository.js';
+
+/**
+ * @typedef {import('../../infrastructure/repositories/certification-repository.js').CertificationRepository} CertificationRepository
+ **/
+
+/**
+ * Using {@link https://jsdoc.app/tags-type "Closure Compiler's syntax"} to document injected dependencies
+ * @typedef {certificationRepository} CertificationRepository
+ **/
+
+const path = dirname(fileURLToPath(import.meta.url));
+
+const dependencies = {
+  certificationRepository,
+};
+
+const usecasesWithoutInjectedDependencies = {
+  ...(await importNamedExportsFromDirectory({
+    path: join(path, './'),
+    ignoredFileNames: ['index.js'],
+  })),
+};
+
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+
+export { usecases };

--- a/api/src/parcoursup/infrastructure/repositories/certification-repository.js
+++ b/api/src/parcoursup/infrastructure/repositories/certification-repository.js
@@ -1,0 +1,7 @@
+import { CertificationResult } from '../../domain/read-models/CertificationResult.js';
+
+const get = ({ ine }) => {
+  return new CertificationResult({ ine });
+};
+
+export { get };

--- a/api/src/shared/domain/types/identifiers-type.js
+++ b/api/src/shared/domain/types/identifiers-type.js
@@ -10,6 +10,14 @@ const implementationType = {
   alphanumeric: Joi.string(),
 };
 
+const inePattern = new RegExp('^[0-9]{9}[a-zA-Z]{2}$');
+const inaPattern = new RegExp('^[0-9]{10}[a-zA-Z]{1}$');
+
+const studentIdentifierType = Joi.alternatives().try(
+  Joi.string().regex(inePattern).required(),
+  Joi.string().regex(inaPattern).required(),
+);
+
 const paramsToExport = {};
 const queryToExport = {};
 
@@ -81,4 +89,9 @@ paramsToExport.positiveInteger32bits = {
   max: postgreSQLSequenceEnd,
 };
 
-export { paramsToExport as identifiersType, queryToExport as optionalIdentifiersType, queriesType };
+export {
+  paramsToExport as identifiersType,
+  queryToExport as optionalIdentifiersType,
+  queriesType,
+  studentIdentifierType,
+};

--- a/api/tests/parcoursup/acceptance/application/certification-routes_test.js
+++ b/api/tests/parcoursup/acceptance/application/certification-routes_test.js
@@ -1,0 +1,41 @@
+import {
+  createServer,
+  databaseBuilder,
+  expect,
+  generateValidRequestAuthorizationHeader,
+  insertUserWithRoleSuperAdmin,
+} from '../../../test-helper.js';
+
+describe('Parcoursup | Acceptance | Application | certification-route', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('GET /api/parcoursup/students/{ine}/certification', function () {
+    it('should return 200 HTTP status code and a certification for a given INE', async function () {
+      // given
+      const ine = '123456789OK';
+      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const options = {
+        method: 'GET',
+        url: `/api/parcoursup/students/${ine}/certification`,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(superAdmin.id),
+        },
+      };
+
+      await databaseBuilder.commit();
+
+      const expectedCertification = { ine };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result).to.deep.equal(expectedCertification);
+    });
+  });
+});

--- a/api/tests/parcoursup/integration/repositories/certification-repository_test.js
+++ b/api/tests/parcoursup/integration/repositories/certification-repository_test.js
@@ -1,0 +1,22 @@
+import * as certificationRepository from '../../../../../api/src/parcoursup/infrastructure/repositories/certification-repository.js';
+import { domainBuilder, expect } from '../../../test-helper.js';
+
+describe('Parcoursup | Infrastructure | Integration | Repositories | certification', function () {
+  describe('#get', function () {
+    describe('when a certification is found', function () {
+      it('should return the certification', async function () {
+        // given
+        const ine = '1234';
+
+        // when
+        const result = await certificationRepository.get({
+          ine,
+        });
+
+        // then
+        const expectedCertification = domainBuilder.parcoursup.buildCertificationResult({ ine });
+        expect(result).to.deep.equal(expectedCertification);
+      });
+    });
+  });
+});

--- a/api/tests/parcoursup/unit/application/certification-route_test.js
+++ b/api/tests/parcoursup/unit/application/certification-route_test.js
@@ -1,0 +1,23 @@
+import { certificationController } from '../../../../src/parcoursup/application/certification-controller.js';
+import * as moduleUnderTest from '../../../../src/parcoursup/application/certification-route.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
+import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
+
+describe('Parcoursup | Unit | Application | Routes | Certification', function () {
+  describe('GET /parcoursup/students/{ine}/certification', function () {
+    it('should return 200', async function () {
+      //given
+      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').returns(true);
+      sinon.stub(certificationController, 'getCertificationResult').callsFake((request, h) => h.response().code(200));
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('GET', '/api/parcoursup/students/123456789OK/certification');
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+});

--- a/api/tests/parcoursup/unit/domain/usecases/get-certification-result_test.js
+++ b/api/tests/parcoursup/unit/domain/usecases/get-certification-result_test.js
@@ -1,0 +1,23 @@
+import { getCertificationResult } from '../../../../../src/parcoursup/domain/usecases/get-certification-result.js';
+import { domainBuilder, expect, sinon } from '../../../../test-helper.js';
+
+describe('Parcoursup | unit | domain | usecases | get certification', function () {
+  describe('#getCertification', function () {
+    it('returns certification', async function () {
+      // given
+      const ine = '1234';
+      const certificationRepository = {
+        get: sinon.stub(),
+      };
+
+      const expectedCertification = domainBuilder.parcoursup.buildCertificationResult({ ine });
+      certificationRepository.get.withArgs({ ine }).resolves(expectedCertification);
+
+      // when
+      const certification = await getCertificationResult({ ine, certificationRepository });
+
+      // then
+      expect(certification).to.deep.equal(expectedCertification);
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -198,6 +198,7 @@ import { buildSessionManagement } from './certification/session-management/build
 import { buildCompetenceForScoring } from './certification/shared/build-competence-for-scoring.js';
 import { buildJuryComment } from './certification/shared/build-jury-comment.js';
 import { buildV3CertificationScoring } from './certification/shared/build-v3-certification-scoring.js';
+import { buildCertificationResult as parcoursupCertificationResult } from './parcoursup/build-certification-result.js';
 import { buildCampaign as boundedContextCampaignBuildCampaign } from './prescription/campaign/build-campaign.js';
 import { buildCampaignParticipation as boundedContextCampaignParticipationBuildCampaignParticipation } from './prescription/campaign-participation/build-campaign-participation.js';
 import { buildStageCollection as buildStageCollectionForTargetProfileManagement } from './target-profile-management/build-stage-collection.js';
@@ -251,6 +252,10 @@ const certification = {
     buildComplementaryCertificationVersioning,
     buildComplementaryCertificationBadge: buildCertificationComplementaryCertificationBadge,
   },
+};
+
+const parcoursup = {
+  buildCertificationResult: parcoursupCertificationResult,
 };
 
 const prescription = {
@@ -436,5 +441,6 @@ export {
   buildValidation,
   buildValidator,
   certification,
+  parcoursup,
   prescription,
 };

--- a/api/tests/tooling/domain-builder/factory/parcoursup/build-certification-result.js
+++ b/api/tests/tooling/domain-builder/factory/parcoursup/build-certification-result.js
@@ -1,0 +1,7 @@
+import { CertificationResult } from '../../../../../src/parcoursup/domain/read-models/CertificationResult.js';
+
+const buildCertificationResult = function ({ ine = '1234' }) {
+  return new CertificationResult({ ine });
+};
+
+export { buildCertificationResult };


### PR DESCRIPTION
## :christmas_tree: Problème

Aujourd'hui, il n'est pas possible d'avoir accès aux résultats de certif des élèves.

## :gift: Proposition

Ajouter une route API pour parcoursup permettant d'accéder, via son INE, au résultat de la dernière certif d'un élève.

## :socks: Remarques

Dans cette PR, nous ne retournons pas encore les données souhaitées.

## :santa: Pour tester

- Lancer le CURL :
```shell
TOKEN=$(curl 'https://api-pr10860.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr10860.review.pix.fr/api/parcoursup/students/123456789OK/certification \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -X GET
```

- ✅ Avoir l'INE en retour