### PR TITLE
[BUGFIX] Affiche le logo sur la page des cgu (PIX-16018)

### DIFF
--- a/orga/app/components/terms-of-service/page-en.hbs
+++ b/orga/app/components/terms-of-service/page-en.hbs
@@ -1,9 +1,9 @@
 <div>
   <div class="terms-of-service-form__logo">
-    <img src="/pix-orga.svg" alt="" role="none" />
+    <img src="/pix-orga-color.svg" alt="" role="none" />
   </div>
 
-  <Ui::PageTitle>
+  <Ui::PageTitle class="terms-of-service-form__title">
     <:title>
       Terms and Conditions of use of the Pix Orga plateform
     </:title>

--- a/orga/app/components/terms-of-service/page-fr.hbs
+++ b/orga/app/components/terms-of-service/page-fr.hbs
@@ -1,9 +1,9 @@
 <div>
   <div class="terms-of-service-form__logo">
-    <img src="/pix-orga.svg" alt="" role="none" />
+    <img src="/pix-orga-color.svg" alt="" role="none" />
   </div>
 
-  <Ui::PageTitle>
+  <Ui::PageTitle class="terms-of-service-form__title">
     <:title>
       Conditions générales d'utilisation de la plateforme Pix Orga
     </:title>

--- a/orga/app/components/terms-of-service/page-nl.hbs
+++ b/orga/app/components/terms-of-service/page-nl.hbs
@@ -1,9 +1,9 @@
 <div>
   <div class="terms-of-service-form__logo">
-    <img src="/pix-orga.svg" alt="" role="none" />
+    <img src="/pix-orga-color.svg" alt="" role="none" />
   </div>
 
-  <Ui::PageTitle>
+  <Ui::PageTitle class="terms-of-service-form__title">
     <:title>
       Algemene gebruiksvoorwaarden van het pix orga-platform
     </:title>

--- a/orga/app/components/ui/page-title.gjs
+++ b/orga/app/components/ui/page-title.gjs
@@ -8,7 +8,7 @@ function setTitleClasses(spaceBetweenTools, centerTitle) {
 }
 
 <template>
-  <header class="page-title">
+  <header class="page-title" ...attributes>
     {{#if (has-block "breadcrumb")}}
       {{yield to="breadcrumb"}}
     {{/if}}

--- a/orga/app/styles/pages/authenticated/terms-of-service.scss
+++ b/orga/app/styles/pages/authenticated/terms-of-service.scss
@@ -31,12 +31,14 @@
   }
 
   &__title {
-    @extend %pix-title-s;
-
-    margin-bottom: 30px;
-    color: var(--pix-neutral-900);
+    width: auto;
+    margin: 0 60px 20px;
     text-align: center;
-    text-transform: uppercase;
+
+    .page-title__title {
+      word-break: unset;
+    }
+
   }
 
   &__line {


### PR DESCRIPTION
## :christmas_tree: Problème

Lors de la mise en place du nouveau layout le logo est devenu blanc. On ne le voit plus lorsque le fond est blanc 

## :gift: Proposition

on remet l'ancien logo  couleur sur les page avec des fonds blanc.

## :socks: Remarques
On profite de la PR pour fixer les marge du title

## :santa: Pour tester


Créer un utilisateur dans pixadmin
Se connecter à orga avec le nouvel utilisateur 
voir les cgu
