### PR TITLE
[BUGFIX] Vérification des CGUs acceptées avant acceptation (PIX-16377)

### DIFF
--- a/api/src/legal-documents/domain/usecases/accept-legal-document-by-user-id.usecase.js
+++ b/api/src/legal-documents/domain/usecases/accept-legal-document-by-user-id.usecase.js
@@ -31,6 +31,11 @@ const acceptLegalDocumentByUserId = withTransaction(
       return;
     }
 
+    const existUserAcceptance = await userAcceptanceRepository.findLastForLegalDocument({ userId, service, type });
+    if (existUserAcceptance) {
+      return;
+    }
+
     await userAcceptanceRepository.create({ userId, legalDocumentVersionId: legalDocument.id });
   },
 );

--- a/api/src/legal-documents/domain/usecases/accept-legal-document-by-user-id.usecase.js
+++ b/api/src/legal-documents/domain/usecases/accept-legal-document-by-user-id.usecase.js
@@ -31,8 +31,12 @@ const acceptLegalDocumentByUserId = withTransaction(
       return;
     }
 
-    const existUserAcceptance = await userAcceptanceRepository.findLastForLegalDocument({ userId, service, type });
-    if (existUserAcceptance) {
+    const doesUserAcceptanceAlreadyExist = await userAcceptanceRepository.findLastForLegalDocument({
+      userId,
+      service,
+      type,
+    });
+    if (doesUserAcceptanceAlreadyExist) {
       return;
     }
 

--- a/api/src/legal-documents/scripts/convert-users-orga-cgu-data.js
+++ b/api/src/legal-documents/scripts/convert-users-orga-cgu-data.js
@@ -84,6 +84,7 @@ export class ConvertUsersOrgaCguData extends Script {
     return knexConnection('users')
       .select('*')
       .where('pixOrgaTermsOfServiceAccepted', true)
+      .orderBy('id')
       .limit(batchSize)
       .offset(offset);
   }

--- a/api/tests/legal-documents/integration/domain/usecases/accept-legal-document-by-user-id.usecase.test.js
+++ b/api/tests/legal-documents/integration/domain/usecases/accept-legal-document-by-user-id.usecase.test.js
@@ -29,6 +29,30 @@ describe('Integration | Legal documents | Domain | Use case | accept-legal-docum
     expect(userAcceptance).to.exist;
   });
 
+  context('when user has already accepted the legal document', function () {
+    it('does not throw an exception', async function () {
+      // given
+      const user = databaseBuilder.factory.buildUser();
+      const document = databaseBuilder.factory.buildLegalDocumentVersion({ service: PIX_ORGA, type: TOS });
+      databaseBuilder.factory.buildLegalDocumentVersionUserAcceptance({
+        userId: user.id,
+        legalDocumentVersionId: document.id,
+        acceptedAt: new Date('2024-03-01'),
+      });
+      await databaseBuilder.commit();
+
+      // when
+      await usecases.acceptLegalDocumentByUserId({ userId: user.id, service: PIX_ORGA, type: TOS });
+
+      // then
+      const userAcceptance = await knex('legal-document-version-user-acceptances')
+        .where('userId', user.id)
+        .where('legalDocumentVersionId', document.id)
+        .first();
+      expect(userAcceptance).to.exist;
+    });
+  });
+
   context('when the legal document is the Terms of Service for Pix Orga', function () {
     it('accepts the Pix Orga CGUs in the legacy and legal document model', async function () {
       // given


### PR DESCRIPTION
## :pancakes: Problème

L’appel `/api/users/{id}/pix-orga-terms-of-service-acceptance` provoque des erreurs 500 quand les CGUs ont déjà été acceptées.

```
DatabaseError: /* path: /api/users/{id}/pix-orga-terms-of-service-acceptance */ insert into "legal-document-version-user-acceptances" ("legalDocumentVersionId", "userId") values ($1, $2) - duplicate key value violates unique constraint "legal_document_version_user_acceptances_userid_legaldocumentver"
```

Cela peut survenir quand l’utilisateur a plusieurs pages d’ouvertes sur lesquelles la validation des CGUs est demandée.

## :bacon: Proposition

Ajouter une vérification au moment de l'acceptation d'un document pour s'assurer qu'elle n'a pas été déjà réalisée.

## 🧃 Remarques

Correction du script de conversion des CGUs des utilisateurs, pour garantir un ordre dans la requête de récupération des utilisateurs paginés.

## :yum: Pour tester

**Pré-requis**
Exécuter le script depuis le dossier API :
```
node src/legal-documents/scripts/add-new-legal-document-version.js --type="TOS" --service="pix-orga" --versionAt="2022-11-30"
```

**Scénario**
1. Se connecter à Pix Orga avec le compte `allorga@example.net`
2. Récupérer l'access token dans le local storage (pour le renseigner dans le CURL suivant)

Exécuter la commande cURL suivante en remplaçant `ACCESS_TOKEN` par le token utilisateur, vérifier que le user id (10001) est celui utilisé, et que l'URL (http://localhost:4201) correspond à votre environnement:
```
curl -X 'PATCH' 'http://localhost:4201/api/users/10001/pix-orga-terms-of-service-acceptance' -H 'Authorization: Bearer ACCESS_TOKEN'
```
_

Cette commande NE DOIT PAS retourner une erreur 500, si elle est exécuter plusieurs fois de suite:
```
{"statusCode":500,"error":"Internal Server Error","message":"An internal server error occurred"}
```