### PR TITLE
[FEATURE] Prévenir l'utilisateur prescrit sur mobile que son expérience risque d'être dégradée (PIX-16078).

### DIFF
--- a/mon-pix/app/components/campaigns/presentation/alert-mobile-experience-modal.gjs
+++ b/mon-pix/app/components/campaigns/presentation/alert-mobile-experience-modal.gjs
@@ -1,0 +1,55 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+
+export default class AlertMobileExperienceModal extends Component {
+  @service media;
+  @service url;
+
+  @tracked isModalVisible = this.isMobileDevice;
+
+  get isMobileDevice() {
+    return this.media.isMobile;
+  }
+
+  @action
+  closeModal() {
+    this.isModalVisible = false;
+  }
+
+  @action
+  async goToHomepage() {
+    return window.location.replace(this.url.homeUrl);
+  }
+
+  <template>
+    {{#if this.isMobileDevice}}
+      <PixModal
+        class="campaign-presentation-mobile-modal"
+        @title={{t "pages.campaign-landing.alert-mobile-experience-modal.title"}}
+        @showModal={{this.isModalVisible}}
+        @onCloseButtonClick={{this.closeModal}}
+      >
+        <:content>
+          <p>{{t "pages.campaign-landing.alert-mobile-experience-modal.content.paragraph1"}}</p>
+          <p>{{t "pages.campaign-landing.alert-mobile-experience-modal.content.paragraph2"}}</p>
+        </:content>
+        <:footer>
+          <div class="campaign-presentation-mobile-modal__actions">
+            <PixButton @triggerAction={{this.closeModal}}>
+              {{t "pages.campaign-landing.alert-mobile-experience-modal.actions.continue"}}
+            </PixButton>
+            <PixButtonLink @route="authentication" @variant="secondary" @isBorderVisible={{true}}>
+              {{t "pages.campaign-landing.alert-mobile-experience-modal.actions.back"}}
+            </PixButtonLink>
+          </div>
+        </:footer>
+      </PixModal>
+    {{/if}}
+  </template>
+}

--- a/mon-pix/app/styles/components/campaigns/index.scss
+++ b/mon-pix/app/styles/components/campaigns/index.scss
@@ -3,3 +3,4 @@
 @import 'assessment/results/evaluation-results-tabs/rewards';
 @import 'assessment/results/evaluation-results-tabs/trainings';
 @import 'invited/learner-reconciliation';
+@import 'presentation/alert-mobile-experience-modal';

--- a/mon-pix/app/styles/components/campaigns/presentation/alert-mobile-experience-modal.scss
+++ b/mon-pix/app/styles/components/campaigns/presentation/alert-mobile-experience-modal.scss
@@ -1,0 +1,7 @@
+.campaign-presentation-mobile-modal__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  justify-content: center;
+  padding-bottom: 0.5rem;
+}

--- a/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
+++ b/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
@@ -1,6 +1,7 @@
 {{page-title (t "pages.campaign-landing.title")}}
 
 <div class="background-banner-wrapper">
+  <Campaigns::Presentation::AlertMobileExperienceModal />
   <div class="background-banner"></div>
   <main class="campaign-landing-page__container rounded-panel--over-background-banner" role="main">
     {{#if this.isAutonomousCourse}}

--- a/mon-pix/tests/integration/components/campaigns/presentation/alert-mobile-experience-modal-test.js
+++ b/mon-pix/tests/integration/components/campaigns/presentation/alert-mobile-experience-modal-test.js
@@ -1,0 +1,99 @@
+import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import { click } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { t } from 'ember-intl/test-support';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Campaigns::Presentation | AlertMobileExperienceModal', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('on mobile', function (hooks) {
+    let screen;
+
+    hooks.beforeEach(async function () {
+      // given
+      class MediaServiceStub extends Service {
+        isMobile = true;
+      }
+      this.owner.register('service:media', MediaServiceStub);
+
+      //  when
+      screen = await render(hbs`<Campaigns::Presentation::AlertMobileExperienceModal />`);
+    });
+
+    test('it should display a modal', async function (assert) {
+      // then
+      const modalTitle = await screen.findByText(t('pages.campaign-landing.alert-mobile-experience-modal.title'));
+      assert.dom(modalTitle).exists();
+      assert
+        .dom(screen.getByText(t('pages.campaign-landing.alert-mobile-experience-modal.content.paragraph1')))
+        .exists();
+      assert
+        .dom(screen.getByText(t('pages.campaign-landing.alert-mobile-experience-modal.content.paragraph2')))
+        .exists();
+      assert
+        .dom(
+          screen.getByRole('button', {
+            name: t('pages.campaign-landing.alert-mobile-experience-modal.actions.continue'),
+          }),
+        )
+        .exists();
+      assert
+        .dom(screen.getByRole('link', { name: t('pages.campaign-landing.alert-mobile-experience-modal.actions.back') }))
+        .exists();
+    });
+
+    module('close action', function () {
+      test('it should be possible to close the modal clicking on continue action', async function (assert) {
+        // when
+        await click(
+          screen.getByRole('button', {
+            name: t('pages.campaign-landing.alert-mobile-experience-modal.actions.continue'),
+          }),
+        );
+
+        // then
+        assert.ok(
+          screen
+            .getByText(t('pages.campaign-landing.alert-mobile-experience-modal.title'))
+            .closest('.pix-modal__overlay')
+            .classList.toString()
+            .includes('pix-modal__overlay--hidden'),
+        );
+      });
+
+      test('it should be possible to close the modal clicking on close button', async function (assert) {
+        // when
+        await click(screen.getByRole('button', { name: 'Fermer' }));
+
+        // then
+        assert.ok(
+          screen
+            .getByText(t('pages.campaign-landing.alert-mobile-experience-modal.title'))
+            .closest('.pix-modal__overlay')
+            .classList.toString()
+            .includes('pix-modal__overlay--hidden'),
+        );
+      });
+    });
+  });
+
+  module('on desktop or tablet', function () {
+    test('it should not display a modal', async function (assert) {
+      // given
+      class MediaServiceStub extends Service {
+        isMobile = false;
+      }
+      this.owner.register('service:media', MediaServiceStub);
+
+      //  when
+      const screen = await render(hbs`<Campaigns::Presentation::AlertMobileExperienceModal />`);
+
+      // then
+      assert.dom(screen.queryByText(t('pages.campaign-landing.alert-mobile-experience-modal.title'))).doesNotExist();
+    });
+  });
+});

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -521,6 +521,17 @@
       }
     },
     "campaign-landing": {
+      "alert-mobile-experience-modal": {
+        "actions": {
+          "back": "Return to the homepage",
+          "continue": "Continue anyway"
+        },
+        "content": {
+          "paragraph1": "Some questions in this course may be difficult to use on a small screen.",
+          "paragraph2": "For the best experience, we recommend using a computer."
+        },
+        "title": "You appear to be using a small screen"
+      },
       "assessment": {
         "action": "Begin",
         "announcement": "Sign up or log in to the Pix platform and start your test.",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -519,6 +519,17 @@
       }
     },
     "campaign-landing": {
+      "alert-mobile-experience-modal": {
+        "title": "Parece que estás usando una pantalla pequeña",
+        "content": {
+          "paragraph1": "Algunas preguntas de este curso pueden resultar difíciles de utilizar en una pantalla pequeña.",
+          "paragraph2": "Para obtener la mejor experiencia, recomendamos utilizar una computadora."
+        },
+        "actions": {
+          "continue": "Continuar cuando lo mismo",
+          "back": "Regresar a la página de inicio"
+        }
+      },
       "assessment": {
         "action": "Empiezo",
         "announcement": "Inscríbete o conéctate a la plataforma Pix y comienza tu prueba.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -521,6 +521,17 @@
       }
     },
     "campaign-landing": {
+      "alert-mobile-experience-modal": {
+        "actions": {
+          "back": "Revenir à l'écran d'accueil",
+          "continue": "Continuer quand même"
+        },
+        "content": {
+          "paragraph1": "Certaines questions de ce parcours peuvent être difficiles à utiliser sur un petit écran.",
+          "paragraph2": "Pour une expérience optimale, nous vous recommandons d’utiliser un ordinateur."
+        },
+        "title": "Vous semblez utiliser un petit écran"
+      },
       "assessment": {
         "action": "Je commence",
         "announcement": "Inscrivez-vous ou connectez-vous sur la plateforme Pix et lancez votre test.",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -519,6 +519,17 @@
       }
     },
     "campaign-landing": {
+      "alert-mobile-experience-modal": {
+        "title": "Het lijkt erop dat u een klein scherm gebruikt",
+        "content": {
+          "paragraph1": "Sommige vragen in deze cursus zijn mogelijk lastig te beantwoorden op een klein scherm.",
+          "paragraph2": "Voor de beste ervaring raden wij u aan een computer te gebruiken."
+        },
+        "actions": {
+          "continue": "Ga toch door",
+          "back": "Terug naar de startpagina"
+        }
+      },
       "assessment": {
         "action": "Ik begin",
         "announcement": "Registreer of log in op het Pix-platform en start je test.",


### PR DESCRIPTION
## :pancakes: Problème

Les épreuves de campagnes sont rarement optimisées sur mobile.

## :bacon: Proposition

Pour un utilisateur prescrit, une fois que l’utilisateur arrive sur la landing page campagne, faire apparaître, direct, une pop up d’informations, si l’utilisateur est sur mobile. 

## :yum: Pour tester

- Se connecter avec un utilisateur en RA
- Aller sur une campagne qui n'est pas déjà commencée
- Constater la présence de la modale uniquement sur petit écran (< 780px)
