### PR TITLE
[BUGFIX] Garanti l'ordonnancement des compétences dans l'attestation de certification

### DIFF
--- a/api/db/seeds/data/common/tooling/session-tooling.js
+++ b/api/db/seeds/data/common/tooling/session-tooling.js
@@ -898,7 +898,11 @@ async function _makeCandidatesCoreCertifiable(databaseBuilder, certificationCand
   // They all passed the hardest skills of each competence,
   // Thus, they will be certifiable in all pix competences, at the best level
   for (const competence of pixCompetences) {
-    coreProfileData[competence.id] = { threeMostDifficultSkillsAndChallenges: [], pixScore: 0, competence };
+    coreProfileData[competence.id] = {
+      threeMostDifficultSkillsAndChallenges: [],
+      pixScore: Math.floor(Math.random() * 56.0),
+      competence,
+    };
     const skills = await learningContent.findActiveSkillsByCompetenceId(competence.id);
     const orderedSkills = _.sortBy(skills, 'level').filter(({ level }) => level <= maxLevel);
     for (const skill of orderedSkills) {

--- a/api/src/certification/results/infrastructure/repositories/competence-tree-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/competence-tree-repository.js
@@ -1,4 +1,4 @@
-import { CompetenceTree } from '../../../../../src/shared//domain/models/CompetenceTree.js';
+import { CompetenceTree } from '../../../../../src/shared/domain/models/CompetenceTree.js';
 import * as areaRepository from '../../../../shared/infrastructure/repositories/area-repository.js';
 
 const get = async function ({ locale, dependencies = { areaRepository } } = {}) {

--- a/api/src/shared/domain/models/Area.js
+++ b/api/src/shared/domain/models/Area.js
@@ -5,7 +5,7 @@ class Area {
     this.name = name;
     this.title = title;
     this.color = color;
-    this.competences = competences;
+    this.competences = competences.sort((a, b) => a.index - b.index);
     this.frameworkId = frameworkId;
   }
 }

--- a/api/tests/shared/unit/domain/models/Area_test.js
+++ b/api/tests/shared/unit/domain/models/Area_test.js
@@ -1,0 +1,52 @@
+import { Area } from '../../../../../src/shared/domain/models/Area.js';
+import { domainBuilder, expect } from '../../../../test-helper.js';
+
+describe('Shared | Unit | domain | models | Area ', function () {
+  it('sorts given competences by Index', function () {
+    const area = new Area({
+      id: 'recvoGdo7z2z7pXWa',
+      code: '1',
+      name: '1. Information et données',
+      title: 'Information et données',
+      color: 'jaffa',
+      frameworkId: 'recAi12kj43h23jrh3',
+      competences: [
+        domainBuilder.buildCompetence({
+          name: 'Mener une recherche et une veille d’information',
+          id: 'recsvLz0W2ShyfD63',
+          index: '1.1',
+        }),
+        domainBuilder.buildCompetence({
+          name: 'Mener une recherche et une veille d’information',
+          id: 'recIkYm646lrGvLNT',
+          index: '1.3',
+        }),
+        domainBuilder.buildCompetence({
+          name: 'Mener une recherche et une veille d’information',
+          id: 'recNv8qhaY887jQb2',
+          index: '1.2',
+        }),
+      ],
+    });
+
+    const expectedSortedAreaCompetences = [
+      domainBuilder.buildCompetence({
+        name: 'Mener une recherche et une veille d’information',
+        id: 'recsvLz0W2ShyfD63',
+        index: '1.1',
+      }),
+      domainBuilder.buildCompetence({
+        name: 'Mener une recherche et une veille d’information',
+        id: 'recNv8qhaY887jQb2',
+        index: '1.2',
+      }),
+      domainBuilder.buildCompetence({
+        name: 'Mener une recherche et une veille d’information',
+        id: 'recIkYm646lrGvLNT',
+        index: '1.3',
+      }),
+    ];
+
+    expect(area.competences).to.deep.equal(expectedSortedAreaCompetences);
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-competence-tree.js
+++ b/api/tests/tooling/domain-builder/factory/build-competence-tree.js
@@ -24,13 +24,13 @@ const buildCompetenceTree = function ({
         }),
         buildCompetence({
           name: 'Mener une recherche et une veille d’information',
-          id: 'recNv8qhaY887jQb2',
-          index: '1.2',
+          id: 'recIkYm646lrGvLNT',
+          index: '1.3',
         }),
         buildCompetence({
           name: 'Mener une recherche et une veille d’information',
-          id: 'recIkYm646lrGvLNT',
-          index: '1.3',
+          id: 'recNv8qhaY887jQb2',
+          index: '1.2',
         }),
       ],
     }),


### PR DESCRIPTION
## :christmas_tree: Problème

Depuis la mise en place de la nouvelle gestion de cache du contenu, la récupération des compétences se fait sur le tri de la requête SQL PG. L'ordonnancement des compétences n'est plus garanti.

Nous avons reçu un signalement à propos d'un écart entre l'attestation PDF de certification et la certification dans l'application Pix. 

## :gift: Proposition

Trier les compétences lorsqu’on place dans le domaine.

## :socks: Remarques

Nous avons aussi réparé les seeds pour avoir des certifications avec des scores par compétences.

Le modèle `Area` est placé dans `src/shared` mais n'est utilisé, pour le moment, que par Certif. Nous le laissons là, car c'est un élément du référentiel, et donc non spécifique à Certif.

## :santa: Pour tester

- se connecter sur Pix Admin
- trouver une session de certification validée qui a des scores
- téléchargé l'attestation
- vérifier que les scores concorde entre le PDF et pixAdmin
- (bonus) vérifier aussi les scores dans PixAPP

