### PR TITLE
[BUGFIX] Update membership fields only if membership is not already deactivated (pix-16014)

### DIFF
--- a/api/db/database-builder/factory/build-membership.js
+++ b/api/db/database-builder/factory/build-membership.js
@@ -11,12 +11,15 @@ const buildMembership = function ({
   organizationId,
   userId,
   createdAt = new Date(),
-  updatedAt = new Date(),
+  updatedAt,
   disabledAt,
+  updatedByUserId,
 } = {}) {
   userId = _.isUndefined(userId) ? buildUser().id : userId;
   organizationId = _.isUndefined(organizationId) ? buildOrganization().id : organizationId;
-
+  if (!updatedAt) {
+    updatedAt = disabledAt || createdAt;
+  }
   const values = {
     id,
     organizationId,
@@ -25,6 +28,7 @@ const buildMembership = function ({
     createdAt,
     updatedAt,
     disabledAt,
+    updatedByUserId,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'memberships',

--- a/api/src/team/infrastructure/repositories/membership.repository.js
+++ b/api/src/team/infrastructure/repositories/membership.repository.js
@@ -172,6 +172,7 @@ export const updateById = async ({ id, membership }) => {
 export const disableMembershipsByUserId = async function ({ userId, updatedByUserId }) {
   const knexConnection = DomainTransaction.getConnection();
   await knexConnection(MEMBERSHIPS_TABLE)
+    .whereNull('disabledAt')
     .where({ userId })
     .update({ disabledAt: new Date(), updatedAt: new Date(), updatedByUserId });
 };


### PR DESCRIPTION
## :christmas_tree: Problème

Actuellement, lorqu'un utilisateur membre de plusieurs organisations est anonymisé, tous les memberships sont actualisés, même ceux qui ont été déjà désactivés auparavant. membre d'équipe de centre de certification est désactivé (depuis PixAdmin ou PixCertif), le champ `updatedAt` de la table `certification-center-memberships` n'est pas mis à jour.

## :gift: Proposition

Lors d'une anonymisation, ne pas modifier un membership déjà désactivé auparavant : ni le champ `updatedAt`, ni le champ `disabledAt`, ni le champ `updatedByUserId`.


## :socks: Remarques

Rappel : L'anonymisation d'un utilisateur membre actif (= non désactivé auparavant) d'organisations doit mettre à jour les champs `udpatedAt`, `disabledAt` (`udpatedAt`= `disabledAt`), `updatedByUserId` dans la table `memberships`.

## :santa: Pour tester

Sur Pix Admin : 
      - Se connecter en tant qu'Admin (par exemple superadmin@example.net).
      - Se rendre sur la page du user allorga@example.net, qui appartient à trois organisations.
      - Désactiver l'un des memberships de allorga@example.net
      - Récupérer en base les informations relatives au membership désactivé : `updatedAt`, `updatedByUserId`, `disabledBy` et vérifier qu'elles ont été correctement mises à jour (test de non régression).
      - Se déconnecter, puis se reconnecter avec un autre compte d'Admin, par exemple gareth.edwards101336@example.net
      - Anonymiser l'utilisateur allorga@example.net
      **- Constater en base qu'aucun champ du membership désactivé en première intention n'a été modifié par l'anonymisation.**
       - Test de non régression : constater en base que les champs `updatedAt`, `updatedByUserId`, `disabledBy` correspondant aux deux autres memberships ont été correctement mis à jour.
 