### PR TITLE
[TECH] Étoffer la documentation de l'endpoint Parcoursup (PIX-15891).

### DIFF
--- a/api/src/parcoursup/application/certification-route.js
+++ b/api/src/parcoursup/application/certification-route.js
@@ -1,6 +1,7 @@
 import Joi from 'joi';
 
 import { studentIdentifierType } from '../../shared/domain/types/identifiers-type.js';
+import { responseObjectErrorDoc } from '../../shared/infrastructure/open-api-doc/response-object-error-doc.js';
 import { certificationController } from './certification-controller.js';
 
 const register = async function (server) {
@@ -20,6 +21,33 @@ const register = async function (server) {
         '- **Cette route est accessible uniquement à Parcours Sup**\n' +
           '- Récupère les informations de la dernière certification de l‘année en cours pour l‘élève identifié via son INE',
       ],
+      response: {
+        failAction: 'log',
+        status: {
+          200: Joi.object({
+            organizationUai: Joi.string().description('UAI de l‘établissement scolaire'),
+            ine: Joi.string().description('INE de l‘élève'),
+            lastName: Joi.string().description('Nom de famille de l‘élève'),
+            firstName: Joi.string().description('Prénom de l‘élève'),
+            birthdate: Joi.date().description('Date de naissance au format JJ/MM/AAAA'),
+            status: Joi.string().description('Statut de la certification'),
+            pixScore: Joi.number().min(0).max(1024).description('Score en nombre de pix'),
+            certificationDate: Joi.date().description('Date de passage de la certification'),
+            competences: Joi.array()
+              .items(
+                Joi.object({
+                  id: Joi.string().description('identifiant unique de la compétence'),
+                  level: Joi.number().min(0).max(8).description('niveau obtenu sur la compétence'),
+                }).label('Competence-Result-Object'),
+              )
+              .description('Résultats par compétence')
+              .label('Competence-Results-Array'),
+          }).label('Certification-Result-Object'),
+          401: responseObjectErrorDoc,
+          403: responseObjectErrorDoc,
+          404: responseObjectErrorDoc,
+        },
+      },
     },
   });
 };

--- a/api/src/parcoursup/application/certification-route.js
+++ b/api/src/parcoursup/application/certification-route.js
@@ -36,8 +36,8 @@ const register = async function (server) {
             competences: Joi.array()
               .items(
                 Joi.object({
-                  id: Joi.string().description('identifiant unique de la compétence'),
-                  level: Joi.number().min(0).max(8).description('niveau obtenu sur la compétence'),
+                  id: Joi.string().description('Identifiant unique de la compétence'),
+                  level: Joi.number().min(0).max(8).description('Niveau obtenu sur la compétence'),
                 }).label('Competence-Result-Object'),
               )
               .description('Résultats par compétence')


### PR DESCRIPTION
## :christmas_tree: Problème

Actuellement la documentation API de notre endpoint Parcoursup manque d'informations sur les données de retour (+ les cas d'erreurs)

<img width="1461" alt="Capture d’écran 2025-01-02 à 11 21 32" src="https://github.com/user-attachments/assets/ba6696df-17e4-4a17-bbf3-466e3321022e" />


## :gift: Proposition

Étoffer la doc en ajoutant le paramètre response.

## :santa: Pour tester

- Aller sur /api/documentation
- Chercher Parcoursup
- Voir que la partie réponse contient des formats de données.

<img width="1406" alt="Capture d’écran 2025-01-02 à 11 39 40" src="https://github.com/user-attachments/assets/b2e7fe69-3499-47ea-bcd4-d3869c16a581" />
