### PR TITLE
[FEATURE] Permettre de télécharger le kit dans l'espace surveillant sur Pix Certif (PIX-16250).

### DIFF
--- a/api/src/certification/session-management/application/invigilator-kit-route.js
+++ b/api/src/certification/session-management/application/invigilator-kit-route.js
@@ -1,8 +1,9 @@
 import Joi from 'joi';
 
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
-import { authorization } from '../../shared/application/pre-handlers/authorization.js';
 import { invigilatorKitController } from './invigilator-kit-controller.js';
+import { authorization } from './pre-handlers/authorization.js';
 
 const register = async function (server) {
   server.route([
@@ -17,7 +18,11 @@ const register = async function (server) {
         },
         pre: [
           {
-            method: authorization.verifySessionAuthorization,
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                authorization.checkUserHaveCertificationCenterMembershipForSession,
+                authorization.checkUserHaveInvigilatorAccessForSession,
+              ])(request, h),
             assign: 'authorizationCheck',
           },
         ],

--- a/api/src/certification/session-management/application/pre-handlers/authorization.js
+++ b/api/src/certification/session-management/application/pre-handlers/authorization.js
@@ -1,0 +1,71 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+import { ForbiddenAccess } from '../../../../shared/domain/errors.js';
+import * as requestResponseUtils from '../../../../shared/infrastructure/utils/request-response-utils.js';
+import * as sessionRepository from '../../../session-management/infrastructure/repositories/session-repository.js';
+import * as supervisorAccessRepository from '../../infrastructure/repositories/supervisor-access-repository.js';
+const { Error: JSONAPIError } = jsonapiSerializer;
+
+const FORBIDDEN_ERROR_MESSAGE = 'User is not allowed to access to this resource.';
+
+function _replyForbiddenError(h) {
+  const errorHttpStatusCode = 403;
+
+  const jsonApiError = new JSONAPIError({
+    code: errorHttpStatusCode,
+    title: 'Forbidden access',
+    detail: 'Missing or insufficient permissions.',
+  });
+
+  return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
+}
+
+async function checkUserHaveCertificationCenterMembershipForSession(request, h, dependencies = { sessionRepository }) {
+  const userId = request.auth.credentials.userId;
+  const sessionId = request.params.sessionId;
+
+  try {
+    const hasMembershipAccess =
+      await dependencies.sessionRepository.doesUserHaveCertificationCenterMembershipForSession({
+        userId,
+        sessionId,
+      });
+
+    if (!hasMembershipAccess) {
+      throw new ForbiddenAccess(FORBIDDEN_ERROR_MESSAGE);
+    }
+    return h.response(true);
+  } catch {
+    return _replyForbiddenError(h);
+  }
+}
+
+async function checkUserHaveInvigilatorAccessForSession(
+  request,
+  h,
+  dependencies = { supervisorAccessRepository, requestResponseUtils },
+) {
+  const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+  const sessionId = request.params.sessionId;
+
+  try {
+    const isSupervisorForSession = await dependencies.supervisorAccessRepository.isUserSupervisorForSession({
+      sessionId,
+      userId,
+    });
+
+    if (!isSupervisorForSession) {
+      throw new ForbiddenAccess(FORBIDDEN_ERROR_MESSAGE);
+    }
+    return h.response(true);
+  } catch {
+    return _replyForbiddenError(h);
+  }
+}
+
+const authorization = {
+  checkUserHaveCertificationCenterMembershipForSession,
+  checkUserHaveInvigilatorAccessForSession,
+};
+
+export { authorization };

--- a/api/tests/acceptance/application/session/session-controller-get-supervisor-kit-PDF_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-supervisor-kit-PDF_test.js
@@ -20,7 +20,6 @@ describe('Acceptance | Controller | session-controller-get-supervisor-kit-pdf', 
       user = databaseBuilder.factory.buildUser();
       databaseBuilder.factory.buildOrganization({ externalId: 'EXT1234' });
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({ externalId: 'EXT1234' }).id;
-      databaseBuilder.factory.buildCertificationCenterMembership({ userId: user.id, certificationCenterId });
 
       const otherUserId = databaseBuilder.factory.buildUser().id;
       const otherCertificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
@@ -30,6 +29,7 @@ describe('Acceptance | Controller | session-controller-get-supervisor-kit-pdf', 
       });
 
       sessionIdAllowed = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
+      databaseBuilder.factory.buildSupervisorAccess({ userId: user.id, sessionId: sessionIdAllowed });
 
       await databaseBuilder.commit();
     });

