### PR TITLE
[FEATURE] Ajouter un bouton pour renvoyer une invitation à rejoindre une orga sur Pix Admin (PIX-10014)

### DIFF
--- a/admin/app/components/organizations/invitations.gjs
+++ b/admin/app/components/organizations/invitations.gjs
@@ -3,9 +3,11 @@ import { fn } from '@ember/helper';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
+import { t } from 'ember-intl';
 
 export default class OrganizationInvitations extends Component {
   @service accessControl;
+  @service intl;
 
   get sortedInvitations() {
     return this.args.invitations.sortBy('updatedAt').reverse();
@@ -38,16 +40,25 @@ export default class OrganizationInvitations extends Component {
                     <td>{{dayjsFormat invitation.updatedAt "DD/MM/YYYY [-] HH:mm"}}</td>
                     {{#if this.accessControl.hasAccessToOrganizationActionsScope}}
                       <td>
-                        <PixButton
-                          @size="small"
-                          @variant="error"
-                          class="organization-invitations-actions__button"
-                          aria-label="Annuler l’invitation de {{invitation.email}}"
-                          @triggerAction={{fn @onCancelOrganizationInvitation invitation}}
-                          @iconBefore="delete"
-                        >
-                          Annuler l’invitation
-                        </PixButton>
+                        <div class="organization-invitations__actions-buttons">
+                          <PixButton
+                            @size="small"
+                            aria-label={{t "common.invitations.send-new-label" invitationEmail=invitation.email}}
+                            @triggerAction={{fn @onSendNewInvitation invitation}}
+                            @iconBefore="refresh"
+                          >
+                            {{t "common.invitations.send-new"}}
+                          </PixButton>
+                          <PixButton
+                            @size="small"
+                            @variant="error"
+                            aria-label="Annuler l’invitation de {{invitation.email}}"
+                            @triggerAction={{fn @onCancelOrganizationInvitation invitation}}
+                            @iconBefore="delete"
+                          >
+                            Annuler l’invitation
+                          </PixButton>
+                        </div>
                       </td>
                     {{/if}}
                   </tr>

--- a/admin/app/controllers/authenticated/organizations/get/invitations.js
+++ b/admin/app/controllers/authenticated/organizations/get/invitations.js
@@ -14,6 +14,7 @@ export default class InvitationsController extends Controller {
   @service store;
   @service accessControl;
   @service errorResponseHandler;
+  @service intl;
 
   CUSTOM_ERROR_MESSAGES = {
     DEFAULT: 'Une erreur s’est produite, veuillez réessayer.',
@@ -43,6 +44,27 @@ export default class InvitationsController extends Controller {
       this.userEmailToInvite = null;
     } catch (err) {
       this.errorResponseHandler.notify(err, this.CUSTOM_ERROR_MESSAGES);
+    }
+    this.isLoading = false;
+  }
+
+  @action
+  async sendNewInvitation(organizationInvitation) {
+    this.isLoading = true;
+    try {
+      await this.store.queryRecord('organization-invitation', {
+        email: organizationInvitation.email,
+        lang: organizationInvitation.lang,
+        role: organizationInvitation.role,
+        organizationId: this.model.organization.id,
+      });
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('common.invitations.send-new-confirm', {
+          invitationEmail: organizationInvitation.email,
+        }),
+      });
+    } catch (error) {
+      this.errorResponseHandler.notify(error, this.CUSTOM_ERROR_MESSAGES);
     }
     this.isLoading = false;
   }

--- a/admin/app/styles/components/organization-invitations.scss
+++ b/admin/app/styles/components/organization-invitations.scss
@@ -12,7 +12,14 @@
     text-align: center;
   }
 
-  &-actions__button {
+  &__actions-buttons   {
+    display: flex;
+    flex-direction: column;
+
+    button {
+      width: 13rem;
+      margin:  0.2rem;
+    }
 
     svg {
       margin-right: 6px;

--- a/admin/app/templates/authenticated/organizations/get/invitations.hbs
+++ b/admin/app/templates/authenticated/organizations/get/invitations.hbs
@@ -9,5 +9,6 @@
 {{/if}}
 <Organizations::Invitations
   @invitations={{@model.organizationInvitations}}
+  @onSendNewInvitation={{this.sendNewInvitation}}
   @onCancelOrganizationInvitation={{this.cancelOrganizationInvitation}}
 />

--- a/admin/tests/integration/components/organizations/invitations-test.gjs
+++ b/admin/tests/integration/components/organizations/invitations-test.gjs
@@ -2,6 +2,7 @@ import { render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
 import dayjs from 'dayjs';
+import { setupIntl } from 'ember-intl/test-support';
 import { setupRenderingTest } from 'ember-qunit';
 import Invitations from 'pix-admin/components/organizations/invitations';
 import { module, test } from 'qunit';
@@ -9,6 +10,7 @@ import sinon from 'sinon';
 
 module('Integration | Component | organization-invitations', function (hooks) {
   setupRenderingTest(hooks);
+  setupIntl(hooks, 'fr');
 
   module('when the admin member have access to organization scope', function (hooks) {
     hooks.beforeEach(function () {
@@ -40,6 +42,7 @@ module('Integration | Component | organization-invitations', function (hooks) {
           {
             email: 'riri@example.net',
             role: 'ADMIN',
+            lang: 'fr',
             roleInFrench: 'Administrateur',
             updatedAt: dayjs('2019-10-08T10:50:00Z').utcOffset(2),
           },
@@ -47,11 +50,13 @@ module('Integration | Component | organization-invitations', function (hooks) {
             email: 'fifi@example.net',
             role: 'MEMBER',
             roleInFrench: 'Membre',
+            lang: 'en',
             updatedAt: dayjs('2019-10-08T10:50:00Z').utcOffset(2),
           },
           {
             email: 'loulou@example.net',
             role: null,
+            lang: 'nl',
             roleInFrench: '-',
             updatedAt: dayjs('2019-10-08T10:50:00Z').utcOffset(2),
           },

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -55,6 +55,11 @@
       "mandatory": "Champ obligatoire",
       "mandatory-fields": "The fields marked '<abbr title=\"required\" class=\"mandatory-mark\">'*'</abbr>' are required"
     },
+    "invitations": {
+      "send-new": "Resend the invitation",
+      "send-new-confirm": "An email has been sent to {invitationEmail}",
+      "send-new-label": "Resend the invitation to {invitationEmail}"
+    },
     "notifications": {
       "close-button": {
         "extra-information": "Close notification"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -55,6 +55,11 @@
       "mandatory": "Champ obligatoire",
       "mandatory-fields": "Les champs marqués de '<abbr title=\"obligatoire\" class=\"mandatory-mark\">'*'</abbr>' sont obligatoires"
     },
+    "invitations": {
+      "send-new": "Renvoyer l'invitation",
+      "send-new-confirm": "Un email a bien été renvoyé à {invitationEmail}",
+      "send-new-label": "Renvoyer l'invitation à {invitationEmail}"
+    },
     "notifications": {
       "close-button": {
         "extra-information": "Fermer la notification"

--- a/api/db/database-builder/factory/build-organization-invitation.js
+++ b/api/db/database-builder/factory/build-organization-invitation.js
@@ -11,6 +11,7 @@ const buildOrganizationInvitation = function ({
   status = OrganizationInvitation.StatusType.PENDING,
   code = 'INVIABC123',
   role = null,
+  locale = 'fr',
   updatedAt = new Date('2020-01-01'),
 } = {}) {
   organizationId = _.isUndefined(organizationId) ? buildOrganization().id : organizationId;
@@ -23,6 +24,7 @@ const buildOrganizationInvitation = function ({
     status,
     code,
     role,
+    locale,
     createdAt: new Date(),
     updatedAt,
   };

--- a/api/db/migrations/20250124150837_add-locale-column-to-organization-invitations-table.js
+++ b/api/db/migrations/20250124150837_add-locale-column-to-organization-invitations-table.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'organization-invitations';
+const COLUMN_NAME = 'locale';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).defaultTo('fr');
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/src/team/domain/models/OrganizationInvitation.js
+++ b/api/src/team/domain/models/OrganizationInvitation.js
@@ -26,6 +26,7 @@ const validationScheme = Joi.object({
   role: Joi.string()
     .valid(...Object.values(roles))
     .optional(),
+  locale: Joi.string().optional(),
   createdAt: Joi.date().optional(),
   updatedAt: Joi.date().optional(),
   organizationId: Joi.number().optional(),
@@ -39,6 +40,7 @@ class OrganizationInvitation {
     code,
     organizationName,
     role,
+    locale,
     createdAt,
     updatedAt,
     //references
@@ -50,6 +52,7 @@ class OrganizationInvitation {
     this.code = code;
     this.organizationName = organizationName;
     this.role = role;
+    this.locale = locale;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
     //references

--- a/api/src/team/domain/services/organization-invitation.service.js
+++ b/api/src/team/domain/services/organization-invitation.service.js
@@ -42,6 +42,7 @@ const createOrUpdateOrganizationInvitation = async ({
       email,
       code,
       role,
+      locale,
     });
   }
 
@@ -99,7 +100,13 @@ const createProOrganizationInvitation = async ({
 
   if (!organizationInvitation) {
     const code = _generateCode();
-    organizationInvitation = await organizationInvitationRepository.create({ organizationId, email, role, code });
+    organizationInvitation = await organizationInvitationRepository.create({
+      organizationId,
+      email,
+      role,
+      code,
+      locale,
+    });
   }
 
   await dependencies.mailService.sendOrganizationInvitationEmail({
@@ -148,7 +155,13 @@ const createScoOrganizationInvitation = async ({
   if (!organizationInvitation) {
     const code = _generateCode();
     const role = Membership.roles.ADMIN;
-    organizationInvitation = await organizationInvitationRepository.create({ organizationId, email, code, role });
+    organizationInvitation = await organizationInvitationRepository.create({
+      organizationId,
+      email,
+      code,
+      role,
+      locale,
+    });
   }
 
   const organization = await organizationRepository.get(organizationId);

--- a/api/src/team/infrastructure/repositories/organization-invitation.repository.js
+++ b/api/src/team/infrastructure/repositories/organization-invitation.repository.js
@@ -10,12 +10,13 @@ import { OrganizationInvitation } from '../../domain/models/OrganizationInvitati
  * @param {string} params.email
  * @param {string} params.code
  * @param {string} params.role
+ * @param {string} params.locale
  * @returns {Promise<OrganizationInvitation>}
  */
-const create = async function ({ organizationId, email, code, role }) {
+const create = async function ({ organizationId, email, code, role, locale }) {
   const status = OrganizationInvitation.StatusType.PENDING;
   const [organizationInvitationCreated] = await knex('organization-invitations')
-    .insert({ organizationId, email, status, code, role })
+    .insert({ organizationId, email, status, code, role, locale })
     .returning('*');
 
   return new OrganizationInvitation(organizationInvitationCreated);

--- a/api/src/team/infrastructure/serializers/jsonapi/organization-invitation.serializer.js
+++ b/api/src/team/infrastructure/serializers/jsonapi/organization-invitation.serializer.js
@@ -4,7 +4,13 @@ const { Serializer, Deserializer } = jsonapiSerializer;
 
 const serialize = function (invitations) {
   return new Serializer('organization-invitations', {
-    attributes: ['organizationId', 'organizationName', 'email', 'status', 'updatedAt', 'role'],
+    transform: (invitations) => {
+      return {
+        ...invitations,
+        lang: invitations.locale,
+      };
+    },
+    attributes: ['organizationId', 'organizationName', 'email', 'status', 'updatedAt', 'role', 'lang'],
   }).serialize(invitations);
 };
 

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -630,6 +630,7 @@ describe('Acceptance | Application | organization-controller', function () {
             email: userToReInvite.email,
             status: OrganizationInvitation.StatusType.PENDING,
             role: null,
+            lang: 'fr',
             'updated-at': now,
           },
         },

--- a/api/tests/team/acceptance/application/organization-invitations/organization-invitation.route.test.js
+++ b/api/tests/team/acceptance/application/organization-invitations/organization-invitation.route.test.js
@@ -345,6 +345,7 @@ describe('Acceptance | Team | Application | Controller | organization-invitation
                 status: OrganizationInvitation.StatusType.PENDING,
                 'updated-at': firstOrganizationInvitation.updatedAt,
                 role: firstOrganizationInvitation.role,
+                lang: firstOrganizationInvitation.locale,
               },
             },
             {
@@ -355,6 +356,7 @@ describe('Acceptance | Team | Application | Controller | organization-invitation
                 status: OrganizationInvitation.StatusType.PENDING,
                 'updated-at': secondOrganizationInvitation.updatedAt,
                 role: secondOrganizationInvitation.role,
+                lang: secondOrganizationInvitation.locale,
               },
             },
           ],
@@ -450,6 +452,7 @@ describe('Acceptance | Team | Application | Controller | organization-invitation
               email: user1.email,
               status,
               role: null,
+              lang: 'fr-fr',
             },
           },
           {
@@ -459,6 +462,7 @@ describe('Acceptance | Team | Application | Controller | organization-invitation
               email: user2.email,
               status,
               role: null,
+              lang: 'fr-fr',
             },
           },
         ];

--- a/api/tests/team/integration/domain/services/organization-invitation.service.test.js
+++ b/api/tests/team/integration/domain/services/organization-invitation.service.test.js
@@ -32,13 +32,15 @@ describe('Integration | Team | Domain | Service | organization-invitation', func
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       await databaseBuilder.commit();
 
-      const email = 'member@organization.org';
+      const email = 'member@example.net';
       const role = Membership.roles.ADMIN;
+      const locale = 'fr';
       const expectedOrganizationInvitation = {
         organizationId,
         email,
         status: OrganizationInvitation.StatusType.PENDING,
         role,
+        locale,
       };
 
       // when
@@ -46,6 +48,7 @@ describe('Integration | Team | Domain | Service | organization-invitation', func
         organizationId,
         email,
         role,
+        locale,
         organizationRepository,
         organizationInvitationRepository,
       });

--- a/api/tests/team/integration/infrastructure/repositories/organization-invitation.repository.test.js
+++ b/api/tests/team/integration/infrastructure/repositories/organization-invitation.repository.test.js
@@ -32,6 +32,7 @@ describe('Integration | Team | Infrastructure | Repository | organization-invita
       const status = OrganizationInvitation.StatusType.PENDING;
       const code = 'ABCDEFGH01';
       const role = Membership.roles.ADMIN;
+      const locale = 'fr';
 
       // when
       const savedInvitation = await organizationInvitationRepository.create({ organizationId, email, code, role });
@@ -43,6 +44,7 @@ describe('Integration | Team | Infrastructure | Repository | organization-invita
       expect(savedInvitation.status).equal(status);
       expect(savedInvitation.code).equal(code);
       expect(savedInvitation.role).equal(role);
+      expect(savedInvitation.locale).equal(locale);
     });
   });
 

--- a/api/tests/team/unit/domain/models/OrganizationInvitation_test.js
+++ b/api/tests/team/unit/domain/models/OrganizationInvitation_test.js
@@ -16,6 +16,7 @@ describe('Unit | Team | Domain | Model | OrganizationInvitation', function () {
         status: 'pending',
         code: 'ABCDEFGH01',
         role: null,
+        locale: 'fr',
         createdAt: today,
         updatedAt: today,
       };
@@ -39,6 +40,7 @@ describe('Unit | Team | Domain | Model | OrganizationInvitation', function () {
         status: 'pending',
         code: 'ABCDEFGH01',
         role: 'SUPER-ADMIN',
+        locale: 'fr',
         createdAt: today,
         updatedAt: today,
       };

--- a/api/tests/team/unit/domain/services/organization-invitation.service.test.js
+++ b/api/tests/team/unit/domain/services/organization-invitation.service.test.js
@@ -67,6 +67,7 @@ describe('Unit | Team | Domain | Service | organization-invitation', function ()
           email: userEmailAddress,
           code: sinon.match.string,
           role,
+          locale,
         });
         expect(mailService.sendOrganizationInvitationEmail).to.has.been.calledWithExactly({
           email: userEmailAddress,
@@ -247,6 +248,7 @@ describe('Unit | Team | Domain | Service | organization-invitation', function ()
         const organization = domainBuilder.buildOrganization();
         const organizationInvitation = new OrganizationInvitation({
           role: Membership.roles.ADMIN,
+          locale,
           status: 'pending',
           code,
         });
@@ -256,6 +258,7 @@ describe('Unit | Team | Domain | Service | organization-invitation', function ()
             email: userEmailAddress,
             code: sinon.match.string,
             role: organizationInvitation.role,
+            locale: organizationInvitation.locale,
           })
           .resolves(organizationInvitation);
         organizationRepository.get.resolves(organization);
@@ -295,6 +298,7 @@ describe('Unit | Team | Domain | Service | organization-invitation', function ()
         const organization = domainBuilder.buildOrganization();
         const organizationInvitation = new OrganizationInvitation({
           role: Membership.roles.ADMIN,
+          locale,
           status: 'pending',
           code,
         });
@@ -304,6 +308,7 @@ describe('Unit | Team | Domain | Service | organization-invitation', function ()
             email: userEmailAddress,
             code: sinon.match.string,
             role: organizationInvitation.role,
+            locale: organizationInvitation.locale,
           })
           .resolves(organizationInvitation);
         organizationRepository.get.resolves(organization);
@@ -425,6 +430,7 @@ describe('Unit | Team | Domain | Service | organization-invitation', function ()
         const organization = domainBuilder.buildOrganization();
         const organizationInvitation = new OrganizationInvitation({
           role: Membership.roles.MEMBER,
+          locale,
           status: 'pending',
           code,
         });
@@ -435,6 +441,7 @@ describe('Unit | Team | Domain | Service | organization-invitation', function ()
             organizationId: organization.id,
             email: userEmailAddress,
             role,
+            locale,
             code: sinon.match.string,
           })
           .resolves(organizationInvitation);

--- a/api/tests/team/unit/infrastructure/serializers/jsonapi/organization-invitation.serializer.test.js
+++ b/api/tests/team/unit/infrastructure/serializers/jsonapi/organization-invitation.serializer.test.js
@@ -22,6 +22,7 @@ describe('Unit | Serializer | JSONAPI | organization-invitation-serializer', fun
             status: invitationObject.status,
             'updated-at': invitationObject.updatedAt,
             role: invitationObject.role,
+            lang: invitationObject.locale,
           },
         },
       };

--- a/api/tests/tooling/domain-builder/factory/build-organization-invitation.js
+++ b/api/tests/tooling/domain-builder/factory/build-organization-invitation.js
@@ -8,6 +8,7 @@ const buildOrganizationInvitation = function ({
   status = OrganizationInvitation.StatusType.PENDING,
   code = 'ABCDE12345',
   role,
+  locale = 'fr',
   createdAt = new Date('2020-01-01'),
   updatedAt = new Date('2020-01-02'),
 } = {}) {
@@ -19,6 +20,7 @@ const buildOrganizationInvitation = function ({
     status,
     code,
     role,
+    locale,
     createdAt,
     updatedAt,
   });


### PR DESCRIPTION
Cette pr est la succession de la pr #11197 qui n'a pas pu être déployer et a été close.
## :pancakes: Problème

Sur Pix admin, section organisation, dans le tableau des personnes invitées à rejoindre l'équipe, on a juste un bouton pour annuler l'invitation.

## :bacon: Proposition

Ajouter un bouton permettant de renvoyer l'invitation, permettant ainsi de ne pas avoir à rentrer une nouvelle fois l'adresse mail.

## 🧃 Remarques
Le bouton est peut-être à remettre en forme.

## :yum: Pour tester
- Se rendre sur Pix Admin: https://admin-pr11246.review.pix.fr/login,
- Se connecter avec le compte superadmin @example.net,
- Aller sur une organisation (n'importe laquelle),
- Dans la section invitation, entrer un email dans le champ correspondant, choisissez une langue et un rôle et appuyez sur Envoyer,
- Une notification indiquant l'envoi de l'email devrait apparaître,
- Un tableau devrait s'afficher avec l'email précédemment entré, le type et la date d'envois de l'invitation,
Dans la colone de droite, à côté du bouton pour annuler, se trouve un bouton Renvoyer l'invitation à...,
- Attendre une minute,
- Cliquer sur le bouton,
- Constater qu'une nouvelle notification de succès apparaît,
- Constater également que la date d'envois a changé.
