### PR TITLE
[FEATURE] Afficher le titre interne comme titre dans la liste des contenus formatifs et la section côté Profil Cible (PIX-16462)

### DIFF
--- a/admin/app/components/trainings/list-summary-items.gjs
+++ b/admin/app/components/trainings/list-summary-items.gjs
@@ -9,7 +9,7 @@ import StateTag from './state-tag';
 
 export default class TrainingListSummaryItems extends Component {
   searchedId = this.args.id;
-  searchedTitle = this.args.title;
+  searchedInternalTitle = this.args.internalTitle;
 
   <template>
     <div class="content-text content-text--small">
@@ -46,8 +46,8 @@ export default class TrainingListSummaryItems extends Component {
                 <td>
                   <PixInput
                     type="text"
-                    value={{this.searchedTitle}}
-                    oninput={{fn @triggerFiltering "title"}}
+                    value={{this.searchedInternalTitle}}
+                    oninput={{fn @triggerFiltering "internalTitle"}}
                     aria-label="Filtrer les contenus formatifs par un titre"
                   />
                 </td>

--- a/admin/app/components/trainings/list-summary-items.gjs
+++ b/admin/app/components/trainings/list-summary-items.gjs
@@ -18,7 +18,7 @@ export default class TrainingListSummaryItems extends Component {
           <thead>
             <tr>
               <th class="table__column table__column--id" id="training-id" scope="col">ID</th>
-              <th id="training-titre" scope="col">Titre</th>
+              <th id="training-internal-title" scope="col">Titre à usage interne</th>
               <th id="training-prerequisite-threshold" scope="col" class="col-status">Prérequis</th>
               <th id="training-goal-threshold" scope="col" class="col-status">Objectif à ne pas dépasser</th>
               <th id="training-target-profile-count" scope="col" class="col-status">Profils cibles associés</th>
@@ -55,9 +55,9 @@ export default class TrainingListSummaryItems extends Component {
               {{#each @summaries as |summary|}}
                 <tr aria-label="Contenu formatif">
                   <td headers="training-id" class="table__column table__column--id">{{summary.id}}</td>
-                  <td headers="training-title">
+                  <td headers="training-internal-title">
                     <LinkTo @route="authenticated.trainings.training" @model={{summary.id}}>
-                      {{summary.title}}
+                      {{summary.internalTitle}}
                     </LinkTo>
                   </td>
                   <td headers="training-prerequisite-threshold">

--- a/admin/app/components/trainings/list-summary-items.gjs
+++ b/admin/app/components/trainings/list-summary-items.gjs
@@ -3,6 +3,7 @@ import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import { fn } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
 import Component from '@glimmer/component';
+import { t } from 'ember-intl';
 
 import StateTag from './state-tag';
 
@@ -14,15 +15,23 @@ export default class TrainingListSummaryItems extends Component {
     <div class="content-text content-text--small">
       <div class="table-admin">
         <table>
-          <caption class="screen-reader-only">Liste des contenus formatifs</caption>
+          <caption class="screen-reader-only">{{t "pages.trainings.training.list.caption"}}</caption>
           <thead>
             <tr>
-              <th class="table__column table__column--id" id="training-id" scope="col">ID</th>
-              <th id="training-internal-title" scope="col">Titre à usage interne</th>
-              <th id="training-prerequisite-threshold" scope="col" class="col-status">Prérequis</th>
-              <th id="training-goal-threshold" scope="col" class="col-status">Objectif à ne pas dépasser</th>
-              <th id="training-target-profile-count" scope="col" class="col-status">Profils cibles associés</th>
-              <th id="training-state" scope="col" class="col-status">État</th>
+              <th class="table__column table__column--id" id="training-id" scope="col">{{t
+                  "pages.trainings.training.list.id"
+                }}</th>
+              <th id="training-internal-title" scope="col">{{t "pages.trainings.training.list.internalTitle"}}</th>
+              <th id="training-prerequisite-threshold" scope="col" class="col-status">{{t
+                  "pages.trainings.training.list.prerequisite"
+                }}</th>
+              <th id="training-goal-threshold" scope="col" class="col-status">{{t
+                  "pages.trainings.training.list.goalThreshold"
+                }}</th>
+              <th id="training-target-profile-count" scope="col" class="col-status">{{t
+                  "pages.trainings.training.list.targetProfileCount"
+                }}</th>
+              <th id="training-state" scope="col" class="col-status">{{t "pages.trainings.training.list.status"}}</th>
             </tr>
             {{#if @triggerFiltering}}
               <tr>
@@ -79,7 +88,7 @@ export default class TrainingListSummaryItems extends Component {
         </table>
 
         {{#unless @summaries}}
-          <div class="table__empty">Aucun résultat</div>
+          <div class="table__empty">{{t "pages.trainings.training.list.noResult"}}</div>
         {{/unless}}
       </div>
     </div>

--- a/admin/app/components/trainings/training-details-card.gjs
+++ b/admin/app/components/trainings/training-details-card.gjs
@@ -20,11 +20,11 @@ export default class TrainingDetailsCard extends Component {
     {{! template-lint-disable no-redundant-role }}
     <article class="training-details-card" role="article">
       <div class="training-details-card__content">
-        <h1 class="training-details-card__title">{{@training.title}}</h1>
+        <h1 class="training-details-card__title">{{@training.internalTitle}}</h1>
         <StateTag @isDisabled={{@training.isDisabled}} />
         <dl class="training-details-card__details">
-          <dt class="training-details-card__details-label">{{t "pages.trainings.training.details.internalTitle"}}</dt>
-          <dd class="training-details-card__details-value">{{@training.internalTitle}}</dd>
+          <dt class="training-details-card__details-label">{{t "pages.trainings.training.details.title"}}</dt>
+          <dd class="training-details-card__details-value">{{@training.title}}</dd>
           <dt class="training-details-card__details-label">{{t "pages.trainings.training.details.publishedOn"}}</dt>
           <dd class="training-details-card__details-value">
             <a

--- a/admin/app/controllers/authenticated/trainings/list.js
+++ b/admin/app/controllers/authenticated/trainings/list.js
@@ -14,13 +14,13 @@ export default class ListController extends Controller {
     return this.accessControl.hasAccessToTrainingsActionsScope;
   }
 
-  queryParams = ['pageNumber', 'pageSize', 'id', 'title'];
+  queryParams = ['pageNumber', 'pageSize', 'id', 'internalTitle'];
   DEBOUNCE_MS = config.pagination.debounce;
 
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
   @tracked pageSize = 10;
   @tracked id = null;
-  @tracked title = null;
+  @tracked internalTitle = null;
 
   updateFilters(filters) {
     for (const filterKey of Object.keys(filters)) {

--- a/admin/app/models/training-summary.js
+++ b/admin/app/models/training-summary.js
@@ -2,6 +2,7 @@ import Model, { attr } from '@ember-data/model';
 
 export default class TrainingSummary extends Model {
   @attr() title;
+  @attr() internalTitle;
   @attr('number') targetProfilesCount;
   @attr('number') prerequisiteThreshold;
   @attr('number') goalThreshold;

--- a/admin/app/routes/authenticated/trainings/list.js
+++ b/admin/app/routes/authenticated/trainings/list.js
@@ -11,7 +11,7 @@ export default class ListRoute extends Route {
     pageNumber: { refreshModel: true },
     pageSize: { refreshModel: true },
     id: { refreshModel: true },
-    title: { refreshModel: true },
+    internalTitle: { refreshModel: true },
   };
 
   beforeModel() {
@@ -25,7 +25,7 @@ export default class ListRoute extends Route {
       trainingSummaries = await this.store.query('training-summary', {
         filter: {
           id: params.id ? params.id.trim() : '',
-          title: params.title ? params.title.trim() : '',
+          internalTitle: params.internalTitle ? params.internalTitle.trim() : '',
         },
         page: {
           number: params.pageNumber,
@@ -46,7 +46,7 @@ export default class ListRoute extends Route {
       controller.pageNumber = 1;
       controller.pageSize = 10;
       controller.id = null;
-      controller.title = null;
+      controller.internalTitle = null;
     }
   }
 }

--- a/admin/app/templates/authenticated/trainings/list.hbs
+++ b/admin/app/templates/authenticated/trainings/list.hbs
@@ -24,7 +24,7 @@
     <Trainings::ListSummaryItems
       @summaries={{@model}}
       @id={{this.id}}
-      @title={{this.title}}
+      @internalTitle={{this.internalTitle}}
       @triggerFiltering={{this.triggerFiltering}}
     />
   </section>

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/training-summaries-test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/training-summaries-test.js
@@ -71,9 +71,9 @@ module('Acceptance | Target Profile Training Summaries', function (hooks) {
 
     module('with multiple trainings', function (hooks) {
       hooks.beforeEach(async function () {
-        server.create('training', { id: 456, title: 'My training', targetProfileIds: [1] });
-        server.create('training-summary', { id: 456, title: 'My training', targetProfileIds: [1] });
-        server.create('training-summary', { id: 789, title: 'My other training', targetProfileIds: [1] });
+        server.create('training', { id: 456, internalTitle: 'My training', targetProfileIds: [1] });
+        server.create('training-summary', { id: 456, internalTitle: 'My training', targetProfileIds: [1] });
+        server.create('training-summary', { id: 789, internalTitle: 'My other training', targetProfileIds: [1] });
       });
 
       test('should list trainings', async function (assert) {

--- a/admin/tests/acceptance/authenticated/trainings/list-test.js
+++ b/admin/tests/acceptance/authenticated/trainings/list-test.js
@@ -46,14 +46,14 @@ module('Acceptance | Trainings | List', function (hooks) {
         server.createList('training-summary', 10);
         server.create('training-summary', {
           id: 11,
-          title: 'Formation 11',
+          internalTitle: 'Formation 11',
           prerequisiteThreshold: 33,
           goalThreshold: 88,
           targetProfilesCount: 40,
         });
         server.create('training-summary', {
           id: 12,
-          title: 'Formation 12',
+          internalTitle: 'Formation 12',
           prerequisiteThreshold: 34,
           goalThreshold: 89,
           targetProfilesCount: 41,
@@ -76,8 +76,8 @@ module('Acceptance | Trainings | List', function (hooks) {
 
       module('when filters are used', function (hooks) {
         hooks.beforeEach(async () => {
-          server.create('training-summary', { id: 1, title: 'Premier' });
-          server.create('training-summary', { id: 2, title: 'Deuxième' });
+          server.create('training-summary', { id: 1, internalTitle: 'Premier' });
+          server.create('training-summary', { id: 2, internalTitle: 'Deuxième' });
         });
 
         test('it should display the current filter when trainings are filtered by title', async function (assert) {
@@ -114,8 +114,8 @@ module('Acceptance | Trainings | List', function (hooks) {
 
       test('it should redirect to training details page when clicking on training name in the list', async function (assert) {
         // given
-        server.create('training-summary', { id: 1, title: 'Formation 1' });
-        server.create('training', { id: 1, title: 'Formation 1' });
+        server.create('training-summary', { id: 1, internalTitle: 'Formation 1' });
+        server.create('training', { id: 1, internalTitle: 'Formation 1' });
         const screen = await visit('/trainings/list');
 
         // when

--- a/admin/tests/acceptance/authenticated/trainings/list-test.js
+++ b/admin/tests/acceptance/authenticated/trainings/list-test.js
@@ -80,9 +80,9 @@ module('Acceptance | Trainings | List', function (hooks) {
           server.create('training-summary', { id: 2, internalTitle: 'Deuxième' });
         });
 
-        test('it should display the current filter when trainings are filtered by title', async function (assert) {
+        test('it should display the current filter when trainings are filtered by internal title', async function (assert) {
           // when
-          const screen = await visit('/trainings/list?title=Premier');
+          const screen = await visit('/trainings/list?internalTitle=Premier');
 
           // then
           assert

--- a/admin/tests/acceptance/authenticated/trainings/training-test.js
+++ b/admin/tests/acceptance/authenticated/trainings/training-test.js
@@ -33,6 +33,7 @@ module('Acceptance | Trainings | Training', function (hooks) {
       server.create('training', {
         id: 1,
         title: 'Devenir tailleur de citrouille',
+        internalTitle: 'Devenir tailleur de citrouille parce que c‘est génial',
         link: 'http://www.example2.net',
         type: 'autoformation',
         duration: { days: 0, hours: 10, minutes: 0 },
@@ -46,6 +47,7 @@ module('Acceptance | Trainings | Training', function (hooks) {
       server.create('training', {
         id: 2,
         title: 'Apprendre à piloter des chauves-souris',
+        internalTitle: 'Apprendre à piloter des chauves-souris comme Batman',
         link: 'http://www.example2.net',
         type: 'webinaire',
         duration: { days: 0, hours: 10, minutes: 0 },
@@ -78,7 +80,7 @@ module('Acceptance | Trainings | Training', function (hooks) {
         await visit(`/trainings/list`);
         await clickByName('Nouveau contenu formatif');
 
-        await fillByLabel('Titre :', 'Nouveau contenu formatif');
+        await fillByLabel('Titre public :', 'Nouveau contenu formatif');
         await fillByLabel('Titre interne :', 'Mon titre interne');
         await fillByLabel('Lien', 'http://www.example.net');
         await click(screen.getByText('Webinaire'));
@@ -134,7 +136,7 @@ module('Acceptance | Trainings | Training', function (hooks) {
 
       // then
       assert.strictEqual(currentURL(), `/trainings/${trainingId}/triggers`);
-      assert.dom(screen.getByRole('heading', { name: 'Apprendre à piloter des chauves-souris' })).exists();
+      assert.dom(screen.getByRole('heading', { name: 'Apprendre à piloter des chauves-souris comme Batman' })).exists();
       assert.dom(screen.getByRole('link', { name: triggersTabName })).exists();
       assert.dom(screen.getByRole('link', { name: triggersTabName })).hasClass('active');
       assert.dom(screen.getByRole('link', { name: targetProfilesTabName })).exists();
@@ -164,12 +166,12 @@ module('Acceptance | Trainings | Training', function (hooks) {
 
         // when
         await click(screen.getByRole('button', { name: 'Modifier' }));
-        await fillByLabel('Titre :', 'Nouveau contenu formatif modifié');
+        await fillByLabel('Titre public :', 'Nouveau contenu formatif modifié');
         await fillByLabel('Titre interne :', 'Mon titre interne');
         await click(screen.getByRole('button', { name: 'Modifier le contenu formatif' }));
 
         // then
-        assert.dom(screen.getByRole('heading', { name: 'Nouveau contenu formatif modifié' })).exists();
+        assert.dom(screen.getByRole('heading', { name: 'Mon titre interne' })).exists();
       });
     });
 

--- a/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
+++ b/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
@@ -20,7 +20,7 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
     );
 
     // then
-    assert.dom(screen.getByLabelText('Titre :')).exists();
+    assert.dom(screen.getByLabelText('Titre public :')).exists();
     assert.dom(screen.getByLabelText('Titre interne :')).exists();
     assert.dom(screen.getByLabelText('Lien')).exists();
     assert.dom(screen.getByLabelText('Format')).exists();
@@ -85,7 +85,7 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
       );
 
       // then
-      assert.dom(screen.getByLabelText('Titre :')).hasValue(model.title);
+      assert.dom(screen.getByLabelText('Titre public :')).hasValue(model.title);
       assert.dom(screen.getByLabelText('Titre interne :')).hasValue(model.internalTitle);
       assert.dom(screen.getByLabelText('Lien')).hasValue(model.link);
       assert.strictEqual(screen.getByLabelText('Format').innerText, typeCategories[model.type]);

--- a/admin/tests/integration/components/trainings/list-summary-items-test.gjs
+++ b/admin/tests/integration/components/trainings/list-summary-items-test.gjs
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import ListSummaryItems from 'pix-admin/components/trainings/list-summary-items';
 import { module, test } from 'qunit';
 
-module('Integration | Component | routes/authenticated/trainings | list-items', function (hooks) {
+module('Integration | Component | list-summary-items', function (hooks) {
   setupRenderingTest(hooks);
 
   const noop = () => {};

--- a/admin/tests/integration/components/trainings/list-summary-items-test.gjs
+++ b/admin/tests/integration/components/trainings/list-summary-items-test.gjs
@@ -8,20 +8,20 @@ module('Integration | Component | list-summary-items', function (hooks) {
 
   const noop = () => {};
 
-  test('it should display header with id and title', async function (assert) {
+  test('it should display header with id and internal title', async function (assert) {
     // when
     const screen = await render(<template><ListSummaryItems @triggerFiltering={{noop}} /></template>);
 
     // then
     assert.dom(screen.getByText('ID')).exists();
-    assert.dom(screen.getByText('Titre')).exists();
+    assert.dom(screen.getByText('Titre à usage interne')).exists();
   });
 
   test('it should display trainings summaries list', async function (assert) {
     // given
     const summaries = [
-      { id: 1, title: "Apprendre en s'amusant" },
-      { id: 2, title: 'Speed training' },
+      { id: 1, title: "Apprendre en s'amusant", internalTitle: 'Apprendre pour + de fun' },
+      { id: 2, title: 'Speed training', internalTitle: 'training long...' },
     ];
     summaries.meta = {
       pagination: { rowCount: 2 },
@@ -38,7 +38,11 @@ module('Integration | Component | list-summary-items', function (hooks) {
 
   test('it should display trainings summaries data', async function (assert) {
     // given
-    const summaries = [{ id: 123, title: 'Comment toiletter son chien' }];
+    const internalTitle = 'Comment avoir un beau chien tout propre !';
+    const id = 123;
+    const title = 'Comment toiletter son chien';
+    const summaries = [{ id, title, internalTitle }];
+
     summaries.meta = {
       pagination: { rowCount: 2 },
     };
@@ -49,7 +53,7 @@ module('Integration | Component | list-summary-items', function (hooks) {
     );
 
     // then
-    assert.dom(screen.getByLabelText('Contenu formatif')).containsText(123);
-    assert.dom(screen.getByLabelText('Contenu formatif')).containsText('Comment toiletter son chien');
+    assert.dom(screen.getByLabelText('Contenu formatif')).containsText(id);
+    assert.dom(screen.getByLabelText('Contenu formatif')).containsText(internalTitle);
   });
 });

--- a/admin/tests/integration/components/trainings/list-summary-items-test.gjs
+++ b/admin/tests/integration/components/trainings/list-summary-items-test.gjs
@@ -1,10 +1,11 @@
 import { render } from '@1024pix/ember-testing-library';
-import { setupRenderingTest } from 'ember-qunit';
 import ListSummaryItems from 'pix-admin/components/trainings/list-summary-items';
 import { module, test } from 'qunit';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | list-summary-items', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   const noop = () => {};
 

--- a/admin/tests/integration/components/trainings/training-details-card-test.gjs
+++ b/admin/tests/integration/components/trainings/training-details-card-test.gjs
@@ -26,8 +26,8 @@ module('Integration | Component | Trainings::TrainingDetailsCard', function (hoo
     const screen = await render(<template><TrainingDetailsCard @training={{training}} /></template>);
 
     // then
-    assert.dom(screen.getByRole('heading', { level: 1, name: 'Un contenu formatif' })).exists();
-    assert.dom(screen.getByText('Mon titre interne')).exists();
+    assert.dom(screen.getByRole('heading', { level: 1, name: training.internalTitle })).exists();
+    assert.dom(screen.getByText(training.title)).exists();
     assert.dom(screen.getByText('https://un-contenu-formatif')).exists();
     assert.dom(screen.getByText('webinaire')).exists();
     assert.dom(screen.getByText('2j')).exists();

--- a/admin/tests/unit/controllers/authenticated/trainings/list-test.js
+++ b/admin/tests/unit/controllers/authenticated/trainings/list-test.js
@@ -24,17 +24,17 @@ module('Unit | Controller | authenticated/trainings/list', function (hooks) {
       });
     });
 
-    module('updating title', function () {
-      test('it should update controller title field', async function (assert) {
+    module('updating internalTitle', function () {
+      test('it should update controller internalTitle field', async function (assert) {
         // given
-        controller.title = 'someTitle';
+        controller.internalTitle = 'someTitle';
         const expectedValue = 'someOtherTitle';
 
         // when
-        await controller.updateFilters({ title: expectedValue });
+        await controller.updateFilters({ internalTitle: expectedValue });
 
         // then
-        assert.strictEqual(controller.title, expectedValue);
+        assert.strictEqual(controller.internalTitle, expectedValue);
       });
     });
   });

--- a/admin/tests/unit/routes/authenticated/trainings/list-test.js
+++ b/admin/tests/unit/routes/authenticated/trainings/list-test.js
@@ -29,7 +29,7 @@ module('Unit | Route | authenticated/trainings/list', function (hooks) {
         // when
         await route.model(params);
         expectedQueryArgs.filter = {
-          title: '',
+          internalTitle: '',
           id: '',
         };
 
@@ -42,10 +42,10 @@ module('Unit | Route | authenticated/trainings/list', function (hooks) {
     module('when queryParams filters are truthy', function () {
       test('it should call store.query with filters containing trimmed values', async function (assert) {
         // given
-        params.title = 'someTitle';
+        params.internalTitle = 'someTitle';
         params.id = 'someId';
         expectedQueryArgs.filter = {
-          title: 'someTitle',
+          internalTitle: 'someTitle',
           id: 'someId',
         };
 

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -747,6 +747,16 @@
           "status": "Status : ",
           "title": "Title : "
         },
+        "list": {
+          "caption": "Trainings list",
+          "goalThreshold": "Goal Threshold",
+          "id": "ID",
+          "internalTitle": "Title for internal use",
+          "noResult": "No result",
+          "prerequisite": "Prerequisite",
+          "status": "Status",
+          "targetProfileCount": "Associated Targets Profiles"
+        },
         "targetProfiles": {
           "tabName": "Target Profiles"
         },

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -745,7 +745,7 @@
           "localizedLanguage": "Localized language : ",
           "publishedOn": "Published on : ",
           "status": "Status : ",
-          "title": "Title : "
+          "title": "Public title : "
         },
         "list": {
           "caption": "Trainings list",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -762,7 +762,7 @@
           "localizedLanguage": "Langue localisée :",
           "publishedOn": "Publié sur :",
           "status": "Statut :",
-          "title": "Titre :"
+          "title": "Titre public :"
         },
         "list": {
           "caption": "Liste des contenus formatifs",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -764,6 +764,16 @@
           "status": "Statut :",
           "title": "Titre :"
         },
+        "list": {
+          "caption": "Liste des contenus formatifs",
+          "goalThreshold": "Objectif à ne pas dépasser",
+          "id": "ID",
+          "internalTitle": "Titre à usage interne",
+          "noResult": "Aucun résultat",
+          "prerequisite": "Prérequis",
+          "status": "État",
+          "targetProfileCount": "Profils cibles associés"
+        },
         "targetProfiles": {
           "tabName": "Profils cibles associés",
           "title": "Rattacher un ou plusieurs profils cibles"

--- a/api/src/devcomp/application/trainings/index.js
+++ b/api/src/devcomp/application/trainings/index.js
@@ -32,7 +32,7 @@ const register = async function (server) {
           query: Joi.object({
             filter: Joi.object({
               id: Joi.number().empty('').allow(null).optional(),
-              title: Joi.string().empty('').allow(null).optional(),
+              internalTitle: Joi.string().empty('').allow(null).optional(),
             }).default({}),
             page: {
               number: Joi.number().integer().empty('').allow(null).optional(),

--- a/api/src/devcomp/infrastructure/repositories/training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/training-repository.js
@@ -225,9 +225,9 @@ function _toDomainSummary({ trainingSummary, trainingTriggers }) {
 }
 
 function _applyFilters(qb, filter) {
-  const { title, id } = filter;
-  if (title) {
-    qb.whereILike('title', `%${title}%`);
+  const { internalTitle, id } = filter;
+  if (internalTitle) {
+    qb.whereILike('internalTitle', `%${internalTitle}%`);
   }
   if (id) {
     qb.where({ id });

--- a/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
@@ -236,16 +236,28 @@ describe('Integration | Repository | training-repository', function () {
 
       it('should return filtered by title results', async function () {
         // given
-        const trainingSummary1 = domainBuilder.buildTrainingSummary({ id: 1, title: 'test' });
-        const trainingSummary2 = domainBuilder.buildTrainingSummary({ id: 2, title: 'test 2' });
-        const trainingSummary3 = domainBuilder.buildTrainingSummary({ id: 3, title: 'dummy' });
+        const trainingSummary1 = domainBuilder.buildTrainingSummary({
+          id: 1,
+          title: 'test',
+          internalTitle: 'internal test',
+        });
+        const trainingSummary2 = domainBuilder.buildTrainingSummary({
+          id: 2,
+          title: 'test 2',
+          internalTitle: 'internal test 2',
+        });
+        const trainingSummary3 = domainBuilder.buildTrainingSummary({
+          id: 3,
+          title: 'dummy',
+          internalTitle: 'internal dummy',
+        });
 
         databaseBuilder.factory.buildTraining({ ...trainingSummary1 });
         databaseBuilder.factory.buildTraining({ ...trainingSummary2 });
         databaseBuilder.factory.buildTraining({ ...trainingSummary3 });
 
         await databaseBuilder.commit();
-        const filter = { title: 'test' };
+        const filter = { internalTitle: 'test' };
         const page = {};
 
         // when

--- a/api/tests/devcomp/unit/domain/usecases/find-paginated-training-summaries_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/find-paginated-training-summaries_test.js
@@ -4,7 +4,7 @@ import { expect, sinon } from '../../../../test-helper.js';
 describe('Unit | Devcomp | Domain | UseCases | find-paginated-training-summaries', function () {
   it('should find filtered training summaries with pagination', async function () {
     // given
-    const filter = { id: 1 };
+    const filter = { id: 1, internalTitle: 'internal title' };
     const page = { number: 1, size: 2 };
 
     const trainingRepository = {


### PR DESCRIPTION
## :pancakes: Problème

Dans Pix Admin, dans le tableau de la liste des contenus formatifs (côté CF et dans les profils cibles), c'est le titre qui est affiché au lieu du titre interne. 

## :bacon: Proposition

Afficher le titre interne au lieu du titre, et changer le libellé dans le tableau en conséquence.

## 🧃 Remarques

- Le composant listant les CF est le même dans l'onglet CF et dans les Profils Cibles.
- Dette technique : pas de test côté api pour les filtres de CF

## :yum: Pour tester

### Page Liste contenu formatif
- Se connecter sur la [RA](https://admin-pr11376.review.pix.fr/) de Pix admin avec le compte superadmin
- Aller sur la [page](https://admin-pr11376.review.pix.fr/trainings/list) listant les contenus formatifs 
- Vérifier que le titre interne s'affiche à la place du titre
- Faire une recherche pour filtrer les titres en mettant par exemple `midi`
- Vérifier que le contenu est bien filtré

### Page Profil cible
- Aller sur la page de détail d'un profil cible ayant des Contenus Formatifs (ex : [Prêt pour la certification du volet 1](https://admin-pr11376.review.pix.fr/target-profiles/8000/training-summaries)
- Vérifier que le titre interne s'affiche bien à la place du titre