### PR TITLE
[TECH] Ajouter une route /api/healthcheck/forwarded-origin (PIX-16368)

### DIFF
--- a/api/src/shared/application/feature-toggles/feature-toggle-controller.js
+++ b/api/src/shared/application/feature-toggles/feature-toggle-controller.js
@@ -1,5 +1,4 @@
 import { config } from '../../../../src/shared/config.js';
-import * as network from '../../../identity-access-management/infrastructure/utils/network.js';
 import { featureToggles } from '../../infrastructure/feature-toggles/index.js';
 import * as serializer from '../../infrastructure/serializers/jsonapi/feature-toggle-serializer.js';
 
@@ -11,11 +10,6 @@ const getActiveFeatures = async function () {
   return serializer.serialize({ ...newFeatureToggles, ...legacyFeatureToggles });
 };
 
-// TODO: Test route to be removed soon
-const getForwardedOrigin = function (request, h) {
-  return h.response(network.getForwardedOrigin(request.headers)).code(200);
-};
+const featureToggleController = { getActiveFeatures };
 
-const featureToggleController = { getActiveFeatures, getForwardedOrigin };
-
-export { featureToggleController, getForwardedOrigin };
+export { featureToggleController };

--- a/api/src/shared/application/feature-toggles/index.js
+++ b/api/src/shared/application/feature-toggles/index.js
@@ -12,21 +12,6 @@ const register = async function (server) {
         cache: false,
       },
     },
-    // TODO: Test route to be removed soon
-    {
-      method: 'GET',
-      path: '/api/test-origin-soon-to-be-remove',
-      config: {
-        auth: false,
-        handler: featureToggleController.getForwardedOrigin,
-        notes: [
-          '- **Route ponctuelle à des fins de test**\n' +
-            '- **Cette route est publique**\n' +
-            '- Récupération de l’origin HTTP de l’application appelante\n',
-        ],
-        tags: ['identity-access-management', 'api', 'user'],
-      },
-    },
   ]);
 };
 

--- a/api/src/shared/application/healthcheck/healthcheck-controller.js
+++ b/api/src/shared/application/healthcheck/healthcheck-controller.js
@@ -2,6 +2,7 @@ import Boom from '@hapi/boom';
 
 import { knex } from '../../../../db/knex-database-connection.js';
 import packageJSON from '../../../../package.json' with { type: 'json' };
+import * as network from '../../../identity-access-management/infrastructure/utils/network.js';
 import { config } from '../../config.js';
 import { redisMonitor } from '../../infrastructure/utils/redis-monitor.js';
 
@@ -37,6 +38,15 @@ const checkRedisStatus = async function () {
   }
 };
 
-const healthcheckController = { get, checkDbStatus, checkRedisStatus };
+const checkForwardedOriginStatus = async function (request, h) {
+  const forwardedOrigin = network.getForwardedOrigin(request.headers);
+  if (!forwardedOrigin) {
+    return h.response('Obtaining Forwarded Origin failed').code(500);
+  }
+
+  return h.response(forwardedOrigin).code(200);
+};
+
+const healthcheckController = { get, checkDbStatus, checkRedisStatus, checkForwardedOriginStatus };
 
 export { healthcheckController };

--- a/api/src/shared/application/healthcheck/index.js
+++ b/api/src/shared/application/healthcheck/index.js
@@ -29,6 +29,16 @@ const register = async function (server) {
         tags: ['api'],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/healthcheck/forwarded-origin',
+      config: {
+        auth: false,
+        handler: healthcheckController.checkForwardedOriginStatus,
+        notes: ['- **Cette route est publique**\n' + '- Récupération de l’origine HTTP de l’application appelante\n'],
+        tags: ['api', 'healthcheck'],
+      },
+    },
   ]);
 };
 

--- a/api/tests/integration/application/healthcheck/index_test.js
+++ b/api/tests/integration/application/healthcheck/index_test.js
@@ -57,4 +57,27 @@ describe('Integration | Application | Route | healthcheckRouter', function () {
       expect(healthCheckController.checkRedisStatus).to.have.been.calledOnce;
     });
   });
