### PR TITLE
[TECH] Corriger la mention fr d'activation d'espace pix-orga (PIX-16179)

### DIFF
--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -853,7 +853,7 @@
       "title": "Connectez-vous"
     },
     "login-form": {
-      "active-or-retrieve": "Vous êtes personnel de direction ? Activez ou devenez l'administrateur de l'espace Pix Orga de votre établissement scolaire",
+      "active-or-retrieve": "Vous êtes personnel de direction ou directeur d'école ? Activez ou devenez l'administrateur de l'espace Pix Orga de votre établissement scolaire",
       "email": "Adresse e-mail",
       "errors": {
         "empty-password": "Le champ mot de passe est obligatoire.",


### PR DESCRIPTION
## :pancakes: Problème

Lors du ticket #11087 une erreur s'est glissée dans la mention fr

## :bacon: Proposition

Correction de la version 
 "Vous êtes personnel de direction ? Activez ou devenez l'administrateur de l'espace Pix Orga de votre établissement scolaire",

par

"Vous êtes personnel de direction ou directeur d'école ? Activez ou devenez l'administrateur de l'espace Pix Orga de votre établissement scolaire"


## 🧃 Remarques

Oups

## :yum: Pour tester

Constater, sur la page de connexion à pix-orga, que la mention est désormais: " Vous êtes personnel de direction ou directeur d'école ? Activez ou devenez l'administrateur de l'espace Pix Orga de votre établissement scolaire"
