### PR TITLE
[TECH] Changer les headers X-Forwarded-xxx utilisés pour la fonction getForwardedOrigin (PIX-16282)

### DIFF
--- a/admin/servers.conf.erb
+++ b/admin/servers.conf.erb
@@ -122,7 +122,7 @@ server {
     proxy_set_header X-Source-Front <%= ENV['APP'] %>;
 
     # Set X-Forwarded-xxx headers for the API to compute getForwardedOrigin
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Proto $scheme;
   }
 

--- a/admin/servers.conf.erb
+++ b/admin/servers.conf.erb
@@ -124,6 +124,9 @@ server {
     # Set X-Forwarded-xxx headers for the API to compute getForwardedOrigin
     proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Proto $scheme;
+
+    # Set X-Forwarded-For header to be able to know the remote client IP
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }
 
   <% end %>

--- a/certif/servers.conf.erb
+++ b/certif/servers.conf.erb
@@ -139,7 +139,7 @@ server {
     proxy_set_header X-Source-Front <%= ENV['APP'] %>;
 
     # Set X-Forwarded-xxx headers for the API to compute getForwardedOrigin
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Proto $scheme;
   }
 

--- a/certif/servers.conf.erb
+++ b/certif/servers.conf.erb
@@ -141,6 +141,9 @@ server {
     # Set X-Forwarded-xxx headers for the API to compute getForwardedOrigin
     proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Proto $scheme;
+
+    # Set X-Forwarded-For header to be able to know the remote client IP
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }
 
   <% end %>

--- a/junior/servers.conf.erb
+++ b/junior/servers.conf.erb
@@ -119,6 +119,9 @@ server {
     # Set X-Forwarded-xxx headers for the API to compute getForwardedOrigin
     proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Proto $scheme;
+
+    # Set X-Forwarded-For header to be able to know the remote client IP
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }
 
   <% end %>

--- a/junior/servers.conf.erb
+++ b/junior/servers.conf.erb
@@ -117,7 +117,7 @@ server {
     proxy_set_header X-Source-Front <%= ENV['APP'] %>;
 
     # Set X-Forwarded-xxx headers for the API to compute getForwardedOrigin
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Proto $scheme;
   }
 

--- a/mon-pix/servers.conf.erb
+++ b/mon-pix/servers.conf.erb
@@ -148,6 +148,9 @@ server {
     # Set X-Forwarded-xxx headers for the API to compute getForwardedOrigin
     proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Proto $scheme;
+
+    # Set X-Forwarded-For header to be able to know the remote client IP
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }
 
   <% end %>

--- a/mon-pix/servers.conf.erb
+++ b/mon-pix/servers.conf.erb
@@ -146,7 +146,7 @@ server {
     proxy_set_header X-Source-Front <%= ENV['APP'] %>;
 
     # Set X-Forwarded-xxx headers for the API to compute getForwardedOrigin
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Proto $scheme;
   }
 

--- a/orga/servers.conf.erb
+++ b/orga/servers.conf.erb
@@ -139,7 +139,7 @@ server {
     proxy_set_header X-Source-Front <%= ENV['APP'] %>;
 
     # Set X-Forwarded-xxx headers for the API to compute getForwardedOrigin
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Proto $scheme;
   }
 

--- a/orga/servers.conf.erb
+++ b/orga/servers.conf.erb
@@ -141,6 +141,9 @@ server {
     # Set X-Forwarded-xxx headers for the API to compute getForwardedOrigin
     proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Proto $scheme;
+
+    # Set X-Forwarded-For header to be able to know the remote client IP
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }
 
   <% end %>


### PR DESCRIPTION
## :pancakes: Problème

Les headers `X-Forwarded-xxx` mis en place avec #11142 ne permettent pas de déterminer la forwarded origin dans les environnements d'integration, recette, production.

## :bacon: Proposition

Utiliser plutôt :

```
proxy_set_header X-Forwarded-Host $http_host;
```

que :

```
proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
```

On garde néanmoins l’envoi du header X-Forwarded-For pour tous les frontaux mais dans une section de configuration nginx dédiée qui indique bien que cette information n'est pas liée à la fonction `getForwardedOrigin`.

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

1. Sur chaque RA, vérifier que l'ajout de ces headers ne provoque pas de régression. Pour cela il suffit de faire quelques requêtes à Pix API, par exemple s'authentifier avec un compte et vérifier que le frontal n'est pas cassé et est fonctionnel.

2. Puis vérifier sur chaque RA que `getForwardedOrigin` fonctionne toujours bien et renvoie toujours bien la valeur attendue :
* https://app-pr11230.review.pix.fr/api/test-origin-soon-to-be-remove → `https://app-pr11230.review.pix.fr/`
* https://app-pr11230.review.pix.org/api/test-origin-soon-to-be-remove → `https://app-pr11230.review.pix.org/`
* https://orga-pr11230.review.pix.fr/api/test-origin-soon-to-be-remove → `https://orga-pr11230.review.pix.fr/`
* https://orga-pr11230.review.pix.org/api/test-origin-soon-to-be-remove → `https://orga-pr11230.review.pix.org/`
* https://certif-pr11230.review.pix.fr/api/test-origin-soon-to-be-remove → `https://certif-pr11230.review.pix.fr/`
* https://certif-pr11230.review.pix.org/api/test-origin-soon-to-be-remove → `https://certif-pr11230.review.pix.org/`
* https://admin-pr11230.review.pix.fr/api/test-origin-soon-to-be-remove → `https://admin-pr11230.review.pix.fr/`


:information_source: On ne pourra vérifier la bonne réception des headers `x-forwarded-host` et `x-forwarded-proto` par Pix API dans les environnements d'_integration_, _recette_ et _production_ que lorsque le code de cette PR sera déployé dans ces environnements.