### PR TITLE
[FEATURE] affiche aussi les participations à des campagnes de collecte de profil (PIX-15798)

### DIFF
--- a/api/src/prescription/campaign-participation/domain/models/CampaignParticipationForUserManagement.js
+++ b/api/src/prescription/campaign-participation/domain/models/CampaignParticipationForUserManagement.js
@@ -1,6 +1,7 @@
+import crypto from 'node:crypto';
+
 class CampaignParticipationForUserManagement {
   constructor({
-    id,
     campaignParticipationId,
     participantExternalId,
     status,
@@ -13,7 +14,7 @@ class CampaignParticipationForUserManagement {
     organizationLearnerFirstName,
     organizationLearnerLastName,
   } = {}) {
-    this.id = id;
+    this.id = crypto.randomUUID();
     this.campaignParticipationId = campaignParticipationId;
     this.createdAt = createdAt;
     this.participantExternalId = null;

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/participations-for-user-management-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/participations-for-user-management-repository.js
@@ -1,17 +1,17 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { Assessment } from '../../../../shared/domain/models/Assessment.js';
+import { CampaignTypes } from '../../../shared/domain/constants.js';
 import { CampaignParticipationForUserManagement } from '../../domain/models/CampaignParticipationForUserManagement.js';
 
 const findByUserId = async function (userId) {
   const campaignParticipations = await knex('assessments')
     .select({
-      id: 'assessments.id',
       campaignParticipationId: 'campaign-participations.id',
       participantExternalId: 'campaign-participations.participantExternalId',
       status: 'campaign-participations.status',
       campaignId: 'campaigns.id',
       campaignCode: 'campaigns.code',
-      createdAt: 'assessments.createdAt',
+      createdAt: knex.raw('COALESCE("campaign-participations"."createdAt", assessments."createdAt")'),
       sharedAt: 'campaign-participations.sharedAt',
       deletedAt: 'campaign-participations.deletedAt',
       updatedAt: 'assessments.updatedAt',
@@ -27,9 +27,32 @@ const findByUserId = async function (userId) {
     )
     .where('assessments.userId', userId)
     .where('assessments.type', Assessment.types.CAMPAIGN)
-    .orderBy('campaign-participations.createdAt', 'desc')
+    .union(function () {
+      this.select({
+        campaignParticipationId: 'campaign-participations.id',
+        participantExternalId: 'campaign-participations.participantExternalId',
+        status: 'campaign-participations.status',
+        campaignId: 'campaigns.id',
+        campaignCode: 'campaigns.code',
+        createdAt: 'campaign-participations.createdAt',
+        sharedAt: 'campaign-participations.sharedAt',
+        deletedAt: 'campaign-participations.deletedAt',
+        updatedAt: 'campaign-participations.deletedAt',
+        organizationLearnerFirstName: 'view-active-organization-learners.firstName',
+        organizationLearnerLastName: 'view-active-organization-learners.lastName',
+      })
+        .from('campaign-participations')
+        .leftJoin('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
+        .leftJoin(
+          'view-active-organization-learners',
+          'view-active-organization-learners.id',
+          'campaign-participations.organizationLearnerId',
+        )
+        .where({ 'campaign-participations.userId': userId, type: CampaignTypes.PROFILES_COLLECTION });
+    })
+    .orderBy('createdAt', 'desc')
     .orderBy('campaignCode', 'asc')
-    .orderBy('campaign-participations.sharedAt', 'desc');
+    .orderBy('sharedAt', 'desc');
 
   return campaignParticipations.map((attributes) => new CampaignParticipationForUserManagement(attributes));
 };

--- a/api/tests/prescription/campaign-participation/acceptance/application/admin-campaign-participation-route_test.js
+++ b/api/tests/prescription/campaign-participation/acceptance/application/admin-campaign-participation-route_test.js
@@ -1,16 +1,25 @@
+import crypto from 'node:crypto';
+
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import {
   createServer,
   databaseBuilder,
   expect,
   generateValidRequestAuthorizationHeader,
+  sinon,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | GET /api/admin/users/{userId}/participations', function () {
-  let server;
+  let server, randomUUIDStub;
 
   beforeEach(async function () {
     server = await createServer();
+    randomUUIDStub = sinon.stub(crypto, 'randomUUID');
+    randomUUIDStub.returns('1234');
+  });
+
+  afterEach(function () {
+    sinon.restore();
   });
 
   it('should return participations', async function () {
@@ -23,7 +32,7 @@ describe('Acceptance | Controller | GET /api/admin/users/{userId}/participations
       campaignId: campaign.id,
       organizationLearnerId: organizationLearner.id,
     });
-    const assessment = databaseBuilder.factory.buildAssessment({
+    databaseBuilder.factory.buildAssessment({
       userId: user.id,
       campaignParticipationId: campaignParticipation.id,
       type: Assessment.types.CAMPAIGN,
@@ -43,7 +52,7 @@ describe('Acceptance | Controller | GET /api/admin/users/{userId}/participations
     expect(response.result).to.deep.equal({
       data: [
         {
-          id: assessment.id.toString(),
+          id: '1234',
           type: 'user-participations',
           attributes: {
             'campaign-participation-id': campaignParticipation.id,

--- a/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipationForUserManagement_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipationForUserManagement_test.js
@@ -1,12 +1,17 @@
+import crypto from 'node:crypto';
+
 import { CampaignParticipationForUserManagement } from '../../../../../../src/prescription/campaign-participation/domain/models/CampaignParticipationForUserManagement.js';
-import { expect } from '../../../../../test-helper.js';
+import { expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | Domain | Models | CampaignParticipationForUserManagement', function () {
+  beforeEach(function () {
+    sinon.stub(crypto, 'randomUUID').returns(1234);
+  });
+
   describe('#constructor', function () {
     it('should not return campaign participation informations when campaignParticipationId is missing', function () {
       // given
       const campaignParticipation = new CampaignParticipationForUserManagement({
-        id: 1,
         campaignParticipationId: null,
         participantExternalId: 'externalId',
         status: 'TOTO',
@@ -21,7 +26,7 @@ describe('Unit | Domain | Models | CampaignParticipationForUserManagement', func
       });
 
       // then
-      expect(campaignParticipation.id).to.be.deep.equals(1);
+      expect(campaignParticipation.id).to.be.deep.equals(1234);
       expect(campaignParticipation.createdAt).to.be.deep.equals(new Date('2020-01-01'));
       expect(campaignParticipation.deletedAt).to.be.deep.equals(new Date('2022-01-01'));
       expect(campaignParticipation.organizationLearnerFullName).to.be.equals('-');


### PR DESCRIPTION
## :christmas_tree: Problème
Depuis qu'on passe par les assessments pour afficher les participations d'un utilisateur, les participations à des campagnes de type `profiles_collection` ne remontent plus

## :gift: Proposition

On remonte aussi les participations a des campagnes de collecte de profils

## :socks: Remarques

RAS

## :santa: Pour tester

- Se connecter avec admin-orga@example.net sur PixApp et participater à une campagne de collecte de profil `PROCOLMUL`
- Se connecter sur admin et afficher les participations d'un utilisateur
- voir la participation
