### PR TITLE
[BUGFIX] Répare Pix Certif suite à la montée de version de `ember-simple-auth` en v7.

### DIFF
--- a/certif/app/session-stores/application.js
+++ b/certif/app/session-stores/application.js
@@ -1,0 +1,3 @@
+import AdaptiveStore from 'ember-simple-auth/session-stores/adaptive';
+
+export default class SessionStore extends AdaptiveStore {}


### PR DESCRIPTION
## :christmas_tree: Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

On est allé un peu vite pour merger la mise à jour d'ember-simple-auth v7 et l'application Pix Certif crash au lancement et est donc inutilisable.

## :gift: Proposition

On suit le guide https://github.com/mainmatter/ember-simple-auth/blob/master/guides/upgrade-to-v7.md et on injecte le session-store par défaut de `ember-simple-auth`.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## :socks: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

Il faudrait investiguer pour comprendre pourquoi nos tests actuels n'ont pas permis la détection de soucis.

## :santa: Pour tester

Lancer l'application Pix Certif.
Tester les connextions et déconnexions.

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
