### PR TITLE
[BUGFIX] cache le filtre du propriétaire de campagne sur la page mes campagnes (pix-15837)

### DIFF
--- a/orga/app/components/campaign/list.gjs
+++ b/orga/app/components/campaign/list.gjs
@@ -94,6 +94,7 @@ export default class List extends Component {
                       @onClearFilters={{fn withFunction @onClear reset}}
                       @numResults={{@campaigns.meta.rowCount}}
                       @canDelete={{this.canDelete}}
+                      @listOnlyCampaignsOfCurrentUser={{@hideCampaignOwnerFilter}}
                     />
                   </InElement>
                   <Headers @destinationId={{headerId}} @showCampaignOwner={{@showCampaignOwner}}>

--- a/orga/app/templates/authenticated/campaigns/list/all-campaigns.hbs
+++ b/orga/app/templates/authenticated/campaigns/list/all-campaigns.hbs
@@ -8,6 +8,7 @@
     @campaigns={{@model.campaigns}}
     @nameFilter={{this.name}}
     @showCampaignOwner={{true}}
+    @hideCampaignOwnerFilter={{false}}
     @ownerNameFilter={{this.ownerName}}
     @statusFilter={{this.status}}
     @onFilter={{this.triggerFiltering}}

--- a/orga/app/templates/authenticated/campaigns/list/my-campaigns.hbs
+++ b/orga/app/templates/authenticated/campaigns/list/my-campaigns.hbs
@@ -13,6 +13,7 @@
     @onClickCampaign={{this.goToCampaignPage}}
     @canDelete={{true}}
     @showCampaignOwner={{false}}
+    @hideCampaignOwnerFilter={{true}}
     @onDeleteCampaigns={{this.onDeleteCampaigns}}
   />
 {{else}}

--- a/orga/tests/integration/components/campaign/list-test.js
+++ b/orga/tests/integration/components/campaign/list-test.js
@@ -48,6 +48,73 @@ module('Integration | Component | Campaign::List', function (hooks) {
   });
 
   module('When there are campaigns to display', function () {
+    module('@showCampaignOwnerFilter', function (hooks) {
+      let campaigns = [];
+
+      hooks.beforeEach(function () {
+        const store = this.owner.lookup('service:store');
+        const campaign = store.createRecord('campaign', {
+          id: '1',
+          name: 'campagne 1',
+          code: 'AAAAAA111',
+          type: 'PROFILES_COLLECTION',
+        });
+        campaigns = [campaign];
+        campaigns.meta = { rowCount: campaigns.length };
+        this.set('campaigns', campaigns);
+      });
+
+      test('it should show the owner filter ', async function (assert) {
+        // when
+        const screen = await render(
+          hbs`<Campaign::List
+  @campaigns={{this.campaigns}}
+  @onFilter={{this.noop}}
+  @onClickCampaign={{this.noop}}
+  @hideCampaignOwnerFilter={{false}}
+/>`,
+        );
+
+        // then
+        assert.ok(screen.getByLabelText(t('pages.campaigns-list.filter.by-owner')));
+      });
+      test('it should hide the owner filter ', async function (assert) {
+        // when
+        const screen = await render(
+          hbs`<Campaign::List
+  @campaigns={{this.campaigns}}
+  @onFilter={{this.noop}}
+  @onClickCampaign={{this.noop}}
+  @hideCampaignOwnerFilter={{true}}
+/>`,
+        );
+
+        // then
+        assert.notOk(screen.queryByLabelText(t('pages.campaigns-list.filter.by-owner')));
+      });
+    });
+
+    test('it should show the owner filter ', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const campaign1 = store.createRecord('campaign', {
+        id: '1',
+        name: 'campagne 1',
+        code: 'AAAAAA111',
+        type: 'PROFILES_COLLECTION',
+      });
+      const campaigns = [campaign1];
+      campaigns.meta = { rowCount: 1 };
+      this.set('campaigns', campaigns);
+
+      // when
+      const screen = await render(
+        hbs`<Campaign::List @campaigns={{this.campaigns}} @onFilter={{this.noop}} @onClickCampaign={{this.noop}} />`,
+      );
+
+      // then
+      assert.dom(screen.getByLabelText(t('pages.campaigns-list.filter.by-owner'))).exists();
+    });
     test('it should display a list of campaigns', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');


### PR DESCRIPTION
## :christmas_tree: Problème

On affiche le filtre du propriétaire de campagne sur la page mes campagnes or celui ci ne sert à rien

## :gift: Proposition

on cache le filtre propriétaire dans mes campagnes

## :socks: Remarques

RAS

## :santa: Pour tester

- Aller sur orga
- Afficher la page "mes campagnes"
- ne pas voir le filtre
- Afficher la page "toutes les campagnes"
- voir le filtre
- faire une recherche