### PR TITLE
[FEATURE] Amélioration du feedback  (PIX-16096)

### DIFF
--- a/junior/app/components/challenge/challenge-content.gjs
+++ b/junior/app/components/challenge/challenge-content.gjs
@@ -119,6 +119,7 @@ export default class ChallengeContent extends Component {
         @disableCheckButton={{@disableCheckButton}}
         @disableLessonButton={{@disableLessonButton}}
         @answerHasBeenValidated={{@answerHasBeenValidated}}
+        @responseColor={{@responseColor}}
       />
     </div>
   </template>

--- a/junior/app/components/challenge/challenge-layout.gjs
+++ b/junior/app/components/challenge/challenge-layout.gjs
@@ -1,5 +1,5 @@
 <template>
-  <div class="challenge-layout">
+  <div class="challenge-layout challenge-layout--{{@color}}">
     <div class="container">
       {{yield}}
     </div>

--- a/junior/app/components/challenge/challenge.gjs
+++ b/junior/app/components/challenge/challenge.gjs
@@ -28,6 +28,23 @@ export default class Challenge extends Component {
     return this.args.challenge.instructions.length * CHALLENGE_DISPLAY_DELAY;
   }
 
+  get layoutColor() {
+    if (this.answer?.result === 'ok') {
+      return 'success';
+    }
+    if (this.answer?.result === 'ko') {
+      return 'error';
+    }
+    return 'default';
+  }
+
+  get answerButtonColor() {
+    if (this.answer?.result === 'ok') {
+      return 'success';
+    }
+    return '';
+  }
+
   bubbleDisplayDelay(index) {
     return (index || 0) * CHALLENGE_DISPLAY_DELAY;
   }
@@ -141,7 +158,7 @@ export default class Challenge extends Component {
 
   <template>
     {{pageTitle (t "pages.challenge.title")}}
-    <ChallengeLayout>
+    <ChallengeLayout @color={{this.layoutColor}}>
       <div class="header_container">
         <RobotDialog @class={{this.robotMood}}>
           {{#each @challenge.instructions as |instruction index|}}
@@ -175,6 +192,7 @@ export default class Challenge extends Component {
           @activity={{@activity}}
           @resume={{this.resume}}
           @isDisabled={{this.hasBeenAnswered}}
+          @responseColor="{{this.answerButtonColor}}"
         />
       </DelayedElement>
     </ChallengeLayout>

--- a/junior/app/components/challenge/content/challenge-actions.gjs
+++ b/junior/app/components/challenge/content/challenge-actions.gjs
@@ -24,7 +24,7 @@ export default class ChallengeActions extends Component {
       {{/unless}}
       {{#if @answerHasBeenValidated}}
         <PixButton
-          class="pix1d-button pix1d-button--success"
+          class="pix1d-button {{if @responseColor 'pix1d-button--success'}}"
           @iconAfter="arrowRight"
           @triggerAction={{@nextAction}}
           @size="large"

--- a/junior/app/styles/components/challenge/challenge-content.scss
+++ b/junior/app/styles/components/challenge/challenge-content.scss
@@ -16,6 +16,7 @@
     grid-template-areas:
     "left  right"
     "left actions";
+    grid-template-rows: 0fr 0fr;
     grid-template-columns: 1fr 1fr;
 
     &--40-60 {

--- a/junior/app/styles/components/challenge/challenge-layout.scss
+++ b/junior/app/styles/components/challenge/challenge-layout.scss
@@ -3,8 +3,21 @@
   justify-content: center;
   min-height: calc(100vh - 48px);
   padding: var(--pix-spacing-4x);
-  background-color: rgba(var(--pix-primary-500-inline), 10%);
   border-radius: 24px;
+
+  &--default {
+    background-color: rgba(var(--pix-primary-500-inline), 10%);
+  }
+
+  &--error {
+    background-color: rgba(var(--pix-error-500-inline), 10%);
+    border: 2px solid var(--pix-error-500);
+  }
+
+  &--success {
+    background-color: rgba(var(--pix-success-500-inline), 10%);
+    border: 2px solid var(--pix-success-500);
+  }
 
   .container {
     width: 100%;

--- a/junior/app/styles/pages/identified/missions/mission.scss
+++ b/junior/app/styles/pages/identified/missions/mission.scss
@@ -28,8 +28,8 @@
     text-align: left;
 
     .details-action {
+      width: fit-content;
       margin-top: 32px;
-      margin-left: auto;
       padding: 16px 32px 16px 40px;
       font-size: 18px;
       border-radius: 100px;
@@ -39,10 +39,6 @@
         height: 25px;
         margin-left: 10px;
         fill: var(--pix-neutral-0);
-      }
-
-      @include breakpoints.device-is('tablet') {
-        margin: 32px 60px 0 auto;
       }
 
       &__loader {


### PR DESCRIPTION
## :pancakes: Problème

Il manque des élements, ou des élements feedback sont parfois contradictoire.

## :bacon: Proposition

Ajouter un fond coloré pour accentuer le feedback.
Revoir certaines couleur de bouton pour le feedback en accord avec le fond.

## 🧃 Remarques

RAS

## :yum: Pour tester

Se balader et réussir / échouer / paillette dans les yeux