### PR TITLE
[FEATURE] Lancer les tests Modulix dans une github action (PIX-16245)

### DIFF
--- a/.github/workflows/test-modulix-content.yaml
+++ b/.github/workflows/test-modulix-content.yaml
@@ -12,6 +12,7 @@ jobs:
   test-modulix-content:
     if: contains(github.event.pull_request.labels.*.name, 'contribution-modulix')
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     steps:
       - name: Checkout
@@ -26,6 +27,30 @@ jobs:
       - name: Install dependencies
         run: npm clean-install
 
-      - name: Run Modulix Tests
-        run: npm run modulix:test
+      - id: tests
+        name: Run Modulix Tests
+        run: |
+          set +e -o pipefail
+          npm run modulix:test 2>&1 | tee test_output.log
+          ERROR_CODE=$?
+          echo "TEST_ERRORS<<EOF" >> $GITHUB_ENV
+          cat test_output.log >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+          exit $ERROR_CODE
 
+      - name: Comment PR with Test Modulix Error details
+        uses: actions/github-script@v6
+        if: ${{ failure() }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Les tests Modulix ont échoué. Voici les détails :
+
+            \`\`\`
+            ${process.env.TEST_ERRORS}
+            \`\`\``
+            })

--- a/.github/workflows/test-modulix-content.yaml
+++ b/.github/workflows/test-modulix-content.yaml
@@ -1,0 +1,31 @@
+name: Test Modulix content
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+defaults:
+  run:
+    working-directory: api
+
+jobs:
+  test-modulix-content:
+    if: contains(github.event.pull_request.labels.*.name, 'contribution-modulix')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: npm
+
+      - name: Install dependencies
+        run: npm clean-install
+
+      - name: Run Modulix Tests
+        run: npm run modulix:test
+


### PR DESCRIPTION
## :pancakes: Problème

L'équipe de contribution de Modulix passe généralement par la CI pour vérifier que les modules ajoutés répondent aux règles de lint/fonctionnels par rapport à l'API et modulix Editor.

Cela cause des boucles de feedbacks longues (une dizaine de minutes) par tests.


## :bacon: Proposition

Ajouter une github action `test-modulix-content` qui lance les tests de l'API modulix et poste un commentaire en cas d'erreur dans la PR concernée.
Cela fonctionne uniquement lorsque le label `contribution-modulix` est mis.

## 🧃 Remarques

RAS

## :yum: Pour tester

- Modifier le didacticiel modulix en mettant par exemple qu'un seul élément dans le stepper
- Pousser cette modif
- Vérifier que la CI envoie bien un commentaire avec les détails de l'erreur !
