### PR TITLE
[TECH] renome le filtre badge en acquiredThematicResults (Pix-16349)

### DIFF
--- a/api/db/seeds/data/team-prescription/build-target-profiles.js
+++ b/api/db/seeds/data/team-prescription/build-target-profiles.js
@@ -70,7 +70,7 @@ async function _createTargetProfileWithBadgesStages(databaseBuilder) {
     cappedTubesDTO,
     badgeId: BADGES_TUBES_CAMP_ID,
     altMessage: '1 RT double critère Campaign & Tubes',
-    imageUrl: 'some_image.svg',
+    imageUrl: 'https://images.pix.fr/badges/Badge_OLYMPIX.svg',
     message: '1 RT double critère Campaign & Tubes',
     title: '1 RT double critère Campaign & Tubes',
     key: `SOME_KEY_FOR_RT_${BADGES_TUBES_CAMP_ID}`,
@@ -84,7 +84,7 @@ async function _createTargetProfileWithBadgesStages(databaseBuilder) {
     cappedTubesDTO,
     badgeId: BADGES_CAMP_ID,
     altMessage: '1 RT simple critère Campaign',
-    imageUrl: 'some_other_image.svg',
+    imageUrl: 'https://images.pix.fr/badges/abcpix/Jevalue_des_informations.svg',
     message: '1 RT simple critère Campaign',
     title: '1 RT simple critère Campaign',
     key: `SOME_KEY_FOR_RT_${BADGES_CAMP_ID}`,
@@ -92,6 +92,7 @@ async function _createTargetProfileWithBadgesStages(databaseBuilder) {
     isAlwaysVisible: true,
     configBadge,
   });
+
   await createStages({
     databaseBuilder,
     targetProfileId,

--- a/api/src/prescription/campaign/application/campaign-results-controller.js
+++ b/api/src/prescription/campaign/application/campaign-results-controller.js
@@ -14,8 +14,8 @@ const findAssessmentParticipationResults = async function (request) {
   if (filters.groups && !Array.isArray(filters.groups)) {
     filters.groups = [filters.groups];
   }
-  if (filters.badges && !Array.isArray(filters.badges)) {
-    filters.badges = [filters.badges];
+  if (filters.acquiredThematicResults && !Array.isArray(filters.acquiredThematicResults)) {
+    filters.acquiredThematicResults = [filters.acquiredThematicResults];
   }
   if (filters.stages && !Array.isArray(filters.stages)) {
     filters.stages = [filters.stages];

--- a/api/src/prescription/campaign/application/campaign-results-route.js
+++ b/api/src/prescription/campaign/application/campaign-results-route.js
@@ -19,7 +19,7 @@ const register = async function (server) {
             filter: Joi.object({
               divisions: Joi.array().items(Joi.string()),
               groups: Joi.array().items(Joi.string()),
-              badges: [Joi.number().integer(), Joi.array().items(Joi.number().integer())],
+              acquiredThematicResults: [Joi.number().integer(), Joi.array().items(Joi.number().integer())],
               stages: [Joi.number().integer(), Joi.array().items(Joi.number().integer())],
               search: Joi.string().empty(''),
             }).default({}),

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-assessment-participation-result-list-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-assessment-participation-result-list-repository.js
@@ -32,7 +32,7 @@ function _getParticipantsResultList(campaignId, stageCollection, filters) {
     .with('campaign_participation_summaries', (qb) => _getParticipations(qb, campaignId, stageCollection, filters))
     .select('*')
     .from('campaign_participation_summaries')
-    .modify(_filterByBadgeAcquisitionsOut, filters)
+    .modify(_filterByThematicResultAcquisitionsOut, filters)
     .orderByRaw('LOWER(??) ASC, LOWER(??) ASC', ['lastName', 'firstName']);
 }
 
@@ -75,7 +75,7 @@ function _getParticipations(qb, campaignId, stageCollection, filters) {
     .where('campaign-participations.deletedAt', 'IS', null)
     .modify(_filterByDivisions, filters)
     .modify(_filterByGroups, filters)
-    .modify(_addAcquiredBadgeIds, filters)
+    .modify(_addAcquiredThematicResultsIds, filters)
     .modify(_filterByStage, stageCollection, filters)
     .modify(_filterBySearch, filters)
     .modify(_orderBy, filters);
@@ -115,8 +115,8 @@ function _filterBySearch(queryBuilder, filters) {
   }
 }
 
-function _addAcquiredBadgeIds(queryBuilder, filters) {
-  if (filters.badges) {
+function _addAcquiredThematicResultsIds(queryBuilder, filters) {
+  if (filters.acquiredThematicResults) {
     queryBuilder
       .select(knex.raw('ARRAY_AGG("badgeId") OVER (PARTITION BY "campaign-participations"."id") as badges_acquired'))
       .join('badge-acquisitions', 'badge-acquisitions.campaignParticipationId', 'campaign-participations.id')
@@ -133,15 +133,15 @@ function _orderBy(queryBuilder, filters) {
       nulls: 'last',
     },
   ];
-  if (filters.badges) {
+  if (filters.acquiredThematicResults) {
     orderByClauses.unshift({ column: 'campaign-participations.id' });
   }
   queryBuilder.orderBy(orderByClauses);
 }
 
-function _filterByBadgeAcquisitionsOut(queryBuilder, filters) {
-  if (filters.badges) {
-    queryBuilder.whereRaw(':badgeIds <@ "badges_acquired"', { badgeIds: filters.badges });
+function _filterByThematicResultAcquisitionsOut(queryBuilder, filters) {
+  if (filters.acquiredThematicResults) {
+    queryBuilder.whereRaw(':badgeIds <@ "badges_acquired"', { badgeIds: filters.acquiredThematicResults });
   }
 }
 

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
@@ -769,7 +769,7 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
       });
     });
 
-    context('when there is a filter on badges', function () {
+    context('when there is a filter on acquired thematic results', function () {
       let badge1;
       let badge2;
       let user1;
@@ -802,7 +802,7 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
         databaseBuilder.factory.learningContent.build(learningContentObjects);
         await databaseBuilder.commit();
       });
-      it('returns participants which have one badge', async function () {
+      it('returns participants which have one thematic result', async function () {
         const campaignParticipation1 = databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
           userId: user1.id,
@@ -837,7 +837,7 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
         // when
         const { participations } = await campaignAssessmentParticipationResultListRepository.findPaginatedByCampaignId({
           campaignId: campaign.id,
-          filters: { badges: [badge1.id] },
+          filters: { acquiredThematicResults: [badge1.id] },
         });
 
         const participantExternalIds = participations.map((result) => result.participantExternalId);
@@ -846,7 +846,7 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
         expect(participantExternalIds).to.exactlyContain(['The good']);
       });
 
-      it('returns participants which have several badges', async function () {
+      it('returns participants which have several thematic results', async function () {
         const campaignParticipation1 = databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
           userId: user1.id,
@@ -879,7 +879,7 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
         // when
         const { participations } = await campaignAssessmentParticipationResultListRepository.findPaginatedByCampaignId({
           campaignId: campaign.id,
-          filters: { badges: [badge1.id, badge2.id] },
+          filters: { acquiredThematicResults: [badge1.id, badge2.id] },
         });
 
         const participantExternalIds = participations.map((result) => result.participantExternalId);

--- a/orga/app/components/campaign/filter/participation-filters.gjs
+++ b/orga/app/components/campaign/filter/participation-filters.gjs
@@ -147,8 +147,8 @@ export default class ParticipationFilters extends Component {
   }
 
   @action
-  onSelectBadge(badges) {
-    this.args.onFilter('badges', badges);
+  onSelectBadge(acquiredThematicResults) {
+    this.args.onFilter('acquiredThematicResults', acquiredThematicResults);
   }
 
   @action

--- a/orga/app/controllers/authenticated/campaigns/campaign/assessment-results.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/assessment-results.js
@@ -11,7 +11,7 @@ export default class AssessmentResultsController extends Controller {
   @tracked pageSize = 50;
   @tracked divisions = [];
   @tracked groups = [];
-  @tracked badges = [];
+  @tracked acquiredThematicResults = [];
   @tracked stages = [];
   @tracked search = null;
 
@@ -42,7 +42,7 @@ export default class AssessmentResultsController extends Controller {
     this.pageNumber = null;
     this.divisions = [];
     this.groups = [];
-    this.badges = [];
+    this.acquiredThematicResults = [];
     this.stages = [];
     this.search = null;
   }

--- a/orga/app/routes/authenticated/campaigns/campaign/assessment-results.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/assessment-results.js
@@ -19,7 +19,7 @@ export default class AssessmentResultsRoute extends Route {
     groups: {
       refreshModel: true,
     },
-    badges: {
+    acquiredThematicResults: {
       refreshModel: true,
     },
     stages: {
@@ -54,7 +54,7 @@ export default class AssessmentResultsRoute extends Route {
       filter: {
         divisions: params.divisions,
         groups: params.groups,
-        badges: params.badges,
+        acquiredThematicResults: params.acquiredThematicResults,
         stages: params.stages,
         search: params.search,
       },
@@ -68,7 +68,7 @@ export default class AssessmentResultsRoute extends Route {
       controller.pageSize = 50;
       controller.divisions = [];
       controller.groups = [];
-      controller.badges = [];
+      controller.acquiredThematicResults = [];
       controller.stages = [];
       controller.search = null;
     }

--- a/orga/app/templates/authenticated/campaigns/campaign/assessment-results.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/assessment-results.hbs
@@ -19,7 +19,7 @@
     @participations={{@model.participations}}
     @selectedDivisions={{this.divisions}}
     @selectedGroups={{this.groups}}
-    @selectedBadges={{this.badges}}
+    @selectedBadges={{this.acquiredThematicResults}}
     @selectedStages={{this.stages}}
     @searchFilter={{this.search}}
     @onClickParticipant={{this.goToAssessmentPage}}

--- a/orga/tests/integration/components/campaign/filter/participation-filters-test.js
+++ b/orga/tests/integration/components/campaign/filter/participation-filters-test.js
@@ -424,7 +424,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         await click(await screen.findByRole('checkbox', { name: 'Les bases' }));
 
         // then
-        assert.ok(triggerFiltering.calledWith('badges', ['badge1']));
+        assert.ok(triggerFiltering.calledWith('acquiredThematicResults', ['badge1']));
       });
     });
 

--- a/orga/tests/unit/controllers/authenticated/campaigns/campaign/assessment-results-test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/campaign/assessment-results-test.js
@@ -43,7 +43,7 @@ module('Unit | Controller | authenticated/campaigns/campaign/assessment-results'
       controller.set('pageNumber', 1);
       controller.set('divisions', ['3eme']);
       controller.set('groups', ['L1']);
-      controller.set('badges', ['badge1']);
+      controller.set('acquiredThematicResult', ['thematic-result']);
       controller.set('stages', ['stage1']);
       controller.set('search', 'dam');
 
@@ -55,7 +55,7 @@ module('Unit | Controller | authenticated/campaigns/campaign/assessment-results'
       assert.deepEqual(controller.search, null);
       assert.deepEqual(controller.divisions, []);
       assert.deepEqual(controller.groups, []);
-      assert.deepEqual(controller.badges, []);
+      assert.deepEqual(controller.acquiredThematicResults, []);
       assert.deepEqual(controller.stages, []);
     });
   });

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/assessment-results-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/assessment-results-test.js
@@ -24,7 +24,7 @@ module('Unit | Route | authenticated/campaigns/campaign/assessment-results', fun
         pageSize: 2,
         divisions: ['4eme'],
         groups: [],
-        badges: [],
+        acquiredThematicResults: [],
         stages: [],
         search: null,
         campaignId: 3,
@@ -44,7 +44,7 @@ module('Unit | Route | authenticated/campaigns/campaign/assessment-results', fun
           filter: {
             divisions: params.divisions,
             groups: params.groups,
-            badges: params.badges,
+            acquiredThematicResults: params.acquiredThematicResults,
             stages: params.stages,
             search: params.search,
           },
@@ -84,10 +84,10 @@ module('Unit | Route | authenticated/campaigns/campaign/assessment-results', fun
         assert.deepEqual(controller.groups, []);
       });
 
-      test('it reset badges', function (assert) {
-        const controller = { badges: ['10'] };
+      test('it reset acquiredThematicResults', function (assert) {
+        const controller = { acquiredThematicResults: ['10'] };
         route.resetController(controller, true);
-        assert.deepEqual(controller.badges, []);
+        assert.deepEqual(controller.acquiredThematicResults, []);
       });
 
       test('it reset stages', function (assert) {


### PR DESCRIPTION
## :pancakes: Problème

Dans le cadre de l'amélioration de la page résultat de pixorga, on souhaite rajouter un filtre sur les résultats thématiques non atteints. Or le filtre actuel des résultats thématiques s'appelle badge (comme la table en bdd), on souhaite donc clarifier le nom du filtre

## :bacon: Proposition
On propose de renommer le nom en `acquiredThematicResults` 

## 🧃 Remarques

Renommage à minima (j'ai pas touché aux nom des relations / model ember / serializers and co)

## :yum: Pour tester
- Allez sur orga
- afficher les resultat de la campagne SCOASSMUL
- filter par RT
