### PR TITLE
[TECH]  Parcoursup : configuration compatible API manager pour exposer la documentation (PIX-16304).

### DIFF
--- a/api/tests/shared/acceptance/application/swaggers_test.js
+++ b/api/tests/shared/acceptance/application/swaggers_test.js
@@ -11,36 +11,15 @@ describe('Acceptance | Controller | Open Api', function () {
     server = await createServer();
   });
 
-  context('Pix API', function () {
-    describe('GET /api/swagger.json', function () {
-      it('should respond with a 200', async function () {
-        // given
-        const options = {
-          method: 'GET',
-          url: '/api/swagger.json',
-          headers: {},
-        };
-
-        // when
-        const response = await server.inject(options);
-
-        // then
-        expect(response.statusCode).to.equal(200);
-        expect(response.result.info.title).to.deep.equal('Welcome to the Pix api catalog');
-      });
-    });
-
-    context('Documentation pages', function () {
-      beforeEach(async function () {
-        await server.start();
-      });
-
-      describe('GET /api/documentation', function () {
+  context('Internal API definitons', function () {
+    context('Pix API', function () {
+      describe('GET /api/swagger.json', function () {
         it('should respond with a 200', async function () {
           // given
           const options = {
             method: 'GET',
-            url: '/api/documentation/',
+            url: '/api/swagger.json',
+            headers: {},
           };
 
           // when
@@ -48,176 +27,201 @@ describe('Acceptance | Controller | Open Api', function () {
 
           // then
           expect(response.statusCode).to.equal(200);
-          expect(response.result).to.contain('Welcome to the Pix api catalog');
+          expect(response.result.info.title).to.deep.equal('Welcome to the Pix api catalog');
+        });
+      });
+
+      context('Documentation pages', function () {
+        beforeEach(async function () {
+          await server.start();
+        });
+
+        describe('GET /api/documentation', function () {
+          it('should respond with a 200', async function () {
+            // given
+            const options = {
+              method: 'GET',
+              url: '/api/documentation/',
+            };
+
+            // when
+            const response = await server.inject(options);
+
+            // then
+            expect(response.statusCode).to.equal(200);
+            expect(response.result).to.contain('Welcome to the Pix api catalog');
+          });
+        });
+      });
+    });
+
+    context('Livret scolaire LSU/LSL', function () {
+      describe('GET /livret-scolaire/swagger.json', function () {
+        it('should respond with a 200', async function () {
+          // given
+          const options = {
+            method: 'GET',
+            url: '/livret-scolaire/swagger.json',
+            headers: {},
+          };
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          expect(response.result.info.title).to.deep.equal('Welcome to the Pix LSU/LSL Open Api');
+        });
+      });
+
+      context('Documentation pages', function () {
+        beforeEach(async function () {
+          await server.start();
+        });
+
+        describe('GET /livret-scolaire/documentation', function () {
+          it('should respond with a 200', async function () {
+            // given
+            const options = {
+              method: 'GET',
+              url: '/livret-scolaire/documentation/',
+            };
+
+            // when
+            const response = await server.inject(options);
+
+            // then
+            expect(response.statusCode).to.equal(200);
+            expect(response.result).to.contain('Welcome to the Pix LSU/LSL Open Api');
+          });
+        });
+      });
+    });
+
+    context('Pole Emploi', function () {
+      describe('GET /pole-emploi/swagger.json', function () {
+        it('should respond with a 200', async function () {
+          // given
+          const options = {
+            method: 'GET',
+            url: '/pole-emploi/swagger.json',
+            headers: {},
+          };
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          expect(response.result.info.title).to.deep.equal('Pix Pôle emploi Open Api');
+        });
+      });
+
+      context('Documentation page', function () {
+        beforeEach(async function () {
+          await server.start();
+        });
+
+        describe('GET /pole-emploi/documentation', function () {
+          it('should respond with a 200', async function () {
+            // given
+            const options = {
+              method: 'GET',
+              url: '/pole-emploi/documentation/',
+            };
+
+            // when
+            const response = await server.inject(options);
+
+            // then
+            expect(response.statusCode).to.equal(200);
+            expect(response.result).to.contain('Pix Pôle emploi Open Api');
+          });
+        });
+      });
+    });
+
+    context('Authorization-server', function () {
+      describe('GET /authorization-server/swagger.json', function () {
+        it('should respond with a 200', async function () {
+          // given
+          const options = {
+            method: 'GET',
+            url: '/authorization-server/swagger.json',
+            headers: {},
+          };
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          expect(response.result.info.title).to.deep.equal('Welcome to the Pix Authorization server');
+        });
+      });
+
+      context('Documentation page', function () {
+        beforeEach(async function () {
+          await server.start();
+        });
+
+        describe('GET /authorization-server/documentation', function () {
+          it('should respond with a 200', async function () {
+            // given
+            const options = {
+              method: 'GET',
+              url: '/authorization-server/documentation/',
+            };
+
+            // when
+            const response = await server.inject(options);
+
+            // then
+            expect(response.statusCode).to.equal(200);
+            expect(response.result).to.contain('Welcome to the Pix Authorization server');
+          });
         });
       });
     });
   });
 
-  context('Livret scolaire LSU/LSL', function () {
-    describe('GET /livret-scolaire/swagger.json', function () {
-      it('should respond with a 200', async function () {
-        // given
-        const options = {
-          method: 'GET',
-          url: '/livret-scolaire/swagger.json',
-          headers: {},
-        };
-        // when
-        const response = await server.inject(options);
-
-        // then
-        expect(response.statusCode).to.equal(200);
-        expect(response.result.info.title).to.deep.equal('Welcome to the Pix LSU/LSL Open Api');
-      });
-    });
-
-    context('Documentation pages', function () {
-      beforeEach(async function () {
-        await server.start();
-      });
-
-      describe('GET /livret-scolaire/documentation', function () {
+  context('API Manager definitions', function () {
+    context('Parcoursup', function () {
+      describe('GET /documentation/parcoursup/openapi.json', function () {
         it('should respond with a 200', async function () {
           // given
           const options = {
             method: 'GET',
-            url: '/livret-scolaire/documentation/',
+            url: '/documentation/parcoursup/openapi.json',
+            headers: {},
           };
-
           // when
           const response = await server.inject(options);
 
           // then
           expect(response.statusCode).to.equal(200);
-          expect(response.result).to.contain('Welcome to the Pix LSU/LSL Open Api');
+          expect(response.result.info.title).to.deep.equal('Pix Parcoursup Open Api');
+          expect(response.result.servers[0].url).to.equal(config.apiManager.url);
         });
       });
-    });
-  });
 
-  context('Pole Emploi', function () {
-    describe('GET /pole-emploi/swagger.json', function () {
-      it('should respond with a 200', async function () {
-        // given
-        const options = {
-          method: 'GET',
-          url: '/pole-emploi/swagger.json',
-          headers: {},
-        };
-        // when
-        const response = await server.inject(options);
-
-        // then
-        expect(response.statusCode).to.equal(200);
-        expect(response.result.info.title).to.deep.equal('Pix Pôle emploi Open Api');
-      });
-    });
-
-    context('Documentation page', function () {
-      beforeEach(async function () {
-        await server.start();
-      });
-
-      describe('GET /pole-emploi/documentation', function () {
-        it('should respond with a 200', async function () {
-          // given
-          const options = {
-            method: 'GET',
-            url: '/pole-emploi/documentation/',
-          };
-
-          // when
-          const response = await server.inject(options);
-
-          // then
-          expect(response.statusCode).to.equal(200);
-          expect(response.result).to.contain('Pix Pôle emploi Open Api');
+      context('Documentation page', function () {
+        beforeEach(async function () {
+          await server.start();
         });
-      });
-    });
-  });
 
-  context('Authorization-server', function () {
-    describe('GET /authorization-server/swagger.json', function () {
-      it('should respond with a 200', async function () {
-        // given
-        const options = {
-          method: 'GET',
-          url: '/authorization-server/swagger.json',
-          headers: {},
-        };
-        // when
-        const response = await server.inject(options);
+        describe('GET /documentation/parcoursup', function () {
+          it('should respond with a 200', async function () {
+            // given
+            const options = {
+              method: 'GET',
+              url: '/documentation/parcoursup',
+            };
 
-        // then
-        expect(response.statusCode).to.equal(200);
-        expect(response.result.info.title).to.deep.equal('Welcome to the Pix Authorization server');
-      });
-    });
+            // when
+            const response = await server.inject(options);
 
-    context('Documentation page', function () {
-      beforeEach(async function () {
-        await server.start();
-      });
-
-      describe('GET /authorization-server/documentation', function () {
-        it('should respond with a 200', async function () {
-          // given
-          const options = {
-            method: 'GET',
-            url: '/authorization-server/documentation/',
-          };
-
-          // when
-          const response = await server.inject(options);
-
-          // then
-          expect(response.statusCode).to.equal(200);
-          expect(response.result).to.contain('Welcome to the Pix Authorization server');
-        });
-      });
-    });
-  });
-
-  context('Parcoursup', function () {
-    describe('GET /api/application/parcoursup/swagger.json', function () {
-      it('should respond with a 200', async function () {
-        // given
-        const options = {
-          method: 'GET',
-          url: '/api/application/parcoursup/swagger.json',
-          headers: {},
-        };
-        // when
-        const response = await server.inject(options);
-
-        // then
-        expect(response.statusCode).to.equal(200);
-        expect(response.result.info.title).to.deep.equal('Pix Parcoursup Open Api');
-        expect(response.result.servers[0].url).to.equal(config.apiManager.url);
-      });
-    });
-
-    context('Documentation page', function () {
-      beforeEach(async function () {
-        await server.start();
-      });
-
-      describe('GET /api/application/parcoursup/documentation', function () {
-        it('should respond with a 200', async function () {
-          // given
-          const options = {
-            method: 'GET',
-            url: '/api/application/parcoursup/documentation/',
-          };
-
-          // when
-          const response = await server.inject(options);
-
-          // then
-          expect(response.statusCode).to.equal(200);
-          expect(response.result).to.contain('Pix Parcoursup Open Api');
+            // then
+            expect(response.statusCode).to.equal(200);
+            expect(response.result).to.contain('Pix Parcoursup Open Api');
+          });
         });
       });
     });


### PR DESCRIPTION
## :pancakes: Problème

Certains assets ne sont pas accessibles via l’APIM

## :bacon: Proposition

Valide avec les captains, a partir d’un reverse proxy en local avec Docker

* Regrouper les assets Swagger sous `/documentation`
* Les rendre accessible via le reverse proxy via un identifiant applicatif (donnera une url d'acces en `/documentation/mon_app_identifier` )

## 🧃 Remarques

Si une nouvelle application souhaitait desormais exposer sa documentation, il n'aura plus qu'a indiquer dans `swagger.js` : `extends ApiManagerAccess` pour rendre dispo sa docuentation cote gateway

## :yum: Pour tester

* Aller sur la RA à l'adresse https://api-pr11248.review.pix.fr/documentation/parcoursup
  * Dans la console de dev verifiez que tous les autres appelssHTTP sont sous  /documentation/ et rien d'autres
* Tenter un try it out complet
  * d'abord token
  * puis Authorize en mettant la valeur 'Bearer <token obtenu>'
  * puis search, par exemple sur l'INE `944385546HU`
 * Verifier que les autres swagger sont toujours OK
   * https://api-pr11248.review.pix.fr/pole-emploi/documentation
   * https://api-pr11248.review.pix.fr/api/documentation
   * https://api-pr11248.review.pix.fr/authorization-server/documentation
   * https://api-pr11248.review.pix.fr/livret-scolaire/documentation
