### PR TITLE
[FEATURE] Reprise mdl bien-ecrire-son-adresse-mail pour coval 16/10 (MODC-2) (closed PR#10189)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -2,6 +2,7 @@
   "id": "f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d",
   "slug": "bien-ecrire-son-adresse-mail",
   "title": "Bien écrire une adresse mail",
+  "isBeta": true,
   "details": {
     "image": "https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg",
     "description": "Écrire une adresse mail, c'est la première étape pour communiquer avec vos contacts. Dans ce module, découvrez les différentes parties de l'adresse mail et apprenez à éviter des erreurs courantes.",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -346,7 +346,7 @@
             {
               "elements": [
                 {
-                  "id": "29195dde-b603-488f-a554-f391fbdf3b24",
+                  "id": "845fe6d7-7ac5-46bb-a5d6-0419148b3978",
                   "type": "qcu",
                   "instruction": "<p>Mickaël et Naomi peuvent avoir le même identifiant et le même fournisseur d'adresse mail.</p>",
                   "proposals": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -96,7 +96,7 @@
                 {
                   "id": "c1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d",
                   "type": "text",
-                  "content": "<h3 class=\"screen-reader-only\">L'identifiant</h3><h4><u>Partie 1&nbsp;: l’identifiant</u>. Cette partie est choisie par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque.</p><p><span aria-hidden=\"true\">✔️</span> Par exemple&nbsp;: <code>mickael.aubert123</code> ou <code>mika671</code> ou <code>g3odu671</code></p><p><span aria-hidden=\"true\">✖️</span> Certains caractères sont interdits (<code>&</code> <code>@</code>  <code>$</code> <code>*</code> <code>€</code>) ou à éviter (accents, majuscules).</p><p><br><span aria-hidden=\"true\">📖</span> Un conseil : si vous voulez envoyer des mails importants, il vaut mieux créer une adresse mail avec un identifiant classique, par exemple <code>prenom.nom</code>.</p>"
+                  "content": "<h3 class=\"screen-reader-only\">L'identifiant</h3><h4><u>Partie 1&nbsp;: l’identifiant</u>. Cette partie est choisie par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque.</p><p><span aria-hidden=\"true\">✔️</span> Par exemple&nbsp;: <code>mickael.aubert123</code> ou <code>mika671</code> ou <code>g3odu671</code></p><p><span aria-hidden=\"true\">✖️</span> Certains caractères sont interdits (<code>\"&</code> <code>@</code>  <code>$</code> <code>*</code> <code>€</code>) ou à éviter (accents, majuscules).</p><p><br><span aria-hidden=\"true\">📖</span> Un conseil : si vous voulez envoyer des mails importants, il vaut mieux créer une adresse mail avec un identifiant classique, par exemple <code>prenom.nom</code>.</p>"
                 }
               ]
             },
@@ -176,7 +176,7 @@
                 {
                     "id": "e494d292-21a8-4b33-affa-96763dbe10e6",
                     "type": "text",
-                    "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'<strong>aide pour écrire ce symbole</strong>, cliquez sur l'indice ci-dessous&nbsp;:</p><details><summary>Indice</summary>Pour écrire le symbole arobase,<ul><li>sur PC, appuyez et maintenez la touche <code>Alt Gr</code> puis appuyez sur la touche <code>à</code> (même touche que le 0)</li><li>sur Mac, appuyez sur la touche @ déjà prévue, en haut à gauche (même touche que #)</li></details>"
+                    "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'<strong>aide pour écrire ce symbole</strong>, cliquez sur l'indice ci-dessous&nbsp;:</p><details><summary>Indice</summary>Pour écrire le symbole arobase,<ul><li>sur PC, appuyez et maintenez la touche <code>Alt Gr</code> puis appuyez sur la touche <code>à</code> (même touche que le 0)</li><li>sur Mac, appuyez sur la touche @ déjà prévue, en haut à gauche (même touche que #)</li></ul></details>"
                 }
               ]
             },
@@ -336,7 +336,7 @@
                     }
                   ],
                   "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span></span></span><p>Google n’est effectivement pas le seul fournisseur d’adresse mail. Il y a en énormément, vous avez peut-être déjà vu des adresses de chez</p><ul><li>Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>La Poste (laposte.net).</li></ul>",
+                    "valid": "<span class=\"feedback__state\">Bonne réponse&#8239;!&nbsp;🎉</span><p>Google n’est effectivement pas le seul fournisseur d’adresse mail. Il y a en énormément, vous avez peut-être déjà vu des adresses de chez</p><ul><li>Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>La Poste (laposte.net).</li></ul>",
                     "invalid": "<span class=\"feedback__state\">Mauvaise réponse</span><p>Il y a d’autres fournisseurs d’adresses mail que Google (gmail.com).</p><p>Il y en a énormément, vous avez peut-être déjà vu des adresses de chez</p><ul><li>Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>La Poste (laposte.net).</li></ul>"
                   },
                   "solution": "2"
