### PR TITLE
[FEATURE] Ne pas générer les attestations des learners désactivés dans le zip pour les prescripteurs (PIX-16098)

### DIFF
--- a/api/db/seeds/data/team-prescription/build-quests.js
+++ b/api/db/seeds/data/team-prescription/build-quests.js
@@ -40,6 +40,11 @@ const USERS = [
     lastName: 'attestation',
     email: 'attestation-blank@example.net',
   },
+  {
+    firstName: 'Disabled',
+    lastName: 'Attestation',
+    email: 'disabled-attestation@example.net',
+  },
 ];
 const ORGANIZATION = { name: 'Attestation', type: 'SCO', isManagingStudents: true };
 const CAMPAIGN = [
@@ -274,7 +279,8 @@ const buildCampaigns = (databaseBuilder, organization, targetProfiles) =>
 
 export const buildQuests = async (databaseBuilder) => {
   // Create USERS
-  const [successUser, successSharedUser, failedUser, pendingUser, blankUser] = buildUsers(databaseBuilder);
+  const [successUser, successSharedUser, failedUser, pendingUser, blankUser, disabledUser] =
+    buildUsers(databaseBuilder);
 
   // Create organization
   const organization = buildOrganization(databaseBuilder);
@@ -314,6 +320,7 @@ export const buildQuests = async (databaseBuilder) => {
     { userId: failedUser.id, division: '6emeA', firstName: 'attestation-failed', lastName: 'attestation-failed' },
     { userId: pendingUser.id, division: '6emeB', firstName: 'attestation-pending', lastName: 'attestation-pending' },
     { userId: blankUser.id, division: '6emeB', firstName: 'attestation-blank', lastName: 'attestation-blank' },
+    { userId: disabledUser.id, division: '6emeB', firstName: 'Disabled', lastName: 'attestation', isDisabled: true },
   ];
 
   const [
@@ -321,6 +328,7 @@ export const buildQuests = async (databaseBuilder) => {
     successSharedOrganizationLearner,
     failedOrganizationLearner,
     pendingOrganizationLearner,
+    disabledOrganizationLearner,
   ] = buildOrganizationLearners(databaseBuilder, organization, organizationLearnersData);
 
   // Create target profile
@@ -368,6 +376,11 @@ export const buildQuests = async (databaseBuilder) => {
       campaignId: campaigns[0],
       organizationLearner: pendingOrganizationLearner,
     },
+    {
+      user: disabledUser,
+      campaignId: campaigns[0],
+      organizationLearner: disabledOrganizationLearner,
+    },
   ]);
 
   // Create attestation quest
@@ -392,10 +405,21 @@ export const buildQuests = async (databaseBuilder) => {
     rewardId,
   });
 
+  const { id: disabledUserProfileRewardId } = databaseBuilder.factory.buildProfileReward({
+    userId: disabledUser.id,
+    rewardType: REWARD_TYPES.ATTESTATION,
+    rewardId,
+  });
+
   // Create link between profile reward and organization
   databaseBuilder.factory.buildOrganizationsProfileRewards({
     organizationId: organization.id,
     profileRewardId: sharedProfileRewardId,
+  });
+
+  databaseBuilder.factory.buildOrganizationsProfileRewards({
+    organizationId: organization.id,
+    profileRewardId: disabledUserProfileRewardId,
   });
 
   // Insert job count in temporary storage for pending user

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
@@ -117,7 +117,10 @@ async function findOrganizationLearnersByDivisions({ organizationId, divisions }
   let organizationLearners;
 
   const knexConnection = DomainTransaction.getConnection();
-  const queryBuilder = knexConnection.from('view-active-organization-learners').where({ organizationId });
+  const queryBuilder = knexConnection
+    .from('view-active-organization-learners')
+    .where({ organizationId })
+    .andWhere('isDisabled', false);
   if (divisions.length > 0) {
     organizationLearners = await queryBuilder.whereIn('division', divisions);
   } else {

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -685,6 +685,28 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
       expect(learners).to.deep.equal([new OrganizationLearner(learner1), new OrganizationLearner(learner2)]);
     });
 
+    it('should not return disabled organization learners', async function () {
+      // given
+      const learner1 = databaseBuilder.factory.buildOrganizationLearner({ organizationId, division: '6eme A' });
+      databaseBuilder.factory.buildOrganizationLearner({
+        organizationId,
+        division: '6eme A',
+        isDisabled: true,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const learners = await organizationLearnerRepository.findOrganizationLearnersByDivisions({
+        organizationId,
+        divisions: ['6eme A'],
+      });
+
+      // then
+      expect(learners).to.have.lengthOf(1);
+      expect(learners).to.deep.equal([new OrganizationLearner(learner1)]);
+    });
+
     context('when there is no organization with organizationId', function () {
       const notExistingOrganizationId = '999999';
 


### PR DESCRIPTION
## :pancakes: Problème
Lors de la génération du zip d'attestation côté PixOrga, on ne vérifie pas si les apprenants sont désactivés ou non.
Il peut donc y avoir des cas ou les prescripteurs se retrouvent avec des attestations mais pour des apprenants plus dans leur organisation

## :bacon: Proposition
Rajouter une condition pour filtrer les apprenants désactivés lors de la récupération de la liste d'attestation à générer

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester
- Se connecter à Pix Orga avec `admin-orga@example.net`
- Aller sur l'organisation Pro Classic
- Aller sur la page `Attestation`
- Télécharger les attestations
- Vérifier que l'apprenant `Dis Abled` n'est pas présent dans la liste des attestations
- (Si on veut être à 100% sur, on peut ensuite en sql passer le `isDisabled` de cet apprenant à `false` (id du learner : `107271`) , refaire la manip et voir que cette fois il apparaît dans la liste d'attestations)
- 🐈‍⬛ 