### PR TITLE
[FEATURE] Sauvegarder les raisons d'abandons à la finalisation (PIX-15523).

### DIFF
--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -37,27 +37,16 @@ export default class SessionsFinalizeController extends Controller {
   }
 
   @action
-  async abort(certificationReport, option) {
-    const abortReason = option;
-
-    try {
-      await certificationReport.abort(abortReason);
-
-      certificationReport.abortReason = abortReason;
-    } catch (error) {
-      const select = document.getElementById(`finalization-report-abort-reason__select${certificationReport.id}`);
-
-      if (certificationReport.abortReason) {
-        select.value = certificationReport.abortReason;
-      } else {
-        select.options[0].selected = true;
-      }
-    }
+  async abort(certificationReport, abortReason) {
+    certificationReport.abortReason = abortReason;
   }
 
   @action
   async finalizeSession() {
     try {
+      for (const certificationReport of this.session.uncompletedCertificationReports) {
+        await certificationReport.abort();
+      }
       await this.session.save({ adapterOptions: { finalization: true } });
       this.pixToast.sendSuccessNotification({
         message: this.intl.t('pages.session-finalization.notification.success'),

--- a/certif/tests/integration/components/session-finalization/finalization-confirmation-modal-test.js
+++ b/certif/tests/integration/components/session-finalization/finalization-confirmation-modal-test.js
@@ -118,7 +118,7 @@ module('Integration | Component | finalization-confirmation-modal', function (ho
   });
 
   module('when the finalization is confirmed', () => {
-    test('it should finalize de session', async function (assert) {
+    test('it should finalize the session', async function (assert) {
       // given
       const finalizeSessionStub = sinon.stub();
       this.set('closeModal', sinon.stub());


### PR DESCRIPTION
## :christmas_tree: Problème

Nous enregistrons la raison d'abandon d'un candidat à chaque fois que celle-ci est modifiée dans la page de finalisation de session.

## :gift: Proposition

Nous faisons en sorte d'enregistrer ces raisons uniquement à la finalisation de la session.

## :socks: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :santa: Pour tester

- Créer une session de certification (`certifv3@example.net`)
- Inscrire un candidat
- Rentrer en session de certification
- Finaliser la session en ajoutant une raison d'abandon au candidat
- Vérifier que la raison est désormais uniquement enregistrée au moment de la finalisation et non plus au changement dans le select
