### PR TITLE
[FEATURE] Utiliser PixCode dans le code candidat pour l'entrée en certification sur Pix App (PIX-16448).

### DIFF
--- a/mon-pix/app/components/certification-starter.hbs
+++ b/mon-pix/app/components/certification-starter.hbs
@@ -1,5 +1,5 @@
 <section class="certification-starter">
-  <h2 class="certification-start-page__title">{{t "pages.certification-start.first-title"}}</h2>
+  <h1 class="certification-start-page__title">{{t "pages.certification-start.first-title"}}</h1>
 
   {{#if @certificationCandidateSubscription.hasSubscription}}
     {{#unless @certificationCandidateSubscription.isV3CoreOnly}}
@@ -52,39 +52,37 @@
       </div>
     {{/unless}}
   {{/if}}
-  <label for="certificationStarterSessionCode" class="certification-start-page__order">
-    {{t "pages.certification-start.access-code"}}
-  </label>
-  <form autocomplete="off">
-    <div class="certification-start-page__session-code-input">
-      <PixInput
-        required={{true}}
-        id="certificationStarterSessionCode"
-        @type="text"
-        @value={{this.inputAccessCode}}
-        maxlength="6"
-        spellcheck={{false}}
-        {{on "input" this.handleAccessCodeInput}}
-      />
-      {{#if this.errorMessage}}
-        <div class="certification-start-page__information">
-          <p class="certification-start-page__information--error">{{this.errorMessage}}</p>
-          {{#if this.technicalErrorInfo}}
-            <details>
-              <summary>{{t "pages.certification-start.error-messages.unknown.summary-label"}}</summary>
-              <p>{{this.technicalErrorInfo}}</p>
-            </details>
-          {{/if}}
-        </div>
-      {{/if}}
-    </div>
 
-    <div class="certification-start-page__field-button">
+  <form class="certification-start-page__form" autocomplete="off">
+    <PixLabel for="certificationStarterSessionCode" @requiredLabel={{t "common.form.mandatory"}}>
+      {{t "pages.certification-start.access-code"}}
+    </PixLabel>
+    <PixCode
+      @id="certificationStarterSessionCode"
+      @length="6"
+      @requiredLabel={{true}}
+      @value={{this.inputAccessCode}}
+      @validationStatus={{this.validationStatus}}
+      @errorMessage={{this.validationErrorMessage}}
+      {{on "keyup" this.clearErrorMessage}}
+      {{on "input" this.handleAccessCodeInput}}
+    />
 
-      <PixButton @type="submit" @triggerAction={{this.submit}}>
-        {{t "pages.certification-start.actions.submit"}}
-      </PixButton>
-    </div>
+    {{#if this.apiErrorMessage}}
+      <PixNotificationAlert @type="error" @withIcon={{true}} class="certification-start-page__error-message">
+        {{this.apiErrorMessage}}
+      </PixNotificationAlert>
+    {{/if}}
+    {{#if this.technicalErrorInformation}}
+      <details class="certification-start-page__information">
+        <summary>{{t "pages.certification-start.error-messages.unknown.summary-label"}}</summary>
+        <p>{{this.technicalErrorInformation}}</p>
+      </details>
+    {{/if}}
+
+    <PixButton @type="submit" @triggerAction={{this.submit}} class="certification-start-page__field-button">
+      {{t "pages.certification-start.actions.submit"}}
+    </PixButton>
   </form>
 
   <div class="certification-start-page__cgu">

--- a/mon-pix/app/styles/components/_certification-starter.scss
+++ b/mon-pix/app/styles/components/_certification-starter.scss
@@ -14,55 +14,30 @@
 .certification-start-page {
   &__block {
     max-width: 980px;
-    margin-bottom: 32px;
-    padding: 12px;
+    margin-bottom: var(--pix-spacing-8x);
+    padding: var(--pix-spacing-3x);
 
     @include breakpoints.device-is('mobile') {
-      padding: 16px;
+      padding: var(--pix-spacing-4x);
     }
   }
 
   &__information {
-    display: flex;
-    flex-direction: column;
-    gap: var(--pix-spacing-3x);
-    align-items: center;
     margin-top: var(--pix-spacing-3x);
+    text-align: center;
 
     @extend %pix-body-s;
-
-    &--error {
-      color: var(--pix-error-500);
-    }
-
-    details {
-      text-align: center;
-    }
-  }
-
-  &__link-to-user-certifications {
-    display: flex;
-    gap: 8px;
-    justify-content: center;
-    margin-top: 16px;
-    padding: 16px;
-    color: var(--pix-neutral-800);
-    background-color: var(--pix-neutral-20);
-    border-radius: 8px;
-
-    a,
-    a:visited {
-      color: var(--pix-neutral-800);
-      text-decoration-line: underline;
-    }
   }
 
   &__title {
-    margin-bottom: 20px;
-    color: var(--pix-neutral-900);
-    font-size: 2.625rem;
-    font-family: fonts.$font-open-sans;
+    margin-bottom: var(--pix-spacing-6x);
     text-align: center;
+
+    @extend %pix-title-m;
+
+    @include breakpoints.device-is('tablet') {
+      margin-bottom: var(--pix-spacing-10x);
+    }
   }
 }
 
@@ -122,102 +97,23 @@
   }
 }
 
-.certification-start-page__order {
-  display: block;
-  margin-top: 5px;
-  margin-bottom: 5px;
-  color: var(--pix-neutral-800);
-  font-size: 1.25rem;
-  font-family: fonts.$font-open-sans;
-  line-height: 28px;
+.certification-start-page__cgu {
+  margin: var(--pix-spacing-2x) var(--pix-spacing-10x);
+  line-height: 18px;
+  text-align: justify;
+
+  @extend %pix-body-xs;
+}
+
+.certification-start-page__form {
   text-align: center;
 }
 
-.certification-start-page__cgu {
-  margin: 5px 30px;
-  color: var(--pix-neutral-800);
-  font-size: 0.75rem;
-  line-height: 18px;
-  text-align: justify;
-}
-
-.certification-start-page__session-code-input {
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
-  align-items: center;
-  margin-top: 20px;
-  margin-bottom: 15px;
-}
-
-#certificationStarterSessionCode {
-  @extend %pix-monospace;
-
-  $space-between-dashes: 0.6ch;
-  $nb-characters: 6;
-  $total-width: $nb-characters * (1ch + $space-between-dashes);
-
-  display: inline-block;
-  box-sizing: content-box;
-  width: $total-width;
-  height: 50px;
-  padding: 0 0.2ch 1px 0.5ch;
-  font-size: 1.875rem;
-  letter-spacing: $space-between-dashes;
-  text-transform: uppercase;
-  background: repeating-linear-gradient(
-      90deg,
-      var(--pix-neutral-100) 0,
-      var(--pix-neutral-100) 1ch,
-      transparent 0,
-      transparent 1ch + $space-between-dashes
-    )
-    0 100% / #{$total-width - $space-between-dashes} 2px no-repeat;
-  background-position-x: 0.5ch;
-  background-position-y: 2.5ch;
-  border: solid 2px var(--pix-neutral-100);
-  border-radius: 3px;
-  outline: none;
-
-  @media all and (-ms-high-contrast: none) {
-    $ie11-modifier: 1.162;
-    $space-between-dashes: $ie11-modifier * 0.6ch;
-    $total-width: $nb-characters * ($ie11-modifier * 1.2ch + $space-between-dashes);
-
-    width: $total-width;
-    padding: 0 0 1px 1ch;
-
-    // display differently for IE because 1 character (ch) is equal to 1.162
-    line-height: 0.7;
-    letter-spacing: $space-between-dashes;
-    background: repeating-linear-gradient(
-        90deg,
-        var(--pix-neutral-100) 0,
-        var(--pix-neutral-100) 1.3ch,
-        transparent 0,
-        transparent 1.3ch + $space-between-dashes
-      )
-      0 100% / #{$total-width - $space-between-dashes} 2px no-repeat;
-    background-position-x: 0.1ch * $ie11-modifier;
-    background-position-y: 2.8ch * $ie11-modifier;
-    background-origin: content-box;
-  }
-
-  &:focus {
-    color: var(--pix-neutral-800);
-    outline: none;
-  }
+.certification-start-page__error-message {
+  display: inline-flex;
+  margin-top: var(--pix-spacing-4x);
 }
 
 .certification-start-page__field-button {
-  display: flex;
-  justify-content: center;
-  margin-top: 25px;
-  margin-bottom: 25px;
-}
-
-.certification-start-page__submit_button {
-  width: content-box;
-  min-width: 150px;
-  white-space: nowrap;
+  margin: var(--pix-spacing-6x) auto;
 }

--- a/mon-pix/tests/integration/components/certification-starter-test.js
+++ b/mon-pix/tests/integration/components/certification-starter-test.js
@@ -193,6 +193,28 @@ module('Integration | Component | certification-starter', function (hooks) {
   });
 
   module('#submit', function () {
+    module('when access code is not provided', function () {
+      test('should display an error message', async function (assert) {
+        // given
+        this.set('certificationCandidateSubscription', { sessionId: 123 });
+        const screen = await render(
+          hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}} />`,
+        );
+        await fillIn(
+          screen.getByRole('textbox', {
+            name: `${t('pages.certification-start.access-code')} *`,
+          }),
+          '',
+        );
+
+        // when
+        await clickByLabel(t('pages.certification-start.actions.submit'));
+
+        // then
+        assert.dom(screen.getByText(t('pages.certification-start.error-messages.missing-code'))).exists();
+      });
+    });
+
     module('when access code is provided', function () {
       module('when the creation of certification course is successful', function () {
         test('should redirect to certifications.resume', async function (assert) {
@@ -228,10 +250,15 @@ module('Integration | Component | certification-starter', function (hooks) {
           routerObserver.replaceWith = sinon.stub();
 
           this.set('certificationCandidateSubscription', { sessionId: 123 });
-          await render(
+          const screen = await render(
             hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}} />`,
           );
-          await fillIn('#certificationStarterSessionCode', 'ABC123');
+          await fillIn(
+            screen.getByRole('textbox', {
+              name: `${t('pages.certification-start.access-code')} *`,
+            }),
+            'ABC123',
+          );
           routerObserver.replaceWith.returns('ok');
 
           // when
@@ -285,7 +312,12 @@ module('Integration | Component | certification-starter', function (hooks) {
           const screen = await render(
             hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}} />`,
           );
-          await fillIn('#certificationStarterSessionCode', 'ABC123');
+          await fillIn(
+            screen.getByRole('textbox', {
+              name: `${t('pages.certification-start.access-code')} *`,
+            }),
+            'ABC123',
+          );
           certificationCourse.save.rejects({ errors: [{ status: '404' }] });
 
           // when
@@ -322,7 +354,12 @@ module('Integration | Component | certification-starter', function (hooks) {
           const screen = await render(
             hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}} />`,
           );
-          await fillIn('#certificationStarterSessionCode', 'ABC123');
+          await fillIn(
+            screen.getByRole('textbox', {
+              name: `${t('pages.certification-start.access-code')} *`,
+            }),
+            'ABC123',
+          );
           certificationCourse.save.rejects({ errors: [{ status: '404' }] });
 
           // when
@@ -358,7 +395,12 @@ module('Integration | Component | certification-starter', function (hooks) {
           const screen = await render(
             hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}} />`,
           );
-          await fillIn('#certificationStarterSessionCode', 'ABC123');
+          await fillIn(
+            screen.getByRole('textbox', {
+              name: `${t('pages.certification-start.access-code')} *`,
+            }),
+            'ABC123',
+          );
           certificationCourse.save.rejects({ errors: [{ status: '412' }] });
 
           // when
@@ -395,7 +437,12 @@ module('Integration | Component | certification-starter', function (hooks) {
             const screen = await render(
               hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}} />`,
             );
-            await fillIn('#certificationStarterSessionCode', 'ABC123');
+            await fillIn(
+              screen.getByRole('textbox', {
+                name: `${t('pages.certification-start.access-code')} *`,
+              }),
+              'ABC123',
+            );
             certificationCourse.save.rejects({
               errors: [{ status: '403', code: 'CANDIDATE_NOT_AUTHORIZED_TO_JOIN_SESSION' }],
             });
@@ -435,7 +482,12 @@ module('Integration | Component | certification-starter', function (hooks) {
             const screen = await render(
               hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}} />`,
             );
-            await fillIn('#certificationStarterSessionCode', 'ABC123');
+            await fillIn(
+              screen.getByRole('textbox', {
+                name: `${t('pages.certification-start.access-code')} *`,
+              }),
+              'ABC123',
+            );
             certificationCourse.save.rejects({
               errors: [{ status: '403', code: 'CANDIDATE_NOT_AUTHORIZED_TO_RESUME_SESSION' }],
             });
@@ -477,7 +529,12 @@ module('Integration | Component | certification-starter', function (hooks) {
             const screen = await render(
               hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}} />`,
             );
-            await fillIn('#certificationStarterSessionCode', 'ABC123');
+            await fillIn(
+              screen.getByRole('textbox', {
+                name: `${t('pages.certification-start.access-code')} *`,
+              }),
+              'ABC123',
+            );
             certificationCourse.save.throws(new Error("Détails de l'erreur à envoyer à Pix"));
 
             // when

--- a/mon-pix/tests/integration/components/certifications/start-test.gjs
+++ b/mon-pix/tests/integration/components/certifications/start-test.gjs
@@ -33,7 +33,7 @@ module('Integration | Component | Certifications | start', function (hooks) {
     );
 
     // then
-    assert.dom(screen.queryByRole('heading', { level: 2, name: t('pages.certification-start.first-title') })).exists();
+    assert.dom(screen.queryByRole('heading', { level: 1, name: t('pages.certification-start.first-title') })).exists();
   });
 
   test('it displays companion blocker page when extension is disabled', async function (assert) {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -800,6 +800,7 @@
         "candidate-not-authorized-to-resume": "Please contact your invigilator to resume your certification test.",
         "candidate-not-authorized-to-start": "Your invigilator has not confirmed your presence in the test room. Therefore, you cannot start your certification test yet. Please inform your invigilator.",
         "generic": "An unexpected server error has occurred.",
+        "missing-code": "You have not entered your access code.",
         "session-not-accessible": "The certification session is no longer available.",
         "unknown": {
           "summary-label": "Show more details:"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -806,6 +806,7 @@
         "candidate-not-authorized-to-resume": "Ponte en contacto con el supervisor para que autorice la reanudación de tu examen.",
         "candidate-not-authorized-to-start": "El supervisor no ha confirmado tu presencia en la sala de prueba. Por lo tanto, aún no puedes empezar la prueba de certificación. Por favor, informa al supervisor.",
         "generic": "Acaba de producirse un error inesperado en el servidor.",
+        "missing-code": "You have not entered your access code.",
         "session-not-accessible": "La sesión de certificación ya no está disponible.",
         "unknown": {
           "summary-label": "Ver más detalles:"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -800,6 +800,7 @@
         "candidate-not-authorized-to-resume": "Merci de contacter votre surveillant afin qu'il autorise la reprise de votre test.",
         "candidate-not-authorized-to-start": "Votre surveillant n’a pas confirmé votre présence dans la salle de test. Vous ne pouvez donc pas encore commencer votre test de certification. Merci de prévenir votre surveillant.",
         "generic": "Une erreur serveur inattendue vient de se produire.",
+        "missing-code": "Votre code d'accès n'est pas renseigné.",
         "session-not-accessible": "La session de certification n'est plus accessible.",
         "unknown": {
           "summary-label": "Afficher plus de détails :"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -806,6 +806,7 @@
         "candidate-not-authorized-to-resume": "Neem contact op met je surveillant om toestemming te vragen om je toets te hervatten.",
         "candidate-not-authorized-to-start": "Je surveillant heeft je aanwezigheid in de testruimte nog niet bevestigd. Je kunt daarom nog niet beginnen met je certificeringstoets. Stel je surveillant hiervan op de hoogte.",
         "generic": "Er is zojuist een onverwachte serverfout opgetreden.",
+        "missing-code": "You have not entered your access code.",
         "session-not-accessible": "De certificeringssessie is niet langer toegankelijk.",
         "unknown": {
           "summary-label": "Bekijk meer details:"


### PR DESCRIPTION
## :pancakes: Problème
Actuellement les champs code sur Pix App ne sont pas des composants Pix UI

## :bacon: Proposition

Utiliser le nouveau composant PixCode.

## :bacon: Remarque

J'ai fait le choix de ne pas dépendre du label dispo avec PixCode mais d'utiliser un PixLabel extérieur, afin de pouvoir le centrer dans la page.
Le label étant beaucoup plus long que le champ, le fait de l'avoir collé coté gauche donnait un rendu étrange.


## :yum: Pour tester

Aller sur sur le formulaire d'entrée en certification et faire une non régression : 

7402 / firstname0-7402 / lastname0-7402 / 04/01/2000


- ne pas mettre de code et valider => erreur sous le champ
<img width="692" alt="Capture d’écran 2025-02-11 à 14 30 44" src="https://github.com/user-attachments/assets/4ac6434e-15bb-48e2-9386-034b1a996cde" />

- mettre un code au hasard => erreur sous le champ
- Si network en offline => détails d'erreur en plus

<img width="692" alt="Capture d’écran 2025-02-11 à 14 31 46" src="https://github.com/user-attachments/assets/0d35e29b-ec4c-4923-8e61-26e3949b70d2" />

- CAS PASSANT : mettre le code `SCOS56` et constater qu'on entre en certification
