### PR TITLE
[TECH] Rendre le code lié à l'authentification des users plus clair et corriger un test erroné (PIX-15878)

### DIFF
--- a/api/src/identity-access-management/application/token/token.controller.js
+++ b/api/src/identity-access-management/application/token/token.controller.js
@@ -1,4 +1,3 @@
-import { BadRequestError } from '../../../shared/application/http-errors.js';
 import { tokenService } from '../../../shared/domain/services/token-service.js';
 import { usecases } from '../../domain/usecases/index.js';
 
@@ -46,8 +45,6 @@ const createToken = async function (request, h, dependencies = { tokenService })
 
     accessToken = tokensInfo.accessToken;
     expirationDelaySeconds = tokensInfo.expirationDelaySeconds;
-  } else {
-    throw new BadRequestError('Invalid grant type');
   }
 
   const userId = dependencies.tokenService.extractUserId(accessToken);

--- a/api/src/identity-access-management/application/token/token.route.js
+++ b/api/src/identity-access-management/application/token/token.route.js
@@ -16,17 +16,21 @@ export const tokenRoutes = [
       },
       validate: {
         payload: Joi.alternatives().try(
-          Joi.object().required().keys({
-            grant_type: 'password',
-            username: Joi.string().required(),
-            password: Joi.string().required(),
-            scope: Joi.string(),
-          }),
-          Joi.object().required().keys({
-            grant_type: 'refresh_token',
-            refresh_token: Joi.string(),
-            scope: Joi.string(),
-          }),
+          Joi.object()
+            .required()
+            .keys({
+              grant_type: Joi.string().valid('password').required(),
+              username: Joi.string().required(),
+              password: Joi.string().required(),
+              scope: Joi.string(),
+            }),
+          Joi.object()
+            .required()
+            .keys({
+              grant_type: Joi.string().valid('refresh_token').required(),
+              refresh_token: Joi.string(),
+              scope: Joi.string(),
+            }),
         ),
       },
       pre: [{ method: monitorPreHandlers.monitorApiTokenRoute }, { method: securityPreHandlers.checkIfUserIsBlocked }],

--- a/api/tests/identity-access-management/acceptance/application/token.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/token.route.test.js
@@ -55,23 +55,6 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
       expect(result.refresh_token).to.exist;
     });
 
