### PR TITLE
[FEATURE] Indiquer si l'utilisateur se connecte via SSO sur Pix admin (PIX-14788)

### DIFF
--- a/admin/app/components/users/user-overview.gjs
+++ b/admin/app/components/users/user-overview.gjs
@@ -27,9 +27,11 @@ export default class UserOverview extends Component {
   @service pixToast;
   @service references;
   @service store;
+  @service oidcIdentityProviders;
 
   @tracked displayAnonymizeModal = false;
   @tracked isEditionMode = false;
+  @tracked authenticationMethods = [];
 
   languages = this.references.availableLanguages;
   locales = this.references.availableLocales;
@@ -39,6 +41,9 @@ export default class UserOverview extends Component {
   constructor() {
     super(...arguments);
     this.form = this.store.createRecord('user-form');
+    Promise.resolve(this.args.user.authenticationMethods).then((authenticationMethods) => {
+      this.authenticationMethods = authenticationMethods;
+    });
   }
 
   get externalURL() {
@@ -84,6 +89,15 @@ export default class UserOverview extends Component {
 
   get isEmailRequired() {
     return this.args.user.username ? null : 'obligatoire';
+  }
+
+  get hasSsoAuthentication() {
+    const oidcProvidersCodes = this.oidcIdentityProviders.list.map((provider) => provider.code);
+    return this.authenticationMethods.any(
+      (authenticationMethod) =>
+        oidcProvidersCodes.includes(authenticationMethod.identityProvider) ||
+        authenticationMethod.identityProvider === 'GAR',
+    );
   }
 
   _initForm() {
@@ -329,6 +343,13 @@ export default class UserOverview extends Component {
                         </PixTooltip>
                       {{/if}}
                     {{/if}}
+                  </span>
+                </li>
+                <li class="user-detail-personal-information-section__user-informations flex space-between gap-4x">
+                  <span>
+                    {{t "components.users.user-overview.sso"}}
+                    :
+                    {{#if this.hasSsoAuthentication}}{{t "common.words.yes"}}{{else}}{{t "common.words.no"}}{{/if}}
                   </span>
                 </li>
               </ul>

--- a/admin/tests/unit/components/users/user-overview-test.js
+++ b/admin/tests/unit/components/users/user-overview-test.js
@@ -13,18 +13,15 @@ module('Unit | Component | users | user-overview', function (hooks) {
   module('#externalURL', function () {
     test('it should generate dashboard URL based on environment and object', async function (assert) {
       // given
-      const component = createGlimmerComponent('component:users/user-overview');
-
-      const args = {
+      const baseUrl = 'https://metabase.pix.fr/dashboard/132?id=';
+      ENV.APP.USER_DASHBOARD_URL = baseUrl;
+      const component = createGlimmerComponent('component:users/user-overview', {
         user: {
           id: 1,
+          authenticationMethods: [],
         },
-      };
-      const baseUrl = 'https://metabase.pix.fr/dashboard/132?id=';
-      const expectedUrl = baseUrl + args.user.id;
-
-      ENV.APP.USER_DASHBOARD_URL = baseUrl;
-      component.args = args;
+      });
+      const expectedUrl = baseUrl + '1';
 
       // when
       const actualUrl = component.externalURL;
@@ -38,9 +35,8 @@ module('Unit | Component | users | user-overview', function (hooks) {
     module('when user already has an email', function () {
       test('it should allow email modification', async function (assert) {
         // given
-        const component = createGlimmerComponent('component:users/user-overview');
-        const user = { email: 'lisa@example.net', firstName: 'Lisa', lastName: 'Dupont' };
-        component.args.user = user;
+        const user = { email: 'lisa@example.net', firstName: 'Lisa', lastName: 'Dupont', authenticationMethods: [] };
+        const component = createGlimmerComponent('component:users/user-overview', { user });
 
         // when & then
         assert.true(component.canModifyEmail);
@@ -50,9 +46,8 @@ module('Unit | Component | users | user-overview', function (hooks) {
     module('when user has an username', function () {
       test('it should also allow email modification', async function (assert) {
         // given
-        const component = createGlimmerComponent('component:users/user-overview');
-        const user = { username: 'lisa.dupont', firstName: 'Lisa', lastName: 'Dupont' };
-        component.args.user = user;
+        const user = { username: 'lisa.dupont', firstName: 'Lisa', lastName: 'Dupont', authenticationMethods: [] };
+        const component = createGlimmerComponent('component:users/user-overview', { user });
 
         // when & then
         assert.true(component.canModifyEmail);
@@ -62,9 +57,8 @@ module('Unit | Component | users | user-overview', function (hooks) {
     module('when user has neither a username nor an email', function () {
       test('it should not allow email modification', async function (assert) {
         // given
-        const component = createGlimmerComponent('component:users/user-overview');
-        const user = { firstName: 'Lisa', lastName: 'Dupont' };
-        component.args.user = user;
+        const user = { firstName: 'Lisa', lastName: 'Dupont', authenticationMethods: [] };
+        const component = createGlimmerComponent('component:users/user-overview', { user });
 
         // when & then
         assert.false(component.canModifyEmail);
@@ -76,7 +70,8 @@ module('Unit | Component | users | user-overview', function (hooks) {
     module('when user has no login informations yet', function () {
       test('should not display temporary blocked date', function (assert) {
         // given
-        const component = createGlimmerComponent('component:users/user-overview');
+        const user = { authenticationMethods: [] };
+        const component = createGlimmerComponent('component:users/user-overview', { user });
 
         // when && then
         assert.false(component.shouldDisplayTemporaryBlockedDate);
@@ -86,9 +81,8 @@ module('Unit | Component | users | user-overview', function (hooks) {
     module('when user has login but not temporary blocked', function () {
       test('should not display temporary blocked date', function (assert) {
         // given
-        const component = createGlimmerComponent('component:users/user-overview');
-        const user = { firstName: 'Lisa', lastName: 'Dupont' };
-        component.args.user = user;
+        const user = { firstName: 'Lisa', lastName: 'Dupont', authenticationMethods: [] };
+        const component = createGlimmerComponent('component:users/user-overview', { user });
         const getTemporaryBlockedUntilProperty = () => null;
         const userLoginProxy = { get: getTemporaryBlockedUntilProperty };
         component.args.user.userLogin = userLoginProxy;
@@ -101,11 +95,10 @@ module('Unit | Component | users | user-overview', function (hooks) {
     module('when user has login and temporary blocked date', function () {
       test('should display temporary blocked date when now date is after temporaty blocked date', function (assert) {
         // given
-        const component = createGlimmerComponent('component:users/user-overview');
-        const user = { firstName: 'Lisa', lastName: 'Dupont' };
+        const user = { firstName: 'Lisa', lastName: 'Dupont', authenticationMethods: [] };
         const getTemporaryBlockedUntilProperty = () => new Date(Date.now() + 3600 * 1000);
+        const component = createGlimmerComponent('component:users/user-overview', { user });
         const userLoginProxy = { get: getTemporaryBlockedUntilProperty };
-        component.args.user = user;
         component.args.user.userLogin = userLoginProxy;
 
         // when && then
@@ -114,9 +107,8 @@ module('Unit | Component | users | user-overview', function (hooks) {
 
       test('should not display temporary blocked date when now date is before temporaty blocked date', function (assert) {
         // given
-        const component = createGlimmerComponent('component:users/user-overview');
-        const user = { firstName: 'Lisa', lastName: 'Dupont' };
-        component.args.user = user;
+        const user = { firstName: 'Lisa', lastName: 'Dupont', authenticationMethods: [] };
+        const component = createGlimmerComponent('component:users/user-overview', { user });
         const getTemporaryBlockedUntilProperty = () => new Date(Date.now() - 3600 * 1000);
         const userLoginProxy = { get: getTemporaryBlockedUntilProperty };
         component.args.user.userLogin = userLoginProxy;
@@ -131,7 +123,7 @@ module('Unit | Component | users | user-overview', function (hooks) {
     test('should empty organization learners', async function (assert) {
       // given
       const organizationLearners = [{ firstName: 'fanny', lastName: 'epi' }];
-      const user = { organizationLearners, save: sinon.stub().resolves() };
+      const user = { organizationLearners, save: sinon.stub().resolves(), authenticationMethods: [] };
       const component = createGlimmerComponent('component:users/user-overview', { user });
 
       // when

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -411,6 +411,9 @@
           }
         },
         "copied": "Copied!"
+      },
+      "user-overview": {
+        "sso": "SSO"
       }
     }
   },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -421,6 +421,9 @@
           }
         },
         "copied": "Copié !"
+      },
+      "user-overview": {
+        "sso": "SSO"
       }
     }
   },

--- a/api/db/database-builder/factory/build-authentication-method.js
+++ b/api/db/database-builder/factory/build-authentication-method.js
@@ -132,6 +132,35 @@ buildAuthenticationMethod.withPoleEmploiAsIdentityProvider = function ({
   });
 };
 
+buildAuthenticationMethod.withSeedAsIdentityProvider = function ({
+  id = databaseBuffer.getNextId(),
+  externalIdentifier,
+  userId,
+}) {
+  userId = isUndefined(userId) ? buildUser().id : userId;
+
+  let generatedIdentifier = externalIdentifier;
+  if (!generatedIdentifier) {
+    generatedIdentifier = `externalIdentifier-${id}`;
+  }
+  const values = {
+    id,
+    identityProvider: 'oidcFromSeeds',
+    externalIdentifier: generatedIdentifier,
+    userId,
+    authenticationComplement: new AuthenticationMethod.OidcAuthenticationComplement({
+      firstName: 'oidc',
+      lastName: 'user',
+    }),
+    createdAt: new Date('2020-01-01'),
+    updatedAt: new Date('2020-01-02'),
+  };
+  return databaseBuffer.pushInsertable({
+    tableName: 'authentication-methods',
+    values,
+  });
+};
+
 buildAuthenticationMethod.withIdentityProvider = function ({
   id = databaseBuffer.getNextId(),
   identityProvider,

--- a/api/db/seeds/data/team-acces/build-users.js
+++ b/api/db/seeds/data/team-acces/build-users.js
@@ -10,6 +10,17 @@ function _buildUserWithPoleEmploiAuthenticationMethod(databaseBuilder) {
   });
 }
 
+function _buildOidcUser(databaseBuilder) {
+  const user = databaseBuilder.factory.buildUser({
+    firstName: 'Oidc',
+    lastName: 'User',
+    email: 'oidc-user@example.net',
+  });
+  databaseBuilder.factory.buildAuthenticationMethod.withSeedAsIdentityProvider({
+    userId: user.id,
+  });
+}
+
 function _buildUsers(databaseBuilder) {
   databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'Salvor',
@@ -39,4 +50,5 @@ function _buildUsers(databaseBuilder) {
 export function buildUsers(databaseBuilder) {
   _buildUsers(databaseBuilder);
   _buildUserWithPoleEmploiAuthenticationMethod(databaseBuilder);
+  _buildOidcUser(databaseBuilder);
 }


### PR DESCRIPTION
## :pancakes: Problème

Lorsqu'on se rend sur la page d'un utilisateur sur Pix admin il faut se rendre dans ses méthodes de connexion pour savoir s’il utilise un SSO.

## :bacon: Proposition

Sous la case `Identifiant`, ajouter un champ `SSO` avec oui ou non.

## 🧃 Remarques

Le GAR fait parti des SSO.

## :yum: Pour tester
- Se rendre sur Pix Admin
- Se connecter avec le compte superadmin@example.net
- Aller sur la section des utilisateurs
- Rechercher l'utilisateur alex-terieur@example.net
- Afficher la page de l'utilisateur
- Constater sous le champ identifiant qu'un nouveau champ est présent avec écrit: "SSO : Non"
- Revenir sur la page des utilisateurs
- Rechercher l'utilisateur oidc-user@example.net présent dans les seeds
- Afficher la page de cet utilisateur
- Constater sous le champ identifiant qu'un nouveau champ est présent avec écrit: "SSO : Oui",
- Revenir sur la liste des utilisateurs,
- Rechercher par email l'utilisateur "eliza-dlj@school.net",
- Constater sous le champ identifiant qu'un nouveau champ est présent avec écrit: "SSO : Oui".