### PR TITLE
[BUGFIX] Changer la phrase d'acceptation des CGUs dans pix-app, orga et certif (PIX-16000)

### DIFF
--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -275,10 +275,10 @@
         },
         "fields": {
           "cgu": {
-            "accept": "I agree to the",
+            "accept": "I accept the",
             "and": "and",
             "data-protection-policy": "personal data protection policy",
-            "error": "You must agree to the Pix terms of use and personal data protection policy to create an account.",
+            "error": "You must accept to the Pix terms of use and personal data protection policy to create an account.",
             "terms-of-use": "Pix terms of use"
           }
         }

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -63,8 +63,8 @@
     "cgu": {
       "cgu": "Pix terms of use",
       "data-protection-policy": "personal data protection policy",
-      "error": "You must agree to the Pix terms of use and personal data protection policy to create an account.",
-      "label": "Agree Pix terms of use and personal data protection policy",
+      "error": "You must accept to the Pix terms of use and personal data protection policy to create an account.",
+      "label": "I accept the terms of use and personal data protection policy of Pix",
       "message": "I agree to the '<'a href=\"{cguUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'Pix terms of use'</a>' and '<'a href=\"{dataProtectionPolicyUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'personal data protection policy'</a>'",
       "read-message": "Read the '<'a href=\"{cguUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'Pix terms of use'</a>' and the '<'a href=\"{dataProtectionPolicyUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'personal data protection policy'</a>'."
     },

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -871,9 +871,9 @@
           "cgu": {
             "accept": "I agree to the",
             "and": "and",
-            "aria-label": "Accept the terms of use of the Pix platform",
+            "aria-label": "I accept the terms of use and personal data protection policy of Pix",
             "data-protection-policy": "personal data protection policy",
-            "error": "You must agree to the Pix terms of use and personal data protection policy to create an account.",
+            "error": "You must accept to the Pix terms of use and personal data protection policy to create an account.",
             "terms-of-use": "Pix terms of use"
           },
           "email": {


### PR DESCRIPTION
## :christmas_tree: Problème

La traduction anglaise de la phrase pour accepter les conditions d'utilisation de Pix App, Pix orga et Certif n'était pas correcte.

## :gift: Proposition

Remplacer la phrase par "I accept the terms of use and personal data protection policy of Pix".

## :socks: Remarques

On remplace finalement tous les termes agree par accept dans les cgu de chaques apps.

## :santa: Pour tester
- Se rendre sur les pagees de création de compte pour les 3 apps,
- En basculant la langue sur anglais, constater que la nouvelle phrase est bien affichée.