### PR TITLE
[TECH] Ajouter la table ke-snapshots dans la description du template de migration (PIX-15850)

### DIFF
--- a/api/db/template.js
+++ b/api/db/template.js
@@ -4,7 +4,12 @@
 // You can design and test your migration to avoid this by following this guide
 // https://1024pix.atlassian.net/wiki/spaces/EDTDT/pages/3849323922/Cr+er+une+migration
 
-// If your migrations target `answers` or `knowledge-elements`
+// If your migrations target :
+//
+// `answers`
+// `knowledge-elements`
+// `knowledge-element-snapshots`
+//
 // contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
 // this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
 const TABLE_NAME = 'book';


### PR DESCRIPTION
## :christmas_tree: Problème

la template de migration ne contient pas la mention de ke snapshots à l'intérieur. ce qui a amené une incompréhension dans le lancement d'une migration qui n'aurait pas du avoir lieu

## :gift: Proposition

Ajouter la mention de cette table 

## :socks: Remarques

RAS

## :santa: Pour tester

CI au vert, vérifier la présence du commentaires dans la création d'une migration