### PR TITLE
[TECH] Mise à jour des dépendances sur Pix Certif (PIX-15884).

### DIFF
--- a/certif/app/components/layout/sidebar.gjs
+++ b/certif/app/components/layout/sidebar.gjs
@@ -49,7 +49,9 @@ export default class Sidebar extends Component {
   get allowedCertificationCenterAccesses() {
     return this.currentUser.certificationPointOfContact.allowedCertificationCenterAccesses
       .map(({ name, externalId, id }) => ({ label: externalId ? `${name} (${externalId})` : name, value: id }))
-      .sortBy('name');
+      .sort((a, b) => {
+        return a.name?.localeCompare(b.name);
+      });
   }
 
   @action

--- a/certif/app/components/session-finalization/completed-reports-information-step.js
+++ b/certif/app/components/session-finalization/completed-reports-information-step.js
@@ -17,7 +17,7 @@ export default class CompletedReportsInformationStep extends Component {
   }
 
   get hasCheckedSomething() {
-    const hasOneOrMoreCheck = this.args.certificationReports.any((report) => report.hasSeenEndTestScreen);
+    const hasOneOrMoreCheck = this.args.certificationReports.some((report) => report.hasSeenEndTestScreen);
     return this.certificationReportsAreNotEmpty && hasOneOrMoreCheck;
   }
 

--- a/certif/app/components/sessions/session-details/enrolled-candidates/index.gjs
+++ b/certif/app/components/sessions/session-details/enrolled-candidates/index.gjs
@@ -100,7 +100,10 @@ export default class EnrolledCandidates extends Component {
     certificationCandidate.extraTimePercentage = this._fromPercentageStringToDecimal(candidate.extraTimePercentage);
     const success = await this.saveCertificationCandidate(certificationCandidate);
     if (success) {
-      this.candidatesInStaging.removeObject(candidate);
+      const candidateIndex = this.candidatesInStaging.indexOf(candidate);
+      if (candidateIndex !== -1) {
+        this.candidatesInStaging.splice(candidateIndex, 1);
+      }
       this.closeNewCandidateModal();
     }
     return success;
@@ -108,7 +111,10 @@ export default class EnrolledCandidates extends Component {
 
   @action
   removeCertificationCandidateFromStaging(candidate) {
-    this.candidatesInStaging.removeObject(candidate);
+    const candidateIndex = this.abc.indexOf(candidate);
+    if (candidateIndex !== -1) {
+      this.candidatesInStaging.splice(candidateIndex, 1);
+    }
   }
 
   @action

--- a/certif/app/components/sessions/session-details/enrolled-candidates/index.gjs
+++ b/certif/app/components/sessions/session-details/enrolled-candidates/index.gjs
@@ -11,7 +11,6 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
 import { t } from 'ember-intl';
-import { or } from 'ember-truth-helpers';
 import get from 'lodash/get';
 import toNumber from 'lodash/toNumber';
 import { SUBSCRIPTION_TYPES } from 'pix-certif/models/subscription';
@@ -29,7 +28,6 @@ export default class EnrolledCandidates extends Component {
   @service currentUser;
   @service pixToast;
   @service featureToggles;
-  @tracked candidatesInStaging = [];
   @tracked newCandidate = {};
   @tracked shouldDisplayCertificationCandidateModal = false;
   @tracked shouldDisplayEditCertificationCandidateModal = false;
@@ -100,21 +98,9 @@ export default class EnrolledCandidates extends Component {
     certificationCandidate.extraTimePercentage = this._fromPercentageStringToDecimal(candidate.extraTimePercentage);
     const success = await this.saveCertificationCandidate(certificationCandidate);
     if (success) {
-      const candidateIndex = this.candidatesInStaging.indexOf(candidate);
-      if (candidateIndex !== -1) {
-        this.candidatesInStaging.splice(candidateIndex, 1);
-      }
       this.closeNewCandidateModal();
     }
     return success;
-  }
-
-  @action
-  removeCertificationCandidateFromStaging(candidate) {
-    const candidateIndex = this.abc.indexOf(candidate);
-    if (candidateIndex !== -1) {
-      this.candidatesInStaging.splice(candidateIndex, 1);
-    }
   }
 
   @action
@@ -354,7 +340,7 @@ export default class EnrolledCandidates extends Component {
         {{/if}}
       </div>
       <div class='table content-text--small certification-candidates-table'>
-        {{#if (or @certificationCandidates this.candidatesInStaging)}}
+        {{#if @certificationCandidates}}
           <table>
             <caption class='screen-reader-only'>
               {{#if @shouldDisplayPrescriptionScoStudentRegistrationFeature}}

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -54,7 +54,7 @@
         "ember-intl": "^7.1.0",
         "ember-keyboard": "^9.0.1",
         "ember-lifeline": "^7.0.0",
-        "ember-load-initializers": "^3.0.0",
+        "ember-load-initializers": "^3.0.1",
         "ember-modifier": "^4.1.0",
         "ember-page-title": "^8.0.0",
         "ember-qunit": "^8.1.0",
@@ -25807,7 +25807,6 @@
       "resolved": "https://registry.npmjs.org/ember-load-initializers/-/ember-load-initializers-3.0.1.tgz",
       "integrity": "sha512-qV3vxJKw5+7TVDdtdLPy8PhVsh58MlK8jwzqh5xeOwJPNP7o0+BlhvwoIlLYTPzGaHdfjEIFCgVSyMRGd74E1g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 18.*"
       },

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -24,7 +24,7 @@
         "@embroider/compat": "^3.7.1",
         "@embroider/core": "^3.4.20",
         "@embroider/macros": "^1.16.10",
-        "@embroider/webpack": "^4.0.0",
+        "@embroider/webpack": "^4.0.9",
         "@formatjs/intl": "^2.10.4",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
@@ -7086,11 +7086,10 @@
       }
     },
     "node_modules/@embroider/webpack": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@embroider/webpack/-/webpack-4.0.8.tgz",
-      "integrity": "sha512-5i1v6+eH1gMHOqtaCzkFX6JPekmapN1+Clacxu+lxiv/piufuJV6bkugyPxIqqGBWjF8bOQA12ncM9BgpLae8A==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@embroider/webpack/-/webpack-4.0.9.tgz",
+      "integrity": "sha512-4pRnY6fC8sdGrhD+Tk8ilblmHbwzlsy1BrA0r1dYGd23TpmGOgrit/CIv3C2ffRQ4EaiZh1XYO0KDVNTMYUFAw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.14.5",
         "@babel/preset-env": "^7.14.5",
@@ -7119,7 +7118,7 @@
         "node": "12.* || 14.* || >= 16"
       },
       "peerDependencies": {
-        "@embroider/core": "^3.4.19",
+        "@embroider/core": "^3.4.20",
         "webpack": "^5.0.0"
       }
     },

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -29,7 +29,7 @@
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
         "dayjs": "^1.11.6",
-        "ember-auto-import": "^2.4.3",
+        "ember-auto-import": "^2.10.0",
         "ember-cli": "^5.8.1",
         "ember-cli-app-version": "^7.0.0",
         "ember-cli-babel": "^8.0.0",
@@ -15950,7 +15950,6 @@
       "resolved": "https://registry.npmjs.org/ember-auto-import/-/ember-auto-import-2.10.0.tgz",
       "integrity": "sha512-bcBFDYVTFHyqyq8BNvsj6UO3pE6Uqou/cNmee0WaqBgZ+1nQqFz0UE26usrtnFAT+YaFZSkqF2H36QW84k0/cg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.7",
         "@babel/plugin-proposal-class-properties": "^7.16.7",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -43,7 +43,7 @@
         "ember-cli-sass": "^11.0.1",
         "ember-composable-helpers": "^5.0.0",
         "ember-cookies": "^1.0.0",
-        "ember-data": "^5.3.2",
+        "ember-data": "^5.3.9",
         "ember-dayjs": "^0.12.0",
         "ember-eslint-parser": "^0.5.0",
         "ember-exam": "9.0.0",
@@ -21161,7 +21161,6 @@
       "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-5.3.9.tgz",
       "integrity": "sha512-fUhvmq3piYapfSFlpFpuQrkGn9SPRzPNj9xfHtFhyUq7UrPSXvjbhsihg+vw46VLxNqlTUwVtU3kLjGuJU6O9Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@ember-data/adapter": "5.3.9",
         "@ember-data/debug": "5.3.9",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -20,7 +20,7 @@
         "@ember-data/model": "^5.3.9",
         "@ember/optional-features": "^2.2.0",
         "@ember/string": "^3.1.1",
-        "@ember/test-helpers": "^3.1.0",
+        "@ember/test-helpers": "^3.3.1",
         "@embroider/compat": "^3.0.0",
         "@embroider/core": "^3.0.0",
         "@embroider/macros": "^1.13.3",
@@ -5211,7 +5211,6 @@
       "resolved": "https://registry.npmjs.org/@ember/test-helpers/-/test-helpers-3.3.1.tgz",
       "integrity": "sha512-h4uFBy4pquBtHsHI+tx9S0wtMmn1L+8dkXiDiyoqG1+3e0Awk6GBujiFM9s4ANq6wC8uIhC3wEFyts10h2OAoQ==",
       "dev": true,
-      "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@ember/test-waiters": "^3.0.2",
         "@embroider/macros": "^1.10.0",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -21,7 +21,7 @@
         "@ember/optional-features": "^2.2.0",
         "@ember/string": "^3.1.1",
         "@ember/test-helpers": "^3.3.1",
-        "@embroider/compat": "^3.0.0",
+        "@embroider/compat": "^3.7.1",
         "@embroider/core": "^3.0.0",
         "@embroider/macros": "^1.13.3",
         "@embroider/webpack": "^4.0.0",
@@ -6187,11 +6187,10 @@
       }
     },
     "node_modules/@embroider/compat": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/@embroider/compat/-/compat-3.6.5.tgz",
-      "integrity": "sha512-h4ZeE28IXMU3JjVZuO3D0ZhKDz0TZxNjkrSWw6VZ3YEyX5fMcIxJTYf6sS362STsTjvIaPHZxG2t3CXmh7ct6Q==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@embroider/compat/-/compat-3.7.1.tgz",
+      "integrity": "sha512-nHgp6AVisPSpNvZlDyUBuIgUarbLBG+VvTV87njCw5NNCPk6w0WGX//xB3DEPjns/HX3akeWYbZ7DyZNyKQmUg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
         "@babel/core": "^7.14.5",
@@ -6202,7 +6201,7 @@
         "@babel/preset-env": "^7.14.5",
         "@babel/runtime": "^7.18.6",
         "@babel/traverse": "^7.14.5",
-        "@embroider/macros": "1.16.9",
+        "@embroider/macros": "1.16.10",
         "@types/babel__code-frame": "^7.0.2",
         "@types/yargs": "^17.0.3",
         "assert-never": "^1.1.0",
@@ -6244,7 +6243,7 @@
         "node": "12.* || 14.* || >= 16"
       },
       "peerDependencies": {
-        "@embroider/core": "^3.4.19"
+        "@embroider/core": "^3.4.20"
       }
     },
     "node_modules/@embroider/compat/node_modules/semver": {
@@ -6261,16 +6260,15 @@
       }
     },
     "node_modules/@embroider/core": {
-      "version": "3.4.19",
-      "resolved": "https://registry.npmjs.org/@embroider/core/-/core-3.4.19.tgz",
-      "integrity": "sha512-nnjQzXa+LkbqcSl7+a5sX6UKzeyHaiKrYCi/Wg5EG5OzyukiFmX2ZNI44fJ/U69htIphCZXAvLsMsEsUPm94ZA==",
+      "version": "3.4.20",
+      "resolved": "https://registry.npmjs.org/@embroider/core/-/core-3.4.20.tgz",
+      "integrity": "sha512-bKy/uIrcoUyJXcBud2d8E7J8R8NRMz0T3xaKbEUx4nxc4/BbBsU+y7wSyzzfggykyJTK/95PwNIxls8gqnyYYA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.14.5",
         "@babel/parser": "^7.14.5",
         "@babel/traverse": "^7.14.5",
-        "@embroider/macros": "1.16.9",
+        "@embroider/macros": "1.16.10",
         "@embroider/shared-internals": "2.8.1",
         "assert-never": "^1.2.1",
         "babel-plugin-ember-template-compilation": "^2.1.1",
@@ -6325,11 +6323,10 @@
       }
     },
     "node_modules/@embroider/macros": {
-      "version": "1.16.9",
-      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.16.9.tgz",
-      "integrity": "sha512-AUrmHQdixczIU3ouv/+HzWxwYVsw/NwssZxAQnXfBDJ3d3/CRtAvGRu3JhY6OT3AAPFwfa2WT66tB5jeAa7r5g==",
+      "version": "1.16.10",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.16.10.tgz",
+      "integrity": "sha512-G0vCsKgNCX0PMmuVNsTLG7IYXz8VkekQMK4Kcllzqpwb7ivFRDwVx2bD4QSvZ9LCTd4eWQ654RsCqVbW5aviww==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@embroider/shared-internals": "2.8.1",
         "assert-never": "^1.2.1",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -16,7 +16,7 @@
         "@1024pix/pix-ui": "^52.0.3",
         "@1024pix/stylelint-config": "^5.1.25",
         "@babel/eslint-parser": "^7.25.9",
-        "@babel/plugin-proposal-decorators": "^7.22.15",
+        "@babel/plugin-proposal-decorators": "^7.25.9",
         "@ember-data/model": "^5.3.2",
         "@ember/optional-features": "^2.0.0",
         "@ember/string": "^3.1.1",
@@ -2216,7 +2216,6 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.25.9.tgz",
       "integrity": "sha512-smkNLL/O1ezy9Nhy4CNosc4Va+1wo5w4gzSZeLe6y6dM4mmHfYOCPolXQPHQxonZCF+ZyebxN9vqOolkYrSn5g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -76,7 +76,7 @@
         "miragejs": "^0.1.48",
         "p-queue": "^8.0.1",
         "prettier": "^3.4.2",
-        "prettier-plugin-ember-template-tag": "^2.0.2",
+        "prettier-plugin-ember-template-tag": "^2.0.4",
         "qunit": "^2.19.3",
         "qunit-dom": "^3.0.0",
         "sass": "^1.66.1",
@@ -36385,14 +36385,13 @@
       }
     },
     "node_modules/prettier-plugin-ember-template-tag": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-ember-template-tag/-/prettier-plugin-ember-template-tag-2.0.2.tgz",
