### PR TITLE
[TECH] Corriger le test flaky d'une méthode dans le repository target-profiles

### DIFF
--- a/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-repository_test.js
+++ b/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-repository_test.js
@@ -66,13 +66,13 @@ describe('Integration | Repository | Target-profile', function () {
 
     it('should return found target profiles', async function () {
       // given
-      const targetProfile2 = databaseBuilder.factory.buildTargetProfile();
-      const targetProfile3 = databaseBuilder.factory.buildTargetProfile();
+      const targetProfile2 = databaseBuilder.factory.buildTargetProfile({ name: 'second target profile' });
+      const targetProfile3 = databaseBuilder.factory.buildTargetProfile({ name: 'third target profile' });
       await databaseBuilder.commit();
 
       targetProfileIds = [targetProfile1.id, targetProfileIdNotExisting, targetProfile2.id, targetProfile3.id];
 
-      const expectedTargetProfilesAttributes = _.map([targetProfile1, targetProfile2, targetProfile3], (item) =>
+      const expectedTargetProfilesAttributes = _.map([targetProfile1, targetProfile3, targetProfile2], (item) =>
         _.pick(item, ['id', 'name', 'organizationId', 'outdated']),
       );
 
@@ -83,7 +83,7 @@ describe('Integration | Repository | Target-profile', function () {
       const foundTargetProfilesAttributes = _.map(foundTargetProfiles, (item) =>
         _.pick(item, ['id', 'name', 'organizationId', 'outdated']),
       );
-      expect(foundTargetProfilesAttributes).to.deep.equal(expectedTargetProfilesAttributes);
+      expect(foundTargetProfilesAttributes).to.deep.members(expectedTargetProfilesAttributes);
     });
 
     it('should return an empty array', async function () {


### PR DESCRIPTION
## :pancakes: Problème
Nous avons un flaky sur le test suivant (l'ordre n'étant pas garanti)

## :bacon: Proposition
On corrige le flaky en vérifiant que le contenu et pas son ordre.
J'ai volontairement inversé l'ordre des PC dans le tableau pour expliciter le flaky et que le test soit plus précis

## 🧃 Remarques
Je ne pense pas que ce soit pertinent dans ce cas d'ajouter un order dans la méthode de repo car on ne l'utilise pas du tout. Et ça obligeait possiblement a modifier d'autres tests

J'ai ajouté des noms aux profils cibles juste pour faciliter la lecture quand on debug, ça évite les doublons de noms

## :yum: Pour tester

- 🤔 
- La CI est toute belle 🫶 
- 🐈‍⬛ 

