### PR TITLE
[FEATURE] Ajout d'une validation automatique pour les embed PixWriter (PIX-16156)

### DIFF
--- a/api/src/school/infrastructure/serializers/challenge-serializer.js
+++ b/api/src/school/infrastructure/serializers/challenge-serializer.js
@@ -18,6 +18,7 @@ const serialize = function (challenges) {
       'format',
       'autoReply',
       'focused',
+      'timer',
       'shuffled',
     ],
     transform: (challenge) => {

--- a/api/tests/school/unit/infrastructure/serializers/challenge-serializer_test.js
+++ b/api/tests/school/unit/infrastructure/serializers/challenge-serializer_test.js
@@ -55,6 +55,7 @@ describe('Unit | Serializer | challenge-serializer', function () {
               prop1: 'value 1',
               prop2: 'value 2',
             },
+            timer: 300,
             'illustration-alt': 'alt',
             'auto-reply': false,
           },

--- a/junior/app/components/challenge/challenge-content.gjs
+++ b/junior/app/components/challenge/challenge-content.gjs
@@ -1,3 +1,4 @@
+import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { or } from 'ember-truth-helpers';
@@ -14,6 +15,7 @@ import Qrocm from './content/qrocm';
 
 export default class ChallengeContent extends Component {
   @tracked isRebootable = false;
+  @tracked isVerifyButtonDisabled = true;
 
   constructor() {
     super(...arguments);
@@ -55,6 +57,11 @@ export default class ChallengeContent extends Component {
 
   get shouldDisplayRebootButton() {
     return this.isRebootable && !this.args.isDisabled;
+  }
+
+  @action
+  enableVerifyButton() {
+    this.isVerifyButtonDisabled = false;
   }
 
   <template>
@@ -107,10 +114,16 @@ export default class ChallengeContent extends Component {
       {{/if}}
       {{#if @challenge.autoReply}}
         <div class="challenge-content__autoreply">
-          <AutoReply @setAnswerValue={{@setAnswerValue}} />
+          <AutoReply
+            @validateAnswer={{@validateAnswer}}
+            @enableVerifyButton={{this.enableVerifyButton}}
+            @isEmbedAutoValidated={{@challenge.isEmbedAutoValidated}}
+            @setAnswerValue={{@setAnswerValue}}
+          />
         </div>
       {{/if}}
       <ChallengeActions
+        @isVerifyButtonDisabled={{this.isVerifyButtonDisabled}}
         @validateAnswer={{@validateAnswer}}
         @skipChallenge={{@skipChallenge}}
         @level={{@activity.level}}
@@ -119,6 +132,7 @@ export default class ChallengeContent extends Component {
         @disableCheckButton={{@disableCheckButton}}
         @disableLessonButton={{@disableLessonButton}}
         @answerHasBeenValidated={{@answerHasBeenValidated}}
+        @isEmbedAutoValidated={{@challenge.isEmbedAutoValidated}}
       />
     </div>
   </template>

--- a/junior/app/components/challenge/content/auto-reply.js
+++ b/junior/app/components/challenge/content/auto-reply.js
@@ -16,8 +16,14 @@ export default class AutoReply extends Component {
 
   _receiveEmbedMessage(event) {
     const message = this._getMessageFromEventData(event);
+
     if (message && message.answer && message.from === 'pix') {
       this.args.setAnswerValue(message.answer);
+
+      if (this.args.isEmbedAutoValidated) {
+        this.args.validateAnswer();
+        this.args.enableVerifyButton();
+      }
     }
   }
 

--- a/junior/app/components/challenge/content/challenge-actions.gjs
+++ b/junior/app/components/challenge/content/challenge-actions.gjs
@@ -22,7 +22,23 @@ export default class ChallengeActions extends Component {
           </span>
         </PixButton>
       {{/unless}}
-      {{#if @answerHasBeenValidated}}
+      {{#if @isEmbedAutoValidated}}
+        <PixButton
+          class="pix1d-button {{unless @isVerifyButtonDisabled 'pix1d-button--success'}}"
+          @iconAfter="arrowRight"
+          @isDisabled={{@isVerifyButtonDisabled}}
+          @triggerAction={{@nextAction}}
+          @size="large"
+        >
+          <span>
+            {{#if @isVerifyButtonDisabled}}
+              {{t "pages.challenge.actions.check"}}
+            {{else}}
+              {{t "pages.challenge.actions.continue"}}
+            {{/if}}
+          </span>
+        </PixButton>
+      {{else if @answerHasBeenValidated}}
         <PixButton
           class="pix1d-button pix1d-button--success"
           @iconAfter="arrowRight"

--- a/junior/app/models/challenge.js
+++ b/junior/app/models/challenge.js
@@ -25,6 +25,7 @@ export default class Challenge extends Model {
   instructions;
   @attr('string') proposals;
   @attr('string') type;
+  @attr('number') timer;
   @attr('boolean') focused;
   @attr('boolean') shuffled;
   @attr() webComponentProps;
@@ -68,6 +69,10 @@ export default class Challenge extends Model {
 
   get hasType() {
     return !!this.type;
+  }
+
+  get isEmbedAutoValidated() {
+    return !!this.timer;
   }
 
   get hasMedia() {

--- a/junior/tests/acceptance/display-challenge-test.js
+++ b/junior/tests/acceptance/display-challenge-test.js
@@ -29,6 +29,27 @@ module('Acceptance | Challenge', function (hooks) {
     assert.dom(screen.getByRole('button', { name: t('pages.challenge.actions.check') })).exists();
   });
 
+  test('displays challenge page with embed autoValidated (timer props)', async function (assert) {
+    const assessment = this.server.create('assessment');
+    const challenge = this.server.create('challenge', {
+      autoReply: true,
+      timer: 200,
+      embedTitle: 'Wow',
+      embedUrl: 'https://bidule',
+      instructions: ['1ère instruction', '2ème instruction'],
+    });
+    this.server.create('activity', { assessmentId: assessment.id });
+    // when
+    const screen = await visit(`/assessments/${assessment.id}/challenges`);
+    // then
+    const validateButton = screen.getByRole('button', { name: t('pages.challenge.actions.check') });
+    assert.dom(screen.getByText(challenge.instructions[0])).exists();
+    assert.dom(screen.getByText(challenge.instructions[1])).exists();
+    assert.dom(screen.getByRole('button', { name: t('pages.challenge.actions.skip') })).exists();
+    assert.dom(validateButton).exists();
+    assert.ok(validateButton.disabled);
+  });
+
   test('Should display the oralization button if learner has feature enabled', async function (assert) {
     const oragnizationLearner = this.server.create('organization-learner', {
       features: ['ORALIZATION'],

--- a/junior/tests/integration/challenge-content_test.gjs
+++ b/junior/tests/integration/challenge-content_test.gjs
@@ -16,6 +16,19 @@ module('Integration | Component | challenge item', function (hooks) {
     assert.dom('.challenge-embed-simulator').exists();
   });
 
+  test('displays embed autoValidated', async function (assert) {
+    const challenge = { hasEmbed: true, autoReply: true, timer: 300, isEmbedAutoValidated: true };
+    const screen = await render(
+      <template><ChallengeContent @challenge={{challenge}} @assessment={{assessment}} /></template>,
+    );
+
+    assert.dom('.challenge-embed-simulator').exists();
+    const buttons = screen
+      .getAllByRole('button')
+      .filter((button) => button.innerText.includes('Je vérifie') && button.disabled);
+    assert.strictEqual(buttons.length, 1);
+  });
+
   test('displays web component', async function (assert) {
     const challenge = { hasWebComponent: true, webComponentTagName: 'qcu-image' };
     const screen = await render(


### PR DESCRIPTION
## :pancakes: Problème

Lors d'épreuve contenant des simulateurs, on avait un boutton `je vérifie` puis un boutton `je continue`. Leurs présences n'étaient pas nécessaire parce que le simulateur notifie tout seul lorsque l'utilisateur à réussi.

## :bacon: Proposition

Créer un process de bouton/vérification/feedback spécialement pour ces challenge.

## 🧃 Remarques

RAS

## :yum: Pour tester

Aller sur des challenges auto-reply mais  non-Gdevelop. Et vérifié que:
- le bouton `Poursuivre` est présent en mode grisé.
- Après réussite du challenge ce même boutton doit passer en mode cliquable