### PR TITLE
[FEATURE] Ajouter un on/off sur l'anonymisation lors de la suppression de prescrits (PIX-15880)

### DIFF
--- a/api/scripts/prod/delete-organization-learners-from-organization.js
+++ b/api/scripts/prod/delete-organization-learners-from-organization.js
@@ -1,128 +1,146 @@
-import * as url from 'node:url';
-
-import { disconnect } from '../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../lib/infrastructure/DomainTransaction.js';
 import { usecases } from '../../src/prescription/learner-management/domain/usecases/index.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
 
-async function deleteOrganizationLearnersFromOrganization(organizationId, date, isAnonymizationOff = false) {
-  if (date && isNaN(Date.parse(date))) {
-    throw new Error("La date passée en paramètre n'est pas valide");
-  }
-
-  await DomainTransaction.execute(async () => {
-    const engineeringUserId = process.env.ENGINEERING_USER_ID;
-
-    let organizationLearnerToDeleteIds;
-
-    if (date) {
-      organizationLearnerToDeleteIds = await _getOrganizationLearnersToDeleteIds({ organizationId, date });
-
-      await _deleteCampaignParticipations({ engineeringUserId, organizationId, date });
-    } else {
-      const knexConnection = DomainTransaction.getConnection();
-      organizationLearnerToDeleteIds = await knexConnection('organization-learners')
-        .where({ organizationId })
-        .whereNull('deletedAt')
-        .pluck('id');
-    }
-
-    await usecases.deleteOrganizationLearners({
-      organizationLearnerIds: organizationLearnerToDeleteIds,
-      userId: engineeringUserId,
-      organizationId,
+export class DeleteOrganizationLearnersFromOrganizationScript extends Script {
+  constructor() {
+    super({
+      description: 'Deletes organization-learners and potentially anonymize them',
+      permanent: true,
+      options: {
+        organizationId: {
+          type: 'number',
+          describe: 'an id from a single organization',
+          demandOption: true,
+          coerce: Number,
+        },
+        date: {
+          type: 'string',
+          describe: 'Delete learners which activity is older than this date, if undefined : delete all learners',
+          demandOption: false,
+        },
+        executeAnonymization: {
+          type: 'boolean',
+          describe: 'Default true, set to false to delete without anonymizing',
+          default: true,
+          demandOption: false,
+          coerce: Boolean,
+        },
+      },
     });
-
-    if (isAnonymizationOff === false) {
-      await _anonymizeOrganizationLearners({ organizationId });
-
-      const campaignParticipations = await _anonymizeCampaignParticipations({ organizationId });
-
-      await _detachAssessmentFromCampaignParticipations({ campaignParticipations });
-    }
-  });
-}
-
-function _getOrganizationLearnersToDeleteIds({ organizationId, date }) {
-  const knexConnection = DomainTransaction.getConnection();
-  return knexConnection('organization-learners')
-    .select(['organization-learners.id'])
-    .where({ organizationId })
-    .whereNull('deletedAt')
-    .whereRaw(`? <= ?`, [
-      knexConnection('campaign-participations')
-        .select('createdAt')
-        .whereRaw('"organizationLearnerId" = "organization-learners"."id"')
-        .orderBy('createdAt', 'desc')
-        .limit(1),
-      date,
-    ])
-    .pluck('organization-learners.id');
-}
-
-async function _deleteCampaignParticipations({ engineeringUserId, organizationId, date }) {
-  const knexConnection = DomainTransaction.getConnection();
-  await knexConnection('campaign-participations')
-    .update({
-      deletedAt: new Date(),
-      deletedBy: engineeringUserId,
-    })
-    .whereNull('deletedAt')
-    .whereRaw('id IN (?)', [
-      knexConnection('campaign-participations')
-        .join('organization-learners', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
-        .where({ organizationId })
-        .pluck('campaign-participations.id'),
-    ])
-    .andWhere('createdAt', '<=', date);
-}
-
-async function _anonymizeOrganizationLearners({ organizationId }) {
-  const knexConnection = DomainTransaction.getConnection();
-  await knexConnection('organization-learners')
-    .update({ firstName: '', lastName: '', userId: null, updatedAt: new Date() })
-    .where({ organizationId })
-    .whereNotNull('deletedAt');
-}
-
-function _anonymizeCampaignParticipations({ organizationId }) {
-  const knexConnection = DomainTransaction.getConnection();
-  return knexConnection('campaign-participations')
-    .update({ participantExternalId: null, userId: null })
-    .whereRaw('id IN (?)', [
-      knexConnection('campaign-participations')
-        .join('organization-learners', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
-        .where({ organizationId })
-        .whereNotNull('campaign-participations.deletedAt')
-        .pluck('campaign-participations.id'),
-    ])
-    .returning('id');
-}
-
-async function _detachAssessmentFromCampaignParticipations({ campaignParticipations }) {
-  const knexConnection = DomainTransaction.getConnection();
-  await knexConnection('assessments')
-    .update({ campaignParticipationId: null, updatedAt: new Date() })
-    .whereIn(
-      'campaignParticipationId',
-      campaignParticipations.map((campaignParticipation) => campaignParticipation.id),
-    );
-}
-
-const modulePath = url.fileURLToPath(import.meta.url);
-const isLaunchedFromCommandLine = process.argv[1] === modulePath;
-
-(async () => {
-  if (isLaunchedFromCommandLine) {
-    try {
-      await deleteOrganizationLearnersFromOrganization(process.argv[2], process.argv[3]);
-      console.log('done');
-    } catch (error) {
-      console.error(error);
-      process.exitCode = 1;
-    } finally {
-      await disconnect();
-    }
   }
-})();
 
-export { deleteOrganizationLearnersFromOrganization };
+  async handle({ options, logger }) {
+    const date = options.date;
+    const organizationId = options.organizationId;
+    const executeAnonymization = options.executeAnonymization;
+
+    if (date && isNaN(Date.parse(date))) {
+      throw new Error("La date passée en paramètre n'est pas valide");
+    }
+    logger.info(`Delete learner from organization : ${options.organizationId}.`);
+    if (date) {
+      logger.info(`Delete learner before ${options.date}`);
+    }
+    logger.info(`Anonymized data : ${options.executeAnonymization}`);
+    await DomainTransaction.execute(async () => {
+      const engineeringUserId = process.env.ENGINEERING_USER_ID;
+
+      let organizationLearnerToDeleteIds;
+
+      if (date) {
+        organizationLearnerToDeleteIds = await this.#getOrganizationLearnersToDeleteIds({ organizationId, date });
+
+        await this.#deleteCampaignParticipations({ engineeringUserId, organizationId, date });
+      } else {
+        const knexConnection = DomainTransaction.getConnection();
+        organizationLearnerToDeleteIds = await knexConnection('organization-learners')
+          .where({ organizationId })
+          .whereNull('deletedAt')
+          .pluck('id');
+      }
+
+      await usecases.deleteOrganizationLearners({
+        organizationLearnerIds: organizationLearnerToDeleteIds,
+        userId: engineeringUserId,
+        organizationId,
+      });
+
+      if (executeAnonymization) {
+        await this.#anonymizeOrganizationLearners({ organizationId });
+
+        const campaignParticipations = await this.#anonymizeCampaignParticipations({ organizationId });
+
+        await this.#detachAssessmentFromCampaignParticipations({ campaignParticipations });
+      }
+    });
+  }
+  async #deleteCampaignParticipations({ engineeringUserId, organizationId, date }) {
+    const knexConnection = DomainTransaction.getConnection();
+    await knexConnection('campaign-participations')
+      .update({
+        deletedAt: new Date(),
+        deletedBy: engineeringUserId,
+      })
+      .whereNull('deletedAt')
+      .whereRaw('id IN (?)', [
+        knexConnection('campaign-participations')
+          .join('organization-learners', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
+          .where({ organizationId })
+          .pluck('campaign-participations.id'),
+      ])
+      .andWhere('createdAt', '<=', date);
+  }
+
+  async #anonymizeOrganizationLearners({ organizationId }) {
+    const knexConnection = DomainTransaction.getConnection();
+    await knexConnection('organization-learners')
+      .update({ firstName: '', lastName: '', userId: null, updatedAt: new Date() })
+      .where({ organizationId })
+      .whereNotNull('deletedAt');
+  }
+
+  #anonymizeCampaignParticipations({ organizationId }) {
+    const knexConnection = DomainTransaction.getConnection();
+    return knexConnection('campaign-participations')
+      .update({ participantExternalId: null, userId: null })
+      .whereRaw('id IN (?)', [
+        knexConnection('campaign-participations')
+          .join('organization-learners', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
+          .where({ organizationId })
+          .whereNotNull('campaign-participations.deletedAt')
+          .pluck('campaign-participations.id'),
+      ])
+      .returning('id');
+  }
+
+  async #detachAssessmentFromCampaignParticipations({ campaignParticipations }) {
+    const knexConnection = DomainTransaction.getConnection();
+    await knexConnection('assessments')
+      .update({ campaignParticipationId: null, updatedAt: new Date() })
+      .whereIn(
+        'campaignParticipationId',
+        campaignParticipations.map((campaignParticipation) => campaignParticipation.id),
+      );
+  }
+
+  #getOrganizationLearnersToDeleteIds({ organizationId, date }) {
+    const knexConnection = DomainTransaction.getConnection();
+    return knexConnection('organization-learners')
+      .select(['organization-learners.id'])
+      .where({ organizationId })
+      .whereNull('deletedAt')
+      .whereRaw(`? <= ?`, [
+        knexConnection('campaign-participations')
+          .select('createdAt')
+          .whereRaw('"organizationLearnerId" = "organization-learners"."id"')
+          .orderBy('createdAt', 'desc')
+          .limit(1),
+        date,
+      ])
+      .pluck('organization-learners.id');
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, DeleteOrganizationLearnersFromOrganizationScript);

--- a/api/scripts/prod/delete-organization-learners-from-organization.js
+++ b/api/scripts/prod/delete-organization-learners-from-organization.js
@@ -4,7 +4,7 @@ import { disconnect } from '../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../lib/infrastructure/DomainTransaction.js';
 import { usecases } from '../../src/prescription/learner-management/domain/usecases/index.js';
 
-async function deleteOrganizationLearnersFromOrganization(organizationId, date) {
+async function deleteOrganizationLearnersFromOrganization(organizationId, date, isAnonymizationOff = false) {
   if (date && isNaN(Date.parse(date))) {
     throw new Error("La date passée en paramètre n'est pas valide");
   }
@@ -32,11 +32,13 @@ async function deleteOrganizationLearnersFromOrganization(organizationId, date) 
       organizationId,
     });
 
-    await _anonymizeOrganizationLearners({ organizationId });
+    if (isAnonymizationOff === false) {
+      await _anonymizeOrganizationLearners({ organizationId });
 
-    const campaignParticipations = await _anonymizeCampaignParticipations({ organizationId });
+      const campaignParticipations = await _anonymizeCampaignParticipations({ organizationId });
 
-    await _detachAssessmentFromCampaignParticipations({ campaignParticipations });
+      await _detachAssessmentFromCampaignParticipations({ campaignParticipations });
+    }
   });
 }
 

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
@@ -61,7 +61,7 @@ const removeByIds = function ({ organizationLearnerIds, userId }) {
   return knexConn('organization-learners')
     .whereIn('id', organizationLearnerIds)
     .whereNull('deletedAt')
-    .update({ deletedAt: new Date(), deletedBy: userId });
+    .update({ updatedAt: new Date(), deletedAt: new Date(), deletedBy: userId });
 };
 
 const disableAllOrganizationLearnersInOrganization = async function ({ organizationId, nationalStudentIds }) {

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -92,10 +92,11 @@ describe('Integration | Repository | Organization Learner Management | Organizat
 
       // then
       const organizationLearnerResult = await knex('organization-learners')
-        .select('deletedAt', 'deletedBy')
+        .select('updatedAt', 'deletedAt', 'deletedBy')
         .where('id', organizationLearnerId)
         .first();
 
+      expect(organizationLearnerResult.updatedAt).to.deep.equal(now);
       expect(organizationLearnerResult.deletedAt).to.deep.equal(now);
       expect(organizationLearnerResult.deletedBy).to.equal(userId);
     });


### PR DESCRIPTION
## :christmas_tree: Problème

Pour répondre à une demande du ministère de l'Economie, qui souhaite faire de la place, on doit supprimer des prescrits appartenant à une liste d'organisations. On leur a proposé d'utiliser le script d'anonymisation à date.
Or, on veut éviter d'avoir un gros rattrapage par la suite à faire sur les knowledge-elements qui auraient été détachés de ces users.

## :gift: Proposition
On veut featuriser l'anonymisation dans le script de la suppression d'organization-learners en ajoutant un 3e paramètre dans la fonction du script.

## :socks: Remarques
On pense bien à mettre à jour "updatedAt" lors de la suppression des prescrits.
On en a profité pour refactoriser le script afin qu'il corresponde au template actuellement utilisé (avec options/handle).

## :santa: Pour tester
Se connecter sur le Scalingo de la RA et lancer le script d'anonymisation avec en paramètres une liste d'id de prescrits, une date, et "true" en 3e paramètre.
Vérifier que les participations et les assessments du prescrits n'ont pas été détachés, et que le user a toujours ses noms / prénoms visibles.