### PR TITLE
[TECH] Rendre swagger.json disponible via reverse proxy (PIX-16228).

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -357,15 +357,7 @@ MAILING_PROVIDER=mailpit
 # presence: optional
 # type: String
 # default: 'https://gateway.pix.fr'
-APIM_URL=http://127.0.0.1:3000/
-
-
-# API Manager Parcoursup endpoint
-#
-# presence: optional
-# type: String
-# default: '/parcoursup'
-APIM_PARCOURSUP_PATH=/api/application
+APIM_URL=http://127.0.0.1:3000/api/application
 
 # ================
 # LEARNING CONTENT

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -119,9 +119,6 @@ const configuration = (function () {
     },
     apiManager: {
       url: process.env.APIM_URL || 'https://gateway.pix.fr',
-      endpoints: {
-        parcoursup: process.env.APIM_PARCOURSUP_PATH || '/parcoursup',
-      },
     },
     apimRegisterApplicationsCredentials: [
       {
@@ -630,6 +627,8 @@ const configuration = (function () {
     config.partner.fetchTimeOut = '10ms';
 
     config.identityProviderConfigKey = null;
+
+    config.apiManager.url = 'http://external-partners-access/';
   }
 
   return config;

--- a/api/src/shared/infrastructure/validate-environment-variables.js
+++ b/api/src/shared/infrastructure/validate-environment-variables.js
@@ -66,7 +66,6 @@ const schema = Joi.object({
   TLD_FR: Joi.string().optional(),
   TLD_ORG: Joi.string().optional(),
   APIM_URL: Joi.string().optional(),
-  APIM_PARCOURSUP_PATH: Joi.string().optional(),
 }).options({ allowUnknown: true });
 
 const validateEnvironmentVariables = function () {

--- a/api/tests/shared/acceptance/application/swaggers_test.js
+++ b/api/tests/shared/acceptance/application/swaggers_test.js
@@ -1,3 +1,4 @@
+import { config } from '../../../../src/shared/config.js';
 import { createServer, expect } from '../../../test-helper.js';
 
 describe('Acceptance | Controller | Open Api', function () {
@@ -180,12 +181,12 @@ describe('Acceptance | Controller | Open Api', function () {
   });
 
   context('Parcoursup', function () {
-    describe('GET /parcoursup/swagger.json', function () {
+    describe('GET /api/application/parcoursup/swagger.json', function () {
       it('should respond with a 200', async function () {
         // given
         const options = {
           method: 'GET',
-          url: '/parcoursup/swagger.json',
+          url: '/api/application/parcoursup/swagger.json',
           headers: {},
         };
         // when
@@ -194,6 +195,7 @@ describe('Acceptance | Controller | Open Api', function () {
         // then
         expect(response.statusCode).to.equal(200);
         expect(response.result.info.title).to.deep.equal('Pix Parcoursup Open Api');
+        expect(response.result.servers[0].url).to.equal(config.apiManager.url);
       });
     });
 
@@ -202,12 +204,12 @@ describe('Acceptance | Controller | Open Api', function () {
         await server.start();
       });
 
-      describe('GET /parcoursup/documentation', function () {
+      describe('GET /api/application/parcoursup/documentation', function () {
         it('should respond with a 200', async function () {
           // given
           const options = {
             method: 'GET',
-            url: '/parcoursup/documentation/',
+            url: '/api/application/parcoursup/documentation/',
           };
 
           // when


### PR DESCRIPTION
## :pancakes: Problème

il y a eu une mise a disposition des ressources swagger UI sous /documentation, facilitant la configuration pour l'accès via un reverse proxy (APIM) devant.
Dans le lot, le swagger.json a été oublié.

## :bacon: Proposition

* Mettre le swagger.json de Parcoursup aussi sous /parcoursup
* Tout regrouper sous `/api/application/parcoursup` pour la facilité de conf reverse proxy + suivi des précos autour du path naming

## 🧃 Remarques

Une variable d'environnement supprimée car devenue inutile grace au respect du regroupement sous `/api/application` du endpoint de la documentation Parcoursup

## :yum: Pour tester

* Ouvrir https://api-pr11198.review.pix.fr/api/application/parcoursup/documentation, avec la console ouverte
* Voir que toutes les ressources swagger.json et swagger-ui sont en subpath de /api/application/parcoursup
  * Toute url qui ne serait pas sous ce path serait un échec du test 
* Verifier que les documentation swaggers fonctionnents toujours
  * Parcoursup : https://api-pr11198.review.pix.fr/api/application/parcoursup/documentation
  * Pole Emploi : https://api-pr11198.review.pix.fr/pole-emploi/documentation
  * Livret Scolaire : https://api-pr11198.review.pix.fr/livret-scolaire/documentation
  * Authorization-server : https://api-pr11198.review.pix.fr/authorization-server/documentation
  * Pix API : https://api-pr11198.review.pix.fr/api/documentation
