### PR TITLE
[FEATURE] Supprimer les liens d'évitements inutiles dans Modulix (PIX-16030)

### DIFF
--- a/mon-pix/app/templates/module/details.hbs
+++ b/mon-pix/app/templates/module/details.hbs
@@ -3,16 +3,6 @@
     <Module::Layout::BetaBanner />
   </div>
 {{/if}}
-<nav>
-  <ul>
-    <li>
-      <Skiplink @href="#main" @label={{t "common.skip-links.skip-to-content"}} />
-    </li>
-    <li>
-      <Skiplink @href="#footer" @label={{t "common.skip-links.skip-to-footer"}} />
-    </li>
-  </ul>
-</nav>
 
 <div class="modulix">
   <Module::Instruction::Details @module={{@model}} />

--- a/mon-pix/tests/acceptance/module/visit-module-details-page_test.js
+++ b/mon-pix/tests/acceptance/module/visit-module-details-page_test.js
@@ -1,7 +1,6 @@
 import { visit } from '@1024pix/ember-testing-library';
 import { currentURL } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import setupIntl from 'mon-pix/tests/helpers/setup-intl';
 import { module, test } from 'qunit';
@@ -11,7 +10,7 @@ module('Acceptance | Module | Routes | details', function (hooks) {
   setupIntl(hooks);
   setupMirage(hooks);
 
-  test('should visit and include the module title, skiplinks and footer', async function (assert) {
+  test('should visit and include the module title and footer', async function (assert) {
     // given
     const module = server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
@@ -35,8 +34,6 @@ module('Acceptance | Module | Routes | details', function (hooks) {
     assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/details');
     assert.ok(document.title.includes(module.title));
     assert.dom(screen.queryByRole('alert')).doesNotExist();
-    assert.dom(screen.getByRole('link', { name: t('common.skip-links.skip-to-content') })).exists();
-    assert.dom(screen.getByRole('link', { name: t('common.skip-links.skip-to-footer') })).exists();
     assert.dom(screen.getByRole('contentinfo')).exists();
   });
 


### PR DESCRIPTION
## :pancakes: Problème
Les liens d'évitement au début d’un module ne sont pas utiles car il y a peu de contenu à éviter (au plus un lien lors du passage du module). De plus, ils ne fonctionnent pas.

cf. https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#12.7.1

## :bacon: Proposition
Retirer les liens d'évitement.

## 🧃 Remarques
RAS

## :yum: Pour tester
Vérifier sur la page de détails d'un module qu'en tabulant le skip link n'apparaît plus.

S'assurer qu'il n'y a pas de code mort avec cette suppression.