### PR TITLE
[TECH] Déprécier l'utilisation du isCancelled au profit du status du dernier AssessmentResult sur Pix Admin (PIX-16470).

### DIFF
--- a/admin/app/components/certifications/certification/details-v3.gjs
+++ b/admin/app/components/certifications/certification/details-v3.gjs
@@ -13,9 +13,10 @@ import { t } from 'ember-intl';
 import { lt } from 'ember-truth-helpers';
 
 import DayjsFormatDuration from '../../../helpers/dayjs-format-duration';
+import { assessmentStates } from '../../../models/certification';
 import { AnswerStatus } from '../../../models/certification-challenges-for-administration';
 import { subcategoryToCode, subcategoryToLabel } from '../../../models/certification-issue-report';
-import { abortReasons, assessmentStates } from '../../../models/v3-certification-course-details-for-administration';
+import { abortReasons } from '../../../models/v3-certification-course-details-for-administration';
 
 const successColor = 'success';
 const errorColor = 'error';
@@ -100,9 +101,10 @@ export default class DetailsV3 extends Component {
   }
 
   get detailStatusLabel() {
-    const { assessmentResultStatus, isCancelled, isRejectedForFraud } = this.args.details;
-    if (isCancelled) {
-      return assessmentResultStatusLabelAndColor('cancelled').label;
+    const { assessmentResultStatus, isRejectedForFraud } = this.args.details;
+    // isCancelled will be removed
+    if (this.args.details.isCertificationCancelled) {
+      return assessmentResultStatusLabelAndColor(assessmentResultStatus).label;
     }
     if (isRejectedForFraud) {
       return assessmentResultStatusLabelAndColor('fraud').label;
@@ -111,8 +113,8 @@ export default class DetailsV3 extends Component {
   }
 
   get detailStatusColor() {
-    const { assessmentResultStatus, isCancelled, isRejectedForFraud } = this.args.details;
-    if (isCancelled) {
+    const { assessmentResultStatus, isRejectedForFraud } = this.args.details;
+    if (this.args.details.isCertificationCancelled) {
       return assessmentResultStatusLabelAndColor('cancelled').color;
     }
     if (isRejectedForFraud) {

--- a/admin/app/components/certifications/certification/informations.gjs
+++ b/admin/app/components/certifications/certification/informations.gjs
@@ -17,12 +17,18 @@ import CertificationComments from './comments';
 export default class Informations extends Component {
   get displayCancelCertificationButton() {
     return (
-      !this.args.certification.isCancelled && !this.args.certification.isPublished && this.args.session.finalizedAt
+      !this.args.certification.isCertificationCancelled &&
+      !this.args.certification.isPublished &&
+      this.args.session.finalizedAt
     );
   }
 
   get displayUncancelCertificationButton() {
-    return this.args.certification.isCancelled && !this.args.certification.isPublished && this.args.session.finalizedAt;
+    return (
+      this.args.certification.isCertificationCancelled &&
+      !this.args.certification.isPublished &&
+      this.args.session.finalizedAt
+    );
   }
 
   <template>

--- a/admin/app/components/certifications/info-tag.gjs
+++ b/admin/app/components/certifications/info-tag.gjs
@@ -5,7 +5,7 @@ import PixTag from '@1024pix/pix-ui/components/pix-tag';
     {{#if @record.isPublished}}
       <PixTag @color="success">Publiée</PixTag>
     {{/if}}
-    {{#if @record.isCancelled}}
+    {{#if @record.isCertificationCancelled}}
       <PixTag @color="error">Annulée</PixTag>
     {{/if}}
   </div>

--- a/admin/app/components/sessions/certifications/header.gjs
+++ b/admin/app/components/sessions/certifications/header.gjs
@@ -15,6 +15,7 @@ export default class CertificationsHeader extends Component {
   @tracked confirmMessage = null;
 
   get canPublish() {
+    // isCancelled will be removed
     return (
       !this.args.juryCertificationSummaries.some(
         (certification) => certification.status === 'error' && !certification.isCancelled,

--- a/admin/app/components/sessions/certifications/status.gjs
+++ b/admin/app/components/sessions/certifications/status.gjs
@@ -1,12 +1,15 @@
 import Component from '@glimmer/component';
 import includes from 'lodash/includes';
-import { ERROR, STARTED } from 'pix-admin/models/certification';
-import { ENDED_BY_SUPERVISOR } from 'pix-admin/models/jury-certification-summary';
+import { assessmentResultStatus, assessmentStates } from 'pix-admin/models/certification';
 
 export default class CertificationStatusComponent extends Component {
   get isStatusBlocking() {
-    const blokingStatuses = [STARTED, ERROR, ENDED_BY_SUPERVISOR];
-    return includes(blokingStatuses, this.args.record.status) || this.args.record.isFlaggedAborted;
+    const blockingStatuses = [
+      assessmentStates.STARTED,
+      assessmentResultStatus.ERROR,
+      assessmentStates.ENDED_BY_SUPERVISOR,
+    ];
+    return includes(blockingStatuses, this.args.record.status) || this.args.record.isFlaggedAborted;
   }
 
   <template>

--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -3,20 +3,27 @@ import { computed } from '@ember/object';
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import dayjs from 'dayjs';
 
-export const ACQUIRED = 'acquired';
-export const REJECTED = 'rejected';
-export const NOT_TAKEN = 'not_taken';
-export const partnerCertificationStatusToDisplayName = {
-  [ACQUIRED]: 'Validée',
-  [REJECTED]: 'Rejetée',
+export const assessmentStates = {
+  COMPLETED: 'completed',
+  STARTED: 'started',
+  ABORTED: 'aborted',
+  ENDED_BY_SUPERVISOR: 'endedBySupervisor',
+  ENDED_DUE_TO_FINALIZATION: 'endedDueToFinalization',
 };
-export const STARTED = 'started';
-export const ERROR = 'error';
+
+export const assessmentResultStatus = {
+  CANCELLED: 'cancelled',
+  ERROR: 'error',
+  VALIDATED: 'validated',
+  REJECTED: 'rejected',
+};
+
 export const certificationStatuses = [
-  { value: STARTED, label: 'Démarrée' },
-  { value: ERROR, label: 'En erreur' },
-  { value: 'validated', label: 'Validée' },
-  { value: 'rejected', label: 'Rejetée' },
+  { value: assessmentResultStatus.CANCELLED, label: 'Annulée' },
+  { value: assessmentStates.STARTED, label: 'Démarrée' },
+  { value: assessmentResultStatus.ERROR, label: 'En erreur' },
+  { value: assessmentResultStatus.VALIDATED, label: 'Validée' },
+  { value: assessmentResultStatus.REJECTED, label: 'Rejetée' },
 ];
 
 export default class Certification extends Model {
@@ -71,6 +78,11 @@ export default class Certification extends Model {
   get publishedText() {
     const value = this.isPublished;
     return value ? 'Oui' : 'Non';
+  }
+
+  // isCancelled will be removed
+  get isCertificationCancelled() {
+    return this.isCancelled || this.status === assessmentResultStatus.CANCELLED;
   }
 
   get hasComplementaryCertifications() {

--- a/admin/app/models/jury-certification-summary.js
+++ b/admin/app/models/jury-certification-summary.js
@@ -50,6 +50,7 @@ export default class JuryCertificationSummary extends Model {
 
   @computed('status', 'isCancelled')
   get statusLabel() {
+    // isCancelled will be removed
     if (this.isCancelled) return 'Annulée';
     const statusWithLabel = find(statuses, { value: this.status });
     return statusWithLabel?.label;

--- a/admin/app/models/jury-certification-summary.js
+++ b/admin/app/models/jury-certification-summary.js
@@ -4,10 +4,11 @@ import Model, { attr } from '@ember-data/model';
 import dayjs from 'dayjs';
 import find from 'lodash/find';
 
-import { certificationStatuses } from './certification';
+import { assessmentStates, certificationStatuses } from './certification';
 
-export const ENDED_BY_SUPERVISOR = 'endedBySupervisor';
-export const juryCertificationSummaryStatuses = [{ value: ENDED_BY_SUPERVISOR, label: 'Terminée par le surveillant' }];
+export const juryCertificationSummaryStatuses = [
+  { value: assessmentStates.ENDED_BY_SUPERVISOR, label: 'Terminée par le surveillant' },
+];
 
 const statuses = [...certificationStatuses, ...juryCertificationSummaryStatuses];
 export default class JuryCertificationSummary extends Model {

--- a/admin/app/models/v3-certification-course-details-for-administration.js
+++ b/admin/app/models/v3-certification-course-details-for-administration.js
@@ -1,21 +1,15 @@
 import Model, { attr, hasMany } from '@ember-data/model';
 import dayjs from 'dayjs';
+import { assessmentResultStatus, assessmentStates } from 'pix-admin/models/certification';
 
 const ONE_HOUR_45_MINUTES_IN_MS = 1 * 60 * 60 * 1000 + 45 * 60 * 1000;
-
-export const assessmentStates = {
-  COMPLETED: 'completed',
-  STARTED: 'started',
-  ABORTED: 'aborted',
-  ENDED_BY_SUPERVISOR: 'endedBySupervisor',
-  ENDED_DUE_TO_FINALIZATION: 'endedDueToFinalization',
-};
 
 export const abortReasons = {
   CANDIDATE: 'candidate',
   TECHNICAL: 'technical',
 };
 
+// isCancelled will be removed
 export default class V3CertificationCourseDetailsForAdministration extends Model {
   @attr('number') certificationCourseId;
   @attr('boolean') isRejectedForFraud;
@@ -50,6 +44,11 @@ export default class V3CertificationCourseDetailsForAdministration extends Model
 
   get wasCompleted() {
     return this.assessmentState === assessmentStates.COMPLETED;
+  }
+
+  // isCancelled will be removed
+  get isCertificationCancelled() {
+    return this.isCancelled || this.assessmentResultStatus === assessmentResultStatus.CANCELLED;
   }
 
   get numberOfOkAnswers() {

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -1,5 +1,6 @@
 import { applyEmberDataSerializers, discoverEmberDataModels } from 'ember-cli-mirage';
 import { createServer, Response } from 'miragejs';
+import { assessmentResultStatus } from 'pix-admin/models/certification';
 
 import { createAdminMember } from './handlers/admin-members';
 import {
@@ -561,7 +562,7 @@ function routes() {
   this.patch('/admin/certification-courses/:id/cancel', (schema, request) => {
     const certificationId = request.params.id;
     const certificationToUpdate = schema.certifications.find(certificationId);
-    certificationToUpdate.update({ isCancelled: true });
+    certificationToUpdate.update({ isCancelled: true, status: assessmentResultStatus.CANCELLED });
 
     return new Response(204);
   });
@@ -569,7 +570,7 @@ function routes() {
   this.patch('/admin/certification-courses/:id/uncancel', (schema, request) => {
     const certificationId = request.params.id;
     const certificationToUpdate = schema.certifications.find(certificationId);
-    certificationToUpdate.update({ isCancelled: false });
+    certificationToUpdate.update({ isCancelled: false, status: assessmentResultStatus.REJECTED });
 
     return new Response(204);
   });

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations-test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations-test.js
@@ -2,6 +2,7 @@ import { clickByName, fillByLabel, visit, within } from '@1024pix/ember-testing-
 import { click, currentURL } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { assessmentResultStatus } from 'pix-admin/models/certification';
 import { module, test } from 'qunit';
 
 import { authenticateAdminMemberWithRole } from '../../../../helpers/test-init';
@@ -45,6 +46,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
       birthInseeCode: '99217',
       birthPostalCode: null,
       version: 2,
+      status: assessmentResultStatus.REJECTED,
       competencesWithMark: [
         {
           id: 152825,
@@ -865,7 +867,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
       module('Uncancel', function (hooks) {
         let screen;
         hooks.beforeEach(async function () {
-          certification.update({ isCancelled: true });
+          certification.update({ isCancelled: true, status: assessmentResultStatus.CANCELLED });
         });
 
         module('when session is finalized and not published yet', function (hooks) {
@@ -912,6 +914,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
                 // given
                 await click(screen.getByRole('button', { name: 'Désannuler la certification' }));
                 await screen.findByRole('dialog');
+
                 // when
                 await clickByName('Confirmer');
 

--- a/admin/tests/integration/components/certifications/info-tag-test.gjs
+++ b/admin/tests/integration/components/certifications/info-tag-test.gjs
@@ -1,6 +1,7 @@
 import { render } from '@1024pix/ember-testing-library';
 import { setupRenderingTest } from 'ember-qunit';
 import InfoTag from 'pix-admin/components/certifications/info-tag';
+import { assessmentResultStatus } from 'pix-admin/models/certification';
 import { module, test } from 'qunit';
 
 module('Integration | Component | certifications/info-tag', function (hooks) {
@@ -35,7 +36,11 @@ module('Integration | Component | certifications/info-tag', function (hooks) {
   module('when certification is cancelled', function () {
     test('it renders cancelled tag', async function (assert) {
       // given
-      const certification = { isCancelled: true };
+      const store = this.owner.lookup('service:store');
+      const certification = store.createRecord('certification', {
+        isCancelled: true,
+        status: assessmentResultStatus.CANCELLED,
+      });
 
       // when
       const screen = await render(<template><InfoTag @record={{certification}} /></template>);

--- a/admin/tests/integration/components/sessions/certifications/status-test.gjs
+++ b/admin/tests/integration/components/sessions/certifications/status-test.gjs
@@ -1,7 +1,7 @@
 import { render } from '@ember/test-helpers';
 import { setupRenderingTest } from 'ember-qunit';
 import Status from 'pix-admin/components/sessions/certifications/status';
-import { ERROR, STARTED } from 'pix-admin/models/certification';
+import { assessmentResultStatus, assessmentStates } from 'pix-admin/models/certification';
 import { module, test } from 'qunit';
 
 module('Integration | Component | certifications/status', function (hooks) {
@@ -14,21 +14,23 @@ module('Integration | Component | certifications/status', function (hooks) {
   });
 
   module('#isStatusBlocking', function () {
-    [{ status: ERROR }, { status: STARTED }].forEach((juryCertificationSummary) => {
-      test(`it renders ${juryCertificationSummary.status} in red`, async function (assert) {
-        // given
-        const record = store.createRecord('jury-certification-summary', {
-          ...juryCertificationSummary,
-          isFlaggedAborted: false,
+    [{ status: assessmentResultStatus.ERROR }, { status: assessmentStates.STARTED }].forEach(
+      (juryCertificationSummary) => {
+        test(`it renders ${juryCertificationSummary.status} in red`, async function (assert) {
+          // given
+          const record = store.createRecord('jury-certification-summary', {
+            ...juryCertificationSummary,
+            isFlaggedAborted: false,
+          });
+
+          // when
+          await render(<template><Status @record={{record}} /></template>);
+
+          // then
+          assert.dom('span.certification-list-page__cell--important').exists();
         });
-
-        // when
-        await render(<template><Status @record={{record}} /></template>);
-
-        // then
-        assert.dom('span.certification-list-page__cell--important').exists();
-      });
-    });
+      },
+    );
 
     test('it renders status in red if certification has been flagged as aborted', async function (assert) {
       // given

--- a/admin/tests/unit/components/certifications/certification/details-v3-test.js
+++ b/admin/tests/unit/components/certifications/certification/details-v3-test.js
@@ -1,4 +1,5 @@
 import { setupTest } from 'ember-qunit';
+import { assessmentResultStatus } from 'pix-admin/models/certification';
 import { module, test } from 'qunit';
 
 import createGlimmerComponent from '../../../../helpers/create-glimmer-component';
@@ -68,7 +69,7 @@ module('Unit | Component | certifications/certification/details-v3', function (h
         details: {
           isRejectedForFraud: false,
           isCancelled: false,
-          assessmentResultStatus: 'validated',
+          assessmentResultStatus: assessmentResultStatus.VALIDATED,
         },
         expectedValue: 'pages.certifications.certification.details.v3.assessment-result-status.validated',
       },
@@ -76,7 +77,7 @@ module('Unit | Component | certifications/certification/details-v3', function (h
         details: {
           isRejectedForFraud: false,
           isCancelled: false,
-          assessmentResultStatus: 'rejected',
+          assessmentResultStatus: assessmentResultStatus.REJECTED,
         },
         expectedValue: 'pages.certifications.certification.details.v3.assessment-result-status.rejected',
       },
@@ -84,7 +85,7 @@ module('Unit | Component | certifications/certification/details-v3', function (h
         details: {
           isRejectedForFraud: false,
           isCancelled: false,
-          assessmentResultStatus: 'error',
+          assessmentResultStatus: assessmentResultStatus.ERROR,
         },
         expectedValue: 'pages.certifications.certification.details.v3.assessment-result-status.error',
       },
@@ -92,7 +93,7 @@ module('Unit | Component | certifications/certification/details-v3', function (h
         details: {
           isRejectedForFraud: false,
           isCancelled: true,
-          assessmentResultStatus: 'validated',
+          assessmentResultStatus: assessmentResultStatus.CANCELLED,
         },
         expectedValue: 'pages.certifications.certification.details.v3.assessment-result-status.cancelled',
       },
@@ -100,7 +101,7 @@ module('Unit | Component | certifications/certification/details-v3', function (h
         details: {
           isRejectedForFraud: true,
           isCancelled: false,
-          assessmentResultStatus: 'validated',
+          assessmentResultStatus: assessmentResultStatus.VALIDATED,
         },
         expectedValue: 'pages.certifications.certification.details.v3.assessment-result-status.fraud',
       },
@@ -125,7 +126,7 @@ module('Unit | Component | certifications/certification/details-v3', function (h
         details: {
           isRejectedForFraud: false,
           isCancelled: false,
-          assessmentResultStatus: 'validated',
+          assessmentResultStatus: assessmentResultStatus.VALIDATED,
         },
         expectedValue: 'success',
       },
@@ -133,7 +134,7 @@ module('Unit | Component | certifications/certification/details-v3', function (h
         details: {
           isRejectedForFraud: false,
           isCancelled: false,
-          assessmentResultStatus: 'rejected',
+          assessmentResultStatus: assessmentResultStatus.REJECTED,
         },
         expectedValue: 'error',
       },
@@ -141,7 +142,7 @@ module('Unit | Component | certifications/certification/details-v3', function (h
         details: {
           isRejectedForFraud: false,
           isCancelled: false,
-          assessmentResultStatus: 'error',
+          assessmentResultStatus: assessmentResultStatus.ERROR,
         },
         expectedValue: 'error',
       },
@@ -149,7 +150,7 @@ module('Unit | Component | certifications/certification/details-v3', function (h
         details: {
           isRejectedForFraud: false,
           isCancelled: true,
-          assessmentResultStatus: 'validated',
+          assessmentResultStatus: assessmentResultStatus.CANCELLED,
         },
         expectedValue: 'error',
       },
@@ -157,7 +158,7 @@ module('Unit | Component | certifications/certification/details-v3', function (h
         details: {
           isRejectedForFraud: true,
           isCancelled: false,
-          assessmentResultStatus: 'validated',
+          assessmentResultStatus: assessmentResultStatus.VALIDATED,
         },
         expectedValue: 'error',
       },

--- a/admin/tests/unit/models/certification-test.js
+++ b/admin/tests/unit/models/certification-test.js
@@ -1,4 +1,5 @@
 import { setupTest } from 'ember-qunit';
+import { assessmentResultStatus, assessmentStates } from 'pix-admin/models/certification';
 import { module, test } from 'qunit';
 
 module('Unit | Model | certification', function (hooks) {
@@ -184,10 +185,11 @@ module('Unit | Model | certification', function (hooks) {
 
   module('#statusLabelAndValue', function () {
     [
-      { value: 'started', label: 'Démarrée' },
-      { value: 'error', label: 'En erreur' },
-      { value: 'validated', label: 'Validée' },
-      { value: 'rejected', label: 'Rejetée' },
+      { value: assessmentStates.STARTED, label: 'Démarrée' },
+      { value: assessmentResultStatus.ERROR, label: 'En erreur' },
+      { value: assessmentResultStatus.VALIDATED, label: 'Validée' },
+      { value: assessmentResultStatus.REJECTED, label: 'Rejetée' },
+      { value: assessmentResultStatus.CANCELLED, label: 'Annulée' },
     ].forEach((certificationStatus) => {
       test('it should return the right pair of label and value', function (assert) {
         // given

--- a/api/src/certification/session-management/domain/models/JuryCertification.js
+++ b/api/src/certification/session-management/domain/models/JuryCertification.js
@@ -17,7 +17,7 @@ class JuryCertification {
    * @param {Date} props.createdAt
    * @param {Date} props.completedAt
    * @param {string} props.status
-   * @param {boolean} props.isCancelled
+   * @param {boolean} props.isCancelled - will be removed
    * @param {boolean} props.isPublished
    * @param {boolean} props.isRejectedForFraud
    * @param {number} props.juryId
@@ -91,6 +91,7 @@ class JuryCertification {
     this.version = version;
   }
 
+  // isCancelled will be removed
   static from({
     juryCertificationDTO,
     certificationIssueReports,

--- a/api/src/certification/session-management/infrastructure/repositories/jury-certification-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/jury-certification-repository.js
@@ -71,6 +71,7 @@ const get = async function ({ certificationCourseId }) {
 export { get };
 
 function _selectJuryCertifications() {
+  // isCancelled will be removed
   return knex
     .select({
       certificationCourseId: 'certification-courses.id',

--- a/api/src/certification/session-management/infrastructure/repositories/v3-certification-course-details-for-administration-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/v3-certification-course-details-for-administration-repository.js
@@ -24,6 +24,7 @@ const getV3DetailsByCertificationCourseId = async function ({ certificationCours
     .where({ 'assessments.certificationCourseId': certificationCourseId })
     .orderBy('validated-live-alerts.createdAt', 'ASC');
 
+  // isCancelled will be removed
   const certificationCourseDTO = await knex
     .select({
       isRejectedForFraud: 'certification-courses.isRejectedForFraud',

--- a/api/src/certification/session-management/infrastructure/serializers/jury-certification-serializer.js
+++ b/api/src/certification/session-management/infrastructure/serializers/jury-certification-serializer.js
@@ -3,6 +3,7 @@ import jsonapiSerializer from 'jsonapi-serializer';
 const { Serializer } = jsonapiSerializer;
 
 const serialize = function (juryCertification, { translate }) {
+  // isCancelled will be removed
   return new Serializer('certifications', {
     transform(juryCertification) {
       return {


### PR DESCRIPTION
## :pancakes: Problème

Nous utilisons `isCancelled` de la certification-course pour signifier qu'une certification est annulée. Pourtant il devrait se trouver du coté du statut de l'assessment-result. Dans le cadre de ce refacto, il nous faut déprécier isCancelled aux endroits où il est appelé.

## :bacon: Proposition

S'assurer que l'utilisation du dernier `AssessmentResult` soit pris en compte.

Est concernée : 

- Tableau des certifications par session (statut)
- Page de détails d'une certification (statut, tag statut, l'affichages des boutons d'annulation/ désannulation)
- Page de détails V3 (statut)

Pour cela passer une certification, accéder à la certification sur PixAdmin et l'annuler (via le bouton) constater que les affichage sont corrects.