### PR TITLE
[TECH] fix redis version

### DIFF
--- a/scalingo.json
+++ b/scalingo.json
@@ -31,7 +31,7 @@
     {
       "plan": "redis:redis-sandbox",
       "options": {
-        "version": "7.2.7"
+        "version": "7.2.5-1"
       }
     }
   ],


### PR DESCRIPTION
## :pancakes: Problème
Le déploiement des RA échoue sur osc-fr1 car la version de redis provisionnée par le fichier scalingo n'existe plus sur osc-fr1.

## :bacon: Proposition
fix la version demandée