### PR TITLE
[FEATURE] Pix Junior - Utiliser les options de validation de challenge provenant de Pix Editor

### DIFF
--- a/api/src/school/infrastructure/serializers/challenge-serializer.js
+++ b/api/src/school/infrastructure/serializers/challenge-serializer.js
@@ -20,6 +20,8 @@ const serialize = function (challenges) {
       'focused',
       'timer',
       'shuffled',
+      'hasEmbedInternalValidation',
+      'noValidationNeeded',
     ],
     transform: (challenge) => {
       return {

--- a/api/src/shared/domain/models/Challenge.js
+++ b/api/src/shared/domain/models/Challenge.js
@@ -89,6 +89,8 @@ class Challenge {
     alternativeVersion,
     blindnessCompatibility,
     colorBlindnessCompatibility,
+    hasEmbedInternalValidation,
+    noValidationNeeded,
   } = {}) {
     this.id = id;
     this.answer = answer;
@@ -121,6 +123,8 @@ class Challenge {
     this.alternativeVersion = alternativeVersion;
     this.blindnessCompatibility = blindnessCompatibility;
     this.colorBlindnessCompatibility = colorBlindnessCompatibility;
+    this.hasEmbedInternalValidation = hasEmbedInternalValidation;
+    this.noValidationNeeded = noValidationNeeded;
   }
 
   isTimed() {

--- a/api/src/shared/infrastructure/repositories/challenge-repository.js
+++ b/api/src/shared/infrastructure/repositories/challenge-repository.js
@@ -256,6 +256,8 @@ function toDomain({ challengeDto, webComponentTagName, webComponentProps, skill,
     blindnessCompatibility: challengeDto.accessibility1,
     colorBlindnessCompatibility: challengeDto.accessibility2,
     successProbabilityThreshold,
+    hasEmbedInternalValidation: challengeDto.hasEmbedInternalValidation,
+    noValidationNeeded: challengeDto.noValidationNeeded,
   });
 }
 

--- a/api/tests/school/unit/infrastructure/serializers/challenge-serializer_test.js
+++ b/api/tests/school/unit/infrastructure/serializers/challenge-serializer_test.js
@@ -29,6 +29,8 @@ describe('Unit | Serializer | challenge-serializer', function () {
         focused: false,
         illustrationAlt: 'alt',
         autoReply: false,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: true,
       });
 
       // when
@@ -58,6 +60,8 @@ describe('Unit | Serializer | challenge-serializer', function () {
             timer: 300,
             'illustration-alt': 'alt',
             'auto-reply': false,
+            'has-embed-internal-validation': true,
+            'no-validation-needed': true,
           },
         },
       });

--- a/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
@@ -44,6 +44,8 @@ describe('Integration | Repository | challenge-repository', function () {
     locales: ['fr', 'nl'],
     competenceId: 'competenceId00',
     skillId: 'skillId00',
+    hasEmbedInternalValidation: true,
+    noValidationNeeded: true,
   };
   const challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson = {
     id: 'challengeId01',
@@ -83,6 +85,8 @@ describe('Integration | Repository | challenge-repository', function () {
     locales: ['fr', 'en'],
     competenceId: 'competenceId00',
     skillId: 'skillId00',
+    hasEmbedInternalValidation: true,
+    noValidationNeeded: true,
   };
   const challengeData02_skill00_qcm_archive_flashCompatible_en_noEmbedJson = {
     id: 'challengeId02',
@@ -531,6 +535,8 @@ describe('Integration | Repository | challenge-repository', function () {
                 }),
                 webComponentTagName: 'web-component',
                 webComponentProps: { prop1: 'value1', prop2: 'value2' },
+                hasEmbedInternalValidation: true,
+                noValidationNeeded: true,
               }),
             );
           });
@@ -584,6 +590,8 @@ describe('Integration | Repository | challenge-repository', function () {
                 difficulty: skillData00_tube00competence00_actif.level,
                 hint: skillData00_tube00competence00_actif.hint_i18n.fr,
               }),
+              hasEmbedInternalValidation: true,
+              noValidationNeeded: true,
             }),
           );
         });

