### PR TITLE
[FEATURE] Ajout d'un script pour supprimer des orga, dpo et tags associés (PIX-16091)

### DIFF
--- a/api/db/seeds/data/team-acces/build-organizations.js
+++ b/api/db/seeds/data/team-acces/build-organizations.js
@@ -1,0 +1,24 @@
+export function buildOrganizations(databaseBuilder) {
+  _buildOrganizationWithoutAdmins(databaseBuilder);
+}
+
+function _buildOrganizationWithoutAdmins(databaseBuilder) {
+  const organization = databaseBuilder.factory.buildOrganization({
+    type: 'PRO',
+    name: 'Accis',
+  });
+
+  const tag1 = databaseBuilder.factory.buildTag({ name: 'tag1' });
+  const tag2 = databaseBuilder.factory.buildTag({ name: 'tag2' });
+  databaseBuilder.factory.buildDataProtectionOfficer.withOrganizationId({
+    firstName: 'justin',
+    lastName: 'instant',
+    email: 'justin-instant@example.net',
+    organizationId: organization.id,
+  });
+  databaseBuilder.factory.buildOrganizationTag({
+    organizationId: organization.id,
+    tagId: tag1.id,
+  });
+  databaseBuilder.factory.buildOrganizationTag({ organizationId: organization.id, tagId: tag2.id });
+}

--- a/api/db/seeds/data/team-acces/data-builder.js
+++ b/api/db/seeds/data/team-acces/data-builder.js
@@ -3,6 +3,7 @@ import { buildBlockedUsers } from './build-blocked-users.js';
 import { buildCertificationCenters } from './build-certification-centers.js';
 import { buildOidcProviders } from './build-oidc-providers.js';
 import { buildOrganizationUsers } from './build-organization-users.js';
+import { buildOrganizations } from './build-organizations.js';
 import { buildPixAdminRoles } from './build-pix-admin-roles.js';
 import { buildResetPasswordUsers } from './build-reset-password-users.js';
 import { buildScoOrganizationLearners } from './build-sco-organization-learners.js';
@@ -20,6 +21,7 @@ async function teamAccesDataBuilder(databaseBuilder) {
   buildScoOrganizationLearners(databaseBuilder);
   await buildCertificationCenters(databaseBuilder);
   await buildOidcProviders(databaseBuilder);
+  await buildOrganizations(databaseBuilder);
 }
 
 export { teamAccesDataBuilder };

--- a/api/src/organizational-entities/infrastructure/repositories/data-protection-officer.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/data-protection-officer.repository.js
@@ -35,6 +35,11 @@ async function create(dataProtectionOfficer) {
   return new DataProtectionOfficer(dataProtectionOfficerRow);
 }
 
