### PR TITLE
[BUGFIX] Permettre de finaliser/publier une session dont une certif ne contient pas de challenge (PIX-16128).

### DIFF
--- a/api/src/certification/flash-certification/domain/services/algorithm-methods/flash.js
+++ b/api/src/certification/flash-certification/domain/services/algorithm-methods/flash.js
@@ -40,7 +40,7 @@ function getPossibleNextChallenges({ availableChallenges, capacity = DEFAULT_CAP
 }
 
 function getCapacityAndErrorRate({ allAnswers, challenges, capacity = DEFAULT_CAPACITY, variationPercent }) {
-  if (allAnswers.length === 0) {
+  if (challenges.length === 0 || allAnswers.length === 0) {
     return { capacity, errorRate: DEFAULT_ERROR_RATE };
   }
 

--- a/api/src/certification/session-management/domain/models/CertificationAssessment.js
+++ b/api/src/certification/session-management/domain/models/CertificationAssessment.js
@@ -197,7 +197,7 @@ class CertificationAssessment {
   }
 
   get isScoringBlockedDueToComplementaryOnlyChallenges() {
-    return this.isComplementaryOnly;
+    return this.certificationChallenges.length > 0 && this.isComplementaryOnly;
   }
 
   _getLastChallenge() {

--- a/api/src/certification/session-management/domain/models/CertificationAssessment.js
+++ b/api/src/certification/session-management/domain/models/CertificationAssessment.js
@@ -35,8 +35,9 @@ const certificationAssessmentSchema = Joi.object({
     .integer()
     .valid(...Object.values(AlgorithmEngineVersion))
     .required(),
-  certificationChallenges: Joi.array().min(1).required(),
-  certificationAnswersByDate: Joi.array().min(0).required(),
+  // TODO: Add a minimum number of 1 challenge
+  certificationChallenges: Joi.array().required(),
+  certificationAnswersByDate: Joi.array().required(),
 });
 
 class CertificationAssessment {
@@ -92,7 +93,7 @@ class CertificationAssessment {
   endDueToFinalization() {
     if (this.state === states.STARTED) {
       this.state = states.ENDED_DUE_TO_FINALIZATION;
-      this.endedAt = this._getLastChallenge().createdAt;
+      this.endedAt = this._getLastChallenge()?.createdAt || this.createdAt;
     }
   }
 

--- a/api/src/certification/session-management/domain/models/V3CertificationChallengeForAdministration.js
+++ b/api/src/certification/session-management/domain/models/V3CertificationChallengeForAdministration.js
@@ -23,7 +23,6 @@ export class V3CertificationChallengeForAdministration {
 
   setCompetenceDetails(list) {
     const competence = list.find(({ id }) => id === this.competenceId);
-
     this.competenceName = competence.name;
     this.competenceIndex = competence.index;
   }

--- a/api/src/certification/session-management/infrastructure/repositories/v3-certification-course-details-for-administration-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/v3-certification-course-details-for-administration-repository.js
@@ -69,7 +69,7 @@ const getV3DetailsByCertificationCourseId = async function ({ certificationCours
       skillName: 'certification-challenges.associatedSkillName',
     })
     .from('assessments')
-    .leftJoin('certification-challenges', 'certification-challenges.courseId', 'assessments.certificationCourseId')
+    .innerJoin('certification-challenges', 'certification-challenges.courseId', 'assessments.certificationCourseId')
     .leftJoin('answers', function () {
       this.on({ 'answers.assessmentId': 'assessments.id' }).andOn({
         'answers.challengeId': 'certification-challenges.challengeId',

--- a/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
@@ -1,5 +1,5 @@
 import * as flash from '../../../../../../../src/certification/flash-certification/domain/services/algorithm-methods/flash.js';
-import { AnswerStatus } from '../../../../../../../src/shared/domain/models/AnswerStatus.js';
+import { AnswerStatus } from '../../../../../../../src/shared/domain/models/index.js';
 import { domainBuilder, expect } from '../../../../../../test-helper.js';
 
 describe('Integration | Domain | Algorithm-methods | Flash', function () {
@@ -91,12 +91,27 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
   });
 
   describe('#getCapacityAndErrorRate', function () {
+    it('should return 0 when there is no challenges', function () {
+      // given
+      const challenges = [];
+
+      // when
+      const result = flash.getCapacityAndErrorRate({ challenges });
+
+      // then
+      expect(result).to.deep.equal({
+        capacity: 0,
+        errorRate: 5,
+      });
+    });
+
     it('should return 0 when there is no answers', function () {
       // given
       const allAnswers = [];
+      const challenges = [];
 
       // when
-      const result = flash.getCapacityAndErrorRate({ allAnswers });
+      const result = flash.getCapacityAndErrorRate({ allAnswers, challenges });
 
       // then
       expect(result).to.deep.equal({

--- a/api/tests/certification/session-management/acceptance/application/finalize-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/finalize-route_test.js
@@ -669,8 +669,6 @@ describe('Certification | Session Management | Acceptance | Application | Route 
         });
       });
     });
-
-    // TODO: it('should rollback the finalize session operations when it fails in processAutoJury');
   });
 });
 

--- a/api/tests/certification/session-management/acceptance/application/finalize-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/finalize-route_test.js
@@ -619,6 +619,57 @@ describe('Certification | Session Management | Acceptance | Application | Route 
       });
     });
 
+    describe('When there were no challenges', function () {
+      describe('when session is v3', function () {
+        it('should set the finalized session as publishable', async function () {
+          // given
+          const { report, assessmentId, userId, session, certificationCourseId } =
+            await _createSessionWithoutChallenge();
+          const options = {
+            method: 'PUT',
+            payload: {
+              data: {
+                attributes: {
+                  'examiner-global-comment': null,
+                  'has-incident': false,
+                  'has-joining-issue': true,
+                },
+                included: [
+                  {
+                    id: report.id,
+                    type: 'certification-reports',
+                    attributes: {
+                      'certification-course-id': report.certificationCourseId,
+                      'examiner-comment': 'What a fine lad this one',
+                      'has-seen-end-test-screen': false,
+                      'is-completed': false,
+                      'abort-reason': 'technical',
+                    },
+                  },
+                ],
+              },
+            },
+            headers: {
+              authorization: generateValidRequestAuthorizationHeader(userId),
+            },
+            url: `/api/sessions/${session.id}/finalization`,
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          const finalizedSession = await knex('finalized-sessions').where({ sessionId: session.id }).first();
+          expect(finalizedSession.isPublishable).to.be.true;
+          const assessmentResult = await knex('assessment-results').where({ assessmentId }).first();
+          expect(assessmentResult.status).to.equal('rejected');
+          const assessment = await knex('assessments').where({ certificationCourseId }).first();
+          expect(assessment.state).to.equal('endedDueToFinalization');
+        });
+      });
+    });
+
     // TODO: it('should rollback the finalize session operations when it fails in processAutoJury');
   });
 });
@@ -729,4 +780,66 @@ const _createSession = async ({ version = 2 } = {}) => {
     session,
     options,
   };
+};
+
+const _createSessionWithoutChallenge = async () => {
+  const version = 3;
+
+  const learningContent = [
+    {
+      id: 'recArea0',
+      competences: [
+        {
+          id: 'recCompetence0',
+          index: '1.1',
+        },
+      ],
+    },
+  ];
+  const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
+  await mockLearningContent(learningContentObjects);
+
+  const userId = databaseBuilder.factory.buildUser().id;
+  const candidateId = databaseBuilder.factory.buildUser().id;
+  const session = databaseBuilder.factory.buildSession({ version });
+  databaseBuilder.factory.buildFlashAlgorithmConfiguration({
+    createdAt: new Date('2024-01-01'),
+  });
+  databaseBuilder.factory.buildScoringConfiguration({
+    createdByUserId: userId,
+    createdAt: new Date('2024-01-01'),
+  });
+  databaseBuilder.factory.buildCompetenceScoringConfiguration({
+    createdByUserId: userId,
+    createdAt: new Date('2024-01-01'),
+    configuration: [],
+  });
+  databaseBuilder.factory.buildCertificationCenterMembership({
+    userId,
+    certificationCenterId: session.certificationCenterId,
+  });
+  databaseBuilder.factory.buildCertificationCandidate({
+    sessionId: session.id,
+    userId: candidateId,
+    reconciledAt: new Date('2024-01-01'),
+  });
+  const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+    sessionId: session.id,
+    completedAt: null,
+    version,
+    abortReason: 'technical',
+    userId: candidateId,
+    createdAt: new Date('2025-01-01'),
+  }).id;
+  const assessmentId = databaseBuilder.factory.buildAssessment({
+    certificationCourseId,
+    state: Assessment.states.STARTED,
+  }).id;
+  const report = databaseBuilder.factory.buildCertificationReport({
+    sessionId: session.id,
+    certificationCourseId,
+  });
+  await databaseBuilder.commit();
+
+  return { assessmentId, report, userId, session, certificationCourseId };
 };

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/v3-certification-course-details-for-administration-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/v3-certification-course-details-for-administration-repository_test.js
@@ -259,5 +259,35 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
         expectedCertificationChallengesForAdministration,
       );
     });
