### PR TITLE
[TECH] Corrige un lien cassé dans la doc  `api-dependencies.md`

### DIFF
--- a/docs/api-dependencies.md
+++ b/docs/api-dependencies.md
@@ -36,7 +36,7 @@ module.exports = async function attachTargetProfilesToOrganization({
 
 Déclarer le composant et ses dépendances dans le fichier [répertoire](../../api/lib/domain/usecases/index.js).
 
-Utiliser l'[injection automatique](../../api/lib/infrastructure/utils/dependency-injection.js) des dépendances en
+Utiliser l'[injection automatique](../api/src/shared/infrastructure/utils/dependency-injection.js) des dépendances en
 utilisant les paramètres objets JS.
 
 #### Test unitaire


### PR DESCRIPTION
## :christmas_tree: Problème

Nous n'arrivons pas à intégrer cette proposition de modification : https://github.com/1024pix/pix/pull/10584 
Elle corrige pourtant un lien cassé dans une doc.

## :gift: Proposition

Faire une autre PR après avoir fait un `cherry-pick` du commit en question

## :socks: Remarques

Merci @GradedJestRisk 

## :santa: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
