### PR TITLE
[FEATURE] Filtrer les SSO sur la page de connexion de Pix app (PIX-16391)

### DIFF
--- a/api/OIDC_PROVIDERS.example.json
+++ b/api/OIDC_PROVIDERS.example.json
@@ -21,6 +21,27 @@
     }
   },
   {
+    "identityProvider": "oidcFromSeeds2",
+    "organizationName": "SEEDS2",
+    "scope": "openid profile",
+    "slug": "seeds2",
+    "source": "sso-oidc-seeds",
+    "clientId": "XXX",
+    "clientSecret": "YYY",
+    "accessTokenLifespan": "48h",
+    "enabled": true,
+    "openidConfigurationUrl": "https://seeds.example.net/.well-known/openid-configuration",
+    "redirectUri": "https://app.dev.pix.org/connexion/seeds",
+    "shouldCloseSession": true,
+    "openidClientExtraMetadata": {
+      "token_endpoint_auth_method": "client_secret_post"
+    },
+    "additionalRequiredProperties": {
+      "logoutUrl": "https://seeds.example.net/logout",
+      "afterLogoutUrl": "https://app.dev.pix.org"
+    }
+  },
+  {
     "identityProvider": "oidcFromSeedsNotVisible",
     "organizationName": "SEEDSNOTVISIBLE",
     "scope": "openid profile",

--- a/api/src/identity-access-management/domain/services/oidc-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/oidc-authentication-service.js
@@ -44,6 +44,7 @@ export class OidcAuthenticationService {
       scope = DEFAULT_SCOPE,
       slug,
       source,
+      isVisible = true,
       claimMapping,
     },
     { sessionTemporaryStorage = defaultSessionTemporaryStorage } = {},
@@ -66,6 +67,7 @@ export class OidcAuthenticationService {
     this.sessionTemporaryStorage = sessionTemporaryStorage;
     this.slug = slug;
     this.source = source;
+    this.isVisible = isVisible;
 
     claimMapping = claimMapping || DEFAULT_CLAIM_MAPPING;
 

--- a/api/src/identity-access-management/infrastructure/serializers/jsonapi/oidc-identity-providers.serializer.js
+++ b/api/src/identity-access-management/infrastructure/serializers/jsonapi/oidc-identity-providers.serializer.js
@@ -12,9 +12,10 @@ const serialize = function (oidcIdentityProviders) {
         slug: oidcIdentityProvider.slug,
         shouldCloseSession: oidcIdentityProvider.shouldCloseSession,
         source: oidcIdentityProvider.source,
+        isVisible: oidcIdentityProvider.isVisible,
       };
     },
-    attributes: ['code', 'organizationName', 'slug', 'shouldCloseSession', 'source'],
+    attributes: ['code', 'organizationName', 'slug', 'shouldCloseSession', 'source', 'isVisible'],
   }).serialize(oidcIdentityProviders);
 };
 

--- a/api/tests/identity-access-management/acceptance/application/oidc-provider.admin.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/oidc-provider.admin.route.test.js
@@ -82,6 +82,7 @@ describe('Acceptance | Identity Access Management | Route | Admin | oidc-provide
             slug: 'oidc-example-net',
             'should-close-session': true,
             source: 'oidcexamplenet',
+            'is-visible': true,
           },
         },
       ]);

--- a/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
@@ -47,6 +47,7 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
             slug: 'oidc-example-net',
             'should-close-session': true,
             source: 'oidcexamplenet',
+            'is-visible': true,
           },
         },
       ]);

--- a/api/tests/identity-access-management/unit/application/oidc-provider.admin.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/oidc-provider.admin.controller.test.js
@@ -110,12 +110,14 @@ describe('Unit | Identity Access Management | Application | Controller | Admin |
           code: 'LIMONADE_OIDC_PROVIDER',
           source: 'limonade_oidc_provider',
           organizationName: 'Limonade OIDC Provider',
+          isVisible: true,
           slug: 'limonade-oidc-provider',
           shouldCloseSession: false,
         },
         {
           code: 'KOMBUCHA_OIDC_PROVIDER',
           source: 'kombucha_oidc_provider',
+          isVisible: true,
           organizationName: 'Kombucha OIDC Provider',
           slug: 'kombucha-oidc-provider',
           shouldCloseSession: true,
@@ -139,6 +141,7 @@ describe('Unit | Identity Access Management | Application | Controller | Admin |
             slug: 'limonade-oidc-provider',
             'should-close-session': false,
             source: 'limonade_oidc_provider',
+            'is-visible': true,
           },
         },
         {
@@ -150,6 +153,7 @@ describe('Unit | Identity Access Management | Application | Controller | Admin |
             slug: 'kombucha-oidc-provider',
             'should-close-session': true,
             source: 'kombucha_oidc_provider',
+            'is-visible': true,
           },
         },
       ]);

