### PR TITLE
[BUGFIX] Afficher les webcomponent sur 60% de la largeur quand ils sont en colonne

### DIFF
--- a/junior/app/components/challenge/challenge-content.gjs
+++ b/junior/app/components/challenge/challenge-content.gjs
@@ -35,18 +35,19 @@ export default class ChallengeContent extends Component {
   }
 
   get challengeContentClassname() {
-    const hasIllustrationAndEmbed = this.args.challenge.illustrationUrl && this.args.challenge.hasEmbed;
-    const hasEmbedAndForm = this.args.challenge.hasEmbed && this.args.challenge.hasForm;
+    const hasEmbedOrWebComponent = this.args.challenge.hasEmbed || this.args.challenge.hasWebComponent;
+    const hasIllustrationAndEmbedOrWC = this.args.challenge.illustrationUrl && hasEmbedOrWebComponent;
+    const hasEmbedOrWCAndForm = hasEmbedOrWebComponent && this.args.challenge.hasForm;
     let classname = '';
 
     if (this.shouldDisplayMultipleElements) {
       classname = 'challenge-content__grid-multiple-element';
 
-      if (hasIllustrationAndEmbed) {
+      if (hasIllustrationAndEmbedOrWC) {
         classname += ' challenge-content__grid-multiple-element--40-60';
       }
 
-      if (hasEmbedAndForm) {
+      if (hasEmbedOrWCAndForm) {
         classname += ' challenge-content__grid-multiple-element--60-40';
       }
     }


### PR DESCRIPTION
## :pancakes: Problème

Les embeds, quand ils sont accompagnés d'une illustration ou d'un formulaire, sont affichés sur 60% de la largeur de l'écran. Hors, les webcomponent s'affichent sur 50% de l'écran uniquement.

## :bacon: Proposition

Afficher les webcomponent eux aussi sur 60% de la largeur.

## :yum: Pour tester

Afficher une épreuve contenant une illustration et un webcomponent : challenge1UWYWAUxSIfi0D
Le webcomponent prend bien plus de place que l'illustration sur la page.

Note : Il n'existe pour le moment pas d'épreuve webcomponent + formulaire.
