### PR TITLE
[FEATURE] Filtrer les organisations en sélectionnant le type (PIX-16125)

### DIFF
--- a/admin/app/components/organizations/list-items.gjs
+++ b/admin/app/components/organizations/list-items.gjs
@@ -2,6 +2,7 @@ import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
+import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
@@ -16,8 +17,14 @@ export default class ActionsOnUsersRoleInOrganization extends Component {
 
   searchedId = this.args.id;
   searchedName = this.args.name;
-  searchedType = this.args.type;
   searchedExternalId = this.args.externalId;
+
+  optionType = [
+    { value: 'PRO', label: 'PRO' },
+    { value: 'SCO', label: 'SCO' },
+    { value: 'SCO-1D', label: 'SCO-1D' },
+    { value: 'SUP', label: 'SUP' },
+  ];
 
   @action
   openModal(organization) {
@@ -35,6 +42,12 @@ export default class ActionsOnUsersRoleInOrganization extends Component {
   async detachOrganizations(organizationId) {
     await this.args.detachOrganizations(organizationId);
     this.closeModal();
+  }
+
+  @action
+  filter(value) {
+    const event = { target: { value } };
+    this.args.triggerFiltering('type', event);
   }
 
   <template>
@@ -59,7 +72,13 @@ export default class ActionsOnUsersRoleInOrganization extends Component {
                 <PixInput id="name" type="text" value={{this.searchedName}} oninput={{fn @triggerFiltering "name"}} />
               </td>
               <td>
-                <PixInput id="type" type="text" value={{this.searchedType}} oninput={{fn @triggerFiltering "type"}} />
+                <PixSelect
+                  @id="type"
+                  @options={{this.optionType}}
+                  @placeholder="- Type -"
+                  @onChange={{this.filter}}
+                  @value={{@type}}
+                />
               </td>
               <td>
                 <PixInput

--- a/admin/tests/acceptance/authenticated/organizations/list-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/list-test.js
@@ -90,8 +90,11 @@ module('Acceptance | Organizations | List', function (hooks) {
         // when
         const screen = await visit('/organizations/list?type=SCO');
 
+        await click(await screen.getByRole('button', { name: 'Type' }));
+        await screen.findByRole('listbox');
+
         // then
-        assert.dom(screen.getByRole('textbox', { name: 'Type' })).hasValue('SCO');
+        assert.dom(screen.getByRole('option', { selected: true })).hasText('SCO');
       });
 
       test('it should display the current filter when organizations are filtered by externalId', async function (assert) {

--- a/admin/tests/integration/components/routes/authenticated/organizations/list-items-test.gjs
+++ b/admin/tests/integration/components/routes/authenticated/organizations/list-items-test.gjs
@@ -32,7 +32,7 @@ module('Integration | Component | routes/authenticated/organizations | list-item
     // then
     assert.dom('table thead tr:nth-child(2) input#id').exists();
     assert.dom('table thead tr:nth-child(2) input#name').exists();
-    assert.dom('table thead tr:nth-child(2) input#type').exists();
+    assert.dom('table thead tr:nth-child(2) button#type').exists();
     assert.dom('table thead tr:nth-child(2) input#externalId').exists();
   });
 

--- a/api/src/shared/infrastructure/repositories/organization-repository.js
+++ b/api/src/shared/infrastructure/repositories/organization-repository.js
@@ -45,7 +45,7 @@ function _setSearchFiltersForQueryBuilder(qb, filter) {
     qb.whereILike('name', `%${name}%`);
   }
   if (type) {
-    qb.whereILike('type', `%${type}%`);
+    qb.where('type', type);
   }
   if (externalId) {
     qb.whereILike('externalId', `%${externalId}%`);

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -614,12 +614,30 @@ describe('Integration | Repository | Organization', function () {
         databaseBuilder.factory.buildOrganization({ type: 'PRO' });
         databaseBuilder.factory.buildOrganization({ type: 'SUP' });
         databaseBuilder.factory.buildOrganization({ type: 'SCO' });
+        databaseBuilder.factory.buildOrganization({ type: 'SCO-1D' });
         return databaseBuilder.commit();
       });
 
-      it('should return only Organizations matching "type" if given in filters', async function () {
+      it('should return only Organizations matching "type" if given in filters S', async function () {
         // given
         const filter = { type: 'S' };
+        const page = { number: 1, size: 10 };
+        const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 3 };
+
+        // when
+        const { models: matchingOrganizations, pagination } = await organizationRepository.findPaginatedFiltered({
+          filter,
+          page,
+        });
+
+        // then
+        expect(_.map(matchingOrganizations, 'type')).to.have.members(['SCO', 'SCO-1D', 'SUP']);
+        expect(pagination).to.deep.equal(expectedPagination);
+      });
+
+      it('should return only Organizations matching "type" if given in filters SCO', async function () {
+        // given
+        const filter = { type: 'SCO' };
         const page = { number: 1, size: 10 };
         const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 2 };
 
@@ -630,7 +648,7 @@ describe('Integration | Repository | Organization', function () {
         });
 
         // then
-        expect(_.map(matchingOrganizations, 'type')).to.have.members(['SUP', 'SCO']);
+        expect(_.map(matchingOrganizations, 'type')).to.have.members(['SCO', 'SCO-1D']);
         expect(pagination).to.deep.equal(expectedPagination);
       });
     });

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -608,7 +608,7 @@ describe('Integration | Repository | Organization', function () {
       });
     });
 
-    context('when there are multiple Organizations matching the same "type" search pattern', function () {
+    context('when there are multiple Organizations matching the same "type" search', function () {
       beforeEach(function () {
         databaseBuilder.factory.buildOrganization({ type: 'PRO' });
         databaseBuilder.factory.buildOrganization({ type: 'PRO' });
@@ -618,11 +618,11 @@ describe('Integration | Repository | Organization', function () {
         return databaseBuilder.commit();
       });
 
-      it('should return only Organizations matching "type" if given in filters S', async function () {
+      it('should return empty array when type is not strict equal', async function () {
         // given
         const filter = { type: 'S' };
         const page = { number: 1, size: 10 };
-        const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 3 };
+        const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 0, rowCount: 0 };
 
         // when
         const { models: matchingOrganizations, pagination } = await organizationRepository.findPaginatedFiltered({
@@ -631,7 +631,7 @@ describe('Integration | Repository | Organization', function () {
         });
 
         // then
-        expect(_.map(matchingOrganizations, 'type')).to.have.members(['SCO', 'SCO-1D', 'SUP']);
+        expect(_.map(matchingOrganizations, 'type')).to.have.members([]);
         expect(pagination).to.deep.equal(expectedPagination);
       });
 
@@ -639,7 +639,7 @@ describe('Integration | Repository | Organization', function () {
         // given
         const filter = { type: 'SCO' };
         const page = { number: 1, size: 10 };
-        const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 2 };
+        const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 1 };
 
         // when
         const { models: matchingOrganizations, pagination } = await organizationRepository.findPaginatedFiltered({
@@ -648,7 +648,7 @@ describe('Integration | Repository | Organization', function () {
         });
 
         // then
-        expect(_.map(matchingOrganizations, 'type')).to.have.members(['SCO', 'SCO-1D']);
+        expect(_.map(matchingOrganizations, 'type')).to.have.members(['SCO']);
         expect(pagination).to.deep.equal(expectedPagination);
       });
     });
@@ -893,7 +893,7 @@ describe('Integration | Repository | Organization', function () {
 
       it('should return only organizations matching "type"', async function () {
         // given
-        const filter = { type: 'S' };
+        const filter = { type: 'SUP' };
         const page = { number: 1, size: 10 };
         const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 1 };
 


### PR DESCRIPTION
## :pancakes: Problème

Dans admin, on peut filtrer les organisations en fonction du type avec un PixInput 
Comme on a maintenant 2 types d'organisations qui commencent de la même façon 'SCO' et 'SCO-1D', c'est plus fastidieux pour la recherche, notamment pour le support. 

## :bacon: Proposition

Comme on a peu de valeurs pour les types, on peut utiliser un PixSelect pour sélectionner directement le type au lieu de le rechercher.

## 🧃 Remarques

Merci à ceux qui m'ont aidée, sans qui je n'en serais pas là aujourd'hui.

## :yum: Pour tester
- se rendre sur PixAdmin 
- sélectionner un type 
- vérifier qu'on a les bonnes organisations filtrées 
- vérifier qu'on a bien le type sélectionné en en-tête
- changer de type etc. 
🫰 