### PR TITLE
[FEATURE] Ne déployer aucun frontend par défaut en RA

### DIFF
--- a/scalingo.json
+++ b/scalingo.json
@@ -16,6 +16,12 @@
     "DOMAIN_PIX_CERTIF": {
       "generator": "template",
       "template": "https://certif-pr%PR_NUMBER%.review.pix"
+    },
+    "CI_FRONT_TASKS": {
+      "value": "ci:none"
+    },
+    "BUILD_FRONT_TASKS": {
+      "value": "build:none"
     }
   },
   "scripts": {


### PR DESCRIPTION
## :pancakes: Problème

Le choix des frontends à déployer étant maintenant possible, on souhaite changer le comportement par défaut pour ne déployer aucun frontend au lieu de tous les frontends.

## :bacon: Proposition

Créer les RAs avec les valeurs par défaut suivantes pour les variables d'environnement :
 - `CI_FRONT_TASKS=ci:none`
 - `BUILD_FRONT_TASKS=build:none`

## 🧃 Remarques

En attente des modifications sur pix-bot.

## :yum: Pour tester

Vérifier qu'aucun frontend n'est déployé.