-      "integrity": "sha512-eSEnrxdD3NtMyIGwG2FxcTPOdpcbCK7VnBNhAufdaoeOIs+mNwmTsZdkWxr/LMhBdgtR1IUQB0l0YQhUQGz6kQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-ember-template-tag/-/prettier-plugin-ember-template-tag-2.0.4.tgz",
+      "integrity": "sha512-Ude3MJyPBMr/Er5aSS9Y0dsnHWX3prpJB+Jj/BKKUT/EvG2ftnIMBsZXmRu68RJA62JJB8MdKBloYmCu2pTRNg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.23.6",
-        "content-tag": "^1.2.2",
+        "content-tag": "^2.0.1",
         "prettier": "^3.1.1"
       },
       "engines": {
@@ -36401,13 +36400,6 @@
       "peerDependencies": {
         "prettier": ">= 3.0.0"
       }
-    },
-    "node_modules/prettier-plugin-ember-template-tag/node_modules/content-tag": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/content-tag/-/content-tag-1.2.2.tgz",
-      "integrity": "sha512-9guqKIx2H+78N17otBpl8yLZbQGL5q1vBO/jDb3gF2JjixtcVpC62jDUNxjVMNoaZ09oxRX84ZOD6VX02qkVvg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/pretty-format": {
       "version": "27.5.1",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -51,7 +51,7 @@
         "ember-file-upload": "^9.1.0",
         "ember-flatpickr": "^8.0.1",
         "ember-inputmask5": "^4.0.2",
-        "ember-intl": "^7.0.0",
+        "ember-intl": "^7.1.0",
         "ember-keyboard": "^9.0.0",
         "ember-lifeline": "^7.0.0",
         "ember-load-initializers": "^3.0.0",
@@ -13073,17 +13073,44 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -13455,11 +13482,10 @@
       }
     },
     "node_modules/cldr-core": {
-      "version": "45.0.0",
-      "resolved": "https://registry.npmjs.org/cldr-core/-/cldr-core-45.0.0.tgz",
-      "integrity": "sha512-gQVxy3gzOQpXiTRGmlKiRQFLYimrr1RgvqGKZCS61JgmdkeNm7+LZGx+Lhw5/AW0t8WMM/uZhf4CMva6LuUobQ==",
-      "dev": true,
-      "license": "Unicode-3.0"
+      "version": "46.1.0",
+      "resolved": "https://registry.npmjs.org/cldr-core/-/cldr-core-46.1.0.tgz",
+      "integrity": "sha512-YWIbxgpO6fUais+FIm6Stl/KoAAhNJx4wDg2sg06QxK6GQ+i1iwdpCiyIJ7CTWduRuqUmRoaYpL/n5/8Q8ywxg==",
+      "dev": true
     },
     "node_modules/clean-base-url": {
       "version": "1.0.0",
@@ -15090,6 +15116,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/eastasianwidth": {
@@ -25498,29 +25538,27 @@
       }
     },
     "node_modules/ember-intl": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/ember-intl/-/ember-intl-7.0.7.tgz",
-      "integrity": "sha512-K9KDkDIm49/qSLguO7OBOp3tB61GQws9DHfPKEdjSztHTbZvLD+uv2vT9ASRE0+xszYG7Q15UwUQqf6tRJGRxQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ember-intl/-/ember-intl-7.1.0.tgz",
+      "integrity": "sha512-AGhUCHKeBBr8wTcuj73vhUFIq3bR9SRe9pvpxcI88pvCAgCBmggwWabhwfa7W+ULdFcF4TldMaN1hv1KeQzKHQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.25.8",
-        "@formatjs/icu-messageformat-parser": "^2.7.10",
-        "@formatjs/intl": "^2.10.8",
+        "@babel/core": "^7.26.0",
+        "@formatjs/icu-messageformat-parser": "^2.9.7",
+        "@formatjs/intl": "^3.0.4",
         "broccoli-caching-writer": "^3.0.3",
         "broccoli-funnel": "^3.0.8",
         "broccoli-merge-trees": "^4.2.0",
         "broccoli-source": "^3.0.1",
         "calculate-cache-key-for-tree": "^2.0.0",
-        "cldr-core": "^45.0.0",
-        "ember-auto-import": "^2.8.1",
+        "cldr-core": "^46.1.0",
+        "ember-auto-import": "^2.10.0",
         "ember-cli-babel": "^8.2.0",
         "ember-cli-typescript": "^5.3.0",
-        "eventemitter3": "^5.0.1",
         "extend": "^3.0.2",
-        "intl-messageformat": "^10.7.0",
+        "intl-messageformat": "^10.7.10",
         "js-yaml": "^4.1.0",
-        "json-stable-stringify": "^1.1.1"
+        "json-stable-stringify": "^1.2.1"
       },
       "engines": {
         "node": "18.* || >= 20"
@@ -25536,6 +25574,78 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ember-intl/node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.1.tgz",
+      "integrity": "sha512-Ip9uV+/MpLXWRk03U/GzeJMuPeOXpJBSB5V1tjA6kJhvqssye5J5LoYLc7Z5IAHb7nR62sRoguzrFiVCP/hnzw==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.5",
+        "@formatjs/intl-localematcher": "0.5.9",
+        "decimal.js": "10",
+        "tslib": "2"
+      }
+    },
+    "node_modules/ember-intl/node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.5.tgz",
+      "integrity": "sha512-6PoewUMrrcqxSoBXAOJDiW1m+AmkrAj0RiXnOMD59GRaswjXhm3MDhgepXPBgonc09oSirAJTsAggzAGQf6A6g==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/ember-intl/node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.9.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.9.7.tgz",
+      "integrity": "sha512-cuEHyRM5VqLQobANOjtjlgU7+qmk9Q3fDQuBiRRJ3+Wp3ZoZhpUPtUfuimZXsir6SaI2TaAJ+SLo9vLnV5QcbA==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.1",
+        "@formatjs/icu-skeleton-parser": "1.8.11",
+        "tslib": "2"
+      }
+    },
+    "node_modules/ember-intl/node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.11.tgz",
+      "integrity": "sha512-8LlHHE/yL/zVJZHAX3pbKaCjZKmBIO6aJY1mkVh4RMSEu/2WRZ4Ysvv3kKXJ9M8RJLBHdnk1/dUQFdod1Dt7Dw==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.1",
+        "tslib": "2"
+      }
+    },
+    "node_modules/ember-intl/node_modules/@formatjs/intl": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-3.0.4.tgz",
+      "integrity": "sha512-pnetak6R7Xp/ET96O5kx9zRYoQQqr6sbRXWkJHKw0Hr/jr3ls4CddZKq+suwCDuW6p/ior2BhpOSh/WLLcJM6w==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.1",
+        "@formatjs/fast-memoize": "2.2.5",
+        "@formatjs/icu-messageformat-parser": "2.9.7",
+        "intl-messageformat": "10.7.10",
+        "tslib": "2"
+      },
+      "peerDependencies": {
+        "typescript": "5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ember-intl/node_modules/@formatjs/intl-localematcher": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.9.tgz",
+      "integrity": "sha512-8zkGu/sv5euxbjfZ/xmklqLyDGQSxsLqg8XOq88JW3cmJtzhCP8EtSJXlaKZnVO4beEaoiT9wj4eIoCQ9smwxA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "2"
       }
     },
     "node_modules/ember-intl/node_modules/ember-cli-typescript": {
@@ -25608,6 +25718,18 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.12.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/intl-messageformat": {
+      "version": "10.7.10",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.10.tgz",
+      "integrity": "sha512-hp7iejCBiJdW3zmOe18FdlJu8U/JsADSDiBPQhfdSeI8B9POtvPRvPh3nMlvhYayGMKLv6maldhR7y3Pf1vkpw==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.1",
+        "@formatjs/fast-memoize": "2.2.5",
+        "@formatjs/icu-messageformat-parser": "2.9.7",
+        "tslib": "2"
       }
     },
     "node_modules/ember-intl/node_modules/semver": {
@@ -28796,14 +28918,10 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
       "engines": {
         "node": ">= 0.4"
       }
@@ -30854,17 +30972,21 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.6.tgz",
+      "integrity": "sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "dunder-proto": "^1.0.0",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -31143,13 +31265,12 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -31258,11 +31379,10 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -32995,13 +33115,13 @@
       "license": "MIT"
     },
     "node_modules/json-stable-stringify": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.1.1.tgz",
