### PR TITLE
[FEATURE] Permettre la navigation au clavier dans le menu Modulix (PIX-16031)

### DIFF
--- a/mon-pix/app/components/module/layout/_navbar.scss
+++ b/mon-pix/app/components/module/layout/_navbar.scss
@@ -21,11 +21,10 @@
 .module-sidebar__list-item {
   @extend %pix-body-l;
 
-  display: inline-block;
   width: 100%;
   padding: var(--pix-spacing-3x) var(--pix-spacing-8x);
   color: var(--pix-neutral-800);
-  cursor: pointer;
+  text-align: left;
 
   &.current-grain {
     --border-width: 5px;

--- a/mon-pix/app/components/module/layout/navbar.gjs
+++ b/mon-pix/app/components/module/layout/navbar.gjs
@@ -75,13 +75,15 @@ export default class ModulixNavbar extends Component {
         <nav>
           <ul>
             {{#each this.grainsWithIdAndTranslatedType as |grain index|}}
-              <li
-                class="module-sidebar__list-item {{if (eq index this.currentGrainIndex) 'current-grain'}}"
-                aria-current={{if (eq index this.currentGrainIndex) "step"}}
-                {{on "click" (fn this.onMenuItemClick grain.id)}}
-                role="link"
-              >
-                {{grain.type}}
+              <li>
+                <button
+                  type="button"
+                  class="module-sidebar__list-item {{if (eq index this.currentGrainIndex) 'current-grain'}}"
+                  aria-current={{if (eq index this.currentGrainIndex) "step"}}
+                  {{on "click" (fn this.onMenuItemClick grain.id)}}
+                >
+                  {{grain.type}}
+                </button>
               </li>
             {{/each}}
           </ul>

--- a/mon-pix/tests/integration/components/module/navbar_test.gjs
+++ b/mon-pix/tests/integration/components/module/navbar_test.gjs
@@ -1,5 +1,5 @@
 import { clickByName, clickByText, render } from '@1024pix/ember-testing-library';
-import { click } from '@ember/test-helpers';
+import { click, tab } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import ModulixNavbar from 'mon-pix/components/module/layout/navbar';
 import { module, test } from 'qunit';
@@ -137,20 +137,53 @@ module('Integration | Component | Module | Navbar', function (hooks) {
 
       // then
       assert.strictEqual(
-        screen.getByRole('link', { name: 'Découverte' }).textContent.trim(),
+        screen.getByRole('button', { name: 'Découverte' }).textContent.trim(),
         t('pages.modulix.grain.tag.discovery'),
       );
       assert.strictEqual(
-        screen.getByRole('link', { name: 'Activité' }).textContent.trim(),
+        screen.getByRole('button', { name: 'Activité' }).textContent.trim(),
         t('pages.modulix.grain.tag.activity'),
       );
       assert.strictEqual(
-        screen.getByRole('link', { name: 'Leçon' }).textContent.trim(),
+        screen.getByRole('button', { name: 'Leçon' }).textContent.trim(),
         t('pages.modulix.grain.tag.lesson'),
       );
-      assert.dom(screen.getByRole('link', { name: 'Leçon' })).hasAria('current', 'step');
+      assert.dom(screen.getByRole('button', { name: 'Leçon' })).hasAria('current', 'step');
 
-      assert.dom(screen.queryByRole('link', { name: "Récap'" })).doesNotExist();
+      assert.dom(screen.queryByRole('button', { name: "Récap'" })).doesNotExist();
+    });
+
+    test('should allow tabulation in sidebar', async function (assert) {
+      // given
+      const module = createModule(this.owner);
+      const threeFirstGrains = module.grains.slice(0, -1);
+      const openSidebarStub = sinon.stub();
+
+      //  when
+      await render(
+        <template>
+          <ModulixNavbar
+            @currentStep={{3}}
+            @totalSteps={{4}}
+            @module={{module}}
+            @grainsToDisplay={{threeFirstGrains}}
+            @onSidebarOpen={{openSidebarStub}}
+          />
+        </template>,
+      );
+      await clickByName('Afficher les étapes du module');
+      await waitForDialog();
+      await tab();
+
+      // then
+      await tab();
+      assert.strictEqual(document.activeElement.textContent.trim(), t('pages.modulix.grain.tag.discovery'));
+
+      await tab();
+      assert.strictEqual(document.activeElement.textContent.trim(), t('pages.modulix.grain.tag.activity'));
+
+      await tab();
+      assert.strictEqual(document.activeElement.textContent.trim(), t('pages.modulix.grain.tag.lesson'));
     });
 
     module('when user clicks on grain’s type', function () {

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -1121,7 +1121,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
       await clickByName('Afficher les étapes du module');
       await waitForDialog();
-      const item = screen.getByRole('link', { name: 'Découverte' });
+      const item = screen.getByRole('button', { name: 'Découverte' });
       await click(item);
 
       //  then
@@ -1157,7 +1157,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
       await clickByName('Afficher les étapes du module');
       await waitForDialog();
-      const item = screen.getByRole('link', { name: 'Découverte' });
+      const item = screen.getByRole('button', { name: 'Découverte' });
       await click(item);
 
       // then


### PR DESCRIPTION
## :pancakes: Problème
Lorsqu’on ouvre le menu Modulix, pendant un passage de module, il n’est pas possible de sélectionner les différentes étapes à l’aide de la touche tab du clavier.

## :bacon: Proposition
Faire en sorte que les liens vers les étapes puissent recevoir le focus.

## 🧃 Remarques
L'approche proposée est de transférer tout le code vers un `button` à l'intérieur de la liste à puce.

## :yum: Pour tester
- Vérifier que la CI passe
- Vérifier qu'on peut tabuler dans la barre de nav d'[un module](https://app-pr11184.review.pix.fr/modules/didacticiel-modulix/passage).
