### PR TITLE
[TECH] CampaignLearningContent hérite de LearningContent (PIX-16195)

### DIFF
--- a/api/lib/infrastructure/repositories/learning-content-repository.js
+++ b/api/lib/infrastructure/repositories/learning-content-repository.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import { knex } from '../../../db/knex-database-connection.js';
 import * as campaignRepository from '../../../src/prescription/campaign/infrastructure/repositories/campaign-repository.js';
 import { NoSkillsInCampaignError, NotFoundError } from '../../../src/shared/domain/errors.js';
+import { CampaignLearningContent } from '../../../src/shared/domain/models/CampaignLearningContent.js';
 import { LearningContent } from '../../../src/shared/domain/models/LearningContent.js';
 import * as areaRepository from '../../../src/shared/infrastructure/repositories/area-repository.js';
 import * as competenceRepository from '../../../src/shared/infrastructure/repositories/competence-repository.js';
@@ -17,7 +18,7 @@ async function findByCampaignId(campaignId, locale) {
 
   const frameworks = await _getLearningContentBySkillIds(skills, locale);
 
-  return new LearningContent(frameworks);
+  return new CampaignLearningContent(frameworks);
 }
 
 async function findByTargetProfileId(targetProfileId, locale) {

--- a/api/src/prescription/campaign-participation/domain/usecases/compute-campaign-participation-analysis.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/compute-campaign-participation-analysis.js
@@ -1,5 +1,4 @@
 import { UserNotAuthorizedToAccessEntityError } from '../../../../shared/domain/errors.js';
-import { CampaignLearningContent } from '../../../../shared/domain/models/CampaignLearningContent.js';
 import { CampaignParticipationDeletedError } from '../errors.js';
 
 const computeCampaignParticipationAnalysis = async function ({
@@ -28,8 +27,7 @@ const computeCampaignParticipationAnalysis = async function ({
     return null;
   }
 
-  const learningContent = await learningContentRepository.findByCampaignId(campaignId, locale);
-  const campaignLearningContent = new CampaignLearningContent(learningContent.frameworks);
+  const campaignLearningContent = await learningContentRepository.findByCampaignId(campaignId, locale);
   const tutorials = await tutorialRepository.list({ locale });
 
   return campaignAnalysisRepository.getCampaignParticipationAnalysis(

--- a/api/src/prescription/campaign-participation/domain/usecases/compute-campaign-participation-analysis.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/compute-campaign-participation-analysis.js
@@ -29,7 +29,7 @@ const computeCampaignParticipationAnalysis = async function ({
   }
 
   const learningContent = await learningContentRepository.findByCampaignId(campaignId, locale);
-  const campaignLearningContent = new CampaignLearningContent(learningContent);
+  const campaignLearningContent = new CampaignLearningContent(learningContent.frameworks);
   const tutorials = await tutorialRepository.list({ locale });
 
   return campaignAnalysisRepository.getCampaignParticipationAnalysis(

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-assessment-participation-result-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-assessment-participation-result-repository.js
@@ -7,7 +7,7 @@ import { CampaignAssessmentParticipationResult } from '../../domain/models/Campa
 
 const getByCampaignIdAndCampaignParticipationId = async function ({ campaignId, campaignParticipationId, locale }) {
   const learningContent = await learningContentRepository.findByCampaignId(campaignId, locale);
-  const campaignLearningContent = new CampaignLearningContent(learningContent);
+  const campaignLearningContent = new CampaignLearningContent(learningContent.frameworks);
   const result = await _fetchCampaignAssessmentParticipationResultAttributesFromCampaignParticipation(
     campaignId,
     campaignParticipationId,

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-assessment-participation-result-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-assessment-participation-result-repository.js
@@ -1,13 +1,11 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 import * as learningContentRepository from '../../../../../lib/infrastructure/repositories/learning-content-repository.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
-import { CampaignLearningContent } from '../../../../shared/domain/models/CampaignLearningContent.js';
 import * as knowledgeElementRepository from '../../../../shared/infrastructure/repositories/knowledge-element-repository.js';
 import { CampaignAssessmentParticipationResult } from '../../domain/models/CampaignAssessmentParticipationResult.js';
 
 const getByCampaignIdAndCampaignParticipationId = async function ({ campaignId, campaignParticipationId, locale }) {
-  const learningContent = await learningContentRepository.findByCampaignId(campaignId, locale);
-  const campaignLearningContent = new CampaignLearningContent(learningContent.frameworks);
+  const campaignLearningContent = await learningContentRepository.findByCampaignId(campaignId, locale);
   const result = await _fetchCampaignAssessmentParticipationResultAttributesFromCampaignParticipation(
     campaignId,
     campaignParticipationId,

--- a/api/src/prescription/campaign/domain/usecases/compute-campaign-analysis.js
+++ b/api/src/prescription/campaign/domain/usecases/compute-campaign-analysis.js
@@ -1,5 +1,4 @@
 import { UserNotAuthorizedToAccessEntityError } from '../../../../shared/domain/errors.js';
-import { CampaignLearningContent } from '../../../../shared/domain/models/CampaignLearningContent.js';
 
 const computeCampaignAnalysis = async function ({
   userId,
@@ -16,8 +15,7 @@ const computeCampaignAnalysis = async function ({
     throw new UserNotAuthorizedToAccessEntityError('User does not have access to this campaign');
   }
 
-  const learningContent = await learningContentRepository.findByCampaignId(campaignId, locale);
-  const campaignLearningContent = new CampaignLearningContent(learningContent.frameworks);
+  const campaignLearningContent = await learningContentRepository.findByCampaignId(campaignId, locale);
   const tutorials = await tutorialRepository.list({ locale });
 
   return campaignAnalysisRepository.getCampaignAnalysis(campaignId, campaignLearningContent, tutorials);

--- a/api/src/prescription/campaign/domain/usecases/compute-campaign-analysis.js
+++ b/api/src/prescription/campaign/domain/usecases/compute-campaign-analysis.js
@@ -17,7 +17,7 @@ const computeCampaignAnalysis = async function ({
   }
 
   const learningContent = await learningContentRepository.findByCampaignId(campaignId, locale);
-  const campaignLearningContent = new CampaignLearningContent(learningContent);
+  const campaignLearningContent = new CampaignLearningContent(learningContent.frameworks);
   const tutorials = await tutorialRepository.list({ locale });
 
   return campaignAnalysisRepository.getCampaignAnalysis(campaignId, campaignLearningContent, tutorials);

--- a/api/src/prescription/campaign/domain/usecases/compute-campaign-collective-result.js
+++ b/api/src/prescription/campaign/domain/usecases/compute-campaign-collective-result.js
@@ -16,7 +16,7 @@ const computeCampaignCollectiveResult = async function ({
   }
 
   const learningContent = await learningContentRepository.findByCampaignId(campaignId, locale);
-  const campaignLearningContent = new CampaignLearningContent(learningContent);
+  const campaignLearningContent = new CampaignLearningContent(learningContent.frameworks);
   return campaignCollectiveResultRepository.getCampaignCollectiveResult(campaignId, campaignLearningContent);
 };
 

--- a/api/src/prescription/campaign/domain/usecases/compute-campaign-collective-result.js
+++ b/api/src/prescription/campaign/domain/usecases/compute-campaign-collective-result.js
@@ -1,5 +1,4 @@
 import { UserNotAuthorizedToAccessEntityError } from '../../../../shared/domain/errors.js';
-import { CampaignLearningContent } from '../../../../shared/domain/models/CampaignLearningContent.js';
 
 const computeCampaignCollectiveResult = async function ({
   userId,
@@ -15,8 +14,7 @@ const computeCampaignCollectiveResult = async function ({
     throw new UserNotAuthorizedToAccessEntityError('User does not have access to this campaign');
   }
 
-  const learningContent = await learningContentRepository.findByCampaignId(campaignId, locale);
-  const campaignLearningContent = new CampaignLearningContent(learningContent.frameworks);
+  const campaignLearningContent = await learningContentRepository.findByCampaignId(campaignId, locale);
   return campaignCollectiveResultRepository.getCampaignCollectiveResult(campaignId, campaignLearningContent);
 };
 

--- a/api/src/prescription/campaign/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
+++ b/api/src/prescription/campaign/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
@@ -64,7 +64,7 @@ const startWritingCampaignAssessmentResultsToStream = async function ({
   const targetProfile = await targetProfileRepository.getByCampaignId(campaign.id);
   const learningContent = await learningContentRepository.findByCampaignId(campaign.id, i18n.getLocale());
   const stageCollection = await stageCollectionRepository.findStageCollection({ campaignId });
-  const campaignLearningContent = new CampaignLearningContent(learningContent);
+  const campaignLearningContent = new CampaignLearningContent(learningContent.frameworks);
 
   const organization = await organizationRepository.get(campaign.organizationId);
   const campaignParticipationInfos = await campaignParticipationInfoRepository.findByCampaignId(campaign.id);

--- a/api/src/prescription/campaign/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
+++ b/api/src/prescription/campaign/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
@@ -5,7 +5,6 @@ dayjs.extend(utc);
 dayjs.extend(timezone);
 
 import { CampaignTypeError } from '../../../../shared/domain/errors.js';
-import { CampaignLearningContent } from '../../../../shared/domain/models/index.js';
 import { CampaignAssessmentExport } from '../../infrastructure/serializers/csv/campaign-assessment-export.js';
 
 /**
@@ -64,7 +63,6 @@ const startWritingCampaignAssessmentResultsToStream = async function ({
   const targetProfile = await targetProfileRepository.getByCampaignId(campaign.id);
   const learningContent = await learningContentRepository.findByCampaignId(campaign.id, i18n.getLocale());
   const stageCollection = await stageCollectionRepository.findStageCollection({ campaignId });
-  const campaignLearningContent = new CampaignLearningContent(learningContent.frameworks);
 
   const organization = await organizationRepository.get(campaign.organizationId);
   const campaignParticipationInfos = await campaignParticipationInfoRepository.findByCampaignId(campaign.id);
@@ -79,7 +77,7 @@ const startWritingCampaignAssessmentResultsToStream = async function ({
     outputStream: writableStream,
     organization,
     targetProfile,
-    learningContent: campaignLearningContent,
+    learningContent,
     stageCollection,
     campaign,
     translate,

--- a/api/src/shared/domain/models/CampaignLearningContent.js
+++ b/api/src/shared/domain/models/CampaignLearningContent.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { LearningContent } from './LearningContent.js';
 
 class CampaignLearningContent extends LearningContent {
@@ -13,79 +11,6 @@ class CampaignLearningContent extends LearningContent {
 
   get competences() {
     return super.competences.sort((a, b) => a.index.localeCompare(b.index));
-  }
-
-  get maxSkillDifficulty() {
-    const skillMaxDifficulty = _.maxBy(this.skills, 'difficulty');
-    return skillMaxDifficulty ? skillMaxDifficulty.difficulty : null;
-  }
-
-  get tubeIds() {
-    return this.tubes.map((tube) => tube.id);
-  }
-
-  getValidatedKnowledgeElementsGroupedByTube(knowledgeElements) {
-    return this._filterTargetedKnowledgeElementAndGroupByTube(
-      knowledgeElements,
-      (knowledgeElement) => knowledgeElement.isValidated,
-    );
-  }
-
-  getKnowledgeElementsGroupedByCompetence(knowledgeElements) {
-    return this._filterTargetedKnowledgeElementAndGroupByCompetence(knowledgeElements);
-  }
-
-  countValidatedTargetedKnowledgeElementsByCompetence(knowledgeElements) {
-    const validatedGroupedByCompetence = this._filterTargetedKnowledgeElementAndGroupByCompetence(
-      knowledgeElements,
-      (knowledgeElement) => knowledgeElement.isValidated,
-    );
-    return _.mapValues(validatedGroupedByCompetence, 'length');
-  }
-
-  get skillNames() {
-    return this.skills.map((skill) => skill.name);
-  }
-
-  _getTubeIdOfSkill(skillId) {
-    const skillTube = this.tubes.find((tube) => tube.hasSkill(skillId));
-
-    return skillTube ? skillTube.id : null;
-  }
-
-  _filterTargetedKnowledgeElementAndGroupByTube(knowledgeElements, knowledgeElementFilter = () => true) {
-    const knowledgeElementsGroupedByTube = {};
-    for (const tubeId of this.tubeIds) {
-      knowledgeElementsGroupedByTube[tubeId] = [];
-    }
-    for (const knowledgeElement of knowledgeElements) {
-      const tubeId = this._getTubeIdOfSkill(knowledgeElement.skillId);
-      if (tubeId && knowledgeElementFilter(knowledgeElement)) {
-        knowledgeElementsGroupedByTube[tubeId].push(knowledgeElement);
-      }
-    }
-
-    return knowledgeElementsGroupedByTube;
-  }
-
-  _filterTargetedKnowledgeElementAndGroupByCompetence(knowledgeElements, knowledgeElementFilter = () => true) {
-    const knowledgeElementsGroupedByCompetence = {};
-    for (const competence of this.competences) {
-      knowledgeElementsGroupedByCompetence[competence.id] = [];
-    }
-    for (const knowledgeElement of knowledgeElements) {
-      const competenceId = this.findCompetenceIdOfSkill(knowledgeElement.skillId);
-      if (competenceId && knowledgeElementFilter(knowledgeElement)) {
-        knowledgeElementsGroupedByCompetence[competenceId].push(knowledgeElement);
-      }
-    }
-
-    return knowledgeElementsGroupedByCompetence;
-  }
-
-  findAreaOfCompetence(competence) {
-    const area = this.findArea(competence.areaId);
-    return area || null;
   }
 }
 

--- a/api/src/shared/domain/models/CampaignLearningContent.js
+++ b/api/src/shared/domain/models/CampaignLearningContent.js
@@ -3,8 +3,8 @@ import _ from 'lodash';
 import { LearningContent } from './LearningContent.js';
 
 class CampaignLearningContent extends LearningContent {
-  constructor(learningContent) {
-    super(learningContent);
+  constructor(frameworks) {
+    super(frameworks);
   }
 
   get areas() {

--- a/api/src/shared/domain/models/CampaignLearningContent.js
+++ b/api/src/shared/domain/models/CampaignLearningContent.js
@@ -1,40 +1,10 @@
 import _ from 'lodash';
 
-class CampaignLearningContent {
+import { LearningContent } from './LearningContent.js';
+
+class CampaignLearningContent extends LearningContent {
   constructor(learningContent) {
-    this._learningContent = learningContent;
-  }
-
-  get skills() {
-    return this._learningContent.skills;
-  }
-
-  get tubes() {
-    return this._learningContent.tubes;
-  }
-
-  get competences() {
-    return this._learningContent.competences.sort((a, b) => a.index.localeCompare(b.index));
-  }
-
-  get areas() {
-    return this._learningContent.areas.sort((a, b) => a.code.localeCompare(b.code));
-  }
-
-  findSkill(skillId) {
-    return this._learningContent.findSkill(skillId);
-  }
-
-  findTube(tubeId) {
-    return this._learningContent.findTube(tubeId);
-  }
-
-  findCompetence(competenceId) {
-    return this._learningContent.findCompetence(competenceId);
-  }
-
-  findArea(areaId) {
-    return this._learningContent.findArea(areaId);
+    super(learningContent);
   }
 
   get maxSkillDifficulty() {
@@ -44,11 +14,6 @@ class CampaignLearningContent {
 
   get tubeIds() {
     return this.tubes.map((tube) => tube.id);
-  }
-
-  /** @deprecated use findCompetence */
-  getCompetence(competenceId) {
-    return this.findCompetence(competenceId);
   }
 
   getValidatedKnowledgeElementsGroupedByTube(knowledgeElements) {
@@ -108,12 +73,6 @@ class CampaignLearningContent {
     }
 
     return knowledgeElementsGroupedByCompetence;
-  }
-
-  findCompetenceIdOfSkill(skillId) {
-    const tubeId = this.findSkill(skillId)?.tubeId;
-    if (!tubeId) return null;
-    return this.findTube(tubeId).competenceId;
   }
 
   findAreaOfCompetence(competence) {

--- a/api/src/shared/domain/models/CampaignLearningContent.js
+++ b/api/src/shared/domain/models/CampaignLearningContent.js
@@ -7,6 +7,14 @@ class CampaignLearningContent extends LearningContent {
     super(learningContent);
   }
 
+  get areas() {
+    return super.areas.sort((a, b) => a.code.localeCompare(b.code));
+  }
+
+  get competences() {
+    return super.competences.sort((a, b) => a.index.localeCompare(b.index));
+  }
+
   get maxSkillDifficulty() {
     const skillMaxDifficulty = _.maxBy(this.skills, 'difficulty');
     return skillMaxDifficulty ? skillMaxDifficulty.difficulty : null;

--- a/api/src/shared/domain/models/LearningContent.js
+++ b/api/src/shared/domain/models/LearningContent.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 class LearningContent {
   constructor(frameworks) {
     this.frameworks = frameworks;
@@ -24,6 +26,14 @@ class LearningContent {
     return this.tubes.flatMap((tube) => tube.skills);
   }
 
+  get skillNames() {
+    return this.skills.map((skill) => skill.name);
+  }
+
+  get tubeIds() {
+    return this.tubes.map((tube) => tube.id);
+  }
+
   findSkill(skillId) {
     return this.skills.find((skill) => skill.id === skillId) ?? null;
   }
@@ -40,6 +50,11 @@ class LearningContent {
     return this.areas.find((area) => area.id === areaId) ?? null;
   }
 
+  findAreaOfCompetence(competence) {
+    const area = this.findArea(competence.areaId);
+    return area || null;
+  }
+
   findFramework(frameworkId) {
     return this.frameworks.find((framework) => framework.id === frameworkId) ?? null;
   }
@@ -54,6 +69,65 @@ class LearningContent {
     const frameworkId = this.findArea(areaId)?.frameworkId;
     if (!frameworkId) return '';
     return this.findFramework(frameworkId).name;
+  }
+  getValidatedKnowledgeElementsGroupedByTube(knowledgeElements) {
+    return this._filterTargetedKnowledgeElementAndGroupByTube(
+      knowledgeElements,
+      (knowledgeElement) => knowledgeElement.isValidated,
+    );
+  }
+
+  getKnowledgeElementsGroupedByCompetence(knowledgeElements) {
+    return this._filterTargetedKnowledgeElementAndGroupByCompetence(knowledgeElements);
+  }
+
+  countValidatedTargetedKnowledgeElementsByCompetence(knowledgeElements) {
+    const validatedGroupedByCompetence = this._filterTargetedKnowledgeElementAndGroupByCompetence(
+      knowledgeElements,
+      (knowledgeElement) => knowledgeElement.isValidated,
+    );
+    return _.mapValues(validatedGroupedByCompetence, 'length');
+  }
+
+  _getTubeIdOfSkill(skillId) {
+    const skillTube = this.tubes.find((tube) => tube.hasSkill(skillId));
+
+    return skillTube ? skillTube.id : null;
+  }
+
+  _filterTargetedKnowledgeElementAndGroupByTube(knowledgeElements, knowledgeElementFilter = () => true) {
+    const knowledgeElementsGroupedByTube = {};
+    for (const tubeId of this.tubeIds) {
+      knowledgeElementsGroupedByTube[tubeId] = [];
+    }
+    for (const knowledgeElement of knowledgeElements) {
+      const tubeId = this._getTubeIdOfSkill(knowledgeElement.skillId);
+      if (tubeId && knowledgeElementFilter(knowledgeElement)) {
+        knowledgeElementsGroupedByTube[tubeId].push(knowledgeElement);
+      }
+    }
+
+    return knowledgeElementsGroupedByTube;
+  }
+
+  _filterTargetedKnowledgeElementAndGroupByCompetence(knowledgeElements, knowledgeElementFilter = () => true) {
+    const knowledgeElementsGroupedByCompetence = {};
+    for (const competence of this.competences) {
+      knowledgeElementsGroupedByCompetence[competence.id] = [];
+    }
+    for (const knowledgeElement of knowledgeElements) {
+      const competenceId = this.findCompetenceIdOfSkill(knowledgeElement.skillId);
+      if (competenceId && knowledgeElementFilter(knowledgeElement)) {
+        knowledgeElementsGroupedByCompetence[competenceId].push(knowledgeElement);
+      }
+    }
+
+    return knowledgeElementsGroupedByCompetence;
+  }
+
+  get maxSkillDifficulty() {
+    const skillMaxDifficulty = _.maxBy(this.skills, 'difficulty');
+    return skillMaxDifficulty ? skillMaxDifficulty.difficulty : null;
   }
 }
 

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-analysis-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-analysis-repository_test.js
@@ -48,7 +48,7 @@ function _createUserWithNonSharedCampaignParticipation(userName, campaignId) {
 describe('Integration | Repository | Campaign analysis repository', function () {
   describe('#getCampaignAnalysis', function () {
     context('in a rich context close to reality', function () {
-      let learningContent;
+      let learningContent, campaignLearningContent;
       let campaignId;
 
       beforeEach(async function () {
@@ -88,7 +88,8 @@ describe('Integration | Repository | Campaign analysis repository', function () 
         });
         const area = domainBuilder.buildArea({ id: 'recArea', color: 'jaffa', competences: [competence] });
         const framework = domainBuilder.buildFramework({ areas: [area] });
-        learningContent = domainBuilder.buildCampaignLearningContent.fromFrameworks([framework]);
+        learningContent = domainBuilder.buildLearningContent([framework]);
+        campaignLearningContent = domainBuilder.buildCampaignLearningContent(learningContent);
 
         return databaseBuilder.commit();
       });
@@ -98,7 +99,7 @@ describe('Integration | Repository | Campaign analysis repository', function () 
         const tutorials = [];
         const actualAnalysis = await campaignAnalysisRepository.getCampaignAnalysis(
           campaignId,
-          learningContent,
+          campaignLearningContent,
           tutorials,
         );
 
@@ -119,25 +120,25 @@ describe('Integration | Repository | Campaign analysis repository', function () 
         const tubeARecommendation = actualAnalysis.campaignTubeRecommendations[0];
         expect(_.pick(tubeARecommendation, pickedAttributes)).to.deep.equal({
           campaignId,
-          tube: learningContent.tubes[0],
-          competenceId: learningContent.competences[0].id,
-          id: `${campaignId}_${learningContent.tubes[0].id}`,
-          competenceName: learningContent.competences[0].name,
-          tubePracticalTitle: learningContent.tubes[0].practicalTitle,
-          areaColor: learningContent.areas[0].color,
-          maxSkillLevel: learningContent.maxSkillDifficulty,
+          tube: campaignLearningContent.tubes[0],
+          competenceId: campaignLearningContent.competences[0].id,
+          id: `${campaignId}_${campaignLearningContent.tubes[0].id}`,
+          competenceName: campaignLearningContent.competences[0].name,
+          tubePracticalTitle: campaignLearningContent.tubes[0].practicalTitle,
+          areaColor: campaignLearningContent.areas[0].color,
+          maxSkillLevel: campaignLearningContent.maxSkillDifficulty,
         });
 
         const tubeBRecommendation = actualAnalysis.campaignTubeRecommendations[1];
         expect(_.pick(tubeBRecommendation, pickedAttributes)).to.deep.equal({
           campaignId,
-          tube: learningContent.tubes[1],
-          competenceId: learningContent.competences[0].id,
-          id: `${campaignId}_${learningContent.tubes[1].id}`,
-          competenceName: learningContent.competences[0].name,
-          tubePracticalTitle: learningContent.tubes[1].practicalTitle,
-          areaColor: learningContent.areas[0].color,
-          maxSkillLevel: learningContent.maxSkillDifficulty,
+          tube: campaignLearningContent.tubes[1],
+          competenceId: campaignLearningContent.competences[0].id,
+          id: `${campaignId}_${campaignLearningContent.tubes[1].id}`,
+          competenceName: campaignLearningContent.competences[0].name,
+          tubePracticalTitle: campaignLearningContent.tubes[1].practicalTitle,
+          areaColor: campaignLearningContent.areas[0].color,
+          maxSkillLevel: campaignLearningContent.maxSkillDifficulty,
         });
       });
 
@@ -147,7 +148,7 @@ describe('Integration | Repository | Campaign analysis repository', function () 
           const tutorials = [];
           const actualAnalysis = await campaignAnalysisRepository.getCampaignAnalysis(
             campaignId,
-            learningContent,
+            campaignLearningContent,
             tutorials,
           );
 
@@ -186,7 +187,7 @@ describe('Integration | Repository | Campaign analysis repository', function () 
           const tutorials = [];
           const actualAnalysis = await campaignAnalysisRepository.getCampaignAnalysis(
             campaignId,
-            learningContent,
+            campaignLearningContent,
             tutorials,
           );
 
@@ -221,7 +222,7 @@ describe('Integration | Repository | Campaign analysis repository', function () 
           const tutorials = [];
           const actualAnalysis = await campaignAnalysisRepository.getCampaignAnalysis(
             campaignId,
-            learningContent,
+            campaignLearningContent,
             tutorials,
           );
 
@@ -321,7 +322,7 @@ describe('Integration | Repository | Campaign analysis repository', function () 
           const tutorials = [];
           const actualAnalysis = await campaignAnalysisRepository.getCampaignAnalysis(
             campaignId,
-            learningContent,
+            campaignLearningContent,
             tutorials,
           );
 
@@ -398,7 +399,7 @@ describe('Integration | Repository | Campaign analysis repository', function () 
           const tutorials = [];
           const actualAnalysis = await campaignAnalysisRepository.getCampaignAnalysis(
             campaignId,
-            learningContent,
+            campaignLearningContent,
             tutorials,
           );
 
@@ -414,7 +415,7 @@ describe('Integration | Repository | Campaign analysis repository', function () 
 
   describe('#getCampaignParticipationAnalysis', function () {
     context('in a rich context close to reality', function () {
-      let learningContent;
+      let learningContent, campaignLearningContent;
       let campaignId;
       let userId;
       let campaignParticipation;
@@ -465,7 +466,8 @@ describe('Integration | Repository | Campaign analysis repository', function () 
         });
         const area = domainBuilder.buildArea({ id: 'recArea', color: 'jaffa', competences: [competence] });
         const framework = domainBuilder.buildFramework({ areas: [area] });
-        learningContent = domainBuilder.buildCampaignLearningContent.fromFrameworks([framework]);
+        learningContent = domainBuilder.buildLearningContent([framework]);
+        campaignLearningContent = domainBuilder.buildCampaignLearningContent(learningContent);
 
         return databaseBuilder.commit();
       });
@@ -476,7 +478,7 @@ describe('Integration | Repository | Campaign analysis repository', function () 
         const actualAnalysis = await campaignAnalysisRepository.getCampaignParticipationAnalysis(
           campaignId,
           campaignParticipation,
-          learningContent,
+          campaignLearningContent,
           tutorials,
         );
 
@@ -497,25 +499,25 @@ describe('Integration | Repository | Campaign analysis repository', function () 
         const tubeARecommendation = actualAnalysis.campaignTubeRecommendations[0];
         expect(_.pick(tubeARecommendation, pickedAttributes)).to.deep.equal({
           campaignId,
-          tube: learningContent.tubes[0],
-          competenceId: learningContent.competences[0].id,
-          id: `${campaignId}_${learningContent.tubes[0].id}`,
-          competenceName: learningContent.competences[0].name,
-          tubePracticalTitle: learningContent.tubes[0].practicalTitle,
-          areaColor: learningContent.areas[0].color,
-          maxSkillLevel: learningContent.maxSkillDifficulty,
+          tube: campaignLearningContent.tubes[0],
+          competenceId: campaignLearningContent.competences[0].id,
+          id: `${campaignId}_${campaignLearningContent.tubes[0].id}`,
+          competenceName: campaignLearningContent.competences[0].name,
+          tubePracticalTitle: campaignLearningContent.tubes[0].practicalTitle,
+          areaColor: campaignLearningContent.areas[0].color,
+          maxSkillLevel: campaignLearningContent.maxSkillDifficulty,
         });
 
         const tubeBRecommendation = actualAnalysis.campaignTubeRecommendations[1];
         expect(_.pick(tubeBRecommendation, pickedAttributes)).to.deep.equal({
           campaignId,
-          tube: learningContent.tubes[1],
-          competenceId: learningContent.competences[0].id,
-          id: `${campaignId}_${learningContent.tubes[1].id}`,
-          competenceName: learningContent.competences[0].name,
-          tubePracticalTitle: learningContent.tubes[1].practicalTitle,
-          areaColor: learningContent.areas[0].color,
-          maxSkillLevel: learningContent.maxSkillDifficulty,
+          tube: campaignLearningContent.tubes[1],
+          competenceId: campaignLearningContent.competences[0].id,
+          id: `${campaignId}_${campaignLearningContent.tubes[1].id}`,
+          competenceName: campaignLearningContent.competences[0].name,
+          tubePracticalTitle: campaignLearningContent.tubes[1].practicalTitle,
+          areaColor: campaignLearningContent.areas[0].color,
+          maxSkillLevel: campaignLearningContent.maxSkillDifficulty,
         });
       });
 
@@ -550,7 +552,7 @@ describe('Integration | Repository | Campaign analysis repository', function () 
           const actualAnalysis = await campaignAnalysisRepository.getCampaignParticipationAnalysis(
             campaignId,
             campaignParticipation,
-            learningContent,
+            campaignLearningContent,
             tutorials,
           );
 

--- a/api/tests/prescription/campaign-participation/unit/domain/usecases/compute-campaign-participation-analysis_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/usecases/compute-campaign-participation-analysis_test.js
@@ -45,7 +45,7 @@ describe('Unit | UseCase | compute-campaign-participation-analysis', function ()
         campaignParticipation.userId = userId;
         campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(campaignParticipation);
         campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(true);
-        learningContentRepository.findByCampaignId.withArgs(campaignId, locale).resolves(learningContent);
+        learningContentRepository.findByCampaignId.withArgs(campaignId, locale).resolves(campaignLearningContent);
         tutorialRepository.list.withArgs({ locale }).resolves(tutorials);
         campaignAnalysisRepository.getCampaignParticipationAnalysis
           .withArgs(campaignId, campaignParticipation, campaignLearningContent, tutorials)

--- a/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/campaign-assessment-participation-result-serializer_test.js
+++ b/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/campaign-assessment-participation-result-serializer_test.js
@@ -22,7 +22,8 @@ describe('Unit | Serializer | JSONAPI | campaign-assessment-participation-result
       });
       const area = domainBuilder.buildArea({ id: 'area1', competences: [competence] });
       const framework = domainBuilder.buildFramework({ areas: [area] });
-      const campaignLearningContent = domainBuilder.buildCampaignLearningContent.fromFrameworks([framework]);
+      const learningContent = domainBuilder.buildLearningContent([framework]);
+      const campaignLearningContent = domainBuilder.buildCampaignLearningContent(learningContent);
 
       expectedJsonApi = {
         data: {

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-collective-result-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-collective-result-repository_test.js
@@ -46,7 +46,7 @@ function _createUserWithNonSharedCampaignParticipation(userName, campaignId) {
 describe('Integration | Repository | Campaign collective result repository', function () {
   describe('#getCampaignCollectiveResults', function () {
     context('in a rich context close to reality', function () {
-      let learningContent;
+      let learningContent, campaignLearningContent;
       let campaignId;
 
       beforeEach(async function () {
@@ -150,8 +150,8 @@ describe('Integration | Repository | Campaign collective result repository', fun
           ],
         });
         const framework = domainBuilder.buildFramework({ areas: [area1, area2] });
-
-        learningContent = domainBuilder.buildCampaignLearningContent.fromFrameworks([framework]);
+        learningContent = domainBuilder.buildLearningContent([framework]);
+        campaignLearningContent = domainBuilder.buildCampaignLearningContent(learningContent);
       });
 
       context('when there is no participant', function () {
@@ -163,7 +163,7 @@ describe('Integration | Repository | Campaign collective result repository', fun
           // when
           const result = await campaignCollectiveResultRepository.getCampaignCollectiveResult(
             campaignId,
-            learningContent,
+            campaignLearningContent,
           );
 
           // then
@@ -248,7 +248,7 @@ describe('Integration | Repository | Campaign collective result repository', fun
           // when
           const result = await campaignCollectiveResultRepository.getCampaignCollectiveResult(
             campaignId,
-            learningContent,
+            campaignLearningContent,
           );
 
           // then
@@ -331,7 +331,7 @@ describe('Integration | Repository | Campaign collective result repository', fun
           // when
           const result = await campaignCollectiveResultRepository.getCampaignCollectiveResult(
             campaignId,
-            learningContent,
+            campaignLearningContent,
           );
 
           // then
@@ -487,7 +487,7 @@ describe('Integration | Repository | Campaign collective result repository', fun
           // when
           const result = await campaignCollectiveResultRepository.getCampaignCollectiveResult(
             campaignId,
-            learningContent,
+            campaignLearningContent,
           );
 
           // then
@@ -901,7 +901,7 @@ describe('Integration | Repository | Campaign collective result repository', fun
           // when
           const result = await campaignCollectiveResultRepository.getCampaignCollectiveResult(
             campaignId,
-            learningContent,
+            campaignLearningContent,
           );
 
           // then
@@ -954,7 +954,7 @@ describe('Integration | Repository | Campaign collective result repository', fun
           // when
           const result = await campaignCollectiveResultRepository.getCampaignCollectiveResult(
             campaignId,
-            learningContent,
+            campaignLearningContent,
           );
 
           // then
@@ -1037,7 +1037,7 @@ describe('Integration | Repository | Campaign collective result repository', fun
           // when
           const result = await campaignCollectiveResultRepository.getCampaignCollectiveResult(
             campaignId,
-            learningContent,
+            campaignLearningContent,
           );
 
           // then

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/knowledge-element-snapshot-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/knowledge-element-snapshot-repository_test.js
@@ -177,7 +177,7 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
     let snappedAt1, snappedAt2, snappedAt3;
     let knowledgeElement1, knowledgeElement2, knowledgeElement3;
     let campaignParticipationId1, campaignParticipationId2, campaignParticipationId3;
-    let learningContent;
+    let learningContent, campaignLearningContent;
 
     beforeEach(async function () {
       userId1 = databaseBuilder.factory.buildUser().id;
@@ -199,7 +199,8 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
       const competence2 = domainBuilder.buildCompetence({ id: 'competence2', tubes: [tube2] });
       const area = domainBuilder.buildArea({ id: 'area1', competences: [competence1, competence2] });
       const framework = domainBuilder.buildFramework({ areas: [area] });
-      learningContent = domainBuilder.buildCampaignLearningContent.fromFrameworks([framework]);
+      learningContent = domainBuilder.buildLearningContent([framework]);
+      campaignLearningContent = domainBuilder.buildCampaignLearningContent(learningContent);
 
       snappedAt1 = new Date('2020-01-02');
       databaseBuilder.factory.buildCampaignParticipation({
@@ -209,8 +210,8 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
       });
       knowledgeElement1 = databaseBuilder.factory.buildKnowledgeElement({
         userId: userId1,
-        competenceId: learningContent.skills[0].competenceId,
-        skillId: learningContent.skills[0].id,
+        competenceId: campaignLearningContent.skills[0].competenceId,
+        skillId: campaignLearningContent.skills[0].id,
       });
       databaseBuilder.factory.buildKnowledgeElementSnapshot({
         userId: userId1,
@@ -227,8 +228,8 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
       });
       knowledgeElement2 = databaseBuilder.factory.buildKnowledgeElement({
         userId: userId2,
-        competenceId: learningContent.skills[1].competenceId,
-        skillId: learningContent.skills[1].id,
+        competenceId: campaignLearningContent.skills[1].competenceId,
+        skillId: campaignLearningContent.skills[1].id,
       });
       databaseBuilder.factory.buildKnowledgeElementSnapshot({
         userId: userId2,
@@ -245,8 +246,8 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
       });
       knowledgeElement3 = databaseBuilder.factory.buildKnowledgeElement({
         userId: userId2,
-        competenceId: learningContent.skills[2].competenceId,
-        skillId: learningContent.skills[2].id,
+        competenceId: campaignLearningContent.skills[2].competenceId,
+        skillId: campaignLearningContent.skills[2].id,
       });
       databaseBuilder.factory.buildKnowledgeElementSnapshot({
         userId: userId2,

--- a/api/tests/prescription/campaign/unit/domain/read-models/CampaignAnalysis_test.js
+++ b/api/tests/prescription/campaign/unit/domain/read-models/CampaignAnalysis_test.js
@@ -14,7 +14,8 @@ describe('Unit | Domain | Read-Models | CampaignAnalysis', function () {
       });
       const area = domainBuilder.buildArea({ id: 'recAreaId', competences: [competence] });
       const framework = domainBuilder.buildFramework({ areas: [area] });
-      const campaignLearningContent = domainBuilder.buildCampaignLearningContent.fromFrameworks([framework]);
+      const learningContent = domainBuilder.buildLearningContent([framework]);
+      const campaignLearningContent = domainBuilder.buildCampaignLearningContent(learningContent);
 
       // when
       const campaignAnalysis = new CampaignAnalysis({

--- a/api/tests/prescription/campaign/unit/domain/usecases/compute-campaign-analysis_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/compute-campaign-analysis_test.js
@@ -31,7 +31,7 @@ describe('Unit | UseCase | compute-campaign-analysis', function () {
       const tutorials = Symbol('tutorials');
       const campaignAnalysis = Symbol('analysis');
       campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(true);
-      learningContentRepository.findByCampaignId.withArgs(campaignId, locale).resolves(learningContent);
+      learningContentRepository.findByCampaignId.withArgs(campaignId, locale).resolves(campaignLearningContent);
       tutorialRepository.list.withArgs({ locale }).resolves(tutorials);
       campaignAnalysisRepository.getCampaignAnalysis
         .withArgs(campaignId, campaignLearningContent, tutorials)

--- a/api/tests/prescription/campaign/unit/domain/usecases/compute-campaign-collective-result_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/compute-campaign-collective-result_test.js
@@ -25,7 +25,7 @@ describe('Unit | UseCase | compute-campaign-collective-result', function () {
   context('User has access to this result', function () {
     beforeEach(function () {
       campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(true);
-      learningContentRepository.findByCampaignId.withArgs(campaignId, locale).resolves(learningContent);
+      learningContentRepository.findByCampaignId.withArgs(campaignId, locale).resolves(campaignLearningContent);
     });
 
     it('should resolve a CampaignCollectiveResult', async function () {

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-collective-result-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-collective-result-serializer_test.js
@@ -42,7 +42,8 @@ describe('Unit | Serializer | JSONAPI | campaign-collective-results-serializer',
       });
 
       const framework = domainBuilder.buildFramework({ areas: [area1, area2] });
-      const campaignLearningContent = domainBuilder.buildCampaignLearningContent.fromFrameworks([framework]);
+      const learningContent = domainBuilder.buildLearningContent([framework]);
+      const campaignLearningContent = domainBuilder.buildCampaignLearningContent(learningContent);
 
       const campaignCollectiveResult = domainBuilder.buildCampaignCollectiveResult({
         id: campaignId,

--- a/api/tests/shared/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -497,7 +497,8 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       const competence2 = domainBuilder.buildCompetence({ id: 'competence2', tubes: [tube2] });
       const area = domainBuilder.buildArea({ id: 'area1', competences: [competence1, competence2] });
       const framework = domainBuilder.buildFramework({ areas: [area] });
-      const learningContent = domainBuilder.buildCampaignLearningContent.fromFrameworks([framework]);
+      const learningContent = domainBuilder.buildLearningContent([framework]);
+      const campaignLearningContent = domainBuilder.buildCampaignLearningContent(learningContent);
       const userId = databaseBuilder.factory.buildUser().id;
       const limitDate = new Date('2020-01-03');
       // relevant kes
@@ -531,7 +532,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
         await knowledgeElementRepository.countValidatedByCompetencesForOneUserWithinCampaign(
           userId,
           limitDate,
-          learningContent,
+          campaignLearningContent,
         );
 
       // then

--- a/api/tests/shared/unit/domain/models/CampaignLearningContent_test.js
+++ b/api/tests/shared/unit/domain/models/CampaignLearningContent_test.js
@@ -1,69 +1,44 @@
 import { expect } from 'chai';
 
-import { Area } from '../../../../../src/shared/domain/models/Area.js';
+import { buildArea } from '../../../../../db/database-builder/factory/learning-content/build-area.js';
+import { buildCompetence } from '../../../../../db/database-builder/factory/learning-content/build-competence.js';
+import { buildFramework } from '../../../../../db/database-builder/factory/learning-content/build-framework.js';
+import { buildSkill } from '../../../../../db/database-builder/factory/learning-content/build-skill.js';
+import { buildTube } from '../../../../../db/database-builder/factory/learning-content/build-tube.js';
 import { CampaignLearningContent } from '../../../../../src/shared/domain/models/CampaignLearningContent.js';
-import { Skill } from '../../../../../src/shared/domain/models/Skill.js';
-import { Tube } from '../../../../../src/shared/domain/models/Tube.js';
+import { domainBuilder } from '../../../../test-helper.js';
 
 describe('Unit | Domain | Models | CampaignLearningContent', function () {
-  let skills, areasSorted, tubesSorted, competencesSorted, areas, competences, jaffaArea, wildStrawberryArea;
+  let framework;
 
   beforeEach(function () {
-    jaffaArea = new Area({ id: 'jaffaArea', code: '1', name: 'area 1', color: 'jaffa' });
-    wildStrawberryArea = new Area({
-      id: 'wildStrawberryArea',
-      code: '2',
-      name: 'area 2',
-      color: 'wild-strawberry',
-    });
-    areas = [wildStrawberryArea, jaffaArea];
-    areasSorted = [jaffaArea, wildStrawberryArea];
-
-    skills = [new Skill({ name: '@web3' }), new Skill({ name: '@web2' })];
-
-    tubesSorted = [new Tube({ skills })];
-
-    (competences = [
-      { id: 2, name: 'Désobéissance civile', index: '6.9', skillIds: [2, 3, 4], areaId: 'wildStrawberryArea' },
-      { id: 1, name: 'Economie symbiotique', index: '5.1', skillIds: [1], areaId: 'jaffaArea' },
-      { id: 3, name: 'Démocratie liquide', index: '8.6', skillIds: [5, 6], areaId: 'wildStrawberryArea' },
-    ]),
-      (competencesSorted = [
-        { id: 1, name: 'Economie symbiotique', index: '5.1', skillIds: [1], areaId: 'jaffaArea' },
-        { id: 2, name: 'Désobéissance civile', index: '6.9', skillIds: [2, 3, 4], areaId: 'wildStrawberryArea' },
-        { id: 3, name: 'Démocratie liquide', index: '8.6', skillIds: [5, 6], areaId: 'wildStrawberryArea' },
-      ]);
+    framework = buildFramework({ id: 'frameworkId', name: 'someFramework' });
+    const skill = buildSkill({ id: 'skillId', tubeId: 'tubeId' });
+    const tube = buildTube({ id: 'tubeId', competenceId: 'competenceId', skills: [skill] });
+    const area1 = buildArea({ id: 'areaId', code: '5', frameworkId: framework.id });
+    const area2 = buildArea({ id: 'areaId', code: '2', frameworkId: framework.id });
+    const competence1 = buildCompetence({ id: 'competenceId', index: '5.1', tubes: [tube] });
+    const competence2 = buildCompetence({ id: 'competenceId', index: '2.4', tubes: [tube] });
+    area1.competences = [competence1];
+    area2.competences = [competence2];
+    framework.areas = [area2, area1];
   });
 
   describe('building model', function () {
     it('should return competences sorted by index', function () {
-      const learningContent = {
-        competences,
-        areas: [wildStrawberryArea, jaffaArea],
-      };
-      const campaignLearningContent = new CampaignLearningContent({
-        skills,
-        tubesSorted,
-        competences: learningContent.competences,
-        areas: [wildStrawberryArea, jaffaArea],
-      });
-      expect(campaignLearningContent.competences).to.deep.equal(competencesSorted);
+      const learningContent = domainBuilder.buildLearningContent([framework]);
+      const campaignLearningContent = new CampaignLearningContent(learningContent.frameworks);
+      expect(campaignLearningContent.competences).to.deep.equal(
+        learningContent.competences.sort((a, b) => a.index.localeCompare(b.index)),
+      );
     });
 
     it('should return areas sorted by code', function () {
-      const learningContent = new CampaignLearningContent({
-        skills,
-        tubesSorted,
-        competences: competencesSorted,
-        areas,
-      });
-      const campaignLearningContent = new CampaignLearningContent({
-        skills,
-        tubesSorted,
-        competencesSorted,
-        areas: learningContent.areas,
-      });
-      expect(campaignLearningContent.areas).to.deep.equal(areasSorted);
+      const learningContent = domainBuilder.buildLearningContent([framework]);
+      const campaignLearningContent = new CampaignLearningContent(learningContent.frameworks);
+      expect(campaignLearningContent.areas).to.deep.equal(
+        learningContent.areas.sort((a, b) => a.code.localeCompare(b.code)),
+      );
     });
   });
 });

--- a/api/tests/tooling/domain-builder/factory/build-campaign-learning-content.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-learning-content.js
@@ -2,7 +2,7 @@ import { CampaignLearningContent } from '../../../../src/shared/domain/models/Ca
 import { buildLearningContent } from './build-learning-content.js';
 
 function buildCampaignLearningContent(learningContent = buildLearningContent()) {
-  return new CampaignLearningContent(learningContent);
+  return new CampaignLearningContent(learningContent.frameworks);
 }
 
 buildCampaignLearningContent.fromFrameworks = (frameworks) => {


### PR DESCRIPTION
## :pancakes: Problème

Beaucoup d'attributs communs entre CampaignLearningContent et LearningContent

## :bacon: Proposition

On crée une relation d'héritage entre les deux classes. CampaignLearningContent hérite de Learning Content (💸 ).

## 🧃 Remarques

## :yum: Pour tester

- Faire un export de résultats sur les campagnes : 
- [x] vérifier en particulier qu'aucune colonne liée aux domaines et aux compétences ne manque par rapport à l'onglet Analyse -> Résultat par compétence
- [x] Vérifier que les domaines et les compétences soient bien dans l'ordre (on fait bientôt un ticket pour réparer l'ordre des acquis).

- [x] Aller sur la page Analyse d'une campagne et vérifier que tout est correct ( Assessment / Collect de profile )

- [ ] Vérifier le fonctionnement de `pickCertificationChallengesForPixPlus` @1024pix/team-certification 