### PR TITLE
[FEATURE] Gestion des doublons d'INE dans Parcoursup (PIX-16361).

### DIFF
--- a/api/src/certification/shared/application/http-error-mapper-configuration.js
+++ b/api/src/certification/shared/application/http-error-mapper-configuration.js
@@ -1,3 +1,4 @@
+import { parcoursupDomainErrorMappingConfiguration } from '../../../parcoursup/application/http-error-mapper-configuration.js';
 import { HttpErrors } from '../../../shared/application/http-errors.js';
 import { DomainErrorMappingConfiguration } from '../../../shared/application/models/domain-error-mapping-configuration.js';
 import { configurationDomainErrorMappingConfiguration } from '../../configuration/application/http-error-mapper-configuration.js';
@@ -24,5 +25,6 @@ certificationDomainErrorMappingConfiguration.push(
   ...enrolmentDomainErrorMappingConfiguration,
   ...sessionDomainErrorMappingConfiguration,
   ...configurationDomainErrorMappingConfiguration,
+  ...parcoursupDomainErrorMappingConfiguration,
 );
 export { certificationDomainErrorMappingConfiguration };

--- a/api/src/parcoursup/application/certification-controller.js
+++ b/api/src/parcoursup/application/certification-controller.js
@@ -1,7 +1,16 @@
 import { usecases } from '../domain/usecases/index.js';
 
 const getCertificationResult = async function (request) {
-  return usecases.getCertificationResult(request.payload);
+  const { ine, organizationUai, lastName, firstName, birthdate, verificationCode } = request.payload;
+
+  return usecases.getCertificationResult({
+    ine,
+    organizationUai,
+    lastName,
+    firstName,
+    birthdate,
+    verificationCode,
+  });
 };
 
 export const certificationController = {

--- a/api/src/parcoursup/application/certification-route.js
+++ b/api/src/parcoursup/application/certification-route.js
@@ -80,6 +80,7 @@ const register = async function (server) {
             401: responseObjectErrorDoc,
             403: responseObjectErrorDoc,
             404: responseObjectErrorDoc,
+            409: responseObjectErrorDoc,
           },
         },
       },

--- a/api/src/parcoursup/application/http-error-mapper-configuration.js
+++ b/api/src/parcoursup/application/http-error-mapper-configuration.js
@@ -1,0 +1,10 @@
+import { HttpErrors } from '../../shared/application/http-errors.js';
+import { DomainErrorMappingConfiguration } from '../../shared/application/models/domain-error-mapping-configuration.js';
+import { MoreThanOneMatchingCertificationError } from '../domain/errors.js';
+
+export const parcoursupDomainErrorMappingConfiguration = [
+  {
+    name: MoreThanOneMatchingCertificationError.name,
+    httpErrorFn: (error) => new HttpErrors.ConflictError(error.message),
+  },
+].map((domainErrorMappingConfiguration) => new DomainErrorMappingConfiguration(domainErrorMappingConfiguration));

--- a/api/src/parcoursup/domain/errors.js
+++ b/api/src/parcoursup/domain/errors.js
@@ -1,0 +1,7 @@
+import { DomainError } from '../../shared/domain/errors.js';
+
+export class MoreThanOneMatchingCertificationError extends DomainError {
+  constructor(message = 'More than one candidate found for current search parameters') {
+    super(message);
+  }
+}

