### PR TITLE
[BUGFIX] Corriger les informations dans le toaster de désactivation des utilisateurs de Pix admin (PIX-13604)

### DIFF
--- a/admin/app/components/team/list.gjs
+++ b/admin/app/components/team/list.gjs
@@ -64,13 +64,13 @@ export default class List extends Component {
   }
 
   @action
-  async deactivateAdminMember(adminMemberToDeactivate) {
+  async deactivateAdminMember() {
     try {
       await this.adminMemberToDeactivate.save({ adapterOptions: { method: 'deactivate' } });
       await this.args.refreshValues();
       this.toggleDisplayConfirm();
       this.pixToast.sendSuccessNotification({
-        message: `L'agent ${adminMemberToDeactivate.firstName} ${adminMemberToDeactivate.lastName} n'a plus accès à Pix Admin.`,
+        message: `L'agent ${this.adminMemberToDeactivate.firstName} ${this.adminMemberToDeactivate.lastName} n'a plus accès à Pix Admin.`,
       });
     } catch (errorResponse) {
       this.toggleDisplayConfirm();
@@ -172,7 +172,7 @@ export default class List extends Component {
       @message={{this.confirmPopUpMessage}}
       @title="Désactivation d'un agent Pix"
       @submitTitle="Confirmer"
-      @confirm={{fn this.deactivateAdminMember this.adminMemberToDeactivate}}
+      @confirm={{this.deactivateAdminMember}}
       @cancel={{this.toggleDisplayConfirm}}
       @show={{this.displayConfirm}}
     />


### PR DESCRIPTION
## :pancakes: Problème

Lorsqu'on désactivait plusieurs utilisateurs depuis la page de pix admin section équipe, les informations tels que le prénom et nom de l'utilisateur désactivé n'étaient pas mises à jour dans le popup confirmant la désactivation. Par exemple si on désactivait l'utilisateur certif admin puis l'utilisateur pix certif, le 2ème popup parlait toujours de certif admin.

## :bacon: Proposition

Retirer le paramètre de la fonction de désactivation et utiliser directement la variable adminMemberToDeactivate.

## 🧃 Remarques

Pourquoi la fonction avait un argument alors qu'on ne l'utilisait qu'une fois sur 2?

## :yum: Pour tester

- Se rendre sur Pix admin,
- Se connecter avec le compte superadmin@example.net,
- Se rendre sur la page équipe,
- Choisir un utilisateur qui n'est pas celui avec lequel on s'est connecté,
- Cliquer sur le bouton pour le désactiver et confirmer,
- Constater que la notification avec les informations sur l'utilisateur est bien là,
- Choisir un autre utilisateur et le désactiver,
- Constater que la notification s'est réaffichée avec les bonnes informations sur le 2ème utilisateur,
- Exécuter la commande pour remettre tous les seeds pour ceux qui passeront derrière:
```shell
scalingo -a pix-api-review-pr11302 run npm run db:seed
```
