### PR TITLE
[TECH] Ne plus lancer la CI des PRs au statut draft

### DIFF
--- a/.github/workflows/trigger-ci.yaml
+++ b/.github/workflows/trigger-ci.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   trigger-ci:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false && github.event.pull_request.state == 'open'
 
     steps:
       - name: Extract branch name


### PR DESCRIPTION
## :pancakes: Problème
Avec #10444, l'équipe @1024pix/team-devcomp temporisait l'exécution de la CI sur les PRs non-draft au sens GitHub (sous entendu prêtes à être revues). Depuis #11199, l'équipe métier DevComp a une boucle de feedback plus efficace que la CI commune.

## :bacon: Proposition
Ne plus exécuter la CI commune sur les PRs en draft (comme proposé il y a quelques mois).

## 🧃 Remarques
J'ai repris la condition de [`check-pr-title.yaml`](https://github.com/1024pix/pix/blob/65acbc637183d12f655f582f7f6674fbf17f6adc/.github/workflows/check-pr-title.yaml#L8).

Il n'est pas évident de chiffrer l'impact financier/écologique de cette action, il conviendra de comparer sur des grosses périodes de temps.

## :yum: Pour tester

- [x] S'assurer que Circle CI n'est pas déclenché lors de l'ouverture de cette PR en draft,
- [ ] S'assurer que Circle CI se déclenche bien une fois que la PR est ouverte à la revue.