--- a/api/tests/tooling/domain-builder/factory/build-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge.js
@@ -37,6 +37,8 @@ const buildChallenge = function ({
   competenceId = 'recCOMP1',
   webComponentTagName,
   webComponentProps,
+  hasEmbedInternalValidation = false,
+  noValidationNeeded = false,
 } = {}) {
   return new Challenge({
     id,
@@ -73,6 +75,8 @@ const buildChallenge = function ({
     skill,
     // references
     competenceId,
+    hasEmbedInternalValidation,
+    noValidationNeeded,
   });
 };
 
@@ -109,6 +113,8 @@ const buildChallengeWithWebComponent = function ({
   skill = buildSkill(),
   // references
   competenceId = 'recCOMP1',
+  hasEmbedInternalValidation,
+  noValidationNeeded,
 } = {}) {
   return new Challenge({
     id,
@@ -143,6 +149,8 @@ const buildChallengeWithWebComponent = function ({
     skill,
     // references
     competenceId,
+    hasEmbedInternalValidation,
+    noValidationNeeded,
   });
 };
 

--- a/junior/app/models/challenge.js
+++ b/junior/app/models/challenge.js
@@ -30,6 +30,8 @@ export default class Challenge extends Model {
   @attr('boolean') shuffled;
   @attr() webComponentProps;
   @attr('string') webComponentTagName;
+  @attr('boolean') hasEmbedInternalValidation;
+  @attr('boolean') noValidationNeeded;
 
   @hasMany('activity-answer', { async: true, inverse: 'challenge' }) activityAnswers;
 
@@ -52,7 +54,7 @@ export default class Challenge extends Model {
   }
 
   get isLesson() {
-    return !!this.focused;
+    return !!this.focused || !!this.noValidationNeeded;
   }
 
   get isQROC() {
@@ -80,7 +82,7 @@ export default class Challenge extends Model {
   }
 
   get isEmbedAutoValidated() {
-    return this.timer !== null && this.timer >= 0;
+    return (this.timer !== null && this.timer >= 0) || !!this.hasEmbedInternalValidation;
   }
 
   get hasMedia() {

--- a/junior/tests/unit/models/challenge-test.js
+++ b/junior/tests/unit/models/challenge-test.js
@@ -40,6 +40,56 @@ module('Unit | Model | Challenge', function (hooks) {
     });
   });
 
+  module('#isLesson', function () {
+    test('should be true if focused is true', function (assert) {
+      const challenge = store.createRecord('challenge', {
+        focused: true,
+      });
+      assert.true(challenge.isLesson);
+    });
+    test('should be true if noValidationNeeded is true', function (assert) {
+      const challenge = store.createRecord('challenge', {
+        noValidationNeeded: true,
+      });
+      assert.true(challenge.isLesson);
+    });
+    test('should be false if noValidationNeeded & focused are not set', function (assert) {
+      const challenge = store.createRecord('challenge');
+      assert.false(challenge.isLesson);
+    });
+    test('should be false if noValidationNeeded & focused are false', function (assert) {
+      const challenge = store.createRecord('challenge', {
+        focused: false,
+        noValidationNeeded: false,
+      });
+      assert.false(challenge.isLesson);
+    });
+  });
+  module('#isEmbedAutoValidated', function () {
+    test('should be true if timer is set', function (assert) {
+      const challenge = store.createRecord('challenge', {
+        timer: 1,
+      });
+      assert.true(challenge.isEmbedAutoValidated);
+    });
+    test('should be true if hasEmbedInternalValidation is true', function (assert) {
+      const challenge = store.createRecord('challenge', {
+        hasEmbedInternalValidation: true,
+      });
+      assert.true(challenge.isEmbedAutoValidated);
+    });
+    test('should be false if timer & hasEmbedInternalValidation are not set', function (assert) {
+      const challenge = store.createRecord('challenge');
+      assert.false(challenge.isEmbedAutoValidated);
+    });
+    test('should be false hasEmbedInternalValidation is false', function (assert) {
+      const challenge = store.createRecord('challenge', {
+        hasEmbedInternalValidation: false,
+      });
+      assert.false(challenge.isEmbedAutoValidated);
+    });
+  });
+
   module('#hasWebComponent', function () {
     test('should be true when web component name and web component props are fields', function (assert) {
       const challenge = store.createRecord('challenge', {


### PR DESCRIPTION
## :pancakes: Problème

Dans Pix Junior, les données focus et timer sont détournées de leur usage pour gérer des cas spécifiques de validation des épreuves :

les leçons contenant uniquement des vidéos ou des fiches récapitulatives sans besoin de validation
les épreuves embeds avec validation interne comme les gdevelop ou les embeds pixwriter de mise en forme.


## :bacon: Proposition

Utiliser les 2 nouvelles colonnes dans le challenge contenant ces informations.

## :yum: Pour tester

Non régression :
Les épreuves indiquées comme focus continuent à s'afficher sans bouton de vérification.
Les épreuves contenant un timer continuent de bénéficier d'une validation automatique.

Test de l'utilisation des nouvelles infos : 
Modifier une épreuve contenant le flag focus, et positionne le flag noValidationNeeded. Le comportement reste inchangé.
Modifier une épreuve contenant un timer, et positionne le flag hasEmbedInternalValidation. Le comportement reste inchangé.
