### PR TITLE
[BUGFIX] Autoriser les IDs de réponse supérieurs à 2**31-1 (PIX-16337)

### DIFF
--- a/api/src/shared/domain/types/identifiers-type.js
+++ b/api/src/shared/domain/types/identifiers-type.js
@@ -2,10 +2,12 @@ import Joi from 'joi';
 import _ from 'lodash';
 
 const postgreSQLSequenceDefaultStart = 1;
-const postgreSQLSequenceEnd = 2 ** 31 - 1;
+const postgreSQLSequenceInt32BitEnd = 2 ** 31 - 1;
+const postgreSQLSequenceInt64BitEnd = 2 ** 63 - 1;
 
 const implementationType = {
-  positiveInteger32bits: Joi.number().integer().min(postgreSQLSequenceDefaultStart).max(postgreSQLSequenceEnd),
+  positiveInteger32bits: Joi.number().integer().min(postgreSQLSequenceDefaultStart).max(postgreSQLSequenceInt32BitEnd),
+  positiveInteger64bits: Joi.number().integer().min(postgreSQLSequenceDefaultStart).max(postgreSQLSequenceInt64BitEnd),
   alphanumeric255: Joi.string().max(255),
   alphanumeric: Joi.string(),
 };
@@ -39,7 +41,6 @@ const queriesType = {
 
 const typesPositiveInteger32bits = [
   'adminMemberId',
-  'answerId',
   'assessmentId',
   'authenticationMethodId',
   'autonomousCourseId',
@@ -79,16 +80,19 @@ const typesPositiveInteger32bits = [
   'userOrgaSettingsId',
 ];
 
+const typesPositiveInteger64bits = ['answerId'];
+
 const typesAlphanumeric = ['courseId', 'tutorialId'];
 const typesAlphanumeric255 = ['challengeId', 'competenceId', 'frameworkId', 'tubeId', 'code', 'skillId'];
 
 _assignValueToExport(typesPositiveInteger32bits, implementationType.positiveInteger32bits);
+_assignValueToExport(typesPositiveInteger64bits, implementationType.positiveInteger64bits);
 _assignValueToExport(typesAlphanumeric, implementationType.alphanumeric);
 _assignValueToExport(typesAlphanumeric255, implementationType.alphanumeric255);
 
 paramsToExport.positiveInteger32bits = {
   min: postgreSQLSequenceDefaultStart,
-  max: postgreSQLSequenceEnd,
+  max: postgreSQLSequenceInt32BitEnd,
 };
 
 export {

--- a/api/tests/shared/unit/domain/types/identifiers-type_test.js
+++ b/api/tests/shared/unit/domain/types/identifiers-type_test.js
@@ -4,7 +4,7 @@ import {
   queriesType,
 } from '../../../../../src/shared/domain/types/identifiers-type.js';
 import { expect } from '../../../../test-helper.js';
-const { userId, competenceId } = identifiersType;
+const { userId, competenceId, answerId } = identifiersType;
 const { organizationId } = optionalIdentifiersType;
 
 describe('Unit | Domain | Type | identifier-types', function () {
@@ -83,6 +83,47 @@ describe('Unit | Domain | Type | identifier-types', function () {
 
           // then
           expect(error.message).to.equal('"value" length must be less than or equal to 255 characters long');
+        });
+      });
+    });
+
+    describe('#answerId', function () {
+      describe('when id is greater than 2**32', function () {
+        it('should be valid', function () {
+          // given
+          const id = (2 ** 33).toString(10);
+
+          // when
+          const { error } = answerId.validate(id);
+
+          // then
+          expect(error).to.be.undefined;
+        });
+      });
+
+      describe('when id is lower than 1', function () {
+        it('should throw an error', function () {
+          // given
+          const id = '0';
+
+          // when
+          const { error } = answerId.validate(id);
+
+          // then
+          expect(error.message).to.equal('"value" must be greater than or equal to 1');
+        });
+      });
+
+      describe('when id is greater than 2**63 - 1', function () {
+        it('should throw an error', function () {
+          // given
+          const id = (2 ** 63).toString(10);
+
+          // when
+          const { error } = answerId.validate(id);
+
+          // then
+          expect(error.message).to.equal('"value" must be a safe number');
         });
       });
     });


### PR DESCRIPTION
## :pancakes: Problème

Le endpoint d’API de récupération de correction n’autorise pas les IDs de réponse supérieurs à 2**31-1.

## :bacon: Proposition

Autoriser des IDs de réponse jusqu’à 2**63-1.

## 🧃 Remarques

N/A

## :yum: Pour tester

La séquence des IDs de réponses a été artificiellement mise à une valeur dépassant 2**31-1 sur la RA.

Répondre à des questions et essayer de consulter les corrections.