### PR TITLE
[FEATURE] Récupération de l'entièreté des données à envoyer à Parcoursup (PIX-15882).

### DIFF
--- a/api/datamart/datamart-builder/factory/build-certification-result.js
+++ b/api/datamart/datamart-builder/factory/build-certification-result.js
@@ -1,8 +1,24 @@
 import { datamartBuffer } from '../datamart-buffer.js';
 
-const buildCertificationResult = function ({ nationalStudentId } = {}) {
+const buildCertificationResult = function ({
+  nationalStudentId,
+  organizationUai,
+  lastName,
+  firstName,
+  birthdate,
+  status,
+  pixScore,
+  certificationDate,
+} = {}) {
   const values = {
     national_student_id: nationalStudentId,
+    organization_uai: organizationUai,
+    last_name: lastName,
+    first_name: firstName,
+    birthdate,
+    status,
+    pix_score: pixScore,
+    certification_date: certificationDate,
   };
 
   datamartBuffer.pushInsertable({

--- a/api/datamart/datamart-builder/factory/build-certification-result.js
+++ b/api/datamart/datamart-builder/factory/build-certification-result.js
@@ -9,6 +9,8 @@ const buildCertificationResult = function ({
   status,
   pixScore,
   certificationDate,
+  competenceId,
+  competenceLevel,
 } = {}) {
   const values = {
     national_student_id: nationalStudentId,
@@ -19,6 +21,8 @@ const buildCertificationResult = function ({
     status,
     pix_score: pixScore,
     certification_date: certificationDate,
+    competence_id: competenceId,
+    competence_level: competenceLevel,
   };
 
   datamartBuffer.pushInsertable({

--- a/api/datamart/migrations/20241230135120-add-certification-results-columns.js
+++ b/api/datamart/migrations/20241230135120-add-certification-results-columns.js
@@ -1,0 +1,32 @@
+const TABLE_NAME = 'data_export_parcoursup_certif_result';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string('organization_uai');
+    table.string('last_name');
+    table.string('first_name');
+    table.date('birthdate');
+    table.text('status');
+    table.integer('pix_score');
+    table.timestamp('certification_date');
+    table.string('competence_id');
+    table.integer('competence_level');
+    table.index('organization_uai');
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn('organization_uai');
+    table.dropColumn('last_name');
+    table.dropColumn('first_name');
+    table.dropColumn('birthdate');
+    table.dropColumn('status');
+    table.dropColumn('pix_score');
+    table.dropColumn('competence_id');
+    table.dropColumn('competence_level');
+    table.dropColumn('certification_date');
+  });
+};
+
+export { down, up };

--- a/api/src/parcoursup/domain/read-models/CertificationResult.js
+++ b/api/src/parcoursup/domain/read-models/CertificationResult.js
@@ -1,6 +1,13 @@
 class CertificationResult {
-  constructor({ ine }) {
+  constructor({ ine, organizationUai, lastName, firstName, birthdate, status, pixScore, certificationDate }) {
     this.ine = ine;
+    this.organizationUai = organizationUai;
+    this.lastName = lastName;
+    this.firstName = firstName;
+    this.birthdate = birthdate;
+    this.status = status;
+    this.pixScore = pixScore;
+    this.certificationDate = certificationDate;
   }
 }
 

--- a/api/src/parcoursup/domain/read-models/CertificationResult.js
+++ b/api/src/parcoursup/domain/read-models/CertificationResult.js
@@ -1,5 +1,15 @@
 class CertificationResult {
-  constructor({ ine, organizationUai, lastName, firstName, birthdate, status, pixScore, certificationDate }) {
+  constructor({
+    ine,
+    organizationUai,
+    lastName,
+    firstName,
+    birthdate,
+    status,
+    pixScore,
+    certificationDate,
+    competences,
+  }) {
     this.ine = ine;
     this.organizationUai = organizationUai;
     this.lastName = lastName;
@@ -8,6 +18,7 @@ class CertificationResult {
     this.status = status;
     this.pixScore = pixScore;
     this.certificationDate = certificationDate;
+    this.competences = competences;
   }
 }
 

--- a/api/src/parcoursup/infrastructure/repositories/certification-repository.js
+++ b/api/src/parcoursup/infrastructure/repositories/certification-repository.js
@@ -10,7 +10,16 @@ const get = async ({ ine }) => {
   if (!certificationResultDto) {
     throw new NotFoundError('No certifications found for given INE');
   }
-  return new CertificationResult({ ine: certificationResultDto.national_student_id });
+  return new CertificationResult({
+    ine: certificationResultDto.national_student_id,
+    organizationUai: certificationResultDto.organization_uai,
+    lastName: certificationResultDto.last_name,
+    firstName: certificationResultDto.first_name,
+    birthdate: certificationResultDto.birthdate,
+    status: certificationResultDto.status,
+    pixScore: certificationResultDto.pix_score,
+    certificationDate: certificationResultDto.certification_date,
+  });
 };
 
 export { get };

--- a/api/src/parcoursup/infrastructure/repositories/certification-repository.js
+++ b/api/src/parcoursup/infrastructure/repositories/certification-repository.js
@@ -3,28 +3,32 @@ import { NotFoundError } from '../../../shared/domain/errors.js';
 import { CertificationResult } from '../../domain/read-models/CertificationResult.js';
 
 const get = async ({ ine }) => {
-  const certificationResultDto = await datamartKnex('data_export_parcoursup_certif_result')
-    .where({ national_student_id: ine })
-    .limit(1)
-    .first();
-  if (!certificationResultDto) {
+  const certificationResultDto = await datamartKnex('data_export_parcoursup_certif_result').where({
+    national_student_id: ine,
+  });
+  if (!certificationResultDto.length) {
     throw new NotFoundError('No certifications found for given INE');
   }
+
+  return _toDomain(certificationResultDto);
+};
+
+const _toDomain = (certificationResultDto) => {
   return new CertificationResult({
-    ine: certificationResultDto.national_student_id,
-    organizationUai: certificationResultDto.organization_uai,
-    lastName: certificationResultDto.last_name,
-    firstName: certificationResultDto.first_name,
-    birthdate: certificationResultDto.birthdate,
-    status: certificationResultDto.status,
-    pixScore: certificationResultDto.pix_score,
-    certificationDate: certificationResultDto.certification_date,
-    competences: [
-      {
+    ine: certificationResultDto[0].national_student_id,
+    organizationUai: certificationResultDto[0].organization_uai,
+    lastName: certificationResultDto[0].last_name,
+    firstName: certificationResultDto[0].first_name,
+    birthdate: certificationResultDto[0].birthdate,
+    status: certificationResultDto[0].status,
+    pixScore: certificationResultDto[0].pix_score,
+    certificationDate: certificationResultDto[0].certification_date,
+    competences: certificationResultDto.map((certificationResultDto) => {
+      return {
         id: certificationResultDto.competence_id,
         level: certificationResultDto.competence_level,
-      },
-    ],
+      };
+    }),
   });
 };
 

--- a/api/src/parcoursup/infrastructure/repositories/certification-repository.js
+++ b/api/src/parcoursup/infrastructure/repositories/certification-repository.js
@@ -19,6 +19,12 @@ const get = async ({ ine }) => {
     status: certificationResultDto.status,
     pixScore: certificationResultDto.pix_score,
     certificationDate: certificationResultDto.certification_date,
+    competences: [
+      {
+        id: certificationResultDto.competence_id,
+        level: certificationResultDto.competence_level,
+      },
+    ],
   });
 };
 

--- a/api/tests/parcoursup/acceptance/application/certification-route_test.js
+++ b/api/tests/parcoursup/acceptance/application/certification-route_test.js
@@ -21,7 +21,7 @@ describe('Parcoursup | Acceptance | Application | certification-route', function
     it('should return 200 HTTP status code and a certification for a given INE', async function () {
       // given
       const ine = '123456789OK';
-      datamartBuilder.factory.buildCertificationResult({
+      const certificationResultData = {
         nationalStudentId: ine,
         organizationUai: 'UAI ETAB ELEVE',
         lastName: 'NOM-ELEVE',
@@ -30,8 +30,16 @@ describe('Parcoursup | Acceptance | Application | certification-route', function
         status: 'validated',
         pixScore: 327,
         certificationDate: '2024-11-22T09:39:54Z',
+      };
+      datamartBuilder.factory.buildCertificationResult({
+        ...certificationResultData,
         competenceId: 'xzef1223443',
         competenceLevel: 3,
+      });
+      datamartBuilder.factory.buildCertificationResult({
+        ...certificationResultData,
+        competenceId: 'otherCompetenceId',
+        competenceLevel: 5,
       });
       await datamartBuilder.commit();
 
@@ -63,6 +71,10 @@ describe('Parcoursup | Acceptance | Application | certification-route', function
             // TODO ask DataTeam to add code and label (1.1 Mener une recherche et une veille d’information)
             id: 'xzef1223443',
             level: 3,
+          },
+          {
+            id: 'otherCompetenceId',
+            level: 5,
           },
         ],
       };

--- a/api/tests/parcoursup/acceptance/application/certification-route_test.js
+++ b/api/tests/parcoursup/acceptance/application/certification-route_test.js
@@ -30,6 +30,8 @@ describe('Parcoursup | Acceptance | Application | certification-route', function
         status: 'validated',
         pixScore: 327,
         certificationDate: '2024-11-22T09:39:54Z',
+        competenceId: 'xzef1223443',
+        competenceLevel: 3,
       });
       await datamartBuilder.commit();
 
@@ -56,6 +58,13 @@ describe('Parcoursup | Acceptance | Application | certification-route', function
         status: 'validated',
         pixScore: 327,
         certificationDate: new Date('2024-11-22T09:39:54Z'),
+        competences: [
+          {
+            // TODO ask DataTeam to add code and label (1.1 Mener une recherche et une veille d’information)
+            id: 'xzef1223443',
+            level: 3,
+          },
+        ],
       };
 
       // when

--- a/api/tests/parcoursup/acceptance/application/certification-route_test.js
+++ b/api/tests/parcoursup/acceptance/application/certification-route_test.js
@@ -21,7 +21,16 @@ describe('Parcoursup | Acceptance | Application | certification-route', function
     it('should return 200 HTTP status code and a certification for a given INE', async function () {
       // given
       const ine = '123456789OK';
-      datamartBuilder.factory.buildCertificationResult({ nationalStudentId: ine });
+      datamartBuilder.factory.buildCertificationResult({
+        nationalStudentId: ine,
+        organizationUai: 'UAI ETAB ELEVE',
+        lastName: 'NOM-ELEVE',
+        firstName: 'PRENOM-ELEVE',
+        birthdate: '2000-01-01',
+        status: 'validated',
+        pixScore: 327,
+        certificationDate: '2024-11-22T09:39:54Z',
+      });
       await datamartBuilder.commit();
 
       const options = {
@@ -38,7 +47,16 @@ describe('Parcoursup | Acceptance | Application | certification-route', function
 
       await databaseBuilder.commit();
 
-      const expectedCertification = { ine };
+      const expectedCertification = {
+        organizationUai: 'UAI ETAB ELEVE',
+        ine,
+        lastName: 'NOM-ELEVE',
+        firstName: 'PRENOM-ELEVE',
+        birthdate: '2000-01-01',
+        status: 'validated',
+        pixScore: 327,
+        certificationDate: new Date('2024-11-22T09:39:54Z'),
+      };
 
       // when
       const response = await server.inject(options);

--- a/api/tests/parcoursup/integration/repositories/certification-repository_test.js
+++ b/api/tests/parcoursup/integration/repositories/certification-repository_test.js
@@ -8,7 +8,7 @@ describe('Parcoursup | Infrastructure | Integration | Repositories | certificati
       it('should return the certification', async function () {
         // given
         const ine = '1234';
-        datamartBuilder.factory.buildCertificationResult({
+        const certificationResultData = {
           nationalStudentId: ine,
           organizationUai: 'UAI ETAB ELEVE',
           lastName: 'NOM-ELEVE',
@@ -17,8 +17,16 @@ describe('Parcoursup | Infrastructure | Integration | Repositories | certificati
           status: 'validated',
           pixScore: 327,
           certificationDate: '2024-11-22T09:39:54',
+        };
+        datamartBuilder.factory.buildCertificationResult({
+          ...certificationResultData,
           competenceId: 'xzef1223443',
           competenceLevel: 3,
+        });
+        datamartBuilder.factory.buildCertificationResult({
+          ...certificationResultData,
+          competenceId: 'otherCompetenceId',
+          competenceLevel: 5,
         });
         await datamartBuilder.commit();
 
@@ -39,6 +47,10 @@ describe('Parcoursup | Infrastructure | Integration | Repositories | certificati
             {
               id: 'xzef1223443',
               level: 3,
+            },
+            {
+              id: 'otherCompetenceId',
+              level: 5,
             },
           ],
         });

--- a/api/tests/parcoursup/integration/repositories/certification-repository_test.js
+++ b/api/tests/parcoursup/integration/repositories/certification-repository_test.js
@@ -17,6 +17,8 @@ describe('Parcoursup | Infrastructure | Integration | Repositories | certificati
           status: 'validated',
           pixScore: 327,
           certificationDate: '2024-11-22T09:39:54',
+          competenceId: 'xzef1223443',
+          competenceLevel: 3,
         });
         await datamartBuilder.commit();
 
@@ -33,6 +35,12 @@ describe('Parcoursup | Infrastructure | Integration | Repositories | certificati
           status: 'validated',
           pixScore: 327,
           certificationDate: new Date('2024-11-22T09:39:54Z'),
+          competences: [
+            {
+              id: 'xzef1223443',
+              level: 3,
+            },
+          ],
         });
         expect(result).to.deep.equal(expectedCertification);
       });

--- a/api/tests/parcoursup/integration/repositories/certification-repository_test.js
+++ b/api/tests/parcoursup/integration/repositories/certification-repository_test.js
@@ -8,14 +8,32 @@ describe('Parcoursup | Infrastructure | Integration | Repositories | certificati
       it('should return the certification', async function () {
         // given
         const ine = '1234';
-        datamartBuilder.factory.buildCertificationResult({ nationalStudentId: ine });
+        datamartBuilder.factory.buildCertificationResult({
+          nationalStudentId: ine,
+          organizationUai: 'UAI ETAB ELEVE',
+          lastName: 'NOM-ELEVE',
+          firstName: 'PRENOM-ELEVE',
+          birthdate: '2000-01-01',
+          status: 'validated',
+          pixScore: 327,
+          certificationDate: '2024-11-22T09:39:54',
+        });
         await datamartBuilder.commit();
 
         // when
         const result = await certificationRepository.get({ ine });
 
         // then
-        const expectedCertification = domainBuilder.parcoursup.buildCertificationResult({ ine });
+        const expectedCertification = domainBuilder.parcoursup.buildCertificationResult({
+          ine,
+          organizationUai: 'UAI ETAB ELEVE',
+          lastName: 'NOM-ELEVE',
+          firstName: 'PRENOM-ELEVE',
+          birthdate: '2000-01-01',
+          status: 'validated',
+          pixScore: 327,
+          certificationDate: new Date('2024-11-22T09:39:54Z'),
+        });
         expect(result).to.deep.equal(expectedCertification);
       });
     });

--- a/api/tests/tooling/domain-builder/factory/parcoursup/build-certification-result.js
+++ b/api/tests/tooling/domain-builder/factory/parcoursup/build-certification-result.js
@@ -9,6 +9,7 @@ const buildCertificationResult = function ({
   status,
   pixScore,
   certificationDate,
+  competences,
 }) {
   return new CertificationResult({
     ine,
@@ -19,6 +20,7 @@ const buildCertificationResult = function ({
     status,
     pixScore,
     certificationDate,
+    competences,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/parcoursup/build-certification-result.js
+++ b/api/tests/tooling/domain-builder/factory/parcoursup/build-certification-result.js
@@ -1,7 +1,25 @@
 import { CertificationResult } from '../../../../../src/parcoursup/domain/read-models/CertificationResult.js';
 
-const buildCertificationResult = function ({ ine = '1234' }) {
-  return new CertificationResult({ ine });
+const buildCertificationResult = function ({
+  ine = '1234',
+  organizationUai,
+  lastName,
+  firstName,
+  birthdate,
+  status,
+  pixScore,
+  certificationDate,
+}) {
+  return new CertificationResult({
+    ine,
+    organizationUai,
+    lastName,
+    firstName,
+    birthdate,
+    status,
+    pixScore,
+    certificationDate,
+  });
 };
 
 export { buildCertificationResult };


### PR DESCRIPTION
## :christmas_tree: Problème

Nous ne renvoyons pas l'intégralité des données à parcoursup à l'heure actuelle, seulement l'INE.

## :gift: Proposition

On récupère les données manquantes et les concatène.

## :socks: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :santa: Pour tester

Sur `https://api-pr10909.review.pix.fr/api/documentation`, générer un token valide avec les bons `client_id`, `client_secret` et `scope`

```shell
TOKEN=<token>
curl https://api-pr10909.review.pix.fr/api/parcoursup/students/123456789OK/certification \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -X GET
```
