### PR TITLE
[BUGFIX] Ordonner les skillName afin de garantir l'ordre des colonnes lors de l'export de résultat (Pix-16196)

### DIFF
--- a/api/src/shared/domain/models/CampaignLearningContent.js
+++ b/api/src/shared/domain/models/CampaignLearningContent.js
@@ -12,6 +12,10 @@ class CampaignLearningContent extends LearningContent {
   get competences() {
     return super.competences.sort((a, b) => a.index.localeCompare(b.index));
   }
+
+  get skills() {
+    return this.competences.flatMap((competence) => competence.skills.sort((a, b) => a.name.localeCompare(b.name)));
+  }
 }
 
 export { CampaignLearningContent };

--- a/api/tests/shared/unit/domain/models/CampaignLearningContent_test.js
+++ b/api/tests/shared/unit/domain/models/CampaignLearningContent_test.js
@@ -1,10 +1,6 @@
 import { expect } from 'chai';
 
-import { buildArea } from '../../../../../db/database-builder/factory/learning-content/build-area.js';
-import { buildCompetence } from '../../../../../db/database-builder/factory/learning-content/build-competence.js';
 import { buildFramework } from '../../../../../db/database-builder/factory/learning-content/build-framework.js';
-import { buildSkill } from '../../../../../db/database-builder/factory/learning-content/build-skill.js';
-import { buildTube } from '../../../../../db/database-builder/factory/learning-content/build-tube.js';
 import { CampaignLearningContent } from '../../../../../src/shared/domain/models/CampaignLearningContent.js';
 import { domainBuilder } from '../../../../test-helper.js';
 
@@ -13,12 +9,26 @@ describe('Unit | Domain | Models | CampaignLearningContent', function () {
 
   beforeEach(function () {
     framework = buildFramework({ id: 'frameworkId', name: 'someFramework' });
-    const skill = buildSkill({ id: 'skillId', tubeId: 'tubeId' });
-    const tube = buildTube({ id: 'tubeId', competenceId: 'competenceId', skills: [skill] });
-    const area1 = buildArea({ id: 'areaId', code: '5', frameworkId: framework.id });
-    const area2 = buildArea({ id: 'areaId', code: '2', frameworkId: framework.id });
-    const competence1 = buildCompetence({ id: 'competenceId', index: '5.1', tubes: [tube] });
-    const competence2 = buildCompetence({ id: 'competenceId', index: '2.4', tubes: [tube] });
+    const tube1 = domainBuilder.buildTube({
+      id: 'tubeId',
+      competenceId: 'competenceId1',
+      skills: [
+        domainBuilder.buildSkill({ id: 'skillId1', tubeId: 'tubeId1', name: '@skill2' }),
+        domainBuilder.buildSkill({ id: 'skillId3', tubeId: 'tubeId1', name: '@skill1' }),
+      ],
+    });
+    const tube2 = domainBuilder.buildTube({
+      id: 'tubeId2',
+      competenceId: 'competenceId2',
+      skills: [
+        domainBuilder.buildSkill({ id: 'idSkill2', tubeId: 'tubeId2', name: '@yep1' }),
+        domainBuilder.buildSkill({ id: 'skillId4', tubeId: 'tubeId2', name: '@bouh1' }),
+      ],
+    });
+    const area1 = domainBuilder.buildArea({ id: 'areaId', code: '5', frameworkId: framework.id });
+    const area2 = domainBuilder.buildArea({ id: 'areaId', code: '2', frameworkId: framework.id });
+    const competence1 = domainBuilder.buildCompetence({ id: 'competenceId1', index: '5.1', tubes: [tube1] });
+    const competence2 = domainBuilder.buildCompetence({ id: 'competenceId2', index: '2.4', tubes: [tube2] });
     area1.competences = [competence1];
     area2.competences = [competence2];
     framework.areas = [area2, area1];
@@ -28,17 +38,24 @@ describe('Unit | Domain | Models | CampaignLearningContent', function () {
     it('should return competences sorted by index', function () {
       const learningContent = domainBuilder.buildLearningContent([framework]);
       const campaignLearningContent = new CampaignLearningContent(learningContent.frameworks);
-      expect(campaignLearningContent.competences).to.deep.equal(
-        learningContent.competences.sort((a, b) => a.index.localeCompare(b.index)),
-      );
+      expect(campaignLearningContent.competences.map((competence) => competence.index)).to.deep.equal(['2.4', '5.1']);
     });
 
     it('should return areas sorted by code', function () {
       const learningContent = domainBuilder.buildLearningContent([framework]);
       const campaignLearningContent = new CampaignLearningContent(learningContent.frameworks);
-      expect(campaignLearningContent.areas).to.deep.equal(
-        learningContent.areas.sort((a, b) => a.code.localeCompare(b.code)),
-      );
+      expect(campaignLearningContent.areas.map((area) => area.code)).to.deep.equal(['2', '5']);
+    });
+
+    it('should return skills sorted by competence then by skill name', function () {
+      const learningContent = domainBuilder.buildLearningContent([framework]);
+      const campaignLearningContent = new CampaignLearningContent(learningContent.frameworks);
+      expect(campaignLearningContent.skills.map((skill) => skill.name)).to.deep.equal([
+        '@bouh1',
+        '@yep1',
+        '@skill1',
+        '@skill2',
+      ]);
     });
   });
 });


### PR DESCRIPTION
## :pancakes: Problème

certains export comporte les nom des acquis pour des traitement plus "fin" . le souci c'est que nous ne garantissons pas l'ordre entre différent export

## :bacon: Proposition

Trier ces noms d'acquis par rapport à sa compétence, puis par son nom.

## 🧃 Remarques

RAS

## :yum: Pour tester

CI au vert, 

Allez sur PixAdmin :
- activé l'affichage des acquis dans l'export de résultat.

Allez sur PixOrga :
- Faire un export CSV d'une campagne d'évaluation et vérifier que l'ordre des acquis sont là