### PR TITLE
[BUGFIX] Fix sur le dépassement d'image/texte dans les cadres Pix Junior (PIX-16296)

### DIFF
--- a/junior/app/styles/components/challenge/challenge-content.scss
+++ b/junior/app/styles/components/challenge/challenge-content.scss
@@ -14,9 +14,9 @@
 
   &__grid-multiple-element {
     grid-template-areas:
-    "left  right"
+    "left right"
     "left actions";
-    grid-template-rows: 0fr 0fr;
+    grid-template-rows: 0fr 1fr;
     grid-template-columns: 1fr 1fr;
 
     &--40-60 {


### PR DESCRIPTION
## :pancakes: Problème

Plusieurs dépassements de cadre ont été observés sur l’application.

## :bacon: Proposition

Ajuster les templates des grid pour enlever les dépassements

## :yum: Pour tester

Vérifier que l'affichage est OK : https://junior-pr11244.review.pix.fr/challenges/challengeVjxiR4HCWo29U/preview