--- a/api/tests/certification/session-management/integration/application/pre-handlers/authorization_test.js
+++ b/api/tests/certification/session-management/integration/application/pre-handlers/authorization_test.js
@@ -1,0 +1,174 @@
+import { authorization } from '../../../../../../src/certification/session-management/application/pre-handlers/authorization.js';
+import {
+  databaseBuilder,
+  expect,
+  generateValidRequestAuthorizationHeader,
+  HttpTestServer,
+} from '../../../../../test-helper.js';
+
+describe('Certification | Session-Management | Integration | Application | Pre-Handlers | Authorization', function () {
+  describe('#checkUserHaveCertificationCenterMembershipForSession', function () {
+    let httpServerTest;
+
+    beforeEach(async function () {
+      const moduleUnderTest = {
+        name: 'security-test',
+        register: async function (server) {
+          server.route([
+            {
+              method: 'GET',
+              path: '/api/test/sessions/{sessionId}/supervisor-kit',
+              handler: (r, h) => h.response().code(200),
+              config: {
+                pre: [
+                  {
+                    method: authorization.checkUserHaveCertificationCenterMembershipForSession,
+                  },
+                ],
+              },
+            },
+          ]);
+        },
+      };
+      httpServerTest = new HttpTestServer();
+      await httpServerTest.register(moduleUnderTest);
+      httpServerTest.setupAuthentication();
+    });
+
+    context(
+      'when the user is authenticated and has certification center membership for the given session',
+      function () {
+        it('should return 200', async function () {
+          // given
+          const { id: userId } = databaseBuilder.factory.buildUser();
+          const { id: certificationCenterId } = databaseBuilder.factory.buildCertificationCenter();
+          const { id: sessionId } = databaseBuilder.factory.buildSession({
+            certificationCenterId,
+          });
+          databaseBuilder.factory.buildCertificationCenterMembership({
+            certificationCenterId,
+            userId,
+          });
+          await databaseBuilder.commit();
+
+          const options = {
+            method: 'GET',
+            url: `/api/test/sessions/${sessionId}/supervisor-kit`,
+            headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+          };
+
+          // when
+          const response = await httpServerTest.requestObject(options);
+
+          // then
+          expect(response.statusCode).to.equal(200);
+        });
+      },
+    );
+
+    context(
+      'when the user is authenticated and has no certification center membership for the given session',
+      function () {
+        it('should return 403', async function () {
+          // given
+          const { id: userId } = databaseBuilder.factory.buildUser();
+          const { id: certificationCenterId } = databaseBuilder.factory.buildCertificationCenter();
+          const { id: sessionId } = databaseBuilder.factory.buildSession({
+            certificationCenterId,
+          });
+          await databaseBuilder.commit();
+
+          const options = {
+            method: 'GET',
+            url: `/api/test/sessions/${sessionId}/supervisor-kit`,
+            headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+          };
+
+          // when
+          const response = await httpServerTest.requestObject(options);
+
+          // then
+          expect(response.statusCode).to.equal(403);
+        });
+      },
+    );
+  });
+
+  describe('#checkUserHaveInvigilatorAccessForSession', function () {
+    let httpServerTest;
+
+    beforeEach(async function () {
+      const moduleUnderTest = {
+        name: 'security-test',
+        register: async function (server) {
+          server.route([
+            {
+              method: 'GET',
+              path: '/api/test/sessions/{sessionId}/supervisor-kit',
+              handler: (r, h) => h.response().code(200),
+              config: {
+                pre: [
+                  {
+                    method: authorization.checkUserHaveInvigilatorAccessForSession,
+                  },
+                ],
+              },
+            },
+          ]);
+        },
+      };
+      httpServerTest = new HttpTestServer();
+      await httpServerTest.register(moduleUnderTest);
+      httpServerTest.setupAuthentication();
+    });
+
+    context('when the user is authenticated and has supervisor access to the given session', function () {
+      it('should return 200', async function () {
+        // given
+        const { id: userId } = databaseBuilder.factory.buildUser();
+        const { id: certificationCenterId } = databaseBuilder.factory.buildCertificationCenter();
+        const { id: sessionId } = databaseBuilder.factory.buildSession({
+          certificationCenterId,
+        });
+        databaseBuilder.factory.buildSupervisorAccess({ userId, sessionId });
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'GET',
+          url: `/api/test/sessions/${sessionId}/supervisor-kit`,
+          headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        };
+
+        // when
+        const response = await httpServerTest.requestObject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+
+    context('when the user is authenticated and has no supervisor access to the given session', function () {
+      it('should return 403', async function () {
+        // given
+        const { id: userId } = databaseBuilder.factory.buildUser();
+        const { id: certificationCenterId } = databaseBuilder.factory.buildCertificationCenter();
+        const { id: sessionId } = databaseBuilder.factory.buildSession({
+          certificationCenterId,
+        });
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'GET',
+          url: `/api/test/sessions/${sessionId}/supervisor-kit`,
+          headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        };
+
+        // when
+        const response = await httpServerTest.requestObject(options);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+  });
+});

--- a/api/tests/certification/session-management/unit/application/invigilator-kit-route_test.js
+++ b/api/tests/certification/session-management/unit/application/invigilator-kit-route_test.js
@@ -1,14 +1,14 @@
 import { invigilatorKitController } from '../../../../../src/certification/session-management/application/invigilator-kit-controller.js';
 import * as moduleUnderTest from '../../../../../src/certification/session-management/application/invigilator-kit-route.js';
-import { authorization } from '../../../../../src/certification/shared/application/pre-handlers/authorization.js';
-import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { authorization } from '../../../../../src/certification/session-management/application/pre-handlers/authorization.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
 describe('Certification | Session Management | Unit | Application | Routes | Invigilator Kit', function () {
   describe('GET /api/sessions/{sessionId}/supervisor-kit', function () {
     it('should return 200', async function () {
       // when
-      sinon.stub(authorization, 'verifySessionAuthorization').resolves(true);
+      sinon.stub(authorization, 'checkUserHaveCertificationCenterMembershipForSession').resolves(true);
       sinon.stub(invigilatorKitController, 'getInvigilatorKitPdf').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
@@ -21,18 +21,21 @@ describe('Certification | Session Management | Unit | Application | Routes | Inv
       expect(response.statusCode).to.equal(200);
     });
 
-    it('should return 404 if the user is not authorized on the session', async function () {
-      // given
-      sinon.stub(authorization, 'verifySessionAuthorization').throws(new NotFoundError());
+    describe('when user is neither a member on certification center nor a invigilator for the session', function () {
+      it('should return an error', async function () {
+        // given
+        sinon
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
+          .returns((request, h) => h.response().code(403).takeover());
+        const auth = { credentials: { userId: 99 }, strategy: {} };
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
 
-      const auth = { credentials: { userId: 99 }, strategy: {} };
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
+        const response = await httpTestServer.request('GET', '/api/sessions/3/supervisor-kit', {}, auth);
 
-      const response = await httpTestServer.request('GET', '/api/sessions/3/supervisor-kit', {}, auth);
-
-      // then
-      expect(response.statusCode).to.equal(404);
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
     });
   });
 });

--- a/certif/app/components/session-supervising/header.hbs
+++ b/certif/app/components/session-supervising/header.hbs
@@ -70,6 +70,18 @@
     </PixNotificationAlert>
   {{/if}}
 
+  <PixButton
+    class="session-supervising-header__download-button"
+    @variant="secondary"
+    @isBorderVisible={{true}}
+    @size="small"
+    aria-label={{t "pages.session-supervising.header.invigilator-kit.extra-information"}}
+    @triggerAction={{@fetchInvigilatorKit}}
+  >
+    <PixIcon @name="download" @plainIcon={{true}} @ariaHidden={{true}} />
+    {{t "pages.session-supervising.header.invigilator-kit.label"}}
+  </PixButton>
+
   <SessionSupervising::ConfirmationModal
     @showModal={{this.isConfirmationModalDisplayed}}
     @closeConfirmationModal={{this.closeConfirmationModal}}

--- a/certif/app/components/sessions/session-details/controls-links.gjs
+++ b/certif/app/components/sessions/session-details/controls-links.gjs
@@ -7,7 +7,6 @@ import { t } from 'ember-intl';
   <div class='session-details__controls-links'>
     <span class='session-details__controls-title'>{{t 'pages.sessions.detail.downloads.label'}}</span>
     <PixButtonLink
-      class='session-details__controls-download-button'
       href='{{@urlToDownloadSessionIssueReportSheet}}'
       @variant='secondary'
       @isBorderVisible={{true}}
@@ -21,7 +20,6 @@ import { t } from 'ember-intl';
       {{t 'pages.sessions.detail.downloads.incident-report.label'}}
     </PixButtonLink>
     <PixButton
-      class='session-details__controls-download-button'
       @variant='secondary'
       @isBorderVisible={{true}}
       @size='small'
@@ -33,7 +31,6 @@ import { t } from 'ember-intl';
     </PixButton>
     {{#if @shouldDisplayDownloadButton}}
       <PixButton
-        class='session-details__controls-download-button'
         @triggerAction={{@fetchAttendanceSheet}}
         @variant='secondary'
         @isBorderVisible={{true}}

--- a/certif/app/controllers/session-supervising.js
+++ b/certif/app/controllers/session-supervising.js
@@ -1,7 +1,12 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 
 export default class SessionSupervisingController extends Controller {
+  @service session;
+  @service pixToast;
+  @service fileSaver;
+
   @action
   async toggleCandidate(candidate) {
     const authorizedToStart = !candidate.authorizedToStart;
@@ -16,5 +21,17 @@ export default class SessionSupervisingController extends Controller {
   @action
   async endAssessmentBySupervisor(candidate) {
     await candidate.endAssessmentBySupervisor();
+  }
+
+  @action
+  async fetchInvigilatorKit() {
+    const token = this.session.data.authenticated.access_token;
+    const url = `/api/sessions/${this.model.id}/supervisor-kit`;
+
+    try {
+      await this.fileSaver.save({ url, token });
+    } catch (error) {
+      this.pixToast.sendErrorNotification({ message: this.intl.t('common.api-error-messages.internal-server-error') });
+    }
   }
 }

--- a/certif/app/styles/components/session-supervising/header.scss
+++ b/certif/app/styles/components/session-supervising/header.scss
@@ -6,7 +6,7 @@
   padding: 16px;
 
   @include breakpoints.device-is("tablet") {
-    padding: 40px 48px;
+    padding: var(--pix-spacing-10x) var(--pix-spacing-12x) var(--pix-spacing-8x) var(--pix-spacing-12x);
   }
 
   @include breakpoints.device-is("desktop") {
@@ -70,6 +70,16 @@
       width: 1rem;
       height: 1rem;
       fill: var(--pix-primary-500);
+    }
+  }
+
+  &__download-button {
+    margin-top: var(--pix-spacing-3x);
+
+    svg {
+      width: 1rem;
+      height: 1rem;
+      margin-right: var(--pix-spacing-1x);
     }
   }
 }

--- a/certif/app/templates/session-supervising.hbs
+++ b/certif/app/templates/session-supervising.hbs
@@ -1,7 +1,7 @@
 {{page-title (t "pages.session-supervising.title" sessionId=@model.id)}}
 
 <div class="session-supervising-page">
-  <SessionSupervising::Header @session={{@model}} />
+  <SessionSupervising::Header @session={{@model}} @fetchInvigilatorKit={{this.fetchInvigilatorKit}} />
   <SessionSupervising::CandidateList
     @authorizeTestResume={{this.authorizeTestResume}}
     @endAssessmentBySupervisor={{this.endAssessmentBySupervisor}}

--- a/certif/tests/integration/components/session-supervising/header-test.js
+++ b/certif/tests/integration/components/session-supervising/header-test.js
@@ -53,6 +53,8 @@ module('Integration | Component | SessionSupervising::Header', function (hooks) 
 
     assert.strictEqual(termsList[3].textContent.trim(), "Code d'accès (candidats)");
     assert.strictEqual(definitionsList[3].textContent.trim(), 'ACCES1');
+
+    assert.dom(screen.getByRole('button', { name: 'Télécharger le kit surveillant' })).exists();
   });
 
   module("when 'Quitter' button is clicked", function () {

--- a/certif/tests/unit/controllers/session-supervising-test.js
+++ b/certif/tests/unit/controllers/session-supervising-test.js
@@ -1,0 +1,60 @@
+import Service from '@ember/service';
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlForModels from '../helpers/setup-intl';
+
+module('Unit | Controller | session-supervising', function (hooks) {
+  setupTest(hooks);
+  setupIntlForModels(hooks);
+
+  let controller;
+
+  hooks.beforeEach(function () {
+    controller = this.owner.lookup('controller:session-supervising');
+  });
+
+  module('#fetchInvigilatorKit', function () {
+    test('should call the file-saver service', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+        id: '123',
+      });
+      const sessionForSupervising = store.createRecord('session-for-supervising', {
+        id: '456',
+      });
+      class CurrentUserStub extends Service {
+        currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+      }
+
+      this.owner.register('service:current-user', CurrentUserStub);
+      const token = 'a token';
+
+      controller.session = {
+        isAuthenticated: true,
+        data: {
+          authenticated: {
+            access_token: token,
+          },
+        },
+      };
+      controller.fileSaver = {
+        save: sinon.stub(),
+      };
+      controller.model = sessionForSupervising;
+
+      // when
+      await controller.fetchInvigilatorKit();
+
+      // then
+      assert.ok(
+        controller.fileSaver.save.calledWith({
+          token,
+          url: '/api/sessions/456/supervisor-kit',
+        }),
+      );
+    });
+  });
+});

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -556,6 +556,10 @@
         },
         "information": "Warning, make sure that all the candidates have finished their exam before exiting the invigilation. To resume the invigilation of this session, you will have to enter again it’s session number and it’s password.",
         "invigilator": "Invigilator(s)",
+        "invigilator-kit": {
+          "extra-information": "Download invigilator’s kit",
+          "label": "Invigilator’s kit"
+        },
         "room": "Room",
         "session-id": "Session {sessionId}"
       },

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -556,6 +556,10 @@
         },
         "information": "Attention, assurez-vous que tous les candidats aient terminé leur test avant de quitter la surveillance. Pour reprendre la surveillance de cette session, vous devrez entrer à nouveau son numéro de session et son mot de passe.",
         "invigilator": "Surveillant(s)",
+        "invigilator-kit": {
+          "extra-information": "Télécharger le kit surveillant",
+          "label": "Kit surveillant"
+        },
         "room": "Salle",
         "session-id": "Session {sessionId}"
       },


### PR DESCRIPTION
## :pancakes: Problème

Actuellement, le kit surveillant est disponible en téléchargement uniquement sur Pix Certif, or les surveillants n’ont pas toujours accès à Pix Certif.

## :bacon: Proposition

 Permettre de télécharger le kit directement dans l'espace surveillant.

## 🧃 Remarques

La route API ne permettait l'accès qu'aux membres d'un centre de certif propriétaire de la session.
Il fallait permettre l'accès aux surveillants.

J'ai fait le choix de profiter de la fonction `hasAtLeastOneAccessOf`, utilisé pour gérer les rôles dans Admin.
Elle est pertinente ici car elle traitera les deux pre-handler et donnera accès si au moins l'une des deux est validé.

A accès à cette route : 
un membre d'un centre qui n'est pas forcément surveillant ✅ 
un surveillant qui n'est pas membre d'un centre ✅ 
un surveillant, également membre d'un centre de certif ✅ 

## :yum: Pour tester

En tant que membre d'un centre de certif (non régression coté API)
- Se connecter avec certif-pro@example.net
- Aller sur la session 7402, et télécharger le kit, constater que ça fonctionne toujours
- Aller dans l'espace surveillant
- 7402 / PIX123
- Cliquer sur le bouton et constater que l'on récupère le kit avec les bonnes infos
- Se déconnecter

En tant que surveillant qui n'est pas membre 
- Se connecter à Pix Certif avec certif-success@example.net
- 7402 / PIX123
- Cliquer sur le bouton et constater que l'on récupère le kit avec les bonnes infos

Avec et sans le bandeau PixCompanion
<img width="351" alt="Capture d’écran 2025-01-27 à 11 38 36" src="https://github.com/user-attachments/assets/b7a12b4b-ee41-43ae-be27-9ae73fed8a16" />
<img width="325" alt="Capture d’écran 2025-01-27 à 11 38 50" src="https://github.com/user-attachments/assets/7699a18d-a276-4e03-810a-b974bfe3ae41" />


