### PR TITLE
[FEATURE]  Ajouter une route pour retourner les badges acquis lors des participations d'une campagne (PIX-16240)

### DIFF
--- a/api/src/prescription/campaign/application/campaign-stats-controller.js
+++ b/api/src/prescription/campaign/application/campaign-stats-controller.js
@@ -1,4 +1,5 @@
 import { usecases } from '../domain/usecases/index.js';
+import * as badgeAcquisitionsStatisticsSerializer from '../infrastructure/serializers/jsonapi/badge-acquisitions-statistics-serializer.js';
 import * as participationsByStageSerializer from '../infrastructure/serializers/jsonapi/campaign-participations-count-by-stage-serializer.js';
 import * as participationsByDaySerializer from '../infrastructure/serializers/jsonapi/campaign-participations-counts-by-day-serializer.js';
 import * as participationsByStatusSerializer from '../infrastructure/serializers/jsonapi/campaign-participations-counts-by-status-serializer.js';
@@ -39,6 +40,18 @@ const getParticipationsByDay = async function (request) {
   });
 };
 
+const getBadgeAcquisitions = async (request) => {
+  const { userId } = request.auth.credentials;
+  const { campaignId } = request.params;
+
+  const badgesAcquisitionStatistics = await usecases.getBadgeAcquisitionsStatistics({ userId, campaignId });
+
+  return badgeAcquisitionsStatisticsSerializer.serialize({
+    campaignId,
+    data: badgesAcquisitionStatistics,
+  });
+};
+
 const getParticipationsCountByMasteryRate = async function (request) {
   const { userId } = request.auth.credentials;
   const { campaignId } = request.params;
@@ -56,6 +69,7 @@ const campaignStatsController = {
   getParticipationsByStatus,
   getParticipationsByDay,
   getParticipationsCountByMasteryRate,
+  getBadgeAcquisitions,
 };
 
 export { campaignStatsController };

--- a/api/src/prescription/campaign/application/campaign-stats-route.js
+++ b/api/src/prescription/campaign/application/campaign-stats-route.js
@@ -22,6 +22,21 @@ const register = async function (server) {
     },
     {
       method: 'GET',
+      path: '/api/campaigns/{campaignId}/stats/badge-acquisitions',
+      config: {
+        validate: {
+          params: Joi.object({ campaignId: identifiersType.campaignId }),
+        },
+        handler: campaignStatsController.getBadgeAcquisitions,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            "- Récupération des statistiques d'obtention de badges",
+        ],
+        tags: ['api', 'campaign', 'stats'],
+      },
+    },
+    {
+      method: 'GET',
       path: '/api/campaigns/{campaignId}/stats/participations-by-status',
       config: {
         validate: {

--- a/api/src/prescription/campaign/domain/read-models/BadgeAcquisitionParticipationStatistic.js
+++ b/api/src/prescription/campaign/domain/read-models/BadgeAcquisitionParticipationStatistic.js
@@ -1,0 +1,11 @@
+export default class BadgeAcquisitionParticipationStatistic {
+  constructor({ badge, count, totalParticipationCount }) {
+    this.badge = badge;
+    this.count = count;
+    this.totalParticipationCount = totalParticipationCount;
+  }
+
+  get percentage() {
+    return this.totalParticipationCount === 0 ? 0 : Math.round((this.count / this.totalParticipationCount) * 100);
+  }
+}

--- a/api/src/prescription/campaign/domain/usecases/statistics/get-badge-acquisitions-statistics.js
+++ b/api/src/prescription/campaign/domain/usecases/statistics/get-badge-acquisitions-statistics.js
@@ -1,0 +1,50 @@
+import { UserNotAuthorizedToAccessEntityError } from '../../../../../shared/domain/errors.js';
+
+/**
+ *
+ * @param {number} userId
+ * @param {number} campaignId
+ *
+ * @param campaignRepository
+ * @param campaignParticipationsStatsRepository
+ * @param badgeRepository
+ * @param badgeAcquisitionRepository
+ *
+ * @returns {Promise<{badge : Badge, count: number, percentage: number}[]>}
+ */
+const getBadgeAcquisitionsStatistics = async function ({
+  userId,
+  campaignId,
+  campaignRepository,
+  campaignParticipationsStatsRepository,
+  badgeRepository,
+  badgeAcquisitionRepository,
+}) {
+  if (!(await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId))) {
+    throw new UserNotAuthorizedToAccessEntityError('User does not belong to the organization that owns the campaign');
+  }
+
+  const badges = await badgeRepository.findByCampaignId(campaignId);
+
+  if (!badges) {
+    return [];
+  }
+
+  const participations = await campaignParticipationsStatsRepository.getAllParticipationsByCampaignId(campaignId);
+
+  const badgesAcquisitions = await badgeAcquisitionRepository.getAcquiredBadgesForCampaignParticipations(
+    participations.map(({ id }) => id),
+  );
+
+  return badges.map((badge) => {
+    const acquiredBadges = badgesAcquisitions.filter((badgeAcquisition) => badgeAcquisition.badgeId === badge.id);
+
+    return {
+      badge,
+      count: acquiredBadges.length,
+      percentage: participations.length ? Math.round((acquiredBadges.length / participations.length) * 100) : 0,
+    };
+  });
+};
+
+export { getBadgeAcquisitionsStatistics };

--- a/api/src/prescription/campaign/domain/usecases/statistics/get-badge-acquisitions-statistics.js
+++ b/api/src/prescription/campaign/domain/usecases/statistics/get-badge-acquisitions-statistics.js
@@ -1,4 +1,5 @@
 import { UserNotAuthorizedToAccessEntityError } from '../../../../../shared/domain/errors.js';
+import BadgeAcquisitionParticipationStatistic from '../../read-models/BadgeAcquisitionParticipationStatistic.js';
 
 /**
  *
@@ -10,7 +11,7 @@ import { UserNotAuthorizedToAccessEntityError } from '../../../../../shared/doma
  * @param badgeRepository
  * @param badgeAcquisitionRepository
  *
- * @returns {Promise<{badge : Badge, count: number, percentage: number}[]>}
+ * @returns {Promise<BadgeAcquisitionParticipationStatistic[]>}
  */
 const getBadgeAcquisitionsStatistics = async function ({
   userId,
@@ -39,11 +40,11 @@ const getBadgeAcquisitionsStatistics = async function ({
   return badges.map((badge) => {
     const acquiredBadges = badgesAcquisitions.filter((badgeAcquisition) => badgeAcquisition.badgeId === badge.id);
 
-    return {
+    return new BadgeAcquisitionParticipationStatistic({
       badge,
       count: acquiredBadges.length,
-      percentage: participations.length ? Math.round((acquiredBadges.length / participations.length) * 100) : 0,
-    };
+      totalParticipationCount: participations.length,
+    });
   });
 };
 

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-participations-stats-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-participations-stats-repository.js
@@ -46,17 +46,14 @@ async function _getCumulativeParticipationCountsByDay(campaignId, column) {
   return data.map(({ day, count }) => ({ day, count: Number(count) }));
 }
 
-const getAllParticipationsByCampaignId = async function (campaignId) {
-  const result = await knex
-    .select('masteryRate', 'validatedSkillsCount')
+const getAllParticipationsByCampaignId = (campaignId) =>
+  knex
+    .select('id', 'masteryRate', 'validatedSkillsCount')
     .from('campaign-participations')
     .where('campaign-participations.campaignId', '=', campaignId)
     .where('campaign-participations.isImproved', '=', false)
     .where('campaign-participations.deletedAt', 'is', null)
     .where('campaign-participations.status', 'SHARED');
-
-  return result;
-};
 
 const countParticipationsByStatus = async function (campaignId, campaignType) {
   const row = await knex('campaign-participations')

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/badge-acquisitions-statistics-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/badge-acquisitions-statistics-serializer.js
@@ -1,0 +1,14 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = (model) =>
+  new Serializer('badge-acquisitions-statistics', {
+    id: 'campaignId',
+    attributes: ['data'],
+    data: {
+      attributes: ['badge', 'count', 'percentage'],
+    },
+  }).serialize(model);
+
+export { serialize };

--- a/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
@@ -79,6 +79,50 @@ describe('Integration | Repository | Badge Acquisition', function () {
     });
   });
 
+  describe('#getAcquiredBadgesForCampaignParticipations', function () {
+    let campaignParticipationId;
+    let campaignParticipationId2;
+    let campaignParticipationId3;
+
+    beforeEach(async function () {
+      const badgeId = databaseBuilder.factory.buildBadge().id;
+      const badgeId2 = databaseBuilder.factory.buildBadge().id;
+      const badgeId3 = databaseBuilder.factory.buildBadge().id;
+      const userId = databaseBuilder.factory.buildUser().id;
+
+      campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ userId }).id;
+      campaignParticipationId2 = databaseBuilder.factory.buildCampaignParticipation({ userId }).id;
+      campaignParticipationId3 = databaseBuilder.factory.buildCampaignParticipation({ userId }).id;
+      [
+        { userId, badgeId, campaignParticipationId },
+        { userId, badgeId: badgeId, campaignParticipationId: campaignParticipationId2 },
+        { userId, badgeId: badgeId2, campaignParticipationId: campaignParticipationId2 },
+        { userId, badgeId: badgeId3, campaignParticipationId: campaignParticipationId3 },
+      ].forEach(databaseBuilder.factory.buildBadgeAcquisition);
+
+      await databaseBuilder.commit();
+    });
+
+    it('should return badges acquisitions for the given campaign participations', async function () {
+      // when
+      const acquiredBadges = await badgeAcquisitionRepository.getAcquiredBadgesForCampaignParticipations([
+        campaignParticipationId,
+        campaignParticipationId2,
+      ]);
+
+      expect(acquiredBadges).to.have.lengthOf(3);
+      expect(
+        acquiredBadges.filter((badge) => badge.campaignParticipationId === campaignParticipationId),
+      ).to.have.lengthOf(1);
+      expect(
+        acquiredBadges.filter((badge) => badge.campaignParticipationId === campaignParticipationId2),
+      ).to.have.lengthOf(2);
+      expect(
+        acquiredBadges.filter((badge) => badge.campaignParticipationId === campaignParticipationId3),
+      ).to.have.lengthOf(0);
+    });
+  });
+
   describe('#getAcquiredBadgeIds', function () {
     let userId;
     let badgeId;

--- a/api/tests/prescription/campaign/integration/domain/usecases/statistics/get-badge-acquisitions-statistics_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/statistics/get-badge-acquisitions-statistics_test.js
@@ -1,3 +1,4 @@
+import BadgeAcquisitionParticipationStatistic from '../../../../../../../src/prescription/campaign/domain/read-models/BadgeAcquisitionParticipationStatistic.js';
 import { usecases } from '../../../../../../../src/prescription/campaign/domain/usecases/index.js';
 import { UserNotAuthorizedToAccessEntityError } from '../../../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, expect } from '../../../../../../test-helper.js';
@@ -129,6 +130,18 @@ describe('Integration | UseCase | Statistics | get-badge-acquisitions-statistics
         });
 
         await databaseBuilder.commit();
+      });
+
+      it('should return an array of BadgeAcquisitionParticipationStatistic', async function () {
+        // when
+        const result = await usecases.getBadgeAcquisitionsStatistics({
+          userId,
+          campaignId,
+        });
+
+        // then
+        expect(result).to.have.lengthOf(3);
+        expect(result[0]).to.be.instanceOf(BadgeAcquisitionParticipationStatistic);
       });
 
       it('should return the expected badges statistics', async function () {

--- a/api/tests/prescription/campaign/integration/domain/usecases/statistics/get-badge-acquisitions-statistics_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/statistics/get-badge-acquisitions-statistics_test.js
@@ -1,0 +1,158 @@
+import { usecases } from '../../../../../../../src/prescription/campaign/domain/usecases/index.js';
+import { UserNotAuthorizedToAccessEntityError } from '../../../../../../../src/shared/domain/errors.js';
+import { catchErr, databaseBuilder, expect } from '../../../../../../test-helper.js';
+
+describe('Integration | UseCase | Statistics | get-badge-acquisitions-statistics', function () {
+  context('when requesting user is not allowed to access campaign informations', function () {
+    it('should throw a UserNotAuthorizedToAccessEntityError error', async function () {
+      const user2 = databaseBuilder.factory.buildUser();
+      const campaignId = databaseBuilder.factory.buildCampaign().id;
+      await databaseBuilder.commit();
+
+      // when
+      const error = await catchErr(usecases.getBadgeAcquisitionsStatistics)({
+        userId: user2.id,
+        campaignId,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
+      expect(error.message).to.equal('User does not belong to the organization that owns the campaign');
+    });
+  });
+
+  context('when requesting user is allowed to access campaign informations', function () {
+    context('when there are no badges for the campaign', function () {
+      let userId;
+      let campaignId;
+      beforeEach(async function () {
+        const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        userId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildMembership({ organizationId, userId });
+        campaignId = databaseBuilder.factory.buildCampaign({ targetProfileId, organizationId }).id;
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaignId,
+          userId: userId,
+        });
+
+        await databaseBuilder.commit();
+      });
+
+      it('should return an empty array', async function () {
+        // when
+        const result = await usecases.getBadgeAcquisitionsStatistics({
+          userId: userId,
+          campaignId,
+        });
+
+        // then
+        expect(result).to.be.empty;
+      });
+    });
+
+    context('when there are no participations for the given campaign', function () {
+      let userId;
+      let campaignId;
+
+      beforeEach(async function () {
+        const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+        databaseBuilder.factory.buildBadge({ targetProfileId }).id;
+        databaseBuilder.factory.buildBadge({ targetProfileId }).id;
+
+        userId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildMembership({ organizationId, userId });
+
+        campaignId = databaseBuilder.factory.buildCampaign({ targetProfileId, organizationId }).id;
+
+        await databaseBuilder.commit();
+      });
+
+      it('should return the expected badge statistics', async function () {
+        // when
+        const result = await usecases.getBadgeAcquisitionsStatistics({
+          userId: userId,
+          campaignId,
+        });
+
+        // then
+        expect(result[0].count).to.equal(0);
+        expect(result[0].percentage).to.equal(0);
+        expect(result[1].count).to.equal(0);
+        expect(result[1].percentage).to.equal(0);
+      });
+    });
+
+    context('when there are badges and participations', function () {
+      let userId;
+      let campaignId;
+
+      let badge1Id;
+      let badge2Id;
+      let badge3Id;
+
+      beforeEach(async function () {
+        const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+        badge1Id = databaseBuilder.factory.buildBadge({ targetProfileId, title: 'badge1' }).id;
+        badge2Id = databaseBuilder.factory.buildBadge({ targetProfileId, title: 'badge2' }).id;
+        badge3Id = databaseBuilder.factory.buildBadge({ targetProfileId, title: 'badge3' }).id;
+
+        userId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildMembership({ organizationId, userId });
+
+        campaignId = databaseBuilder.factory.buildCampaign({ targetProfileId, organizationId }).id;
+        const campaignParticipation1 = databaseBuilder.factory.buildCampaignParticipation({ campaignId });
+        const campaignParticipation2 = databaseBuilder.factory.buildCampaignParticipation({ campaignId });
+        const campaignParticipation3 = databaseBuilder.factory.buildCampaignParticipation({ campaignId });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId });
+
+        databaseBuilder.factory.buildBadgeAcquisition({
+          userId: campaignParticipation1.userId,
+          campaignParticipationId: campaignParticipation1.id,
+          badgeId: badge1Id,
+        });
+        databaseBuilder.factory.buildBadgeAcquisition({
+          userId: campaignParticipation2.userId,
+          campaignParticipationId: campaignParticipation2.id,
+          badgeId: badge2Id,
+        });
+        databaseBuilder.factory.buildBadgeAcquisition({
+          userId: campaignParticipation3.userId,
+          campaignParticipationId: campaignParticipation3.id,
+          badgeId: badge2Id,
+        });
+
+        await databaseBuilder.commit();
+      });
+
+      it('should return the expected badges statistics', async function () {
+        // when
+        const result = await usecases.getBadgeAcquisitionsStatistics({
+          userId,
+          campaignId,
+        });
+
+        // then
+        expect(result).to.have.lengthOf(3);
+
+        const badge1Stats = result.find((badgeStats) => badgeStats.badge.id === badge1Id);
+        expect(badge1Stats.count).to.equal(1);
+        expect(badge1Stats.percentage).to.equal(17);
+
+        const badge2Stats = result.find((badgeStats) => badgeStats.badge.id === badge2Id);
+        expect(badge2Stats.count).to.equal(2);
+        expect(badge2Stats.percentage).to.equal(33);
+
+        const badge3Stats = result.find((badgeStats) => badgeStats.badge.id === badge3Id);
+        expect(badge3Stats.count).to.equal(0);
+        expect(badge3Stats.percentage).to.equal(0);
+      });
+    });
+  });
+});

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participations-stats-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participations-stats-repository_test.js
@@ -248,16 +248,20 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
 
     it('returns the list of the campaign', async function () {
       databaseBuilder.factory.buildCampaignParticipation({ masteryRate: 0 });
-      databaseBuilder.factory.buildCampaignParticipation({ campaignId, masteryRate: 0, validatedSkillsCount: 0 });
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        masteryRate: 0,
+        validatedSkillsCount: 0,
+      }).id;
       await databaseBuilder.commit();
 
       const result = await campaignParticipationsStatsRepository.getAllParticipationsByCampaignId(campaignId);
 
-      expect(result).to.deep.equal([{ masteryRate: '0.00', validatedSkillsCount: 0 }]);
+      expect(result).to.deep.equal([{ masteryRate: '0.00', validatedSkillsCount: 0, id: campaignParticipationId }]);
     });
 
     it('returns the list of only isImproved=false participations', async function () {
-      databaseBuilder.factory.buildCampaignParticipation({
+      const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
         campaignId,
         masteryRate: 0,
         validatedSkillsCount: 0,
@@ -273,11 +277,11 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
 
       const result = await campaignParticipationsStatsRepository.getAllParticipationsByCampaignId(campaignId);
 
-      expect(result).to.deep.equal([{ masteryRate: '0.00', validatedSkillsCount: 0 }]);
+      expect(result).to.deep.equal([{ masteryRate: '0.00', validatedSkillsCount: 0, id: campaignParticipationId }]);
     });
 
     it('returns the list of not deleted participations', async function () {
-      databaseBuilder.factory.buildCampaignParticipation({
+      const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
         campaignId,
         masteryRate: 0,
         deletedAt: null,
@@ -293,7 +297,7 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
 
       const result = await campaignParticipationsStatsRepository.getAllParticipationsByCampaignId(campaignId);
 
-      expect(result).to.deep.equal([{ masteryRate: '0.00', validatedSkillsCount: 0 }]);
+      expect(result).to.deep.equal([{ masteryRate: '0.00', validatedSkillsCount: 0, id: campaignParticipationId }]);
     });
   });
 

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/badge-acquisitions-statistics-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/badge-acquisitions-statistics-serializer_test.js
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+
+import * as serializer from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/badge-acquisitions-statistics-serializer.js';
+
+describe('Unit | Serializer | JSONAPI | badge-acquisitions-statistics-serializer', function () {
+  describe('#serialize', function () {
+    it('should convert badge acquisitions statistics into JSON API data', function () {
+      const badge1 = Symbol('badge1');
+      const badge2 = Symbol('badge2');
+
+      const json = serializer.serialize({
+        campaignId: 1,
+        data: [
+          { badge: badge1, percentage: 12, count: 1 },
+          { badge: badge2, percentage: 24, count: 2 },
+        ],
+      });
+
+      expect(json).to.deep.equal({
+        data: {
+          type: 'badge-acquisitions-statistics',
+          id: '1',
+          attributes: {
+            data: [
+              { badge: badge1, percentage: 12, count: 1 },
+              { badge: badge2, percentage: 24, count: 2 },
+            ],
+          },
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :pancakes: Problème
On souhaite ajouter une statistique d'obtention de résultats thématiques sur la page de résultat de l'application orga.

## :bacon: Proposition
Ajouter une route qui permet de retourner cette statistique.

## 🧃 Remarques
badgeAcquisitionRepository traine toujours dans lib.

## :yum: Pour tester
- Tests au vert
- Vous pouvez tenter un appel sur la route
