### PR TITLE
[TECH] Ajouter un script pour actualiser les fichiers de traductions

### DIFF
--- a/api/scripts/update-audit-api-csv-file.js
+++ b/api/scripts/update-audit-api-csv-file.js
@@ -60,7 +60,7 @@ async function main() {
   }
 
   // fetch current route from prod
-  // eslint-disable-next-line n/no-unsupported-features/node-builtins
+
   const response = await fetch(swaggerUrl);
   const swaggerJson = await response.json();
   const currentPixRoutes = extractRoutes(swaggerJson);

--- a/api/scripts/update-translations.js
+++ b/api/scripts/update-translations.js
@@ -1,0 +1,128 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { Script } from '../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../src/shared/application/scripts/script-runner.js';
+
+export class UpdateTranslations extends Script {
+  constructor() {
+    super({
+      description: 'This script is used to update the translations in the application',
+      permanent: true,
+      options: {
+        source: {
+          type: 'string',
+          describe: 'The source file',
+          demandOption: true,
+        },
+        targets: {
+          type: 'array',
+          describe: 'The list of target files.',
+          demandOption: true,
+        },
+        dryRun: {
+          type: 'boolean',
+          describe: 'If true: Write in files',
+          default: false,
+        },
+      },
+    });
+    this.informations = {
+      new: 0,
+      old: 0,
+      write: 0,
+      delete: 0,
+    };
+  }
+
+  async handle({ options, logger }) {
+    const { source, targets, dryRun } = options;
+    this.checkExtension(source, targets);
+    const sourceFile = await this.readAndConvertFile(source);
+    for (const target of targets) {
+      logger.info(`Runs on ${target}`);
+      const targetFile = await this.readAndConvertFile(target);
+      const updater = this.checkAndUpdate({ baseLanguage: sourceFile, targetLanguage: targetFile, logger, dryRun });
+      const withoutOld = this.clearOldValues({ baseLanguage: sourceFile, targetLanguage: updater, logger, dryRun });
+      if (!dryRun) {
+        await this.writeFile(target, withoutOld);
+      }
+      logger.info(
+        `Done with ${this.informations.new} new key found, ${this.informations.write} written, ${this.informations.old} old translation and ${this.informations.delete} deleted.`,
+      );
+      this.informations = {
+        new: 0,
+        old: 0,
+        write: 0,
+        delete: 0,
+      };
+    }
+  }
+
+  checkExtension(source, targets) {
+    const sourceExtension = path.extname(source);
+    if (sourceExtension !== '.json') {
+      throw new Error('The source file must be a JSON file');
+    }
+    if (targets.map((target) => path.extname(target)).some((ext) => ext !== '.json')) {
+      throw new Error('All target files must be JSON files');
+    }
+    return true;
+  }
+
+  async readAndConvertFile(filePath) {
+    const file = await fs.promises.readFile(filePath, 'utf-8');
+    return JSON.parse(file);
+  }
+
+  async writeFile(filePath, content) {
+    await fs.promises.writeFile(filePath, JSON.stringify(content, null, 2));
+  }
+
+  checkAndUpdate({ baseLanguage, targetLanguage, dryRun, logger }) {
+    for (const key in baseLanguage) {
+      if (typeof baseLanguage[key] === 'object') {
+        targetLanguage[key] = this.checkAndUpdate({
+          baseLanguage: baseLanguage[key],
+          targetLanguage: targetLanguage[key] || {},
+          logger,
+          dryRun,
+        });
+      } else {
+        if (!targetLanguage[key]) {
+          logger.info(`New key found: ${key}`);
+          if (!dryRun) {
+            targetLanguage[key] = `*${baseLanguage[key]}`;
+            this.informations.write++;
+          }
+          this.informations.new++;
+        }
+      }
+    }
+    return targetLanguage;
+  }
+
+  clearOldValues({ baseLanguage, targetLanguage, logger, dryRun }) {
+    for (const key in targetLanguage) {
+      if (typeof targetLanguage[key] === 'object') {
+        targetLanguage[key] = this.clearOldValues({
+          baseLanguage: baseLanguage[key] || {},
+          targetLanguage: targetLanguage[key],
+          logger,
+          dryRun,
+        });
+      }
+      if (!baseLanguage[key]) {
+        logger.info(`Old key found: ${key}`);
+        if (!dryRun) {
+          delete targetLanguage[key];
+          this.informations.delete++;
+        }
+        this.informations.old++;
+      }
+    }
+    return targetLanguage;
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, UpdateTranslations);

--- a/api/scripts/wait-for-api-deployment.js
+++ b/api/scripts/wait-for-api-deployment.js
@@ -21,7 +21,6 @@ while (true) {
 async function fetchApiInfoURL() {
   console.info('Fetching', apiInfoURL.href);
 
-  // eslint-disable-next-line n/no-unsupported-features/node-builtins
   const res = await fetch(apiInfoURL);
   if (!res.ok) {
     if (res.status === 404) {

--- a/api/tests/integration/scripts/update-translations_test.js
+++ b/api/tests/integration/scripts/update-translations_test.js
@@ -1,0 +1,123 @@
+import fs from 'node:fs';
+
+import { UpdateTranslations } from '../../../scripts/update-translations.js';
+import { expect, sinon } from '../../test-helper.js';
+
+describe('integration | scripts | update-translations', function () {
+  let script;
+  let logger;
+
+  beforeEach(function () {
+    logger = { info: sinon.stub() };
+    script = new UpdateTranslations();
+    sinon.stub(fs.promises, 'writeFile');
+    sinon.stub(fs.promises, 'readFile');
+  });
+
+  describe('#handle', function () {
+    context('when a file is not a json', function () {
+      it('should return an error if source is not a json', function () {
+        // given
+        const source = 'source';
+        const target = ['target.json'];
+
+        // when
+        const result = script.handle(source, target, logger);
+
+        // then
+        expect(result).to.be.rejectedWith('The source file must be a JSON file');
+      });
+      it('should return an error if one target file is not a json', function () {
+        // given
+        const source = 'source.json';
+        const target = ['target1'];
+
+        // when
+        const result = script.handle(source, target, logger);
+
+        // then
+        expect(result).to.be.rejectedWith('The target file must be a JSON file');
+      });
+    });
+
+    describe('dryRun mode', function () {
+      it('should display translations informations', async function () {
+        // given
+        const source = 'source.json';
+        const targets = ['target.json'];
+        fs.promises.readFile.withArgs(source).resolves('{"key": "value", "key2": "value2"}');
+        fs.promises.readFile.withArgs(targets[0]).resolves('{"key": "value"}');
+
+        // when
+        await script.handle({ options: { source, targets, dryRun: true }, logger });
+
+        // then
+        expect(logger.info).to.have.been.calledWith('New key found: key2');
+        expect(logger.info).to.have.been.calledWith(
+          'Done with 1 new key found, 0 written, 0 old translation and 0 deleted.',
+        );
+      });
+    });
+
+    describe('without dryRun', function () {
+      it('should actualize translations', async function () {
+        // given
+        const source = 'source.json';
+        const targets = ['target1.json', 'target2.json'];
+        const sourceTranslation = {
+          key: 'value',
+          key2: 'value2',
+          object: { subkey1: 'subvalue1', subkey2: 'subvalue2' },
+        };
+        const targetTranslation1 = {
+          key: 'value',
+          object: { subkey1: 'subvalue1', subkey2: 'subvalue2' },
+        };
+        const expectedTranslation1 = {
+          key: 'value',
+          object: { subkey1: 'subvalue1', subkey2: 'subvalue2' },
+          key2: '*value2',
+        };
+        const targetTranslation2 = { key: 'value', key3: 'value3', object: { subkey1: 'subvalue1' } };
+        const expectedTranslation2 = {
+          key: 'value',
+          object: { subkey1: 'subvalue1', subkey2: '*subvalue2' },
+          key2: '*value2',
+        };
+        fs.promises.readFile.withArgs(source).resolves(JSON.stringify(sourceTranslation));
+        fs.promises.readFile.withArgs(targets[0]).resolves(JSON.stringify(targetTranslation1));
+        fs.promises.readFile.withArgs(targets[1]).resolves(JSON.stringify(targetTranslation2));
+        fs.promises.writeFile.withArgs(targets[0], expectedTranslation1).resolves();
+        fs.promises.writeFile.withArgs(targets[1], expectedTranslation2).resolves();
+
+        // when
+        await script.handle({ options: { source, targets, dryRun: false }, logger });
+
+        // then
+        const expectedLogs = [
+          'Runs on target1.json',
+          'New key found: key2',
+          'Done with 1 new key found, 1 written, 0 old translation and 0 deleted.',
+          'Runs on target2.json',
+          'New key found: key2',
+          'New key found: subkey2',
+          'Old key found: key3',
+          'Done with 2 new key found, 2 written, 1 old translation and 1 deleted.',
+        ];
+        expect(logger.info).to.have.callCount(expectedLogs.length);
+        expectedLogs.forEach((log, index) => {
+          expect(logger.info.getCall(index)).to.have.been.calledWith(log);
+        });
+        expect(fs.promises.writeFile).to.have.callCount(2);
+        expect(fs.promises.writeFile).to.have.been.calledWith(
+          targets[0],
+          JSON.stringify(expectedTranslation1, null, 2),
+        );
+        expect(fs.promises.writeFile).to.have.been.calledWith(
+          targets[1],
+          JSON.stringify(expectedTranslation2, null, 2),
+        );
+      });
+    });
+  });
+});

--- a/api/tests/unit/scripts/update-translations_test.js
+++ b/api/tests/unit/scripts/update-translations_test.js
@@ -1,0 +1,150 @@
+import fs from 'node:fs';
+
+import { UpdateTranslations } from '../../../scripts/update-translations.js';
+import { expect, sinon } from '../../test-helper.js';
+
+describe('unit | scripts | update-translations', function () {
+  let script;
+  let logger;
+
+  beforeEach(function () {
+    logger = { info: sinon.stub() };
+    script = new UpdateTranslations();
+  });
+
+  describe('#checkExtension', function () {
+    it('should return an error if source file is incorrect', function () {
+      // given
+      const sourceFile = 'test.txt';
+      const targetFiles = ['test.json'];
+      // when / then
+      expect(() => script.checkExtension(sourceFile, targetFiles)).to.throw('The source file must be a JSON file');
+    });
+
+    it('should return an error if extension of any target files is incorrect', function () {
+      // given
+      const sourceFile = 'test.json';
+      const targetFiles = ['test0.json', 'test.txt'];
+
+      // when / then
+      expect(() => script.checkExtension(sourceFile, targetFiles)).to.throw('All target files must be JSON files');
+    });
+
+    it('should return true if all files format is correct', function () {
+      // given
+      const sourceFile = 'test.json';
+      const targetFiles = ['test0.json', 'test1.json'];
+
+      // when
+      const result = script.checkExtension(sourceFile, targetFiles);
+
+      // then
+      expect(result).to.be.true;
+    });
+  });
+
+  describe('#readAndConvertFile', function () {
+    beforeEach(function () {
+      sinon.stub(fs.promises, 'readFile');
+    });
+
+    it('should return the json content', function () {
+      // given
+      const filePath = 'test.json';
+      const fileContent = '{"key": "value"}';
+      fs.promises.readFile.resolves(fileContent);
+
+      // when
+      const result = script.readAndConvertFile(filePath);
+
+      // then
+      return expect(result).to.eventually.deep.equal({ key: 'value' });
+    });
+  });
+
+  describe('#writeFile', function () {
+    beforeEach(function () {
+      sinon.stub(fs.promises, 'writeFile');
+    });
+
+    it('should write in file', function () {
+      // given
+      const filePath = 'test.json';
+      const content = { key: 'value' };
+
+      // when
+      script.writeFile(filePath, content);
+
+      // then
+      expect(fs.promises.writeFile).to.have.been.calledWith(filePath, JSON.stringify(content, null, 2));
+    });
+  });
+
+  describe('#checkAndUpdate', function () {
+    it('should not update if dryRun', function () {
+      // given
+      const baseLanguage = { key: 'value' };
+      const targetLanguage = {};
+
+      // when
+      script.checkAndUpdate({ baseLanguage, targetLanguage, dryRun: true, logger });
+
+      // then
+      expect(targetLanguage).to.deep.equal({});
+      expect(logger.info).to.have.been.calledWith('New key found: key');
+    });
+
+    it('should modify if not dryRun', function () {
+      // given
+      const baseLanguage = { key: 'value' };
+      const targetLanguage = {};
+
+      // when
+      script.checkAndUpdate({ baseLanguage, targetLanguage, dryRun: false, logger });
+
+      // then
+      expect(targetLanguage).to.deep.equal({ key: '*value' });
+      expect(logger.info).to.have.been.calledWith('New key found: key');
+    });
+
+    it('should modify with a complex object', function () {
+      // given
+      const baseLanguage = { key: { key1: 'value1' }, key2: 'value2' };
+      const targetLanguage = { key: { key1: 'value1' } };
+
+      // when
+      script.checkAndUpdate({ baseLanguage, targetLanguage, dryRun: false, logger });
+
+      // then
+      expect(targetLanguage).to.deep.equal({ key: { key1: 'value1' }, key2: '*value2' });
+      expect(logger.info).to.have.been.calledWith('New key found: key2');
+    });
+  });
+
+  describe('#clearOldValues', function () {
+    it('should not clear if dryRun', function () {
+      // given
+      const baseLanguage = { key: 'value' };
+      const targetLanguage = { key: 'value', key2: 'value2' };
+
+      // when
+      script.clearOldValues({ baseLanguage, targetLanguage, dryRun: true, logger });
+
+      // then
+      expect(targetLanguage).to.deep.equal({ key: 'value', key2: 'value2' });
+      expect(logger.info).to.have.been.calledWith('Old key found: key2');
+    });
+
+    it('should modify if not dryRun', function () {
+      // given
+      const baseLanguage = { key: 'value' };
+      const targetLanguage = { key: 'value', key2: 'value2' };
+
+      // when
+      script.clearOldValues({ baseLanguage, targetLanguage, dryRun: false, logger });
+
+      // then
+      expect(targetLanguage).to.deep.equal({ key: 'value' });
+    });
+  });
+});


### PR DESCRIPTION
## :pancakes: Problème

Lorsqu'on ajoute une nouvelle traduction, il faut l'ajouter à la main dans les fichiers anglais et français, voir les autres langues dans certains cas. Cela peut être rapidement agaçant et nécessite de manipuler les fichiers de traduction.

## :bacon: Proposition

Concevoir un script qui va, à partir d'un fichier source, actualiser toutes les clef dans les fichiers cibles. Les clefs seront ajoutées aux fichiers cible et préremplis avec la chaîne du fichier d'origine, n'attendant plus qu'à être traduites par qui de droit.

## 🧃 Remarques

On n'utilisera pas de système de traduction automatique.

## :yum: Pour tester

- Prendre 2 fichiers de traductions de 2 langues différentes, par exemple français et anglais de l'API,
- Exécuter cette comande en local depuis l'API:
```shell
node scripts/update-translations.js --source <fichier_source.json> --targets <fichier1.json> <fichier2.json>
```
- Constater ensuite dans les fichiers de l'argument --targets que de nouvelles clef sont apparues avec des chaînes dans la langue du fichier d'origine avec un * au début de la chaîne.
Astuce: Vous pouvez ajouter --dryRun dans la commande pour juste voir les fichiers qui seront modifier sans rendre les modifications effectives.