+async function deleteDpoByOrganizationId(organizationId) {
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn(DATA_PROTECTION_OFFICERS_TABLE_NAME).where({ organizationId }).delete();
+}
+
 async function update(dataProtectionOfficer) {
   const knexConn = DomainTransaction.getConnection();
   const { firstName, lastName, email, organizationId, certificationCenterId } = dataProtectionOfficer;
@@ -54,4 +59,4 @@ async function update(dataProtectionOfficer) {
   return new DataProtectionOfficer(dataProtectionOfficerRow);
 }
 
-export { batchAddDataProtectionOfficerToOrganization, create, get, update };
+export { batchAddDataProtectionOfficerToOrganization, create, deleteDpoByOrganizationId, get, update };

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -217,14 +217,14 @@ const update = async function (organization) {
 };
 
 /**
- * @typedef {Object} OrganizationForAdminRepository
- * @property {archive} archive
- * @property {exist} exist
- * @property {findChildrenByParentOrganizationId} findChildrenByParentOrganizationId
- * @property {get} get
- * @property {save} save
- * @property {update} update
+ * @type {function}
+ * @param organizationId
+ * @return {Promise<void>}
  */
+const deleteById = async function (organizationId) {
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn(ORGANIZATIONS_TABLE_NAME).where({ id: organizationId }).delete();
+};
 
 async function _addOrUpdateDataProtectionOfficer(knexConn, dataProtectionOfficer) {
   await knexConn(DATA_PROTECTION_OFFICERS_TABLE_NAME)
@@ -320,4 +320,12 @@ function _toDomain(rawOrganization) {
   return organization;
 }
 
-export const organizationForAdminRepository = { archive, exist, findChildrenByParentOrganizationId, get, save, update };
+export const organizationForAdminRepository = {
+  archive,
+  exist,
+  findChildrenByParentOrganizationId,
+  get,
+  save,
+  update,
+  deleteById,
+};

--- a/api/src/organizational-entities/infrastructure/repositories/organization-tag.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-tag.repository.js
@@ -52,4 +52,9 @@ const getRecentlyUsedTags = async function ({ tagId, numberOfRecentTags }) {
   return tags.map(({ tagId: id, name }) => new Tag({ id, name }));
 };
 
-export { batchCreate, create, getRecentlyUsedTags, isExistingByOrganizationIdAndTagId };
+const deleteTagsByOrganizationId = async function (organizationId) {
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn('organization-tags').where({ organizationId }).delete();
+};
+
+export { batchCreate, create, deleteTagsByOrganizationId, getRecentlyUsedTags, isExistingByOrganizationIdAndTagId };

--- a/api/src/organizational-entities/scripts/delete-organizations-script.js
+++ b/api/src/organizational-entities/scripts/delete-organizations-script.js
@@ -1,0 +1,64 @@
+import Joi from 'joi';
+
+import { csvFileParser } from '../../shared/application/scripts/parsers.js';
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+import * as dataProtectionOfficerRepository from '../infrastructure/repositories/data-protection-officer.repository.js';
+import { organizationForAdminRepository } from '../infrastructure/repositories/organization-for-admin.repository.js';
+import * as organizationTagRepository from '../infrastructure/repositories/organization-tag.repository.js';
+
+const columnsSchema = [{ name: 'Organization ID', schema: Joi.number().required() }];
+
+export class DeleteOrganizationsScript extends Script {
+  constructor() {
+    super({
+      description: 'Delete all organizations and associated tags',
+      permanent: false,
+      options: {
+        file: {
+          type: 'string',
+          describe: 'File path to CSV file with organizations to delete',
+          demandOption: true,
+          requiresArg: true,
+          coerce: csvFileParser(columnsSchema),
+        },
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run the script without actually deleting anything',
+          default: false,
+        },
+      },
+    });
+  }
+
+  async handle({
+    options,
+    logger,
+    dependencies = { organizationForAdminRepository, organizationTagRepository, dataProtectionOfficerRepository },
+  }) {
+    const { file, dryRun } = options;
+
+    let count = 0;
+    for (const row of file) {
+      const organizationId = row['Organization ID'];
+      if (!dryRun) {
+        logger.info(organizationId);
+        // Delete data protection officer via data-protection-officer.repository
+        await dependencies.dataProtectionOfficerRepository.deleteDpoByOrganizationId(organizationId);
+        // delete organization tags via organization-tags.repository
+        await dependencies.organizationTagRepository.deleteTagsByOrganizationId(organizationId);
+        // delete organizationvia organization-for-admin.repository
+        await dependencies.organizationForAdminRepository.deleteById(organizationId);
+      }
+      count++;
+    }
+
+    if (dryRun) {
+      logger.info(`Would delete ${count} organizations.`);
+    } else {
+      logger.info(`Deleted ${count} organizations.`);
+    }
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, DeleteOrganizationsScript);

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/data-protection-officer.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/data-protection-officer.repository.test.js
@@ -80,6 +80,37 @@ describe('Integration | Organizational Entities | Repository | data-protection-o
     });
   });
 
