### PR TITLE
[FEATURE] Envoi automatique de la réponse pour les embed avec auto-validation (PIX-16156)

### DIFF
--- a/api/src/school/infrastructure/serializers/challenge-serializer.js
+++ b/api/src/school/infrastructure/serializers/challenge-serializer.js
@@ -18,6 +18,7 @@ const serialize = function (challenges) {
       'format',
       'autoReply',
       'focused',
+      'timer',
       'shuffled',
     ],
     transform: (challenge) => {

--- a/api/tests/school/unit/infrastructure/serializers/challenge-serializer_test.js
+++ b/api/tests/school/unit/infrastructure/serializers/challenge-serializer_test.js
@@ -55,6 +55,7 @@ describe('Unit | Serializer | challenge-serializer', function () {
               prop1: 'value 1',
               prop2: 'value 2',
             },
+            timer: 300,
             'illustration-alt': 'alt',
             'auto-reply': false,
           },

--- a/junior/app/components/challenge/challenge-content.gjs
+++ b/junior/app/components/challenge/challenge-content.gjs
@@ -107,7 +107,11 @@ export default class ChallengeContent extends Component {
       {{/if}}
       {{#if @challenge.autoReply}}
         <div class="challenge-content__autoreply">
-          <AutoReply @setAnswerValue={{@setAnswerValue}} />
+          <AutoReply
+            @validateAnswer={{@validateAnswer}}
+            @isEmbedAutoValidated={{@challenge.isEmbedAutoValidated}}
+            @setAnswerValue={{@setAnswerValue}}
+          />
         </div>
       {{/if}}
       <ChallengeActions

--- a/junior/app/components/challenge/challenge.gjs
+++ b/junior/app/components/challenge/challenge.gjs
@@ -127,8 +127,7 @@ export default class Challenge extends Component {
       await this.answer.save({ adapterOptions: { assessmentId: this.#assessmentId, isPreview: this.#isPreview } });
       this.answerHasBeenValidated = true;
       this.scrollToTop();
-      // eslint-disable-next-line no-unused-vars
-    } catch (error) {
+    } catch {
       this.answer.rollbackAttributes();
     }
   }

--- a/junior/app/components/challenge/content/auto-reply.js
+++ b/junior/app/components/challenge/content/auto-reply.js
@@ -16,8 +16,13 @@ export default class AutoReply extends Component {
 
   _receiveEmbedMessage(event) {
     const message = this._getMessageFromEventData(event);
+
     if (message && message.answer && message.from === 'pix') {
       this.args.setAnswerValue(message.answer);
+
+      if (this.args.isEmbedAutoValidated) {
+        this.args.validateAnswer();
+      }
     }
   }
 

--- a/junior/app/models/challenge.js
+++ b/junior/app/models/challenge.js
@@ -25,6 +25,7 @@ export default class Challenge extends Model {
   instructions;
   @attr('string') proposals;
   @attr('string') type;
+  @attr('number') timer;
   @attr('boolean') focused;
   @attr('boolean') shuffled;
   @attr() webComponentProps;
@@ -68,6 +69,10 @@ export default class Challenge extends Model {
 
   get hasType() {
     return !!this.type;
+  }
+
+  get isEmbedAutoValidated() {
+    return this.timer !== null && this.timer >= 0;
   }
 
   get hasMedia() {

--- a/junior/tests/acceptance/display-challenge-test.js
+++ b/junior/tests/acceptance/display-challenge-test.js
@@ -29,6 +29,27 @@ module('Acceptance | Challenge', function (hooks) {
     assert.dom(screen.getByRole('button', { name: t('pages.challenge.actions.check') })).exists();
   });
 
+  test('displays challenge page with embed autoValidated (timer props)', async function (assert) {
+    const assessment = this.server.create('assessment');
+    const challenge = this.server.create('challenge', {
+      autoReply: true,
+      timer: 200,
+      embedTitle: 'Wow',
+      embedUrl: 'https://bidule',
+      instructions: ['1ère instruction', '2ème instruction'],
+    });
+    this.server.create('activity', { assessmentId: assessment.id });
+    // when
+    const screen = await visit(`/assessments/${assessment.id}/challenges`);
+    // then
+    const validateButton = screen.getByRole('button', { name: t('pages.challenge.actions.check') });
+    assert.dom(screen.getByText(challenge.instructions[0])).exists();
+    assert.dom(screen.getByText(challenge.instructions[1])).exists();
+    assert.dom(screen.getByRole('button', { name: t('pages.challenge.actions.skip') })).exists();
+    assert.dom(validateButton).exists();
+    assert.ok(validateButton.disabled);
+  });
+
   test('Should display the oralization button if learner has feature enabled', async function (assert) {
     const oragnizationLearner = this.server.create('organization-learner', {
       features: ['ORALIZATION'],


### PR DESCRIPTION
## :pancakes: Problème

Lors d'épreuves contenant des simulateurs, on avait un bouton `je vérifie` puis un bouton `je continue`. Leurs présences n'étaient pas nécessaires parce que le simulateur notifie tout seul lorsque l'utilisateur a réussi.

## :bacon: Proposition

Créer un process de bouton/vérification/feedback spécialement pour ces challenges.

## 🧃 Remarques

RAS

## :yum: Pour tester

Aller sur des challenges en auto-validation (propriété timer positionnée). Ex : `challenge1zjYxfricm0yIF`
-> le bouton `Je vérifie` est présent en mode grisé tant que l'épreuve n'est pas terminée.
Après réussite de l'épreuve : 
-> le feedback est donné par le robot sans avoir à cliquer sur le bouton `Je vérifie`. Le bouton affiché est maintenant `Je continue`