### PR TITLE
[BUGFIX] Autoriser la suppression / desactivation des apprenants n'ayant pas de studentNumber ou nationalStudeId (PIX-15831)

### DIFF
--- a/api/src/prescription/learner-management/infrastructure/repositories/sup-organization-learner-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/sup-organization-learner-repository.js
@@ -71,7 +71,9 @@ async function _deleteOrganizationLearnersNotInList(queryBuilder, organizationId
     .update({ deletedBy: userId, deletedAt: knex.raw('CURRENT_TIMESTAMP') })
     .where({ organizationId })
     .whereNull('deletedAt')
-    .whereNotIn('studentNumber', studentNumberList)
+    .where(function () {
+      this.whereNotIn('studentNumber', studentNumberList).orWhereNull('studentNumber');
+    })
     .returning('*');
 
   const deletedOrganizationLearnerIds = deletedOrganizationLearners.map((deletedLearner) => deletedLearner.id);


### PR DESCRIPTION
## :christmas_tree: Problème
Certains apprenant ne sont pas supprimé alors qu'il devrait l'être. 
Mais dit moi Jamy ! Pourquoi ?

La condition `where <column> In <mes_data>` en SQL ne prend pas en compte les `null `. il faut spécifier que l'on veut aussi inclure la valeur `null` dans les résultats

## :gift: Proposition

Inclur cette valeur null dans les requêtes de suppression côté SUP et de désactivation côté SCO  CSV / XML

## :socks: Remarques

Le cas SUP est OK

## :santa: Pour tester

Orga SUP sans import => avec des learners

Ajout isManagingStudent => import suppression des learners sans studentNumber