### PR TITLE
[BUGFIX] Changer des messages sur les pages de connexion et réinitialisation (PIX-15996)

### DIFF
--- a/mon-pix/app/components/authentication/login-form.gjs
+++ b/mon-pix/app/components/authentication/login-form.gjs
@@ -122,8 +122,14 @@ export default class LoginForm extends Component {
           },
         };
         break;
-      default:
-        this.globalError = HTTP_ERROR_MESSAGES[responseError.status] || HTTP_ERROR_MESSAGES['default'];
+      default: {
+        const properties = HTTP_ERROR_MESSAGES[responseError.status] || HTTP_ERROR_MESSAGES['default'];
+        if (!HTTP_ERROR_MESSAGES[responseError.status]) {
+          properties.values.supportHomeUrl = this.url.supportHomeUrl;
+        }
+        this.globalError = properties;
+        return;
+      }
     }
   }
 

--- a/mon-pix/app/components/authentication/signup-form/index.gjs
+++ b/mon-pix/app/components/authentication/signup-form/index.gjs
@@ -37,6 +37,7 @@ const EMAIL_API_ERRORS = {
 export default class SignupForm extends Component {
   @service session;
   @service intl;
+  @service url;
 
   @tracked isLoading = false;
   @tracked globalError = null;
@@ -128,9 +129,14 @@ export default class SignupForm extends Component {
           values: { localeNotSupported: error.meta.locale },
         };
         return;
-      default:
-        this.globalError = HTTP_ERROR_MESSAGES[statusCode] || HTTP_ERROR_MESSAGES['default'];
+      default: {
+        const properties = HTTP_ERROR_MESSAGES[statusCode] || HTTP_ERROR_MESSAGES['default'];
+        if (!HTTP_ERROR_MESSAGES[statusCode]) {
+          properties.values.supportHomeUrl = this.url.supportHomeUrl;
+        }
+        this.globalError = properties;
         return;
+      }
     }
   }
 

--- a/mon-pix/tests/integration/components/authentication/login-form-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/login-form-test.gjs
@@ -23,11 +23,13 @@ module('Integration | Component | Authentication | LoginForm', function (hooks) 
   let storeService;
   let routerService;
   let sessionService;
+  let urlService;
 
   hooks.beforeEach(async function () {
     storeService = this.owner.lookup('service:store');
     routerService = this.owner.lookup('service:router');
     sessionService = stubSessionService(this.owner, { isAuthenticated: false });
+    urlService = this.owner.lookup('service:url');
 
     screen = await render(<template><LoginForm /></template>);
   });
@@ -221,6 +223,7 @@ module('Integration | Component | Authentication | LoginForm', function (hooks) 
 
     test('it displays error message for other HTTP status code', async function (assert) {
       // given
+      sinon.stub(urlService, 'supportHomeUrl').value('http://support.example.net');
       sessionService.authenticateUser.rejects(_buildApiReponseError({ status: 500 }));
 
       // when
@@ -230,8 +233,8 @@ module('Integration | Component | Authentication | LoginForm', function (hooks) 
       const errorMessage = 'Impossible de se connecter. Veuillez réessayer dans quelques instants.';
       assert.dom(screen.getByText(errorMessage, { exact: false })).exists();
 
-      const errorMessageLink = screen.getByRole('link', { name: 'merci de nous contacter' });
-      assert.dom(errorMessageLink).hasAttribute('href', 'https://pix.fr/support');
+      const errorMessageLink = screen.getByRole('link', { name: 'contactez-nous via le centre d’aide' });
+      assert.dom(errorMessageLink).hasAttribute('href', urlService.supportHomeUrl);
     });
   });
 });

