### PR TITLE
[FEATURE] Mise en place d’une nouvelle fonction getForwardedOrigin qui récupére l’origin HTTP de l’application (PIX-15925)

### DIFF
--- a/api/src/identity-access-management/infrastructure/utils/network.js
+++ b/api/src/identity-access-management/infrastructure/utils/network.js
@@ -1,0 +1,21 @@
+/**
+ * Returns the HTTP origin of the given HTTP request headers, based on the x-forwarded-proto and x-forwarded-host headers
+ *
+ * @param {Object} headers
+ * @returns {string} an URL as a string
+ */
+function getForwardedOrigin(headers) {
+  const protoHeader = headers['x-forwarded-proto'];
+  const hostHeader = headers['x-forwarded-host'];
+  if (!protoHeader || !hostHeader) {
+    return '';
+  }
+
+  return `${_getHeaderFirstValue(protoHeader)}://${_getHeaderFirstValue(hostHeader)}`;
+}
+
+function _getHeaderFirstValue(headerValue) {
+  return headerValue.split(',')[0];
+}
+
+export { getForwardedOrigin };

--- a/api/src/shared/application/feature-toggles/feature-toggle-controller.js
+++ b/api/src/shared/application/feature-toggles/feature-toggle-controller.js
@@ -1,10 +1,16 @@
 import { config } from '../../../../src/shared/config.js';
+import * as network from '../../../identity-access-management/infrastructure/utils/network.js';
 import * as serializer from '../../infrastructure/serializers/jsonapi/feature-toggle-serializer.js';
 
 const getActiveFeatures = function () {
   return serializer.serialize(config.featureToggles);
 };
 
-const featureToggleController = { getActiveFeatures };
+// TODO: Test route to be removed soon
+const getForwardedOrigin = function (request, h) {
+  return h.response(network.getForwardedOrigin(request.headers)).code(200);
+};
 
-export { featureToggleController };
+const featureToggleController = { getActiveFeatures, getForwardedOrigin };
+
+export { featureToggleController, getForwardedOrigin };

--- a/api/src/shared/application/feature-toggles/index.js
+++ b/api/src/shared/application/feature-toggles/index.js
@@ -11,6 +11,21 @@ const register = async function (server) {
         tags: ['api'],
       },
     },
+    // TODO: Test route to be removed soon
+    {
+      method: 'GET',
+      path: '/api/test-origin-soon-to-be-remove',
+      config: {
+        auth: false,
+        handler: featureToggleController.getForwardedOrigin,
+        notes: [
+          '- **Route ponctuelle à des fins de test**\n' +
+            '- **Cette route est publique**\n' +
+            '- Récupération de l’origin HTTP de l’application appelante\n',
+        ],
+        tags: ['identity-access-management', 'api', 'user'],
+      },
+    },
   ]);
 };
 

--- a/api/tests/identity-access-management/unit/infrastructure/utils/network.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/utils/network.test.js
@@ -1,0 +1,87 @@
+import { getForwardedOrigin } from '../../../../../src/identity-access-management/infrastructure/utils/network.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Identity Access Management | Infrastructure | Utils | network', function () {
+  describe('#getForwardedOrigin', function () {
+    context('when port is HTTP standard port 80', function () {
+      it('returns an HTTP URL', async function () {
+        // given
+        const headers = {
+          'x-forwarded-proto': 'http',
+          'x-forwarded-port': '80',
+          'x-forwarded-host': 'localhost',
+        };
+
+        // when
+        const origin = getForwardedOrigin(headers);
+
+        // then
+        expect(origin).to.equal('http://localhost');
+      });
+    });
+
+    context('when port is HTTPS standard port 443', function () {
+      it('returns an HTTPS URL', async function () {
+        // given
+        const headers = {
+          'x-forwarded-proto': 'https',
+          'x-forwarded-port': '443',
+          'x-forwarded-host': 'app-pr10823.review.pix.fr',
+        };
+
+        // when
+        const origin = getForwardedOrigin(headers);
+
+        // then
+        expect(origin).to.equal('https://app-pr10823.review.pix.fr');
+      });
+    });
+
+    context('when port is neither HTTP nor HTTPS standard ports', function () {
+      it('returns an URL with a specific port', async function () {
+        // given
+        const headers = {
+          'x-forwarded-proto': 'http',
+          'x-forwarded-port': '4200',
+          'x-forwarded-host': 'localhost:4200',
+        };
+
+        // when
+        const origin = getForwardedOrigin(headers);
+
+        // then
+        expect(origin).to.equal('http://localhost:4200');
+      });
+    });
+
+    context('when x-forwarded-proto and x-forwarded-port have multiple values (ember serve --proxy)', function () {
+      it('returns an URL corresponding to the first HTTP proxy facing the user', async function () {
+        // given
+        const headers = {
+          'x-forwarded-proto': 'https,http',
+          'x-forwarded-port': '80',
+          'x-forwarded-host': 'app.dev.pix.org',
+        };
+
+        // when
+        const origin = getForwardedOrigin(headers);
+
+        // then
+        expect(origin).to.equal('https://app.dev.pix.org');
+      });
+    });
+
+    context('when x-forwarded-proto and x-forwarded-port are not defined', function () {
+      it('doesn’t choke and returns an empty string', async function () {
+        // given
+        const headers = {};
+
+        // when
+        const origin = getForwardedOrigin(headers);
+
+        // then
+        expect(origin).to.equal('');
+      });
+    });
+  });
+});

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -49,4 +49,24 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
       expect(response.result).to.deep.equal(expectedData);
     });
   });
