### PR TITLE
[TECH] :truck: Déplace le service d'export pour le CPF vers `src`

### DIFF
--- a/api/src/certification/session-management/application/jobs/cpf-export-builder-job-controller.js
+++ b/api/src/certification/session-management/application/jobs/cpf-export-builder-job-controller.js
@@ -5,7 +5,7 @@ import dayjs from 'dayjs';
 import timezone from 'dayjs/plugin/timezone.js';
 import utc from 'dayjs/plugin/utc.js';
 
-import * as cpfCertificationXmlExportService from '../../../../../lib/domain/services/cpf-certification-xml-export-service.js';
+import * as cpfCertificationXmlExportService from '../../../../../src/certification/session-management/domain/services/cpf-certification-xml-export-service.js';
 import { JobController } from '../../../../shared/application/jobs/job-controller.js';
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 import { CpfExportBuilderJob } from '../../domain/models/CpfExportBuilderJob.js';

--- a/api/src/certification/session-management/domain/services/cpf-certification-xml-export-service.js
+++ b/api/src/certification/session-management/domain/services/cpf-certification-xml-export-service.js
@@ -3,7 +3,7 @@ import timezone from 'dayjs/plugin/timezone.js';
 import utc from 'dayjs/plugin/utc.js';
 import xmlbuilder2 from 'xmlbuilder2';
 
-import { config } from '../../../src/shared/config.js';
+import { config } from '../../../../shared/config.js';
 
 const { create, fragment } = xmlbuilder2;
 

--- a/api/tests/certification/session-management/integration/application/jobs/cpf-export-builder-job-controller_test.js
+++ b/api/tests/certification/session-management/integration/application/jobs/cpf-export-builder-job-controller_test.js
@@ -8,8 +8,8 @@ import timezone from 'dayjs/plugin/timezone.js';
 import utc from 'dayjs/plugin/utc.js';
 import lodash from 'lodash';
 
-import * as cpfCertificationXmlExportService from '../../../../../../lib/domain/services/cpf-certification-xml-export-service.js';
 import { CpfExportBuilderJobController } from '../../../../../../src/certification/session-management/application/jobs/cpf-export-builder-job-controller.js';
+import * as cpfCertificationXmlExportService from '../../../../../../src/certification/session-management/domain/services/cpf-certification-xml-export-service.js';
 import { usecases } from '../../../../../../src/certification/session-management/domain/usecases/index.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 

--- a/api/tests/unit/domain/services/cpf/cpf-certification-xml-export-service_test.js
+++ b/api/tests/unit/domain/services/cpf/cpf-certification-xml-export-service_test.js
@@ -4,7 +4,7 @@ import dayjs from 'dayjs';
 import timezone from 'dayjs/plugin/timezone.js';
 import utc from 'dayjs/plugin/utc.js';
 
-import * as cpfCertificationXmlExportService from '../../../../../lib/domain/services/cpf-certification-xml-export-service.js';
+import * as cpfCertificationXmlExportService from '../../../../../src/certification/session-management/domain/services/cpf-certification-xml-export-service.js';
 import { domainBuilder, expect, sinon, streamToPromise } from '../../../../test-helper.js';
 
 const { PassThrough } = stream;


### PR DESCRIPTION
## :christmas_tree: Problème

Le service d'export XML pour le CPF est dans `lib`

## :gift: Proposition

Déplacer le service d'export XML pour le CPF dans le répertoire `src`

## :socks: Remarques

## :santa: Pour tester

