### PR TITLE
[FEATURE] Pouvoir ajouter plusieurs orgas enfants en une seule saisie dans Pix-Admin (PIX-10865)

### DIFF
--- a/admin/app/adapters/organization.js
+++ b/admin/app/adapters/organization.js
@@ -44,8 +44,8 @@ export default class OrganizationAdapter extends ApplicationAdapter {
     return this.ajax(url, 'POST', { data: payload });
   }
 
-  attachChildOrganization({ childOrganizationId, parentOrganizationId }) {
+  attachChildOrganization({ childOrganizationIds, parentOrganizationId }) {
     const url = `${this.host}/${this.namespace}/organizations/${parentOrganizationId}/attach-child-organization`;
-    return this.ajax(url, 'POST', { data: { childOrganizationId } });
+    return this.ajax(url, 'POST', { data: { childOrganizationIds } });
   }
 }

--- a/admin/app/components/organizations/children/attach-child-form.gjs
+++ b/admin/app/components/organizations/children/attach-child-form.gjs
@@ -7,18 +7,18 @@ import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
 export default class OrganizationsChildrenAttachChildFormComponent extends Component {
-  @tracked childOrganization = '';
+  @tracked childOrganizationIds = '';
 
   @action
   childOrganizationInputValueChanged(event) {
-    this.childOrganization = event.target.value;
+    this.childOrganizationIds = event.target.value;
   }
 
   @action
   submitForm(event) {
     event.preventDefault();
-    this.args.onFormSubmitted(this.childOrganization);
-    this.childOrganization = '';
+    this.args.onFormSubmitted(this.childOrganizationIds);
+    this.childOrganizationIds = '';
   }
 
   <template>
@@ -29,9 +29,9 @@ export default class OrganizationsChildrenAttachChildFormComponent extends Compo
     >
       <div class="organization__attach-child-form__content">
         <PixInput
-          @id="child-organization"
+          @id="child-organizations"
           @subLabel={{t "components.organizations.children.attach-child-form.input-information"}}
-          value={{this.childOrganization}}
+          value={{this.childOrganizationIds}}
           {{on "change" this.childOrganizationInputValueChanged}}
         >
           <:label>{{t "components.organizations.children.attach-child-form.input-label"}}</:label>

--- a/admin/app/controllers/authenticated/organizations/get/children.js
+++ b/admin/app/controllers/authenticated/organizations/get/children.js
@@ -10,12 +10,12 @@ export default class AuthenticatedOrganizationsGetChildrenController extends Con
   @service store;
 
   @action
-  async handleFormSubmitted(childOrganizationId) {
+  async handleFormSubmitted(childOrganizationIds) {
     const organizationAdapter = this.store.adapterFor('organization');
     const parentOrganizationId = this.model.organization.id;
 
     try {
-      await organizationAdapter.attachChildOrganization({ childOrganizationId, parentOrganizationId });
+      await organizationAdapter.attachChildOrganization({ childOrganizationIds, parentOrganizationId });
       this.pixToast.sendSuccessNotification({
         message: this.intl.t('pages.organization-children.notifications.success.attach-child-organization'),
       });

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -647,8 +647,8 @@ function _configureOrganizationsRoutes(context) {
 
   context.post('/admin/organizations/:organizationId/attach-child-organization', (schema, request) => {
     const parentOrganization = schema.organizations.find(request.params.organizationId);
-    const { childOrganizationId } = JSON.parse(request.requestBody);
-    const childOrganization = schema.organizations.find(childOrganizationId);
+    const { childOrganizationIds } = JSON.parse(request.requestBody);
+    const childOrganization = schema.organizations.find(childOrganizationIds[0]);
 
     childOrganization.update({
       parentOrganizationId: parentOrganization.id,

--- a/admin/tests/acceptance/authenticated/organizations/get/children-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get/children-test.js
@@ -66,7 +66,7 @@ module('Acceptance | Organizations | Children', function (hooks) {
       const screen = await visit(`/organizations/${parentOrganizationId}/children`);
 
       // then
-      assert.dom(screen.getByRole('form', { name: `Formulaire d'ajout d'une organisation fille` })).exists();
+      assert.dom(screen.getByRole('form', { name: `Formulaire d'ajout d'organisation(s) fille(s)` })).exists();
     });
 
     module('when attaching child organization', function () {
@@ -75,7 +75,7 @@ module('Acceptance | Organizations | Children', function (hooks) {
         const parentOrganization = this.server.create('organization', { id: 1, name: 'Parent Organization Name' });
         this.server.create('organization', { id: 2, name: 'Child Organization Name' });
         const screen = await visit(`/organizations/${parentOrganization.id}/children`);
-        await fillByLabel(`Ajouter une organisation fille ID de l'organisation à ajouter`, '2');
+        await fillByLabel(`Ajouter une ou plusieurs organisations filles ID d'organisation(s) à ajouter`, '2');
 
         // when
         await clickByName('Ajouter');
@@ -102,7 +102,9 @@ module('Acceptance | Organizations | Children', function (hooks) {
         const screen = await visit(`/organizations/${parentOrganizationId}/children`);
 
         // then
-        assert.dom(screen.queryByRole('form', { name: `Formulaire d'ajout d'une organisation fille` })).doesNotExist();
+        assert
+          .dom(screen.queryByRole('form', { name: `Formulaire d'ajout d'organisation(s) fille(s)` }))
+          .doesNotExist();
       });
     });
   });

--- a/admin/tests/integration/components/organizations/children/attach-child-form-test.gjs
+++ b/admin/tests/integration/components/organizations/children/attach-child-form-test.gjs
@@ -13,9 +13,13 @@ module('Integration | Component |  organizations/children/attach-child-form', fu
     const screen = await renderScreen(<template><AttachChildForm /></template>);
 
     // then
-    assert.dom(screen.getByRole('form', { name: `Formulaire d'ajout d'une organisation fille` })).exists();
+    assert.dom(screen.getByRole('form', { name: `Formulaire d'ajout d'organisation(s) fille(s)` })).exists();
     assert
-      .dom(screen.getByRole('textbox', { name: `Ajouter une organisation fille ID de l'organisation à ajouter` }))
+      .dom(
+        screen.getByRole('textbox', {
+          name: `Ajouter une ou plusieurs organisations filles ID d'organisation(s) à ajouter`,
+        }),
+      )
       .exists();
     assert.dom(screen.getByRole('button', { name: 'Ajouter' })).exists();
   });
@@ -25,7 +29,7 @@ module('Integration | Component |  organizations/children/attach-child-form', fu
       // given
       const onFormSubmitted = sinon.stub();
       const screen = await renderScreen(<template><AttachChildForm @onFormSubmitted={{onFormSubmitted}} /></template>);
-      await fillByLabel(`Ajouter une organisation fille ID de l'organisation à ajouter`, '12345');
+      await fillByLabel(`Ajouter une ou plusieurs organisations filles ID d'organisation(s) à ajouter`, '12345');
 
       // when
       await clickByName('Ajouter');
@@ -33,7 +37,11 @@ module('Integration | Component |  organizations/children/attach-child-form', fu
       // then
       assert.true(onFormSubmitted.calledOnceWithExactly('12345'));
       assert
-        .dom(screen.getByRole('textbox', { name: `Ajouter une organisation fille ID de l'organisation à ajouter` }))
+        .dom(
+          screen.getByRole('textbox', {
+            name: `Ajouter une ou plusieurs organisations filles ID d'organisation(s) à ajouter`,
+          }),
+        )
         .hasValue('');
     });
   });

--- a/admin/tests/unit/adapters/organization-test.js
+++ b/admin/tests/unit/adapters/organization-test.js
@@ -68,18 +68,18 @@ module('Unit | Adapters | organization', function (hooks) {
   module('#attachChildOrganization', function () {
     test('sends an HTTP POST request', async function (assert) {
       // given
-      const childOrganizationId = 123;
+      const childOrganizationIds = '123,456';
       const parentOrganizationId = 2;
 
       // when
-      await adapter.attachChildOrganization({ childOrganizationId, parentOrganizationId });
+      await adapter.attachChildOrganization({ childOrganizationIds, parentOrganizationId });
 
       // then
       assert.true(
         adapter.ajax.calledOnceWithExactly(
           'http://localhost:3000/api/admin/organizations/2/attach-child-organization',
           'POST',
-          { data: { childOrganizationId } },
+          { data: { childOrganizationIds } },
         ),
       );
     });

--- a/admin/tests/unit/components/organizations/children/attach-children-form-test.js
+++ b/admin/tests/unit/components/organizations/children/attach-children-form-test.js
@@ -14,15 +14,15 @@ module('Unit | Component | organizations/children/attach-child-form', function (
   });
 
   module('when form input value changes', function () {
-    test('updates "childOrganization" component attribute', function (assert) {
+    test('updates "childOrganizationIds" component attribute', function (assert) {
       // given
-      const event = { target: { value: '5432' } };
+      const event = { target: { value: '5432,789' } };
 
       // when
       component.childOrganizationInputValueChanged(event);
 
       // then
-      assert.strictEqual(component.childOrganization, '5432');
+      assert.strictEqual(component.childOrganizationIds, '5432,789');
     });
   });
 
@@ -32,7 +32,7 @@ module('Unit | Component | organizations/children/attach-child-form', function (
       const onFormSubmitted = sinon.stub();
       const event = { preventDefault: sinon.stub() };
 
-      component.childOrganization = '1234';
+      component.childOrganizationIds = '1234';
       component.args.onFormSubmitted = onFormSubmitted;
 
       // when
@@ -41,7 +41,7 @@ module('Unit | Component | organizations/children/attach-child-form', function (
       // then
       assert.true(event.preventDefault.calledOnce);
       assert.true(onFormSubmitted.calledOnceWithExactly('1234'));
-      assert.strictEqual(component.childOrganization, '');
+      assert.strictEqual(component.childOrganizationIds, '');
     });
   });
 });

--- a/admin/tests/unit/controllers/authenticated/organizations/get/children-test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/get/children-test.js
@@ -42,7 +42,7 @@ module('Unit | Controller | authenticated/organizations/get/children', function 
       assert.true(store.adapterFor.calledWithExactly('organization'));
       assert.true(
         organizationAdapter.attachChildOrganization.calledWithExactly({
-          childOrganizationId: '1234',
+          childOrganizationIds: '1234',
           parentOrganizationId: '12',
         }),
       );

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -332,9 +332,9 @@
       },
       "children": {
         "attach-child-form": {
-          "input-information": "ID of organisation to add",
-          "input-label": "Add a child organisation",
-          "name": "Add a child organisation form"
+          "input-information": "ID of organisation(s) to add",
+          "input-label": "Add one or more child organisations",
+          "name": "Add child organisation(s) form"
         }
       },
       "children-list": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -340,9 +340,9 @@
       },
       "children": {
         "attach-child-form": {
-          "input-information": "ID de l'organisation à ajouter",
-          "input-label": "Ajouter une organisation fille",
-          "name": "Formulaire d'ajout d'une organisation fille"
+          "input-information": "ID d'organisation(s) à ajouter",
+          "input-label": "Ajouter une ou plusieurs organisations filles",
+          "name": "Formulaire d'ajout d'organisation(s) fille(s)"
         }
       },
       "children-list": {

--- a/api/src/organizational-entities/application/organization/organization.admin.controller.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.controller.js
@@ -11,10 +11,10 @@ const addTagsToOrganizations = async function (request, h) {
 };
 
 const attachChildOrganization = async function (request, h) {
-  const { childOrganizationId } = request.payload;
+  const { childOrganizationIds } = request.payload;
   const { organizationId: parentOrganizationId } = request.params;
 
-  await usecases.attachChildOrganizationToOrganization({ childOrganizationId, parentOrganizationId });
+  await usecases.attachChildOrganizationToOrganization({ childOrganizationIds, parentOrganizationId });
 
   return h.response().code(204);
 };

--- a/api/src/organizational-entities/application/organization/organization.admin.route.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.route.js
@@ -96,7 +96,7 @@ const register = async function (server) {
             organizationId: identifiersType.organizationId,
           }),
           payload: Joi.object({
-            childOrganizationId: identifiersType.organizationId,
+            childOrganizationIds: Joi.string().required(),
           }),
         },
         handler: (request, h) => organizationAdminController.attachChildOrganization(request, h),

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -282,14 +282,22 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
   describe('POST /api/admin/organizations/{organizationId}/attach-child-organization', function () {
     context('success cases', function () {
       let parentOrganizationId;
-      let childOrganization;
+      let firstChildOrganization;
+      let secondChildOrganization;
 
       beforeEach(async function () {
         parentOrganizationId = databaseBuilder.factory.buildOrganization({
           name: 'Parent Organization',
           type: 'SCO',
         }).id;
-        childOrganization = databaseBuilder.factory.buildOrganization({ name: 'Parent Organization', type: 'SCO' });
+        firstChildOrganization = databaseBuilder.factory.buildOrganization({
+          name: 'child Organization',
+          type: 'SCO',
+        });
+        secondChildOrganization = databaseBuilder.factory.buildOrganization({
+          name: 'child Organization',
+          type: 'SCO',
+        });
         await databaseBuilder.commit();
       });
 
@@ -301,7 +309,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
             url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
             headers: generateAuthenticatedUserRequestHeaders({ userId: admin.id }),
             payload: {
-              childOrganizationId: childOrganization.id,
+              childOrganizationIds: `${firstChildOrganization.id},${secondChildOrganization.id}`,
             },
           };
 
@@ -309,9 +317,15 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
           const response = await server.inject(options);
 
           // then
-          const updatedChildOrganization = await knex('organizations').where({ id: childOrganization.id }).first();
+          const updatedFirstChildOrganization = await knex('organizations')
+            .where({ id: firstChildOrganization.id })
+            .first();
+          const updatedSecondChildOrganization = await knex('organizations')
+            .where({ id: secondChildOrganization.id })
+            .first();
           expect(response.statusCode).to.equal(204);
-          expect(updatedChildOrganization.parentOrganizationId).to.equal(parentOrganizationId);
+          expect(updatedFirstChildOrganization.parentOrganizationId).to.equal(parentOrganizationId);
+          expect(updatedSecondChildOrganization.parentOrganizationId).to.equal(parentOrganizationId);
         });
       });
     });
@@ -340,7 +354,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
                 url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
                 headers: generateAuthenticatedUserRequestHeaders({ userId }),
                 payload: {
-                  childOrganizationId,
+                  childOrganizationIds: `${childOrganizationId}`,
                 },
               };
 
@@ -364,7 +378,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
               url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
               headers: generateAuthenticatedUserRequestHeaders({ userId }),
               payload: {
-                childOrganizationId,
+                childOrganizationIds: `${childOrganizationId}`,
               },
             };
 
@@ -398,7 +412,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
               url: `/api/admin/organizations/985421/attach-child-organization`,
               headers: generateAuthenticatedUserRequestHeaders({ userId }),
               payload: {
-                childOrganizationId,
+                childOrganizationIds: `${childOrganizationId}`,
               },
             };
 
@@ -418,7 +432,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
               url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
               headers: generateAuthenticatedUserRequestHeaders({ userId: admin.id }),
               payload: {
-                childOrganizationId: 984512,
+                childOrganizationIds: '984512',
               },
             };
 
@@ -442,7 +456,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
             url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
             headers: generateAuthenticatedUserRequestHeaders({ userId: admin.id }),
             payload: {
-              childOrganizationId: parentOrganizationId,
+              childOrganizationIds: `${parentOrganizationId}`,
             },
           };
 
