### PR TITLE
[BUGFIX] Corriger l'export des résultats avec présence des acquis (PIX-16080)

### DIFF
--- a/api/src/prescription/campaign/infrastructure/exports/campaigns/campaign-assessment-result-line.js
+++ b/api/src/prescription/campaign/infrastructure/exports/campaigns/campaign-assessment-result-line.js
@@ -35,7 +35,10 @@ class CampaignAssessmentResultLine {
       _.map(participantKnowledgeElementsByCompetenceId, (knowledgeElements) => knowledgeElements.length),
     );
     this.targetedKnowledgeElementsByCompetence = participantKnowledgeElementsByCompetenceId;
-    this.acquiredBadges = acquiredBadges;
+    this.acquiredBadges =
+      acquiredBadges && acquiredBadges[campaignParticipationInfo.campaignParticipationId]
+        ? acquiredBadges[campaignParticipationInfo.campaignParticipationId].map((badge) => badge.title)
+        : [];
     this.campaignParticipationService = campaignParticipationService;
     this.translate = translate;
 

--- a/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-assessment-export.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-assessment-export.js
@@ -221,9 +221,7 @@ class CampaignAssessmentExport {
         });
     }
 
-    return {
-      acquiredBadgesByCampaignParticipations,
-    };
+    return acquiredBadgesByCampaignParticipations;
   }
 }
 

--- a/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -460,6 +460,21 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
           });
         });
 
+        const badge1 = databaseBuilder.factory.buildBadge({
+          title: 'Mon super badge',
+          targetProfileId: targetProfile.id,
+        });
+        databaseBuilder.factory.buildBadge({
+          title: 'Mon autre super badge',
+          targetProfileId: targetProfile.id,
+        });
+
+        databaseBuilder.factory.buildBadgeAcquisition({
+          badgeId: badge1.id,
+          userId: participant.id,
+          campaignParticipationId: campaignParticipation.id,
+        });
+
         await databaseBuilder.commit();
       });
 
@@ -479,6 +494,8 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
           '"Oui";' +
           `"${sharedAtFormated}";` +
           '1;' +
+          '"Non";' +
+          '"Oui";' +
           '"Non";' +
           '0,67;' +
           '0,67;' +
@@ -762,5 +779,3 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
     });
   });
 });
-
-// tester le filename

--- a/api/tests/prescription/campaign/unit/infrastructure/exports/campaigns/campaign-assessment-result-line_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/exports/campaigns/campaign-assessment-result-line_test.js
@@ -693,7 +693,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
             participantKnowledgeElementsByCompetenceId: {
               [learningContent.competences[0].id]: [knowledgeElement],
             },
-            acquiredBadges: [badge.title],
+            acquiredBadges: { [campaignParticipationInfo.campaignParticipationId]: [{ title: badge.title }] },
             translate,
           });
 


### PR DESCRIPTION
## :christmas_tree: Problème

l'export des résultats remonte que rien n'est validé alors que si

## :gift: Proposition

Trouver cette petite erreur

## :socks: Remarques

RAS

## :santa: Pour tester

Aller sur l'orga SCO_SIECLE_MANAGING, export campaign type assessment. vérifier que les badge sont bien à oui non oui non et pas que non non non non 