### PR TITLE
[TECH] Ajouts de logs d’erreurs de lecture du Learning Content (PIX-16374)

### DIFF
--- a/api/lib/infrastructure/repositories/framework-repository.js
+++ b/api/lib/infrastructure/repositories/framework-repository.js
@@ -1,8 +1,11 @@
 import { NotFoundError } from '../../../src/shared/domain/errors.js';
 import { Framework } from '../../../src/shared/domain/models/index.js';
 import { LearningContentRepository } from '../../../src/shared/infrastructure/repositories/learning-content-repository.js';
+import { child, SCOPES } from '../../../src/shared/infrastructure/utils/logger.js';
 
 const TABLE_NAME = 'learningcontent.frameworks';
+
+const logger = child('learningcontent:repository', { event: SCOPES.LEARNING_CONTENT });
 
 export async function list() {
   const cacheKey = 'list';
@@ -16,6 +19,7 @@ export async function getByName(name) {
   const findByNameCallback = (knex) => knex.where('name', name).limit(1);
   const [frameworkDto] = await getInstance().find(cacheKey, findByNameCallback);
   if (!frameworkDto) {
+    logger.warn({ frameworkName: name }, 'Référentiel introuvable');
     throw new NotFoundError(`Framework not found for name ${name}`);
   }
   return toDomain(frameworkDto);

--- a/api/src/shared/infrastructure/repositories/area-repository.js
+++ b/api/src/shared/infrastructure/repositories/area-repository.js
@@ -2,10 +2,13 @@ import { PIX_ORIGIN } from '../../domain/constants.js';
 import { NotFoundError } from '../../domain/errors.js';
 import { Area } from '../../domain/models/Area.js';
 import { getTranslatedKey } from '../../domain/services/get-translated-text.js';
+import { child, SCOPES } from '../utils/logger.js';
 import * as competenceRepository from './competence-repository.js';
 import { LearningContentRepository } from './learning-content-repository.js';
 
 const TABLE_NAME = 'learningcontent.areas';
+
+const logger = child('learningcontent:repository', { event: SCOPES.LEARNING_CONTENT });
 
 export async function list({ locale } = {}) {
   const cacheKey = 'list()';
@@ -57,6 +60,7 @@ export async function getAreaCodeByCompetenceId(competenceId) {
 export async function get({ id, locale }) {
   const areaDto = await getInstance().load(id);
   if (!areaDto) {
+    logger.warn({ areaId: id }, 'Domaine introuvable');
     throw new NotFoundError(`Area "${id}" not found.`);
   }
   return toDomain(areaDto, locale);

--- a/api/src/shared/infrastructure/repositories/challenge-repository.js
+++ b/api/src/shared/infrastructure/repositories/challenge-repository.js
@@ -20,7 +20,8 @@ const ACCESSIBLE_STATUSES = [Accessibility.RAS, Accessibility.OK];
 export async function get(id, { forCorrection = false } = {}) {
   const challengeDto = await getInstance().load(id);
   if (!challengeDto) {
-    throw new NotFoundError();
+    logger.warn({ challengeId: id }, 'Épreuve introuvable');
+    throw new NotFoundError('Épreuve introuvable');
   }
   if (forCorrection) {
     return {
@@ -45,9 +46,11 @@ export async function get(id, { forCorrection = false } = {}) {
 
 export async function getMany(ids, locale) {
   const challengeDtos = await getInstance().loadMany(ids);
-  if (challengeDtos.some((challengeDto) => !challengeDto)) {
-    throw new NotFoundError();
-  }
+  challengeDtos.forEach((challengeDto, index) => {
+    if (challengeDto) return;
+    logger.warn({ challengeId: ids[index] }, 'Épreuve introuvable');
+    throw new NotFoundError('Épreuve introuvable');
+  });
   const localeChallengeDtos = locale
     ? challengeDtos.filter((challengeDto) => challengeDto.locales.includes(locale))
     : challengeDtos;

--- a/api/src/shared/infrastructure/repositories/competence-repository.js
+++ b/api/src/shared/infrastructure/repositories/competence-repository.js
@@ -2,10 +2,13 @@ import { LOCALE, PIX_ORIGIN } from '../../domain/constants.js';
 import { NotFoundError } from '../../domain/errors.js';
 import { Competence } from '../../domain/models/index.js';
 import { getTranslatedKey } from '../../domain/services/get-translated-text.js';
+import { child, SCOPES } from '../utils/logger.js';
 import { LearningContentRepository } from './learning-content-repository.js';
 
 const { FRENCH_FRANCE } = LOCALE;
 const TABLE_NAME = 'learningcontent.competences';
+
+const logger = child('learningcontent:repository', { event: SCOPES.LEARNING_CONTENT });
 
 export async function list({ locale = FRENCH_FRANCE } = {}) {
   const cacheKey = 'list()';
@@ -24,6 +27,7 @@ export async function listPixCompetencesOnly({ locale = FRENCH_FRANCE } = {}) {
 export async function get({ id, locale }) {
   const competenceDto = await getInstance().load(id);
   if (!competenceDto) {
+    logger.warn({ competenceId: id }, 'Compétence introuvable');
     throw new NotFoundError('La compétence demandée n’existe pas');
   }
   return toDomain({ competenceDto, locale });

--- a/api/src/shared/infrastructure/repositories/skill-repository.js
+++ b/api/src/shared/infrastructure/repositories/skill-repository.js
@@ -2,6 +2,7 @@ import { knex } from '../../../../db/knex-database-connection.js';
 import { NotFoundError } from '../../domain/errors.js';
 import { Skill } from '../../domain/models/Skill.js';
 import { getTranslatedKey } from '../../domain/services/get-translated-text.js';
+import { child, SCOPES } from '../utils/logger.js';
 import { LearningContentRepository } from './learning-content-repository.js';
 
 const TABLE_NAME = 'learningcontent.skills';
@@ -9,9 +10,12 @@ const ACTIVE_STATUS = 'actif';
 const ARCHIVED_STATUS = 'archivé';
 const OPERATIVE_STATUSES = [ACTIVE_STATUS, ARCHIVED_STATUS];
 
+const logger = child('learningcontent:repository', { event: SCOPES.LEARNING_CONTENT });
+
 export async function get(id, { locale, useFallback } = { locale: null, useFallback: true }) {
   const skillDto = await getInstance().load(id);
   if (!skillDto) {
+    logger.warn({ skillId: id }, 'Acquis introuvable');
     throw new NotFoundError('Erreur, acquis introuvable');
   }
   return toDomain(skillDto, locale, useFallback);

--- a/api/src/shared/infrastructure/repositories/tube-repository.js
+++ b/api/src/shared/infrastructure/repositories/tube-repository.js
@@ -2,14 +2,18 @@ import { knex } from '../../../../db/knex-database-connection.js';
 import { LearningContentResourceNotFound } from '../../domain/errors.js';
 import { Tube } from '../../domain/models/Tube.js';
 import { getTranslatedKey } from '../../domain/services/get-translated-text.js';
+import { child, SCOPES } from '../utils/logger.js';
 import { LearningContentRepository } from './learning-content-repository.js';
 
 const TABLE_NAME = 'learningcontent.tubes';
 const ACTIVE_STATUS = 'actif';
 
+const logger = child('learningcontent:repository', { event: SCOPES.LEARNING_CONTENT });
+
 export async function get(id) {
   const tubeDto = await getInstance().load(id);
   if (!tubeDto) {
+    logger.warn({ tubeId: id }, 'Tube introuvable');
     throw new LearningContentResourceNotFound();
   }
   return toDomain(tubeDto);

--- a/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
@@ -485,6 +485,7 @@ describe('Integration | Repository | challenge-repository', function () {
 
         // then
         expect(err).to.be.instanceOf(NotFoundError);
+        expect(err).to.have.property('message', 'Épreuve introuvable');
       });
     });
 
@@ -618,6 +619,7 @@ describe('Integration | Repository | challenge-repository', function () {
 
           // then
           expect(err).to.be.instanceOf(NotFoundError);
+          expect(err).to.have.property('message', 'Épreuve introuvable');
         });
       });
       context('when all challenges are found', function () {
@@ -774,6 +776,7 @@ describe('Integration | Repository | challenge-repository', function () {
 
           // then
           expect(err).to.be.instanceOf(NotFoundError);
+          expect(err).to.have.property('message', 'Épreuve introuvable');
         });
       });
       context('when all challenges are found', function () {


### PR DESCRIPTION
## :pancakes: Problème

Quand des erreurs 404 surviennent sur l’API Pix en Prod, il est difficile de savoir si ces erreurs sont provoquées par la lecture du Learning Content.

## :bacon: Proposition

Ajouter des logs pour mettre en évidence les cas où le Learning Content est effectivement en cause.

## 🧃 Remarques

N/A

## :yum: Pour tester

N/A