### PR TITLE
[TECH] :truck: Déplace le `tube-repository` vers `src/shared`

### DIFF
--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -107,6 +107,7 @@ import * as courseRepository from '../../../src/shared/infrastructure/repositori
 import * as organizationLearnerRepository from '../../../src/shared/infrastructure/repositories/organization-learner-repository.js';
 import * as organizationRepository from '../../../src/shared/infrastructure/repositories/organization-repository.js';
 import * as skillRepository from '../../../src/shared/infrastructure/repositories/skill-repository.js';
+import * as tubeRepository from '../../../src/shared/infrastructure/repositories/tube-repository.js';
 import * as userLoginRepository from '../../../src/shared/infrastructure/repositories/user-login-repository.js';
 import * as codeUtils from '../../../src/shared/infrastructure/utils/code-utils.js';
 import * as writeCsvUtils from '../../../src/shared/infrastructure/utils/csv/write-csv-utils.js';
@@ -143,7 +144,6 @@ import * as targetProfileRepository from '../../infrastructure/repositories/targ
 import * as targetProfileShareRepository from '../../infrastructure/repositories/target-profile-share-repository.js';
 import * as targetProfileTrainingRepository from '../../infrastructure/repositories/target-profile-training-repository.js';
 import * as thematicRepository from '../../infrastructure/repositories/thematic-repository.js';
-import * as tubeRepository from '../../infrastructure/repositories/tube-repository.js';
 import * as stageCollectionRepository from '../../infrastructure/repositories/user-campaign-results/stage-collection-repository.js';
 import * as userOrganizationsForAdminRepository from '../../infrastructure/repositories/user-organizations-for-admin-repository.js';
 import * as learningContentConversionService from '../services/learning-content/learning-content-conversion-service.js';

--- a/api/lib/infrastructure/repositories/campaign-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-repository.js
@@ -1,9 +1,9 @@
 import { knex } from '../../../db/knex-database-connection.js';
-import * as tubeRepository from '../../../lib/infrastructure/repositories/tube-repository.js';
 import { CAMPAIGN_FEATURES } from '../../../src/shared/domain/constants.js';
 import { NotFoundError } from '../../../src/shared/domain/errors.js';
 import { Campaign } from '../../../src/shared/domain/models/Campaign.js';
 import * as skillRepository from '../../../src/shared/infrastructure/repositories/skill-repository.js';
