### PR TITLE
[FEATURE] Envoyer un email d'avertissement si l'utilisateur ne s'est pas connecté depuis 12 mois ou plus (PIX-16126)

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -304,6 +304,12 @@ MAILING_PROVIDER=mailpit
 # default: none
 # BREVO_SELF_ACCOUNT_DELETION_TEMPLATE_ID=
 
+# ID of the template used to warn user who hasn't logged in for a year or more
+#
+# presence: required only if emailing is enabled and provider is Brevo
+# type: Number
+# default: none
+#BREVO_WARNING_CONNECTION_TEMPLATE_ID=
 
 # String for links in emails redirect to a specific domain when user comes from french domain
 #

--- a/api/sample.env
+++ b/api/sample.env
@@ -754,6 +754,12 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: 50
 # LOGIN_BLOCKING_LIMIT_FAILURE_COUNT=50
 
+# Disconnection duration after which a warning email is sent
+# presence: optional
+# type: string
+# default: '1y'
+# EMAIL_CONNECTION_WARNING_PERIOD=1y
+
 # ===================
 # FEATURE TOGGLES
 # ===================

--- a/api/src/identity-access-management/domain/emails/create-reset-password-demand.email.js
+++ b/api/src/identity-access-management/domain/emails/create-reset-password-demand.email.js
@@ -16,7 +16,6 @@ export function createResetPasswordDemandEmail({ email, temporaryKey, locale = L
   const factory = new EmailFactory({ app: 'pix-app', locale });
 
   const { i18n, defaultVariables } = factory;
-
   const pixAppUrl = urlBuilder.getPixAppBaseUrl(locale);
 
   return factory.buildEmail({

--- a/api/src/identity-access-management/domain/emails/create-warning-connection.email.js
+++ b/api/src/identity-access-management/domain/emails/create-warning-connection.email.js
@@ -1,0 +1,48 @@
+import { LOCALE } from '../../../shared/domain/constants.js';
+import { urlBuilder } from '../../../shared/infrastructure/utils/url-builder.js';
+import { EmailFactory } from '../../../shared/mail/domain/models/EmailFactory.js';
+import { mailer } from '../../../shared/mail/infrastructure/services/mailer.js';
+
+/**
+ * Creates an email to warn users for suspicious connection.
+ *
+ * @param {Object} params - The parameters for creating the email.
+ * @param {string} params.locale - The locale for the email.
+ * @param {string} params.email - The recipient's email address.
+ * @param {string} params.firstName - The recipient's first name.
+ * @returns {Email} The email object.
+ */
+export function createWarningConnectionEmail({ locale, email, firstName }) {
+  locale = locale || LOCALE.FRENCH_FRANCE;
+  const lang = new Intl.Locale(locale).language;
+  const factory = new EmailFactory({ app: 'pix-app', locale });
+
+  const { i18n, defaultVariables } = factory;
+  const pixAppUrl = urlBuilder.getPixAppBaseUrl(locale);
+  const resetUrl = `${pixAppUrl}/mot-de-passe-oublie?lang=${lang}`;
+
+  return factory.buildEmail({
+    template: mailer.warningConnectionTemplateId,
+    subject: i18n.__('warning-connection-email.subject'),
+    to: email,
+    variables: {
+      homeName: defaultVariables.homeName,
+      homeUrl: defaultVariables.homeUrl,
+      helpDeskUrl: defaultVariables.helpdeskUrl,
+      displayNationalLogo: defaultVariables.displayNationalLogo,
+      contactUs: i18n.__('common.email.contactUs'),
+      doNotAnswer: i18n.__('common.email.doNotAnswer'),
+      moreOn: i18n.__('common.email.moreOn'),
+      pixPresentation: i18n.__('common.email.pixPresentation'),
+      hello: i18n.__('warning-connection-email.params.hello', { firstName }),
+      context: i18n.__('warning-connection-email.params.context'),
+      disclaimer: i18n.__('warning-connection-email.params.disclaimer'),
+      warningMessage: i18n.__('warning-connection-email.params.warningMessage'),
+      resetMyPassword: i18n.__('warning-connection-email.params.resetMyPassword'),
+      resetUrl,
+      supportContact: i18n.__('warning-connection-email.params.supportContact'),
+      thanks: i18n.__('warning-connection-email.params.thanks'),
+      signing: i18n.__('warning-connection-email.params.signing'),
+    },
+  });
+}

--- a/api/src/identity-access-management/domain/models/UserLogin.js
+++ b/api/src/identity-access-management/domain/models/UserLogin.js
@@ -34,6 +34,18 @@ class UserLogin {
     return this.failureCount % config.login.temporaryBlockingThresholdFailureCount === 0;
   }
 
+  shouldSendConnectionWarning() {
+    if (!this.lastLoggedAt) {
+      return false;
+    }
+
+    const emailConnectionWarningPeriodMs = config.login.emailConnectionWarningPeriod;
+    const nowMs = new Date().getTime();
+
+    const userLastConnexionMs = new Date(this.lastLoggedAt).getTime();
+    return nowMs - userLastConnexionMs >= emailConnectionWarningPeriodMs;
+  }
+
   markUserAsTemporarilyBlocked() {
     const commonRatio = Math.pow(2, this.failureCount / config.login.temporaryBlockingThresholdFailureCount - 1);
     this.temporaryBlockedUntil = new Date(Date.now() + config.login.temporaryBlockingBaseTimeMs * commonRatio);

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -330,6 +330,7 @@ const configuration = (function () {
       ),
       temporaryBlockingBaseTimeMs: ms(process.env.LOGIN_TEMPORARY_BLOCKING_BASE_TIME || '2m'),
       blockingLimitFailureCount: _getNumber(process.env.LOGIN_BLOCKING_LIMIT_FAILURE_COUNT || 30),
+      emailConnectionWarningPeriod: ms(process.env.EMAIL_CONNECTION_WARNING_PERIOD || '1y'),
     },
     logOpsMetrics: toBoolean(process.env.LOG_OPS_METRICS),
     mailing: {
@@ -354,7 +355,7 @@ const configuration = (function () {
           passwordResetTemplateId: process.env.BREVO_PASSWORD_RESET_TEMPLATE_ID,
           selfAccountDeletionTemplateId: process.env.BREVO_SELF_ACCOUNT_DELETION_TEMPLATE_ID,
           targetProfileNotCertifiableTemplateId: process.env.BREVO_TARGET_PROFILE_NOT_CERTIFIABLE_TEMPLATE_ID,
-          warningConnectionTemplateId: process.env.BREVO_BREVO_WARNING_CONNECTION_TEMPLATE_ID,
+          warningConnectionTemplateId: process.env.BREVO_WARNING_CONNECTION_TEMPLATE_ID,
         },
       },
     },
@@ -522,6 +523,7 @@ const configuration = (function () {
     config.mailing.brevo.templates.acquiredCleaResultTemplateId = 'test-acquired-clea-result-template-id';
     config.mailing.brevo.templates.targetProfileNotCertifiableTemplateId =
       'test-target-profile-no-certifiable-template-id';
+    config.mailing.brevo.templates.warningConnectionTemplateId = 'test-warning-connection-template-id';
 
     config.bcryptNumberOfSaltRounds = 1;
 

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -354,6 +354,7 @@ const configuration = (function () {
           passwordResetTemplateId: process.env.BREVO_PASSWORD_RESET_TEMPLATE_ID,
           selfAccountDeletionTemplateId: process.env.BREVO_SELF_ACCOUNT_DELETION_TEMPLATE_ID,
           targetProfileNotCertifiableTemplateId: process.env.BREVO_TARGET_PROFILE_NOT_CERTIFIABLE_TEMPLATE_ID,
+          warningConnectionTemplateId: process.env.BREVO_BREVO_WARNING_CONNECTION_TEMPLATE_ID,
         },
       },
     },

--- a/api/src/shared/infrastructure/utils/url-builder.js
+++ b/api/src/shared/infrastructure/utils/url-builder.js
@@ -1,5 +1,5 @@
 import { config } from '../../config.js';
-import { LOCALE } from '../../domain/constants.js';
+import { LOCALE, SUPPORTED_LOCALES } from '../../domain/constants.js';
 
 const PIX_APP_DOMAIN_FR = `${config.domain.pixApp + config.domain.tldFr}`;
 const PIX_APP_DOMAIN_ORG = `${config.domain.pixApp + config.domain.tldOrg}`;
@@ -13,7 +13,7 @@ function getPixAppBaseUrl(locale) {
 
   if (locale?.toLocaleLowerCase() === LOCALE.FRENCH_FRANCE) return PIX_APP_DOMAIN_FR;
 
-  if (!Object.values(LOCALE).includes(locale)) return PIX_APP_DOMAIN_FR;
+  if (!SUPPORTED_LOCALES.includes(locale)) return PIX_APP_DOMAIN_FR;
 
   return PIX_APP_DOMAIN_ORG;
 }

--- a/api/src/shared/mail/infrastructure/services/mailer.js
+++ b/api/src/shared/mail/infrastructure/services/mailer.js
@@ -107,6 +107,9 @@ class Mailer {
   get selfAccountDeletionTemplateId() {
     return mailing[this._providerName].templates.selfAccountDeletionTemplateId;
   }
+  get warningConnectionTemplateId() {
+    return mailing[this._providerName].templates.warningConnexionTemplateId;
+  }
 }
 
 const mailer = new Mailer();

--- a/api/src/shared/mail/infrastructure/services/mailer.js
+++ b/api/src/shared/mail/infrastructure/services/mailer.js
@@ -108,7 +108,7 @@ class Mailer {
     return mailing[this._providerName].templates.selfAccountDeletionTemplateId;
   }
   get warningConnectionTemplateId() {
-    return mailing[this._providerName].templates.warningConnexionTemplateId;
+    return mailing[this._providerName].templates.warningConnectionTemplateId;
   }
 }
 

--- a/api/tests/identity-access-management/unit/domain/emails/create-warning-connection.email.test.js
+++ b/api/tests/identity-access-management/unit/domain/emails/create-warning-connection.email.test.js
@@ -1,0 +1,95 @@
+import { createWarningConnectionEmail } from '../../../../../src/identity-access-management/domain/emails/create-warning-connection.email.js';
+import { Email } from '../../../../../src/shared/mail/domain/models/Email.js';
+import { mailer } from '../../../../../src/shared/mail/infrastructure/services/mailer.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Identity Access Management | Domain | Email | create-warning-connection', function () {
+  it('creates warning connection email with the right parameters', function () {
+    const emailParams = {
+      email: 'test@example.com',
+      locale: 'fr',
+      firstName: 'John',
+    };
+
+    const email = createWarningConnectionEmail(emailParams);
+
+    expect(email).to.be.instanceof(Email);
+    expect(email).to.have.property('subject').that.is.a('string');
+    expect(email.to).to.equal(emailParams.email);
+    expect(email.template).to.equal(mailer.warningConnectionTemplateId);
+
+    const variables = email.variables;
+
+    expect(variables).to.have.property('homeName').that.is.a('string');
+    expect(variables).to.have.property('homeUrl').that.is.a('string');
+    expect(variables).to.have.property('displayNationalLogo').that.is.a('boolean');
+    expect(variables).to.have.property('contactUs').that.is.a('string');
+    expect(variables).to.have.property('doNotAnswer').that.is.a('string');
+    expect(variables).to.have.property('moreOn').that.is.a('string');
+    expect(variables).to.have.property('pixPresentation').that.is.a('string');
+    expect(variables).to.have.property('hello').that.is.a('string');
+    expect(variables).to.have.property('context').that.is.a('string');
+    expect(variables).to.have.property('disclaimer').that.is.a('string');
+    expect(variables).to.have.property('warningMessage').that.is.a('string');
+    expect(variables).to.have.property('resetMyPassword').that.is.a('string');
+    expect(variables).to.have.property('supportContact').that.is.a('string');
+    expect(variables).to.have.property('helpDeskUrl').that.is.a('string');
+    expect(variables).to.have.property('resetUrl').that.is.a('string');
+    expect(variables).to.have.property('thanks').that.is.a('string');
+    expect(variables).to.have.property('signing').that.is.a('string');
+  });
+
+  describe('when the locale is en', function () {
+    it('provides the correct reset password URL', function () {
+      // given
+      const emailParams = {
+        email: 'toto@example.net',
+        locale: 'en',
+        firstName: 'John',
+      };
+
+      // when
+      const email = createWarningConnectionEmail(emailParams);
+
+      // then
+      const resetUrl = email.variables.resetUrl;
+      expect(resetUrl).to.equal('https://test.app.pix.org/mot-de-passe-oublie?lang=en');
+    });
+  });
+
+  describe('when the locale is fr-fr', function () {
+    it('provides the correct reset password URL', function () {
+      // given
+      const emailParams = {
+        email: 'toto@example.net',
+        locale: 'fr-fr',
+        firstName: 'John',
+      };
+
+      // when
+      const email = createWarningConnectionEmail(emailParams);
+
+      // then
+      const resetUrl = email.variables.resetUrl;
+      expect(resetUrl).to.equal('https://test.app.pix.fr/mot-de-passe-oublie?lang=fr');
+    });
+  });
+
+  describe('when the locale is nl-BE', function () {
+    it('provides the correct reset password URL', function () {
+      // given
+      const emailParams = {
+        email: 'toto@example.net',
+        locale: 'nl-BE',
+        firstName: 'John',
+      };
+
+      // when
+      const email = createWarningConnectionEmail(emailParams);
+
+      // then
+      const resetUrl = email.variables.resetUrl;
+      expect(resetUrl).to.equal('https://test.app.pix.org/mot-de-passe-oublie?lang=nl');
+    });
+  });
+});

--- a/api/tests/identity-access-management/unit/domain/usecases/authenticate-user_test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/authenticate-user_test.js
@@ -11,7 +11,6 @@ import { UserNotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { ForbiddenAccess } from '../../../../../src/shared/domain/errors.js';
 import { AdminMember } from '../../../../../src/shared/domain/models/AdminMember.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.js';
-import { UserLogin } from '../../../../../src/identity-access-management/domain/models/UserLogin.js';
 
 describe('Unit | Identity Access Management | Domain | UseCases | authenticate-user', function () {
   let refreshTokenRepository;
@@ -382,12 +381,12 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
         const expirationDelaySeconds = 1;
         const audience = 'https://certif.pix.fr';
 
-      const user = domainBuilder.buildUser({ email: userEmail });
-      const userLogins = new UserLogin({
-        id: 1,
-        userId: user.id,
-        lastLoggedAt: '2020-01-01',
-      });
+        const user = domainBuilder.buildUser({ email: userEmail });
+        const userLogins = domainBuilder.identityAccessManagement.buildUserLogin({
+          id: 1,
+          userId: user.id,
+          lastLoggedAt: '2020-01-01',
+        });
 
         const expectedEmail = createWarningConnectionEmail({
           email: user.email,
@@ -434,7 +433,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
 
         user.email = null;
 
-        const userLogins = new UserLogin({
+        const userLogins = domainBuilder.identityAccessManagement.buildUserLogin({
           id: 1,
           userId: user.id,
           lastLoggedAt: '2020-01-01',
@@ -478,7 +477,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
       const audience = 'https://certif.pix.fr';
 
       const user = domainBuilder.buildUser({ email: userEmail });
-      const userLogins = new UserLogin({
+      const userLogins = domainBuilder.identityAccessManagement.buildUserLogin({
         id: 1,
         userId: user.id,
         lastLoggedAt: '2024-12-01',

--- a/api/tests/tooling/domain-builder/factory/identity-access-management/build-user-login.js
+++ b/api/tests/tooling/domain-builder/factory/identity-access-management/build-user-login.js
@@ -1,0 +1,23 @@
+import { UserLogin } from '../../../../../src/identity-access-management/domain/models/UserLogin.js';
+
+export function buildUserLogin({
+  id = 123,
+  userId = 456,
+  failureCount = 0,
+  temporaryBlockedUntil = null,
+  blockedAt = null,
+  createdAt = null,
+  updatedAt = null,
+  lastLoggedAt = null,
+} = {}) {
+  return new UserLogin({
+    id,
+    userId,
+    failureCount,
+    temporaryBlockedUntil,
+    blockedAt,
+    createdAt,
+    updatedAt,
+    lastLoggedAt,
+  });
+}

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -199,6 +199,7 @@ import { buildSessionManagement } from './certification/session-management/build
 import { buildCompetenceForScoring } from './certification/shared/build-competence-for-scoring.js';
 import { buildJuryComment } from './certification/shared/build-jury-comment.js';
 import { buildV3CertificationScoring } from './certification/shared/build-v3-certification-scoring.js';
+import { buildUserLogin } from './identity-access-management/build-user-login.js';
 import { buildCertificationResult as parcoursupCertificationResult } from './parcoursup/build-certification-result.js';
 import { buildCompetence as parcoursupCompetence } from './parcoursup/build-competence.js';
 import { buildCampaign as boundedContextCampaignBuildCampaign } from './prescription/campaign/build-campaign.js';
@@ -273,6 +274,10 @@ const prescription = {
   campaignParticipation: {
     buildCampaignParticipation: boundedContextCampaignParticipationBuildCampaignParticipation,
   },
+};
+
+const identityAccessManagement = {
+  buildUserLogin,
 };
 
 export {
@@ -450,6 +455,7 @@ export {
   buildValidation,
   buildValidator,
   certification,
+  identityAccessManagement,
   parcoursup,
   prescription,
 };

--- a/api/tests/unit/domain/models/UserLogin_test.js
+++ b/api/tests/unit/domain/models/UserLogin_test.js
@@ -1,6 +1,6 @@
 import { UserLogin } from '../../../../src/identity-access-management/domain/models/UserLogin.js';
 import { config } from '../../../../src/shared/config.js';
-import { expect, sinon } from '../../../test-helper.js';
+import { domainBuilder, expect, sinon } from '../../../test-helper.js';
 
 describe('Unit | Domain | Models | UserLogin', function () {
   let clock;
@@ -311,6 +311,50 @@ describe('Unit | Domain | Models | UserLogin', function () {
 
         // then
         expect(result).to.be.true;
+      });
+    });
+  });
+
+  describe('#shouldSendConnectionWarning', function () {
+    context('when user has connected after a long period since last connection date', function () {
+      it('returns true', function () {
+        // given
+        const emailConnectionWarningPeriodMs = config.login.emailConnectionWarningPeriod;
+        const lastConnectionDate = new Date(Date.now() - emailConnectionWarningPeriodMs);
+        const userLogin = domainBuilder.identityAccessManagement.buildUserLogin({ lastLoggedAt: lastConnectionDate });
+
+        // when
+        const result = userLogin.shouldSendConnectionWarning();
+
+        // then
+        expect(result).to.be.true;
+      });
+    });
+
+    context('when user has connected before the connection warning period', function () {
+      it('returns false', function () {
+        // given
+        const lastConnectionDate = new Date(Date.now() - 1);
+        const userLogin = domainBuilder.identityAccessManagement.buildUserLogin({ lastLoggedAt: lastConnectionDate });
+
+        // when
+        const result = userLogin.shouldSendConnectionWarning();
+
+        // then
+        expect(result).to.be.false;
+      });
+    });
+
+    context("when user's last connection is not specified", function () {
+      it('returns false', function () {
+        // given
+        const userLogin = domainBuilder.identityAccessManagement.buildUserLogin();
+
+        // when
+        const result = userLogin.shouldSendConnectionWarning();
+
+        // then
+        expect(result).to.be.false;
       });
     });
   });

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -406,5 +406,18 @@
       "warningMessage": "If this wasn’t you, please reset your password as soon as possible in order to secure your account."
     },
     "subject": "Your Pix code is {code}"
+  },
+  "warning-connection-email": {
+    "params": {
+      "context": "We noticed a new connection to your Pix account after a period of inactivity of 12 months or more.",
+      "disclaimer": "If this connection really comes from you, no action is necessary.",
+      "hello": "Hello {firstName},",
+      "resetMyPassword": "Set a new password",
+      "signing": "Pix team",
+      "supportContact": "If in doubt or if you have any questions, our support is available to help you.",
+      "thanks": "Thank you for your vigilance,",
+      "warningMessage": "If this is not the case, we invite you to change your password immediately to secure your account by clicking on the button below:"
+    },
+    "subject": "Recent activity on your Pix account"
   }
 }

--- a/api/translations/es.json
+++ b/api/translations/es.json
@@ -418,5 +418,18 @@
       "warningMessage": "Si no has sido tú, restablece tu contraseña lo antes posible para garantizar la seguridad de tu cuenta."
     },
     "subject": "Tu código Pix es {code}"
+  },
+  "warning-connection-email": {
+    "params": {
+      "context": "We noticed a new connection to your Pix account after a period of inactivity of 12 months or more.",
+      "disclaimer": "If this connection really comes from you, no action is necessary.",
+      "hello": "Hello {firstName},",
+      "resetMyPassword": "Set a new password",
+      "signing": "Pix team",
+      "supportContact": "If in doubt or if you have any questions, our support is available to help you.",
+      "thanks": "Thank you for your vigilance,",
+      "warningMessage": "If this is not the case, we invite you to change your password immediately to secure your account by clicking on the button below:"
+    },
+    "subject": "Recent activity on your Pix account"
   }
 }

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -420,5 +420,18 @@
       "warningMessage": "Si ce n'était pas vous, nous vous invitons à réinitialiser votre mot de passe au plus vite afin de sécuriser votre compte."
     },
     "subject": "Votre code Pix est {code}"
+  },
+  "warning-connection-email": {
+    "params": {
+      "hello": "Bonjour {firstName},",
+      "context": "Nous avons remarqué une nouvelle connexion à votre compte Pix après une période d’inactivité de 12 mois ou plus.",
+      "disclaimer": "Si cette connexion provient bien de vous, aucune action n’est nécessaire.",
+      "warningMessage": "Si ce n’est pas le cas, nous vous invitons à changer votre mot de passe immédiatement pour sécuriser votre compte en cliquant sur le bouton ci-dessous :",
+      "resetMyPassword": "Définir un nouveau mot de passe",
+      "supportContact": "En cas de doute ou si vous avez des questions, notre support est à votre disposition pour vous aider.",
+      "thanks": "Merci de votre vigilance,",
+      "signing": "L'équipe Pix"
+    },
+    "subject": "Activité récente sur votre compte Pix"
   }
 }

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -423,14 +423,14 @@
   },
   "warning-connection-email": {
     "params": {
-      "hello": "Bonjour {firstName},",
       "context": "Nous avons remarqué une nouvelle connexion à votre compte Pix après une période d’inactivité de 12 mois ou plus.",
       "disclaimer": "Si cette connexion provient bien de vous, aucune action n’est nécessaire.",
-      "warningMessage": "Si ce n’est pas le cas, nous vous invitons à changer votre mot de passe immédiatement pour sécuriser votre compte en cliquant sur le bouton ci-dessous :",
+      "hello": "Bonjour {firstName},",
       "resetMyPassword": "Définir un nouveau mot de passe",
+      "signing": "L'équipe Pix",
       "supportContact": "En cas de doute ou si vous avez des questions, notre support est à votre disposition pour vous aider.",
       "thanks": "Merci de votre vigilance,",
-      "signing": "L'équipe Pix"
+      "warningMessage": "Si ce n’est pas le cas, nous vous invitons à changer votre mot de passe immédiatement pour sécuriser votre compte en cliquant sur le bouton ci-dessous :"
     },
     "subject": "Activité récente sur votre compte Pix"
   }

--- a/api/translations/nl.json
+++ b/api/translations/nl.json
@@ -410,5 +410,18 @@
       "warningMessage": "Als jij het niet was, stel je wachtwoord dan zo snel mogelijk opnieuw in om de veiligheid van je account te garanderen."
     },
     "subject": "Je Pix-code is {code}."
+  },
+  "warning-connection-email": {
+    "params": {
+      "context": "We noticed a new connection to your Pix account after a period of inactivity of 12 months or more.",
+      "disclaimer": "If this connection really comes from you, no action is necessary.",
+      "hello": "Hello {firstName},",
+      "resetMyPassword": "Set a new password",
+      "signing": "Pix team",
+      "supportContact": "If in doubt or if you have any questions, our support is available to help you.",
+      "thanks": "Thank you for your vigilance,",
+      "warningMessage": "If this is not the case, we invite you to change your password immediately to secure your account by clicking on the button below:"
+    },
+    "subject": "Recent activity on your Pix account"
   }
 }


### PR DESCRIPTION
## :pancakes: Problème

Une connexion après un temps long de déconnexion (égal ou supérieur à un an) n'est pas signalée à l'utilisateur

## :bacon: Proposition

Il faut ajouter une fonctionnalité pour avertir l’utilisateur lors d’une reconnexion à 12 mois et plus de la dernière connexion.
![Capture d’écran du 2025-02-10 12-35-37](https://github.com/user-attachments/assets/10751189-ba8e-4316-9333-3d11d40c0d57)

- Ajout de la variable d’env BREVO_WARNING_CONNECTION_TEMPLATE_ID + sa description côté api

- Ajout les clés de traduction dans les fichiers de traduction .json

- ajouter une variable d’environnement EMAIL_CONNECTION_WARNING_PERIOD définissant la période de 12 mois.

- L’information de dernière connexion de l’utilisateur se trouve dans lastLoggedAt de la table user-logins (accessible via userId)

- Si la ligne n’est pas renseignée, on n’envoie pas l’email

- L’envoi d’email doit être fait au niveau de la route /api/token, juste avant la mise à jour de la colonne lastLoggedAt (dans le usecase AuthenticateUser)



## 🧃 Remarques

- Notez que la locale 'fr' est comprise comme "FRENCH-SPOKEN" et qu'elle redirige vers le domaine .org, contrairement à la locale fr-FR
- le lien vers le support a été élargi à toute la phrase et pas seulement au mot "support", comme cela avait été décidé pour l'email de suppression de compte en autonomie

## :yum: Pour tester
- Variables d'environnement :
MAILING_ENABLED=true
MAILING_PROVIDER=brevo
BREVO_API_KEY=[récupérer la clé de api BREVO]
BREVO_WARNING_CONNECTION_TEMPLATE_ID=562
- Pour tester cette pr en local il faut au préalable lancer les jobs, sinon l'envoi d'email par la job queue ne pourra pas avoir lieu :

```
cd api/
npm run start:job

```
- Changer l'email d'un utilisateur non connecté depuis un an ou plus (par exemple (`gaal.dornick@foundation.verse`) pour y mettre le vôtre en base de données
- Se connecter sur Pix App ( https://app.pix.fr ) avec votre email
- Vérifier la réception d'un mail **en français**, **avec le logo Marianne**, et dont le bouton "définir un nouveau mot de passe" pointe vers le domaine attendu (https://app.pix.fr/mot-de-passe-oublie )
- Vérifier que le lien vers le support est correct ( https://pix.fr/support/ )
- Se déconnecter
- Se reconnecter et vérifier qu'aucun email n'est reçu, car la date de dernière connexion est trop récente
- Modifier la date de dernière connexion en base pour qu'elle ait plus d'un an
- Changer la locale de l'utilisateur (par exemple nl-BE, ou en, ou fr)
- Se connecter sur Pix App ( https://app.pix.org ) avec votre email
- Vérifier la réception d'un mail **en néerlandais**, **sans le logo Marianne**, et dont le bouton de reset de mot de passe pointe vers le domaine attendu (https://app.pix.org/mot-de-passe-oublie )
- Vérifier que le lien vers le support est correct : https://pix.org/fr/support/ ou https://pix.org/nl-BE/support ou https://pix.org/en/support/