### PR TITLE
[FEATURE] Donner la possibilitée aux organisations sans imports de télécharger des attestations (PIX-15612)

### DIFF
--- a/api/db/seeds/data/common/organization-builder.js
+++ b/api/db/seeds/data/common/organization-builder.js
@@ -33,7 +33,6 @@ async function _createScoOrganization(databaseBuilder) {
     features: [
       { id: FEATURE_COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY_ID },
       { id: FEATURE_MULTIPLE_SENDING_ASSESSMENT_ID },
-      { id: FEATURE_ATTESTATIONS_MANAGEMENT_ID },
     ],
   });
 
@@ -46,7 +45,7 @@ async function _createScoOrganization(databaseBuilder) {
     externalId: 'SCO_NOT_MANAGING',
     adminIds: [USER_ID_ADMIN_ORGANIZATION],
     memberIds: [USER_ID_MEMBER_ORGANIZATION],
-    features: [{ id: FEATURE_MULTIPLE_SENDING_ASSESSMENT_ID }],
+    features: [{ id: FEATURE_MULTIPLE_SENDING_ASSESSMENT_ID }, { id: FEATURE_ATTESTATIONS_MANAGEMENT_ID }],
   });
 
   await organization.createOrganization({

--- a/api/db/seeds/data/team-prescription/build-quests.js
+++ b/api/db/seeds/data/team-prescription/build-quests.js
@@ -6,6 +6,7 @@ import { temporaryStorage } from '../../../../src/shared/infrastructure/temporar
 import {
   AEFE_TAG,
   FEATURE_ATTESTATIONS_MANAGEMENT_ID,
+  SCO_ORGANIZATION_ID,
   USER_ID_ADMIN_ORGANIZATION,
   USER_ID_MEMBER_ORGANIZATION,
 } from '../common/constants.js';
@@ -399,4 +400,20 @@ export const buildQuests = async (databaseBuilder) => {
 
   // Insert job count in temporary storage for pending user
   await profileRewardTemporaryStorage.increment(pendingUser.id);
+
+  // Create learner with profile rewards for SCO organization without import
+  const { id: otherUserId } = databaseBuilder.factory.buildUser({ firstName: 'Alex', lastName: 'Tension' });
+  databaseBuilder.factory.buildOrganizationLearner({
+    organizationId: SCO_ORGANIZATION_ID,
+    userId: otherUserId,
+  });
+  const { id: otherUserProfileRewardId } = databaseBuilder.factory.buildProfileReward({
+    userId: otherUserId,
+    rewardType: REWARD_TYPES.ATTESTATION,
+    rewardId,
+  });
+  databaseBuilder.factory.buildOrganizationsProfileRewards({
+    organizationId: SCO_ORGANIZATION_ID,
+    profileRewardId: otherUserProfileRewardId,
+  });
 };

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
@@ -114,11 +114,15 @@ async function findPaginatedLearners({ organizationId, page, filter }) {
 }
 
 async function findOrganizationLearnersByDivisions({ organizationId, divisions }) {
+  let organizationLearners;
+
   const knexConnection = DomainTransaction.getConnection();
-  const organizationLearners = await knexConnection
-    .from('view-active-organization-learners')
-    .where({ organizationId })
-    .whereIn('division', divisions);
+  const queryBuilder = knexConnection.from('view-active-organization-learners').where({ organizationId });
+  if (divisions.length > 0) {
+    organizationLearners = await queryBuilder.whereIn('division', divisions);
+  } else {
+    organizationLearners = await queryBuilder;
+  }
   return organizationLearners.map((organizationLearner) => new OrganizationLearner(organizationLearner));
 }
 

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -724,5 +724,23 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
         expect(result).to.be.empty;
       });
     });
