### PR TITLE
[FEATURE] Matomo - Envoyer les events liés à l'utilisation du Expand (toggle) (PIX-15774)

### DIFF
--- a/mon-pix/app/components/module/element.gjs
+++ b/mon-pix/app/components/module/element.gjs
@@ -31,7 +31,7 @@ export default class ModulixElement extends Component {
     {{else if (eq @element.type "embed")}}
       <EmbedElement @embed={{@element}} @onAnswer={{@onElementAnswer}} />
     {{else if (eq @element.type "expand")}}
-      <ExpandElement @expand={{@element}} />
+      <ExpandElement @expand={{@element}} @onExpandToggle={{@onExpandToggle}} />
     {{else if (eq @element.type "separator")}}
       <SeparatorElement />
     {{else if (eq @element.type "flashcards")}}

--- a/mon-pix/app/components/module/element/_expand.scss
+++ b/mon-pix/app/components/module/element/_expand.scss
@@ -1,0 +1,5 @@
+.modulix-expand {
+  &__title {
+    cursor: pointer;
+  }
+}

--- a/mon-pix/app/components/module/element/expand.gjs
+++ b/mon-pix/app/components/module/element/expand.gjs
@@ -1,8 +1,20 @@
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+
 import { htmlUnsafe } from '../../../helpers/html-unsafe';
 
-<template>
-  <details>
-    <summary>{{@expand.title}}</summary>
-    {{htmlUnsafe @expand.content}}
-  </details>
-</template>
+export default class ModulixExpand extends Component {
+  @action
+  onExpandToggle(event) {
+    const isOpen = event.srcElement.open;
+    this.args.onExpandToggle({ elementId: this.args.expand.id, isOpen });
+  }
+
+  <template>
+    <details class="modulix-expand" {{on "toggle" this.onExpandToggle}}>
+      <summary class="modulix-expand__title">{{@expand.title}}</summary>
+      {{htmlUnsafe @expand.content}}
+    </details>
+  </template>
+}

--- a/mon-pix/app/components/module/grain.gjs
+++ b/mon-pix/app/components/module/grain.gjs
@@ -218,6 +218,7 @@ export default class ModuleGrain extends Component {
                   @onVideoTranscriptionOpen={{@onVideoTranscriptionOpen}}
                   @onVideoPlay={{@onVideoPlay}}
                   @onFileDownload={{@onFileDownload}}
+                  @onExpandToggle={{@onExpandToggle}}
                 />
               </div>
             {{/if}}

--- a/mon-pix/app/components/module/grain.gjs
+++ b/mon-pix/app/components/module/grain.gjs
@@ -201,6 +201,7 @@ export default class ModuleGrain extends Component {
                   @onVideoPlay={{@onVideoPlay}}
                   @getLastCorrectionForElement={{this.getLastCorrectionForElement}}
                   @onFileDownload={{@onFileDownload}}
+                  @onExpandToggle={{@onExpandToggle}}
                 />
               </div>
             {{else if (eq component.type "stepper")}}

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -219,6 +219,17 @@ export default class ModulePassage extends Component {
     });
   }
 
+  @action
+  async onExpandToggle({ elementId, isOpen }) {
+    const eventToggle = isOpen ? 'Ouverture' : 'Fermeture';
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Modulix',
+      'pix-event-action': `Passage du module : ${this.args.module.id}`,
+      'pix-event-name': `${eventToggle} de l'élément Expand : ${elementId}`,
+    });
+  }
+
   <template>
     {{pageTitle @module.title}}
     {{#if @module.isBeta}}
@@ -258,10 +269,11 @@ export default class ModulePassage extends Component {
             @onGrainContinue={{this.onGrainContinue}}
             @onGrainSkip={{this.onGrainSkip}}
             @shouldDisplayTerminateButton={{this.grainShouldDisplayTerminateButton index}}
-            @onModuleTerminate={{this.onModuleTerminate}}
             @hasJustAppeared={{this.hasGrainJustAppeared index}}
+            @onModuleTerminate={{this.onModuleTerminate}}
             @onVideoPlay={{this.onVideoPlay}}
             @onFileDownload={{this.onFileDownload}}
+            @onExpandToggle={{this.onExpandToggle}}
           />
         {{/each}}
       </div>

--- a/mon-pix/app/components/module/step.gjs
+++ b/mon-pix/app/components/module/step.gjs
@@ -47,6 +47,7 @@ export default class ModulixStep extends Component {
               @onVideoTranscriptionOpen={{@onVideoTranscriptionOpen}}
               @onVideoPlay={{@onVideoPlay}}
               @onFileDownload={{@onFileDownload}}
+              @onExpandToggle={{@onExpandToggle}}
             />
           </div>
         {{/each}}

--- a/mon-pix/app/components/module/stepper.gjs
+++ b/mon-pix/app/components/module/stepper.gjs
@@ -93,6 +93,7 @@ export default class ModulixStepper extends Component {
             @onVideoTranscriptionOpen={{@onVideoTranscriptionOpen}}
             @onVideoPlay={{@onVideoPlay}}
             @onFileDownload={{@onFileDownload}}
+            @onExpandToggle={{@onExpandToggle}}
           />
         {{/each}}
         {{#if this.shouldDisplayNextButton}}

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -77,6 +77,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @import '../components/module/stepper';
 @import '../components/module/element/download';
 @import '../components/module/element/embed';
+@import '../components/module/element/expand';
 @import '../components/module/element/flashcards/flashcards';
 @import '../components/module/element/flashcards/flashcards-card';
 @import '../components/module/element/image';

--- a/mon-pix/tests/integration/components/module/expand_test.gjs
+++ b/mon-pix/tests/integration/components/module/expand_test.gjs
@@ -1,6 +1,8 @@
 import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import ModulixExpandElement from 'mon-pix/components/module/element/expand';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -23,5 +25,58 @@ module('Integration | Component | Module | Expand', function (hooks) {
     assert.dom(detailsElement).exists();
     assert.dom(screen.getByText(expandElement.title)).exists();
     assert.dom(screen.getByText(content)).exists();
+  });
+
+  module('when user opens Expand element', function () {
+    test('should call method onExpandToggle with isOpen set to true', async function (assert) {
+      // given
+      const content = 'My content';
+      const expandElement = {
+        id: 'f5e7ce21-b71d-4054-8886-a4e9a17016ff',
+        title: 'Expand title',
+        content: `<p>${content}</p>`,
+      };
+      const onExpandToggleStub = sinon.stub();
+
+      //  when
+      const screen = await render(
+        <template><ModulixExpandElement @expand={{expandElement}} @onExpandToggle={{onExpandToggleStub}} /></template>,
+      );
+      const detailsElement = screen.getByRole('group');
+
+      const expandSummarySelector = '.modulix-expand__title';
+      await click(expandSummarySelector);
+
+      // then
+      sinon.assert.calledOnceWithExactly(onExpandToggleStub, { elementId: expandElement.id, isOpen: true });
+      assert.dom(detailsElement).hasAttribute('open');
+    });
+  });
+
+  module('when Expand element is open and user closes it', function () {
+    test('should call method onExpandToggle with isOpen set to false', async function (assert) {
+      // given
+      const content = 'My content';
+      const expandElement = {
+        id: 'f5e7ce21-b71d-4054-8886-a4e9a17016ff',
+        title: 'Expand title',
+        content: `<p>${content}</p>`,
+      };
+      const onExpandToggleStub = sinon.stub();
+
+      //  when
+      const screen = await render(
+        <template><ModulixExpandElement @expand={{expandElement}} @onExpandToggle={{onExpandToggleStub}} /></template>,
+      );
+      const detailsElement = screen.getByRole('group');
+      detailsElement.open = true;
+
+      const expandSummarySelector = '.modulix-expand__title';
+      await click(expandSummarySelector);
+
+      // then
+      sinon.assert.calledOnceWithExactly(onExpandToggleStub, { elementId: expandElement.id, isOpen: false });
+      assert.dom(detailsElement).doesNotHaveAttribute('open');
+    });
   });
 });

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -1170,4 +1170,95 @@ module('Integration | Component | Module | Passage', function (hooks) {
       assert.ok(true);
     });
   });
+
+  module('when user opens Expand element', function () {
+    test('should push metrics event with "Ouverture" event name', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const expandElement = {
+        id: 'f5e7ce21-b71d-4054-8886-a4e9a17016ff',
+        type: 'expand',
+        isAnswerable: false,
+        title: 'Mon Expand',
+        content: "<p>Ceci est le contenu d'un expand dans mon module</p>",
+      };
+      const grain = store.createRecord('grain', {
+        title: 'Grain title',
+        type: 'discovery',
+        id: '123-abc',
+        components: [{ type: 'element', element: expandElement }],
+      });
+
+      const module = store.createRecord('module', {
+        title: 'Didacticiel',
+        grains: [grain],
+        transitionTexts: [],
+      });
+      const passage = store.createRecord('passage');
+      const metrics = this.owner.lookup('service:metrics');
+      metrics.add = sinon.stub();
+
+      //  when
+      await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
+
+      const expandSummarySelector = '.modulix-expand__title';
+      await click(expandSummarySelector);
+
+      // then
+      sinon.assert.calledWithExactly(metrics.add, {
+        event: 'custom-event',
+        'pix-event-category': 'Modulix',
+        'pix-event-action': `Passage du module : ${module.id}`,
+        'pix-event-name': `Ouverture de l'élément Expand : ${expandElement.id}`,
+      });
+      assert.ok(true);
+    });
+  });
+
+  module('when user closes Expand element', function () {
+    test('should push metrics event with "Fermeture" event name', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const expandElement = {
+        id: 'f5e7ce21-b71d-4054-8886-a4e9a17016ff',
+        type: 'expand',
+        isAnswerable: false,
+        title: 'Mon Expand',
+        content: "<p>Ceci est le contenu d'un expand dans mon module</p>",
+      };
+      const grain = store.createRecord('grain', {
+        title: 'Grain title',
+        type: 'discovery',
+        id: '123-abc',
+        components: [{ type: 'element', element: expandElement }],
+      });
+
+      const module = store.createRecord('module', {
+        title: 'Didacticiel',
+        grains: [grain],
+        transitionTexts: [],
+      });
+      const passage = store.createRecord('passage');
+      const metrics = this.owner.lookup('service:metrics');
+      metrics.add = sinon.stub();
+
+      //  when
+      const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
+
+      const details = await screen.getByRole('group');
+      details.open = true;
+
+      const expandSummarySelector = '.modulix-expand__title';
+      await click(expandSummarySelector);
+
+      // then
+      sinon.assert.calledWithExactly(metrics.add, {
+        event: 'custom-event',
+        'pix-event-category': 'Modulix',
+        'pix-event-action': `Passage du module : ${module.id}`,
+        'pix-event-name': `Fermeture de l'élément Expand : ${expandElement.id}`,
+      });
+      assert.ok(true);
+    });
+  });
 });


### PR DESCRIPTION
## :gift: Proposition

Ajouter une fonction dans Passage pour appeler le service metrics et envoyer des informations à Matomo sur le click d'un Expand

## :socks: Remarques

- Pour le futur : refacto du passage et de ses nombreuses méthodes ?
- Utilisation de l'événement `toggle` comme mis dans la doc de la balise [details](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#events)
- Pour les tests, nous avons dû simuler un clic sur la balise `summary` sinon le contenu ne s'affiche pas.
- Nous en avons profité pour ajouter un curseur `pointer` sur le balise `summary`

## :santa: Pour tester (en local)
- [Aller sur le didacticiel Modulix](https://app-pr10889.review.pix.fr/modules/didacticiel-modulix/details)
- Afficher la console navigateur 
- Cliquer sur l'élément Expand en dessous des flashcards
- Vérifier que l'event Matomo dans la console est bien envoyé 🎉 

