### PR TITLE
[FEATURE] Utiliser PixCode dans la vérification des certificats sur Pix App (PIX-16429).

### DIFF
--- a/mon-pix/app/components/certification-verification-code-form.gjs
+++ b/mon-pix/app/components/certification-verification-code-form.gjs
@@ -1,0 +1,96 @@
+import PixBackgroundHeader from '@1024pix/pix-ui/components/pix-background-header';
+import PixBlock from '@1024pix/pix-ui/components/pix-block';
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixCode from '@1024pix/pix-ui/components/pix-code';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+
+export default class CertificationVerificationCodeForm extends Component {
+  @service intl;
+
+  @tracked certificateVerificationCode = null;
+  @tracked errorMessage = null;
+  @tracked status = 'default';
+
+  codeRegex = /^P-[0-9A-Z]{8}$/i;
+
+  @action
+  handleVerificationCodeInput(event) {
+    this.certificateVerificationCode = event.target.value;
+  }
+
+  @action
+  clearErrors() {
+    this.errorMessage = null;
+    this.status = 'default';
+    this.args.clearErrors();
+  }
+
+  get isVerificationCodeValid() {
+    return this.codeRegex.test(this.certificateVerificationCode);
+  }
+
+  @action
+  async checkCertificate(event) {
+    event.preventDefault();
+    this.clearErrors();
+
+    if (!this.certificateVerificationCode) {
+      this.errorMessage = this.intl.t('pages.fill-in-certificate-verification-code.errors.missing-code');
+      this.status = 'error';
+      return;
+    }
+
+    if (!this.isVerificationCodeValid) {
+      this.errorMessage = this.intl.t('pages.fill-in-certificate-verification-code.errors.wrong-format');
+      this.status = 'error';
+      return;
+    }
+
+    this.args.checkCertificate(this.certificateVerificationCode);
+  }
+
+  <template>
+    <PixBackgroundHeader id="main">
+      <PixBlock class="fill-in-certificate-verification-code">
+        <h1 class="fill-in-certificate-verification-code__title">
+          {{t "pages.fill-in-certificate-verification-code.first-title"}}
+        </h1>
+
+        <p class="fill-in-certificate-verification-code__description">
+          {{t "pages.fill-in-certificate-verification-code.description"}}
+        </p>
+
+        <form class="fill-in-certificate-verification-code__form" autocomplete="off">
+          <PixCode
+            @length="10"
+            @requiredLabel={{t "common.forms.mandatory"}}
+            @subLabel={{t "pages.fill-in-certificate-verification-code.sub-label"}}
+            @value={{this.certificateVerificationCode}}
+            @validationStatus={{this.status}}
+            @errorMessage={{this.errorMessage}}
+            {{on "keyup" this.clearErrors}}
+            {{on "input" this.handleVerificationCodeInput}}
+          >
+            <:label>{{t "pages.fill-in-certificate-verification-code.label"}}</:label>
+          </PixCode>
+
+          <PixButton @type="submit" @triggerAction={{this.checkCertificate}} class="form__actions">
+            {{t "pages.fill-in-certificate-verification-code.verify"}}
+          </PixButton>
+
+          {{#if @apiErrorMessage}}
+            <PixNotificationAlert @type="error" @withIcon={{true}}>
+              {{@apiErrorMessage}}
+            </PixNotificationAlert>
+          {{/if}}
+        </form>
+      </PixBlock>
+    </PixBackgroundHeader>
+  </template>
+}

--- a/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
@@ -2,26 +2,27 @@
 @use 'pix-design-tokens/typography';
 
 .fill-in-certificate-verification-code {
-  max-width: max-content;
-  margin: 0 auto 32px;
-  padding: 48px 24px;
-  text-align: center;
+  width: 75%;
+  margin: 0 auto var(--pix-spacing-8x);
+  padding: var(--pix-spacing-12x) var(--pix-spacing-6x);
 
   @extend %pix-body-m;
 
   @include breakpoints.device-is('tablet') {
-    padding: 48px 60px;
+    padding: var(--pix-spacing-12x) 60px;
   }
 
   &__title {
+    text-align: center;
+
     @extend %pix-title-m;
   }
 
   &__description {
-    max-width: 500px;
     margin: var(--pix-spacing-6x) 0;
     color: var(--pix-neutral-500);
-    line-height: 22px;
+    line-height: 1.375rem;
+    text-align: center;
   }
 
   &__form {
@@ -29,38 +30,8 @@
     flex-direction: column;
     align-items: center;
 
-    .form__input-and-label {
-      display: flex;
-      flex-direction: column;
-
-      label {
-        margin-bottom: 6px;
-        line-height: 22px;
-        letter-spacing: 0.15px;
-        text-align: left;
-
-        @extend %pix-body-s;
-      }
-
-      input {
-        width: 15.3ch;
-      }
-
-      @media all and (-ms-high-contrast: none) {
-        input {
-          width: 17.4ch;
-        }
-      }
-    }
-
     .form__actions {
       margin: var(--pix-spacing-6x) 0;
-    }
-
-    .form__error--validation {
-      color: var(--pix-error-700);
-
-      @extend %pix-body-s;
     }
   }
 }

--- a/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
+++ b/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
@@ -2,50 +2,10 @@
 
 <Global::AppLayout>
   <main role="main">
-    <PixBackgroundHeader id="main">
-      <PixBlock class="fill-in-certificate-verification-code">
-        <h1 class="fill-in-certificate-verification-code__title">
-          {{t "pages.fill-in-certificate-verification-code.first-title"}}
-        </h1>
-
-        <p class="fill-in-certificate-verification-code__description">
-          {{t "pages.fill-in-certificate-verification-code.description"}}
-        </p>
-
-        <form class="fill-in-certificate-verification-code__form" autocomplete="off">
-          <div class="form__input-and-label">
-            <label for="certificate-verification-code">
-              {{t "pages.fill-in-certificate-verification-code.label"}}
-            </label>
-            <PixInput
-              required
-              class="input-code"
-              type="text"
-              id="certificate-verification-code"
-              @value={{this.certificateVerificationCode}}
-              maxlength="10"
-              {{on "keyup" this.clearErrors}}
-              {{on "input" this.handleVerificationCodeInput}}
-            />
-          </div>
-
-          <PixButton @type="submit" @triggerAction={{this.checkCertificate}} class="form__actions">
-            {{t "pages.fill-in-certificate-verification-code.verify"}}
-          </PixButton>
-
-          {{#if this.errorMessage}}
-            <div class="form__error--validation" aria-live="polite">
-              {{this.errorMessage}}
-            </div>
-          {{/if}}
-
-          {{#if this.showNotFoundCertificationErrorMessage}}
-            <PixNotificationAlert @type="error" @withIcon={{true}}>
-              {{t "pages.fill-in-certificate-verification-code.errors.not-found"}}
-            </PixNotificationAlert>
-          {{/if}}
-        </form>
-      </PixBlock>
-    </PixBackgroundHeader>
+    <CertificationVerificationCodeForm
+      @checkCertificate={{this.checkCertificate}}
+      @apiErrorMessage={{this.apiErrorMessage}}
+      @clearErrors={{this.clearErrors}}
+    />
   </main>
 </Global::AppLayout>

--- a/mon-pix/tests/acceptance/fill-in-certificate-verification-code-test.js
+++ b/mon-pix/tests/acceptance/fill-in-certificate-verification-code-test.js
@@ -11,28 +11,11 @@ module('Acceptance | Certificate verification', function (hooks) {
   setupMirage(hooks);
   setupIntl(hooks);
 
-  test('display a verification section', async function (assert) {
-    // given & when
-    const screen = await visit('/verification-certificat');
-
-    // then
-    assert.dom(screen.getByRole('heading', { name: 'Vérifier un certificat Pix' })).exists();
-    assert
-      .dom(
-        screen.getByText(
-          'La certification Pix atteste d’un niveau de maîtrise des compétences numériques : saisissez ci-après le "code de vérification" du certificat Pix à vérifier.',
-        ),
-      )
-      .exists();
-    assert.dom(screen.getByRole('textbox', { name: 'Code de vérification (P-XXXXXXXX)' })).exists();
-    assert.dom(screen.getByRole('button', { name: 'Vérifier le certificat' })).exists();
-  });
-
   module('when certificate verification code is valid', function () {
     test('redirects to certificate details page', async function (assert) {
       // given
       const screen = await visit('/verification-certificat');
-      await fillIn(screen.getByRole('textbox', { name: 'Code de vérification (P-XXXXXXXX)' }), 'P-123VALID');
+      await fillIn(screen.getByRole('textbox', { name: 'Code de vérification * Exemple: P-XXXXXXXX' }), 'P-123VALID');
 
       // when
       await click(screen.getByRole('button', { name: 'Vérifier le certificat' }));
@@ -46,25 +29,13 @@ module('Acceptance | Certificate verification', function (hooks) {
     test('does not redirect to certificate details page', async function (assert) {
       // given
       const screen = await visit('/verification-certificat');
-      await fillIn(screen.getByRole('textbox', { name: 'Code de vérification (P-XXXXXXXX)' }), 'P-12345678');
+      await fillIn(screen.getByRole('textbox', { name: 'Code de vérification * Exemple: P-XXXXXXXX' }), 'P-12345678');
 
       // when
       await click(screen.getByRole('button', { name: 'Vérifier le certificat' }));
 
       // then
       assert.strictEqual(currentURL(), '/verification-certificat');
-    });
-
-    test('shows error message', async function (assert) {
-      // given
-      const screen = await visit('/verification-certificat');
-      await fillIn(screen.getByRole('textbox', { name: 'Code de vérification (P-XXXXXXXX)' }), 'P-12345678');
-
-      // when
-      await click(screen.getByRole('button', { name: 'Vérifier le certificat' }));
-
-      // then
-      assert.dom(screen.getByText("Il n'y a pas de certificat Pix correspondant.")).exists();
     });
   });
 

--- a/mon-pix/tests/integration/components/certification-verification-code-form-test.gjs
+++ b/mon-pix/tests/integration/components/certification-verification-code-form-test.gjs
@@ -1,0 +1,58 @@
+import { render } from '@1024pix/ember-testing-library';
+import { click, fillIn } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { t } from 'ember-intl/test-support';
+import CertificationVerificationCodeForm from 'mon-pix/components/certification-verification-code-form';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+
+module('Integration | Component | certification verification code form', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('should display component', async function (assert) {
+    // given
+    // when
+    const screen = await render(<template><CertificationVerificationCodeForm /></template>);
+
+    // then
+    assert
+      .dom(screen.getByRole('heading', { name: t('pages.fill-in-certificate-verification-code.first-title') }))
+      .exists();
+    assert.dom(screen.getByText(t('pages.fill-in-certificate-verification-code.description'))).exists();
+    assert.dom(screen.getByRole('textbox', { name: 'Code de vérification * Exemple: P-XXXXXXXX' })).exists();
+    assert.dom(screen.getByRole('button', { name: t('pages.fill-in-certificate-verification-code.verify') })).exists();
+  });
+
+  module('error cases', function () {
+    module('when certificate verification code is empty', function () {
+      test('displays error message', async function (assert) {
+        // given
+        this.set('clearErrors', () => {});
+        const screen = await render(hbs`<CertificationVerificationCodeForm @clearErrors={{this.clearErrors}}/>`);
+        await fillIn(screen.getByRole('textbox', { name: 'Code de vérification * Exemple: P-XXXXXXXX' }), '');
+
+        // when
+        await click(screen.getByRole('button', { name: t('pages.fill-in-certificate-verification-code.verify') }));
+
+        // then
+        assert.dom(screen.getByText(t('pages.fill-in-certificate-verification-code.errors.missing-code'))).exists();
+      });
+    });
+
+    module('when certificate verification code is wrong', function () {
+      test('displays error message', async function (assert) {
+        // given
+        this.set('clearErrors', () => {});
+        const screen = await render(hbs`<CertificationVerificationCodeForm @clearErrors={{this.clearErrors}}/>`);
+        await fillIn(screen.getByRole('textbox', { name: 'Code de vérification * Exemple: P-XXXXXXXX' }), '12345678');
+
+        // when
+        await click(screen.getByRole('button', { name: t('pages.fill-in-certificate-verification-code.verify') }));
+
+        // then
+        assert.dom(screen.getByText(t('pages.fill-in-certificate-verification-code.errors.wrong-format'))).exists();
+      });
+    });
+  });
+});

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1320,11 +1320,12 @@
       "errors": {
         "missing-code": "Please enter the verification code in this format: P-XXXXXXXX",
         "not-found": "There is no corresponding Pix Certificate.",
-        "unallowed-access": "Please fill out the field above with the verification code in this format: P-XXXXXXXX",
-        "wrong-format": "Please check your verification code"
+        "unallowed-access": "Please fill out the field above with the verification code in this format: P-XXXXXXXX.",
+        "wrong-format": "Please check your verification code."
       },
       "first-title": "Verify the score of a Pix Certificate",
-      "label": "Verification code (P-XXXXXXXX)",
+      "label": "Verification code",
+      "sub-label": "Example: P-XXXXXXXX",
       "title": "Verify the authenticity of a Pix Certificate",
       "verify": "Verify the score"
     },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1330,7 +1330,8 @@
         "wrong-format": "Comprueba el formato del código (P-XXXXXXXX)."
       },
       "first-title": "Comprobar un certificado Pix",
-      "label": "Código de comprobación (P-XXXXXXXX)",
+      "label": "Código de comprobación",
+      "sub-label": "Ejemplo: P-XXXXXXXX",
       "title": "Comprobar un certificado Pix",
       "verify": "Comprobar el certificado"
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1324,7 +1324,8 @@
         "wrong-format": "Veuillez vérifier le format de votre code (P-XXXXXXXX)."
       },
       "first-title": "Vérifier un certificat Pix",
-      "label": "Code de vérification (P-XXXXXXXX)",
+      "label": "Code de vérification",
+      "sub-label": "Exemple: P-XXXXXXXX",
       "title": "Vérifier un certificat Pix",
       "verify": "Vérifier le certificat"
     },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1330,7 +1330,8 @@
         "wrong-format": "Controleer het formaat van je code (P-XXXXXXXX)."
       },
       "first-title": "Een Pix-certificaat controleren",
-      "label": "Verificatiecode (P-XXXXXXXX)",
+      "label": "Verificatiecode",
+      "sub-label": "voorbeeld: P-XXXXXXXX",
       "title": "Een Pix-certificaat controleren",
       "verify": "Controleer het certificaat"
     },


### PR DESCRIPTION
## :pancakes: Problème
Actuellement les champs code sur Pix App ne sont pas des composants Pix UI

## :bacon: Proposition

Utiliser le nouveau composant PixCode.

## 🧃 Remarques

Création d'un composant pour cette page

## :yum: Pour tester

Aller sur [/verification-certificat](https://app-pr11343.review.pix.fr/verification-certificat) et faire une non régression : 
- ne pas mettre de code et valider => erreur sous le champ
- mettre un code sans le "P-" => erreur sous le champ
- mettre un code avec "P-" mais inconnu de la BDD => erreur en notificationAlert
- couper la connexion et valider => erreur par défaut en notificationAlert
- CAS PASSANT : P-12836133 => vérifier qu'on est redirigé vers le résultat

<img width="896" alt="Capture d’écran 2025-02-05 à 14 53 18" src="https://github.com/user-attachments/assets/4b2e9e75-56c4-49d5-b6bd-1a2780e34a2f" />
