### PR TITLE
[FEATURE] Ajouter la possibilité de renvoyer une invitation à rejoindre une organisation sur pix-admin (PIX-1014)

### DIFF
--- a/admin/app/components/organizations/invitations.gjs
+++ b/admin/app/components/organizations/invitations.gjs
@@ -48,6 +48,16 @@ export default class OrganizationInvitations extends Component {
                         >
                           Annuler l’invitation
                         </PixButton>
+                        <PixButton
+                          @size="small"
+                          @variant="error"
+                          class="organization-invitations-actions__button"
+                          aria-label="Renvoyer l’invitation de {{invitation.email}}"
+                          @triggerAction={{fn @onSendNewInvitation invitation}}
+                          @iconBefore="send"
+                        >
+                          Renvoyer l'invitation
+                        </PixButton>
                       </td>
                     {{/if}}
                   </tr>

--- a/admin/app/controllers/authenticated/organizations/get/invitations.js
+++ b/admin/app/controllers/authenticated/organizations/get/invitations.js
@@ -47,6 +47,25 @@ export default class InvitationsController extends Controller {
     this.isLoading = false;
   }
 
+  @action
+  async sendNewInvitation(organizationInvitation) {
+    this.isLoading = true;
+    try {
+      this.store.queryRecord('organization-invitation', {
+        email: organizationInvitation.email,
+        lang: organizationInvitation.lang,
+        role: organizationInvitation.role,
+        organizationId: this.model.organization.id,
+      });
+      this.pixToast.sendSuccessNotification({
+        message: `Un email a bien a été envoyé à l'adresse ${organizationInvitation.email}.`,
+      });
+    } catch (error) {
+      this.errorResponseHandler.notify(error, this.CUSTOM_ERROR_MESSAGES);
+    }
+    this.isLoading = false;
+  }
+
   _isEmailToInviteValid(email) {
     if (!email) {
       this.userEmailToInviteError = 'Ce champ est requis.';

--- a/admin/app/templates/authenticated/organizations/get/invitations.hbs
+++ b/admin/app/templates/authenticated/organizations/get/invitations.hbs
@@ -9,5 +9,6 @@
 {{/if}}
 <Organizations::Invitations
   @invitations={{@model.organizationInvitations}}
+  @onSendNewInvitation={{this.sendNewInvitation}}
   @onCancelOrganizationInvitation={{this.cancelOrganizationInvitation}}
 />

--- a/admin/tests/unit/controllers/authenticated/organizations/get/invitations-test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/get/invitations-test.js
@@ -96,4 +96,22 @@ module('Unit | Controller | authenticated/organizations/get/invitations', functi
       assert.ok(notifyStub.calledWithExactly(anError, customErrors));
     });
   });
+  module('#sendNewInvitation', function () {
+    test('it should send a new invitation', function (assert) {
+      // given
+      const queryRecordStub = sinon.stub();
+      store.queryRecord = queryRecordStub;
+      controller.model = { organization: { id: 1 } };
+      const organizationInvitation = { email: 'test@example.net', lang: 'en', role: 'MEMBER' };
+      // when
+      controller.sendNewInvitation(organizationInvitation);
+      // then
+      assert.ok(
+        queryRecordStub.calledWith('organization-invitation', {
+          ...organizationInvitation,
+          organizationId: 1,
+        }),
+      );
+    });
+  });
 });


### PR DESCRIPTION
## :pancakes: Problème

Sur Pix admin, dans le tableau des personnes invitées à rejoindre l'équipe, on a juste un bouton pour annuler l'invitation.

## :bacon: Proposition

Ajouter un bouton permettant de renvoyer l'invitation, permettant ainsi de ne pas avoir à rentrer une nouvelle fois l'adresse mail.

## 🧃 Remarques
Le bouton est peut-être à remettre en forme.

## :yum: Pour tester
- Se rendre sur Pix admin,
- Se connecter avec le compte superadmin @example.net,
- Aller sur une organisation (n'importe laquelle),
- Dans la section invitation, entrer un email dans le champ correspondant, choisissez une langue et un rôle et appuyez sur Envoyer,
- Une noitification indiquant l'envoi de l'email devrait apparaître,
- Un tableau devrait s'afficher avec l'email précédemment entré, le type et la date d'envois de l'invitation,
Dans la colone de droite, à côté du bouton pour annuler, se trouve un bouton Renvoyer l'invitation à...,
- Attendre une minute,
- Cliquer sur le bouton,
- Constater qu'une nouvelle notification de succès apparaît,
- Constater également que la date d'envois a changé.