--- a/api/src/parcoursup/domain/read-models/CertificationResult.js
+++ b/api/src/parcoursup/domain/read-models/CertificationResult.js
@@ -1,4 +1,20 @@
-class CertificationResult {
+export class CertificationResult {
+  /**
+   * @param {Object} props
+   * @param {string} props.[ine]
+   * @param {string} props.[organizationUai]
+   * @param {string} props.lastName
+   * @param {string} props.firstName
+   * @param {string} props.birthdate
+   * @param {string} props.status
+   * @param {string} props.pixScore
+   * @param {Date} props.certificationDate
+   * @param {Array<Object>} props.competences
+   *        @param {string} props.competences.competence_code
+   *        @param {string} props.competences.competence_name
+   *        @param {string} props.competences.area_name
+   *        @param {string} props.competences.competence_level
+   */
   constructor({
     ine,
     organizationUai,
@@ -21,5 +37,3 @@ class CertificationResult {
     this.competences = competences;
   }
 }
-
-export { CertificationResult };

--- a/api/src/parcoursup/domain/read-models/CertificationResult.js
+++ b/api/src/parcoursup/domain/read-models/CertificationResult.js
@@ -1,3 +1,7 @@
+/**
+ * @typedef {import('./Competence.js').Competence} Competence
+ */
+
 export class CertificationResult {
   /**
    * @param {Object} props
@@ -9,11 +13,7 @@ export class CertificationResult {
    * @param {string} props.status
    * @param {string} props.pixScore
    * @param {Date} props.certificationDate
-   * @param {Array<Object>} props.competences
-   *        @param {string} props.competences.competence_code
-   *        @param {string} props.competences.competence_name
-   *        @param {string} props.competences.area_name
-   *        @param {string} props.competences.competence_level
+   * @param {Array<Competence>} props.competences
    */
   constructor({
     ine,

--- a/api/src/parcoursup/domain/read-models/Competence.js
+++ b/api/src/parcoursup/domain/read-models/Competence.js
@@ -1,0 +1,15 @@
+export class Competence {
+  /**
+   * @param {Object} props
+   * @param {string} props.code
+   * @param {string} props.name
+   * @param {string} props.areaName
+   * @param {string} props.level
+   */
+  constructor({ code, name, areaName, level }) {
+    this.code = code;
+    this.name = name;
+    this.areaName = areaName;
+    this.level = level;
+  }
+}

--- a/api/src/parcoursup/infrastructure/repositories/certification-repository.js
+++ b/api/src/parcoursup/infrastructure/repositories/certification-repository.js
@@ -19,7 +19,26 @@ const getByOrganizationUAI = async ({ organizationUai, lastName, firstName, birt
 
 const _getBySearchParams = async (searchParams) => {
   const certificationResultDto = await datamartKnex('data_export_parcoursup_certif_result')
-    .select(
+    .select({
+      national_student_id: 'national_student_id',
+      organization_uai: 'organization_uai',
+      last_name: 'last_name',
+      first_name: 'first_name',
+      birthdate: 'birthdate',
+      status: 'status',
+      pix_score: 'pix_score',
+      certification_date: 'certification_date',
+      competences: datamartKnex.raw(
+        `json_agg(json_build_object(
+          'competence_code', "competence_code",
+          'competence_name', "competence_name",
+          'area_name', "area_name",
+          'competence_level', "competence_level"
+        ))`,
+      ),
+    })
+    .where(searchParams)
+    .groupBy(
       'national_student_id',
       'organization_uai',
       'last_name',
@@ -28,12 +47,8 @@ const _getBySearchParams = async (searchParams) => {
       'status',
       'pix_score',
       'certification_date',
-      'competence_code',
-      'competence_name',
-      'area_name',
-      'competence_level',
-    )
-    .where(searchParams);
+    );
+
   if (!certificationResultDto.length) {
     throw new NotFoundError('No certifications found for given search parameters');
   }
@@ -43,21 +58,27 @@ const _getBySearchParams = async (searchParams) => {
 
 const getByVerificationCode = async ({ verificationCode }) => {
   const certificationResultDto = await datamartKnex('data_export_parcoursup_certif_result_code_validation')
-    .select(
-      'last_name',
-      'first_name',
-      'birthdate',
-      'status',
-      'pix_score',
-      'certification_date',
-      'competence_code',
-      'competence_name',
-      'area_name',
-      'competence_level',
-    )
+    .select({
+      last_name: 'last_name',
+      first_name: 'first_name',
+      birthdate: 'birthdate',
+      status: 'status',
+      pix_score: 'pix_score',
+      certification_date: 'certification_date',
+      competences: datamartKnex.raw(
+        `json_agg(json_build_object(
+          'competence_code', "competence_code",
+          'competence_name', "competence_name",
+          'area_name', "area_name",
+          'competence_level', "competence_level"
+        ))`,
+      ),
+    })
     .where({
       certification_code_verification: verificationCode,
-    });
+    })
+    .groupBy('last_name', 'first_name', 'birthdate', 'status', 'pix_score', 'certification_date');
+
   if (!certificationResultDto.length) {
     throw new NotFoundError('No certifications found for given search parameters');
   }
@@ -65,24 +86,29 @@ const getByVerificationCode = async ({ verificationCode }) => {
   return _toDomain(certificationResultDto);
 };
 
+/**
+ * @returns {Array<CertificationResult>}
+ */
 const _toDomain = (certificationResultDto) => {
-  return new CertificationResult({
-    ine: certificationResultDto[0].national_student_id,
-    organizationUai: certificationResultDto[0].organization_uai,
-    lastName: certificationResultDto[0].last_name,
-    firstName: certificationResultDto[0].first_name,
-    birthdate: certificationResultDto[0].birthdate,
-    status: certificationResultDto[0].status,
-    pixScore: certificationResultDto[0].pix_score,
-    certificationDate: certificationResultDto[0].certification_date,
-    competences: certificationResultDto.map((certificationResultDto) => {
-      return {
-        code: certificationResultDto.competence_code,
-        name: certificationResultDto.competence_name,
-        areaName: certificationResultDto.area_name,
-        level: certificationResultDto.competence_level,
-      };
-    }),
+  return certificationResultDto.map((certificationResult) => {
+    return new CertificationResult({
+      ine: certificationResult.national_student_id,
+      organizationUai: certificationResult.organization_uai,
+      lastName: certificationResult.last_name,
+      firstName: certificationResult.first_name,
+      birthdate: certificationResult.birthdate,
+      status: certificationResult.status,
+      pixScore: certificationResult.pix_score,
+      certificationDate: certificationResult.certification_date,
+      competences: certificationResult.competences.map((competence) => {
+        return {
+          code: competence.competence_code,
+          name: competence.competence_name,
+          areaName: competence.area_name,
+          level: competence.competence_level,
+        };
+      }),
+    });
   });
 };
 

--- a/api/src/parcoursup/infrastructure/repositories/certification-repository.js
+++ b/api/src/parcoursup/infrastructure/repositories/certification-repository.js
@@ -1,6 +1,7 @@
 import { datamartKnex } from '../../../../db/knex-database-connection.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { CertificationResult } from '../../domain/read-models/CertificationResult.js';
+import { Competence } from '../../domain/read-models/Competence.js';
 
 const getByINE = async ({ ine }) => {
   return _getBySearchParams({
@@ -91,6 +92,15 @@ const getByVerificationCode = async ({ verificationCode }) => {
  */
 const _toDomain = (certificationResultDto) => {
   return certificationResultDto.map((certificationResult) => {
+    const competences = certificationResult.competences.map((competence) => {
+      return new Competence({
+        code: competence.competence_code,
+        name: competence.competence_name,
+        areaName: competence.area_name,
+        level: competence.competence_level,
+      });
+    });
+
     return new CertificationResult({
       ine: certificationResult.national_student_id,
       organizationUai: certificationResult.organization_uai,
@@ -100,14 +110,7 @@ const _toDomain = (certificationResultDto) => {
       status: certificationResult.status,
       pixScore: certificationResult.pix_score,
       certificationDate: certificationResult.certification_date,
-      competences: certificationResult.competences.map((competence) => {
-        return {
-          code: competence.competence_code,
-          name: competence.competence_name,
-          areaName: competence.area_name,
-          level: competence.competence_level,
-        };
-      }),
+      competences,
     });
   });
 };

--- a/api/tests/parcoursup/acceptance/application/certification-route_test.js
+++ b/api/tests/parcoursup/acceptance/application/certification-route_test.js
@@ -217,36 +217,5 @@ describe('Parcoursup | Acceptance | Application | certification-route', function
       expect(response.statusCode).to.equal(200);
       expect(response.result).to.deep.equal(expectedCertification);
     });
-
-    it('should return 409 HTTP status code in case of duplicated certification results', async function () {
-      // given
-      // Same candidate but with another birthdate
-      datamartBuilder.factory.buildCertificationResult({
-        ...certificationResultData,
-        birthdate: '1999-01-01',
-      });
-      await datamartBuilder.commit();
-
-      const options = {
-        method: 'POST',
-        url: `/api/application/parcoursup/certification/search`,
-        headers: {
-          authorization: generateValidRequestAuthorizationHeaderForApplication(
-            PARCOURSUP_CLIENT_ID,
-            PARCOURSUP_SOURCE,
-            PARCOURSUP_SCOPE,
-          ),
-        },
-        payload: {
-          ine,
-        },
-      };
-
-      // when
-      const response = await server.inject(options);
-
-      // then
-      expect(response.statusCode).to.equal(409);
-    });
   });
 });

--- a/api/tests/parcoursup/integration/repositories/certification-repository_test.js
+++ b/api/tests/parcoursup/integration/repositories/certification-repository_test.js
@@ -48,18 +48,18 @@ describe('Parcoursup | Infrastructure | Integration | Repositories | certificati
           pixScore: 327,
           certificationDate: new Date('2024-11-22T09:39:54Z'),
           competences: [
-            {
+            domainBuilder.parcoursup.buildCompetence({
               code: '1.1',
               name: 'Mener une recherche et une veille d’information',
               areaName: 'Informations et données',
               level: 3,
-            },
-            {
+            }),
+            domainBuilder.parcoursup.buildCompetence({
               code: '1.2',
               name: 'Gérer des données',
               areaName: 'Informations et données',
               level: 5,
-            },
+            }),
           ],
         });
         expect(results).to.deep.equal([expectedCertification]);
@@ -134,18 +134,18 @@ describe('Parcoursup | Infrastructure | Integration | Repositories | certificati
           pixScore: 327,
           certificationDate: new Date('2024-11-22T09:39:54Z'),
           competences: [
-            {
+            domainBuilder.parcoursup.buildCompetence({
               code: '1.1',
               name: 'Mener une recherche et une veille d’information',
               areaName: 'Informations et données',
               level: 3,
-            },
-            {
+            }),
+            domainBuilder.parcoursup.buildCompetence({
               code: '1.2',
               name: 'Gérer des données',
               areaName: 'Informations et données',
               level: 5,
-            },
+            }),
           ],
         });
         expect(results).to.deep.equal([expectedCertification]);
@@ -222,18 +222,18 @@ describe('Parcoursup | Infrastructure | Integration | Repositories | certificati
           pixScore: 327,
           certificationDate: new Date('2024-11-22T09:39:54Z'),
           competences: [
-            {
+            domainBuilder.parcoursup.buildCompetence({
               code: '1.1',
               name: 'Mener une recherche et une veille d’information',
               areaName: 'Informations et données',
               level: 3,
-            },
-            {
+            }),
+            domainBuilder.parcoursup.buildCompetence({
               code: '1.2',
               name: 'Gérer des données',
               areaName: 'Informations et données',
               level: 5,
-            },
+            }),
           ],
         });
         expect(results).to.deep.equal([expectedCertification]);

--- a/api/tests/parcoursup/integration/repositories/certification-repository_test.js
+++ b/api/tests/parcoursup/integration/repositories/certification-repository_test.js
@@ -35,7 +35,7 @@ describe('Parcoursup | Infrastructure | Integration | Repositories | certificati
         await datamartBuilder.commit();
 
         // when
-        const result = await certificationRepository.getByINE({ ine });
+        const results = await certificationRepository.getByINE({ ine });
 
         // then
         const expectedCertification = domainBuilder.parcoursup.buildCertificationResult({
@@ -62,7 +62,7 @@ describe('Parcoursup | Infrastructure | Integration | Repositories | certificati
             },
           ],
         });
-        expect(result).to.deep.equal(expectedCertification);
+        expect(results).to.deep.equal([expectedCertification]);
       });
     });
 
@@ -116,7 +116,7 @@ describe('Parcoursup | Infrastructure | Integration | Repositories | certificati
         await datamartBuilder.commit();
 
         // when
-        const result = await certificationRepository.getByOrganizationUAI({
+        const results = await certificationRepository.getByOrganizationUAI({
           organizationUai,
           lastName,
           firstName,
@@ -148,7 +148,7 @@ describe('Parcoursup | Infrastructure | Integration | Repositories | certificati
             },
           ],
         });
-        expect(result).to.deep.equal(expectedCertification);
+        expect(results).to.deep.equal([expectedCertification]);
       });
     });
 
@@ -209,7 +209,7 @@ describe('Parcoursup | Infrastructure | Integration | Repositories | certificati
         await datamartBuilder.commit();
 
         // when
-        const result = await certificationRepository.getByVerificationCode({
+        const results = await certificationRepository.getByVerificationCode({
           verificationCode,
         });
 
@@ -236,7 +236,7 @@ describe('Parcoursup | Infrastructure | Integration | Repositories | certificati
             },
           ],
         });
-        expect(result).to.deep.equal(expectedCertification);
+        expect(results).to.deep.equal([expectedCertification]);
       });
     });
 

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -200,6 +200,7 @@ import { buildCompetenceForScoring } from './certification/shared/build-competen
 import { buildJuryComment } from './certification/shared/build-jury-comment.js';
 import { buildV3CertificationScoring } from './certification/shared/build-v3-certification-scoring.js';
 import { buildCertificationResult as parcoursupCertificationResult } from './parcoursup/build-certification-result.js';