--- a/mon-pix/tests/integration/components/authentication/signup-form/index-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/signup-form/index-test.gjs
@@ -20,9 +20,11 @@ module('Integration | Component | Authentication | SignupForm | index', function
   setupIntlRenderingTest(hooks);
 
   let sessionService;
+  let urlService;
 
   hooks.beforeEach(async function () {
     sessionService = stubSessionService(this.owner, { isAuthenticated: false });
+    urlService = this.owner.lookup('service:url');
   });
 
   test('it signs up successfully', async function (assert) {
@@ -259,6 +261,7 @@ module('Integration | Component | Authentication | SignupForm | index', function
 
     test('it displays error message for other HTTP status code', async function (assert) {
       // given
+      sinon.stub(urlService, 'supportHomeUrl').value('http://support.example.net');
       sessionService.authenticateUser.rejects(_buildApiReponseError({ status: 500 }));
 
       // when
@@ -268,8 +271,8 @@ module('Integration | Component | Authentication | SignupForm | index', function
       const errorMessage = 'Impossible de se connecter. Veuillez réessayer dans quelques instants.';
       assert.dom(screen.getByText(errorMessage, { exact: false })).exists();
 
-      const errorMessageLink = screen.getByRole('link', { name: 'merci de nous contacter' });
-      assert.dom(errorMessageLink).hasAttribute('href', 'https://pix.fr/support');
+      const errorMessageLink = screen.getByRole('link', { name: 'contactez-nous via le centre d’aide' });
+      assert.dom(errorMessageLink).hasAttribute('href', urlService.supportHomeUrl);
     });
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -56,7 +56,7 @@
       "gateway-timeout-error": "The service is being slow. Please try again later.",
       "internal-server-error": "An error occurred, our teams are working on finding a solution. Please try again later.",
       "login-unauthorized-error": "There was an error in the email address or username/password entered.",
-      "login-unexpected-error": "Unable to connect. Please try again in a few moments. If the problem persists, '<'a href=\"https://pix.org/en/support\" target=\"blank\"'>'please contact us'</a>'.",
+      "login-unexpected-error": "Unable to connect. Please try again in a few moments. If the problem persists, '<'a href=\"{supportHomeUrl}\" target=\"blank\"'>'please contact us via the help center'</a>'.",
       "login-user-blocked-error": "Your account has reached the maximum number of failed login attempts and has been temporarily blocked. Please '<'a href=\"{url}\"'>'contact us'</a>' to unblock it.",
       "login-user-temporary-blocked-error": "You have reached too many failed login attempts. Please try again later or '<'a href=\"{url}\"'>'reset your password here'</a>'."
     },

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -184,7 +184,7 @@
           "receive-reset-button": "Receive a reset link"
         },
         "contact-us-link": {
-          "link-text": "Contact us"
+          "link-text": "Consult the help center"
         },
         "fields": {
           "email": {
@@ -193,7 +193,7 @@
             "placeholder": "e.g. john.smith@email.com"
           }
         },
-        "no-email-question": "No email address?",
+        "no-email-question": "Having trouble connecting to Pix?",
         "rule": "All fields are required."
       },
       "password-reset-demand-received-info": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -57,7 +57,7 @@
       "gateway-timeout-error": "El servicio está experimentando ralentizaciones. Vuelve a intentarlo más tarde.",
       "internal-server-error": "Se ha producido un error interno. Nuestros equipos están resolviendo el problema. Vuelve a intentarlo más tarde.",
       "login-unauthorized-error": "La dirección de correo electrónico o el nombre de usuario y/o la contraseña introducidos son incorrectos.",
-      "login-unexpected-error": "No se ha podido conectar. Por favor, inténtelo de nuevo en unos momentos. Si el problema persiste, '<'a href=\"https://pix.fr/support\" target=\"blank\"'>'póngase en contacto con nosotros'</a>'.",
+      "login-unexpected-error": "No se ha podido conectar. Por favor, inténtelo de nuevo en unos momentos. Si el problema persiste, '<'a href=\"{supportHomeUrl}\" target=\"blank\"'>'póngase en contacto con nosotros'</a>'.",
       "login-user-blocked-error": "Tu cuenta está bloqueada porque has realizado demasiados intentos de conexión. Para desbloquearla, '<'a href=\"{url}\"'>'ponte en contacto con nosotros'</a>'.",
       "login-user-temporary-blocked-error": "Has realizado demasiados intentos de conexión. Inténtalo de nuevo más tarde o haz clic en '<'a href=\"{url}\"'>'contraseña olvidada'</a>' para restablecerla."
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -56,7 +56,7 @@
       "gateway-timeout-error": "Le service subit des ralentissements. Veuillez réessayer ultérieurement.",
       "internal-server-error": "Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.",
       "login-unauthorized-error": "L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects.",
-      "login-unexpected-error": "Impossible de se connecter. Veuillez réessayer dans quelques instants. Si le problème persiste, '<'a href=\"https://pix.fr/support\" target=\"blank\"'>'merci de nous contacter'</a>'.",
+      "login-unexpected-error": "Impossible de se connecter. Veuillez réessayer dans quelques instants. Si le problème persiste, '<'a href=\"{supportHomeUrl}\" target=\"blank\"'>'contactez-nous via le centre d’aide'</a>'.",
       "login-user-blocked-error": "Votre compte est bloqué car vous avez effectué trop de tentatives de connexion. Pour le débloquer, '<'a href=\"{url}\"'>'contactez-nous'</a>'.",
       "login-user-temporary-blocked-error": "Vous avez effectué trop de tentatives de connexion. Réessayez plus tard ou cliquez sur '<'a href=\"{url}\"'>'mot de passe oublié'</a>' pour le réinitialiser."
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -184,7 +184,7 @@
           "receive-reset-button": "Recevoir un lien de réinitialisation"
         },
         "contact-us-link": {
-          "link-text": "Contactez-nous"
+          "link-text": "Consultez le centre d'aide"
         },
         "fields": {
           "email": {
@@ -193,7 +193,7 @@
             "placeholder": "ex: jean.dupont@email.com"
           }
         },
-        "no-email-question": "Pas d’adresse e-mail renseignée ?",
+        "no-email-question": "Un problème pour vous connecter à Pix ?",
         "rule": "Tous les champs sont obligatoires."
       },
       "password-reset-demand-received-info": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -57,7 +57,7 @@
       "gateway-timeout-error": "De service ondervindt vertragingen. Probeer het later nog eens.",
       "internal-server-error": "Er is een interne fout opgetreden. Onze teams zijn bezig het probleem op te lossen. Probeer het later nog eens.",
       "login-unauthorized-error": "Het e-mailadres of de ingevoerde gebruikersnaam en/of wachtwoord zijn onjuist.",
