### PR TITLE
[FEATURE] Ajouter la forwarded origin HTTP pour les parcours autonomes anonymes (PIX-16244)

### DIFF
--- a/api/src/identity-access-management/application/token/token.controller.js
+++ b/api/src/identity-access-management/application/token/token.controller.js
@@ -4,7 +4,8 @@ import { getForwardedOrigin } from '../../infrastructure/utils/network.js';
 
 const authenticateAnonymousUser = async function (request, h) {
   const { campaign_code: campaignCode, lang } = request.payload;
-  const accessToken = await usecases.authenticateAnonymousUser({ campaignCode, lang });
+  const origin = getForwardedOrigin(request.headers);
+  const accessToken = await usecases.authenticateAnonymousUser({ campaignCode, lang, audience: origin });
 
   const response = {
     token_type: 'bearer',

--- a/api/src/identity-access-management/domain/usecases/authenticate-anonymous-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/authenticate-anonymous-user.usecase.js
@@ -27,5 +27,5 @@ export const authenticateAnonymousUser = async function ({
   const userToAdd = UserToCreate.createAnonymous({ lang });
   const newUser = await userToCreateRepository.create({ user: userToAdd });
 
-  return tokenService.createAccessTokenFromAnonymousUser(newUser.id);
+  return tokenService.createAccessTokenFromAnonymousUser({ userId: newUser.id });
 };

--- a/api/src/identity-access-management/domain/usecases/authenticate-anonymous-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/authenticate-anonymous-user.usecase.js
@@ -4,6 +4,7 @@ import { UserToCreate } from '../models/UserToCreate.js';
 /**
  * @param {{
  *   campaignCode: string,
+ *   audience: string,
  *   lang: string,
  *   campaignToJoinRepository,
  *   userToCreateRepository,
@@ -15,6 +16,7 @@ import { UserToCreate } from '../models/UserToCreate.js';
 export const authenticateAnonymousUser = async function ({
   campaignCode,
   lang = 'fr',
+  audience,
   campaignToJoinRepository,
   userToCreateRepository,
   tokenService,
@@ -27,5 +29,5 @@ export const authenticateAnonymousUser = async function ({
   const userToAdd = UserToCreate.createAnonymous({ lang });
   const newUser = await userToCreateRepository.create({ user: userToAdd });
 
-  return tokenService.createAccessTokenFromAnonymousUser({ userId: newUser.id });
+  return tokenService.createAccessTokenFromAnonymousUser({ userId: newUser.id, audience });
 };

--- a/api/src/shared/domain/services/token-service.js
+++ b/api/src/shared/domain/services/token-service.js
@@ -23,7 +23,7 @@ function createAccessTokenFromUser({ userId, source, audience }) {
   return { accessToken, expirationDelaySeconds };
 }
 
-function createAccessTokenFromAnonymousUser(userId) {
+function createAccessTokenFromAnonymousUser({ userId }) {
   const expirationDelaySeconds = config.anonymous.accessTokenLifespanMs / 1000;
   return _createAccessToken({ userId, source: 'pix', expirationDelaySeconds });
 }

--- a/api/src/shared/domain/services/token-service.js
+++ b/api/src/shared/domain/services/token-service.js
@@ -23,9 +23,9 @@ function createAccessTokenFromUser({ userId, source, audience }) {
   return { accessToken, expirationDelaySeconds };
 }
 
-function createAccessTokenFromAnonymousUser({ userId }) {
+function createAccessTokenFromAnonymousUser({ userId, audience }) {
   const expirationDelaySeconds = config.anonymous.accessTokenLifespanMs / 1000;
-  return _createAccessToken({ userId, source: 'pix', expirationDelaySeconds });
+  return _createAccessToken({ userId, source: 'pix', expirationDelaySeconds, audience });
 }
 
 function createAccessTokenForSaml({ userId, audience }) {

--- a/api/tests/identity-access-management/acceptance/application/token.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/token.route.test.js
@@ -412,6 +412,8 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
           url: '/api/token/anonymous',
           headers: {
             'content-type': 'application/x-www-form-urlencoded',
+            'x-forwarded-proto': 'https',
+            'x-forwarded-host': 'app.pix.fr',
           },
           payload: querystring.stringify({
             campaign_code: campaignCode,
@@ -448,6 +450,8 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
           url: '/api/token/anonymous',
           headers: {
             'content-type': 'application/x-www-form-urlencoded',
+            'x-forwarded-proto': 'https',
+            'x-forwarded-host': 'app.pix.fr',
           },
           payload: querystring.stringify({
             campaign_code: simplifiedAccessCampaignCode,
@@ -468,6 +472,10 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
 
         expect(result.token_type).to.equal('bearer');
         expect(result.access_token).to.exist;
+        const decodedToken = await decodeIfValid(result.access_token);
+        expect(decodedToken).to.include({
+          aud: 'https://app.pix.fr',
+        });
       });
 
       it('creates an anonymous user', async function () {

--- a/api/tests/identity-access-management/unit/application/token.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/token.controller.test.js
@@ -11,10 +11,19 @@ describe('Unit | Identity Access Management | Application | Controller | Token',
       const request = {
         headers: {
           'content-type': 'application/x-www-form-urlencoded',
+          'x-forwarded-proto': 'https',
+          'x-forwarded-host': 'app.pix.fr',
         },
         payload: { campaign_code: campaignCode, lang },
       };
-      sinon.stub(usecases, 'authenticateAnonymousUser').resolves('valid access token');
+      sinon
+        .stub(usecases, 'authenticateAnonymousUser')
+        .withArgs({
+          campaignCode,
+          audience: 'https://app.pix.fr',
+          lang,
+        })
+        .resolves('valid access token');
 
       // when
       const { statusCode, source } = await tokenController.authenticateAnonymousUser(request, hFake);
@@ -22,7 +31,6 @@ describe('Unit | Identity Access Management | Application | Controller | Token',
       // then
       expect(statusCode).to.equal(200);
       expect(source).to.deep.equal({ access_token: 'valid access token', token_type: 'bearer' });
-      expect(usecases.authenticateAnonymousUser).to.have.been.calledWithExactly({ campaignCode, lang });
     });
   });
 

--- a/api/tests/identity-access-management/unit/domain/usecases/authenticate-anonymous-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/authenticate-anonymous-user.usecase.test.js
@@ -8,6 +8,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-an
   let campaignToJoinRepository;
   let userToCreateRepository;
   let tokenService;
+  const audience = 'https://app.pix.fr';
 
   beforeEach(function () {
     campaignCode = 'SIMPLIFIE';
@@ -27,11 +28,12 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-an
   it('creates an anonymous user', async function () {
     // given
     userToCreateRepository.create.resolves({ id: 1 });
-    tokenService.createAccessTokenFromAnonymousUser.withArgs({ userId: 1 }).returns('access-token');
+    tokenService.createAccessTokenFromAnonymousUser.withArgs({ userId: 1, audience }).returns('access-token');
 
     // when
     await authenticateAnonymousUser({
       campaignCode,
+      audience,
       lang,
       campaignToJoinRepository,
       userToCreateRepository,
@@ -57,11 +59,12 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-an
     const accessToken = 'access.token';
 
     userToCreateRepository.create.resolves({ id: userId });
-    tokenService.createAccessTokenFromAnonymousUser.withArgs({ userId }).returns(accessToken);
+    tokenService.createAccessTokenFromAnonymousUser.withArgs({ userId, audience }).returns(accessToken);
 
     // when
     const result = await authenticateAnonymousUser({
       campaignCode,
+      audience,
       campaignToJoinRepository,
       userToCreateRepository,
       tokenService,

--- a/api/tests/identity-access-management/unit/domain/usecases/authenticate-anonymous-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/authenticate-anonymous-user.usecase.test.js
@@ -27,7 +27,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-an
   it('creates an anonymous user', async function () {
     // given
     userToCreateRepository.create.resolves({ id: 1 });
-    tokenService.createAccessTokenFromAnonymousUser.returns('access-token');
+    tokenService.createAccessTokenFromAnonymousUser.withArgs({ userId: 1 }).returns('access-token');
 
     // when
     await authenticateAnonymousUser({
@@ -57,7 +57,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-an
     const accessToken = 'access.token';
 
     userToCreateRepository.create.resolves({ id: userId });
-    tokenService.createAccessTokenFromAnonymousUser.withArgs(userId).returns(accessToken);
+    tokenService.createAccessTokenFromAnonymousUser.withArgs({ userId }).returns(accessToken);
 
     // when
     const result = await authenticateAnonymousUser({

--- a/api/tests/shared/unit/domain/services/token-service_test.js
+++ b/api/tests/shared/unit/domain/services/token-service_test.js
@@ -460,13 +460,14 @@ describe('Unit | Shared | Domain | Services | Token Service', function () {
       const userId = 1;
       sinon.stub(settings.authentication, 'secret').value('SECRET_KEY');
       sinon.stub(settings.anonymous, 'accessTokenLifespanMs').value(10000);
-      const payload = { user_id: userId, source: 'pix', aud: undefined };
+      const audience = 'https://app.pix.fr';
+      const payload = { user_id: userId, source: 'pix', aud: audience };
       const secret = 'SECRET_KEY';
       const options = { expiresIn: 10 };
       sinon.stub(jsonwebtoken, 'sign').returns('VALID_ACCESS_TOKEN');
 
       // when
-      const result = tokenService.createAccessTokenFromAnonymousUser({ userId });
+      const result = tokenService.createAccessTokenFromAnonymousUser({ userId, audience });
 
       // then
       expect(jsonwebtoken.sign).to.have.been.calledWithExactly(payload, secret, options);

--- a/api/tests/shared/unit/domain/services/token-service_test.js
+++ b/api/tests/shared/unit/domain/services/token-service_test.js
@@ -466,7 +466,7 @@ describe('Unit | Shared | Domain | Services | Token Service', function () {
       sinon.stub(jsonwebtoken, 'sign').returns('VALID_ACCESS_TOKEN');
 
       // when
-      const result = tokenService.createAccessTokenFromAnonymousUser(userId);
+      const result = tokenService.createAccessTokenFromAnonymousUser({ userId });
 
       // then
       expect(jsonwebtoken.sign).to.have.been.calledWithExactly(payload, secret, options);


### PR DESCRIPTION
## :pancakes: Problème

Dans le cadre du confinement des Tokens utilisateurs, nous souhaitons ajouter l'origine de l'appel http des front dans les access tokens pour les utilisateurs anonymes.

## :bacon: Proposition

Conformément aux RFC ajouter un attribut aud aux tokens utilisateurs anonymes.

## 🧃 Remarques

C'est la suite de #11177 

## :yum: Pour tester

Depuis pix app

- Sans se connecter, commencer un parcours autonome: https://app-pr11207.review.pix.fr/campagnes/AUTOCOURS1
- Cliquer sur "Je commence sans compte Pix"
- Constater que la route `api/token/anonymous` est appelée et qu'elle envoie un access token
- Décoder le token et constater la présence de l'aud: `"aud":"https://app-pr11207.review.pix.fr"`