### PR TITLE
[BUGFIX] Autoriser un temps de réponse plus long pour le ping Companion (PIX-16287)

### DIFF
--- a/mon-pix/app/services/pix-companion.js
+++ b/mon-pix/app/services/pix-companion.js
@@ -35,7 +35,7 @@ export default class PixCompanion extends Service {
   }
 
   checkExtensionIsEnabled(windowRef = window) {
-    const pong = promiseWithResolverAndTimeout(100, windowRef);
+    const pong = promiseWithResolverAndTimeout(500, windowRef);
     const pongListener = (event) => {
       try {
         this.version = event.detail?.version;

--- a/mon-pix/tests/unit/services/pix-companion-test.js
+++ b/mon-pix/tests/unit/services/pix-companion-test.js
@@ -122,7 +122,7 @@ module('Unit | Service | pix-companion', function (hooks) {
         setTimeout: sinon.stub(),
       };
       windowStub.setTimeout.callsFake((callback, timeout) => {
-        assert.strictEqual(timeout, 100);
+        assert.strictEqual(timeout, 500);
         callback();
       });
       pixCompanion._isExtensionEnabled = true;


### PR DESCRIPTION
## :pancakes: Problème

L’extension ne répond parfois pas dans les 100ms imparties.

## :bacon: Proposition

Autoriser un temps de réponse de 500ms.

## 🧃 Remarques

Il y a eu un allongement du temps de réponse car on forward le ping au background script.
Ce forward a été mis en place pour tous les navigateurs mais n’est nécessaire que pour Safari.

## :yum: Pour tester

Problème aléatoire donc dur à valider.