-      "login-unexpected-error": "Kan geen verbinding maken. Probeer het over enkele ogenblikken opnieuw. Als het probleem zich blijft voordoen, '<'a href=\"https://pix.fr/support\" target=\"blank\"'>'neem dan contact met ons op'</a>'.",
+      "login-unexpected-error": "Kan geen verbinding maken. Probeer het over enkele ogenblikken opnieuw. Als het probleem zich blijft voordoen, '<'a href=\"{supportHomeUrl}\" target=\"blank\"'>'neem dan contact met ons op'</a>'.",
       "login-user-blocked-error": "Je account is geblokkeerd omdat je te veel verbindingspogingen hebt gedaan. U kunt de blokkering opheffen door '<'a href=\"{url}\"'>'contact us'</a>'.",
       "login-user-temporary-blocked-error": "Je hebt te veel inlogpogingen gedaan. Probeer het later nog eens of klik op '<'a href=\"{url}\"'>'wachtwoord vergeten'</a>' om het opnieuw in te stellen."
     },


### PR DESCRIPTION
## :christmas_tree: Problème

Dans la page de réinitialisation du mot de passe, ainsi que lors d'une erreur de connexion, les messages mentionnaient un contact direct avec Pix alors qu'il s'agit plutôt d'accéder au centre d'aide.

## :gift: Proposition

Modifier les traductions anglaises et françaises pour les ajuster en conséquence.

## :socks: Remarques

- Les traductions en es et nl n'ont pas été modifiées.
- Des liens sont écrits en dur dans les sections de traduction concernés.
- Les liens de la traduction française redirigent vers pix.fr systématiquement.

## :santa: Pour tester

### Pour la page de réinitialisation de mot de passe
- Se rendre sur [cette page](https://app-pr11088.review.pix.fr/mot-de-passe-oublie),
- Constater en français puis en anglais que les messages correspondent à ce qui était attendu, soit:
- - “Un problème pour vous connecter à Pix ? Consultez le centre d’aide”,
- - “Having trouble connecting to Pix ? Consult the help center”.

### Pour le message d'erreur
- En local, modifier la route de connexion pour renvoyer systématiquement une erreur,
- Constater la présence en anglais et français des nouveaux messages, soit:
- - “Impossible de se connecter. Veuillez réessayer dans quelques instants. Si le problème persiste, contactez-nous via le centre d’aide”,
- - “‘Unable to connect. Please try again in a few moments. If the problem persists, please contact us via the help center’