### PR TITLE
[TECH] Refacto - méthodes dans OrganizationPlacesLotRepository (PIX-15818)

### DIFF
--- a/api/src/prescription/organization-place/domain/usecases/find-organization-places-lot.js
+++ b/api/src/prescription/organization-place/domain/usecases/find-organization-places-lot.js
@@ -1,5 +1,5 @@
 const findOrganizationPlacesLot = async function ({ organizationId, organizationPlacesLotRepository }) {
-  return organizationPlacesLotRepository.findByOrganizationId(organizationId);
+  return organizationPlacesLotRepository.findByOrganizationIdWithJoinedUsers(organizationId);
 };
 
 export { findOrganizationPlacesLot };

--- a/api/src/prescription/organization-place/domain/usecases/get-data-organizations-places-statistics.js
+++ b/api/src/prescription/organization-place/domain/usecases/get-data-organizations-places-statistics.js
@@ -11,7 +11,9 @@ const getDataOrganizationsPlacesStatistics = withTransaction(async function ({
 
   const organizationWithPlacesIds = organizationWithPlaces.map((organization) => organization.id);
 
-  const placesLots = await organizationPlacesLotRepository.findAllByOrganizationIds(organizationWithPlacesIds);
+  const placesLots = await organizationPlacesLotRepository.findAllByOrganizationIds({
+    organizationIds: organizationWithPlacesIds,
+  });
 
   const placeRepartitions =
     await organizationLearnerRepository.findAllLearnerWithAtLeastOneParticipationByOrganizationIds(

--- a/api/src/prescription/organization-place/domain/usecases/get-organization-places-lots.js
+++ b/api/src/prescription/organization-place/domain/usecases/get-organization-places-lots.js
@@ -9,11 +9,18 @@
 
 /**
  * @typedef {object} organizationPlacesLotRepository
- * @property {function} findAllByOrganizationId
+ * @property {function} findAllByOrganizationIds
  */
 
 const getOrganizationPlacesLots = async function ({ organizationId, organizationPlacesLotRepository }) {
-  return await organizationPlacesLotRepository.findAllNotDeletedByOrganizationId(organizationId);
+  if (!organizationId) {
+    throw new Error('You must provide at least one organizationId.');
+  }
+
+  return organizationPlacesLotRepository.findAllByOrganizationIds({
+    organizationIds: [organizationId],
+    callOrderByAndRemoveDeleted: true,
+  });
 };
 
 export { getOrganizationPlacesLots };

--- a/api/src/prescription/organization-place/domain/usecases/get-organization-places-statistics.js
+++ b/api/src/prescription/organization-place/domain/usecases/get-organization-places-statistics.js
@@ -25,7 +25,13 @@ const getOrganizationPlacesStatistics = async function ({
   organizationPlacesLotRepository,
   organizationLearnerRepository,
 }) {
-  const placesLots = await organizationPlacesLotRepository.findAllByOrganizationId(organizationId);
+  if (!organizationId) {
+    throw new Error('You must provide at least one organizationId.');
+  }
+
+  const placesLots = await organizationPlacesLotRepository.findAllByOrganizationIds({
+    organizationIds: [organizationId],
+  });
 
   const placeRepartition =
     await organizationLearnerRepository.findAllLearnerWithAtLeastOneParticipationByOrganizationId(organizationId);

--- a/api/tests/prescription/organization-place/integration/infrastructure/repositories/organization-places-lot-repository_test.js
+++ b/api/tests/prescription/organization-place/integration/infrastructure/repositories/organization-places-lot-repository_test.js
@@ -8,7 +8,7 @@ import { DeletedError, NotFoundError } from '../../../../../../src/shared/domain
 import { catchErr, databaseBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Integration | Repository | Organization Places Lot', function () {
-  describe('#findByOrganizationId', function () {
+  describe('#findByOrganizationIdWithJoinedUsers', function () {
     it('should return organization place model for given id', async function () {
       // given
       const organizationId = databaseBuilder.factory.buildOrganization().id;
@@ -26,7 +26,8 @@ describe('Integration | Repository | Organization Places Lot', function () {
       await databaseBuilder.commit();
 
       // when
-      const foundOrganizationPlace = await organizationPlacesLotRepository.findByOrganizationId(organizationId);
+      const foundOrganizationPlace =
+        await organizationPlacesLotRepository.findByOrganizationIdWithJoinedUsers(organizationId);
 
       // then
       expect(foundOrganizationPlace[0].id).to.equal(placeGZ.id);
@@ -35,7 +36,6 @@ describe('Integration | Repository | Organization Places Lot', function () {
       expect(foundOrganizationPlace[0].category).to.equal(OrganizationPlacesLotManagement.categories[placeGZ.category]);
       expect(foundOrganizationPlace[0].reference).to.equal(placeGZ.reference);
       expect(foundOrganizationPlace[0].creatorFullName).to.equal(`${user.firstName} ${user.lastName}`);
-
       expect(foundOrganizationPlace[0].activationDate).to.deep.equal(placeGZ.activationDate);
       expect(foundOrganizationPlace[0].expirationDate).to.deep.equal(placeGZ.expirationDate);
     });
@@ -63,7 +63,8 @@ describe('Integration | Repository | Organization Places Lot', function () {
       await databaseBuilder.commit();
 
       // when
-      const foundOrganizationPlace = await organizationPlacesLotRepository.findByOrganizationId(organizationId);
+      const foundOrganizationPlace =
+        await organizationPlacesLotRepository.findByOrganizationIdWithJoinedUsers(organizationId);
 
       // then
       expect(foundOrganizationPlace).to.have.lengthOf(2);
@@ -80,7 +81,8 @@ describe('Integration | Repository | Organization Places Lot', function () {
       await databaseBuilder.commit();
 
       // when
-      const foundOrganizationPlace = await organizationPlacesLotRepository.findByOrganizationId(organizationId);
+      const foundOrganizationPlace =
+        await organizationPlacesLotRepository.findByOrganizationIdWithJoinedUsers(organizationId);
       // then
       expect(foundOrganizationPlace).to.have.lengthOf(0);
     });
@@ -98,7 +100,8 @@ describe('Integration | Repository | Organization Places Lot', function () {
       await databaseBuilder.commit();
 
       // when
-      const foundOrganizationPlace = await organizationPlacesLotRepository.findByOrganizationId(organizationId);
+      const foundOrganizationPlace =
+        await organizationPlacesLotRepository.findByOrganizationIdWithJoinedUsers(organizationId);
 
       // then
       expect(foundOrganizationPlace).to.have.lengthOf(0);
@@ -118,7 +121,8 @@ describe('Integration | Repository | Organization Places Lot', function () {
       await databaseBuilder.commit();
 
       // when
-      const foundOrganizationPlace = await organizationPlacesLotRepository.findByOrganizationId(organizationId);
+      const foundOrganizationPlace =
+        await organizationPlacesLotRepository.findByOrganizationIdWithJoinedUsers(organizationId);
 
       // then
       expect(foundOrganizationPlace[0].creatorFullName).to.equal(`${user.firstName} ${user.lastName}`);
@@ -142,7 +146,8 @@ describe('Integration | Repository | Organization Places Lot', function () {
         await databaseBuilder.commit();
 
         // when
-        const foundOrganizationPlace = await organizationPlacesLotRepository.findByOrganizationId(organizationId);
+        const foundOrganizationPlace =
+          await organizationPlacesLotRepository.findByOrganizationIdWithJoinedUsers(organizationId);
 
         // then
         expect(foundOrganizationPlace[0].id).to.deep.equal(organizationPlace2.id);
@@ -171,7 +176,8 @@ describe('Integration | Repository | Organization Places Lot', function () {
         await databaseBuilder.commit();
 
         // when
-        const foundOrganizationPlace = await organizationPlacesLotRepository.findByOrganizationId(organizationId);
+        const foundOrganizationPlace =
+          await organizationPlacesLotRepository.findByOrganizationIdWithJoinedUsers(organizationId);
 
         // then
         expect(foundOrganizationPlace[0].id).to.deep.equal(organizationPlace1.id);
@@ -201,7 +207,8 @@ describe('Integration | Repository | Organization Places Lot', function () {
         await databaseBuilder.commit();
 
         // when
-        const foundOrganizationPlace = await organizationPlacesLotRepository.findByOrganizationId(organizationId);
+        const foundOrganizationPlace =
+          await organizationPlacesLotRepository.findByOrganizationIdWithJoinedUsers(organizationId);
 
         // then
         expect(foundOrganizationPlace[0].id).to.deep.equal(organizationPlace2.id);
@@ -210,7 +217,7 @@ describe('Integration | Repository | Organization Places Lot', function () {
     });
   });
 
-  describe('#findAllByOrganizationId', function () {
+  describe('#findAllByOrganizationIds', function () {
     let organizationId;
 
     beforeEach(async function () {
@@ -222,7 +229,9 @@ describe('Integration | Repository | Organization Places Lot', function () {
       databaseBuilder.factory.buildOrganizationPlace({ organizationId });
       await databaseBuilder.commit();
 
-      const places = await organizationPlacesLotRepository.findAllByOrganizationId(organizationId);
+      const places = await organizationPlacesLotRepository.findAllByOrganizationIds({
+        organizationIds: [organizationId],
+      });
 
       expect(places[0]).to.be.instanceOf(PlacesLot);
     });
@@ -230,7 +239,9 @@ describe('Integration | Repository | Organization Places Lot', function () {
     it('should return empty array if there is no placeslots', async function () {
       await databaseBuilder.commit();
 
-      const places = await organizationPlacesLotRepository.findAllByOrganizationId(organizationId);
+      const places = await organizationPlacesLotRepository.findAllByOrganizationIds({
+        organizationIds: [organizationId],
+      });
 
       expect(places).to.be.empty;
     });
@@ -247,7 +258,9 @@ describe('Integration | Repository | Organization Places Lot', function () {
       });
       await databaseBuilder.commit();
 
-      const places = await organizationPlacesLotRepository.findAllByOrganizationId(organizationId);
+      const places = await organizationPlacesLotRepository.findAllByOrganizationIds({
+        organizationIds: [organizationId],
+      });
 
       expect(places).to.have.lengthOf(2);
       expect(places[0].count).to.equal(7);
@@ -260,70 +273,11 @@ describe('Integration | Repository | Organization Places Lot', function () {
       databaseBuilder.factory.buildOrganizationPlace({ organizationId });
       await databaseBuilder.commit();
 
-      const places = await organizationPlacesLotRepository.findAllByOrganizationId(anotherOrganizationId);
+      const places = await organizationPlacesLotRepository.findAllByOrganizationIds({
+        organizationIds: [anotherOrganizationId],
+      });
 
       expect(places).to.have.lengthOf(0);
-    });
-  });
-
-  describe('#findAllByOrganizationIds', function () {
-    let firstOrganizationId;
-    let secondOrganizationId;
-
-    beforeEach(async function () {
-      firstOrganizationId = databaseBuilder.factory.buildOrganization().id;
-      secondOrganizationId = databaseBuilder.factory.buildOrganization().id;
-      await databaseBuilder.commit();
-    });
-
-    it('should return empty array if there is no placesLot', async function () {
-      const organizationIds = [firstOrganizationId, secondOrganizationId];
-
-      const places = await organizationPlacesLotRepository.findAllByOrganizationIds(organizationIds);
-
-      expect(places).to.be.empty;
-    });
-
-    it('should return places if there are places for given organizationIds', async function () {
-      databaseBuilder.factory.buildOrganizationPlace({
-        organizationId: firstOrganizationId,
-        count: 7,
-      });
-      databaseBuilder.factory.buildOrganizationPlace({
-        organizationId: secondOrganizationId,
-        count: 3,
-      });
-      await databaseBuilder.commit();
-      const organizationIds = [firstOrganizationId, secondOrganizationId];
-
-      const places = await organizationPlacesLotRepository.findAllByOrganizationIds(organizationIds);
-
-      expect(places).to.have.lengthOf(2);
-      expect(places[0]).to.be.an.instanceOf(PlacesLot);
-      expect(places[1]).to.be.an.instanceOf(PlacesLot);
-
-      const firstOrganizationIdPlaces = places.find((place) => place.organizationId === firstOrganizationId);
-      expect(firstOrganizationIdPlaces.count).to.equal(7);
-
-      const secondOrganizationIdPlaces = places.find((place) => place.organizationId === secondOrganizationId);
-      expect(secondOrganizationIdPlaces.count).to.equal(3);
-    });
-
-    it('should not return places for others organization than given', async function () {
-      databaseBuilder.factory.buildOrganizationPlace({
-        organizationId: firstOrganizationId,
-        count: 7,
-      });
-      databaseBuilder.factory.buildOrganizationPlace({
-        organizationId: secondOrganizationId,
-        count: 3,
-      });
-      await databaseBuilder.commit();
-      const organizationIds = [firstOrganizationId];
-
-      const places = await organizationPlacesLotRepository.findAllByOrganizationIds(organizationIds);
-      expect(places).to.have.lengthOf(1);
-      expect(places[0].organizationId).to.equal(firstOrganizationId);
     });
   });
 
@@ -452,7 +406,7 @@ describe('Integration | Repository | Organization Places Lot', function () {
     });
   });
 
-  describe('#findAllNotDeletedByOrganizationId', function () {
+  describe('#findAllByOrganizationId when we filter out deleted places lots', function () {
     let clock;
 
     beforeEach(function () {
@@ -492,8 +446,10 @@ describe('Integration | Repository | Organization Places Lot', function () {
       await databaseBuilder.commit();
 
       // when
-      const foundOrganizationPlace =
-        await organizationPlacesLotRepository.findAllNotDeletedByOrganizationId(organizationId);
+      const foundOrganizationPlace = await organizationPlacesLotRepository.findAllByOrganizationIds({
+        organizationIds: [organizationId],
+        callOrderByAndRemoveDeleted: true,
+      });
 
       // then
       expect(foundOrganizationPlace).to.have.lengthOf(2);
@@ -510,7 +466,8 @@ describe('Integration | Repository | Organization Places Lot', function () {
       await databaseBuilder.commit();
 
       // when
-      const foundOrganizationPlace = await organizationPlacesLotRepository.findByOrganizationId(organizationId);
+      const foundOrganizationPlace =
+        await organizationPlacesLotRepository.findByOrganizationIdWithJoinedUsers(organizationId);
       // then
       expect(foundOrganizationPlace).to.have.lengthOf(0);
     });
@@ -528,7 +485,8 @@ describe('Integration | Repository | Organization Places Lot', function () {
       await databaseBuilder.commit();
 
       // when
-      const foundOrganizationPlace = await organizationPlacesLotRepository.findByOrganizationId(organizationId);
+      const foundOrganizationPlace =
+        await organizationPlacesLotRepository.findByOrganizationIdWithJoinedUsers(organizationId);
 
       // then
       expect(foundOrganizationPlace).to.have.lengthOf(0);
@@ -563,8 +521,10 @@ describe('Integration | Repository | Organization Places Lot', function () {
         await databaseBuilder.commit();
 
         // when
-        const foundOrganizationPlace =
-          await organizationPlacesLotRepository.findAllNotDeletedByOrganizationId(organizationId);
+        const foundOrganizationPlace = await organizationPlacesLotRepository.findAllByOrganizationIds({
+          organizationIds: [organizationId],
+          callOrderByAndRemoveDeleted: true,
+        });
 
         // then
         expect(foundOrganizationPlace[0].activationDate).to.deep.equal(organizationPlaceActive.activationDate);
@@ -593,8 +553,10 @@ describe('Integration | Repository | Organization Places Lot', function () {
         await databaseBuilder.commit();
 
         // when
-        const foundOrganizationPlace =
-          await organizationPlacesLotRepository.findAllNotDeletedByOrganizationId(organizationId);
+        const foundOrganizationPlace = await organizationPlacesLotRepository.findAllByOrganizationIds({
+          organizationIds: [organizationId],
+          callOrderByAndRemoveDeleted: true,
+        });
 
         // then
         expect(foundOrganizationPlace[0].expirationDate).to.deep.equal(organizationPlaceActive2.expirationDate);
@@ -622,8 +584,10 @@ describe('Integration | Repository | Organization Places Lot', function () {
         await databaseBuilder.commit();
 
         // when
-        const foundOrganizationPlace =
-          await organizationPlacesLotRepository.findAllNotDeletedByOrganizationId(organizationId);
+        const foundOrganizationPlace = await organizationPlacesLotRepository.findAllByOrganizationIds({
+          organizationIds: [organizationId],
+          callOrderByAndRemoveDeleted: true,
+        });
 
         // then
         expect(foundOrganizationPlace[0].activationDate).to.deep.equal(organizationPlaceActive2.activationDate);
@@ -653,8 +617,10 @@ describe('Integration | Repository | Organization Places Lot', function () {
         await databaseBuilder.commit();
 
         // when
-        const foundOrganizationPlace =
-          await organizationPlacesLotRepository.findAllNotDeletedByOrganizationId(organizationId);
+        const foundOrganizationPlace = await organizationPlacesLotRepository.findAllByOrganizationIds({
+          organizationIds: [organizationId],
+          callOrderByAndRemoveDeleted: true,
+        });
 
         // then
         expect(foundOrganizationPlace[0].count).to.deep.equal(organizationPlaceActive2.count);

--- a/api/tests/prescription/organization-place/unit/domain/usecases/find-organization-places-lot_test.js
+++ b/api/tests/prescription/organization-place/unit/domain/usecases/find-organization-places-lot_test.js
@@ -4,12 +4,14 @@ import { expect, sinon } from '../../../../../test-helper.js';
 describe('Unit | Domain | Use Cases | find-organization-places', function () {
   it('should get the organization places', async function () {
     // given
-    const organizationId = Symbol('organizationId');
+    const organizationId = 123;
     const expectedOrganizationPlaces = Symbol('OrganizationPlaces');
     const organizationPlacesLotRepository = {
-      findByOrganizationId: sinon.stub(),
+      findByOrganizationIdWithJoinedUsers: sinon.stub(),
     };
-    organizationPlacesLotRepository.findByOrganizationId.withArgs(organizationId).resolves(expectedOrganizationPlaces);
+    organizationPlacesLotRepository.findByOrganizationIdWithJoinedUsers
+      .withArgs(organizationId)
+      .resolves(expectedOrganizationPlaces);
 
     // when
     const organizationPlace = await findOrganizationPlacesLot({

--- a/api/tests/prescription/organization-place/unit/domain/usecases/get-organization-places-lots_test.js
+++ b/api/tests/prescription/organization-place/unit/domain/usecases/get-organization-places-lots_test.js
@@ -4,14 +4,16 @@ import { expect, sinon } from '../../../../../test-helper.js';
 describe('Unit | Domain | Use Cases | get-organization-places-lots', function () {
   it('should get the organization places lots', async function () {
     // given
-    const organizationId = Symbol('organizationId');
+    const organizationId = 123;
     const placesLots = Symbol('PlacesLots');
 
     const organizationPlacesLotRepository = {
-      findAllNotDeletedByOrganizationId: sinon.stub(),
+      findAllByOrganizationIds: sinon.stub(),
     };
 
-    organizationPlacesLotRepository.findAllNotDeletedByOrganizationId.withArgs(organizationId).resolves(placesLots);
+    await organizationPlacesLotRepository.findAllByOrganizationIds
+      .withArgs({ organizationIds: [organizationId], callOrderByAndRemoveDeleted: true })
+      .resolves(placesLots);
 
     // when
     const organizationPlacesLots = await getOrganizationPlacesLots({

--- a/api/tests/prescription/organization-place/unit/domain/usecases/get-organization-places-statistics_test.js
+++ b/api/tests/prescription/organization-place/unit/domain/usecases/get-organization-places-statistics_test.js
@@ -13,12 +13,14 @@ describe('Unit | Domain | Use Cases | get-organization-places-statistics', funct
     const placeStatisticsBuildFromStub = sinon.stub(PlaceStatistics, 'buildFrom').returns(placeStatistics);
 
     const organizationPlacesLotRepository = {
-      findAllByOrganizationId: sinon.stub(),
+      findAllByOrganizationIds: sinon.stub(),
     };
     const organizationLearnerRepository = {
       findAllLearnerWithAtLeastOneParticipationByOrganizationId: sinon.stub(),
     };
-    organizationPlacesLotRepository.findAllByOrganizationId.withArgs(organizationId).resolves(placesLots);
+    organizationPlacesLotRepository.findAllByOrganizationIds
+      .withArgs({ organizationIds: [organizationId] })
+      .resolves(placesLots);
 
     organizationLearnerRepository.findAllLearnerWithAtLeastOneParticipationByOrganizationId
       .withArgs(organizationId)


### PR DESCRIPTION
## :christmas_tree: Problème

A l'intérieur de organization-places-lot-repository, on a 4 méthodes qui font sensiblement la même chose, à quelques colonnes et conditions près : récupérer les lots de places pour une organisation donnée (voir findAllByOrganizationId, findAllByOrganizationIds, et des déclinaisons similaires pour récupérer les utilisateurs non supprimés et ajouter un order by).

## :gift: Proposition

- On créée une requête de base dans le repository
- On ajoute des méthodes supplémentaires dans le repository pour rajouter des colonnes dans les requêtes ou faire un orderBy de manière optionnelle
- On déplace les renvois d'erreurs vers le domaine

## :socks: Remarques

## :santa: Pour tester

- On vérifie que la récupération du nombre de places pour une organisation donnée fonctionne bien
- On peut aussi modifier le nombre de place pour une organisation donnée côté admin et vérifier que la modif est bien prise en compte côté orga