### PR TITLE
[BUGFIX] Corriger le script de suppression en masse des orgas (PIX-16224)

### DIFF
--- a/api/src/organizational-entities/infrastructure/repositories/organization-feature-repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-feature-repository.js
@@ -59,4 +59,15 @@ async function findAllOrganizationFeaturesFromOrganizationId({ organizationId })
   return organizationFeatures.map((organizationFeature) => new OrganizationFeatureItem(organizationFeature));
 }
 
-export { findAllOrganizationFeaturesFromOrganizationId, saveInBatch };
+/**
+ * @function
+ * @name delete
+ *
+ * @param {number} organizationId
+ */
+async function deleteOrganizationFeatureByOrganizationId(organizationId) {
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn('organization-features').where({ organizationId }).delete();
+}
+
+export { deleteOrganizationFeatureByOrganizationId, findAllOrganizationFeaturesFromOrganizationId, saveInBatch };

--- a/api/src/organizational-entities/scripts/delete-organizations-script.js
+++ b/api/src/organizational-entities/scripts/delete-organizations-script.js
@@ -1,9 +1,11 @@
 import Joi from 'joi';
 
+import * as schoolRepository from '../../school/infrastructure/repositories/school-repository.js';
 import { csvFileParser } from '../../shared/application/scripts/parsers.js';
 import { Script } from '../../shared/application/scripts/script.js';
 import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
 import * as dataProtectionOfficerRepository from '../infrastructure/repositories/data-protection-officer.repository.js';
+import * as organizationFeatureRepository from '../infrastructure/repositories/organization-feature-repository.js';
 import { organizationForAdminRepository } from '../infrastructure/repositories/organization-for-admin.repository.js';
 import * as organizationTagRepository from '../infrastructure/repositories/organization-tag.repository.js';
 
@@ -34,7 +36,13 @@ export class DeleteOrganizationsScript extends Script {
   async handle({
     options,
     logger,
-    dependencies = { organizationForAdminRepository, organizationTagRepository, dataProtectionOfficerRepository },
+    dependencies = {
+      organizationForAdminRepository,
+      organizationTagRepository,
+      dataProtectionOfficerRepository,
+      organizationFeatureRepository,
+      schoolRepository,
+    },
   }) {
     const { file, dryRun } = options;
 
@@ -47,6 +55,10 @@ export class DeleteOrganizationsScript extends Script {
         await dependencies.dataProtectionOfficerRepository.deleteDpoByOrganizationId(organizationId);
         // delete organization tags via organization-tags.repository
         await dependencies.organizationTagRepository.deleteTagsByOrganizationId(organizationId);
+        // delete organization features via organization-feature.repository
+        await dependencies.organizationFeatureRepository.deleteOrganizationFeatureByOrganizationId(organizationId);
+        // delete school via school.repository
+        await dependencies.schoolRepository.deleteByOrganizationId({ organizationId: organizationId });
         // delete organizationvia organization-for-admin.repository
         await dependencies.organizationForAdminRepository.deleteById(organizationId);
       }

--- a/api/src/school/infrastructure/repositories/school-repository.js
+++ b/api/src/school/infrastructure/repositories/school-repository.js
@@ -52,7 +52,12 @@ const getSessionExpirationDate = async function ({ code }) {
   return sessionExpirationDate;
 };
 
+const deleteByOrganizationId = async function ({ organizationId }) {
+  await knex('schools').where({ organizationId }).delete();
+};
+
 export {
+  deleteByOrganizationId,
   getByCode,
   getById,
   getDivisions,

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-feature-repository_test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-feature-repository_test.js
@@ -190,4 +190,21 @@ describe('Integration | Repository | Organization-for-admin', function () {
       expect(results).to.be.lengthOf(0);
     });
   });
+
+  describe('#deleteOrganizationFeatureByOrganizationId', function () {
+    it('should delete all organization features from an organization', async function () {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      const feature = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.PLACES_MANAGEMENT);
+      databaseBuilder.factory.buildOrganizationFeature({ organizationId: organization.id, featureId: feature.id });
+      await databaseBuilder.commit();
+
+      // when
+      await organizationFeatureRepository.deleteOrganizationFeatureByOrganizationId(organization.id);
+
+      // then
+      const result = await knex('organization-features').where({ organizationId: organization.id });
+      expect(result).to.have.lengthOf(0);
+    });
+  });
 });

--- a/api/tests/organizational-entities/unit/scripts/delete-organizations-script.test.js
+++ b/api/tests/organizational-entities/unit/scripts/delete-organizations-script.test.js
@@ -8,6 +8,8 @@ describe('DeleteOrganizationsScript', function () {
     let organizationForAdminRepository;
     let organizationTagRepository;
     let dataProtectionOfficerRepository;
+    let organizationFeatureRepository;
+    let schoolRepository;
 
     beforeEach(function () {
       script = new DeleteOrganizationsScript();
@@ -15,6 +17,8 @@ describe('DeleteOrganizationsScript', function () {
       organizationForAdminRepository = { deleteById: sinon.stub() };
       organizationTagRepository = { deleteTagsByOrganizationId: sinon.stub() };
       dataProtectionOfficerRepository = { deleteDpoByOrganizationId: sinon.stub() };
+      organizationFeatureRepository = { deleteOrganizationFeatureByOrganizationId: sinon.stub() };
+      schoolRepository = { deleteByOrganizationId: sinon.stub() };
     });
 
     it('handles data correctly', async function () {
@@ -27,6 +31,8 @@ describe('DeleteOrganizationsScript', function () {
           organizationForAdminRepository,
           organizationTagRepository,
           dataProtectionOfficerRepository,
+          organizationFeatureRepository,
+          schoolRepository,
         },
       });
       expect(organizationForAdminRepository.deleteById.calledWith(1)).to.be.true;
@@ -35,6 +41,10 @@ describe('DeleteOrganizationsScript', function () {
       expect(organizationTagRepository.deleteTagsByOrganizationId.calledWith(2)).to.be.true;
       expect(dataProtectionOfficerRepository.deleteDpoByOrganizationId.calledWith(1)).to.be.true;
       expect(dataProtectionOfficerRepository.deleteDpoByOrganizationId.calledWith(2)).to.be.true;
+      expect(organizationFeatureRepository.deleteOrganizationFeatureByOrganizationId.calledWith(1)).to.be.true;
+      expect(organizationFeatureRepository.deleteOrganizationFeatureByOrganizationId.calledWith(2)).to.be.true;
+      expect(schoolRepository.deleteByOrganizationId.calledWith({ organizationId: 1 })).to.be.true;
+      expect(schoolRepository.deleteByOrganizationId.calledWith({ organizationId: 2 })).to.be.true;
     });
   });
 });

--- a/api/tests/school/integration/infrastructure/repositories/school-repository_test.js
+++ b/api/tests/school/integration/infrastructure/repositories/school-repository_test.js
@@ -168,4 +168,20 @@ describe('Integration | Repository | School', function () {
       expect(sessionExpirationDate).to.equal(undefined);
     });
   });
+
+  describe('#deleteByOrganizationId', function () {
+    it('should delete the school corresponding to the organizationId', async function () {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      databaseBuilder.factory.buildSchool({ organizationId: organization.id });
+      await databaseBuilder.commit();
+
+      // when
+      await repositories.schoolRepository.deleteByOrganizationId({ organizationId: organization.id });
+
+      // then
+      const school = await knex('schools').first();
+      expect(school).to.be.undefined;
+    });
+  });
 });


### PR DESCRIPTION
## :pancakes: Problème

Au moment de l'exécution du script en recette on s'est rendu compte que pour certaines organisations  d'autres éléments devaient être supprimés d'autre tables. Par exemple organization-feature et schools.

## :bacon: Proposition

Rajouter:
- Une fonction pour supprimer les organizations-feature,
- Une fonction pour supprimer une ligne de la table schools,
- L'appel de ces 2 fonctions dans le script de suppression en masse.

## 🧃 Remarques

Il faudrait rajouter des seeds sco-1d.

## :yum: Pour tester
Appliquer les mêmes consignes que pour la pr #11124 en créant d'abord des orgas de type sco1d via PixAdmin (création d'organisations en masses), à l'aide de ce fichier dans lequel il faut remplacer *** par l'id du superadmin.
[Echantillon - SCO-1D - Création des orgas - Feuille 1.csv](https://github.com/user-attachments/files/18507331/Echantillon.-.SCO-1D.-.Creation.des.orgas.-.Feuille.1.csv)

Puis supprimer les organisations avec le script.

S'assurer que les organisations ont été supprimées.