### PR TITLE
[TECH] Stocker la config des features toggles dans Redis

### DIFF
--- a/api/src/shared/infrastructure/feature-toggles/feature-toggles-client.js
+++ b/api/src/shared/infrastructure/feature-toggles/feature-toggles-client.js
@@ -51,6 +51,8 @@ export class FeatureTogglesClient {
         await this.storage.save({ key, value: featureToggle.defaultValue });
       }
     }
+
+    await this.storage.save({ key: '_config', value: this.config });
   }
 
   /**

--- a/api/tests/shared/unit/infrastructure/feature-toggles/feature-toggles-client.test.js
+++ b/api/tests/shared/unit/infrastructure/feature-toggles/feature-toggles-client.test.js
@@ -18,7 +18,7 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
   });
 
   describe('init', function () {
-    it('initialize the storage with default values', async function () {
+    it('initialize the storage with config and default values', async function () {
       // given
       const featureToggles = new FeatureTogglesClient(storage);
 
@@ -26,6 +26,9 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
       await featureToggles.init(config);
 
       // then
+      const savedConfig = await storage.get('_config');
+      expect(savedConfig).to.deep.equal(config);
+
       const all = await featureToggles.all();
       expect(all).to.deep.equal({ myToggle1: false, myToggle2: true, myToggle3: 'foo' });
     });
@@ -44,7 +47,7 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
 
       // then
       const keys = await storage.keys('*');
-      expect(keys).to.deep.equal(['myToggle1', 'myToggle4']);
+      expect(keys).to.deep.equal(['myToggle1', 'myToggle4', '_config']);
 
       const all = await featureToggles.all();
       expect(all).to.deep.equal({ myToggle1: false, myToggle4: 1 });


### PR DESCRIPTION
## :pancakes: Problème

On souhaite exploiter les feature toggles "à chaud" depuis Pix Exploit. Pour cela, il est nécessaire d'avoir leur configuration qui est actuellement définie dans le fichier `feature-toggles-config.js`

## :bacon: Proposition

Stocker la configuration du nouveau système de features toggles dans Redis pour qu'elle soit disponible depuis Pix Exploit. Elle sera disponible sous la clé `"feature-toggles:_config"`

## :yum: Pour tester

- Lancer l'API
- Utiliser `redis-cli` et faire `get feature-toggles:_config` pour voir la configuration des feature toggles


