### PR TITLE
[BUGFIX] Pix Junior indisponible sur d'anciennes version de Safari (PIX-16209)

### DIFF
--- a/junior/app/components/device-warning-modal.gjs
+++ b/junior/app/components/device-warning-modal.gjs
@@ -44,7 +44,7 @@ export default class DeviceWarningModal extends Component {
       this.showModal = true;
     }
 
-    screen.orientation.addEventListener('change', () => {
+    screen.orientation?.addEventListener('change', () => {
       this.showModal = this.shouldDisplayModal();
     });
   }

--- a/junior/app/services/device.js
+++ b/junior/app/services/device.js
@@ -13,9 +13,13 @@ export const types = {
 
 export default class DeviceService extends Service {
   get info() {
+    let orientation = screen.orientation?.type;
+    if (!orientation) {
+      orientation = screen.width > screen.height ? 'landscape' : 'portrait';
+    }
     return {
-      orientation: screen.orientation.type,
-      type: this.getType(screen.orientation.type),
+      orientation: orientation,
+      type: this.getType(orientation),
     };
   }
 


### PR DESCRIPTION
## :pancakes: Problème

La fonction screen.orientation n'est pas disponible sur d'anciennes versions de Safari et provoque un écran blanc sur Pix Junior.

## :bacon: Proposition

Gérer l'indisponibilité de cette fonction en évaluant l'orientation en fonction du rapport hauteur/largeur, ce qui permet de gérer la popup indiquant de tourner la tablette ou que Pix Junior n'est pas disponible sur téléphone.


## :yum: Pour tester

Accéder à Pix Junior sur une version de Safari strictement inférieure à la 16.4.
L'application Pix Junior s'affiche.
Tester l'affichage de la popup.
