### PR TITLE
[TECH] ♻️  migre le repository target-profile-repository dans le contexte prescription (pix-16073)

### DIFF
--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -21,6 +21,7 @@ import * as authenticationMethodRepository from '../../../src/identity-access-ma
 import * as userRepository from '../../../src/identity-access-management/infrastructure/repositories/user.repository.js';
 import * as campaignRepository from '../../../src/prescription/campaign/infrastructure/repositories/campaign-repository.js';
 import * as poleEmploiSendingRepository from '../../../src/prescription/campaign-participation/infrastructure/repositories/pole-emploi-sending-repository.js';
+import * as targetProfileRepository from '../../../src/prescription/target-profile/infrastructure/repositories/target-profile-repository.js';
 import { config } from '../../../src/shared/config.js';
 import { monitoringTools as MonitoringTools } from '../../../src/shared/infrastructure/monitoring-tools.js';
 import * as answerRepository from '../../../src/shared/infrastructure/repositories/answer-repository.js';
@@ -39,7 +40,6 @@ import { EventDispatcherLogger } from '../../infrastructure/events/EventDispatch
 import * as badgeAcquisitionRepository from '../../infrastructure/repositories/badge-acquisition-repository.js';
 import * as complementaryCertificationCourseResultRepository from '../../infrastructure/repositories/complementary-certification-course-result-repository.js';
 import * as complementaryCertificationScoringCriteriaRepository from '../../infrastructure/repositories/complementary-certification-scoring-criteria-repository.js';
-import * as targetProfileRepository from '../../infrastructure/repositories/target-profile-repository.js';
 import { handleCertificationRescoring } from './handle-certification-rescoring.js';
 import { handleComplementaryCertificationsScoring } from './handle-complementary-certifications-scoring.js';
 

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -84,6 +84,7 @@ import * as prescriptionOrganizationLearnerRepository from '../../../src/prescri
 import * as studentRepository from '../../../src/prescription/learner-management/infrastructure/repositories/student-repository.js';
 import * as organizationLearnerActivityRepository from '../../../src/prescription/organization-learner/infrastructure/repositories/organization-learner-activity-repository.js';
 import * as registrationOrganizationLearnerRepository from '../../../src/prescription/organization-learner/infrastructure/repositories/registration-organization-learner-repository.js';
+import * as targetProfileRepository from '../../../src/prescription/target-profile/infrastructure/repositories/target-profile-repository.js';
 import * as targetProfileSummaryForAdminRepository from '../../../src/prescription/target-profile/infrastructure/repositories/target-profile-summary-for-admin-repository.js';
 import * as activityAnswerRepository from '../../../src/school/infrastructure/repositories/activity-answer-repository.js';
 import * as missionRepository from '../../../src/school/infrastructure/repositories/mission-repository.js';
@@ -137,7 +138,6 @@ import { repositories } from '../../infrastructure/repositories/index.js';
 import { certificationCompletedJobRepository } from '../../infrastructure/repositories/jobs/certification-completed-job-repository.js';
 import * as learningContentRepository from '../../infrastructure/repositories/learning-content-repository.js';
 import * as organizationMemberIdentityRepository from '../../infrastructure/repositories/organization-member-identity-repository.js';
-import * as targetProfileRepository from '../../infrastructure/repositories/target-profile-repository.js';
 import * as targetProfileShareRepository from '../../infrastructure/repositories/target-profile-share-repository.js';
 import * as targetProfileTrainingRepository from '../../infrastructure/repositories/target-profile-training-repository.js';
 import * as thematicRepository from '../../infrastructure/repositories/thematic-repository.js';

--- a/api/scripts/prod/insert-missing-pole-emploi-sending-from-date.js
+++ b/api/scripts/prod/insert-missing-pole-emploi-sending-from-date.js
@@ -4,7 +4,6 @@ import dayjs from 'dayjs';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 import * as badgeAcquisitionRepository from '../../lib/infrastructure/repositories/badge-acquisition-repository.js';
-import * as targetProfileRepository from '../../lib/infrastructure/repositories/target-profile-repository.js';
 import * as badgeRepository from '../../src/evaluation/infrastructure/repositories/badge-repository.js';
 import * as userRepository from '../../src/identity-access-management/infrastructure/repositories/user.repository.js';
 import * as campaignRepository from '../../src/prescription/campaign/infrastructure/repositories/campaign-repository.js';
