### PR TITLE
[BUGFIX] Corriger les phrases d'acceptation des CGUs partie 2 (PIX-16000)

### DIFF
--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -884,7 +884,7 @@
             "label": "Sign up"
           },
           "cgu": {
-            "accept": "I agree to the",
+            "accept": "I accept the",
             "and": "and",
             "aria-label": "I accept the terms of use and personal data protection policy of Pix",
             "data-protection-policy": "personal data protection policy",


### PR DESCRIPTION
## :christmas_tree: Problème
Dans [cette pr](https://github.com/1024pix/pix/pull/11069), une phrase a été oubliée:(

## :gift: Proposition
Corriger la phrase manquante.


## :socks: Remarques

Bien vérifier qu'il n'en manque pas d'autre.

## :santa: Pour tester
Reproduir le parcour de [cette PR](https://github.com/1024pix/pix/pull/11069).
La phrase mauvaise se situait dans les traductions de pix orga.