@@ -477,7 +491,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
             url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
             headers: generateAuthenticatedUserRequestHeaders({ userId: admin.id }),
             payload: {
-              childOrganizationId,
+              childOrganizationIds: `${childOrganizationId}`,
             },
           };
 
@@ -512,7 +526,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
             url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
             headers: generateAuthenticatedUserRequestHeaders({ userId: admin.id }),
             payload: {
-              childOrganizationId,
+              childOrganizationIds: `${childOrganizationId}`,
             },
           };
 
@@ -544,7 +558,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
             url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
             headers: generateAuthenticatedUserRequestHeaders({ userId: admin.id }),
             payload: {
-              childOrganizationId,
+              childOrganizationIds: `${childOrganizationId}`,
             },
           };
 
@@ -582,7 +596,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
             url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
             headers: generateAuthenticatedUserRequestHeaders({ userId: admin.id }),
             payload: {
-              childOrganizationId,
+              childOrganizationIds: `${childOrganizationId}`,
             },
           };
 


### PR DESCRIPTION
## :pancakes: Problème

L’utilisateur Super Admin doit pouvoir ajouter plusieurs orgas enfants en une seule saisie via le champ “Ajouter une ou plusieurs organisations filles” qui se trouve dans la fiche de l’organisation mère.

## :bacon: Proposition

rendre possible l'envoie de plusieurs id séparés par des ',' via le même input.

## :yum: Pour tester

- Dans Pix-Admin `organizations/1003/children`
- Ajouter les organisations 1000 et 1002 en une seule saisie dans l'input `Ajouter une ou plusieurs organisations filles`: 1000,1002
- Constater l'ajout avec succès des deux organisation filles