### PR TITLE
[FEATURE] Ajuster la mention "Activez ou récupérer votre espace Pix Orga" car elle crée de la confusion pour nos utilisateurs (PIX-16035)

### DIFF
--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -847,7 +847,7 @@
       "title": "Log in"
     },
     "login-form": {
-      "active-or-retrieve": "Activate or retrieve your Pix Orga space",
+      "active-or-retrieve": "Are you a headteacher? Activate or become the administrator of your school's Pix Orga space",
       "email": "Email address",
       "errors": {
         "empty-password": "Your password can't be empty.",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -853,7 +853,7 @@
       "title": "Connectez-vous"
     },
     "login-form": {
-      "active-or-retrieve": "Activez ou récupérez votre espace Pix Orga",
+      "active-or-retrieve": "Vous êtes personnel de direction ? Activez ou devenez l'administrateur de l'espace Pix Orga de votre établissement scolaire",
       "email": "Adresse e-mail",
       "errors": {
         "empty-password": "Le champ mot de passe est obligatoire.",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -843,7 +843,7 @@
       "organization-code": "UAI/RNE van de instelling"
     },
     "login-form": {
-      "active-or-retrieve": "Activeer of herstel je Pix Orga-ruimte",
+      "active-or-retrieve": "Are you a headteacher? Activate or become the administrator of your school's Pix Orga space",
       "email": "E-mailadres",
       "errors": {
         "empty-password": "Het veld wachtwoord is verplicht.",


### PR DESCRIPTION
## :christmas_tree: Problème

Sur la page https://orga.pix.fr/connexion, la mention “Activez ou récupérez votre espace Pix Orga” est affichée pour permettre aux utilisateurs des espaces Pix Orga du SCO de récupérer l’accès à l’espace en cas de départ de la personne précédemment responsable au sein de l’établissement.

En revanche, la mention crée de la confusion auprès de nos utilisateurs suite à la suppression en masse des mots de passe en décembre 2024. Les utilisateurs ont tendance à cliquer sur le lien puis contactent le support. Il faudrait être plus précis. 

## :gift: Proposition

Modifier “Activez ou récupérer votre espace Pix Orga” par : Vous êtes personnel de direction ? Activez ou devenez l'administrateur de l'espace Pix Orga de votre établissement scolaire



## :santa: Pour tester

- Constater, sur la page de connexion à pix-orga, que la mention est désormais:  " Vous êtes personnel de direction ? Activez ou devenez l'administrateur de l'espace Pix Orga de votre établissement scolaire"