+import * as tubeRepository from '../../../src/shared/infrastructure/repositories/tube-repository.js';
 import { DomainTransaction } from '../DomainTransaction.js';
 
 const areKnowledgeElementsResettable = async function ({ id }) {

--- a/api/lib/infrastructure/repositories/learning-content-repository.js
+++ b/api/lib/infrastructure/repositories/learning-content-repository.js
@@ -6,11 +6,11 @@ import { LearningContent } from '../../../src/shared/domain/models/LearningConte
 import * as areaRepository from '../../../src/shared/infrastructure/repositories/area-repository.js';
 import * as competenceRepository from '../../../src/shared/infrastructure/repositories/competence-repository.js';
 import * as skillRepository from '../../../src/shared/infrastructure/repositories/skill-repository.js';
+import * as tubeRepository from '../../../src/shared/infrastructure/repositories/tube-repository.js';
 import * as learningContentConversionService from '../../domain/services/learning-content/learning-content-conversion-service.js';
 import * as campaignRepository from './campaign-repository.js';
 import * as frameworkRepository from './framework-repository.js';
 import * as thematicRepository from './thematic-repository.js';
-import * as tubeRepository from './tube-repository.js';
 
 async function findByCampaignId(campaignId, locale) {
   const skills = await campaignRepository.findSkills({ campaignId });

--- a/api/scripts/prod/target-profile-migrations/common.js
+++ b/api/scripts/prod/target-profile-migrations/common.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 
-import * as tubeRepository from '../../../lib/infrastructure/repositories/tube-repository.js';
 import * as skillRepository from '../../../src/shared/infrastructure/repositories/skill-repository.js';
+import * as tubeRepository from '../../../src/shared/infrastructure/repositories/tube-repository.js';
 
 let allSkills;
 let allTubes;

--- a/api/scripts/prod/target-profile-migrations/parse-xls-files-for-target-profiles-migration.js
+++ b/api/scripts/prod/target-profile-migrations/parse-xls-files-for-target-profiles-migration.js
@@ -16,8 +16,8 @@ import XLSX from 'xlsx';
 
 import { disconnect, knex } from '../../../db/knex-database-connection.js';
 import { normalizeAndRemoveAccents } from '../../../lib/domain/services/validation-treatments.js';
-import * as tubeRepository from '../../../lib/infrastructure/repositories/tube-repository.js';
 import { learningContentCache as cache } from '../../../src/shared/infrastructure/caches/learning-content-cache.js';
+import * as tubeRepository from '../../../src/shared/infrastructure/repositories/tube-repository.js';
 import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import { autoMigrateTargetProfile } from './common.js';
 

--- a/api/src/certification/results/infrastructure/repositories/certified-profile-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certified-profile-repository.js
@@ -5,10 +5,6 @@ import { LOCALE } from '../../../../shared/domain/constants.js';
 const { FRENCH_SPOKEN } = LOCALE;
 import { knex } from '../../../../../db/knex-database-connection.js';
 import * as knowledgeElementRepository from '../../../../../lib/infrastructure/repositories/knowledge-element-repository.js';
-import * as tubeRepository from '../../../../../lib/infrastructure/repositories/tube-repository.js';
-import * as areaRepository from '../../../../../src/shared/infrastructure/repositories/area-repository.js';
-import * as competenceRepository from '../../../../../src/shared/infrastructure/repositories/competence-repository.js';
-import * as skillRepository from '../../../../../src/shared/infrastructure/repositories/skill-repository.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import {
   CertifiedArea,
@@ -17,6 +13,10 @@ import {
   CertifiedSkill,
   CertifiedTube,
 } from '../../../../shared/domain/read-models/CertifiedProfile.js';
+import * as areaRepository from '../../../../shared/infrastructure/repositories/area-repository.js';
+import * as competenceRepository from '../../../../shared/infrastructure/repositories/competence-repository.js';
+import * as skillRepository from '../../../../shared/infrastructure/repositories/skill-repository.js';
+import * as tubeRepository from '../../../../shared/infrastructure/repositories/tube-repository.js';
 
 const get = async function (certificationCourseId) {
   const certificationDatas = await knex

--- a/api/src/devcomp/infrastructure/repositories/training-trigger-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/training-trigger-repository.js
@@ -1,11 +1,11 @@
 import _ from 'lodash';
 
 import * as thematicRepository from '../../../../lib/infrastructure/repositories/thematic-repository.js';
-import * as tubeRepository from '../../../../lib/infrastructure/repositories/tube-repository.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import * as areaRepository from '../../../shared/infrastructure/repositories/area-repository.js';
 import * as competenceRepository from '../../../shared/infrastructure/repositories/competence-repository.js';
+import * as tubeRepository from '../../../shared/infrastructure/repositories/tube-repository.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { TrainingTrigger } from '../../domain/models/TrainingTrigger.js';
 import { TrainingTriggerTube } from '../../domain/models/TrainingTriggerTube.js';

--- a/api/src/learning-content/infrastructure/repositories/tube-repository.js
+++ b/api/src/learning-content/infrastructure/repositories/tube-repository.js
@@ -1,4 +1,4 @@
-import { clearCache } from '../../../../lib/infrastructure/repositories/tube-repository.js';
+import { clearCache } from '../../../shared/infrastructure/repositories/tube-repository.js';
 import { LearningContentRepository } from './learning-content-repository.js';
 
 class TubeRepository extends LearningContentRepository {

--- a/api/src/prescription/target-profile/infrastructure/repositories/target-profile-administration-repository.js
+++ b/api/src/prescription/target-profile/infrastructure/repositories/target-profile-administration-repository.js
@@ -2,7 +2,6 @@ import _ from 'lodash';
 
 import { knex } from '../../../../../db/knex-database-connection.js';
 import * as thematicRepository from '../../../../../lib/infrastructure/repositories/thematic-repository.js';
-import * as tubeRepository from '../../../../../lib/infrastructure/repositories/tube-repository.js';
 import { TargetProfileForAdmin } from '../../../../prescription/target-profile/domain/models/TargetProfileForAdmin.js';
 import { LOCALE } from '../../../../shared/domain/constants.js';
 import { constants } from '../../../../shared/domain/constants.js';
@@ -14,6 +13,7 @@ import { StageCollection } from '../../../../shared/domain/models/target-profile
 import * as areaRepository from '../../../../shared/infrastructure/repositories/area-repository.js';
 import * as competenceRepository from '../../../../shared/infrastructure/repositories/competence-repository.js';
 import * as skillRepository from '../../../../shared/infrastructure/repositories/skill-repository.js';
+import * as tubeRepository from '../../../../shared/infrastructure/repositories/tube-repository.js';
 import { TargetProfileSummaryForAdmin } from '../../domain/models/TargetProfileSummaryForAdmin.js';
 
 const { FRENCH_FRANCE } = LOCALE;

--- a/api/src/shared/infrastructure/repositories/tube-repository.js
+++ b/api/src/shared/infrastructure/repositories/tube-repository.js
@@ -1,8 +1,8 @@
-import { knex } from '../../../db/knex-database-connection.js';
-import { LearningContentResourceNotFound } from '../../../src/shared/domain/errors.js';
-import { Tube } from '../../../src/shared/domain/models/Tube.js';
-import { getTranslatedKey } from '../../../src/shared/domain/services/get-translated-text.js';
-import { LearningContentRepository } from '../../../src/shared/infrastructure/repositories/learning-content-repository.js';
+import { knex } from '../../../../db/knex-database-connection.js';
+import { LearningContentResourceNotFound } from '../../domain/errors.js';
+import { Tube } from '../../domain/models/Tube.js';
+import { getTranslatedKey } from '../../domain/services/get-translated-text.js';
+import { LearningContentRepository } from './learning-content-repository.js';
 
 const TABLE_NAME = 'learningcontent.tubes';
 const ACTIVE_STATUS = 'actif';

--- a/api/tests/shared/integration/infrastructure/repositories/tube-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/tube-repository_test.js
@@ -1,6 +1,6 @@
-import * as tubeRepository from '../../../../lib/infrastructure/repositories/tube-repository.js';
-import { LearningContentResourceNotFound } from '../../../../src/shared/domain/errors.js';
-import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../test-helper.js';
+import { LearningContentResourceNotFound } from '../../../../../src/shared/domain/errors.js';
+import * as tubeRepository from '../../../../../src/shared/infrastructure/repositories/tube-repository.js';
+import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
 
 describe('Integration | Repository | tube-repository', function () {
   const tubeData0 = {

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -21,7 +21,6 @@ import { DatabaseBuilder } from '../db/database-builder/database-builder.js';
 import { datamartKnex, disconnect, knex } from '../db/knex-database-connection.js';
 import * as frameworkRepository from '../lib/infrastructure/repositories/framework-repository.js';
 import * as thematicRepository from '../lib/infrastructure/repositories/thematic-repository.js';
-import * as tubeRepository from '../lib/infrastructure/repositories/tube-repository.js';
 import { PIX_ADMIN } from '../src/authorization/domain/constants.js';
 import * as tutorialRepository from '../src/devcomp/infrastructure/repositories/tutorial-repository.js';
 import * as missionRepository from '../src/school/infrastructure/repositories/mission-repository.js';
@@ -33,6 +32,7 @@ import * as challengeRepository from '../src/shared/infrastructure/repositories/
 import * as competenceRepository from '../src/shared/infrastructure/repositories/competence-repository.js';
 import * as courseRepository from '../src/shared/infrastructure/repositories/course-repository.js';
 import * as skillRepository from '../src/shared/infrastructure/repositories/skill-repository.js';
+import * as tubeRepository from '../src/shared/infrastructure/repositories/tube-repository.js';
 import * as customChaiHelpers from './tooling/chai-custom-helpers/index.js';
 import * as domainBuilder from './tooling/domain-builder/factory/index.js';
 import { jobChai } from './tooling/jobs/expect-job.js';


### PR DESCRIPTION
## :christmas_tree: Problème

Le `tube-repository` est encore dans `lib` et utilisé par beaucoup de context.

## :gift: Proposition

Déplacer le `tube-repository` dans le répertoire `src/shared`

## :socks: Remarques

## :santa: Pour tester

