### PR TITLE
[BUGFIX] Modification du lien "Mot de passe oublié" de l'application www.orga.pix.org (PIX-15940)

### DIFF
--- a/orga/app/components/auth/login-form.hbs
+++ b/orga/app/components/auth/login-form.hbs
@@ -55,7 +55,7 @@
     </PixButton>
 
     <div class="login-form__forgotten-password">
-      <a href="{{t 'pages.login-form.forgotten-password-url'}}" target="_blank" rel="noopener noreferrer">
+      <a href="{{this.forgottenPasswordUrl}}" target="_blank" rel="noopener noreferrer">
         {{t "pages.login-form.forgot-password"}}
       </a>
     </div>

--- a/orga/app/components/auth/login-form.js
+++ b/orga/app/components/auth/login-form.js
@@ -29,6 +29,10 @@ export default class LoginForm extends Component {
     return !this.args.isWithInvitation;
   }
 
+  get forgottenPasswordUrl() {
+    return this.url.forgottenPasswordUrl;
+  }
+
   @action
   async authenticate(event) {
     event.preventDefault();

--- a/orga/app/services/url.js
+++ b/orga/app/services/url.js
@@ -50,8 +50,7 @@ export default class Url extends Service {
   }
 
   get homeUrl() {
-    const currentLanguage = this.intl.primaryLocale;
-    return `${this.definedHomeUrl}?lang=${currentLanguage}`;
+    return `${this.definedHomeUrl}?lang=${this._getCurrentLanguage()}`;
   }
 
   get legalNoticeUrl() {
@@ -75,20 +74,20 @@ export default class Url extends Service {
   }
 
   get serverStatusUrl() {
-    const currentLanguage = this.intl.primaryLocale;
-
-    return `${PIX_STATUS_DOMAIN}?locale=${currentLanguage}`;
+    return `${PIX_STATUS_DOMAIN}?locale=${this._getCurrentLanguage()}`;
   }
 
   get forgottenPasswordUrl() {
-    const currentLanguage = this.intl.primaryLocale;
-
     let url = `${this.pixAppUrlWithoutExtension}${this.currentDomain.getExtension()}/mot-de-passe-oublie`;
-    if (currentLanguage !== FRENCH_LOCALE) {
-      url += `?lang=${currentLanguage}`;
+    if (this._getCurrentLanguage() !== FRENCH_LOCALE) {
+      url += `?lang=${this._getCurrentLanguage()}`;
     }
 
     return url;
+  }
+
+  _getCurrentLanguage() {
+    return this.intl.primaryLocale;
   }
 
   get pixJuniorSchoolUrl() {
@@ -101,13 +100,11 @@ export default class Url extends Service {
   }
 
   _computeShowcaseWebsiteUrl({ en: englishPath, fr: frenchPath, nl: dutchPath }) {
-    const currentLanguage = this.intl.primaryLocale;
-
     if (this.currentDomain.isFranceDomain) {
       return `${PIX_FR_DOMAIN}${frenchPath}`;
     }
 
-    switch (currentLanguage) {
+    switch (this._getCurrentLanguage()) {
       case FRENCH_LOCALE:
         return `${PIX_ORG_DOMAIN_FR_LOCALE}${frenchPath}`;
       case ENGLISH_LOCALE:

--- a/orga/app/services/url.js
+++ b/orga/app/services/url.js
@@ -83,9 +83,10 @@ export default class Url extends Service {
   get forgottenPasswordUrl() {
     const currentLanguage = this.intl.primaryLocale;
     let url = `${this.pixAppUrlWithoutExtension}${this.currentDomain.getExtension()}/mot-de-passe-oublie`;
-    if (currentLanguage === 'en') {
-      url += '?lang=en';
+    if (currentLanguage !== FRENCH_LOCALE) {
+      url += `?lang=${currentLanguage}`;
     }
+
     return url;
   }
 

--- a/orga/app/services/url.js
+++ b/orga/app/services/url.js
@@ -82,6 +82,7 @@ export default class Url extends Service {
 
   get forgottenPasswordUrl() {
     const currentLanguage = this.intl.primaryLocale;
+
     let url = `${this.pixAppUrlWithoutExtension}${this.currentDomain.getExtension()}/mot-de-passe-oublie`;
     if (currentLanguage !== FRENCH_LOCALE) {
       url += `?lang=${currentLanguage}`;

--- a/orga/tests/integration/components/auth/login-form-test.js
+++ b/orga/tests/integration/components/auth/login-form-test.js
@@ -289,6 +289,10 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
         get isFranceDomain() {
           return false;
         }
+
+        getExtension() {
+          return '.org';
+        }
       }
       this.owner.register('service:currentDomain', CurrentDomainServiceStub);
 
@@ -306,6 +310,10 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
       class CurrentDomainServiceStub extends Service {
         get isFranceDomain() {
           return true;
+        }
+
+        getExtension() {
+          return '.fr';
         }
       }
       this.owner.register('service:currentDomain', CurrentDomainServiceStub);

--- a/orga/tests/unit/services/url-test.js
+++ b/orga/tests/unit/services/url-test.js
@@ -1,3 +1,4 @@
+import Service from '@ember/service';
 import { setLocale } from 'ember-intl/test-support';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -98,6 +99,52 @@ module('Unit | Service | url', function (hooks) {
           // then
           assert.strictEqual(url, expectedUrl);
         });
+      });
+    });
+  });
+
+  module('#forgottenPasswordUrl', function () {
+    [
+      {
+        locale: 'en',
+        currentDomain: 'org',
+        expectedUrl: 'https://app.pix.org/mot-de-passe-oublie?lang=en',
+      },
+      {
+        locale: 'fr',
+        currentDomain: 'fr',
+        expectedUrl: 'https://app.pix.fr/mot-de-passe-oublie',
+      },
+      {
+        locale: 'fr',
+        currentDomain: 'org',
+        expectedUrl: 'https://app.pix.org/mot-de-passe-oublie',
+      },
+      {
+        locale: 'nl',
+        currentDomain: 'org',
+        expectedUrl: 'https://app.pix.org/mot-de-passe-oublie?lang=nl',
+      },
+    ].forEach(({ locale, expectedUrl, currentDomain }) => {
+      test(`returns forgotten password url url when locale is ${locale} and domain is ${currentDomain}`, function (assert) {
+        // given
+        const urlService = this.owner.lookup('service:url');
+        class CurrentDomainServiceStub extends Service {
+          getExtension() {
+            return currentDomain;
+          }
+        }
+        this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+
+        urlService.intl = {
+          primaryLocale: locale,
+        };
+
+        // when
+        const url = urlService.forgottenPasswordUrl;
+
+        // then
+        assert.strictEqual(url, expectedUrl);
       });
     });
   });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -845,7 +845,6 @@
         }
       },
       "forgot-password": "Forgot your password?",
-      "forgotten-password-url": "https://app.pix.org/mot-de-passe-oublie?lang=en",
       "invitation-already-accepted": "This invitation has already been accepted. Please log in or contact the administrator of your Pix Orga space.",
       "invitation-was-cancelled": "This invitation is no longer valid. Please contact the administrator of your Pix Orga space.",
       "is-only-accessible": "Pix Orga is only accessible to invited members. Please contact your Pix Orga administrator in order to be invited.",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -851,7 +851,6 @@
         }
       },
       "forgot-password": "Mot de passe oublié ?",
-      "forgotten-password-url": "https://app.pix.fr/mot-de-passe-oublie",
       "invitation-already-accepted": "Cette invitation a déjà été acceptée. Connectez-vous ou contactez l'administrateur de votre espace Pix Orga.",
       "invitation-was-cancelled": "Cette invitation n’est plus valide. Contactez l’administrateur de votre espace Pix Orga.",
       "is-only-accessible": "L'accès à Pix Orga est limité aux membres invités. Contactez l’administrateur Pix Orga de votre organisation pour qu'il vous invite.",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -841,7 +841,6 @@
         }
       },
       "forgot-password": "Wachtwoord vergeten?",
