### PR TITLE
[TECH] :wrench: Ajoute une tache `npm` pour executer uniquement les fichiers de test en cours de modification

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -178,6 +178,7 @@
     "test:api:watch": "NODE_ENV=test nodemon --exec 'mocha --recursive tests --reporter dot'",
     "test:api:bail": "npm run test:api:unit -- --bail && npm run test:api:integration -- --bail && npm run test:api:acceptance -- --bail",
     "test:lint": "npm test && npm run lint",
+    "test:api:watch": "git ls-files -m -- '*test.js' | xargs npm run test:api:path -- $1",
     "monitoring:arborescence": "node scripts/arborescence-monitoring/arborescence-monitoring.js",
     "monitoring:metrics": "node scripts/arborescence-monitoring/add-metrics-to-gist.js",
     "modulix:test": "npm run test:api:path -- 'tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js' 'tests/devcomp/acceptance/module-instantiation_test.js' 'tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js'"

--- a/api/package.json
+++ b/api/package.json
@@ -178,7 +178,7 @@
     "test:api:watch": "NODE_ENV=test nodemon --exec 'mocha --recursive tests --reporter dot'",
     "test:api:bail": "npm run test:api:unit -- --bail && npm run test:api:integration -- --bail && npm run test:api:acceptance -- --bail",
     "test:lint": "npm test && npm run lint",
-    "test:api:watch": "git ls-files -m -- '*test.js' | xargs npm run test:api:path -- $1",
+    "test:api:git-modified": "git ls-files -m -- '*test.js' | xargs npm run test:api:path -- $1",
     "monitoring:arborescence": "node scripts/arborescence-monitoring/arborescence-monitoring.js",
     "monitoring:metrics": "node scripts/arborescence-monitoring/add-metrics-to-gist.js",
     "modulix:test": "npm run test:api:path -- 'tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js' 'tests/devcomp/acceptance/module-instantiation_test.js' 'tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js'"


### PR DESCRIPTION
## :pancakes: Problème

Ce n'est pas toujours simple d'exécuté uniquement les tests qui ont été modifiés, surtout si on en modifie plusieurs par commit...

## :bacon: Proposition

```shell
npm run test:api:git-modified
```

Suite à la discussion slack https://1024pix.slack.com/archives/C038PTJ9UJE/p1736948910624919 où 
- @HEYGUL partage sa découverte de combinaison d'usage de `git ls-files` avec `xargs` et `npm run test:api:path -- `
- @laura-bergoens qui propos de mettre en place une tâche permettant pour exécuter uniquement les tests en cours de modification
- @Steph0 qui précise la commande `git ls-files` pour qu'elle ne remonte QUE les fichiers de tests;

j'ai simplement pris la commande et ajouter une action pour permettre de lancer `npm run test:api:git-modified` :)

## 🧃 Remarques

RAS

## :yum: Pour tester

1. Modifier des fichiers de test
2. Exécuter la commande `npm run test:api:git-modified`
3. Constater que seuls les fichiers de test modifiés et non commités sont lancés
