### PR TITLE
[BUGFIX] Récupérer uniquement les compétences sur le référentiel Pix Coeur pour le scoring V3 (PIX-16272).

### DIFF
--- a/api/src/certification/shared/infrastructure/repositories/scoring-configuration-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/scoring-configuration-repository.js
@@ -6,6 +6,7 @@ import { V3CertificationScoring } from '../../domain/models/V3CertificationScori
 
 export const getLatestByDateAndLocale = async ({ locale, date }) => {
   const allAreas = await areaRepository.list();
+  // NOTE : only works for certification of core competencies
   const competenceList = await competenceRepository.listPixCompetencesOnly({ locale });
 
   const competenceScoringConfiguration = await knex('competence-scoring-configurations')

--- a/api/src/certification/shared/infrastructure/repositories/scoring-configuration-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/scoring-configuration-repository.js
@@ -6,7 +6,7 @@ import { V3CertificationScoring } from '../../domain/models/V3CertificationScori
 
 export const getLatestByDateAndLocale = async ({ locale, date }) => {
   const allAreas = await areaRepository.list();
-  const competenceList = await competenceRepository.list({ locale });
+  const competenceList = await competenceRepository.listPixCompetencesOnly({ locale });
 
   const competenceScoringConfiguration = await knex('competence-scoring-configurations')
     .select('configuration')


### PR DESCRIPTION
## :pancakes: Problème

A l’heure actuelle, dans l'étape de scoring, nous récupérons l’entièreté du référentiel de Pix (Coeur + 1D + Complémentaires, etc) et donc des compétences qui le composent.

Lors du calcul de niveau par compétence, nous passons par la méthode V3CertificationScoring.fromConfigurations()

Cette méthode se base sur la configuration de score par compétence enregistrée en BDD et dont le schéma est comme suit : 

```
[
  { competence: "1.1", values: [{competenceLevel: 0, bounds: {min: -8, max: -6}, {competenceLevel: 1, bounds: {min: -6, max: -4}, ...},
  { competence: "1.2", values: [{competenceLevel: 0, bounds: {min: -8, max: -5.5}, {competenceLevel: 1, bounds: {min: -5.5, max: -3}, ...}, 
  ...
]
```

A partir de cette liste, nous tentons de calculer le niveau par compétence du candidat.
Pour cela, nous retrouvons la compétence en question en se basant sur le code de chaque compétence (ex: competence: "1.1") utilisé dans la configuration ci-dessus, de façon à ce qu’il corresponde à l’un des codes de compétences passés en paramètre de la fonction sous le nom de competenceList 

Or, ce code peut être retrouvé dans plusieurs référentiels de Pix et ne peut donc être utilisé pour trouver la compétence en question.
Ceci entraine l’enregistrement de competence-marks dont l’ origin (= réferentiel) est erronée. 

## :bacon: Proposition

Récupérer uniquement les compétences provenant du référentiel Pix Coeur

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

- Créer une session V3
- Ajouter un candidat
- Passer la certification
- Une fois le test complété, vérifier en BDD que l'origin des competences-marks qui ont été créées soit uniquement `Pix`
