### PR TITLE
[TECH] :truck: Déplace le repository `audit logger` vers `src/`

### DIFF
--- a/api/src/identity-access-management/application/jobs/event-logging.job-controller.js
+++ b/api/src/identity-access-management/application/jobs/event-logging.job-controller.js
@@ -1,6 +1,6 @@
-import { auditLoggerRepository } from '../../../../lib/infrastructure/repositories/audit-logger-repository.js';
 import { JobController } from '../../../shared/application/jobs/job-controller.js';
 import { EventLoggingJob } from '../../domain/models/jobs/EventLoggingJob.js';
+import { auditLoggerRepository } from '../../infrastructure/repositories/audit-logger-repository.js';
 
 export class EventLoggingJobController extends JobController {
   constructor() {

--- a/api/src/identity-access-management/application/jobs/gar-anonymized-batch-events-logging.job-controller.js
+++ b/api/src/identity-access-management/application/jobs/gar-anonymized-batch-events-logging.job-controller.js
@@ -1,6 +1,6 @@
-import { auditLoggerRepository } from '../../../../lib/infrastructure/repositories/audit-logger-repository.js';
 import { JobController } from '../../../shared/application/jobs/job-controller.js';
 import { GarAnonymizedBatchEventsLoggingJob } from '../../domain/models/GarAnonymizedBatchEventsLoggingJob.js';
+import { auditLoggerRepository } from '../../infrastructure/repositories/audit-logger-repository.js';
 
 const AUDIT_LOGGER_ANONYMIZATION_GAR_ACTION = 'ANONYMIZATION_GAR';
 

--- a/api/src/identity-access-management/infrastructure/repositories/audit-logger-repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/audit-logger-repository.js
@@ -1,6 +1,6 @@
-import { config } from '../../../src/shared/config.js';
-import { AuditLoggerApiError } from '../../../src/shared/domain/errors.js';
-import { httpAgent } from '../http/http-agent.js';
+import { httpAgent } from '../../../../lib/infrastructure/http/http-agent.js';
+import { config } from '../../../shared/config.js';
+import { AuditLoggerApiError } from '../../../shared/domain/errors.js';
 
 const { auditLogger } = config;
 const basicAuthorizationToken = btoa(`pix-api:${auditLogger.clientSecret}`);

--- a/api/src/shared/application/jobs/audit-log/user-anonymized-event-logging-job-controller.js
+++ b/api/src/shared/application/jobs/audit-log/user-anonymized-event-logging-job-controller.js
@@ -1,5 +1,5 @@
-import { auditLoggerRepository } from '../../../../../lib/infrastructure/repositories/audit-logger-repository.js';
 import { UserAnonymizedEventLoggingJob } from '../../../../identity-access-management/domain/models/UserAnonymizedEventLoggingJob.js';
+import { auditLoggerRepository } from '../../../../identity-access-management/infrastructure/repositories/audit-logger-repository.js';
 import { JobController } from '../job-controller.js';
 
 export class UserAnonymizedEventLoggingJobController extends JobController {

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/audit-logger-repository_test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/audit-logger-repository_test.js
@@ -1,8 +1,8 @@
-import { httpAgent } from '../../../../lib/infrastructure/http/http-agent.js';
-import { auditLoggerRepository } from '../../../../lib/infrastructure/repositories/audit-logger-repository.js';
-import { config } from '../../../../src/shared/config.js';
-import { AuditLoggerApiError } from '../../../../src/shared/domain/errors.js';
-import { catchErr, expect, sinon } from '../../../test-helper.js';
+import { httpAgent } from '../../../../../lib/infrastructure/http/http-agent.js';
+import { auditLoggerRepository } from '../../../../../src/identity-access-management/infrastructure/repositories/audit-logger-repository.js';
+import { config } from '../../../../../src/shared/config.js';
+import { AuditLoggerApiError } from '../../../../../src/shared/domain/errors.js';
+import { catchErr, expect, sinon } from '../../../../test-helper.js';
 
 const { auditLogger } = config;
 

--- a/api/tests/shared/unit/application/jobs/audit-log/UserAnonymizedEventLoggingJobController_test.js
+++ b/api/tests/shared/unit/application/jobs/audit-log/UserAnonymizedEventLoggingJobController_test.js
@@ -1,5 +1,5 @@
-import { auditLoggerRepository } from '../../../../../../lib/infrastructure/repositories/audit-logger-repository.js';
 import { UserAnonymizedEventLoggingJob } from '../../../../../../src/identity-access-management/domain/models/UserAnonymizedEventLoggingJob.js';
+import { auditLoggerRepository } from '../../../../../../src/identity-access-management/infrastructure/repositories/audit-logger-repository.js';
 import { UserAnonymizedEventLoggingJobController } from '../../../../../../src/shared/application/jobs/audit-log/user-anonymized-event-logging-job-controller.js';
 import { expect, sinon } from '../../../../../test-helper.js';
 


### PR DESCRIPTION
## :pancakes: Problème

Le repository `audit logger` est encore dans `lib/`

## :bacon: Proposition

Déplacer le repository `audit logger` vers `src/`

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
