### PR TITLE
[FEATURE] Mettre les éléments utils dans des liens

### DIFF
--- a/admin/app/components/certification-centers/list-items.gjs
+++ b/admin/app/components/certification-centers/list-items.gjs
@@ -53,7 +53,9 @@ export default class CertificationCenterListItems extends Component {
                 Nom
               </:header>
               <:cell>
-                {{certificationCenter.name}}
+                <LinkTo @route="authenticated.certification-centers.get" @model={{certificationCenter.id}}>
+                  {{certificationCenter.name}}
+                </LinkTo>
               </:cell>
             </PixTableColumn>
             <PixTableColumn @context={{context}}>

--- a/admin/app/components/organizations/campaigns-section.gjs
+++ b/admin/app/components/organizations/campaigns-section.gjs
@@ -19,7 +19,11 @@ import CampaignType from '../campaigns/type';
         </PixTableColumn>
         <PixTableColumn @context={{context}}>
           <:header>Nom</:header>
-          <:cell>{{campaign.name}}</:cell>
+          <:cell>
+            <LinkTo @route="authenticated.campaigns.campaign" @model={{campaign.id}}>
+              {{campaign.name}}
+            </LinkTo>
+          </:cell>
         </PixTableColumn>
         <PixTableColumn @context={{context}}>
           <:header>Type</:header>

--- a/admin/app/components/organizations/children/list-item.gjs
+++ b/admin/app/components/organizations/children/list-item.gjs
@@ -18,7 +18,9 @@ import { t } from 'ember-intl';
       {{t "components.organizations.children-list.table-headers.name"}}
     </:header>
     <:cell>
-      {{@organization.name}}
+      <LinkTo @route="authenticated.organizations.get" @model={{@organization.id}}>
+        {{@organization.name}}
+      </LinkTo>{{@organization.name}}
     </:cell>
   </PixTableColumn>
   <PixTableColumn @context={{@context}} class="break-word">

--- a/admin/app/components/organizations/list-items.gjs
+++ b/admin/app/components/organizations/list-items.gjs
@@ -103,7 +103,7 @@ export default class ActionsOnUsersRoleInOrganization extends Component {
               Nom
             </:header>
             <:cell>
-              {{organization.name}}
+              <LinkTo @route="authenticated.organizations.get" @model={{organization.id}}>{{organization.name}}</LinkTo>
             </:cell>
           </PixTableColumn>
           <PixTableColumn @context={{context}}>

--- a/admin/app/components/organizations/member-item.gjs
+++ b/admin/app/components/organizations/member-item.gjs
@@ -32,7 +32,9 @@ export default class MemberItem extends Component {
         Prénom
       </:header>
       <:cell>
-        {{@organizationMembership.user.firstName}}
+        <LinkTo @route="authenticated.users.get" @model={{@organizationMembership.user.id}}>
+          {{@organizationMembership.user.firstName}}
+        </LinkTo>
       </:cell>
     </PixTableColumn>
     <PixTableColumn @context={{@context}}>
@@ -40,7 +42,9 @@ export default class MemberItem extends Component {
         Nom
       </:header>
       <:cell>
-        {{@organizationMembership.user.lastName}}
+        <LinkTo @route="authenticated.users.get" @model={{@organizationMembership.user.id}}>
+          {{@organizationMembership.user.lastName}}
+        </LinkTo>
       </:cell>
     </PixTableColumn>
     <PixTableColumn @context={{@context}} class="break-word">

--- a/admin/app/components/sessions/list-items.gjs
+++ b/admin/app/components/sessions/list-items.gjs
@@ -168,7 +168,9 @@ export default class ListItems extends Component {
                 {{t "pages.sessions.table.headers.certification-name"}}
               </:header>
               <:cell>
-                {{session.certificationCenterName}}
+                <LinkTo @route="authenticated.sessions.session" @model={{session.id}}>
+                  {{session.certificationCenterName}}
+                </LinkTo>
               </:cell>
             </PixTableColumn>
             <PixTableColumn @context={{context}} class="break-word">

--- a/admin/app/components/users/list-items.gjs
+++ b/admin/app/components/users/list-items.gjs
@@ -28,7 +28,9 @@ import { t } from 'ember-intl';
             Prénom
           </:header>
           <:cell>
-            {{user.firstName}}
+            <LinkTo @route="authenticated.users.get" @model={{user.id}}>
+              {{user.firstName}}
+            </LinkTo>
           </:cell>
         </PixTableColumn>
         <PixTableColumn @context={{context}}>
@@ -36,7 +38,9 @@ import { t } from 'ember-intl';
             Nom
           </:header>
           <:cell>
-            {{user.lastName}}
+            <LinkTo @route="authenticated.users.get" @model={{user.id}}>
+              {{user.lastName}}
+            </LinkTo>
           </:cell>
         </PixTableColumn>
         <PixTableColumn @context={{context}} class="break-word">
@@ -52,7 +56,9 @@ import { t } from 'ember-intl';
             Identifiant
           </:header>
           <:cell>
-            {{user.username}}
+            <LinkTo @route="authenticated.users.get" @model={{user.id}}>
+              {{user.username}}
+            </LinkTo>
           </:cell>
         </PixTableColumn>
       </:columns>


### PR DESCRIPTION
## :pancakes: Problème

Sur Pix admin on a plusieurs zones, comme la page des orgas ou celle des centres de certif qui sont concernées par le problème suivant:
Dans le tableau présentant les différents éléments, les seuls éléments cliquable sont les identifiant. Or cela n'est pas très pratique surtout lorsqu'on navigue au clavier, car il faut se déplacer sur la colone des noms, puis revenir cliquer sur l'identifiant.

## :bacon: Proposition

Dans les pages où cela est util, faire apparaître comme un lien et rendre cliquable le nom de l'élément.

## 🧃 Remarques

Il s'agirait de passer toutes les pages en revu pour savoir lesquelles doivent être touchées.

## :yum: Pour tester

Sur pix admin, regarder toutes les pages où il y a des tableaux et si il y a des colone du type nom/prénom/titre, que les éléments dans ces colones sont bien des liens cliquables.