### PR TITLE
[FEATURE] affiche le logo pix-orga sur la page Activer / Récupérer son espace  (pix-16020)

### DIFF
--- a/orga/app/styles/components/join-request-form.scss
+++ b/orga/app/styles/components/join-request-form.scss
@@ -1,6 +1,8 @@
 .join-request-form {
   font-family: $font-roboto;
-
+  .pix-button {
+    width: 100%;
+  }
   &__information {
     margin: 14px 0 24px 0;
     font-size: 0.875rem;
@@ -16,13 +18,13 @@
   &__back {
     margin-top: var(--pix-spacing-4x);
     font-size: 1rem;
-    text-align: left;
+    display: flex;
+    justify-content: space-between;
 
     a {
       color: var(--pix-communication-dark);
       text-decoration: none;
       fill: var(--pix-communication-dark);
-
       svg {
         margin-right: 4px;
         transition: all 0.2s ease-in-out;

--- a/orga/app/styles/pages/join-request.scss
+++ b/orga/app/styles/pages/join-request.scss
@@ -56,8 +56,4 @@
     letter-spacing: 0.15px;
     text-align: center;
   }
-
-  .pix-button {
-    width: 100%;
-  }
 }

--- a/orga/app/templates/join-request.hbs
+++ b/orga/app/templates/join-request.hbs
@@ -2,7 +2,7 @@
 <div class="join-request">
   <div class="panel join-request__panel">
     <div class="panel__image">
-      <img src="/pix-orga.svg" alt="" role="none" />
+      <img src="/pix-orga-color.svg" alt="" role="none" />
     </div>
     {{#if this.isSubmit}}
       <p class="join-request__success">
@@ -42,10 +42,9 @@
       <Auth::JoinRequestForm @onSubmit={{this.createScoOrganizationInvitation}} />
     {{/if}}
     <div class="join-request-form__back">
-      <LinkTo @route="login">
-        <PixIcon @name="arrowLeft" />
-        Revenir à la page de connexion
-      </LinkTo>
+      <PixButtonLink @variant="tertiary" iconBefore="arrowLeft" @route="login">
+        <PixIcon @name="arrowLeft" />Revenir à la page de connexion
+      </PixButtonLink>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## :christmas_tree: Problème

Suite à la mise à jour du layout dans pixOrga, on a perdu le logo (blanc sur blanc)

## :gift: Proposition

On remet l'ancien logo couleur

## :socks: Remarques

On en profites pour fixer aussi le lien de retour en bas de page

## :santa: Pour tester

aller sur la page Activer / Récupérer mon espace
