### PR TITLE
[FEATURE] Ajouter plusieurs paliers d'un seul coup (PIX-15833).

### DIFF
--- a/api/src/evaluation/scripts/add-multiple-level-stages.js
+++ b/api/src/evaluation/scripts/add-multiple-level-stages.js
@@ -1,0 +1,58 @@
+import Joi from 'joi';
+import _ from 'lodash';
+const { groupBy } = _;
+
+import { csvFileParser } from '../../shared/application/scripts/parsers.js';
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../shared/domain/DomainTransaction.js';
+import { evaluationUsecases } from '../domain/usecases/index.js';
+const columnsSchemas = [
+  { name: 'targetProfileId', schema: Joi.number().integer().positive().required() },
+  { name: 'level', schema: Joi.number().integer().min(0).required() },
+  { name: 'title', schema: Joi.string().max(255).required() },
+  { name: 'message', schema: Joi.string().required() },
+];
+
+class AddMultipleLevelStagesScript extends Script {
+  constructor() {
+    super({
+      description: 'Script to add multiple level stages',
+      permanent: false,
+      options: {
+        file: {
+          type: 'string',
+          describe: 'CSV File containing multiple stages to add',
+          demandOption: true,
+          coerce: csvFileParser(columnsSchemas),
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    logger.info(`add-multiple-level-stages script has started`);
+
+    const { file } = options;
+
+    await DomainTransaction.execute(async () => {
+      const stagesGroupedByTargetProfileId = groupBy(file, 'targetProfileId');
+      for (const [targetProfileId, stageCollection] of Object.entries(stagesGroupedByTargetProfileId)) {
+        logger.info(`${stageCollection.length} stages to create for target profile ${targetProfileId}`);
+        const enrichedStageCollection = stageCollection.map((stage) => ({
+          ...stage,
+          prescriberTitle: stage.title,
+          prescriberDescription: stage.message,
+        }));
+        await evaluationUsecases.createOrUpdateStageCollection({
+          targetProfileId: parseInt(targetProfileId),
+          stagesFromPayload: enrichedStageCollection,
+        });
+      }
+    });
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, AddMultipleLevelStagesScript);
+
+export { AddMultipleLevelStagesScript };

--- a/api/tests/evaluation/integration/scripts/add-multiple-level-stages.test.js
+++ b/api/tests/evaluation/integration/scripts/add-multiple-level-stages.test.js
@@ -1,0 +1,133 @@
+import * as url from 'node:url';
+
+import { AddMultipleLevelStagesScript } from '../../../../src/evaluation/scripts/add-multiple-level-stages.js';
+import {
+  databaseBuilder,
+  expect,
+  knex,
+  learningContentBuilder,
+  mockLearningContent,
+  sinon,
+} from '../../../test-helper.js';
+
+const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
+
+describe('Integration | Evaluation | Scripts | add-multiple-level-stages-script', function () {
+  describe('Options', function () {
+    it('has the correct options', function () {
+      const script = new AddMultipleLevelStagesScript();
+
+      const { options } = script.metaInfo;
+      expect(options.file).to.deep.include({
+        type: 'string',
+        describe: 'CSV File containing multiple stages to add',
+        demandOption: true,
+      });
+    });
+
+    it('parses CSV data correctly', async function () {
+      const testCsvFile = `${currentDirectory}files/stages-test.csv`;
+
+      const script = new AddMultipleLevelStagesScript();
+
+      const { options } = script.metaInfo;
+      const parsedData = await options.file.coerce(testCsvFile);
+      expect(parsedData).to.be.an('array').that.deep.includes({
+        targetProfileId: 1,
+        level: 0,
+        title: 'Parcours presque terminé !',
+        message: 'presque Bravo',
+      });
+      expect(parsedData).to.be.an('array').that.deep.includes({
+        targetProfileId: 1,
+        level: 1,
+        title: 'Parcours terminé !',
+        message: 'Bravo',
+      });
+    });
+  });
+
+  describe('#handle', function () {
+    const now = new Date();
+    let clock;
+
+    beforeEach(async function () {
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    });
+
+    afterEach(async function () {
+      clock.restore();
+    });
+
+    it('should insert stages', async function () {
+      // given
+      const learningContent = [
+        {
+          id: 'recArea0',
+          code: 'area0',
+          competences: [
+            {
+              id: 'recCompetence0',
+              index: '1.1',
+              tubes: [
+                {
+                  id: 'recTube0_0',
+                  skills: [
+                    {
+                      id: 'recSkill1_0',
+                      nom: '@recSkill1_0',
+                      challenges: [{ id: 'recChallenge1_0_0' }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+      const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
+      await mockLearningContent(learningContentObjects);
+
+      const targetProfile = databaseBuilder.factory.buildTargetProfile();
+      databaseBuilder.factory.buildTargetProfileTube({ tubeId: 'recTube0_0', targetProfileId: targetProfile.id });
+
+      await databaseBuilder.commit();
+
+      const stagesToCreate = [
+        {
+          targetProfileId: targetProfile.id,
+          level: 0,
+          title: 'Parcours presque terminé !',
+          message: 'presque Bravo',
+        },
+        {
+          targetProfileId: targetProfile.id,
+          level: 1,
+          title: 'Parcours terminé !',
+          message: 'Bravo',
+        },
+      ];
+
+      const loggerStub = { info: sinon.stub() };
+
+      // when
+      const script = new AddMultipleLevelStagesScript();
+      await script.handle({ options: { file: stagesToCreate }, logger: loggerStub });
+
+      // then
+      const stages = await knex('stages').select('*').where('targetProfileId', targetProfile.id);
+      expect(stages).to.have.length(2);
+      expect(stages[0].title).to.equal('Parcours presque terminé !');
+      expect(stages[0].message).to.equal('presque Bravo');
+      expect(stages[0].level).to.equal(0);
+      expect(stages[0].prescriberTitle).to.equal('Parcours presque terminé !');
+      expect(stages[0].prescriberDescription).to.equal('presque Bravo');
+
+      expect(stages[1].title).to.equal('Parcours terminé !');
+      expect(stages[1].message).to.equal('Bravo');
+      expect(stages[1].level).to.equal(1);
+      expect(stages[1].prescriberTitle).to.equal('Parcours terminé !');
+      expect(stages[1].prescriberDescription).to.equal('Bravo');
+    });
+  });
+});

--- a/api/tests/evaluation/integration/scripts/files/stages-test.csv
+++ b/api/tests/evaluation/integration/scripts/files/stages-test.csv
@@ -1,0 +1,3 @@
+targetProfileId,level,title,message
+1,0,Parcours presque terminé !,presque Bravo
+1,1,Parcours terminé !,Bravo


### PR DESCRIPTION
## :pancakes: Problème
Actuellement le métier souhaite ajouter pas mal de paliers d'un seul coup pour différents profils cibles. C'est fastidieux

## :bacon: Proposition
Créer un script qui permette de prendre en entrée un fichier csv et créer les nouveaux paliers d'un seul coup.

## 🧃 Remarques
Ce script pourra être supprimé une fois utilisé car cela reste un besoin ponctuel

## :yum: Pour tester
- créer un fichier csv en local contenant les informations suivantes : 
```
targetProfileId,level,title,message
56,0,Parcours presque terminé !,presque Bravo
56,1,Parcours terminé !,Bravo
```
- Le passer paramètre d'entrée au script créé :  
` node src/evaluation/scripts/add-multiple-level-stages.js --file <path-du-fichier-csv>
`
- Faire une requête en local sur la table `stages` et vérifier que les paliers ont bien été créés.

>Pour upload le CSV sur une RA : scalingo --app pix-api-review-pr11125 run --file ./test-stages-script-1.csv bash 
