### PR TITLE
[TECH] :recycle: Utilise l'enum de `AssessmentResult.status` plutôt qu'une valeur en dur

### DIFF
--- a/api/src/certification/results/infrastructure/repositories/certification-livret-scolaire-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certification-livret-scolaire-repository.js
@@ -1,4 +1,5 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
+import { AssessmentResult } from '../../../../shared/domain/models/AssessmentResult.js';
 import { Certificate } from '../../domain/read-models/livret-scolaire/Certificate.js';
 
 const getCertificatesByOrganizationUAI = async function (uai) {
@@ -65,7 +66,7 @@ const getCertificatesByOrganizationUAI = async function (uai) {
           'certification-courses-last-assessment-results.lastAssessmentResultId',
           'assessment-results.assessmentId',
         )
-        .whereRaw('"assessment-results"."status" = \'cancelled\''),
+        .whereRaw('"assessment-results"."status" = ?', AssessmentResult.status.CANCELLED),
     )
     .where({ 'certification-courses.isCancelled': false })
     .where({ 'view-active-organization-learners.isDisabled': false })


### PR DESCRIPTION
## :pancakes: Problème

Dans une PR précédente (#11318) nous avons ajouté une clause avec une valeur en dur.

## :bacon: Proposition

Utiliser plutôt l'enum de `AssessmentResult.status`

## 🧃 Remarques



## :yum: Pour tester


