### PR TITLE
[FEATURE] Ajouter la forwarded origin HTTP dans les tokens utilisateurs lors du login par SSO GAR (PIX-16204)

### DIFF
--- a/api/lib/application/authentication/authentication-controller.js
+++ b/api/lib/application/authentication/authentication-controller.js
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
+import { getForwardedOrigin } from '../../../src/identity-access-management/infrastructure/utils/network.js';
 import { usecases } from '../../domain/usecases/index.js';
 
 const authenticateExternalUser = async function (request, h) {
@@ -10,11 +11,14 @@ const authenticateExternalUser = async function (request, h) {
     'expected-user-id': expectedUserId,
   } = request.payload.data.attributes;
 
+  const origin = getForwardedOrigin(request.headers);
+
   const accessToken = await usecases.authenticateExternalUser({
     username,
     password,
     externalUserToken,
     expectedUserId,
+    audience: origin,
   });
 
   const response = {

--- a/api/lib/application/sco-organization-learners/sco-organization-learner-controller.js
+++ b/api/lib/application/sco-organization-learners/sco-organization-learner-controller.js
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 
+import { getForwardedOrigin } from '../../../src/identity-access-management/infrastructure/utils/network.js';
 import * as scoOrganizationLearnerSerializer from '../../../src/prescription/learner-management/infrastructure/serializers/jsonapi/sco-organization-learner-serializer.js';
 import { DomainTransaction } from '../../../src/shared/domain/DomainTransaction.js';
 import * as requestResponseUtils from '../../../src/shared/infrastructure/utils/request-response-utils.js';
@@ -66,10 +67,12 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
 ) {
   const { birthdate, 'campaign-code': campaignCode, 'external-user-token': token } = request.payload.data.attributes;
 
+  const origin = getForwardedOrigin(request.headers);
   const accessToken = await usecases.createUserAndReconcileToOrganizationLearnerFromExternalUser({
     birthdate,
     campaignCode,
     token,
+    audience: origin,
   });
 
   const scoOrganizationLearner = {

--- a/api/lib/domain/usecases/authenticate-external-user.js
+++ b/api/lib/domain/usecases/authenticate-external-user.js
@@ -15,6 +15,7 @@ async function authenticateExternalUser({
   username,
   password,
   externalUserToken,
+  audience,
   expectedUserId,
   tokenService,
   pixAuthenticationService,
@@ -53,7 +54,7 @@ async function authenticateExternalUser({
       throw new UserShouldChangePasswordError(undefined, passwordResetToken);
     }
 
-    const token = tokenService.createAccessTokenForSaml({ userId: userFromCredentials.id });
+    const token = tokenService.createAccessTokenForSaml({ userId: userFromCredentials.id, audience });
 
     await userLoginRepository.updateLastLoggedAt({ userId: userFromCredentials.id });
 

--- a/api/lib/domain/usecases/authenticate-external-user.js
+++ b/api/lib/domain/usecases/authenticate-external-user.js
@@ -53,7 +53,7 @@ async function authenticateExternalUser({
       throw new UserShouldChangePasswordError(undefined, passwordResetToken);
     }
 
-    const token = tokenService.createAccessTokenForSaml(userFromCredentials.id);
+    const token = tokenService.createAccessTokenForSaml({ userId: userFromCredentials.id });
 
     await userLoginRepository.updateLastLoggedAt({ userId: userFromCredentials.id });
 

--- a/api/lib/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
+++ b/api/lib/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
@@ -16,6 +16,7 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
   token,
   obfuscationService,
   tokenService,
+  audience,
   userReconciliationService,
   userService,
   authenticationMethodRepository,
@@ -114,7 +115,7 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
     }
   }
   const tokenUserId = userWithSamlId ? userWithSamlId.id : userId;
-  const accessToken = tokenService.createAccessTokenForSaml({ userId: tokenUserId });
+  const accessToken = tokenService.createAccessTokenForSaml({ userId: tokenUserId, audience });
   await userLoginRepository.updateLastLoggedAt({ userId: tokenUserId });
   return accessToken;
 };

--- a/api/lib/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
+++ b/api/lib/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
@@ -114,7 +114,7 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
     }
   }
   const tokenUserId = userWithSamlId ? userWithSamlId.id : userId;
-  const accessToken = tokenService.createAccessTokenForSaml(tokenUserId);
+  const accessToken = tokenService.createAccessTokenForSaml({ userId: tokenUserId });
   await userLoginRepository.updateLastLoggedAt({ userId: tokenUserId });
   return accessToken;
 };

--- a/api/src/identity-access-management/application/saml/saml.controller.js
+++ b/api/src/identity-access-management/application/saml/saml.controller.js
@@ -3,6 +3,7 @@ import { tokenService } from '../../../shared/domain/services/token-service.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { usecases } from '../../domain/usecases/index.js';
 import * as saml from '../../infrastructure/saml.js';
+import { getForwardedOrigin } from '../../infrastructure/utils/network.js';
 
 const metadata = function (request, h) {
   return h.response(saml.getServiceProviderMetadata()).type('application/xml');
@@ -22,10 +23,12 @@ const assert = async function (request, h) {
   }
 
   try {
+    const origin = getForwardedOrigin(request.headers);
     const redirectionUrl = await usecases.getSamlAuthenticationRedirectionUrl({
       userAttributes,
       tokenService,
       config,
+      audience: origin,
     });
 
     return h.redirect(redirectionUrl);

--- a/api/src/identity-access-management/domain/usecases/get-saml-authentication-redirection-url.js
+++ b/api/src/identity-access-management/domain/usecases/get-saml-authentication-redirection-url.js
@@ -8,6 +8,7 @@ const getSamlAuthenticationRedirectionUrl = async function ({
   authenticationMethodRepository,
   tokenService,
   config,
+  audience,
 }) {
   const { attributeMapping } = config.saml;
   const externalUser = {
@@ -21,6 +22,7 @@ const getSamlAuthenticationRedirectionUrl = async function ({
   if (user) {
     return await _getUrlWithAccessToken({
       user,
+      audience,
       externalUser,
       tokenService,
       userLoginRepository,
@@ -35,12 +37,13 @@ export { getSamlAuthenticationRedirectionUrl };
 
 async function _getUrlWithAccessToken({
   user,
+  audience,
   externalUser,
   tokenService,
   userLoginRepository,
   authenticationMethodRepository,
 }) {
-  const token = tokenService.createAccessTokenForSaml({ userId: user.id });
+  const token = tokenService.createAccessTokenForSaml({ userId: user.id, audience });
   await userLoginRepository.updateLastLoggedAt({ userId: user.id });
   await _saveUserFirstAndLastName({ authenticationMethodRepository, user, externalUser });
   return `/connexion/gar#${encodeURIComponent(token)}`;

--- a/api/src/identity-access-management/domain/usecases/get-saml-authentication-redirection-url.js
+++ b/api/src/identity-access-management/domain/usecases/get-saml-authentication-redirection-url.js
@@ -40,7 +40,7 @@ async function _getUrlWithAccessToken({
   userLoginRepository,
   authenticationMethodRepository,
 }) {
-  const token = tokenService.createAccessTokenForSaml(user.id);
+  const token = tokenService.createAccessTokenForSaml({ userId: user.id });
   await userLoginRepository.updateLastLoggedAt({ userId: user.id });
   await _saveUserFirstAndLastName({ authenticationMethodRepository, user, externalUser });
   return `/connexion/gar#${encodeURIComponent(token)}`;

--- a/api/src/shared/domain/services/token-service.js
+++ b/api/src/shared/domain/services/token-service.js
@@ -28,7 +28,7 @@ function createAccessTokenFromAnonymousUser(userId) {
   return _createAccessToken({ userId, source: 'pix', expirationDelaySeconds });
 }
 
-function createAccessTokenForSaml(userId) {
+function createAccessTokenForSaml({ userId }) {
   const expirationDelaySeconds = config.saml.accessTokenLifespanMs / 1000;
   return _createAccessToken({ userId, source: 'external', expirationDelaySeconds });
 }

--- a/api/src/shared/domain/services/token-service.js
+++ b/api/src/shared/domain/services/token-service.js
@@ -28,9 +28,9 @@ function createAccessTokenFromAnonymousUser(userId) {
   return _createAccessToken({ userId, source: 'pix', expirationDelaySeconds });
 }
 
-function createAccessTokenForSaml({ userId }) {
+function createAccessTokenForSaml({ userId, audience }) {
   const expirationDelaySeconds = config.saml.accessTokenLifespanMs / 1000;
-  return _createAccessToken({ userId, source: 'external', expirationDelaySeconds });
+  return _createAccessToken({ userId, source: 'external', expirationDelaySeconds, audience });
 }
 
 function createAccessTokenFromApplication(

--- a/api/tests/acceptance/application/authentication/authentication-route_test.js
+++ b/api/tests/acceptance/application/authentication/authentication-route_test.js
@@ -1,7 +1,7 @@
 import querystring from 'node:querystring';
 
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../src/identity-access-management/domain/constants/identity-providers.js';
-import { tokenService } from '../../../../src/shared/domain/services/token-service.js';
+import { decodeIfValid, tokenService } from '../../../../src/shared/domain/services/token-service.js';
 import { createServer, databaseBuilder, expect, knex } from '../../../test-helper.js';
 
 describe('Acceptance | Controller | authentication-controller', function () {
@@ -30,6 +30,10 @@ describe('Acceptance | Controller | authentication-controller', function () {
         const options = {
           method: 'POST',
           url: '/api/token-from-external-user',
+          headers: {
+            'x-forwarded-proto': 'https',
+            'x-forwarded-host': 'app.pix.fr',
+          },
           payload: {
             data: {
               attributes: {
@@ -51,6 +55,10 @@ describe('Acceptance | Controller | authentication-controller', function () {
         // then
         expect(response.statusCode).to.equal(200);
         expect(response.result.data.attributes['access-token']).to.exist;
+        const decodedAccessToken = await decodeIfValid(response.result.data.attributes['access-token']);
+        expect(decodedAccessToken).to.include({
+          aud: 'https://app.pix.fr',
+        });
       });
 
       it('should add GAR authentication method', async function () {
@@ -70,6 +78,10 @@ describe('Acceptance | Controller | authentication-controller', function () {
         const options = {
           method: 'POST',
           url: '/api/token-from-external-user',
+          headers: {
+            'x-forwarded-proto': 'https',
+            'x-forwarded-host': 'app.pix.fr',
+          },
           payload: {
             data: {
               attributes: {
@@ -117,6 +129,8 @@ describe('Acceptance | Controller | authentication-controller', function () {
         url: '/api/application/token',
         headers: {
           'content-type': 'application/x-www-form-urlencoded',
+          'x-forwarded-proto': 'https',
+          'x-forwarded-host': 'app.pix.fr',
         },
       };
     });

--- a/api/tests/identity-access-management/acceptance/application/saml.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/saml.route.test.js
@@ -195,6 +195,10 @@ describe('Acceptance | Identity Access Management | Route | Saml', function () {
       // when
       const firstVisitResponse = await server.inject({
         method: 'POST',
+        headers: {
+          'x-forwarded-proto': 'https',
+          'x-forwarded-host': 'app.pix.fr',
+        },
         url: '/api/saml/assert',
         payload: {
           SAMLResponse: validSamlResponse.context,
@@ -228,6 +232,10 @@ describe('Acceptance | Identity Access Management | Route | Saml', function () {
       // when
       const response = await server.inject({
         method: 'POST',
+        headers: {
+          'x-forwarded-proto': 'https',
+          'x-forwarded-host': 'app.pix.fr',
+        },
         url: '/api/saml/assert',
         payload: {
           SAMLResponse: validSamlResponse.context,

--- a/api/tests/identity-access-management/unit/domain/usecases/get-saml-authentication-redirection-url_test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/get-saml-authentication-redirection-url_test.js
@@ -10,6 +10,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
   let authenticationMethodRepository;
   let tokenService;
   let samlSettings;
+  const audience = 'https://app.pix.fr';
 
   beforeEach(function () {
     userRepository = {
@@ -97,11 +98,12 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
       authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(
         domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider(),
       );
-      tokenService.createAccessTokenForSaml.returns('access-token');
+      tokenService.createAccessTokenForSaml.withArgs({ userId: 1, audience }).returns('access-token');
 
       // when
       const result = await getSamlAuthenticationRedirectionUrl({
         userAttributes,
+        audience,
         userRepository,
         userLoginRepository,
         authenticationMethodRepository,

--- a/api/tests/shared/integration/domain/services/token-service_test.js
+++ b/api/tests/shared/integration/domain/services/token-service_test.js
@@ -9,7 +9,7 @@ describe('Integration | Shared | Domain | Services | Token Service', function ()
       const userId = 123;
 
       // when
-      const result = tokenService.createAccessTokenForSaml(userId);
+      const result = tokenService.createAccessTokenForSaml({ userId });
 
       // then
       const token = tokenService.getDecodedToken(result);

--- a/api/tests/shared/integration/domain/services/token-service_test.js
+++ b/api/tests/shared/integration/domain/services/token-service_test.js
@@ -7,13 +7,14 @@ describe('Integration | Shared | Domain | Services | Token Service', function ()
     it('should return a valid json web token', function () {
       // given
       const userId = 123;
+      const audience = 'https://app.pix.fr';
 
       // when
-      const result = tokenService.createAccessTokenForSaml({ userId });
+      const result = tokenService.createAccessTokenForSaml({ userId, audience });
 
       // then
       const token = tokenService.getDecodedToken(result);
-      expect(token).to.include({ source: 'external', user_id: userId });
+      expect(token).to.include({ source: 'external', user_id: userId, aud: audience });
 
       const expirationDelaySeconds = token.exp - token.iat;
       const expectedExpirationDelaySeconds = settings.saml.accessTokenLifespanMs / 1000;

--- a/api/tests/shared/unit/domain/services/token-service_test.js
+++ b/api/tests/shared/unit/domain/services/token-service_test.js
@@ -86,6 +86,30 @@ describe('Unit | Shared | Domain | Services | Token Service', function () {
     });
   });
 
+  describe('#createAccessTokenForSaml', function () {
+    it('returns a valid json web token', function () {
+      // given
+      const secret = 'a secret';
+      const userId = 123;
+      const source = 'external';
+
+      sinon.stub(settings.authentication, 'secret').value(secret);
+      sinon.stub(settings.authentication, 'accessTokenLifespanMs').value(1000);
+      const accessToken = 'valid access token';
+      const audience = 'https://app.pix.fr';
+      const payload = { user_id: userId, source, aud: audience };
+      const secretOrPrivateKey = secret;
+      const options = { expiresIn: 1 };
+      sinon.stub(jsonwebtoken, 'sign').withArgs(payload, secretOrPrivateKey, options).returns(accessToken);
+
+      // when
+      const result = tokenService.createAccessTokenForSaml({ userId, audience });
+
+      // then
+      expect(result).to.be.deep.equal(accessToken);
+    });
+  });
+
   describe('#extractExternalUserFromIdToken', function () {
     it('should return external user if the idToken is valid', async function () {
       // given

--- a/api/tests/shared/unit/domain/services/token-service_test.js
+++ b/api/tests/shared/unit/domain/services/token-service_test.js
@@ -43,17 +43,19 @@ describe('Unit | Shared | Domain | Services | Token Service', function () {
   describe('#createAccessTokenFromUser', function () {
     it('should create access token with user id and source', function () {
       // given
+      const secret = 'a secret';
       const userId = 123;
       const source = 'pix';
-      sinon.stub(settings.authentication, 'secret').value('a secret');
+
+      sinon.stub(settings.authentication, 'secret').value(secret);
       sinon.stub(settings.authentication, 'accessTokenLifespanMs').value(1000);
       const accessToken = 'valid access token';
       const audience = 'https://admin.pix.fr';
       const expirationDelaySeconds = 1;
-      const firstParameter = { user_id: userId, source, aud: audience };
-      const secondParameter = 'a secret';
-      const thirdParameter = { expiresIn: 1 };
-      sinon.stub(jsonwebtoken, 'sign').withArgs(firstParameter, secondParameter, thirdParameter).returns(accessToken);
+      const payload = { user_id: userId, source, aud: audience };
+      const secretOrPrivateKey = secret;
+      const options = { expiresIn: 1 };
+      sinon.stub(jsonwebtoken, 'sign').withArgs(payload, secretOrPrivateKey, options).returns(accessToken);
 
       // when
       const result = tokenService.createAccessTokenFromUser({ userId, source, audience });

--- a/api/tests/unit/application/authentication/authentication-controller_test.js
+++ b/api/tests/unit/application/authentication/authentication-controller_test.js
@@ -13,8 +13,13 @@ describe('Unit | Application | Controller | Authentication', function () {
       };
       const externalUserToken = 'SamlJacksonToken';
       const expectedUserId = 1;
+      const audience = 'https://app.pix.fr';
 
       const request = {
+        headers: {
+          'x-forwarded-proto': 'https',
+          'x-forwarded-host': 'app.pix.fr',
+        },
         payload: {
           data: {
             attributes: {
@@ -35,6 +40,7 @@ describe('Unit | Application | Controller | Authentication', function () {
           password: user.password,
           externalUserToken,
           expectedUserId,
+          audience,
         })
         .resolves(accessToken);
 

--- a/api/tests/unit/application/sco-organization-learners/sco-organization-learner-controller_test.js
+++ b/api/tests/unit/application/sco-organization-learners/sco-organization-learner-controller_test.js
@@ -19,6 +19,10 @@ describe('Unit | Application | Controller | sco-organization-learner', function 
       // given
       hFake.request = { path: {} };
       request = {
+        headers: {
+          'x-forwarded-proto': 'https',
+          'x-forwarded-host': 'app.pix.fr',
+        },
         payload: {
           data: {
             attributes: {

--- a/api/tests/unit/domain/usecases/authenticate-external-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-external-user_test.js
@@ -65,7 +65,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
       });
 
       const expectedToken = 'expected returned token';
-      tokenService.createAccessTokenForSaml.withArgs(user.id).resolves(expectedToken);
+      tokenService.createAccessTokenForSaml.withArgs({ userId: user.id }).resolves(expectedToken);
 
       // when
       const token = await authenticateExternalUser({
@@ -104,7 +104,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
       });
 
       const expectedToken = 'expected returned token';
-      tokenService.createAccessTokenForSaml.withArgs(user.id).resolves(expectedToken);
+      tokenService.createAccessTokenForSaml.withArgs({ userId: user.id }).resolves(expectedToken);
 
       // when
       await authenticateExternalUser({

--- a/api/tests/unit/domain/usecases/authenticate-external-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-external-user_test.js
@@ -20,6 +20,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
   let authenticationMethodRepository;
   let userRepository;
   let userLoginRepository;
+  const audience = 'https://app.pix.fr';
 
   beforeEach(function () {
     tokenService = {
@@ -65,7 +66,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
       });
 
       const expectedToken = 'expected returned token';
-      tokenService.createAccessTokenForSaml.withArgs({ userId: user.id }).resolves(expectedToken);
+      tokenService.createAccessTokenForSaml.withArgs({ userId: user.id, audience }).resolves(expectedToken);
 
       // when
       const token = await authenticateExternalUser({
@@ -73,6 +74,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
         password,
         externalUserToken,
         expectedUserId: user.id,
+        audience,
         tokenService,
         pixAuthenticationService,
         obfuscationService,
@@ -104,7 +106,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
       });
 
       const expectedToken = 'expected returned token';
-      tokenService.createAccessTokenForSaml.withArgs({ userId: user.id }).resolves(expectedToken);
+      tokenService.createAccessTokenForSaml.withArgs({ userId: user.id, audience }).resolves(expectedToken);
 
       // when
       await authenticateExternalUser({
@@ -112,6 +114,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
         password,
         externalUserToken,
         expectedUserId: user.id,
+        audience,
         tokenService,
         pixAuthenticationService,
         obfuscationService,

--- a/api/tests/unit/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/unit/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -12,6 +12,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
   let userLoginRepository;
   let organizationLearnerRepository;
   let studentRepository;
+  const audience = 'https://app.pix.fr';
 
   beforeEach(function () {
     campaignRepository = {
@@ -84,7 +85,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
         organizationLearner,
       );
       userRepository.getBySamlId.resolves(user);
-      tokenService.createAccessTokenForSaml.withArgs({ userId: user.id }).resolves(token);
+      tokenService.createAccessTokenForSaml.withArgs({ userId: user.id, audience }).resolves(token);
 
       // when
       const result = await createUserAndReconcileToOrganizationLearnerFromExternalUser({
@@ -93,6 +94,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
         token: 'a token',
         obfuscationService,
         tokenService,
+        audience,
         userReconciliationService,
         userService,
         authenticationMethodRepository,
@@ -158,7 +160,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
       );
       userRepository.getBySamlId.resolves(null);
       userService.createAndReconcileUserToOrganizationLearner.resolves(user.id);
-      tokenService.createAccessTokenForSaml.withArgs({ userId: user.id }).resolves(token);
+      tokenService.createAccessTokenForSaml.withArgs({ userId: user.id, audience }).resolves(token);
 
       // when
       const result = await createUserAndReconcileToOrganizationLearnerFromExternalUser({
@@ -167,6 +169,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
         token: 'a token',
         obfuscationService,
         tokenService,
+        audience,
         userReconciliationService,
         userService,
         authenticationMethodRepository,

--- a/api/tests/unit/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/unit/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -84,7 +84,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
         organizationLearner,
       );
       userRepository.getBySamlId.resolves(user);
-      tokenService.createAccessTokenForSaml.withArgs(user.id).resolves(token);
+      tokenService.createAccessTokenForSaml.withArgs({ userId: user.id }).resolves(token);
 
       // when
       const result = await createUserAndReconcileToOrganizationLearnerFromExternalUser({
@@ -158,7 +158,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
       );
       userRepository.getBySamlId.resolves(null);
       userService.createAndReconcileUserToOrganizationLearner.resolves(user.id);
-      tokenService.createAccessTokenForSaml.withArgs(user.id).resolves(token);
+      tokenService.createAccessTokenForSaml.withArgs({ userId: user.id }).resolves(token);
 
       // when
       const result = await createUserAndReconcileToOrganizationLearnerFromExternalUser({


### PR DESCRIPTION
## :pancakes: Problème

Dans le cadre du confinement des Tokens utilisateurs, nous souhaitons ajouter l'origine de l'appel http des front dans les access tokens et refresh tokens pour les utilisateurs du GAR.

## :bacon: Proposition

Conformément aux RFC ajouter un attribut aud aux tokens utilisateurs GAR.


## 🧃 Remarques

C'est la suite de #11137

## :yum: Pour tester

- Recupérer et décoder l'AT après connection par GAR
- Vérifier que l'audience est bien présente

--- 

### Vérification d’un Access Token

Une fois authentifié, dans le `localStorage` chercher l'objet `ember_simple_auth-session`. L’Access Token est dans la propriété `ember_simple_auth-session.authenticated.access_token`. L’Access Token est un JWT, et donc le plus simple est d'utiliser un outil prévu pour manipuler les JWT pour pouvoir extraire l'attribut `aud`. Et justement nous avons à notre disposition le paquet npm `jsonwebtoken` qui est utilisé par Pix API pour manipuler les JWT et qui est disponible quand on se positionne dans le code source de Pix API comme suit : 

```javascript
cd 1024pix/pix
cd api
const { default: jwt } = await import('jsonwebtoken')
jwt.decode('yxx…')
{
  user_id: 1000003,
  aud: 'https://app.dev.pix.fr',
  iat: 1737369974,
  exp: 1737542774
}
```
