### PR TITLE
[TECH] Migrer la route de réinitialisation de scorecard (PIX-15881).

### DIFF
--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -156,32 +156,6 @@ const register = async function (server) {
         tags: ['api', 'user', 'trainings'],
       },
     },
-    {
-      method: 'POST',
-      path: '/api/users/{userId}/competences/{competenceId}/reset',
-      config: {
-        pre: [
-          {
-            method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
-            assign: 'requestedUserIsAuthenticatedUser',
-          },
-        ],
-        validate: {
-          params: Joi.object({
-            userId: identifiersType.userId,
-            competenceId: identifiersType.competenceId,
-          }),
-        },
-        handler: userController.resetScorecard,
-        notes: [
-          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
-            "- Cette route réinitialise le niveau d'un utilisateur donné (**userId**) pour une compétence donnée (**competenceId**)",
-          '- Cette route retourne les nouvelles informations de niveau de la compétence',
-          '- L’id demandé doit correspondre à celui de l’utilisateur authentifié',
-        ],
-        tags: ['api', 'user', 'scorecard'],
-      },
-    },
   ]);
 };
 

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -1,7 +1,5 @@
 import { usecases as devcompUsecases } from '../../../src/devcomp/domain/usecases/index.js';
 import * as trainingSerializer from '../../../src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js';
-import { evaluationUsecases } from '../../../src/evaluation/domain/usecases/index.js';
-import * as scorecardSerializer from '../../../src/evaluation/infrastructure/serializers/jsonapi/scorecard-serializer.js';
 import * as userDetailsForAdminSerializer from '../../../src/identity-access-management/infrastructure/serializers/jsonapi/user-details-for-admin.serializer.js';
 import * as certificationCenterMembershipSerializer from '../../../src/shared/infrastructure/serializers/jsonapi/certification-center-membership.serializer.js';
 import * as requestResponseUtils from '../../../src/shared/infrastructure/utils/request-response-utils.js';
@@ -26,16 +24,6 @@ const findPaginatedUserRecommendedTrainings = async function (
   });
 
   return dependencies.trainingSerializer.serialize(userRecommendedTrainings, meta);
-};
-
-const resetScorecard = function (request, h, dependencies = { scorecardSerializer, requestResponseUtils }) {
-  const authenticatedUserId = request.auth.credentials.userId;
-  const competenceId = request.params.competenceId;
-  const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
-
-  return evaluationUsecases
-    .resetScorecard({ userId: authenticatedUserId, competenceId, locale })
-    .then(dependencies.scorecardSerializer.serialize);
 };
 
 const addPixAuthenticationMethodByEmail = async function (
@@ -98,7 +86,6 @@ const userController = {
   findPaginatedUserRecommendedTrainings,
   findUserOrganizationsForAdmin,
   reassignAuthenticationMethods,
-  resetScorecard,
 };
 
 export { userController };

--- a/api/src/evaluation/application/scorecards/index.js
+++ b/api/src/evaluation/application/scorecards/index.js
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
+import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { scorecardController } from './scorecard-controller.js';
 
 const register = async function (server) {
@@ -26,6 +30,32 @@ const register = async function (server) {
             '- L’id demandé doit correspondre à celui de l’utilisateur authentifié',
         ],
         tags: ['api'],
+      },
+    },
+    {
+      method: 'POST',
+      path: '/api/users/{userId}/competences/{competenceId}/reset',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
+            assign: 'requestedUserIsAuthenticatedUser',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            userId: identifiersType.userId,
+            competenceId: identifiersType.competenceId,
+          }),
+        },
+        handler: scorecardController.resetScorecard,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            "- Cette route réinitialise le niveau d'un utilisateur donné (**userId**) pour une compétence donnée (**competenceId**)",
+          '- Cette route retourne les nouvelles informations de niveau de la compétence',
+          '- L’id demandé doit correspondre à celui de l’utilisateur authentifié',
+        ],
+        tags: ['api', 'user', 'scorecard'],
       },
     },
   ]);

