### PR TITLE
[BUGFIX] Corriger le bug d'affichage de la page de résultat (PIX-16318).

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
@@ -22,6 +22,7 @@ export default class EvaluationResultsHero extends Component {
   @service store;
   @service tabManager;
   @service featureToggles;
+  @service campaignParticipationResult;
 
   @tracked hasGlobalError = false;
   @tracked isButtonLoading = false;
@@ -101,13 +102,8 @@ export default class EvaluationResultsHero extends Component {
       this.isButtonLoading = true;
 
       const campaignParticipationResult = this.args.campaignParticipationResult;
-      const adapter = this.store.adapterFor('campaign-participation-result');
 
-      if (this.hasQuestResults && this.args.questResults[0].obtained) {
-        await adapter.shareProfileReward(campaignParticipationResult.id, this.args.questResults[0].profileRewardId);
-      }
-
-      await adapter.share(campaignParticipationResult.id);
+      await this.campaignParticipationResult.share(campaignParticipationResult, this.args.questResults);
 
       campaignParticipationResult.isShared = true;
       campaignParticipationResult.canImprove = false;

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/index.gjs
@@ -63,7 +63,8 @@ export default class EvaluationResultsTabs extends Component {
                 @trainings={{@trainings}}
                 @isParticipationShared={{@campaignParticipationResult.isShared}}
                 @isSharableCampaign={{@isSharableCampaign}}
-                @campaignParticipationResultId={{@campaignParticipationResult.id}}
+                @questResults={{@questResults}}
+                @campaignParticipationResult={{@campaignParticipationResult}}
                 @campaignId={{@campaign.id}}
               />
             </Panel>

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/trainings.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/trainings.gjs
@@ -10,8 +10,8 @@ import TrainingCard from '../../../../training/card';
 
 export default class EvaluationResultsTabsTrainings extends Component {
   @service currentUser;
-  @service store;
   @service metrics;
+  @service campaignParticipationResult;
 
   @tracked isShareResultsLoading = false;
   @tracked isShareResultsError = false;
@@ -33,22 +33,15 @@ export default class EvaluationResultsTabsTrainings extends Component {
 
   @action
   async shareResults() {
-    const adapter = this.store.adapterFor('campaign-participation-result');
-
     try {
       this.isShareResultsError = false;
       this.isShareResultsLoading = true;
 
-      await adapter.share(this.args.campaignParticipationResultId);
+      const campaignParticipationResultToShare = this.args.campaignParticipationResult;
+      await this.campaignParticipationResult.share(campaignParticipationResultToShare, this.args.questResults);
 
-      await this.store.queryRecord(
-        'campaign-participation-result',
-        {
-          campaignId: this.args.campaignId,
-          userId: this.currentUser.user.id,
-        },
-        { reload: true },
-      );
+      campaignParticipationResultToShare.isShared = true;
+      campaignParticipationResultToShare.canImprove = false;
 
       this.metrics.add({
         event: 'custom-event',

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results.gjs
@@ -57,6 +57,7 @@ export default class EvaluationResults extends Component {
       <EvaluationResultsTabs
         @campaign={{@model.campaign}}
         @campaignParticipationResult={{@model.campaignParticipationResult}}
+        @questResults={{@model.questResults}}
         @isSharableCampaign={{this.isSharableCampaign}}
         @trainings={{@model.trainings}}
       />

--- a/mon-pix/app/services/campaign-participation-result.js
+++ b/mon-pix/app/services/campaign-participation-result.js
@@ -1,0 +1,15 @@
+import Service, { service } from '@ember/service';
+
+export default class CampaignParticipationResult extends Service {
+  @service store;
+
+  async share(campaignParticipationResult, questResults) {
+    const adapter = this.store.adapterFor('campaign-participation-result');
+
+    if (questResults && questResults.length > 0 && questResults[0].obtained) {
+      await adapter.shareProfileReward(campaignParticipationResult.id, questResults[0].profileRewardId);
+    }
+
+    await adapter.share(campaignParticipationResult.id);
+  }
+}

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/tabs/trainings-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/tabs/trainings-test.js
@@ -126,43 +126,28 @@ module('Integration | Components | Campaigns | Assessment | Evaluation Results T
       });
 
       module('when clicking on the share results button', function (hooks) {
-        let adapter, storeService;
+        let campaignParticipationResultService;
 
         hooks.beforeEach(function () {
           stubCurrentUserService(this.owner, { id: '1' });
-
-          storeService = this.owner.lookup('service:store');
-          adapter = storeService.adapterFor('campaign-participation-result');
+          campaignParticipationResultService = this.owner.lookup('service:campaign-participation-result');
         });
 
-        test('it should call the share method of the adapter and reload campaign-participation-result model', async function (assert) {
+        test('it should call the campaignParticipationResult service', async function (assert) {
           // given
-          const createShareStub = sinon.stub(adapter, 'share');
-          sinon.stub(storeService, 'queryRecord');
+          const campaignParticipationResultServiceStub = sinon.stub(campaignParticipationResultService, 'share');
 
           // when
           await click(screen.queryByRole('button', { name: t('pages.skill-review.actions.send') }));
 
           // then
-          assert.ok(createShareStub.calledOnce);
-          sinon.assert.calledWithExactly(createShareStub, 1);
-
-          assert.ok(storeService.queryRecord.calledOnce);
-          sinon.assert.calledWithExactly(
-            storeService.queryRecord,
-            'campaign-participation-result',
-            {
-              campaignId: this.campaignId,
-              userId: '1',
-            },
-            { reload: true },
-          );
+          assert.true(campaignParticipationResultServiceStub.calledOnce);
         });
 
         module('when share action fails', function () {
           test('it should display an error message', async function (assert) {
             // given
-            sinon.stub(adapter, 'share').rejects();
+            sinon.stub(campaignParticipationResultService, 'share').rejects();
 
             // when
             await click(screen.queryByRole('button', { name: t('pages.skill-review.actions.send') }));

--- a/mon-pix/tests/unit/services/campaign-participation-result-test.js
+++ b/mon-pix/tests/unit/services/campaign-participation-result-test.js
@@ -1,0 +1,48 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Service | campaign-participation-result', function (hooks) {
+  setupTest(hooks);
+  let campaignParticipationResultService, campaignParticipationResultAdapter;
+
+  hooks.beforeEach(function () {
+    const store = this.owner.lookup('service:store');
+    campaignParticipationResultService = this.owner.lookup('service:campaign-participation-result');
+    campaignParticipationResultAdapter = store.adapterFor('campaign-participation-result');
+  });
+
+  module('when there is no questsResults', function () {
+    test('it should only share campaign', async function (assert) {
+      // given
+      const campaignParticipationId = Symbol('campaignParticipationId');
+      const questResults = [];
+      const shareStub = sinon.stub(campaignParticipationResultAdapter, 'share');
+      const shareProfileRewardStub = sinon.stub(campaignParticipationResultAdapter, 'shareProfileReward');
+
+      //when
+      await campaignParticipationResultService.share(campaignParticipationId, questResults);
+
+      // then
+      assert.true(shareStub.calledOnce);
+      assert.false(shareProfileRewardStub.calledOnce);
+    });
+  });
+
+  module('when there is at least one questsResult', function () {
+    test('it should share campaign and profile reward', async function (assert) {
+      // given
+      const campaignParticipationId = Symbol('campaignParticipationId');
+      const questResults = [{ obtained: true }];
+      const shareStub = sinon.stub(campaignParticipationResultAdapter, 'share');
+      const shareProfileRewardStub = sinon.stub(campaignParticipationResultAdapter, 'shareProfileReward');
+
+      //when
+      await campaignParticipationResultService.share(campaignParticipationId, questResults);
+
+      // then
+      assert.true(shareStub.calledOnce);
+      assert.true(shareProfileRewardStub.calledOnce);
+    });
+  });
+});


### PR DESCRIPTION
## :pancakes: Problème
Actuellement, il existe deux moyens pour envoyer ses résultats en fin de campagne. Un dans le bloc d'afficahge des résultats, l'autre dans le bloc d'affichage des contenus formatif. Celle dans le bloc d'affichage des contenus formatif cause un bug d'affichage du pourcentage de réussite après partage des résultats. Elle n'utilise pas non plus la même logique que le bouton situé dans le bloc d'affichage des résultats, ce qui pourrait causer des écarts de comportement.

## :bacon: Proposition
Dédupliquer le code utilisé pour partager les réusltats.

## 🧃 Remarques
Il pourrait être judicieux de déplacer côté `api` la logique présente dans le `service` créé. Il serait même nécessaire de le faire dans le cas où il y aurait besoin d'une logique transactionnelle entre le partage des résultats d'une participation de campagne, et le partage d'une attestation.

## :yum: Pour tester

- se connecter en RA avec le mail : dave-comp@example.net
- remettre à 0 et tout retenter [cette campagne ](http://localhost:4200/campagnes/EDUMULTIP)
- partager le résultat depuis l'onglet des contenus formatifs
- constater le bon affichage du pourcentage de réussite
- remettre à 0 la [campagne](http://localhost:4200/campagnes/EDUMULTIP)
- repasser la campagne
- la partager depuis le bloc d'affichage des résultats
- constater le bon affichage du pourcentage de réussite
