### PR TITLE
[FEATURE] Ajouter la colonne "internalTitle" dans la table "trainings" (PIX-16222)

### DIFF
--- a/api/db/migrations/20250122131501_add-internal-title-column-to-trainings-table.js
+++ b/api/db/migrations/20250122131501_add-internal-title-column-to-trainings-table.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'trainings';
+const COLUMN_NAME = 'internalTitle';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).defaultTo(null).comment('Internally used title, only displayed in Pix Admin');
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## :unicorn: Problème

Il n'y a pas de colonne pour gérer le titre interne des contenus formatifs.

## :robot: Proposition

Ajouter une colonne `internalTitle` à la table `trainings`

## :rainbow: Remarques

RAS

## :100: Pour tester

1. Jouer les migrations avec la commande `npm run db:migrate`
2. Constater l'ajout d'une colonne `internalTitle` à la table `trainings` avec un type varchar(255)
3. Jouer un rollback avec la commande `npm run db:rollback:latest`
4. Constater la suppression de la colonne `internalTitle` à la table `trainings`