### PR TITLE
[FEATURE] Humaniser les seeds Devcomp (PIX-15835)

### DIFF
--- a/api/db/seeds/data/team-devcomp/build-campaigns.js
+++ b/api/db/seeds/data/team-devcomp/build-campaigns.js
@@ -2,7 +2,7 @@ import { USER_ID_ADMIN_ORGANIZATION } from '../common/constants.js';
 import { createAssessmentCampaign } from '../common/tooling/campaign-tooling.js';
 import { PIX_EDU_SMALL_TARGET_PROFILE_ID, TEAM_DEVCOMP_ORGANIZATION_ID } from './constants.js';
 
-async function _createScoCampaigns(databaseBuilder, trainingIds) {
+async function _createScoCampaigns(databaseBuilder, trainingIds, participantCount) {
   await createAssessmentCampaign({
     databaseBuilder,
     organizationId: TEAM_DEVCOMP_ORGANIZATION_ID,
@@ -12,7 +12,7 @@ async function _createScoCampaigns(databaseBuilder, trainingIds) {
     idPixLabel: 'IdPixLabel',
     targetProfileId: PIX_EDU_SMALL_TARGET_PROFILE_ID,
     configCampaign: {
-      participantCount: 3,
+      participantCount,
       profileDistribution: { beginner: 1, perfect: 1, blank: 1 },
       recommendedTrainingsIds: trainingIds,
     },
@@ -27,13 +27,13 @@ async function _createScoCampaigns(databaseBuilder, trainingIds) {
     multipleSendings: true,
     targetProfileId: PIX_EDU_SMALL_TARGET_PROFILE_ID,
     configCampaign: {
-      participantCount: 3,
+      participantCount,
       profileDistribution: { beginner: 1, perfect: 1, blank: 1 },
       recommendedTrainingsIds: trainingIds,
     },
   });
 }
 
-export function buildCampaigns(databaseBuilder, trainingIds) {
-  return _createScoCampaigns(databaseBuilder, trainingIds);
+export function buildCampaigns(databaseBuilder, trainingIds, participantCount) {
+  return _createScoCampaigns(databaseBuilder, trainingIds, participantCount);
 }

--- a/api/db/seeds/data/team-devcomp/build-organization-learners.js
+++ b/api/db/seeds/data/team-devcomp/build-organization-learners.js
@@ -1,0 +1,62 @@
+import { TEAM_DEVCOMP_ORGANIZATION_ID } from './constants.js';
+
+export async function createDevcompOrganizationLearners(databaseBuilder) {
+  const firstUser = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Dave',
+    lastName: 'Comp',
+    email: 'dave-comp@example.net',
+    username: 'dave.comp',
+  });
+
+  const firstUserDetails = {
+    birthdate: '2012-01-01',
+    nationalStudentId: '0123456789DC',
+    user: firstUser,
+  };
+
+  const secondUser = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Kat',
+    lastName: 'Alloguicks',
+    email: 'kat-alloguicks@example.net',
+    username: 'kat.alloguicks',
+  });
+
+  const secondUserDetails = {
+    birthdate: '2012-02-02',
+    nationalStudentId: '0123456789JA',
+    user: secondUser,
+  };
+
+  const thirdUser = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Maude',
+    lastName: 'Hulix',
+    email: 'maude-hulix@example.net',
+    username: 'maude.hulix',
+  });
+
+  const thirdUserDetails = {
+    birthdate: '2012-03-03',
+    nationalStudentId: '0123456789MH',
+    user: thirdUser,
+  };
+
+  const userDetails = [firstUserDetails, secondUserDetails, thirdUserDetails];
+
+  userDetails.forEach((userDetails) => _buildOrganizationLearners({ ...userDetails, databaseBuilder }));
+
+  return userDetails.length;
+}
+
+function _buildOrganizationLearners({ birthdate, databaseBuilder, nationalStudentId, user }) {
+  const { id: userId, firstName, lastName } = user;
+  databaseBuilder.factory.buildOrganizationLearner({
+    firstName,
+    lastName,
+    birthdate,
+    division: '6E',
+    group: null,
+    organizationId: TEAM_DEVCOMP_ORGANIZATION_ID,
+    userId,
+    nationalStudentId,
+  });
+}

--- a/api/db/seeds/data/team-devcomp/data-builder.js
+++ b/api/db/seeds/data/team-devcomp/data-builder.js
@@ -1,13 +1,17 @@
 import { buildCampaigns } from './build-campaigns.js';
 import { createDevcompOrganization } from './build-organization.js';
+import { createDevcompOrganizationLearners } from './build-organization-learners.js';
 import { buildTargetProfiles } from './build-target-profiles.js';
 import { buildTrainings } from './build-trainings.js';
 
 async function teamDevcompDataBuilder({ databaseBuilder }) {
-  await buildTargetProfiles(databaseBuilder);
   await createDevcompOrganization(databaseBuilder);
+  const learnersCount = await createDevcompOrganizationLearners(databaseBuilder);
+  await databaseBuilder.commit();
+
+  await buildTargetProfiles(databaseBuilder);
   const trainingsIds = await buildTrainings(databaseBuilder);
-  await buildCampaigns(databaseBuilder, trainingsIds);
+  await buildCampaigns(databaseBuilder, trainingsIds, learnersCount);
 }
 
 export { teamDevcompDataBuilder };


### PR DESCRIPTION
## :christmas_tree: Problème

Les comptes utilisateurs Devcomp n'ont pas de nom parlant.

## :gift: Proposition

Leur donner des noms réalistes 😄 

## :socks: Remarques

RAS

## :santa: Pour tester

### Test en local
- Lancer la commande `SEEDS_CONTEXT=DEVCOMP npm run db:seed`
- Vérifier, dans la base, que les utilisateurs Maude Hulix, Jim Agine et Dave Comp existent bien.
- Vérifier aussi dans la base que les anciens utilisateurs learneremail8000_0@example.net, learneremail8000_1@example.net et learneremail8000_2@example.net n'existent plus

### Test sur Pix App
- Se connecter avec les nouveaux utilisateurs (maude-hulix@example.net...) sur Pix App et voir que ça fonctionne bien

### Test sur Pix Orga
- Sur Pix Orga, se connecter avec le compte admin-orga@example.net
- Aller sur l'organisation Devcomp puis sur l'onglet Elèves
- Vérifier que les nouveaux prescrits apparaissent et qu'ils ont un nombre de participations à 2.