-      "integrity": "sha512-SU/971Kt5qVQfJpyDveVhQ/vya+5hvrjClFOcr8c0Fq5aODJjMwutrOfCU+eCnVD5gpx1Q3fEqkyom77zH1iIg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.2.1.tgz",
+      "integrity": "sha512-Lp6HbbBgosLmJbjx0pBLbgvx68FaFU1sdkmBuckmhhJ88kL13OA51CDtR2yJB50eCNMH9wRqtQNNiAqQH4YXnA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "isarray": "^2.0.5",
         "jsonify": "^0.0.1",
         "object-keys": "^1.1.1"
@@ -33810,6 +33930,15 @@
       },
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/mathml-tag-names": {

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -15,7 +15,7 @@
         "@1024pix/eslint-config": "^1.3.8",
         "@1024pix/pix-ui": "^52.0.3",
         "@1024pix/stylelint-config": "^5.1.25",
-        "@babel/eslint-parser": "^7.22.15",
+        "@babel/eslint-parser": "^7.25.9",
         "@babel/plugin-proposal-decorators": "^7.22.15",
         "@ember-data/model": "^5.3.2",
         "@ember/optional-features": "^2.0.0",
@@ -1770,7 +1770,6 @@
       "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.25.9.tgz",
       "integrity": "sha512-5UXfgpK0j0Xr/xIdgdLEhOFxaDZ0bRPWJJchRpqOSur/3rZoPbqqki5mm0p4NE2cs28krBEiSM2MB7//afRSQQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
         "eslint-visitor-keys": "^2.1.0",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -52,7 +52,7 @@
         "ember-flatpickr": "^8.0.1",
         "ember-inputmask5": "^4.0.2",
         "ember-intl": "^7.1.0",
-        "ember-keyboard": "^9.0.0",
+        "ember-keyboard": "^9.0.1",
         "ember-lifeline": "^7.0.0",
         "ember-load-initializers": "^3.0.0",
         "ember-modifier": "^4.1.0",
@@ -25766,7 +25766,6 @@
       "resolved": "https://registry.npmjs.org/ember-keyboard/-/ember-keyboard-9.0.1.tgz",
       "integrity": "sha512-zCIrs8ktI8nxDTBLodASYrWtg5I5ZTZ7hdfFr+upfyRKzbLub5Pnvlj60zpvSAVDyNJBlQJ7eSn3sZlwEA01wQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@embroider/addon-shim": "^1.8.4",
         "ember-destroyable-polyfill": "^2.0.3",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -18,7 +18,7 @@
         "@babel/eslint-parser": "^7.25.9",
         "@babel/plugin-proposal-decorators": "^7.25.9",
         "@ember-data/model": "^5.3.9",
-        "@ember/optional-features": "^2.0.0",
+        "@ember/optional-features": "^2.2.0",
         "@ember/string": "^3.1.1",
         "@ember/test-helpers": "^3.1.0",
         "@embroider/compat": "^3.0.0",
@@ -3805,7 +3805,6 @@
       "resolved": "https://registry.npmjs.org/@ember/optional-features/-/optional-features-2.2.0.tgz",
       "integrity": "sha512-a1OQ+w9vDvMXd9BNA9r779yr8MAPguGaMGbIeTMPWACeWBdD6bACBB5iKE3gNyrJAYKMq2wab6BKmRFS3Qw3hw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "ember-cli-version-checker": "^5.1.2",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -44,7 +44,7 @@
         "ember-composable-helpers": "^5.0.0",
         "ember-cookies": "^1.3.0",
         "ember-data": "^5.3.9",
-        "ember-dayjs": "^0.12.0",
+        "ember-dayjs": "^0.12.4",
         "ember-eslint-parser": "^0.5.0",
         "ember-exam": "9.0.0",
         "ember-fetch": "^8.1.2",
@@ -21204,7 +21204,6 @@
       "resolved": "https://registry.npmjs.org/ember-dayjs/-/ember-dayjs-0.12.4.tgz",
       "integrity": "sha512-Avslpo+hNGBPcYYiIVMk4l+erChT7YWfeEghpBx0Q9wVN3HHpu2h2nI0r5ckeOea4OM3IL8oUBiQcO9NsHm5Qw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@embroider/addon-shim": "^1.8.9",
         "@embroider/macros": "^1.16.1",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -75,7 +75,7 @@
         "lodash": "^4.17.21",
         "miragejs": "^0.1.48",
         "p-queue": "^8.0.1",
-        "prettier": "^3.3.2",
+        "prettier": "^3.4.2",
         "prettier-plugin-ember-template-tag": "^2.0.2",
         "qunit": "^2.19.3",
         "qunit-dom": "^3.0.0",
@@ -36357,11 +36357,10 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -56,7 +56,7 @@
         "ember-lifeline": "^7.0.0",
         "ember-load-initializers": "^3.0.1",
         "ember-modifier": "^4.2.0",
-        "ember-page-title": "^8.0.0",
+        "ember-page-title": "^8.2.3",
         "ember-qunit": "^8.1.0",
         "ember-resolver": "^12.0.0",
         "ember-simple-auth": "^6.1.0",
@@ -26554,7 +26554,6 @@
       "resolved": "https://registry.npmjs.org/ember-page-title/-/ember-page-title-8.2.3.tgz",
       "integrity": "sha512-9XH4EVPCpSCyXRsLPzdDydU4HgQnaVeJJTrRF0WVh5bZERI9DgxuHv1NPmZU28todHRH91KcBc5nx8kIVJmqUw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@embroider/addon-shim": "^1.8.7",
         "@simple-dom/document": "^1.4.0"

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -77,7 +77,7 @@
         "p-queue": "^8.0.1",
         "prettier": "^3.4.2",
         "prettier-plugin-ember-template-tag": "^2.0.4",
-        "qunit": "^2.19.3",
+        "qunit": "^2.23.1",
         "qunit-dom": "^3.0.0",
         "sass": "^1.66.1",
         "sinon": "^19.0.0",
@@ -36652,11 +36652,10 @@
       }
     },
     "node_modules/qunit": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.22.0.tgz",
-      "integrity": "sha512-wPYvAvpjTL3zlUeyCX75T8gfZfdVXZa8y1EVkGe/XZNORIsCH/WI2X8R2KlemT921X9EKSZUL6CLGSPC7Ks08g==",
+      "version": "2.23.1",
+      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.23.1.tgz",
+      "integrity": "sha512-CGrsGy7NhkQmfiyOixBpbexh2PT7ekIb35uWiBi/hBNdTJF1W98UonyACFJJs8UmcP96lH+YJlX99dYZi5rZkg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "commander": "7.2.0",
         "node-watch": "0.7.3",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -83,7 +83,7 @@
         "sinon": "^19.0.2",
         "stylelint": "^16.12.0",
         "tracked-built-ins": "^3.4.0",
-        "webpack": "^5.76.2"
+        "webpack": "^5.97.1"
       },
       "engines": {
         "node": "^20.18.1"
@@ -9748,6 +9748,16 @@
         "@types/json-schema": "*"
       }
     },
+    "node_modules/@types/eslint-scope": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+      "dev": true,
+      "dependencies": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -10008,163 +10018,148 @@
       }
     },
     "node_modules/@webassemblyjs/ast": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
-      "integrity": "sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/helper-numbers": "1.11.6",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6"
+        "@webassemblyjs/helper-numbers": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
       }
     },
     "node_modules/@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
-      "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+      "dev": true
     },
     "node_modules/@webassemblyjs/helper-api-error": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
-      "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+      "dev": true
     },
     "node_modules/@webassemblyjs/helper-buffer": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.12.1.tgz",
-      "integrity": "sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw==",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+      "dev": true
     },
     "node_modules/@webassemblyjs/helper-numbers": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
-      "integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/floating-point-hex-parser": "1.11.6",
-        "@webassemblyjs/helper-api-error": "1.11.6",
+        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+        "@webassemblyjs/helper-api-error": "1.13.2",
         "@xtuc/long": "4.2.2"
       }
     },
     "node_modules/@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
-      "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+      "dev": true
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.12.1.tgz",
-      "integrity": "sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/wasm-gen": "1.12.1"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/wasm-gen": "1.14.1"
       }
     },
     "node_modules/@webassemblyjs/ieee754": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
-      "integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
     },
     "node_modules/@webassemblyjs/leb128": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
-      "integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
     },
     "node_modules/@webassemblyjs/utf8": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
-      "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+      "dev": true
     },
     "node_modules/@webassemblyjs/wasm-edit": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz",
-      "integrity": "sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/helper-wasm-section": "1.12.1",
-        "@webassemblyjs/wasm-gen": "1.12.1",
-        "@webassemblyjs/wasm-opt": "1.12.1",
-        "@webassemblyjs/wasm-parser": "1.12.1",
-        "@webassemblyjs/wast-printer": "1.12.1"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/helper-wasm-section": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-opt": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1",
+        "@webassemblyjs/wast-printer": "1.14.1"
       }
     },
     "node_modules/@webassemblyjs/wasm-gen": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.12.1.tgz",