+
+    describe('when there are no challenges', function () {
+      it('should return a V3CertificationCourseDetails without challenges', async function () {
+        // given
+        const certificationCourseId = 123;
+        const flashAlgorithmConfigurationCreationDate = new Date('2020-01-01');
+        const assessmentId = 78;
+
+        databaseBuilder.factory.buildFlashAlgorithmConfiguration({
+          maximumAssessmentLength: 3,
+          createdAt: flashAlgorithmConfigurationCreationDate,
+        });
+        databaseBuilder.factory.buildCertificationCourse({ id: certificationCourseId });
+        databaseBuilder.factory.buildAssessment({
+          id: assessmentId,
+          certificationCourseId,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const certificationChallenges =
+          await v3CertificationCourseDetailsForAdministrationRepository.getV3DetailsByCertificationCourseId({
+            certificationCourseId,
+          });
+
+        // then
+        expect(certificationChallenges.certificationChallengesForAdministration).to.deep.equal([]);
+      });
+    });
   });
 });

--- a/api/tests/certification/session-management/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/certification/session-management/unit/domain/models/CertificationAssessment_test.js
@@ -1078,5 +1078,19 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
       // then
       expect(isScoringBlockedDueToComplementaryOnlyChallenges).to.be.false;
     });
+
+    it('should return false if there are no challenges', function () {
+      //given
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationChallenges: [],
+        certificationAnswersByDate: [],
+      });
+
+      // when
+      const isComplementaryOnly = certificationAssessment.isScoringBlockedDueToComplementaryOnlyChallenges;
+
+      // then
+      expect(isComplementaryOnly).to.be.false;
+    });
   });
 });

