### PR TITLE
[BUGFIX] Tolérance aux doublons dans les réponses sur Pix Junior

### DIFF
--- a/api/src/school/domain/models/Mission.js
+++ b/api/src/school/domain/models/Mission.js
@@ -58,6 +58,10 @@ class Mission {
     }
   }
 
+  getLastChallengeIds(activityInfo) {
+    return this.getChallengeIds(activityInfo).at(-1);
+  }
+
   getChallengeIndex(activityInfo, challengeId) {
     return this.getChallengeIds(activityInfo).findIndex((challengeVersionIds) =>
       challengeVersionIds.includes(challengeId),

--- a/api/src/school/domain/models/Mission.js
+++ b/api/src/school/domain/models/Mission.js
@@ -58,6 +58,12 @@ class Mission {
     }
   }
 
+  getChallengeIndex(activityInfo, challengeId) {
+    return this.getChallengeIds(activityInfo).findIndex((challengeVersionIds) =>
+      challengeVersionIds.includes(challengeId),
+    );
+  }
+
   get stepCount() {
     return this.content.steps.length;
   }

--- a/api/src/school/domain/services/update-current-activity.js
+++ b/api/src/school/domain/services/update-current-activity.js
@@ -9,8 +9,7 @@ export async function updateCurrentActivity({
   missionRepository,
 }) {
   const lastActivity = await activityRepository.getLastActivity(assessmentId);
-  const answers = await activityAnswerRepository.findByActivity(lastActivity.id);
-  const lastAnswer = answers.at(-1);
+  const lastAnswer = await activityAnswerRepository.findLastByActivity(lastActivity.id);
 
   if (lastAnswer.result.isOK() || lastActivity.isTutorial) {
     const { missionId } = await missionAssessmentRepository.getByAssessmentId(assessmentId);
@@ -27,6 +26,6 @@ export async function updateCurrentActivity({
 }
 
 function _isActivityFinished(mission, lastActivity, lastAnswer) {
-  const challengeIds = mission.getChallengeIds(new ActivityInfo(lastActivity));
-  return challengeIds.at(-1).includes(lastAnswer.challengeId);
+  const lastChallengeIds = mission.getLastChallengeIds(new ActivityInfo(lastActivity));
+  return lastChallengeIds.includes(lastAnswer.challengeId);
 }

--- a/api/src/school/domain/services/update-current-activity.js
+++ b/api/src/school/domain/services/update-current-activity.js
@@ -15,7 +15,7 @@ export async function updateCurrentActivity({
   if (lastAnswer.result.isOK() || lastActivity.isTutorial) {
     const { missionId } = await missionAssessmentRepository.getByAssessmentId(assessmentId);
     const mission = await missionRepository.get(missionId);
-    if (_isActivityFinished(mission, lastActivity, answers)) {
+    if (_isActivityFinished(mission, lastActivity, lastAnswer)) {
       return activityRepository.updateStatus({ activityId: lastActivity.id, status: Activity.status.SUCCEEDED });
     }
     return lastActivity;
@@ -26,6 +26,7 @@ export async function updateCurrentActivity({
   return activityRepository.updateStatus({ activityId: lastActivity.id, status: Activity.status.SKIPPED });
 }
 
-function _isActivityFinished(mission, lastActivity, answers) {
-  return mission.getChallengeIds(new ActivityInfo(lastActivity)).length === answers.length;
+function _isActivityFinished(mission, lastActivity, lastAnswer) {
+  const challengeIds = mission.getChallengeIds(new ActivityInfo(lastActivity));
+  return challengeIds.at(-1).includes(lastAnswer.challengeId);
 }

--- a/api/src/school/domain/usecases/get-next-challenge.js
+++ b/api/src/school/domain/usecases/get-next-challenge.js
@@ -18,9 +18,11 @@ export async function getNextChallenge({
   const mission = await missionRepository.get(missionId);
   const answers = await activityAnswerRepository.findByActivity(activity.id);
 
+  const activityInfo = new ActivityInfo({ level: activity.level, stepIndex: activity.stepIndex });
+  const previousChallengeIndex = mission.getChallengeIndex(activityInfo, answers.at(-1).challengeId);
   const challengeId = mission.getChallengeId({
-    activityInfo: new ActivityInfo({ level: activity.level, stepIndex: activity.stepIndex }),
-    challengeIndex: answers.length,
+    activityInfo,
+    challengeIndex: previousChallengeIndex + 1,
     alternativeVersion: activity.alternativeVersion,
   });
 

--- a/api/src/school/domain/usecases/get-next-challenge.js
+++ b/api/src/school/domain/usecases/get-next-challenge.js
@@ -16,13 +16,17 @@ export async function getNextChallenge({
   }
   const { missionId } = await missionAssessmentRepository.getByAssessmentId(assessmentId);
   const mission = await missionRepository.get(missionId);
-  const answers = await activityAnswerRepository.findByActivity(activity.id);
+  const lastAnswer = await activityAnswerRepository.findLastByActivity(activity.id);
 
   const activityInfo = new ActivityInfo({ level: activity.level, stepIndex: activity.stepIndex });
-  const previousChallengeIndex = mission.getChallengeIndex(activityInfo, answers.at(-1).challengeId);
+  let challengeIndex = 0;
+  if (lastAnswer) {
+    const previousChallengeIndex = mission.getChallengeIndex(activityInfo, lastAnswer?.challengeId);
+    challengeIndex = previousChallengeIndex + 1;
+  }
   const challengeId = mission.getChallengeId({
     activityInfo,
-    challengeIndex: previousChallengeIndex + 1,
+    challengeIndex,
     alternativeVersion: activity.alternativeVersion,
   });
 

--- a/api/src/school/infrastructure/repositories/activity-answer-repository.js
+++ b/api/src/school/infrastructure/repositories/activity-answer-repository.js
@@ -14,22 +14,26 @@ function _adaptAnswerToDb(answer) {
 }
 
 function _toDomain(answerDTO) {
+  if (answerDTO === undefined) {
+    return undefined;
+  }
   return new ActivityAnswer({
     ...answerDTO,
     result: answerStatusDatabaseAdapter.fromSQLString(answerDTO.result),
   });
 }
 
-function _toDomainArray(answerDTOs) {
-  return _.map(answerDTOs, _toDomain);
-}
-
 const COLUMNS = Object.freeze(['id', 'challengeId', 'activityId', 'value', 'result', 'resultDetails']);
 
-const findByActivity = async function (activityId) {
+const findLastByActivity = async function (activityId) {
   const knexConn = DomainTransaction.getConnection();
-  const answerDTOs = await knexConn.select(COLUMNS).from('activity-answers').where({ activityId }).orderBy('createdAt');
-  return _toDomainArray(answerDTOs);
+  const [lastAnswer] = await knexConn
+    .select(COLUMNS)
+    .from('activity-answers')
+    .where({ activityId })
+    .orderBy('createdAt', 'desc')
+    .limit(1);
+  return _toDomain(lastAnswer);
 };
 
 const save = async function (answer) {
@@ -39,4 +43,4 @@ const save = async function (answer) {
   return _toDomain(savedAnswerDTO);
 };
 
-export { findByActivity, save };
+export { findLastByActivity, save };

--- a/api/tests/school/integration/domain/services/update-current-activity_test.js
+++ b/api/tests/school/integration/domain/services/update-current-activity_test.js
@@ -89,11 +89,13 @@ describe('Integration | UseCase | update current activity', function () {
             activityId,
             challengeId: 'di_challenge_id',
             result,
+            createdAt: new Date('2020-01-01T10:00:00Z'),
           });
           databaseBuilder.factory.buildActivityAnswer({
             activityId,
             challengeId: 'di_next_challenge_id',
             result,
+            createdAt: new Date('2020-01-01T10:01:00Z'),
           });
 
           await databaseBuilder.commit();
@@ -289,11 +291,13 @@ describe('Integration | UseCase | update current activity', function () {
             activityId,
             challengeId: 'va_challenge_id',
             result: AnswerStatus.statuses.OK,
+            createdAt: new Date('2020-01-01T10:00:00Z'),
           });
           databaseBuilder.factory.buildActivityAnswer({
             activityId,
             challengeId: 'va_next_challenge_id',
             result: AnswerStatus.statuses.OK,
+            createdAt: new Date('2020-01-01T10:01:00Z'),
           });
 
           await databaseBuilder.commit();

--- a/api/tests/school/integration/domain/services/update-current-activity_test.js
+++ b/api/tests/school/integration/domain/services/update-current-activity_test.js
@@ -223,6 +223,58 @@ describe('Integration | UseCase | update current activity', function () {
           expect(currentActivity.status).equals(Activity.status.STARTED);
         });
       });
+      context('when activity is not finished but has answer duplicate', function () {
+        it('should not update current activity status', async function () {
+          const { assessmentId, missionId } = databaseBuilder.factory.buildMissionAssessment();
+          const { id: activityId } = databaseBuilder.factory.buildActivity({
+            assessmentId,
+            level: Activity.levels.VALIDATION,
+            status: Activity.status.STARTED,
+            stepIndex: 0,
+          });
+          databaseBuilder.factory.buildActivityAnswer({
+            activityId,
+            challengeId: 'va_challenge_id',
+            result: AnswerStatus.statuses.OK,
+          });
+          // Anwser duplicate
+          databaseBuilder.factory.buildActivityAnswer({
+            activityId,
+            challengeId: 'va_challenge_id',
+            result: AnswerStatus.statuses.OK,
+          });
+
+          await databaseBuilder.commit();
+
+          await mockLearningContent({
+            missions: [
+              learningContentBuilder.buildMission({
+                id: missionId,
+                content: {
+                  steps: [
+                    {
+                      validationChallenges: [['va_challenge_id'], ['va_next_challenge_id']],
+                    },
+                  ],
+                },
+              }),
+            ],
+          });
+
+          const currentActivity = await updateCurrentActivity({
+            assessmentId,
+            activityRepository,
+            activityAnswerRepository,
+            missionAssessmentRepository,
+            missionRepository,
+          });
+
+          const activities = await knex('activities').where({ assessmentId });
+          expect(activities).to.have.lengthOf(1);
+          expect(activities[0].status).to.equal(Activity.status.STARTED);
+          expect(currentActivity.status).equals(Activity.status.STARTED);
+        });
+      });
 
       context('when activity is finished', function () {
         it('should update current activity with SUCCEEDED status', async function () {

--- a/api/tests/school/integration/domain/usecases/get-next-challenge_test.js
+++ b/api/tests/school/integration/domain/usecases/get-next-challenge_test.js
@@ -103,5 +103,61 @@ describe('Integration | School | Usecase | get-next-challenge', function () {
         expect(updatedAssessment.lastChallengeId).to.equal('second_va_challenge_on_step_2_id');
       });
     });
+    context('when last activity is started but has answer duplicate', function () {
+      it('should return next challenge and update assessment', async function () {
+        const { assessmentId, missionId } = databaseBuilder.factory.buildMissionAssessment();
+
+        const { id: firstStepActivityId } = databaseBuilder.factory.buildActivity({
+          assessmentId,
+          level: Activity.levels.VALIDATION,
+          status: Activity.status.STARTED,
+          stepIndex: 0,
+          createdAt: new Date('2022-09-14'),
+        });
+        databaseBuilder.factory.buildActivityAnswer({
+          activityId: firstStepActivityId,
+          challengeId: 'first_va_challenge_id',
+        });
+        // Answer duplicate
+        databaseBuilder.factory.buildActivityAnswer({
+          activityId: firstStepActivityId,
+          challengeId: 'first_va_challenge_id',
+        });
+
+        await databaseBuilder.commit();
+
+        await mockLearningContent({
+          challenges: [learningContentBuilder.buildChallenge({ id: 'second_va_challenge_id', skillId: 'skill_id' })],
+          skills: [learningContentBuilder.buildSkill({ id: 'skill_id' })],
+          missions: [
+            learningContentBuilder.buildMission({
+              id: missionId,
+              content: {
+                steps: [
+                  {
+                    validationChallenges: [['first_va_challenge_id'], ['second_va_challenge_id']],
+                  },
+                ],
+              },
+            }),
+          ],
+        });
+
+        const challenge = await getNextChallenge({
+          assessmentId,
+          activityRepository,
+          activityAnswerRepository,
+          challengeRepository,
+          assessmentRepository,
+          missionAssessmentRepository,
+          missionRepository,
+        });
+
+        const updatedAssessment = await knex('assessments').where({ id: assessmentId }).first();
+        expect(challenge.id).to.equal('second_va_challenge_id');
+        expect(challenge).to.be.instanceOf(Challenge);
+        expect(updatedAssessment.lastChallengeId).to.equal('second_va_challenge_id');
+      });
+    });
   });
 });

--- a/api/tests/school/integration/infrastructure/repositories/activity-answer-repository_test.js
+++ b/api/tests/school/integration/infrastructure/repositories/activity-answer-repository_test.js
@@ -6,22 +6,22 @@ import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStat
 import { databaseBuilder, domainBuilder, expect, knex } from '../../../../test-helper.js';
 
 describe('Integration | Repository | activityAnswerRepository', function () {
-  describe('#findByActivity', function () {
+  describe('#findLastByActivity', function () {
     context('when activity does not exists', function () {
-      it('should return an empty array', async function () {
+      it('should return undefined', async function () {
         // given
         databaseBuilder.factory.buildActivity({ id: 123, level: Activity.levels.TUTORIAL });
         await databaseBuilder.commit();
 
         // when
-        const foundAnswers = await activityAnswerRepository.findByActivity(456);
+        const lastAnswer = await activityAnswerRepository.findLastByActivity(456);
 
         // then
-        expect(foundAnswers).to.be.empty;
+        expect(lastAnswer).to.be.undefined;
       });
     });
     context('when there is no answer for the activity', function () {
-      it('should return an empty array', async function () {
+      it('should return undefined', async function () {
         // given
         // no answer activity
         databaseBuilder.factory.buildActivity({ id: 123 });
@@ -33,10 +33,10 @@ describe('Integration | Repository | activityAnswerRepository', function () {
         await databaseBuilder.commit();
 
         // when
-        const foundAnswers = await activityAnswerRepository.findByActivity(123);
+        const lastAnswer = await activityAnswerRepository.findLastByActivity(123);
 
         // then
-        expect(foundAnswers).to.be.empty;
+        expect(lastAnswer).to.be.undefined;
       });
     });
     context('when activity has some activity answers', function () {
@@ -45,22 +45,23 @@ describe('Integration | Repository | activityAnswerRepository', function () {
         databaseBuilder.factory.buildActivity({ id: 123 });
         databaseBuilder.factory.buildActivityAnswer({
           activityId: 123,
+          challengeId: 'challenge1',
           createdAt: new Date('2023-06-01T15:01:00Z'),
           result: 'ko',
         });
         databaseBuilder.factory.buildActivityAnswer({
           activityId: 123,
+          challengeId: 'challenge2',
           createdAt: new Date('2023-06-01T15:00:00Z'),
           result: 'ok',
         });
         await databaseBuilder.commit();
 
         // when
-        const foundAnswers = await activityAnswerRepository.findByActivity(123);
+        const lastAnswer = await activityAnswerRepository.findLastByActivity(123);
 
         // then
-        expect(foundAnswers[0].result).to.deep.equal(AnswerStatus.OK);
-        expect(foundAnswers[1].result).to.deep.equal(AnswerStatus.KO);
+        expect(lastAnswer.result).to.deep.equal(AnswerStatus.KO);
       });
     });
   });

--- a/api/tests/school/unit/domain/models/Mission_test.js
+++ b/api/tests/school/unit/domain/models/Mission_test.js
@@ -234,4 +234,30 @@ describe('Unit | Domain | School', function () {
       expect(challengeIndex).to.equal(1);
     });
   });
+
+  describe('#getLastChallengeIds', function () {
+    it('should index of given challenge in given activity', function () {
+      const mission = domainBuilder.buildMission({
+        content: {
+          steps: [
+            {
+              tutorialChallenges: [
+                ['tutorial-challenge-id-1'],
+                ['tutorial-challenge-id-2'],
+                ['tutorial-challenge-id-3'],
+              ],
+            },
+          ],
+        },
+      });
+      const lastChallengeIds = mission.getLastChallengeIds(
+        new ActivityInfo({
+          level: Activity.levels.TUTORIAL,
+          stepIndex: 0,
+        }),
+      );
+
+      expect(lastChallengeIds).to.deep.equal(['tutorial-challenge-id-3']);
+    });
+  });
 });

--- a/api/tests/school/unit/domain/models/Mission_test.js
+++ b/api/tests/school/unit/domain/models/Mission_test.js
@@ -36,7 +36,7 @@ describe('Unit | Domain | School', function () {
       });
     });
 
-    it('should call challengeRepository#get with challenge id of accurate number in activity', function () {
+    it('should return challenge id of accurate index in activity', function () {
       const mission = domainBuilder.buildMission({
         content: {
           steps: [
@@ -208,6 +208,30 @@ describe('Unit | Domain | School', function () {
 
         expect(challengeIds).to.deep.equal(expectedChallengeIds);
       });
+    });
+  });
+
+  describe('#getChallengeIndex', function () {
+    it('should return the index of given challenge in given activity', function () {
+      const mission = domainBuilder.buildMission({
+        content: {
+          steps: [
+            {
+              tutorialChallenges: [
+                ['tutorial-challenge-id-1'],
+                ['tutorial-challenge-id-2'],
+                ['tutorial-challenge-id-3'],
+              ],
+            },
+          ],
+        },
+      });
+      const challengeIndex = mission.getChallengeIndex(
+        new ActivityInfo({ level: Activity.levels.TUTORIAL, stepIndex: 0 }),
+        'tutorial-challenge-id-2',
+      );
+
+      expect(challengeIndex).to.equal(1);
     });
   });
 });


### PR DESCRIPTION
## :pancakes: Problème

Depuis l'introduction des épreuves auto-validées, des doublons apparaissent dans les réponses aux challenges ce qui provoque des erreurs côté Pix Junior qui n'est pas tolérant à ces doublons.

## :bacon: Proposition

Rendre Pix Junior tolérant à ces doublons.

## :yum: Pour tester

Passer des missions sur Pix Junior (toutes activités, échec, réussite, abandon), le comportement de l'algorithme n'a pas changé.
En base, doubler les réponses dans `activity-answers` à différents moments du passage de la mission. Les doublons n'ont pas d'incidence sur le passage de la mission.