@@ -14,6 +13,7 @@ import * as campaignParticipationRepository from '../../src/prescription/campaig
 import { campaignParticipationResultRepository } from '../../src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-result-repository.js';
 import * as poleEmploiSendingRepository from '../../src/prescription/campaign-participation/infrastructure/repositories/pole-emploi-sending-repository.js';
 import { CampaignParticipationStatuses } from '../../src/prescription/shared/domain/constants.js';
+import * as targetProfileRepository from '../../src/prescription/target-profile/infrastructure/repositories/target-profile-repository.js';
 import { Assessment } from '../../src/shared/domain/models/Assessment.js';
 import * as assessmentRepository from '../../src/shared/infrastructure/repositories/assessment-repository.js';
 import * as organizationRepository from '../../src/shared/infrastructure/repositories/organization-repository.js';

--- a/api/src/devcomp/domain/usecases/index.js
+++ b/api/src/devcomp/domain/usecases/index.js
@@ -1,11 +1,11 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import * as targetProfileRepository from '../../../../lib/infrastructure/repositories/target-profile-repository.js';
 import * as targetProfileTrainingRepository from '../../../../lib/infrastructure/repositories/target-profile-training-repository.js';
 import * as userRepository from '../../../identity-access-management/infrastructure/repositories/user.repository.js';
 import * as campaignRepository from '../../../prescription/campaign/infrastructure/repositories/campaign-repository.js';
 import * as campaignParticipationRepository from '../../../prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js';
+import * as targetProfileRepository from '../../../prescription/target-profile/infrastructure/repositories/target-profile-repository.js';
 import * as knowledgeElementRepository from '../../../shared/infrastructure/repositories/knowledge-element-repository.js';
 import * as skillRepository from '../../../shared/infrastructure/repositories/skill-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';

--- a/api/src/evaluation/domain/usecases/index.js
+++ b/api/src/evaluation/domain/usecases/index.js
@@ -1,10 +1,10 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import * as targetProfileRepository from '../../../../lib/infrastructure/repositories/target-profile-repository.js';
 import * as campaignRepository from '../../../prescription/campaign/infrastructure/repositories/campaign-repository.js';
 import * as campaignParticipationRepository from '../../../prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js';
 import * as targetProfileAdministrationRepository from '../../../prescription/target-profile/infrastructure/repositories/target-profile-administration-repository.js';
+import * as targetProfileRepository from '../../../prescription/target-profile/infrastructure/repositories/target-profile-repository.js';
 import * as answerRepository from '../../../shared/infrastructure/repositories/answer-repository.js';
 import * as areaRepository from '../../../shared/infrastructure/repositories/area-repository.js';
 import * as assessmentRepository from '../../../shared/infrastructure/repositories/assessment-repository.js';

--- a/api/src/prescription/campaign-participation/domain/usecases/index.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/index.js
@@ -4,7 +4,6 @@ import { fileURLToPath } from 'node:url';
 import * as badgeAcquisitionRepository from '../../../../../lib/infrastructure/repositories/badge-acquisition-repository.js';
 import * as badgeForCalculationRepository from '../../../../../lib/infrastructure/repositories/badge-for-calculation-repository.js';
 import * as learningContentRepository from '../../../../../lib/infrastructure/repositories/learning-content-repository.js';
-import * as targetProfileRepository from '../../../../../lib/infrastructure/repositories/target-profile-repository.js';
 import * as stageCollectionRepository from '../../../../../lib/infrastructure/repositories/user-campaign-results/stage-collection-repository.js';
 import * as tutorialRepository from '../../../../devcomp/infrastructure/repositories/tutorial-repository.js';
 import * as compareStagesAndAcquiredStages from '../../../../evaluation/domain/services/stages/stage-and-stage-acquisition-comparison-service.js';