+  describe('#deleteByOrganizationId', function () {
+    it('deletes DPO from data protection officers table by organisation id ', async function () {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      const organization2 = databaseBuilder.factory.buildOrganization();
+      databaseBuilder.factory.buildDataProtectionOfficer.withOrganizationId({
+        firstName: 'Justin',
+        lastName: 'Ninstan',
+        email: 'justin-ninstan@example.net',
+        organizationId: organization.id,
+      });
+      databaseBuilder.factory.buildDataProtectionOfficer.withOrganizationId({
+        firstName: 'Justin',
+        lastName: 'Ninstan',
+        email: 'justin-ninstan@example.net',
+        organizationId: organization2.id,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+
+      await dataProtectionOfficerRepository.deleteDpoByOrganizationId(organization2.id);
+
+      // then
+      const dataProtectionOfficers = await knex('data-protection-officers').select();
+      expect(dataProtectionOfficers).to.have.lengthOf(1);
+      expect(dataProtectionOfficers[0]).to.have.property('organizationId', organization.id);
+    });
+  });
+
   describe('#get', function () {
     context('when DPO exists', function () {
       it('returns a DPO domain object', async function () {

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -869,4 +869,22 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       expect(nbOrganizationsAfterUpdate).to.equal(nbOrganizationsBeforeUpdate);
     });
   });
+
+  describe('#deleteById', function () {
+    it('deletes organization by id', async function () {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      const organization2 = databaseBuilder.factory.buildOrganization();
+      await databaseBuilder.commit();
+
+      // when
+      await organizationForAdminRepository.deleteById(organization.id);
+
+      // then
+      const organizationDeleted = await knex('organizations').where({ id: organization.id });
+      expect(organizationDeleted).to.have.lengthOf(0);
+      const organizationNotDeleted = await knex('organizations').where({ id: organization2.id });
+      expect(organizationNotDeleted).to.have.lengthOf(1);
+    });
+  });
 });

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-tag.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-tag.repository.test.js
@@ -96,4 +96,34 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       expect(foundOrganizations).to.have.lengthOf(2);
     });
   });
+
+  describe('#deleteTag', function () {
+    it('delete organizationTags', async function () {
+      // given
+      const organization1 = databaseBuilder.factory.buildOrganization();
+      const organization2 = databaseBuilder.factory.buildOrganization();
+      const tag1 = databaseBuilder.factory.buildTag({ name: 'tag1' });
+      const tag2 = databaseBuilder.factory.buildTag({ name: 'tag2' });
+      databaseBuilder.factory.buildOrganizationTag({
+        organizationId: organization1.id,
+        tagId: tag1.id,
+      });
+      databaseBuilder.factory.buildOrganizationTag({
+        organizationId: organization2.id,
+        tagId: tag2.id,
+      });
+      databaseBuilder.factory.buildOrganizationTag({
+        organizationId: organization1.id,
+        tagId: tag2.id,
+      });
+      await databaseBuilder.commit();
+      // when
+      await organizationTagRepository.deleteTagsByOrganizationId(organization1.id);
+      // then
+      const organizationTags = await knex('organization-tags').select();
+      expect(organizationTags).to.have.lengthOf(1);
+      expect(organizationTags[0]).to.have.property('tagId', tag2.id);
+      expect(organizationTags[0]).to.have.property('organizationId', organization2.id);
+    });
+  });
 });

