### PR TITLE
[FEATURE] Ajout d'un lien vers les explications de résultats sur le Certificat Pix (PIX-16247).

### DIFF
--- a/mon-pix/app/components/user-certifications-detail-header.hbs
+++ b/mon-pix/app/components/user-certifications-detail-header.hbs
@@ -37,6 +37,16 @@
           {{t "pages.certificate.professionalizing-warning"}}</p>
       {{/if}}
 
+      {{#if this.displayCertificationResultsExplanation}}
+        <PixButtonLink
+          @href={{this.certificationResultsExplanationUrl}}
+          target="_blank"
+          rel="noopener noreferrer"
+          @variant="tertiary"
+          @iconAfter="openNew"
+        > {{t "pages.certificate.learn-about-certification-results"}}</PixButtonLink>
+      {{/if}}
+
     </div>
   </div>
   {{#if @certification.verificationCode}}

--- a/mon-pix/app/components/user-certifications-detail-header.js
+++ b/mon-pix/app/components/user-certifications-detail-header.js
@@ -25,7 +25,7 @@ export default class UserCertificationsDetailHeader extends Component {
   }
 
   get displayCertificationResultsExplanation() {
-    return this.currentDomain.isFranceDomain || this.isUserFrenchReader;
+    return this.args.certification.isV3 && (this.currentDomain.isFranceDomain || this.isUserFrenchReader);
   }
 
   get certificationResultsExplanationUrl() {

--- a/mon-pix/app/components/user-certifications-detail-header.js
+++ b/mon-pix/app/components/user-certifications-detail-header.js
@@ -10,12 +10,26 @@ export default class UserCertificationsDetailHeader extends Component {
   @service fileSaver;
   @service session;
   @service currentDomain;
+  @service currentUser;
+  @service url;
 
   @tracked tooltipText = this.intl.t('pages.certificate.verification-code.copy');
   @tracked attestationDownloadErrorMessage = null;
 
   get birthdateMidnightLocalTime() {
     return parseISODateOnly(this.args.certification.birthdate);
+  }
+
+  get isUserFrenchReader() {
+    return this.currentUser.user && this.currentUser.user.lang === 'fr';
+  }
+
+  get displayCertificationResultsExplanation() {
+    return this.currentDomain.isFranceDomain || this.isUserFrenchReader;
+  }
+
+  get certificationResultsExplanationUrl() {
+    return this.url.certificationResultsExplanationUrl;
   }
 
   @action

--- a/mon-pix/app/models/certification.js
+++ b/mon-pix/app/models/certification.js
@@ -50,6 +50,10 @@ export default class Certification extends Model {
     );
   }
 
+  get isV3() {
+    return this.version === 3;
+  }
+
   get maxReachablePixCountOnCertificationDate() {
     return this.maxReachableLevelOnCertificationDate * 8 * 16;
   }

--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -132,6 +132,14 @@ export default class Url extends Service {
     return `https://status.pix.org/?locale=${currentLanguage}`;
   }
 
+  get certificationResultsExplanationUrl() {
+    if (this.currentDomain.isFranceDomain) {
+      return 'https://pix.fr/certification-comprendre-score-niveau';
+    }
+
+    return 'https://pix.org/fr/certification-comprendre-score-niveau';
+  }
+
   get _showcaseWebsiteUrl() {
     const currentLanguage = this.intl.primaryLocale;
 

--- a/mon-pix/tests/helpers/service-stubs.js
+++ b/mon-pix/tests/helpers/service-stubs.js
@@ -67,6 +67,7 @@ export function stubSessionService(owner, sessionData = {}) {
  * @param {string} [userData.firstName='John'] - The first name of the user.
  * @param {string} [userData.lastName='Doe'] - The last name of the user.
  * @param {string} [userData.email] - The email of the user.
+ * @param {string} [userData.lang] - The language of the user.
  * @param {Object} [userData.profile] - The profile of the user.
  * @param {boolean} [userData.mustValidateTermsOfService=false] - Indicates if the user must validate terms of service.
  * @param {boolean} [userData.hasRecommendedTrainings=false] - Indicates if the user has recommended trainings.
@@ -85,6 +86,7 @@ export function stubCurrentUserService(owner, userData = {}, { withStoreStubbed 
   const firstName = userData.firstName || 'John';
   const lastName = userData.lastName || 'Doe';
   const fullName = `${firstName} ${lastName}`;
+  const lang = userData.lang || 'fr';
   const email = userData.email || `${firstName.toLowerCase()}.${lastName.toLowerCase()}@example.net`;
   const codeForLastProfileToShare = userData.codeForLastProfileToShare || null;
   const mustValidateTermsOfService = userData.mustValidateTermsOfService || false;
@@ -123,6 +125,7 @@ export function stubCurrentUserService(owner, userData = {}, { withStoreStubbed 
             firstName,
             lastName,
             fullName,
+            lang,
             profile,
             codeForLastProfileToShare,
             mustValidateTermsOfService,

--- a/mon-pix/tests/integration/components/user-certifications-detail-header-test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-header-test.js
@@ -140,7 +140,7 @@ module('Integration | Component | user certifications detail header', function (
       });
     });
 
-    module('when certification is delivered before 2022-01-01', function () {
+    module('when certification is v2 and delivered before 2022-01-01', function () {
       test('should not display the professionalizing warning', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
@@ -260,6 +260,7 @@ module('Integration | Component | user certifications detail header', function (
         date: new Date('2018-02-15T15:15:52Z'),
         isPublished: true,
         status: 'validated',
+        version: 3,
       });
       this.set('certification', certification);
 
@@ -368,6 +369,7 @@ module('Integration | Component | user certifications detail header', function (
           date: new Date('2018-02-15T15:15:52Z'),
           isPublished: true,
           status: 'validated',
+          version: 3,
         });
         this.set('certification', certification);
 

--- a/mon-pix/tests/unit/services/url-test.js
+++ b/mon-pix/tests/unit/services/url-test.js
@@ -507,4 +507,36 @@ module('Unit | Service | url', function (hooks) {
       });
     });
   });
+
+  module('#certificationResultsExplanationUrl', function () {
+    module('when domain extension is .fr', function () {
+      test('returns the pix.fr website certification details page', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url');
+        service.currentDomain = { isFranceDomain: true };
+        const expectedCertificationResultsExplanationUrl = 'https://pix.fr/certification-comprendre-score-niveau';
+
+        // when
+        const certificationResultsExplanationUrl = service.certificationResultsExplanationUrl;
+
+        // then
+        assert.strictEqual(certificationResultsExplanationUrl, expectedCertificationResultsExplanationUrl);
+      });
+    });
+
+    module('when domain extension is .org', function () {
+      test('returns the pix.org website certification details page', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url');
+        service.currentDomain = { isFranceDomain: false };
+        const expectedCertificationResultsExplanationUrl = 'https://pix.org/fr/certification-comprendre-score-niveau';
+
+        // when
+        const certificationResultsExplanationUrl = service.certificationResultsExplanationUrl;
+
+        // then
+        assert.strictEqual(certificationResultsExplanationUrl, expectedCertificationResultsExplanationUrl);
+      });
+    });
+  });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -599,6 +599,7 @@
       "issued-on": "Delivered on",
       "jury-info": "Notes from the examining body are not displayed on the verification page of your certificate.",
       "jury-title": "Notes from the examining body",
+      "learn-about-certification-results": "Learn more about my Pix Certification results",
       "professionalizing-warning": "The Pix certificate is recognised as professionalising by France Compétences upon reaching a minimum score of 120 pix.",
       "title": "Pix Certificate",
       "verification-code": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -599,6 +599,7 @@
       "issued-on": "Délivré le",
       "jury-info": "Les observations du jury ne sont pas partagées sur la page de vérification de votre certificat.",
       "jury-title": "Observations du jury",
+      "learn-about-certification-results": "Comprendre mes résultats de Certification Pix",
       "professionalizing-warning": "Le certificat Pix est reconnu comme professionnalisant par France compétences à compter d’un score minimal de 120 pix",
       "title": "Certificat Pix",
       "verification-code": {


### PR DESCRIPTION
## :pancakes: Problème

Lorsque le candidat se connecte sur son espace Pix App, il peut aller consulter ses certificats Pix dans l’onglet “Mes certifications”.

Or, la certification Pix ayant évolué, le candidat peut avoir du mal à comprendre les résultats qui lui sont affichés.

## :bacon: Proposition

Ajout d'un lien vers l'explication des résultats de certif depuis les pages de certification sur Pix App :

- PixButtonLink en variant tertiary avec le texte “Comprendre mes résultats de Certification Pix” avec l’icône “lien externe” (à droite openNew)
- ouverture dans un nouvel onglet page Pix site : 
- UNIQUEMENT sur la version FR du Certificat Pix (page Pix Site non traduite en EN)

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

Se connecter à Pix-app `https://app-pr11250.review.pix.fr` avec `certif-success@example.net` (compte en français)
Aller sur la page des certificats
Aller sur la page de détails d'un des certificats
Vérifier que le lien vers le descriptif des résultats est présent et renvoie bien à l'adresse indiquée

Se connecter à Pix-app `https://app-pr11250.review.pix.org` avec `certif-success@example.net` (compte en français)
Aller sur la page des certificats
Aller sur la page de détails d'un des certificats
Vérifier que le lien vers le descriptif des résultats est présent et renvoie bien à l'adresse indiquée
Passer le compte du candidat dans une langue autre que le français dans ses paramètres
Vérifier que le lien n'est plus visible
