### PR TITLE
[FEATURE] Page de fin de module : changer le bouton "revenir aux détails du module"(PIX-16426)

### DIFF
--- a/mon-pix/app/components/module/instruction/recap.gjs
+++ b/mon-pix/app/components/module/instruction/recap.gjs
@@ -31,8 +31,8 @@ import ModuleBetaBanner from 'mon-pix/components/module/layout/beta-banner';
       </div>
     {{/if}}
     <div class="module-recap__link-details">
-      <PixButtonLink @model={{@module.id}} @size="large" @route="module.details" @variant="secondary">
-        {{t "pages.modulix.recap.backToModuleDetails"}}
+      <PixButtonLink @size="large" @route="authenticated.user-dashboard" @variant="secondary">
+        {{t "pages.modulix.recap.goToHomepage"}}
       </PixButtonLink>
     </div>
   </main>

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
@@ -5,12 +5,15 @@ import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
+import { authenticate } from '../../helpers/authentication';
 import setupIntl from '../../helpers/setup-intl';
 
 module('Acceptance | Module | Routes | navigateIntoTheModuleRecap', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   setupIntl(hooks);
+
+  let user;
 
   module('when user arrive on the module recap page', function (hooks) {
     let screen;
@@ -20,6 +23,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleRecap', function (ho
         type: 'text',
         content: '<h3>content</h3>',
       };
+      user = server.create('user', 'withEmail');
 
       const grain = server.create('grain', {
         id: 'grain1',
@@ -38,6 +42,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleRecap', function (ho
           objectives: ['Objectif #1'],
         },
       });
+      await authenticate(user);
 
       screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
       await clickByName('Terminer');
@@ -50,14 +55,14 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleRecap', function (ho
     });
 
     module('when module has status beta', function () {
-      test('should display the links to details button and to form builder', async function (assert) {
+      test('should display the links to homepage button and to form builder', async function (assert) {
         // when
         const formLink = screen.getByRole('link', { name: t('pages.modulix.recap.goToForm') });
 
         // then
         const passage = server.schema.passages.all().models[0];
         assert.ok(formLink);
-        assert.ok(screen.queryByRole('link', { name: t('pages.modulix.recap.backToModuleDetails') }));
+        assert.ok(screen.queryByRole('link', { name: t('pages.modulix.recap.goToHomepage') }));
         assert.strictEqual(
           formLink.getAttribute('href'),
           `https://form-eu.123formbuilder.com/71180/modulix-experimentation?2850087=${passage.id}`,
@@ -65,12 +70,12 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleRecap', function (ho
       });
     });
 
-    test('should navigate to details page by clicking on back to module details button', async function (assert) {
+    test('should navigate to homepage by clicking on go to homepage button', async function (assert) {
       // when
-      await click(screen.getByRole('link', { name: t('pages.modulix.recap.backToModuleDetails') }));
+      await click(screen.getByRole('link', { name: t('pages.modulix.recap.goToHomepage') }));
 
       // then
-      assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/details');
+      assert.strictEqual(currentURL(), '/accueil');
     });
   });
 });

--- a/mon-pix/tests/acceptance/module/retake_completed_module_test.js
+++ b/mon-pix/tests/acceptance/module/retake_completed_module_test.js
@@ -65,7 +65,7 @@ module('Acceptance | Module | Routes | retakeCompletedModule', function (hooks) 
     });
 
     // when
-    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+    let screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
     await click(screen.getByLabelText('I am the right answer!'));
 
     const verifyButton = screen.getByRole('button', { name: 'Vérifier' });
@@ -83,8 +83,7 @@ module('Acceptance | Module | Routes | retakeCompletedModule', function (hooks) 
       return screen.queryByRole('heading', { name: 'Bravo ! Module terminé', level: 1 });
     });
 
-    const backToDetailsButton = screen.getByRole('link', { name: 'Revenir aux détails du module' });
-    await click(backToDetailsButton);
+    screen = await visit('/modules/bien-ecrire-son-adresse-mail/');
 
     const startModuleButton = screen.getByRole('button', { name: 'Commencer le module' });
     await click(startModuleButton);

--- a/mon-pix/tests/integration/components/module/recap_test.gjs
+++ b/mon-pix/tests/integration/components/module/recap_test.gjs
@@ -112,4 +112,15 @@ module('Integration | Component | Module | Recap', function (hooks) {
     );
     assert.ok(screen.getByText('Objectif 1'));
   });
+
+  test('should display link to go to homepage', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const module = store.createRecord('module', { id: 'mon-slug', title: 'Module title', isBeta: true });
+    // when
+    const screen = await render(<template><ModuleRecap @module={{module}} /></template>);
+
+    // then
+    assert.dom(screen.getByRole('link', { name: 'Continuer mon expérience sur Pix' })).exists();
+  });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1636,6 +1636,7 @@
       "recap": {
         "backToModuleDetails": "Back to module details",
         "goToForm": "Answer the questionnaire",
+        "goToHomepage": "Continue my Pix experience",
         "subtitle": "You have achieved the following objectives:",
         "title": "Congratulations! Module completed"
       },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1644,6 +1644,7 @@
       },
       "recap": {
         "backToModuleDetails": "Volver a los detalles del módulo",
+        "goToHomepage": "Continuar mi experiencia Pix",
         "goToForm": "Responder al cuestionario",
         "subtitle": "Has alcanzado los siguientes objetivos:",
         "title": "¡Enhorabuena! Módulo completado"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1636,6 +1636,7 @@
       "recap": {
         "backToModuleDetails": "Revenir aux détails du module",
         "goToForm": "Répondre au questionnaire",
+        "goToHomepage": "Continuer mon expérience sur Pix",
         "subtitle": "Vous avez atteint les objectifs suivants :",
         "title": "Bravo ! Module terminé"
       },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1644,6 +1644,7 @@
       },
       "recap": {
         "backToModuleDetails": "Terug naar moduledetails",
+        "goToHomepage": "Mijn Pix-ervaring voortzetten",
         "goToForm": "Beantwoord de vragenlijst",
         "subtitle": "Je hebt de volgende doelen bereikt:",
         "title": "Gefeliciteerd! Module voltooid"


### PR DESCRIPTION
## :pancakes: Problème

Après avoir fini le module, afficher un bouton dans le récap pour aller sur la page d'accueil Pix, et non sur le détail du module.

## :bacon: Proposition

Changer le label et la route de redirection du bouton "Revenir aux détails du module"

## 🧃 Remarques

RAS

## :yum: Pour tester

- Se rendre sur la page d'un module : https://app-pr11359.review.pix.fr/modules/didacticiel-modulix/details
- Commencer le module, et le parcourir entièrement pour arriver sur la page de détails
- Vérifier que le bouton "continuer mon expérience sur Pix" apparaît bien
- Cliquer sur ce bouton, vous devez être redirigé sur la page d'accueil de Pix
- Si vous n'êtes pas connecté, vous devez être redirigé vers la page de Connexion
