### PR TITLE
[FEATURE] déduplique les participations retentée (Pix-15885)

### DIFF
--- a/api/src/prescription/campaign-participation/infrastructure/repositories/participations-for-user-management-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/participations-for-user-management-repository.js
@@ -4,52 +4,82 @@ import { CampaignTypes } from '../../../shared/domain/constants.js';
 import { CampaignParticipationForUserManagement } from '../../domain/models/CampaignParticipationForUserManagement.js';
 
 const findByUserId = async function (userId) {
-  const campaignParticipations = await knex('assessments')
-    .select({
-      campaignParticipationId: 'campaign-participations.id',
-      participantExternalId: 'campaign-participations.participantExternalId',
-      status: 'campaign-participations.status',
-      campaignId: 'campaigns.id',
-      campaignCode: 'campaigns.code',
-      createdAt: knex.raw('COALESCE("campaign-participations"."createdAt", assessments."createdAt")'),
-      sharedAt: 'campaign-participations.sharedAt',
-      deletedAt: 'campaign-participations.deletedAt',
-      updatedAt: 'assessments.updatedAt',
-      organizationLearnerFirstName: 'view-active-organization-learners.firstName',
-      organizationLearnerLastName: 'view-active-organization-learners.lastName',
-    })
-    .leftJoin('campaign-participations', 'assessments.campaignParticipationId', 'campaign-participations.id')
-    .leftJoin('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
-    .leftJoin(
-      'view-active-organization-learners',
-      'view-active-organization-learners.id',
-      'campaign-participations.organizationLearnerId',
-    )
-    .where('assessments.userId', userId)
-    .where('assessments.type', Assessment.types.CAMPAIGN)
-    .union(function () {
-      this.select({
-        campaignParticipationId: 'campaign-participations.id',
-        participantExternalId: 'campaign-participations.participantExternalId',
-        status: 'campaign-participations.status',
-        campaignId: 'campaigns.id',
-        campaignCode: 'campaigns.code',
-        createdAt: 'campaign-participations.createdAt',
-        sharedAt: 'campaign-participations.sharedAt',
-        deletedAt: 'campaign-participations.deletedAt',
-        updatedAt: 'campaign-participations.deletedAt',
-        organizationLearnerFirstName: 'view-active-organization-learners.firstName',
-        organizationLearnerLastName: 'view-active-organization-learners.lastName',
-      })
-        .from('campaign-participations')
+  const campaignParticipations = await knex
+    .with(
+      'participations',
+      knex('assessments')
+        .select({
+          campaignParticipationId: 'campaign-participations.id',
+          participantExternalId: 'campaign-participations.participantExternalId',
+          status: 'campaign-participations.status',
+          campaignId: 'campaigns.id',
+          campaignCode: 'campaigns.code',
+          createdAt: knex.raw('COALESCE("campaign-participations"."createdAt", assessments."createdAt")'),
+          sharedAt: 'campaign-participations.sharedAt',
+          deletedAt: 'campaign-participations.deletedAt',
+          updatedAt: 'assessments.updatedAt',
+          organizationLearnerFirstName: 'view-active-organization-learners.firstName',
+          organizationLearnerLastName: 'view-active-organization-learners.lastName',
+        })
+        .leftJoin('campaign-participations', 'assessments.campaignParticipationId', 'campaign-participations.id')
         .leftJoin('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
         .leftJoin(
           'view-active-organization-learners',
           'view-active-organization-learners.id',
           'campaign-participations.organizationLearnerId',
         )
-        .where({ 'campaign-participations.userId': userId, type: CampaignTypes.PROFILES_COLLECTION });
-    })
+        .where('assessments.userId', userId)
+        .where('assessments.type', Assessment.types.CAMPAIGN)
+        .union(function () {
+          // using UNION will remove lines having the exact same attibutes
+          this.select({
+            campaignParticipationId: 'campaign-participations.id',
+            participantExternalId: 'campaign-participations.participantExternalId',
+            status: 'campaign-participations.status',
+            campaignId: 'campaigns.id',
+            campaignCode: 'campaigns.code',
+            createdAt: 'campaign-participations.createdAt',
+            sharedAt: 'campaign-participations.sharedAt',
+            deletedAt: 'campaign-participations.deletedAt',
+            updatedAt: 'campaign-participations.deletedAt',
+            organizationLearnerFirstName: 'view-active-organization-learners.firstName',
+            organizationLearnerLastName: 'view-active-organization-learners.lastName',
+          })
+            .from('campaign-participations')
+            .leftJoin('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
+            .leftJoin(
+              'view-active-organization-learners',
+              'view-active-organization-learners.id',
+              'campaign-participations.organizationLearnerId',
+            )
+            .where({ 'campaign-participations.userId': userId, type: CampaignTypes.PROFILES_COLLECTION });
+        }),
+    )
+    .select([
+      'campaignParticipationId',
+      'participantExternalId',
+      'status',
+      'campaignId',
+      'campaignCode',
+      knex.raw('min("createdAt") as "createdAt"'),
+      'sharedAt',
+      'deletedAt',
+      knex.raw('max("updatedAt") as "updatedAt"'),
+      'organizationLearnerFirstName',
+      'organizationLearnerLastName',
+    ])
+    .from('participations')
+    .groupBy(
+      'campaignParticipationId',
+      'participantExternalId',
+      'status',
+      'campaignId',
+      'campaignCode',
+      'sharedAt',
+      'deletedAt',
+      'organizationLearnerFirstName',
+      'organizationLearnerLastName',
+    )
     .orderBy('createdAt', 'desc')
     .orderBy('campaignCode', 'asc')
     .orderBy('sharedAt', 'desc');

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/participations-for-user-management-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/participations-for-user-management-repository_test.js
@@ -216,158 +216,161 @@ describe('Integration | Repository | Participations-For-User-Management', functi
           });
         });
       });
