### PR TITLE
[FIX] #16477 Update a nextcloud doc link

### DIFF
--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -52,7 +52,7 @@ export default class Url extends Service {
 
   get joiningIssueSheetUrl() {
     if (this.#isFrenchSpoken()) {
-      return 'https://cloud.pix.fr/s/zf3fGimWwPQCeWF/download/Probl%C3%A8mes%20d%27acc%C3%A8s%20en%20session.pdf';
+      return 'https://cloud.pix.fr/s/b8BFXX94Ys2WGxM/download/Probl%C3%A8mes%20d%27acc%C3%A8s%20en%20session.pdf';
     }
 
     return 'https://cloud.pix.fr/s/JmBn2q5rpzgrjxN/download';


### PR DESCRIPTION
## :pancakes: Problème

Sur la page de finalisation de session, le lien vers le doc “problème d’accès en session.pdf” n’est plus valide.
Voici le lien qui a été généré : [Problèmes d'accès en session.pdf](https://cloud.pix.fr/s/b8BFXX94Ys2WGxM) , si possible de le modifier avec le lien précédent du coup : https://cloud.pix.fr/s/zf3fGimWwPQCeWF

## :bacon: Proposition

mettre à jour le lien

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