--- a/api/tests/certification/session-management/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/certification/session-management/unit/domain/models/CertificationAssessment_test.js
@@ -8,7 +8,7 @@ import { CertificationAnswerStatusChangeAttempt } from '../../../../../../src/ce
 import { CertificationAssessment } from '../../../../../../src/certification/session-management/domain/models/CertificationAssessment.js';
 import { NeutralizationAttempt } from '../../../../../../src/certification/session-management/domain/models/NeutralizationAttempt.js';
 import { ObjectValidationError } from '../../../../../../src/shared/domain/errors.js';
-import { AnswerStatus } from '../../../../../../src/shared/domain/models/AnswerStatus.js';
+import { AnswerStatus } from '../../../../../../src/shared/domain/models/index.js';
 import { domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Domain | Models | CertificationAssessment', function () {
@@ -24,7 +24,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
         completedAt: new Date('2020-01-01'),
         state: CertificationAssessment.states.STARTED,
         version: 2,
-        certificationChallenges: ['challenge'],
+        certificationChallenges: [],
         certificationAnswersByDate: ['answer'],
       };
     });
@@ -88,13 +88,6 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
     it('should throw an ObjectValidationError when version is not valid', function () {
       // when
       expect(() => new CertificationAssessment({ ...validArguments, version: 'glouglou' })).to.throw(
-        ObjectValidationError,
-      );
-    });
-
-    it('should throw an ObjectValidationError when certificationChallenges is not valid', function () {
-      // when
-      expect(() => new CertificationAssessment({ ...validArguments, certificationChallenges: [] })).to.throw(
         ObjectValidationError,
       );
     });
