### PR TITLE
[BUGFIX] Rajouter la trad title maquante pour les Attestations (PIX-15873)

### DIFF
--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -422,7 +422,8 @@
       "divisions-description": "Select the class for which you wish to export attestations in PDF format.",
       "download-attestations-button": "Download",
       "no-attestations": "No attestation available",
-      "select-label": "Select one or more classes"
+      "select-label": "Select one or more classes",
+      "title": "Attestations"
     },
     "campaign": {
       "actions": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -428,7 +428,8 @@
       "divisions-description": "Sélectionnez la classe pour laquelle vous souhaitez exporter les attestations au format PDF.",
       "download-attestations-button": "Télécharger",
       "no-attestations": "Aucune attestation disponible pour votre sélection",
-      "select-label": "Sélectionnez une ou plusieurs classes"
+      "select-label": "Sélectionnez une ou plusieurs classes",
+      "title": "Attestations"
     },
     "campaign": {
       "actions": {


### PR DESCRIPTION
## :christmas_tree: Problème
Une clé de trad a été supprimé par inadvertence

## :gift: Proposition

La rajouter (presque ni vu ni connu)

## :socks: Remarques

RAS

## :santa: Pour tester

Aller sur la page des attestations et vérifier que le titre de la page s'affiche correctement