### PR TITLE
[BUGFIX] Rendre optionnel l'url d'une image dans une Flashcards (PIX-16150)

### DIFF
--- a/api/src/devcomp/domain/models/element/flashcards/Card.js
+++ b/api/src/devcomp/domain/models/element/flashcards/Card.js
@@ -1,8 +1,12 @@
 class Card {
   constructor({ id, recto, verso }) {
     this.id = id;
-    this.recto = recto;
-    this.verso = verso;
+    this.recto = this.#buildSideIgnoringEmptyImageUrl(recto);
+    this.verso = this.#buildSideIgnoringEmptyImageUrl(verso);
+  }
+
+  #buildSideIgnoringEmptyImageUrl(side) {
+    return side.image?.url?.length > 0 ? side : { text: side.text };
   }
 }
 

--- a/api/src/devcomp/domain/models/element/flashcards/Flashcards.js
+++ b/api/src/devcomp/domain/models/element/flashcards/Flashcards.js
@@ -1,4 +1,5 @@
 import { Element } from '../Element.js';
+import { Card } from './Card.js';
 
 class Flashcards extends Element {
   constructor({ id, title, instruction, introImage, cards }) {
@@ -7,7 +8,8 @@ class Flashcards extends Element {
     this.title = title;
     this.instruction = instruction;
     this.introImage = introImage;
-    this.cards = cards;
+    this.cards = cards.map(({ id, recto, verso }) => new Card({ id, recto, verso }));
   }
 }
+
 export { Flashcards };

--- a/api/src/devcomp/domain/models/element/flashcards/Flashcards.js
+++ b/api/src/devcomp/domain/models/element/flashcards/Flashcards.js
@@ -7,8 +7,12 @@ class Flashcards extends Element {
 
     this.title = title;
     this.instruction = instruction;
-    this.introImage = introImage;
+    this.setIntroImage(introImage);
     this.cards = cards.map(({ id, recto, verso }) => new Card({ id, recto, verso }));
+  }
+
+  setIntroImage(introImage) {
+    this.introImage = introImage?.url?.length > 0 ? introImage : undefined;
   }
 }
 

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -64,7 +64,7 @@
                 },
                 "verso": {
                   "image": {
-                    "url": "https://images.pix.fr/modulix/didacticiel/chaton.jpg"
+                    "url": ""
                   },
                   "text": "<p>Arthur Rimbaud</p>"
                 }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/flashcards.sample.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/flashcards.sample.js
@@ -1,0 +1,45 @@
+import { randomUUID } from 'node:crypto';
+
+export function getFlashcardsSample() {
+  return {
+    id: randomUUID(),
+    type: 'flashcards',
+    title: "Introduction à l'adresse e-mail",
+    instruction: '<p>...</p>',
+    introImage: {
+      url: 'https://example.org/image.jpeg',
+    },
+    cards: [
+      {
+        id: randomUUID(),
+        recto: {
+          image: {
+            url: 'https://example.org/image.jpeg',
+          },
+          text: "A quoi sert l'arobase dans mon adresse email ?",
+        },
+        verso: {
+          image: {
+            url: 'https://example.org/image.jpeg',
+          },
+          text: "Parce que c'est joli",
+        },
+      },
+      {
+        id: randomUUID(),
+        recto: {
+          image: {
+            url: '',
+          },
+          text: "A quoi sert l'apostrophe typographique ?",
+        },
+        verso: {
+          image: {
+            url: '',
+          },
+          text: "Parce que c'est joli",
+        },
+      },
+    ],
+  };
+}

--- a/api/tests/devcomp/unit/domain/models/element/flashcards/Card_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/flashcards/Card_test.js
@@ -1,4 +1,5 @@
 import { Card } from '../../../../../../../src/devcomp/domain/models/element/flashcards/Card.js';
