### PR TITLE
[TECH] Ajout des headers x-forwarded-host et x-forwarded-proto pour getForwardedOrigin de l'API en integration, recette et production.

### DIFF
--- a/admin/servers.conf.erb
+++ b/admin/servers.conf.erb
@@ -120,6 +120,10 @@ server {
     proxy_pass https://$upstream;
     proxy_set_header Host $upstream_host;
     proxy_set_header X-Source-Front <%= ENV['APP'] %>;
+
+    # Set X-Forwarded-xxx headers for the API to compute getForwardedOrigin
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
   }
 
   <% end %>

--- a/certif/servers.conf.erb
+++ b/certif/servers.conf.erb
@@ -137,6 +137,10 @@ server {
     proxy_pass https://$upstream;
     proxy_set_header Host $upstream_host;
     proxy_set_header X-Source-Front <%= ENV['APP'] %>;
+
+    # Set X-Forwarded-xxx headers for the API to compute getForwardedOrigin
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
   }
 
   <% end %>

--- a/junior/servers.conf.erb
+++ b/junior/servers.conf.erb
@@ -115,6 +115,10 @@ server {
     proxy_redirect default;
     proxy_set_header Host <%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>;
     proxy_set_header X-Source-Front <%= ENV['APP'] %>;
+
+    # Set X-Forwarded-xxx headers for the API to compute getForwardedOrigin
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
   }
 
   <% end %>

--- a/mon-pix/servers.conf.erb
+++ b/mon-pix/servers.conf.erb
@@ -144,6 +144,10 @@ server {
     proxy_pass https://$upstream;
     proxy_set_header Host $upstream_host;
     proxy_set_header X-Source-Front <%= ENV['APP'] %>;
+
+    # Set X-Forwarded-xxx headers for the API to compute getForwardedOrigin
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
   }
 
   <% end %>

--- a/orga/servers.conf.erb
+++ b/orga/servers.conf.erb
@@ -137,6 +137,10 @@ server {
     proxy_pass https://$upstream;
     proxy_set_header Host $upstream_host;
     proxy_set_header X-Source-Front <%= ENV['APP'] %>;
+
+    # Set X-Forwarded-xxx headers for the API to compute getForwardedOrigin
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
   }
 
   <% end %>


### PR DESCRIPTION
## :pancakes: Problème

Dans les environnements d'_integration_, _recette_ et _production_, les frontaux n'envoient pas les headers `x-forwarded-host` et `x-forwarded-proto` nécessaires à la fonction `getForwardedOrigin` de l'API ajoutée avec #11104.

Lors des précédents tests effectués lors de la revue de #11104 sur ses RA, on avait eu l'impression que tous les headers nécessaires seraient bien présents dans tous les environnements, et donc qu'ils seraient présents en _integration_, _recette_ et _production_. Mais ce n'était pas le cas car ces headers étaient positionnés par https://github.com/1024pix/pix-review-router/blob/main/nginx.conf.erb

## :bacon: Proposition

Ajouter l'envoi des headers `x-forwarded-host` et `x-forwarded-proto` dans la configuration nginx de chaque frontal.

## 🧃 Remarques

RAS

## :yum: Pour tester

1. Sur chaque RA, vérifier que l'ajout de ces headers ne provoque pas de régression. Pour cela il suffit de faire quelques requêtes à Pix API, par exemple s'authentifier avec un compte et vérifier que le frontal n'est pas cassé et est fonctionnel.

2. Puis vérifier sur chaque RA que `getForwardedOrigin` fonctionne toujours bien et renvoie toujours bien la valeur attendue : 
* https://app-pr11142.review.pix.fr/api/test-origin-soon-to-be-remove → `https://app-pr11142.review.pix.fr/`
* https://app-pr11142.review.pix.org/api/test-origin-soon-to-be-remove → `https://app-pr11142.review.pix.org/`
* https://orga-pr11142.review.pix.fr/api/test-origin-soon-to-be-remove → `https://orga-pr11142.review.pix.fr/`
* https://orga-pr11142.review.pix.org/api/test-origin-soon-to-be-remove → `https://orga-pr11142.review.pix.org/`
* https://certif-pr11142.review.pix.fr/api/test-origin-soon-to-be-remove → `https://certif-pr11142.review.pix.fr/`
* https://certif-pr11142.review.pix.org/api/test-origin-soon-to-be-remove → `https://certif-pr11142.review.pix.org/`
* https://admin-pr11142.review.pix.fr/api/test-origin-soon-to-be-remove → `https://admin-pr11142.review.pix.fr/`


On ne pourra vérifier la bonne réception des headers `x-forwarded-host` et `x-forwarded-proto` par Pix API dans les environnements d'_integration_, _recette_ et _production_ que lorsque le code de cette PR sera déployé dans ces environnements.