### PR TITLE
[TECH] :truck: Déplace `Certification rescored by script event` vers `src/`

### DIFF
--- a/api/lib/domain/events/handle-certification-rescoring.js
+++ b/api/lib/domain/events/handle-certification-rescoring.js
@@ -3,13 +3,13 @@ import { ChallengeNeutralized } from '../../../src/certification/evaluation/doma
 import { services } from '../../../src/certification/evaluation/domain/services/index.js';
 import { AssessmentResultFactory } from '../../../src/certification/scoring/domain/models/factories/AssessmentResultFactory.js';
 import { CertificationCourseRejected } from '../../../src/certification/session-management/domain/events/CertificationCourseRejected.js';
+import CertificationRescoredByScript from '../../../src/certification/session-management/domain/events/CertificationRescoredByScript.js';
 import { AlgorithmEngineVersion } from '../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { V3_REPRODUCIBILITY_RATE } from '../../../src/shared/domain/constants.js';
 import { CertificationComputeError } from '../../../src/shared/domain/errors.js';
 import { CertificationResult } from '../../../src/shared/domain/models/CertificationResult.js';
 import { CertificationCourseUnrejected } from './CertificationCourseUnrejected.js';
 import { CertificationJuryDone } from './CertificationJuryDone.js';
-import CertificationRescoredByScript from './CertificationRescoredByScript.js';
 import { CertificationRescoringCompleted } from './CertificationRescoringCompleted.js';
 import { checkEventTypes } from './check-event-types.js';
 

--- a/api/src/certification/session-management/application/jobs/certification-rescoring-by-script-job-controller.js
+++ b/api/src/certification/session-management/application/jobs/certification-rescoring-by-script-job-controller.js
@@ -1,6 +1,6 @@
-import CertificationRescoredByScript from '../../../../../lib/domain/events/CertificationRescoredByScript.js';
 import { eventDispatcher } from '../../../../../lib/domain/events/index.js';
 import { JobController } from '../../../../shared/application/jobs/job-controller.js';
+import CertificationRescoredByScript from '../../domain/events/CertificationRescoredByScript.js';
 import { CertificationRescoringByScriptJob } from '../../domain/models/CertificationRescoringByScriptJob.js';
 
 class CertificationRescoringByScriptJobController extends JobController {

--- a/api/src/certification/session-management/domain/events/CertificationRescoredByScript.js
+++ b/api/src/certification/session-management/domain/events/CertificationRescoredByScript.js
@@ -1,4 +1,4 @@
-import { assertNotNullOrUndefined } from '../../../src/shared/domain/models/asserts.js';
+import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 
 export default class CertificationRescoredByScript {
   /**


### PR DESCRIPTION
## :pancakes: Problème

l'événement `Certification rescored by script` est encore dans `lib/`

## :bacon: Proposition

Déplacer `Certification rescored by script event` vers `src/`

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
