### PR TITLE
[FEATURE] Prendre en compte la valeur par défaut des proposals "input" dans les QROCm Modulix (PIX-16034)

### DIFF
--- a/mon-pix/app/components/module/element/qrocm.gjs
+++ b/mon-pix/app/components/module/element/qrocm.gjs
@@ -13,7 +13,17 @@ import ModulixFeedback from 'mon-pix/components/module/feedback';
 import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
 
 export default class ModuleQrocm extends ModuleElement {
-  @tracked selectedValues;
+  @tracked selectedValues = {};
+
+  constructor() {
+    super(...arguments);
+
+    this.element.proposals.forEach((proposal) => {
+      if (proposal.defaultValue) {
+        this.selectedValues[proposal.input] = proposal.defaultValue;
+      }
+    });
+  }
 
   get canValidateElement() {
     return this.element.proposals

--- a/mon-pix/tests/integration/components/module/qrocm_test.gjs
+++ b/mon-pix/tests/integration/components/module/qrocm_test.gjs
@@ -71,6 +71,53 @@ module('Integration | Component | Module | QROCM', function (hooks) {
     assert.dom('.element-qrocm-proposals__input--block').exists({ count: 2 });
   });
 
+  test('should display a block QROCM with a default value', async function (assert) {
+    // given
+    const qrocm = {
+      id: '994b6a96-a3c2-47ae-a461-87548ac6e02b',
+      instruction: 'Mon instruction',
+      proposals: [
+        { content: '<span>Ma première proposition</span>', type: 'text' },
+        {
+          input: 'symbole',
+          inputType: 'text',
+          display: 'inline',
+          size: 1,
+          placeholder: '',
+          ariaLabel: 'input-aria',
+          defaultValue: 'tadaaa',
+          type: 'input',
+        },
+        {
+          input: 'deuxieme-partie',
+          type: 'select',
+          display: 'block',
+          placeholder: '',
+          ariaLabel: 'select-aria',
+          defaultValue: '1',
+          options: [
+            {
+              id: '1',
+              content: 'totoro',
+            },
+            {
+              id: '2',
+              content: 'taratata',
+            },
+          ],
+        },
+      ],
+      type: 'qrocm',
+    };
+    const screen = await render(<template><ModuleQrocm @element={{qrocm}} /></template>);
+
+    // then
+    const inputContent = screen.getByRole('textbox');
+    const buttonContent = find('.pix-select-button__text');
+    assert.dom(inputContent).hasValue('tadaaa');
+    assert.dom(buttonContent).hasText('totoro');
+  });
+
   test('should display an inline QROCM', async function (assert) {
     // given
     const qrocm = {

--- a/mon-pix/tests/unit/components/module/qrocm_test.js
+++ b/mon-pix/tests/unit/components/module/qrocm_test.js
@@ -12,13 +12,13 @@ module('Unit | Component | Module | QROCM', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const correctionResponse = store.createRecord('correction-response', { status: 'ko' });
-        const qrocmElement = { id: '994b6a96-a3c2-47ae-a461-87548ac6e02b' };
+        const qrocmElement = { id: '994b6a96-a3c2-47ae-a461-87548ac6e02b', proposals: [] };
         store.createRecord('element-answer', {
           correction: correctionResponse,
           element: qrocmElement,
         });
         const component = createGlimmerComponent('module/element/qrocm', {
-          qrocm: qrocmElement,
+          element: qrocmElement,
           correction: correctionResponse,
         });
 
@@ -35,13 +35,13 @@ module('Unit | Component | Module | QROCM', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const correctionResponse = store.createRecord('correction-response', { status: 'ok' });
-        const qrocmElement = { id: 'qrocm-id' };
+        const qrocmElement = { id: 'qrocm-id', proposals: [] };
         store.createRecord('element-answer', {
           correction: correctionResponse,
           elementId: qrocmElement.id,
         });
         const component = createGlimmerComponent('module/element/qrocm', {
-          qrocm: qrocmElement,
+          element: qrocmElement,
           correction: correctionResponse,
         });
 


### PR DESCRIPTION
## :pancakes: Problème

La valeur par défaut saisie pour les QROCM dans Modulix Editor n'était pas prise en compte dans l'affichage des QROCM dans Pix App.

## :bacon: Proposition

Initialiser la selectedValue du QROCM avec la valeur par défaut lors de l'initialisation du composant.

## 🧃 Remarques

- Avant de merger, remettre bien-ecrire-son-adresse-mail sans default-value (effacer le premier commit)
- Test unitaire de QROCM qui ne passe plus avec l'ajout d'un constructor, mais mauvais pratique d'avoir des tests unitaires pour des composants Ember => est-ce qu'on supprime les tests unitaires de QROCM ?

## :yum: Pour tester

- Ouvrir le module bien-ecrire-son-adresse-mail
- Vérifier que dans le troisième grain : 
  - la valeur du premier input est bien `Test`
  - la valeur du premier select est bien `l'identifiant `
