### PR TITLE
[FEATURE] Ajouter la colone isVisible dans la table oidc-providers (PIX-16077)

### DIFF
--- a/api/db/migrations/20250205101750_add-isVisible-column-to-oidc-providers-tables.js
+++ b/api/db/migrations/20250205101750_add-isVisible-column-to-oidc-providers-tables.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'oidc-providers';
+const COLUMN_NAME = 'isVisible';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.boolean(COLUMN_NAME).defaultTo(true);
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## :pancakes: Problème

Afin de permettre ou non l'affichage d'un OIDC, on avait besoin d'une nouvelle colone avec ce paramètre.

## :bacon: Proposition

Ajouter une nouvelle colone nommée "isVisible" dans la table "oidc-providers".

## 🧃 Remarques

C'est une simple brique du chantier.

## :yum: Pour tester
- Se connecter à la RA avec la commande suivante:
```shell
scalingo -a pix-api-review-pr11335 psql-console
```
- Inscrire cette commande:
```sql
SELECT * FROM "oidc-providers";
```
- Constater que la dernière colone est bien la colone nommée "isVisible".