### PR TITLE
[FEATURE]  Ajoute une route parcoursup pour la récupération de certification à partir du code de vérification (PIX-15894)

### DIFF
--- a/api/datamart/datamart-builder/datamart-builder.js
+++ b/api/datamart/datamart-builder/datamart-builder.js
@@ -47,6 +47,10 @@ class DatamartBuilder {
       rawQuery += `DELETE FROM ${tableName};`;
     });
 
+    ['data_export_parcoursup_certif_result_code_validation'].forEach((tableName) => {
+      rawQuery += `DELETE FROM ${tableName};`;
+    });
+
     try {
       await this.knex.raw(rawQuery);
     } catch {

--- a/api/datamart/datamart-builder/datamart-builder.js
+++ b/api/datamart/datamart-builder/datamart-builder.js
@@ -43,13 +43,11 @@ class DatamartBuilder {
   async clean() {
     let rawQuery = '';
 
-    ['data_export_parcoursup_certif_result'].forEach((tableName) => {
-      rawQuery += `DELETE FROM ${tableName};`;
-    });
-
-    ['data_export_parcoursup_certif_result_code_validation'].forEach((tableName) => {
-      rawQuery += `DELETE FROM ${tableName};`;
-    });
+    ['data_export_parcoursup_certif_result', 'data_export_parcoursup_certif_result_code_validation'].forEach(
+      (tableName) => {
+        rawQuery += `DELETE FROM ${tableName};`;
+      },
+    );
 
     try {
       await this.knex.raw(rawQuery);

--- a/api/datamart/datamart-builder/factory/build-certification-result-code-validation.js
+++ b/api/datamart/datamart-builder/factory/build-certification-result-code-validation.js
@@ -1,0 +1,32 @@
+import { datamartBuffer } from '../datamart-buffer.js';
+
+const buildCertificationResultCodeValidation = function ({
+  verificationCode,
+  lastName,
+  firstName,
+  birthdate,
+  status,
+  pixScore,
+  certificationDate,
+  competenceId,
+  competenceLevel,
+} = {}) {
+  const values = {
+    certification_code_verification: verificationCode,
+    last_name: lastName,
+    first_name: firstName,
+    birthdate,
+    status,
+    pix_score: pixScore,
+    certification_date: certificationDate,
+    competence_id: competenceId,
+    competence_level: competenceLevel,
+  };
+
+  datamartBuffer.pushInsertable({
+    tableName: 'data_export_parcoursup_certif_result_code_validation',
+    values,
+  });
+};
+
+export { buildCertificationResultCodeValidation };

--- a/api/datamart/migrations/20250103134809-create-data-export-parcoursup-certif-result-code-validation-table.js
+++ b/api/datamart/migrations/20250103134809-create-data-export-parcoursup-certif-result-code-validation-table.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'data_export_parcoursup_certif_result_code_validation';
+
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.string('certification_code_verification');
+    table.string('last_name');
+    table.string('first_name');
+    table.date('birthdate');
+    table.text('status');
+    table.integer('pix_score');
+    table.timestamp('certification_date');
+    table.string('competence_id');
+    table.integer('competence_level');
+    table.index('certification_code_verification');
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };

--- a/api/src/parcoursup/application/certification-route.js
+++ b/api/src/parcoursup/application/certification-route.js
@@ -1,6 +1,9 @@
 import Joi from 'joi';
 
-import { studentIdentifierType } from '../../shared/domain/types/identifiers-type.js';
+import {
+  certificationVerificationCodeType,
+  studentIdentifierType,
+} from '../../shared/domain/types/identifiers-type.js';
 import { responseObjectErrorDoc } from '../../shared/infrastructure/open-api-doc/response-object-error-doc.js';
 import { certificationController } from './certification-controller.js';
 
@@ -22,9 +25,7 @@ const register = async function (server) {
             birthdate: Joi.string().required(),
           }),
           Joi.object({
-            verificationCode: Joi.string()
-              .regex(/^P-[a-zA-Z0-9]{8}$/)
-              .required(),
+            verificationCode: certificationVerificationCodeType.required(),
           }),
         ),
       },
