### PR TITLE
[FEATURE] Ajouter les champs licence et légende pour l'élément Image côté API (PIX-15990)

### DIFF
--- a/api/src/devcomp/domain/models/element/Image.js
+++ b/api/src/devcomp/domain/models/element/Image.js
@@ -2,6 +2,15 @@ import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asser
 import { Element } from './Element.js';
 
 class Image extends Element {
+  /**
+   * @param{object} params
+   * @param{string} params.id
+   * @param{string} url
+   * @param{string} alt
+   * @param{string} alternativeText
+   * @param{string} legend
+   * @param{string} licence
+   */
   constructor({ id, url, alt, alternativeText, legend, licence }) {
     super({ id, type: 'image' });
 

--- a/api/src/devcomp/domain/models/element/Image.js
+++ b/api/src/devcomp/domain/models/element/Image.js
@@ -2,7 +2,7 @@ import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asser
 import { Element } from './Element.js';
 
 class Image extends Element {
-  constructor({ id, url, alt, alternativeText }) {
+  constructor({ id, url, alt, alternativeText, legend, licence }) {
     super({ id, type: 'image' });
 
     assertNotNullOrUndefined(url, 'The URL is required for an image');
@@ -12,6 +12,8 @@ class Image extends Element {
     this.url = url;
     this.alt = alt;
     this.alternativeText = alternativeText;
+    this.legend = legend;
+    this.licence = licence;
   }
 }
 

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -149,7 +149,9 @@
             "type": "image",
             "url": "https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg",
             "alt": "Dessin détaillé dans l'alternative textuelle",
-            "alternativeText": "Dessin d'un ordinateur dans un univers spatial."
+            "alternativeText": "Dessin d'un ordinateur dans un univers spatial.",
+            "legend": "Faite avant le séminaire de juin 2023",
+            "licence": "©Pix Corporation & Fun, 2025, Challenge Accepted Inc. "
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -151,6 +151,8 @@ export class ModuleFactory {
       url: element.url,
       alt: element.alt,
       alternativeText: element.alternativeText,
+      legend: element.legend,
+      licence: element.licence,
     });
   }
 

--- a/api/tests/devcomp/unit/domain/models/element/Image_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Image_test.js
@@ -6,13 +6,22 @@ describe('Unit | Devcomp | Domain | Models | Element | Image', function () {
   describe('#constructor', function () {
     it('should create an image and keep attributes', function () {
       // when
-      const image = new Image({ id: 'id', url: 'url', alt: 'alt', alternativeText: 'alternativeText' });
+      const image = new Image({
+        id: 'id',
+        url: 'url',
+        alt: 'alt',
+        alternativeText: 'alternativeText',
+        legend: 'legend',
+        licence: 'licence',
+      });
 
       // then
       expect(image.id).to.equal('id');
       expect(image.url).to.equal('url');
       expect(image.alt).to.equal('alt');
       expect(image.alternativeText).to.equal('alternativeText');
+      expect(image.legend).to.equal('legend');
+      expect(image.licence).to.equal('licence');
       expect(image.type).to.equal('image');
     });
   });

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/image-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/image-schema.js
@@ -8,6 +8,8 @@ const imageElementSchema = Joi.object({
   url: Joi.string().uri().required(),
   alt: htmlNotAllowedSchema.allow('').required(),
   alternativeText: htmlSchema.allow(''),
+  legend: htmlNotAllowedSchema.allow(''),
+  licence: htmlNotAllowedSchema.allow(''),
 }).required();
 
 export { imageElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
@@ -362,6 +362,8 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
                     url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg',
                     alt: 'Alternative',
                     alternativeText: 'Alternative textuelle',
+                    legend: 'legend',
+                    licence: 'licence',
                   },
                 },
               ],

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -220,7 +220,14 @@ function getComponents() {
       element: qrocmElement,
     }),
     new ComponentElement({
-      element: new Image({ id: '3', url: 'url', alt: 'alt', alternativeText: 'alternativeText' }),
+      element: new Image({
+        id: '3',
+        url: 'url',
+        alt: 'alt',
+        alternativeText: 'alternativeText',
+        licence: 'mon copyright',
+        legend: 'ma légende',
+      }),
     }),
     new ComponentElement({
       element: new Embed({
@@ -393,6 +400,8 @@ function getAttributesComponents() {
         isAnswerable: false,
         type: 'image',
         url: 'url',
+        legend: 'ma légende',
+        licence: 'mon copyright',
       },
     },
     {


### PR DESCRIPTION
## :christmas_tree: Problème

L'élément image ne permet pas d'ajouter une légende ou licence à celle-ci.

## :gift: Proposition

Ajouter, côté API, les champs correspondants dans l'élément Image.

## :socks: Remarques

RAS

## :santa: Pour tester

- Ouvrir la console navigateur
- Aller sur le [didacticiel Modulix](https://app-pr11022.review.pix.fr/modules/didacticiel-modulix/details) 
- Vérifier dans la réponse de l'appel `/api/modules/didacticiel-modulix`, qu'on reçoit bien 2 attributs en plus pour l'élément de type image (`"legend":"Faite avant le séminaire de juin 2023","licence":"Pix"`)