@@ -381,7 +381,7 @@
           "element": {
             "id": "b0fcb950-b5b1-4384-886e-79fb852d5bb7",
             "type": "text",
-            "content": "<h3><span aria-hidden=\"true\">📌</span> Résumons avant de passer à la suite :</h3><ul><li>C'est l'<strong>utilisateur qui choisit son identifiant</strong> d'adresse mail. Il peut utiliser des <strong>chiffres</strong> ou des <strong>majuscules</strong>.<br><span aria-hidden=\"true\">✔️</span> Exemples&nbsp;: <code>mickael.aubert123</code> ; <code>M3g4Cool1415</code>, etc.</li><br><li>Il y a une <strong>arobase</strong> (@) dans une adresse mail. Elle permet de <strong>séparer l’identifiant et le fournisseur</strong> d’adresse mail.</li><br><li>Après l'arobase, les adresses mail <strong>se terminent de différentes manières</strong>, selon le <strong>fournisseur d’adresse</strong> mail.<br><span aria-hidden=\"true\">✔️</span> Exemples&nbsp;: laposte.net, free.fr, gmail.com, yahoo.com, etc.</li></ul>"
+            "content": "<h3><span aria-hidden=\"true\">📌</span> Résumons avant de passer à la suite :</h3><ul><li>C'est l'<strong>utilisateur qui choisit son identifiant</strong> d'adresse mail. Il peut utiliser des <strong>chiffres</strong> ou des <strong>majuscules</strong>.<br><span aria-hidden=\"true\">✔️</span> Exemples&nbsp;: <code>mickael.aubert123</code> ; <code>M3g4Cool1415</code>, etc.<br></li><li>Il y a une <strong>arobase</strong> (@) dans une adresse mail. Elle permet de <strong>séparer l’identifiant et le fournisseur</strong> d’adresse mail.<br></li><li>Après l'arobase, les adresses mail <strong>se terminent de différentes manières</strong>, selon le <strong>fournisseur d’adresse</strong> mail.<br><span aria-hidden=\"true\">✔️</span> Exemples&nbsp;: laposte.net, free.fr, gmail.com, yahoo.com, etc.</li></ul>"
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -96,7 +96,7 @@
                 {
                   "id": "c1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d",
                   "type": "text",
-                  "content": "<h3 class=\"screen-reader-only\">L'identifiant</h3><h4><u>Partie 1&nbsp;: l’identifiant</u>. Cette partie est choisie par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque.</p><p><span aria-hidden=\"true\">✔️</span> Par exemple&nbsp;: <code>mickael.aubert123</code> ou <code>mika671</code> ou <code>g3odu671</code></p><p><span aria-hidden=\"true\">✖️</span> Certains caractères sont interdits (<code>\"&</code> <code>@</code>  <code>$</code> <code>*</code> <code>€</code>) ou à éviter (accents, majuscules).</p><p><br><span aria-hidden=\"true\">📖</span> Un conseil : si vous voulez envoyer des mails importants, il vaut mieux créer une adresse mail avec un identifiant classique, par exemple <code>prenom.nom</code>.</p>"
+                  "content": "<h3 class=\"screen-reader-only\">L'identifiant</h3><h4><u>Partie 1&nbsp;: l’identifiant</u>. Cette partie est choisie par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque.</p><p><span aria-hidden=\"true\">✔️</span> Par exemple&nbsp;: <code>mickael.aubert123</code> ou <code>mika671</code> ou <code>g3odu671</code></p><p><span aria-hidden=\"true\">✖️</span> Certains caractères sont interdits (<code>&amp;</code> <code>@</code>  <code>$</code> <code>*</code> <code>€</code>) ou à éviter (accents, majuscules).</p><p><br><span aria-hidden=\"true\">📖</span> Un conseil : si vous voulez envoyer des mails importants, il vaut mieux créer une adresse mail avec un identifiant classique, par exemple <code>prenom.nom</code>.</p>"
                 }
               ]
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -1,42 +1,41 @@
 {
   "id": "f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d",
   "slug": "bien-ecrire-son-adresse-mail",
-  "title": "Bien écrire son adresse mail",
-  "isBeta": true,
+  "title": "Bien écrire une adresse mail",
   "details": {
     "image": "https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg",
-    "description": "Bien écrire son adresse mail est important. Dans ce module, vous allez apprendre à écrire correctement une adresse e-mail pour mieux communiquer et éviter les erreurs courantes.",
-    "duration": 12,
+    "description": "Écrire une adresse mail, c'est la première étape pour communiquer avec vos contacts. Dans ce module, découvrez les différentes parties de l'adresse mail et apprenez à éviter des erreurs courantes.",
+    "duration": 10,
     "level": "Débutant",
     "tabletSupport": "comfortable",
     "objectives": [
-      "Connaître les différentes parties d’une adresse mail et les identifier sur des exemples",
-      "Comprendre les fonctions de chaque partie d’une adresse mail",
+      "Reconnaître les différentes parties d’une adresse mail et les identifier sur des exemples",
+      "Associer chaque partie d'une adresse mail à sa fonction",
       "Écrire une adresse mail correctement, en évitant les erreurs courantes"
     ]
   },
   "transitionTexts": [
     {
-      "content": "<p>Naomi a oublié l’adresse mail de son ami Mickaël.&nbsp;<span aria-hidden=\"true\">🤷‍♀</span><br> Elle en a besoin pour envoyer un document à son ami. Naomi lui demande donc par SMS de lui redonner son adresse mail. <br> Lancez la vidéo pour voir leur discussion.&nbsp;<span aria-hidden=\"true\">📺</span></p>",
+      "content": "<p>Naomi veut envoyer un document par mail à son ami Mickaël.<br>Mais, Naomi ne trouve plus l'adresse mail de Mickaël.&nbsp;<span aria-hidden=\"true\">🤷‍♀</span><br>Elle décide de lui demander par message.<br>Lancez la vidéo pour voir leur discussion.&nbsp;<span aria-hidden=\"true\">📺</span></p>",
       "grainId": "34d225e8-5d52-4ebd-9acd-8bde8438cfc9"
     },
     {
-      "content": "<p>Et oui&#8239;! Naomi le sait&nbsp;: les adresses mails ont une forme particulière.</p><p>Étudions en détails l’adresse mail de Mickaël.&nbsp;<span aria-hidden=\"true\">👨‍🏫👩‍🏫</span></p>",
+      "content": "<p>Eh oui&#8239;! Naomi le sait&nbsp;: toutes les adresses mail ont le même format.</p><p>Nous allons étudier en détail l’adresse mail de Mickaël.&nbsp;<span aria-hidden=\"true\">🔎</span></p>",
       "grainId": "af860b1e-0566-4b06-bcb4-a68a5151d621"
     },
     {
-      "content": "<p>Récapitulons ensemble avec quelques questions.</p>",
+      "content": "<p>Récapitulons ensemble avec quelques questions. <span aria-hidden=\"true\">🎯</span></p>",
       "grainId": "edd7fec3-a649-425b-b8e3-65b13c6c47ea"
     },
     {
-      "content": "<p>Maintenant, à vous de jouer pour trouver l'adresse mail de Naomi.</p>",
+      "content": "<p>Pour finir, à vous de jouer : vous allez devoir trouver l'adresse mail de Naomi. <span aria-hidden=\"true\">💫</span></p>",
       "grainId": "b7ea7630-824a-4a49-83d1-abb9b8d0d120"
     }
   ],
   "grains": [
     {
       "id": "34d225e8-5d52-4ebd-9acd-8bde8438cfc9",
-      "type": "lesson",
+      "type": "discovery",
       "title": "Sûr de ton adresse mail ?",
       "components": [
         {
@@ -47,7 +46,7 @@
             "title": "Le format des adresses mail",
             "url": "https://videos.pix.fr/modulix/bien-ecrire-adresse-mail/chat_animation.mp4",
             "subtitles": "https://videos.pix.fr/modulix/bien-ecrire-adresse-mail/chat_animation.vtt",
-            "transcription": "<ul><li>Naomi&nbsp;: Salut, tu peux me redonner ton adresse mail stp&#8239;?&nbsp;<span aria-hidden=\"true\">😇</span></li> <li>Mickaël&nbsp;: Oui, c’est mickael.aubert123#laposte.net</li><li>Naomi&nbsp;: T’es sûr&#8239;?&nbsp;<span aria-hidden=\"true\">😬</span></li><li>Naomi&nbsp;: Tu veux dire mickael.aubert123@laposte.net</li><li>Mickaël&nbsp;: Ah oui désolé&#8239;!&nbsp;<span aria-hidden=\"true\">😣</span></li><li>Mickaël&nbsp;: comment tu as su&#8239;? </li><li>Naomi&nbsp;: …</li></ul>"
+            "transcription": "<ul><li>Naomi&nbsp;: Salut, tu peux me redonner ton adresse mail stp&#8239;?&nbsp;<span aria-hidden=\"true\">😇</span></li> <li>Mickaël&nbsp;: Oui, c’est mickael.aubert123#laposte.net</li><li>Naomi&nbsp;: T’es sûr&#8239;?&nbsp;<span aria-hidden=\"true\">😬</span></li><li>Naomi&nbsp;: Tu veux dire mickael.aubert123@laposte.net</li><li>Mickaël&nbsp;: Ah oui désolé&#8239;!&nbsp;<span aria-hidden=\"true\">😣</span></li><li>Mickaël&nbsp;: comment tu as su&#8239;? </li><li>Naomi&nbsp;: Dans une adresse mail, il y a toujours le symbole arobase !</li></ul>"
           }
         }
       ]
@@ -58,6 +57,14 @@
       "title": "Explications : les parties d’une adresse mail",
       "components": [
         {
+          "type": "element",
+          "element": {
+            "id": "acf16c79-b788-4ebe-b7a1-4138eef3db2f",
+            "type": "text",
+            "content": "<p>Après cette leçon, vous devrez répondre à des questions sur les différentes parties de l'adresse mail.</p>"
+          }
+        },
+        {
           "type": "stepper",
           "steps": [
             {
@@ -65,7 +72,7 @@
                 {
                   "id": "d4bf1c51-b113-440a-949a-f21c1e001daa",
                   "type": "text",
-                  "content": "<h3 class=\"screen-reader-only\">L'adresse mail de Mickaël</h3><h4>L'adresse mail de Mickaël est composée de deux parties et d'un séparateur au centre.</h4>"
+                  "content": "<p>L'adresse mail de Mickaël est <strong>mickael.aubert123@laposte.net</strong>.<br>Cette adresse est composée de <strong>deux parties</strong> et d'<strong>un séparateur</strong> au centre.</p>"
                 },
                 {
                   "id": "167907eb-ee0d-4de0-9fc8-609b2b62ed9f",
@@ -88,7 +95,7 @@
                 {
                   "id": "c1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d",
                   "type": "text",
-                  "content": "<h3 class=\"screen-reader-only\">L'identifiant</h3><h4>Partie 1&nbsp;: l’identifiant choisi par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque, même avec des majuscules&#8239;!</p><p><span aria-hidden=\"true\">✅</span> Par exemple&nbsp;: mika671 ou G3oDu671</p><p class=\"pix-list-inline\"><span aria-hidden=\"true\">❌</span> Mais certains caractères sont interdits&nbsp;:</p><ul><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>"
+                  "content": "<h3 class=\"screen-reader-only\">L'identifiant</h3><h4><u>Partie 1&nbsp;: l’identifiant</u>. Cette partie est choisie par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque.</p><p><span aria-hidden=\"true\">✔️</span> Par exemple&nbsp;: <code>mickael.aubert123</code> ou <code>mika671</code> ou <code>g3odu671</code></p><p><span aria-hidden=\"true\">✖️</span> Certains caractères sont interdits (<code>&</code> <code>@</code>  <code>$</code> <code>*</code> <code>€</code>) ou à éviter (accents, majuscules).</p><p><br><span aria-hidden=\"true\">📖</span> Un conseil : si vous voulez envoyer des mails importants, il vaut mieux créer une adresse mail avec un identifiant classique, par exemple <code>prenom.nom</code>.</p>"
                 }
               ]
             },
@@ -104,7 +111,7 @@
                 {
                   "id": "ad8ad08a-3ff7-4228-8233-6cd5ce0f4812",
                   "type": "text",
-                  "content": "<h3 class=\"screen-reader-only\">L'arobase</h3><h4>Au centre&nbsp;: l’arobase qui sépare l’identifiant du fournisseur d’adresse mail.</h4><p><span aria-hidden=\"true\">🇬🇧</span> En anglais, ce symbole se lit <i lang=\"en\">“at”</i> et veut dire “chez”.</p><p><span aria-hidden=\"true\">🤔</span> Le saviez-vous&nbsp;? L'arobase est un symbole qui était utilisé bien avant l’informatique, pour compter des quantités par exemple.</p>"
+                  "content": "<h3 class=\"screen-reader-only\">L'arobase</h3><h4><u>Au centre, l’arobase</u> (@) sépare l’identifiant du fournisseur d’adresse mail.</h4><p>En anglais, ce symbole se lit <i lang=\"en\">“at”</i> et veut dire “chez”.</p><p><br><span aria-hidden=\"true\">💡</span> L'arobase est un symbole qui était utilisé avant l’informatique. En 1970, il a été choisi pour écrire les adresses mail car il était très peu utilisé et facile à repérer.</p>"
                 }
               ]
             },
@@ -120,7 +127,7 @@
                 {
                   "id": "1fd829f8-1799-4779-a28d-5d26fba31b8b",
                   "type": "text",
-                  "content": "<h3 class=\"screen-reader-only\">Le fournisseur d’adresse mail</h3><h4>Partie 2&nbsp;: le fournisseur d’adresse mail. Cette partie de l’adresse est donnée par le fournisseur.</h4><p><span aria-hidden=\"true\">✅</span> Voici des exemples de fournisseurs d’adresses mail&nbsp;: </p><ul><li>La Poste (laposte.net)</li><li>Google (gmail.com)</li><li>Yahoo (yahoo.com, yahoo.fr)</li><li>Microsoft (hotmail.com, live.fr)</li></ul>"
+                  "content": "<h3 class=\"screen-reader-only\">Le fournisseur d’adresse mail</h3><h4><u>Partie 2&nbsp;: le fournisseur d’adresse mail</u>. Cette partie de l’adresse est donnée par le fournisseur.</h4><p><span aria-hidden=\"true\">✔️</span> Voici des exemples de fournisseurs d’adresses mail&nbsp;: </p><ul><li>La Poste (laposte.net)</li><li>Google (gmail.com)</li><li>Yahoo (yahoo.com, yahoo.fr)</li><li>Microsoft (hotmail.com, live.fr)</li></ul><p><br>Quand vous écrivez une adresse mail, soyez attentifs à l'extension (<code>.fr</code>, <code>.com</code>, etc.). C'est important pour que le mail soit envoyé à la bonne adresse. <span aria-hidden=\"true\">🧐</span></p>"
                 }
               ]
             }
@@ -134,104 +141,116 @@
       "title": "Les parties d’une adresse mail : applications",
       "components": [
         {
-          "type": "element",
-          "element": {
-            "id": "fd702cb8-9ad2-41aa-b21d-449f1342ef03",
-            "type": "qrocm",
-            "instruction": "<p>Quel symbole permet de séparer les deux parties d'une adresse mail&#8239;?</p>",
-            "proposals": [
-              {
-                "type": "text",
-                "content": "<span>Symbole&nbsp;:</span>"
-              },
-              {
-                "input": "symbole",
-                "type": "input",
-                "inputType": "text",
-                "size": 3,
-                "display": "block",
-                "placeholder": "",
-                "ariaLabel": "Réponse 1 sur 1",
-                "defaultValue": "",
-                "tolerances": ["t1"],
-                "solutions": ["@"]
-              }
-            ],
-            "feedbacks": {
-              "valid": "<span class=\"feedback__state\">Correct.&nbsp;<span aria-hidden=\"true\">🎉</span></span>",
-              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p>Cherchez le symbole @ sur votre clavier pour pouvoir l'écrire.</p>"
-            }
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "1d8f5308-4d40-452d-8bf4-5d2c820734f6",
-            "type": "text",
-            "content": "<hr>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "98c51fa7-03b7-49b1-8c5e-49341d35909c",
-            "type": "qrocm",
-            "instruction": "<p>Quelles sont les deux parties d'une adresse mail&nbsp;?</p>",
-            "proposals": [
-              {
-                "type": "text",
-                "content": "<span>Partie 1&nbsp;:</span>"
-              },
-              {
-                "input": "premiere-partie",
-                "type": "select",
-                "display": "block",
-                "placeholder": "- Sélectionner -",
-                "ariaLabel": "Réponse 1 sur 2",
-                "defaultValue": "",
-                "tolerances": [],
-                "options": [
-                  {
-                    "id": "1",
-                    "content": "l'identifiant"
-                  },
-                  {
-                    "id": "2",
-                    "content": "le fournisseur d'adresse mail"
+          "type": "stepper",
+          "steps": [
+            {
+              "elements": [
+                {
+                  "id": "fd702cb8-9ad2-41aa-b21d-449f1342ef03",
+                  "type": "qrocm",
+                  "instruction": "<p>Quel symbole permet de séparer les deux parties d'une adresse mail&#8239;?</p>",
+                  "proposals": [
+                    {
+                      "type": "text",
+                      "content": "<span>Symbole&nbsp;:</span>"
+                    },
+                    {
+                      "input": "symbole",
+                      "type": "input",
+                      "inputType": "text",
+                      "size": 3,
+                      "display": "inline",
+                      "placeholder": "",
+                      "ariaLabel": "Réponse 1 sur 1",
+                      "defaultValue": "",
+                      "tolerances": ["t1"],
+                      "solutions": ["@"]
+                    }
+                  ],
+                  "feedbacks": {
+                    "valid": "<span class=\"feedback__state\">Correct.&nbsp;<span aria-hidden=\"true\">🎉</span></span>",
+                    "invalid": "<span class=\"feedback__state\">Incorrect.</span><p>Pour réussir la prochaine fois, remontez voir la leçon ou utilisez l'indice ci-dessous.</p>"
                   }
-                ],
-                "solutions": ["1"]
-              },
-              {
-                "type": "text",
-                "content": "<span>Partie 2&nbsp;:</span>"
-              },
-              {
-                "input": "seconde-partie",
-                "type": "select",
-                "display": "block",
-                "placeholder": "- Sélectionner -",
-                "ariaLabel": "Réponse 2 sur 2",
-                "defaultValue": "",
-                "tolerances": [],
-                "options": [
-                  {
-                    "id": "1",
-                    "content": "l'identifiant"
-                  },
-                  {
-                    "id": "2",
-                    "content": "le fournisseur d'adresse mail"
+                },
+                {
+                    "id": "e494d292-21a8-4b33-affa-96763dbe10e6",
+                    "type": "text",
+                    "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'<strong>aide pour écrire ce symbole</strong>, cliquez sur l'indice ci-dessous&nbsp;:</p><details><summary>Indice</summary>Pour écrire le symbole arobase,<ul><li>sur PC, appuyez et maintenez la touche <code>Alt Gr</code> puis appuyez sur la touche <code>à</code> (même touche que le 0)</li><li>sur Mac, appuyez sur la touche @ déjà prévue, en haut à gauche (même touche que #)</li></details>"
+                }
+              ]
+            },
+            {
+              "elements": [
+                {
+                  "id": "98c51fa7-03b7-49b1-8c5e-49341d35909c",
+                  "type": "qrocm",
+                  "instruction": "<p>Quelles sont les deux parties d'une adresse mail&nbsp;?</p>",
+                  "proposals": [
+                    {
+                      "type": "text",
+                      "content": "<span>Partie 1&nbsp;:</span>"
+                    },
+                    {
+                      "input": "premiere-partie",
+                      "type": "select",
+                      "display": "inline",
+                      "placeholder": "- Sélectionner -",
+                      "ariaLabel": "Réponse 1 sur 2",
+                      "defaultValue": "",
+                      "tolerances": [],
+                      "options": [
+                        {
+                          "id": "3",
+                          "content": "le séparateur"
+                        },
+                        {
+                          "id": "1",
+                          "content": "l'identifiant"
+                        },
+                        {
+                          "id": "2",
+                          "content": "le fournisseur d'adresse mail"
+                        }
+                      ],
+                      "solutions": ["1"]
+                    },
+                    {
+                      "type": "text",
+                      "content": "<br><span>Partie 2&nbsp;:</span>"
+                    },
+                    {
+                      "input": "seconde-partie",
+                      "type": "select",
+                      "display": "inline",
+                      "placeholder": "- Sélectionner -",
+                      "ariaLabel": "Réponse 2 sur 2",
+                      "defaultValue": "",
+                      "tolerances": [],
+                      "options": [
+                        {
+                          "id": "3",
+                          "content": "le séparateur"
+                        },
+                        {
+                          "id": "1",
+                          "content": "l'identifiant"
+                        },
+                        {
+                          "id": "2",
+                          "content": "le fournisseur d'adresse mail"
+                        }
+                      ],
+                      "solutions": ["2"]
+                    }
+                  ],
+                  "feedbacks": {
+                    "valid": "<span class=\"feedback__state\">Correct&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span></span><p>Vous avez retrouvé le bon format d’une adresse mail.</p>",
+                    "invalid": "<span class=\"feedback__state\">Incorrect&#8239;!</span><p>Pour avoir de l’aide, revenez en arrière.&nbsp;<span aria-hidden=\"true\">👆</span></p>"
                   }
-                ],
-                "solutions": ["2"]
-              }
-            ],
-            "feedbacks": {
-              "valid": "<span class=\"feedback__state\">Correct&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span></span><p>Vous avez retrouvé le bon format d’une adresse mail.</p>",
-              "invalid": "<span class=\"feedback__state\">Incorrect&#8239;!</span><p>Pour avoir de l’aide, revenez en arrière.&nbsp;<span aria-hidden=\"true\">👆</span></p>"
+                }
+              ]
             }
-          }
+          ]
         }
       ]
     },
@@ -245,138 +264,115 @@
           "element": {
             "id": "2f4794e7-f5f1-4cb6-8b4f-08f4e64b8aa5",
             "type": "text",
-            "content": "<p>Pour chaque affimation, choisissez si elle est vraie ou fausse.</p>"
+            "content": "<p>Pour chaque affirmation, choisissez si elle est vraie ou fausse.</p>"
           }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "71482f12-b439-43ca-8c9c-d26928895829",
-            "type": "text",
-            "content": "<hr>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "29195dde-b603-488f-a554-f391fbdf3b24",
-            "type": "qcu",
-            "instruction": "<p>On peut avoir des chiffres dans l’identifiant de son adresse mail.</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "Vrai"
-              },
-              {
-                "id": "2",
-                "content": "Faux"
-              }
-            ],
-            "feedbacks": {
-              "valid": "<p class=\"feedback__state\">Oui, aucun problème&#8239;!</p><p class=\"pix-list-inline\">Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>",
-              "invalid": "<p class=\"feedback__state\">Et si&#8239;!</p><p class=\"pix-list-inline\">Les chiffres sont autorisés dans l’identifiant d’une adresse mail. Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>"
+          "type": "stepper",
+          "steps": [
+            {
+              "elements": [
+                {
+                  "id": "ba78dead-a806-4954-b408-e8ef28d28fab",
+                  "type": "qcu",
+                  "instruction": "<p>L’adresse mail M3g4Cool1415@gmail.com est correctement écrite.</p>",
+                  "proposals": [
+                    {
+                      "id": "1",
+                      "content": "Vrai"
+                    },
+                    {
+                      "id": "2",
+                      "content": "Faux"
+                    }
+                  ],
+                  "feedbacks": {
+                    "valid": "<span class=\"feedback__state\">Bonne réponse&#8239;! <span aria-hidden=\"true\">🎉</span></span><p>Cette adresse est correctement écrite.<br>On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>",
+                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse</span><p>Cette adresse est correctement écrite.<br>On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>"
+                  },
+                  "solution": "1"
+                }
+              ]
             },
-            "solution": "1"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "9ebba6bc-f7f7-437e-9a88-b15d45a50a1c",
-            "type": "text",
-            "content": "<hr>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "ba78dead-a806-4954-b408-e8ef28d28fab",
-            "type": "qcu",
-            "instruction": "<p>L’adresse mail M3g4Cool1415@gmail.com est correctement écrite.</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "Vrai"
-              },
-              {
-                "id": "2",
-                "content": "Faux"
-              }
-            ],
-            "feedbacks": {
-              "valid": "<span class=\"feedback__state\">Et oui&#8239;!</span><p>Cette adresse est correctement écrite. On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>",
-              "invalid": "<span class=\"feedback__state\">Et si&#8239;!</span><p>Cette adresse est correctement écrite. On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>"
+            {
+              "elements": [
+                {
+                  "id": "4231af7b-dca5-4d79-acfe-b485e0127ae1",
+                  "type": "qcu",
+                  "instruction": "<p>Il y a toujours un symbole @ dans une adresse mail.</p>",
+                  "proposals": [
+                    {
+                      "id": "1",
+                      "content": "Vrai"
+                    },
+                    {
+                      "id": "2",
+                      "content": "Faux"
+                    }
+                  ],
+                  "feedbacks": {
+                    "valid": "<span class=\"feedback__state\">Bonne réponse&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span></span><p>Le symbole @ (arobase) permet de séparer l’identifiant et le fournisseur d’adresse. Il y donc toujours un arobase.</p>",
+                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse</span><p>Le symbole @ (arobase) permet de séparer l’identifiant et le fournisseur d’adresse. Il y donc toujours un arobase.</p>"
+                  },
+                  "solution": "1"
+                }
+              ]
             },
-            "solution": "1"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "502092ae-adbc-4c0f-bb4c-a8576accb6d7",
-            "type": "text",
-            "content": "<hr>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "4231af7b-dca5-4d79-acfe-b485e0127ae1",
-            "type": "qcu",
-            "instruction": "<p>Il faut toujours un symbole @ dans une adresse mail.</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "Vrai"
-              },
-              {
-                "id": "2",
-                "content": "Faux"
-              }
-            ],
-            "feedbacks": {
-              "valid": "<span class=\"feedback__state\">Correct&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span></span><p>Il faut pouvoir séparer l’identifiant et le fournisseur d’adresse. Il y a donc un seul symbole @ entre les deux.</p>",
-              "invalid": "<span class=\"feedback__state\">Incorrect&#8239;!</span><p>Il faut pouvoir séparer l’identifiant et le fournisseur d’adresse. Il y a donc un seul symbole @ entre les deux.</p>"
+            {
+              "elements": [
+                {
+                  "id": "9bd65c37-ea5d-49a9-a59c-4e07ab3f1049",
+                  "type": "qcu",
+                  "instruction": "<p>Toutes les adresses mail se terminent par <code>gmail.com</code>.</p>",
+                  "proposals": [
+                    {
+                      "id": "1",
+                      "content": "Vrai"
+                    },
+                    {
+                      "id": "2",
+                      "content": "Faux"
+                    }
+                  ],
+                  "feedbacks": {
+                    "valid": "<span class=\"feedback__state\">Bonne réponse&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span></span></span><p>Google n’est effectivement pas le seul fournisseur d’adresse mail. Il y a en énormément, vous avez peut-être déjà vu des adresses de chez</p><ul><li>Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>La Poste (laposte.net).</li></ul>",
+                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse</span><p>Il y a d’autres fournisseurs d’adresses mail que Google (gmail.com).</p><p>Il y en a énormément, vous avez peut-être déjà vu des adresses de chez</p><ul><li>Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>La Poste (laposte.net).</li></ul>"
+                  },
+                  "solution": "2"
+                }
+              ]
             },
-            "solution": "1"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "20738498-66d5-48b0-b8b6-d5ccaf8077df",
-            "type": "text",
-            "content": "<hr>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "9bd65c37-ea5d-49a9-a59c-4e07ab3f1049",
-            "type": "qcu",
-            "instruction": "<p>Toutes les adresses mails se terminent par gmail.com. </p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "Vrai"
-              },
-              {
-                "id": "2",
-                "content": "Faux"
-              }
-            ],
-            "feedbacks": {
-              "valid": "<span class=\"feedback__state\">Bien vu&#8239;!</span><p>Google n’est effectivement pas le seul fournisseur d’adresse mail. Il y en énormément, vous avez peut-être déjà vu des adresses de chez</p><ul><li>Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>La Poste (laposte.net).</li></ul>",
-              "invalid": "<span class=\"feedback__state\">Incorrect&#8239;!</span><p>Il y a d’autres fournisseurs d’adresses mails que Google (gmail.com).</p><p>Il y en a énormément, vous avez peut-être déjà vu des adresses de chez</p><ul><li>Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>La Poste (laposte.net).</li></ul>"
-            },
-            "solution": "2"
-          }
+            {
+              "elements": [
+                {
+                  "id": "29195dde-b603-488f-a554-f391fbdf3b24",
+                  "type": "qcu",
+                  "instruction": "<p>Mickaël et Naomi peuvent avoir le même identifiant et le même fournisseur d'adresse mail.</p>",
+                  "proposals": [
+                    {
+                      "id": "1",
+                      "content": "Vrai"
+                    },
+                    {
+                      "id": "2",
+                      "content": "Faux"
+                    }
+                  ],
+                  "feedbacks": {
+                    "valid": "<p class=\"feedback__state\">Bonne réponse&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span></p><p>Une adresse mail est <strong>unique</strong>.<br>Au moment de la création d'une adresse mail, vous saurez si un identifiant est disponible ou pas.</p>",
+                    "invalid": "<p class=\"feedback__state\">Mauvaise réponse</p><p>Une adresse mail est <strong>unique</strong>.<br>Au moment de la création d'une adresse mail, vous saurez si un identifiant est disponible ou pas.</p>"
+                  },
+                  "solution": "2"
+                }
+              ]
+            }
+          ]
         }
       ]
     },
     {
       "id": "d54142a3-43df-4bde-b1a3-8a795384f428",
-      "type": "lesson",
+      "type": "summary",
       "title": "Diversité des identifiants et des fournisseurs d’adresse mail : synthèse",
       "components": [
         {
@@ -384,14 +380,14 @@
           "element": {
             "id": "b0fcb950-b5b1-4384-886e-79fb852d5bb7",
             "type": "text",
-            "content": "<h3>Ce qu’il faut retenir&nbsp;:</h3><ul><li>Il peut y avoir des chiffres dans l’identifiant d’une adresse mail. Ils peuvent être n’importe où dans l’identifiant. <br></li><li>Il y a une seule @ (arobase) dans une adresse mail. Elle permet de séparer l’identifiant du fournisseur d’adresse mail.</li><li>Les adresses mails se terminent de différentes manières après l'@, selon le fournisseur d’adresse mail.<br><span aria-hidden=\"true\">✅</span> Exemples&nbsp;: laposte.net, free.fr, gmail.com, yahoo.com, etc.</li></ul>"
+            "content": "<h3><span aria-hidden=\"true\">📌</span> Résumons avant de passer à la suite :</h3><ul><li>C'est l'<strong>utilisateur qui choisit son identifiant</strong> d'adresse mail. Il peut utiliser des <strong>chiffres</strong> ou des <strong>majuscules</strong>.<br><span aria-hidden=\"true\">✔️</span> Exemples&nbsp;: <code>mickael.aubert123</code> ; <code>M3g4Cool1415</code>, etc.</li><br><li>Il y a une <strong>arobase</strong> (@) dans une adresse mail. Elle permet de <strong>séparer l’identifiant et le fournisseur</strong> d’adresse mail.</li><br><li>Après l'arobase, les adresses mail <strong>se terminent de différentes manières</strong>, selon le <strong>fournisseur d’adresse</strong> mail.<br><span aria-hidden=\"true\">✔️</span> Exemples&nbsp;: laposte.net, free.fr, gmail.com, yahoo.com, etc.</li></ul>"
           }
         }
       ]
     },
     {
       "id": "b7ea7630-824a-4a49-83d1-abb9b8d0d120",
-      "type": "activity",
+      "type": "challenge",
       "title": "Écrire une adresse mail correctement",
       "components": [
         {
@@ -399,7 +395,7 @@
           "element": {
             "id": "8709ad92-093e-447a-a7b6-3223e6171196",
             "type": "qrocm",
-            "instruction": "<p>Écrivez l'adresse mail de Naomi à partir des informations suivantes&nbsp;:</p><ul><li>Son identifiant est <code>naomizao457</code></li><li>Son fournisseur d’adresse mail est Yahoo</li></ul>",
+            "instruction": "<p>Écrivez l'adresse mail de Naomi à partir des informations suivantes&nbsp;:</p><ul><li>son identifiant est <code>naomizao457</code></li><li>son fournisseur d’adresse mail est Yahoo</li></ul>",
             "proposals": [
               {
                 "type": "text",
@@ -410,7 +406,7 @@
                 "type": "input",
                 "inputType": "text",
                 "size": 20,
-                "display": "block",
+                "display": "inline",
                 "placeholder": "",
                 "ariaLabel": "Adresse mail de Naomi",
                 "defaultValue": "",
@@ -419,7 +415,7 @@
               }
             ],
             "feedbacks": {
-              "valid": "<span class=\"feedback__state\">Correct.&nbsp;<span aria-hidden=\"true\">🎉</span></span><p>Tout est dans l'ordre&nbsp;: l'identifiant, l'arobase puis le fournisseur d'adresse mail</p>",
+              "valid": "<span class=\"feedback__state\">Bravo !&nbsp;<span aria-hidden=\"true\">💫</span></span><p>Tout est dans l'ordre&nbsp;: l'identifiant, l'arobase puis le fournisseur d'adresse mail</p>",
               "invalid": "<span class=\"feedback__state\">Incorrect.</span><p>Pour réussir la prochaine fois, utilisez les indices ci-dessous&nbsp;<span aria-hidden=\"true\">👇</span> </p>"
             }
           }
@@ -429,7 +425,7 @@
           "element": {
             "id": "6c69a919-4fc6-4039-9abc-ad70c49be7d8",
             "type": "text",
-            "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p><details><summary>Indice 1</summary><p>L'ordre à suivre est&nbsp;: l'identifiant, l'arobase puis le fournisseur d'adresse mail.</p></details><details><summary>Indice 2</summary><p>L'adresse mail se termine par <code>yahoo.com</code> quand le fournisseur est Yahoo.</p></details>"
+            "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p><details><summary>Indice 1</summary><p>L'ordre est l'identifiant, l'arobase puis le fournisseur d'adresse mail.</p></details><details><summary>Indice 2</summary><p>L'adresse mail se termine par <code>yahoo.com</code> quand le fournisseur est Yahoo.</p></details>"
           }
         }
       ]

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -6,7 +6,7 @@ import {
   knex,
 } from '../../../../test-helper.js';
 
-describe('Acceptance | Controller | passage-controller', function () {
+describe.only('Acceptance | Controller | passage-controller', function () {
   let server;
 
   beforeEach(async function () {
@@ -105,7 +105,7 @@ describe('Acceptance | Controller | passage-controller', function () {
           userResponse: [{ input: 'email', answer: 'naomizao457@yahoo.com' }],
           expectedUserResponseValue: { email: 'naomizao457@yahoo.com' },
           expectedFeedback:
-            '<span class="feedback__state">Correct.&nbsp;<span aria-hidden="true">🎉</span></span><p>Tout est dans l\'ordre&nbsp;: l\'identifiant, l\'arobase puis le fournisseur d\'adresse mail</p>',
+            '<span class="feedback__state">Bravo !&nbsp;<span aria-hidden="true">💫</span></span><p>Tout est dans l\'ordre&nbsp;: l\'identifiant, l\'arobase puis le fournisseur d\'adresse mail</p>',
           expectedSolution: {
             email: ['naomizao457@yahoo.com', 'naomizao457@yahoo.fr'],
           },

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -6,7 +6,7 @@ import {
   knex,
 } from '../../../../test-helper.js';
 
-describe.only('Acceptance | Controller | passage-controller', function () {
+describe('Acceptance | Controller | passage-controller', function () {
   let server;
 
   beforeEach(async function () {
@@ -91,12 +91,12 @@ describe.only('Acceptance | Controller | passage-controller', function () {
         {
           case: 'QCU',
           moduleId: 'bien-ecrire-son-adresse-mail',
-          elementId: '29195dde-b603-488f-a554-f391fbdf3b24',
-          userResponse: ['1'],
-          expectedUserResponseValue: '1',
+          elementId: '845fe6d7-7ac5-46bb-a5d6-0419148b3978',
+          userResponse: ['2'],
+          expectedUserResponseValue: '2',
           expectedFeedback:
-            '<p class="feedback__state">Oui, aucun problème&#8239;!</p><p class="pix-list-inline">Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>',
-          expectedSolution: '1',
+            '<p class="feedback__state">Bonne réponse&#8239;!&nbsp;<span aria-hidden="true">🎉</span></p><p>Une adresse mail est <strong>unique</strong>.<br>Au moment de la création d\'une adresse mail, vous saurez si un identifiant est disponible ou pas.</p>',
+          expectedSolution: '2',
         },
         {
           case: 'QROCM-ind',


### PR DESCRIPTION
## :pancakes: Problème

Il faut màj ce module. Cela a été fait dans [cette PR](https://github.com/1024pix/pix/pull/10189) mais la branche était trop vieille.


## :bacon: Proposition

Vu avec la team engineering : créer une nouvelle branche et y ramener le .json actualisé.
Fermer la "vieille" PR

## 🧃 Remarques

Vigilance sur les potentiels nouveaux champs à remplir qui n'était pas dans le .json de l'époque. On va voir les tests

## :yum: Pour tester

Suivre le lien : 