### PR TITLE
[TECH] Rendre le code lié à l'authentification des applications plus clair (PIX-15876)

### DIFF
--- a/api/lib/domain/usecases/authenticate-application.js
+++ b/api/lib/domain/usecases/authenticate-application.js
@@ -11,6 +11,21 @@ const { find } = lodash;
 import { config } from '../../../src/shared/config.js';
 const { apimRegisterApplicationsCredentials, jwtConfig } = config;
 
+const authenticateApplication = async function ({ clientId, clientSecret, scope, tokenService }) {
+  const application = find(apimRegisterApplicationsCredentials, { clientId });
+  _checkClientId(application, clientId);
+  _checkClientSecret(application, clientSecret);
+  _checkAppScope(application, scope);
+
+  return tokenService.createAccessTokenFromApplication(
+    clientId,
+    application.source,
+    scope,
+    jwtConfig[application.source].secret,
+    jwtConfig[application.source].tokenLifespan,
+  );
+};
+
 function _checkClientId(application, clientId) {
   if (!application || application.clientId !== clientId) {
     throw new ApplicationWithInvalidClientIdError('The client ID is invalid.');
@@ -28,20 +43,5 @@ function _checkAppScope(application, scope) {
     throw new ApplicationScopeNotAllowedError('The scope is invalid.');
   }
 }
-
-const authenticateApplication = async function ({ clientId, clientSecret, scope, tokenService }) {
-  const application = find(apimRegisterApplicationsCredentials, { clientId });
-  _checkClientId(application, clientId);
-  _checkClientSecret(application, clientSecret);
-  _checkAppScope(application, scope);
-
-  return tokenService.createAccessTokenFromApplication(
-    clientId,
-    application.source,
-    scope,
-    jwtConfig[application.source].secret,
-    jwtConfig[application.source].tokenLifespan,
-  );
-};
 
 export { authenticateApplication };

--- a/api/lib/domain/usecases/authenticate-application.js
+++ b/api/lib/domain/usecases/authenticate-application.js
@@ -1,15 +1,14 @@
 import lodash from 'lodash';
 
+import { config } from '../../../src/shared/config.js';
 import {
   ApplicationScopeNotAllowedError,
   ApplicationWithInvalidClientIdError,
   ApplicationWithInvalidClientSecretError,
 } from '../../../src/shared/domain/errors.js';
+const { apimRegisterApplicationsCredentials, jwtConfig } = config;
 
 const { find } = lodash;
-
-import { config } from '../../../src/shared/config.js';
-const { apimRegisterApplicationsCredentials, jwtConfig } = config;
 
 const authenticateApplication = async function ({ clientId, clientSecret, scope, tokenService }) {
   const application = find(apimRegisterApplicationsCredentials, { clientId });

--- a/api/lib/infrastructure/authentication.js
+++ b/api/lib/infrastructure/authentication.js
@@ -1,11 +1,10 @@
-import lodash from 'lodash';
-
-const { find } = lodash;
-
 import boom from '@hapi/boom';
+import lodash from 'lodash';
 
 import { config } from '../../src/shared/config.js';
 import { tokenService } from '../../src/shared/domain/services/token-service.js';
+
+const { find } = lodash;
 
 const authentication = {
   schemeName: 'jwt-scheme',

--- a/api/lib/infrastructure/authentication.js
+++ b/api/lib/infrastructure/authentication.js
@@ -7,51 +7,6 @@ import boom from '@hapi/boom';
 import { config } from '../../src/shared/config.js';
 import { tokenService } from '../../src/shared/domain/services/token-service.js';
 
-async function _checkIsAuthenticated(request, h, { key, validate }) {
-  if (!request.headers.authorization) {
-    return boom.unauthorized(null, 'jwt');
-  }
-
-  const authorizationHeader = request.headers.authorization;
-  const accessToken = tokenService.extractTokenFromAuthChain(authorizationHeader);
-
-  if (!accessToken) {
-    return boom.unauthorized();
-  }
-
-  const decodedAccessToken = tokenService.getDecodedToken(accessToken, key);
-  if (decodedAccessToken) {
-    const { isValid, credentials, errorCode } = validate(decodedAccessToken, request, h);
-    if (isValid) {
-      return h.authenticated({ credentials });
-    }
-
-    if (errorCode === 403) {
-      return boom.forbidden();
-    }
-  }
-
-  return boom.unauthorized();
-}
-
-function validateUser(decoded) {
-  return { isValid: true, credentials: { userId: decoded.user_id } };
-}
-
-function validateClientApplication(decoded) {
-  const application = find(config.apimRegisterApplicationsCredentials, { clientId: decoded.client_id });
-
-  if (!application) {
-    return { isValid: false, errorCode: 401 };
-  }
-
-  if (decoded.scope !== application.scope) {
-    return { isValid: false, errorCode: 403 };
-  }
-
-  return { isValid: true, credentials: { client_id: decoded.clientId, scope: decoded.scope, source: decoded.source } };
-}
-
 const authentication = {
   schemeName: 'jwt-scheme',
 
@@ -99,5 +54,50 @@ const authentication = {
 
   defaultStrategy: 'jwt-user',
 };
+
+function validateUser(decoded) {
+  return { isValid: true, credentials: { userId: decoded.user_id } };
+}
+
+function validateClientApplication(decoded) {
+  const application = find(config.apimRegisterApplicationsCredentials, { clientId: decoded.client_id });
+
+  if (!application) {
+    return { isValid: false, errorCode: 401 };
+  }
+
+  if (decoded.scope !== application.scope) {
+    return { isValid: false, errorCode: 403 };
+  }
+
+  return { isValid: true, credentials: { client_id: decoded.clientId, scope: decoded.scope, source: decoded.source } };
+}
+
+async function _checkIsAuthenticated(request, h, { key, validate }) {
+  if (!request.headers.authorization) {
+    return boom.unauthorized(null, 'jwt');
+  }
+
+  const authorizationHeader = request.headers.authorization;
+  const accessToken = tokenService.extractTokenFromAuthChain(authorizationHeader);
+
+  if (!accessToken) {
+    return boom.unauthorized();
+  }
+
+  const decodedAccessToken = tokenService.getDecodedToken(accessToken, key);
+  if (decodedAccessToken) {
+    const { isValid, credentials, errorCode } = validate(decodedAccessToken, request, h);
+    if (isValid) {
+      return h.authenticated({ credentials });
+    }
+
+    if (errorCode === 403) {
+      return boom.forbidden();
+    }
+  }
+
+  return boom.unauthorized();
+}
 
 export { authentication };

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -532,26 +532,26 @@ const configuration = (function () {
 
     config.apimRegisterApplicationsCredentials = [
       {
-        clientId: 'apimOsmoseClientId',
-        clientSecret: 'apimOsmoseClientSecret',
+        clientId: 'test-apimOsmoseClientId',
+        clientSecret: 'test-apimOsmoseClientSecret',
         scope: 'organizations-certifications-result',
         source: 'livretScolaire',
       },
       {
-        clientId: 'poleEmploiClientId',
-        clientSecret: 'poleEmploiClientSecret',
+        clientId: 'test-poleEmploiClientId',
+        clientSecret: 'test-poleEmploiClientSecret',
         scope: 'pole-emploi-participants-result',
         source: 'poleEmploi',
       },
       {
-        clientId: 'pixDataCliendId',
+        clientId: 'test-pixDataCliendId',
         clientSecret: 'pixDataClientSecret',
         scope: 'statistics',
         source: 'pixData',
       },
       {
-        clientId: 'parcoursupClientId',
-        clientSecret: 'parcoursupClientSecret',
+        clientId: 'test-parcoursupClientId',
+        clientSecret: 'test-parcoursupClientSecret',
         scope: 'parcoursup',
         source: 'parcoursup',
       },
@@ -586,10 +586,10 @@ const configuration = (function () {
       cron: '0 3 * * *',
     };
 
-    config.jwtConfig.livretScolaire = { secret: 'secretosmose', tokenLifespan: '1h' };
-    config.jwtConfig.poleEmploi = { secret: 'secretPoleEmploi', tokenLifespan: '1h' };
-    config.jwtConfig.pixData = { secret: 'secretPixData', tokenLifespan: '1h' };
-    config.jwtConfig.parcoursup = { secret: 'secretPixParcoursup', tokenLifespan: '1h' };
+    config.jwtConfig.livretScolaire = { secret: 'test-secretOsmose', tokenLifespan: '1h' };
+    config.jwtConfig.poleEmploi = { secret: 'test-secretPoleEmploi', tokenLifespan: '1h' };
+    config.jwtConfig.pixData = { secret: 'test-secretPixData', tokenLifespan: '1h' };
+    config.jwtConfig.parcoursup = { secret: 'test-secretPixParcoursup', tokenLifespan: '1h' };
 
     config.logging.enabled = toBoolean(process.env.TEST_LOG_ENABLED);
     config.logging.enableLogKnexQueries = false;

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -586,10 +586,10 @@ const configuration = (function () {
       cron: '0 3 * * *',
     };
 
-    config.jwtConfig.livretScolaire = { secret: 'test-secretOsmose', tokenLifespan: '1h' };
-    config.jwtConfig.poleEmploi = { secret: 'test-secretPoleEmploi', tokenLifespan: '1h' };
-    config.jwtConfig.pixData = { secret: 'test-secretPixData', tokenLifespan: '1h' };
-    config.jwtConfig.parcoursup = { secret: 'test-secretPixParcoursup', tokenLifespan: '1h' };
+    config.jwtConfig.livretScolaire.secret = 'test-secretOsmose';
+    config.jwtConfig.poleEmploi.secret = 'test-secretPoleEmploi';
+    config.jwtConfig.pixData.secret = 'test-secretPixData';
+    config.jwtConfig.parcoursup.secret = 'test-secretPixParcoursup';
 
     config.logging.enabled = toBoolean(process.env.TEST_LOG_ENABLED);
     config.logging.enableLogKnexQueries = false;

--- a/api/tests/acceptance/application/authentication/authentication-route_test.js
+++ b/api/tests/acceptance/application/authentication/authentication-route_test.js
@@ -106,8 +106,8 @@ describe('Acceptance | Controller | authentication-controller', function () {
   describe('POST /api/application/token', function () {
     let server;
     let options;
-    const OSMOSE_CLIENT_ID = 'apimOsmoseClientId';
-    const OSMOSE_CLIENT_SECRET = 'apimOsmoseClientSecret';
+    const OSMOSE_CLIENT_ID = 'test-apimOsmoseClientId';
+    const OSMOSE_CLIENT_SECRET = 'test-apimOsmoseClientSecret';
     const SCOPE = 'organizations-certifications-result';
 
     beforeEach(async function () {

--- a/api/tests/certification/results/acceptance/application/livret-scolaire-route_test.js
+++ b/api/tests/certification/results/acceptance/application/livret-scolaire-route_test.js
@@ -23,7 +23,7 @@ describe('Certification | Results | Acceptance | Application | Livret Scolaire',
     const uai = '789567AA';
     let type;
     const verificationCode = 'P-123498NN';
-    const OSMOSE_CLIENT_ID = 'apimOsmoseClientId';
+    const OSMOSE_CLIENT_ID = 'test-apimOsmoseClientId';
     const OSMOSE_SCOPE = 'organizations-certifications-result';
     const OSMOSE_SOURCE = 'livretScolaire';
 

--- a/api/tests/parcoursup/acceptance/application/certification-route_test.js
+++ b/api/tests/parcoursup/acceptance/application/certification-route_test.js
@@ -9,7 +9,7 @@ import {
 describe('Parcoursup | Acceptance | Application | certification-route', function () {
   let server;
 
-  const PARCOURSUP_CLIENT_ID = 'parcoursupClientId';
+  const PARCOURSUP_CLIENT_ID = 'test-parcoursupClientId';
   const PARCOURSUP_SCOPE = 'parcoursup';
   const PARCOURSUP_SOURCE = 'parcoursup';
 

--- a/api/tests/parcoursup/unit/application/certification-route_test.js
+++ b/api/tests/parcoursup/unit/application/certification-route_test.js
@@ -17,7 +17,7 @@ describe('Parcoursup | Unit | Application | Routes | Certification', function ()
       httpTestServer.setupAuthentication();
       await httpTestServer.register(moduleUnderTest);
 
-      const PARCOURSUP_CLIENT_ID = 'parcoursupClientId';
+      const PARCOURSUP_CLIENT_ID = 'test-parcoursupClientId';
       const PARCOURSUP_SCOPE = 'parcoursup';
       const PARCOURSUP_SOURCE = 'parcoursup';
 
@@ -45,7 +45,7 @@ describe('Parcoursup | Unit | Application | Routes | Certification', function ()
         httpTestServer.setupAuthentication();
         await httpTestServer.register(moduleUnderTest);
 
-        const PARCOURSUP_CLIENT_ID = 'parcoursupClientId';
+        const PARCOURSUP_CLIENT_ID = 'test-parcoursupClientId';
         const PARCOURSUP_SCOPE = 'a-wrong-scope';
         const PARCOURSUP_SOURCE = 'parcoursup';
 

--- a/api/tests/prescription/campaign-participation/acceptance/application/pole-emploi-controller_test.js
+++ b/api/tests/prescription/campaign-participation/acceptance/application/pole-emploi-controller_test.js
@@ -16,7 +16,7 @@ describe('Acceptance | Application | Pole Emploi Controller', function () {
     context('Sucess case', function () {
       it('returns a 200 HTTP status code', async function () {
         // given
-        const POLE_EMPLOI_CLIENT_ID = 'poleEmploiClientId';
+        const POLE_EMPLOI_CLIENT_ID = 'test-poleEmploiClientId';
         const POLE_EMPLOI_SCOPE = 'pole-emploi-participants-result';
         const POLE_EMPLOI_SOURCE = 'poleEmploi';
         const curseur = await generateCursor({

--- a/api/tests/prescription/campaign-participation/acceptance/application/pole-emploi-route_test.js
+++ b/api/tests/prescription/campaign-participation/acceptance/application/pole-emploi-route_test.js
@@ -13,7 +13,7 @@ import { config as settings } from '../../../../../src/shared/config.js';
 describe('Acceptance | API | Pole Emploi envois', function () {
   let server, options;
 
-  const POLE_EMPLOI_CLIENT_ID = 'poleEmploiClientId';
+  const POLE_EMPLOI_CLIENT_ID = 'test-poleEmploiClientId';
   const POLE_EMPLOI_SCOPE = 'pole-emploi-participants-result';
   const POLE_EMPLOI_SOURCE = 'poleEmploi';
 

--- a/api/tests/prescription/campaign-participation/unit/application/pole-emploi-route_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/pole-emploi-route_test.js
@@ -16,7 +16,7 @@ describe('Unit | Router | pole-emploi-router', function () {
       httpTestServer.setupAuthentication();
       await httpTestServer.register(moduleUnderTest);
 
-      const POLE_EMPLOI_CLIENT_ID = 'poleEmploiClientId';
+      const POLE_EMPLOI_CLIENT_ID = 'test-poleEmploiClientId';
       const POLE_EMPLOI_SCOPE = 'pole-emploi-participants-result';
       const POLE_EMPLOI_SOURCE = 'poleEmploi';
 

--- a/api/tests/prescription/organization-place/acceptance/application/get-data-organization-places_test.js
+++ b/api/tests/prescription/organization-place/acceptance/application/get-data-organization-places_test.js
@@ -6,7 +6,7 @@ describe('Acceptance | Route | Get Data Organization Places', function () {
   describe('GET /api/data/organization-places', function () {
     it('should return 200 HTTP status code', async function () {
       // given
-      const PIX_DATA_CLIENT_ID = 'pixDataCliendId';
+      const PIX_DATA_CLIENT_ID = 'test-pixDataCliendId';
       const PIX_DATA_CLIENT_SECRET = 'pixDataClientSecret';
       const PIX_DATA_SCOPE = 'statistics';
 


### PR DESCRIPTION
## :christmas_tree: Problème

Le code lié à l'authentification des applications n'est pas très clair à lire, notamment pour les valeurs qui se trouvent dans le fichier `api/src/shared/config.js` où on distingue mal, notamment dans les diff des PR ou de l'historique Git, quelles sont les valeurs utilisées en production des valeurs surchargées pour les tests.

## :gift: Proposition

* Pour la partie de la configuration dédiée aux tests (`process.env.NODE_ENV === 'test'`), rendre les valeurs surchargées pour les tests explicites en les faisant commencer par le préfixe `test-`
* Pour la partie de la configuration dédiée aux tests (`process.env.NODE_ENV === 'test'`), surcharger uniquement les propriétés qui ont besoin de l’être
* Déplacer les fonctions privées en fin de fichier

## :socks: Remarques

RAS

## :santa: Pour tester

* Vérifier que la CI passe
* Vérifier que les tests en local passent