+import { buildCompetence as parcoursupCompetence } from './parcoursup/build-competence.js';
 import { buildCampaign as boundedContextCampaignBuildCampaign } from './prescription/campaign/build-campaign.js';
 import { buildCampaignParticipation as boundedContextCampaignParticipationBuildCampaignParticipation } from './prescription/campaign-participation/build-campaign-participation.js';
 import { buildStageCollection as buildStageCollectionForTargetProfileManagement } from './target-profile-management/build-stage-collection.js';
@@ -262,6 +263,7 @@ const certification = {
 
 const parcoursup = {
   buildCertificationResult: parcoursupCertificationResult,
+  buildCompetence: parcoursupCompetence,
 };
 
 const prescription = {

--- a/api/tests/tooling/domain-builder/factory/parcoursup/build-competence.js
+++ b/api/tests/tooling/domain-builder/factory/parcoursup/build-competence.js
@@ -1,0 +1,5 @@
+import { Competence } from '../../../../../src/parcoursup/domain/read-models/Competence.js';
+
+export const buildCompetence = function ({ code, name, areaName, level }) {
+  return new Competence({ code, name, areaName, level });
+};


### PR DESCRIPTION
Coches deja obtenues dans une autre PR, mais soucis avec la CI
Voir https://github.com/1024pix/pix/pull/11319

## :pancakes: Problème

Pour le datamart avec INE et celui avec UAI, une seule certif est retournée
par contre, un INE peut être lié à 2 élèves différents

## :bacon: Proposition

* Implementation d'un code d'erreur en cas d'impossibilite a determiner une unique certification

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester
* Se connecter sur l'API via [https://api-pr11341.review.pix.fr/documentation/parcoursup](https://api-pr11341.review.pix.fr/documentation/parcoursup)
* Tenter une recherche sur une INE en double
  * Constater une erreur avec le code HTTP 409
* Tenter une autre recherche, par exemple INE 086369926RY
  * Constater que tout fonctionne correctement   