--- a/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
@@ -251,6 +251,7 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
         {
           code: 'SOME_OIDC_PROVIDER',
           source: 'some_oidc_provider',
+          isVisible: true,
           organizationName: 'Some OIDC Provider',
           slug: 'some-oidc-provider',
           shouldCloseSession: false,
@@ -273,6 +274,7 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
           'organization-name': 'Some OIDC Provider',
           slug: 'some-oidc-provider',
           'should-close-session': false,
+          'is-visible': true,
         },
       });
     });

--- a/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service_test.js
+++ b/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service_test.js
@@ -34,6 +34,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         // then
         expect(oidcAuthenticationService.shouldCloseSession).to.be.false;
         expect(oidcAuthenticationService.scope).to.equal('openid profile');
+        expect(oidcAuthenticationService.isVisible).to.equal(true);
       });
     });
 

--- a/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/oidc-identity-providers.serializer.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/oidc-identity-providers.serializer.test.js
@@ -7,7 +7,14 @@ describe('Unit | Identity Access Management | Infrastructure | Serializer | JSON
       // given
       const code = 'OIDC_PARTNER';
       const organizationName = 'Partenaire OIDC';
-      const oidc = { slug: 'oidc-partner', code, organizationName, source: 'oidc-external', shouldCloseSession: true };
+      const oidc = {
+        slug: 'oidc-partner',
+        code,
+        organizationName,
+        source: 'oidc-external',
+        shouldCloseSession: true,
+        isVisible: true,
+      };
 
       // when
       const json = serializer.serialize(oidc);
@@ -23,6 +30,7 @@ describe('Unit | Identity Access Management | Infrastructure | Serializer | JSON
             slug: 'oidc-partner',
             'should-close-session': true,
             source: 'oidc-external',
+            'is-visible': true,
           },
         },
       };

--- a/mon-pix/app/components/authentication/oidc-provider-selector.gjs
+++ b/mon-pix/app/components/authentication/oidc-provider-selector.gjs
@@ -10,10 +10,9 @@ export default class OidcProviderSelector extends Component {
   get providerOptions() {
     const { providers = [] } = this.args;
 
-    const options = providers.map((provider) => ({
-      label: provider.organizationName,
-      value: provider.id,
-    }));
+    const options = providers.reduce((acc, provider) => {
+      return provider.isVisible ? [...acc, { label: provider.organizationName, value: provider.id }] : acc;
+    }, []);
 
     return options.sort((option1, option2) => option1.label.localeCompare(option2.label));
   }

--- a/mon-pix/app/models/oidc-identity-provider.js
+++ b/mon-pix/app/models/oidc-identity-provider.js
@@ -6,4 +6,5 @@ export default class OidcIdentityProvider extends Model {
   @attr() slug;
   @attr() shouldCloseSession;
   @attr() source;
+  @attr() isVisible;
 }

--- a/mon-pix/mirage/routes/authentication/oidc/index.js
+++ b/mon-pix/mirage/routes/authentication/oidc/index.js
@@ -44,6 +44,7 @@ export default function (config) {
             slug: 'partenaire-oidc',
             'should-close-session': false,
             source: 'oidc-externe',
+            'is-visible': true,
           },
         },
       ],

