### PR TITLE
[TECH] Mettre à jour Pix-UI dans la dernière version sur Pix-Orga (PIX-16473)

### DIFF
--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -14,7 +14,7 @@
         "@1024pix/ember-matomo-tag-manager": "^2.4.3",
         "@1024pix/ember-testing-library": "^3.0.6",
         "@1024pix/eslint-plugin": "^2.0.5",
-        "@1024pix/pix-ui": "^54.6.0",
+        "@1024pix/pix-ui": "^54.8.0",
         "@1024pix/stylelint-config": "^5.1.27",
         "@babel/eslint-parser": "^7.25.9",
         "@babel/plugin-proposal-decorators": "^7.25.9",
@@ -908,9 +908,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "54.6.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-54.6.0.tgz",
-      "integrity": "sha512-5D6qAy7ShdEJYQQ7d3nZghjA0I0Mq1NCunR/vc+wLBHVjOoLyeFCOOdKKZ4RxVtB9uwWLrZZn3d0ZTNDf7ztDg==",
+      "version": "54.8.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-54.8.0.tgz",
+      "integrity": "sha512-CwTlW6JrZmdC4BxtTpTBp2iiJI393IlgJYrMzNv1+t47Uvu0QHSDqeuFZADlt+59nqXAT7Q5DEY7kOT7J5Xujg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/orga/package.json
+++ b/orga/package.json
@@ -58,7 +58,7 @@
     "@1024pix/ember-matomo-tag-manager": "^2.4.3",
     "@1024pix/ember-testing-library": "^3.0.6",
     "@1024pix/eslint-plugin": "^2.0.5",
-    "@1024pix/pix-ui": "^54.6.0",
+    "@1024pix/pix-ui": "^54.8.0",
     "@1024pix/stylelint-config": "^5.1.27",
     "@babel/eslint-parser": "^7.25.9",
     "@babel/plugin-proposal-decorators": "^7.25.9",


### PR DESCRIPTION
## :pancakes: Problème
La dernière version de PixUI embarque les changements effectués pour les icones dans la liste d'options d'un select

## :bacon: Proposition
Mettre a jour PixUI dans sa dernière version sur PixOrga

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

- CI Verte 🟢 💚 
- 🐈‍⬛ 
