### PR TITLE
[BUGFIX] Corriger l'url des liens vers la prévisualisation d'images (PIX-16100)

### DIFF
--- a/admin/app/components/target-profiles/badge-form.gjs
+++ b/admin/app/components/target-profiles/badge-form.gjs
@@ -113,7 +113,7 @@ export default class BadgeForm extends Component {
             <p class="badge-form__information">
               <a
                 class="badge-form__information--link"
-                href="https://1024pix.github.io/pix-images-list/badges.html"
+                href="https://1024pix.github.io/pix-images-list/viewer.html?directory=badges"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/admin/app/components/trainings/create-or-update-training-form.gjs
+++ b/admin/app/components/trainings/create-or-update-training-form.gjs
@@ -182,7 +182,7 @@ export default class CreateOrUpdateTrainingForm extends Component {
             </PixInput>
             <small>
               <a
-                href="https://1024pix.github.io/pix-images-list/editeurs-cf.html"
+                href="https://1024pix.github.io/pix-images-list/viewer.html?directory=contenu-formatif/editeur/"
                 target="_blank"
                 rel="noopener noreferrer"
               >


### PR DESCRIPTION
## :unicorn: Problème

Les liens dans Pix Admin pour prévisualiser les images de badges et de logos d'éditeurs
de contenus formatifs n'étaient plus bons.

## :robot: Proposition

Mettre à jour ces liens.

## :rainbow: Remarques

RAS

## :100: Pour tester

1. Se connecter à Pix Admin
2. Se rendre sur la page **Contenus formatifs**
3. Cliquer sur **Nouveau contenu formatif**
4. Constater que le lien "Voir la liste des logos éditeur" fonctionne
5. Se rendre dans **Profil cible**
6. Cliquer sur un profil cible
7. Cliquer sur l'onglet **Clés de lecture**
8. Cliquer sur **Nouveau résultat thématique**
9. Constater que le lien *Voir la liste des résultats thématiques* fonctionne

