### PR TITLE
[FEATURE] Passage > Mettre la Beta Banner au dessus de la navbar (PIX-15698)(PIX-15832)

### DIFF
--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -221,6 +221,9 @@ export default class ModulePassage extends Component {
 
   <template>
     {{pageTitle @module.title}}
+    {{#if @module.isBeta}}
+      <BetaBanner />
+    {{/if}}
     <ModuleNavbar
       @currentStep={{this.currentPassageStep}}
       @totalSteps={{this.displayableGrains.length}}
@@ -231,10 +234,6 @@ export default class ModulePassage extends Component {
     />
 
     <main class="module-passage">
-      {{#if @module.isBeta}}
-        <BetaBanner />
-      {{/if}}
-
       <div class="module-passage__title">
         <h1>{{@module.title}}</h1>
       </div>


### PR DESCRIPTION
## :christmas_tree: Problème

Dans le passage d'un module, la bannière Beta est affichée sous la navbar, en largeur réduite. On veut garder une cohérence avec l'affichage dans `details` et `recap`.

## :gift: Proposition

Afficher la betaBanner au dessus de la navbar d'un module.

## :socks: Remarques

- Choix de ne pas ancrer le beta-banner, comme dans `details.js`
- Pour l'instant, on continue à utiliser le composant `PixNotificationAlert`, en attendant le nouveau variant Pix-UI pour `PixBannerAlert`.

## :santa: Pour tester

- [Ouvrir un module dans Pix](https://app-pr10898.review.pix.fr/modules/didacticiel-modulix/passage)
- Commencer le module
- Vérifier que la bannière beta s'affiche en haut de page, au dessus de la NavBar
