### PR TITLE
[BUGFIX] Permettre un arrêt graceful  du serveur

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -35,7 +35,7 @@ async function _exitOnSignal(signal) {
   logger.info(`Received signal: ${signal}.`);
   logger.info('Stopping HAPI server...');
   await server.stop({ timeout: 30000 });
-  server.directMetrics?.clearMetrics();
+  await server.directMetrics?.clearMetrics();
   if (server.oppsy) {
     logger.info('Stopping HAPI Oppsy server...');
     await server.oppsy.stop();

--- a/api/worker.js
+++ b/api/worker.js
@@ -48,7 +48,7 @@ async function startPgBoss() {
 function createJobQueues(pgBoss) {
   const jobQueues = new JobQueue(pgBoss);
   process.on('SIGINT', async () => {
-    metrics.clearMetrics();
+    await metrics.clearMetrics();
     await jobQueues.stop();
 
     // Make sure pgBoss stopped before quitting


### PR DESCRIPTION
## :christmas_tree: Problème
Lors de la PR d'ajout des métriques, un await a été oublié ce qui empêche l'arrêt immédiat du serveur.

## :gift: Proposition
Ajouter un await lors de l'arrêt du serveur et du worker
