### PR TITLE
[tech] add cache header on route

### DIFF
--- a/api/src/shared/application/feature-toggles/index.js
+++ b/api/src/shared/application/feature-toggles/index.js
@@ -5,10 +5,13 @@ const register = async function (server) {
     {
       method: 'GET',
       path: '/api/feature-toggles',
-      config: {
+      options: {
         auth: false,
         handler: featureToggleController.getActiveFeatures,
         tags: ['api'],
+        cache: {
+          expiresIn: 30 * 1000,
+        },
       },
     },
     // TODO: Test route to be removed soon


### PR DESCRIPTION
## :pancakes: Problème
Certaines routes servent des flux json qui sont presque statiques : aujourd'hui ils ne sont pas mis en cache car servis par l'api.

## :bacon: Proposition
Add cache header on route to be cached by baleen

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