@@ -432,26 +425,47 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
         expect(certificationAssessment.state).to.equal(CertificationAssessment.states.ENDED_DUE_TO_FINALIZATION);
       });
 
-      it('should set endedAt date', function () {
-        // given
-        const firstChallengeDate = new Date('2020-12-31T10:00:00Z');
-        const lastChallengeDate = new Date('2020-12-31T10:02:00Z');
-        const certificationChallenge = domainBuilder.buildCertificationChallenge({
-          createdAt: firstChallengeDate,
-        });
-        const lastCertificationChallenge = domainBuilder.buildCertificationChallenge({
-          createdAt: lastChallengeDate,
-        });
-        const certificationAssessment = domainBuilder.buildCertificationAssessment({
-          state: CertificationAssessment.states.STARTED,
-          certificationChallenges: [lastCertificationChallenge, certificationChallenge],
-        });
+      describe('where there are challenges', function () {
+        it('should set the last challenge creation date as certification end date', function () {
+          // given
+          const firstChallengeDate = new Date('2020-12-31T10:00:00Z');
+          const lastChallengeDate = new Date('2020-12-31T10:02:00Z');
+          const certificationChallenge = domainBuilder.buildCertificationChallenge({
+            createdAt: firstChallengeDate,
+          });
+          const lastCertificationChallenge = domainBuilder.buildCertificationChallenge({
+            createdAt: lastChallengeDate,
+          });
+          const certificationAssessment = domainBuilder.buildCertificationAssessment({
+            state: CertificationAssessment.states.STARTED,
+            certificationChallenges: [lastCertificationChallenge, certificationChallenge],
+          });
 
-        // when
-        certificationAssessment.endDueToFinalization();
+          // when
+          certificationAssessment.endDueToFinalization();
 
-        // then
-        expect(certificationAssessment.endedAt).to.deep.equal(lastChallengeDate);
+          // then
+          expect(certificationAssessment.endedAt).to.deep.equal(lastChallengeDate);
+        });
+      });
+
+      describe('where there are no challenges', function () {
+        it('should set the certification course created date as end date', function () {
+          // given
+          const certificationCourseCreatedAt = new Date('2020-01-01');
+
+          const certificationAssessment = domainBuilder.buildCertificationAssessment({
+            state: CertificationAssessment.states.STARTED,
+            createdAt: certificationCourseCreatedAt,
+            certificationChallenges: [],
+          });
+
+          // when
+          certificationAssessment.endDueToFinalization();
+
+          // then
+          expect(certificationAssessment.endedAt).to.deep.equal(certificationCourseCreatedAt);
+        });
       });
     });
 

--- a/api/tests/certification/session-management/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/certification/session-management/unit/domain/models/CertificationAssessment_test.js
@@ -449,7 +449,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
         });
       });
 
