### PR TITLE
[BUGFIX] Safari ne comprend pas les width:auto  (PIX-16206)

### DIFF
--- a/junior/app/styles/components/oralization-button.scss
+++ b/junior/app/styles/components/oralization-button.scss
@@ -19,7 +19,7 @@
     background-color: var(--pix-primary-500);
 
     svg {
-      width: auto;
+      width: 100%;
       height: 30px;
       margin-left: 4px;
       fill: var(--pix-neutral-0);


### PR DESCRIPTION
## :pancakes: Problème

Sur les navigateur safari nos boutton d'oralisation ne s'affiche pas correctement.
![image](https://github.com/user-attachments/assets/ab6a0224-9e61-4a60-a5ab-177974a48ab8)

## :bacon: Proposition

Régler le problème!

## 🧃 Remarques

safarie ne comprend pas dans les fichiers css les propriétés `width:auto` 

## :yum: Pour tester

Se connecter sur la RA avec un utilisateur ayant l'oralisation activé. Observer que le bouton oralization possède bien une  image

Les boutons doivent ressembler à ça  =>
![image](https://github.com/user-attachments/assets/bf38aeb3-0f6c-488e-a8b2-7865f6cdb8d4)
