### PR TITLE
[FEATURE] Ajout d'une contrainte d'unicité sur campaignParticipationId dans les Ke Snapshots (PIX-16258)

### DIFF
--- a/api/src/prescription/scripts/add-unicity-constraint-knwoledge-element-snapshots.js
+++ b/api/src/prescription/scripts/add-unicity-constraint-knwoledge-element-snapshots.js
@@ -1,0 +1,51 @@
+import { knex } from '../../../db/knex-database-connection.js';
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+
+class AddUnicityConstraintKnowledgeElementSnapshots extends Script {
+  constructor() {
+    super({
+      description: 'Script to add campaignParticipationId unicity constraint on knowledge-element-snapshots',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'execute script without commit',
+          demandOption: false,
+          default: true,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    logger.info(`add-unicity-constraint-knowledge-element-snapshots | START`);
+    logger.info(`add-unicity-constraint-knowledge-element-snapshots | dryRun ${options.dryRun}`);
+
+    const trx = await knex.transaction();
+    try {
+      await trx.schema.table('knowledge-element-snapshots', function (table) {
+        table.unique('campaignParticipationId', {
+          indexName: 'one_snapshot_by_campaignParticipationId',
+        });
+      });
+
+      if (options.dryRun) {
+        logger.info(`add-unicity-constraint-knowledge-element-snapshots | rollback`);
+        await trx.rollback();
+      } else {
+        logger.info(`add-unicity-constraint-knowledge-element-snapshots | commit`);
+        await trx.commit();
+      }
+    } catch (err) {
+      logger.error(`add-unicity-constraint-knowledge-element-snapshots | FAIL | Reason : ${err}`);
+      await trx.rollback();
+    } finally {
+      logger.info(`add-unicity-constraint-knowledge-element-snapshots | END`);
+    }
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, AddUnicityConstraintKnowledgeElementSnapshots);
+
+export { AddUnicityConstraintKnowledgeElementSnapshots };

--- a/api/tests/prescription/scripts/add-unicity-constraint-knwoledge-element-snapshots_test.js
+++ b/api/tests/prescription/scripts/add-unicity-constraint-knwoledge-element-snapshots_test.js
@@ -1,0 +1,63 @@
+import { AddUnicityConstraintKnowledgeElementSnapshots } from '../../../src/prescription/scripts/add-unicity-constraint-knwoledge-element-snapshots.js';
+import { expect, knex, sinon } from '../../test-helper.js';
+
+describe('Integration | Prescription | Scripts | add-unicity-constraint-knwoledge-element-snapshots', function () {
+  let script;
+  let loggerStub;
+  const TABLE_NAME = 'knowledge-element-snapshots';
+  const CONSTRAINT_NAME = 'one_snapshot_by_campaignParticipationId';
+
+  before(async function () {
+    script = new AddUnicityConstraintKnowledgeElementSnapshots();
+    loggerStub = { info: sinon.stub(), error: sinon.stub() };
+  });
+
+  afterEach(async function () {
+    const constraint = await knex.select('constraint_name').from('information_schema.table_constraints').where({
+      table_name: TABLE_NAME,
+      constraint_name: CONSTRAINT_NAME,
+    });
+
+    if (constraint.length > 0) {
+      await knex.schema.table(TABLE_NAME, function (table) {
+        table.dropUnique('campaignParticipationId', CONSTRAINT_NAME);
+      });
+    }
+  });
+
+  describe('Options', function () {
+    it('has the correct options', function () {
+      const { options } = script.metaInfo;
+      expect(options.dryRun).to.deep.include({
+        type: 'boolean',
+        describe: 'execute script without commit',
+        demandOption: false,
+        default: true,
+      });
+    });
+  });
+
+  describe('#handle', function () {
+    it('should not add unicity contraint on dryRun mode', async function () {
+      await script.handle({ options: { dryRun: true }, logger: loggerStub });
+
+      const constraint = await knex.select('constraint_name').from('information_schema.table_constraints').where({
+        table_name: TABLE_NAME,
+        constraint_name: CONSTRAINT_NAME,
+      });
+
+      expect(constraint).to.be.empty;
+    });
+
+    it('should add unicity contraint without dryRun mode', async function () {
+      await script.handle({ options: { dryRun: false }, logger: loggerStub });
+
+      const constraint = await knex.select('constraint_name').from('information_schema.table_constraints').where({
+        table_name: TABLE_NAME,
+        constraint_name: CONSTRAINT_NAME,
+      });
+
+      expect(constraint).to.be.not.empty;
+    });
+  });
+});


### PR DESCRIPTION
## :pancakes: Problème

Suite à l'ajout de la colonne campaignParticipationId dans le table ke S, nous nous sommes rendu compte qu'il lui manque une propriété. celle de l'unicité

## :bacon: Proposition

Ajouter cette unicité via un script dans un premier temps. Pour ensuite la rajouter dans un scripts de migration avec la vérification que la contrainte n'existe pas avant de tenter l'insertion

## 🧃 Remarques

RAS - Ajout d'un dryRun

## :yum: Pour tester

 - [x] `node ./src/prescription/scripts/add-unicity-constraint-knwoledge-element-snapshots.js --help` ( vérifier que les args sont cohérent )

- [x] executer le script en mode dryRun sur la RA vérifier que la contrainte n'est pas posé. ( `node ./src/prescription/scripts/add-unicity-constraint-knwoledge-element-snapshots.js` )
- [x] executer le scription sur la RA sans dryRun, vérifier que la contrainte est en BDD ( `node ./src/prescription/scripts/add-unicity-constraint-knwoledge-element-snapshots.js --dryRun false`)