### PR TITLE
[FEATURE] Ajouter un feature toggle pour le confinement des access tokens (PIX-15924)

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -860,6 +860,11 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: false
 # FT_NEW_LEGAL_DOCUMENTS_VERSIONING=false
 
+# Enable user token aud confinement
+# type: boolean
+# default: false
+# FT_USER_TOKEN_AUD_CONFINEMENT_ENABLED=false
+
 # =====
 # CPF
 # =====

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -266,6 +266,7 @@ const configuration = (function () {
       isPixCompanionEnabled: toBoolean(process.env.FT_PIX_COMPANION_ENABLED),
       isSelfAccountDeletionEnabled: toBoolean(process.env.FT_SELF_ACCOUNT_DELETION),
       isQuestEnabled: toBoolean(process.env.FT_ENABLE_QUESTS),
+      isUserTokenAudConfinementEnabled: toBoolean(process.env.FT_USER_TOKEN_AUD_CONFINEMENT_ENABLED),
       isTextToSpeechButtonEnabled: toBoolean(process.env.FT_ENABLE_TEXT_TO_SPEECH_BUTTON),
       isLegalDocumentsVersioningEnabled: toBoolean(process.env.FT_NEW_LEGAL_DOCUMENTS_VERSIONING),
       setupEcosystemBeforeStart: toBoolean(process.env.FT_SETUP_ECOSYSTEM_BEFORE_START) || false,
@@ -496,6 +497,7 @@ const configuration = (function () {
     config.featureToggles.isSelfAccountDeletionEnabled = false;
     config.featureToggles.isQuestEnabled = false;
     config.featureToggles.isAsyncQuestRewardingCalculationEnabled = false;
+    config.featureToggles.isUserTokenAudConfinementEnabled = false;
     config.featureToggles.isTextToSpeechButtonEnabled = false;
     config.featureToggles.isLegalDocumentsVersioningEnabled = false;
     config.featureToggles.showNewResultPage = false;

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -29,6 +29,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-pix1d-enabled': true,
             'is-pix-companion-enabled': false,
             'is-quest-enabled': false,
+            'is-user-token-aud-confinement-enabled': false,
             'is-self-account-deletion-enabled': false,
             'is-text-to-speech-button-enabled': false,
             'is-legal-documents-versioning-enabled': false,


### PR DESCRIPTION
## :christmas_tree: Problème

On souhaite avoir un feature toggle permettant de tester une future implémentation d'access tokens.

## :gift: Proposition

Ajouter le feature toggle et le définir à false par défaut sur la RA.

## :socks: Remarques
La variable `isUserTokenAudConfimentEnabled` a été placée dans `config.featureToggles` même si elle n'est pas utilisée dans le front. On a choisi de ne pas créer un objet spécialement pour cette variable.

## :santa: Pour tester
#### Avec la valeur sur False
Faire cette requête dans un terminal:
```shell
curl -X GET --location "https://api-pr11063.review.pix.fr/api/feature-toggles"
```
Vérifier que cette ligne est présente:
```
"is-user-token-aud-confinement-enabled": false,
```

#### Avec la valeur sur true
- Se rendre sur le [scalingo des variables d'env](https://dashboard.scalingo.com/apps/osc-fr1/pix-api-review-pr11063/environment) et passer FT_USER_TOKEN_AUD_CONFINEMENT_ENABLED à true
- Relancer le déploiement
- Faire cette requête dans un terminal:
```shell
curl -X GET --location "https://api-pr11063.review.pix.fr/api/feature-toggles"
```
Vérifier que cette ligne est présente:
```
"is-user-token-aud-confinement-enabled": true,
```