-      "integrity": "sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/ieee754": "1.11.6",
-        "@webassemblyjs/leb128": "1.11.6",
-        "@webassemblyjs/utf8": "1.11.6"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
       }
     },
     "node_modules/@webassemblyjs/wasm-opt": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.12.1.tgz",
-      "integrity": "sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/wasm-gen": "1.12.1",
-        "@webassemblyjs/wasm-parser": "1.12.1"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1"
       }
     },
     "node_modules/@webassemblyjs/wasm-parser": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz",
-      "integrity": "sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-api-error": "1.11.6",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/ieee754": "1.11.6",
-        "@webassemblyjs/leb128": "1.11.6",
-        "@webassemblyjs/utf8": "1.11.6"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
       }
     },
     "node_modules/@webassemblyjs/wast-printer": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.12.1.tgz",
-      "integrity": "sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
+        "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
       }
     },
@@ -10182,15 +10177,13 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-      "dev": true,
-      "license": "BSD-3-Clause"
+      "dev": true
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-      "dev": true,
-      "license": "Apache-2.0"
+      "dev": true
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -10255,16 +10248,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-import-attributes": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "acorn": "^8"
       }
     },
     "node_modules/acorn-jsx": {
@@ -41585,19 +41568,18 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.95.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.95.0.tgz",
-      "integrity": "sha512-2t3XstrKULz41MNMBF+cJ97TyHdyQ8HCt//pqErqDvNjU9YQBnZxIHa11VXsi7F3mb5/aO2tuDxdeTPdU7xu9Q==",
+      "version": "5.97.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
+      "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@types/estree": "^1.0.5",
-        "@webassemblyjs/ast": "^1.12.1",
-        "@webassemblyjs/wasm-edit": "^1.12.1",
-        "@webassemblyjs/wasm-parser": "^1.12.1",
-        "acorn": "^8.7.1",
-        "acorn-import-attributes": "^1.9.5",
-        "browserslist": "^4.21.10",
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.6",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.14.0",
+        "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
         "enhanced-resolve": "^5.17.1",
         "es-module-lexer": "^1.2.1",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -48,7 +48,7 @@
         "ember-eslint-parser": "^0.5.7",
         "ember-exam": "9.0.0",
         "ember-fetch": "^8.1.2",
-        "ember-file-upload": "^9.0.0",
+        "ember-file-upload": "^9.1.0",
         "ember-flatpickr": "^8.0.0",
         "ember-inputmask5": "^4.0.2",
         "ember-intl": "^7.0.0",
@@ -23094,7 +23094,6 @@
       "resolved": "https://registry.npmjs.org/ember-file-upload/-/ember-file-upload-9.1.0.tgz",
       "integrity": "sha512-2t/LRpdbYP3GUnkUexjpWs/hE2QZeLh+Y3vM8GTzsyg+uYOaVNd4JFWrlFkazmo0Vp6Lf0rL+1Yj4tiefc+djQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@ember/test-waiters": "^3.0.0",
         "@embroider/addon-shim": "^1.5.0",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -79,7 +79,7 @@
         "prettier-plugin-ember-template-tag": "^2.0.4",
         "qunit": "^2.23.1",
         "qunit-dom": "^3.4.0",
-        "sass": "^1.66.1",
+        "sass": "^1.83.0",
         "sinon": "^19.0.0",
         "stylelint": "^16.0.0",
         "tracked-built-ins": "^3.2.0",
@@ -9203,6 +9203,7 @@
       "integrity": "sha512-HNjmfLQEVRZmHRET336f20H/8kOozUGwk7yajvsonjNxbj2wBTK1WsQuHkD5yYh9RxFGL2EyDHryOihOwUoKDA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "detect-libc": "^1.0.3",
         "is-glob": "^4.0.3",
@@ -14952,6 +14953,7 @@
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -31883,11 +31885,10 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
-      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
-      "dev": true,
-      "license": "MIT"
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.3.tgz",
+      "integrity": "sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw==",
+      "dev": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -34529,7 +34530,8 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -37932,15 +37934,13 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.80.4",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.80.4.tgz",
-      "integrity": "sha512-rhMQ2tSF5CsuuspvC94nPM9rToiAFw2h3JTrLlgmNw1MH79v8Cr3DH6KF6o6r+8oofY3iYVPUf66KzC8yuVN1w==",
+      "version": "1.83.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.83.0.tgz",
+      "integrity": "sha512-qsSxlayzoOjdvXMVLkzF84DJFc2HZEL/rFyGIKbbilYtAvlCxyuzUeff9LawTn4btVnLKg75Z8MMr1lxU1lfGw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@parcel/watcher": "^2.4.1",
         "chokidar": "^4.0.0",
-        "immutable": "^4.0.0",
+        "immutable": "^5.0.2",
         "source-map-js": ">=0.6.2 <2.0.0"
       },
       "bin": {
@@ -37948,6 +37948,9 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
       }
     },
     "node_modules/saxes": {

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -49,7 +49,7 @@
         "ember-exam": "9.0.0",
         "ember-fetch": "^8.1.2",
         "ember-file-upload": "^9.1.0",
-        "ember-flatpickr": "^8.0.0",
+        "ember-flatpickr": "^8.0.1",
         "ember-inputmask5": "^4.0.2",
         "ember-intl": "^7.0.0",
         "ember-keyboard": "^9.0.0",
@@ -23126,7 +23126,6 @@
       "resolved": "https://registry.npmjs.org/ember-flatpickr/-/ember-flatpickr-8.0.1.tgz",
       "integrity": "sha512-Y2SJeg+wMcxG9FxRx8BiPldGCJ4AknnKPlLzVDxOWwmyeY2Ka5U42wP9lHewHWDSjyxEB1d43sjf1pft53Z/SA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@ember/render-modifiers": "^2.0.3",
         "@ember/test-helpers": "^3.3.0",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -42,7 +42,7 @@
         "ember-cli-mirage": "^3.0.3",
         "ember-cli-sass": "^11.0.1",
         "ember-composable-helpers": "^5.0.0",
-        "ember-cookies": "^1.0.0",
+        "ember-cookies": "^1.3.0",
         "ember-data": "^5.3.9",
         "ember-dayjs": "^0.12.0",
         "ember-eslint-parser": "^0.5.0",
@@ -21143,16 +21143,18 @@
       }
     },
     "node_modules/ember-cookies": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-1.1.2.tgz",
-      "integrity": "sha512-6GaN0eEDZT9SEUSZBxWzZMlvxjcGKXFTJNjv30LVXTTOxozE5IBmIxiDAEq0udi0UpWUGHLYQBgnANn4jdll7w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-1.3.0.tgz",
+      "integrity": "sha512-nhVDm9lql4EVLpbjxyosyEITFvuNAmHr7cod8K2FmIyw2KcAFWSS0v88quIWc+GvcawBTz3KSMRXOJq/0InVpg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@embroider/addon-shim": "^1.7.1"
       },
       "engines": {
         "node": ">= 16.*"
+      },
+      "peerDependencies": {
+        "ember-source": ">=4.0"
       }
     },
     "node_modules/ember-data": {

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -25,7 +25,7 @@
         "@embroider/core": "^3.4.20",
         "@embroider/macros": "^1.16.10",
         "@embroider/webpack": "^4.0.9",
-        "@formatjs/intl": "^2.10.4",
+        "@formatjs/intl": "^2.10.15",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
         "dayjs": "^1.11.6",
@@ -7261,63 +7261,58 @@
       }
     },
     "node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.2.1.tgz",
-      "integrity": "sha512-O4ywpkdJybrjFc9zyL8qK5aklleIAi5O4nYhBVJaOFtCkNrnU+lKFeJOFC48zpsZQmR8Aok2V79hGpHnzbmFpg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.2.4.tgz",
+      "integrity": "sha512-lFyiQDVvSbQOpU+WFd//ILolGj4UgA/qXrKeZxdV14uKiAUiPAtX6XAn7WBCRi7Mx6I7EybM9E5yYn4BIpZWYg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@formatjs/fast-memoize": "2.2.2",
-        "@formatjs/intl-localematcher": "0.5.6",
+        "@formatjs/fast-memoize": "2.2.3",
+        "@formatjs/intl-localematcher": "0.5.8",
         "tslib": "2"
       }
     },
     "node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.2.tgz",
-      "integrity": "sha512-mzxZcS0g1pOzwZTslJOBTmLzDXseMLLvnh25ymRilCm8QLMObsQ7x/rj9GNrH0iUhZMlFisVOD6J1n6WQqpKPQ==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.3.tgz",
+      "integrity": "sha512-3jeJ+HyOfu8osl3GNSL4vVHUuWFXR03Iz9jjgI7RwjG6ysu/Ymdr0JRCPHfF5yGbTE6JCrd63EpvX1/WybYRbA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "tslib": "2"
       }
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.9.1.tgz",
-      "integrity": "sha512-7AYk4tjnLi5wBkxst2w7qFj38JLMJoqzj7BhdEl7oTlsWMlqwgx4p9oMmmvpXWTSDGNwOKBRc1SfwMh5MOHeNg==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.9.4.tgz",
+      "integrity": "sha512-Tbvp5a9IWuxUcpWNIW6GlMQYEc4rwNHR259uUFoKWNN1jM9obf9Ul0e+7r7MvFOBNcN+13K7NuKCKqQiAn1QEg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.1",
-        "@formatjs/icu-skeleton-parser": "1.8.5",
+        "@formatjs/ecma402-abstract": "2.2.4",
+        "@formatjs/icu-skeleton-parser": "1.8.8",
         "tslib": "2"
       }
     },
     "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.5.tgz",
