### PR TITLE
[TECH] Déprécie l'utilisation du `isCancelled` au profit du status du dernier `AssessmentResult`

### DIFF
--- a/api/db/database-builder/factory/build-certification-course.js
+++ b/api/db/database-builder/factory/build-certification-course.js
@@ -5,6 +5,7 @@ import { databaseBuffer } from '../database-buffer.js';
 import { buildSession } from './build-session.js';
 import { buildUser } from './build-user.js';
 
+// isCancelled will be removed
 const buildCertificationCourse = function ({
   id = databaseBuffer.getNextId(),
   lastName = 'last-name',

--- a/api/db/seeds/data/common/tooling/session-tooling.js
+++ b/api/db/seeds/data/common/tooling/session-tooling.js
@@ -260,6 +260,7 @@ async function createStartedSession({
   certificationCandidates.forEach((certificationCandidate) => {
     if (!certificationCandidate.userId) return;
 
+    // isCancelled will be removed
     const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
       userId: certificationCandidate.userId,
       sessionId,
@@ -1100,6 +1101,7 @@ function _makeCandidatesPassCertification({
   configSession,
 }) {
   for (const certificationCandidate of certificationCandidates) {
+    // isCancelled will be removed
     const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
       userId: certificationCandidate.userId,
       sessionId,

--- a/api/src/certification/enrolment/domain/models/PixCertification.js
+++ b/api/src/certification/enrolment/domain/models/PixCertification.js
@@ -1,5 +1,12 @@
 export class PixCertification {
   constructor({ pixScore, status, isCancelled, isRejectedForFraud }) {
+    /**
+     * @param {Object} props
+     * @param {number} props.pixScore
+     * @param {string} props.status
+     * @param {boolean} props.isCancelled - will be removed
+     * @param {boolean} props.isRejectedForFraud
+     *    */
     this.pixScore = pixScore;
     this.status = status;
     this.isCancelled = isCancelled;

--- a/api/src/certification/enrolment/domain/usecases/get-user-certification-eligibility.js
+++ b/api/src/certification/enrolment/domain/usecases/get-user-certification-eligibility.js
@@ -172,6 +172,7 @@ function _getLowerLevelBadge(allComplementaryCertificationBadgesForSameTargetPro
 async function _getValidatedUserPixCertifications({ userId, pixCertificationRepository }) {
   const userPixCertifications = await pixCertificationRepository.findByUserId({ userId });
 
+  // isCancelled will be removed
   return userPixCertifications.filter(
     (pixCertification) =>
       !pixCertification.isCancelled &&

--- a/api/src/certification/enrolment/domain/usecases/verify-candidate-subscriptions.js
+++ b/api/src/certification/enrolment/domain/usecases/verify-candidate-subscriptions.js
@@ -124,6 +124,7 @@ function _doesNeedEligibilityCheck(session, candidate) {
 }
 
 function _hasValidCoreCertification(userPixCertifications) {
+  // isCancelled will be removed
   return _.some(
     userPixCertifications,
     (certification) =>
@@ -134,6 +135,7 @@ function _hasValidCoreCertification(userPixCertifications) {
 }
 
 function _getHighestUserValidPixScore(userPixCertifications) {
+  // isCancelled will be removed
   const validPixCertifications = _.chain(userPixCertifications)
     .filter(
       (pixCertification) =>

--- a/api/src/certification/enrolment/infrastructure/repositories/pix-certification-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/pix-certification-repository.js
@@ -2,6 +2,7 @@ import { knex } from '../../../../../db/knex-database-connection.js';
 import { PixCertification } from '../../domain/models/PixCertification.js';
 
 export async function findByUserId({ userId }) {
+  // isCancelled will be removed
   const results = await knex('certification-courses')
     .select(
       'certification-courses.isRejectedForFraud',

--- a/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
+++ b/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
@@ -105,6 +105,7 @@ export const handleV3CertificationScoring = async ({
     juryId: event?.juryId,
   });
 
+  // isCancelled will be removed
   if (_hasV3CertificationLacksOfAnswersForTechnicalReason({ allAnswers: candidateAnswers, certificationCourse })) {
     certificationCourse.cancel();
   }

--- a/api/src/certification/results/infrastructure/repositories/certificate-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certificate-repository.js
@@ -131,6 +131,7 @@ export {
 };
 
 function _selectCertificationAttestations() {
+  // isCancelled will be removed
   return _getCertificateQuery()
     .select({
       id: 'certification-courses.id',
@@ -190,6 +191,7 @@ function _selectPrivateCertificates() {
 }
 
 function _selectShareableCertificates() {
+  // isCancelled will be removed
   return _getCertificateQuery()
     .select({
       id: 'certification-courses.id',

--- a/api/src/certification/results/infrastructure/repositories/certification-livret-scolaire-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certification-livret-scolaire-repository.js
@@ -3,6 +3,7 @@ import { AssessmentResult } from '../../../../shared/domain/models/AssessmentRes
 import { Certificate } from '../../domain/read-models/livret-scolaire/Certificate.js';
 
 const getCertificatesByOrganizationUAI = async function (uai) {
+  // isCancelled will be removed
   const result = await knex
     .select({
       id: 'certification-courses.id',

--- a/api/src/certification/session-management/domain/services/session-publication-service.js
+++ b/api/src/certification/session-management/domain/services/session-publication-service.js
@@ -17,7 +17,7 @@ import { SessionAlreadyPublishedError } from '../errors.js';
 
 const { some, uniqBy } = lodash;
 
-import { status } from '../../../../shared/domain/models/AssessmentResult.js';
+import { AssessmentResult } from '../../../../shared/domain/models/AssessmentResult.js';
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 
 /**
@@ -42,9 +42,7 @@ async function publishSession({
 
   const certificationStatuses = await certificationRepository.getStatusesBySessionId(sessionId);
 
-  const hasCertificationInError = _hasCertificationInError(certificationStatuses);
-  const hasCertificationWithNoAssessmentResultStatus = _hasCertificationWithNoScoring(certificationStatuses);
-  if (hasCertificationInError || hasCertificationWithNoAssessmentResultStatus) {
+  if (_isAnyCertificationNotPublishable(certificationStatuses)) {
     throw new CertificationCourseNotPublishableError(sessionId);
   }
 
@@ -187,14 +185,23 @@ async function _updateFinalizedSession(finalizedSessionRepository, sessionId, pu
   await finalizedSessionRepository.save({ finalizedSession });
 }
 
+function _isAnyCertificationNotPublishable(certificationStatuses) {
+  const hasCertificationInError = _hasCertificationInError(certificationStatuses);
+  const hasCertificationWithNoAssessmentResultStatus = _hasCertificationWithNoScoring(certificationStatuses);
+  return hasCertificationInError || hasCertificationWithNoAssessmentResultStatus;
+}
+
 function _hasCertificationInError(certificationStatus) {
   return certificationStatus.some(
-    ({ pixCertificationStatus, isCancelled }) => pixCertificationStatus === status.ERROR && !isCancelled,
+    // DEPRECATED : isCancelled will be remove
+    ({ pixCertificationStatus, isCancelled }) =>
+      pixCertificationStatus === AssessmentResult.status.ERROR && !isCancelled,
   );
 }
 
 function _hasCertificationWithNoScoring(certificationStatuses) {
   return certificationStatuses.some(
+    // DEPRECATED : isCancelled will be remove
     ({ pixCertificationStatus, isCancelled }) => pixCertificationStatus === null && !isCancelled,
   );
 }

--- a/api/src/certification/session-management/domain/services/session-publication-service.js
+++ b/api/src/certification/session-management/domain/services/session-publication-service.js
@@ -193,7 +193,7 @@ function _isAnyCertificationNotPublishable(certificationStatuses) {
 
 function _hasCertificationInError(certificationStatus) {
   return certificationStatus.some(
-    // DEPRECATED : isCancelled will be remove
+    // DEPRECATED : isCancelled will be removed
     ({ pixCertificationStatus, isCancelled }) =>
       pixCertificationStatus === AssessmentResult.status.ERROR && !isCancelled,
   );

--- a/api/src/certification/session-management/infrastructure/repositories/certification-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/certification-repository.js
@@ -1,6 +1,7 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 
 const getStatusesBySessionId = async function (sessionId) {
+  // isCancelled will be removed
   return knex('certification-courses')
     .select({
       certificationCourseId: 'certification-courses.id',

--- a/api/src/certification/shared/domain/models/CertificationCourse.js
+++ b/api/src/certification/shared/domain/models/CertificationCourse.js
@@ -1,3 +1,10 @@
+/**
+ * @typedef {import('../../../../shared/domain/models/Assessment.js').Assessment} Assessment
+ * @typedef {import('../../../../shared/domain/models/Challenge.js').Challenge} Challenge
+ * @typedef {import('./CertificationIssueReport.js').CertificationIssueReport} CertificationIssueReport
+ * @typedef {import('../../../session-management/domain/models/ComplementaryCertificationCourse.js').ComplementaryCertificationCourse} ComplementaryCertificationCourse
+ * @typedef {import('./AlgorithmEngineVersion.js').AlgorithmEngineVersion} AlgorithmEngineVersion
+ */
 import JoiDate from '@joi/date';
 import BaseJoi from 'joi';
 import _ from 'lodash';
@@ -13,6 +20,38 @@ export const ABORT_REASONS = {
 };
 
 class CertificationCourse {
+  /**
+   * @param {Object} props
+   * @param {number} props.id
+   * @param {string} props.firstName
+   * @param {string} props.lastName
+   * @param {Date} props.birthdate
+   * @param {string} props.birthplace
+   * @param {string} props.birthPostalCode
+   * @param {string} props.birthINSEECode
+   * @param {string} props.birthCountry
+   * @param {string} props.sex
+   * @param {number} props.externalId
+   * @param {boolean} props.hasSeenEndTestScreen
+   * @param {Date} props.createdAt
+   * @param {Date} props.completedAt
+   * @param {boolean} props.isPublished
+   * @param {string} props.verificationCode
+   * @param {Assessment} props.assessment
+   * @param {Array<Challenge>} props.challenges
+   * @param {Array<CertificationIssueReport>} props.certificationIssueReports
+   * @param {number} props.userId
+   * @param {number} props.sessionId
+   * @param {Date} props.maxReachableLevelOnCertificationDate
+   * @param {boolean} props.isCancelled - will be removed
+   * @param {string} props.abortReason
+   * @param {Array<ComplementaryCertificationCourse>} props.complementaryCertificationCourses
+   * @param {number} props.numberOfChallenges
+   * @param {AlgorithmEngineVersion} props.version
+   * @param {boolean} props.isRejectedForFraud
+   * @param {boolean} props.isAdjustedForAccessibility
+   * @param {string} props.lang
+   */
   constructor({
     id,
     firstName,
@@ -119,14 +158,17 @@ class CertificationCourse {
     this._certificationIssueReports.push(issueReport);
   }
 
+  // isCancelled will be removed
   isCancelled() {
     return this._isCancelled;
   }
 
+  // isCancelled will be removed
   cancel() {
     this._isCancelled = true;
   }
 
+  // isCancelled will be removed
   uncancel() {
     this._isCancelled = false;
   }

--- a/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
@@ -260,6 +260,7 @@ function _adaptModelToDb(certificationCourse) {
 }
 
 function _pickUpdatableProperties(certificationCourse) {
+  // isCancelled will be removed
   return _.pick(certificationCourse.toDTO(), [
     'id',
     'isCancelled',

--- a/api/src/shared/domain/events/handle-certification-rescoring.js
+++ b/api/src/shared/domain/events/handle-certification-rescoring.js
@@ -134,6 +134,7 @@ async function _handleV3CertificationScoring({
     dependencies: { findByCertificationCourseId: services.findByCertificationCourseId },
   });
 
+  // isCancelled will be removed
   if (certificationCourse.isCancelled()) {
     await certificationCourseRepository.update({ certificationCourse });
   }

--- a/api/tests/certification/session-management/unit/domain/services/session-publication-service_test.js
+++ b/api/tests/certification/session-management/unit/domain/services/session-publication-service_test.js
@@ -9,7 +9,7 @@ import {
   manageEmails,
   publishSession,
 } from '../../../../../../src/certification/session-management/domain/services/session-publication-service.js';
-import { status } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
+import { AssessmentResult } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
 import { EmailingAttempt } from '../../../../../../src/shared/domain/models/index.js';
 import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
@@ -164,7 +164,7 @@ describe('Certification | Session Management | Unit | Domain | Services | sessio
             sharedSessionRepository.getWithCertificationCandidates.withArgs({ id: 'sessionId' }).resolves(session);
             certificationRepository.getStatusesBySessionId
               .withArgs('sessionId')
-              .resolves([{ pixCertificationStatus: status.ERROR }]);
+              .resolves([{ pixCertificationStatus: AssessmentResult.status.ERROR }]);
 
             // when
             const error = await catchErr(publishSession)({
@@ -182,6 +182,7 @@ describe('Certification | Session Management | Unit | Domain | Services | sessio
         });
 
         context('when the certification is cancelled', function () {
+          // DEPRECATED : will be remove when isCancelled will be remove
           it('should not throw', async function () {
             // given
             const session = domainBuilder.certification.sessionManagement.buildSession({
@@ -199,7 +200,7 @@ describe('Certification | Session Management | Unit | Domain | Services | sessio
             sharedSessionRepository.getWithCertificationCandidates.withArgs({ id: 'sessionId' }).resolves(session);
             certificationRepository.getStatusesBySessionId
               .withArgs('sessionId')
-              .resolves([{ pixCertificationStatus: status.ERROR, isCancelled: true }]);
+              .resolves([{ pixCertificationStatus: AssessmentResult.status.ERROR, isCancelled: true }]);
             finalizedSessionRepository.get.resolves(domainBuilder.buildFinalizedSession());
 
             // when/then
@@ -246,6 +247,7 @@ describe('Certification | Session Management | Unit | Domain | Services | sessio
           });
         });
         context('when the certification is cancelled', function () {
+          // DEPRECATED : will be remove when isCancelled will be remove
           it('should not throw', async function () {
             // given
             const session = domainBuilder.certification.sessionManagement.buildSession({


### PR DESCRIPTION
## :pancakes: Problème

Nous utilisons `isCancelled` de la certification

## :bacon: Proposition

S'assurer que l'utilisation du dernier `AssessmentResult` soit pris en compte.

## 🧃 Remarques

Concerne la publication de session : une certification en erreur mais non annulée ne peut être publiée.
Si on veut que l'annulation soit dans le statut on ne peut faire cohéxister les deux. Quid du statut en erreur ?

## :yum: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
