### PR TITLE
[TECH] Mise à jour de la version des web-components

### DIFF
--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -15,7 +15,7 @@
         "@1024pix/eslint-plugin": "^2.0.5",
         "@1024pix/pix-ui": "^54.2.0",
         "@1024pix/stylelint-config": "^5.1.27",
-        "@1024pix/web-components": "^0.2.6",
+        "@1024pix/web-components": "^0.2.7",
         "@babel/eslint-parser": "^7.26.5",
         "@babel/plugin-proposal-decorators": "^7.25.9",
         "@ember/optional-features": "^2.2.0",
@@ -914,11 +914,11 @@
       }
     },
     "node_modules/@1024pix/web-components": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@1024pix/web-components/-/web-components-0.2.6.tgz",
-      "integrity": "sha512-dKcqF4T0m69Pd95689qzwX5bjt5RYIh9b5AMFJlRxJE4kOkBF+yVN1gXbCOns3p3Gjb/kTMx/YWzpPHDbMJonw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@1024pix/web-components/-/web-components-0.2.7.tgz",
+      "integrity": "sha512-wNSshEoSt/kIEyQSlXPLDFWgMlPe4tsEMYXVrgla2jEN/YYcu1OwL92a0ldPdxz2tQRa1p3Pxc2ns+xmYL/Ssw==",
       "dev": true,
-      "license": "ISC"
+      "license": "UNLICENSED"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",

--- a/junior/package.json
+++ b/junior/package.json
@@ -42,7 +42,7 @@
     "@1024pix/eslint-plugin": "^2.0.5",
     "@1024pix/pix-ui": "^54.2.0",
     "@1024pix/stylelint-config": "^5.1.27",
-    "@1024pix/web-components": "^0.2.6",
+    "@1024pix/web-components": "^0.2.7",
     "@babel/eslint-parser": "^7.26.5",
     "@babel/plugin-proposal-decorators": "^7.25.9",
     "@ember/optional-features": "^2.2.0",


### PR DESCRIPTION
## :pancakes: Problème

Les dernières évolutions des embeds qcu-image en web-component ne sont pas encore présentes dans Pix Junior

## :bacon: Proposition

Mettre à jour la version de la librairie @1024pix/web-components en 0.2.7.

## :yum: Pour tester

Tester le qcu-image junior_tttxt1_structuration_en en json.
https://junior-pr11273.review.pix.fr/challenges/challenge2fAMpBfzlhvDkC/preview 