### PR TITLE
[TECH] :rewind: Retour sur l'insertion en masse de job avec PgBoss (PIX-16478)

### DIFF
--- a/api/src/shared/infrastructure/repositories/jobs/job-repository.js
+++ b/api/src/shared/infrastructure/repositories/jobs/job-repository.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
+import { DomainTransaction } from '../../../domain/DomainTransaction.js';
 import { EntityValidationError } from '../../../domain/errors.js';
-import { pgBoss } from './pg-boss.js';
 
 export class JobRepository {
   #schema = Joi.object({
@@ -47,18 +47,20 @@ export class JobRepository {
     return {
       name: this.name,
       data,
-      retryLimit: this.retry.retryLimit,
-      retryDelay: this.retry.retryDelay,
-      retryBackoff: this.retry.retryBackoff,
-      expireInSeconds: this.expireIn,
-      onComplete: true,
+      retrylimit: this.retry.retryLimit,
+      retrydelay: this.retry.retryDelay,
+      retrybackoff: this.retry.retryBackoff,
+      expirein: this.expireIn,
+      on_complete: true,
       priority: this.priority,
     };
   }
 
   async #send(jobs) {
-    await pgBoss.insert(jobs);
-    return { rowCount: jobs.length };
+    const knexConn = DomainTransaction.getConnection();
+    const results = await knexConn.batchInsert('pgboss.job', jobs);
+    const rowCount = results.reduce((total, batchResult) => total + (batchResult.rowCount || 0), 0);
+    return { rowCount };
   }
 
   async performAsync(...datas) {

--- a/api/tests/evaluation/unit/infrastructure/repositories/answer-job-repository_test.js
+++ b/api/tests/evaluation/unit/infrastructure/repositories/answer-job-repository_test.js
@@ -1,12 +1,18 @@
 import { AnswerJobRepository } from '../../../../../src/evaluation/infrastructure/repositories/answer-job-repository.js';
 import { config } from '../../../../../src/shared/config.js';
-import { pgBoss } from '../../../../../src/shared/infrastructure/repositories/jobs/pg-boss.js';
+import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
 import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Evaluation | Unit | Infrastructure | Repositories | AnswerJobRepository', function () {
   beforeEach(function () {
     sinon.stub(config, 'featureToggles');
-    sinon.stub(pgBoss, 'insert').resolves([]);
+    //TODO : comment this stub to quickfix problem (see https://1024pix.atlassian.net/wiki/spaces/DC/pages/4986372097/Erreur+en+RECETTE+Les+certifications+compl+t+es+ne+sont+pas+scor+es+2025-02-07)
+    //sinon.stub(pgBoss, 'insert').resolves([]);
+    const knexStub = { batchInsert: sinon.stub().resolves([]) };
+    sinon.stub(DomainTransaction, 'getConnection').returns(knexStub);
+    sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
+      return callback();
+    });
     config.featureToggles.isQuestEnabled = true;
     config.featureToggles.isAsyncQuestRewardingCalculationEnabled = true;
   });


### PR DESCRIPTION
## :pancakes: Problème

Nous avons détecté un problème en fin de certification sur la recette : plus de jobs PGBoss publies.

https://1024pix.atlassian.net/wiki/spaces/DC/pages/4986372097/Erreur+en+RECETTE+Les+certifications+compl+t+es+ne+sont+pas+scor+es+2025-02-07

## :bacon: Proposition

* Revenir en arrière sur la partie « insertion en masse de jobs » de la PR #11308 pour débloquer le déploiement.

## 🧃 Remarques

* Il faudra sans doute investiguer un peu plus sur pourquoi le `pgBoss.insert(jobs)` ne fonctionne pas... 
  * Une inquietude aussi sur le fait que le insert ne publiait pas sans generer de log ou d'erreur visible
* Dans la PR precedente on a aussi perdu le cote transactionnel
  * Dans le cas de notre test, cela a mis dans un etat bancal (test de recette) la certification, car avant si les jobs sont pas publies car la transaction mere aurait ete rollback 

## :yum: Pour tester

⚠️ Bien s'assurer que l'on tourne avec un worker + START_JOB_IN_WEB_PROCESS = false

* Pix certif : creer une certif
* Pix App : passer une certification **jusqu'au bout** (ecran de fin de test)
* Pix Admin : voir que la certification n'est pas en statut demarre, ni dans la section a traiter, et que son score est OK
  * Si ce n'est pas le cas : c'est que le job n'a pas ete publie ou traite 
  
* Niveau tech : tout est OK si on voit un evenement CertificationCompletedJob pour le certification-course dans la table pgboss.job