+import { expect } from '../../../../../../test-helper.js';
 import { validateCard } from '../../../../../shared/validateFlashcards.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | Flashcards | Card', function () {
@@ -26,6 +27,34 @@ describe('Unit | Devcomp | Domain | Models | Element | Flashcards | Card', funct
 
       // then
       validateCard(card, attributes);
+    });
+
+    describe('when the image‘s url is empty or null for ‘recto‘ or ‘verso‘ field', function () {
+      it('should create a card without image field', function () {
+        // given
+        const attributes = {
+          id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+          recto: {
+            image: {
+              url: '',
+            },
+            text: "A quoi sert l'arobase dans mon adresse email ?",
+          },
+          verso: {
+            image: {
+              url: null,
+            },
+            text: "Parce que c'est joli",
+          },
+        };
+
+        // when
+        const card = new Card(attributes);
+
+        // then
+        expect(card.recto.image).to.be.undefined;
+        expect(card.verso.image).to.be.undefined;
+      });
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/element/flashcards/Flashcards_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/flashcards/Flashcards_test.js
@@ -1,5 +1,6 @@
 import { Card } from '../../../../../../../src/devcomp/domain/models/element/flashcards/Card.js';
 import { Flashcards } from '../../../../../../../src/devcomp/domain/models/element/flashcards/Flashcards.js';
+import { expect } from '../../../../../../test-helper.js';
 import { validateFlashcards } from '../../../../../shared/validateFlashcards.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | Flashcards | Flashcards', function () {
@@ -31,6 +32,38 @@ describe('Unit | Devcomp | Domain | Models | Element | Flashcards | Flashcards',
 
       // then
       validateFlashcards(flashcards, attributes);
+    });
+
+    describe('when ‘introImage.url‘ is empty or undefined', function () {
+      it('should create a Flashcards without ‘introImage‘', function () {
+        const attributes = {
+          id: 'id',
+          title: 'title',
+          instruction: 'instruction',
+          introImage: {
+            url: '',
+          },
+          cards: [
+            new Card({
+              id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+              recto: { image: { url: 'https://...' } },
+              verso: {
+                image: {
+                  url: 'https://...',
+                },
+              },
+            }),
+          ],
+        };
+        const attributesWithUndefinedIntroImageUrl = { ...attributes, introImage: { url: undefined } };
+        const flashcardsAttributes = [attributes, attributesWithUndefinedIntroImageUrl];
+
+        // when
+        const flashcards = flashcardsAttributes.map((flashcardAttribute) => new Flashcards(flashcardAttribute));
+
+        // then
+        flashcards.forEach((flashcard) => expect(flashcard.introImage).to.be.undefined);
+      });
     });
   });
 });

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/flashcards-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/flashcards-schema.js
@@ -3,7 +3,7 @@ import Joi from 'joi';
 import { htmlNotAllowedSchema, htmlSchema, uuidSchema } from '../utils.js';
 
 const image = Joi.object({
-  url: Joi.string().uri().required(),
+  url: Joi.string().uri().allow('').required(),
 });
 
 const rectoSide = Joi.object({

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -1,5 +1,6 @@
 import { getDownloadSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/download.sample.js';
 import { getEmbedSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/embed.sample.js';
+import { getFlashcardsSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/flashcards.sample.js';
 import { getImageSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/image.sample.js';
 import { getQcmSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/qcm.sample.js';
 import { getQcuSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/qcu.sample.js';
@@ -10,6 +11,7 @@ import { getVideoSample } from '../../../../../../../src/devcomp/infrastructure/
 import { expect } from '../../../../../../test-helper.js';
 import { downloadElementSchema } from './element/download-schema.js';
 import { embedElementSchema } from './element/embed-schema.js';
+import { flashcardsElementSchema } from './element/flashcards-schema.js';
 import { imageElementSchema } from './element/image-schema.js';
 import { qcmElementSchema } from './element/qcm-schema.js';
 import { qcuElementSchema } from './element/qcu-schema.js';
@@ -34,6 +36,15 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
     it('should validate sample embed structure', async function () {
       try {
         await embedElementSchema.validateAsync(getEmbedSample(), { abortEarly: false });
+      } catch (joiError) {
+        const formattedError = joiErrorParser.format(joiError);
+        expect(joiError).to.equal(undefined, formattedError);
+      }
+    });
+
+    it('should validate sample flashcard structure', async function () {
+      try {
+        await flashcardsElementSchema.validateAsync(getFlashcardsSample(), { abortEarly: false });
       } catch (joiError) {
         const formattedError = joiErrorParser.format(joiError);
         expect(joiError).to.equal(undefined, formattedError);


### PR DESCRIPTION
## :pancakes: Problème

Lorsqu’on crée une flashcard sans image dans Modulix Editor, la validation échoue, car la propriété image (qui est facultative) est présente mais la propriété `image.url` (qui est obligatoire si image est présent) est une chaine de caractère vide.

## :bacon: Proposition

Permettre de créer des flashcards avec un champ `image.url` égal à une chaîne de caractère vide

## 🧃 Remarques

- Nous avons modifié la responsabilité du domaine pour les `Card` et `Flashcards` afin de ne pas instancier d'image si le champ image.url est vide.

## :yum: Pour tester
- Dans le didacticiel, on a édité une carte de flaschards où on a mis une URL vide. On doit pouvoir afficher le module didacticiel dans Modulix sans erreur : https://app-pr11159.review.pix.fr/modules/didacticiel-modulix/passage