--- a/api/tests/organizational-entities/unit/scripts/delete-organizations-script.test.js
+++ b/api/tests/organizational-entities/unit/scripts/delete-organizations-script.test.js
@@ -1,0 +1,40 @@
+import { DeleteOrganizationsScript } from '../../../../src/organizational-entities/scripts/./delete-organizations-script.js';
+import { expect, sinon } from '../../../test-helper.js';
+
+describe('DeleteOrganizationsScript', function () {
+  describe('Handle', function () {
+    let script;
+    let logger;
+    let organizationForAdminRepository;
+    let organizationTagRepository;
+    let dataProtectionOfficerRepository;
+
+    beforeEach(function () {
+      script = new DeleteOrganizationsScript();
+      logger = { info: sinon.spy() };
+      organizationForAdminRepository = { deleteById: sinon.stub() };
+      organizationTagRepository = { deleteTagsByOrganizationId: sinon.stub() };
+      dataProtectionOfficerRepository = { deleteDpoByOrganizationId: sinon.stub() };
+    });
+
+    it('handles data correctly', async function () {
+      const file = [{ 'Organization ID': 1 }, { 'Organization ID': 2 }];
+
+      await script.handle({
+        options: { file },
+        logger,
+        dependencies: {
+          organizationForAdminRepository,
+          organizationTagRepository,
+          dataProtectionOfficerRepository,
+        },
+      });
+      expect(organizationForAdminRepository.deleteById.calledWith(1)).to.be.true;
+      expect(organizationForAdminRepository.deleteById.calledWith(2)).to.be.true;
+      expect(organizationTagRepository.deleteTagsByOrganizationId.calledWith(1)).to.be.true;
+      expect(organizationTagRepository.deleteTagsByOrganizationId.calledWith(2)).to.be.true;
+      expect(dataProtectionOfficerRepository.deleteDpoByOrganizationId.calledWith(1)).to.be.true;
+      expect(dataProtectionOfficerRepository.deleteDpoByOrganizationId.calledWith(2)).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
## :pancakes: Problème

Suite à une mauvaise manipulation sur Pix admin, des organisations ont été ajoutées en double et il faudrait les retirer.

## :bacon: Proposition

Concevoir un script qui va parcourir le csv contenant tous les identifiants des organisations à supprimer et va successivement:
- Supprimer l'organisation de la table data-protection-officers,
- Supprimer l'association de l'organisation et de tous ces tags dans la table organization-tags,
- Supprimer l'organisation de la table organizations.

## 🧃 Remarques

Ce script n'a pas vocation à rester, mais il a permis d'ajouter les méthodes suivantes:
- Supprimer une dpo,
- Retirer tous les tags associés à une organisation sans supprimer les tags,
- Supprimer une organisation.

## :yum: Pour tester
Le teste peut être fait en RA, mais il est plus simple et confortable de le faire en local. La procédure ne diffère cependant pas beaucoup.

#### En local:
- Faire un reset de la db pour avoir le nouveau seed:
```shell
cd api
npm run db:reset
```
- Lancer l'api et pix-admin,
- Se connecter sur pix-admin avec le compte superadmin@example.net,
- Sur la page des organisations, constater que l'organisation "Accis est présente,
- Noter son identifiant,
- Créer un fichier .csv avec le contenu suivant:
```
"Organization ID";
<identifiant de l'organisation>;
```
- Sauvegarder le fichier,
- Dans le dossier api, exécuter ce script:
```shell
node api/src/organizational-entities/scripts/delete-organizations-script.js --dryRun --file <chemin/vers/votre/fichier.csv>
```
L'option dryRun est une sécurité, elle n'efface pas les éléments. Un message de ce type sera affiché:
"Would delete {nombre} organizations.".
- Répéter la même commande en supprimant l'option --dryRun, soit:
```shell
node api/src/organizational-entities/scripts/delete-organizations-script.js --file <chemin/vers/votre/fichier.csv>
```
Cette fois, le message "Deleted {nombre} organizations." sera afiché.
- Retourner sur Pix admin et constater dans la liste des organisations que "Accis" a disparru.

#### En RA
- Se connecter sur pix-admin avec le compte superadmin@example.net,
- Sur la page des organisations, constater que l'organisation "Accis est présente,
- Noter son identifiant,
- Créer un fichier .csv avec le contenu suivant:
```
"Organization ID";
<identifiant de l'organisation>;
```
- Sauvegarder le fichier,
- En ligne de commande, avec scalingo connecté, exécuter la commande suivante:
```shell
scalingo -a pix-api-review-pr11124 run --file <chemin/vers/votre/fichier.csv> /src/organizational-entities/scripts/delete-organizations-script.js --dryRun --file /tmp/uploads/<fichier.csv>
```
L'option dryRun est une sécurité, elle n'efface pas les éléments. Un message de ce type sera affiché "Would delete {nombre} organizations.".
- Répéter la même commande en supprimant l'option --dryRun, soit:
```shell
scalingo -a pix-api-review-pr11124 run --file <chemin/vers/votre/fichier.csv> /src/organizational-entities/scripts/delete-organizations-script.js --file /tmp/uploads/<fichier.csv>
```
Cette fois, le message "Deleted {nombre} organizations." sera afiché.
- Retourner sur Pix admin et constater dans la liste des organisations que "Accis" a disparru,
- Afin de permettre aux personnes suivante de tester, relancez les seeds avec cette commande:
```shell
scalingo -a pix-api-review-pr11124 run npm run db:seed
```