+    context('when divisions is an empty array', function () {
+      it('should return all learners', async function () {
+        // given
+        databaseBuilder.factory.buildOrganizationLearner({ organizationId, division: '6eme A' });
+        databaseBuilder.factory.buildOrganizationLearner({ organizationId, division: '6eme B' });
+
+        await databaseBuilder.commit();
+
+        // when
+        const result = await organizationLearnerRepository.findOrganizationLearnersByDivisions({
+          organizationId,
+          divisions: [],
+        });
+
+        // then
+        expect(result).to.have.lengthOf(2);
+      });
+    });
   });
 });

--- a/orga/app/components/attestations/sixth-grade.gjs
+++ b/orga/app/components/attestations/sixth-grade.gjs
@@ -2,14 +2,17 @@ import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
+import { eq } from 'ember-truth-helpers';
 
 import PageTitle from '../ui/page-title';
 
 export default class AttestationsSixthGrade extends Component {
   @tracked selectedDivisions = [];
+  @service currentUser;
 
   @action
   onSubmit(event) {
@@ -30,27 +33,37 @@ export default class AttestationsSixthGrade extends Component {
   <template>
     <PageTitle>
       <:title>{{t "pages.attestations.title"}}</:title>
-      <:subtitle>
-        <p class="attestations-page__text">
-          {{t "pages.attestations.description"}}
-        </p>
-      </:subtitle>
     </PageTitle>
 
-    <form class="attestations-page__action" {{on "submit" this.onSubmit}}>
-      <PixMultiSelect
-        @isSearchable={{true}}
-        @options={{@divisions}}
-        @values={{this.selectedDivisions}}
-        @onChange={{this.onSelectDivision}}
-        @placeholder={{t "common.filters.placeholder"}}
-      >
-        <:label>{{t "pages.attestations.select-label"}}</:label>
-        <:default as |option|>{{option.label}}</:default>
-      </PixMultiSelect>
-      <PixButton @type="submit" id="download_attestations" @size="small" @isDisabled={{this.isDisabled}}>
-        {{t "pages.attestations.download-attestations-button"}}
-      </PixButton>
-    </form>
+    {{#if (eq @divisions undefined)}}
+      <div>
+        <p class="attestations-page__text">
+          {{t "pages.attestations.basic-description"}}
+        </p>
+        <PixButton @triggerAction={{this.onSubmit}} @size="small">
+          {{t "pages.attestations.download-attestations-button"}}
+        </PixButton>
+      </div>
+    {{else}}
+      <p class="attestations-page__text">
+        {{t "pages.attestations.divisions-description"}}
+      </p>
+
+      <form class="attestations-page__action" {{on "submit" this.onSubmit}}>
+        <PixMultiSelect
+          @isSearchable={{true}}
+          @options={{@divisions}}
+          @values={{this.selectedDivisions}}
+          @onChange={{this.onSelectDivision}}
+          @placeholder={{t "common.filters.placeholder"}}
+        >
+          <:label>{{t "pages.attestations.select-label"}}</:label>
+          <:default as |option|>{{option.label}}</:default>
+        </PixMultiSelect>
+        <PixButton @type="submit" id="download_attestations" @size="small" @isDisabled={{this.isDisabled}}>
+          {{t "pages.attestations.download-attestations-button"}}
+        </PixButton>
+      </form>
+    {{/if}}
   </template>
 }

--- a/orga/app/controllers/authenticated/attestations.js
+++ b/orga/app/controllers/authenticated/attestations.js
@@ -15,12 +15,18 @@ export default class AuthenticatedAttestationsController extends Controller {
   @action
   async downloadSixthGradeAttestationsFile(selectedDivisions) {
     try {
+      let url;
       const organizationId = this.currentUser.organization.id;
-      const formatedDivisionsForQuery = selectedDivisions
-        .map((division) => `divisions[]=${encodeURIComponent(division)}`)
-        .join('&');
+      const baseUrl = `/api/organizations/${organizationId}/attestations/${SIXTH_GRADE_ATTESTATION_KEY}`;
+      if (selectedDivisions.length > 0) {
+        const formatedDivisionsForQuery = selectedDivisions
+          .map((division) => `divisions[]=${encodeURIComponent(division)}`)
+          .join('&');
 
-      const url = `/api/organizations/${organizationId}/attestations/${SIXTH_GRADE_ATTESTATION_KEY}?${formatedDivisionsForQuery}`;
+        url = baseUrl + `?${formatedDivisionsForQuery}`;
+      } else {
+        url = baseUrl;
+      }
 
       const token = this.session.isAuthenticated ? this.session.data.authenticated.access_token : '';
 

--- a/orga/app/routes/authenticated/attestations.js
+++ b/orga/app/routes/authenticated/attestations.js
@@ -12,8 +12,10 @@ export default class AuthenticatedAttestationsRoute extends Route {
   }
 
   async model() {
-    const divisions = await this.currentUser.organization.divisions;
-    const options = divisions.map(({ name }) => ({ label: name, value: name }));
-    return { options };
+    if (this.currentUser.organization.isManagingStudents) {
+      const divisions = await this.currentUser.organization.divisions;
+      const options = divisions.map(({ name }) => ({ label: name, value: name }));
+      return { options };
+    }
   }
 }

--- a/orga/tests/integration/components/attestations/sixth-grade-test.gjs
+++ b/orga/tests/integration/components/attestations/sixth-grade-test.gjs
@@ -10,61 +10,99 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | Attestations | Sixth-grade', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it should display all basics informations', async function (assert) {
-    // given
-    const onSubmit = sinon.stub();
-    const divisions = [];
+  module('when organization has divisions', function () {
+    test('it should display all specifics informations for divisions', async function (assert) {
+      // given
+      const onSubmit = sinon.stub();
+      const divisions = [];
 
-    // when
-    const screen = await render(<template><SixthGrade @divisions={{divisions}} @onSubmit={{onSubmit}} /></template>);
-    // then
-    assert.ok(screen.getByRole('heading', { name: t('pages.attestations.title') }));
-    assert.ok(screen.getByText(t('pages.attestations.description')));
-    assert.ok(screen.getByRole('textbox', { name: t('pages.attestations.select-label') }));
-    assert.ok(screen.getByPlaceholderText(t('common.filters.placeholder')));
-    assert.ok(screen.getByRole('button', { name: t('pages.attestations.download-attestations-button') }));
-  });
-
-  test('download button is disabled if there is no selected divisions', async function (assert) {
-    // given
-    const onSubmit = sinon.stub();
-    const divisions = [];
-
-    // when
-    const screen = await render(<template><SixthGrade @divisions={{divisions}} @onSubmit={{onSubmit}} /></template>);
-
-    // then
-    const downloadButton = await screen.getByRole('button', {
-      name: t('pages.attestations.download-attestations-button'),
-    });
-    assert.dom(downloadButton).isDisabled();
-  });
-
-  test('it should call onSubmit action with selected divisions', async function (assert) {
-    // given
-    const onSubmit = sinon.stub();
-
-    const divisions = [{ label: 'division1', value: 'division1' }];
-
-    // when
-    const screen = await render(<template><SixthGrade @divisions={{divisions}} @onSubmit={{onSubmit}} /></template>);
-
-    const multiSelect = await screen.getByRole('textbox', { name: t('pages.attestations.select-label') });
-    await click(multiSelect);
-
-    const firstDivisionOption = await screen.findByRole('checkbox', { name: 'division1' });
-    await click(firstDivisionOption);
-
-    const downloadButton = await screen.getByRole('button', {
-      name: t('pages.attestations.download-attestations-button'),
+      // when
+      const screen = await render(<template><SixthGrade @divisions={{divisions}} @onSubmit={{onSubmit}} /></template>);
+      // then
+      assert.ok(screen.getByRole('heading', { name: t('pages.attestations.title') }));
+      assert.ok(screen.getByText(t('pages.attestations.divisions-description')));
+      assert.ok(screen.getByRole('textbox', { name: t('pages.attestations.select-label') }));
+      assert.ok(screen.getByPlaceholderText(t('common.filters.placeholder')));
+      assert.ok(screen.getByRole('button', { name: t('pages.attestations.download-attestations-button') }));
     });
 
-    // we need to get out of input choice to click on download button, so we have to click again on the multiselect to close it
-    await click(multiSelect);
-    await click(downloadButton);
+    test('download button is disabled if there is no selected divisions', async function (assert) {
+      // given
+      const onSubmit = sinon.stub();
+      const divisions = [];
 
-    // then
-    sinon.assert.calledWithExactly(onSubmit, ['division1']);
-    assert.ok(true);
+      // when
+      const screen = await render(<template><SixthGrade @divisions={{divisions}} @onSubmit={{onSubmit}} /></template>);
+
+      // then
+      const downloadButton = await screen.getByRole('button', {
+        name: t('pages.attestations.download-attestations-button'),
+      });
+      assert.dom(downloadButton).isDisabled();
+    });
+
+    test('it should call onSubmit action with selected divisions', async function (assert) {
+      // given
+      const onSubmit = sinon.stub();
+
+      const divisions = [{ label: 'division1', value: 'division1' }];
+
+      // when
+      const screen = await render(<template><SixthGrade @divisions={{divisions}} @onSubmit={{onSubmit}} /></template>);
+
+      const multiSelect = await screen.getByRole('textbox', { name: t('pages.attestations.select-label') });
+      await click(multiSelect);
+
+      const firstDivisionOption = await screen.findByRole('checkbox', { name: 'division1' });
+      await click(firstDivisionOption);
+
+      const downloadButton = await screen.getByRole('button', {
+        name: t('pages.attestations.download-attestations-button'),
+      });
+
+      // we need to get out of input choice to click on download button, so we have to click again on the multiselect to close it
+      await click(multiSelect);
+      await click(downloadButton);
+
+      // then
+      sinon.assert.calledWithExactly(onSubmit, ['division1']);
+      assert.ok(true);
+    });
+  });
+
+  module('when organization does not have divisions', function () {
+    test('it should display all basics informations', async function (assert) {
+      // given
+      const onSubmit = sinon.stub();
+      const divisions = undefined;
+
+      // when
+      const screen = await render(<template><SixthGrade @divisions={{divisions}} @onSubmit={{onSubmit}} /></template>);
+      // then
+      assert.notOk(screen.queryByRole('textbox', { name: t('pages.attestations.select-label') }));
+      assert.ok(screen.getByRole('heading', { name: t('pages.attestations.title') }));
+      assert.ok(screen.getByText(t('pages.attestations.basic-description')));
+      assert.ok(screen.getByRole('button', { name: t('pages.attestations.download-attestations-button') }));
+    });
+
+    test('it should call onSubmit action with empty divisions', async function (assert) {
+      // given
+      const onSubmit = sinon.stub();
+
+      const divisions = undefined;
+
+      // when
+      const screen = await render(<template><SixthGrade @divisions={{divisions}} @onSubmit={{onSubmit}} /></template>);
+
+      const downloadButton = await screen.getByRole('button', {
+        name: t('pages.attestations.download-attestations-button'),
+      });
+
+      await click(downloadButton);
+
+      // then
+      sinon.assert.calledWithExactly(onSubmit, []);
+      assert.ok(true);
+    });
   });
 });

--- a/orga/tests/unit/controllers/authenticated/attestations-test.js
+++ b/orga/tests/unit/controllers/authenticated/attestations-test.js
@@ -12,50 +12,100 @@ module('Unit | Controller | authenticated/attestations', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   module('#downloadSixthGradeAttestationsFile', function () {
-    test('should call the file-saver service with the right parameters', async function (assert) {
-      // given
-      this.intl = this.owner.lookup('service:intl');
-      const controller = this.owner.lookup('controller:authenticated/attestations');
+    module('when there are selected divisions', function () {
+      test('should call the file-saver service with the right parameters', async function (assert) {
+        // given
+        this.intl = this.owner.lookup('service:intl');
+        const controller = this.owner.lookup('controller:authenticated/attestations');
 
-      const token = 'a token';
-      const organizationId = 12345;
-      const selectedDivision = ['3èmea'];
+        const token = 'a token';
+        const organizationId = 12345;
+        const selectedDivision = ['3èmea'];
 
-      controller.session = {
-        isAuthenticated: true,
-        data: {
-          authenticated: {
-            access_token: token,
+        controller.session = {
+          isAuthenticated: true,
+          data: {
+            authenticated: {
+              access_token: token,
+            },
           },
-        },
-      };
+        };
 
-      controller.currentUser = {
-        organization: {
-          id: organizationId,
-        },
-      };
+        controller.currentUser = {
+          organization: {
+            id: organizationId,
+          },
+        };
 
-      controller.fileSaver = {
-        save: sinon.stub(),
-      };
+        controller.fileSaver = {
+          save: sinon.stub(),
+        };
 
-      controller.model = {
-        options: [{ label: '3èmeA', value: '3èmeA' }],
-      };
+        controller.model = {
+          options: [{ label: '3èmeA', value: '3èmeA' }],
+        };
 
-      // when
-      await controller.downloadSixthGradeAttestationsFile(selectedDivision);
+        // when
+        await controller.downloadSixthGradeAttestationsFile(selectedDivision);
 
-      // then
-      assert.ok(
-        controller.fileSaver.save.calledWith({
-          token,
-          url: `/api/organizations/${organizationId}/attestations/${SIXTH_GRADE_ATTESTATION_KEY}?divisions[]=${encodeURIComponent(selectedDivision)}`,
-          fileName: SIXTH_GRADE_ATTESTATION_FILE_NAME,
-          noContentMessageNotification: this.intl.t('pages.attestations.no-attestations'),
-        }),
-      );
+        // then
+        assert.ok(
+          controller.fileSaver.save.calledWith({
+            token,
+            url: `/api/organizations/${organizationId}/attestations/${SIXTH_GRADE_ATTESTATION_KEY}?divisions[]=${encodeURIComponent(selectedDivision)}`,
+            fileName: SIXTH_GRADE_ATTESTATION_FILE_NAME,
+            noContentMessageNotification: this.intl.t('pages.attestations.no-attestations'),
+          }),
+        );
+      });
+    });
+
+    module('when selected divisions is empty', function () {
+      test('should call the file-saver service with the right parameters', async function (assert) {
+        // given
+        this.intl = this.owner.lookup('service:intl');
+        const controller = this.owner.lookup('controller:authenticated/attestations');
+
+        const token = 'a token';
+        const organizationId = 12345;
+        const selectedDivision = [];
+
+        controller.session = {
+          isAuthenticated: true,
+          data: {
+            authenticated: {
+              access_token: token,
+            },
+          },
+        };
+
+        controller.currentUser = {
+          organization: {
+            id: organizationId,
+          },
+        };
+
+        controller.fileSaver = {
+          save: sinon.stub(),
+        };
+
+        controller.model = {
+          options: [],
+        };
+
+        // when
+        await controller.downloadSixthGradeAttestationsFile(selectedDivision);
+
+        // then
+        assert.ok(
+          controller.fileSaver.save.calledWith({
+            token,
+            url: `/api/organizations/${organizationId}/attestations/${SIXTH_GRADE_ATTESTATION_KEY}`,
+            fileName: SIXTH_GRADE_ATTESTATION_FILE_NAME,
+            noContentMessageNotification: this.intl.t('pages.attestations.no-attestations'),
+          }),
+        );
+      });
     });
 
     test('it should not call file-save service and display an error if an error occurs', async function (assert) {

--- a/orga/tests/unit/routes/authenticated/attestations-test.js
+++ b/orga/tests/unit/routes/authenticated/attestations-test.js
@@ -55,6 +55,7 @@ module('Unit | Route | authenticated/attestations', function (hooks) {
         organization = {
           id: 12345,
           divisions,
+          isManagingStudents: true,
         };
       }
 
@@ -84,6 +85,35 @@ module('Unit | Route | authenticated/attestations', function (hooks) {
           },
         ],
       });
+    });
+
+    test('it should return undefined if current organization is not managing students', async function (assert) {
+      // given
+      const divisions = [{ name: '3èmeA' }, { name: '2ndE' }];
+      class CurrentUserStub extends Service {
+        canAccessAttestationsPage = true;
+        organization = {
+          id: 12345,
+          divisions,
+          isManagingStudents: false,
+        };
+      }
+
+      const findRecordStub = sinon.stub();
+      class StoreStub extends Service {
+        findRecord = findRecordStub;
+      }
+
+      this.owner.register('service:current-user', CurrentUserStub);
+      this.owner.register('service:store', StoreStub);
+
+      const route = this.owner.lookup('route:authenticated/attestations');
+
+      // when
+      const actualOptions = await route.model();
+
+      // then
+      assert.deepEqual(actualOptions, undefined);
     });
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -418,7 +418,8 @@
     },
     "attestations": {
       "title": "Attestations",
-      "description": "Select the class for which you wish to export attestations in PDF format.",
+      "basic-description" : "Export all attestations in PDF format",
+      "divisions-description": "Select the class for which you wish to export attestations in PDF format.",
       "download-attestations-button": "Download",
       "no-attestations": "No attestation available",
       "select-label": "Select one or more classes"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -424,7 +424,8 @@
     },
     "attestations": {
       "title": "Attestations",
-      "description": "Sélectionnez la classe pour laquelle vous souhaitez exporter les attestations au format PDF.",
+      "basic-description": "Exportez toutes les attestations au format PDF",
+      "divisions-description": "Sélectionnez la classe pour laquelle vous souhaitez exporter les attestations au format PDF.",
       "download-attestations-button": "Télécharger",
       "no-attestations": "Aucune attestation disponible pour votre sélection",
       "select-label": "Sélectionnez une ou plusieurs classes"

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -417,10 +417,11 @@
       "title": "Resultaten voor {firstName} {lastName}"
     },
     "attestations": {
-      "no-attestations": "Er zijn geen certificaten beschikbaar voor jouw selectie",
       "title": "Certificaten",
-      "description": "Selecteer de klas waarvoor je de attesten in PDF-formaat wilt exporteren.",
+      "basic-description" : "Alle attesten exporteren in PDF-formaat",
+      "divisions-description": "Selecteer de klas waarvoor je de attesten in PDF-formaat wilt exporteren.",
       "download-attestations-button": "Downloaden",
+      "no-attestations": "Er zijn geen certificaten beschikbaar voor jouw selectie",
       "select-label": "Selecteer een of meer klassen"
     },
     "campaign-activity": {


### PR DESCRIPTION
## :christmas_tree: Problème
Les EFE n’ont pas d’import, les élèves n’ont donc pas de classe
Nous n’avons pas anticipé ce cas lors de dev de la page attestations, il faut que le prescripteur puisse télécharger toutes les attestations dans les EFE. 

## :gift: Proposition
Rendre possible le téléchargement des attestations même pour les organisations n'ayant pas d'import

## :socks: Remarques
La page `sixth-grade.gjs` ainsi que son fonctionnement sera surement a revoir, et est prévu pour la v2

## :santa: Pour tester
 ### Test de non régression
- Se connecter avec `admin-orga@example.net`
- Aller sur l'organisation `Attestations`
- Aller sur la page `Attestations`
- Constater que l'affichage n'a pas évolué pour ce type d'orga ( Sco avec import ) 
- Essayer de télécharger les attestations et constater que le fonctionnement est toujours ISO
### Nouveau Test
- Aller sur l'organisation `Sco Classic`
- Vérifier le nouvel affichage pour les organisations sans import
- Essayer de télécharger l'attestation 
- 🐈‍⬛ 