### PR TITLE
[FEATURE] Ajouter le champ titre interne dans la page de détails du CF (PIX-16068)

### DIFF
--- a/admin/app/components/trainings/training-details-card.gjs
+++ b/admin/app/components/trainings/training-details-card.gjs
@@ -22,6 +22,8 @@ export default class TrainingDetailsCard extends Component {
         <h1 class="training-details-card__title">{{@training.title}}</h1>
         <StateTag @isDisabled={{@training.isDisabled}} />
         <dl class="training-details-card__details">
+          <dt class="training-details-card__details-label">Titre interne&nbsp;:&nbsp;</dt>
+          <dd class="training-details-card__details-value">{{@training.internalTitle}}</dd>
           <dt class="training-details-card__details-label">Publié sur&nbsp;:&nbsp;</dt>
           <dd class="training-details-card__details-value">
             <a

--- a/admin/app/components/trainings/training-details-card.gjs
+++ b/admin/app/components/trainings/training-details-card.gjs
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import { t } from 'ember-intl';
 
 import { localeCategories } from '../../models/training';
 import StateTag from './state-tag';
@@ -22,9 +23,9 @@ export default class TrainingDetailsCard extends Component {
         <h1 class="training-details-card__title">{{@training.title}}</h1>
         <StateTag @isDisabled={{@training.isDisabled}} />
         <dl class="training-details-card__details">
-          <dt class="training-details-card__details-label">Titre interne&nbsp;:&nbsp;</dt>
+          <dt class="training-details-card__details-label">{{t "pages.trainings.training.details.internalTitle"}}</dt>
           <dd class="training-details-card__details-value">{{@training.internalTitle}}</dd>
-          <dt class="training-details-card__details-label">Publié sur&nbsp;:&nbsp;</dt>
+          <dt class="training-details-card__details-label">{{t "pages.trainings.training.details.publishedOn"}}</dt>
           <dd class="training-details-card__details-value">
             <a
               href={{@training.link}}
@@ -35,17 +36,19 @@ export default class TrainingDetailsCard extends Component {
               {{@training.link}}
             </a>
           </dd>
-          <dt class="training-details-card__details-label">Type de contenu&nbsp;:&nbsp;</dt>
+          <dt class="training-details-card__details-label">{{t "pages.trainings.training.details.contentType"}}</dt>
           <dd class="training-details-card__details-value">{{@training.type}}</dd>
-          <dt class="training-details-card__details-label">Durée&nbsp;:&nbsp;</dt>
+          <dt class="training-details-card__details-label">{{t "pages.trainings.training.details.duration"}}</dt>
           <dd class="training-details-card__details-value">{{this.formattedDuration}}</dd>
-          <dt class="training-details-card__details-label">Langue localisée&nbsp;:&nbsp;</dt>
+          <dt class="training-details-card__details-label">{{t
+              "pages.trainings.training.details.localizedLanguage"
+            }}</dt>
           <dd class="training-details-card__details-value">{{this.formattedLocale}}</dd>
-          <dt class="training-details-card__details-label">Nom d'éditeur&nbsp;:&nbsp;</dt>
+          <dt class="training-details-card__details-label">{{t "pages.trainings.training.details.editorName"}}</dt>
           <dd class="training-details-card__details-value">{{@training.editorName}}</dd>
-          <dt class="training-details-card__details-label">Logo de l'éditeur&nbsp;:&nbsp;</dt>
+          <dt class="training-details-card__details-label">{{t "pages.trainings.training.details.editorLogo"}}</dt>
           <dd class="training-details-card__details-value">{{@training.editorLogoUrl}}</dd>
-          <dt class="training-details-card__details-label">Statut&nbsp;:&nbsp;</dt>
+          <dt class="training-details-card__details-label">{{t "pages.trainings.training.details.status"}}</dt>
           <dd class="training-details-card__details-value">{{if
               @training.isRecommendable
               "Déclenchable"

--- a/admin/app/models/training.js
+++ b/admin/app/models/training.js
@@ -23,6 +23,7 @@ export const optionsLocaleList = formatList(localeCategories);
 
 export default class Training extends Model {
   @attr('string') title;
+  @attr('string') internalTitle;
   @attr('string') link;
   @attr('string') type;
   @attr('string') locale;

--- a/admin/app/styles/components/trainings/training-details-card.scss
+++ b/admin/app/styles/components/trainings/training-details-card.scss
@@ -15,6 +15,7 @@
 
   &__details-label {
     float: left;
+    margin-right: var(--pix-spacing-1x);
   }
 
   &__details-value {

--- a/admin/tests/integration/components/trainings/training-details-card-test.gjs
+++ b/admin/tests/integration/components/trainings/training-details-card-test.gjs
@@ -8,6 +8,7 @@ module('Integration | Component | Trainings::TrainingDetailsCard', function (hoo
 
   const training = {
     title: 'Un contenu formatif',
+    internalTitle: 'Mon titre interne',
     link: 'https://un-contenu-formatif',
     type: 'webinaire',
     locale: 'fr-fr',
@@ -25,6 +26,7 @@ module('Integration | Component | Trainings::TrainingDetailsCard', function (hoo
 
     // then
     assert.dom(screen.getByRole('heading', { level: 1, name: 'Un contenu formatif' })).exists();
+    assert.dom(screen.getByText('Mon titre interne')).exists();
     assert.dom(screen.getByText('https://un-contenu-formatif')).exists();
     assert.dom(screen.getByText('webinaire')).exists();
     assert.dom(screen.getByText('2j')).exists();

--- a/admin/tests/integration/components/trainings/training-details-card-test.gjs
+++ b/admin/tests/integration/components/trainings/training-details-card-test.gjs
@@ -24,7 +24,7 @@ module('Integration | Component | Trainings::TrainingDetailsCard', function (hoo
     const screen = await render(<template><TrainingDetailsCard @training={{training}} /></template>);
 
     // then
-    assert.dom(screen.getByText('Un contenu formatif')).exists();
+    assert.dom(screen.getByRole('heading', { level: 1, name: 'Un contenu formatif' })).exists();
     assert.dom(screen.getByText('https://un-contenu-formatif')).exists();
     assert.dom(screen.getByText('webinaire')).exists();
     assert.dom(screen.getByText('2j')).exists();

--- a/admin/tests/integration/components/trainings/training-details-card-test.gjs
+++ b/admin/tests/integration/components/trainings/training-details-card-test.gjs
@@ -2,6 +2,8 @@ import { render } from '@1024pix/ember-testing-library';
 import TrainingDetailsCard from 'pix-admin/components/trainings/training-details-card';
 import { module, test } from 'qunit';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | Trainings::TrainingDetailsCard', function (hooks) {
   setupIntlRenderingTest(hooks);
 

--- a/admin/tests/integration/components/trainings/training-details-card-test.gjs
+++ b/admin/tests/integration/components/trainings/training-details-card-test.gjs
@@ -1,10 +1,9 @@
 import { render } from '@1024pix/ember-testing-library';
-import { setupRenderingTest } from 'ember-qunit';
 import TrainingDetailsCard from 'pix-admin/components/trainings/training-details-card';
 import { module, test } from 'qunit';
 
 module('Integration | Component | Trainings::TrainingDetailsCard', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   const training = {
     title: 'Un contenu formatif',

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -725,6 +725,16 @@
     },
     "trainings": {
       "training": {
+        "details": {
+          "contentType": "Content type : ",
+          "duration": "Duration : ",
+          "editorLogo": "Editor logo : ",
+          "editorName": "Editor name : ",
+          "internalTitle": "Internal title : ",
+          "localizedLanguage": "Localized language : ",
+          "publishedOn": "Published on : ",
+          "status": "Status : "
+        },
         "targetProfiles": {
           "tabName": "Target Profiles"
         },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -742,6 +742,16 @@
     },
     "trainings": {
       "training": {
+        "details": {
+          "contentType": "Type de contenu :",
+          "duration": "Durée :",
+          "editorLogo": "Logo de l'éditeur :",
+          "editorName": "Nom d'éditeur :",
+          "internalTitle": "Titre interne :",
+          "localizedLanguage": "Langue localisée :",
+          "publishedOn": "Publié sur :",
+          "status": "Statut :"
+        },
         "targetProfiles": {
           "tabName": "Profils cibles associés",
           "title": "Rattacher un ou plusieurs profils cibles"


### PR DESCRIPTION
## :pancakes: Problème
Le champ "titre interne" du Contenu Formatif est rempli mais pas encore affiché.

## :bacon: Proposition
L'afficher dans la page de détails d'un CF

## 🧃 Remarques
RAS

## :yum: Pour tester
Sur la page de détails d'un CF s'assurer que le champ "titre interne" est maintenant affiché avec une valeur par défaut.
