### PR TITLE
[BUGFIX] Raccrocher les collecte de profile anonymisé avec leur Knowledge-element-snapshots (PIX-16326)

### DIFF
--- a/api/scripts/prod/populate-campaign-participation-id-in-knowledge-element-snapshot.js
+++ b/api/scripts/prod/populate-campaign-participation-id-in-knowledge-element-snapshot.js
@@ -1,5 +1,4 @@
 import { knex } from '../../db/knex-database-connection.js';
-import { CampaignTypes } from '../../src/prescription/shared/domain/constants.js';
 import { Script } from '../../src/shared/application/scripts/script.js';
 import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
 
@@ -73,6 +72,11 @@ export class PopulateCampaignParticipationIdScript extends Script {
         .whereIn('knowledge-element-snapshots.id', ids);
 
       totalUddatedRows += updatedRows;
+      logger.info(
+        { event: 'PopulateCampaignParticipationIdScript' },
+        `loop: ${updatedRows} rows updated from "knwoledge-element-snapshots"`,
+      );
+
       ids = await getEmptyParticipationKnowlegdeElementSnapshotIds(ids[ids.length - 1] + 1, options.chunkSize);
       if (ids.length > 0 && options.pauseDuration > 0) {
         await dependencies.pause(options.pauseDuration);
@@ -95,7 +99,7 @@ export class PopulateCampaignParticipationIdScript extends Script {
     const anonymisedParticipations = await knex('campaign-participations')
       .select(['campaign-participations.id', 'sharedAt'])
       .join('campaigns', function () {
-        this.on('campaigns.id', 'campaign-participations.campaignId').onVal('campaigns.type', CampaignTypes.ASSESSMENT);
+        this.on('campaigns.id', 'campaign-participations.campaignId');
       })
       .whereNull('userId')
       .whereNotNull('sharedAt');

--- a/api/tests/integration/scripts/prod/populate-campaign-participation-id-in-knowledge-element-snapshot_test.js
+++ b/api/tests/integration/scripts/prod/populate-campaign-participation-id-in-knowledge-element-snapshot_test.js
@@ -1,4 +1,5 @@
 import { PopulateCampaignParticipationIdScript } from '../../../../scripts/prod/populate-campaign-participation-id-in-knowledge-element-snapshot.js';
+import { CampaignTypes } from '../../../../src/prescription/shared/domain/constants.js';
 import { databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
 
 describe('Script | Prod | Delete Organization Learners From Organization', function () {
@@ -38,7 +39,7 @@ describe('Script | Prod | Delete Organization Learners From Organization', funct
         userId: user.id,
       });
 
-      campaign = databaseBuilder.factory.buildCampaign();
+      campaign = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.PROFILES_COLLECTION });
       otherCampaign = databaseBuilder.factory.buildCampaign();
       await databaseBuilder.commit();
     });


### PR DESCRIPTION
## :pancakes: Problème

Pour raccrocher les participations anonymisé nous avons exclu intentionnellement MAIS à tort les collecte de profils

## :bacon: Proposition

Supprimer la condition qui exclu les collecte de profil

## 🧃 Remarques

Ajout d'un log dans la loop

## :yum: Pour tester

Anonymizer une campagne de collecte de profile
Anonymizer une campaign d'évaluation

Lancer le super script  `node ./scripts/prod/populate-campaign-participation-id-in-knowledge-element-snapshot.js` 

vérifier que tout le monde détient ses campaignParticipationId dans la table `knowledge-element-snapshots`