### PR TITLE
[FEATURE] Mesurer l'utilisation du bouton "Télécharger" des attestations (PIX-14954)

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/attestation-result.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/attestation-result.gjs
@@ -11,6 +11,7 @@ import kebabCase from 'lodash/kebabCase';
 export default class AttestationResult extends Component {
   @service session;
   @service fileSaver;
+  @service metrics;
   @service intl;
 
   get result() {
@@ -23,7 +24,7 @@ export default class AttestationResult extends Component {
 
   @action async onClick() {
     const { access_token: token, user_id: userId } = this.session.data.authenticated;
-
+    this.sendMetrics();
     const url = `/api/users/${userId}/attestations/${this.result.reward.key}`;
     const fileName = kebabCase(deburr(this.intl.t(this.resultTitle)));
 
@@ -32,6 +33,15 @@ export default class AttestationResult extends Component {
     } catch {
       this.args.onError();
     }
+  }
+
+  sendMetrics() {
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Fin de parcours',
+      'pix-event-action': 'Cliquer sur le bouton Télécharger (attestation)',
+      'pix-event-name': 'Clic sur le bouton Télécharger (attestation)',
+    });
   }
 
   <template>

--- a/orga/app/controllers/authenticated/attestations.js
+++ b/orga/app/controllers/authenticated/attestations.js
@@ -9,12 +9,14 @@ export default class AuthenticatedAttestationsController extends Controller {
   @service fileSaver;
   @service session;
   @service currentUser;
+  @service metrics;
   @service notifications;
   @service intl;
 
   @action
   async downloadSixthGradeAttestationsFile(selectedDivisions) {
     try {
+      this.sendMetrics();
       let url;
       const organizationId = this.currentUser.organization.id;
       const baseUrl = `/api/organizations/${organizationId}/attestations/${SIXTH_GRADE_ATTESTATION_KEY}`;
@@ -41,5 +43,14 @@ export default class AuthenticatedAttestationsController extends Controller {
     } catch (error) {
       this.notifications.sendError(error.message, { autoClear: false });
     }
+  }
+
+  sendMetrics() {
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Attestations',
+      'pix-event-action': 'Cliquer sur le bouton Télécharger sur la page Attestations',
+      'pix-event-name': 'Clic sur le bouton Télécharger (attestations)',
+    });
   }
 }

--- a/orga/tests/unit/controllers/authenticated/attestations-test.js
+++ b/orga/tests/unit/controllers/authenticated/attestations-test.js
@@ -58,6 +58,23 @@ module('Unit | Controller | authenticated/attestations', function (hooks) {
           }),
         );
       });
+      test('should call send metrics when download button is clicked', async function (assert) {
+        const metrics = this.owner.lookup('service:metrics');
+        metrics.add = sinon.stub();
+        const controller = this.owner.lookup('controller:authenticated/attestations');
+        const selectedDivision = ['3èmea'];
+
+        //when
+        await controller.downloadSixthGradeAttestationsFile(selectedDivision);
+
+        sinon.assert.calledWithExactly(metrics.add, {
+          event: 'custom-event',
+          'pix-event-category': 'Attestations',
+          'pix-event-action': 'Cliquer sur le bouton Télécharger sur la page Attestations',
+          'pix-event-name': 'Clic sur le bouton Télécharger (attestations)',
+        });
+        assert.ok(true);
+      });
     });
 
     module('when selected divisions is empty', function () {


### PR DESCRIPTION
## :pancakes: Problème

On souhaite mesurer le nombre de clics sur le bouton "Téléchargement" pour les attestations, à la fois côté prescrit et prescripteur.

## :bacon: Proposition

On ajoute deux appels à des custom-event Matomo, un dans Pix App et un côté Orga.

## 🧃 Remarques

## :yum: Pour tester

Se connecter sur Matomo, et vérifier dans "Visit Logs" de "Local test" que les events partent correctement.
Checker la console du navigateur pour voir les appels à piwik partir.
