### PR TITLE
[FEATURE] Remplir le mail automatiquement sur la page de réinitialisation du mot de passe si celui-ci a déjà été remplis sur la page de connexion (PIX13572)

### DIFF
--- a/mon-pix/app/components/authentication/login-form.gjs
+++ b/mon-pix/app/components/authentication/login-form.gjs
@@ -29,6 +29,7 @@ const VALIDATION_ERRORS = {
 export default class LoginForm extends Component {
   @service url;
   @service session;
+  @service storage;
   @service store;
   @service router;
 
@@ -72,6 +73,7 @@ export default class LoginForm extends Component {
   updateLogin(event) {
     this.login = event.target.value?.trim();
     this.validation.login.validate(this.login);
+    this.storage.setLogin(this.login);
   }
 
   @action

--- a/mon-pix/app/components/authentication/password-reset-demand/password-reset-demand-form.gjs
+++ b/mon-pix/app/components/authentication/password-reset-demand/password-reset-demand-form.gjs
@@ -16,11 +16,17 @@ import PasswordResetDemandReceivedInfo from './password-reset-demand-received-in
 export default class PasswordResetDemandForm extends Component {
   @service errors;
   @service requestManager;
+  @service storage;
   @service url;
 
   @tracked globalError = this.errors.hasErrors && this.errors.shift();
   @tracked isLoading = false;
   @tracked isPasswordResetDemandReceived = false;
+
+  constructor() {
+    super(...arguments);
+    this.email = this.storage.getLogin();
+  }
 
   validation = new FormValidation({
     email: {

--- a/mon-pix/app/services/storage.js
+++ b/mon-pix/app/services/storage.js
@@ -1,0 +1,13 @@
+import Service from '@ember/service';
+
+const SESSIONSTORAGE_LOGIN = 'PIX_LOGIN';
+
+export default class Storage extends Service {
+  setLogin(login) {
+    sessionStorage.setItem(SESSIONSTORAGE_LOGIN, login);
+  }
+
+  getLogin() {
+    return sessionStorage.getItem(SESSIONSTORAGE_LOGIN);
+  }
+}

--- a/mon-pix/tests/unit/services/storage-test.js
+++ b/mon-pix/tests/unit/services/storage-test.js
@@ -1,0 +1,43 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Service | storage', function (hooks) {
+  setupTest(hooks);
+
+  test('setLogin', function (assert) {
+    // given
+    const service = this.owner.lookup('service:storage');
+    const login = 'someone@example.net';
+
+    // when
+    service.setLogin(login);
+
+    // then
+    assert.strictEqual(sessionStorage.getItem('PIX_LOGIN'), login);
+  });
+
+  test('getLogin', function (assert) {
+    // given
+    const service = this.owner.lookup('service:storage');
+    const login = 'someone@example.net';
+    sessionStorage.setItem('PIX_LOGIN', login);
+
+    // when
+    const result = service.getLogin();
+
+    // then
+    assert.strictEqual(result, login);
+  });
+
+  test('getLogin with no login', function (assert) {
+    // given
+    const service = this.owner.lookup('service:storage');
+    sessionStorage.clear();
+
+    // when
+    const result = service.getLogin();
+
+    // then
+    assert.strictEqual(result, null);
+  });
+});


### PR DESCRIPTION
## :pancakes: Problème

Lorsqu'on est sur la page de connexion, si on clique sur "Mot de passe oublié", on est obligé de resaisir son email.

## :bacon: Proposition

Utiliser le sesssionStorage pour faire passer directement le mail dans le nouveau champ.

## 🧃 Remarques

Pourquoi ça n'a pas marché lors de mes premiers essais, aucune idée, mais là ça marche.
De plus, on efface la valeur après utilisation afin de libérer la mémoire.
Enfin, on créé un service dédié au storage qui va notamment fixer et récupérer la valeur de login.

## :yum: Pour tester
- Se rendre sur Pix-app,
- Entrer un mail dans la page de connexion,
- Faire "Mot de passe oublié",
- Constater que le mail saisi précédemment est déjà rempli