-      "integrity": "sha512-zRZ/e3B5qY2+JCLs7puTzWS1Jb+t/K+8Jur/gEZpA2EjWeLDE17nsx8thyo9P48Mno7UmafnPupV2NCJXX17Dg==",
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.8.tgz",
+      "integrity": "sha512-vHwK3piXwamFcx5YQdCdJxUQ1WdTl6ANclt5xba5zLGDv5Bsur7qz8AD7BevaKxITwpgDeU0u8My3AIibW9ywA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.1",
+        "@formatjs/ecma402-abstract": "2.2.4",
         "tslib": "2"
       }
     },
     "node_modules/@formatjs/intl": {
-      "version": "2.10.11",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.10.11.tgz",
-      "integrity": "sha512-FNLZjzE1QRlv1Wf0oinnM97AbvZU1zQnQMHI0Oza2F7PxzrPf6bYFRs0ugapq/O4FrvNwDt9F9nyRNwsMM118g==",
+      "version": "2.10.15",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.10.15.tgz",
+      "integrity": "sha512-i6+xVqT+6KCz7nBfk4ybMXmbKO36tKvbMKtgFz9KV+8idYFyFbfwKooYk8kGjyA5+T5f1kEPQM5IDLXucTAQ9g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.1",
-        "@formatjs/fast-memoize": "2.2.2",
-        "@formatjs/icu-messageformat-parser": "2.9.1",
-        "@formatjs/intl-displaynames": "6.8.1",
-        "@formatjs/intl-listformat": "7.7.1",
-        "intl-messageformat": "10.7.3",
+        "@formatjs/ecma402-abstract": "2.2.4",
+        "@formatjs/fast-memoize": "2.2.3",
+        "@formatjs/icu-messageformat-parser": "2.9.4",
+        "@formatjs/intl-displaynames": "6.8.5",
+        "@formatjs/intl-listformat": "7.7.5",
+        "intl-messageformat": "10.7.7",
         "tslib": "2"
       },
       "peerDependencies": {
@@ -7330,35 +7325,32 @@
       }
     },
     "node_modules/@formatjs/intl-displaynames": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.8.1.tgz",
-      "integrity": "sha512-nyWfJk4BZ1+GzLq9a40BgVPSRpBkRAVzrSpql+92i0i+lX11m9eS1trSRf/h3j/XcQ+h1h+ntA4Ra4jETK7nNg==",
+      "version": "6.8.5",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.8.5.tgz",
+      "integrity": "sha512-85b+GdAKCsleS6cqVxf/Aw/uBd+20EM0wDpgaxzHo3RIR3bxF4xCJqH/Grbzx8CXurTgDDZHPdPdwJC+May41w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.1",
-        "@formatjs/intl-localematcher": "0.5.6",
+        "@formatjs/ecma402-abstract": "2.2.4",
+        "@formatjs/intl-localematcher": "0.5.8",
         "tslib": "2"
       }
     },
     "node_modules/@formatjs/intl-listformat": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-7.7.1.tgz",
-      "integrity": "sha512-bjBxWaUhYAbJFUlFSMWZGn3r2mglXwk+BLyGRu8dY8Q83ZPsqmmVQzjQKENHE3lV6eoQGHT2oZHxUaVndJlk6Q==",
+      "version": "7.7.5",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-7.7.5.tgz",
+      "integrity": "sha512-Wzes10SMNeYgnxYiKsda4rnHP3Q3II4XT2tZyOgnH5fWuHDtIkceuWlRQNsvrI3uiwP4hLqp2XdQTCsfkhXulg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.1",
-        "@formatjs/intl-localematcher": "0.5.6",
+        "@formatjs/ecma402-abstract": "2.2.4",
+        "@formatjs/intl-localematcher": "0.5.8",
         "tslib": "2"
       }
     },
     "node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.6.tgz",
-      "integrity": "sha512-roz1+Ba5e23AHX6KUAWmLEyTRZegM5YDuxuvkHCyK3RJddf/UXB2f+s7pOMm9ktfPGla0g+mQXOn5vsuYirnaA==",
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.8.tgz",
+      "integrity": "sha512-I+WDNWWJFZie+jkfkiK5Mp4hEDyRSEvmyfYadflOno/mmKJKcB17fEpEH0oJu/OWhhCJ8kJBDz2YMd/6cDl7Mg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "tslib": "2"
       }
@@ -31989,15 +31981,14 @@
       }
     },
     "node_modules/intl-messageformat": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.3.tgz",
-      "integrity": "sha512-AAo/3oyh7ROfPhDuh7DxTTydh97OC+lv7h1Eq5LuHWuLsUMKOhtzTYuyXlUReuwZ9vANDHo4CS1bGRrn7TZRtg==",
+      "version": "10.7.7",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.7.tgz",
+      "integrity": "sha512-F134jIoeYMro/3I0h08D0Yt4N9o9pjddU/4IIxMMURqbAtI2wu70X8hvG1V48W49zXHXv3RKSF/po+0fDfsGjA==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.1",
-        "@formatjs/fast-memoize": "2.2.2",
-        "@formatjs/icu-messageformat-parser": "2.9.1",
+        "@formatjs/ecma402-abstract": "2.2.4",
+        "@formatjs/fast-memoize": "2.2.3",
+        "@formatjs/icu-messageformat-parser": "2.9.4",
         "tslib": "2"
       }
     },

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -58,7 +58,7 @@
         "ember-modifier": "^4.2.0",
         "ember-page-title": "^8.2.3",
         "ember-qunit": "^8.1.1",
-        "ember-resolver": "^12.0.0",
+        "ember-resolver": "^12.0.1",
         "ember-simple-auth": "^6.1.0",
         "ember-source": "^5.8.0",
         "ember-template-imports": "^4.1.1",
@@ -26602,7 +26602,6 @@
       "resolved": "https://registry.npmjs.org/ember-resolver/-/ember-resolver-12.0.1.tgz",
       "integrity": "sha512-U+ZBdbEHMhmvcZly1xhZKwqeH5/igjT93p9bbD6x+mQVg7hm4jrsQA4jsxHu3BqgL5MmqOVx0gtAuYEWV1x2MQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ember-cli-babel": "^7.26.11"
       },

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -78,7 +78,7 @@
         "prettier": "^3.4.2",
         "prettier-plugin-ember-template-tag": "^2.0.4",
         "qunit": "^2.23.1",
-        "qunit-dom": "^3.0.0",
+        "qunit-dom": "^3.4.0",
         "sass": "^1.66.1",
         "sinon": "^19.0.0",
         "stylelint": "^16.0.0",
@@ -36669,11 +36669,10 @@
       }
     },
     "node_modules/qunit-dom": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/qunit-dom/-/qunit-dom-3.2.1.tgz",
-      "integrity": "sha512-+qSm8zQ7hPA9NijmTDVsUFNGEFP/K+DTymjlsU01O3NhkGtb9rsZRztJXwaiAlmVSX4vSzjydPxpZCRhpWIq4A==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/qunit-dom/-/qunit-dom-3.4.0.tgz",
+      "integrity": "sha512-N5PYbJ20RD3JZN4whINdl7dDfxScUy7eNuO8IwUtBWC7d6SH+BqtBqVZdRn9evxLQVzuask6OGvMy4gdpiCceg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "dom-element-descriptors": "^0.5.1"
       }

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -23,7 +23,7 @@
         "@ember/test-helpers": "^3.3.1",
         "@embroider/compat": "^3.7.1",
         "@embroider/core": "^3.4.20",
-        "@embroider/macros": "^1.13.3",
+        "@embroider/macros": "^1.16.10",
         "@embroider/webpack": "^4.0.0",
         "@formatjs/intl": "^2.10.4",
         "@glimmer/component": "^1.1.2",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -74,7 +74,7 @@
         "loader.js": "^4.7.0",
         "lodash": "^4.17.21",
         "miragejs": "^0.1.48",
-        "p-queue": "^8.0.0",
+        "p-queue": "^8.0.1",
         "prettier": "^3.3.2",
         "prettier-plugin-ember-template-tag": "^2.0.2",
         "qunit": "^2.19.3",
@@ -35333,7 +35333,6 @@
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.0.1.tgz",
       "integrity": "sha512-NXzu9aQJTAzbBqOt2hwsR63ea7yvxJc0PwN/zobNAudYfb1B7R08SzB4TsLeSbUCuG467NhnoT0oO6w1qRO+BA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.1",
         "p-timeout": "^6.1.2"

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -73,7 +73,7 @@
         "eslint-plugin-qunit": "^8.0.0",
         "loader.js": "^4.7.0",
         "lodash": "^4.17.21",
-        "miragejs": "^0.1.46",
+        "miragejs": "^0.1.48",
         "p-queue": "^8.0.0",
         "prettier": "^3.3.2",
         "prettier-plugin-ember-template-tag": "^2.0.2",
@@ -34298,7 +34298,6 @@
       "resolved": "https://registry.npmjs.org/miragejs/-/miragejs-0.1.48.tgz",
       "integrity": "sha512-MGZAq0Q3OuRYgZKvlB69z4gLN4G3PvgC4A2zhkCXCXrLD5wm2cCnwNB59xOBVA+srZ0zEes6u+VylcPIkB4SqA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@miragejs/pretender-node-polyfill": "^0.1.0",
         "inflected": "^2.0.4",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -81,7 +81,7 @@
         "qunit-dom": "^3.4.0",
         "sass": "^1.83.0",
         "sinon": "^19.0.2",
-        "stylelint": "^16.0.0",
+        "stylelint": "^16.12.0",
         "tracked-built-ins": "^3.2.0",
         "webpack": "^5.76.2"
       },