+      context('sort', function () {
+        it('should sort participations by descending createdAt', async function () {
+          const campaign1 = databaseBuilder.factory.buildCampaign();
+          const campaign2 = databaseBuilder.factory.buildCampaign();
+          const campaign3 = databaseBuilder.factory.buildCampaign();
 
-      it('should sort participations by descending createdAt', async function () {
-        const campaign1 = databaseBuilder.factory.buildCampaign();
-        const campaign2 = databaseBuilder.factory.buildCampaign();
-        const campaign3 = databaseBuilder.factory.buildCampaign();
+          // given
+          const participationToCampaign1InJanuary = databaseBuilder.factory.buildCampaignParticipation({
+            userId,
+            campaignId: campaign1.id,
+            participantExternalId: 'Created-January',
+            createdAt: new Date('2024-01-01'),
+          });
+          databaseBuilder.factory.buildAssessment({
+            campaignParticipationId: participationToCampaign1InJanuary.id,
+            type: Assessment.types.CAMPAIGN,
+            userId,
+          });
+          const participationToCampaign2InFebruary = databaseBuilder.factory.buildCampaignParticipation({
+            userId,
+            campaignId: campaign2.id,
+            participantExternalId: 'Created-February',
+            createdAt: new Date('2024-02-01'),
+          });
+          databaseBuilder.factory.buildAssessment({
+            campaignParticipationId: participationToCampaign2InFebruary.id,
+            type: Assessment.types.CAMPAIGN,
+            userId,
+          });
+          const participationToCampaign3InMarch = databaseBuilder.factory.buildCampaignParticipation({
+            userId,
+            campaignId: campaign3.id,
+            participantExternalId: 'Created-March',
+            createdAt: new Date('2024-03-01'),
+          });
+          databaseBuilder.factory.buildAssessment({
+            campaignParticipationId: participationToCampaign3InMarch.id,
+            type: Assessment.types.CAMPAIGN,
+            userId,
+          });
+          await databaseBuilder.commit();
 
-        // given
-        const participationToCampaign1InJanuary = databaseBuilder.factory.buildCampaignParticipation({
-          userId,
-          campaignId: campaign1.id,
-          participantExternalId: 'Created-January',
-          createdAt: new Date('2024-01-01'),
-        });
-        databaseBuilder.factory.buildAssessment({
-          campaignParticipationId: participationToCampaign1InJanuary.id,
-          type: Assessment.types.CAMPAIGN,
-          userId,
-        });
-        const participationToCampaign2InFebruary = databaseBuilder.factory.buildCampaignParticipation({
-          userId,
-          campaignId: campaign2.id,
-          participantExternalId: 'Created-February',
-          createdAt: new Date('2024-02-01'),
-        });
-        databaseBuilder.factory.buildAssessment({
-          campaignParticipationId: participationToCampaign2InFebruary.id,
-          type: Assessment.types.CAMPAIGN,
-          userId,
-        });
-        const participationToCampaign3InMarch = databaseBuilder.factory.buildCampaignParticipation({
-          userId,
-          campaignId: campaign3.id,
-          participantExternalId: 'Created-March',
-          createdAt: new Date('2024-03-01'),
-        });
-        databaseBuilder.factory.buildAssessment({
-          campaignParticipationId: participationToCampaign3InMarch.id,
-          type: Assessment.types.CAMPAIGN,
-          userId,
-        });
-        await databaseBuilder.commit();
+          // when
+          const participationsForUserManagement = await participationsForUserManagementRepository.findByUserId(userId);
 
-        // when
-        const participationsForUserManagement = await participationsForUserManagementRepository.findByUserId(userId);
+          // then
+          expect(participationsForUserManagement[0].campaignParticipationId).to.equal(
+            participationToCampaign3InMarch.id,
+          );
+          expect(participationsForUserManagement[1].campaignParticipationId).to.equal(
+            participationToCampaign2InFebruary.id,
+          );
+          expect(participationsForUserManagement[2].campaignParticipationId).to.equal(
+            participationToCampaign1InJanuary.id,
+          );
+        });
 
-        // then
-        expect(participationsForUserManagement[0].campaignParticipationId).to.equal(participationToCampaign3InMarch.id);
-        expect(participationsForUserManagement[1].campaignParticipationId).to.equal(
-          participationToCampaign2InFebruary.id,
-        );
-        expect(participationsForUserManagement[2].campaignParticipationId).to.equal(
-          participationToCampaign1InJanuary.id,
-        );
-      });
+        it('should sort participations by ascending campaign code when createdAt is the same', async function () {
+          const campaignA = databaseBuilder.factory.buildCampaign({ code: 'AAAAAAA' });
+          const campaignB = databaseBuilder.factory.buildCampaign({ code: 'BBBBBBB' });
+          const campaignC = databaseBuilder.factory.buildCampaign({ code: 'CCCCCCC' });
 
-      it('should sort participations by ascending campaign code when createdAt is the same', async function () {
-        const campaignA = databaseBuilder.factory.buildCampaign({ code: 'AAAAAAA' });
-        const campaignB = databaseBuilder.factory.buildCampaign({ code: 'BBBBBBB' });
-        const campaignC = databaseBuilder.factory.buildCampaign({ code: 'CCCCCCC' });
+          // given
+          const participationToCampaignC = databaseBuilder.factory.buildCampaignParticipation({
+            userId,
+            campaignId: campaignC.id,
+            createdAt: new Date('2020-01-02'),
+          });
+          databaseBuilder.factory.buildAssessment({
+            campaignParticipationId: participationToCampaignC.id,
+            type: Assessment.types.CAMPAIGN,
+            userId,
+          });
+          const participationToCampaignB = databaseBuilder.factory.buildCampaignParticipation({
+            userId,
+            campaignId: campaignB.id,
+            createdAt: new Date('2020-01-02'),
+          });
+          databaseBuilder.factory.buildAssessment({
+            campaignParticipationId: participationToCampaignB.id,
+            type: Assessment.types.CAMPAIGN,
+            userId,
+          });
+          const participationToCampaignA = databaseBuilder.factory.buildCampaignParticipation({
+            userId,
+            campaignId: campaignA.id,
+            createdAt: new Date('2020-01-02'),
+          });
+          databaseBuilder.factory.buildAssessment({
+            campaignParticipationId: participationToCampaignA.id,
+            type: Assessment.types.CAMPAIGN,
+            userId,
+          });
+          await databaseBuilder.commit();
 
-        // given
-        const participationToCampaignC = databaseBuilder.factory.buildCampaignParticipation({
-          userId,
-          campaignId: campaignC.id,
-          createdAt: new Date('2020-01-02'),
-        });
-        databaseBuilder.factory.buildAssessment({
-          campaignParticipationId: participationToCampaignC.id,
-          type: Assessment.types.CAMPAIGN,
-          userId,
-        });
-        const participationToCampaignB = databaseBuilder.factory.buildCampaignParticipation({
-          userId,
-          campaignId: campaignB.id,
-          createdAt: new Date('2020-01-02'),
-        });
-        databaseBuilder.factory.buildAssessment({
-          campaignParticipationId: participationToCampaignB.id,
-          type: Assessment.types.CAMPAIGN,
-          userId,
-        });
-        const participationToCampaignA = databaseBuilder.factory.buildCampaignParticipation({
-          userId,
-          campaignId: campaignA.id,
-          createdAt: new Date('2020-01-02'),
-        });
-        databaseBuilder.factory.buildAssessment({
-          campaignParticipationId: participationToCampaignA.id,
-          type: Assessment.types.CAMPAIGN,
-          userId,
-        });
-        await databaseBuilder.commit();
+          // when
+          const participationsForUserManagement = await participationsForUserManagementRepository.findByUserId(userId);
 
-        // when
-        const participationsForUserManagement = await participationsForUserManagementRepository.findByUserId(userId);
+          // then
+          expect(participationsForUserManagement[0].campaignParticipationId).to.equal(participationToCampaignA.id);
+          expect(participationsForUserManagement[1].campaignParticipationId).to.equal(participationToCampaignB.id);
+          expect(participationsForUserManagement[2].campaignParticipationId).to.equal(participationToCampaignC.id);
+        });
 
-        // then
-        expect(participationsForUserManagement[0].campaignParticipationId).to.equal(participationToCampaignA.id);
-        expect(participationsForUserManagement[1].campaignParticipationId).to.equal(participationToCampaignB.id);
-        expect(participationsForUserManagement[2].campaignParticipationId).to.equal(participationToCampaignC.id);
-      });
+        it('should sort participations by descending sharedAt when createdAt is the same and campaign code is the same', async function () {
+          const campaign = databaseBuilder.factory.buildCampaign();
+          // given
+          const participationSharedInJanuary = databaseBuilder.factory.buildCampaignParticipation({
+            userId,
+            campaignId: campaign.id,
+            participantExternalId: 'Shared-January',
+            createdAt: new Date('2020-01-02'),
+            sharedAt: new Date('2023-01-01'),
+            isImproved: true,
+          });
+          databaseBuilder.factory.buildAssessment({
+            campaignParticipationId: participationSharedInJanuary.id,
+            type: Assessment.types.CAMPAIGN,
+            userId,
+          });
+          const participationSharedInFebruary = databaseBuilder.factory.buildCampaignParticipation({
+            userId,
+            campaignId: campaign.id,
+            participantExternalId: 'Shared-February',
+            createdAt: new Date('2020-01-02'),
+            sharedAt: new Date('2023-02-01'),
+          });
+          databaseBuilder.factory.buildAssessment({
+            campaignParticipationId: participationSharedInFebruary.id,
+            type: Assessment.types.CAMPAIGN,
+            userId,
+          });
+          const participationSharedInMarch = databaseBuilder.factory.buildCampaignParticipation({
+            userId,
+            campaignId: campaign.id,
+            participantExternalId: 'Shared-March',
+            createdAt: new Date('2020-01-02'),
+            sharedAt: new Date('2023-03-01'),
+            isImproved: true,
+          });
+          databaseBuilder.factory.buildAssessment({
+            campaignParticipationId: participationSharedInMarch.id,
+            type: Assessment.types.CAMPAIGN,
+            userId,
+          });
+          await databaseBuilder.commit();
 
-      it('should sort participations by descending sharedAt when createdAt is the same and campaign code is the same', async function () {
-        const campaign = databaseBuilder.factory.buildCampaign();
-        // given
-        const participationSharedInJanuary = databaseBuilder.factory.buildCampaignParticipation({
-          userId,
-          campaignId: campaign.id,
-          participantExternalId: 'Shared-January',
-          createdAt: new Date('2020-01-02'),
-          sharedAt: new Date('2023-01-01'),
-          isImproved: true,
-        });
-        databaseBuilder.factory.buildAssessment({
-          campaignParticipationId: participationSharedInJanuary.id,
-          type: Assessment.types.CAMPAIGN,
-          userId,
-        });
-        const participationSharedInFebruary = databaseBuilder.factory.buildCampaignParticipation({
-          userId,
-          campaignId: campaign.id,
-          participantExternalId: 'Shared-February',
-          createdAt: new Date('2020-01-02'),
-          sharedAt: new Date('2023-02-01'),
-        });
-        databaseBuilder.factory.buildAssessment({
-          campaignParticipationId: participationSharedInFebruary.id,
-          type: Assessment.types.CAMPAIGN,
-          userId,
-        });
-        const participationSharedInMarch = databaseBuilder.factory.buildCampaignParticipation({
-          userId,
-          campaignId: campaign.id,
-          participantExternalId: 'Shared-March',
-          createdAt: new Date('2020-01-02'),
-          sharedAt: new Date('2023-03-01'),
-          isImproved: true,
-        });
-        databaseBuilder.factory.buildAssessment({
-          campaignParticipationId: participationSharedInMarch.id,
-          type: Assessment.types.CAMPAIGN,
-          userId,
-        });
-        await databaseBuilder.commit();
+          // when
+          const participationsForUserManagement = await participationsForUserManagementRepository.findByUserId(userId);
 
-        // when
-        const participationsForUserManagement = await participationsForUserManagementRepository.findByUserId(userId);
-
-        // then
-        expect(participationsForUserManagement[0].campaignParticipationId).to.equal(participationSharedInMarch.id);
-        expect(participationsForUserManagement[1].campaignParticipationId).to.equal(participationSharedInFebruary.id);
-        expect(participationsForUserManagement[2].campaignParticipationId).to.equal(participationSharedInJanuary.id);
+          // then
+          expect(participationsForUserManagement[0].campaignParticipationId).to.equal(participationSharedInMarch.id);
+          expect(participationsForUserManagement[1].campaignParticipationId).to.equal(participationSharedInFebruary.id);
+          expect(participationsForUserManagement[2].campaignParticipationId).to.equal(participationSharedInJanuary.id);
+        });
       });
     });
   });


### PR DESCRIPTION
## :christmas_tree: Problème

Sur admin, suite à la récupération des participations depuis la table `assessments`, lorsqu'on fait un retenter, on se retrouve avec 2 fois la même participation.

## :gift: Proposition

On utilise un `GROUP BY` pour dédoublonner les participation qui ont été retentée.

## :socks: Remarques
On s'est aperçu que le `union` sql dé dupliquer les lignes qui ont exactement les même attributs
  
## :santa: Pour tester

- passer un campagne et faire retenter
- aller sur admin et afficher les participations de l'utilisateur
- voir qu'on a qu'une seule participation à la campagne
