### PR TITLE
[FEATURE] Accéder à un board metabase sur les PC depuis PixAdmin (PIX-16427)

### DIFF
--- a/admin/app/components/target-profiles/target-profile.gjs
+++ b/admin/app/components/target-profiles/target-profile.gjs
@@ -9,6 +9,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import { pageTitle } from 'ember-page-title';
+import ENV from 'pix-admin/config/environment';
 
 import formatDate from '../../helpers/format-date';
 import ConfirmPopup from '../confirm-popup';
@@ -49,6 +50,11 @@ export default class TargetProfile extends Component {
 
   get hasLinkedAutonomousCourse() {
     return Boolean(this.args.model.hasLinkedAutonomousCourse);
+  }
+
+  get externalURL() {
+    const urlDashboardPrefix = ENV.APP.TARGET_PROFILE_DASHBOARD_URL;
+    return urlDashboardPrefix && `${urlDashboardPrefix}?id=${this.args.model.id}`;
   }
 
   displayBooleanState = (bool) => {
@@ -235,21 +241,26 @@ export default class TargetProfile extends Component {
             @route="authenticated.target-profiles.edit"
             @model={{@model.id}}
             @size="small"
-            @variant="secondary"
+            @variant="primary"
           >
             {{t "common.actions.edit"}}
           </PixButtonLink>
-          <div class="target-profile__actions-separator"></div>
 
-          {{#unless @model.isSimplifiedAccess}}
-            <PixButton
-              @size="small"
-              @variant="secondary"
-              @triggerAction={{this.toggleDisplaySimplifiedAccessPopupConfirm}}
-            >
-              Marquer comme accès simplifié
-            </PixButton>
-          {{/unless}}
+          <PixButton @size="small" @variant="primary" @triggerAction={{this.openCopyModal}}>{{t
+              "pages.target-profiles.copy.button.label"
+            }}</PixButton>
+
+          <Copy @isOpen={{this.showCopyModal}} @onClose={{this.closeCopyModal}} @onSubmit={{this.copyTargetProfile}} />
+
+          <div class="target-profile__actions-separator"></div>
+          <PixButtonLink
+            @variant="secondary"
+            @href="{{this.externalURL}}"
+            @size="small"
+            target="_blank"
+            rel="noopener noreferrer"
+          >Tableau de bord
+          </PixButtonLink>
 
           <PixButton @triggerAction={{this.downloadJSON}} @size="small" @variant="success">
             Télécharger le profil cible (JSON)
@@ -259,14 +270,14 @@ export default class TargetProfile extends Component {
             Télécharger le profil cible (PDF)
           </PixButton>
 
-          <PixButton @size="small" @triggerAction={{this.openCopyModal}}>{{t
-              "pages.target-profiles.copy.button.label"
-            }}</PixButton>
-
-          <Copy @isOpen={{this.showCopyModal}} @onClose={{this.closeCopyModal}} @onSubmit={{this.copyTargetProfile}} />
+          <div class="target-profile__actions-separator"></div>
+          {{#unless @model.isSimplifiedAccess}}
+            <PixButton @size="small" @variant="error" @triggerAction={{this.toggleDisplaySimplifiedAccessPopupConfirm}}>
+              Marquer comme accès simplifié
+            </PixButton>
+          {{/unless}}
 
           {{#unless @model.outdated}}
-            <div class="target-profile__actions-spacer"></div>
             <PixButton @size="small" @variant="error" @triggerAction={{this.toggleDisplayConfirm}}>
               Marquer comme obsolète
             </PixButton>

--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -73,6 +73,7 @@ module.exports = function (environment) {
         minValue: 1,
       }),
       ORGANIZATION_DASHBOARD_URL: process.env.ORGANIZATION_DASHBOARD_URL,
+      TARGET_PROFILE_DASHBOARD_URL: process.env.TARGET_PROFILE_DASHBOARD_URL,
       CERTIFICATION_CENTER_DASHBOARD_URL: process.env.CERTIFICATION_CENTER_DASHBOARD_URL,
       USER_DASHBOARD_URL: process.env.USER_DASHBOARD_URL,
       MAX_LEVEL: 8,
@@ -124,6 +125,7 @@ module.exports = function (environment) {
     // ENV.APP.LOG_TRANSITIONS = true;
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
+    ENV.APP.TARGET_PROFILE_DASHBOARD_URL = 'https://exemple.net';
     if (analyticsEnabled) {
       ENV.matomo.url = process.env.WEB_ANALYTICS_URL;
       ENV.matomo.debug = true;
@@ -133,12 +135,12 @@ module.exports = function (environment) {
   if (environment === 'test') {
     // Testem prefers this...
     ENV.locationType = 'none';
-
     ENV.APP.API_HOST = 'http://localhost:3000';
 
     // keep test console output quieter
     ENV.APP.LOG_ACTIVE_GENERATION = false;
     ENV.APP.LOG_VIEW_LOOKUPS = false;
+    ENV.APP.TARGET_PROFILE_DASHBOARD_URL = 'https://example.net';
 
     ENV.APP.rootElement = '#ember-testing';
     ENV.APP.autoboot = false;

--- a/admin/tests/integration/components/target-profiles/target-profile-test.gjs
+++ b/admin/tests/integration/components/target-profiles/target-profile-test.gjs
@@ -1,6 +1,7 @@
 import { render } from '@1024pix/ember-testing-library';
 import { t } from 'ember-intl/test-support';
 import TargetProfile from 'pix-admin/components/target-profiles/target-profile';
+import ENV from 'pix-admin/config/environment';
 import { module, test } from 'qunit';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
@@ -40,6 +41,18 @@ module('Integration | Component | TargetProfile', function (hooks) {
         assert.ok(_findByListItemText(screen, 'Parcours Accès Simplifié : Non'));
         assert.ok(_findByListItemText(screen, `${t('pages.target-profiles.resettable-checkbox.label')} : Non`));
         assert.ok(_findByListItemText(screen, `${t('pages.target-profiles.tubes-count')} : ${model.tubesCount}`));
+      });
+      test('it should display link to a metabase dashboard', async function (assert) {
+        //given
+        const model = { ...targetProfileSampleData };
+
+        // when
+        const screen = await render(<template><TargetProfile @model={{model}} /></template>);
+
+        //then
+        const buttonLink = screen.getByRole('link', { name: 'Tableau de bord' });
+        assert.ok(buttonLink);
+        assert.strictEqual(buttonLink.getAttribute('href'), `${ENV.APP.TARGET_PROFILE_DASHBOARD_URL}?id=${model.id}`);
       });
     });
 


### PR DESCRIPTION
## :pancakes: Problème

Lorsque le pôle déploiement cherche des informations sur un PC (participations, temps moyen etc.) ils doivent reporter l'id dans des boards metabase. 

## :bacon: Proposition

Cela aiderait de pouvoir accéder à un board directement depuis admin comme c'est le cas pour les orgas. 
On propose donc d'ajouter un button link qui renvoie vers le board avec l'id du PC. 

## 🧃 Remarques

J'ai regroupé les boutons et modifié les variants selon leurs usages.

## :yum: Pour tester
- la var d'env à créer : TARGET_PROFILE_DASHBOARD_URL
- l'URL du board : https://metabase.pix.fr/dashboard/1456-recherche-infos-profil-cible-donnees-froides
- aller sur une page profile cible sur PixAdmin
- cliquer sur le bouton "tableau de bord" 
- s'assurer que lien est fonctionnel et que l'id est le bon 
- :hand_with_index_finger_and_thumb_crossed: