### PR TITLE
[FEATURE] Créer une fonction de révocation des accès utilisateurs (PIX-15947)

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -712,6 +712,12 @@ REFRESH_TOKEN_LIFESPAN=7d
 # default: '7d'
 # REFRESH_TOKEN_LIFESPAN_PIX_ADMIN=7d
 
+# Revoked user access lifespan
+# presence: optional
+# type: String
+# default: '7d'
+# REVOKED_USER_ACCESS_LIFESPAN=7d
+
 # Saml access token lifespan
 # presence: optional
 # type: String

--- a/api/src/identity-access-management/domain/errors.js
+++ b/api/src/identity-access-management/domain/errors.js
@@ -70,6 +70,18 @@ class UserCantBeCreatedError extends DomainError {
   }
 }
 
+class RevokeUntilMustBeAnInstanceOfDate extends DomainError {
+  constructor(message = 'Revoke Until must be an instance of Date') {
+    super(message);
+  }
+}
+
+class UserIdIsRequiredError extends DomainError {
+  constructor(message = 'User Id is required') {
+    super(message);
+  }
+}
+
 class UserShouldChangePasswordError extends DomainError {
   constructor(message = 'User password must be changed.', meta) {
     super(message);
@@ -87,6 +99,8 @@ export {
   OrganizationLearnerNotBelongToOrganizationIdentityError,
   PasswordNotMatching,
   PasswordResetDemandNotFoundError,
+  RevokeUntilMustBeAnInstanceOfDate,
   UserCantBeCreatedError,
+  UserIdIsRequiredError,
   UserShouldChangePasswordError,
 };

--- a/api/src/identity-access-management/domain/models/RevokedUserAccess.js
+++ b/api/src/identity-access-management/domain/models/RevokedUserAccess.js
@@ -1,0 +1,12 @@
+export class RevokedUserAccess {
+  constructor(revokeTimeStamp) {
+    this.revokeTimeStamp = revokeTimeStamp;
+  }
+  isAccessTokenRevoked(decodedToken) {
+    const issuedAt = decodedToken.iat;
+    if (!this.revokeTimeStamp) {
+      return false;
+    }
+    return issuedAt < this.revokeTimeStamp;
+  }
+}

--- a/api/src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js
@@ -1,0 +1,31 @@
+import { config } from '../../../../src/shared/config.js';
+import { temporaryStorage } from '../../../../src/shared/infrastructure/key-value-storages/index.js';
+import { UserIdIsRequiredError } from '../../domain/errors.js';
+import { RevokeUntilMustBeAnInstanceOfDate } from '../../domain/errors.js';
+import { RevokedUserAccess } from '../../domain/models/RevokedUserAccess.js';
+
+const revokedUserAccessTemporaryStorage = temporaryStorage.withPrefix('revoked-user-access:');
+const revokedUserAccessLifespanMs = config.authentication.revokedUserAccessLifespanMs;
+
+const saveForUser = async function (userId, revokeUntil) {
+  if (!userId) {
+    throw new UserIdIsRequiredError();
+  }
+
+  if (!(revokeUntil instanceof Date)) {
+    throw new RevokeUntilMustBeAnInstanceOfDate();
+  }
+
+  await revokedUserAccessTemporaryStorage.save({
+    key: userId,
+    value: Math.floor(revokeUntil.getTime() / 1000),
+    expirationDelaySeconds: revokedUserAccessLifespanMs / 1000,
+  });
+};
+
+const findByUserId = async function (userId) {
+  const value = await revokedUserAccessTemporaryStorage.get(userId);
+  return new RevokedUserAccess(value);
+};
+
+export const revokedUserAccessRepository = { saveForUser, findByUserId };

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -161,6 +161,7 @@ const configuration = (function () {
         'pix-certif': ms(process.env.REFRESH_TOKEN_LIFESPAN_PIX_CERTIF || '7d'),
         'pix-admin': ms(process.env.REFRESH_TOKEN_LIFESPAN_PIX_ADMIN || '7d'),
       },
+      revokedUserAccessLifespanMs: ms(process.env.REVOKED_USER_ACCESS_LIFESPAN || '7d'),
       tokenForCampaignResultLifespan: process.env.CAMPAIGN_RESULT_ACCESS_TOKEN_LIFESPAN || '1h',
       tokenForStudentReconciliationLifespan: '1h',
       passwordResetTokenLifespan: '1h',

--- a/api/src/shared/infrastructure/validate-environment-variables.js
+++ b/api/src/shared/infrastructure/validate-environment-variables.js
@@ -1,6 +1,7 @@
 import Joi from 'joi';
 
 const schema = Joi.object({
+  ACCESS_TOKEN_LIFESPAN: Joi.string().optional(),
   AUTH_SECRET: Joi.string().required(),
   AUTONOMOUS_COURSES_ORGANIZATION_ID: Joi.number().required(),
   API_DATA_URL: Joi.string().uri().optional(),
@@ -59,6 +60,7 @@ const schema = Joi.object({
   POLE_EMPLOI_SENDING_URL: Joi.string().uri().optional(),
   POLE_EMPLOI_TOKEN_URL: Joi.string().uri().optional(),
   REDIS_URL: Joi.string().uri().optional(),
+  REVOKED_USER_ACCESS_LIFESPAN: Joi.string().optional(),
   SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES: Joi.number().integer().min(1).optional(),
   TEST_DATABASE_URL: Joi.string().optional(),
   TEST_LOG_ENABLED: Joi.string().optional().valid('true', 'false'),

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/revoked-user-access.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/revoked-user-access.repository.test.js
@@ -1,0 +1,45 @@
+import { RevokedUserAccess } from '../../../../../src/identity-access-management/domain/models/RevokedUserAccess.js';
+import { revokedUserAccessRepository } from '../../../../../src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js';
+import { temporaryStorage } from '../../../../../src/shared/infrastructure/key-value-storages/index.js';
+import { expect } from '../../../../test-helper.js';
+
+const revokedUserAccessTemporaryStorage = temporaryStorage.withPrefix('revoked-user-access:');
+
+describe('Integration | Identity Access Management | Infrastructure | Repository | revoked-user', function () {
+  beforeEach(async function () {
+    await revokedUserAccessTemporaryStorage.flushAll();
+  });
+
+  describe('#saveForUser', function () {
+    it('saves revoked user access in Redis', async function () {
+      // given
+      const revokeUntil = new Date();
+      const revokedTimeStamp = Math.floor(revokeUntil.getTime() / 1000);
+
+      // when
+      await revokedUserAccessRepository.saveForUser(12345, revokeUntil);
+
+      // then
+      const result = await revokedUserAccessTemporaryStorage.get(12345);
+      expect(result).to.equal(revokedTimeStamp);
+    });
+  });
+
+  describe('#findByUserId', function () {
+    it('finds revoked user access by user id', async function () {
+      // given
+      const revokeUntil = new Date();
+      const revokeTimeStamp = Math.floor(new Date().getTime() / 1000);
+      await revokedUserAccessRepository.saveForUser(12345, revokeUntil);
+
+      // when
+      const result = await revokedUserAccessRepository.findByUserId(12345);
+
+      // then
+      expect(result).to.deep.equal({
+        revokeTimeStamp: revokeTimeStamp,
+      });
+      expect(result).to.be.instanceOf(RevokedUserAccess);
+    });
+  });
+});

--- a/api/tests/identity-access-management/unit/domain/models/RevokedUserAccess.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/RevokedUserAccess.test.js
@@ -1,0 +1,48 @@
+import { RevokedUserAccess } from '../../../../../src/identity-access-management/domain/models/RevokedUserAccess.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Identity Access Management | Domain | Model | RevokedUserAccess', function () {
+  describe('#constructor', function () {
+    it('builds a revoke user access model', function () {
+      //when
+      const revokeTimeStamp = Math.floor(new Date().getTime() / 1000);
+      const revokedUserAccess = new RevokedUserAccess(revokeTimeStamp);
+
+      //then
+      expect(revokedUserAccess.revokeTimeStamp).to.equal(revokeTimeStamp);
+    });
+  });
+
+  describe('#isAccessTokenRevoked', function () {
+    context('when access token is revoked', function () {
+      it('returns true', function () {
+        //given
+        const revokeTimeStamp = Math.floor(new Date('2024-12-01').getTime() / 1000);
+        const iat = Math.floor(new Date('2024-11-01').getTime() / 1000);
+        const decodedToken = { iat: iat };
+        const revokedUserAccess = new RevokedUserAccess(revokeTimeStamp);
+
+        //when
+        const result = revokedUserAccess.isAccessTokenRevoked(decodedToken);
+
+        //then
+        expect(result).to.equal(true);
+      });
+    });
+    context('when access token is not revoked', function () {
+      it('returns false', function () {
+        //given
+        const revokeTimeStamp = Math.floor(new Date('2024-10-01').getTime() / 1000);
+        const iat = Math.floor(new Date('2024-12-01').getTime() / 1000);
+        const decodedToken = { iat: iat };
+        const revokedUserAccess = new RevokedUserAccess(revokeTimeStamp);
+
+        //when
+        const result = revokedUserAccess.isAccessTokenRevoked(decodedToken);
+
+        //then
+        expect(result).to.equal(false);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :pancakes: Problème

Créer une fonction de révocation des accès utilisateurs.

## :bacon: Proposition

Utiliser une logique basée sur le fait que les tokens JWT contiennent les attributs user_id et iat (issued at) et stocker dans Redis, en durée limitée, des couples userId - revokeTokensFromUserBeforeDate qui permettent de refuser tout AC qui correspondrait à la condition : 
`accessToken.user_id == revokeTokensFromUserId && accessToken.issuedAt < revokeTokensFromUserBeforeDate`


## 🧃 Remarques
Le fichier authentication sera remanié ultérieurement pour séparer les logiques de usecase et de controller


## :yum: Pour tester
- Avec FT_USER_TOKEN_AUD_CONFINEMENT_ENABLED=false
-- se connecter avec un utilisateur de votre choix
--Dans redis placer la clé/valeur suivante : `"set" "temporary-storage:revoked-user-access:uuuuu" "dddddddddd" "ex" "1739808582"`
en remplaçant uuuuu par le userId de votre utilisateur connecté et dddddddddd par un timestamp **en secondes**, **postérieur** à la date de connection
-- Naviguer dans l'espace Pix App de votre utilisateur
-- Constater que les appels à l'api renvoient des 200
- Avec FT_USER_TOKEN_AUD_CONFINEMENT_ENABLED=true
--Tenter une navigation dans votre espace
-- constater que vous êtes déconnecté et que vous ne pouvez pas vous reconnecter
--Modifier la clé/valeur de Redis : `"set" "temporary-storage:revoked-user-access:uuuuu" "dddddddddd" "ex" "1739808582"`
en remplaçant uuuuu par le userId de votre utilisateur et dddddddddd par un timestamp **en secondes**, **antérieur** à la date de connection
--Constater que vous pouvez vous reconnecter sur ce compte



