### PR TITLE
[FEATURE] Modifier l'appel Pix Admin qui récupère le statut des CGU

### DIFF
--- a/api/src/legal-documents/domain/usecases/get-legal-document-status-by-user-id.usecase.js
+++ b/api/src/legal-documents/domain/usecases/get-legal-document-status-by-user-id.usecase.js
@@ -27,7 +27,6 @@ const getLegalDocumentStatusByUserId = async ({
   LegalDocumentType.assert(type);
 
   const { isLegalDocumentsVersioningEnabled } = featureToggles;
-
   if (!isLegalDocumentsVersioningEnabled) {
     const user = await userRepository.findPixOrgaCgusByUserId(userId);
     return LegalDocumentStatus.buildForLegacyPixOrgaCgu(user);


### PR DESCRIPTION
## :christmas_tree: Problème

Afin de mettre en place le versionement des CGU de Pix Orga, il est nécessaire de modifier l’API permettant de récupérer leur valeur afin de se baser sur le nouveau modèle.

## :gift: Proposition

Récupérer les informations de CGU en se basant sur la nouvelle API `getLegalDocumentStatusByUserId` du contexte _legal-documents_.

## :socks: Remarques

L'api a été directement importée dans le userRepository, pour deux raisons : 
- la cohérence interne : ce repository utilise déjà une api interne, qui est importée directement et non injectée. 
- les imports/injections de dépendance feront l'objet d'un refactoring global dans une prochaine PR.

## :santa: Pour tester

1. Test de non-régression sur Pix Admin
  - Vérifier que `FT_NEW_LEGAL_DOCUMENTS_VERSIONING=false`
  - Aller sur Pix Admin avec un compte super admin
  - Aller sur la page d'un utilisateur : certif-pro@example.net (= requête à l'API `GET http://localhost:4202/api/admin/users/{id}` )
  - Vérifier dans la console que cet appel renvoie les CGU attendues 
`last-pix-orga-terms-of-service-validated-at	[date actuelle]`
`pix-orga-terms-of-service-accepted	true`

2. Test du nouveau modèle de gestion des CGU
  - Vérifier que `FT_NEW_LEGAL_DOCUMENTS_VERSIONING=true`
  - Créer un legal document avec la commande
`node src/legal-documents/scripts/add-new-legal-document-version.js --type 'TOS' --service 'pix-orga' --versionAt '2024-01-02'`
  - Depuis Pix Admin, afficher la page de l'utilisateur certif-pro@example.net
  - Constater que l'appel `http://localhost:4202/api/admin/users/{id}` renvoie les CGU :
  `last-pix-orga-terms-of-service-validated-at	NULL`
`pix-orga-terms-of-service-accepted	false`
En effet même si les conditions ont été acceptées, le nouveau modèle ne les récupère pas dans la table users.
  - Depuis le compte `allorga@example.net` sur Pix Orga, inviter `certif-pro@example.net`, et confimer l'invitation avec ce compte déjà existant.
 - Constater que l'appel `http://localhost:4202/api/admin/users/{id}` renvoie les CGU
  `last-pix-orga-terms-of-service-validated-at	[date actuelle]`
`pix-orga-terms-of-service-accepted	true`