+
+  describe('GET /api/healthcheck/forwarded-origin', function () {
+    context('when forwarded origin is not obtained', function () {
+      it('returns an HTTP status code 500', async function () {
+        // given
+        const options = {
+          method: 'GET',
+          url: '/api/healthcheck/forwarded-origin',
+          headers: {
+            'x-forwarded-proto': 'https',
+            'x-forwarded-host-is-missing': 'there is a problem with the nginx configuration',
+          },
+        };
+
+        // when
+        const response = await httpTestServer.requestObject(options);
+
+        // then
+        expect(response.statusCode).to.equal(500);
+        expect(response.result).to.equal('Obtaining Forwarded Origin failed');
+      });
+    });
+  });
 });

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -51,24 +51,4 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
       expect(response.result).to.deep.equal(expectedData);
     });
   });
-
-  describe('GET /api/test-origin-soon-to-be-remove. Test route soon to be removed.', function () {
-    const options = {
-      method: 'GET',
-      url: '/api/test-origin-soon-to-be-remove',
-      headers: { 'x-forwarded-proto': 'http', 'x-forwarded-host': 'test.pix.org' },
-    };
-
-    it('returns an empty string because the calling application HTTP Origin', async function () {
-      // given
-      const expectedData = 'http://test.pix.org';
-
-      // when
-      const response = await server.inject(options);
-
-      // then
-      expect(response.statusCode).to.equal(200);
-      expect(response.result).to.deep.equal(expectedData);
-    });
-  });
 });

--- a/api/tests/shared/acceptance/application/healthcheck.route.test.js
+++ b/api/tests/shared/acceptance/application/healthcheck.route.test.js
@@ -1,0 +1,27 @@
+import { createServer, expect } from '../../../test-helper.js';
+
+describe('Acceptance | Shared | Application | Route | healthcheck', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('GET /api/healthcheck/forwarded-origin', function () {
+    it('returns an HTTP status code 200 with the forwarded origin', async function () {
+      // given
+      const options = {
+        method: 'GET',
+        url: '/api/healthcheck/forwarded-origin',
+        headers: { 'x-forwarded-proto': 'https', 'x-forwarded-host': 'app.pix.org' },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result).to.equal('https://app.pix.org');
+    });
+  });
+});


### PR DESCRIPTION
## :pancakes: Problème

Cette PR fait suite à #11230

Il faut réécrire de manière pérenne la route canari `/api/test-origin-soon-to-be-remove` de manière : 
* à ce qu'elle soit efficacement supervisée par les captains
* à ce que le code soit placé dans le bon contexte DDD

## :bacon: Proposition

Création d'une nouvelle route `/api/healthcheck/forwarded-origin` qui : 
* répond `200` avec la _forwarded origin_ obtenue quand tout va bien
* répond `500` en cas d'erreur

Renvoyer la _forwarded origin_ obtenue lorsque tout va bien permet de pouvoir facilement vérifier la valeur obtenue, ce qui serait utile en cas de régression si par exemple un proxy venait à être ajouté entre les frontaux et Pix API.

Répondre par `500` en cas d'incapacité à obtenir une _forwarded origin_ permet de faire remonter l'alerte immédiatement dans les tableaux de supervision.

## 🧃 Remarques

Un contexte DDD `api/src/monitoring/` existe et aurait sûrement été le bon contexte pour placer la route canari, mais il existe déjà un `healthcheckController` bien établi. Idéalement il serait sûrement bon de déplacer dans une autre PR ce `healthcheckController` dans le contexte DDD `api/src/monitoring/`.

## :yum: Pour tester

Vérifier sur chaque RA que `getForwardedOrigin` fonctionne toujours bien et renvoie toujours bien la valeur attendue :
* https://app-pr11321.review.pix.fr/api/healthcheck/forwarded-origin → `https://app-pr11321.review.pix.fr/`
* https://app-pr11321.review.pix.org/api/healthcheck/forwarded-origin → `https://app-pr11321.review.pix.org/`
* https://orga-pr11321.review.pix.fr/api/healthcheck/forwarded-origin → `https://orga-pr11321.review.pix.fr/`
* https://orga-pr11321.review.pix.org/api/healthcheck/forwarded-origin → `https://orga-pr11321.review.pix.org/`
* https://certif-pr11321.review.pix.fr/api/healthcheck/forwarded-origin → `https://certif-pr11321.review.pix.fr/`
* https://certif-pr11321.review.pix.org/api/healthcheck/forwarded-origin → `https://certif-pr11321.review.pix.org/`
* https://admin-pr11321.review.pix.fr/api/healthcheck/forwarded-origin → `https://admin-pr11321.review.pix.fr/`