-      describe('where there are no challenges', function () {
+      describe('when there are no challenges', function () {
         it('should set the certification course created date as end date', function () {
           // given
           const certificationCourseCreatedAt = new Date('2020-01-01');

--- a/api/tests/certification/session-management/unit/domain/models/V3CertificationCourseDetailsForAdministration_test.js
+++ b/api/tests/certification/session-management/unit/domain/models/V3CertificationCourseDetailsForAdministration_test.js
@@ -2,43 +2,71 @@ import { domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Domain | Models | V3CertificationCourseDetailsForAdministration', function () {
   describe('setCompetencesDetails', function () {
-    it('should set the competence name and ids', function () {
-      const certificationCourseId = 123;
-      const competenceId = 'competenceID';
-      const competenceName = 'competenceName';
-      const competenceIndex = '1.2';
+    describe('if there are challenges', function () {
+      it('should set the competence name and ids', function () {
+        const certificationCourseId = 123;
+        const competenceId = 'competenceID';
+        const competenceName = 'competenceName';
+        const competenceIndex = '1.2';
 
-      const competenceList = [
-        domainBuilder.buildCompetence({
-          id: competenceId,
-          name: competenceName,
-          index: competenceIndex,
-        }),
-        domainBuilder.buildCompetence({
-          id: 'other',
-          name: 'otherName',
-          index: 'otherIndex',
-        }),
-      ];
+        const competenceList = [
+          domainBuilder.buildCompetence({
+            id: competenceId,
+            name: competenceName,
+            index: competenceIndex,
+          }),
+          domainBuilder.buildCompetence({
+            id: 'other',
+            name: 'otherName',
+            index: 'otherIndex',
+          }),
+        ];
 
-      const challenge = domainBuilder.buildV3CertificationChallengeForAdministration({
-        competenceId,
-      });
-
-      const courseDetails = domainBuilder.buildV3CertificationCourseDetailsForAdministration({
-        certificationCourseId,
-        certificationChallengesForAdministration: [challenge],
-      });
-
-      courseDetails.setCompetencesDetails(competenceList);
-
-      expect(courseDetails.certificationChallengesForAdministration[0]).to.deep.equal(
-        domainBuilder.buildV3CertificationChallengeForAdministration({
+        const challenge = domainBuilder.buildV3CertificationChallengeForAdministration({
           competenceId,
-          competenceName,
-          competenceIndex,
-        }),
-      );
+        });
+
+        const courseDetails = domainBuilder.buildV3CertificationCourseDetailsForAdministration({
+          certificationCourseId,
+          certificationChallengesForAdministration: [challenge],
+        });
+
+        courseDetails.setCompetencesDetails(competenceList);
+
+        expect(courseDetails.certificationChallengesForAdministration[0]).to.deep.equal(
+          domainBuilder.buildV3CertificationChallengeForAdministration({
+            competenceId,
+            competenceName,
+            competenceIndex,
+          }),
+        );
+      });
+    });
+
+    describe('if there are not challenges', function () {
+      it('should set the competence name and ids', function () {
+        const certificationCourseId = 123;
+        const competenceId = 'competenceID';
+        const competenceName = 'competenceName';
+        const competenceIndex = '1.2';
+
+        const competenceList = [
+          domainBuilder.buildCompetence({
+            id: competenceId,
+            name: competenceName,
+            index: competenceIndex,
+          }),
+        ];
+
+        const courseDetails = domainBuilder.buildV3CertificationCourseDetailsForAdministration({
+          certificationCourseId,
+          certificationChallengesForAdministration: [],
+        });
+
+        courseDetails.setCompetencesDetails(competenceList);
+
+        expect(courseDetails.certificationChallengesForAdministration).to.deep.equal([]);
+      });
     });
   });
 });


### PR DESCRIPTION
## :pancakes: Problème

Il est arrivé que des candidats n’aient pas réussi à obtenir de certification-challenge en se connectant à leur test.
Ceci empêche le scoring de la certification lors de la finalisation.

Dans un premier temps, il faudrait que le fait de ne pas avoir eu de challenges n’empêche pas la finalisation.

## :bacon: Proposition

Ne pas bloquer le process de finalisation/publication si une certif ne contient pas de challenge

## 🧃 Remarques

Nous gérons l'origine du problème dans un autre ticket.

## :yum: Pour tester

- Créer une nouvelle session de certif (`certifv3@example.net`)
- Ajouter un candidat
- Faire rentrer le candidat en session de certif (`certif-success@example.net`)
- Ne pas répondre à la première question
- Supprimer la première question du candidat dans la table `certification-challenges` en récupérant son id grâce aux requêtes suivantes: 

```sql
select id from "certification-challenges" order by "createdAt" desc limit 1;
```
 Puis 
 ```sql
 delete from "certification-challenges" where id = <id>
```

- Terminer le test du candidat via l'espace surveillant
- Finaliser la session en ajoutant `Problème technique` comme raison d'abandon du candidat
- Sur pix-admin (`superadmin@example.net`), aller sur la page de détails
- Vérifier que celle-ci s'affiche
- Publier la session
- Vérifier que tout le process s'est déroulé sans accroc