### PR TITLE
[TECH] :truck: Déplace `certifiable-profile-for-learning-content-repository.js` vers `src/`

### DIFF
--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -130,7 +130,6 @@ import { userOrgaSettingsRepository } from '../../../src/team/infrastructure/rep
 import * as obfuscationService from '../../domain/services/obfuscation-service.js';
 import * as badgeAcquisitionRepository from '../../infrastructure/repositories/badge-acquisition-repository.js';
 import * as badgeForCalculationRepository from '../../infrastructure/repositories/badge-for-calculation-repository.js';
-import * as certifiableProfileForLearningContentRepository from '../../infrastructure/repositories/certifiable-profile-for-learning-content-repository.js';
 import * as complementaryCertificationCourseResultRepository from '../../infrastructure/repositories/complementary-certification-course-result-repository.js';
 import * as flashAssessmentResultRepository from '../../infrastructure/repositories/flash-assessment-result-repository.js';
 import * as frameworkRepository from '../../infrastructure/repositories/framework-repository.js';
@@ -209,7 +208,6 @@ const dependencies = {
   campaignProfileRepository,
   campaignRepository,
   centerRepository,
-  certifiableProfileForLearningContentRepository,
   certificationAssessmentRepository,
   certificationBadgesService,
   certificationCandidateRepository,

--- a/api/src/certification/evaluation/domain/services/certification-challenges-service.js
+++ b/api/src/certification/evaluation/domain/services/certification-challenges-service.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 
-import * as certifiableProfileForLearningContentRepository from '../../../../../lib/infrastructure/repositories/certifiable-profile-for-learning-content-repository.js';
 import * as learningContentRepository from '../../../../../lib/infrastructure/repositories/learning-content-repository.js';
 import {
   MAX_CHALLENGES_PER_AREA_FOR_CERTIFICATION_PLUS,
@@ -13,6 +12,7 @@ import { KnowledgeElement } from '../../../../shared/domain/models/KnowledgeElem
 import * as answerRepository from '../../../../shared/infrastructure/repositories/answer-repository.js';
 import * as challengeRepository from '../../../../shared/infrastructure/repositories/challenge-repository.js';
 import * as knowledgeElementRepository from '../../../../shared/infrastructure/repositories/knowledge-element-repository.js';
+import * as certifiableProfileForLearningContentRepository from '../../infrastructure/repositories/certifiable-profile-for-learning-content-repository.js';
 
 const pickCertificationChallenges = async function (
   placementProfile,

--- a/api/src/certification/evaluation/domain/usecases/index.js
+++ b/api/src/certification/evaluation/domain/usecases/index.js
@@ -7,6 +7,7 @@ import * as placementProfileService from '../../../../shared/domain/services/pla
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as verifyCertificateCodeService from '../../../evaluation/domain/services/verify-certificate-code-service.js';
+import * as certifiableProfileForLearningContentRepository from '../../../evaluation/infrastructure/repositories/certifiable-profile-for-learning-content-repository.js';
 import * as flashAlgorithmService from '../../../flash-certification/domain/services/algorithm-methods/flash.js';
 import {
   answerRepository,
@@ -34,6 +35,7 @@ import * as certificationChallengesService from '../services/certification-chall
  * @typedef {certificationCompanionAlertRepository} CertificationCompanionAlertRepository
  * @typedef {certificationChallengeRepository} CertificationChallengeRepository
  * @typedef {certificationAssessmentRepository} CertificationAssessmentRepository
+ * @typedef {certifiableProfileForLearningContentRepository} CertifiableProfileForLearningContentRepository
  */
 
 const dependencies = {
@@ -41,6 +43,7 @@ const dependencies = {
   sessionManagementCertificationChallengeRepository,
   challengeCalibrationRepository,
   certificationCandidateRepository,
+  certifiableProfileForLearningContentRepository,
   assessmentRepository,
   sharedCertificationCandidateRepository,
   verifyCertificateCodeService,

--- a/api/src/certification/evaluation/infrastructure/repositories/certifiable-profile-for-learning-content-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/certifiable-profile-for-learning-content-repository.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 
-import { knex } from '../../../db/knex-database-connection.js';
-import { CertifiableProfileForLearningContent } from '../../../src/shared/domain/models/CertifiableProfileForLearningContent.js';
-import * as knowledgeElementRepository from '../../../src/shared/infrastructure/repositories/knowledge-element-repository.js';
+import { knex } from '../../../../../db/knex-database-connection.js';
+import { CertifiableProfileForLearningContent } from '../../../../shared/domain/models/CertifiableProfileForLearningContent.js';
+import * as knowledgeElementRepository from '../../../../shared/infrastructure/repositories/knowledge-element-repository.js';
 
 const get = async function ({ id, profileDate, learningContent }) {
   const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId: id, limitDate: profileDate });

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/certifiable-profile-for-learning-content-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/certifiable-profile-for-learning-content-repository_test.js
@@ -1,7 +1,7 @@
-import * as certifiableProfileForLearningContentRepository from '../../../../lib/infrastructure/repositories/certifiable-profile-for-learning-content-repository.js';
-import { CertifiableProfileForLearningContent } from '../../../../src/shared/domain/models/CertifiableProfileForLearningContent.js';
-import { KnowledgeElement } from '../../../../src/shared/domain/models/KnowledgeElement.js';
-import { databaseBuilder, domainBuilder, expect } from '../../../test-helper.js';
+import * as certifiableProfileForLearningContentRepository from '../../../../../../src/certification/evaluation/infrastructure/repositories/certifiable-profile-for-learning-content-repository.js';
+import { CertifiableProfileForLearningContent } from '../../../../../../src/shared/domain/models/CertifiableProfileForLearningContent.js';
+import { KnowledgeElement } from '../../../../../../src/shared/domain/models/KnowledgeElement.js';
+import { databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | Repository | certifiable-profile-for-learning-content', function () {
   describe('#get', function () {


### PR DESCRIPTION
## :pancakes: Problème

Le fichier `certifiable-profile-for-learning-content-repository.js` est toujours dans `lib/`

## :bacon: Proposition

Déplacer `certifiable-profile-for-learning-content-repository.js` vers `src/`

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
