### PR TITLE
[TECH] Corriger la couleurs des bannières sur la page de finalisation sur Pix Certif (PIX-16236).

### DIFF
--- a/certif/app/styles/components/session-finalization-step-container.scss
+++ b/certif/app/styles/components/session-finalization-step-container.scss
@@ -16,7 +16,6 @@
 
   p {
     margin-top: var(--pix-spacing-2x);
-    color: var(--pix-neutral-500);
 
     @extend %pix-body-s;
   }


### PR DESCRIPTION
## :pancakes: Problème
Actuellement sur Pix Certif, sur la page de finalisation, certaines bannières sont en grisés sur fond bleu, ce qui n'est pas iso au design system.

<img width="1024" alt="Capture d’écran 2025-01-23 à 10 31 06" src="https://github.com/user-attachments/assets/83e43b5b-3fb5-46bc-9903-eeaf1f7c1054" />

## :bacon: Proposition

Supprimer cette couleur et ré-afficher la couleur par défaut en cas de bannière de type information.

## 🧃 Remarques

Une bannière dans l'espace signalement présente une icône plus petite que les autres. Il s'agit d'un fix à faire coté composant Pix UI. 
En effet, quand le texte est important, l'icône n'est pas censé s'adapter en se réduisant.

## :yum: Pour tester

- Se connecter sur Pix Certif avec certif-pro@example.net
- Aller sur la session 7405, et finaliser la session
- Ajouter un signalement sur un candidat
- Aller sur le C7 et C8 et constater que les bannières sont en bleu
- Cliquer sur la checkbox tout en bas de la page de finalisation "Un ou plusieurs candidats étaient présents en session de certification mais n'ont pas pu rejoindre la session."
- Constater que la bannière est en bleu.
