### PR TITLE
[BUGFIX] Fix de l'affichage de la bordure de PixWriter (PIX-15979)

### DIFF
--- a/junior/app/styles/components/challenge/challenge-embed-simulator.scss
+++ b/junior/app/styles/components/challenge/challenge-embed-simulator.scss
@@ -5,7 +5,9 @@
     position: relative;
     width: 100%;
     border: none;
-
+    border-top: 1px solid var(--pix-neutral-100);
+    border-left: 1px solid var(--pix-neutral-100);
+    border-radius: 5px;
   }
 
   &__overlay {


### PR DESCRIPTION
## :christmas_tree: Problème

Il manque la ligne verticale à gauche de l'embed.

## :gift: Proposition

Afficher la bordure en haut et à gauche.

## :socks: Remarques

La bordure actuelle est en faite une `shadow` sur un élément de webix. On. va compenser en faisant une bordure haut et gauche sur l'iframe. 

## :santa: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
