### PR TITLE
[FEATURE] Afficher dans les détails d'une organisation si la fonctionnalitée Attestations est activée (PIX-15550)

### DIFF
--- a/admin/app/components/organizations/information-section-view.gjs
+++ b/admin/app/components/organizations/information-section-view.gjs
@@ -187,6 +187,9 @@ export default class OrganizationInformationSection extends Component {
             {{#if @organization.isComputeCertificabilityEnabled}}
               <li>Certificabilité automatique activée</li>
             {{/if}}
+            {{#if @organization.isAttestationsEnabled}}
+              <li>{{t "components.organizations.information-section-view.features.attestations"}}</li>
+            {{/if}}
 
           </ul>
           {{#if this.accessControl.hasAccessToOrganizationActionsScope}}

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -43,12 +43,18 @@ export default class Organization extends Model {
       PLACES_MANAGEMENT: 'PLACES_MANAGEMENT',
       COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY: 'COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY',
       LEARNER_IMPORT: 'LEARNER_IMPORT',
+      ATTESTATIONS_MANAGEMENT: 'ATTESTATIONS_MANAGEMENT',
     };
   }
 
   get isComputeCertificabilityEnabled() {
     if (!this.features) return false;
     return this.features[Organization.featureList.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY].active;
+  }
+
+  get isAttestationsEnabled() {
+    if (!this.features) return false;
+    return this.features[Organization.featureList.ATTESTATIONS_MANAGEMENT].active;
   }
 
   get isLearnerImportEnabled() {

--- a/admin/tests/acceptance/authenticated/organizations/information-management-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management-test.js
@@ -23,6 +23,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
           LEARNER_IMPORT: { active: false },
           MULTIPLE_SENDING_ASSESSMENT: { active: false },
           COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY: { active: false },
+          ATTESTATIONS_MANAGEMENT: { active: false },
         },
       });
       this.server.create('organization', { id: '1234' });

--- a/admin/tests/integration/components/organizations/information-section-view-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-view-test.gjs
@@ -1,6 +1,7 @@
 import { render } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
+import { t } from 'ember-intl/test-support';
 import InformationSectionView from 'pix-admin/components/organizations/information-section-view';
 import { module, test } from 'qunit';
 
@@ -319,30 +320,65 @@ module('Integration | Component | organizations/information-section-view', funct
     });
 
     module('Features', function () {
-      module('when compute certificability is true', function () {
-        test('should display this information', async function (assert) {
-          // given
-          const organization = EmberObject.create({
-            isComputeCertificabilityEnabled: true,
-          });
+      module('Compute certificability', function () {
+        module('when compute certificability is true', function () {
+          test('should display this information', async function (assert) {
+            // given
+            const organization = EmberObject.create({
+              isComputeCertificabilityEnabled: true,
+            });
 
-          // when
-          const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
-          // then
-          assert.ok(screen.getByText('Certificabilité automatique activée'));
+            // when
+            const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+            // then
+            assert.ok(screen.getByText('Certificabilité automatique activée'));
+          });
+        });
+
+        module('when compute certificability is false', function () {
+          test('should not display this information', async function (assert) {
+            // given
+            const organization = EmberObject.create({
+              isComputeCertificabilityEnabled: false,
+            });
+
+            // when
+            const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+            // then
+            assert.notOk(screen.queryByText('Certificabilité automatique activée'));
+          });
         });
       });
-      module('when compute certificability is false', function () {
-        test('should not display this information', async function (assert) {
-          // given
-          const organization = EmberObject.create({
-            isComputeCertificabilityEnabled: false,
-          });
 
-          // when
-          const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
-          // then
-          assert.notOk(screen.queryByText('Certificabilité automatique activée'));
+      module('Attestations', function () {
+        module('when attestations is enabled', function () {
+          test('should display this information', async function (assert) {
+            // given
+            const organization = EmberObject.create({
+              isAttestationsEnabled: true,
+            });
+
+            // when
+            const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+            // then
+            assert.ok(screen.getByText(t('components.organizations.information-section-view.features.attestations')));
+          });
+        });
+
+        module('when attestations is not enabled', function () {
+          test('should not display this information', async function (assert) {
+            // given
+            const organization = EmberObject.create({
+              isAttestationsEnabled: false,
+            });
+
+            // when
+            const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+            // then
+            assert.notOk(
+              screen.queryByText(t('components.organizations.information-section-view.features.attestations')),
+            );
+          });
         });
       });
     });

--- a/admin/tests/unit/models/organization-test.js
+++ b/admin/tests/unit/models/organization-test.js
@@ -48,6 +48,50 @@ module('Unit | Model | organization', function (hooks) {
     });
   });
 
+  module('#isAttestationsEnabled', function () {
+    module('#get', function () {
+      test('it returns true when feature is enabled', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const model = store.createRecord('organization', {
+          features: { ['ATTESTATIONS_MANAGEMENT']: { active: true } },
+        });
+
+        // when
+        const isAttestationsEnabled = model.isAttestationsEnabled;
+
+        // then
+        assert.true(isAttestationsEnabled);
+      });
+
+      test('it returns false when feature is disabled', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const model = store.createRecord('organization', {
+          features: { ['ATTESTATIONS_MANAGEMENT']: { active: false } },
+        });
+
+        // when
+        const isAttestationsEnabled = model.isAttestationsEnabled;
+
+        // then
+        assert.false(isAttestationsEnabled);
+      });
+
+      test('it returns false when no features are provided', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const model = store.createRecord('organization', {});
+
+        // when
+        const isAttestationsEnabled = model.isAttestationsEnabled;
+
+        // then
+        assert.false(isAttestationsEnabled);
+      });
+    });
+  });
+
   module('#isLearnerImportEnabled', function () {
     module('#get', function () {
       test('it returns true when feature is enabled', function (assert) {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -342,6 +342,9 @@
       },
       "information-section-view": {
         "child-organization": "Child organization",
+        "features": {
+          "attestations": "Attestations enabled"
+        },
         "parent-organization": "Parent organization"
       }
     },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -350,6 +350,9 @@
       },
       "information-section-view": {
         "child-organization": "Organisation fille",
+        "features": {
+          "attestations": "Attestations activée"
+        },
         "parent-organization": "Organisation mère"
       }
     },


### PR DESCRIPTION
## :pancakes: Problème
On informe pas les utilisateurs de PixAdmin si la feature "Attestations" est activée pour une organisation dans la page de détail de celle-ci

## :bacon: Proposition
Ajouter l'information uniquement dans le cas ou la feature est activée

## 🧃 Remarques
Un refacto sur ce composant/model concernant les features sera fait dans une prochaine PR dédiée

## :yum: Pour tester

- Se connecter a PixAdmin
- Aller sur l'orga "Attestations"
- Vérifier que l'information de la feature activée est bien présente
- Aller sur la page de l'orga "PRO Classic"
- Vérifier que l'information maintenant n'apparait pas
- 🐈‍⬛ 