--- a/api/src/evaluation/application/scorecards/scorecard-controller.js
+++ b/api/src/evaluation/application/scorecards/scorecard-controller.js
@@ -32,5 +32,15 @@ const findTutorials = function (request, h, dependencies = { requestResponseUtil
     .then(dependencies.tutorialSerializer.serialize);
 };
 
-const scorecardController = { getScorecard, findTutorials };
+const resetScorecard = function (request, h, dependencies = { scorecardSerializer, requestResponseUtils }) {
+  const authenticatedUserId = request.auth.credentials.userId;
+  const competenceId = request.params.competenceId;
+  const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
+
+  return evaluationUsecases
+    .resetScorecard({ userId: authenticatedUserId, competenceId, locale })
+    .then(dependencies.scorecardSerializer.serialize);
+};
+
+const scorecardController = { getScorecard, findTutorials, resetScorecard };
 export { scorecardController };

--- a/api/tests/evaluation/integration/application/scorecards/index_test.js
+++ b/api/tests/evaluation/integration/application/scorecards/index_test.js
@@ -1,7 +1,7 @@
-import * as moduleUnderTest from '../../../../lib/application/users/index.js';
-import { userController } from '../../../../lib/application/users/user-controller.js';
-import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
-import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
+import * as moduleUnderTest from '../../../../../src/evaluation/application/scorecards/index.js';
+import { scorecardController } from '../../../../../src/evaluation/application/scorecards/scorecard-controller.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
+import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Application | Users | Routes', function () {
   let httpTestServer;
@@ -12,7 +12,7 @@ describe('Integration | Application | Users | Routes', function () {
       .stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser')
       .callsFake((request, h) => h.response(true));
 
-    sinon.stub(userController, 'resetScorecard').returns('ok');
+    sinon.stub(scorecardController, 'resetScorecard').returns('ok');
 
     httpTestServer = new HttpTestServer();
     await httpTestServer.register(moduleUnderTest);

--- a/api/tests/evaluation/unit/application/scorecards/index_test.js
+++ b/api/tests/evaluation/unit/application/scorecards/index_test.js
@@ -1,5 +1,6 @@
 import * as moduleUnderTest from '../../../../../src/evaluation/application/scorecards/index.js';
 import { scorecardController } from '../../../../../src/evaluation/application/scorecards/scorecard-controller.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Router | scorecard-router', function () {
@@ -33,6 +34,29 @@ describe('Unit | Router | scorecard-router', function () {
       const options = {
         method: 'GET',
         url: '/api/scorecards/foo/tutorials',
+      };
+
+      // when
+      const response = await httpTestServer.request(options.method, options.url);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+
+  describe('POST /api/users/{userId}/competences/{competenceId}/reset', function () {
+    it('should exist', async function () {
+      // given
+      sinon.stub(scorecardController, 'resetScorecard').returns('ok');
+      sinon
+        .stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser')
+        .callsFake((request, h) => h.response(true));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const options = {
+        method: 'POST',
+        url: '/api/users/1/competences/comp1234/reset',
       };
 
       // when

--- a/api/tests/evaluation/unit/application/scorecards/scorecard-controller_test.js
+++ b/api/tests/evaluation/unit/application/scorecards/scorecard-controller_test.js
@@ -87,4 +87,39 @@ describe('Unit | Controller | scorecard-controller', function () {
       expect(result).to.be.equal(tutorials);
     });
   });
+
+  describe('#resetScorecard', function () {
+    beforeEach(function () {
+      sinon.stub(evaluationUsecases, 'resetScorecard').resolves({
+        name: 'Comp1',
+      });
+    });
+
+    it('should call the expected usecase', async function () {
+      // given
+      const scorecardSerializer = { serialize: sinon.stub() };
+      scorecardSerializer.serialize.resolves();
+      const userId = '12';
+      const competenceId = '875432';
+      const locale = 'fr-fr';
+
+      const request = {
+        auth: {
+          credentials: {
+            userId,
+          },
+        },
+        params: {
+          userId,
+          competenceId,
+        },
+      };
+
+      // when
+      await scorecardController.resetScorecard(request, hFake, { scorecardSerializer, requestResponseUtils });
+
+      // then
+      expect(evaluationUsecases.resetScorecard).to.have.been.calledWithExactly({ userId, competenceId, locale });
+    });
+  });
 });

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -1,10 +1,8 @@
 import { userController } from '../../../../lib/application/users/user-controller.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
 import { usecases as devcompUsecases } from '../../../../src/devcomp/domain/usecases/index.js';
-import { evaluationUsecases } from '../../../../src/evaluation/domain/usecases/index.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../src/identity-access-management/domain/constants/identity-providers.js';
 import { UserOrganizationForAdmin } from '../../../../src/shared/domain/read-models/UserOrganizationForAdmin.js';
-import * as requestResponseUtils from '../../../../src/shared/infrastructure/utils/request-response-utils.js';
 import { domainBuilder, expect, hFake, sinon } from '../../../test-helper.js';
 
 describe('Unit | Controller | user-controller', function () {
@@ -48,41 +46,6 @@ describe('Unit | Controller | user-controller', function () {
       });
       expect(trainingSerializer.serialize).to.have.been.calledWithExactly(userRecommendedTrainings, meta);
       expect(response).to.equal(expectedResult);
-    });
-  });
-
-  describe('#resetScorecard', function () {
-    beforeEach(function () {
-      sinon.stub(evaluationUsecases, 'resetScorecard').resolves({
-        name: 'Comp1',
-      });
-    });
-
-    it('should call the expected usecase', async function () {
-      // given
-      const scorecardSerializer = { serialize: sinon.stub() };
-      scorecardSerializer.serialize.resolves();
-      const userId = '12';
-      const competenceId = '875432';
-      const locale = 'fr-fr';
-
-      const request = {
-        auth: {
-          credentials: {
-            userId,
-          },
-        },
-        params: {
-          userId,
-          competenceId,
-        },
-      };
-
-      // when
-      await userController.resetScorecard(request, hFake, { scorecardSerializer, requestResponseUtils });
-
-      // then
-      expect(evaluationUsecases.resetScorecard).to.have.been.calledWithExactly({ userId, competenceId, locale });
     });
   });
 


### PR DESCRIPTION
## :gift: Proposition
Migrer la route de reset des scorecard dans le dossier Evaluation/Scorecard.

## :santa: Pour tester
- Se connecter avec un compte ayant déjà des compétences avec des Pix (par exemple certif-success@example.net)
- Aller sur la page des compétences et cliquer sur une compétence pour l'ouvrir
- Cliquer sur le bouton Remettre à zéro
- La remise à zéro de la compétence doit avoir eu lieu
