### PR TITLE
[FEATURE] [API] Pouvoir enregistrer un titre interne d’un CF (PIX-16218)

### DIFF
--- a/api/src/devcomp/application/trainings/index.js
+++ b/api/src/devcomp/application/trainings/index.js
@@ -176,6 +176,7 @@ const register = async function (server) {
               attributes: Joi.object({
                 link: Joi.string().allow(null),
                 title: Joi.string().allow(null),
+                'internal-title': Joi.string().allow(null),
                 duration: Joi.object({
                   days: Joi.number().min(0).required(),
                   hours: Joi.number().min(0).max(23).required(),

--- a/api/src/devcomp/application/trainings/index.js
+++ b/api/src/devcomp/application/trainings/index.js
@@ -127,6 +127,7 @@ const register = async function (server) {
               attributes: Joi.object({
                 link: Joi.string().uri().required(),
                 title: Joi.string().required(),
+                'internal-title': Joi.string().optional(),
                 duration: Joi.object({
                   days: Joi.number().min(0).default(0),
                   hours: Joi.number().min(0).max(23).default(0),

--- a/api/src/devcomp/infrastructure/repositories/training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/training-repository.js
@@ -135,6 +135,7 @@ async function create({ training }) {
   const knexConn = DomainTransaction.getConnection();
   const pickedAttributes = pick(training, [
     'title',
+    'internalTitle',
     'link',
     'type',
     'duration',

--- a/api/src/devcomp/infrastructure/repositories/training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/training-repository.js
@@ -150,6 +150,7 @@ async function create({ training }) {
 async function update({ id, attributesToUpdate }) {
   const pickedAttributesToUpdate = pick(attributesToUpdate, [
     'title',
+    'internalTitle',
     'link',
     'type',
     'duration',

--- a/api/tests/devcomp/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/trainings/training-controller_test.js
@@ -212,6 +212,7 @@ describe('Acceptance | Controller | training-controller', function () {
         await databaseBuilder.commit();
         const updatedTraining = {
           title: 'new title',
+          internalTitle: 'new internal title',
           editorName: 'editor name',
           editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/logo.svg',
           duration: {
@@ -230,6 +231,7 @@ describe('Acceptance | Controller | training-controller', function () {
               type: 'trainings',
               attributes: {
                 title: updatedTraining.title,
+                'internal-title': updatedTraining.internalTitle,
                 'editor-name': updatedTraining.editorName,
                 'editor-logo-url': updatedTraining.editorLogoUrl,
                 duration: {
@@ -249,6 +251,7 @@ describe('Acceptance | Controller | training-controller', function () {
             id: '1',
             attributes: {
               title: updatedTraining.title,
+              internalTitle: updatedTraining.internalTitle,
               link: training.link,
               duration: training.duration,
               editorName: updatedTraining.editorName,
@@ -266,6 +269,9 @@ describe('Acceptance | Controller | training-controller', function () {
         expect(response.result.data.type).to.deep.equal(expectedResponse.data.type);
         expect(response.result.data.id).to.exist;
         expect(response.result.data.attributes.title).to.deep.equal(expectedResponse.data.attributes.title);
+        expect(response.result.data.attributes['internal-title']).to.deep.equal(
+          expectedResponse.data.attributes.internalTitle,
+        );
         expect(response.result.data.attributes.link).to.deep.equal(expectedResponse.data.attributes.link);
         expect(response.result.data.attributes['editor-name']).to.deep.equal(
           expectedResponse.data.attributes.editorName,

--- a/api/tests/devcomp/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/trainings/training-controller_test.js
@@ -155,7 +155,7 @@ describe('Acceptance | Controller | training-controller', function () {
         id: '101064',
         attributes: {
           title: 'Titre du training',
-          'internal-title': null,
+          'internal-title': 'Titre interne du training',
           link: 'https://training-link.org',
           type: 'webinaire',
           duration: {

--- a/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
@@ -582,6 +582,7 @@ describe('Integration | Repository | training-repository', function () {
       // given
       const training = {
         title: 'Titre du training',
+        internalTitle: 'Titre interne du training',
         link: 'https://training-link.org',
         type: 'webinaire',
         duration: '6h',

--- a/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
@@ -615,6 +615,7 @@ describe('Integration | Repository | training-repository', function () {
 
       const attributesToUpdate = {
         title: 'Mon nouveau titre',
+        internalTitle: 'Mon nouveau titre interne',
         link: 'https://example.net/mon-nouveau-lien',
         editorName: 'Mon nouvel editeur',
         editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/nouveau-logo.svg',
@@ -628,6 +629,7 @@ describe('Integration | Repository | training-repository', function () {
       // then
       const updatedTraining = await knex('trainings').where({ id: training.id }).first();
       expect(updatedTraining.title).to.equal(attributesToUpdate.title);
+      expect(updatedTraining.internalTitle).to.equal(attributesToUpdate.internalTitle);
       expect(updatedTraining.link).to.equal(attributesToUpdate.link);
       expect(updatedTraining.locale).to.equal(training.locale);
       expect(updatedTraining.type).to.equal(training.type);
@@ -649,6 +651,7 @@ describe('Integration | Repository | training-repository', function () {
 
       const attributesToUpdate = {
         title: 'Mon nouveau titre',
+        internalTitle: 'Mon nouveau titre interne',
         link: 'https://example.net/mon-nouveau-lien',
         editorName: 'Mon nouvel editeur',
         editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/nouveau-logo.svg',
@@ -661,6 +664,7 @@ describe('Integration | Repository | training-repository', function () {
       // then
       expect(updatedTraining).to.be.instanceOf(TrainingForAdmin);
       expect(updatedTraining.title).to.equal(attributesToUpdate.title);
+      expect(updatedTraining.internalTitle).to.equal(attributesToUpdate.internalTitle);
       expect(updatedTraining.link).to.equal(attributesToUpdate.link);
       expect(updatedTraining.editorName).to.be.equal(attributesToUpdate.editorName);
       expect(updatedTraining.editorLogoUrl).to.be.equal(attributesToUpdate.editorLogoUrl);
@@ -676,6 +680,7 @@ describe('Integration | Repository | training-repository', function () {
 
       const attributesToUpdate = {
         title: 'Mon nouveau titre',
+        internalTitle: 'Mon nouveau titre interne',
         link: 'https://example.net/mon-nouveau-lien',
         editorName: 'Mon nouvel editeur',
         editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/nouveau-logo.svg',
@@ -686,10 +691,11 @@ describe('Integration | Repository | training-repository', function () {
 
       // then
       const trainingNotUpdated = await knex('trainings')
-        .select('title', 'link', 'editorName', 'editorLogoUrl')
+        .select('title', 'internalTitle', 'link', 'editorName', 'editorLogoUrl')
         .where({ id: trainingNotToBeUpdated.id })
         .first();
       expect(trainingNotUpdated.title).to.equal(trainingNotToBeUpdated.title);
+      expect(trainingNotUpdated.internalTitle).to.equal(trainingNotToBeUpdated.internalTitle);
       expect(trainingNotUpdated.link).to.equal(trainingNotToBeUpdated.link);
       expect(trainingNotUpdated.editorName).to.equal(trainingNotToBeUpdated.editorName);
       expect(trainingNotUpdated.editorLogoUrl).to.equal(trainingNotToBeUpdated.editorLogoUrl);

--- a/api/tests/devcomp/unit/application/trainings/training-controller_test.js
+++ b/api/tests/devcomp/unit/application/trainings/training-controller_test.js
@@ -73,10 +73,12 @@ describe('Unit | Devcomp | Application | Trainings | Controller | training-contr
   describe('#create', function () {
     const deserializedTraining = {
       title: 'Training title',
+      internalTitle: 'Training internal title',
       duration: '2d2h2m',
     };
     const createdTraining = {
       title: 'Training title',
+      internalTitle: 'Training internal title',
       duration: {
         days: 2,
         hours: 2,
@@ -100,6 +102,7 @@ describe('Unit | Devcomp | Application | Trainings | Controller | training-contr
         data: {
           attributes: {
             title: 'A new training',
+            internalTitle: 'A new internal training title',
             locale: 'fr',
             duration: {
               days: 2,
@@ -122,6 +125,7 @@ describe('Unit | Devcomp | Application | Trainings | Controller | training-contr
       // given
       const expectedSerializedTraining = {
         title: 'A new training',
+        internalTitle: 'A new internal training title',
         duration: {
           hours: 5,
         },
@@ -135,6 +139,7 @@ describe('Unit | Devcomp | Application | Trainings | Controller | training-contr
           data: {
             attributes: {
               title: 'A new training',
+              internalTitle: 'A new internal training title',
               duration: {
                 hours: 5,
               },


### PR DESCRIPTION
## :bacon: Proposition

Ajouter ou mettre à jour le titre interne d'une CF par l'API de Pix.

## 🧃 Remarques

TODO

## :yum: Pour tester
1. Dans Pix Admin, créer un Contenu Formatif avec les devtools ouvertes,
2. Dans les devtools, modifier la requête pour mettre un autre `internalTitle`,
3. La renvoyer et s'assurer que le retour est bien le bon.

------

1. Modifier un CF dans l'interface,
2. Dans les devtools, modifier la requête pour mettre un autre `internalTitle`,
3. La renvoyer et s'assurer que le retour est bien le bon.