### PR TITLE
[TECH] Retourner une 204 No Content à l'appel GET /

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -181,6 +181,21 @@ const setupRoutesAndPlugins = async function (server) {
     ...certificationRoutes,
     ...prescriptionRoutes,
     ...parcoursupRoutes,
+    {
+      name: 'root',
+      register: async function (server) {
+        server.route([
+          {
+            method: 'GET',
+            path: '/',
+            config: {
+              auth: false,
+              handler: (_, h) => h.response().code(204),
+            },
+          },
+        ]);
+      },
+    },
   );
   await server.register(configuration);
 };

--- a/api/src/shared/infrastructure/utils/RedisClient.js
+++ b/api/src/shared/infrastructure/utils/RedisClient.js
@@ -13,7 +13,7 @@ class RedisClient {
 
     this._client.on('connect', () => logger.info({ redisClient: this._clientName }, 'Connected to server'));
     this._client.on('end', () => logger.info({ redisClient: this._clientName }, 'Disconnected from server'));
-    this._client.on('error', (err) => logger.warn({ redisClient: this._clientName, err }, 'Error encountered'));
+    this._client.on('error', (err) => logger.error({ redisClient: this._clientName, err }, 'Error encountered'));
 
     this._clientWithLock = new Redlock(
       [this._client],


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, un GET sur la route `/` renvoie une 404 ce qui cause des warnings inutiles côté Datadog.  

## :gift: Proposition
Renvoyer une 204 No Content à l'appel de GET /

## :socks: Remarques
Le niveau de log a aussi été revu dans Redis Client afin de ne pas faire apparaître les erreurs comme des warnings. 

## :santa: Pour tester
Aller sur https://pix-api-review-pr10927.osc-fr1.scalingo.io/ et vérifier que le server renvoie bien une 204.