@@ -24,6 +23,7 @@ import * as organizationRepository from '../../../../shared/infrastructure/repos
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as campaignRepository from '../../../campaign/infrastructure/repositories/campaign-repository.js';
+import * as targetProfileRepository from '../../../target-profile/infrastructure/repositories/target-profile-repository.js';
 import * as disabledPoleEmploiNotifier from '../../infrastructure/externals/pole-emploi/disabled-pole-emploi-notifier.js';
 import * as poleEmploiNotifier from '../../infrastructure/externals/pole-emploi/pole-emploi-notifier.js';
 import * as campaignAnalysisRepository from '../../infrastructure/repositories/campaign-analysis-repository.js';
@@ -56,6 +56,7 @@ import * as poleEmploiSendingRepository from '../../infrastructure/repositories/
  * @typedef { import ('../../infrastructure/repositories/campaign-participation-repository.js')} CampaignParticipationRepository
  * @typedef { import ('../../infrastructure/repositories/campaign-profile-repository.js')} CampaignProfileRepository
  * @typedef { import ('../../../campaign/infrastructure/repositories/campaign-repository.js')} CampaignRepository
+ * @typedef { import ('../../../target-profile/infrastructure/repositories/target-profile-repository.js')} targetProfileRepository
  * @typedef { import ('../../../../evaluation/domain/services/stages/stage-and-stage-acquisition-comparison-service.js')} CompareStagesAndAcquiredStages
  * @typedef { import ('../../../../evaluation/infrastructure/repositories/competence-evaluation-repository.js')} CompetenceEvaluationRepository
  * @typedef { import ('../../../../shared/infrastructure/repositories/competence-repository.js')} CompetenceRepository

--- a/api/src/prescription/target-profile/domain/usecases/index.js
+++ b/api/src/prescription/target-profile/domain/usecases/index.js
@@ -3,11 +3,11 @@ import { fileURLToPath } from 'node:url';
 
 import * as learningContentConversionService from '../../../../../lib/domain/services/learning-content/learning-content-conversion-service.js';
 import * as learningContentRepository from '../../../../../lib/infrastructure/repositories/learning-content-repository.js';
-import * as targetProfileRepository from '../../../../../lib/infrastructure/repositories/target-profile-repository.js';
 import { adminMemberRepository } from '../../../../shared/infrastructure/repositories/admin-member.repository.js';
 import * as organizationRepository from '../../../../shared/infrastructure/repositories/organization-repository.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
+import * as targetProfileRepository from '../../../target-profile/infrastructure/repositories/target-profile-repository.js';
 import * as organizationsToAttachToTargetProfileRepository from '../../infrastructure/repositories/organizations-to-attach-to-target-profile-repository.js';
 import * as targetProfileAdministrationRepository from '../../infrastructure/repositories/target-profile-administration-repository.js';
 import * as targetProfileBondRepository from '../../infrastructure/repositories/target-profile-bond-repository.js';

--- a/api/src/prescription/target-profile/infrastructure/repositories/target-profile-repository.js
+++ b/api/src/prescription/target-profile/infrastructure/repositories/target-profile-repository.js
@@ -1,9 +1,9 @@
-import { knex } from '../../../db/knex-database-connection.js';
-import { Badge } from '../../../src/evaluation/domain/models/Badge.js';
-import { NotFoundError } from '../../../src/shared/domain/errors.js';
-import { ObjectValidationError } from '../../../src/shared/domain/errors.js';
-import { TargetProfile } from '../../../src/shared/domain/models/index.js';
-import { DomainTransaction } from '../DomainTransaction.js';
+import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';
+import { Badge } from '../../../../evaluation/domain/models/Badge.js';
+import { NotFoundError } from '../../../../shared/domain/errors.js';
+import { ObjectValidationError } from '../../../../shared/domain/errors.js';
+import { TargetProfile } from '../../../../shared/domain/models/index.js';
 
 const TARGET_PROFILE_TABLE = 'target-profiles';
 

--- a/api/tests/evaluation/integration/domain/usecases/create-badge_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/create-badge_test.js
@@ -1,10 +1,10 @@
 import _ from 'lodash';
 
