### PR TITLE
[TECH] Utilise l'`AssessmentResult` qui a été annulé en plus du statut `isCancelled` pour le repo du LSU/LSL (PIX-16394)

### DIFF
--- a/api/src/certification/results/infrastructure/repositories/certification-livret-scolaire-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certification-livret-scolaire-repository.js
@@ -56,7 +56,17 @@ const getCertificatesByOrganizationUAI = async function (uai) {
         .whereRaw('"last-certification-courses"."isCancelled"= false')
         .whereRaw('"certification-courses"."createdAt" < "last-certification-courses"."createdAt"'),
     )
-
+    .whereNotExists(
+      knex
+        .select(1)
+        .from('certification-courses-last-assessment-results')
+        .innerJoin(
+          'assessment-results',
+          'certification-courses-last-assessment-results.lastAssessmentResultId',
+          'assessment-results.assessmentId',
+        )
+        .whereRaw('"assessment-results"."status" = \'cancelled\''),
+    )
     .where({ 'certification-courses.isCancelled': false })
     .where({ 'view-active-organization-learners.isDisabled': false })
     .whereRaw('LOWER("organizations"."externalId") = LOWER(?)', uai)

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/certification-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/certification-repository_test.js
@@ -21,7 +21,7 @@ describe('Certification | Session-management | Integration | Infrastructure | Re
       // then
 
       expect(statuses).to.have.length(3);
-      expect(statuses).to.deep.equal([
+      expect(statuses).to.have.deep.members([
         {
           certificationCourseId: 1,
           isCancelled: false,


### PR DESCRIPTION
## :pancakes: Problème

Nous avons mis en place un nouveau moyen de gérer les annulations de certification. Mais pour le livret scolaire, nous utilisons encore le statut `isCancelled` dans la certification pour faire le tri.

## :bacon: Proposition

Utiliser, en plus du `isCancelled` le `lastAssessmentResult` annulé pour faire le tri.

## 🧃 Remarques

L'utilisation du `isCancelled` sera à supprimer plus tard.

## :yum: Pour tester

- [ ] Générer un token sur le swagger de la review app https://api-pr11318.review.pix.fr/api/documentation#/authorization-server/postApiApplicationToken
- [ ] Authoriser le token sur le swagger du LSU https://api-pr11318.review.pix.fr/livret-scolaire/documentation# (bouton authorize en haut à droite)
- [ ] faire un appel au endpoint avec un UAI et le token https://api-pr11318.review.pix.fr/livret-scolaire/documentation#/api/getApiOrganizationsUaiCertifications
