### PR TITLE
[FEATURE] Afficher le nombre de méthodes de connexion actives dans Pix Admin (PIX-14787)

### DIFF
--- a/admin/app/models/user.js
+++ b/admin/app/models/user.js
@@ -51,4 +51,7 @@ export default class User extends Model {
   get participationCount() {
     return this.participations.length;
   }
+  get authenticationMethodCount() {
+    return this.username && this.email ? this.authenticationMethods.length + 1 : this.authenticationMethods.length;
+  }
 }

--- a/admin/app/models/user.js
+++ b/admin/app/models/user.js
@@ -42,13 +42,13 @@ export default class User extends Model {
     return this.lang?.toUpperCase();
   }
 
-  get organizationMembershipsCount() {
+  get organizationMembershipCount() {
     return this.organizationMemberships.length;
   }
-  get certificationCenterMembershipsCount() {
+  get certificationCenterMembershipCount() {
     return this.certificationCenterMemberships.length;
   }
-  get participationsCount() {
+  get participationCount() {
     return this.participations.length;
   }
 }

--- a/admin/app/templates/authenticated/users/get.hbs
+++ b/admin/app/templates/authenticated/users/get.hbs
@@ -28,7 +28,7 @@
 
     <LinkTo @route="authenticated.users.get.campaign-participations" @model={{@model}} class="navbar-item">
       {{t "pages.user-details.navbar.participations-list"}}
-      ({{@model.participationsCount}})
+      ({{@model.participationCount}})
     </LinkTo>
 
     <LinkTo
@@ -38,7 +38,7 @@
       class="navbar-item"
     >
       {{t "pages.user-details.navbar.organizations-list"}}
-      ({{@model.organizationMembershipsCount}})
+      ({{@model.organizationMembershipCount}})
     </LinkTo>
 
     <LinkTo
@@ -47,7 +47,7 @@
       class="navbar-item"
     >
       {{t "pages.user-details.navbar.certification-centers-list"}}
-      ({{@model.certificationCenterMembershipsCount}})
+      ({{@model.certificationCenterMembershipCount}})
     </LinkTo>
 
     <LinkTo

--- a/admin/app/templates/authenticated/users/get.hbs
+++ b/admin/app/templates/authenticated/users/get.hbs
@@ -20,6 +20,7 @@
 
     <LinkTo @route="authenticated.users.get.authentication-methods" @model={{@model}} class="navbar-item">
       {{t "pages.user-details.navbar.authentication-methods"}}
+      ({{@model.authenticationMethodCount}})
     </LinkTo>
 
     <LinkTo @route="authenticated.users.get.profile" @model={{@model}} class="navbar-item">


### PR DESCRIPTION
## :christmas_tree: Problème

Dans Pix Admin, sur la page d'un utilisateur, il faut cliquer sur l'onglet "Méthodes de connexion" pour savoir de combien de méthodes de connexion dispose cet utilisateur

## :gift: Proposition

Ajouter le nombre de méthodes de connexion entre parenthèses à côté du texte de l'onglet , par exemple 
"Méthodes de connexion (3)"
 comme cela existe déjà pour le nombre d'organisations ou de centre de certifications.

## :socks: Remarques

ras

## :santa: Pour tester

Se connecter sur Pix Admin avec le compte superadmin
Choisir un utilisateur ayant plusieurs méthodes de connexions, par exemple Bob Leponge (identifiant et Mediacentre).
Constater que le nombre de méthodes de connexions affiché dans l'onglet est correct (2)
Ajouter une adresse mail à cet utilisateur et vérifier que le nombre de méthode de connexions est correct (3)
Supprimer la méthode de connexion GAR et vérifier que le nombre de méthodes de connexions est repassé à 2.
