### PR TITLE
[BUGFIX] Afficher le tableau de la page statistiques même quand le titre du sujet est vide (PIX-15821).

### DIFF
--- a/orga/app/components/statistics/index.gjs
+++ b/orga/app/components/statistics/index.gjs
@@ -18,7 +18,7 @@ export default class Statistics extends Component {
 
   get analysisByTubes() {
     return this.args.model.data.sort(
-      (a, b) => a.competence_code.localeCompare(b.competence_code) || a.sujet.localeCompare(b.sujet),
+      (a, b) => a.competence_code.localeCompare(b.competence_code) || a.sujet?.localeCompare(b.sujet),
     );
   }
 

--- a/orga/app/styles/components/statistics.scss
+++ b/orga/app/styles/components/statistics.scss
@@ -1,4 +1,4 @@
-.statistics-page{
+.statistics-page {
   &__header {
     display: flex;
     gap: var(--pix-spacing-2x);
@@ -18,6 +18,8 @@
   }
 
   &__cover-rate {
+    margin-bottom: var(--pix-spacing-8x);
+
     tbody > tr {
       &:nth-child(odd) {
         background-color: var(--pix-neutral-20);

--- a/orga/tests/integration/components/statistics/index-test.gjs
+++ b/orga/tests/integration/components/statistics/index-test.gjs
@@ -75,6 +75,38 @@ module('Integration | Component | Statistics | Index', function (hooks) {
     assert.ok(screen.getByRole('cell', { name: t('pages.statistics.level.novice') }));
   });
 
+  test('it should display rows data when tube is null', async function (assert) {
+    //given
+    const model = {
+      data: [
+        {
+          domaine: '2. Communication et collaboration',
+          competence_code: '2.1',
+          competence: 'Foo',
+          sujet: undefined,
+          niveau_par_user: '1.30',
+          niveau_par_sujet: '1.50',
+        },
+        {
+          domaine: '3. Communication et collaboration',
+          competence_code: '3.1',
+          competence: 'Bar',
+          sujet: 'Gérer ses contacts',
+          niveau_par_user: '3.30',
+          niveau_par_sujet: '3.50',
+        },
+      ],
+    };
+
+    //when
+    const screen = await render(<template><Statistics @model={{model}} /></template>);
+
+    //then
+    assert.ok(screen.getByRole('cell', { name: '2.1 Foo' }));
+    assert.ok(screen.getByRole('cell', { name: '' }));
+    assert.ok(screen.getByRole('cell', { name: '3.1 Bar' }));
+    assert.ok(screen.getByRole('cell', { name: 'Gérer ses contacts' }));
+  });
   test('it should display table description', async function (assert) {
     //given
     const model = {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1469,10 +1469,10 @@
         "label": "On the topic, your participants achieved a level of {userLevel} out of a maximum reachable level of {tubeLevel}."
       },
       "level": {
-        "advanced": "advanced",
-        "expert": "expert",
-        "independent": "independent",
-        "novice": "novice"
+        "advanced": "Advanced",
+        "expert": "Expert",
+        "independent": "Independent",
+        "novice": "Novice"
       },
       "select-label": "Domain",
       "table": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1475,10 +1475,10 @@
         "label": "Sur le sujet vos participants ont obtenu un niveau de {userLevel} sur un niveau maximum atteignable de {tubeLevel}."
       },
       "level": {
-        "advanced": "avancé",
-        "expert": "expert",
-        "independent": "indépendant",
-        "novice": "novice"
+        "advanced": "Avancé",
+        "expert": "Expert",
+        "independent": "Indépendant",
+        "novice": "Novice"
       },
       "select-label": "Domaine",
       "table": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1470,10 +1470,10 @@
         "label": "Je deelnemers behaalden een {userLevel} op een maximaal haalbaar niveau van {tubeLevel}."
       },
       "level": {
-        "advanced": "geavanceerd",
-        "expert": "expert",
-        "independent": "onafhankelijk",
-        "novice": "beginnende"
+        "advanced": "Geavanceerd",
+        "expert": "Expert",
+        "independent": "Onafhankelijk",
+        "novice": "Beginnende"
       },
       "table": {
         "caption": "Deze tabel toont de resultaten van alle deelnemers per onderwerp. Voor elke regel wordt de vaardigheid, het onderwerp, het dekkingspercentage en het behaalde niveau aangegeven.",


### PR DESCRIPTION
## :christmas_tree: Problème

Sur Pix Orga, lorsqu'un sujet n'a pas de titre le tableau ne s'affiche pas.

## :gift: Proposition

Permettre le tri quand un élément du tableau a un sujet sans titre

## :socks: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :santa: Pour tester
- Se connecter sur Pix Orga `admin-orga@example.net`
- Aller sur la page `/statistiques` et constater le bon fonctionnement