### PR TITLE
[BUGFIX] Corriger l'affichage de la double mire sur PixOrga (PIX-16070)

### DIFF
--- a/orga/app/components/auth/login-or-register.hbs
+++ b/orga/app/components/auth/login-or-register.hbs
@@ -1,7 +1,7 @@
 <div class="login-or-register">
   <div class="panel login-or-register__panel">
     <div>
-      <img src="/pix-orga.svg" alt="" role="none" class="login-or-register-panel__logo" />
+      <img src="/pix-orga-color.svg" alt="" role="none" class="login-or-register-panel__logo" />
     </div>
     <span class="login-or-register-panel__invitation">{{t
         "pages.login-or-register.title"


### PR DESCRIPTION
## :christmas_tree: Problème

On a un peu oublié de remplacer un dernier logo sur PixOrga a changer. 

## :gift: Proposition

Utiliser le bon logo

## :socks: Remarques

RAS

## :santa: Pour tester

CI au vert. lancer une invitation dans PxiAdmin, récupérer son code et l'id générer pour aller sur 

[rejoindre?code=Y1RUEPFHBC&invitationId=1](https://orga-pr11084.review.pix.fr/rejoindre?code=Y1RUEPFHBC&invitationId=1)