### PR TITLE
[FEATURE] Supprimer le lien "Qu'est-ce qu'un code parcours et comment l'utiliser ?" (PIX-16248)

### DIFF
--- a/mon-pix/app/templates/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/fill-in-campaign-code.hbs
@@ -53,16 +53,6 @@
           </div>
         {{/if}}
 
-        <div class="fill-in-campaign-code__explanation">
-          <a
-            href={{t "pages.fill-in-campaign-code.explanation-link"}}
-            class="link"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {{t "pages.fill-in-campaign-code.explanation-message"}}
-          </a>
-        </div>
       </PixBlock>
       {{#if this.canDisplayLanguageSwitcher}}
         <LanguageSwitcher @selectedLanguage={{this.selectedLanguage}} @onLanguageChange={{this.onLanguageChange}} />

--- a/mon-pix/tests/acceptance/fill-in-campaign-code-test.js
+++ b/mon-pix/tests/acceptance/fill-in-campaign-code-test.js
@@ -36,25 +36,6 @@ module('Acceptance | Fill in campaign code page', function (hooks) {
     });
   });
 
-  module('Explanation link', function () {
-    test('should redirect on the right support page', async function (assert) {
-      // given
-      await authenticate(user);
-      await visit('/campagnes');
-
-      // when
-      await clickByLabel(t('pages.fill-in-campaign-code.explanation-message'));
-
-      // then
-      assert
-        .dom(
-          '[href="https://support.pix.org/fr/support/solutions/articles/15000029147-qu-est-ce-qu-un-code-parcours-et-comment-l-utiliser-"]',
-        )
-        .exists();
-      assert.dom('[target="_blank"]').exists();
-    });
-  });
-
   module('when user is not connected to his Mediacentre', function () {
     module('and starts a campaign with GAR as identity provider', function () {
       test('should not redirect the user and display a modal', async function (assert) {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1296,8 +1296,6 @@
         "missing-code": "Please enter a code.",
         "not-found": "Your code is incorrect. Please check its format (ex: ABCDEF234) or contact the organiser."
       },
-      "explanation-link": "https://support.pix.org/en/support/solutions/articles/15000029147-what-is-a-customised-test-code-and-how-do-i-use-it-",
-      "explanation-message": "What is a customised test code and how do I use it?",
       "first-title-connected": "{ firstName }, enter your code",
       "first-title-not-connected": "Enter your code",
       "label": "Enter your code to start",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1303,8 +1303,6 @@
         "missing-code": "Por favor, introduce un código.",
         "not-found": "Tu código es incorrecto, comprueba el formato (por ejemplo, ABCDEF234) o ponte en contacto con el organizador."
       },
-      "explanation-link": "https://support.pix.org/fr/support/solutions/articles/15000029147-qu-est-ce-qu-un-code-parcours-et-comment-l-utiliser-",
-      "explanation-message": "¿Qué es un código de test y cómo se utiliza?",
       "first-title-connected": "{ firstName }, introduce tu código",
       "first-title-not-connected": "Introduce tu código",
       "label": "Introducir tu código para empezar.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1296,8 +1296,6 @@
         "missing-code": "Veuillez saisir un code.",
         "not-found": "Votre code est erroné, veuillez vérifier son format (ex: ABCDEF234) ou contacter l’organisateur."
       },
-      "explanation-link": "https://support.pix.org/fr/support/solutions/articles/15000029147-qu-est-ce-qu-un-code-parcours-et-comment-l-utiliser-",
-      "explanation-message": "Qu’est-ce qu’un code parcours et comment l’utiliser ?",
       "first-title-connected": "{ firstName }, saisissez votre code",
       "first-title-not-connected": "Saisissez votre code",
       "label": "Saisir votre code pour commencer.",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1303,8 +1303,6 @@
         "missing-code": "Voer een code in.",
         "not-found": "Je code is verkeerd, controleer de indeling (bijv. ABCDEF234) of neem contact op met de organisator."
       },
-      "explanation-link": "https://pix.org/nl-be/wat-is-een-code-en-hoe-gebruik-je-die",
-      "explanation-message": "Wat is een routecode en hoe gebruik je die?",
       "first-title-connected": "{ firstName }, voer uw code in",
       "first-title-not-connected": "Voer uw code in",
       "label": "Voer je code in om te beginnen.",


### PR DESCRIPTION
## :pancakes: Problème
<img width="500" alt="image" src="https://github.com/user-attachments/assets/8b6bccac-1eb4-4d0f-8933-05fe47693b47" />

Le lien [Qu’est-ce qu’un code parcours et comment l’utiliser ?](https://support.pix.org/fr/support/solutions/articles/15000029147-qu-est-ce-qu-un-code-parcours-et-comment-l-utiliser-) nécessiterait d'être mis à jour pour gérer les différents langues (mais relou).
Après échange support-produit, on estime que l'on peut se permettre de supprimer ce lien.

## :bacon: Proposition

Supprimer le lien, les trads et tests liés. 

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

- aller sur pix app
- cliquer sur "j'ai un code" 
- constater qu'il n'y a plus de lien et que tout fonctionne quand même 
- 🫰 