-import * as targetProfileRepository from '../../../../../lib/infrastructure/repositories/target-profile-repository.js';
 import { Badge } from '../../../../../src/evaluation/domain/models/Badge.js';
 import { createBadge } from '../../../../../src/evaluation/domain/usecases/create-badge.js';
 import * as badgeCriteriaRepository from '../../../../../src/evaluation/infrastructure/repositories/badge-criteria-repository.js';
 import * as badgeRepository from '../../../../../src/evaluation/infrastructure/repositories/badge-repository.js';
+import * as targetProfileRepository from '../../../../../src/prescription/target-profile/infrastructure/repositories/target-profile-repository.js';
 import {
   AlreadyExistingEntityError,
   MissingBadgeCriterionError,

--- a/api/tests/prescription/target-profile/integration/domain/usecases/attach-organizations-from-existing-target-profile_test.js
+++ b/api/tests/prescription/target-profile/integration/domain/usecases/attach-organizations-from-existing-target-profile_test.js
@@ -1,6 +1,6 @@
-import * as targetProfileRepository from '../../../../../../lib/infrastructure/repositories/target-profile-repository.js';
 import { attachOrganizationsFromExistingTargetProfile } from '../../../../../../src/prescription/target-profile/domain/usecases/attach-organizations-from-existing-target-profile.js';
 import * as organizationsToAttachToTargetProfileRepository from '../../../../../../src/prescription/target-profile/infrastructure/repositories/organizations-to-attach-to-target-profile-repository.js';
+import * as targetProfileRepository from '../../../../../../src/prescription/target-profile/infrastructure/repositories/target-profile-repository.js';
 import { NoOrganizationToAttach, NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, expect, knex } from '../../../../../test-helper.js';
 

--- a/api/tests/prescription/target-profile/integration/domain/usecases/copy-target-profile_test.js
+++ b/api/tests/prescription/target-profile/integration/domain/usecases/copy-target-profile_test.js
@@ -1,6 +1,6 @@
-import * as targetProfileRepository from '../../../../../../lib/infrastructure/repositories/target-profile-repository.js';
 import { copyTargetProfile } from '../../../../../../src/prescription/target-profile/domain/usecases/copy-target-profile.js';
 import * as targetProfileAdministrationRepository from '../../../../../../src/prescription/target-profile/infrastructure/repositories/target-profile-administration-repository.js';
+import * as targetProfileRepository from '../../../../../../src/prescription/target-profile/infrastructure/repositories/target-profile-repository.js';
 import { categories } from '../../../../../../src/shared/domain/models/TargetProfile.js';
 import { databaseBuilder, expect, knex } from '../../../../../test-helper.js';
 

--- a/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-repository_test.js
+++ b/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-repository_test.js
@@ -1,9 +1,9 @@
 import _ from 'lodash';
 
-import * as targetProfileRepository from '../../../../lib/infrastructure/repositories/target-profile-repository.js';
-import { NotFoundError } from '../../../../src/shared/domain/errors.js';
-import { TargetProfile } from '../../../../src/shared/domain/models/index.js';
-import { catchErr, databaseBuilder, expect } from '../../../test-helper.js';
+import * as targetProfileRepository from '../../../../../../src/prescription/target-profile/infrastructure/repositories/target-profile-repository.js';
+import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
+import { TargetProfile } from '../../../../../../src/shared/domain/models/index.js';
+import { catchErr, databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | Repository | Target-profile', function () {
   describe('#get', function () {


### PR DESCRIPTION
## :christmas_tree: Problème

certain repository sont encore dans lib

## :gift: Proposition

on les déplace dans le contexte prescription

## :socks: Remarques

ras

## :santa: Pour tester
Dans pix
- envoyer les résultats d'une participation à pole emploi ✅ 

Dans orga 
- exporter les résultats d'un assessment ✅ 

Dans admin
- attacher un profile cible sur un trainings ✅ 
- créer un Resultat thématique dans un profil cible ✅ 
- créer un parcours autonome ✅ 
- rattacher les organisations d'un profil cible ✅ 
- rattacher les profils cible d'une organisation ✅ 
- dupliquer un profil cible ✅ 
