### PR TITLE
[BUGFIX] Orga - avoir une option par défaut pour l'external Id dans la création de campagne (PIX-16081)

### DIFF
--- a/orga/app/components/campaign/create-form.gjs
+++ b/orga/app/components/campaign/create-form.gjs
@@ -80,10 +80,6 @@ export default class CreateForm extends Component {
     return this.args.campaign.type === 'PROFILES_COLLECTION';
   }
 
-  get isExternalIdNotSelectedChecked() {
-    return this.args.campaign.idPixLabel === null;
-  }
-
   get isExternalIdSelectedChecked() {
     return this.wantIdPix === true;
   }
@@ -364,7 +360,7 @@ export default class CreateForm extends Component {
               name="external-id-label"
               @value="false"
               {{on "change" this.doNotAskLabelIdPix}}
-              checked={{this.isExternalIdNotSelectedChecked}}
+              checked={{not this.isExternalIdSelectedChecked}}
             >
               <:label>{{t "pages.campaign-creation.no"}}</:label>
             </PixRadioButton>

--- a/orga/tests/integration/components/campaign/create-form-test.js
+++ b/orga/tests/integration/components/campaign/create-form-test.js
@@ -829,7 +829,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   });
 
   module('when user has not chosen yet to ask or not an external user ID', function () {
-    test('it should not fill external user ID selection', async function (assert) {
+    test('it should fill the default external user ID selection', async function (assert) {
       // when
       const screen = await render(
         hbs`<Campaign::CreateForm
@@ -847,7 +847,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         .getByText(t('pages.campaign-creation.external-id-label.question-label'), { selector: 'legend' })
         .closest('fieldset');
 
-      assert.dom(within(externalIdentifier).getByLabelText(t('pages.campaign-creation.no'))).isNotChecked();
+      assert.dom(within(externalIdentifier).getByLabelText(t('pages.campaign-creation.no'))).isChecked();
       assert.dom(within(externalIdentifier).getByLabelText(t('pages.campaign-creation.yes'))).isNotChecked();
     });
 


### PR DESCRIPTION
## :pancakes: Problème

![image](https://github.com/user-attachments/assets/e38d0bc8-8de2-4de9-b70c-781842c8201e)

Il n'y a pas de choix par défaut sur l'externalId. Même si la validation de ce champ n'est pas obligatoire, il faut notifier à l'utilisateur le choix par défaut.

## :bacon: Proposition

On checke le "non" par défaut, tant que l'utilisateur ne change pas l'option en "oui".

## 🧃 Remarques

## :yum: Pour tester

Créer deux campagnes, une avec externalId et l'autre sans.
Vérifier ensuite dans l'interface sur Orga que tout est cohérent.