### PR TITLE
[FEATURE] Ajout de metrics sur le filtre RT (PIX-16345)

### DIFF
--- a/orga/app/components/campaign/filter/participation-filters.gjs
+++ b/orga/app/components/campaign/filter/participation-filters.gjs
@@ -18,6 +18,7 @@ const debounceTime = ENV.pagination.debounce;
 export default class ParticipationFilters extends Component {
   @service intl;
   @service currentUser;
+  @service metrics;
 
   @tracked stages = [];
   @tracked isStagesLoading = true;
@@ -149,6 +150,13 @@ export default class ParticipationFilters extends Component {
   @action
   onSelectBadge(badges) {
     this.args.onFilter('badges', badges);
+
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Campagnes',
+      'pix-event-action': 'Filtrer les participations',
+      'pix-event-name': 'Usage du filtre par Résultats Thématiques',
+    });
   }
 
   @action

--- a/orga/tests/integration/components/campaign/filter/participation-filters-test.js
+++ b/orga/tests/integration/components/campaign/filter/participation-filters-test.js
@@ -407,6 +407,9 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         this.set('triggerFiltering', triggerFiltering);
         this.set('selectedBadges', []);
 
+        const metrics = this.owner.lookup('service:metrics');
+        metrics.add = sinon.stub();
+
         // when
         const screen = await render(
           hbs`<Campaign::Filter::ParticipationFilters
@@ -425,6 +428,13 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
 
         // then
         assert.ok(triggerFiltering.calledWith('badges', ['badge1']));
+
+        sinon.assert.calledWithExactly(metrics.add, {
+          event: 'custom-event',
+          'pix-event-category': 'Campagnes',
+          'pix-event-action': 'Filtrer les participations',
+          'pix-event-name': 'Usage du filtre par Résultats Thématiques',
+        });
       });
     });
 


### PR DESCRIPTION
## :pancakes: Problème

Afin de commencer notre amélioration de résultats de campagnes avec Résultats Thématiques, nous souhaitons pouvoir suivre et étudier l'usage de l'existant avant l'ajout des améliorations.
Cela pourra nous permettre de comprendre l'usage du futur filtre "Lacunes" par rapport au filtre déjà existant "Résultats Thématiques" ainsi que de voir si cela a un impact sur le traffic sur la page.

## :bacon: Proposition

Ajouter 2 metrics afin de pouvoir suivre sur Matomo :
- Combien de temps ils passent sur la page “voir les résultats” pour les campagnes à RT
- Combien de fois est utilisé le filtre “Résultats thématiques”


## 🧃 Remarques

Le premier élément ne semble pas avoir besoin de code pour être traçable cependant je n'ai pas trouvé de stat ne prenant pas en compte spécifiquement les campagnes 🤔 

## :yum: Pour tester

- La CI au vert ✅ <!-- Des infos supplémentaires, trucs et astuces ? -->
- filtrer les participations d'une campagne par RT et vérifier dans le réseau qu'un envoi à piwik est effectué
