### PR TITLE
[BUGFIX] Placer le curseur de l'utilisateur sur les en-têtes des pages de réinitialisation de mot de passe (PIX-15937)

### DIFF
--- a/mon-pix/app/components/authentication/password-reset-demand/password-reset-demand-received-info.gjs
+++ b/mon-pix/app/components/authentication/password-reset-demand/password-reset-demand-received-info.gjs
@@ -1,8 +1,10 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import { hash } from '@ember/helper';
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
+import didInsert from 'mon-pix/modifiers/modifier-did-insert';
 
 export default class PasswordResetDemandReceivedInfo extends Component {
   @service intl;
@@ -10,10 +12,16 @@ export default class PasswordResetDemandReceivedInfo extends Component {
   get locale() {
     return this.intl.primaryLocale;
   }
+
+  @action
+  setFocus(element) {
+    element.focus({ focusVisible: false });
+  }
+
   <template>
     <div class="authentication-password-reset-demand-received-info">
       <img src="/images/mail.svg" alt="" />
-      <h2 class="authentication-password-reset-demand-received-info__heading">
+      <h2 class="authentication-password-reset-demand-received-info__heading" tabindex="-1" {{didInsert this.setFocus}}>
         {{t "components.authentication.password-reset-demand-received-info.heading"}}
       </h2>
       <p class="authentication-password-reset-demand-received-info__message">

--- a/mon-pix/app/components/authentication/password-reset-form.gjs
+++ b/mon-pix/app/components/authentication/password-reset-form.gjs
@@ -8,6 +8,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import get from 'lodash/get';
+import didInsert from 'mon-pix/modifiers/modifier-did-insert';
 import { FormValidation } from 'mon-pix/utils/form-validation';
 import isPasswordValid, { PASSWORD_RULES } from 'mon-pix/utils/password-validator.js';
 
@@ -102,10 +103,14 @@ export default class PasswordResetForm extends Component {
   </template>
 }
 
+const setFocus = (element) => {
+  element.focus({ focusVisible: false });
+};
+
 const PasswordResetSucceededInfo = <template>
   <div class="password-reset-succeeded-info">
     <img src="/images/success-check.svg" alt="" />
-    <h2 class="password-reset-succeeded-info__heading">
+    <h2 class="password-reset-succeeded-info__heading" tabindex="-1" {{didInsert setFocus}}>
       {{t "components.authentication.password-reset-form.success-info.message"}}
     </h2>
   </div>


### PR DESCRIPTION
## :christmas_tree: Problème

Lorsqu'on se trouvait sur la page mot de passe oublié, ou encore sur la page de récupération du mot de passe, il n'y avait aucune indication lorsque le composant changeait, par exemple lorsque le message indiquant qu'un mail avait été envoyé était affichée à l'écran.
Cela pouvait être problématique pour les lecteurs d'écran, car l'utilisateur pouvait pensé que rien ne s'était produit sur sa page.

## :gift: Proposition

Pour ces 2 composants, faire en sorte que le cursseur de l'utilisateur soit placé automatiquement sur l'en-tête.

## :socks: Remarques

On a pu constaté que lors du changement de route, le lecteur d'écran ne signalait pas forcément qu'une nouvelle page était affichée. Serait-il utile de mettre (à plus grande échelle) une instruction plaçant l'utilisateur dans la zone principale de la page?

## :santa: Pour tester

### Avec un lecteur d'écran

Activer son lecteur d'écran, VoiceOver sur Mac ou le narrateur sous Windows.

#### Sur la page de demande de réinitialisation
- Se rendre sur la page de mot de passe oublié,
- Entrer un mail de teste et appuyé sur le bouton en faisant tab pour trouver le bouton,
- Constaté que le lecteur d'écran annonce bien le titre.

#### Sur la page de réinitialisation
- Entrer le nouveau mot de passe,
- Appuyé sur le bouton en faisant tab puis entré,
- Constaté que le lecteur d'écran annonce bien le titre..

### Avec un navigateur visuel

:information_source: Avec les navigateurs visuels le déplacement de focus dans la page ne semble se manifester que lorsqu'on navigue au clavier, avec des tab donc.

#### Avec Chrome

- Le focus de la page doit se déplacer sur le titre 2 et une zone visuelle indiquera la zone du focus.

![Screenshot_20250107_162355](https://github.com/user-attachments/assets/d0f0c5bc-e054-4b74-96a8-0289d184880d)

#### Avec Firefox

- Le focus de la page doit se déplacer sur le titre 2 mais sans indiquer de zone visuelle. C'est ce qu'on souhaite, mais actuellement seul Firefox a cette fonctionnalité : https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus
