### PR TITLE
[TECH] Suppression de la mise en cache sur certaines routes pour gérer le cache par Baleen

### DIFF
--- a/api/src/banner/application/banner-route.js
+++ b/api/src/banner/application/banner-route.js
@@ -8,9 +8,7 @@ const register = async function (server) {
       options: {
         auth: false,
         handler: bannerController.getInformationBanner,
-        cache: {
-          expiresIn: 30 * 1000,
-        },
+        cache: false,
       },
     },
   ]);

--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.route.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.route.js
@@ -7,7 +7,7 @@ export const oidcProviderRoutes = [
   {
     method: 'GET',
     path: '/api/oidc/identity-providers',
-    config: {
+    options: {
       validate: {
         query: Joi.object({
           target: Joi.string().optional().default('app'),

--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.route.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.route.js
@@ -14,6 +14,7 @@ export const oidcProviderRoutes = [
         }),
       },
       auth: false,
+      cache: false,
       handler: (request, h) => oidcProviderController.getIdentityProviders(request, h),
       notes: [
         'Cette route renvoie une liste contenant les informations requises par le front pour les partenaires OIDC',

--- a/api/src/shared/application/feature-toggles/index.js
+++ b/api/src/shared/application/feature-toggles/index.js
@@ -9,7 +9,7 @@ const register = async function (server) {
         auth: false,
         handler: featureToggleController.getActiveFeatures,
         tags: ['api'],
-        cache: { expiresIn: 30 * 1000 },
+        cache: false,
       },
     },
     // TODO: Test route to be removed soon


### PR DESCRIPTION
## :pancakes: Problème
Certaines routes sont quasiment statiques mais sont servies à chaque fois car baleen ne les cache pas à cause du header cache-control

## :bacon: Proposition

supprimer le header cache-control

## Remarque
Depuis Hapi.dev v17, config a été déprécié et remplacé par options. Toutefois le nom config restait pour compatibilité ascendante.
Or lors de nos tests, il semble que config.cache ne soit pas pris en compte, d'où le changement vers la notation state of the art afin de pouvoir changer le comportement du cache.