### PR TITLE
[TECH] Récupère le snapshot avec l'id d'une participation à une campagne (pix-15758)

### DIFF
--- a/api/scripts/prod/compute-participation-results.js
+++ b/api/scripts/prod/compute-participation-results.js
@@ -102,7 +102,8 @@ async function _getCampaignParticipationChunks(campaign) {
 }
 
 async function _computeResults(skillIds, competences, campaignParticipations) {
-  const knowledgeElementByUser = await _getKnowledgeElementsByUser(campaignParticipations);
+  const knowledgeElementByCampaignParticipationId =
+    await _getKnowledgeElementsByCampaignParticipation(campaignParticipations);
 
   const participations = campaignParticipations.map(({ userId, sharedAt, id }) => {
     return { userId, sharedAt, campaignParticipationId: id };
@@ -115,19 +116,18 @@ async function _computeResults(skillIds, competences, campaignParticipations) {
   return campaignParticipations.map(({ userId, id }) => {
     return new ParticipantResultsShared({
       campaignParticipationId: id,
-      knowledgeElements: knowledgeElementByUser[userId],
+      knowledgeElements: knowledgeElementByCampaignParticipationId[id],
       skillIds,
       placementProfile: placementProfiles.find((placementProfile) => placementProfile.userId === userId),
     });
   });
 }
 
-async function _getKnowledgeElementsByUser(campaignParticipations) {
-  const sharingDateByUserId = {};
-  campaignParticipations.forEach(({ userId, sharedAt }) => (sharingDateByUserId[userId] = sharedAt));
-  const knowledgeElementByUser =
-    await knowlegeElementSnapshotRepository.findByUserIdsAndSnappedAtDates(sharingDateByUserId);
-  return knowledgeElementByUser;
+async function _getKnowledgeElementsByCampaignParticipation(campaignParticipations) {
+  const campaignParticipationIds = campaignParticipations.map(({ id }) => id);
+  const knowledgeElementByCampaingParticipationId =
+    await knowlegeElementSnapshotRepository.findByCampaignParticipationIds(campaignParticipationIds);
+  return knowledgeElementByCampaingParticipationId;
 }
 
 function _toSQLValues(participantsResults) {

--- a/api/scripts/prod/compute-participation-results.js
+++ b/api/scripts/prod/compute-participation-results.js
@@ -104,11 +104,11 @@ async function _getCampaignParticipationChunks(campaign) {
 async function _computeResults(skillIds, competences, campaignParticipations) {
   const knowledgeElementByUser = await _getKnowledgeElementsByUser(campaignParticipations);
 
-  const userIdsAndDates = campaignParticipations.map(({ userId, sharedAt }) => {
-    return { userId, sharedAt };
+  const participations = campaignParticipations.map(({ userId, sharedAt, id }) => {
+    return { userId, sharedAt, campaignParticipationId: id };
   });
   const placementProfiles = await placementProfileService.getPlacementProfilesWithSnapshotting({
-    userIdsAndDates,
+    participations,
     competences,
     allowExcessPixAndLevels: false,
   });

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
@@ -116,12 +116,12 @@ async function _makeMemoizedGetPlacementProfileForUser(results) {
   const sharedResultsChunks = await PromiseUtils.mapSeries(
     chunk(sharedResults, CHUNK_SIZE_CAMPAIGN_RESULT_PROCESSING),
     (sharedResultsChunk) => {
-      const userIdsAndDates = sharedResultsChunk.map(({ userId, sharedAt }) => {
-        return { userId, sharedAt };
+      const participations = sharedResultsChunk.map(({ campaignParticipationId, userId, sharedAt }) => {
+        return { campaignParticipationId, userId, sharedAt };
       });
 
       return placementProfileService.getPlacementProfilesWithSnapshotting({
-        userIdsAndDates,
+        participations,
         allowExcessPixAndLevels: false,
         competences,
       });

--- a/api/src/prescription/campaign/infrastructure/repositories/knowledge-element-snapshot-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/knowledge-element-snapshot-repository.js
@@ -1,22 +1,9 @@
-import _ from 'lodash';
-
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { AlreadyExistingEntityError } from '../../../../shared/domain/errors.js';
 import { KnowledgeElement } from '../../../../shared/domain/models/KnowledgeElement.js';
 import * as knexUtils from '../../../../shared/infrastructure/utils/knex-utils.js';
 import { CampaignParticipationKnowledgeElementSnapshots } from '../../../shared/domain/read-models/CampaignParticipationKnowledgeElementSnapshots.js';
-
-function _toKnowledgeElementCollection({ snapshot } = {}) {
-  if (!snapshot) return null;
-  return snapshot.map(
-    (data) =>
-      new KnowledgeElement({
-        ...data,
-        createdAt: new Date(data.createdAt),
-      }),
-  );
-}
 
 const save = async function ({ userId, snappedAt, knowledgeElements, campaignParticipationId }) {
   try {
@@ -35,36 +22,6 @@ const save = async function ({ userId, snappedAt, knowledgeElements, campaignPar
     }
   }
 };
-
-const findByUserIdsAndSnappedAtDates = async function (userIdsAndSnappedAtDates = {}) {
-  const params = Object.entries(userIdsAndSnappedAtDates);
-  const results = await knex
-    .select('userId', 'snapshot')
-    .from('knowledge-element-snapshots')
-    .whereIn(['userId', 'snappedAt'], params);
-
-  const knowledgeElementsByUserId = {};
-  for (const result of results) {
-    knowledgeElementsByUserId[result.userId] = _toKnowledgeElementCollection(result);
-  }
-
-  const userIdsWithoutSnapshot = _.difference(
-    Object.keys(userIdsAndSnappedAtDates),
-    Object.keys(knowledgeElementsByUserId),
-  );
-  for (const userId of userIdsWithoutSnapshot) {
-    knowledgeElementsByUserId[userId] = null;
-  }
-
-  return knowledgeElementsByUserId;
-};
-
-/**
- * @typedef FindMultipleSnapshotsPayload
- * @type {object}
- * @property {number} userId
- * @property {date} sharedAt
- */
 
 /**
  * @function
@@ -105,9 +62,4 @@ const findByCampaignParticipationIds = async function (campaignParticipationIds)
   );
 };
 
-export {
-  findByCampaignParticipationIds,
-  findByUserIdsAndSnappedAtDates,
-  findCampaignParticipationKnowledgeElementSnapshots,
-  save,
-};
+export { findByCampaignParticipationIds, findCampaignParticipationKnowledgeElementSnapshots, save };

--- a/api/src/prescription/campaign/infrastructure/repositories/knowledge-element-snapshot-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/knowledge-element-snapshot-repository.js
@@ -68,31 +68,20 @@ const findByUserIdsAndSnappedAtDates = async function (userIdsAndSnappedAtDates 
 
 /**
  * @function
- * @name findMultipleUsersFromUserIdsAndSnappedAtDates
+ * @name findCampaignParticipationKnowledgeElementSnapshots
  *
- * @param {Array<FindMultipleSnapshotsPayload>} userIdsAndSnappedAtDates
+ * @param {number[]} campaignParticipationIds
  * @returns {Promise<Array<CampaignParticipationKnowledgeElementSnapshots>>}
  */
-const findMultipleUsersFromUserIdsAndSnappedAtDates = async function (userIdsAndSnappedAtDates) {
-  const params = userIdsAndSnappedAtDates.map((userIdAndDate) => {
-    return [userIdAndDate.userId, userIdAndDate.sharedAt];
-  });
-
-  const results = await knex
-    .select('userId', 'snapshot', 'snappedAt', 'campaignParticipationId')
-    .from('knowledge-element-snapshots')
-    .whereIn(['knowledge-element-snapshots.userId', 'snappedAt'], params);
-
-  return results.map((result) => {
-    const mappedKnowledgeElements = _toKnowledgeElementCollection({ snapshot: result.snapshot });
-
-    return new CampaignParticipationKnowledgeElementSnapshots({
-      userId: result.userId,
-      snappedAt: result.snappedAt,
-      knowledgeElements: mappedKnowledgeElements,
-      campaignParticipationId: result.campaignParticipationId,
-    });
-  });
+const findCampaignParticipationKnowledgeElementSnapshots = async function (campaignParticipationIds) {
+  const knowledgeElementsByCampaignParticipation = await findByCampaignParticipationIds(campaignParticipationIds);
+  return campaignParticipationIds.map(
+    (campaignParticipationId) =>
+      new CampaignParticipationKnowledgeElementSnapshots({
+        knowledgeElements: knowledgeElementsByCampaignParticipation[campaignParticipationId],
+        campaignParticipationId: campaignParticipationId,
+      }),
+  );
 };
 
 /**
@@ -119,6 +108,6 @@ const findByCampaignParticipationIds = async function (campaignParticipationIds)
 export {
   findByCampaignParticipationIds,
   findByUserIdsAndSnappedAtDates,
-  findMultipleUsersFromUserIdsAndSnappedAtDates,
+  findCampaignParticipationKnowledgeElementSnapshots,
   save,
 };

--- a/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-assessment-export.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-assessment-export.js
@@ -176,17 +176,16 @@ class CampaignAssessmentExport {
     let participantKnowledgeElementsByCompetenceId = [];
     if (campaignParticipationInfo.isShared) {
       const sharedKnowledgeElementsByUserIdAndCompetenceId =
-        await knowledgeElementSnapshotRepository.findMultipleUsersFromUserIdsAndSnappedAtDates(
-          sharedParticipations.map(({ userId, sharedAt }) => ({ userId, sharedAt })),
+        await knowledgeElementSnapshotRepository.findCampaignParticipationKnowledgeElementSnapshots(
+          sharedParticipations.map(({ campaignParticipationId }) => campaignParticipationId),
         );
       const sharedResultInfo = sharedKnowledgeElementsByUserIdAndCompetenceId.find(
         (knowledElementForSharedParticipation) => {
-          const sameUserId = campaignParticipationInfo.userId === knowledElementForSharedParticipation.userId;
-          const sameDate =
-            campaignParticipationInfo.sharedAt &&
-            campaignParticipationInfo.sharedAt.getTime() === knowledElementForSharedParticipation.snappedAt.getTime();
+          const sameParticipationId =
+            campaignParticipationInfo.campaignParticipationId ===
+            knowledElementForSharedParticipation.campaignParticipationId;
 
-          return sameUserId && sameDate;
+          return sameParticipationId;
         },
       );
 

--- a/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-profiles-collection-export.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-profiles-collection-export.js
@@ -80,12 +80,14 @@ class CampaignProfilesCollectionExport {
   }
 
   async _getUsersPlacementProfiles(campaignParticipationResultDataChunk, placementProfileService) {
-    const userIdsAndDates = campaignParticipationResultDataChunk.map(({ userId, sharedAt }) => {
-      return { userId, sharedAt };
-    });
+    const participations = campaignParticipationResultDataChunk.map(
+      ({ id: campaignParticipationId, userId, sharedAt }) => {
+        return { campaignParticipationId, userId, sharedAt };
+      },
+    );
 
     const placementProfiles = await placementProfileService.getPlacementProfilesWithSnapshotting({
-      userIdsAndDates,
+      participations,
       competences: this.competences,
       allowExcessPixAndLevels: false,
     });

--- a/api/src/prescription/shared/domain/read-models/CampaignParticipationKnowledgeElementSnapshots.js
+++ b/api/src/prescription/shared/domain/read-models/CampaignParticipationKnowledgeElementSnapshots.js
@@ -1,7 +1,5 @@
 class CampaignParticipationKnowledgeElementSnapshots {
-  constructor({ userId, snappedAt, knowledgeElements, campaignParticipationId } = {}) {
-    this.userId = userId;
-    this.snappedAt = snappedAt;
+  constructor({ knowledgeElements, campaignParticipationId } = {}) {
     this.knowledgeElements = knowledgeElements;
     this.campaignParticipationId = campaignParticipationId;
   }

--- a/api/tests/integration/scripts/prod/compute-participation-results_test.js
+++ b/api/tests/integration/scripts/prod/compute-participation-results_test.js
@@ -253,6 +253,7 @@ function _buildParticipationWithSnapshot(participationAttributes, knowledgeEleme
     userId: participation.userId,
     snappedAt: participation.sharedAt,
     knowledgeElementsAttributes,
+    campaignParticipationId: participation.id,
   });
 
   return participation;

--- a/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -202,6 +202,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
           userId: participant.id,
           snappedAt: sharedAt,
           snapshot: JSON.stringify([ke1, ke2, ke3]),
+          campaignParticipationId: campaignParticipation.id,
         });
 
         ['recSkillWeb1', 'recSkillWeb2', 'recSkillWeb3'].forEach((skillId) => {
@@ -341,6 +342,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
           userId: participant.id,
           snappedAt: sharedAt,
           snapshot: JSON.stringify([ke1, ke2, ke3]),
+          campaignParticipationId: campaignParticipation.id,
         });
 
         ['recSkillWeb1', 'recSkillWeb2', 'recSkillWeb3'].forEach((skillId) => {
@@ -450,6 +452,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
           userId: participant.id,
           snappedAt: sharedAt,
           snapshot: JSON.stringify([ke1, ke2, ke3]),
+          campaignParticipationId: campaignParticipation.id,
         });
 
         ['recSkillWeb1', 'recSkillWeb2', 'recSkillWeb3'].forEach((skillId) => {
@@ -613,7 +616,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
     });
 
     context('multiple participations', function () {
-      let secondParticipationDateCreatedAt, secondParticipationCreatedFormated;
+      let secondCampaignParticipation, secondParticipationDateCreatedAt, secondParticipationCreatedFormated;
       beforeEach(async function () {
         secondParticipationDateCreatedAt = new Date('2019-03-05T11:23:00Z');
         secondParticipationCreatedFormated = '05/03/2019 12:23';
@@ -645,7 +648,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
         });
 
         // second participation
-        campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+        secondCampaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           status: CampaignParticipationStatuses.STARTED,
           campaignId: campaign.id,
           organizationLearnerId: organizationLearner.id,
@@ -655,7 +658,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
         });
 
         databaseBuilder.factory.buildAssessment({
-          campaignParticipationId: campaignParticipation.id,
+          campaignParticipationId: secondCampaignParticipation.id,
           userId: participant.id,
           state: Assessment.states.STARTED,
           type: Assessment.types.CAMPAIGN,
@@ -695,6 +698,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
           userId: participant.id,
           snappedAt: sharedAt,
           snapshot: JSON.stringify([ke1, ke2, ke3]),
+          campaignParticipationId: campaignParticipation.id,
         });
 
         ['recSkillWeb1', 'recSkillWeb2', 'recSkillWeb3'].forEach((skillId) => {

--- a/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -32,6 +32,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
     let writableStream;
     let csvPromise;
     let i18n;
+    let ke1, ke2, ke3, ke4, ke5;
 
     const createdAt = new Date('2019-02-25T10:00:00Z');
     const sharedAt = new Date('2019-03-01T23:04:05Z');
@@ -49,7 +50,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
 
       participant = databaseBuilder.factory.buildUser();
 
-      const ke1 = databaseBuilder.factory.buildKnowledgeElement({
+      ke1 = databaseBuilder.factory.buildKnowledgeElement({
         status: 'validated',
         pixScore: 2,
         skillId: skillWeb1.id,
@@ -58,7 +59,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
         userId: participant.id,
         createdAt,
       });
-      const ke2 = databaseBuilder.factory.buildKnowledgeElement({
+      ke2 = databaseBuilder.factory.buildKnowledgeElement({
         status: 'validated',
         pixScore: 2,
         skillId: skillWeb2.id,
@@ -67,7 +68,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
         userId: participant.id,
         createdAt,
       });
-      const ke3 = databaseBuilder.factory.buildKnowledgeElement({
+      ke3 = databaseBuilder.factory.buildKnowledgeElement({
         status: 'invalidated',
         pixScore: 2,
         skillId: skillWeb3.id,
@@ -76,7 +77,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
         userId: participant.id,
         createdAt,
       });
-      const ke4 = databaseBuilder.factory.buildKnowledgeElement({
+      ke4 = databaseBuilder.factory.buildKnowledgeElement({
         status: 'validated',
         skillId: skillUrl1.id,
         earnedPix: 2,
@@ -84,19 +85,13 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
         userId: participant.id,
         createdAt,
       });
-      const ke5 = databaseBuilder.factory.buildKnowledgeElement({
+      ke5 = databaseBuilder.factory.buildKnowledgeElement({
         status: 'validated',
         skillId: skillUrl8.id,
         earnedPix: 64,
         competenceId: 'recCompetence2',
         userId: participant.id,
         createdAt,
-      });
-
-      databaseBuilder.factory.buildKnowledgeElementSnapshot({
-        userId: participant.id,
-        snappedAt: sharedAt,
-        snapshot: JSON.stringify([ke1, ke2, ke3, ke4, ke5]),
       });
 
       databaseBuilder.factory.learningContent.buildFramework({
@@ -156,15 +151,18 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
         });
 
         organizationLearner = { firstName: '@Jean', lastName: '=Bono' };
-        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(organizationLearner, {
-          createdAt,
-          sharedAt,
-          status: CampaignParticipationStatuses.SHARED,
-          campaignId: campaign.id,
-          userId: participant.id,
-          pixScore: 52,
-          isImproved: true,
-        });
+        const participationShared = databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          organizationLearner,
+          {
+            createdAt,
+            sharedAt,
+            status: CampaignParticipationStatuses.SHARED,
+            campaignId: campaign.id,
+            userId: participant.id,
+            pixScore: 52,
+            isImproved: true,
+          },
+        );
 
         databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(organizationLearner, {
           createdAt,
@@ -174,6 +172,13 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           userId: participant.id,
           pixScore: 0,
           isImproved: false,
+        });
+
+        databaseBuilder.factory.buildKnowledgeElementSnapshot({
+          userId: participationShared.userId,
+          snappedAt: participationShared.sharedAt,
+          snapshot: JSON.stringify([ke1, ke2, ke3, ke4, ke5]),
+          campaignParticipationId: participationShared.id,
         });
 
         await databaseBuilder.commit();
@@ -228,15 +233,25 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
         });
 
         organizationLearner = { firstName: '@Jean', lastName: '=Bono' };
-        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(organizationLearner, {
-          createdAt,
-          sharedAt,
-          status: CampaignParticipationStatuses.SHARED,
-          participantExternalId: '+Mon mail pro',
-          campaignId: campaign.id,
-          userId: participant.id,
-          pixScore: 52,
-          isImproved: true,
+        const participationShared = databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          organizationLearner,
+          {
+            createdAt,
+            sharedAt,
+            status: CampaignParticipationStatuses.SHARED,
+            participantExternalId: '+Mon mail pro',
+            campaignId: campaign.id,
+            userId: participant.id,
+            pixScore: 52,
+            isImproved: true,
+          },
+        );
+
+        databaseBuilder.factory.buildKnowledgeElementSnapshot({
+          userId: participationShared.userId,
+          snappedAt: participationShared.sharedAt,
+          snapshot: JSON.stringify([ke1, ke2, ke3, ke4, ke5]),
+          campaignParticipationId: participationShared.id,
         });
 
         await databaseBuilder.commit();
@@ -370,14 +385,23 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
         });
 
         organizationLearner = { firstName: '@Jean', lastName: '=Bono' };
-        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(organizationLearner, {
-          createdAt,
-          sharedAt,
-          campaignId: campaign.id,
-          userId: participant.id,
-          pixScore: 52,
-        });
+        const participationShared = databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          organizationLearner,
+          {
+            createdAt,
+            sharedAt,
+            campaignId: campaign.id,
+            userId: participant.id,
+            pixScore: 52,
+          },
+        );
 
+        databaseBuilder.factory.buildKnowledgeElementSnapshot({
+          userId: participationShared.userId,
+          snappedAt: participationShared.sharedAt,
+          snapshot: JSON.stringify([ke1, ke2, ke3, ke4, ke5]),
+          campaignParticipationId: participationShared.id,
+        });
         await databaseBuilder.commit();
       });
 
@@ -446,13 +470,20 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           title: null,
         });
 
-        databaseBuilder.factory.buildCampaignParticipation({
+        const participationShared = databaseBuilder.factory.buildCampaignParticipation({
           createdAt,
           sharedAt,
           campaignId: campaign.id,
           userId: participant.id,
           organizationLearnerId: organizationLearner.id,
           pixScore: 52,
+        });
+
+        databaseBuilder.factory.buildKnowledgeElementSnapshot({
+          userId: participationShared.userId,
+          snappedAt: participationShared.sharedAt,
+          snapshot: JSON.stringify([ke1, ke2, ke3, ke4, ke5]),
+          campaignParticipationId: participationShared.id,
         });
 
         await databaseBuilder.commit();
@@ -525,13 +556,20 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           title: null,
         });
 
-        databaseBuilder.factory.buildCampaignParticipation({
+        const participationShared = databaseBuilder.factory.buildCampaignParticipation({
           createdAt,
           sharedAt,
           campaignId: campaign.id,
           userId: participant.id,
           organizationLearnerId: organizationLearner.id,
           pixScore: 52,
+        });
+
+        databaseBuilder.factory.buildKnowledgeElementSnapshot({
+          userId: participationShared.userId,
+          snappedAt: participationShared.sharedAt,
+          snapshot: JSON.stringify([ke1, ke2, ke3, ke4, ke5]),
+          campaignParticipationId: participationShared.id,
         });
 
         await databaseBuilder.commit();

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
@@ -172,6 +172,7 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
           userId: campaignParticipation.userId,
           snappedAt: campaignParticipation.sharedAt,
           snapshot: JSON.stringify([ke1, ke2]),
+          campaignParticipationId: campaignParticipation.id,
         });
 
         await databaseBuilder.commit();

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/knowledge-element-snapshot-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/knowledge-element-snapshot-repository_test.js
@@ -270,7 +270,7 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
     });
   });
 
-  describe('#findMultipleUsersFromUserIdsAndSnappedAtDates', function () {
+  describe('#findCampaignParticipationKnowledgeElementSnapshots', function () {
     let userId1, userId2;
     let snappedAt1, snappedAt2, snappedAt3;
     let knowledgeElement1, knowledgeElement2, knowledgeElement3;
@@ -360,10 +360,10 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
     it('should find knowledge elements snapshoted grouped by campaign participation id for given userIds and their respective dates', async function () {
       // when
       const knowledgeElementsByUserId =
-        await knowledgeElementSnapshotRepository.findMultipleUsersFromUserIdsAndSnappedAtDates([
-          { userId: userId1, sharedAt: snappedAt1 },
-          { userId: userId2, sharedAt: snappedAt2 },
-          { userId: userId2, sharedAt: snappedAt3 },
+        await knowledgeElementSnapshotRepository.findCampaignParticipationKnowledgeElementSnapshots([
+          campaignParticipationId1,
+          campaignParticipationId2,
+          campaignParticipationId3,
         ]);
 
       // then
@@ -371,50 +371,18 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
 
       expect(knowledgeElementsByUserId).to.deep.members([
         {
-          userId: userId1,
-          snappedAt: snappedAt1,
           knowledgeElements: [knowledgeElement1],
           campaignParticipationId: campaignParticipationId1,
         },
         {
-          userId: userId2,
-          snappedAt: snappedAt2,
           knowledgeElements: [knowledgeElement2],
           campaignParticipationId: campaignParticipationId2,
         },
         {
-          userId: userId2,
-          snappedAt: snappedAt3,
           knowledgeElements: [knowledgeElement3],
           campaignParticipationId: campaignParticipationId3,
         },
       ]);
-    });
-
-    it('should return empty list of snapshoted knowledge elements given unmatching dates', async function () {
-      // when
-      const snappedAt = new Date('2023-02-01');
-      const knowledgeElementsByUserId =
-        await knowledgeElementSnapshotRepository.findMultipleUsersFromUserIdsAndSnappedAtDates([
-          { userId: userId1, sharedAt: snappedAt },
-        ]);
-
-      // then
-      expect(knowledgeElementsByUserId).lengthOf(0);
-    });
-
-    it('should return empty list of snapshoted knowledge elements given unmatching userId', async function () {
-      const userId = databaseBuilder.factory.buildUser().id;
-
-      await databaseBuilder.commit();
-      // when
-      const knowledgeElementsByUserId =
-        await knowledgeElementSnapshotRepository.findMultipleUsersFromUserIdsAndSnappedAtDates([
-          { userId, sharedAt: snappedAt1 },
-        ]);
-
-      // then
-      expect(knowledgeElementsByUserId).lengthOf(0);
     });
   });
 });

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/knowledge-element-snapshot-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/knowledge-element-snapshot-repository_test.js
@@ -121,57 +121,6 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
     });
   });
 
-  describe('#findByUserIdsAndSnappedAtDates', function () {
-    let userId1, userId2, campaignParticipationId;
-
-    beforeEach(function () {
-      userId1 = databaseBuilder.factory.buildUser().id;
-      userId2 = databaseBuilder.factory.buildUser().id;
-      campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation().id;
-      return databaseBuilder.commit();
-    });
-
-    it('should find knowledge elements snapshoted grouped by userId for userIds and their respective dates', async function () {
-      // given
-      const snappedAt1 = new Date('2020-01-02');
-      const knowledgeElement1 = databaseBuilder.factory.buildKnowledgeElement({ userId: userId1 });
-      databaseBuilder.factory.buildKnowledgeElementSnapshot({
-        userId: userId1,
-        snappedAt: snappedAt1,
-        snapshot: JSON.stringify([knowledgeElement1]),
-        campaignParticipationId,
-      });
-      const snappedAt2 = new Date('2020-02-02');
-      const knowledgeElement2 = databaseBuilder.factory.buildKnowledgeElement({ userId: userId2 });
-      databaseBuilder.factory.buildKnowledgeElementSnapshot({
-        userId: userId2,
-        snappedAt: snappedAt2,
-        snapshot: JSON.stringify([knowledgeElement2]),
-        campaignParticipationId,
-      });
-      await databaseBuilder.commit();
-
-      // when
-      const knowledgeElementsByUserId = await knowledgeElementSnapshotRepository.findByUserIdsAndSnappedAtDates({
-        [userId1]: snappedAt1,
-        [userId2]: snappedAt2,
-      });
-
-      // then
-      expect(knowledgeElementsByUserId[userId1]).to.deep.equal([knowledgeElement1]);
-      expect(knowledgeElementsByUserId[userId2]).to.deep.equal([knowledgeElement2]);
-    });
-
-    it('should return null associated to userId when user does not have a snapshot', async function () {
-      // when
-      const knowledgeElementsByUserId = await knowledgeElementSnapshotRepository.findByUserIdsAndSnappedAtDates({
-        [userId1]: new Date('2020-04-01T00:00:00Z'),
-      });
-
-      expect(knowledgeElementsByUserId[userId1]).to.be.null;
-    });
-  });
-
   describe('#findByCampaignParticipationIds', function () {
     let userId1, userId2, campaignParticipationId, secondCampaignParticipationId, otherCampaignParticipationId;
 
@@ -258,15 +207,6 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
         [campaignParticipationId]: [knowledgeElement1],
         [secondCampaignParticipationId]: [knowledgeElement2],
       });
-    });
-
-    it('should return null associated to userId when user does not have a snapshot', async function () {
-      // when
-      const knowledgeElementsByUserId = await knowledgeElementSnapshotRepository.findByUserIdsAndSnappedAtDates({
-        [userId1]: new Date('2020-04-01T00:00:00Z'),
-      });
-
-      expect(knowledgeElementsByUserId[userId1]).to.be.null;
     });
   });
 

--- a/api/tests/shared/integration/domain/services/placement-profile-service_test.js
+++ b/api/tests/shared/integration/domain/services/placement-profile-service_test.js
@@ -477,7 +477,7 @@ describe('Shared | Integration | Domain | Services | Placement Profile Service',
     it('should assign 0 pixScore and level of 0 to user competence when not assessed', async function () {
       // when
       const actualPlacementProfiles = await placementProfileService.getPlacementProfilesWithSnapshotting({
-        userIdsAndDates: [{ userId, sharedAt: new Date() }],
+        participations: [{ campaignParticipationId: campaignParticipation.id }],
         competences,
       });
 
@@ -530,13 +530,14 @@ describe('Shared | Integration | Domain | Services | Placement Profile Service',
           userId: userId,
           snappedAt: sharedAt,
           snapshot: JSON.stringify([ke]),
+          campaignParticipationId: campaignParticipation.id,
         });
 
         await databaseBuilder.commit();
 
         // when
         const actualPlacementProfiles = await placementProfileService.getPlacementProfilesWithSnapshotting({
-          userIdsAndDates: [{ userId, sharedAt }],
+          participations: [{ campaignParticipationId: campaignParticipation.id }],
           competences,
         });
 
@@ -580,12 +581,13 @@ describe('Shared | Integration | Domain | Services | Placement Profile Service',
           userId: userId,
           snappedAt: sharedAt,
           snapshot: JSON.stringify([ke1, ke2]),
+          campaignParticipationId: campaignParticipation.id,
         });
         await databaseBuilder.commit();
 
         // when
         const actualPlacementProfiles = await placementProfileService.getPlacementProfilesWithSnapshotting({
-          userIdsAndDates: [{ userId, sharedAt }],
+          participations: [{ campaignParticipationId: campaignParticipation.id }],
           competences,
         });
 
@@ -595,7 +597,6 @@ describe('Shared | Integration | Domain | Services | Placement Profile Service',
 
       context('when we dont want to limit pix score', function () {
         it('should not limit pixScore and level to the max reachable for user competence based on knowledge elements', async function () {
-          const sharedAt = new Date('2022-01-05');
           const ke = databaseBuilder.factory.buildKnowledgeElement({
             competenceId: 'competenceRecordIdOne',
             earnedPix: 64,
@@ -605,16 +606,15 @@ describe('Shared | Integration | Domain | Services | Placement Profile Service',
           });
 
           databaseBuilder.factory.buildKnowledgeElementSnapshot({
-            userId: userId,
-            snappedAt: sharedAt,
             snapshot: JSON.stringify([ke]),
+            campaignParticipationId: campaignParticipation.id,
           });
 
           await databaseBuilder.commit();
 
           // when
           const actualPlacementProfiles = await placementProfileService.getPlacementProfilesWithSnapshotting({
-            userIdsAndDates: [{ userId, sharedAt }],
+            participations: [{ campaignParticipationId: campaignParticipation.id }],
             competences,
             allowExcessPixAndLevels: true,
           });
@@ -630,7 +630,6 @@ describe('Shared | Integration | Domain | Services | Placement Profile Service',
 
       context('when we want to limit pix score', function () {
         it('should limit pixScore to 40 and level to 5', async function () {
-          const sharedAt = new Date('2022-01-05');
           const ke = databaseBuilder.factory.buildKnowledgeElement({
             competenceId: 'competenceRecordIdOne',
             earnedPix: 64,
@@ -640,8 +639,7 @@ describe('Shared | Integration | Domain | Services | Placement Profile Service',
           });
 
           databaseBuilder.factory.buildKnowledgeElementSnapshot({
-            userId: userId,
-            snappedAt: sharedAt,
+            campaignParticipationId: campaignParticipation.id,
             snapshot: JSON.stringify([ke]),
           });
 
@@ -649,7 +647,7 @@ describe('Shared | Integration | Domain | Services | Placement Profile Service',
 
           // when
           const actualPlacementProfiles = await placementProfileService.getPlacementProfilesWithSnapshotting({
-            userIdsAndDates: [{ userId, sharedAt }],
+            participations: [{ campaignParticipationId: campaignParticipation.id }],
             competences,
             allowExcessPixAndLevels: false,
           });


### PR DESCRIPTION
 ## :pancakes: Problème

On ne souhaite plus accéder au snapshot en utilisant le coupe userId, snappedAt car ces colonnes vount être supprimées.

## :bacon: Proposition
On récupérer les snapshot en utilisant la colonne campaignParticipationId

## 🧃 Remarques

On supprimer la fonction `findByUserIdsAndSnappedAtDates` car on a remplacé sont usage par `findByCampaignParticipationId`

## :yum: Pour tester

 - faire des export de résultats de campagnes d'eval et de collecte de profile
 - commencer une  campagne d'eval et se balader sur son profil 
 - terminer (sans partager) une campagne d'eval et se balader sur son profil 
 - partager une campagne d'eval et se balader sur son profil 
