### PR TITLE
[BUGFIX] Ajoute la marge entre la PixNotificationAlert et le contenu de la page  (PIX-16050) 

### DIFF
--- a/orga/app/components/places/capacity-alert.gjs
+++ b/orga/app/components/places/capacity-alert.gjs
@@ -4,7 +4,7 @@ import { gt } from 'ember-truth-helpers';
 
 <template>
   {{#if (gt @occupied @total)}}
-    <PixNotificationAlert class="capacity-alert" @type="error" @withIcon={{true}}>
+    <PixNotificationAlert @type="error" @withIcon={{true}}>
       {{t "banners.over-capacity.message"}}
     </PixNotificationAlert>
   {{/if}}

--- a/orga/app/components/places/places-lot-alert.gjs
+++ b/orga/app/components/places/places-lot-alert.gjs
@@ -29,7 +29,7 @@ function isAlertVisible(placesLots) {
 
 <template>
   {{#if (isAlertVisible @placesLots)}}
-    <PixNotificationAlert class="places-lots-alert" @type="warning" @withIcon="true">
+    <PixNotificationAlert @type="warning" @withIcon="true">
       {{t "banners.last-places-lot-available.message" days=(getCountdDownDays @placesLots)}}
     </PixNotificationAlert>
   {{/if}}

--- a/orga/app/components/places/title.gjs
+++ b/orga/app/components/places/title.gjs
@@ -18,9 +18,9 @@ function todayDate() {
       <span class="places-header-date">{{t "pages.places.before-date"}}
         {{todayDate}}</span>
     </:tools>
-    <:notification-alert>
+    <:notificationAlert>
       <PlacesLotAlert @placesLots={{@placesLots}} />
       <CapacityAlert @occupied={{@occupied}} @total={{@total}} />
-    </:notification-alert>
+    </:notificationAlert>
   </PageTitle>
 </template>

--- a/orga/app/components/places/title.gjs
+++ b/orga/app/components/places/title.gjs
@@ -2,6 +2,8 @@ import dayjs from 'dayjs';
 import { t } from 'ember-intl';
 
 import PageTitle from '../ui/page-title';
+import CapacityAlert from './capacity-alert';
+import PlacesLotAlert from './places-lot-alert';
 
 function todayDate() {
   return dayjs().format('D MMM YYYY');
@@ -16,5 +18,9 @@ function todayDate() {
       <span class="places-header-date">{{t "pages.places.before-date"}}
         {{todayDate}}</span>
     </:tools>
+    <:notification-alert>
+      <PlacesLotAlert @placesLots={{@placesLots}} />
+      <CapacityAlert @occupied={{@occupied}} @total={{@total}} />
+    </:notification-alert>
   </PageTitle>
 </template>

--- a/orga/app/components/ui/page-title.gjs
+++ b/orga/app/components/ui/page-title.gjs
@@ -19,9 +19,9 @@ function setTitleClasses(spaceBetweenTools, centerTitle) {
       {{/if}}
     </div>
 
-    {{#if (has-block "notification-alert")}}
+    {{#if (has-block "notificationAlert")}}
       <div class="page-title__notification-alert">
-        {{yield to="notification-alert"}}
+        {{yield to="notificationAlert"}}
       </div>
     {{/if}}
 

--- a/orga/app/components/ui/page-title.gjs
+++ b/orga/app/components/ui/page-title.gjs
@@ -19,10 +19,17 @@ function setTitleClasses(spaceBetweenTools, centerTitle) {
       {{/if}}
     </div>
 
+    {{#if (has-block "notification-alert")}}
+      <div class="page-title__notification-alert">
+        {{yield to="notification-alert"}}
+      </div>
+    {{/if}}
+
     {{#if (has-block "subtitle")}}
       <div class="page-title__sub-title">
         {{yield to="subtitle"}}
       </div>
     {{/if}}
+
   </header>
 </template>

--- a/orga/app/styles/components/places/capacity-alert.scss
+++ b/orga/app/styles/components/places/capacity-alert.scss
@@ -1,3 +1,0 @@
-.capacity-alert {
-  margin-top: var(--pix-spacing-8x);
-}

--- a/orga/app/styles/components/places/index.scss
+++ b/orga/app/styles/components/places/index.scss
@@ -1,7 +1,4 @@
 @import 'title';
 @import 'statistics';
 @import 'place-info';
-@import 'capacity-alert';
 @import 'places-lots';
-@import 'places-lots-alert';
-

--- a/orga/app/styles/components/places/places-lots-alert.scss
+++ b/orga/app/styles/components/places/places-lots-alert.scss
@@ -1,3 +1,0 @@
-.places-lots-alert {
-  margin-top: var(--pix-spacing-8x);
-}

--- a/orga/app/styles/components/ui/page-title.scss
+++ b/orga/app/styles/components/ui/page-title.scss
@@ -45,6 +45,13 @@
     color: var(--pix-neutral-900);
     word-break: break-all;
   }
+
+  &__notification-alert {
+    margin-bottom: var(--pix-spacing-6x);
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-2x);
+  }
 }
 
 .page-sub-title {

--- a/orga/app/styles/components/ui/page-title.scss
+++ b/orga/app/styles/components/ui/page-title.scss
@@ -47,10 +47,10 @@
   }
 
   &__notification-alert {
-    margin-bottom: var(--pix-spacing-6x);
     display: flex;
     flex-direction: column;
     gap: var(--pix-spacing-2x);
+    margin-bottom: var(--pix-spacing-6x);
   }
 }
 

--- a/orga/app/templates/authenticated/places.hbs
+++ b/orga/app/templates/authenticated/places.hbs
@@ -1,9 +1,10 @@
 {{page-title (t "pages.places.title")}}
 
-<Places::Title />
-
-<Places::PlacesLotAlert @placesLots={{@model.placesLots}} />
-<Places::CapacityAlert @occupied={{@model.statistics.occupied}} @total={{@model.statistics.total}} />
+<Places::Title
+  @placesLots={{@model.placesLots}}
+  @occupied={{@model.statistics.occupied}}
+  @total={{@model.statistics.total}}
+/>
 <Places::Statistics @model={{@model.statistics}} />
 <Places::PlaceInfo @hasAnonymousSeat={{@model.statistics.hasAnonymousSeat}} />
 <Places::PlacesLotTable @placesLots={{@model.placesLots}} />


### PR DESCRIPTION
## :christmas_tree: Problème

Suite à des modifications faites dans le layout, on veut rétablir une marge en bas des PixNotificationAlert dans Pix Orga.

## :gift: Proposition

On passe capacityAlert et notificationAlert dans le title sur la page des places. 
Et on ajoute une marge du bas dans le bloc d'alerte.

## :socks: Remarques

## :santa: Pour tester
- Aller modifier le nombre de places dans PixAdmin  :
* une situation dans laquelle le nombre de places occupées est supérieur au nombre de places disponibles pour tester CapacityAlert
* aller supprimer un lot de places et en créant un lot de place qui périme dans les 29 jours
