### PR TITLE
[BUGFIX] corriger l'affichage du dashboard en version espagnole

### DIFF
--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1253,7 +1253,7 @@
           "text": "Más información",
           "url": "https://pix.fr/actualites/decouvrez-votre-nouveau-tableau-de-bord"
         },
-        "message": "<h2>Hola, { firstname }: descubre tu panel de control.</h2><p>Accede rápida y fácilmente a los tests y pruebas de competencias que ya has empezado.<br/>Comprueba cómo progresa tu puntuación Pix y si tu perfil está listo para la certificación Pix.</p>"
+        "message": "<h2>Hola, descubre tu panel de control.</h2><p>Accede rápida y fácilmente a los tests y pruebas de competencias que ya has empezado.<br/>Comprueba cómo progresa tu puntuación Pix y si tu perfil está listo para la certificación Pix.</p>"
       },
       "recommended-competences": {
         "extra-information": "Acceder a todas las competencias recomendadas",


### PR DESCRIPTION
## :christmas_tree: Problème

Le dashboard de Pix App ne s'affiche pas correctement en espagnol et cela empêche toute navigation dans PixApp :boom: .

## :gift: Proposition

Le bug est causé par une valeur désormais incorrecte de la clé de traduction `pages.dashboard.presentation.message`, qu'il faut corriger.

## :socks: Remarques

ras

## :santa: Pour tester

Se créer un compte en espagnol et une fois connecté, constater que la page d'accueil s'affiche bien et qu'elle permet la navigation sur les onglets `competencias`, `certificacion`, `mis tutoriales`.
