### PR TITLE
[FEATURE] Ajouter un script pour envoyer des invitations à rejoindre une organization en masse (PIX-16265)

### DIFF
--- a/api/src/team/domain/models/OrganizationInvitation.js
+++ b/api/src/team/domain/models/OrganizationInvitation.js
@@ -75,5 +75,6 @@ class OrganizationInvitation {
 }
 
 OrganizationInvitation.StatusType = statuses;
+OrganizationInvitation.RoleType = roles;
 
 export { OrganizationInvitation, statuses };

--- a/api/src/team/scripts/send-organization-invitations-script.js
+++ b/api/src/team/scripts/send-organization-invitations-script.js
@@ -1,0 +1,83 @@
+import { setTimeout } from 'node:timers/promises';
+
+import Joi from 'joi';
+import _ from 'lodash';
+
+import { csvFileParser } from '../../shared/application/scripts/parsers.js';
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+import { OrganizationInvitation } from '../domain/models/OrganizationInvitation.js';
+import { usecases } from '../domain/usecases/index.js';
+
+const DEFAULT_BATCH_SIZE = 200;
+const DEFAULT_THROTTE_DELAY = 1000;
+
+const columnsSchemas = [
+  { name: 'Organization ID', schema: Joi.number() },
+  { name: 'email', schema: Joi.string().trim().replace(' ', '').lowercase() },
+  { name: 'locale', schema: Joi.string().trim().lowercase() },
+  {
+    name: 'role',
+    schema: Joi.string()
+      .trim()
+      .optional()
+      .valid(...Object.values(OrganizationInvitation.RoleType)),
+  },
+];
+
+export class SendOrganizationInvitationsScript extends Script {
+  constructor() {
+    super({
+      description: 'this script used to send invitations for one organization with a csv file',
+      permanent: true,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'Just to check, not action',
+          default: false,
+        },
+        file: {
+          type: 'string',
+          describe: 'The file path',
+          demandOption: true,
+          coerce: csvFileParser(columnsSchemas),
+        },
+        batchSize: {
+          type: 'number',
+          describe: 'The batch size',
+          default: DEFAULT_BATCH_SIZE,
+        },
+        throttleDelay: {
+          type: 'number',
+          describe: 'The throttle delay',
+          default: DEFAULT_THROTTE_DELAY,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger, sendOrganizationInvitation = usecases.createOrganizationInvitationByAdmin }) {
+    const { file, dryRun, batchSize, throttleDelay } = options;
+    const batches = _.chunk(file, batchSize);
+    let batchCount = 1;
+    for (const batch of batches) {
+      logger.info(`Batch #${batchCount++}`);
+      batch.map(async (invitation) => {
+        if (!dryRun) {
+          await sendOrganizationInvitation({
+            organizationId: invitation['Organization ID'],
+            email: invitation.email,
+            locale: invitation.locale,
+            role: invitation.role || null,
+          });
+        }
+      });
+      await setTimeout(throttleDelay);
+      if (dryRun) {
+        logger.info('Dry run, no action');
+      }
+    }
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, SendOrganizationInvitationsScript);

--- a/api/tests/team/unit/scripts/files/send-organization-invitations.csv
+++ b/api/tests/team/unit/scripts/files/send-organization-invitations.csv
@@ -1,0 +1,2 @@
+"Organization ID","email","locale","role"
+1,test@example.net,fr,MEMBER

--- a/api/tests/team/unit/scripts/send-organization-invitations-script_test.js
+++ b/api/tests/team/unit/scripts/send-organization-invitations-script_test.js
@@ -1,0 +1,108 @@
+import * as url from 'node:url';
+
+import { SendOrganizationInvitationsScript } from '../../../../src/team/scripts/send-organization-invitations-script.js';
+import { expect, sinon } from '../../../test-helper.js';
+
+const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
+
+describe('unit | team | scripts | send-organization-invitations-script', function () {
+  describe('options', function () {
+    it('Check the csv parser', async function () {
+      // given
+      const testCsvFile = `${currentDirectory}files/send-organization-invitations.csv`;
+      const script = new SendOrganizationInvitationsScript();
+
+      // when
+      const { options } = script.metaInfo;
+      const fileData = await options.file.coerce(testCsvFile);
+
+      // then
+      expect(fileData).to.be.deep.equal([
+        { 'Organization ID': 1, email: 'test@example.net', locale: 'fr', role: 'MEMBER' },
+      ]);
+    });
+  });
+
+  describe('#handle', function () {
+    let file;
+    let script;
+    let logger;
+    let sendOrganizationInvitation;
+
+    beforeEach(function () {
+      file = [
+        { 'Organization Id': 1, email: 'test1@example.net', locale: 'fr', role: 'MEMBER' },
+        { 'Organization Id': 2, email: 'test2@example.net', locale: 'en', role: 'ADMIN' },
+        { 'Organization Id': 3, email: 'test3@example.net', locale: 'fr', role: 'MEMBER' },
+      ];
+      script = new SendOrganizationInvitationsScript();
+      logger = { info: sinon.spy() };
+      sendOrganizationInvitation = sinon.stub();
+    });
+
+    it('Runs the script', async function () {
+      // when
+      await script.handle({
+        options: { file },
+        logger,
+        sendOrganizationInvitation,
+      });
+
+      // then
+      expect(sendOrganizationInvitation).to.have.callCount(3);
+      expect(sendOrganizationInvitation).to.have.calledWith({
+        organizationId: file[0]['Organization ID'],
+        email: file[0].email,
+        locale: file[0].locale,
+        role: file[0].role,
+      });
+    });
+
+    it('runs the script and replace empty role by null', async function () {
+      // given
+      const file = [{ 'Organization ID': 1, email: 'test@example.net', locale: 'fr' }];
+
+      // when
+      await script.handle({
+        options: { file },
+        logger,
+        sendOrganizationInvitation,
+      });
+
+      // then
+      expect(sendOrganizationInvitation).to.have.been.calledWith({
+        organizationId: 1,
+        email: 'test@example.net',
+        locale: 'fr',
+        role: null,
+      });
+    });
+
+    it('Runs the script with batch', async function () {
+      // when
+      await script.handle({
+        options: { file, batchSize: 1 },
+        logger,
+        sendOrganizationInvitation,
+      });
+
+      // then
+      expect(logger.info).to.have.been.calledWith('Batch #1');
+      expect(logger.info).to.have.been.calledWith('Batch #2');
+      expect(logger.info).to.have.been.calledWith('Batch #3');
+    });
+
+    it('runs the script with dryRun', async function () {
+      // when
+      await script.handle({
+        options: { file, dryRun: true },
+        logger,
+        sendOrganizationInvitation,
+      });
+
+      // then
+      expect(logger.info).to.have.been.calledWith('Dry run, no action');
+      expect(sendOrganizationInvitation).to.not.have.been.called;
+    });
+  });
+});


### PR DESCRIPTION
## :pancakes: Problème

En interne, on a besoin de pouvoir envoyer massivement des invitations à rejoindre une organisation. Ces invitations seraient normalement envoyées via Pix admin mais on parle de jeu de 100 à 2000 invitations. 

## :bacon: Proposition

Concevoir un script qui va prendre les paramètres suivant:
- file: Un fichier au format csv,
- batchSize: un nombre qui servira à diviser le jeu de donné en morceau (ce nombre indiquera combiens d'invitations peut contenir un bloque),
- throtteDelay: nombre de milisecondes: Indiquera le temps d'attente entre la lecture et les actions sur chaques bloques.

## 🧃 Remarques

Le format du fichier csv doit être le suivant:
- "Organization ID": L'identifiant de l'orgagnisation,
- "email": L'email de la personne à inviter,
- "locale": La langue de l'invité,
- "role": Le role à attribuer à la personne (si vide, sera remplacé par null).
Note: On distingue "fr-fr" qui représente le domaine ".fr" et "fr" qui représente le ".org" avec la langue française.

## :yum: Pour tester

- Aller sur Pix admin,
- Se connecter avec les identifiants superadmin@example.net,
- Dans la liste des organisations, choisir celles à qui on souhaite ajouter des membres,
- Créer un fichier csv qui reprend le format suivant en remplaçant "<organizationId>" par l'identifiant de l'organisation et en mettant le mail que vous souhaitez.
```text/plain
"Organization ID","email","locale","role"
<organizationId>,<email>,fr,MEMBER
<organizationId>,<email>,fr,ADMIN
<organizationId>,<email>,fr
<organizationId>,<email>,en
<organizationId>,<email>,fr-fr,MEMBER
````
- Sauvegarder le fichier sous le nom file.csv (nécessaire pour simplifier le teste),
- Exécuter cette commande en remplaçant "<chemain/ver/votre/fichier>" par le véritable chemin vers votre fichier:
```shell
scalingo -a pix-api-review-pr... run --file <chemin/vers/votre/fichier/file.csv> node src/team/scripts/send-organization-invitations-script.js --file /tmp/uploads/file.csv --dryRun
```
- La phrase "Dry run, no action" devrait s'afficher autant de fois qu'il y a de lignes,
- Retirer l'option dryRun de cette façon:
```shell
scalingo -a pix-api-review-pr... run --file <chemin/vers/votre/fichier/file.csv> node src/team/scripts/send-organization-invitations-script.js --file /tmp/uploads/file.csv
```
- Constater que les mails ont bien été envoyés.