@@ -3459,9 +3459,9 @@
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.3.tgz",
-      "integrity": "sha512-15WQTALDyxAwSgAvLt7BksAssiSrNNhTv4zM7qX9U6R7FtpNskVVakzWQlYODlwPwXhGpKPmB10LM943pxMe7w==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.4.tgz",
+      "integrity": "sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A==",
       "dev": true,
       "funding": [
         {
@@ -3473,12 +3473,11 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-tokenizer": "^3.0.2"
+        "@csstools/css-tokenizer": "^3.0.3"
       }
     },
     "node_modules/@csstools/css-tokenizer": {
@@ -3496,15 +3495,14 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@csstools/media-query-list-parser": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-3.0.1.tgz",
-      "integrity": "sha512-HNo8gGD02kHmcbX6PvCoUuOQvn4szyB9ca63vZHKX5A81QytgDG4oxG4IaEfHTlEZSZ6MjPEMWIVU+zF2PZcgw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.2.tgz",
+      "integrity": "sha512-EUos465uvVvMJehckATTlNqGj4UJWkTmdWuDMjqvSUkjGpmOyFZBVwb4knxCm/k2GMTXY+c/5RkdndzFYWeX5A==",
       "dev": true,
       "funding": [
         {
@@ -3516,36 +3514,12 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.1",
-        "@csstools/css-tokenizer": "^3.0.1"
-      }
-    },
-    "node_modules/@csstools/selector-specificity": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-4.0.0.tgz",
-      "integrity": "sha512-189nelqtPd8++phaHNwYovKZI0FOzH1vQEE3QhHHkNIGrg5fSs9CbYP3RvfEH5geztnIA9Jwq91wyOIwAW5JIQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "postcss-selector-parser": "^6.1.0"
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3"
       }
     },
     "node_modules/@dual-bundle/import-meta-resolve": {
@@ -10874,7 +10848,6 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -33562,8 +33535,7 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
@@ -35872,9 +35844,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.47",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
-      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+      "version": "8.4.49",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
       "dev": true,
       "funding": [
         {
@@ -35890,10 +35862,9 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.7",
-        "picocolors": "^1.1.0",
+        "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
@@ -38336,7 +38307,6 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
       "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -39184,9 +39154,9 @@
       "license": "MIT"
     },
     "node_modules/stylelint": {
-      "version": "16.10.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.10.0.tgz",
-      "integrity": "sha512-z/8X2rZ52dt2c0stVwI9QL2AFJhLhbPkyfpDFcizs200V/g7v+UYY6SNcB9hKOLcDDX/yGLDsY/pX08sLkz9xQ==",
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.12.0.tgz",
+      "integrity": "sha512-F8zZ3L/rBpuoBZRvI4JVT20ZanPLXfQLzMOZg1tzPflRVh9mKpOZ8qcSIhh1my3FjAjZWG4T2POwGnmn6a6hbg==",
       "dev": true,
       "funding": [
         {
@@ -39198,18 +39168,17 @@
           "url": "https://github.com/sponsors/stylelint"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.1",
-        "@csstools/css-tokenizer": "^3.0.1",
-        "@csstools/media-query-list-parser": "^3.0.1",
-        "@csstools/selector-specificity": "^4.0.0",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "@csstools/media-query-list-parser": "^4.0.2",
+        "@csstools/selector-specificity": "^5.0.0",
         "@dual-bundle/import-meta-resolve": "^4.1.0",
         "balanced-match": "^2.0.0",
         "colord": "^2.9.3",
         "cosmiconfig": "^9.0.0",
         "css-functions-list": "^3.2.3",
-        "css-tree": "^3.0.0",
+        "css-tree": "^3.0.1",
         "debug": "^4.3.7",
         "fast-glob": "^3.3.2",
         "fastest-levenshtein": "^1.0.16",
@@ -39221,22 +39190,22 @@
         "ignore": "^6.0.2",
         "imurmurhash": "^0.1.4",
         "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.34.0",
+        "known-css-properties": "^0.35.0",
         "mathml-tag-names": "^2.1.3",
         "meow": "^13.2.0",
         "micromatch": "^4.0.8",
         "normalize-path": "^3.0.0",
-        "picocolors": "^1.0.1",
-        "postcss": "^8.4.47",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.49",
         "postcss-resolve-nested-selector": "^0.1.6",
         "postcss-safe-parser": "^7.0.1",
-        "postcss-selector-parser": "^6.1.2",
+        "postcss-selector-parser": "^7.0.0",
         "postcss-value-parser": "^4.2.0",
         "resolve-from": "^5.0.0",
         "string-width": "^4.2.3",
         "supports-hyperlinks": "^3.1.0",
         "svg-tags": "^1.0.0",
-        "table": "^6.8.2",
+        "table": "^6.9.0",
         "write-file-atomic": "^5.0.1"
       },
       "bin": {
@@ -39393,6 +39362,28 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/stylelint/node_modules/@csstools/selector-specificity": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
+      "integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      }
+    },
     "node_modules/stylelint/node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -39411,13 +39402,12 @@
       "license": "MIT"
     },
     "node_modules/stylelint/node_modules/css-tree": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.0.0.tgz",
-      "integrity": "sha512-o88DVQ6GzsABn1+6+zo2ct801dBO5OASVyxbbvA2W20ue2puSh/VOuqUj90eUeMSX/xqGqBmOKiRQN7tJOuBXw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "mdn-data": "2.10.0",
+        "mdn-data": "2.12.2",
         "source-map-js": "^1.0.1"
       },
       "engines": {
@@ -39533,12 +39523,17 @@
         "node": ">= 4"
       }
     },
+    "node_modules/stylelint/node_modules/known-css-properties": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.35.0.tgz",
+      "integrity": "sha512-a/RAk2BfKk+WFGhhOCAYqSiFLc34k8Mt/6NWRI4joER0EYUzXIcFivjjnoD3+XU1DggLn/tZc3DOAgke7l8a4A==",
+      "dev": true
+    },
     "node_modules/stylelint/node_modules/mdn-data": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.10.0.tgz",
-      "integrity": "sha512-qq7C3EtK3yJXMwz1zAab65pjl+UhohqMOctTgcqjLOWABqmwj+me02LSsCuEUxnst9X1lCBpoE0WArGKgdGDzw==",
-      "dev": true,
-      "license": "CC0-1.0"
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true
     },
     "node_modules/stylelint/node_modules/normalize-path": {
       "version": "3.0.0",
@@ -39558,6 +39553,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stylelint/node_modules/postcss-selector-parser": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
+      "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/stylelint/node_modules/resolve-from": {
@@ -39771,11 +39779,10 @@
       }
     },
     "node_modules/table": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.8.2.tgz",
-      "integrity": "sha512-w2sfv80nrAh2VCbqR5AK27wswXhqcck2AhfnNW76beQXskGZ1V12GwS//yYVa3d3fcvAip2OUnbDAjW2k3v9fA==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "ajv": "^8.0.1",
         "lodash.truncate": "^4.4.2",
@@ -39792,7 +39799,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -39808,8 +39814,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/tap-parser": {
       "version": "7.0.0",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -80,7 +80,7 @@
         "qunit": "^2.23.1",
         "qunit-dom": "^3.4.0",
         "sass": "^1.83.0",
-        "sinon": "^19.0.0",
+        "sinon": "^19.0.2",
         "stylelint": "^16.0.0",
         "tracked-built-ins": "^3.2.0",
         "webpack": "^5.76.2"
@@ -38285,7 +38285,6 @@
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-19.0.2.tgz",
       "integrity": "sha512-euuToqM+PjO4UgXeLETsfQiuoyPXlqFezr6YZDFwHR3t4qaX0fZUe1MfPMznTL5f8BWrVS89KduLdMUsxFCO6g==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
         "@sinonjs/fake-timers": "^13.0.2",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -17,7 +17,7 @@
         "@1024pix/stylelint-config": "^5.1.25",
         "@babel/eslint-parser": "^7.25.9",
         "@babel/plugin-proposal-decorators": "^7.25.9",
-        "@ember-data/model": "^5.3.2",
+        "@ember-data/model": "^5.3.9",
         "@ember/optional-features": "^2.0.0",
         "@ember/string": "^3.1.1",
         "@ember/test-helpers": "^3.1.0",
@@ -3650,7 +3650,6 @@
       "resolved": "https://registry.npmjs.org/@ember-data/model/-/model-5.3.9.tgz",
       "integrity": "sha512-cYNkxiAvTCO67FMuPDagvvs/iYr68l9Dg40qB7em1Jhy0QmwpajvxkyEaj6q/fOrGaH69KmzHJhOvu4eKGTz8Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@ember/edition-utils": "^1.2.0",
         "@embroider/macros": "^1.16.6",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -45,7 +45,7 @@
         "ember-cookies": "^1.3.0",
         "ember-data": "^5.3.9",
         "ember-dayjs": "^0.12.4",
-        "ember-eslint-parser": "^0.5.0",
+        "ember-eslint-parser": "^0.5.7",
         "ember-exam": "9.0.0",
         "ember-fetch": "^8.1.2",
         "ember-file-upload": "^9.0.0",
@@ -21918,17 +21918,18 @@
       }
     },
     "node_modules/ember-eslint-parser": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/ember-eslint-parser/-/ember-eslint-parser-0.5.3.tgz",
-      "integrity": "sha512-FYsoiVcGUGDAybPq8X551hcs9NA0SDx77kfU1sHCTLYqfG4zQ0Rcy+lGxoaXaskH7sTf+Up3/oVyjx/+nJ3joA==",
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/ember-eslint-parser/-/ember-eslint-parser-0.5.7.tgz",
+      "integrity": "sha512-d0nIQxC6TXsMebi7GcpH6meFDVhTUTYZpQ6Yg5n92+eZHqygAEKWZX55lLa49/wucBXS+Wadp2g6okPcN463aA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "@babel/eslint-parser": "^7.23.10",
         "@glimmer/syntax": "^0.92.0",
         "content-tag": "^2.0.1",
         "eslint-scope": "^7.2.2",
-        "html-tags": "^3.3.1"
+        "html-tags": "^3.3.1",
+        "mathml-tag-names": "^2.1.3",
+        "svg-tags": "^1.0.0"
       },
       "engines": {
         "node": ">=16.0.0"

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -64,7 +64,7 @@
         "ember-template-imports": "^4.2.0",
         "ember-template-lint": "^6.0.0",
         "ember-template-lint-plugin-prettier": "^5.0.0",
-        "ember-truth-helpers": "^4.0.0",
+        "ember-truth-helpers": "^4.0.3",
         "eslint": "^8.48.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-ember": "^12.1.1",
@@ -28672,7 +28672,6 @@
       "resolved": "https://registry.npmjs.org/ember-truth-helpers/-/ember-truth-helpers-4.0.3.tgz",
       "integrity": "sha512-T6Ogd3pk9FxYiZfSxdjgn3Hb3Ksqgw7CD23V9qfig9jktNdkNEHo4+3PA3cSD/+3a2kdH3KmNvKyarVuzdtEkA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@embroider/addon-shim": "^1.8.6",
         "ember-functions-as-helper-polyfill": "^2.1.2"

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -22,7 +22,7 @@
         "@ember/string": "^3.1.1",
         "@ember/test-helpers": "^3.3.1",
         "@embroider/compat": "^3.7.1",
-        "@embroider/core": "^3.0.0",
+        "@embroider/core": "^3.4.20",
         "@embroider/macros": "^1.13.3",
         "@embroider/webpack": "^4.0.0",
         "@formatjs/intl": "^2.10.4",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -55,7 +55,7 @@
         "ember-keyboard": "^9.0.1",
         "ember-lifeline": "^7.0.0",
         "ember-load-initializers": "^3.0.1",
-        "ember-modifier": "^4.1.0",
+        "ember-modifier": "^4.2.0",
         "ember-page-title": "^8.0.0",
         "ember-qunit": "^8.1.0",
         "ember-resolver": "^12.0.0",
@@ -25819,7 +25819,6 @@
       "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-4.2.0.tgz",
       "integrity": "sha512-BJ48eTEGxD8J7+lofwVmee7xDgNDgpr5dd6+MSu4gk+I6xb35099RMNorXY5hjjwMJEyi/IRR6Yn3M7iJMz8Zw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@embroider/addon-shim": "^1.8.7",
         "decorator-transforms": "^2.0.0",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -57,7 +57,7 @@
         "ember-load-initializers": "^3.0.1",
         "ember-modifier": "^4.2.0",
         "ember-page-title": "^8.2.3",
-        "ember-qunit": "^8.1.0",
+        "ember-qunit": "^8.1.1",
         "ember-resolver": "^12.0.0",
         "ember-simple-auth": "^6.1.0",
         "ember-source": "^5.8.0",
@@ -26581,11 +26581,10 @@
       }
     },
     "node_modules/ember-qunit": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/ember-qunit/-/ember-qunit-8.1.0.tgz",
