### PR TITLE
[TECH] ne plus enregistrer les userId / assessmentId dans les snapshot (Pix-16285)

### DIFF
--- a/api/db/database-builder/factory/build-knowledge-element-snapshot.js
+++ b/api/db/database-builder/factory/build-knowledge-element-snapshot.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 
+import { KnowledgeElementCollection } from '../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { databaseBuffer } from '../database-buffer.js';
 import { buildKnowledgeElement } from './build-knowledge-element.js';
 import { buildUser } from './build-user.js';
@@ -17,7 +18,7 @@ const buildKnowledgeElementSnapshot = function ({
     const knowledgeElements = [];
     knowledgeElements.push(buildKnowledgeElement({ userId, createdAt: dateMinusOneDay }));
     knowledgeElements.push(buildKnowledgeElement({ userId, createdAt: dateMinusOneDay }));
-    snapshot = JSON.stringify(knowledgeElements);
+    snapshot = new KnowledgeElementCollection(knowledgeElements).toSnapshot();
   }
 
   const values = {

--- a/api/db/seeds/data/common/tooling/campaign-tooling.js
+++ b/api/db/seeds/data/common/tooling/campaign-tooling.js
@@ -5,6 +5,7 @@ import {
   CampaignExternalIdTypes,
   CampaignParticipationStatuses,
 } from '../../../../../src/prescription/shared/domain/constants.js';
+import { KnowledgeElementCollection } from '../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { Assessment, KnowledgeElement } from '../../../../../src/shared/domain/models/index.js';
 import { getPlacementProfile } from '../../../../../src/shared/domain/services/placement-profile-service.js';
 import { FEATURE_CAMPAIGN_EXTERNAL_ID } from '../constants.js';
@@ -240,7 +241,7 @@ async function createAssessmentCampaign({
         databaseBuilder.factory.buildKnowledgeElementSnapshot({
           userId,
           snappedAt: sharedAt,
-          snapshot: JSON.stringify(keDataForSnapshot),
+          snapshot: new KnowledgeElementCollection(keDataForSnapshot).toSnapshot(),
           campaignParticipationId,
         });
 
@@ -404,7 +405,7 @@ async function createProfilesCollectionCampaign({
       databaseBuilder.factory.buildKnowledgeElementSnapshot({
         userId,
         snappedAt: sharedAt,
-        snapshot: JSON.stringify(keDataForSnapshot),
+        snapshot: new KnowledgeElementCollection(keDataForSnapshot).toSnapshot(),
         campaignParticipationId,
       });
 

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
@@ -9,6 +9,7 @@ import { Campaign } from '../../../../shared/domain/models/Campaign.js';
 import * as knowledgeElementRepository from '../../../../shared/infrastructure/repositories/knowledge-element-repository.js';
 import * as knowledgeElementSnapshotRepository from '../../../campaign/infrastructure/repositories/knowledge-element-snapshot-repository.js';
 import { CampaignParticipationStatuses, CampaignTypes } from '../../../shared/domain/constants.js';
+import { KnowledgeElementCollection } from '../../../shared/domain/models/KnowledgeElementCollection.js';
 import { CampaignParticipation } from '../../domain/models/CampaignParticipation.js';
 import { AvailableCampaignParticipation } from '../../domain/read-models/AvailableCampaignParticipation.js';
 
@@ -36,7 +37,7 @@ const updateWithSnapshot = async function (campaignParticipation) {
   await knowledgeElementSnapshotRepository.save({
     userId: campaignParticipation.userId,
     snappedAt: campaignParticipation.sharedAt,
-    knowledgeElements,
+    snapshot: new KnowledgeElementCollection(knowledgeElements).toSnapshot(),
     campaignParticipationId: campaignParticipation.id,
   });
 };

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-collective-result-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-collective-result-repository.js
@@ -14,7 +14,6 @@ const getCampaignCollectiveResult = async function (campaignId, campaignLearning
   });
 
   const userIdsAndSharedDatesChunks = await _getChunksSharedParticipationsWithUserIdsAndDates(campaignId);
-
   let participantCount = 0;
   for (const userIdsAndSharedDates of userIdsAndSharedDatesChunks) {
     participantCount += userIdsAndSharedDates.length;

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-collective-result-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-collective-result-repository.js
@@ -13,12 +13,12 @@ const getCampaignCollectiveResult = async function (campaignId, campaignLearning
     campaignLearningContent,
   });
 
-  const userIdsAndSharedDatesChunks = await _getChunksSharedParticipationsWithUserIdsAndDates(campaignId);
+  const sharedCampaignParticipationIdsChunks = await _getChunksSharedParticipations(campaignId);
   let participantCount = 0;
-  for (const userIdsAndSharedDates of userIdsAndSharedDatesChunks) {
-    participantCount += userIdsAndSharedDates.length;
+  for (const campaignParticipationIds of sharedCampaignParticipationIdsChunks) {
+    participantCount += campaignParticipationIds.length;
     const knowledgeElementsGroupedByCampaignParticipationId =
-      await knowledgeElementSnapshotRepository.findByCampaignParticipationIds(userIdsAndSharedDates);
+      await knowledgeElementSnapshotRepository.findByCampaignParticipationIds(campaignParticipationIds);
     const knowledgeElements = Object.values(knowledgeElementsGroupedByCampaignParticipationId).flat();
     const validatedTargetedKnowledgeElementsCountByCompetenceId =
       campaignLearningContent.countValidatedTargetedKnowledgeElementsByCompetence(knowledgeElements);
@@ -31,7 +31,7 @@ const getCampaignCollectiveResult = async function (campaignId, campaignLearning
 
 export { getCampaignCollectiveResult };
 
-async function _getChunksSharedParticipationsWithUserIdsAndDates(campaignId) {
+async function _getChunksSharedParticipations(campaignId) {
   const results = await knex
     .from('campaign-participations')
     .max('id')

--- a/api/src/prescription/campaign/infrastructure/repositories/knowledge-element-snapshot-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/knowledge-element-snapshot-repository.js
@@ -5,13 +5,13 @@ import { KnowledgeElement } from '../../../../shared/domain/models/KnowledgeElem
 import * as knexUtils from '../../../../shared/infrastructure/utils/knex-utils.js';
 import { CampaignParticipationKnowledgeElementSnapshots } from '../../../shared/domain/read-models/CampaignParticipationKnowledgeElementSnapshots.js';
 
-const save = async function ({ userId, snappedAt, knowledgeElements, campaignParticipationId }) {
+const save = async function ({ userId, snappedAt, snapshot, campaignParticipationId }) {
   try {
     const knexConn = DomainTransaction.getConnection();
     return await knexConn('knowledge-element-snapshots').insert({
       userId,
       snappedAt,
-      snapshot: JSON.stringify(knowledgeElements),
+      snapshot,
       campaignParticipationId,
     });
   } catch (error) {

--- a/api/src/prescription/shared/domain/models/KnowledgeElementCollection.js
+++ b/api/src/prescription/shared/domain/models/KnowledgeElementCollection.js
@@ -1,0 +1,23 @@
+import _ from 'lodash';
+
+import { KnowledgeElement } from '../../../../shared/domain/models/KnowledgeElement.js';
+
+class KnowledgeElementCollection {
+  constructor(knowledgeElements = []) {
+    this.knowledgeElements = knowledgeElements;
+  }
+
+  get latestUniqNonResetKnowledgeElements() {
+    return _(this.knowledgeElements)
+      .orderBy('createdAt', 'desc')
+      .reject({ status: KnowledgeElement.StatusType.RESET })
+      .uniqBy('skillId')
+      .value();
+  }
+
+  toSnapshot() {
+    return JSON.stringify(this.latestUniqNonResetKnowledgeElements.map((ke) => _.omit(ke, ['assessmentId', 'userId'])));
+  }
+}
+
+export { KnowledgeElementCollection };

--- a/api/src/prescription/shared/domain/models/KnowledgeElementCollection.js
+++ b/api/src/prescription/shared/domain/models/KnowledgeElementCollection.js
@@ -10,13 +10,15 @@ class KnowledgeElementCollection {
   get latestUniqNonResetKnowledgeElements() {
     return _(this.knowledgeElements)
       .orderBy('createdAt', 'desc')
-      .reject({ status: KnowledgeElement.StatusType.RESET })
       .uniqBy('skillId')
+      .reject({ status: KnowledgeElement.StatusType.RESET })
       .value();
   }
 
   toSnapshot() {
-    return JSON.stringify(this.latestUniqNonResetKnowledgeElements.map((ke) => _.omit(ke, ['assessmentId', 'userId'])));
+    return JSON.stringify(
+      this.latestUniqNonResetKnowledgeElements.map((ke) => _.omit(ke, ['id', 'assessmentId', 'userId'])),
+    );
   }
 }
 

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -20,6 +20,7 @@ describe('Integration | Repository | Campaign Participation', function () {
   describe('#updateWithSnapshot', function () {
     let clock;
     let campaignParticipation;
+    let ke;
     const frozenTime = new Date('1987-09-01T00:00:00Z');
 
     beforeEach(async function () {
@@ -28,7 +29,7 @@ describe('Integration | Repository | Campaign Participation', function () {
         sharedAt: null,
       });
 
-      databaseBuilder.factory.buildKnowledgeElement({
+      ke = databaseBuilder.factory.buildKnowledgeElement({
         userId: campaignParticipation.userId,
         createdAt: new Date('1985-09-01T00:00:00Z'),
       });
@@ -75,8 +76,22 @@ describe('Integration | Repository | Campaign Participation', function () {
       });
 
       // then
-      const snapshotInDB = await knex.select('id').from('knowledge-element-snapshots');
+      const snapshotInDB = await knex.pluck('snapshot').from('knowledge-element-snapshots');
       expect(snapshotInDB).to.have.lengthOf(1);
+      expect(snapshotInDB).to.deep.equal([
+        [
+          {
+            id: ke.id,
+            answerId: ke.answerId,
+            competenceId: ke.competenceId,
+            createdAt: ke.createdAt.toISOString(),
+            earnedPix: 2,
+            skillId: ke.skillId,
+            source: ke.source,
+            status: ke.status,
+          },
+        ],
+      ]);
     });
 
     context('when there is a transaction', function () {

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -81,7 +81,6 @@ describe('Integration | Repository | Campaign Participation', function () {
       expect(snapshotInDB).to.deep.equal([
         [
           {
-            id: ke.id,
             answerId: ke.answerId,
             competenceId: ke.competenceId,
             createdAt: ke.createdAt.toISOString(),

--- a/api/tests/prescription/campaign/acceptance/application/campaign-results-route_test.js
+++ b/api/tests/prescription/campaign/acceptance/application/campaign-results-route_test.js
@@ -1,3 +1,4 @@
+import { KnowledgeElementCollection } from '../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
 import {
   createServer,
@@ -577,7 +578,7 @@ describe('Acceptance | API | campaign-results-route', function () {
       databaseBuilder.factory.buildKnowledgeElementSnapshot({
         userId,
         campaignParticipationId: campaignParticipation.id,
-        snapshot: JSON.stringify([ke]),
+        snapshot: new KnowledgeElementCollection([ke]).toSnapshot(),
         snappedAt: campaignParticipation.sharedAt,
       });
 

--- a/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -6,6 +6,7 @@ import dayjs from 'dayjs';
 
 import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
 import { CampaignExternalIdTypes } from '../../../../../../src/prescription/shared/domain/constants.js';
+import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { CAMPAIGN_FEATURES, ORGANIZATION_FEATURE } from '../../../../../../src/shared/domain/constants.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { CampaignParticipationStatuses, KnowledgeElement } from '../../../../../../src/shared/domain/models/index.js';
@@ -108,7 +109,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
         databaseBuilder.factory.buildKnowledgeElementSnapshot({
           userId: participant.id,
           snappedAt: sharedAt,
-          snapshot: JSON.stringify([ke1]),
+          snapshot: new KnowledgeElementCollection([ke1]).toSnapshot(),
         });
 
         ['recSkillWeb1'].forEach((skillId) => {
@@ -201,8 +202,8 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
         databaseBuilder.factory.buildKnowledgeElementSnapshot({
           userId: participant.id,
           snappedAt: sharedAt,
-          snapshot: JSON.stringify([ke1, ke2, ke3]),
           campaignParticipationId: campaignParticipation.id,
+          snapshot: new KnowledgeElementCollection([ke1, ke2, ke3]).toSnapshot(),
         });
 
         ['recSkillWeb1', 'recSkillWeb2', 'recSkillWeb3'].forEach((skillId) => {
@@ -341,8 +342,8 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
         databaseBuilder.factory.buildKnowledgeElementSnapshot({
           userId: participant.id,
           snappedAt: sharedAt,
-          snapshot: JSON.stringify([ke1, ke2, ke3]),
           campaignParticipationId: campaignParticipation.id,
+          snapshot: new KnowledgeElementCollection([ke1, ke2, ke3]).toSnapshot(),
         });
 
         ['recSkillWeb1', 'recSkillWeb2', 'recSkillWeb3'].forEach((skillId) => {
@@ -451,8 +452,8 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
         databaseBuilder.factory.buildKnowledgeElementSnapshot({
           userId: participant.id,
           snappedAt: sharedAt,
-          snapshot: JSON.stringify([ke1, ke2, ke3]),
           campaignParticipationId: campaignParticipation.id,
+          snapshot: new KnowledgeElementCollection([ke1, ke2, ke3]).toSnapshot(),
         });
 
         ['recSkillWeb1', 'recSkillWeb2', 'recSkillWeb3'].forEach((skillId) => {
@@ -697,8 +698,8 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
         databaseBuilder.factory.buildKnowledgeElementSnapshot({
           userId: participant.id,
           snappedAt: sharedAt,
-          snapshot: JSON.stringify([ke1, ke2, ke3]),
           campaignParticipationId: campaignParticipation.id,
+          snapshot: new KnowledgeElementCollection([ke1, ke2, ke3]).toSnapshot(),
         });
 
         ['recSkillWeb1', 'recSkillWeb2', 'recSkillWeb3'].forEach((skillId) => {

--- a/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -11,6 +11,7 @@ import {
   CampaignExternalIdTypes,
   CampaignParticipationStatuses,
 } from '../../../../../../src/prescription/shared/domain/constants.js';
+import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import {
   CAMPAIGN_FEATURES,
   MAX_REACHABLE_LEVEL,
@@ -177,7 +178,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
         databaseBuilder.factory.buildKnowledgeElementSnapshot({
           userId: participationShared.userId,
           snappedAt: participationShared.sharedAt,
-          snapshot: JSON.stringify([ke1, ke2, ke3, ke4, ke5]),
+          snapshot: new KnowledgeElementCollection([ke1, ke2, ke3, ke4, ke5]).toSnapshot(),
           campaignParticipationId: participationShared.id,
         });
 
@@ -250,7 +251,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
         databaseBuilder.factory.buildKnowledgeElementSnapshot({
           userId: participationShared.userId,
           snappedAt: participationShared.sharedAt,
-          snapshot: JSON.stringify([ke1, ke2, ke3, ke4, ke5]),
+          snapshot: new KnowledgeElementCollection([ke1, ke2, ke3, ke4, ke5]).toSnapshot(),
           campaignParticipationId: participationShared.id,
         });
 
@@ -399,7 +400,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
         databaseBuilder.factory.buildKnowledgeElementSnapshot({
           userId: participationShared.userId,
           snappedAt: participationShared.sharedAt,
-          snapshot: JSON.stringify([ke1, ke2, ke3, ke4, ke5]),
+          snapshot: new KnowledgeElementCollection([ke1, ke2, ke3, ke4, ke5]).toSnapshot(),
           campaignParticipationId: participationShared.id,
         });
         await databaseBuilder.commit();
@@ -482,7 +483,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
         databaseBuilder.factory.buildKnowledgeElementSnapshot({
           userId: participationShared.userId,
           snappedAt: participationShared.sharedAt,
-          snapshot: JSON.stringify([ke1, ke2, ke3, ke4, ke5]),
+          snapshot: new KnowledgeElementCollection([ke1, ke2, ke3, ke4, ke5]).toSnapshot(),
           campaignParticipationId: participationShared.id,
         });
 
@@ -568,7 +569,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
         databaseBuilder.factory.buildKnowledgeElementSnapshot({
           userId: participationShared.userId,
           snappedAt: participationShared.sharedAt,
-          snapshot: JSON.stringify([ke1, ke2, ke3, ke4, ke5]),
+          snapshot: new KnowledgeElementCollection([ke1, ke2, ke3, ke4, ke5]).toSnapshot(),
           campaignParticipationId: participationShared.id,
         });
 

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-collective-result-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-collective-result-repository_test.js
@@ -3,8 +3,8 @@ import _ from 'lodash';
 import { CampaignCollectiveResult } from '../../../../../../src/prescription/campaign/domain/read-models/CampaignCollectiveResult.js';
 import * as campaignCollectiveResultRepository from '../../../../../../src/prescription/campaign/infrastructure/repositories/campaign-collective-result-repository.js';
 import { CampaignParticipationStatuses } from '../../../../../../src/prescription/shared/domain/constants.js';
+import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
-
 const { STARTED } = CampaignParticipationStatuses;
 
 function _createUserWithSharedCampaignParticipation(userName, campaignId, sharedAt, isImproved) {
@@ -887,54 +887,50 @@ describe('Integration | Repository | Campaign collective result repository', fun
           ];
 
           const knowledgeElementsAlice = knowledgeElementsDataAlice.map(databaseBuilder.factory.buildKnowledgeElement);
-          const snapshotsAlice = _(knowledgeElementsAlice).orderBy('createdAt', 'desc').uniqBy('skillId').value();
 
           databaseBuilder.factory.buildKnowledgeElementSnapshot({
             userId: userWithCampaignParticipationAlice.userId,
             snappedAt: userWithCampaignParticipationAlice.campaignParticipation.sharedAt,
-            snapshot: JSON.stringify(snapshotsAlice),
+            snapshot: new KnowledgeElementCollection(
+              knowledgeElementsAlice.filter(({ createdAt }) => createdAt <= campaignParticipationShareDate),
+            ).toSnapshot(),
             campaignParticipationId: userWithCampaignParticipationAlice.campaignParticipation.id,
           });
 
           const knowledgeElementsCharlie = knowledgeElementsDataCharlie.map(
             databaseBuilder.factory.buildKnowledgeElement,
           );
-          const snapshotsCharlie = _(knowledgeElementsCharlie)
-            .filter((o) => o.createdAt <= campaignParticipationShareDate)
-            .orderBy('createdAt', 'desc')
-            .uniqBy('skillId')
-            .value();
 
           databaseBuilder.factory.buildKnowledgeElementSnapshot({
             userId: userWithCampaignParticipationCharlie.userId,
             snappedAt: userWithCampaignParticipationCharlie.campaignParticipation.sharedAt,
-            snapshot: JSON.stringify(snapshotsCharlie),
+            snapshot: new KnowledgeElementCollection(
+              knowledgeElementsCharlie.filter(({ createdAt }) => createdAt <= campaignParticipationShareDate),
+            ).toSnapshot(),
             campaignParticipationId: userWithCampaignParticipationCharlie.campaignParticipation.id,
           });
 
           const knowledgeElementsBob = knowledgeElementsDataBob.map(databaseBuilder.factory.buildKnowledgeElement);
-          const snapshotsBob = _(knowledgeElementsBob)
-            .filter((o) => o.createdAt <= campaignParticipationShareDate)
-            .orderBy('createdAt', 'desc')
-            .uniqBy('skillId')
-            .value();
 
           databaseBuilder.factory.buildKnowledgeElementSnapshot({
             userId: userWithCampaignParticipationBob.userId,
             snappedAt: userWithCampaignParticipationBob.campaignParticipation.sharedAt,
-            snapshot: JSON.stringify(snapshotsBob),
+            snapshot: new KnowledgeElementCollection(
+              knowledgeElementsBob.filter(({ createdAt }) => createdAt <= campaignParticipationShareDate),
+            ).toSnapshot(),
             campaignParticipationId: userWithCampaignParticipationBob.campaignParticipation.id,
           });
 
           knowledgeElementsDataDan.map(databaseBuilder.factory.buildKnowledgeElement);
 
           const knowledgeElementsElo = knowledgeElementsDataElo.map(databaseBuilder.factory.buildKnowledgeElement);
-          const snapshotsElo = _(knowledgeElementsElo).orderBy('createdAt', 'desc').uniqBy('skillId').value();
 
           databaseBuilder.factory.buildKnowledgeElementSnapshot({
             userId: userWithCampaignParticipationElo.userId,
             snappedAt: userWithCampaignParticipationElo.campaignParticipation.sharedAt,
-            snapshot: JSON.stringify(snapshotsElo),
+            snapshot: new KnowledgeElementCollection(
+              knowledgeElementsElo.filter(({ createdAt }) => createdAt <= campaignParticipationShareDate),
+            ).toSnapshot(),
             campaignParticipationId: userWithCampaignParticipationElo.campaignParticipation.id,
           });
 

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-collective-result-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-collective-result-repository_test.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { CampaignCollectiveResult } from '../../../../../../src/prescription/campaign/domain/read-models/CampaignCollectiveResult.js';
 import * as campaignCollectiveResultRepository from '../../../../../../src/prescription/campaign/infrastructure/repositories/campaign-collective-result-repository.js';
 import { CampaignParticipationStatuses } from '../../../../../../src/prescription/shared/domain/constants.js';
@@ -471,7 +469,9 @@ describe('Integration | Repository | Campaign collective result repository', fun
             userId: fredId,
             campaignParticipationId: userWithCampaignParticipationFred.campaignParticipation.id,
             snappedAt: userWithCampaignParticipationFred.sharedAt,
-            snapshot: JSON.stringify(knowledgeElements.map(domainBuilder.buildKnowledgeElement)),
+            snapshot: new KnowledgeElementCollection(
+              knowledgeElements.map(domainBuilder.buildKnowledgeElement),
+            ).toSnapshot(),
           });
 
           return databaseBuilder.commit();
@@ -984,7 +984,7 @@ describe('Integration | Repository | Campaign collective result repository', fun
           databaseBuilder.factory.buildKnowledgeElementSnapshot({
             userId: userId,
             snappedAt: campaignParticipation.sharedAt,
-            snapshot: JSON.stringify([knowledgeElement]),
+            snapshot: new KnowledgeElementCollection([knowledgeElement]).toSnapshot(),
             campaignParticipationId: campaignParticipation.id,
           });
 
@@ -1067,26 +1067,20 @@ describe('Integration | Repository | Campaign collective result repository', fun
           ];
 
           const knowledgeElementsAlice = knowledgeElementsDataAlice.map(databaseBuilder.factory.buildKnowledgeElement);
-          const snapshotsAlice = _(knowledgeElementsAlice).orderBy('createdAt', 'desc').uniqBy('skillId').value();
 
           const knowledgeElementsBob = knowledgeElementsDataBob.map(databaseBuilder.factory.buildKnowledgeElement);
-          const snapshotsBob = _(knowledgeElementsBob)
-            .filter((o) => o.createdAt <= campaignParticipationShareDate)
-            .orderBy('createdAt', 'desc')
-            .uniqBy('skillId')
-            .value();
 
           databaseBuilder.factory.buildKnowledgeElementSnapshot({
             userId: userWithCampaignParticipationAlice.userId,
             snappedAt: userWithCampaignParticipationAlice.campaignParticipation.sharedAt,
-            snapshot: JSON.stringify(snapshotsAlice),
+            snapshot: new KnowledgeElementCollection(knowledgeElementsAlice).toSnapshot(),
             campaignParticipationId: userWithCampaignParticipationAlice.campaignParticipation.id,
           });
 
           databaseBuilder.factory.buildKnowledgeElementSnapshot({
             userId: userWithCampaignParticipationBob.userId,
             snappedAt: userWithCampaignParticipationBob.campaignParticipation.sharedAt,
-            snapshot: JSON.stringify(snapshotsBob),
+            snapshot: new KnowledgeElementCollection(knowledgeElementsBob).toSnapshot(),
             campaignParticipationId: userWithCampaignParticipationBob.campaignParticipation.id,
           });
 

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
@@ -4,6 +4,7 @@ import {
   CampaignParticipationStatuses,
   CampaignTypes,
 } from '../../../../../../src/prescription/shared/domain/constants.js';
+import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { databaseBuilder, expect } from '../../../../../test-helper.js';
 
 const { STARTED, TO_SHARE, SHARED } = CampaignParticipationStatuses;
@@ -171,8 +172,8 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
         databaseBuilder.factory.buildKnowledgeElementSnapshot({
           userId: campaignParticipation.userId,
           snappedAt: campaignParticipation.sharedAt,
-          snapshot: JSON.stringify([ke1, ke2]),
           campaignParticipationId: campaignParticipation.id,
+          snapshot: new KnowledgeElementCollection([ke1, ke2]).toSnapshot(),
         });
 
         await databaseBuilder.commit();

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/knowledge-element-snapshot-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/knowledge-element-snapshot-repository_test.js
@@ -1,7 +1,6 @@
 import * as knowledgeElementSnapshotRepository from '../../../../../../src/prescription/campaign/infrastructure/repositories/knowledge-element-snapshot-repository.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { AlreadyExistingEntityError } from '../../../../../../src/shared/domain/errors.js';
-import { KnowledgeElement } from '../../../../../../src/shared/domain/models/KnowledgeElement.js';
 import { catchErr, databaseBuilder, domainBuilder, expect, knex } from '../../../../../test-helper.js';
 
 describe('Integration | Repository | KnowledgeElementSnapshotRepository', function () {
@@ -19,26 +18,23 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
         userId,
         createdAt: new Date('2019-03-01'),
       });
-      const knowledgeElements = [knowledgeElement1, knowledgeElement2];
+      const knowledgeElements = new KnowledgeElementCollection([knowledgeElement1, knowledgeElement2]);
       await databaseBuilder.commit();
 
       // when
-      await knowledgeElementSnapshotRepository.save({ userId, snappedAt, knowledgeElements, campaignParticipationId });
+      await knowledgeElementSnapshotRepository.save({
+        userId,
+        snappedAt,
+        snapshot: knowledgeElements.toSnapshot(),
+        campaignParticipationId,
+      });
 
       // then
       const actualUserSnapshot = await knex.select('*').from('knowledge-element-snapshots').first();
       expect(actualUserSnapshot.userId).to.deep.equal(userId);
       expect(actualUserSnapshot.snappedAt).to.deep.equal(snappedAt);
-      const actualKnowledgeElements = [];
-      for (const knowledgeElementData of actualUserSnapshot.snapshot) {
-        actualKnowledgeElements.push(
-          new KnowledgeElement({
-            ...knowledgeElementData,
-            createdAt: new Date(knowledgeElementData.createdAt),
-          }),
-        );
-      }
-      expect(actualKnowledgeElements).to.deep.equal(knowledgeElements);
+
+      expect(actualUserSnapshot.snapshot).to.deep.equal(JSON.parse(knowledgeElements.toSnapshot()));
     });
 
     it('should throw an error if knowledge elements snapshot already exist for userId and a date', async function () {
@@ -53,7 +49,7 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
       const error = await catchErr(knowledgeElementSnapshotRepository.save)({
         userId,
         snappedAt,
-        knowledgeElements: [],
+        snapshot: JSON.stringify([]),
         campaignParticipationId,
       });
 
@@ -65,30 +61,28 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
       it('saves knowledge elements snapshot using a transaction', async function () {
         const snappedAt = new Date('2019-04-01');
         const userId = databaseBuilder.factory.buildUser().id;
+        const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation().id;
+
         const knowledgeElement1 = databaseBuilder.factory.buildKnowledgeElement({
           userId,
           createdAt: new Date('2019-03-01'),
         });
-        const knowledgeElements = [knowledgeElement1];
+        const knowledgeElements = new KnowledgeElementCollection([knowledgeElement1]);
+
         await databaseBuilder.commit();
 
-        await DomainTransaction.execute(() => {
-          return knowledgeElementSnapshotRepository.save({ userId, snappedAt, knowledgeElements });
+        await DomainTransaction.execute(async () => {
+          await knowledgeElementSnapshotRepository.save({
+            userId,
+            snappedAt,
+            snapshot: knowledgeElements.toSnapshot(),
+            campaignParticipationId,
+          });
         });
-
         const actualUserSnapshot = await knex.select('*').from('knowledge-element-snapshots').first();
         expect(actualUserSnapshot.userId).to.deep.equal(userId);
         expect(actualUserSnapshot.snappedAt).to.deep.equal(snappedAt);
-        const actualKnowledgeElements = [];
-        for (const knowledgeElementData of actualUserSnapshot.snapshot) {
-          actualKnowledgeElements.push(
-            new KnowledgeElement({
-              ...knowledgeElementData,
-              createdAt: new Date(knowledgeElementData.createdAt),
-            }),
-          );
-        }
-        expect(actualKnowledgeElements).to.deep.equal(knowledgeElements);
+        expect(actualUserSnapshot.snapshot).to.deep.equal(JSON.parse(knowledgeElements.toSnapshot()));
       });
 
       it('does not save knowledge elements snapshot using a transaction', async function () {
@@ -163,7 +157,16 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
         secondCampaignParticipationId,
       ]);
       // then
-      expect(knowledgeElementsByUserId).to.deep.equal({ [campaignParticipationId]: [knowledgeElement1] });
+      expect(knowledgeElementsByUserId).to.deep.equal({
+        [campaignParticipationId]: [
+          {
+            ...knowledgeElement1,
+            id: undefined,
+            assessmentId: undefined,
+            userId: undefined,
+          },
+        ],
+      });
     });
 
     it('should find knowledge elements snapshoted grouped by campaignParticipationIds', async function () {
@@ -204,8 +207,22 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
 
       // then
       expect(knowledgeElementsByUserId).to.deep.equals({
-        [campaignParticipationId]: [knowledgeElement1],
-        [secondCampaignParticipationId]: [knowledgeElement2],
+        [campaignParticipationId]: [
+          {
+            ...knowledgeElement1,
+            id: undefined,
+            assessmentId: undefined,
+            userId: undefined,
+          },
+        ],
+        [secondCampaignParticipationId]: [
+          {
+            ...knowledgeElement2,
+            id: undefined,
+            assessmentId: undefined,
+            userId: undefined,
+          },
+        ],
       });
     });
   });
@@ -311,15 +328,36 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
 
       expect(knowledgeElementsByUserId).to.deep.members([
         {
-          knowledgeElements: [knowledgeElement1],
+          knowledgeElements: [
+            {
+              ...knowledgeElement1,
+              id: undefined,
+              assessmentId: undefined,
+              userId: undefined,
+            },
+          ],
           campaignParticipationId: campaignParticipationId1,
         },
         {
-          knowledgeElements: [knowledgeElement2],
+          knowledgeElements: [
+            {
+              ...knowledgeElement2,
+              id: undefined,
+              assessmentId: undefined,
+              userId: undefined,
+            },
+          ],
           campaignParticipationId: campaignParticipationId2,
         },
         {
-          knowledgeElements: [knowledgeElement3],
+          knowledgeElements: [
+            {
+              ...knowledgeElement3,
+              id: undefined,
+              assessmentId: undefined,
+              userId: undefined,
+            },
+          ],
           campaignParticipationId: campaignParticipationId3,
         },
       ]);

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/knowledge-element-snapshot-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/knowledge-element-snapshot-repository_test.js
@@ -1,4 +1,5 @@
 import * as knowledgeElementSnapshotRepository from '../../../../../../src/prescription/campaign/infrastructure/repositories/knowledge-element-snapshot-repository.js';
+import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { AlreadyExistingEntityError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, domainBuilder, expect, knex } from '../../../../../test-helper.js';
@@ -146,7 +147,7 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
       databaseBuilder.factory.buildKnowledgeElementSnapshot({
         userId: userId1,
         snappedAt: snappedAt1,
-        snapshot: JSON.stringify([knowledgeElement1]),
+        snapshot: new KnowledgeElementCollection([knowledgeElement1]).toSnapshot(),
         campaignParticipationId,
       });
 
@@ -176,7 +177,7 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
       databaseBuilder.factory.buildKnowledgeElementSnapshot({
         userId: userId1,
         snappedAt: snappedAt1,
-        snapshot: JSON.stringify([knowledgeElement1]),
+        snapshot: new KnowledgeElementCollection([knowledgeElement1]).toSnapshot(),
         campaignParticipationId,
       });
       const snappedAt2 = new Date('2020-02-02');
@@ -184,7 +185,7 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
       databaseBuilder.factory.buildKnowledgeElementSnapshot({
         userId: userId2,
         snappedAt: snappedAt2,
-        snapshot: JSON.stringify([knowledgeElement2]),
+        snapshot: new KnowledgeElementCollection([knowledgeElement2]).toSnapshot(),
         campaignParticipationId: secondCampaignParticipationId,
       });
 
@@ -193,7 +194,7 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
       databaseBuilder.factory.buildKnowledgeElementSnapshot({
         userId: userId2,
         snappedAt: snappedAt3,
-        snapshot: JSON.stringify([knowledgeElement3]),
+        snapshot: new KnowledgeElementCollection([knowledgeElement3]).toSnapshot(),
         campaignParticipationId: otherCampaignParticipationId,
       });
 
@@ -271,7 +272,7 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
       databaseBuilder.factory.buildKnowledgeElementSnapshot({
         userId: userId1,
         snappedAt: snappedAt1,
-        snapshot: JSON.stringify([knowledgeElement1]),
+        snapshot: new KnowledgeElementCollection([knowledgeElement1]).toSnapshot(),
         campaignParticipationId: campaignParticipationId1,
       });
 
@@ -289,7 +290,7 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
       databaseBuilder.factory.buildKnowledgeElementSnapshot({
         userId: userId2,
         snappedAt: snappedAt2,
-        snapshot: JSON.stringify([knowledgeElement2]),
+        snapshot: new KnowledgeElementCollection([knowledgeElement2]).toSnapshot(),
         campaignParticipationId: campaignParticipationId2,
       });
 
@@ -307,7 +308,7 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
       databaseBuilder.factory.buildKnowledgeElementSnapshot({
         userId: userId2,
         snappedAt: snappedAt3,
-        snapshot: JSON.stringify([knowledgeElement3]),
+        snapshot: new KnowledgeElementCollection([knowledgeElement3]).toSnapshot(),
         campaignParticipationId: campaignParticipationId3,
       });
 

--- a/api/tests/prescription/shared/unit/domain/models/KnowledgeElementCollection_test.js
+++ b/api/tests/prescription/shared/unit/domain/models/KnowledgeElementCollection_test.js
@@ -1,0 +1,92 @@
+import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
+import { KnowledgeElement } from '../../../../../../src/shared/domain/models/KnowledgeElement.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+import { buildKnowledgeElement } from '../../../../../tooling/domain-builder/factory/build-knowledge-element.js';
+
+describe('Unit | Domain | Models | KnowledgeElementCollection', function () {
+  describe('#toSnapshot', function () {
+    it('should return a stringified JSON array of skills', function () {
+      const ke1 = buildKnowledgeElement({
+        skillId: 'rec1',
+        competenceId: 5,
+        createdAt: new Date('2025-01-10'),
+        earnedPix: 4,
+        answerId: 1,
+        assessmentId: 2,
+        id: 1,
+        userId: 1,
+      });
+      const keCollection = new KnowledgeElementCollection([ke1]);
+      expect(keCollection.toSnapshot()).equal(
+        '[{"createdAt":"2025-01-10T00:00:00.000Z","source":"direct","status":"validated","earnedPix":4,"answerId":1,"skillId":"rec1","competenceId":5}]',
+      );
+    });
+
+    it('should call latestUniqNonResetKnowledgeElements method', function () {
+      const ke1 = buildKnowledgeElement({
+        skillId: 'rec1',
+        competenceId: 5,
+        createdAt: new Date('2025-01-10'),
+        earnedPix: 4,
+        answerId: 1,
+        assessmentId: 2,
+        id: 1,
+        userId: 1,
+      });
+      const keCollection = new KnowledgeElementCollection([ke1]);
+
+      // we stub the method to contorl its output
+      const stub = sinon.stub(keCollection, 'latestUniqNonResetKnowledgeElements');
+      stub.get(() => []);
+
+      const snapshot = keCollection.toSnapshot();
+      expect(snapshot).equals('[]');
+    });
+
+    it('should drop id, userId, skillId', function () {
+      const ke1 = buildKnowledgeElement({
+        skillId: 'rec1',
+        competenceId: 5,
+        createdAt: new Date('2025-01-10'),
+        earnedPix: 4,
+        answerId: 1,
+        assessmentId: 2,
+        id: 1,
+        userId: 1,
+      });
+      const keCollection = new KnowledgeElementCollection([ke1]);
+      const snapshot = keCollection.toSnapshot();
+      expect(snapshot).not.match(/"userId":/i);
+      expect(snapshot).not.match(/"id":/i);
+      expect(snapshot).not.match(/"assessmentId":/i);
+    });
+  });
+
+  describe('latestUniqNonResetKnowledgeElements', function () {
+    it('should returns ke', function () {
+      const ke1 = buildKnowledgeElement({ skillId: 'rec1', answerId: 1, createdAt: new Date('2025-01-10'), id: 1 });
+      const ke2 = buildKnowledgeElement({ skillId: 'rec2', answerId: 2, createdAt: new Date('2025-01-11'), id: 2 });
+      const keCollection = new KnowledgeElementCollection([ke1, ke2]);
+      expect(keCollection.latestUniqNonResetKnowledgeElements).to.deep.equal([ke2, ke1]);
+    });
+
+    it('should drop reset skillId', function () {
+      const ke1 = buildKnowledgeElement({
+        skillId: 'rec1',
+        answerId: 1,
+        status: KnowledgeElement.StatusType.RESET,
+        createdAt: new Date('2025-01-10'),
+        id: 1,
+      });
+      const keCollection = new KnowledgeElementCollection([ke1]);
+      expect(keCollection.latestUniqNonResetKnowledgeElements).to.deep.equal([]);
+    });
+
+    it('should return most recent uniq skillId', function () {
+      const ke1 = buildKnowledgeElement({ skillId: 'rec1', answerId: 1, createdAt: new Date('2025-01-10'), id: 1 });
+      const ke2 = buildKnowledgeElement({ skillId: 'rec1', answerId: 2, createdAt: new Date('2025-01-11'), id: 2 });
+      const keCollection = new KnowledgeElementCollection([ke1, ke2]);
+      expect(keCollection.latestUniqNonResetKnowledgeElements).to.deep.equal([ke2]);
+    });
+  });
+});

--- a/api/tests/shared/integration/domain/services/placement-profile-service_test.js
+++ b/api/tests/shared/integration/domain/services/placement-profile-service_test.js
@@ -1,3 +1,4 @@
+import { KnowledgeElementCollection } from '../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { LOCALE } from '../../../../../src/shared/domain/constants.js';
 import {
   CampaignParticipationStatuses,
@@ -529,8 +530,8 @@ describe('Shared | Integration | Domain | Services | Placement Profile Service',
         databaseBuilder.factory.buildKnowledgeElementSnapshot({
           userId: userId,
           snappedAt: sharedAt,
-          snapshot: JSON.stringify([ke]),
           campaignParticipationId: campaignParticipation.id,
+          snapshot: new KnowledgeElementCollection([ke]).toSnapshot(),
         });
 
         await databaseBuilder.commit();
@@ -580,8 +581,8 @@ describe('Shared | Integration | Domain | Services | Placement Profile Service',
         databaseBuilder.factory.buildKnowledgeElementSnapshot({
           userId: userId,
           snappedAt: sharedAt,
-          snapshot: JSON.stringify([ke1, ke2]),
           campaignParticipationId: campaignParticipation.id,
+          snapshot: new KnowledgeElementCollection([ke1, ke2]).toSnapshot(),
         });
         await databaseBuilder.commit();
 
@@ -606,8 +607,10 @@ describe('Shared | Integration | Domain | Services | Placement Profile Service',
           });
 
           databaseBuilder.factory.buildKnowledgeElementSnapshot({
-            snapshot: JSON.stringify([ke]),
             campaignParticipationId: campaignParticipation.id,
+            userId: userId,
+            snappedAt: campaignParticipation.sharedAt,
+            snapshot: new KnowledgeElementCollection([ke]).toSnapshot(),
           });
 
           await databaseBuilder.commit();
@@ -640,7 +643,9 @@ describe('Shared | Integration | Domain | Services | Placement Profile Service',
 
           databaseBuilder.factory.buildKnowledgeElementSnapshot({
             campaignParticipationId: campaignParticipation.id,
-            snapshot: JSON.stringify([ke]),
+            userId: userId,
+            snappedAt: campaignParticipation.sharedAt,
+            snapshot: new KnowledgeElementCollection([ke]).toSnapshot(),
           });
 
           await databaseBuilder.commit();


### PR DESCRIPTION
## :pancakes: Problème

on souhaite enlever les références à `userId` et `assessmentId` dans le champ `snapshot` de la table `knowledge-element-snapshots` pour éviter de pouvoir faire de lien entre un utilisateur anonymiser et une campagne.

## :bacon: Proposition
on arrête de sauvegarder les `userId` et `assessmentId` dans le champ `snapshot`

## 🧃 Remarques

On ajoute le modèle `KnowledgeElementCollection` pour gérer les collection de knowledgeElement à enregistrer pour en faire des snapshot

## :yum: Pour tester

- participer à une campagne et partager sa participation
- se connecter avec pgconsole sur l'api
- afficher le snapshot de la participation
- ne pas voir de référence à `userId` et `assessmentId` dans le snapshot
