### PR TITLE
[FEATURE] Appliquer un ratio aux embeds GDevelop (PIX-16168)

### DIFF
--- a/junior/app/components/challenge/challenge-content.gjs
+++ b/junior/app/components/challenge/challenge-content.gjs
@@ -71,6 +71,7 @@ export default class ChallengeContent extends Component {
             @url={{@challenge.embedUrl}}
             @title={{@challenge.embedTitle}}
             @height={{@challenge.embedHeight}}
+            @isGDevelop={{@challenge.isEmbedGDevelop}}
             @hideSimulator={{@isDisabled}}
             @isMediaWithForm={{this.isMediaWithForm}}
             @shouldDisplayRebootButton={{this.shouldDisplayRebootButton}}

--- a/junior/app/components/challenge/content/embedded-simulator.gjs
+++ b/junior/app/components/challenge/content/embedded-simulator.gjs
@@ -8,10 +8,10 @@ import didRender from '../../../modifiers/did-render';
 
 export default class EmbeddedSimulator extends Component {
   get embedDocumentHeightStyle() {
-    const baseHeight = this.args.height ?? '600';
-    const itemMedia = document.getElementsByClassName('challenge-content__media ')[0];
-    const height = this.args.isMediaWithForm ? (baseHeight * itemMedia.offsetWidth) / 710 : baseHeight;
-    return htmlSafe(`height: ${height}px; max-height: ${baseHeight}px`);
+    const { isGDevelop, height: configuredHeight } = this.args;
+    const height = configuredHeight ?? '600';
+    const cssProperties = isGDevelop ? `max-height: ${height}px; aspect-ratio: 860/680` : `height: ${height}px`;
+    return htmlSafe(cssProperties);
   }
 
   @action

--- a/junior/app/models/challenge.js
+++ b/junior/app/models/challenge.js
@@ -39,6 +39,14 @@ export default class Challenge extends Model {
     return !!embedUrl && !!this.embedTitle && !this.hasWebComponent && embedUrl.toLowerCase().indexOf('https://') === 0; // fixes bug on IE: startsWith in not supported (PR #242)
   }
 
+  get isEmbedGDevelop() {
+    if (this.hasEmbed) {
+      const embedUrl = this.embedUrl;
+      return embedUrl.toLowerCase().indexOf('https://1024pix.github.io/') === 0;
+    }
+    return false;
+  }
+
   get hasWebComponent() {
     return !!this.webComponentProps && !!this.webComponentTagName;
   }


### PR DESCRIPTION
## :pancakes: Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## :bacon: Proposition

Si l’embed est hébergé sur https://1024pix.github.io/, appliquer le ratio 860/680.

La hauteur fournie doit, dans ce cas, être utilisée comme max-height et non height 

Supprimer le calcul concernant les max-height & height qui n’est pas pertinent.

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

Challenges avec GDevelop : 
En pleine page : https://junior-pr11278.review.pix.fr/challenges/challenge2VTmlwD6v1ZHKU/preview 
En colonne : https://junior-pr11278.review.pix.fr/challenges/challenge1M1iOQOyfluX5a/preview