-      "integrity": "sha512-55/xqvVQwhiNcnh/tCzWyvlYzrYqwDY0/cIPyDQbAxGKtkUt9jCfRUGllfyOofC6LX0fL/0fIi+5e9sg1m6vXw==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/ember-qunit/-/ember-qunit-8.1.1.tgz",
+      "integrity": "sha512-nT+6s74j3BKNn+QQY/hINC3Xw3kn0NF0cU9zlgVQmCBWoyis1J24xWrY2LFOMThPmF6lHqcrUb5JwvBD4BXEXg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@embroider/addon-shim": "^1.8.6",
         "@embroider/macros": "^1.13.1",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -82,7 +82,7 @@
         "sass": "^1.83.0",
         "sinon": "^19.0.2",
         "stylelint": "^16.12.0",
-        "tracked-built-ins": "^3.2.0",
+        "tracked-built-ins": "^3.4.0",
         "webpack": "^5.76.2"
       },
       "engines": {
@@ -40643,13 +40643,13 @@
       }
     },
     "node_modules/tracked-built-ins": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/tracked-built-ins/-/tracked-built-ins-3.3.0.tgz",
-      "integrity": "sha512-ewKFrW/AQs05oLPM5isOUb/1aOwBRfHfmF408CCzTk21FLAhKrKVOP5Q5ebX+zCT4kvg81PGBGwrBiEGND1nWA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/tracked-built-ins/-/tracked-built-ins-3.4.0.tgz",
+      "integrity": "sha512-aRwWQXC3VkY50oYxS7wKZiavkjf3uaN+UYUH30D5gxUqbxDN2LnNsfWyDfckmxHUGw4gJDH5lpRS0jX/tim0vw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@embroider/addon-shim": "^1.8.3",
+        "@embroider/addon-shim": "^1.8.7",
+        "decorator-transforms": "^2.0.0",
         "ember-tracked-storage-polyfill": "^1.0.0"
       }
     },

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -61,7 +61,7 @@
         "ember-resolver": "^12.0.1",
         "ember-simple-auth": "^6.1.0",
         "ember-source": "^5.8.0",
-        "ember-template-imports": "^4.1.1",
+        "ember-template-imports": "^4.2.0",
         "ember-template-lint": "^6.0.0",
         "ember-template-lint-plugin-prettier": "^5.0.0",
         "ember-truth-helpers": "^4.0.0",
@@ -27467,19 +27467,24 @@
       }
     },
     "node_modules/ember-template-imports": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ember-template-imports/-/ember-template-imports-4.1.3.tgz",
-      "integrity": "sha512-0R7FBozyG2lLH7DxeB8w/PVsdQdG2W+jZx8Y9aPWtfV7qjZlsZ9mfRgn1acF0OD1J5wEUduaSC4MAmWL+A7maQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ember-template-imports/-/ember-template-imports-4.2.0.tgz",
+      "integrity": "sha512-qwf/38E1ut8M2/1tsFJl6kL99799MvxQrx0lN3LAc0HJRQhM/lYHqnHhzS30rkH76g+76TfxcMB5JJZQabWk2A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "broccoli-stew": "^3.0.0",
-        "content-tag": "^2.0.1",
+        "content-tag": "^3.0.0",
         "ember-cli-version-checker": "^5.1.2"
       },
       "engines": {
         "node": "16.* || >= 18"
       }
+    },
+    "node_modules/ember-template-imports/node_modules/content-tag": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/content-tag/-/content-tag-3.1.0.tgz",
+      "integrity": "sha512-gSESx+fia81/vKjorui0V6wY7IBpuitd84LcQnaPVF9Xe9ctLAf4saHwbUi3SAhYfi9kxs5ODfAVnm5MmjojCQ==",
+      "dev": true
     },
     "node_modules/ember-template-lint": {
       "version": "6.0.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -95,7 +95,7 @@
     "ember-keyboard": "^9.0.1",
     "ember-lifeline": "^7.0.0",
     "ember-load-initializers": "^3.0.1",
-    "ember-modifier": "^4.1.0",
+    "ember-modifier": "^4.2.0",
     "ember-page-title": "^8.0.0",
     "ember-qunit": "^8.1.0",
     "ember-resolver": "^12.0.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -115,7 +115,7 @@
     "lodash": "^4.17.21",
     "miragejs": "^0.1.48",
     "p-queue": "^8.0.1",
-    "prettier": "^3.3.2",
+    "prettier": "^3.4.2",
     "prettier-plugin-ember-template-tag": "^2.0.2",
     "qunit": "^2.19.3",
     "qunit-dom": "^3.0.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -97,7 +97,7 @@
     "ember-load-initializers": "^3.0.1",
     "ember-modifier": "^4.2.0",
     "ember-page-title": "^8.2.3",
-    "ember-qunit": "^8.1.0",
+    "ember-qunit": "^8.1.1",
     "ember-resolver": "^12.0.0",
     "ember-simple-auth": "^6.1.0",
     "ember-source": "^5.8.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -121,7 +121,7 @@
     "qunit-dom": "^3.4.0",
     "sass": "^1.83.0",
     "sinon": "^19.0.2",
-    "stylelint": "^16.0.0",
+    "stylelint": "^16.12.0",
     "tracked-built-ins": "^3.2.0",
     "webpack": "^5.76.2"
   }

--- a/certif/package.json
+++ b/certif/package.json
@@ -62,7 +62,7 @@
     "@ember/string": "^3.1.1",
     "@ember/test-helpers": "^3.3.1",
     "@embroider/compat": "^3.7.1",
-    "@embroider/core": "^3.0.0",
+    "@embroider/core": "^3.4.20",
     "@embroider/macros": "^1.13.3",
     "@embroider/webpack": "^4.0.0",
     "@formatjs/intl": "^2.10.4",

--- a/certif/package.json
+++ b/certif/package.json
@@ -69,7 +69,7 @@
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "dayjs": "^1.11.6",
-    "ember-auto-import": "^2.4.3",
+    "ember-auto-import": "^2.10.0",
     "ember-cli": "^5.8.1",
     "ember-cli-app-version": "^7.0.0",
     "ember-cli-babel": "^8.0.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -91,7 +91,7 @@
     "ember-file-upload": "^9.1.0",
     "ember-flatpickr": "^8.0.1",
     "ember-inputmask5": "^4.0.2",
-    "ember-intl": "^7.0.0",
+    "ember-intl": "^7.1.0",
     "ember-keyboard": "^9.0.0",
     "ember-lifeline": "^7.0.0",
     "ember-load-initializers": "^3.0.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -85,7 +85,7 @@
     "ember-cookies": "^1.3.0",
     "ember-data": "^5.3.9",
     "ember-dayjs": "^0.12.4",
-    "ember-eslint-parser": "^0.5.0",
+    "ember-eslint-parser": "^0.5.7",
     "ember-exam": "9.0.0",
     "ember-fetch": "^8.1.2",
     "ember-file-upload": "^9.0.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -56,7 +56,7 @@
     "@1024pix/pix-ui": "^52.0.3",
     "@1024pix/stylelint-config": "^5.1.25",
     "@babel/eslint-parser": "^7.25.9",
-    "@babel/plugin-proposal-decorators": "^7.22.15",
+    "@babel/plugin-proposal-decorators": "^7.25.9",
     "@ember-data/model": "^5.3.2",
     "@ember/optional-features": "^2.0.0",
     "@ember/string": "^3.1.1",

--- a/certif/package.json
+++ b/certif/package.json
@@ -84,7 +84,7 @@
     "ember-composable-helpers": "^5.0.0",
     "ember-cookies": "^1.3.0",
     "ember-data": "^5.3.9",
-    "ember-dayjs": "^0.12.0",
+    "ember-dayjs": "^0.12.4",
     "ember-eslint-parser": "^0.5.0",
     "ember-exam": "9.0.0",
     "ember-fetch": "^8.1.2",

--- a/certif/package.json
+++ b/certif/package.json
@@ -61,7 +61,7 @@
     "@ember/optional-features": "^2.2.0",
     "@ember/string": "^3.1.1",
     "@ember/test-helpers": "^3.3.1",
-    "@embroider/compat": "^3.0.0",
+    "@embroider/compat": "^3.7.1",
     "@embroider/core": "^3.0.0",
     "@embroider/macros": "^1.13.3",
     "@embroider/webpack": "^4.0.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -122,7 +122,7 @@
     "sass": "^1.83.0",
     "sinon": "^19.0.2",
     "stylelint": "^16.12.0",
-    "tracked-built-ins": "^3.2.0",
+    "tracked-built-ins": "^3.4.0",
     "webpack": "^5.76.2"
   }
 }

--- a/certif/package.json
+++ b/certif/package.json
@@ -89,7 +89,7 @@
     "ember-exam": "9.0.0",
     "ember-fetch": "^8.1.2",
     "ember-file-upload": "^9.1.0",
-    "ember-flatpickr": "^8.0.0",
+    "ember-flatpickr": "^8.0.1",
     "ember-inputmask5": "^4.0.2",
     "ember-intl": "^7.0.0",
     "ember-keyboard": "^9.0.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -60,7 +60,7 @@
     "@ember-data/model": "^5.3.9",
     "@ember/optional-features": "^2.2.0",
     "@ember/string": "^3.1.1",
-    "@ember/test-helpers": "^3.1.0",
+    "@ember/test-helpers": "^3.3.1",
     "@embroider/compat": "^3.0.0",
     "@embroider/core": "^3.0.0",
     "@embroider/macros": "^1.13.3",

--- a/certif/package.json
+++ b/certif/package.json
@@ -55,7 +55,7 @@
     "@1024pix/eslint-config": "^1.3.8",
     "@1024pix/pix-ui": "^52.0.3",
     "@1024pix/stylelint-config": "^5.1.25",
