### PR TITLE
[BUGFIX] Garder toujours le même ordre de colonnes dans le fichier d'export des résultats (PIX-16099)

### DIFF
--- a/api/src/prescription/campaign/infrastructure/exports/campaigns/campaign-assessment-result-line.js
+++ b/api/src/prescription/campaign/infrastructure/exports/campaigns/campaign-assessment-result-line.js
@@ -19,6 +19,8 @@ class CampaignAssessmentResultLine {
     targetProfile,
     additionalHeaders,
     learningContent,
+    areas,
+    competences,
     stageCollection,
     participantKnowledgeElementsByCompetenceId,
     acquiredBadges,
@@ -30,6 +32,8 @@ class CampaignAssessmentResultLine {
     this.campaignParticipationInfo = campaignParticipationInfo;
     this.targetProfile = targetProfile;
     this.learningContent = learningContent;
+    this.areas = areas;
+    this.competences = competences;
     this.stageCollection = stageCollection;
     this.targetedKnowledgeElementsCount = _.sum(
       _.map(participantKnowledgeElementsByCompetenceId, (knowledgeElements) => knowledgeElements.length),
@@ -73,7 +77,7 @@ class CampaignAssessmentResultLine {
   }
 
   _makeCompetenceColumns() {
-    return _.flatMap(this.learningContent.competences, (competence) =>
+    return _.flatMap(this.competences, (competence) =>
       this._makeSharedStatsColumns({
         id: competence.id,
         ...this._getStatsForCompetence(competence),
@@ -82,7 +86,7 @@ class CampaignAssessmentResultLine {
   }
 
   _makeAreaColumns() {
-    return _.flatMap(this.learningContent.areas, ({ id, competences }) => {
+    return _.flatMap(this.areas, ({ id, competences }) => {
       const areaCompetenceStats = competences.map(this._getStatsForCompetence);
 
       const targetedSkillCount = _.sumBy(areaCompetenceStats, 'targetedSkillCount');
@@ -156,8 +160,8 @@ class CampaignAssessmentResultLine {
 
   _makeNotSharedColumns() {
     return [
-      ...this._makeEmptyColumns(this.learningContent.competences.length * STATS_COLUMNS_COUNT),
-      ...this._makeEmptyColumns(this.learningContent.areas.length * STATS_COLUMNS_COUNT),
+      ...this._makeEmptyColumns(this.competences.length * STATS_COLUMNS_COUNT),
+      ...this._makeEmptyColumns(this.areas.length * STATS_COLUMNS_COUNT),
       ...(this.organization.showSkills ? this._makeEmptyColumns(this.learningContent.skills.length) : []),
     ];
   }

--- a/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-assessment-export.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-assessment-export.js
@@ -27,6 +27,7 @@ class CampaignAssessmentExport {
     this.stageCollection = stageCollection;
     this.idPixLabel = campaign.idPixLabel;
     this.competences = learningContent.competences;
+    this.areas = learningContent.areas;
     this.translate = translate;
     this.additionalHeaders = additionalHeaders;
   }
@@ -117,7 +118,7 @@ class CampaignAssessmentExport {
   }
 
   #competenceColumnHeaders() {
-    return _.flatMap(this.learningContent.competences, (competence) => [
+    return _.flatMap(this.competences, (competence) => [
       this.translate('campaign-export.assessment.skill.mastery-percentage', { name: competence.name }),
       this.translate('campaign-export.assessment.skill.total-items', { name: competence.name }),
       this.translate('campaign-export.assessment.skill.items-successfully-completed', { name: competence.name }),
@@ -125,7 +126,7 @@ class CampaignAssessmentExport {
   }
 
   #areaColumnHeaders() {
-    return _.flatMap(this.learningContent.areas, (area) => [
+    return _.flatMap(this.areas, (area) => [
       this.translate('campaign-export.assessment.competence-area.mastery-percentage', { name: area.title }),
       this.translate('campaign-export.assessment.competence-area.total-items', { name: area.title }),
       this.translate('campaign-export.assessment.competence-area.items-successfully-completed', { name: area.title }),
@@ -147,6 +148,8 @@ class CampaignAssessmentExport {
       targetProfile: this.targetProfile,
       additionalHeaders: this.additionalHeaders,
       learningContent: this.learningContent,
+      areas: this.areas,
+      competences: this.competences,
       stageCollection: this.stageCollection,
       participantKnowledgeElementsByCompetenceId: await this.#getParticipantKnowledgeElementsByCompetenceId({
         campaignParticipationInfo,

--- a/api/src/shared/domain/models/CampaignLearningContent.js
+++ b/api/src/shared/domain/models/CampaignLearningContent.js
@@ -14,11 +14,11 @@ class CampaignLearningContent {
   }
 
   get competences() {
-    return this._learningContent.competences;
+    return this._learningContent.competences.sort((a, b) => a.index.localeCompare(b.index));
   }
 
   get areas() {
-    return this._learningContent.areas;
+    return this._learningContent.areas.sort((a, b) => a.code.localeCompare(b.code));
   }
 
   findSkill(skillId) {

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
@@ -170,7 +170,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-ser
           {
             attributes: {
               id: `recArea1_${trainingTriggerId}`,
-              code: 5,
+              code: '5',
               color: 'red',
               title: 'Super domaine',
             },
@@ -273,7 +273,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-ser
           },
           {
             attributes: {
-              code: 5,
+              code: '5',
               color: 'red',
               id: 'recArea1_789',
               title: 'Super domaine',

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-trigger-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-trigger-serializer_test.js
@@ -121,7 +121,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-tri
           },
           {
             attributes: {
-              code: 5,
+              code: '5',
               color: 'red',
               title: 'Super domaine',
             },

--- a/api/tests/prescription/campaign/unit/infrastructure/exports/campaigns/campaign-assessment-result-line_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/exports/campaigns/campaign-assessment-result-line_test.js
@@ -11,7 +11,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
   });
 
   describe('#toCsvLine', function () {
-    let organization, campaign, targetProfile, learningContent, stageCollection;
+    let organization, campaign, targetProfile, learningContent, stageCollection, areas, competences;
     const createdAt = new Date('2020-03-01T10:00:00Z');
     const createdAtFormated = '01/03/2020 11:00';
     const sharedAt = new Date('2020-04-01T10:00:00Z');
@@ -22,6 +22,8 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
       campaign = domainBuilder.buildCampaign({ idPixLabel: null });
       targetProfile = domainBuilder.buildTargetProfile();
       learningContent = domainBuilder.buildLearningContent.withSimpleContent();
+      areas = learningContent.areas;
+      competences = learningContent.competences;
       stageCollection = domainBuilder.buildStageCollectionForUserCampaignResults({
         campaignId: campaign.id,
         stages: [],
@@ -42,9 +44,11 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
           campaignParticipationInfo,
           targetProfile,
           learningContent,
+          competences,
+          areas,
           stageCollection,
           participantKnowledgeElementsByCompetenceId: {
-            [learningContent.competences[0].id]: [],
+            [competences[0].id]: [],
           },
           translate,
         });
@@ -91,9 +95,11 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
           campaignParticipationInfo,
           targetProfile,
           learningContent,
+          competences,
+          areas,
           stageCollection,
           participantKnowledgeElementsByCompetenceId: {
-            [learningContent.competences[0].id]: [],
+            [competences[0].id]: [],
           },
           translate,
         });
@@ -143,9 +149,11 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
             additionalHeaders,
             targetProfile,
             learningContent,
+            competences,
+            areas,
             stageCollection,
             participantKnowledgeElementsByCompetenceId: {
-              [learningContent.competences[0].id]: [],
+              [competences[0].id]: [],
             },
             translate,
           });
@@ -195,9 +203,11 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
             additionalHeaders: [],
             targetProfile,
             learningContent,
+            competences,
+            areas,
             stageCollection,
             participantKnowledgeElementsByCompetenceId: {
-              [learningContent.competences[0].id]: [],
+              [competences[0].id]: [],
             },
             translate,
           });
@@ -248,9 +258,11 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
           campaignParticipationInfo,
           targetProfile,
           learningContent,
+          competences,
+          areas,
           stageCollection,
           participantKnowledgeElementsByCompetenceId: {
-            [learningContent.competences[0].id]: [],
+            [competences[0].id]: [],
           },
           translate,
         });
@@ -308,7 +320,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
             learningContent,
             stageCollection,
             participantKnowledgeElementsByCompetenceId: {
-              [learningContent.competences[0].id]: [],
+              [competences[0].id]: [],
             },
             translate,
           });
@@ -317,7 +329,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
           const csvLine = campaignAssessmentCsvLine.toCsvLine();
 
           // then
-          const csvExcpectedLine =
+          const csvExpectedLine =
             `"${organization.name}";` +
             `${campaign.id};` +
             `"${campaign.code}";` +
@@ -332,17 +344,11 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
             `"${createdAtFormated}";` +
             '"Non";' +
             '"NA";' +
-            '"NA";' +
-            '"NA";' +
-            '"NA";' +
-            '"NA";' +
-            '"NA";' +
-            '"NA";' +
             '"NA"' +
             '\n';
 
           // then
-          expect(csvLine).to.equal(csvExcpectedLine);
+          expect(csvLine).to.equal(csvExpectedLine);
         });
       });
 
@@ -369,7 +375,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
             learningContent,
             stageCollection,
             participantKnowledgeElementsByCompetenceId: {
-              [learningContent.competences[0].id]: [],
+              [competences[0].id]: [],
             },
             translate,
           });
@@ -391,12 +397,6 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
             '0;' +
             `"${createdAtFormated}";` +
             '"Non";' +
-            '"NA";' +
-            '"NA";' +
-            '"NA";' +
-            '"NA";' +
-            '"NA";' +
-            '"NA";' +
             '"NA";' +
             '"NA"' +
             '\n';
@@ -500,6 +500,8 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
               campaignParticipationInfo,
               targetProfile,
               learningContent,
+              competences: learningContent.competences,
+              areas: learningContent.areas,
               stageCollection,
               participantKnowledgeElementsByCompetenceId,
               translate,
@@ -562,6 +564,8 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
               campaignParticipationInfo,
               targetProfile,
               learningContent,
+              competences,
+              areas,
               stageCollection,
               participantKnowledgeElementsByCompetenceId,
               translate,
@@ -581,15 +585,6 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
               '1;' +
               `"${createdAtFormated}";` +
               '"Non";' +
-              '"NA";' +
-              '"NA";' +
-              '"NA";' +
-              '"NA";' +
-              '"NA";' +
-              '"NA";' +
-              '"NA";' +
-              '"NA";' +
-              '"NA";' +
               '"NA";' +
               '"NA";' +
               '"NA";' +
@@ -625,9 +620,11 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
             campaignParticipationInfo,
             targetProfile,
             learningContent,
+            competences,
+            areas,
             stageCollection,
             participantKnowledgeElementsByCompetenceId: {
-              [learningContent.competences[0].id]: [],
+              [competences[0].id]: [],
             },
             acquiredBadges: [badge],
             translate,
@@ -689,9 +686,11 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
             campaignParticipationInfo,
             targetProfile,
             learningContent,
+            competences,
+            areas,
             stageCollection,
             participantKnowledgeElementsByCompetenceId: {
-              [learningContent.competences[0].id]: [knowledgeElement],
+              [competences[0].id]: [knowledgeElement],
             },
             acquiredBadges: { [campaignParticipationInfo.campaignParticipationId]: [{ title: badge.title }] },
             translate,
@@ -746,9 +745,11 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
             campaignParticipationInfo,
             targetProfile,
             learningContent,
+            competences,
+            areas,
             stageCollection,
             participantKnowledgeElementsByCompetenceId: {
-              [learningContent.competences[0].id]: [knowledgeElement],
+              [competences[0].id]: [knowledgeElement],
             },
             translate,
           });
@@ -849,6 +850,8 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
               campaignParticipationInfo,
               targetProfile,
               learningContent,
+              areas: learningContent.areas,
+              competences: learningContent.competences,
               stageCollection,
               participantKnowledgeElementsByCompetenceId,
               translate,
@@ -900,6 +903,8 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
               campaignParticipationInfo,
               targetProfile,
               learningContent,
+              competences: learningContent.competences,
+              areas: learningContent.areas,
               stageCollection,
               participantKnowledgeElementsByCompetenceId,
               translate,
@@ -950,6 +955,8 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
             campaignParticipationInfo,
             targetProfile,
             learningContent,
+            competences,
+            areas,
             stageCollection,
             participantKnowledgeElementsByCompetenceId,
             translate,

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/csv/campaign-assessment-export_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/csv/campaign-assessment-export_test.js
@@ -28,7 +28,7 @@ describe('Unit | Serializer | CSV | campaign-assessment-export', function () {
         badges: [],
       };
       stageCollection = {};
-      learningContent = { skillNames: [], competence: [], areas: [] };
+      learningContent = { skillNames: [], competences: [], areas: [] };
       campaign = {};
 
       const listSkills1 = domainBuilder.buildSkillCollection({ name: '@web', minLevel: 1, maxLevel: 5 });

--- a/api/tests/shared/unit/domain/models/CampaignLearningContent_test.js
+++ b/api/tests/shared/unit/domain/models/CampaignLearningContent_test.js
@@ -1,0 +1,69 @@
+import { expect } from 'chai';
+
+import { Area } from '../../../../../src/shared/domain/models/Area.js';
+import { CampaignLearningContent } from '../../../../../src/shared/domain/models/CampaignLearningContent.js';
+import { Skill } from '../../../../../src/shared/domain/models/Skill.js';
+import { Tube } from '../../../../../src/shared/domain/models/Tube.js';
+
+describe('Unit | Domain | Models | CampaignLearningContent', function () {
+  let skills, areasSorted, tubesSorted, competencesSorted, areas, competences, jaffaArea, wildStrawberryArea;
+
+  beforeEach(function () {
+    jaffaArea = new Area({ id: 'jaffaArea', code: '1', name: 'area 1', color: 'jaffa' });
+    wildStrawberryArea = new Area({
+      id: 'wildStrawberryArea',
+      code: '2',
+      name: 'area 2',
+      color: 'wild-strawberry',
+    });
+    areas = [wildStrawberryArea, jaffaArea];
+    areasSorted = [jaffaArea, wildStrawberryArea];
+
+    skills = [new Skill({ name: '@web3' }), new Skill({ name: '@web2' })];
+
+    tubesSorted = [new Tube({ skills })];
+
+    (competences = [
+      { id: 2, name: 'Désobéissance civile', index: '6.9', skillIds: [2, 3, 4], areaId: 'wildStrawberryArea' },
+      { id: 1, name: 'Economie symbiotique', index: '5.1', skillIds: [1], areaId: 'jaffaArea' },
+      { id: 3, name: 'Démocratie liquide', index: '8.6', skillIds: [5, 6], areaId: 'wildStrawberryArea' },
+    ]),
+      (competencesSorted = [
+        { id: 1, name: 'Economie symbiotique', index: '5.1', skillIds: [1], areaId: 'jaffaArea' },
+        { id: 2, name: 'Désobéissance civile', index: '6.9', skillIds: [2, 3, 4], areaId: 'wildStrawberryArea' },
+        { id: 3, name: 'Démocratie liquide', index: '8.6', skillIds: [5, 6], areaId: 'wildStrawberryArea' },
+      ]);
+  });
+
+  describe('building model', function () {
+    it('should return competences sorted by index', function () {
+      const learningContent = {
+        competences,
+        areas: [wildStrawberryArea, jaffaArea],
+      };
+      const campaignLearningContent = new CampaignLearningContent({
+        skills,
+        tubesSorted,
+        competences: learningContent.competences,
+        areas: [wildStrawberryArea, jaffaArea],
+      });
+      expect(campaignLearningContent.competences).to.deep.equal(competencesSorted);
+    });
+
+    it('should return areas sorted by code', function () {
+      const learningContent = new CampaignLearningContent({
+        skills,
+        tubesSorted,
+        competences: competencesSorted,
+        areas,
+      });
+      const campaignLearningContent = new CampaignLearningContent({
+        skills,
+        tubesSorted,
+        competencesSorted,
+        areas: learningContent.areas,
+      });
+      expect(campaignLearningContent.areas).to.deep.equal(areasSorted);
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-area.js
+++ b/api/tests/tooling/domain-builder/factory/build-area.js
@@ -2,7 +2,7 @@ import { Area } from '../../../../src/shared/domain/models/Area.js';
 
 const buildArea = function ({
   id = 'recArea123',
-  code = 5,
+  code = '5',
   title = 'Super domaine',
   competences = [],
   color = 'red',
@@ -20,10 +20,6 @@ const buildArea = function ({
     frameworkId,
   });
 
-  // c koi ce truc
-  //competences.forEach((competence) => {
-  //  competence.area = area;
-  //});
   return area;
 };
 


### PR DESCRIPTION
## :pancakes: Problème

On nous a remonté le fait que l'ordre des colonnes des domaines et des compétences dans le fichier d'export des résultats n'est pas toujours le même.

## :bacon: Proposition

On ajoute un sort() explicite au modèle CampaignLearningContent.

## 🧃 Remarques

## :yum: Pour tester
Réaliser un export d'une campagne avec un profil cible à plusieurs domaines / plusieurs compétences (par exemple, SCO_SIECLE sur la RA) et vérifier si les domaines et les compétences sont bien classés par leur index / code du plus petit au plus grand + que tous les domaines / compétences du PC sont bien là.

Exemple
Sur la campagne SCOASSMUL de SCO_SIECLE, le profil cible a pour première compétence du domaine 2, "2.3 Collaborer", comme deuxième compétence "2.4 S'insérer dans le monde numérique".
Il faut qu'elle se trouvent avant les compétences du domaine "3. Création de contenu", comme "3.1 Développer des documents textuels" 