### PR TITLE
[BUGFIX] Autoriser les certifs terminées par finalisation à être rescorées (PIX-16107).

### DIFF
--- a/api/src/certification/session-management/domain/usecases/process-auto-jury.js
+++ b/api/src/certification/session-management/domain/usecases/process-auto-jury.js
@@ -128,10 +128,7 @@ async function _handleAutoJuryV3({ sessionFinalized, certificationCourses, certi
 }
 
 function _v3CertificationShouldBeScored(certificationAssessment) {
-  return (
-    certificationAssessment.state === CertificationAssessment.states.STARTED ||
-    certificationAssessment.state === CertificationAssessment.states.ENDED_BY_SUPERVISOR
-  );
+  return certificationAssessment.state !== CertificationAssessment.states.COMPLETED;
 }
 
 async function _autoCompleteUnfinishedTest({

--- a/api/tests/certification/session-management/unit/domain/usecases/process-auto-jury_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/process-auto-jury_test.js
@@ -8,7 +8,7 @@ import {
   CertificationIssueReportCategory,
   CertificationIssueReportSubcategories,
 } from '../../../../../../src/certification/shared/domain/models/CertificationIssueReportCategory.js';
-import { AnswerStatus } from '../../../../../../src/shared/domain/models/AnswerStatus.js';
+import { AnswerStatus } from '../../../../../../src/shared/domain/models/index.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | process-auto-jury', function () {
@@ -977,14 +977,15 @@ describe('Unit | UseCase | process-auto-jury', function () {
     });
 
     describe('when the certification was ended due to finalization', function () {
-      it('does not return a CertificationJuryDone event', async function () {
+      it('returns a CertificationJuryDone event', async function () {
         // given
-        _initializeV3CourseAndAssessment({
+        const { certificationCourse } = _initializeV3CourseAndAssessment({
           certificationState: CertificationAssessment.states.ENDED_DUE_TO_FINALIZATION,
           certificationAssessmentRepository,
           certificationCourseRepository,
           certificationIssueReportRepository,
         });
+
         const sessionFinalized = new SessionFinalized({
           sessionId: 1234,
           finalizedAt: new Date(),
@@ -995,7 +996,7 @@ describe('Unit | UseCase | process-auto-jury', function () {
         });
 
         // when
-        const { autoJuryDone } = await processAutoJury({
+        const { certificationJuryDoneEvents } = await processAutoJury({
           sessionFinalized,
           certificationIssueReportRepository,
           certificationAssessmentRepository,
@@ -1003,7 +1004,11 @@ describe('Unit | UseCase | process-auto-jury', function () {
         });
 
         // then
-        expect(autoJuryDone).to.be.instanceOf(AutoJuryDone);
+        expect(certificationJuryDoneEvents[0]).to.deepEqualInstance(
+          new CertificationJuryDone({
+            certificationCourseId: certificationCourse.getId(),
+          }),
+        );
       });
     });
 


### PR DESCRIPTION
## :pancakes: Problème

Les certifications terminées lors lors de la finalisation ne sont pas autorisées à être rescorées, nous empêchant de corriger un problème rencontré en production.

## :bacon: Proposition

Autoriser ce statut de certif à être rescoré

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

- Créer une session de certification V3
- Ajouter un candidat
- Rentrer en certification
- Répondre à au moins 20 questions
- Finaliser la session
- Définaliser la session
- Refinaliser la session
- Vérifier en BDD que l'on a 2 assessment-results pour le candidat