### PR TITLE
[FEATURE] Avoir un champ "Titre interne" lors de l'édition et création d’un CF (PIX-16435)

### DIFF
--- a/admin/app/components/trainings/create-or-update-training-form.gjs
+++ b/admin/app/components/trainings/create-or-update-training-form.gjs
@@ -15,6 +15,7 @@ import Card from '../card';
 
 class Form {
   @tracked title;
+  @tracked internalTitle;
   @tracked link;
   @tracked type;
   @tracked duration = {
@@ -27,8 +28,9 @@ class Form {
   @tracked editorName;
   @tracked isDisabled;
 
-  constructor({ title, link, type, duration, locale, editorLogoUrl, editorName, isDisabled } = {}) {
+  constructor({ title, internalTitle, link, type, duration, locale, editorLogoUrl, editorName, isDisabled } = {}) {
     this.title = title || null;
+    this.internalTitle = internalTitle || null;
     this.link = link || null;
     this.type = type || null;
     this.duration = duration || { days: 0, hours: 0, minutes: 0 };
@@ -70,6 +72,7 @@ export default class CreateOrUpdateTrainingForm extends Component {
 
     const training = {
       title: this.form.title,
+      internalTitle: this.form.internalTitle,
       link: this.form.link,
       type: this.form.type,
       duration: this.form.duration,
@@ -100,6 +103,15 @@ export default class CreateOrUpdateTrainingForm extends Component {
             {{on "change" (fn this.updateForm "title")}}
           >
             <:label>Titre</:label>
+          </PixInput>
+          <PixInput
+            @id="trainingInternalTitle"
+            required={{true}}
+            aria-required={{true}}
+            @value={{this.form.internalTitle}}
+            {{on "change" (fn this.updateForm "internalTitle")}}
+          >
+            <:label>Titre à usage interne</:label>
           </PixInput>
           <PixInput
             @id="trainingLink"

--- a/admin/app/components/trainings/create-or-update-training-form.gjs
+++ b/admin/app/components/trainings/create-or-update-training-form.gjs
@@ -102,7 +102,7 @@ export default class CreateOrUpdateTrainingForm extends Component {
             @value={{this.form.title}}
             {{on "change" (fn this.updateForm "title")}}
           >
-            <:label>Titre</:label>
+            <:label>{{t "pages.trainings.training.details.title"}}</:label>
           </PixInput>
           <PixInput
             @id="trainingInternalTitle"
@@ -111,7 +111,7 @@ export default class CreateOrUpdateTrainingForm extends Component {
             @value={{this.form.internalTitle}}
             {{on "change" (fn this.updateForm "internalTitle")}}
           >
-            <:label>Titre à usage interne</:label>
+            <:label>{{t "pages.trainings.training.details.internalTitle"}}</:label>
           </PixInput>
           <PixInput
             @id="trainingLink"

--- a/admin/tests/acceptance/authenticated/trainings/training-test.js
+++ b/admin/tests/acceptance/authenticated/trainings/training-test.js
@@ -78,8 +78,8 @@ module('Acceptance | Trainings | Training', function (hooks) {
         await visit(`/trainings/list`);
         await clickByName('Nouveau contenu formatif');
 
-        await fillByLabel('Titre', 'Nouveau contenu formatif');
-        await fillByLabel('Titre à usage interne', 'Mon titre interne');
+        await fillByLabel('Titre :', 'Nouveau contenu formatif');
+        await fillByLabel('Titre interne :', 'Mon titre interne');
         await fillByLabel('Lien', 'http://www.example.net');
         await click(screen.getByText('Webinaire'));
 
@@ -164,8 +164,8 @@ module('Acceptance | Trainings | Training', function (hooks) {
 
         // when
         await click(screen.getByRole('button', { name: 'Modifier' }));
-        await fillByLabel('Titre', 'Nouveau contenu formatif modifié');
-        await fillByLabel('Titre à usage interne', 'Mon titre interne');
+        await fillByLabel('Titre :', 'Nouveau contenu formatif modifié');
+        await fillByLabel('Titre interne :', 'Mon titre interne');
         await click(screen.getByRole('button', { name: 'Modifier le contenu formatif' }));
 
         // then

--- a/admin/tests/acceptance/authenticated/trainings/training-test.js
+++ b/admin/tests/acceptance/authenticated/trainings/training-test.js
@@ -79,6 +79,7 @@ module('Acceptance | Trainings | Training', function (hooks) {
         await clickByName('Nouveau contenu formatif');
 
         await fillByLabel('Titre', 'Nouveau contenu formatif');
+        await fillByLabel('Titre à usage interne', 'Mon titre interne');
         await fillByLabel('Lien', 'http://www.example.net');
         await click(screen.getByText('Webinaire'));
 
@@ -164,6 +165,7 @@ module('Acceptance | Trainings | Training', function (hooks) {
         // when
         await click(screen.getByRole('button', { name: 'Modifier' }));
         await fillByLabel('Titre', 'Nouveau contenu formatif modifié');
+        await fillByLabel('Titre à usage interne', 'Mon titre interne');
         await click(screen.getByRole('button', { name: 'Modifier le contenu formatif' }));
 
         // then

--- a/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
+++ b/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
@@ -20,8 +20,8 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
     );
 
     // then
-    assert.dom(screen.getByLabelText('Titre')).exists();
-    assert.dom(screen.getByLabelText('Titre à usage interne')).exists();
+    assert.dom(screen.getByLabelText('Titre :')).exists();
+    assert.dom(screen.getByLabelText('Titre interne :')).exists();
     assert.dom(screen.getByLabelText('Lien')).exists();
     assert.dom(screen.getByLabelText('Format')).exists();
     assert.dom(screen.getByLabelText('Jours (JJ)')).exists();
@@ -85,8 +85,8 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
       );
 
       // then
-      assert.dom(screen.getByLabelText('Titre')).hasValue(model.title);
-      assert.dom(screen.getByLabelText('Titre à usage interne')).hasValue(model.internalTitle);
+      assert.dom(screen.getByLabelText('Titre :')).hasValue(model.title);
+      assert.dom(screen.getByLabelText('Titre interne :')).hasValue(model.internalTitle);
       assert.dom(screen.getByLabelText('Lien')).hasValue(model.link);
       assert.strictEqual(screen.getByLabelText('Format').innerText, typeCategories[model.type]);
       assert.dom(screen.getByLabelText('Jours (JJ)')).hasValue(model.duration.days.toString());

--- a/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
+++ b/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
@@ -21,6 +21,7 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
 
     // then
     assert.dom(screen.getByLabelText('Titre')).exists();
+    assert.dom(screen.getByLabelText('Titre à usage interne')).exists();
     assert.dom(screen.getByLabelText('Lien')).exists();
     assert.dom(screen.getByLabelText('Format')).exists();
     assert.dom(screen.getByLabelText('Jours (JJ)')).exists();
@@ -66,6 +67,7 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
       const editorLogo = 'un-logo.svg';
       const model = {
         title: 'Un contenu formatif',
+        internalTitle: 'Mon titre interne',
         link: 'https://un-contenu-formatif',
         type: 'webinaire',
         locale: 'fr-fr',
@@ -84,6 +86,7 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
 
       // then
       assert.dom(screen.getByLabelText('Titre')).hasValue(model.title);
+      assert.dom(screen.getByLabelText('Titre à usage interne')).hasValue(model.internalTitle);
       assert.dom(screen.getByLabelText('Lien')).hasValue(model.link);
       assert.strictEqual(screen.getByLabelText('Format').innerText, typeCategories[model.type]);
       assert.dom(screen.getByLabelText('Jours (JJ)')).hasValue(model.duration.days.toString());

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -733,7 +733,8 @@
           "internalTitle": "Internal title : ",
           "localizedLanguage": "Localized language : ",
           "publishedOn": "Published on : ",
-          "status": "Status : "
+          "status": "Status : ",
+          "title": "Title : "
         },
         "targetProfiles": {
           "tabName": "Target Profiles"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -750,7 +750,8 @@
           "internalTitle": "Titre interne :",
           "localizedLanguage": "Langue localisée :",
           "publishedOn": "Publié sur :",
-          "status": "Statut :"
+          "status": "Statut :",
+          "title": "Titre :"
         },
         "targetProfiles": {
           "tabName": "Profils cibles associés",


### PR DESCRIPTION
## :bacon: Problème
On a ajouté un champ "Titre interne" mais qui n'est pour l'instant pas modifiable par l'utilisateur.

## 🧃 Proposition
Permettre à l'utilisateur de modifier le titre interne d'un CF

## :yum: Pour tester
Dans Pix Admin, vérifier qu'on peut créer un CF avec son titre interne, le consulter et le modifier.
