### PR TITLE
[BUGFIX] Fix sur les réponses envoyées en double sur les embeds auto-validés (PIX-16363)

### DIFF
--- a/junior/app/components/challenge/challenge.gjs
+++ b/junior/app/components/challenge/challenge.gjs
@@ -50,7 +50,9 @@ export default class Challenge extends Component {
   }
 
   get disableCheckButton() {
-    return this.answerValue === null || this.answerValue === '';
+    const autoReplyAndAnswerNotValidated = this.args.challenge.isEmbedAutoValidated && !this.answerHasBeenValidated;
+
+    return autoReplyAndAnswerNotValidated || this.answerValue === null || this.answerValue === '';
   }
 
   get disableLessonButton() {


### PR DESCRIPTION
## :pancakes: Problème

Une erreur 500 a été remontée en production par l'équipe Captains.
Après analyse, nous avons trouvé sur l’assessment concernée, 2 réponses de suite au même challenge, configuré en auto-validation.

Nous avons observé sur un poste que le bouton droit ne passait pas directement de “Je vérifie” en désactivé, à “Je continue”, mais était un moment “Je vérifie” activé.

Nous pensons donc que l'élève a eu le temps de cliquer sur “Je vérifie” et que la réponse a par ailleurs été envoyée automatiquement (soit 2 fois).

## :bacon: Proposition

Faire en sorte que le bouton “Je vérifie” ne soit jamais accessible dans cette configuration (embed auto-validé)

Ajouter éventuellement un garde fou côté back pour que même en cas d’envoi double, seul une réponse puisse être enregistrée pour un passage d'activité et un id de challenge.

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

Vérifier que cette épreuve a le bouton "valider" inactif : /challenges/challenge1WEJzOTYnGSxGx/preview
Vérifier que cette épreuve a toujours le bouton "valider" actif : /assessments/136943/challenges
