### PR TITLE
[FEATURE] Ajouter un affichage dans le cas ou il n'y a pas de données de statistiques Pix Orga (PIX-16229)

### DIFF
--- a/orga/app/components/statistics/index.gjs
+++ b/orga/app/components/statistics/index.gjs
@@ -93,70 +93,86 @@ export default class Statistics extends Component {
     return dayjs(this.analysisByTubes[0]?.extraction_date).format('D MMM YYYY');
   }
 
+  get hasDataToDisplay() {
+    return this.args.model.data && this.args.model.data.length > 0;
+  }
+
   <template>
     <PageTitle @spaceBetweenTools={{true}}>
       <:title>
         {{t "pages.statistics.title"}}
       </:title>
+
       <:tools>
-        <span class="statistics-page-header__date">{{t "pages.statistics.before-date"}}
-          {{this.extractedDate}}</span>
+        {{#if this.hasDataToDisplay}}
+          <span class="statistics-page-header__date">{{t "pages.statistics.before-date"}}
+            {{this.extractedDate}}</span>
+        {{/if}}
       </:tools>
+
     </PageTitle>
 
-    <section class="statistics-page__info">
-      <p class="statistics-page-info__paragraph">
-        {{t "pages.statistics.description" htmlSafe="true"}}
-      </p>
-    </section>
+    {{#if this.hasDataToDisplay}}
+      <section class="statistics-page__info">
+        <p class="statistics-page-info__paragraph">
+          {{t "pages.statistics.description" htmlSafe="true"}}
+        </p>
+      </section>
 
-    <section class="statistics-page__filter">
-      <PixSelect
-        @onChange={{this.handleDomainFilter}}
-        @value={{this.currentDomainFilter}}
-        @options={{this.domainsName}}
-        @placeholder={{t "common.filters.placeholder"}}
-        @hideDefaultOption={{true}}
-      >
-        <:label>{{t "pages.statistics.select-label"}}</:label>
-      </PixSelect>
-      <PixButton @size="small" @variant="tertiary" @triggerAction={{this.removeFilter}}>{{t
-          "common.filters.actions.clear"
-        }}</PixButton>
-    </section>
+      <section class="statistics-page__filter">
+        <PixSelect
+          @onChange={{this.handleDomainFilter}}
+          @value={{this.currentDomainFilter}}
+          @options={{this.domainsName}}
+          @placeholder={{t "common.filters.placeholder"}}
+          @hideDefaultOption={{true}}
+        >
+          <:label>{{t "pages.statistics.select-label"}}</:label>
+        </PixSelect>
+        <PixButton @size="small" @variant="tertiary" @triggerAction={{this.removeFilter}}>{{t
+            "common.filters.actions.clear"
+          }}</PixButton>
+      </section>
 
-    <section class="statistics-page__cover-rate">
-      <table class="panel">
-        <caption class="screen-reader-only">{{t "pages.statistics.table.caption"}}</caption>
-        <thead>
-          <tr>
-            <Header @size="wide" scope="col">{{t "pages.statistics.table.headers.skills"}}</Header>
-            <Header @size="medium" scope="col">{{t "pages.statistics.table.headers.topics"}}</Header>
-            <Header @size="medium" @align="center" scope="col">{{t
-                "pages.statistics.table.headers.positioning"
-              }}</Header>
-            <Header @align="center" @size="medium" scope="col">{{t
-                "pages.statistics.table.headers.reached-level"
-              }}</Header>
-          </tr>
-        </thead>
-        <tbody>
-          {{#each this.currentVisibleAnalysis as |line|}}
+      <section class="statistics-page__cover-rate">
+        <table class="panel">
+          <caption class="screen-reader-only">{{t "pages.statistics.table.caption"}}</caption>
+          <thead>
             <tr>
-              <td>{{line.competence_code}} {{line.competence}}</td>
-              <td>{{line.sujet}}</td>
-              <td>
-                <CoverRateGauge @userLevel={{line.niveau_par_user}} @tubeLevel={{line.niveau_par_sujet}} />
-              </td>
-              <td class="table__column--center">
-                <TagLevel @level={{line.niveau_par_user}} />
-              </td>
+              <Header @size="wide" scope="col">{{t "pages.statistics.table.headers.skills"}}</Header>
+              <Header @size="medium" scope="col">{{t "pages.statistics.table.headers.topics"}}</Header>
+              <Header @size="medium" @align="center" scope="col">{{t
+                  "pages.statistics.table.headers.positioning"
+                }}</Header>
+              <Header @align="center" @size="medium" scope="col">{{t
+                  "pages.statistics.table.headers.reached-level"
+                }}</Header>
             </tr>
-          {{/each}}
-        </tbody>
-      </table>
-    </section>
+          </thead>
+          <tbody>
+            {{#each this.currentVisibleAnalysis as |line|}}
+              <tr>
+                <td>{{line.competence_code}} {{line.competence}}</td>
+                <td>{{line.sujet}}</td>
+                <td>
+                  <CoverRateGauge @userLevel={{line.niveau_par_user}} @tubeLevel={{line.niveau_par_sujet}} />
+                </td>
+                <td class="table__column--center">
+                  <TagLevel @level={{line.niveau_par_user}} />
+                </td>
+              </tr>
+            {{/each}}
+          </tbody>
+        </table>
+      </section>
 
-    <PixPagination @pagination={{this.pagination}} @locale={{this.currentLocale}} />
+      <PixPagination @pagination={{this.pagination}} @locale={{this.currentLocale}} />
+    {{else}}
+      <section class="panel empty-state">
+        <div class="empty-state__text">
+          <p>{{t "pages.statistics.empty-state"}}</p>
+        </div>
+      </section>
+    {{/if}}
   </template>
 }

--- a/orga/tests/integration/components/statistics/index-test.gjs
+++ b/orga/tests/integration/components/statistics/index-test.gjs
@@ -11,161 +11,32 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | Statistics | Index', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it should display title and extracted date', async function (assert) {
-    //given
-    const extractionDate = '2024-12-08';
-    const model = {
-      data: [
-        {
-          competence_code: '2.1',
-          competence: 'Interagir',
-          sujet: 'Gérer ses contacts',
-          niveau_par_user: '1.30',
-          niveau_par_sujet: '1.50',
-          extraction_date: extractionDate,
-        },
-      ],
-    };
-
-    //when
-    const screen = await render(<template><Statistics @model={{model}} /></template>);
-
-    //then
-    assert.ok(screen.getByRole('heading', { name: t('pages.statistics.title'), level: 1 }));
-    assert.ok(screen.getByText(dayjs(extractionDate).format('D MMM YYYY'), { exact: false }));
-  });
-
-  test('it should display table headers', async function (assert) {
-    //given
-    const model = {
-      data: [],
-    };
-
-    //when
-    const screen = await render(<template><Statistics @model={{model}} /></template>);
-
-    //then
-    assert.ok(screen.getByRole('columnheader', { name: t('pages.statistics.table.headers.skills') }));
-    assert.ok(screen.getByRole('columnheader', { name: t('pages.statistics.table.headers.topics') }));
-    assert.ok(screen.getByRole('columnheader', { name: t('pages.statistics.table.headers.reached-level') }));
-    assert.ok(screen.getByRole('columnheader', { name: t('pages.statistics.table.headers.positioning') }));
-  });
-
-  test('it should display rows data', async function (assert) {
-    //given
-    const model = {
-      data: [
-        {
-          domaine: '2. Communication et collaboration',
-          competence_code: '2.1',
-          competence: 'Interagir',
-          sujet: 'Gérer ses contacts',
-          niveau_par_user: '1.30',
-          niveau_par_sujet: '1.50',
-        },
-      ],
-    };
-
-    //when
-    const screen = await render(<template><Statistics @model={{model}} /></template>);
-
-    //then
-    assert.ok(screen.getByRole('cell', { name: '2.1 Interagir' }));
-    assert.ok(screen.getByRole('cell', { name: 'Gérer ses contacts' }));
-    assert.ok(screen.getByRole('cell', { name: t('pages.statistics.level.novice') }));
-  });
-
-  test('it should display rows data when tube is null', async function (assert) {
-    //given
-    const model = {
-      data: [
-        {
-          domaine: '2. Communication et collaboration',
-          competence_code: '2.1',
-          competence: 'Foo',
-          sujet: undefined,
-          niveau_par_user: '1.30',
-          niveau_par_sujet: '1.50',
-        },
-        {
-          domaine: '3. Communication et collaboration',
-          competence_code: '3.1',
-          competence: 'Bar',
-          sujet: 'Gérer ses contacts',
-          niveau_par_user: '3.30',
-          niveau_par_sujet: '3.50',
-        },
-      ],
-    };
-
-    //when
-    const screen = await render(<template><Statistics @model={{model}} /></template>);
-
-    //then
-    assert.ok(screen.getByRole('cell', { name: '2.1 Foo' }));
-    assert.ok(screen.getByRole('cell', { name: '' }));
-    assert.ok(screen.getByRole('cell', { name: '3.1 Bar' }));
-    assert.ok(screen.getByRole('cell', { name: 'Gérer ses contacts' }));
-  });
-  test('it should display table description', async function (assert) {
-    //given
-    const model = {
-      data: [],
-    };
-
-    //when
-    await render(<template><Statistics @model={{model}} /></template>);
-
-    //then
-    assert.ok(
-      getByTextWithHtml(
-        'Le tableau ci-dessous vous permet de visualiser le positionnement de vos participants par sujet.<br> Le positionnement rend compte du niveau moyen de vos participants sur le niveau maximum qu’ils auraient pu atteindre.<br> Ces données tiennent compte de toutes les participations partagées dans le cadre des campagnes d’évaluation non supprimées de votre organisation.',
-      ),
-    );
-  });
-
-  module('pagination', function () {
-    test('should have pagination on page', async function (assert) {
+  module('when there are data to display', function () {
+    test('it should display title and extracted date', async function (assert) {
       //given
+      const extractionDate = '2024-12-08';
       const model = {
         data: [
           {
-            domaine: '2. Communication et collaboration',
             competence_code: '2.1',
             competence: 'Interagir',
             sujet: 'Gérer ses contacts',
             niveau_par_user: '1.30',
             niveau_par_sujet: '1.50',
-          },
-          {
-            domaine: '2. Communication et collaboration',
-            competence_code: '2.1',
-            competence: 'Interagir',
-            sujet: 'Gérer ses contacts',
-            niveau_par_user: '1.30',
-            niveau_par_sujet: '1.50',
+            extraction_date: extractionDate,
           },
         ],
       };
-      class Router extends Service {
-        currentRoute = {
-          queryParams: {
-            pageSize: 1,
-          },
-        };
-      }
-      this.owner.register('service:router', Router);
 
       //when
       const screen = await render(<template><Statistics @model={{model}} /></template>);
+
       //then
-      assert.ok(screen.getByText('1-1 sur 2 éléments'));
-      assert.ok(screen.getByLabelText("Nombre d'élément à afficher par page"));
-      assert.ok(screen.getByRole('button', { name: 'Aller à la page précédente' }));
-      assert.ok(screen.getByRole('button', { name: 'Aller à la page suivante' }));
+      assert.ok(screen.getByRole('heading', { name: t('pages.statistics.title'), level: 1 }));
+      assert.ok(screen.getByText(dayjs(extractionDate).format('D MMM YYYY'), { exact: false }));
     });
 
-    test('should show first page without pageNumber in query params', async function (assert) {
+    test('it should display table headers', async function (assert) {
       //given
       const model = {
         data: [
@@ -177,6 +48,23 @@ module('Integration | Component | Statistics | Index', function (hooks) {
             niveau_par_user: '1.30',
             niveau_par_sujet: '1.50',
           },
+        ],
+      };
+
+      //when
+      const screen = await render(<template><Statistics @model={{model}} /></template>);
+
+      //then
+      assert.ok(screen.getByRole('columnheader', { name: t('pages.statistics.table.headers.skills') }));
+      assert.ok(screen.getByRole('columnheader', { name: t('pages.statistics.table.headers.topics') }));
+      assert.ok(screen.getByRole('columnheader', { name: t('pages.statistics.table.headers.reached-level') }));
+      assert.ok(screen.getByRole('columnheader', { name: t('pages.statistics.table.headers.positioning') }));
+    });
+
+    test('it should display rows data', async function (assert) {
+      //given
+      const model = {
+        data: [
           {
             domaine: '2. Communication et collaboration',
             competence_code: '2.1',
@@ -187,24 +75,17 @@ module('Integration | Component | Statistics | Index', function (hooks) {
           },
         ],
       };
-      class Router extends Service {
-        currentRoute = {
-          queryParams: {
-            pageSize: 1,
-          },
-        };
-      }
-      this.owner.register('service:router', Router);
 
       //when
       const screen = await render(<template><Statistics @model={{model}} /></template>);
 
       //then
       assert.ok(screen.getByRole('cell', { name: '2.1 Interagir' }));
+      assert.ok(screen.getByRole('cell', { name: 'Gérer ses contacts' }));
       assert.ok(screen.getByRole('cell', { name: t('pages.statistics.level.novice') }));
     });
 
-    test('should show specific page when pageNumber is set', async function (assert) {
+    test('it should display rows data when tube is null', async function (assert) {
       //given
       const model = {
         data: [
@@ -212,53 +93,35 @@ module('Integration | Component | Statistics | Index', function (hooks) {
             domaine: '2. Communication et collaboration',
             competence_code: '2.1',
             competence: 'Foo',
-            sujet: 'Gérer ses contacts',
+            sujet: undefined,
             niveau_par_user: '1.30',
             niveau_par_sujet: '1.50',
           },
           {
-            domaine: '2. Communication et collaboration',
-            competence_code: '2.1',
-            competence: 'Interagir',
+            domaine: '3. Communication et collaboration',
+            competence_code: '3.1',
+            competence: 'Bar',
             sujet: 'Gérer ses contacts',
-            niveau_par_user: '1.30',
-            niveau_par_sujet: '1.50',
+            niveau_par_user: '3.30',
+            niveau_par_sujet: '3.50',
           },
         ],
       };
-      class Router extends Service {
-        currentRoute = {
-          queryParams: {
-            pageSize: 1,
-            pageNumber: 2,
-          },
-        };
-      }
-      this.owner.register('service:router', Router);
 
       //when
       const screen = await render(<template><Statistics @model={{model}} /></template>);
 
       //then
-      assert.ok(screen.getByRole('cell', { name: '2.1 Interagir' }));
-      assert.ok(screen.getByRole('cell', { name: t('pages.statistics.level.novice') }));
+      assert.ok(screen.getByRole('cell', { name: '2.1 Foo' }));
+      assert.ok(screen.getByRole('cell', { name: '' }));
+      assert.ok(screen.getByRole('cell', { name: '3.1 Bar' }));
+      assert.ok(screen.getByRole('cell', { name: 'Gérer ses contacts' }));
     });
-  });
-
-  module('filter', function () {
-    test('should filtered analysis', async function (assert) {
+    test('it should display table description', async function (assert) {
       //given
       const model = {
         data: [
           {
-            domaine: '1. Information et données',
-            competence_code: '1.1 ',
-            competence: 'Mener une recherche et une veille d’information',
-            sujet: "Indices de qualité d'une page web",
-            niveau_par_user: '1.30',
-            niveau_par_sujet: '1.50',
-          },
-          {
             domaine: '2. Communication et collaboration',
             competence_code: '2.1',
             competence: 'Interagir',
@@ -268,42 +131,242 @@ module('Integration | Component | Statistics | Index', function (hooks) {
           },
         ],
       };
-      class Router extends Service {
-        currentRoute = {
-          queryParams: {
-            pageSize: 1,
-            pageNumber: 2,
-          },
+
+      //when
+      await render(<template><Statistics @model={{model}} /></template>);
+
+      //then
+      assert.ok(
+        getByTextWithHtml(
+          'Le tableau ci-dessous vous permet de visualiser le positionnement de vos participants par sujet.<br> Le positionnement rend compte du niveau moyen de vos participants sur le niveau maximum qu’ils auraient pu atteindre.<br> Ces données tiennent compte de toutes les participations partagées dans le cadre des campagnes d’évaluation non supprimées de votre organisation.',
+        ),
+      );
+    });
+
+    module('pagination', function () {
+      test('should have pagination on page', async function (assert) {
+        //given
+        const model = {
+          data: [
+            {
+              domaine: '2. Communication et collaboration',
+              competence_code: '2.1',
+              competence: 'Interagir',
+              sujet: 'Gérer ses contacts',
+              niveau_par_user: '1.30',
+              niveau_par_sujet: '1.50',
+            },
+            {
+              domaine: '2. Communication et collaboration',
+              competence_code: '2.1',
+              competence: 'Interagir',
+              sujet: 'Gérer ses contacts',
+              niveau_par_user: '1.30',
+              niveau_par_sujet: '1.50',
+            },
+          ],
         };
-        replaceWith = ({ queryParams }) => {
-          this.currentRoute.queryParams.pageNumber = queryParams.pageNumber;
+        class Router extends Service {
+          currentRoute = {
+            queryParams: {
+              pageSize: 1,
+            },
+          };
+        }
+        this.owner.register('service:router', Router);
+
+        //when
+        const screen = await render(<template><Statistics @model={{model}} /></template>);
+        //then
+        assert.ok(screen.getByText('1-1 sur 2 éléments'));
+        assert.ok(screen.getByLabelText("Nombre d'élément à afficher par page"));
+        assert.ok(screen.getByRole('button', { name: 'Aller à la page précédente' }));
+        assert.ok(screen.getByRole('button', { name: 'Aller à la page suivante' }));
+      });
+
+      test('should show first page without pageNumber in query params', async function (assert) {
+        //given
+        const model = {
+          data: [
+            {
+              domaine: '2. Communication et collaboration',
+              competence_code: '2.1',
+              competence: 'Interagir',
+              sujet: 'Gérer ses contacts',
+              niveau_par_user: '1.30',
+              niveau_par_sujet: '1.50',
+            },
+            {
+              domaine: '2. Communication et collaboration',
+              competence_code: '2.1',
+              competence: 'Interagir',
+              sujet: 'Gérer ses contacts',
+              niveau_par_user: '1.30',
+              niveau_par_sujet: '1.50',
+            },
+          ],
         };
-      }
-      this.owner.register('service:router', Router);
+        class Router extends Service {
+          currentRoute = {
+            queryParams: {
+              pageSize: 1,
+            },
+          };
+        }
+        this.owner.register('service:router', Router);
+
+        //when
+        const screen = await render(<template><Statistics @model={{model}} /></template>);
+
+        //then
+        assert.ok(screen.getByRole('cell', { name: '2.1 Interagir' }));
+        assert.ok(screen.getByRole('cell', { name: t('pages.statistics.level.novice') }));
+      });
+
+      test('should show specific page when pageNumber is set', async function (assert) {
+        //given
+        const model = {
+          data: [
+            {
+              domaine: '2. Communication et collaboration',
+              competence_code: '2.1',
+              competence: 'Foo',
+              sujet: 'Gérer ses contacts',
+              niveau_par_user: '1.30',
+              niveau_par_sujet: '1.50',
+            },
+            {
+              domaine: '2. Communication et collaboration',
+              competence_code: '2.1',
+              competence: 'Interagir',
+              sujet: 'Gérer ses contacts',
+              niveau_par_user: '1.30',
+              niveau_par_sujet: '1.50',
+            },
+          ],
+        };
+        class Router extends Service {
+          currentRoute = {
+            queryParams: {
+              pageSize: 1,
+              pageNumber: 2,
+            },
+          };
+        }
+        this.owner.register('service:router', Router);
+
+        //when
+        const screen = await render(<template><Statistics @model={{model}} /></template>);
+
+        //then
+        assert.ok(screen.getByRole('cell', { name: '2.1 Interagir' }));
+        assert.ok(screen.getByRole('cell', { name: t('pages.statistics.level.novice') }));
+      });
+    });
+
+    module('filter', function () {
+      test('should filtered analysis', async function (assert) {
+        //given
+        const model = {
+          data: [
+            {
+              domaine: '1. Information et données',
+              competence_code: '1.1 ',
+              competence: 'Mener une recherche et une veille d’information',
+              sujet: "Indices de qualité d'une page web",
+              niveau_par_user: '1.30',
+              niveau_par_sujet: '1.50',
+            },
+            {
+              domaine: '2. Communication et collaboration',
+              competence_code: '2.1',
+              competence: 'Interagir',
+              sujet: 'Gérer ses contacts',
+              niveau_par_user: '1.30',
+              niveau_par_sujet: '1.50',
+            },
+          ],
+        };
+        class Router extends Service {
+          currentRoute = {
+            queryParams: {
+              pageSize: 1,
+              pageNumber: 2,
+            },
+          };
+          replaceWith = ({ queryParams }) => {
+            this.currentRoute.queryParams.pageNumber = queryParams.pageNumber;
+          };
+        }
+        this.owner.register('service:router', Router);
+
+        //when
+        const screen = await render(<template><Statistics @model={{model}} /></template>);
+
+        //then
+        assert.ok(screen.getByText('2-2 sur 2 éléments'));
+
+        // when
+        const select = screen.getByRole('button', { name: t('pages.statistics.select-label') });
+        await click(select);
+        const option = await screen.findByRole('option', { name: '2. Communication et collaboration' });
+        await click(option);
+
+        // then
+        assert.ok(screen.getByText('1 élément'));
+        assert.ok(screen.getByRole('cell', { name: '2.1 Interagir' }));
+        assert.ok(screen.getByRole('cell', { name: 'Gérer ses contacts' }));
+        assert.ok(screen.getByRole('cell', { name: t('pages.statistics.level.novice') }));
+
+        // when
+        await clickByName(t('common.filters.actions.clear'));
+
+        // then
+        assert.ok(screen.getByText('1-1 sur 2 éléments'));
+      });
+    });
+  });
+
+  module('when there is no data to display', function () {
+    test('should display title without extracted date', async function (assert) {
+      //given
+      const extractionDate = '2024-12-08';
+      const model = {
+        data: [],
+      };
 
       //when
       const screen = await render(<template><Statistics @model={{model}} /></template>);
 
       //then
-      assert.ok(screen.getByText('2-2 sur 2 éléments'));
+      assert.ok(screen.getByRole('heading', { name: t('pages.statistics.title'), level: 1 }));
+      assert.notOk(screen.queryByText(dayjs(extractionDate).format('D MMM YYYY'), { exact: false }));
+    });
 
-      // when
-      const select = screen.getByRole('button', { name: t('pages.statistics.select-label') });
-      await click(select);
-      const option = await screen.findByRole('option', { name: '2. Communication et collaboration' });
-      await click(option);
+    test('should display empty state if data did not exists', async function (assert) {
+      //given
+      const model = {
+        data: undefined,
+      };
 
-      // then
-      assert.ok(screen.getByText('1 élément'));
-      assert.ok(screen.getByRole('cell', { name: '2.1 Interagir' }));
-      assert.ok(screen.getByRole('cell', { name: 'Gérer ses contacts' }));
-      assert.ok(screen.getByRole('cell', { name: t('pages.statistics.level.novice') }));
+      //when
+      const screen = await render(<template><Statistics @model={{model}} /></template>);
 
-      // when
-      await clickByName(t('common.filters.actions.clear'));
+      //then
+      assert.ok(screen.getByText(t('pages.statistics.empty-state')));
+    });
 
-      // then
-      assert.ok(screen.getByText('1-1 sur 2 éléments'));
+    test('should display empty state if data is empty', async function (assert) {
+      //given
+      const model = {
+        data: [],
+      };
+
+      //when
+      const screen = await render(<template><Statistics @model={{model}} /></template>);
+
+      //then
+      assert.ok(screen.getByText(t('pages.statistics.empty-state')));
     });
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1470,6 +1470,7 @@
     "statistics": {
       "before-date": "on",
       "description": "The table below shows how your participants are positioned by subject.'<br>' Positioning reflects the average level of your participants in relation to the maximum level they could have reached.'<br>' This data takes into account all participations shared as part of your organisation's evaluation campaigns that have not been deleted.",
+      "empty-state": "No data available",
       "gauge": {
         "label": "On the topic, your participants achieved a level of {userLevel} out of a maximum reachable level of {tubeLevel}."
       },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1476,6 +1476,7 @@
     "statistics": {
       "before-date": "au",
       "description": "Le tableau ci-dessous vous permet de visualiser le positionnement de vos participants par sujet.'<br>' Le positionnement rend compte du niveau moyen de vos participants sur le niveau maximum qu’ils auraient pu atteindre.'<br>' Ces données tiennent compte de toutes les participations partagées dans le cadre des campagnes d’évaluation non supprimées de votre organisation.",
+      "empty-state": "Aucune donnée disponible",
       "gauge": {
         "label": "Sur le sujet vos participants ont obtenu un niveau de {userLevel} sur un niveau maximum atteignable de {tubeLevel}."
       },

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1472,6 +1472,7 @@
       "title": "Statistieken",
       "before-date": "op",
       "description": "De tabel hieronder laat zien hoe je deelnemers per onderwerp zijn gepositioneerd.'<br>' Positionering geeft het gemiddelde niveau van je deelnemers weer ten opzichte van het maximale niveau dat ze hadden kunnen bereiken.'<br>' Deze gegevens houden rekening met alle deelnames die zijn gedeeld als onderdeel van de evaluatiecampagnes van je organisatie en die niet zijn verwijderd.",
+      "empty-state": "Geen gegevens beschikbaar",
       "gauge": {
         "label": "Je deelnemers behaalden een {userLevel} op een maximaal haalbaar niveau van {tubeLevel}."
       },


### PR DESCRIPTION
## :pancakes: Problème
Dans le cas où on active la feature Statistiques à une orga pour laquelle le TDC n’est pas encore dispo via l’API, on a une erreur 500

## :bacon: Proposition
On veut gérer l’erreur et informer l’utilisateur que les données sont indispos 

## 🧃 Remarques
Penser en local pour les tests a ajouter les var d'env suivantes :
API_DATA_URL=
API_DATA_USERNAME=
API_DATA_PASSWORD=
API_DATA_QUERIES=

## :yum: Pour tester
Aller sur l'organisation `Pro Classic`
Aller sur la page Statistiques
Vérifier l'affichage indiquant qu'il n'y a pas de données disponible

Pour tester le cas ou les données existe, faire en Local : 
Ajouter les vars d'env ci-dessus
(Je vous donnerai les valeurs a mettre)
Remplacer dans le fichier `api/db/seeds/data/common/constants.js` la valeur de : 
`const PRO_ORGANIZATION_ID=432` 
Aller sur PixOrga sur l'organisation Pro Classic, sur la page statistiques et vérifier le bon affichage de la page
🐈‍⬛ 