### PR TITLE
[TECH] Afficher un statut annulée en cas de certification avec problème technique et - 20 questions (PIX-16476).

### DIFF
--- a/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
+++ b/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
@@ -172,7 +172,6 @@ function _createV3AssessmentResult({
     return AssessmentResultFactory.buildLackOfAnswersForTechnicalReason({
       pixScore: certificationAssessmentScore.nbPix,
       reproducibilityRate: certificationAssessmentScore.getPercentageCorrectAnswers(),
-      status: certificationAssessmentScore.status,
       assessmentId: certificationAssessment.id,
       emitter,
       juryId,

--- a/api/src/certification/scoring/domain/models/factories/AssessmentResultFactory.js
+++ b/api/src/certification/scoring/domain/models/factories/AssessmentResultFactory.js
@@ -110,7 +110,6 @@ export class AssessmentResultFactory {
   static buildLackOfAnswersForTechnicalReason({
     pixScore,
     reproducibilityRate,
-    status,
     assessmentId,
     juryId,
     emitter,
@@ -130,7 +129,7 @@ export class AssessmentResultFactory {
       emitter,
       pixScore,
       reproducibilityRate,
-      status,
+      status: AssessmentResult.status.CANCELLED,
       assessmentId,
       juryId,
       competenceMarks,

--- a/api/tests/certification/scoring/unit/domain/factories/AssessmentResultFactory_test.js
+++ b/api/tests/certification/scoring/unit/domain/factories/AssessmentResultFactory_test.js
@@ -197,4 +197,36 @@ describe('Certification | Scoring | Unit | Domain | Factories | AssessmentResult
       expect(actualAssessmentResult).to.deepEqualInstance(expectedAssessmentResult);
     });
   });
+
+  describe('#buildLackOfAnswersForTechnicalReason', function () {
+    it('should return a cancelled AssessmentResult', function () {
+      // when
+      const actualAssessmentResult = AssessmentResultFactory.buildLackOfAnswersForTechnicalReason({
+        emitter: CertificationResult.emitters.PIX_ALGO,
+        pixScore: 0,
+        reproducibilityRate: 49,
+        assessmentId: 123,
+        juryId: 456,
+      });
+
+      // then
+      const expectedAssessmentResult = domainBuilder.buildAssessmentResult({
+        status: AssessmentResult.status.CANCELLED,
+        pixScore: 0,
+        reproducibilityRate: 49,
+        assessmentId: 123,
+        juryId: 456,
+        emitter: CertificationResult.emitters.PIX_ALGO,
+        commentForCandidate: domainBuilder.certification.shared.buildJuryComment.candidate({
+          commentByAutoJury: AutoJuryCommentKeys.CANCELLED_DUE_TO_LACK_OF_ANSWERS_FOR_TECHNICAL_REASON,
+        }),
+        commentForOrganization: domainBuilder.certification.shared.buildJuryComment.organization({
+          commentByAutoJury: AutoJuryCommentKeys.CANCELLED_DUE_TO_LACK_OF_ANSWERS_FOR_TECHNICAL_REASON,
+        }),
+      });
+      expectedAssessmentResult.id = undefined;
+      expectedAssessmentResult.createdAt = undefined;
+      expect(actualAssessmentResult).to.deepEqualInstance(expectedAssessmentResult);
+    });
+  });
 });

--- a/api/tests/certification/session-management/acceptance/application/finalize-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/finalize-route_test.js
@@ -4,7 +4,12 @@ import {
   CertificationIssueReportSubcategories,
 } from '../../../../../src/certification/shared/domain/models/CertificationIssueReportCategory.js';
 import { SESSIONS_VERSIONS } from '../../../../../src/certification/shared/domain/models/SessionVersion.js';
-import { AnswerStatus, Assessment, CertificationResult } from '../../../../../src/shared/domain/models/index.js';
+import {
+  AnswerStatus,
+  Assessment,
+  AssessmentResult,
+  CertificationResult,
+} from '../../../../../src/shared/domain/models/index.js';
 import {
   createServer,
   databaseBuilder,
@@ -651,7 +656,7 @@ describe('Certification | Session Management | Acceptance | Application | Route 
           const finalizedSession = await knex('finalized-sessions').where({ sessionId: session.id }).first();
           expect(finalizedSession.isPublishable).to.be.true;
           const assessmentResult = await knex('assessment-results').where({ assessmentId }).first();
-          expect(assessmentResult.status).to.equal('rejected');
+          expect(assessmentResult.status).to.equal(AssessmentResult.status.CANCELLED);
           const assessment = await knex('assessments').where({ certificationCourseId }).first();
           expect(assessment.state).to.equal('endedDueToFinalization');
         });


### PR DESCRIPTION
## :pancakes: Problème

Actuellement, le cas métier de la certification  (problème technique avec moins de 20 questions) retourne une certification rejetée/annulée. Et la cause est ce booléen isCancelled qui gère l'annulation.
On veut retourner un statut unique, le annulée.

## :bacon: Proposition

Pour ce cas métier, retourner un statut cancelled.

## :yum: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

- Créer une session V3
- Y inscrire un candidat
- sur Pix App , certif-success@example.net
- Passer une certif en répondant à 3 questions
- Finaliser la session en indiquant que la raison d'abandon est TECHNIQUE
- Sur Admin, constater que la certification est flaggué annulée
- Le certificationCourse possède toujours le booléen isCancelled à true et l'assessmentResult à le status en CANCELLED


ℹ️ ⚠️ Ne cherchez pas à désannuler une certification dans ce cas de figure, elle restera annulée :D 