### PR TITLE
[TECH] :package: chore(junior) mise à jour du paquet `ember-cli-mirage` de pix Junior

### DIFF
--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -41,7 +41,7 @@
         "ember-cli-dependency-checker": "^3.3.2",
         "ember-cli-htmlbars": "^6.3.0",
         "ember-cli-inject-live-reload": "^2.1.0",
-        "ember-cli-mirage": "^3.0.3",
+        "ember-cli-mirage": "^3.0.4",
         "ember-cli-sass": "^11.0.1",
         "ember-component-css": "^0.8.1",
         "ember-data": "~5.3.3",

--- a/junior/package.json
+++ b/junior/package.json
@@ -68,7 +68,7 @@
     "ember-cli-dependency-checker": "^3.3.2",
     "ember-cli-htmlbars": "^6.3.0",
     "ember-cli-inject-live-reload": "^2.1.0",
-    "ember-cli-mirage": "^3.0.3",
+    "ember-cli-mirage": "^3.0.4",
     "ember-cli-sass": "^11.0.1",
     "ember-component-css": "^0.8.1",
     "ember-data": "~5.3.3",


### PR DESCRIPTION
## :christmas_tree: Problème

La mise à jour de `ember/test-helper` est bloqué parce qu'`ember-cli-mirage` n'est pas à jour (pr #10956 bloquée)

## :gift: Proposition

Mettre à jour `ember-cli-mirage`


## :socks: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :santa: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