--- a/mon-pix/tests/integration/components/authentication/oidc-provider-selector-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/oidc-provider-selector-test.gjs
@@ -17,18 +17,18 @@ module('Integration | Component | Authentication | oidc-provider-selector', func
   setupIntlRenderingTest(hooks);
 
   test('it displays an Oidc Provider selector with correct labels', async function (assert) {
-    //given
+    // given
     const providers = [
-      { id: '1', organizationName: 'ConnectEtMoi' },
-      { id: '2', organizationName: 'StarConnect' },
+      { id: '1', organizationName: 'ConnectEtMoi', isVisible: true },
+      { id: '2', organizationName: 'StarConnect', isVisible: true },
     ];
 
-    //when
+    // when
     const screen = await render(<template><OidcProviderSelector @providers={{providers}} /></template>);
     await click(screen.getByRole('button', { name: t(I18N_KEYS.selectLabel) }));
     await screen.findByRole('listbox');
 
-    //then
+    // then
     assert.dom(screen.getAllByText(t(I18N_KEYS.selectPlaceholder))[0]).exists();
     assert.dom(screen.getByText(t(I18N_KEYS.searchLabel))).exists();
     assert.dom(screen.getByText('ConnectEtMoi')).isVisible();
@@ -37,9 +37,9 @@ module('Integration | Component | Authentication | oidc-provider-selector', func
   test('it displays a sorted list of oidc providers', async function (assert) {
     // given
     const providers = [
-      { id: '1', organizationName: 'Third' },
-      { id: '2', organizationName: 'Second' },
-      { id: '3', organizationName: 'First' },
+      { id: '1', organizationName: 'Third', isVisible: true },
+      { id: '2', organizationName: 'Second', isVisible: true },
+      { id: '3', organizationName: 'First', isVisible: true },
     ];
 
     // when
@@ -54,12 +54,31 @@ module('Integration | Component | Authentication | oidc-provider-selector', func
     assert.deepEqual(optionsLabels, ['First', 'Second', 'Third']);
   });
 
+  test('it displays only visible oidc providers', async function (assert) {
+    // given
+    const providers = [
+      { id: '1', organizationName: 'Third', isVisible: true },
+      { id: '2', organizationName: 'Second', isVisible: true },
+      { id: '3', organizationName: 'First', isVisible: false },
+    ];
+
+    // when
+    const screen = await render(<template><OidcProviderSelector @providers={{providers}} /></template>);
+    await click(screen.getByRole('button', { name: t(I18N_KEYS.selectLabel) }));
+    await screen.findByRole('listbox');
+
+    // then
+    assert.dom(screen.getByText('Third')).exists();
+    assert.dom(screen.getByText('Second')).exists();
+    assert.dom(screen.queryByText('First')).doesNotExist();
+  });
+
   module('when user selects a provider', function () {
     test('it triggers the onProviderChange property', async function (assert) {
       // given
       const providers = [
-        { id: '1', organizationName: 'ConnectEtMoi' },
-        { id: '2', organizationName: 'StarConnect' },
+        { id: '1', organizationName: 'ConnectEtMoi', isVisible: true },
+        { id: '2', organizationName: 'StarConnect', isVisible: true },
       ];
 
       const onProviderChangeStub = sinon.stub();

--- a/mon-pix/tests/integration/components/authentication/sso-selection-form-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/sso-selection-form-test.gjs
@@ -10,10 +10,10 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 class OidcProvidersServiceStub extends Service {
   get list() {
     return [
-      { id: 'cem', code: 'CEM', organizationName: 'ConnectEtMoi' },
-      { id: 'sc', code: 'SC', organizationName: 'StarConnect' },
-      { id: 'hidden1', code: 'FWB', organizationName: 'Not displayed provider 1' },
-      { id: 'hidden2', code: 'GOOGLE', organizationName: 'Not displayed provider 2' },
+      { id: 'cem', code: 'CEM', organizationName: 'ConnectEtMoi', isVisible: true },
+      { id: 'sc', code: 'SC', organizationName: 'StarConnect', isVisible: true },
+      { id: 'hidden1', code: 'FWB', organizationName: 'Not displayed provider 1', isVisible: true },
+      { id: 'hidden2', code: 'GOOGLE', organizationName: 'Not displayed provider 2', isVisible: true },
     ];
   }
 }


### PR DESCRIPTION
Cette pr est la succession des pr #11335 et #11344. Elle doit être mergée après.

## :pancakes: Problème

Après avoir ajouté la colone dans la table "oidc-providers" et modifié l'API, on ajoute le filtre sur le sélecteur de SSO.

## :bacon: Proposition

Modifier le serializer de l'API pour prendre en compte le paramètre "isVisible" et l'ajouter dans pix app.

## 🧃 Remarques

On a également modifié Mirage pour inclure le paramètre "isVisible", ainsi que le fichier des exemples oidc.

## :yum: Pour tester
- Se rendre sur Pix App,
- Cliquer sur "Choisir une autre organisation",
- Constater que les organisations "Seed1" et "seed2" apparaissent,
- Se connecter à la RA via la ligne de commande:
```shell
scalingo -a pix-api-review-pr11363 psql-console
```
- Entrer cette commande:
```sql
SELECT "identityProvider", "isVisible" FROM "oidc-providers";
```
- Constater l'affichage suivant:
```sql
identityProvider     | isVisible 
-------------------------+-----------
 oidcFromSeeds           | t
 oidcFromSeedsNotVisible | f
 oidcFromSeeds2          | t
(3 rows)
```