### PR TITLE
[FEATURE] Traduction en NL des CGU (PIX-16183)

### DIFF
--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -313,17 +313,17 @@
     },
     "terms-of-service": {
       "actions": {
-        "accept": "Accept and continue",
-        "document-link": "Read terms of service",
-        "reject": "Decline and quit"
+        "accept": "Accepteren en doorgaan",
+        "document-link": "Gebruiksvoorwaarden lezen",
+        "reject": "Weigeren en stoppen"
       },
       "message": {
-        "requested": "To continue using Pix, please read and accept our Terms of service.",
-        "update-requested": "We have updated our Terms of service. Please review the changes and accept them to continue."
+        "requested": "Lees en accepteer onze servicevoorwaarden om Pix te blijven gebruiken.",
+        "update-requested": "We hebben onze Servicevoorwaarden bijgewerkt. Bekijk de wijzigingen en accepteer ze om verder te gaan."
       },
       "title": {
-        "requested": "Please accept our Terms of service",
-        "update-requested": "Important update to the Terms of service"
+        "requested": "Accepteer onze servicevoorwaarden",
+        "update-requested": "Belangrijke update van de servicevoorwaarden"
       }
     },
     "ui": {


### PR DESCRIPTION
## :pancakes: Problème

Lorsque Pix Orga était affiché en néerlandais, le process utilisateur d'acceptation des CGU (nouvel utilisateur ou ancien utilisateur) était en anglais. 

## :bacon: Proposition

Traduire en néerlandais les clés correspondantes.

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

**Nouvel utilisateur** 

* Aller dans Pix Orga sur le domaine .org
* Aller dans Equipes
* Aller dans "Inviter un membre"
* Envoyer une invitation à votre adresse e-mail
* Accepter l'invitation 
* Sur la double mire, mettre le néerlandais
* Se créer un compte et valider
* Constater l'affichage de la page d'acceptation des CGU en néerlandais

**Ancien utilisateur**

* Ajouter une nouvelle version des CGU avec la commande appropriée
* Se connecter avec le compte du premier test
* Constater l'affichage en néerlandais de la page d'acceptation des CGU MAJ
