### PR TITLE
[TECH] Limiter l'exposition des données persos en paramètre de la route parcoursup (PIX-15952) .

### DIFF
--- a/api/src/parcoursup/application/certification-controller.js
+++ b/api/src/parcoursup/application/certification-controller.js
@@ -1,7 +1,7 @@
 import { usecases } from '../domain/usecases/index.js';
 
 const getCertificationResult = async function (request) {
-  return usecases.getCertificationResult(request.query);
+  return usecases.getCertificationResult(request.payload);
 };
 
 const certificationController = {

--- a/api/src/parcoursup/application/certification-route.js
+++ b/api/src/parcoursup/application/certification-route.js
@@ -9,33 +9,35 @@ import { certificationController } from './certification-controller.js';
 
 const register = async function (server) {
   server.route({
-    method: 'GET',
+    method: 'POST',
     path: '/api/parcoursup/certification/search',
     config: {
       auth: 'jwt-parcoursup',
       validate: {
-        query: Joi.alternatives().try(
-          Joi.object({
-            ine: studentIdentifierType,
-          }),
-          Joi.object({
-            organizationUai: Joi.string().required(),
-            lastName: Joi.string().required(),
-            firstName: Joi.string().required(),
-            birthdate: Joi.string().required(),
-          }),
-          Joi.object({
-            verificationCode: certificationVerificationCodeType.required(),
-          }),
-        ),
+        payload: Joi.alternatives()
+          .try(
+            Joi.object({
+              ine: studentIdentifierType.required(),
+            }),
+            Joi.object({
+              organizationUai: Joi.string().required(),
+              lastName: Joi.string().required(),
+              firstName: Joi.string().required(),
+              birthdate: Joi.string().required(),
+            }),
+            Joi.object({
+              verificationCode: certificationVerificationCodeType.required(),
+            }),
+          )
+          .required(),
       },
       handler: certificationController.getCertificationResult,
       tags: ['api', 'parcoursup'],
       notes: [
-        '- **Cette route est accessible uniquement à Parcoursup**\n' +
-          '- avec un INE, récupère la dernière certification de l‘année en cours pour l‘élève identifié' +
-          '- avec un UAI, nom, prénom et date de naissance, récupère la dernière certification de l‘année en cours pour l‘élève identifié' +
-          '- avec un code de vérification, récupère la certification correspondante',
+        '**Cette route est accessible uniquement à Parcoursup**\n' +
+          '- Avec un INE, récupère la dernière certification de l‘année en cours pour l‘élève identifié\n' +
+          '- Avec un UAI, nom, prénom et date de naissance, récupère la dernière certification de l‘année en cours pour l‘élève identifié\n' +
+          '- Avec un code de vérification, récupère la certification correspondante',
       ],
       response: {
         failAction: 'log',

--- a/api/tests/parcoursup/acceptance/application/certification-route_test.js
+++ b/api/tests/parcoursup/acceptance/application/certification-route_test.js
@@ -1,51 +1,87 @@
 import {
   createServer,
-  databaseBuilder,
   datamartBuilder,
   expect,
   generateValidRequestAuthorizationHeaderForApplication,
 } from '../../../test-helper.js';
 
 describe('Parcoursup | Acceptance | Application | certification-route', function () {
-  let server;
-
-  const PARCOURSUP_CLIENT_ID = 'test-parcoursupClientId';
-  const PARCOURSUP_SCOPE = 'parcoursup';
-  const PARCOURSUP_SOURCE = 'parcoursup';
+  let server,
+    ine,
+    organizationUai,
+    lastName,
+    firstName,
+    birthdate,
+    PARCOURSUP_CLIENT_ID,
+    PARCOURSUP_SCOPE,
+    PARCOURSUP_SOURCE,
+    expectedCertification;
 
   beforeEach(async function () {
     server = await createServer();
+
+    PARCOURSUP_CLIENT_ID = 'test-parcoursupClientId';
+    PARCOURSUP_SCOPE = 'parcoursup';
+    PARCOURSUP_SOURCE = 'parcoursup';
+
+    ine = '123456789OK';
+    organizationUai = 'UAI ETAB ELEVE';
+    lastName = 'NOM-ELEVE';
+    firstName = 'PRENOM-ELEVE';
+    birthdate = '2000-01-01';
+
+    const certificationResultData = {
+      nationalStudentId: ine,
+      organizationUai,
+      lastName,
+      firstName,
+      birthdate,
+      status: 'validated',
+      pixScore: 327,
+      certificationDate: '2024-11-22T09:39:54Z',
+    };
+
+    expectedCertification = {
+      organizationUai,
+      ine,
+      lastName,
+      firstName,
+      birthdate,
+      status: 'validated',
+      pixScore: 327,
+      certificationDate: new Date('2024-11-22T09:39:54Z'),
+      competences: [
+        {
+          id: 'xzef1223443',
+          level: 3,
+        },
+        {
+          id: 'otherCompetenceId',
+          level: 5,
+        },
+      ],
+    };
+
+    datamartBuilder.factory.buildCertificationResult({
+      ...certificationResultData,
+      competenceId: 'xzef1223443',
+      competenceLevel: 3,
+    });
+    datamartBuilder.factory.buildCertificationResult({
+      ...certificationResultData,
+      competenceId: 'otherCompetenceId',
+      competenceLevel: 5,
+    });
+
+    await datamartBuilder.commit();
   });
 
-  describe('GET /api/parcoursup/certification/search', function () {
+  describe('POST /api/parcoursup/certification/search', function () {
     it('should return 200 HTTP status code and a certification for a given INE', async function () {
       // given
-      const ine = '123456789OK';
-      const certificationResultData = {
-        nationalStudentId: ine,
-        organizationUai: 'UAI ETAB ELEVE',
-        lastName: 'NOM-ELEVE',
-        firstName: 'PRENOM-ELEVE',
-        birthdate: '2000-01-01',
-        status: 'validated',
-        pixScore: 327,
-        certificationDate: '2024-11-22T09:39:54Z',
-      };
-      datamartBuilder.factory.buildCertificationResult({
-        ...certificationResultData,
-        competenceId: 'xzef1223443',
-        competenceLevel: 3,
-      });
-      datamartBuilder.factory.buildCertificationResult({
-        ...certificationResultData,
-        competenceId: 'otherCompetenceId',
-        competenceLevel: 5,
-      });
-      await datamartBuilder.commit();
-
       const options = {
-        method: 'GET',
-        url: `/api/parcoursup/certification/search?ine=${ine}`,
+        method: 'POST',
+        url: `/api/parcoursup/certification/search`,
         headers: {
           authorization: generateValidRequestAuthorizationHeaderForApplication(
             PARCOURSUP_CLIENT_ID,
@@ -53,30 +89,9 @@ describe('Parcoursup | Acceptance | Application | certification-route', function
             PARCOURSUP_SCOPE,
           ),
         },
-      };
-
-      await databaseBuilder.commit();
-
-      const expectedCertification = {
-        organizationUai: 'UAI ETAB ELEVE',
-        ine,
-        lastName: 'NOM-ELEVE',
-        firstName: 'PRENOM-ELEVE',
-        birthdate: '2000-01-01',
-        status: 'validated',
-        pixScore: 327,
-        certificationDate: new Date('2024-11-22T09:39:54Z'),
-        competences: [
-          {
-            // TODO ask DataTeam to add code and label (1.1 Mener une recherche et une veille d’information)
-            id: 'xzef1223443',
-            level: 3,
-          },
-          {
-            id: 'otherCompetenceId',
-            level: 5,
-          },
-        ],
+        payload: {
+          ine,
+        },
       };
 
       // when
@@ -86,40 +101,12 @@ describe('Parcoursup | Acceptance | Application | certification-route', function
       expect(response.statusCode).to.equal(200);
       expect(response.result).to.deep.equal(expectedCertification);
     });
-  });
 
-  describe('GET /api/parcoursup/certification/search?organizationUai={UAI}&lastName={lastName}&firstName={firstName}&birthdate={birthdate}', function () {
     it('should return 200 HTTP status code and a certification for a given UAI, last name, first name and birthdate', async function () {
       // given
-      const organizationUai = '1234567A';
-      const lastName = 'NOM-ELEVE';
-      const firstName = 'PRENOM-ELEVE';
-      const birthdate = '2000-01-01';
-      const certificationResultData = {
-        nationalStudentId: '123456789OK',
-        organizationUai,
-        lastName,
-        firstName,
-        birthdate,
-        status: 'validated',
-        pixScore: 327,
-        certificationDate: '2024-11-22T09:39:54Z',
-      };
-      datamartBuilder.factory.buildCertificationResult({
-        ...certificationResultData,
-        competenceId: 'xzef1223443',
-        competenceLevel: 3,
-      });
-      datamartBuilder.factory.buildCertificationResult({
-        ...certificationResultData,
-        competenceId: 'otherCompetenceId',
-        competenceLevel: 5,
-      });
-      await datamartBuilder.commit();
-
       const options = {
-        method: 'GET',
-        url: `/api/parcoursup/certification/search?organizationUai=${organizationUai}&lastName=${lastName}&firstName=${firstName}&birthdate=${birthdate}`,
+        method: 'POST',
+        url: `/api/parcoursup/certification/search`,
         headers: {
           authorization: generateValidRequestAuthorizationHeaderForApplication(
             PARCOURSUP_CLIENT_ID,
@@ -127,29 +114,12 @@ describe('Parcoursup | Acceptance | Application | certification-route', function
             PARCOURSUP_SCOPE,
           ),
         },
-      };
-
-      await databaseBuilder.commit();
-
-      const expectedCertification = {
-        organizationUai,
-        ine: '123456789OK',
-        lastName,
-        firstName,
-        birthdate,
-        status: 'validated',
-        pixScore: 327,
-        certificationDate: new Date('2024-11-22T09:39:54Z'),
-        competences: [
-          {
-            id: 'xzef1223443',
-            level: 3,
-          },
-          {
-            id: 'otherCompetenceId',
-            level: 5,
-          },
-        ],
+        payload: {
+          organizationUai,
+          lastName,
+          firstName,
+          birthdate,
+        },
       };
 
       // when
@@ -159,9 +129,7 @@ describe('Parcoursup | Acceptance | Application | certification-route', function
       expect(response.statusCode).to.equal(200);
       expect(response.result).to.deep.equal(expectedCertification);
     });
-  });
 
-  describe('GET /api/parcoursup/certification/search?verificationCode={verificationCode}', function () {
     it('should return 200 HTTP status code and a certification for a given vérificationCode', async function () {
       // given
       const verificationCode = 'P-1234567A';
@@ -190,8 +158,8 @@ describe('Parcoursup | Acceptance | Application | certification-route', function
       await datamartBuilder.commit();
 
       const options = {
-        method: 'GET',
-        url: `/api/parcoursup/certification/search?verificationCode=${verificationCode}`,
+        method: 'POST',
+        url: '/api/parcoursup/certification/search',
         headers: {
           authorization: generateValidRequestAuthorizationHeaderForApplication(
             PARCOURSUP_CLIENT_ID,
@@ -199,9 +167,10 @@ describe('Parcoursup | Acceptance | Application | certification-route', function
             PARCOURSUP_SCOPE,
           ),
         },
+        payload: {
+          verificationCode,
+        },
       };
-
-      await databaseBuilder.commit();
 
       const expectedCertification = {
         ine: undefined,

--- a/api/tests/parcoursup/unit/application/certification-route_test.js
+++ b/api/tests/parcoursup/unit/application/certification-route_test.js
@@ -8,236 +8,192 @@ import {
 } from '../../../test-helper.js';
 
 describe('Parcoursup | Unit | Application | Routes | Certification', function () {
-  describe('GET /parcoursup/certification/search?ine={ine}', function () {
-    it('should return 200', async function () {
-      //given
-      sinon.stub(certificationController, 'getCertificationResult').callsFake((request, h) => h.response().code(200));
+  let url, method, headers, httpTestServer;
 
-      const httpTestServer = new HttpTestServer();
-      httpTestServer.setupAuthentication();
-      await httpTestServer.register(moduleUnderTest);
+  beforeEach(async function () {
+    url = '/api/parcoursup/certification/search';
+    sinon.stub(certificationController, 'getCertificationResult').callsFake((request, h) => h.response().code(200));
 
-      const PARCOURSUP_CLIENT_ID = 'test-parcoursupClientId';
-      const PARCOURSUP_SCOPE = 'parcoursup';
-      const PARCOURSUP_SOURCE = 'parcoursup';
+    httpTestServer = new HttpTestServer();
+    httpTestServer.setupAuthentication();
+    await httpTestServer.register(moduleUnderTest);
 
-      const method = 'GET';
-      const url = '/api/parcoursup/certification/search?ine=123456789OK';
-      const headers = {
-        authorization: generateValidRequestAuthorizationHeaderForApplication(
-          PARCOURSUP_CLIENT_ID,
-          PARCOURSUP_SOURCE,
-          PARCOURSUP_SCOPE,
-        ),
-      };
+    const PARCOURSUP_CLIENT_ID = 'test-parcoursupClientId';
+    const PARCOURSUP_SCOPE = 'parcoursup';
+    const PARCOURSUP_SOURCE = 'parcoursup';
 
-      // when
-      const response = await httpTestServer.request(method, url, null, null, headers);
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-
-    context('when the param is missing', function () {
-      let httpTestServer, headers;
-      beforeEach(async function () {
-        httpTestServer = new HttpTestServer();
-        httpTestServer.setupAuthentication();
-        await httpTestServer.register(moduleUnderTest);
-
-        const PARCOURSUP_CLIENT_ID = 'test-parcoursupClientId';
-        const PARCOURSUP_SCOPE = 'parcoursup';
-        const PARCOURSUP_SOURCE = 'parcoursup';
-
-        headers = {
-          authorization: generateValidRequestAuthorizationHeaderForApplication(
-            PARCOURSUP_CLIENT_ID,
-            PARCOURSUP_SOURCE,
-            PARCOURSUP_SCOPE,
-          ),
-        };
-      });
-
-      it('return 400 error', async function () {
-        const url = '/api/parcoursup/certification/search?ine=';
-
-        // when
-        const response = await httpTestServer.request('GET', url, null, null, headers);
-
-        // then
-        expect(response.statusCode).to.equal(400);
-      });
-    });
-
-    context('with the wrong scope', function () {
-      it('should return 403', async function () {
-        //given
-        const httpTestServer = new HttpTestServer();
-        httpTestServer.setupAuthentication();
-        await httpTestServer.register(moduleUnderTest);
-
-        const PARCOURSUP_CLIENT_ID = 'test-parcoursupClientId';
-        const PARCOURSUP_SCOPE = 'a-wrong-scope';
-        const PARCOURSUP_SOURCE = 'parcoursup';
-
-        const method = 'GET';
-        const url = '/api/parcoursup/certification/search?ine=123456789OK';
-        const headers = {
-          authorization: generateValidRequestAuthorizationHeaderForApplication(
-            PARCOURSUP_CLIENT_ID,
-            PARCOURSUP_SOURCE,
-            PARCOURSUP_SCOPE,
-          ),
-        };
-
-        // when
-        const response = await httpTestServer.request(method, url, null, null, headers);
-
-        // then
-        expect(response.statusCode).to.equal(403);
-      });
-    });
-
-    context('with the wrong clientId', function () {
-      it('should return 401', async function () {
-        //given
-        const httpTestServer = new HttpTestServer();
-        httpTestServer.setupAuthentication();
-        await httpTestServer.register(moduleUnderTest);
-
-        const PARCOURSUP_CLIENT_ID = 'wrongClientId';
-        const PARCOURSUP_SCOPE = 'parcoursup';
-        const PARCOURSUP_SOURCE = 'parcoursup';
-
-        const method = 'GET';
-        const url = '/api/parcoursup/certification/search?ine=123456789OK';
-        const headers = {
-          authorization: generateValidRequestAuthorizationHeaderForApplication(
-            PARCOURSUP_CLIENT_ID,
-            PARCOURSUP_SOURCE,
-            PARCOURSUP_SCOPE,
-          ),
-        };
-
-        // when
-        const response = await httpTestServer.request(method, url, null, null, headers);
-
-        // then
-        expect(response.statusCode).to.equal(401);
-      });
-    });
+    method = 'POST';
+    headers = {
+      authorization: generateValidRequestAuthorizationHeaderForApplication(
+        PARCOURSUP_CLIENT_ID,
+        PARCOURSUP_SOURCE,
+        PARCOURSUP_SCOPE,
+      ),
+    };
   });
 
-  describe('GET /parcoursup/certification/search?organizationUai={organizationUai}&lastName={lastName}&firstName={firstName}&birthdate={birthdate}', function () {
-    it('should return 200', async function () {
+  describe('POST /parcoursup/certification/search', function () {
+    it('should return 200 with a valid ine params in body', async function () {
       //given
-      sinon.stub(certificationController, 'getCertificationResult').callsFake((request, h) => h.response().code(200));
-
-      const httpTestServer = new HttpTestServer();
-      httpTestServer.setupAuthentication();
-      await httpTestServer.register(moduleUnderTest);
-
-      const PARCOURSUP_CLIENT_ID = 'test-parcoursupClientId';
-      const PARCOURSUP_SCOPE = 'parcoursup';
-      const PARCOURSUP_SOURCE = 'parcoursup';
-
-      const method = 'GET';
-      const url =
-        '/api/parcoursup/certification/search?organizationUai=1234567A&lastName=LEPONGE&firstName=BOB&birthdate=2000-01-01';
-      const headers = {
-        authorization: generateValidRequestAuthorizationHeaderForApplication(
-          PARCOURSUP_CLIENT_ID,
-          PARCOURSUP_SOURCE,
-          PARCOURSUP_SCOPE,
-        ),
+      const payload = {
+        ine: '123456789OK',
       };
-
       // when
-      const response = await httpTestServer.request(method, url, null, null, headers);
+      const response = await httpTestServer.request(method, url, payload, null, headers);
 
       // then
       expect(response.statusCode).to.equal(200);
     });
 
-    context('return 400 error when any required query param is missing', function () {
-      let httpTestServer, headers;
-      beforeEach(async function () {
-        httpTestServer = new HttpTestServer();
-        httpTestServer.setupAuthentication();
-        await httpTestServer.register(moduleUnderTest);
+    it('should return 200 with with valid organizationUai, lastName, firstName and birthdate in body params', async function () {
+      //given
+      const payload = {
+        organizationUai: '1234567A',
+        lastName: 'LEPONGE',
+        firstName: 'BOB',
+        birthdate: '2000-01-01',
+      };
 
-        const PARCOURSUP_CLIENT_ID = 'test-parcoursupClientId';
-        const PARCOURSUP_SCOPE = 'parcoursup';
-        const PARCOURSUP_SOURCE = 'parcoursup';
+      // when
+      const response = await httpTestServer.request(method, url, payload, null, headers);
 
-        headers = {
-          authorization: generateValidRequestAuthorizationHeaderForApplication(
-            PARCOURSUP_CLIENT_ID,
-            PARCOURSUP_SOURCE,
-            PARCOURSUP_SCOPE,
-          ),
-        };
-      });
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
 
-      it('case of organizationUai', async function () {
-        const url = '/api/parcoursup/certification/search?lastName=LEPONGE&firstName=BOB&birthdate=2000-01-01';
+    it('should return 200 with a valide verificationCode params in body', async function () {
+      //given
+      const payload = {
+        verificationCode: 'P-1234567A',
+      };
+
+      // when
+      const response = await httpTestServer.request(method, url, payload, null, headers);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    context('return 400 error', function () {
+      it('case of empty payload', async function () {
+        const payload = {};
 
         // when
-        const response = await httpTestServer.request('GET', url, null, null, headers);
+        const response = await httpTestServer.request(method, url, payload, null, headers);
 
         // then
         expect(response.statusCode).to.equal(400);
       });
 
-      it('case of lastName', async function () {
-        const url = '/api/parcoursup/certification/search?organizationUai=1234567A&firstName=BOB&birthdate=2000-01-01';
+      it('case of null payload', async function () {
+        const payload = null;
 
         // when
-        const response = await httpTestServer.request('GET', url, null, null, headers);
+        const response = await httpTestServer.request(method, url, payload, null, headers);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+      it('case of missing INE', async function () {
+        const payload = { ine: '' };
+
+        // when
+        const response = await httpTestServer.request(method, url, payload, null, headers);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+      it('case of missing organizationUai', async function () {
+        const payload = {
+          lastName: 'LEPONGE',
+          firstName: 'BOB',
+          birthdate: '2000-01-01',
+        };
+
+        // when
+        const response = await httpTestServer.request(method, url, payload, null, headers);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+      it('case of missing lastName', async function () {
+        const payload = {
+          organizationUai: '1234567A',
+          firstName: 'BOB',
+          birthdate: '2000-01-01',
+        };
+
+        // when
+        const response = await httpTestServer.request(method, url, payload, null, headers);
 
         // then
         expect(response.statusCode).to.equal(400);
       });
 
       it('case of firstName', async function () {
-        const url =
-          '/api/parcoursup/certification/search?organizationUai=1234567A&lastName=LEPONGE&birthdate=2000-01-01';
+        const payload = {
+          organizationUai: '1234567A',
+          lastName: 'LEPONGE',
+          birthdate: '2000-01-01',
+        };
 
         // when
-        const response = await httpTestServer.request('GET', url, null, null, headers);
+        const response = await httpTestServer.request(method, url, payload, null, headers);
 
         // then
         expect(response.statusCode).to.equal(400);
       });
 
       it('case of birthdate', async function () {
-        const url = '/api/parcoursup/certification/search?organizationUai=1234567A&lastName=LEPONGE&firstName=BOB';
+        const payload = {
+          organizationUai: '1234567A',
+          lastName: 'LEPONGE',
+          firstName: 'BOB',
+        };
 
         // when
-        const response = await httpTestServer.request('GET', url, null, null, headers);
+        const response = await httpTestServer.request(method, url, payload, null, headers);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+      it('case of verificationCode format is invalid', async function () {
+        const payload = {
+          verificationCode: '1234567A',
+        };
+
+        // when
+        const response = await httpTestServer.request(method, url, payload, null, headers);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+      it('case of ine AND organizationUai', async function () {
+        const payload = {
+          ine: '123456789OK',
+          organizationUai: '123orgaUai',
+        };
+
+        // when
+        const response = await httpTestServer.request(method, url, payload, null, headers);
 
         // then
         expect(response.statusCode).to.equal(400);
       });
     });
-  });
 
-  describe('GET /parcoursup/certification/search?verificationCode={verificationCode}', function () {
-    it('should return 200', async function () {
+    it('should return 403 with a wrong scope', async function () {
       //given
-      sinon.stub(certificationController, 'getCertificationResult').callsFake((request, h) => h.response().code(200));
-
-      const httpTestServer = new HttpTestServer();
-      httpTestServer.setupAuthentication();
-      await httpTestServer.register(moduleUnderTest);
-
       const PARCOURSUP_CLIENT_ID = 'test-parcoursupClientId';
-      const PARCOURSUP_SCOPE = 'parcoursup';
+      const PARCOURSUP_SCOPE = 'a-wrong-scope';
       const PARCOURSUP_SOURCE = 'parcoursup';
 
-      const method = 'GET';
-      const url = '/api/parcoursup/certification/search?verificationCode=P-1234567A';
-      const headers = {
+      const payload = { ine: '123456789OK' };
+      headers = {
         authorization: generateValidRequestAuthorizationHeaderForApplication(
           PARCOURSUP_CLIENT_ID,
           PARCOURSUP_SOURCE,
@@ -246,70 +202,34 @@ describe('Parcoursup | Unit | Application | Routes | Certification', function ()
       };
 
       // when
-      const response = await httpTestServer.request(method, url, null, null, headers);
+      const response = await httpTestServer.request(method, url, payload, null, headers);
 
       // then
-      expect(response.statusCode).to.equal(200);
+      expect(response.statusCode).to.equal(403);
     });
 
-    context('when verificationCode format is invalid', function () {
-      it('returns 400 error', async function () {
-        const httpTestServer = new HttpTestServer();
-        httpTestServer.setupAuthentication();
-        await httpTestServer.register(moduleUnderTest);
+    it('should return 401 with the wrong clientId', async function () {
+      //given
+      const PARCOURSUP_CLIENT_ID = 'wrongClientId';
+      const PARCOURSUP_SCOPE = 'parcoursup';
+      const PARCOURSUP_SOURCE = 'parcoursup';
 
-        const PARCOURSUP_CLIENT_ID = 'test-parcoursupClientId';
-        const PARCOURSUP_SCOPE = 'parcoursup';
-        const PARCOURSUP_SOURCE = 'parcoursup';
+      const payload = {
+        ine: '123456789OK',
+      };
+      headers = {
+        authorization: generateValidRequestAuthorizationHeaderForApplication(
+          PARCOURSUP_CLIENT_ID,
+          PARCOURSUP_SOURCE,
+          PARCOURSUP_SCOPE,
+        ),
+      };
 
-        const url = '/api/parcoursup/certification/search?verificationCode=1234567A';
-        const headers = {
-          authorization: generateValidRequestAuthorizationHeaderForApplication(
-            PARCOURSUP_CLIENT_ID,
-            PARCOURSUP_SOURCE,
-            PARCOURSUP_SCOPE,
-          ),
-        };
+      // when
+      const response = await httpTestServer.request(method, url, payload, null, headers);
 
-        // when
-        const response = await httpTestServer.request('GET', url, null, null, headers);
-
-        // then
-        expect(response.statusCode).to.equal(400);
-      });
-    });
-  });
-
-  describe('GET /parcoursup/certification/search?ine={ine}&organizationUai={organizationUai}', function () {
-    context('when both ine and organizationUai are used', function () {
-      let httpTestServer, headers;
-      beforeEach(async function () {
-        httpTestServer = new HttpTestServer();
-        httpTestServer.setupAuthentication();
-        await httpTestServer.register(moduleUnderTest);
-
-        const PARCOURSUP_CLIENT_ID = 'test-parcoursupClientId';
-        const PARCOURSUP_SCOPE = 'parcoursup';
-        const PARCOURSUP_SOURCE = 'parcoursup';
-
-        headers = {
-          authorization: generateValidRequestAuthorizationHeaderForApplication(
-            PARCOURSUP_CLIENT_ID,
-            PARCOURSUP_SOURCE,
-            PARCOURSUP_SCOPE,
-          ),
-        };
-      });
-
-      it('returns 400 error ', async function () {
-        const url = '/api/parcoursup/certification/search?ine=123456789OK&organizationUai=123orgaUai';
-
-        // when
-        const response = await httpTestServer.request('GET', url, null, null, headers);
-
-        // then
-        expect(response.statusCode).to.equal(400);
-      });
+      // then
+      expect(response.statusCode).to.equal(401);
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème

Le fait de passer par une requête GET pour parcoursup expose des données personnelles dans les paramètres de requête de l'url.

## :gift: Proposition

Remplacer la méthode de la route par un POST, et les paramètres de recherche par un payload

## :socks: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :santa: Pour tester

Aller sur `https://api-pr10962.review.pix.fr/api/documentation` et générer un token valide avec les bons `client_id`, `scope` et `client_secret`

Une fois le token créé, effectuer les requêtes suivantes :

Pour une recherche à partir d'un numéro INE
```bash
TOKEN=<token>
curl https://api-pr10962.review.pix.fr/api/parcoursup/certification/search \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -X POST \
    -d '{ "ine": "714347660RP" }'
```

Pour une recherche à partir d'un numéro d'`organizationUai`, `firstName`, `lastName`, et `birthdate`
```bash
TOKEN=<token>
curl https://api-pr10962.review.pix.fr/api/parcoursup/certification/search \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -X POST \
    -d '{ "organizationUai": "8664450K", "birthdate": "1926-01-07",  "firstName": "Mathilde", "lastName": "Durand" }'
```

Pour une recherche à partir d'un numéro de vérification de certification
```bash
TOKEN=<token>
curl https://api-pr10962.review.pix.fr/api/parcoursup/certification/search \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -X POST \
    -d '{ "verificationCode": "P-D1VAF1GU" }'
```