-    it('returns a 400 if grant type is invalid', async function () {
-      // when
-      const errorResponse = await server.inject({
-        method: 'POST',
-        url: '/api/token',
-        headers: {
-          'content-type': 'application/x-www-form-urlencoded',
-        },
-        payload: querystring.stringify({
-          grant_type: 'appleSauce',
-        }),
-      });
-
-      // then
-      expect(errorResponse.statusCode).to.equal(400);
-    });
-
     it('returns http code 401 when user should change password', async function () {
       // given
       databaseBuilder.factory.buildUser.withRawPassword({

--- a/api/tests/identity-access-management/integration/routes.test.js
+++ b/api/tests/identity-access-management/integration/routes.test.js
@@ -24,7 +24,7 @@ describe('Integration | Identity Access Management | Application | Router', func
       'content-type': 'application/x-www-form-urlencoded',
     };
 
-    it('should return a response with HTTP status code 200 even if there is no scope in the request', async function () {
+    it('returns a response with HTTP status code 200 even if there is no scope in the request', async function () {
       // given
       const payload = querystring.stringify({
         grant_type: 'password',
@@ -39,7 +39,7 @@ describe('Integration | Identity Access Management | Application | Router', func
       expect(response.statusCode).to.equal(200);
     });
 
-    it('should return a 400 when grant type is not "password"', async function () {
+    it('returns a 400 when grant type is not "password"', async function () {
       // given
       const payload = querystring.stringify({
         grant_type: 'authorization_code',
@@ -54,7 +54,7 @@ describe('Integration | Identity Access Management | Application | Router', func
       expect(response.statusCode).to.equal(400);
     });
 
-    it('should return a 400 when username is missing', async function () {
+    it('returns a 400 when username is missing', async function () {
       // given
       const payload = querystring.stringify({
         grant_type: 'password',
@@ -68,7 +68,7 @@ describe('Integration | Identity Access Management | Application | Router', func
       expect(response.statusCode).to.equal(400);
     });
 
-    it('should return a 400 when password is missing', async function () {
+    it('returns a 400 when password is missing', async function () {
       // given
       const payload = querystring.stringify({
         grant_type: 'password',
@@ -82,7 +82,7 @@ describe('Integration | Identity Access Management | Application | Router', func
       expect(response.statusCode).to.equal(400);
     });
 
-    it('should return a 400 when username is not an email', async function () {
+    it('returns a 400 when username is not an email', async function () {
       // given
       const payload = querystring.stringify({
         grant_type: 'authorization_code',
@@ -97,7 +97,7 @@ describe('Integration | Identity Access Management | Application | Router', func
       expect(response.statusCode).to.equal(400);
     });
 
-    it('should return a JSON API error (415) when request "Content-Type" header is not "application/x-www-form-urlencoded"', async function () {
+    it('returns a JSON API error (415) when request "Content-Type" header is not "application/x-www-form-urlencoded"', async function () {
       // given
       headers['content-type'] = 'text/html';
       const payload = querystring.stringify({

--- a/api/tests/identity-access-management/integration/routes.test.js
+++ b/api/tests/identity-access-management/integration/routes.test.js
@@ -26,6 +26,22 @@ describe('Integration | Identity Access Management | Application | Router', func
     const method = 'POST';
     const url = '/api/token';
 
+    context('when grant_type is missing', function () {
+      it('returns a 400 HTTP status code', async function () {
+        // given
+        const payload = querystring.stringify({
+          username: 'valid@email.com',
+          password: 'valid_password',
+        });
+
+        // when
+        const response = await server.inject({ method, url, payload, auth: null, headers });
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+
     context('when grant_type is neither "password" nor "refresh_token"', function () {
       it('returns a 400 HTTP status code', async function () {
         // given

--- a/api/tests/identity-access-management/integration/routes.test.js
+++ b/api/tests/identity-access-management/integration/routes.test.js
@@ -82,21 +82,6 @@ describe('Integration | Identity Access Management | Application | Router', func
       expect(response.statusCode).to.equal(400);
     });
 
-    it('returns a 400 when username is not an email', async function () {
-      // given
-      const payload = querystring.stringify({
-        grant_type: 'authorization_code',
-        username: 'a_login_not_an_email',
-        password: 'valid_password',
-      });
-
-      // when
-      const response = await server.inject({ method, url, payload, auth: null, headers });
-
-      // then
-      expect(response.statusCode).to.equal(400);
-    });
-
     it('returns a JSON API error (415) when request "Content-Type" header is not "application/x-www-form-urlencoded"', async function () {
       // given
       headers['content-type'] = 'text/html';

--- a/api/tests/identity-access-management/integration/routes.test.js
+++ b/api/tests/identity-access-management/integration/routes.test.js
@@ -24,20 +24,9 @@ describe('Integration | Identity Access Management | Application | Router', func
       'content-type': 'application/x-www-form-urlencoded',
     };
 
-    let payload;
-
-    beforeEach(function () {
-      payload = querystring.stringify({
-        grant_type: 'password',
-        username: 'user.username2453  ',
-        password: 'user_password',
-        scope: 'pix-orga',
-      });
-    });
-
     it('should return a response with HTTP status code 200 even if there is no scope in the request', async function () {
       // given
-      payload = querystring.stringify({
+      const payload = querystring.stringify({
         grant_type: 'password',
         username: 'user@email.com',
         password: 'user_password',
@@ -52,7 +41,7 @@ describe('Integration | Identity Access Management | Application | Router', func
 
     it('should return a 400 when grant type is not "password"', async function () {
       // given
-      payload = querystring.stringify({
+      const payload = querystring.stringify({
         grant_type: 'authorization_code',
         username: 'valid@email.com',
         password: 'valid_password',
@@ -67,7 +56,7 @@ describe('Integration | Identity Access Management | Application | Router', func
 
     it('should return a 400 when username is missing', async function () {
       // given
-      payload = querystring.stringify({
+      const payload = querystring.stringify({
         grant_type: 'password',
         password: 'valid_password',
       });
@@ -81,7 +70,7 @@ describe('Integration | Identity Access Management | Application | Router', func
 
     it('should return a 400 when password is missing', async function () {
       // given
-      payload = querystring.stringify({
+      const payload = querystring.stringify({
         grant_type: 'password',
         username: 'valid@email.com',
       });
@@ -95,7 +84,7 @@ describe('Integration | Identity Access Management | Application | Router', func
 
     it('should return a 400 when username is not an email', async function () {
       // given
-      payload = querystring.stringify({
+      const payload = querystring.stringify({
         grant_type: 'authorization_code',
         username: 'a_login_not_an_email',
         password: 'valid_password',
@@ -111,6 +100,12 @@ describe('Integration | Identity Access Management | Application | Router', func
     it('should return a JSON API error (415) when request "Content-Type" header is not "application/x-www-form-urlencoded"', async function () {
       // given
       headers['content-type'] = 'text/html';
+      const payload = querystring.stringify({
+        grant_type: 'password',
+        username: 'user.username2453  ',
+        password: 'user_password',
+        scope: 'pix-orga',
+      });
 
       // when
       const response = await server.inject({ method, url, payload, auth: null, headers });


### PR DESCRIPTION
## :christmas_tree: Problème

Avant le travail de confinement des access tokens utilisateurs, des points gênants ont été identifiés : 

* dissémination de la validation dans la gestion des Access Tokens et Refresh Tokens
* présence d’un test totalement erroné sur la génération d’Access Tokens pour utilisateur
* tests sur les Access Tokens et Refresh Tokens utilisateurs pas très bien agencés

## :gift: Proposition

* Pour la route `/api/token` le code assurant la validation du `grant_type` dissémine la logique de validation entre la route (avec la validation _joi_) et le controller (avec des `if`-`else` dans `tokenController.createToken`). Il faut choisir : soit la validation complète du `grant_type` est à faire au niveau dans la validation joi au niveau de la route, soit la validation complète du `grant_type` est à faire au niveau du controller. La philosophie actuelle du code est de plutôt mettre toute la validation de la payload (avec son `grant_type` donc) dans la route. Cela a du sens car ce sont des paramètres plutôt techniques (très lié au domaine de l'authentification technique) que métier. Le refactor proposé est donc de rapatrier toute la logique de validation dans la définition de la route.
* Suppression du test erroné
* Petite réorganisation minimum des autres tests

## :socks: Remarques

RAS

## :santa: Pour tester

* Vérifier que l'authentification utilisateur par mot de passe fonctionne (en se connectant par exemple sur _Pix App_ avec le compte `superadmin@example.net`)
* Vérifier que la génération d'un nouvel Access Token à partir d'un Refresh Tokens se produit bien sans erreur (en se connectant par exemple sur _Pix App_ avec le compte `superadmin@example.net` en ayant au préalable dans le `.env` configuré `ACCESS_TOKEN_LIFESPAN=10s` de manière à ne pas attendre trop longtemps la génération d'un nouvel Access Token à partir du Refresh Token)
* Vérifier qu'aucun `grant_type` autre que `password` et `refresh_token` n'est autorisé et que le script ci-dessous renvoie une erreur `400` (remplacer `XXX` par le bon mot de passe) : 
```shell
curl -X POST \
--data 'grant_type=wrongGrantType' \
--data 'username=superadmin@example.net' \
--data 'password=XXX' \
http://localhost:3000/api/token
```
