### PR TITLE
[TECH] Ajouter "ORDER BY id" sur une requête dans le script de partage de profil  (PIX-16342)

### DIFF
--- a/api/src/profile/scripts/sixth-grade-organization-share.js
+++ b/api/src/profile/scripts/sixth-grade-organization-share.js
@@ -76,7 +76,7 @@ export class SixthGradeOrganizationShare extends Script {
    */
   async fetchProfileRewards(limit, offset) {
     const knexConnection = DomainTransaction.getConnection();
-    return await knexConnection('profile-rewards').select('userId', 'id').limit(limit).offset(offset);
+    return await knexConnection('profile-rewards').select('userId', 'id').limit(limit).offset(offset).orderBy('id');
   }
 
   async fetchUserOrganizations(userId) {

--- a/api/tests/profile/integration/scripts/sixth-grade-organization-share_test.js
+++ b/api/tests/profile/integration/scripts/sixth-grade-organization-share_test.js
@@ -27,7 +27,7 @@ describe('Integration | Profile | Scripts | sixth-grade-organization-share  ', f
         databaseBuilder.factory.buildOrganizationLearner({ organizationId: firstOrganizationId, userId }),
       );
 
-      // build an other organization learner for userId 3
+      // build another organization learner for userId 3
       databaseBuilder.factory.buildOrganizationLearner({ organizationId: secondOrganizationId, userId: 3 });
 
       // build profile rewards


### PR DESCRIPTION
## :pancakes: Problème
Nous avons oublie la contrainte de tri sur la requete des "profile-rewards". Elle est necessaire pour assurer la coherence des contraintes d'offset et de limit.
 
## :bacon: Proposition
Ajouter orderBy('id') a la requete.

## 🧃 Remarques
https://stackoverflow.com/a/6586018/3077647

## :yum: Pour tester
Tests au vert 