@@ -34,13 +35,12 @@ const register = async function (server) {
         '- **Cette route est accessible uniquement à Parcoursup**\n' +
           '- avec un INE, récupère la dernière certification de l‘année en cours pour l‘élève identifié' +
           '- avec un UAI, nom, prénom et date de naissance, récupère la dernière certification de l‘année en cours pour l‘élève identifié' +
-          '- avec un code de vérification récupère la certification correspondante',
+          '- avec un code de vérification, récupère la certification correspondante',
       ],
       response: {
         failAction: 'log',
         status: {
           200: Joi.object({
-            verificationCode: Joi.string().description('Code de vérification de la certification de l’élève'),
             organizationUai: Joi.string().description('UAI de l‘établissement scolaire'),
             ine: Joi.string().description('INE de l‘élève'),
             lastName: Joi.string().description('Nom de famille de l‘élève'),

--- a/api/src/parcoursup/application/certification-route.js
+++ b/api/src/parcoursup/application/certification-route.js
@@ -25,8 +25,6 @@ const register = async function (server) {
             verificationCode: Joi.string()
               .regex(/^P-[a-zA-Z0-9]{8}$/)
               .required(),
-            lastName: Joi.string().required(),
-            firstName: Joi.string().required(),
           }),
         ),
       },
@@ -36,7 +34,7 @@ const register = async function (server) {
         '- **Cette route est accessible uniquement à Parcoursup**\n' +
           '- avec un INE, récupère la dernière certification de l‘année en cours pour l‘élève identifié' +
           '- avec un UAI, nom, prénom et date de naissance, récupère la dernière certification de l‘année en cours pour l‘élève identifié' +
-          '- avec un code de vérification, nom et prénom, récupère la certification correspondante',
+          '- avec un code de vérification récupère la certification correspondante',
       ],
       response: {
         failAction: 'log',

--- a/api/src/parcoursup/application/certification-route.js
+++ b/api/src/parcoursup/application/certification-route.js
@@ -34,12 +34,15 @@ const register = async function (server) {
       tags: ['api', 'parcoursup'],
       notes: [
         '- **Cette route est accessible uniquement à Parcoursup**\n' +
-          '- Récupère la dernière certification de l‘année en cours pour l‘élève identifié via ses informations',
+          '- avec un INE, récupère la dernière certification de l‘année en cours pour l‘élève identifié' +
+          '- avec un UAI, nom, prénom et date de naissance, récupère la dernière certification de l‘année en cours pour l‘élève identifié' +
+          '- avec un code de vérification, nom et prénom, récupère la certification correspondante',
       ],
       response: {
         failAction: 'log',
         status: {
           200: Joi.object({
+            verificationCode: Joi.string().description('Code de vérification de la certification de l’élève'),
             organizationUai: Joi.string().description('UAI de l‘établissement scolaire'),
             ine: Joi.string().description('INE de l‘élève'),
             lastName: Joi.string().description('Nom de famille de l‘élève'),

--- a/api/src/parcoursup/application/certification-route.js
+++ b/api/src/parcoursup/application/certification-route.js
@@ -11,15 +11,24 @@ const register = async function (server) {
     config: {
       auth: 'jwt-parcoursup',
       validate: {
-        query: Joi.object({
-          ine: studentIdentifierType,
-          organizationUai: Joi.string(),
-          lastName: Joi.string(),
-          firstName: Joi.string(),
-          birthdate: Joi.string(),
-        })
-          .xor('ine', 'organizationUai')
-          .and('organizationUai', 'lastName', 'firstName', 'birthdate'),
+        query: Joi.alternatives().try(
+          Joi.object({
+            ine: studentIdentifierType,
+          }),
+          Joi.object({
+            organizationUai: Joi.string().required(),
+            lastName: Joi.string().required(),
+            firstName: Joi.string().required(),
+            birthdate: Joi.string().required(),
+          }),
+          Joi.object({
+            verificationCode: Joi.string()
+              .regex(/^P-[a-zA-Z0-9]{8}$/)
+              .required(),
+            lastName: Joi.string().required(),
+            firstName: Joi.string().required(),
+          }),
+        ),
       },
       handler: certificationController.getCertificationResult,
       tags: ['api', 'parcoursup'],

--- a/api/src/parcoursup/domain/read-models/CertificationResult.js
+++ b/api/src/parcoursup/domain/read-models/CertificationResult.js
@@ -2,6 +2,7 @@ class CertificationResult {
   constructor({
     ine,
     organizationUai,
+    verificationCode,
     lastName,
     firstName,
     birthdate,
@@ -12,6 +13,7 @@ class CertificationResult {
   }) {
     this.ine = ine;
     this.organizationUai = organizationUai;
+    this.verificationCode = verificationCode;
     this.lastName = lastName;
     this.firstName = firstName;
     this.birthdate = birthdate;

--- a/api/src/parcoursup/domain/read-models/CertificationResult.js
+++ b/api/src/parcoursup/domain/read-models/CertificationResult.js
@@ -2,7 +2,6 @@ class CertificationResult {
   constructor({
     ine,
     organizationUai,
-    verificationCode,
     lastName,
     firstName,
     birthdate,
@@ -13,7 +12,6 @@ class CertificationResult {
   }) {
     this.ine = ine;
     this.organizationUai = organizationUai;
-    this.verificationCode = verificationCode;
     this.lastName = lastName;
     this.firstName = firstName;
     this.birthdate = birthdate;

--- a/api/src/parcoursup/domain/usecases/get-certification-result.js
+++ b/api/src/parcoursup/domain/usecases/get-certification-result.js
@@ -5,6 +5,7 @@ const getCertificationResult = function ({
   firstName,
   birthdate,
   certificationRepository,
+  verificationCode,
 }) {
   if (ine) {
     return certificationRepository.get({ ine });
@@ -12,6 +13,10 @@ const getCertificationResult = function ({
 
   if (organizationUai && lastName && firstName && birthdate) {
     return certificationRepository.getByStudentDetails({ organizationUai, lastName, firstName, birthdate });
+  }
+
+  if (verificationCode && lastName && firstName) {
+    return certificationRepository.getByVerificationCode({ verificationCode, lastName, firstName });
   }
 };
 

--- a/api/src/parcoursup/domain/usecases/get-certification-result.js
+++ b/api/src/parcoursup/domain/usecases/get-certification-result.js
@@ -16,7 +16,7 @@ const getCertificationResult = function ({
   }
 
   if (verificationCode) {
-    return certificationRepository.getByVerificationCode({ verificationCode, lastName, firstName });
+    return certificationRepository.getByVerificationCode({ verificationCode });
   }
 };
 

--- a/api/src/parcoursup/domain/usecases/get-certification-result.js
+++ b/api/src/parcoursup/domain/usecases/get-certification-result.js
@@ -8,14 +8,14 @@ const getCertificationResult = function ({
   verificationCode,
 }) {
   if (ine) {
-    return certificationRepository.get({ ine });
+    return certificationRepository.getByINE({ ine });
   }
 
-  if (organizationUai && lastName && firstName && birthdate) {
-    return certificationRepository.getByStudentDetails({ organizationUai, lastName, firstName, birthdate });
+  if (organizationUai) {
+    return certificationRepository.getByOrganizationUAI({ organizationUai, lastName, firstName, birthdate });
   }
 
-  if (verificationCode && lastName && firstName) {
+  if (verificationCode) {
     return certificationRepository.getByVerificationCode({ verificationCode, lastName, firstName });
   }
 };

--- a/api/src/parcoursup/infrastructure/repositories/certification-repository.js
+++ b/api/src/parcoursup/infrastructure/repositories/certification-repository.js
@@ -26,11 +26,9 @@ const _getBySearchParams = async (searchParams) => {
   return _toDomain(certificationResultDto);
 };
 
-const getByVerificationCode = async ({ verificationCode, lastName, firstName }) => {
+const getByVerificationCode = async ({ verificationCode }) => {
   const certificationResultDto = await datamartKnex('data_export_parcoursup_certif_result_code_validation').where({
     certification_code_verification: verificationCode,
-    last_name: lastName,
-    first_name: firstName,
   });
   if (!certificationResultDto.length) {
     throw new NotFoundError('No certifications found for given search parameters');

--- a/api/src/parcoursup/infrastructure/repositories/certification-repository.js
+++ b/api/src/parcoursup/infrastructure/repositories/certification-repository.js
@@ -41,7 +41,6 @@ const _toDomain = (certificationResultDto) => {
   return new CertificationResult({
     ine: certificationResultDto[0].national_student_id,
     organizationUai: certificationResultDto[0].organization_uai,
-    verificationCode: certificationResultDto[0].verificationCode,
     lastName: certificationResultDto[0].last_name,
     firstName: certificationResultDto[0].first_name,
     birthdate: certificationResultDto[0].birthdate,

--- a/api/src/parcoursup/infrastructure/repositories/certification-repository.js
+++ b/api/src/parcoursup/infrastructure/repositories/certification-repository.js
@@ -26,10 +26,24 @@ const _getBySearchParams = async (searchParams) => {
   return _toDomain(certificationResultDto);
 };
 
+const getByVerificationCode = async ({ verificationCode, lastName, firstName }) => {
+  const certificationResultDto = await datamartKnex('data_export_parcoursup_certif_result_code_validation').where({
+    certification_code_verification: verificationCode,
+    last_name: lastName,
+    first_name: firstName,
+  });
+  if (!certificationResultDto.length) {
+    throw new NotFoundError('No certifications found for given search parameters');
+  }
+
+  return _toDomain(certificationResultDto);
+};
+
 const _toDomain = (certificationResultDto) => {
   return new CertificationResult({
     ine: certificationResultDto[0].national_student_id,
     organizationUai: certificationResultDto[0].organization_uai,
+    verificationCode: certificationResultDto[0].verificationCode,
     lastName: certificationResultDto[0].last_name,
     firstName: certificationResultDto[0].first_name,
     birthdate: certificationResultDto[0].birthdate,
@@ -45,4 +59,4 @@ const _toDomain = (certificationResultDto) => {
   });
 };
 
-export { get, getByStudentDetails };
+export { get, getByStudentDetails, getByVerificationCode };

--- a/api/src/parcoursup/infrastructure/repositories/certification-repository.js
+++ b/api/src/parcoursup/infrastructure/repositories/certification-repository.js
@@ -2,13 +2,13 @@ import { datamartKnex } from '../../../../db/knex-database-connection.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { CertificationResult } from '../../domain/read-models/CertificationResult.js';
 
-const get = async ({ ine }) => {
+const getByINE = async ({ ine }) => {
   return _getBySearchParams({
     national_student_id: ine,
   });
 };
 
-const getByStudentDetails = async ({ organizationUai, lastName, firstName, birthdate }) => {
+const getByOrganizationUAI = async ({ organizationUai, lastName, firstName, birthdate }) => {
   return _getBySearchParams({
     organization_uai: organizationUai,
     last_name: lastName,
@@ -59,4 +59,4 @@ const _toDomain = (certificationResultDto) => {
   });
 };
 
-export { get, getByStudentDetails, getByVerificationCode };
+export { getByINE, getByOrganizationUAI, getByVerificationCode };

--- a/api/src/shared/domain/types/identifiers-type.js
+++ b/api/src/shared/domain/types/identifiers-type.js
@@ -10,6 +10,8 @@ const implementationType = {
   alphanumeric: Joi.string(),
 };
 
+const certificationVerificationCodeType = Joi.string().regex(/^P-[a-zA-Z0-9]{8}$/);
+
 const inePattern = new RegExp('^[0-9]{9}[a-zA-Z]{2}$');
 const inaPattern = new RegExp('^[0-9]{10}[a-zA-Z]{1}$');
 
@@ -90,6 +92,7 @@ paramsToExport.positiveInteger32bits = {
 };
 
 export {
+  certificationVerificationCodeType,
   paramsToExport as identifiersType,
   queryToExport as optionalIdentifiersType,
   queriesType,

--- a/api/tests/parcoursup/acceptance/application/certification-route_test.js
+++ b/api/tests/parcoursup/acceptance/application/certification-route_test.js
@@ -58,6 +58,7 @@ describe('Parcoursup | Acceptance | Application | certification-route', function
       await databaseBuilder.commit();
 
       const expectedCertification = {
+        verificationCode: undefined,
         organizationUai: 'UAI ETAB ELEVE',
         ine,
         lastName: 'NOM-ELEVE',
@@ -132,8 +133,82 @@ describe('Parcoursup | Acceptance | Application | certification-route', function
       await databaseBuilder.commit();
 
       const expectedCertification = {
+        verificationCode: undefined,
         organizationUai,
         ine: '123456789OK',
+        lastName,
+        firstName,
+        birthdate,
+        status: 'validated',
+        pixScore: 327,
+        certificationDate: new Date('2024-11-22T09:39:54Z'),
+        competences: [
+          {
+            id: 'xzef1223443',
+            level: 3,
+          },
+          {
+            id: 'otherCompetenceId',
+            level: 5,
+          },
+        ],
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result).to.deep.equal(expectedCertification);
+    });
+  });
+
+  describe('GET /api/parcoursup/certification/search?verificationCode={verificationCode}&lastName={lastName}&firstName={firstName}', function () {
+    it('should return 200 HTTP status code and a certification for a given UAI, last name, first name and birthdate', async function () {
+      // given
+      const verificationCode = 'P-1234567A';
+      const lastName = 'NOM-ELEVE';
+      const firstName = 'PRENOM-ELEVE';
+      const birthdate = '2000-01-01';
+      const certificationResultData = {
+        verificationCode,
+        lastName,
+        firstName,
+        birthdate,
+        status: 'validated',
+        pixScore: 327,
+        certificationDate: '2024-11-22T09:39:54Z',
+      };
+      datamartBuilder.factory.buildCertificationResultCodeValidation({
+        ...certificationResultData,
+        competenceId: 'xzef1223443',
+        competenceLevel: 3,
+      });
+      datamartBuilder.factory.buildCertificationResultCodeValidation({
+        ...certificationResultData,
+        competenceId: 'otherCompetenceId',
+        competenceLevel: 5,
+      });
+      await datamartBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: `/api/parcoursup/certification/search?verificationCode=${verificationCode}&lastName=${lastName}&firstName=${firstName}`,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeaderForApplication(
+            PARCOURSUP_CLIENT_ID,
+            PARCOURSUP_SOURCE,
+            PARCOURSUP_SCOPE,
+          ),
+        },
+      };
+
+      await databaseBuilder.commit();
+
+      const expectedCertification = {
+        verificationCode: undefined,
+        ine: undefined,
+        organizationUai: undefined,
         lastName,
         firstName,
         birthdate,

--- a/api/tests/parcoursup/acceptance/application/certification-route_test.js
+++ b/api/tests/parcoursup/acceptance/application/certification-route_test.js
@@ -58,7 +58,6 @@ describe('Parcoursup | Acceptance | Application | certification-route', function
       await databaseBuilder.commit();
 
       const expectedCertification = {
-        verificationCode: undefined,
         organizationUai: 'UAI ETAB ELEVE',
         ine,
         lastName: 'NOM-ELEVE',
@@ -133,7 +132,6 @@ describe('Parcoursup | Acceptance | Application | certification-route', function
       await databaseBuilder.commit();
 
       const expectedCertification = {
-        verificationCode: undefined,
         organizationUai,
         ine: '123456789OK',
         lastName,
@@ -206,7 +204,6 @@ describe('Parcoursup | Acceptance | Application | certification-route', function
       await databaseBuilder.commit();
 
       const expectedCertification = {
-        verificationCode: undefined,
         ine: undefined,
         organizationUai: undefined,
         lastName,

--- a/api/tests/parcoursup/acceptance/application/certification-route_test.js
+++ b/api/tests/parcoursup/acceptance/application/certification-route_test.js
@@ -163,8 +163,8 @@ describe('Parcoursup | Acceptance | Application | certification-route', function
     });
   });
 
-  describe('GET /api/parcoursup/certification/search?verificationCode={verificationCode}&lastName={lastName}&firstName={firstName}', function () {
-    it('should return 200 HTTP status code and a certification for a given UAI, last name, first name and birthdate', async function () {
+  describe('GET /api/parcoursup/certification/search?verificationCode={verificationCode}', function () {
+    it('should return 200 HTTP status code and a certification for a given vérificationCode', async function () {
       // given
       const verificationCode = 'P-1234567A';
       const lastName = 'NOM-ELEVE';
@@ -193,7 +193,7 @@ describe('Parcoursup | Acceptance | Application | certification-route', function
 
       const options = {
         method: 'GET',
-        url: `/api/parcoursup/certification/search?verificationCode=${verificationCode}&lastName=${lastName}&firstName=${firstName}`,
+        url: `/api/parcoursup/certification/search?verificationCode=${verificationCode}`,
         headers: {
           authorization: generateValidRequestAuthorizationHeaderForApplication(
             PARCOURSUP_CLIENT_ID,

--- a/api/tests/parcoursup/integration/repositories/certification-repository_test.js
+++ b/api/tests/parcoursup/integration/repositories/certification-repository_test.js
@@ -191,8 +191,6 @@ describe('Parcoursup | Infrastructure | Integration | Repositories | certificati
         // when
         const result = await certificationRepository.getByVerificationCode({
           verificationCode,
-          lastName,
-          firstName,
         });
 
         // then
@@ -223,14 +221,10 @@ describe('Parcoursup | Infrastructure | Integration | Repositories | certificati
       it('should throw Not Found Error', async function () {
         // given
         const verificationCode = 'P-1234567B';
-        const lastName = 'LEPONGE';
-        const firstName = 'Bob';
 
         // when
         const err = await catchErr(certificationRepository.getByVerificationCode)({
           verificationCode,
-          lastName,
-          firstName,
         });
 
         // then

--- a/api/tests/parcoursup/integration/repositories/certification-repository_test.js
+++ b/api/tests/parcoursup/integration/repositories/certification-repository_test.js
@@ -3,7 +3,7 @@ import { NotFoundError } from '../../../../src/shared/domain/errors.js';
 import { catchErr, datamartBuilder, domainBuilder, expect } from '../../../test-helper.js';
 
 describe('Parcoursup | Infrastructure | Integration | Repositories | certification', function () {
-  describe('#get', function () {
+  describe('#getByINE', function () {
     describe('when a certification is found', function () {
       it('should return the certification', async function () {
         // given
@@ -31,7 +31,7 @@ describe('Parcoursup | Infrastructure | Integration | Repositories | certificati
         await datamartBuilder.commit();
 
         // when
-        const result = await certificationRepository.get({ ine });
+        const result = await certificationRepository.getByINE({ ine });
 
         // then
         const expectedCertification = domainBuilder.parcoursup.buildCertificationResult({
@@ -64,7 +64,7 @@ describe('Parcoursup | Infrastructure | Integration | Repositories | certificati
         const ine = '1234';
 
         // when
-        const err = await catchErr(certificationRepository.get)({ ine });
+        const err = await catchErr(certificationRepository.getByINE)({ ine });
 
         // then
         expect(err).to.be.instanceOf(NotFoundError);
@@ -73,7 +73,7 @@ describe('Parcoursup | Infrastructure | Integration | Repositories | certificati
     });
   });
 
-  describe('#getByStudentDetails', function () {
+  describe('#getByOrganizationUAI', function () {
     describe('when a certification is found', function () {
       it('should return the certification', async function () {
         // given
@@ -104,7 +104,7 @@ describe('Parcoursup | Infrastructure | Integration | Repositories | certificati
         await datamartBuilder.commit();
 
         // when
-        const result = await certificationRepository.getByStudentDetails({
+        const result = await certificationRepository.getByOrganizationUAI({
           organizationUai,
           lastName,
           firstName,
@@ -145,7 +145,7 @@ describe('Parcoursup | Infrastructure | Integration | Repositories | certificati
         const birthdate = '2000-01-01';
 
         // when
-        const err = await catchErr(certificationRepository.getByStudentDetails)({
+        const err = await catchErr(certificationRepository.getByOrganizationUAI)({
           organizationUai,
           lastName,
           firstName,

--- a/api/tests/parcoursup/integration/repositories/certification-repository_test.js
+++ b/api/tests/parcoursup/integration/repositories/certification-repository_test.js
@@ -195,7 +195,6 @@ describe('Parcoursup | Infrastructure | Integration | Repositories | certificati
 
         // then
         const expectedCertification = domainBuilder.parcoursup.buildCertificationResult({
-          verificationCode,
           lastName,
           firstName,
           birthdate,

--- a/api/tests/parcoursup/unit/application/certification-route_test.js
+++ b/api/tests/parcoursup/unit/application/certification-route_test.js
@@ -222,7 +222,7 @@ describe('Parcoursup | Unit | Application | Routes | Certification', function ()
     });
   });
 
-  describe('GET /parcoursup/certification/search?verificationCode={verificationCode}&lastName={lastName}&firstName={firstName}', function () {
+  describe('GET /parcoursup/certification/search?verificationCode={verificationCode}', function () {
     it('should return 200', async function () {
       //given
       sinon.stub(certificationController, 'getCertificationResult').callsFake((request, h) => h.response().code(200));
@@ -236,7 +236,7 @@ describe('Parcoursup | Unit | Application | Routes | Certification', function ()
       const PARCOURSUP_SOURCE = 'parcoursup';
 
       const method = 'GET';
-      const url = '/api/parcoursup/certification/search?verificationCode=P-1234567A&lastName=LEPONGE&firstName=BOB';
+      const url = '/api/parcoursup/certification/search?verificationCode=P-1234567A';
       const headers = {
         authorization: generateValidRequestAuthorizationHeaderForApplication(
           PARCOURSUP_CLIENT_ID,
@@ -262,7 +262,7 @@ describe('Parcoursup | Unit | Application | Routes | Certification', function ()
         const PARCOURSUP_SCOPE = 'parcoursup';
         const PARCOURSUP_SOURCE = 'parcoursup';
 
-        const url = '/api/parcoursup/certification/search?verificationCode=1234567A&lastName=LEPONGE&firstName=BOB';
+        const url = '/api/parcoursup/certification/search?verificationCode=1234567A';
         const headers = {
           authorization: generateValidRequestAuthorizationHeaderForApplication(
             PARCOURSUP_CLIENT_ID,

--- a/api/tests/parcoursup/unit/application/certification-route_test.js
+++ b/api/tests/parcoursup/unit/application/certification-route_test.js
@@ -222,6 +222,64 @@ describe('Parcoursup | Unit | Application | Routes | Certification', function ()
     });
   });
 
+  describe('GET /parcoursup/certification/search?verificationCode={verificationCode}&lastName={lastName}&firstName={firstName}', function () {
+    it('should return 200', async function () {
+      //given
+      sinon.stub(certificationController, 'getCertificationResult').callsFake((request, h) => h.response().code(200));
+
+      const httpTestServer = new HttpTestServer();
+      httpTestServer.setupAuthentication();
+      await httpTestServer.register(moduleUnderTest);
+
+      const PARCOURSUP_CLIENT_ID = 'test-parcoursupClientId';
+      const PARCOURSUP_SCOPE = 'parcoursup';
+      const PARCOURSUP_SOURCE = 'parcoursup';
+
+      const method = 'GET';
+      const url = '/api/parcoursup/certification/search?verificationCode=P-1234567A&lastName=LEPONGE&firstName=BOB';
+      const headers = {
+        authorization: generateValidRequestAuthorizationHeaderForApplication(
+          PARCOURSUP_CLIENT_ID,
+          PARCOURSUP_SOURCE,
+          PARCOURSUP_SCOPE,
+        ),
+      };
+
+      // when
+      const response = await httpTestServer.request(method, url, null, null, headers);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    context('when verificationCode format is invalid', function () {
+      it('returns 400 error', async function () {
+        const httpTestServer = new HttpTestServer();
+        httpTestServer.setupAuthentication();
+        await httpTestServer.register(moduleUnderTest);
+
+        const PARCOURSUP_CLIENT_ID = 'test-parcoursupClientId';
+        const PARCOURSUP_SCOPE = 'parcoursup';
+        const PARCOURSUP_SOURCE = 'parcoursup';
+
+        const url = '/api/parcoursup/certification/search?verificationCode=1234567A&lastName=LEPONGE&firstName=BOB';
+        const headers = {
+          authorization: generateValidRequestAuthorizationHeaderForApplication(
+            PARCOURSUP_CLIENT_ID,
+            PARCOURSUP_SOURCE,
+            PARCOURSUP_SCOPE,
+          ),
+        };
+
+        // when
+        const response = await httpTestServer.request('GET', url, null, null, headers);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+  });
+
   describe('GET /parcoursup/certification/search?ine={ine}&organizationUai={organizationUai}', function () {
     context('when both ine and organizationUai are used', function () {
       let httpTestServer, headers;

--- a/api/tests/parcoursup/unit/domain/usecases/get-certification-result_test.js
+++ b/api/tests/parcoursup/unit/domain/usecases/get-certification-result_test.js
@@ -60,34 +60,26 @@ describe('Parcoursup | unit | domain | usecases | get certification', function (
       });
     });
 
-    context('with a verification code, last name and first name', function () {
+    context('with a verification code', function () {
       it('returns matching certification', async function () {
         // given
         const verificationCode = 'P-1234567A';
-        const lastName = 'LEPONGE';
-        const firstName = 'Bob';
         const certificationRepository = {
           getByVerificationCode: sinon.stub(),
         };
 
         const expectedCertification = domainBuilder.parcoursup.buildCertificationResult({
           verificationCode,
-          lastName,
-          firstName,
         });
         certificationRepository.getByVerificationCode
           .withArgs({
             verificationCode,
-            lastName,
-            firstName,
           })
           .resolves(expectedCertification);
 
         // when
         const certification = await getCertificationResult({
           verificationCode,
-          lastName,
-          firstName,
           certificationRepository,
         });
 

--- a/api/tests/parcoursup/unit/domain/usecases/get-certification-result_test.js
+++ b/api/tests/parcoursup/unit/domain/usecases/get-certification-result_test.js
@@ -7,11 +7,11 @@ describe('Parcoursup | unit | domain | usecases | get certification', function (
       // given
       const ine = '1234';
       const certificationRepository = {
-        get: sinon.stub(),
+        getByINE: sinon.stub(),
       };
 
       const expectedCertification = domainBuilder.parcoursup.buildCertificationResult({ ine });
-      certificationRepository.get.withArgs({ ine }).resolves(expectedCertification);
+      certificationRepository.getByINE.withArgs({ ine }).resolves(expectedCertification);
 
       // when
       const certification = await getCertificationResult({ ine, certificationRepository });
@@ -28,7 +28,7 @@ describe('Parcoursup | unit | domain | usecases | get certification', function (
         const firstName = 'Bob';
         const birthdate = '2000-01-01';
         const certificationRepository = {
-          getByStudentDetails: sinon.stub(),
+          getByOrganizationUAI: sinon.stub(),
         };
 
         const expectedCertification = domainBuilder.parcoursup.buildCertificationResult({
@@ -37,7 +37,7 @@ describe('Parcoursup | unit | domain | usecases | get certification', function (
           firstName,
           birthdate,
         });
-        certificationRepository.getByStudentDetails
+        certificationRepository.getByOrganizationUAI
           .withArgs({
             organizationUai,
             lastName,

--- a/api/tests/parcoursup/unit/domain/usecases/get-certification-result_test.js
+++ b/api/tests/parcoursup/unit/domain/usecases/get-certification-result_test.js
@@ -19,6 +19,7 @@ describe('Parcoursup | unit | domain | usecases | get certification', function (
       // then
       expect(certification).to.deep.equal(expectedCertification);
     });
+
     context('with organizationUai, last name, first name and birthdate', function () {
       it('returns matching certification', async function () {
         // given
@@ -51,6 +52,42 @@ describe('Parcoursup | unit | domain | usecases | get certification', function (
           lastName,
           firstName,
           birthdate,
+          certificationRepository,
+        });
+
+        // then
+        expect(certification).to.deep.equal(expectedCertification);
+      });
+    });
+
+    context('with a verification code, last name and first name', function () {
+      it('returns matching certification', async function () {
+        // given
+        const verificationCode = 'P-1234567A';
+        const lastName = 'LEPONGE';
+        const firstName = 'Bob';
+        const certificationRepository = {
+          getByVerificationCode: sinon.stub(),
+        };
+
+        const expectedCertification = domainBuilder.parcoursup.buildCertificationResult({
+          verificationCode,
+          lastName,
+          firstName,
+        });
+        certificationRepository.getByVerificationCode
+          .withArgs({
+            verificationCode,
+            lastName,
+            firstName,
+          })
+          .resolves(expectedCertification);
+
+        // when
+        const certification = await getCertificationResult({
+          verificationCode,
+          lastName,
+          firstName,
           certificationRepository,
         });
 

--- a/api/tests/tooling/domain-builder/factory/parcoursup/build-certification-result.js
+++ b/api/tests/tooling/domain-builder/factory/parcoursup/build-certification-result.js
@@ -1,7 +1,7 @@
 import { CertificationResult } from '../../../../../src/parcoursup/domain/read-models/CertificationResult.js';
 
 const buildCertificationResult = function ({
-  ine = '1234',
+  ine,
   organizationUai,
   lastName,
   firstName,


### PR DESCRIPTION
## :christmas_tree: Problème

Nous n'avons pas de moyen de récupérer la certification d'un élève à partir de son code de vérification.

## :gift: Proposition

Ajouter la possibilité de récupérer une certification pour parcoursup à partir du code de vérification.


## :socks: Remarques

Nous vérifions aussi le nom et prénom pour réduire les risques d'utilisation du code de quelqu'un d'autres.

## :santa: Pour tester

Sur `https://api-pr10935.review.pix.fr/api/documentation`, générer un token valide avec les bons `client_id`, `client_secret` et `scope`

```shell
TOKEN=<token>
curl https://api-pr10935.review.pix.fr/api/parcoursup/certification/search?verificationCode=P-D1VAF1GU \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -X GET
```
