### PR TITLE
[BUGFIX] Ré-ajoute la raison d'abandon du candidat (PIX-15969).

### DIFF
--- a/api/src/certification/session-management/application/certification-report-route.js
+++ b/api/src/certification/session-management/application/certification-report-route.js
@@ -3,6 +3,7 @@ import Joi from 'joi';
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { authorization } from '../../shared/application/pre-handlers/authorization.js';
+import { ABORT_REASONS } from '../../shared/domain/models/CertificationCourse.js';
 import { certificationReportController } from './certification-report-controller.js';
 
 const register = async function (server) {
@@ -37,6 +38,13 @@ const register = async function (server) {
         validate: {
           params: Joi.object({
             certificationCourseId: identifiersType.certificationCourseId,
+          }),
+          payload: Joi.object({
+            data: {
+              reason: Joi.string()
+                .valid(...Object.values(ABORT_REASONS))
+                .required(),
+            },
           }),
         },
         pre: [

--- a/api/tests/certification/session-management/acceptance/application/certification-report-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/certification-report-route_test.js
@@ -69,7 +69,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
       const options = {
         method: 'POST',
         url: `/api/certification-reports/${certificationCourseId}/abort`,
-        payload: { data: { attributes: { 'abort-reason': 'technical' } } },
+        payload: { data: { reason: 'technical' } },
         headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
       };
 

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -45,7 +45,7 @@ export default class SessionsFinalizeController extends Controller {
   async finalizeSession() {
     try {
       for (const certificationReport of this.session.uncompletedCertificationReports) {
-        await certificationReport.abort();
+        await certificationReport.abort(certificationReport.abortReason);
       }
       await this.session.save({ adapterOptions: { finalization: true } });
       this.pixToast.sendSuccessNotification({

--- a/certif/tests/unit/controllers/authenticated/sessions/finalize-test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/finalize-test.js
@@ -382,7 +382,9 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
       test('it finalizes the session', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
-        const certificationReport = store.createRecord('certification-report');
+        const certificationReport = store.createRecord('certification-report', {
+          abortReason: 'technical',
+        });
         certificationReport.abort = sinon.stub();
         const session = store.createRecord('session-management', {
           certificationReports: [certificationReport],
@@ -402,7 +404,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
         await controller.finalizeSession();
 
         // then
-        sinon.assert.calledOnce(certificationReport.abort);
+        sinon.assert.calledOnceWithExactly(certificationReport.abort, certificationReport.abortReason);
         assert.ok(true);
       });
     });


### PR DESCRIPTION
## :christmas_tree: Problème

Suite à la PR #10914 , la raison d'abandon du candidat n'était plus enregistrée lors de la finalisation de la session.

## :gift: Proposition

On ré-ajoute la raison d'abandon à la fois côté front et via une validation côté API qui n'existait pas.

## :socks: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :santa: Pour tester

- Créer une session avec `certifv3@example.net`
- Ajouter un candidat
- Passer une question du test avec `certif-success@example.net`
- Essayer de finaliser la session sans raison d'abandon
- Vérifier qu'une erreur est retournée
- Finaliser la session avec une raison d'abandon
- Vérifier que la finalisation s'est bien passée en regardant la présence de la raison en BDD dans `certification-courses`
BONUS: Vérifier que le statut de l'assessment-result créé est `rejected` (si vous avez répondu à moins de 20 questions)
