### PR TITLE
[TECH] Ne plus planifier de job unitaire pour chaque calcul de certificabilité.

### DIFF
--- a/api/src/prescription/learner-management/application/jobs/schedule-compute-organization-learners-certificability-job-controller.js
+++ b/api/src/prescription/learner-management/application/jobs/schedule-compute-organization-learners-certificability-job-controller.js
@@ -8,6 +8,7 @@ import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.j
 import * as organizationLearnerRepository from '../../../../shared/infrastructure/repositories/organization-learner-repository.js';
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 import { computeCertificabilityJobRepository } from '../../../learner-management/infrastructure/repositories/jobs/compute-certificability-job-repository.js';
+import { usecases } from '../../domain/usecases/index.js';
 
 class ScheduleComputeOrganizationLearnersCertificabilityJobController extends JobScheduleController {
   constructor() {
@@ -26,8 +27,11 @@ class ScheduleComputeOrganizationLearnersCertificabilityJobController extends Jo
   }) {
     const skipLoggedLastDayCheck = data?.skipLoggedLastDayCheck;
     const onlyNotComputed = data?.onlyNotComputed;
-    const chunkSize = dependencies.config.features.scheduleComputeOrganizationLearnersCertificability.chunkSize;
-    const cronConfig = dependencies.config.features.scheduleComputeOrganizationLearnersCertificability.cron;
+    const {
+      chunkSize,
+      cron: cronConfig,
+      synchronously,
+    } = dependencies.config.features.scheduleComputeOrganizationLearnersCertificability;
 
     const isolationLevel = 'repeatable read';
 
@@ -71,6 +75,17 @@ class ScheduleComputeOrganizationLearnersCertificabilityJobController extends Jo
             `ScheduleComputeOrganizationLearnersCertificabilityJobHandler - Ids count  : ${organizationLearnerIds.length}`,
           );
 
+          if (synchronously) {
+            for (const organizationLearnerId of organizationLearnerIds) {
+              await usecases.computeOrganizationLearnerCertificability({ organizationLearnerId });
+            }
+
+            dependencies.logger.info(
+              `ScheduleComputeOrganizationLearnersCertificabilityJobHandler - Certificability computed count : ${organizationLearnerIds.length}`,
+            );
+            continue;
+          }
+
           const jobsToInsert = organizationLearnerIds.map(
             (organizationLearnerId) => new ComputeCertificabilityJob({ organizationLearnerId }),
           );
@@ -83,6 +98,13 @@ class ScheduleComputeOrganizationLearnersCertificabilityJobController extends Jo
           );
         }
 
+        if (synchronously) {
+          dependencies.logger.info(
+            `ScheduleComputeOrganizationLearnersCertificabilityJobHandler - Total certificability computed count : ${totalJobsInserted}`,
+          );
+
+          return;
+        }
         dependencies.logger.info(
           `ScheduleComputeOrganizationLearnersCertificabilityJobHandler - Total jobs inserted count : ${totalJobsInserted}`,
         );

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -249,6 +249,7 @@ const configuration = (function () {
       scheduleComputeOrganizationLearnersCertificability: {
         cron: process.env.SCHEDULE_COMPUTE_LEARNERS_CERTIFICABILITY_JOB_CRON || '0 21 * * *',
         chunkSize: process.env.SCHEDULE_COMPUTE_LEARNERS_CERTIFICABILITY_CHUNK_SIZE || 1000,
+        synchronously: process.env.SCHEDULE_COMPUTE_LEARNERS_CERTIFICABILITY_SYNCHRONOUSLY || false,
       },
       scoAccountRecoveryKeyLifetimeMinutes: process.env.SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES,
     },

--- a/api/tests/prescription/learner-management/integration/application/jobs/schedule-compute-organization-learners-certificability-job-controller_test.js
+++ b/api/tests/prescription/learner-management/integration/application/jobs/schedule-compute-organization-learners-certificability-job-controller_test.js
@@ -32,31 +32,64 @@ describe('Integration | Infrastructure | Jobs | scheduleComputeOrganizationLearn
       };
     });
 
