### PR TITLE
[FEATURE] Amélioration de la documentation d'API pour Parcoursup et ajout de nouveaux seeds (PIX-16022).

### DIFF
--- a/api/datamart/migrations/20250109114100-add-missing-column.js
+++ b/api/datamart/migrations/20250109114100-add-missing-column.js
@@ -1,0 +1,23 @@
+const up = async function (knex) {
+  await knex.schema.table('data_export_parcoursup_certif_result_code_validation', function (table) {
+    table.string('certification_courses_id');
+    table.string('national_student_id');
+    table.string('organization_uai');
+  });
+  await knex.schema.table('data_export_parcoursup_certif_result', function (table) {
+    table.string('certification_courses_id');
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table('data_export_parcoursup_certif_result_code_validation', function (table) {
+    table.dropColumn('certification_courses_id');
+    table.dropColumn('national_student_id');
+    table.dropColumn('organization_uai');
+  });
+  await knex.schema.table('data_export_parcoursup_certif_result', function (table) {
+    table.dropColumn('certification_courses_id');
+  });
+};
+
+export { down, up };

--- a/api/datamart/seeds/csv/data_export_parcoursup_certif_result.csv
+++ b/api/datamart/seeds/csv/data_export_parcoursup_certif_result.csv
@@ -1,49 +1,66 @@
-birthdate,certification_date,competence_id,competence_level,first_name,last_name,national_student_id,organization_uai,pix_score,status
-1926-01-07,2024-12-22 11:11:16.18144+00,recsvLz0W2ShyfD63,2,Mathilde,Durand,714347660RP,8664450K,314,validated
-1926-01-07,2024-12-22 11:11:16.18144+00,recIkYm646lrGvLNT,1,Mathilde,Durand,714347660RP,8664450K,314,validated
-1926-01-07,2024-12-22 11:11:16.18144+00,recNv8qhaY887jQb2,4,Mathilde,Durand,714347660RP,8664450K,314,validated
-1926-01-07,2024-12-22 11:11:16.18144+00,recDH19F7kKrfL3Ii,0,Mathilde,Durand,714347660RP,8664450K,314,validated
-1926-01-07,2024-12-22 11:11:16.18144+00,rec6rHqas39zvLZep,3,Mathilde,Durand,714347660RP,8664450K,314,validated
-1926-01-07,2024-12-22 11:11:16.18144+00,recgxqQfz3BqEbtzh,5,Mathilde,Durand,714347660RP,8664450K,314,validated
-1926-01-07,2024-12-22 11:11:16.18144+00,recMiZPNl7V1hyE1d,6,Mathilde,Durand,714347660RP,8664450K,314,validated
-1926-01-07,2024-12-22 11:11:16.18144+00,recFpYXCKcyhLI3Nu,5,Mathilde,Durand,714347660RP,8664450K,314,validated
-1926-01-07,2024-12-22 11:11:16.18144+00,recOdC9UDVJbAXHAm,6,Mathilde,Durand,714347660RP,8664450K,314,validated
-1926-01-07,2024-12-22 11:11:16.18144+00,recbDTF8KwupqkeZ6,2,Mathilde,Durand,714347660RP,8664450K,314,validated
-1926-01-07,2024-12-22 11:11:16.18144+00,recHmIWG6D0huq6Kx,3,Mathilde,Durand,714347660RP,8664450K,314,validated
-1926-01-07,2024-12-22 11:11:16.18144+00,rece6jYwH4WEw549z,3,Mathilde,Durand,714347660RP,8664450K,314,validated
-1926-01-07,2024-12-22 11:11:16.18144+00,recofJCxg0NqTqTdP,1,Mathilde,Durand,714347660RP,8664450K,314,validated
-1926-01-07,2024-12-22 11:11:16.18144+00,recfr0ax8XrfvJ3ER,0,Mathilde,Durand,714347660RP,8664450K,314,validated
-1926-01-07,2024-12-22 11:11:16.18144+00,recIhdrmCuEmCDAzj,2,Mathilde,Durand,714347660RP,8664450K,314,validated
-1926-01-07,2024-12-22 11:11:16.18144+00,recudHE5Omrr10qrx,2,Mathilde,Durand,714347660RP,8664450K,314,validated
-2000-12-02,2024-12-04 20:41:38.430868+00,recsvLz0W2ShyfD63,7,Sylvie,Lacroix,544890735EF,8045351T,397,cancelled
-2000-12-02,2024-12-04 20:41:38.430868+00,recIkYm646lrGvLNT,6,Sylvie,Lacroix,544890735EF,8045351T,397,cancelled
-2000-12-02,2024-12-04 20:41:38.430868+00,recNv8qhaY887jQb2,2,Sylvie,Lacroix,544890735EF,8045351T,397,cancelled
-2000-12-02,2024-12-04 20:41:38.430868+00,recDH19F7kKrfL3Ii,6,Sylvie,Lacroix,544890735EF,8045351T,397,cancelled
-2000-12-02,2024-12-04 20:41:38.430868+00,rec6rHqas39zvLZep,4,Sylvie,Lacroix,544890735EF,8045351T,397,cancelled
-2000-12-02,2024-12-04 20:41:38.430868+00,recgxqQfz3BqEbtzh,6,Sylvie,Lacroix,544890735EF,8045351T,397,cancelled
-2000-12-02,2024-12-04 20:41:38.430868+00,recMiZPNl7V1hyE1d,3,Sylvie,Lacroix,544890735EF,8045351T,397,cancelled
-2000-12-02,2024-12-04 20:41:38.430868+00,recFpYXCKcyhLI3Nu,7,Sylvie,Lacroix,544890735EF,8045351T,397,cancelled
-2000-12-02,2024-12-04 20:41:38.430868+00,recOdC9UDVJbAXHAm,2,Sylvie,Lacroix,544890735EF,8045351T,397,cancelled
-2000-12-02,2024-12-04 20:41:38.430868+00,recbDTF8KwupqkeZ6,7,Sylvie,Lacroix,544890735EF,8045351T,397,cancelled
-2000-12-02,2024-12-04 20:41:38.430868+00,recHmIWG6D0huq6Kx,3,Sylvie,Lacroix,544890735EF,8045351T,397,cancelled
-2000-12-02,2024-12-04 20:41:38.430868+00,rece6jYwH4WEw549z,4,Sylvie,Lacroix,544890735EF,8045351T,397,cancelled
-2000-12-02,2024-12-04 20:41:38.430868+00,recofJCxg0NqTqTdP,6,Sylvie,Lacroix,544890735EF,8045351T,397,cancelled
-2000-12-02,2024-12-04 20:41:38.430868+00,recfr0ax8XrfvJ3ER,6,Sylvie,Lacroix,544890735EF,8045351T,397,cancelled
-2000-12-02,2024-12-04 20:41:38.430868+00,recIhdrmCuEmCDAzj,1,Sylvie,Lacroix,544890735EF,8045351T,397,cancelled
-2000-12-02,2024-12-04 20:41:38.430868+00,recudHE5Omrr10qrx,3,Sylvie,Lacroix,544890735EF,8045351T,397,cancelled
-1937-10-25,2024-12-07 06:22:50.031555+00,recsvLz0W2ShyfD63,0,Julien,Boyer,127885732NY,5325800E,650,rejected
-1937-10-25,2024-12-07 06:22:50.031555+00,recIkYm646lrGvLNT,1,Julien,Boyer,127885732NY,5325800E,650,rejected
-1937-10-25,2024-12-07 06:22:50.031555+00,recNv8qhaY887jQb2,4,Julien,Boyer,127885732NY,5325800E,650,rejected
-1937-10-25,2024-12-07 06:22:50.031555+00,recDH19F7kKrfL3Ii,6,Julien,Boyer,127885732NY,5325800E,650,rejected
-1937-10-25,2024-12-07 06:22:50.031555+00,rec6rHqas39zvLZep,5,Julien,Boyer,127885732NY,5325800E,650,rejected
-1937-10-25,2024-12-07 06:22:50.031555+00,recgxqQfz3BqEbtzh,6,Julien,Boyer,127885732NY,5325800E,650,rejected
-1937-10-25,2024-12-07 06:22:50.031555+00,recMiZPNl7V1hyE1d,1,Julien,Boyer,127885732NY,5325800E,650,rejected
-1937-10-25,2024-12-07 06:22:50.031555+00,recFpYXCKcyhLI3Nu,1,Julien,Boyer,127885732NY,5325800E,650,rejected
-1937-10-25,2024-12-07 06:22:50.031555+00,recOdC9UDVJbAXHAm,5,Julien,Boyer,127885732NY,5325800E,650,rejected
-1937-10-25,2024-12-07 06:22:50.031555+00,recbDTF8KwupqkeZ6,7,Julien,Boyer,127885732NY,5325800E,650,rejected
-1937-10-25,2024-12-07 06:22:50.031555+00,recHmIWG6D0huq6Kx,4,Julien,Boyer,127885732NY,5325800E,650,rejected
-1937-10-25,2024-12-07 06:22:50.031555+00,rece6jYwH4WEw549z,1,Julien,Boyer,127885732NY,5325800E,650,rejected
-1937-10-25,2024-12-07 06:22:50.031555+00,recofJCxg0NqTqTdP,2,Julien,Boyer,127885732NY,5325800E,650,rejected
-1937-10-25,2024-12-07 06:22:50.031555+00,recfr0ax8XrfvJ3ER,3,Julien,Boyer,127885732NY,5325800E,650,rejected
-1937-10-25,2024-12-07 06:22:50.031555+00,recIhdrmCuEmCDAzj,6,Julien,Boyer,127885732NY,5325800E,650,rejected
-1937-10-25,2024-12-07 06:22:50.031555+00,recudHE5Omrr10qrx,7,Julien,Boyer,127885732NY,5325800E,650,rejected
+certification_courses_id,organization_uai,national_student_id,last_name,first_name,birthdate,status,pix_score,certification_date,competence_code,competence_name,area_name,competence_level
+4178834,9499060P,944385546HU,Dupré,Auguste,2004-12-12,rejected,66,2024-11-24 11:44:54.481486,1.1,Mener une recherche et une veille d’information,1. Information et données,5
+4178834,9499060P,944385546HU,Dupré,Auguste,2004-12-12,rejected,66,2024-11-24 11:44:54.481486,1.2,Gérer des données,1. Information et données,7
+4178834,9499060P,944385546HU,Dupré,Auguste,2004-12-12,rejected,66,2024-11-24 11:44:54.481486,1.3,Traiter des données,1. Information et données,1
+4178834,9499060P,944385546HU,Dupré,Auguste,2004-12-12,rejected,66,2024-11-24 11:44:54.481486,2.1,Interagir,2. Communication et collaboration,5
+4178834,9499060P,944385546HU,Dupré,Auguste,2004-12-12,rejected,66,2024-11-24 11:44:54.481486,2.2,Partager et publier,2. Communication et collaboration,2
+4178834,9499060P,944385546HU,Dupré,Auguste,2004-12-12,rejected,66,2024-11-24 11:44:54.481486,2.3,Collaborer,2. Communication et collaboration,0
+4178834,9499060P,944385546HU,Dupré,Auguste,2004-12-12,rejected,66,2024-11-24 11:44:54.481486,2.4,S’insérer dans le monde numérique,2. Communication et collaboration,5
+4178834,9499060P,944385546HU,Dupré,Auguste,2004-12-12,rejected,66,2024-11-24 11:44:54.481486,3.1,Développer des documents textuels,3. Création de contenu,2
+4178834,9499060P,944385546HU,Dupré,Auguste,2004-12-12,rejected,66,2024-11-24 11:44:54.481486,3.2,Développer des documents multimedia,3. Création de contenu,4
+4178834,9499060P,944385546HU,Dupré,Auguste,2004-12-12,rejected,66,2024-11-24 11:44:54.481486,3.3,Adapter les documents à leur finalité,3. Création de contenu,7
+4178834,9499060P,944385546HU,Dupré,Auguste,2004-12-12,rejected,66,2024-11-24 11:44:54.481486,3.4,Programmer,3. Création de contenu,0
+4178834,9499060P,944385546HU,Dupré,Auguste,2004-12-12,rejected,66,2024-11-24 11:44:54.481486,4.1,Sécuriser l’environnement numérique,4. Protection et sécurité,5
+4178834,9499060P,944385546HU,Dupré,Auguste,2004-12-12,rejected,66,2024-11-24 11:44:54.481486,4.2,Protéger les données personnelles et la vie privée,4. Protection et sécurité,4
+4178834,9499060P,944385546HU,Dupré,Auguste,2004-12-12,rejected,66,2024-11-24 11:44:54.481486,4.3,"Protéger la santé, le bien-être et l’environnement",4. Protection et sécurité,2
+4178834,9499060P,944385546HU,Dupré,Auguste,2004-12-12,rejected,66,2024-11-24 11:44:54.481486,5.1,Résoudre des problèmes techniques,5. Environnement numérique,1
+4178834,9499060P,944385546HU,Dupré,Auguste,2004-12-12,rejected,66,2024-11-24 11:44:54.481486,5.2,Construire un environnement numérique,5. Environnement numérique,2
+9558218,1452233K,086369926RY,De Sousa,Élise,1938-05-24,rejected,633,2024-12-19 18:44:41.769281,1.1,Mener une recherche et une veille d’information,1. Information et données,7
+9558218,1452233K,086369926RY,De Sousa,Élise,1938-05-24,rejected,633,2024-12-19 18:44:41.769281,1.2,Gérer des données,1. Information et données,3
+9558218,1452233K,086369926RY,De Sousa,Élise,1938-05-24,rejected,633,2024-12-19 18:44:41.769281,1.3,Traiter des données,1. Information et données,7
+9558218,1452233K,086369926RY,De Sousa,Élise,1938-05-24,rejected,633,2024-12-19 18:44:41.769281,2.1,Interagir,2. Communication et collaboration,6
+9558218,1452233K,086369926RY,De Sousa,Élise,1938-05-24,rejected,633,2024-12-19 18:44:41.769281,2.2,Partager et publier,2. Communication et collaboration,1
+9558218,1452233K,086369926RY,De Sousa,Élise,1938-05-24,rejected,633,2024-12-19 18:44:41.769281,2.3,Collaborer,2. Communication et collaboration,1
+9558218,1452233K,086369926RY,De Sousa,Élise,1938-05-24,rejected,633,2024-12-19 18:44:41.769281,2.4,S’insérer dans le monde numérique,2. Communication et collaboration,6
+9558218,1452233K,086369926RY,De Sousa,Élise,1938-05-24,rejected,633,2024-12-19 18:44:41.769281,3.1,Développer des documents textuels,3. Création de contenu,6
+9558218,1452233K,086369926RY,De Sousa,Élise,1938-05-24,rejected,633,2024-12-19 18:44:41.769281,3.2,Développer des documents multimedia,3. Création de contenu,5
+9558218,1452233K,086369926RY,De Sousa,Élise,1938-05-24,rejected,633,2024-12-19 18:44:41.769281,3.3,Adapter les documents à leur finalité,3. Création de contenu,4
+9558218,1452233K,086369926RY,De Sousa,Élise,1938-05-24,rejected,633,2024-12-19 18:44:41.769281,3.4,Programmer,3. Création de contenu,1
+9558218,1452233K,086369926RY,De Sousa,Élise,1938-05-24,rejected,633,2024-12-19 18:44:41.769281,4.1,Sécuriser l’environnement numérique,4. Protection et sécurité,2
+9558218,1452233K,086369926RY,De Sousa,Élise,1938-05-24,rejected,633,2024-12-19 18:44:41.769281,4.2,Protéger les données personnelles et la vie privée,4. Protection et sécurité,6
+9558218,1452233K,086369926RY,De Sousa,Élise,1938-05-24,rejected,633,2024-12-19 18:44:41.769281,4.3,"Protéger la santé, le bien-être et l’environnement",4. Protection et sécurité,1
+9558218,1452233K,086369926RY,De Sousa,Élise,1938-05-24,rejected,633,2024-12-19 18:44:41.769281,5.1,Résoudre des problèmes techniques,5. Environnement numérique,3
+9558218,1452233K,086369926RY,De Sousa,Élise,1938-05-24,rejected,633,2024-12-19 18:44:41.769281,5.2,Construire un environnement numérique,5. Environnement numérique,7
+7691841,9837276V,154505101GF,Aubert,Timothée,1911-03-15,validated,388,2024-12-16 13:43:25.949649,1.1,Mener une recherche et une veille d’information,1. Information et données,4
+7691841,9837276V,154505101GF,Aubert,Timothée,1911-03-15,validated,388,2024-12-16 13:43:25.949649,1.2,Gérer des données,1. Information et données,5
+7691841,9837276V,154505101GF,Aubert,Timothée,1911-03-15,validated,388,2024-12-16 13:43:25.949649,1.3,Traiter des données,1. Information et données,2
+7691841,9837276V,154505101GF,Aubert,Timothée,1911-03-15,validated,388,2024-12-16 13:43:25.949649,2.1,Interagir,2. Communication et collaboration,4
+7691841,9837276V,154505101GF,Aubert,Timothée,1911-03-15,validated,388,2024-12-16 13:43:25.949649,2.2,Partager et publier,2. Communication et collaboration,3
+7691841,9837276V,154505101GF,Aubert,Timothée,1911-03-15,validated,388,2024-12-16 13:43:25.949649,2.3,Collaborer,2. Communication et collaboration,0
+7691841,9837276V,154505101GF,Aubert,Timothée,1911-03-15,validated,388,2024-12-16 13:43:25.949649,2.4,S’insérer dans le monde numérique,2. Communication et collaboration,6
+7691841,9837276V,154505101GF,Aubert,Timothée,1911-03-15,validated,388,2024-12-16 13:43:25.949649,3.1,Développer des documents textuels,3. Création de contenu,2
+7691841,9837276V,154505101GF,Aubert,Timothée,1911-03-15,validated,388,2024-12-16 13:43:25.949649,3.2,Développer des documents multimedia,3. Création de contenu,5
+7691841,9837276V,154505101GF,Aubert,Timothée,1911-03-15,validated,388,2024-12-16 13:43:25.949649,3.3,Adapter les documents à leur finalité,3. Création de contenu,4
+7691841,9837276V,154505101GF,Aubert,Timothée,1911-03-15,validated,388,2024-12-16 13:43:25.949649,3.4,Programmer,3. Création de contenu,7
+7691841,9837276V,154505101GF,Aubert,Timothée,1911-03-15,validated,388,2024-12-16 13:43:25.949649,4.1,Sécuriser l’environnement numérique,4. Protection et sécurité,2
+7691841,9837276V,154505101GF,Aubert,Timothée,1911-03-15,validated,388,2024-12-16 13:43:25.949649,4.2,Protéger les données personnelles et la vie privée,4. Protection et sécurité,3
+7691841,9837276V,154505101GF,Aubert,Timothée,1911-03-15,validated,388,2024-12-16 13:43:25.949649,4.3,"Protéger la santé, le bien-être et l’environnement",4. Protection et sécurité,7
+7691841,9837276V,154505101GF,Aubert,Timothée,1911-03-15,validated,388,2024-12-16 13:43:25.949649,5.1,Résoudre des problèmes techniques,5. Environnement numérique,2
+7691841,9837276V,154505101GF,Aubert,Timothée,1911-03-15,validated,388,2024-12-16 13:43:25.949649,5.2,Construire un environnement numérique,5. Environnement numérique,6
+7120695,9494980T,598302001KB,Millet,Inès,1941-01-06,validated,8,2024-12-29 17:06:01.759697,1.1,Mener une recherche et une veille d’information,1. Information et données,2
+7120695,9494980T,598302001KB,Millet,Inès,1941-01-06,validated,8,2024-12-29 17:06:01.759697,1.2,Gérer des données,1. Information et données,2
+7120695,9494980T,598302001KB,Millet,Inès,1941-01-06,validated,8,2024-12-29 17:06:01.759697,1.3,Traiter des données,1. Information et données,1
+7120695,9494980T,598302001KB,Millet,Inès,1941-01-06,validated,8,2024-12-29 17:06:01.759697,2.1,Interagir,2. Communication et collaboration,4
+7120695,9494980T,598302001KB,Millet,Inès,1941-01-06,validated,8,2024-12-29 17:06:01.759697,2.2,Partager et publier,2. Communication et collaboration,7
+7120695,9494980T,598302001KB,Millet,Inès,1941-01-06,validated,8,2024-12-29 17:06:01.759697,2.3,Collaborer,2. Communication et collaboration,6
+7120695,9494980T,598302001KB,Millet,Inès,1941-01-06,validated,8,2024-12-29 17:06:01.759697,2.4,S’insérer dans le monde numérique,2. Communication et collaboration,7
+7120695,9494980T,598302001KB,Millet,Inès,1941-01-06,validated,8,2024-12-29 17:06:01.759697,3.1,Développer des documents textuels,3. Création de contenu,3
+7120695,9494980T,598302001KB,Millet,Inès,1941-01-06,validated,8,2024-12-29 17:06:01.759697,3.2,Développer des documents multimedia,3. Création de contenu,3
+7120695,9494980T,598302001KB,Millet,Inès,1941-01-06,validated,8,2024-12-29 17:06:01.759697,3.3,Adapter les documents à leur finalité,3. Création de contenu,3
+7120695,9494980T,598302001KB,Millet,Inès,1941-01-06,validated,8,2024-12-29 17:06:01.759697,3.4,Programmer,3. Création de contenu,6
+7120695,9494980T,598302001KB,Millet,Inès,1941-01-06,validated,8,2024-12-29 17:06:01.759697,4.1,Sécuriser l’environnement numérique,4. Protection et sécurité,7
+7120695,9494980T,598302001KB,Millet,Inès,1941-01-06,validated,8,2024-12-29 17:06:01.759697,4.2,Protéger les données personnelles et la vie privée,4. Protection et sécurité,0
+7120695,9494980T,598302001KB,Millet,Inès,1941-01-06,validated,8,2024-12-29 17:06:01.759697,4.3,"Protéger la santé, le bien-être et l’environnement",4. Protection et sécurité,7
+7120695,9494980T,598302001KB,Millet,Inès,1941-01-06,validated,8,2024-12-29 17:06:01.759697,5.1,Résoudre des problèmes techniques,5. Environnement numérique,7
+7120695,9494980T,598302001KB,Millet,Inès,1941-01-06,validated,8,2024-12-29 17:06:01.759697,5.2,Construire un environnement numérique,5. Environnement numérique,4
+

--- a/api/datamart/seeds/csv/data_export_parcoursup_certif_result_code_validation.csv
+++ b/api/datamart/seeds/csv/data_export_parcoursup_certif_result_code_validation.csv
@@ -1,0 +1,66 @@
+certification_code_verification,certification_courses_id,organization_uai,national_student_id,last_name,first_name,birthdate,status,pix_score,certification_date,competence_code,competence_name,area_name,competence_level
+P-K9YAM1HV,7546749,7700918L,564756152RS,Bonnet,Amélie,1937-04-13,rejected,560,2024-12-25 22:47:33.323837,1.1,Mener une recherche et une veille d’information,1. Information et données,0
+P-K9YAM1HV,7546749,7700918L,564756152RS,Bonnet,Amélie,1937-04-13,rejected,560,2024-12-25 22:47:33.323837,1.2,Gérer des données,1. Information et données,3
+P-K9YAM1HV,7546749,7700918L,564756152RS,Bonnet,Amélie,1937-04-13,rejected,560,2024-12-25 22:47:33.323837,1.3,Traiter des données,1. Information et données,3
+P-K9YAM1HV,7546749,7700918L,564756152RS,Bonnet,Amélie,1937-04-13,rejected,560,2024-12-25 22:47:33.323837,2.1,Interagir,2. Communication et collaboration,5
+P-K9YAM1HV,7546749,7700918L,564756152RS,Bonnet,Amélie,1937-04-13,rejected,560,2024-12-25 22:47:33.323837,2.2,Partager et publier,2. Communication et collaboration,4
+P-K9YAM1HV,7546749,7700918L,564756152RS,Bonnet,Amélie,1937-04-13,rejected,560,2024-12-25 22:47:33.323837,2.3,Collaborer,2. Communication et collaboration,1
+P-K9YAM1HV,7546749,7700918L,564756152RS,Bonnet,Amélie,1937-04-13,rejected,560,2024-12-25 22:47:33.323837,2.4,S’insérer dans le monde numérique,2. Communication et collaboration,5
+P-K9YAM1HV,7546749,7700918L,564756152RS,Bonnet,Amélie,1937-04-13,rejected,560,2024-12-25 22:47:33.323837,3.1,Développer des documents textuels,3. Création de contenu,1
+P-K9YAM1HV,7546749,7700918L,564756152RS,Bonnet,Amélie,1937-04-13,rejected,560,2024-12-25 22:47:33.323837,3.2,Développer des documents multimedia,3. Création de contenu,5
+P-K9YAM1HV,7546749,7700918L,564756152RS,Bonnet,Amélie,1937-04-13,rejected,560,2024-12-25 22:47:33.323837,3.3,Adapter les documents à leur finalité,3. Création de contenu,1
+P-K9YAM1HV,7546749,7700918L,564756152RS,Bonnet,Amélie,1937-04-13,rejected,560,2024-12-25 22:47:33.323837,3.4,Programmer,3. Création de contenu,1
+P-K9YAM1HV,7546749,7700918L,564756152RS,Bonnet,Amélie,1937-04-13,rejected,560,2024-12-25 22:47:33.323837,4.1,Sécuriser l’environnement numérique,4. Protection et sécurité,6
+P-K9YAM1HV,7546749,7700918L,564756152RS,Bonnet,Amélie,1937-04-13,rejected,560,2024-12-25 22:47:33.323837,4.2,Protéger les données personnelles et la vie privée,4. Protection et sécurité,2
+P-K9YAM1HV,7546749,7700918L,564756152RS,Bonnet,Amélie,1937-04-13,rejected,560,2024-12-25 22:47:33.323837,4.3,"Protéger la santé, le bien-être et l’environnement",4. Protection et sécurité,6
+P-K9YAM1HV,7546749,7700918L,564756152RS,Bonnet,Amélie,1937-04-13,rejected,560,2024-12-25 22:47:33.323837,5.1,Résoudre des problèmes techniques,5. Environnement numérique,0
+P-K9YAM1HV,7546749,7700918L,564756152RS,Bonnet,Amélie,1937-04-13,rejected,560,2024-12-25 22:47:33.323837,5.2,Construire un environnement numérique,5. Environnement numérique,4
+P-S2CSF3FR,9951954,1329309G,090457162VL,Diaz,Alain,1959-01-28,cancelled,889,2024-12-23 09:54:26.346039,1.1,Mener une recherche et une veille d’information,1. Information et données,0
+P-S2CSF3FR,9951954,1329309G,090457162VL,Diaz,Alain,1959-01-28,cancelled,889,2024-12-23 09:54:26.346039,1.2,Gérer des données,1. Information et données,6
+P-S2CSF3FR,9951954,1329309G,090457162VL,Diaz,Alain,1959-01-28,cancelled,889,2024-12-23 09:54:26.346039,1.3,Traiter des données,1. Information et données,3
+P-S2CSF3FR,9951954,1329309G,090457162VL,Diaz,Alain,1959-01-28,cancelled,889,2024-12-23 09:54:26.346039,2.1,Interagir,2. Communication et collaboration,7
+P-S2CSF3FR,9951954,1329309G,090457162VL,Diaz,Alain,1959-01-28,cancelled,889,2024-12-23 09:54:26.346039,2.2,Partager et publier,2. Communication et collaboration,1
+P-S2CSF3FR,9951954,1329309G,090457162VL,Diaz,Alain,1959-01-28,cancelled,889,2024-12-23 09:54:26.346039,2.3,Collaborer,2. Communication et collaboration,0
+P-S2CSF3FR,9951954,1329309G,090457162VL,Diaz,Alain,1959-01-28,cancelled,889,2024-12-23 09:54:26.346039,2.4,S’insérer dans le monde numérique,2. Communication et collaboration,1
+P-S2CSF3FR,9951954,1329309G,090457162VL,Diaz,Alain,1959-01-28,cancelled,889,2024-12-23 09:54:26.346039,3.1,Développer des documents textuels,3. Création de contenu,2
+P-S2CSF3FR,9951954,1329309G,090457162VL,Diaz,Alain,1959-01-28,cancelled,889,2024-12-23 09:54:26.346039,3.2,Développer des documents multimedia,3. Création de contenu,7
+P-S2CSF3FR,9951954,1329309G,090457162VL,Diaz,Alain,1959-01-28,cancelled,889,2024-12-23 09:54:26.346039,3.3,Adapter les documents à leur finalité,3. Création de contenu,6
+P-S2CSF3FR,9951954,1329309G,090457162VL,Diaz,Alain,1959-01-28,cancelled,889,2024-12-23 09:54:26.346039,3.4,Programmer,3. Création de contenu,4
+P-S2CSF3FR,9951954,1329309G,090457162VL,Diaz,Alain,1959-01-28,cancelled,889,2024-12-23 09:54:26.346039,4.1,Sécuriser l’environnement numérique,4. Protection et sécurité,2
+P-S2CSF3FR,9951954,1329309G,090457162VL,Diaz,Alain,1959-01-28,cancelled,889,2024-12-23 09:54:26.346039,4.2,Protéger les données personnelles et la vie privée,4. Protection et sécurité,6
+P-S2CSF3FR,9951954,1329309G,090457162VL,Diaz,Alain,1959-01-28,cancelled,889,2024-12-23 09:54:26.346039,4.3,"Protéger la santé, le bien-être et l’environnement",4. Protection et sécurité,5
+P-S2CSF3FR,9951954,1329309G,090457162VL,Diaz,Alain,1959-01-28,cancelled,889,2024-12-23 09:54:26.346039,5.1,Résoudre des problèmes techniques,5. Environnement numérique,2
+P-S2CSF3FR,9951954,1329309G,090457162VL,Diaz,Alain,1959-01-28,cancelled,889,2024-12-23 09:54:26.346039,5.2,Construire un environnement numérique,5. Environnement numérique,5
+P-R7TIF9FN,5312912,7710934Z,593254732WF,Humbert,Honoré,1972-05-12,cancelled,419,2024-11-26 02:20:27.769306,1.1,Mener une recherche et une veille d’information,1. Information et données,5
+P-R7TIF9FN,5312912,7710934Z,593254732WF,Humbert,Honoré,1972-05-12,cancelled,419,2024-11-26 02:20:27.769306,1.2,Gérer des données,1. Information et données,5
+P-R7TIF9FN,5312912,7710934Z,593254732WF,Humbert,Honoré,1972-05-12,cancelled,419,2024-11-26 02:20:27.769306,1.3,Traiter des données,1. Information et données,0
+P-R7TIF9FN,5312912,7710934Z,593254732WF,Humbert,Honoré,1972-05-12,cancelled,419,2024-11-26 02:20:27.769306,2.1,Interagir,2. Communication et collaboration,5
+P-R7TIF9FN,5312912,7710934Z,593254732WF,Humbert,Honoré,1972-05-12,cancelled,419,2024-11-26 02:20:27.769306,2.2,Partager et publier,2. Communication et collaboration,3
+P-R7TIF9FN,5312912,7710934Z,593254732WF,Humbert,Honoré,1972-05-12,cancelled,419,2024-11-26 02:20:27.769306,2.3,Collaborer,2. Communication et collaboration,1
+P-R7TIF9FN,5312912,7710934Z,593254732WF,Humbert,Honoré,1972-05-12,cancelled,419,2024-11-26 02:20:27.769306,2.4,S’insérer dans le monde numérique,2. Communication et collaboration,2
+P-R7TIF9FN,5312912,7710934Z,593254732WF,Humbert,Honoré,1972-05-12,cancelled,419,2024-11-26 02:20:27.769306,3.1,Développer des documents textuels,3. Création de contenu,4
+P-R7TIF9FN,5312912,7710934Z,593254732WF,Humbert,Honoré,1972-05-12,cancelled,419,2024-11-26 02:20:27.769306,3.2,Développer des documents multimedia,3. Création de contenu,7
+P-R7TIF9FN,5312912,7710934Z,593254732WF,Humbert,Honoré,1972-05-12,cancelled,419,2024-11-26 02:20:27.769306,3.3,Adapter les documents à leur finalité,3. Création de contenu,3
+P-R7TIF9FN,5312912,7710934Z,593254732WF,Humbert,Honoré,1972-05-12,cancelled,419,2024-11-26 02:20:27.769306,3.4,Programmer,3. Création de contenu,2
+P-R7TIF9FN,5312912,7710934Z,593254732WF,Humbert,Honoré,1972-05-12,cancelled,419,2024-11-26 02:20:27.769306,4.1,Sécuriser l’environnement numérique,4. Protection et sécurité,0
+P-R7TIF9FN,5312912,7710934Z,593254732WF,Humbert,Honoré,1972-05-12,cancelled,419,2024-11-26 02:20:27.769306,4.2,Protéger les données personnelles et la vie privée,4. Protection et sécurité,3
+P-R7TIF9FN,5312912,7710934Z,593254732WF,Humbert,Honoré,1972-05-12,cancelled,419,2024-11-26 02:20:27.769306,4.3,"Protéger la santé, le bien-être et l’environnement",4. Protection et sécurité,4
+P-R7TIF9FN,5312912,7710934Z,593254732WF,Humbert,Honoré,1972-05-12,cancelled,419,2024-11-26 02:20:27.769306,5.1,Résoudre des problèmes techniques,5. Environnement numérique,1
+P-R7TIF9FN,5312912,7710934Z,593254732WF,Humbert,Honoré,1972-05-12,cancelled,419,2024-11-26 02:20:27.769306,5.2,Construire un environnement numérique,5. Environnement numérique,1
+P-C1IIA3EA,8398082,7978102B,926981169BI,Aubry,Éric,1942-03-10,cancelled,178,2024-12-09 22:21:46.634376,1.1,Mener une recherche et une veille d’information,1. Information et données,6
+P-C1IIA3EA,8398082,7978102B,926981169BI,Aubry,Éric,1942-03-10,cancelled,178,2024-12-09 22:21:46.634376,1.2,Gérer des données,1. Information et données,4
+P-C1IIA3EA,8398082,7978102B,926981169BI,Aubry,Éric,1942-03-10,cancelled,178,2024-12-09 22:21:46.634376,1.3,Traiter des données,1. Information et données,4
+P-C1IIA3EA,8398082,7978102B,926981169BI,Aubry,Éric,1942-03-10,cancelled,178,2024-12-09 22:21:46.634376,2.1,Interagir,2. Communication et collaboration,5
+P-C1IIA3EA,8398082,7978102B,926981169BI,Aubry,Éric,1942-03-10,cancelled,178,2024-12-09 22:21:46.634376,2.2,Partager et publier,2. Communication et collaboration,6
+P-C1IIA3EA,8398082,7978102B,926981169BI,Aubry,Éric,1942-03-10,cancelled,178,2024-12-09 22:21:46.634376,2.3,Collaborer,2. Communication et collaboration,5
+P-C1IIA3EA,8398082,7978102B,926981169BI,Aubry,Éric,1942-03-10,cancelled,178,2024-12-09 22:21:46.634376,2.4,S’insérer dans le monde numérique,2. Communication et collaboration,6
+P-C1IIA3EA,8398082,7978102B,926981169BI,Aubry,Éric,1942-03-10,cancelled,178,2024-12-09 22:21:46.634376,3.1,Développer des documents textuels,3. Création de contenu,7
+P-C1IIA3EA,8398082,7978102B,926981169BI,Aubry,Éric,1942-03-10,cancelled,178,2024-12-09 22:21:46.634376,3.2,Développer des documents multimedia,3. Création de contenu,7
+P-C1IIA3EA,8398082,7978102B,926981169BI,Aubry,Éric,1942-03-10,cancelled,178,2024-12-09 22:21:46.634376,3.3,Adapter les documents à leur finalité,3. Création de contenu,0
+P-C1IIA3EA,8398082,7978102B,926981169BI,Aubry,Éric,1942-03-10,cancelled,178,2024-12-09 22:21:46.634376,3.4,Programmer,3. Création de contenu,3
+P-C1IIA3EA,8398082,7978102B,926981169BI,Aubry,Éric,1942-03-10,cancelled,178,2024-12-09 22:21:46.634376,4.1,Sécuriser l’environnement numérique,4. Protection et sécurité,3
+P-C1IIA3EA,8398082,7978102B,926981169BI,Aubry,Éric,1942-03-10,cancelled,178,2024-12-09 22:21:46.634376,4.2,Protéger les données personnelles et la vie privée,4. Protection et sécurité,7
+P-C1IIA3EA,8398082,7978102B,926981169BI,Aubry,Éric,1942-03-10,cancelled,178,2024-12-09 22:21:46.634376,4.3,"Protéger la santé, le bien-être et l’environnement",4. Protection et sécurité,5
+P-C1IIA3EA,8398082,7978102B,926981169BI,Aubry,Éric,1942-03-10,cancelled,178,2024-12-09 22:21:46.634376,5.1,Résoudre des problèmes techniques,5. Environnement numérique,2
+P-C1IIA3EA,8398082,7978102B,926981169BI,Aubry,Éric,1942-03-10,cancelled,178,2024-12-09 22:21:46.634376,5.2,Construire un environnement numérique,5. Environnement numérique,1
+

--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -46,7 +46,7 @@ const register = async function (server) {
           },
         },
         handler: authenticationController.authenticateApplication,
-        tags: ['api', 'authorization-server'],
+        tags: ['api', 'authorization-server', 'parcoursup'],
       },
     },
     {

--- a/api/sample.env
+++ b/api/sample.env
@@ -547,6 +547,30 @@ AUTH_SECRET=the-password-must-be-at-least-32-characters-long
 # sample: PUSH_DATA_TO_POLE_EMPLOI_ENABLED=true
 
 # ===================
+# PARCOURSUP CONFIGURATION
+# ===================
+
+# Client ID
+#
+# presence: required for PARCOURSUP authentication, optional otherwise
+# type: string
+# sample: APIM_PIX_PARCOURSUP_CLIENT_ID=parcoursup
+
+# Client secret
+#
+# presence: required for PARCOURSUP authentication, optional otherwise
+# type: string
+# sample: APIM_PIX_PARCOURSUP_CLIENT_SECRET=parcoursup-secret-de-trente-deux-caracteres
+
+# Auth secret
+#
+# Secret salt value used in PARCOURSUP JWT token generation.
+# presence: required for PARCOURSUP authentication, optional otherwise
+# type: String
+# sample: PIX_PARCOURSUP_AUTH_SECRET=secret-parcoursup
+
+
+# ===================
 # AUTHENTICATION SESSION CONFIGURATION
 # ===================
 

--- a/api/src/parcoursup/infrastructure/repositories/certification-repository.js
+++ b/api/src/parcoursup/infrastructure/repositories/certification-repository.js
@@ -18,7 +18,22 @@ const getByOrganizationUAI = async ({ organizationUai, lastName, firstName, birt
 };
 
 const _getBySearchParams = async (searchParams) => {
-  const certificationResultDto = await datamartKnex('data_export_parcoursup_certif_result').where(searchParams);
+  const certificationResultDto = await datamartKnex('data_export_parcoursup_certif_result')
+    .select(
+      'national_student_id',
+      'organization_uai',
+      'last_name',
+      'first_name',
+      'birthdate',
+      'status',
+      'pix_score',
+      'certification_date',
+      'competence_code',
+      'competence_name',
+      'area_name',
+      'competence_level',
+    )
+    .where(searchParams);
   if (!certificationResultDto.length) {
     throw new NotFoundError('No certifications found for given search parameters');
   }
@@ -27,9 +42,22 @@ const _getBySearchParams = async (searchParams) => {
 };
 
 const getByVerificationCode = async ({ verificationCode }) => {
-  const certificationResultDto = await datamartKnex('data_export_parcoursup_certif_result_code_validation').where({
-    certification_code_verification: verificationCode,
-  });
+  const certificationResultDto = await datamartKnex('data_export_parcoursup_certif_result_code_validation')
+    .select(
+      'last_name',
+      'first_name',
+      'birthdate',
+      'status',
+      'pix_score',
+      'certification_date',
+      'competence_code',
+      'competence_name',
+      'area_name',
+      'competence_level',
+    )
+    .where({
+      certification_code_verification: verificationCode,
+    });
   if (!certificationResultDto.length) {
     throw new NotFoundError('No certifications found for given search parameters');
   }

--- a/api/src/shared/swaggers.js
+++ b/api/src/shared/swaggers.js
@@ -32,7 +32,7 @@ const swaggerOptionsPoleEmploi = {
 const swaggerOptionsParcoursup = {
   routeTag: 'parcoursup',
   info: {
-    title: 'Pix Paroursup open api',
+    title: 'Pix Parcoursup open api',
     version: packageJSON.version,
   },
   jsonPath: '/swagger.json',

--- a/api/src/shared/swaggers.js
+++ b/api/src/shared/swaggers.js
@@ -29,17 +29,49 @@ const swaggerOptionsPoleEmploi = {
   jsonPath: '/swagger.json',
 };
 
+const swaggerOptionsParcoursup = {
+  routeTag: 'parcoursup',
+  info: {
+    title: 'Pix Paroursup open api',
+    version: packageJSON.version,
+  },
+  jsonPath: '/swagger.json',
+  securityDefinitions: {
+    bearerAuth: {
+      name: 'Authorization',
+      scheme: 'Bearer',
+      in: 'header',
+      description: 'Example: Bearer eyJ...z',
+      type: 'apiKey',
+    },
+  },
+  security: [{ bearerAuth: [], jwt: [] }],
+};
+
 const swaggerOptionsIn = {
   basePath: '/api',
   grouping: 'tags',
   routeTag: 'api',
   OAS: 'v3.0',
+  uiOptions: {
+    url: 'swagger.json',
+  },
   info: {
     title: 'Welcome to the Pix api catalog',
     version: packageJSON.version,
   },
   documentationPath: '/documentation',
   jsonPath: '/swagger.json',
+  securityDefinitions: {
+    bearerAuth: {
+      name: 'Authorization',
+      scheme: 'Bearer',
+      in: 'header',
+      description: 'Example: Bearer eyJ...z',
+      type: 'apiKey',
+    },
+  },
+  security: [{ bearerAuth: [], jwt: [] }],
 };
 
 function _buildSwaggerArgs(swaggerOptions) {
@@ -58,6 +90,7 @@ const swaggers = [
   swaggerOptionsAuthorizationServer,
   swaggerOptionsLivretScolaire,
   swaggerOptionsPoleEmploi,
+  swaggerOptionsParcoursup,
   swaggerOptionsIn,
 ].map(_buildSwaggerArgs);
 


### PR DESCRIPTION
## :christmas_tree: Problème

Nous souhaitons avoir une documentation technique consultable librement pour Parcoursup.

## :gift: Proposition

* Creer un Swagger pour Parcoursup
* Mettre a jour nos seeds pour prendre en compte les dernieres modifications

## :socks: Remarques

## :santa: Pour tester

* Se rendre sur la RA sur l'url https://api-pr11039.review.pix.fr/parcoursup/documentation#/api/postApiApplicationToken
* Faire Try it out sur l'API d'authentification de cette page, puis execute, et recuperer le token genere en reponse
* Tout en haut a droite de la page, cliquez sur Authorize et mettre "Bearer MON_TOKEN"
* Faire Try it out sur l'API de recherche, par exemple avec l'UAI "944385546HU", et verifier que une reponse HTTP 200
