### PR TITLE
[FEATURE] Ne pas afficher les boutons d'annulation si la session n'est pas finalisée (PIX-16141).

### DIFF
--- a/admin/app/components/certifications/certification/informations.gjs
+++ b/admin/app/components/certifications/certification/informations.gjs
@@ -85,7 +85,7 @@ import CertificationComments from './comments';
         <CertificationInfoField @value={{@certification.publishedText}} @edition={{false}} @label="Publiée :" />
       </div>
 
-      <div class="certification-informations__card {{if @editingCandidateInformations 'border-primary'}}">
+      <div class="certification-informations__card">
         <h2 class="certification-informations__card__title">Candidat</h2>
         <div class="certification-info-field">
           <span>Prénom :</span>

--- a/admin/app/components/certifications/certification/informations.gjs
+++ b/admin/app/components/certifications/certification/informations.gjs
@@ -16,11 +16,13 @@ import CertificationComments from './comments';
 
 export default class Informations extends Component {
   get displayCancelCertificationButton() {
-    return !this.args.certification.isCancelled && this.args.session.finalizedAt;
+    return (
+      !this.args.certification.isCancelled && !this.args.certification.isPublished && this.args.session.finalizedAt
+    );
   }
 
   get displayUncancelCertificationButton() {
-    return this.args.certification.isCancelled && this.args.session.finalizedAt;
+    return this.args.certification.isCancelled && !this.args.certification.isPublished && this.args.session.finalizedAt;
   }
 
   <template>

--- a/admin/app/components/certifications/certification/informations.gjs
+++ b/admin/app/components/certifications/certification/informations.gjs
@@ -3,6 +3,7 @@ import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import Component from '@glimmer/component';
 import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
 
 import ConfirmPopup from '../../confirm-popup';
@@ -13,28 +14,37 @@ import CertificationInfoTag from '../info-tag';
 import CertificationIssueReports from '../issue-reports';
 import CertificationComments from './comments';
 
-<template>
-  <div class="certification-informations">
-    <div class="certification-informations__row">
-      <PixButtonLink @route="authenticated.users.get" @size="small" @model={{@certification.userId}}>
-        Voir les détails de l'utilisateur
-      </PixButtonLink>
-      {{#if @certification.isCancelled}}
-        <PixButton @variant="error" @size="small" @triggerAction={{@onUncancelCertificationButtonClick}}>
-          Désannuler la certification
-        </PixButton>
-      {{else}}
-        <span class="certification-informations__row__actions">
-          <PixButton @variant="secondary" @size="small" @triggerAction={{@onCancelCertificationButtonClick}}>
-            Annuler la certification
-          </PixButton>
+export default class Informations extends Component {
+  get displayCancelCertificationButton() {
+    return !this.args.certification.isCancelled && this.args.session.finalizedAt;
+  }
 
+  get displayUncancelCertificationButton() {
+    return this.args.certification.isCancelled && this.args.session.finalizedAt;
+  }
+
+  <template>
+    <div class="certification-informations">
+      <div class="certification-informations__row">
+        <PixButtonLink @route="authenticated.users.get" @size="small" @model={{@certification.userId}}>
+          Voir les détails de l'utilisateur
+        </PixButtonLink>
+        <div class="certification-informations__row__actions">
+          {{#if this.displayUncancelCertificationButton}}
+            <PixButton @variant="error" @size="small" @triggerAction={{@onUncancelCertificationButtonClick}}>
+              Désannuler la certification
+            </PixButton>
+          {{/if}}
+          {{#if this.displayCancelCertificationButton}}
+            <PixButton @variant="secondary" @size="small" @triggerAction={{@onCancelCertificationButtonClick}}>
+              Annuler la certification
+            </PixButton>
+          {{/if}}
           {{#if @shouldDisplayUnrejectCertificationButton}}
             <PixButton @variant="error" @size="small" @triggerAction={{@onUnrejectCertificationButtonClick}}>
               Annuler le rejet
             </PixButton>
           {{/if}}
-
           {{#if @shouldDisplayRejectCertificationButton}}
             {{#if @certification.isPublished}}
               <PixTooltip @position="left" @isWide={{true}}>
@@ -59,224 +69,224 @@ import CertificationComments from './comments';
               </PixButton>
             {{/if}}
           {{/if}}
-        </span>
-      {{/if}}
-    </div>
+        </div>
 
-    <div class="certification-informations__row">
-      <div class="certification-informations__card">
-        <h2 class="certification-informations__card__title">
-          <CertificationInfoTag @record={{@certification}} @float={{true}} />
-          État
-        </h2>
-        <CertificationInfoField
-          @value={{@certification.sessionId}}
-          @edition={{false}}
-          @label="Session :"
-          @linkRoute="authenticated.sessions.session"
-        />
-        <CertificationInfoField
-          @value={{@certification.statusLabelAndValue.label}}
-          @edition={{false}}
-          @label="Statut :"
-        />
-        <CertificationInfoField @value={{@certification.creationDate}} @edition={{false}} @label="Créée le :" />
-        <CertificationInfoField @value={{@certification.completionDate}} @edition={{false}} @label="Terminée le :" />
-        <CertificationInfoField @value={{@certification.publishedText}} @edition={{false}} @label="Publiée :" />
       </div>
-
-      <div class="certification-informations__card">
-        <h2 class="certification-informations__card__title">Candidat</h2>
-        <div class="certification-info-field">
-          <span>Prénom :</span>
-          <span>{{@certification.firstName}}</span>
-        </div>
-        <div class="certification-info-field">
-          <span>Nom de famille :</span>
-          <span>{{@certification.lastName}}</span>
-        </div>
-        <div class="certification-info-field">
-          <span>Date de naissance :</span>
-          <span>{{dayjsFormat @certification.birthdate "DD/MM/YYYY" allow-empty=true}}</span>
-        </div>
-        <div class="certification-info-field">
-          <span>Sexe :</span>
-          <span>{{@certification.sex}}</span>
-        </div>
-        <div class="certification-info-field">
-          <span>Commune de naissance :</span>
-          <span>{{@certification.birthplace}}</span>
-        </div>
-        <div class="certification-info-field">
-          <span>Code postal de naissance :</span>
-          <span>{{@certification.birthPostalCode}}</span>
-        </div>
-        <div class="certification-info-field">
-          <span>Code INSEE de naissance :</span>
-          <span>{{@certification.birthInseeCode}}</span>
-        </div>
-        <div class="certification-info-field">
-          <span>Pays de naissance :</span>
-          <span>{{@certification.birthCountry}}</span>
-        </div>
-
-        <div class="candidate-informations__actions">
-          <PixButton
-            @size="small"
-            @triggerAction={{@openCandidateEditModal}}
-            aria-label="Modifier les informations du candidat"
-          >
-            Modifier infos candidat
-          </PixButton>
-        </div>
-      </div>
-    </div>
-
-    {{#if @certification.hasComplementaryCertifications}}
       <div class="certification-informations__row">
         <div class="certification-informations__card">
-          <h2 class="certification-informations__card__title">Certification complémentaire</h2>
+          <h2 class="certification-informations__card__title">
+            <CertificationInfoTag @record={{@certification}} @float={{true}} />
+            État
+          </h2>
+          <CertificationInfoField
+            @value={{@session.id}}
+            @edition={{false}}
+            @label="Session :"
+            @linkRoute="authenticated.sessions.session"
+          />
+          <CertificationInfoField
+            @value={{@certification.statusLabelAndValue.label}}
+            @edition={{false}}
+            @label="Statut :"
+          />
+          <CertificationInfoField @value={{@certification.creationDate}} @edition={{false}} @label="Créée le :" />
+          <CertificationInfoField @value={{@certification.completionDate}} @edition={{false}} @label="Terminée le :" />
+          <CertificationInfoField @value={{@certification.publishedText}} @edition={{false}} @label="Publiée :" />
+        </div>
 
-          {{#if @certification.commonComplementaryCertificationCourseResult}}
-            <ul class="certification-informations__card__list">
-              <li class="certification-informations__card__list-item">
-                <span class="certification-informations__card__list-label">
-                  {{@certification.commonComplementaryCertificationCourseResult.label}}
-                  :
-                </span>
-                {{@certification.commonComplementaryCertificationCourseResult.status}}
-              </li>
-            </ul>
-          {{/if}}
+        <div class="certification-informations__card">
+          <h2 class="certification-informations__card__title">Candidat</h2>
+          <div class="certification-info-field">
+            <span>Prénom :</span>
+            <span>{{@certification.firstName}}</span>
+          </div>
+          <div class="certification-info-field">
+            <span>Nom de famille :</span>
+            <span>{{@certification.lastName}}</span>
+          </div>
+          <div class="certification-info-field">
+            <span>Date de naissance :</span>
+            <span>{{dayjsFormat @certification.birthdate "DD/MM/YYYY" allow-empty=true}}</span>
+          </div>
+          <div class="certification-info-field">
+            <span>Sexe :</span>
+            <span>{{@certification.sex}}</span>
+          </div>
+          <div class="certification-info-field">
+            <span>Commune de naissance :</span>
+            <span>{{@certification.birthplace}}</span>
+          </div>
+          <div class="certification-info-field">
+            <span>Code postal de naissance :</span>
+            <span>{{@certification.birthPostalCode}}</span>
+          </div>
+          <div class="certification-info-field">
+            <span>Code INSEE de naissance :</span>
+            <span>{{@certification.birthInseeCode}}</span>
+          </div>
+          <div class="certification-info-field">
+            <span>Pays de naissance :</span>
+            <span>{{@certification.birthCountry}}</span>
+          </div>
 
-          {{#if @certification.complementaryCertificationCourseResultWithExternal}}
-            <section class="certification-informations__pix-edu">
-              <h2 class="certification-informations__pix-edu__title">Résultats de la certification complémentaire Pix+
-                Edu :</h2>
-              <div class="certification-informations__row">
-                <div class="certification-informations__card certification-informations__card--pix-edu">
-                  <p>VOLET PIX</p>
-                  <p class="certification-informations__card__score">
-                    {{@certification.complementaryCertificationCourseResultWithExternal.pixResult}}
-                  </p>
-                </div>
-                <div class="certification-informations__card certification-informations__card--pix-edu">
-                  <p>VOLET JURY</p>
-                  {{#if @displayJuryLevelSelect}}
-                    <div class="certification-informations__pix-edu__row__jury-level-editor">
-                      <section>
-                        <PixSelect
-                          @screenReaderOnly={{true}}
-                          @options={{@juryLevelOptions}}
-                          @value={{@selectedJuryLevel}}
-                          @hideDefaultOption={{true}}
-                          @onChange={{@selectJuryLevel}}
-                          @placeholder="Choisir un niveau"
-                        >
-                          <:label>Sélectionner un niveau</:label>
-                        </PixSelect>
-                      </section>
-                      <section>
-                        <PixButton
-                          @variant="secondary"
-                          @size="small"
-                          @triggerAction={{@onCancelJuryLevelEditButtonClick}}
-                        >
-                          Annuler
-                        </PixButton>
-                        <PixButton
-                          @size="small"
-                          @triggerAction={{@onEditJuryLevelSave}}
-                          aria-label="Modifier le niveau du jury"
-                        >
-                          Enregistrer
-                        </PixButton>
-                      </section>
-                    </div>
-                  {{else}}
-                    <div class="certification-informations__pix-edu__row__jury-level">
-                      <p class="certification-informations__card__score">
-                        {{@certification.complementaryCertificationCourseResultWithExternal.externalResult}}
-                      </p>
-                      {{#if @shouldDisplayJuryLevelEditButton}}
-                        <PixIconButton
-                          class="jury-level-edit-icon-button"
-                          @ariaLabel="Modifier le volet jury"
-                          @triggerAction={{@editJury}}
-                          @iconName="edit"
-                        />
-                      {{/if}}
-                    </div>
-                  {{/if}}
-                </div>
-                <div class="certification-informations__card certification-informations__card--pix-edu">
-                  <p>NIVEAU FINAL</p>
-                  <p
-                    class="certification-informations__card__score"
-                  >{{@certification.complementaryCertificationCourseResultWithExternal.finalResult}}</p>
-                </div>
-              </div>
-            </section>
-          {{/if}}
+          <div class="candidate-informations__actions">
+            <PixButton
+              @size="small"
+              @triggerAction={{@openCandidateEditModal}}
+              aria-label="Modifier les informations du candidat"
+            >
+              Modifier infos candidat
+            </PixButton>
+          </div>
         </div>
       </div>
-    {{/if}}
 
-    {{#if @hasIssueReports}}
-      <section
-        class="certification-informations__row certification-informations__card certification-informations__certification-issue-reports"
-      >
-        <h2 class="card-title certification-informations__card__title">Signalements</h2>
-        <CertificationIssueReports
-          @hasImpactfulIssueReports={{@hasImpactfulIssueReports}}
-          @hasUnimpactfulIssueReports={{@hasUnimpactfulIssueReports}}
-          @impactfulCertificationIssueReports={{@impactfulCertificationIssueReports}}
-          @unimpactfulCertificationIssueReports={{@unimpactfulCertificationIssueReports}}
-          @resolveIssueReport={{@resolveIssueReport}}
-        />
-      </section>
-    {{/if}}
+      {{#if @certification.hasComplementaryCertifications}}
+        <div class="certification-informations__row">
+          <div class="certification-informations__card">
+            <h2 class="certification-informations__card__title">Certification complémentaire</h2>
 
-    <CertificationComments @onJuryCommentSave={{@onJuryCommentSave}} @certification={{@certification}} />
+            {{#if @certification.commonComplementaryCertificationCourseResult}}
+              <ul class="certification-informations__card__list">
+                <li class="certification-informations__card__list-item">
+                  <span class="certification-informations__card__list-label">
+                    {{@certification.commonComplementaryCertificationCourseResult.label}}
+                    :
+                  </span>
+                  {{@certification.commonComplementaryCertificationCourseResult.status}}
+                </li>
+              </ul>
+            {{/if}}
 
-    <div class="certification-informations__row">
-      <div class="certification-informations__card">
-        <h2 class="certification-informations__card__title">Résultats</h2>
-        <CertificationInfoField
-          @value={{@certification.pixScore}}
-          @edition={{false}}
-          @label="Score :"
-          @fieldId="certification-pixScore"
-          @suffix=" Pix"
-        />
+            {{#if @certification.complementaryCertificationCourseResultWithExternal}}
+              <section class="certification-informations__pix-edu">
+                <h2 class="certification-informations__pix-edu__title">Résultats de la certification complémentaire Pix+
+                  Edu :</h2>
+                <div class="certification-informations__row">
+                  <div class="certification-informations__card certification-informations__card--pix-edu">
+                    <p>VOLET PIX</p>
+                    <p class="certification-informations__card__score">
+                      {{@certification.complementaryCertificationCourseResultWithExternal.pixResult}}
+                    </p>
+                  </div>
+                  <div class="certification-informations__card certification-informations__card--pix-edu">
+                    <p>VOLET JURY</p>
+                    {{#if @displayJuryLevelSelect}}
+                      <div class="certification-informations__pix-edu__row__jury-level-editor">
+                        <section>
+                          <PixSelect
+                            @screenReaderOnly={{true}}
+                            @options={{@juryLevelOptions}}
+                            @value={{@selectedJuryLevel}}
+                            @hideDefaultOption={{true}}
+                            @onChange={{@selectJuryLevel}}
+                            @placeholder="Choisir un niveau"
+                          >
+                            <:label>Sélectionner un niveau</:label>
+                          </PixSelect>
+                        </section>
+                        <section>
+                          <PixButton
+                            @variant="secondary"
+                            @size="small"
+                            @triggerAction={{@onCancelJuryLevelEditButtonClick}}
+                          >
+                            Annuler
+                          </PixButton>
+                          <PixButton
+                            @size="small"
+                            @triggerAction={{@onEditJuryLevelSave}}
+                            aria-label="Modifier le niveau du jury"
+                          >
+                            Enregistrer
+                          </PixButton>
+                        </section>
+                      </div>
+                    {{else}}
+                      <div class="certification-informations__pix-edu__row__jury-level">
+                        <p class="certification-informations__card__score">
+                          {{@certification.complementaryCertificationCourseResultWithExternal.externalResult}}
+                        </p>
+                        {{#if @shouldDisplayJuryLevelEditButton}}
+                          <PixIconButton
+                            class="jury-level-edit-icon-button"
+                            @ariaLabel="Modifier le volet jury"
+                            @triggerAction={{@editJury}}
+                            @iconName="edit"
+                          />
+                        {{/if}}
+                      </div>
+                    {{/if}}
+                  </div>
+                  <div class="certification-informations__card certification-informations__card--pix-edu">
+                    <p>NIVEAU FINAL</p>
+                    <p
+                      class="certification-informations__card__score"
+                    >{{@certification.complementaryCertificationCourseResultWithExternal.finalResult}}</p>
+                  </div>
+                </div>
+              </section>
+            {{/if}}
+          </div>
+        </div>
+      {{/if}}
 
-        <CertificationCompetenceList
-          @competences={{@certification.competences}}
-          @shouldDisplayPixScore={{@shouldDisplayPixScore}}
-          @edition={{false}}
-          @onUpdateScore={{@onUpdateScore}}
-          @onUpdateLevel={{@onUpdateLevel}}
-        />
+      {{#if @hasIssueReports}}
+        <section
+          class="certification-informations__row certification-informations__card certification-informations__certification-issue-reports"
+        >
+          <h2 class="card-title certification-informations__card__title">Signalements</h2>
+          <CertificationIssueReports
+            @hasImpactfulIssueReports={{@hasImpactfulIssueReports}}
+            @hasUnimpactfulIssueReports={{@hasUnimpactfulIssueReports}}
+            @impactfulCertificationIssueReports={{@impactfulCertificationIssueReports}}
+            @unimpactfulCertificationIssueReports={{@unimpactfulCertificationIssueReports}}
+            @resolveIssueReport={{@resolveIssueReport}}
+          />
+        </section>
+      {{/if}}
+
+      <CertificationComments @onJuryCommentSave={{@onJuryCommentSave}} @certification={{@certification}} />
+
+      <div class="certification-informations__row">
+        <div class="certification-informations__card">
+          <h2 class="certification-informations__card__title">Résultats</h2>
+          <CertificationInfoField
+            @value={{@certification.pixScore}}
+            @edition={{false}}
+            @label="Score :"
+            @fieldId="certification-pixScore"
+            @suffix=" Pix"
+          />
+
+          <CertificationCompetenceList
+            @competences={{@certification.competences}}
+            @shouldDisplayPixScore={{@shouldDisplayPixScore}}
+            @edition={{false}}
+            @onUpdateScore={{@onUpdateScore}}
+            @onUpdateLevel={{@onUpdateLevel}}
+          />
+        </div>
       </div>
     </div>
-  </div>
 
-  <ConfirmPopup
-    @title={{@modalTitle}}
-    @message={{@confirmMessage}}
-    @error={{@confirmErrorMessage}}
-    @confirm={{@confirmAction}}
-    @show={{@displayConfirm}}
-    @cancel={{@onCancelConfirm}}
-  />
-
-  {{#if @isCandidateEditModalOpen}}
-    <CandidateEditModal
-      @onCancelButtonsClicked={{@closeCandidateEditModal}}
-      @onFormSubmit={{@onCandidateInformationSave}}
-      @candidate={{@certification}}
-      @countries={{@countries}}
-      @isDisplayed={{@isCandidateEditModalOpen}}
+    <ConfirmPopup
+      @title={{@modalTitle}}
+      @message={{@confirmMessage}}
+      @error={{@confirmErrorMessage}}
+      @confirm={{@confirmAction}}
+      @show={{@displayConfirm}}
+      @cancel={{@onCancelConfirm}}
     />
-  {{/if}}
-</template>
+
+    {{#if @isCandidateEditModalOpen}}
+      <CandidateEditModal
+        @onCancelButtonsClicked={{@closeCandidateEditModal}}
+        @onFormSubmit={{@onCandidateInformationSave}}
+        @candidate={{@certification}}
+        @countries={{@countries}}
+        @isDisplayed={{@isCandidateEditModalOpen}}
+      />
+    {{/if}}
+  </template>
+}

--- a/admin/app/routes/authenticated/certifications/certification/informations.js
+++ b/admin/app/routes/authenticated/certifications/certification/informations.js
@@ -8,8 +8,10 @@ export default class CertificationInformationsRoute extends Route {
 
   async model() {
     const certification = await this.modelFor('authenticated.certifications.certification').reload();
+    const session = await this.store.findRecord('session', certification.sessionId);
     const certificationIssueReports = await certification.certificationIssueReports;
     return RSVP.hash({
+      session,
       certification,
       certificationIssueReports,
       countries: this.store.findAll('country'),

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -1,5 +1,6 @@
 <Certifications::Certification::Informations
   @certification={{this.certification}}
+  @session={{this.model.session}}
   @onUncancelCertificationButtonClick={{this.onUncancelCertificationButtonClick}}
   @onCancelCertificationButtonClick={{this.onCancelCertificationButtonClick}}
   @shouldDisplayUnrejectCertificationButton={{this.shouldDisplayUnrejectCertificationButton}}

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -6,7 +6,6 @@
   @onUnrejectCertificationButtonClick={{this.onUnrejectCertificationButtonClick}}
   @shouldDisplayRejectCertificationButton={{this.shouldDisplayRejectCertificationButton}}
   @onRejectCertificationButtonClick={{this.onRejectCertificationButtonClick}}
-  @editingCandidateInformations={{this.editingCandidateInformations}}
   @openCandidateEditModal={{this.openCandidateEditModal}}
   @displayJuryLevelSelect={{this.displayJuryLevelSelect}}
   @juryLevelOptions={{this.juryLevelOptions}}

--- a/admin/tests/acceptance/authenticated/certifications/certification/certification-test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/certification-test.js
@@ -78,8 +78,10 @@ module('Acceptance | Route | routes/authenticated/certifications/certification',
       // given
       this.server.create('user', { id: 888 });
 
+      const session = this.server.create('session');
       const certification = this.server.create('certification', {
         id: 123,
+        sessionId: session.id,
         firstName: 'Bora Horza',
         lastName: 'Gobuchul',
         birthdate: '1987-07-24',
@@ -108,9 +110,10 @@ module('Acceptance | Route | routes/authenticated/certifications/certification',
     test('it should display the neutralization tab', async function (assert) {
       // given
       this.server.create('user', { id: 888 });
-
+      const session = this.server.create('session');
       const certification = this.server.create('certification', {
         id: 123,
+        sessionId: session.id,
         firstName: 'Bora Horza',
         lastName: 'Gobuchul',
         birthdate: '1987-07-24',

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations-test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations-test.js
@@ -10,7 +10,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  let certification;
+  let certification, session;
 
   hooks.beforeEach(async function () {
     this.server.create('user', { id: 888 });
@@ -25,8 +25,13 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
       name: 'GROENLAND',
     });
 
+    session = this.server.create('session', {
+      finalizedAt: new Date('2020-01-01'),
+    });
+
     certification = this.server.create('certification', {
       id: 123,
+      sessionId: session.id,
       firstName: 'Bora Horza',
       lastName: 'Gobuchul',
       birthdate: '1987-07-24',
@@ -768,109 +773,152 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
     });
 
     module('Certification cancellation', function () {
-      module('Cancel', function (hooks) {
-        hooks.beforeEach(async function () {
-          certification.update({ status: 'validated' });
+      module('Cancel', function () {
+        let screen;
+        module('when session is finalized', function (hooks) {
+          hooks.beforeEach(async function () {
+            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+            screen = await visit(`/certifications/${certification.id}`);
+          });
+
+          module('when cancellation button is clicked', function () {
+            test('should display confirmation popup for cancellation', async function (assert) {
+              // given
+              // when
+              await clickByName('Annuler la certification');
+
+              await screen.findByRole('dialog');
+              // then
+              assert
+                .dom(
+                  screen.getByText(
+                    'Êtes-vous sûr·e de vouloir annuler cette certification ? Cliquez sur confirmer pour poursuivre.',
+                  ),
+                )
+                .exists();
+            });
+          });
+
+          module('in the confirmation popup', function () {
+            module('when aborting action', function () {
+              test('should not cancel the certification', async function (assert) {
+                // given
+                await clickByName('Annuler la certification');
+                await screen.findByRole('dialog');
+
+                // when
+                await clickByName('Fermer');
+
+                // then
+                assert.dom(screen.getByRole('button', { name: 'Annuler la certification' })).exists();
+              });
+            });
+
+            module('when confirming action', function () {
+              test('should cancel the certification', async function (assert) {
+                // given
+                await clickByName('Annuler la certification');
+                await screen.findByRole('dialog');
+
+                // when
+                await clickByName('Confirmer');
+
+                // then
+                assert.dom(await screen.findByRole('button', { name: 'Désannuler la certification' })).exists();
+              });
+            });
+          });
         });
 
-        test('should display confirmation popup for cancellation when certification is not yet cancelled and cancellation button is clicked', async function (assert) {
-          // given
-          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-          const screen = await visit(`/certifications/${certification.id}`);
+        module('when session is not finalized', function (hooks) {
+          hooks.beforeEach(async function () {
+            session.update({ finalizedAt: null });
+            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+            screen = await visit(`/certifications/${certification.id}`);
+          });
 
-          // when
-          await clickByName('Annuler la certification');
-
-          await screen.findByRole('dialog');
-          // then
-          assert
-            .dom(
-              screen.getByText(
-                'Êtes-vous sûr·e de vouloir annuler cette certification ? Cliquez sur confirmer pour poursuivre.',
-              ),
-            )
-            .exists();
-        });
-
-        test('should not cancel the certification when aborting action in the confirmation popup', async function (assert) {
-          // given
-          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-          const screen = await visit(`/certifications/${certification.id}`);
-          await clickByName('Annuler la certification');
-
-          await screen.findByRole('dialog');
-          // when
-          await clickByName('Fermer');
-
-          // then
-          assert.dom(screen.getByRole('button', { name: 'Annuler la certification' })).exists();
-        });
-
-        test('should cancel the certification when confirming action in the confirmation popup', async function (assert) {
-          // given
-          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-          const screen = await visit(`/certifications/${certification.id}`);
-          await clickByName('Annuler la certification');
-          await screen.findByRole('dialog');
-
-          // when
-          await clickByName('Confirmer');
-
-          // then
-          assert.dom(await screen.findByRole('button', { name: 'Désannuler la certification' })).exists();
+          test('should not display the cancellation button', function (assert) {
+            // given
+            // when
+            // then
+            assert.dom(screen.queryByRole('button', { name: 'Annuler la certification' })).doesNotExist();
+          });
         });
       });
 
       module('Uncancel', function (hooks) {
+        let screen;
         hooks.beforeEach(async function () {
           certification.update({ isCancelled: true });
         });
 
-        test('should display confirmation popup for uncancellation when certification is cancelled and uncancellation button is clicked', async function (assert) {
-          // given
-          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-          const screen = await visit(`/certifications/${certification.id}`);
+        module('when session is finalized', function (hooks) {
+          hooks.beforeEach(async function () {
+            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+            screen = await visit(`/certifications/${certification.id}`);
+          });
 
-          // when
-          await clickByName('Désannuler la certification');
-          await screen.findByRole('dialog');
-          // then
-          assert
-            .dom(
-              screen.getByText(
-                'Êtes-vous sûr·e de vouloir désannuler cette certification ? Cliquez sur confirmer pour poursuivre.',
-              ),
-            )
-            .exists();
+          module('when certification is cancelled and uncancellation button is clicked', function () {
+            test('should display confirmation popup for uncancellation', async function (assert) {
+              // given
+              // when
+              await click(screen.getByRole('button', { name: 'Désannuler la certification' }));
+              await screen.findByRole('dialog');
+
+              // then
+              assert
+                .dom(
+                  screen.getByText(
+                    'Êtes-vous sûr·e de vouloir désannuler cette certification ? Cliquez sur confirmer pour poursuivre.',
+                  ),
+                )
+                .exists();
+            });
+          });
+
+          module('in the confirmation popup', function () {
+            module('when aborting action', function () {
+              test('should not uncancel the certification', async function (assert) {
+                // given
+                await click(screen.getByRole('button', { name: 'Désannuler la certification' }));
+                await screen.findByRole('dialog');
+
+                // when
+                await clickByName('Fermer');
+
+                // then
+                assert.dom(screen.getByRole('button', { name: 'Désannuler la certification' })).exists();
+              });
+            });
+
+            module('when confirming action', function () {
+              test('should uncancel the certification', async function (assert) {
+                // given
+                await click(screen.getByRole('button', { name: 'Désannuler la certification' }));
+                await screen.findByRole('dialog');
+                // when
+                await clickByName('Confirmer');
+
+                // then
+                assert.dom(await screen.findByRole('button', { name: 'Annuler la certification' })).exists();
+              });
+            });
+          });
         });
 
-        test('should not uncancel the certification when aborting action in the confirmation popup', async function (assert) {
-          // given
-          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-          const screen = await visit(`/certifications/${certification.id}`);
-          await clickByName('Désannuler la certification');
+        module('when session is not finalized', function (hooks) {
+          hooks.beforeEach(async function () {
+            session.update({ finalizedAt: null });
+            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+            screen = await visit(`/certifications/${certification.id}`);
+          });
 
-          await screen.findByRole('dialog');
-
-          // when
-          await clickByName('Fermer');
-
-          // then
-          assert.dom(screen.getByRole('button', { name: 'Désannuler la certification' })).exists();
-        });
-
-        test('should uncancel the certification when confirming action in the confirmation popup', async function (assert) {
-          // given
-          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-          const screen = await visit(`/certifications/${certification.id}`);
-          await clickByName('Désannuler la certification');
-
-          await screen.findByRole('dialog');
-          // when
-          await clickByName('Confirmer');
-
-          // then
-          assert.dom(await screen.findByRole('button', { name: 'Annuler la certification' })).exists();
+          test('should not display the cancellation button', function (assert) {
+            // given
+            // when
+            // then
+            assert.dom(screen.queryByRole('button', { name: 'Désannuler la certification' })).doesNotExist();
+          });
         });
       });
     });

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations-test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations-test.js
@@ -39,6 +39,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
       userId: 888,
       sex: 'M',
       isCancelled: false,
+      isPublished: false,
       isRejectedForFraud: false,
       birthCountry: 'JAPON',
       birthInseeCode: '99217',
@@ -775,7 +776,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
     module('Certification cancellation', function () {
       module('Cancel', function () {
         let screen;
-        module('when session is finalized', function (hooks) {
+        module('when session is finalized and not published yet', function (hooks) {
           hooks.beforeEach(async function () {
             await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
             screen = await visit(`/certifications/${certification.id}`);
@@ -844,6 +845,21 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
             assert.dom(screen.queryByRole('button', { name: 'Annuler la certification' })).doesNotExist();
           });
         });
+
+        module('when session is finalized and published', function (hooks) {
+          hooks.beforeEach(async function () {
+            certification.update({ isPublished: true });
+            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+            screen = await visit(`/certifications/${certification.id}`);
+          });
+
+          test('should not display the cancellation button', function (assert) {
+            // given
+            // when
+            // then
+            assert.dom(screen.queryByRole('button', { name: 'Annuler la certification' })).doesNotExist();
+          });
+        });
       });
 
       module('Uncancel', function (hooks) {
@@ -852,7 +868,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
           certification.update({ isCancelled: true });
         });
 
-        module('when session is finalized', function (hooks) {
+        module('when session is finalized and not published yet', function (hooks) {
           hooks.beforeEach(async function () {
             await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
             screen = await visit(`/certifications/${certification.id}`);
@@ -913,7 +929,22 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
             screen = await visit(`/certifications/${certification.id}`);
           });
 
-          test('should not display the cancellation button', function (assert) {
+          test('should not display the uncancellation button', function (assert) {
+            // given
+            // when
+            // then
+            assert.dom(screen.queryByRole('button', { name: 'Désannuler la certification' })).doesNotExist();
+          });
+        });
+
+        module('when session is finalized and published', function (hooks) {
+          hooks.beforeEach(async function () {
+            certification.update({ isPublished: true });
+            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+            screen = await visit(`/certifications/${certification.id}`);
+          });
+
+          test('should not display the uncancellation button', function (assert) {
             // given
             // when
             // then

--- a/admin/tests/acceptance/authenticated/certifications/certification/neutralization-test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/neutralization-test.js
@@ -307,8 +307,8 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
           index: '1.2',
         },
       ];
-
-      const certificationId = this.server.create('certification').id;
+      const session = this.server.create('session');
+      const certificationId = this.server.create('certification', { sessionId: session.id }).id;
       this.server.create('certification-detail', {
         id: certificationId,
         competencesWithMark,


### PR DESCRIPTION
## :pancakes: Problème

Actuellement, les boutons pour annuler et désannuler une certification sont affichés même si la session n'est pas encore finalisée.
Même si on est protégée coté API pour ne pas permettre ces actions si on est dans ce cas de figure, on ne devrait pas pouvoir les voir coté front.

## :bacon: Proposition

Ne pas afficher les boutons d'annulation si la session n'est pas finalisée

## 🧃 Remarques

Choix de déclencher un appel get session pour récupérer la donnée `finalizedAt`.

## :yum: A tester

- Se connecter sur Pix Admin
- Aller dans l'onglet sessions de certification
- selectionner dans les champs le statut finalisée
- Cliquer sur une des sessions proposées
- Dans la page de détails, cliquer sur l'onglet certifications
- Un tableau liste plusieurs candidat, en sélectionner un
- Constater sur cette nouvelle page que le bouton annuler une certification apparaît
- Annuler la certification
- Voir que le bouton "Désannuler une certification" le remplace
- revenir dans la liste des certifications de la session
- Dépublier la session si elle l'est, puis dé-finaliser la session
- revenir sur la page du candidat dont on a annulé la certification
- constater que le bouton "Désannuler une certification" n'apparaît plus