-    it('should schedule multiple ComputeCertificabilityJob', async function () {
-      // given
-      const scheduleComputeOrganizationLearnersCertificabilityJobHandler =
-        new ScheduleComputeOrganizationLearnersCertificabilityJobController();
+    context('when computation is asynchronous', function () {
+      it('should schedule multiple ComputeCertificabilityJob', async function () {
+        // given
+        const scheduleComputeOrganizationLearnersCertificabilityJobHandler =
+          new ScheduleComputeOrganizationLearnersCertificabilityJobController();
 
-      // when
-      await scheduleComputeOrganizationLearnersCertificabilityJobHandler.handle({
-        data: { skipLoggedLastDayCheck: true, onlyNotComputed: false },
-        dependencies: {
-          logger,
-          organizationLearnerRepository,
-          computeCertificabilityJobRepository,
-          config: {
-            features: {
-              scheduleComputeOrganizationLearnersCertificability: {
-                chunkSize: 2,
-                cron: '0 21 * * *',
+        // when
+        await scheduleComputeOrganizationLearnersCertificabilityJobHandler.handle({
+          data: { skipLoggedLastDayCheck: true, onlyNotComputed: false },
+          dependencies: {
+            logger,
+            organizationLearnerRepository,
+            computeCertificabilityJobRepository,
+            config: {
+              features: {
+                scheduleComputeOrganizationLearnersCertificability: {
+                  chunkSize: 2,
+                  cron: '0 21 * * *',
+                  synchronously: false,
+                },
               },
             },
           },
-        },
-      });
-      // then
+        });
 
-      await expect('ComputeCertificabilityJob').to.have.been.performed.withJobsCount(2);
+        // then
+        await expect('ComputeCertificabilityJob').to.have.been.performed.withJobsCount(2);
+      });
+    });
+
+    context('when computation is synchronous', function () {
+      it('should not schedule any ComputeCertificabilityJob', async function () {
+        // given
+        const scheduleComputeOrganizationLearnersCertificabilityJobHandler =
+          new ScheduleComputeOrganizationLearnersCertificabilityJobController();
+
+        // when
+        await scheduleComputeOrganizationLearnersCertificabilityJobHandler.handle({
+          data: { skipLoggedLastDayCheck: true, onlyNotComputed: false },
+          dependencies: {
+            logger,
+            organizationLearnerRepository,
+            computeCertificabilityJobRepository,
+            config: {
+              features: {
+                scheduleComputeOrganizationLearnersCertificability: {
+                  chunkSize: 2,
+                  cron: '0 21 * * *',
+                  synchronously: true,
+                },
+              },
+            },
+          },
+        });
+
+        // then
+        await expect('ComputeCertificabilityJob').to.have.been.performed.withJobsCount(0);
+      });
     });
   });
 });


### PR DESCRIPTION
## :pancakes: Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Chaque soir à 21h, un job asynchrone est lancé pour planifier des jobs de calculs de la certificabilité de manière unitaire (ie. 1 job par organization learner).
Ce fonctionnement a pour effet de planifier ~50 000 jobs chaque nuit, mettant une pression considérable sur la pgboss et donc la base de données.

## :bacon: Proposition

On appelle directement le usecase de calcul de la certificabilité plutôt que de planifier un job asynchrone pour le faire.
Pour le moment, cet appel est conditioné par la variable d'environnement `SCHEDULE_COMPUTE_LEARNERS_CERTIFICABILITY_SYNCHRONOUSLY` qui est considéré `false` par défaut afin de conserver le fonctionnement actuel pour les environnements n'ayant pas opter pour ce nouveau fonctionnement.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

Valoriser la variable d'environnement `SCHEDULE_COMPUTE_LEARNERS_CERTIFICABILITY_SYNCHRONOUSLY` à `true`.

S'assurer que les certifiableAt et isCertifiable de organization-learners sont vide (oui c'est violent mais c'est la RA)

```
update "organization-learners" set "isCertifiable" = null, "certifiableAt" = null;
```

Insérer dans pg-boss

```
INSERT INTO "pgboss"."job" 
  (name, retrylimit, retrydelay, on_complete, data) 
  VALUES
  ('ScheduleComputeOrganizationLearnersCertificabilityJob', 0, 30, true, '{"skipLoggedLastDayCheck":true, "onlyNotComputed":true}');

```

Vérifier que pg-boss a bien excuté le job. et que dans PixOrga: 
- admin-orga@example.net
- organization SCO_SIECLE_MANAGING
- Page élèves

Vérifier que le calcul de la certificabilité est passée ( tout les élèves doivent avoir une valeur dans la liste )