### PR TITLE
[BUGFIX] Gerer les erreurs en cas de conflit avec la contrainte d'unicité de profile rewards (PIX-16129)

### DIFF
--- a/api/src/profile/infrastructure/repositories/profile-reward-repository.js
+++ b/api/src/profile/infrastructure/repositories/profile-reward-repository.js
@@ -14,11 +14,14 @@ const ATTESTATIONS_TABLE_NAME = 'attestations';
  */
 export const save = async ({ userId, rewardId, rewardType = REWARD_TYPES.ATTESTATION }) => {
   const knexConnection = await DomainTransaction.getConnection();
-  await knexConnection(PROFILE_REWARDS_TABLE_NAME).insert({
-    userId,
-    rewardId,
-    rewardType,
-  });
+  await knexConnection(PROFILE_REWARDS_TABLE_NAME)
+    .insert({
+      userId,
+      rewardId,
+      rewardType,
+    })
+    .onConflict()
+    .ignore();
 };
 
 /**

--- a/api/tests/profile/integration/infrastructure/repositories/profile-reward-repository_test.js
+++ b/api/tests/profile/integration/infrastructure/repositories/profile-reward-repository_test.js
@@ -34,6 +34,29 @@ describe('Profile | Integration | Repository | profile-reward', function () {
       expect(result[0].rewardId).to.equal(rewardId);
       expect(result[0].rewardType).to.equal(REWARD_TYPES.ATTESTATION);
     });
+
+    it('should not throw error if user already have reward', async function () {
+      // given
+      const { id: userId } = databaseBuilder.factory.buildUser();
+      const { rewardId } = databaseBuilder.factory.buildQuest({
+        rewardType: REWARD_TYPES.ATTESTATION,
+        eligibilityRequirements: {},
+        successRequirements: {},
+      });
+      databaseBuilder.factory.buildProfileReward({ rewardId, userId });
+      await databaseBuilder.commit();
+
+      // when
+      await save({ userId: userId, rewardId });
+
+      // then
+      const result = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId: userId });
+
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].userId).to.equal(userId);
+      expect(result[0].rewardId).to.equal(rewardId);
+      expect(result[0].rewardType).to.equal(REWARD_TYPES.ATTESTATION);
+    });
   });
 
   describe('#getById', function () {

--- a/api/tests/profile/integration/infrastructure/repositories/profile-reward-repository_test.js
+++ b/api/tests/profile/integration/infrastructure/repositories/profile-reward-repository_test.js
@@ -35,7 +35,7 @@ describe('Profile | Integration | Repository | profile-reward', function () {
       expect(result[0].rewardType).to.equal(REWARD_TYPES.ATTESTATION);
     });
 
-    it('should not throw error if user already have reward', async function () {
+    it('should not throw unicity error if user already have reward', async function () {
       // given
       const { id: userId } = databaseBuilder.factory.buildUser();
       const { rewardId } = databaseBuilder.factory.buildQuest({


### PR DESCRIPTION
## :pancakes: Problème
Nous avons gérés au niveau du usecase le cas ou un utilisateur a déjà obtenu la récompense liée a la quête en cours. Mais il est arrivé un cas où un utilisateur qui spam un peu les réponses arrive a avoir deux requêtes en parallèle pour la même récompense et donc fait casser l'insertion à cause de la contrainte d'unicité mise en place sur la table profile reward

## :bacon: Proposition
Nous n'avons pas besoin de "gérer" le traitement de cette erreur car ce n'est pas un cas qui doit arriver dans un cas d'usage standard, donc on décide de simplement ignorer l'insertion si la ligne existe déjà et qu'elle déclenche l'erreur de la contraeinte d'unicité

## 🧃 Remarques
L'équipe xp d'éval à déjà eu des soucis de concurrence sur cette route (/api/answers), ces bugs seront peut être corrigés dans un futur mais sont déjà connus.

## :yum: Pour tester
Compliqué de faire un test fonctionnel pour ce cas la car c'est difficile a reproduire la concurrence des requêtes dans les environnements de tests
J'ai écris le test d'intégration en premier pour "reproduire" le cas d'erreur qu'on a eu, et effectivement, il cassait avant d'ajouter le onConflict 👍 
🐈‍⬛ 
