### PR TITLE
[BUGFIX] Gérer les pages hors connexion dans le nouveau gabarit (PIX-16378).

### DIFF
--- a/mon-pix/app/components/global/app-layout.gjs
+++ b/mon-pix/app/components/global/app-layout.gjs
@@ -10,8 +10,13 @@ import AppMainHeader from './app-main-header';
 import AppNavigation from './app-navigation';
 
 export default class AppLayout extends Component {
+  @service currentUser;
   @service media;
   @service featureToggles;
+
+  get displayAppMainHeader() {
+    return this.currentUser.user && !this.media.isMobile;
+  }
 
   <template>
     {{#if this.featureToggles.featureToggles.isPixAppNewLayoutEnabled}}
@@ -24,9 +29,9 @@ export default class AppLayout extends Component {
         </:navigation>
         <:main>
           <div>
-            {{#unless this.media.isMobile}}
+            {{#if this.displayAppMainHeader}}
               <AppMainHeader />
-            {{/unless}}
+            {{/if}}
             {{yield}}
           </div>
         </:main>

--- a/mon-pix/app/components/global/app-navigation.gjs
+++ b/mon-pix/app/components/global/app-navigation.gjs
@@ -83,6 +83,9 @@ export default class AppNavigation extends Component {
           </PixButtonLink>
           <PixNavigationSeparator />
           <strong>{{this.currentUser.user.fullName}}</strong>
+          <PixButtonLink @route="authenticated.user-certifications" @variant="tertiary" @iconBefore="awards">
+            {{t "navigation.user.certifications"}}
+          </PixButtonLink>
           <PixButtonLink @route="authenticated.user-account" @iconBefore="shieldPerson">
             {{t "navigation.user.account"}}
           </PixButtonLink>

--- a/mon-pix/app/components/global/app-navigation.gjs
+++ b/mon-pix/app/components/global/app-navigation.gjs
@@ -39,28 +39,37 @@ export default class AppNavigation extends Component {
         <PixLogo @color="white" />
       </:brand>
       <:navElements>
-        <PixNavigationButton @route="authenticated.user-dashboard" @icon="home">
-          {{t "navigation.main.dashboard"}}
-        </PixNavigationButton>
-        <PixNavigationButton @route="authenticated.profile" @icon="star">
-          {{t "navigation.main.skills"}}
-        </PixNavigationButton>
-        {{#if this.showAssessmentsNavItem}}
-          <PixNavigationButton @route="authenticated.user-tests" @icon="conversionPath">
-            {{t "navigation.user.tests"}}
+        {{#if this.currentUser.user}}
+          <PixNavigationButton @route="authenticated.user-dashboard" @icon="home">
+            {{t "navigation.main.dashboard"}}
           </PixNavigationButton>
-        {{/if}}
-        <PixNavigationButton @route="authenticated.certifications" @icon="newRealease">
-          {{t "navigation.main.start-certification"}}
-        </PixNavigationButton>
-        {{#if this.showTrainingsNavItem}}
-          <PixNavigationButton @route="authenticated.user-trainings" @icon="book">
-            {{t "navigation.main.trainings"}}
+          <PixNavigationButton @route="authenticated.profile" @icon="star">
+            {{t "navigation.main.skills"}}
           </PixNavigationButton>
+          {{#if this.showAssessmentsNavItem}}
+            <PixNavigationButton @route="authenticated.user-tests" @icon="conversionPath">
+              {{t "navigation.user.tests"}}
+            </PixNavigationButton>
+          {{/if}}
+          <PixNavigationButton @route="authenticated.certifications" @icon="newRealease">
+            {{t "navigation.main.start-certification"}}
+          </PixNavigationButton>
+          {{#if this.showTrainingsNavItem}}
+            <PixNavigationButton @route="authenticated.user-trainings" @icon="book">
+              {{t "navigation.main.trainings"}}
+            </PixNavigationButton>
+          {{/if}}
+          <PixNavigationButton @route="authenticated.user-tutorials" @icon="bookmark">
+            {{t "navigation.main.tutorials"}}
+          </PixNavigationButton>
+        {{else}}
+          <PixButtonLink @route="authentication.login" @variant="primary-bis" @iconBefore="login">
+            {{t "navigation.not-logged.sign-in"}}
+          </PixButtonLink>
+          <PixButtonLink @route="inscription" @variant="primary">
+            {{t "navigation.not-logged.sign-up"}}
+          </PixButtonLink>
         {{/if}}
-        <PixNavigationButton @route="authenticated.user-tutorials" @icon="bookmark">
-          {{t "navigation.main.tutorials"}}
-        </PixNavigationButton>
       </:navElements>
       <:footer>
         {{#if this.media.isMobile}}

--- a/mon-pix/tests/integration/components/global/app-layout-test.gjs
+++ b/mon-pix/tests/integration/components/global/app-layout-test.gjs
@@ -11,17 +11,6 @@ module('Integration | Component | Global | App Layout', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   hooks.beforeEach(function () {
-    stubCurrentUserService(
-      this.owner,
-      {
-        firstName: 'Banana',
-        lastName: 'Split',
-        email: 'banana.split@example.net',
-        profile: { pixScore: 100 },
-      },
-      { withStoreStubbed: false },
-    );
-
     class FeatureTogglesStub extends Service {
       featureToggles = { isPixAppNewLayoutEnabled: true };
     }
@@ -52,37 +41,7 @@ module('Integration | Component | Global | App Layout', function (hooks) {
   });
 
   module('main header', function () {
-    test('it should display the user pix score', async function (assert) {
-      // given & when
-      const screen = await render(<template><AppLayout /></template>);
-
-      // then
-      assert.dom(screen.getByRole('link', { name: '100 Pix' })).exists();
-    });
-
-    test('it should display a campaign code link', async function (assert) {
-      // given & when
-      const screen = await render(<template><AppLayout /></template>);
-
-      // then
-      assert.dom(screen.getByRole('link', { name: t('navigation.main.code') })).exists();
-    });
-
-    test('it should display the UserLoggedMenu component', async function (assert) {
-      // given & when
-      const screen = await render(<template><AppLayout /></template>);
-
-      // then
-      assert
-        .dom(
-          screen.getByRole('button', {
-            name: `Banana ${t('navigation.user-logged-menu.details')}`,
-          }),
-        )
-        .exists();
-    });
-
-    module('on mobile device', function () {
+    module('when user is not connected', function () {
       test('it should not be displayed', async function (assert) {
         // given & when
         class MediaServiceStub extends Service {
@@ -94,6 +53,66 @@ module('Integration | Component | Global | App Layout', function (hooks) {
 
         // then
         assert.dom(screen.queryByRole('link', { name: '100 Pix' })).doesNotExist();
+      });
+    });
+
+    module('when user is connected', function (hooks) {
+      hooks.beforeEach(function () {
+        stubCurrentUserService(
+          this.owner,
+          {
+            firstName: 'Banana',
+            lastName: 'Split',
+            email: 'banana.split@example.net',
+            profile: { pixScore: 100 },
+          },
+          { withStoreStubbed: false },
+        );
+      });
+
+      test('it should display the user pix score', async function (assert) {
+        // given & when
+        const screen = await render(<template><AppLayout /></template>);
+
+        // then
+        assert.dom(screen.getByRole('link', { name: '100 Pix' })).exists();
+      });
+
+      test('it should display a campaign code link', async function (assert) {
+        // given & when
+        const screen = await render(<template><AppLayout /></template>);
+
+        // then
+        assert.dom(screen.getByRole('link', { name: t('navigation.main.code') })).exists();
+      });
+
+      test('it should display the UserLoggedMenu component', async function (assert) {
+        // given & when
+        const screen = await render(<template><AppLayout /></template>);
+
+        // then
+        assert
+          .dom(
+            screen.getByRole('button', {
+              name: `Banana ${t('navigation.user-logged-menu.details')}`,
+            }),
+          )
+          .exists();
+      });
+
+      module('on mobile device', function () {
+        test('it should not be displayed', async function (assert) {
+          // given & when
+          class MediaServiceStub extends Service {
+            isMobile = true;
+          }
+          this.owner.register('service:media', MediaServiceStub);
+
+          const screen = await render(<template><AppLayout /></template>);
+
+          // then
+          assert.dom(screen.queryByRole('link', { name: '100 Pix' })).doesNotExist();
+        });
       });
     });
   });

--- a/mon-pix/tests/integration/components/global/app-navigation-test.gjs
+++ b/mon-pix/tests/integration/components/global/app-navigation-test.gjs
@@ -13,9 +13,6 @@ module('Integration | Component | Global | App Navigation', function (hooks) {
   module('logos', function () {
     module('when it is not the french domain', function () {
       test('it should only display the Pix logo', async function (assert) {
-        // given
-        _stubCurrentUser(this.owner);
-
         // when
         const screen = await render(<template><AppNavigation /></template>);
 
@@ -30,9 +27,6 @@ module('Integration | Component | Global | App Navigation', function (hooks) {
 
     module('when it is the french domain', function () {
       test('it should only display the Pix logo', async function (assert) {
-        // given
-        _stubCurrentUser(this.owner);
-
         class CurrentDomainServiceStub extends Service {
           get isFranceDomain() {
             return true;
@@ -50,50 +44,75 @@ module('Integration | Component | Global | App Navigation', function (hooks) {
   });
 
   module('links list', function () {
-    test('it should always display a links list', async function (assert) {
-      // given
-      _stubCurrentUser(this.owner);
-
-      // when
-      const screen = await render(<template><AppNavigation /></template>);
-
-      // then
-      const nav = screen.getByLabelText('navigation principale');
-
-      assert.dom(within(nav).getByRole('link', { name: t('navigation.main.dashboard') })).exists();
-      assert.dom(within(nav).getByRole('link', { name: t('navigation.main.skills') })).exists();
-      assert.dom(within(nav).getByRole('link', { name: t('navigation.main.start-certification') })).exists();
-      assert.dom(within(nav).getByRole('link', { name: t('navigation.main.tutorials') })).exists();
-
-      assert.dom(within(nav).queryByRole('link', { name: t('navigation.user.tests') })).doesNotExist();
-      assert.dom(within(nav).queryByRole('link', { name: t('navigation.main.trainings') })).doesNotExist();
-    });
-
-    module('when user has started assessments', function () {
-      test('it should display a specific link', async function (assert) {
+    module('when user is connected', function () {
+      test('it should always display a links list', async function (assert) {
         // given
-        _stubCurrentUser(this.owner, { hasAssessmentParticipations: true });
+        _stubCurrentUser(this.owner);
 
         // when
         const screen = await render(<template><AppNavigation /></template>);
 
         // then
         const nav = screen.getByLabelText('navigation principale');
-        assert.dom(within(nav).getByRole('link', { name: t('navigation.user.tests') })).exists();
+
+        assert.dom(within(nav).getByRole('link', { name: t('navigation.main.dashboard') })).exists();
+        assert.dom(within(nav).getByRole('link', { name: t('navigation.main.skills') })).exists();
+        assert.dom(within(nav).getByRole('link', { name: t('navigation.main.start-certification') })).exists();
+        assert.dom(within(nav).getByRole('link', { name: t('navigation.main.tutorials') })).exists();
+
+        assert.dom(within(nav).queryByRole('link', { name: t('navigation.user.tests') })).doesNotExist();
+        assert.dom(within(nav).queryByRole('link', { name: t('navigation.main.trainings') })).doesNotExist();
+
+        assert.dom(within(nav).queryByRole('link', { name: t('navigation.not-logged.sign-in') })).doesNotExist();
+        assert.dom(within(nav).queryByRole('link', { name: t('navigation.not-logged.sign-up') })).doesNotExist();
+      });
+
+      module('when user has started assessments', function () {
+        test('it should display a specific link', async function (assert) {
+          // given
+          _stubCurrentUser(this.owner, { hasAssessmentParticipations: true });
+
+          // when
+          const screen = await render(<template><AppNavigation /></template>);
+
+          // then
+          const nav = screen.getByLabelText('navigation principale');
+          assert.dom(within(nav).getByRole('link', { name: t('navigation.user.tests') })).exists();
+        });
+      });
+
+      module('when user has recommended trainings', function () {
+        test('it should display a specific link', async function (assert) {
+          // given
+          _stubCurrentUser(this.owner, { hasRecommendedTrainings: true });
+
+          // when
+          const screen = await render(<template><AppNavigation /></template>);
+
+          // then
+          const nav = screen.getByLabelText('navigation principale');
+          assert.dom(within(nav).getByRole('link', { name: t('navigation.main.trainings') })).exists();
+        });
       });
     });
 
-    module('when user has recommended trainings', function () {
-      test('it should display a specific link', async function (assert) {
-        // given
-        _stubCurrentUser(this.owner, { hasRecommendedTrainings: true });
-
+    module('when user is not connected', function () {
+      test('it should only display sign-in and sign-up links', async function (assert) {
         // when
         const screen = await render(<template><AppNavigation /></template>);
 
         // then
         const nav = screen.getByLabelText('navigation principale');
-        assert.dom(within(nav).getByRole('link', { name: t('navigation.main.trainings') })).exists();
+
+        assert.dom(within(nav).getByRole('link', { name: t('navigation.not-logged.sign-in') })).exists();
+        assert.dom(within(nav).getByRole('link', { name: t('navigation.not-logged.sign-up') })).exists();
+
+        assert.dom(within(nav).queryByRole('link', { name: t('navigation.main.dashboard') })).doesNotExist();
+        assert.dom(within(nav).queryByRole('link', { name: t('navigation.main.skills') })).doesNotExist();
+        assert.dom(within(nav).queryByRole('link', { name: t('navigation.main.start-certification') })).doesNotExist();
+        assert.dom(within(nav).queryByRole('link', { name: t('navigation.main.tutorials') })).doesNotExist();
+        assert.dom(within(nav).queryByRole('link', { name: t('navigation.user.tests') })).doesNotExist();
+        assert.dom(within(nav).queryByRole('link', { name: t('navigation.main.trainings') })).doesNotExist();
       });
     });
   });

--- a/mon-pix/tests/integration/components/global/app-navigation-test.gjs
+++ b/mon-pix/tests/integration/components/global/app-navigation-test.gjs
@@ -151,6 +151,7 @@ module('Integration | Component | Global | App Navigation', function (hooks) {
       assert.dom(within(footer).getByRole('link', { name: t('navigation.main.code') })).exists();
       assert.dom(within(footer).getByText('Banana Split')).exists();
       assert.dom(within(footer).getByRole('link', { name: t('navigation.user.account') })).exists();
+      assert.dom(within(footer).getByRole('link', { name: t('navigation.user.certifications') })).exists();
       assert.dom(within(footer).getByRole('link', { name: t('navigation.user.sign-out') })).exists();
       assert.dom(within(footer).getByRole('link', { name: t('navigation.footer.help-center') })).exists();
     });


### PR DESCRIPTION
## :pancakes: Problème

Le nouveau gabarit ne gérait pas le cas des pages ne nécessitant pas la connexion de l'utilisateur.

## :bacon: Proposition

Quand on est déconnecté, on doit avoir :
- 2 boutons `Se connecter` et `S’inscrire` dans la navigation 
- une en-tête de droite cachée (celle avec le score Pix et le bouton "j'ai un code")

## :yum: Pour tester

Sans être connecté sur la RA, aller sur les pages:
- [/campagnes](https://app-pr11307.review.pix.fr/campagnes)
- [/verification-certificat](https://app-pr11307.review.pix.fr/verification-certificat)

Constater que tout s'affiche comme souhaité.
