### PR TITLE
[TECH] Utiliser l'`AssessmentResult.status` dans les manipulations de CSV de certification (PIX-16458)

### DIFF
--- a/api/src/certification/results/infrastructure/repositories/certificate-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certificate-repository.js
@@ -212,7 +212,6 @@ function _selectShareableCertificates() {
           ORDER BY "competence-marks"."competence_code" asc
         )`),
     })
-
     .where('assessment-results.status', AssessmentResult.status.VALIDATED)
     .where('certification-courses.isPublished', true)
     .where('certification-courses.isCancelled', false);

--- a/api/src/certification/results/infrastructure/repositories/certification-result-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certification-result-repository.js
@@ -46,6 +46,7 @@ const findByCertificationCandidateIds = async function ({ certificationCandidate
 export { findByCertificationCandidateIds, findBySessionId };
 
 function _selectCertificationResults() {
+  // isCancelled will be removed
   return knex
     .select({
       id: 'certification-courses.id',

--- a/api/src/certification/results/infrastructure/serializers/shareable-certificate-serializer.js
+++ b/api/src/certification/results/infrastructure/serializers/shareable-certificate-serializer.js
@@ -38,7 +38,6 @@ const attributes = [
   'firstName',
   'deliveredAt',
   'isPublished',
-  'isCancelled',
   'lastName',
   'pixScore',
   'resultCompetenceTree',

--- a/api/src/shared/domain/models/CertificationResult.js
+++ b/api/src/shared/domain/models/CertificationResult.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import { CompetenceMark } from '../../../certification/shared/domain/models/CompetenceMark.js';
 import { ComplementaryCertificationCourseResult } from '../../../certification/shared/domain/models/ComplementaryCertificationCourseResult.js';
 import { JuryComment, JuryCommentContexts } from '../../../certification/shared/domain/models/JuryComment.js';
+import { AssessmentResult } from './AssessmentResult.js';
 
 /**
  * @readonly
@@ -79,7 +80,11 @@ class CertificationResult {
 
   static from({ certificationResultDTO }) {
     let certificationStatus;
-    if (certificationResultDTO.isCancelled) {
+    // isCancelled will be removed
+    if (
+      certificationResultDTO.isCancelled ||
+      certificationResultDTO.assessmentResultStatus === AssessmentResult.status.CANCELLED
+    ) {
       certificationStatus = status.CANCELLED;
     } else {
       certificationStatus = certificationResultDTO?.assessmentResultStatus ?? status.STARTED;

--- a/api/tests/certification/results/integration/infrastructure/repositories/certificate-repository_test.js
+++ b/api/tests/certification/results/integration/infrastructure/repositories/certificate-repository_test.js
@@ -2,7 +2,7 @@ import * as certificateRepository from '../../../../../../src/certification/resu
 import { AutoJuryCommentKeys } from '../../../../../../src/certification/shared/domain/models/JuryComment.js';
 import { SESSIONS_VERSIONS } from '../../../../../../src/certification/shared/domain/models/SessionVersion.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
-import { AssessmentResult, status } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
+import { AssessmentResult } from '../../../../../../src/shared/domain/models/index.js';
 import {
   catchErr,
   databaseBuilder,
@@ -1050,7 +1050,10 @@ describe('Integration | Infrastructure | Repository | Certification', function (
           certificationCenterId,
         });
 
-        _buildCertificationAttestationWithSeveralResults(certificationAttestationData, status.VALIDATED);
+        _buildCertificationAttestationWithSeveralResults(
+          certificationAttestationData,
+          AssessmentResult.status.VALIDATED,
+        );
         _linkCertificationAttestationToOrganization({
           certificationAttestationData,
           organizationLearnerId: 55,
@@ -1070,7 +1073,10 @@ describe('Integration | Infrastructure | Repository | Certification', function (
           certificationCenterId,
           version: SESSIONS_VERSIONS.V2,
         });
-        _buildCertificationAttestationWithSeveralResults(certificationAttestationDataRejected, status.REJECTED);
+        _buildCertificationAttestationWithSeveralResults(
+          certificationAttestationDataRejected,
+          AssessmentResult.status.REJECTED,
+        );
         const candidate = databaseBuilder.factory.buildCertificationCandidate({
           userId: 456,
           sessionId: certificationAttestationDataRejected.sessionId,
@@ -1284,7 +1290,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
       databaseBuilder.factory.buildAssessmentResult.last({
         certificationCourseId,
         pixScore: privateCertificateData.pixScore,
-        status: 'validated',
+        status: AssessmentResult.status.VALIDATED,
       });
 
       await databaseBuilder.commit();
@@ -1336,7 +1342,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
       databaseBuilder.factory.buildAssessmentResult.last({
         certificationCourseId,
         pixScore: privateCertificateData.pixScore,
-        status: 'validated',
+        status: AssessmentResult.status.VALIDATED,
       });
 
       await databaseBuilder.commit();
@@ -1389,7 +1395,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
       databaseBuilder.factory.buildAssessmentResult.last({
         certificationCourseId,
         pixScore: privateCertificateData.pixScore,
-        status: 'rejected',
+        status: AssessmentResult.status.REJECTED,
       });
       await databaseBuilder.commit();
 
@@ -1592,7 +1598,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
       databaseBuilder.factory.buildAssessmentResult({
         certificationCourseId,
         pixScore: privateCertificateData.pixScore,
-        status: 'validated',
+        status: AssessmentResult.status.VALIDATED,
       });
       await databaseBuilder.commit();
 
@@ -1645,7 +1651,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
       databaseBuilder.factory.buildAssessmentResult.last({
         certificationCourseId,
         pixScore: privateCertificateData.pixScore,
-        status: 'validated',
+        status: AssessmentResult.status.VALIDATED,
       });
       await databaseBuilder.commit();
 
@@ -1699,7 +1705,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
       databaseBuilder.factory.buildAssessmentResult.last({
         certificationCourseId,
         pixScore: privateCertificateData.pixScore,
-        status: 'rejected',
+        status: AssessmentResult.status.REJECTED,
       });
       await databaseBuilder.commit();
 
@@ -2222,7 +2228,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
       databaseBuilder.factory.buildAssessmentResult({
         assessmentId,
         pixScore: shareableCertificateData.pixScore,
-        status: 'validated',
+        status: AssessmentResult.status.CANCELLED,
       });
       await databaseBuilder.commit();
 
@@ -2274,7 +2280,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
       databaseBuilder.factory.buildAssessmentResult({
         assessmentId,
         pixScore: shareableCertificateData.pixScore,
-        status: 'validated',
+        status: AssessmentResult.status.VALIDATED,
       });
       await databaseBuilder.commit();
 
@@ -2326,7 +2332,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
       databaseBuilder.factory.buildAssessmentResult({
         assessmentId,
         pixScore: shareableCertificateData.pixScore,
-        status: 'rejected',
+        status: AssessmentResult.status.REJECTED,
       });
       await databaseBuilder.commit();
 
@@ -2703,7 +2709,7 @@ function _buildRejected(certificationAttestationData) {
   databaseBuilder.factory.buildAssessmentResult.last({
     certificationCourseId: certificationAttestationData.id,
     pixScore: certificationAttestationData.pixScore,
-    status: 'rejected',
+    status: AssessmentResult.status.REJECTED,
   });
 }
 
@@ -2754,7 +2760,7 @@ async function _buildValidPrivateCertificate(privateCertificateData, buildCompet
   const assessmentResultId = databaseBuilder.factory.buildAssessmentResult.last({
     certificationCourseId,
     pixScore: privateCertificateData.pixScore,
-    status: 'validated',
+    status: AssessmentResult.status.VALIDATED,
     commentForCandidate: privateCertificateData.commentForCandidate,
     commentByAutoJury: privateCertificateData.commentByAutoJury,
     createdAt: new Date('2021-01-01'),
@@ -2795,7 +2801,7 @@ async function _buildValidPrivateCertificateWithSeveralResults(privateCertificat
   const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult.last({
     certificationCourseId,
     pixScore: privateCertificateData.pixScore,
-    status: 'validated',
+    status: AssessmentResult.status.VALIDATED,
     commentForCandidate: privateCertificateData.commentForCandidate,
     createdAt: new Date('2021-03-01'),
   });
@@ -2827,7 +2833,7 @@ function _buildValidCertificationAttestation(certificationAttestationData, build
   const assessmentResultId = databaseBuilder.factory.buildAssessmentResult.last({
     certificationCourseId: certificationAttestationData.id,
     pixScore: certificationAttestationData.pixScore,
-    status: 'validated',
+    status: AssessmentResult.status.VALIDATED,
     createdAt: new Date('2020-01-02'),
   }).id;
 
@@ -2852,7 +2858,10 @@ function _buildSession({ userId, sessionId, publishedAt, certificationCenter }) 
   });
 }
 
-function _buildCertificationAttestationWithSeveralResults(certificationAttestationData, status = 'validated') {
+function _buildCertificationAttestationWithSeveralResults(
+  certificationAttestationData,
+  status = AssessmentResult.status.VALIDATED,
+) {
   databaseBuilder.factory.buildCertificationCourse({
     id: certificationAttestationData.id,
     firstName: certificationAttestationData.firstName,
@@ -2873,7 +2882,7 @@ function _buildCertificationAttestationWithSeveralResults(certificationAttestati
   const assessmentResultId1 = databaseBuilder.factory.buildAssessmentResult({
     assessmentId,
     pixScore: certificationAttestationData.pixScore,
-    status: 'rejected',
+    status: AssessmentResult.status.REJECTED,
     createdAt: new Date('2019-01-01'),
   }).id;
   const assessmentResultId2 = databaseBuilder.factory.buildAssessmentResult.last({
@@ -2942,7 +2951,7 @@ async function _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
   databaseBuilder.factory.buildAssessmentResult.last({
     certificationCourseId,
     pixScore: privateCertificateData.pixScore,
-    status: 'validated',
+    status: AssessmentResult.status.VALIDATED,
     commentForCandidate: privateCertificateData.commentForCandidate,
     createdAt: new Date('2021-01-01'),
   });
@@ -3011,7 +3020,7 @@ async function _buildValidShareableCertificate(shareableCertificateData, buildCo
   const assessmentResultId = databaseBuilder.factory.buildAssessmentResult.last({
     certificationCourseId: shareableCertificateData.id,
     pixScore: shareableCertificateData.pixScore,
-    status: 'validated',
+    status: AssessmentResult.status.VALIDATED,
     createdAt: new Date('2020-01-02'),
   }).id;
 
@@ -3051,7 +3060,7 @@ async function _buildValidShareableCertificateWithAcquiredBadges({ shareableCert
   const assessmentResultId = databaseBuilder.factory.buildAssessmentResult.last({
     certificationCourseId,
     pixScore: shareableCertificateData.pixScore,
-    status: 'validated',
+    status: AssessmentResult.status.VALIDATED,
   }).id;
 
   acquiredBadges?.forEach(

--- a/api/tests/certification/results/integration/infrastructure/repositories/certification-result-repository_test.js
+++ b/api/tests/certification/results/integration/infrastructure/repositories/certification-result-repository_test.js
@@ -1,7 +1,7 @@
 import * as certificationResultRepository from '../../../../../../src/certification/results/infrastructure/repositories/certification-result-repository.js';
 import { ComplementaryCertificationCourseResult } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationCourseResult.js';
 import { AutoJuryCommentKeys } from '../../../../../../src/certification/shared/domain/models/JuryComment.js';
-import { CertificationResult } from '../../../../../../src/shared/domain/models/index.js';
+import { AssessmentResult, CertificationResult } from '../../../../../../src/shared/domain/models/index.js';
 import { databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Certification | Results | Integration | Infrastructure | Repository | Certification Result', function () {
@@ -49,13 +49,13 @@ describe('Certification | Results | Integration | Infrastructure | Repository | 
       const assessmentResultId1 = databaseBuilder.factory.buildAssessmentResult.last({
         certificationCourseId: certificationCourseId1,
         pixScore: 123,
-        status: CertificationResult.status.VALIDATED,
+        status: AssessmentResult.status.VALIDATED,
         commentForOrganization: 'Un commentaire orga 1',
       }).id;
       databaseBuilder.factory.buildAssessmentResult.last({
         certificationCourseId: certificationCourseId2,
         pixScore: 0,
-        status: CertificationResult.status.REJECTED,
+        status: AssessmentResult.status.REJECTED,
         commentForOrganization: 'Un commentaire orga 2',
       }).id;
       databaseBuilder.factory.buildCompetenceMark({
@@ -162,7 +162,7 @@ describe('Certification | Results | Integration | Infrastructure | Repository | 
       const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({
         assessmentId,
         pixScore: 123,
-        status: CertificationResult.status.VALIDATED,
+        status: AssessmentResult.status.VALIDATED,
         commentForOrganization: 'Un commentaire orga 1',
       }).id;
       databaseBuilder.factory.buildCompetenceMark({
@@ -543,8 +543,14 @@ describe('Certification | Results | Integration | Infrastructure | Repository | 
       databaseBuilder.factory.buildAssessmentResult.last({
         certificationCourseId: certificationCourseId2,
         pixScore: 0,
-        status: CertificationResult.status.REJECTED,
+        status: AssessmentResult.status.REJECTED,
         commentForOrganization: 'Un commentaire orga 2',
+      }).id;
+      databaseBuilder.factory.buildAssessmentResult.last({
+        certificationCourseId: certificationCourseId3,
+        pixScore: 0,
+        status: AssessmentResult.status.CANCELLED,
+        commentForOrganization: 'Un commentaire orga',
       }).id;
 
       databaseBuilder.factory.buildCompetenceMark({
@@ -625,13 +631,13 @@ describe('Certification | Results | Integration | Infrastructure | Repository | 
         createdAt: new Date('2020-10-10'),
         sessionId,
         status: CertificationResult.status.CANCELLED,
-        pixScore: null,
+        pixScore: 0,
         commentForOrganization: domainBuilder.certification.shared.buildJuryComment.organization({
-          fallbackComment: null,
+          fallbackComment: 'Un commentaire orga',
         }),
         competencesWithMark: [],
         complementaryCertificationCourseResults: [],
-        emitter: null,
+        emitter: 'PIX-ALGO',
       });
       const expectedThirdCertificationResult = domainBuilder.buildCertificationResult({
         id: certificationCourseId1,
@@ -690,7 +696,7 @@ describe('Certification | Results | Integration | Infrastructure | Repository | 
       const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({
         assessmentId,
         pixScore: 123,
-        status: CertificationResult.status.VALIDATED,
+        status: AssessmentResult.status.VALIDATED,
         commentForOrganization: 'Un commentaire orga 1',
       }).id;
       databaseBuilder.factory.buildCompetenceMark({

--- a/api/tests/unit/domain/models/CertificationResult_test.js
+++ b/api/tests/unit/domain/models/CertificationResult_test.js
@@ -126,6 +126,7 @@ describe('Unit | Domain | Models | CertificationResult', function () {
       });
     });
 
+    // isCancelled will be removed
     context('status', function () {
       // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
@@ -134,7 +135,7 @@ describe('Unit | Domain | Models | CertificationResult', function () {
           statusName: 'cancelled',
           isCancelled: true,
 
-          assessmentResultStatus: CERTIFICATION_RESULT_STATUS_VALIDATED,
+          assessmentResultStatus: CERTIFICATION_RESULT_STATUS_CANCELLED,
           validationFunction: 'isCancelled',
         },
         {


### PR DESCRIPTION
## :pancakes: Problème

Nous utilisons QUE le `isCancelled` de la certification. 

## :bacon: Proposition

Déprécier le `isCancelled` de la certification pour utiliser le statut de l'`AssessmentResult`.

## 🧃 Remarques

`isCancelled` a été supprimé du serializer car il n'était pas du tout utilisé dans le `toDomain` par la suite.

## :yum: Pour tester

api/sessions/download-all-results
Elle retourne tous les résultats de certifications d'une session, sous format CSV

/api/sessions/download-results/{token}
Elle retourne les résultats de certifications d'une session agrégés par email de destinataire des résultats, sous format CSV


/api/organizations/{organizationId}/certification-results
Elle retourne les certifications liées à l'organisation sous forme de fichier CSV