### PR TITLE
[FEATURE] Utiliser le composant BannerAlert sur la bannière beta des modules (PIX-15861)

### DIFF
--- a/mon-pix/app/components/module/beta-banner.gjs
+++ b/mon-pix/app/components/module/beta-banner.gjs
@@ -1,8 +1,8 @@
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import PixBannerAlert from '@1024pix/pix-ui/components/pix-banner-alert';
 import { t } from 'ember-intl';
 
 <template>
-  <PixNotificationAlert @type="communication" @withIcon="true" role="alert">
+  <PixBannerAlert @type="info">
     {{t "pages.modulix.beta-banner"}}
-  </PixNotificationAlert>
+  </PixBannerAlert>
 </template>

--- a/mon-pix/tests/integration/components/module/beta-banner_test.gjs
+++ b/mon-pix/tests/integration/components/module/beta-banner_test.gjs
@@ -1,0 +1,21 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import ModuleBetaBanner from 'mon-pix/components/module/beta-banner';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Module | Beta banner', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('displays a banner with an "alert" role and an info text', async function (assert) {
+    // when
+    const screen = await render(<template><ModuleBetaBanner /></template>);
+
+    // then
+    const infoText = t('pages.modulix.beta-banner');
+
+    assert.dom(screen.getByRole('alert')).exists();
+    assert.dom(screen.getByText(infoText)).exists();
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème

La bannière bêta n'utilisait pas le bon composant pour afficher la bannière.

## :gift: Proposition

Utiliser le composant `BannerAlert` pour ça !

## :socks: Remarques

- Vu avec Quentin, on part sur le variant info 🚀 
- Nous avons aussi ajouté des tests pour ce composant 🌮 

## :santa: Pour tester
- Aller sur le didacticiel modulix `/modules/didacticiel-modulix/details`
- Vérifier que la nouvelle bannière apparaît et basta cosi 😄 
