### PR TITLE
[TECH] Ajout du prefixe application a Parcoursup (PIX-16090).

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -357,8 +357,15 @@ MAILING_PROVIDER=mailpit
 # presence: optional
 # type: String
 # default: 'https://gateway.pix.fr'
-#APIM_URL=
+APIM_URL=http://127.0.0.1:3000/
 
+
+# API Manager Parcoursup endpoint
+#
+# presence: optional
+# type: String
+# default: '/parcoursup'
+APIM_PARCOURSUP_PATH=/api/application
 
 # ================
 # LEARNING CONTENT

--- a/api/src/parcoursup/application/certification-controller.js
+++ b/api/src/parcoursup/application/certification-controller.js
@@ -4,7 +4,6 @@ const getCertificationResult = async function (request) {
   return usecases.getCertificationResult(request.payload);
 };
 
-const certificationController = {
+export const certificationController = {
   getCertificationResult,
 };
-export { certificationController };

--- a/api/src/parcoursup/application/certification-route.js
+++ b/api/src/parcoursup/application/certification-route.js
@@ -10,7 +10,7 @@ import { certificationController } from './certification-controller.js';
 const register = async function (server) {
   server.route({
     method: 'POST',
-    path: '/api/parcoursup/certification/search',
+    path: '/api/application/parcoursup/certification/search',
     config: {
       auth: 'jwt-parcoursup',
       validate: {

--- a/api/src/parcoursup/application/certification-route.js
+++ b/api/src/parcoursup/application/certification-route.js
@@ -54,8 +54,10 @@ const register = async function (server) {
         failAction: 'log',
         status: {
           200: Joi.object({
-            organizationUai: Joi.string().description('UAI de l‘établissement scolaire'),
-            ine: Joi.string().description('INE de l‘élève'),
+            organizationUai: Joi.string().description(
+              'UAI/RNE (Unité Administrative Immatriculée anciennement Répertoire National des Établissements)',
+            ),
+            ine: Joi.string().description('INE (identifiant national élève, étudiant ou apprenti)'),
             lastName: Joi.string().description('Nom de famille de l‘élève'),
             firstName: Joi.string().description('Prénom de l‘élève'),
             birthdate: Joi.date().description('Date de naissance au format AAAA-MM-JJ'),

--- a/api/src/parcoursup/application/certification-route.js
+++ b/api/src/parcoursup/application/certification-route.js
@@ -8,81 +8,150 @@ import { responseObjectErrorDoc } from '../../shared/infrastructure/open-api-doc
 import { certificationController } from './certification-controller.js';
 
 const register = async function (server) {
-  server.route({
-    method: 'POST',
-    path: '/api/application/parcoursup/certification/search',
-    config: {
-      auth: 'jwt-parcoursup',
-      validate: {
-        payload: Joi.alternatives()
-          .try(
-            Joi.object({
-              ine: studentIdentifierType
-                .required()
-                .description('INE (identifiant national élève, étudiant ou apprenti)'),
-            }),
-            Joi.object({
-              organizationUai: Joi.string()
-                .required()
-                .description(
-                  'UAI/RNE (Unité Administrative Immatriculée anciennement Répertoire National des Établissements)',
-                ),
-              lastName: Joi.string().required().description('Nom de famille de l‘élève'),
-              firstName: Joi.string().required().description('Prénom de l‘élève'),
-              birthdate: Joi.string()
-                .pattern(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/)
-                .required()
-                .description('Date de naissance au format AAAA-MM-JJ'),
-            }),
-            Joi.object({
-              verificationCode: certificationVerificationCodeType
-                .required()
-                .description('Code de vérification du certificat Pix à vérifier'),
-            }),
-          )
-          .required(),
-      },
-      handler: certificationController.getCertificationResult,
-      tags: ['api', 'parcoursup'],
-      notes: [
-        '**Cette route est accessible uniquement à Parcoursup**\n' +
-          '- Avec un INE, récupère la dernière certification de l‘année en cours pour l‘élève identifié\n' +
-          '- Avec un UAI, nom, prénom et date de naissance, récupère la dernière certification de l‘année en cours pour l‘élève identifié\n' +
-          '- Avec un code de vérification, récupère la certification correspondante',
-      ],
-      response: {
-        failAction: 'log',
-        status: {
-          200: Joi.object({
-            organizationUai: Joi.string().description(
-              'UAI/RNE (Unité Administrative Immatriculée anciennement Répertoire National des Établissements)',
-            ),
-            ine: Joi.string().description('INE (identifiant national élève, étudiant ou apprenti)'),
-            lastName: Joi.string().description('Nom de famille de l‘élève'),
-            firstName: Joi.string().description('Prénom de l‘élève'),
-            birthdate: Joi.date().description('Date de naissance au format AAAA-MM-JJ'),
-            status: Joi.string().description('Statut de la certification'),
-            pixScore: Joi.number().min(0).max(1024).description('Score en nombre de pix'),
-            certificationDate: Joi.date().description('Date de passage de la certification'),
-            competences: Joi.array()
-              .items(
-                Joi.object({
-                  code: Joi.string().description('Code de la compétence'),
-                  name: Joi.string().description('Nom de la compétence'),
-                  level: Joi.number().min(0).max(8).description('Niveau obtenu sur la compétence'),
-                  areaName: Joi.string().description('Domaine de la compétence'),
-                }).label('Competence-Result-Object'),
-              )
-              .description('Résultats par compétence')
-              .label('Competence-Results-Array'),
-          }).label('Certification-Result-Object'),
-          401: responseObjectErrorDoc,
-          403: responseObjectErrorDoc,
-          404: responseObjectErrorDoc,
+  server.route([
+    {
+      method: 'POST',
+      path: '/api/parcoursup/certification/search',
+      config: {
+        plugins: {
+          'hapi-swagger': {
+            deprecated: true,
+          },
+        },
+        auth: 'jwt-parcoursup',
+        validate: {
+          payload: Joi.alternatives()
+            .try(
+              Joi.object({
+                ine: studentIdentifierType.required(),
+              }),
+              Joi.object({
+                organizationUai: Joi.string().required(),
+                lastName: Joi.string().required(),
+                firstName: Joi.string().required(),
+                birthdate: Joi.string().required(),
+              }),
+              Joi.object({
+                verificationCode: certificationVerificationCodeType.required(),
+              }),
+            )
+            .required(),
+        },
+        handler: certificationController.getCertificationResult,
+        tags: ['api', 'parcoursup'],
+        notes: [
+          '**Cette route est accessible uniquement à Parcoursup**\n' +
+            '- Avec un INE, récupère la dernière certification de l‘année en cours pour l‘élève identifié\n' +
+            '- Avec un UAI, nom, prénom et date de naissance, récupère la dernière certification de l‘année en cours pour l‘élève identifié\n' +
+            '- Avec un code de vérification, récupère la certification correspondante',
+        ],
+        response: {
+          failAction: 'log',
+          status: {
+            200: Joi.object({
+              organizationUai: Joi.string().description('UAI de l‘établissement scolaire'),
+              ine: Joi.string().description('INE de l‘élève'),
+              lastName: Joi.string().description('Nom de famille de l‘élève'),
+              firstName: Joi.string().description('Prénom de l‘élève'),
+              birthdate: Joi.date().description('Date de naissance au format AAAA-MM-JJ'),
+              status: Joi.string().description('Statut de la certification'),
+              pixScore: Joi.number().min(0).max(1024).description('Score en nombre de pix'),
+              certificationDate: Joi.date().description('Date de passage de la certification'),
+              competences: Joi.array()
+                .items(
+                  Joi.object({
+                    code: Joi.string().description('Code de la compétence'),
+                    name: Joi.string().description('Nom de la compétence'),
+                    level: Joi.number().min(0).max(8).description('Niveau obtenu sur la compétence'),
+                    areaName: Joi.string().description('Domaine de la compétence'),
+                  }).label('Competence-Result-Object'),
+                )
+                .description('Résultats par compétence')
+                .label('Competence-Results-Array'),
+            }).label('Certification-Result-Object'),
+            401: responseObjectErrorDoc,
+            403: responseObjectErrorDoc,
+            404: responseObjectErrorDoc,
+          },
         },
       },
     },
-  });
+    {
+      method: 'POST',
+      path: '/api/application/parcoursup/certification/search',
+      config: {
+        auth: 'jwt-parcoursup',
+        validate: {
+          payload: Joi.alternatives()
+            .try(
+              Joi.object({
+                ine: studentIdentifierType
+                  .required()
+                  .description('INE (identifiant national élève, étudiant ou apprenti)'),
+              }),
+              Joi.object({
+                organizationUai: Joi.string()
+                  .required()
+                  .description(
+                    'UAI/RNE (Unité Administrative Immatriculée anciennement Répertoire National des Établissements)',
+                  ),
+                lastName: Joi.string().required().description('Nom de famille de l‘élève'),
+                firstName: Joi.string().required().description('Prénom de l‘élève'),
+                birthdate: Joi.string()
+                  .pattern(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/)
+                  .required()
+                  .description('Date de naissance au format AAAA-MM-JJ'),
+              }),
+              Joi.object({
+                verificationCode: certificationVerificationCodeType
+                  .required()
+                  .description('Code de vérification du certificat Pix à vérifier'),
+              }),
+            )
+            .required(),
+        },
+        handler: certificationController.getCertificationResult,
+        tags: ['api', 'parcoursup'],
+        notes: [
+          '**Cette route est accessible uniquement à Parcoursup**\n' +
+            '- Avec un INE, récupère la dernière certification de l‘année en cours pour l‘élève identifié\n' +
+            '- Avec un UAI, nom, prénom et date de naissance, récupère la dernière certification de l‘année en cours pour l‘élève identifié\n' +
+            '- Avec un code de vérification, récupère la certification correspondante',
+        ],
+        response: {
+          failAction: 'log',
+          status: {
+            200: Joi.object({
+              organizationUai: Joi.string().description(
+                'UAI/RNE (Unité Administrative Immatriculée anciennement Répertoire National des Établissements)',
+              ),
+              ine: Joi.string().description('INE (identifiant national élève, étudiant ou apprenti)'),
+              lastName: Joi.string().description('Nom de famille de l‘élève'),
+              firstName: Joi.string().description('Prénom de l‘élève'),
+              birthdate: Joi.date().description('Date de naissance au format AAAA-MM-JJ'),
+              status: Joi.string().description('Statut de la certification'),
+              pixScore: Joi.number().min(0).max(1024).description('Score en nombre de pix'),
+              certificationDate: Joi.date().description('Date de passage de la certification'),
+              competences: Joi.array()
+                .items(
+                  Joi.object({
+                    code: Joi.string().description('Code de la compétence'),
+                    name: Joi.string().description('Nom de la compétence'),
+                    level: Joi.number().min(0).max(8).description('Niveau obtenu sur la compétence'),
+                    areaName: Joi.string().description('Domaine de la compétence'),
+                  }).label('Competence-Result-Object'),
+                )
+                .description('Résultats par compétence')
+                .label('Competence-Results-Array'),
+            }).label('Certification-Result-Object'),
+            401: responseObjectErrorDoc,
+            403: responseObjectErrorDoc,
+            404: responseObjectErrorDoc,
+          },
+        },
+      },
+    },
+  ]);
 };
 const name = 'parcoursup-api';
 export { name, register };

--- a/api/src/parcoursup/application/certification-route.js
+++ b/api/src/parcoursup/application/certification-route.js
@@ -17,16 +17,27 @@ const register = async function (server) {
         payload: Joi.alternatives()
           .try(
             Joi.object({
-              ine: studentIdentifierType.required(),
+              ine: studentIdentifierType
+                .required()
+                .description('INE (identifiant national élève, étudiant ou apprenti)'),
             }),
             Joi.object({
-              organizationUai: Joi.string().required(),
-              lastName: Joi.string().required(),
-              firstName: Joi.string().required(),
-              birthdate: Joi.string().required(),
+              organizationUai: Joi.string()
+                .required()
+                .description(
+                  'UAI/RNE (Unité Administrative Immatriculée anciennement Répertoire National des Établissements)',
+                ),
+              lastName: Joi.string().required().description('Nom de famille de l‘élève'),
+              firstName: Joi.string().required().description('Prénom de l‘élève'),
+              birthdate: Joi.string()
+                .pattern(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/)
+                .required()
+                .description('Date de naissance au format AAAA-MM-JJ'),
             }),
             Joi.object({
-              verificationCode: certificationVerificationCodeType.required(),
+              verificationCode: certificationVerificationCodeType
+                .required()
+                .description('Code de vérification du certificat Pix à vérifier'),
             }),
           )
           .required(),

--- a/api/src/parcoursup/domain/usecases/get-certification-result.js
+++ b/api/src/parcoursup/domain/usecases/get-certification-result.js
@@ -1,11 +1,25 @@
-const getCertificationResult = function ({
+/**
+ * @typedef {import('../../domain/usecases/index.js').CertificationRepository} CertificationRepository
+ */
+
+/**
+ * @param {Object} params
+ * @param {string} params.ine
+ * @param {string} params.organizationUai
+ * @param {string} params.lastName
+ * @param {string} params.firstName
+ * @param {string} params.birthdate - Format YYYY-MM-DD
+ * @param {string} params.verificationCode
+ * @param {CertificationRepository} params.certificationRepository
+ **/
+export const getCertificationResult = function ({
   ine,
   organizationUai,
   lastName,
   firstName,
   birthdate,
-  certificationRepository,
   verificationCode,
+  certificationRepository,
 }) {
   if (ine) {
     return certificationRepository.getByINE({ ine });
@@ -19,5 +33,3 @@ const getCertificationResult = function ({
     return certificationRepository.getByVerificationCode({ verificationCode });
   }
 };
-
-export { getCertificationResult };

--- a/api/src/parcoursup/domain/usecases/index.js
+++ b/api/src/parcoursup/domain/usecases/index.js
@@ -5,16 +5,12 @@ import { injectDependencies } from '../../../shared/infrastructure/utils/depende
 import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as certificationRepository from '../../infrastructure/repositories/certification-repository.js';
 
-/**
- * @typedef {import('../../infrastructure/repositories/certification-repository.js').CertificationRepository} CertificationRepository
- **/
+const path = dirname(fileURLToPath(import.meta.url));
 
 /**
  * Using {@link https://jsdoc.app/tags-type "Closure Compiler's syntax"} to document injected dependencies
  * @typedef {certificationRepository} CertificationRepository
  **/
-
-const path = dirname(fileURLToPath(import.meta.url));
 
 const dependencies = {
   certificationRepository,

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -119,6 +119,9 @@ const configuration = (function () {
     },
     apiManager: {
       url: process.env.APIM_URL || 'https://gateway.pix.fr',
+      endpoints: {
+        parcoursup: process.env.APIM_PARCOURSUP_PATH || '/parcoursup',
+      },
     },
     apimRegisterApplicationsCredentials: [
       {

--- a/api/src/shared/infrastructure/validate-environment-variables.js
+++ b/api/src/shared/infrastructure/validate-environment-variables.js
@@ -65,6 +65,8 @@ const schema = Joi.object({
   TEST_REDIS_URL: Joi.string().optional(),
   TLD_FR: Joi.string().optional(),
   TLD_ORG: Joi.string().optional(),
+  APIM_URL: Joi.string().optional(),
+  APIM_PARCOURSUP_PATH: Joi.string().optional(),
 }).options({ allowUnknown: true });
 
 const validateEnvironmentVariables = function () {

--- a/api/src/shared/swaggers.js
+++ b/api/src/shared/swaggers.js
@@ -2,6 +2,7 @@ import HapiSwagger from 'hapi-swagger';
 
 import packageJSON from '../../package.json' with { type: 'json' };
 import { config } from './config.js';
+import { logger } from './infrastructure/utils/logger.js';
 
 const swaggerOptionsAuthorizationServer = {
   routeTag: 'authorization-server',
@@ -33,12 +34,7 @@ const swaggerOptionsPoleEmploi = {
 const swaggerOptionsParcoursup = {
   routeTag: 'parcoursup',
   OAS: 'v3.0',
-  servers: [
-    {
-      url: `${config.apiManager.url}/parcoursup/`,
-      description: 'External Partners access',
-    },
-  ],
+  servers: _buildParcoursupServers(),
   pathReplacements: [
     {
       replaceIn: 'all',
@@ -99,6 +95,28 @@ function _buildSwaggerArgs(swaggerOptions) {
       routes: { prefix: '/' + swaggerOptions.routeTag },
     },
   ];
+}
+
+function _buildParcoursupServers() {
+  try {
+    const servers = [
+      {
+        url: new URL(config.apiManager.endpoints.parcoursup, config.apiManager.url).href,
+        description: 'External Partners access',
+      },
+    ];
+
+    if (config.environment === 'development') {
+      servers.push({
+        url: `http://127.0.0.1:${config.port}/api/application`,
+        description: 'Development endpoint',
+      });
+    }
+
+    return servers;
+  } catch (error) {
+    logger.error(error);
+  }
 }
 
 const swaggers = [

--- a/api/src/shared/swaggers.js
+++ b/api/src/shared/swaggers.js
@@ -99,21 +99,12 @@ function _buildSwaggerArgs(swaggerOptions) {
 
 function _buildParcoursupServers() {
   try {
-    const servers = [
+    return [
       {
         url: new URL(config.apiManager.endpoints.parcoursup, config.apiManager.url).href,
         description: 'External Partners access',
       },
     ];
-
-    if (config.environment === 'development') {
-      servers.push({
-        url: `http://127.0.0.1:${config.port}/api/application`,
-        description: 'Development endpoint',
-      });
-    }
-
-    return servers;
   } catch (error) {
     logger.error(error);
   }

--- a/api/src/shared/swaggers.js
+++ b/api/src/shared/swaggers.js
@@ -1,6 +1,7 @@
 import HapiSwagger from 'hapi-swagger';
 
 import packageJSON from '../../package.json' with { type: 'json' };
+import { config } from './config.js';
 
 const swaggerOptionsAuthorizationServer = {
   routeTag: 'authorization-server',
@@ -31,8 +32,22 @@ const swaggerOptionsPoleEmploi = {
 
 const swaggerOptionsParcoursup = {
   routeTag: 'parcoursup',
+  OAS: 'v3.0',
+  servers: [
+    {
+      url: `${config.apiManager.url}/parcoursup/`,
+      description: 'External Partners access',
+    },
+  ],
+  pathReplacements: [
+    {
+      replaceIn: 'all',
+      pattern: /api\/application\//,
+      replacement: '',
+    },
+  ],
   info: {
-    title: 'Pix Parcoursup open api',
+    title: 'Pix Parcoursup Open Api',
     version: packageJSON.version,
   },
   jsonPath: '/swagger.json',

--- a/api/tests/parcoursup/acceptance/application/certification-route_test.js
+++ b/api/tests/parcoursup/acceptance/application/certification-route_test.js
@@ -84,12 +84,12 @@ describe('Parcoursup | Acceptance | Application | certification-route', function
     await datamartBuilder.commit();
   });
 
-  describe('POST /api/parcoursup/certification/search', function () {
+  describe('POST /api/application/parcoursup/certification/search', function () {
     it('should return 200 HTTP status code and a certification for a given INE', async function () {
       // given
       const options = {
         method: 'POST',
-        url: `/api/parcoursup/certification/search`,
+        url: `/api/application/parcoursup/certification/search`,
         headers: {
           authorization: generateValidRequestAuthorizationHeaderForApplication(
             PARCOURSUP_CLIENT_ID,
@@ -114,7 +114,7 @@ describe('Parcoursup | Acceptance | Application | certification-route', function
       // given
       const options = {
         method: 'POST',
-        url: `/api/parcoursup/certification/search`,
+        url: `/api/application/parcoursup/certification/search`,
         headers: {
           authorization: generateValidRequestAuthorizationHeaderForApplication(
             PARCOURSUP_CLIENT_ID,
@@ -171,7 +171,7 @@ describe('Parcoursup | Acceptance | Application | certification-route', function
 
       const options = {
         method: 'POST',
-        url: '/api/parcoursup/certification/search',
+        url: '/api/application/parcoursup/certification/search',
         headers: {
           authorization: generateValidRequestAuthorizationHeaderForApplication(
             PARCOURSUP_CLIENT_ID,

--- a/api/tests/parcoursup/unit/application/certification-route_test.js
+++ b/api/tests/parcoursup/unit/application/certification-route_test.js
@@ -11,7 +11,7 @@ describe('Parcoursup | Unit | Application | Routes | Certification', function ()
   let url, method, headers, httpTestServer;
 
   beforeEach(async function () {
-    url = '/api/parcoursup/certification/search';
+    url = '/api/application/parcoursup/certification/search';
     sinon.stub(certificationController, 'getCertificationResult').callsFake((request, h) => h.response().code(200));
 
     httpTestServer = new HttpTestServer();

--- a/api/tests/parcoursup/unit/domain/usecases/get-certification-result_test.js
+++ b/api/tests/parcoursup/unit/domain/usecases/get-certification-result_test.js
@@ -1,23 +1,25 @@
 import { getCertificationResult } from '../../../../../src/parcoursup/domain/usecases/get-certification-result.js';
 import { domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
-describe('Parcoursup | unit | domain | usecases | get certification', function () {
-  describe('#getCertification', function () {
-    it('returns certification', async function () {
-      // given
-      const ine = '1234';
-      const certificationRepository = {
-        getByINE: sinon.stub(),
-      };
+describe('Parcoursup | Unit | Domain | UseCase | getCertificationResult', function () {
+  describe('#getCertificationResult', function () {
+    context('with INE', function () {
+      it('returns matching certification', async function () {
+        // given
+        const ine = '1234';
+        const certificationRepository = {
+          getByINE: sinon.stub(),
+        };
 
-      const expectedCertification = domainBuilder.parcoursup.buildCertificationResult({ ine });
-      certificationRepository.getByINE.withArgs({ ine }).resolves(expectedCertification);
+        const expectedCertification = domainBuilder.parcoursup.buildCertificationResult({ ine });
+        certificationRepository.getByINE.withArgs({ ine }).resolves(expectedCertification);
 
-      // when
-      const certification = await getCertificationResult({ ine, certificationRepository });
+        // when
+        const certification = await getCertificationResult({ ine, certificationRepository });
 
-      // then
-      expect(certification).to.deep.equal(expectedCertification);
+        // then
+        expect(certification).to.deep.equal(expectedCertification);
+      });
     });
 
     context('with organizationUai, last name, first name and birthdate', function () {


### PR DESCRIPTION
## :pancakes: Problème

Suite à une revue avec Team Acces + Team Secu, pour harmoniser et mieux gérer finement les applications de l’API Pix, il manque un /application au niveau de la route /api/parcoursup/certification/search

## :bacon: Proposition

* Modifier l’URL en /api/application/parcoursup/certification/search
* Mettre à jour la partie Swagger
  * Documentation externe renforcee
  * Choix possible selon si on est partenaires ou dev
    * Adaptation de l'URL d'appel selon l'acces choisi

## 🧃 Remarques

* La documentation Swagger va être capable automatiquement de gérer son path selon là ou elle est (via APIM ou direct), c'est gérer via les variables d'environnement, du coup ça s'adaptera à l'URL de l'APIM
* J'ai renforcé la validation Joi car la valeur de la date de naissance parce qu'elle laissait passer des valeurs qui ne sont pas à un format acceptable

## :yum: Pour tester

* Aller sur la RA à l'adresse https://api-pr11112.review.pix.fr/parcoursup/documentation
* Vérifier la capacité à choisir entre les serveurs
* Tenter un try it out complet
  * d'abord token
  * puis Authorize en mettant la valeur 'Bearer <token obtenu>'
  * puis search, par exemple sur l'INE `944385546HU`
  * puis search sur UAI, vérifier que le format de la date de naissance st désormais valide par Joi

![image](https://github.com/user-attachments/assets/88c90acc-39e4-432d-a5f8-8b056d7b2a44)

