### PR TITLE
[BUGFIX] Si l'utilisateur a un identifiant renseigné alors le champ "e-mail" ne doit pas être obligatoire dans Pix Admin (PIX-15540)

### DIFF
--- a/admin/app/components/users/user-overview.gjs
+++ b/admin/app/components/users/user-overview.gjs
@@ -82,6 +82,10 @@ export default class UserOverview extends Component {
     return hasBeenAnonymised || isPixAgent;
   }
 
+  get isEmailRequired() {
+    return this.args.user.username ? null : 'obligatoire';
+  }
+
   _initForm() {
     this.form.firstName = this.args.user.firstName;
     this.form.lastName = this.args.user.lastName;
@@ -201,7 +205,7 @@ export default class UserOverview extends Component {
             {{#if this.canModifyEmail}}
               <div class="form-field">
                 <PixInput
-                  @requiredLabel="obligatoire"
+                  @requiredLabel={{this.isEmailRequired}}
                   @errorMessage={{this.form.emailError.message}}
                   @validationStatus={{this.form.emailError.status}}
                   @value={{this.form.email}}

--- a/admin/tests/acceptance/authenticated/users/get-test.js
+++ b/admin/tests/acceptance/authenticated/users/get-test.js
@@ -83,7 +83,7 @@ module('Acceptance | authenticated/users/get', function (hooks) {
       // when
       await fillIn(screen.getByLabelText('Prénom *', { exact: false }), 'john');
       await fillIn(screen.getByLabelText(/Nom */), 'doe');
-      await fillIn(screen.getByLabelText('Adresse e-mail *', { exact: false }), 'john.doe@example.net');
+      await fillIn(screen.getByLabelText('Adresse e-mail', { exact: false }), 'john.doe@example.net');
       await fillIn(screen.getByLabelText('Identifiant *', { exact: false }), 'john.doe0101');
       await click(screen.getByRole('button', { name: 'Langue' }));
 

--- a/admin/tests/integration/components/users/user-overview-test.gjs
+++ b/admin/tests/integration/components/users/user-overview-test.gjs
@@ -515,7 +515,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
           assert.dom(screen.getByRole('textbox', { name: 'Identifiant *' })).hasValue(user.username);
         });
 
-        test('displays email', async function (assert) {
+        test('displays not required email', async function (assert) {
           // given
           const user = EmberObject.create({
             lastName: 'Harry',
@@ -529,7 +529,9 @@ module('Integration | Component | users | user-overview', function (hooks) {
           await clickByName('Modifier');
 
           // then
-          assert.dom(screen.getByRole('textbox', { name: 'Adresse e-mail *' })).exists();
+          const emailInput = screen.getByRole('textbox', { name: 'Adresse e-mail' });
+          assert.dom(emailInput).exists();
+          assert.dom(emailInput).hasNoAttribute('required');
         });
       });
 


### PR DESCRIPTION
## :christmas_tree: Problème

Lorsqu’un agent PIX tente de modifier une fiche utilisateur dans Pix Admin (par exemple, en changeant le nom) pour un utilisateur disposant d’un identifiant comme seule méthode de connexion alors la modification est bloquée car Pix Admin exige une adresse e-mail alors que cela ne devrait pas l’être dans ce contexte.


## :gift: Proposition

Ne pas rendre obligatoire l'email si le user a une méthode de connexion par identifiant

## :socks: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :santa: Pour tester
Depuis Orga:
- Modifier un élève en cliquant sur les 3 points > Gerer le compte > Ajouter l'identifiant
![image](https://github.com/user-attachments/assets/0943f826-2cb3-411d-b6bb-1c3d6ae68ed5)
![image](https://github.com/user-attachments/assets/86761979-4e80-45ea-b985-4396b5e10955)

Depuis Admin:
- Retirer la méthode de connection par mail de cet utilisateur
- Cliquer sur Modifier pour mettre à jour son prénom par exemple
- Constater que le formulaire ne bloque pas l'appel même avec un email vide