-      "forgotten-password-url": "https://app.pix.org/mot-de-passe-oublie?lang=nl",
       "invitation-already-accepted": "Deze uitnodiging is al geaccepteerd. Log in of neem contact op met de beheerder van je Pix Orga-ruimte.",
       "invitation-was-cancelled": "Deze uitnodiging is niet langer geldig. Neem contact op met de beheerder van je Pix Orga-ruimte.",
       "is-only-accessible": "Toegang tot Pix Orga is beperkt tot uitgenodigde leden. Neem contact op met de Pix Orga-beheerder van je organisatie om je uit te nodigen.",


### PR DESCRIPTION
## :christmas_tree: Problème

depuis la mire de connexion, lorsque l’utilisateur souhaite réinitialiser son mot de passe en cliquant sur “Mot de passe oublié ?”, il est redirigé vers https://app.pix.fr/mot-de-passe-oublie au lieu de https://app.pix.org/mot-de-passe-oublie 


## :gift: Proposition

corriger l’url de réinitialisation du mot de passe sur la mire de connexion en mettant : https://app.pix.org/mot-de-passe-oublie  


## :santa: Pour tester

- Sur https://orga-pr10974.review.pix.org/
  - cliquer sur “Mot de passe oublié ?”
  - constater que la redirection se fait sur "https://app.pix.org/mot-de-passe-oublie" 
 
- Sur https://orga-pr10974.review.pix.fr/
  - cliquer sur “Mot de passe oublié ?”
  - constater que la redirection se fait sur "https://app.pix.fr/mot-de-passe-oublie" 
  
- Effectuer les même tests sur les versions En et Nl