+
+  describe('GET /api/test-origin-soon-to-be-remove. Test route soon to be removed.', function () {
+    const options = {
+      method: 'GET',
+      url: '/api/test-origin-soon-to-be-remove',
+      headers: { 'x-forwarded-proto': 'http', 'x-forwarded-host': 'test.pix.org' },
+    };
+
+    it('returns an empty string because the calling application HTTP Origin', async function () {
+      // given
+      const expectedData = 'http://test.pix.org';
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result).to.deep.equal(expectedData);
+    });
+  });
 });


### PR DESCRIPTION
## :christmas_tree: Problème

On a besoin de connaitre l'_origin_ (au sens HTTP) de l'application faisant les requêtes à Pix API, pour pouvoir créer des Access Tokens porteurs de cette information, et aussi ensuite vérifier qu'un Access Token émis pour une application est bien utilisé uniquement pour cette application.

## :gift: Proposition

Mise en place d’une nouvelle fonction **getForwardedOrigin** qui récupére l’_origin_ HTTP de l’application à partir des headers de proxy `x-forwarded-host` et `x-forwarded-proto`. Ces headers sont ajoutés par nginx.

Dans cette PR on a ajouté temporairement une nouvelle route `/api/test-origin-soon-to-be-remove` dans le featureToggleController de manière à pouvoir tester en vrai que cette nouvelle fonction **getForwardedOrigin** fonctionne bien dans tous les environnements et une fois que le bon fonctionnement sera attesté il faudra faire un revert de ce commit dans une PR suivante.

## :socks: Remarques

Ne pas oublier, plus tard, de faire le revert du 2ème commit ajoutant la route `/api/test-origin-soon-to-be-remove`.

## :santa: Pour tester

Vérifier que pour chaque application la route `/api/test-origin-soon-to-be-remove`
retourne bien l'URL de l'origine de l'application, c'est à dire `https://app-pr11104.review.pix.fr/` (et non `https://app-pr11104.review.pix.fr/api/test-origin-soon-to-be-remove` avec la route inclus ou encore `http://localhost:4200` l'URL local dans le conteneur, etc.).

En local sur un poste de dev : 
* http://localhost:4200/api/test-origin-soon-to-be-remove (cas correspondant à ember-cli seul) → `http://localhost:4200/`
* https://app.dev.pix.fr/api/test-origin-soon-to-be-remove (cas correspondant à ember-cli + Caddy) → `https://app.dev.pix.fr/`
* https://app.dev.pix.org/api/test-origin-soon-to-be-remove (cas correspondant à ember-cli + Caddy) → `https://app.dev.pix.org/`

Sur les RA : 
* https://app-pr11104.review.pix.fr/api/test-origin-soon-to-be-remove → `https://app-pr11104.review.pix.fr/`
* https://app-pr11104.review.pix.org/api/test-origin-soon-to-be-remove → `https://app-pr11104.review.pix.org/`
* https://orga-pr11104.review.pix.fr/api/test-origin-soon-to-be-remove → `https://orga-pr11104.review.pix.fr/`
* https://orga-pr11104.review.pix.org/api/test-origin-soon-to-be-remove → `https://orga-pr11104.review.pix.org/`
* https://certif-pr11104.review.pix.fr/api/test-origin-soon-to-be-remove → `https://certif-pr11104.review.pix.fr/`
* https://certif-pr11104.review.pix.org/api/test-origin-soon-to-be-remove → `https://certif-pr11104.review.pix.org/`
* https://admin-pr11104.review.pix.fr/api/test-origin-soon-to-be-remove → `https://admin-pr11104.review.pix.fr/`
