### PR TITLE
[FEATURE] Passage module chatgpt-vraiment-neutre en tabletSupport=comfortable

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-vraiment-neutre.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-vraiment-neutre.json
@@ -13,7 +13,7 @@
       "<p>Générer et analyser des résultats biaisés de LLM</p>",
       "<p>Comparer les résultats de différents LLM</p>"
     ],
-    "tabletSupport": "inconvenient"
+    "tabletSupport": "comfortable"
   },
   "transitionTexts": [
     {


### PR DESCRIPTION
## :pancakes: Problème

On était en tabletSupport = inconvenient du fait que l'outil externe compar:ia était pas mobile-friendly.
C'est maintenant le cas.
## :bacon: Proposition

Changer le champ

## 🧃 Remarques

Module va être testé sur mobile ce vendredi donc pas envie qu'ils aient la pop up de warning
## :yum: Pour tester
pour vérifier : cf. le commit avant après


