### PR TITLE
[BUGFIX] Rendre accessibles les contenus formatifs associés aux campagnes non partageables (PIX-15836).

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/index.gjs
@@ -62,6 +62,7 @@ export default class EvaluationResultsTabs extends Component {
               <Trainings
                 @trainings={{@trainings}}
                 @isParticipationShared={{@campaignParticipationResult.isShared}}
+                @isSharableCampaign={{@isSharableCampaign}}
                 @campaignParticipationResultId={{@campaignParticipationResult.id}}
                 @campaignId={{@campaign.id}}
               />

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/trainings.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/trainings.gjs
@@ -27,6 +27,10 @@ export default class EvaluationResultsTabsTrainings extends Component {
     });
   }
 
+  get canShareResults() {
+    return this.args.isSharableCampaign && !this.args.isParticipationShared;
+  }
+
   @action
   async shareResults() {
     const adapter = this.store.adapterFor('campaign-participation-result');
@@ -62,12 +66,12 @@ export default class EvaluationResultsTabsTrainings extends Component {
   <template>
     <div
       class="evaluation-results-tab__trainings
-        {{unless @isParticipationShared 'evaluation-results-tab__trainings--with-modal'}}"
+        {{if this.canShareResults 'evaluation-results-tab__trainings--with-modal'}}"
     >
       <div
         class="evaluation-results-tab__trainings-content"
-        inert={{unless @isParticipationShared "true"}}
-        role={{unless @isParticipationShared "presentation"}}
+        inert={{if this.canShareResults "true"}}
+        role={{if this.canShareResults "presentation"}}
       >
         <h2 class="evaluation-results-tab__title">{{t "pages.skill-review.tabs.trainings.title"}}</h2>
         <p class="evaluation-results-tab__description">{{t "pages.skill-review.tabs.trainings.description"}}</p>
@@ -81,7 +85,7 @@ export default class EvaluationResultsTabsTrainings extends Component {
         </ul>
       </div>
 
-      {{#unless @isParticipationShared}}
+      {{#if this.canShareResults}}
         <div class="evaluation-results-tab__share-results-modal" role="dialog">
           <div class="evaluation-results-tab-share-results-modal__content">
             <p>{{t "pages.skill-review.tabs.trainings.modal.content" htmlSafe=true}}</p>
@@ -95,7 +99,7 @@ export default class EvaluationResultsTabsTrainings extends Component {
             {{/if}}
           </div>
         </div>
-      {{/unless}}
+      {{/if}}
     </div>
   </template>
 }

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results.gjs
@@ -57,6 +57,7 @@ export default class EvaluationResults extends Component {
       <EvaluationResultsTabs
         @campaign={{@model.campaign}}
         @campaignParticipationResult={{@model.campaignParticipationResult}}
+        @isSharableCampaign={{this.isSharableCampaign}}
         @trainings={{@model.trainings}}
       />
     </main>

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/tabs/trainings-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/tabs/trainings-test.js
@@ -11,7 +11,7 @@ import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-renderi
 module('Integration | Components | Campaigns | Assessment | Evaluation Results Tabs | Trainings', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  module('when participation is already shared', function () {
+  module("when participation can't be shared", function () {
     test('it should display the trainings list', async function (assert) {
       // given
 
@@ -33,7 +33,7 @@ module('Integration | Components | Campaigns | Assessment | Evaluation Results T
       const screen = await render(
         hbs`<Campaigns::Assessment::Results::EvaluationResultsTabs::Trainings
   @trainings={{this.trainings}}
-  @isParticipationShared={{true}}
+  @isSharableCampaign={{false}}
 />`,
       );
 
@@ -49,86 +49,128 @@ module('Integration | Components | Campaigns | Assessment | Evaluation Results T
     });
   });
 
-  module('when participation is not already shared', function (hooks) {
-    let screen;
+  module('when participation can be shared', function () {
+    module('when participation is already shared', function () {
+      test('it should display the trainings list', async function (assert) {
+        // given
 
-    hooks.beforeEach(async function () {
-      // given
-      this.set('isParticipationShared', false);
-      this.set('campaignId', 1);
-      this.set('campaignParticipationResultId', 1);
+        const store = this.owner.lookup('service:store');
+        const training1 = store.createRecord('training', {
+          title: 'Mon super training',
+          link: 'https://exemple.net/',
+          duration: { days: 2 },
+        });
+        const training2 = store.createRecord('training', {
+          title: 'Mon autre super training',
+          link: 'https://exemple.net/',
+          duration: { days: 2 },
+        });
 
-      // when
-      screen = await render(
-        hbs`<Campaigns::Assessment::Results::EvaluationResultsTabs::Trainings
+        this.set('trainings', [training1, training2]);
+
+        // when
+        const screen = await render(
+          hbs`<Campaigns::Assessment::Results::EvaluationResultsTabs::Trainings
+  @trainings={{this.trainings}}
+  @isParticipationShared={{true}}
+  @isSharableCampaign={{true}}
+/>`,
+        );
+
+        // then
+        assert.dom(screen.getByRole('heading', { name: t('pages.skill-review.tabs.trainings.title') })).isVisible();
+        assert.dom(screen.getByText(t('pages.skill-review.tabs.trainings.description'))).isVisible();
+
+        assert.strictEqual(screen.getAllByRole('link').length, 2);
+        assert.dom(screen.getByText('Mon super training')).isVisible();
+        assert.dom(screen.getByText('Mon autre super training')).isVisible();
+
+        assert.dom(screen.queryByRole('dialog')).doesNotExist();
+      });
+    });
+
+    module('when participation is not already shared', function (hooks) {
+      let screen;
+
+      hooks.beforeEach(async function () {
+        // given
+        this.set('isParticipationShared', false);
+        this.set('campaignId', 1);
+        this.set('campaignParticipationResultId', 1);
+
+        // when
+        screen = await render(
+          hbs`<Campaigns::Assessment::Results::EvaluationResultsTabs::Trainings
+  @isSharableCampaign={{true}}
   @isParticipationShared={{this.isParticipationShared}}
   @campaignParticipationResultId={{this.campaignParticipationResultId}}
   @campaignId={{this.campaignId}}
 />`,
-      );
-    });
-
-    test('it should display a dialog with share results button', async function (assert) {
-      // then
-      assert.dom(screen.getByRole('dialog')).isVisible();
-      assert.dom(screen.getByText(/Envoyez vos résultats pour permettre/)).isVisible();
-      assert.dom(screen.getByRole('button', { name: t('pages.skill-review.actions.send') })).isVisible();
-    });
-
-    test('it should have an inert trainings list', async function (assert) {
-      // then
-      const trainingsListTitle = screen.getByRole('heading', {
-        name: t('pages.skill-review.tabs.trainings.title'),
-      });
-      assert.dom(trainingsListTitle).isVisible();
-      assert.dom(trainingsListTitle.closest('[role="presentation"]')).hasAttribute('inert');
-    });
-
-    module('when clicking on the share results button', function (hooks) {
-      let adapter, storeService;
-
-      hooks.beforeEach(function () {
-        stubCurrentUserService(this.owner, { id: 1 });
-
-        storeService = this.owner.lookup('service:store');
-        adapter = storeService.adapterFor('campaign-participation-result');
-      });
-
-      test('it should call the share method of the adapter and reload campaign-participation-result model', async function (assert) {
-        // given
-        const createShareStub = sinon.stub(adapter, 'share');
-        sinon.stub(storeService, 'queryRecord');
-
-        // when
-        await click(screen.queryByRole('button', { name: t('pages.skill-review.actions.send') }));
-
-        // then
-        assert.ok(createShareStub.calledOnce);
-        sinon.assert.calledWithExactly(createShareStub, 1);
-
-        assert.ok(storeService.queryRecord.calledOnce);
-        sinon.assert.calledWithExactly(
-          storeService.queryRecord,
-          'campaign-participation-result',
-          {
-            campaignId: this.campaignId,
-            userId: 1,
-          },
-          { reload: true },
         );
       });
 
-      module('when share action fails', function () {
-        test('it should display an error message', async function (assert) {
+      test('it should display a dialog with share results button', async function (assert) {
+        // then
+        assert.dom(screen.getByRole('dialog')).isVisible();
+        assert.dom(screen.getByText(/Envoyez vos résultats pour permettre/)).isVisible();
+        assert.dom(screen.getByRole('button', { name: t('pages.skill-review.actions.send') })).isVisible();
+      });
+
+      test('it should have an inert trainings list', async function (assert) {
+        // then
+        const trainingsListTitle = screen.getByRole('heading', {
+          name: t('pages.skill-review.tabs.trainings.title'),
+        });
+        assert.dom(trainingsListTitle).isVisible();
+        assert.dom(trainingsListTitle.closest('[role="presentation"]')).hasAttribute('inert');
+      });
+
+      module('when clicking on the share results button', function (hooks) {
+        let adapter, storeService;
+
+        hooks.beforeEach(function () {
+          stubCurrentUserService(this.owner, { id: 1 });
+
+          storeService = this.owner.lookup('service:store');
+          adapter = storeService.adapterFor('campaign-participation-result');
+        });
+
+        test('it should call the share method of the adapter and reload campaign-participation-result model', async function (assert) {
           // given
-          sinon.stub(adapter, 'share').rejects();
+          const createShareStub = sinon.stub(adapter, 'share');
+          sinon.stub(storeService, 'queryRecord');
 
           // when
           await click(screen.queryByRole('button', { name: t('pages.skill-review.actions.send') }));
 
           // then
-          assert.dom(screen.queryByRole('dialog')).exists();
-          assert.dom(screen.getByText(t('pages.skill-review.tabs.trainings.modal.share-error'))).exists();
+          assert.ok(createShareStub.calledOnce);
+          sinon.assert.calledWithExactly(createShareStub, 1);
+
+          assert.ok(storeService.queryRecord.calledOnce);
+          sinon.assert.calledWithExactly(
+            storeService.queryRecord,
+            'campaign-participation-result',
+            {
+              campaignId: this.campaignId,
+              userId: 1,
+            },
+            { reload: true },
+          );
+        });
+
+        module('when share action fails', function () {
+          test('it should display an error message', async function (assert) {
+            // given
+            sinon.stub(adapter, 'share').rejects();
+
+            // when
+            await click(screen.queryByRole('button', { name: t('pages.skill-review.actions.send') }));
+
+            // then
+            assert.dom(screen.queryByRole('dialog')).exists();
+            assert.dom(screen.getByText(t('pages.skill-review.tabs.trainings.modal.share-error'))).exists();
+          });
         });
       });
     });


### PR DESCRIPTION
## :christmas_tree: Problème

Dans la page de fin d'un parcours qui n'a pas pour objectif d'être partagé (ex: parcours autonome), l'onglet "Contenus formatifs" demande l'envoi des résultats.
Ce qui rend les contenus formatifs inaccessibles.

## :gift: Proposition

Pour ces campagnes, enlever la modale d'envoi des résultats qui cache les contenus formatifs.

## :santa: Pour tester

- Se connecter avec `eval-sco@example.net`
- Aller à l'écran de fin du parcours `AUTOCOURS1` : https://app-pr10902.review.pix.fr/campagnes/AUTOCOURS1/evaluation/resultats
- Constater que les contenus formatifs sont accessibles sans avoir besoin de partager les résultats