-    "@babel/eslint-parser": "^7.22.15",
+    "@babel/eslint-parser": "^7.25.9",
     "@babel/plugin-proposal-decorators": "^7.22.15",
     "@ember-data/model": "^5.3.2",
     "@ember/optional-features": "^2.0.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -92,7 +92,7 @@
     "ember-flatpickr": "^8.0.1",
     "ember-inputmask5": "^4.0.2",
     "ember-intl": "^7.1.0",
-    "ember-keyboard": "^9.0.0",
+    "ember-keyboard": "^9.0.1",
     "ember-lifeline": "^7.0.0",
     "ember-load-initializers": "^3.0.0",
     "ember-modifier": "^4.1.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -63,7 +63,7 @@
     "@ember/test-helpers": "^3.3.1",
     "@embroider/compat": "^3.7.1",
     "@embroider/core": "^3.4.20",
-    "@embroider/macros": "^1.13.3",
+    "@embroider/macros": "^1.16.10",
     "@embroider/webpack": "^4.0.0",
     "@formatjs/intl": "^2.10.4",
     "@glimmer/component": "^1.1.2",

--- a/certif/package.json
+++ b/certif/package.json
@@ -57,7 +57,7 @@
     "@1024pix/stylelint-config": "^5.1.25",
     "@babel/eslint-parser": "^7.25.9",
     "@babel/plugin-proposal-decorators": "^7.25.9",
-    "@ember-data/model": "^5.3.2",
+    "@ember-data/model": "^5.3.9",
     "@ember/optional-features": "^2.0.0",
     "@ember/string": "^3.1.1",
     "@ember/test-helpers": "^3.1.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -123,6 +123,6 @@
     "sinon": "^19.0.2",
     "stylelint": "^16.12.0",
     "tracked-built-ins": "^3.4.0",
-    "webpack": "^5.76.2"
+    "webpack": "^5.97.1"
   }
 }

--- a/certif/package.json
+++ b/certif/package.json
@@ -101,7 +101,7 @@
     "ember-resolver": "^12.0.1",
     "ember-simple-auth": "^6.1.0",
     "ember-source": "^5.8.0",
-    "ember-template-imports": "^4.1.1",
+    "ember-template-imports": "^4.2.0",
     "ember-template-lint": "^6.0.0",
     "ember-template-lint-plugin-prettier": "^5.0.0",
     "ember-truth-helpers": "^4.0.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -120,7 +120,7 @@
     "qunit": "^2.23.1",
     "qunit-dom": "^3.4.0",
     "sass": "^1.83.0",
-    "sinon": "^19.0.0",
+    "sinon": "^19.0.2",
     "stylelint": "^16.0.0",
     "tracked-built-ins": "^3.2.0",
     "webpack": "^5.76.2"

--- a/certif/package.json
+++ b/certif/package.json
@@ -65,7 +65,7 @@
     "@embroider/core": "^3.4.20",
     "@embroider/macros": "^1.16.10",
     "@embroider/webpack": "^4.0.9",
-    "@formatjs/intl": "^2.10.4",
+    "@formatjs/intl": "^2.10.15",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "dayjs": "^1.11.6",

--- a/certif/package.json
+++ b/certif/package.json
@@ -104,7 +104,7 @@
     "ember-template-imports": "^4.2.0",
     "ember-template-lint": "^6.0.0",
     "ember-template-lint-plugin-prettier": "^5.0.0",
-    "ember-truth-helpers": "^4.0.0",
+    "ember-truth-helpers": "^4.0.3",
     "eslint": "^8.48.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-ember": "^12.1.1",

--- a/certif/package.json
+++ b/certif/package.json
@@ -117,7 +117,7 @@
     "p-queue": "^8.0.1",
     "prettier": "^3.4.2",
     "prettier-plugin-ember-template-tag": "^2.0.4",
-    "qunit": "^2.19.3",
+    "qunit": "^2.23.1",
     "qunit-dom": "^3.0.0",
     "sass": "^1.66.1",
     "sinon": "^19.0.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -83,7 +83,7 @@
     "ember-cli-sass": "^11.0.1",
     "ember-composable-helpers": "^5.0.0",
     "ember-cookies": "^1.0.0",
-    "ember-data": "^5.3.2",
+    "ember-data": "^5.3.9",
     "ember-dayjs": "^0.12.0",
     "ember-eslint-parser": "^0.5.0",
     "ember-exam": "9.0.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -88,7 +88,7 @@
     "ember-eslint-parser": "^0.5.7",
     "ember-exam": "9.0.0",
     "ember-fetch": "^8.1.2",
-    "ember-file-upload": "^9.0.0",
+    "ember-file-upload": "^9.1.0",
     "ember-flatpickr": "^8.0.0",
     "ember-inputmask5": "^4.0.2",
     "ember-intl": "^7.0.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -113,7 +113,7 @@
     "eslint-plugin-qunit": "^8.0.0",
     "loader.js": "^4.7.0",
     "lodash": "^4.17.21",
-    "miragejs": "^0.1.46",
+    "miragejs": "^0.1.48",
     "p-queue": "^8.0.0",
     "prettier": "^3.3.2",
     "prettier-plugin-ember-template-tag": "^2.0.2",

--- a/certif/package.json
+++ b/certif/package.json
@@ -58,7 +58,7 @@
     "@babel/eslint-parser": "^7.25.9",
     "@babel/plugin-proposal-decorators": "^7.25.9",
     "@ember-data/model": "^5.3.9",
-    "@ember/optional-features": "^2.0.0",
+    "@ember/optional-features": "^2.2.0",
     "@ember/string": "^3.1.1",
     "@ember/test-helpers": "^3.1.0",
     "@embroider/compat": "^3.0.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -64,7 +64,7 @@
     "@embroider/compat": "^3.7.1",
     "@embroider/core": "^3.4.20",
     "@embroider/macros": "^1.16.10",
-    "@embroider/webpack": "^4.0.0",
+    "@embroider/webpack": "^4.0.9",
     "@formatjs/intl": "^2.10.4",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",

--- a/certif/package.json
+++ b/certif/package.json
@@ -82,7 +82,7 @@
     "ember-cli-mirage": "^3.0.3",
     "ember-cli-sass": "^11.0.1",
     "ember-composable-helpers": "^5.0.0",
-    "ember-cookies": "^1.0.0",
+    "ember-cookies": "^1.3.0",
     "ember-data": "^5.3.9",
     "ember-dayjs": "^0.12.0",
     "ember-eslint-parser": "^0.5.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -96,7 +96,7 @@
     "ember-lifeline": "^7.0.0",
     "ember-load-initializers": "^3.0.1",
     "ember-modifier": "^4.2.0",
-    "ember-page-title": "^8.0.0",
+    "ember-page-title": "^8.2.3",
     "ember-qunit": "^8.1.0",
     "ember-resolver": "^12.0.0",
     "ember-simple-auth": "^6.1.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -119,7 +119,7 @@
     "prettier-plugin-ember-template-tag": "^2.0.4",
     "qunit": "^2.23.1",
     "qunit-dom": "^3.4.0",
-    "sass": "^1.66.1",
+    "sass": "^1.83.0",
     "sinon": "^19.0.0",
     "stylelint": "^16.0.0",
     "tracked-built-ins": "^3.2.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -98,7 +98,7 @@
     "ember-modifier": "^4.2.0",
     "ember-page-title": "^8.2.3",
     "ember-qunit": "^8.1.1",
-    "ember-resolver": "^12.0.0",
+    "ember-resolver": "^12.0.1",
     "ember-simple-auth": "^6.1.0",
     "ember-source": "^5.8.0",
     "ember-template-imports": "^4.1.1",

--- a/certif/package.json
+++ b/certif/package.json
@@ -114,7 +114,7 @@
     "loader.js": "^4.7.0",
     "lodash": "^4.17.21",
     "miragejs": "^0.1.48",
-    "p-queue": "^8.0.0",
+    "p-queue": "^8.0.1",
     "prettier": "^3.3.2",
     "prettier-plugin-ember-template-tag": "^2.0.2",
     "qunit": "^2.19.3",

--- a/certif/package.json
+++ b/certif/package.json
@@ -116,7 +116,7 @@
     "miragejs": "^0.1.48",
     "p-queue": "^8.0.1",
     "prettier": "^3.4.2",
-    "prettier-plugin-ember-template-tag": "^2.0.2",
+    "prettier-plugin-ember-template-tag": "^2.0.4",
     "qunit": "^2.19.3",
     "qunit-dom": "^3.0.0",
     "sass": "^1.66.1",

--- a/certif/package.json
+++ b/certif/package.json
@@ -118,7 +118,7 @@
     "prettier": "^3.4.2",
     "prettier-plugin-ember-template-tag": "^2.0.4",
     "qunit": "^2.23.1",
-    "qunit-dom": "^3.0.0",
+    "qunit-dom": "^3.4.0",
     "sass": "^1.66.1",
     "sinon": "^19.0.0",
     "stylelint": "^16.0.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -94,7 +94,7 @@
     "ember-intl": "^7.1.0",
     "ember-keyboard": "^9.0.1",
     "ember-lifeline": "^7.0.0",
-    "ember-load-initializers": "^3.0.0",
+    "ember-load-initializers": "^3.0.1",
     "ember-modifier": "^4.1.0",
     "ember-page-title": "^8.0.0",
     "ember-qunit": "^8.1.0",

--- a/certif/tests/integration/components/session-finalization-step-container-test.js
+++ b/certif/tests/integration/components/session-finalization-step-container-test.js
@@ -9,7 +9,7 @@ module('Integration | Component | session-finalization-step-container', function
 
   test('it renders', async function (assert) {
     // when
-    const screen = await render(hbs`<SessionFinalizationStepContainer @title='Étape 1 : title'>
+    const screen = await render(hbs`<SessionFinalizationStepContainer @title='Étape 1 : title' @iconName='info'>
   template block text
 </SessionFinalizationStepContainer>`);
 


### PR DESCRIPTION
## :christmas_tree: Problème

La version 6 d'Ember est sortie.
Les dépendances actuelles de l'application Pix Certif ne sont pas à jour, ne facilitant pas la MAJ vers cette nouvelle version.

## :gift: Proposition

Mise à jour des dépendances
Suppression des alertes de dépréciation en console

Doc MAJ des méthodes de tableaux Ember vers JS natif : https://deprecations.emberjs.com/id/deprecate-array-prototype-extensions/

## :socks: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :santa: Pour tester

Tests verts
Se balader sur l'application Certif et vérifier qu'il n'y ait pas de régression
Vérifier en console qu'il n'y ait pas d'alertes liées à des dépréciations
