### PR TITLE
[BUGFIX] L'icone en cas de succès d'import a disparu (PIX-15762)

### DIFF
--- a/orga/app/components/import/banner.gjs
+++ b/orga/app/components/import/banner.gjs
@@ -96,7 +96,7 @@ export default class ImportBanner extends Component {
   <template>
     {{#if this.displaySuccess}}
       <p class="import-banner--success">
-        <PixIcon @name="circleCheck" @plainIcon={{true}} class="import-banner__icon" />
+        <PixIcon @name="checkCircle" @plainIcon={{true}} class="import-banner__icon" />
         {{this.successBanner}}
       </p>
     {{/if}}


### PR DESCRIPTION
## :christmas_tree: Problème

On n'a plus d'icône dans le message de succès d'import côté Orga.

## :gift: Proposition

On retrouve le bon nom de l'icône 🕵️

## :santa: Pour tester

Importer un fichier sco OK sur la RA, attendre un peu puis rafraîchir.