### PR TITLE
[BUGFIX] Sur Pix App .org corriger les liens vers le support qui ne sont pas bons sur les pages de réinitialisation du mot de passe (PIX-16033)

### DIFF
--- a/mon-pix/app/components/authentication/password-reset-demand/password-reset-demand-form.gjs
+++ b/mon-pix/app/components/authentication/password-reset-demand/password-reset-demand-form.gjs
@@ -16,6 +16,7 @@ import PasswordResetDemandReceivedInfo from './password-reset-demand-received-in
 export default class PasswordResetDemandForm extends Component {
   @service errors;
   @service requestManager;
+  @service url;
 
   @tracked globalError = this.errors.hasErrors && this.errors.shift();
   @tracked isLoading = false;
@@ -114,7 +115,7 @@ export default class PasswordResetDemandForm extends Component {
         <section class="authentication-password-reset-demand-form__help">
           <h2>
             {{t "components.authentication.password-reset-demand-form.no-email-question"}}</h2>
-          <a href="{{t 'components.authentication.password-reset-demand-form.contact-us-link.link-url'}}">
+          <a href="{{this.url.supportHomeUrl}}">
             {{t "components.authentication.password-reset-demand-form.contact-us-link.link-text"}}
           </a>
         </section>

--- a/mon-pix/app/services/locale.js
+++ b/mon-pix/app/services/locale.js
@@ -8,6 +8,8 @@ export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 export const FRENCH_FRANCE_LOCALE = 'fr-FR';
 export const DEFAULT_LOCALE = FRENCH_INTERNATIONAL_LOCALE;
 
+const SUPPORTED_LOCALES = ['en', 'es', 'fr', 'fr-BE', 'fr-FR', 'nl-BE', 'nl'];
+
 const supportedLanguages = Object.keys(languages);
 
 export default class LocaleService extends Service {
@@ -15,6 +17,15 @@ export default class LocaleService extends Service {
   @service currentDomain;
   @service intl;
   @service dayjs;
+
+  isSupportedLocale(locale) {
+    try {
+      const localeCanonicalName = Intl.getCanonicalLocales(locale)?.[0];
+      return SUPPORTED_LOCALES.some((supportedLocale) => localeCanonicalName == supportedLocale);
+    } catch {
+      return false;
+    }
+  }
 
   handleUnsupportedLanguage(language) {
     if (!language) return;

--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -8,6 +8,7 @@ const SPANISH_INTERNATIONAL_LOCALE = 'es';
 export default class Url extends Service {
   @service currentDomain;
   @service intl;
+  @service locale;
 
   definedHomeUrl = ENV.rootURL;
 
@@ -108,22 +109,22 @@ export default class Url extends Service {
   }
 
   get supportHomeUrl() {
-    const currentLanguage = this.intl.primaryLocale;
+    const currentLocale = this.intl.primaryLocale;
 
     if (this.currentDomain.isFranceDomain) {
       return 'https://pix.fr/support';
     }
 
-    switch (currentLanguage) {
-      case ENGLISH_INTERNATIONAL_LOCALE:
-        return 'https://pix.org/en/support';
-      case DUTCH_INTERNATIONAL_LOCALE:
-        return 'https://pix.org/nl-be/support';
-      case SPANISH_INTERNATIONAL_LOCALE:
-        return 'https://pix.org/en/support';
-      default:
-        return 'https://pix.org/fr/support';
+    let locale;
+    if (currentLocale == 'nl') {
+      locale = 'nl-BE';
+    } else if (this.locale.isSupportedLocale(currentLocale)) {
+      locale = currentLocale;
+    } else {
+      locale = ENGLISH_INTERNATIONAL_LOCALE;
     }
+
+    return `https://pix.org/${locale}/support`;
   }
 
   get serverStatusUrl() {

--- a/mon-pix/tests/integration/components/authentication/password-reset-demand/password-reset-demand-form-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/password-reset-demand/password-reset-demand-form-test.gjs
@@ -1,4 +1,5 @@
 import { fillByLabel, render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
 import { setLocale, t } from 'ember-intl/test-support';
 import PasswordResetDemandForm from 'mon-pix/components/authentication/password-reset-demand/password-reset-demand-form';
@@ -30,6 +31,17 @@ module('Integration | Component | Authentication | PasswordResetDemand | passwor
 
   test('it displays all elements of component successfully', async function (assert) {
     // given
+    class CurrentDomainServiceStub extends Service {
+      get isFranceDomain() {
+        return true;
+      }
+
+      getExtension() {
+        return '.fr';
+      }
+    }
+    this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+
     const screen = await render(<template><PasswordResetDemandForm /></template>);
 
     // then

--- a/mon-pix/tests/unit/services/locale-test.js
+++ b/mon-pix/tests/unit/services/locale-test.js
@@ -27,6 +27,60 @@ module('Unit | Services | locale', function (hooks) {
     sinon.stub(intlService, 'setLocale');
   });
 
+  module('#isSupportedLocale', function () {
+    module('when locale is supported', function () {
+      test('returns true', function (assert) {
+        // given
+        const locale = 'nl-BE';
+
+        // when
+        const result = localeService.isSupportedLocale(locale);
+
+        // then
+        assert.true(result);
+      });
+    });
+
+    module('when locale is supported but not given in canonical form', function () {
+      test('returns true', function (assert) {
+        // given
+        const locale = 'nl-be';
+
+        // when
+        const result = localeService.isSupportedLocale(locale);
+
+        // then
+        assert.true(result);
+      });
+    });
+
+    module('when locale is valid but not supported', function () {
+      test('returns false', function (assert) {
+        // given
+        const locale = 'ko';
+
+        // when
+        const result = localeService.isSupportedLocale(locale);
+
+        // then
+        assert.false(result);
+      });
+    });
+
+    module('when locale is invalid', function () {
+      test('returns false', function (assert) {
+        // given
+        const locale = 'invalid_locale_in_bad_format';
+
+        // when
+        const result = localeService.isSupportedLocale(locale);
+
+        // then
+        assert.false(result);
+      });
+    });
+  });
+
   module('#handleUnsupportedLanguage', function () {
     module('when language is not supported', function () {
       test('returns default language', function (assert) {

--- a/mon-pix/tests/unit/services/url-test.js
+++ b/mon-pix/tests/unit/services/url-test.js
@@ -496,7 +496,7 @@ module('Unit | Service | url', function (hooks) {
           const service = this.owner.lookup('service:url');
           service.currentDomain = { isFranceDomain: false };
           service.intl = { primaryLocale: DUTCH_INTERNATIONAL_LOCALE };
-          const expectedSupportHomeUrl = 'https://pix.org/nl-be/support';
+          const expectedSupportHomeUrl = 'https://pix.org/nl-BE/support';
 
           // when
           const supportHomeUrl = service.supportHomeUrl;

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -184,8 +184,7 @@
           "receive-reset-button": "Receive a reset link"
         },
         "contact-us-link": {
-          "link-text": "Contact us",
-          "link-url": "https://pix.org/en/support"
+          "link-text": "Contact us"
         },
         "fields": {
           "email": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -190,8 +190,7 @@
           "receive-reset-button": "Reiniciar contraseña"
         },
         "contact-us-link": {
-          "link-text": "Contáctanos.",
-          "link-url": "https://pix.fr/support"
+          "link-text": "Contáctanos."
         },
         "fields": {
           "email": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -184,8 +184,7 @@
           "receive-reset-button": "Recevoir un lien de réinitialisation"
         },
         "contact-us-link": {
-          "link-text": "Contactez-nous",
-          "link-url": "https://pix.fr/support"
+          "link-text": "Contactez-nous"
         },
         "fields": {
           "email": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -190,8 +190,7 @@
           "receive-reset-button": "Een reset-link ontvangen"
         },
         "contact-us-link": {
-          "link-text": "Contacteer ons",
-          "link-url": "https://pix.fr/support"
+          "link-text": "Contacteer ons"
         },
         "fields": {
           "email": {


### PR DESCRIPTION
## :christmas_tree: Problème

Sur Pix App .org, sur les pages de réinitialisation du mot de passe, les liens vers le support (les liens avec le texte _« Contactez-nous »_) ne sont pas les bons.

On note notamment les cas problématiques suivants : 

* FR : le lien est https://pix.fr/support au lieu de https://pix.org/fr/support/
* NL : le lien est https://pix.fr/support  au lieu de https://pix.org/nl-be/support/ 

## :gift: Proposition

Le problème vient que les liens vers le support étaient écrits en dur dans les fichiers de traduction, au lieu d'être calculés plus intelligemment et de manière centralisée dans un service adapté.

La proposition est, pour le formulaire de demande de réinitialisation de mot de passe (`password-reset-demand-form.gjs`), de récupérer l'URL du support en le demandant à l’urlService.

On profite de cette PR pour faire évoluer un peu l'urlService pour qu'il gère plus génériquement les locales à l'aide du localeService au lieu de faire du spécifique pour chacune de ses fonctions.

## :socks: Remarques

À noter que le lien vers le support fournit par le code de cette PR est https://pix.org/nl-BE/support et non https://pix.org/nl-be/support car cette PR s'aligne au maximum sur l’[ADR Logique et stratégie de gestion des paramètres régionaux et des langues (locales & languages)](https://github.com/1024pix/pix/blob/dev/docs/adr/0040-locales-languages.md)

Il faudrait utiliser systématiquement l’urlService pour récupérer des URL et ne jamais en récupérer dans des fichiers de traduction.

## :santa: Pour tester

### Pix App .org

* Aller sur la [page de réinitialisation du mot de passe pour NL](https://app-pr11065.review.pix.org/mot-de-passe-oublie?lang=nl) et constater que le lien vers le support est :
   https://pix.org/nl-BE/support
* Aller sur la [page de réinitialisation du mot de passe pour FR](https://app-pr11065.review.pix.org/mot-de-passe-oublie?lang=fr) et constater que le lien vers le support est :
   https://pix.org/fr/support
* Aller sur la [page de réinitialisation du mot de passe pour EN](https://app-pr11065.review.pix.org/mot-de-passe-oublie?lang=en) et constater que le lien vers le support est :
   https://pix.org/en/support

### Pix App .fr

* Vérifier qu'il n'y a pas de régression et que sur [la page de réinitialisation du mot de passe de Pix App .fr](https://app-pr11065.review.pix.fr/mot-de-passe-oublie)  le lien vers le support est toujours : 
   https://pix.fr/support