### PR TITLE
[TECH] :package: Déplace le repo `badgeForCalculation` vers `src/`

### DIFF
--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -135,6 +135,7 @@ import * as answerRepository from '../../../src/shared/infrastructure/repositori
 import * as areaRepository from '../../../src/shared/infrastructure/repositories/area-repository.js';
 import * as assessmentRepository from '../../../src/shared/infrastructure/repositories/assessment-repository.js';
 import * as assessmentResultRepository from '../../../src/shared/infrastructure/repositories/assessment-result-repository.js';
+import * as badgeForCalculationRepository from '../../../src/shared/infrastructure/repositories/badge-for-calculation-repository.js';
 import * as challengeRepository from '../../../src/shared/infrastructure/repositories/challenge-repository.js';
 import * as competenceRepository from '../../../src/shared/infrastructure/repositories/competence-repository.js';
 import * as courseRepository from '../../../src/shared/infrastructure/repositories/course-repository.js';
@@ -166,7 +167,6 @@ import { organizationInvitationRepository } from '../../../src/team/infrastructu
 import { userOrgaSettingsRepository } from '../../../src/team/infrastructure/repositories/user-orga-settings-repository.js';
 import * as obfuscationService from '../../domain/services/obfuscation-service.js';
 import * as badgeAcquisitionRepository from '../../infrastructure/repositories/badge-acquisition-repository.js';
-import * as badgeForCalculationRepository from '../../infrastructure/repositories/badge-for-calculation-repository.js';
 import * as complementaryCertificationCourseResultRepository from '../../infrastructure/repositories/complementary-certification-course-result-repository.js';
 import * as flashAssessmentResultRepository from '../../infrastructure/repositories/flash-assessment-result-repository.js';
 import { repositories } from '../../infrastructure/repositories/index.js';

--- a/api/src/certification/shared/domain/services/certification-badges-service.js
+++ b/api/src/certification/shared/domain/services/certification-badges-service.js
@@ -3,8 +3,8 @@
  */
 import _ from 'lodash';
 
-import * as badgeForCalculationRepository from '../../../../../lib/infrastructure/repositories/badge-for-calculation-repository.js';
 import * as certifiableBadgeAcquisitionRepository from '../../../../../lib/infrastructure/repositories/certifiable-badge-acquisition-repository.js';
+import * as badgeForCalculationRepository from '../../../../shared/infrastructure/repositories/badge-for-calculation-repository.js';
 import * as knowledgeElementRepository from '../../../../shared/infrastructure/repositories/knowledge-element-repository.js';
 import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 

--- a/api/src/prescription/campaign-participation/domain/usecases/index.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/index.js
@@ -2,7 +2,6 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import * as badgeAcquisitionRepository from '../../../../../lib/infrastructure/repositories/badge-acquisition-repository.js';
-import * as badgeForCalculationRepository from '../../../../../lib/infrastructure/repositories/badge-for-calculation-repository.js';
 import * as learningContentRepository from '../../../../../lib/infrastructure/repositories/learning-content-repository.js';
 import * as stageCollectionRepository from '../../../../../lib/infrastructure/repositories/user-campaign-results/stage-collection-repository.js';
 import * as tutorialRepository from '../../../../devcomp/infrastructure/repositories/tutorial-repository.js';
@@ -16,6 +15,7 @@ import * as userRepository from '../../../../identity-access-management/infrastr
 import { config } from '../../../../shared/config.js';
 import * as areaRepository from '../../../../shared/infrastructure/repositories/area-repository.js';
 import * as assessmentRepository from '../../../../shared/infrastructure/repositories/assessment-repository.js';
+import * as badgeForCalculationRepository from '../../../../shared/infrastructure/repositories/badge-for-calculation-repository.js';
 import * as competenceRepository from '../../../../shared/infrastructure/repositories/competence-repository.js';
 import * as knowledgeElementRepository from '../../../../shared/infrastructure/repositories/knowledge-element-repository.js';
 import * as organizationLearnerRepository from '../../../../shared/infrastructure/repositories/organization-learner-repository.js';

--- a/api/src/shared/infrastructure/repositories/badge-for-calculation-repository.js
+++ b/api/src/shared/infrastructure/repositories/badge-for-calculation-repository.js
@@ -1,9 +1,9 @@
 import _ from 'lodash';
 
-import * as campaignRepository from '../../../src/prescription/campaign/infrastructure/repositories/campaign-repository.js';
-import { DomainTransaction } from '../../../src/shared/domain/DomainTransaction.js';
-import { SCOPES } from '../../../src/shared/domain/models/BadgeDetails.js';
-import { BadgeCriterionForCalculation, BadgeForCalculation } from '../../../src/shared/domain/models/index.js';
+import * as campaignRepository from '../../../prescription/campaign/infrastructure/repositories/campaign-repository.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
+import { SCOPES } from '../../domain/models/BadgeDetails.js';
+import { BadgeCriterionForCalculation, BadgeForCalculation } from '../../domain/models/index.js';
 
 export { findByCampaignId, findByCampaignParticipationId, getByCertifiableBadgeAcquisition };
 

--- a/api/tests/shared/integration/infrastructure/repositories/badge-for-calculation-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/badge-for-calculation-repository_test.js
@@ -1,6 +1,6 @@
-import * as badgeForCalculationRepository from '../../../../lib/infrastructure/repositories/badge-for-calculation-repository.js';
-import { SCOPES } from '../../../../src/shared/domain/models/BadgeDetails.js';
-import { databaseBuilder, domainBuilder, expect, learningContentBuilder } from '../../../test-helper.js';
+import { SCOPES } from '../../../../../src/shared/domain/models/BadgeDetails.js';
+import * as badgeForCalculationRepository from '../../../../../src/shared/infrastructure/repositories/badge-for-calculation-repository.js';
+import { databaseBuilder, domainBuilder, expect, learningContentBuilder } from '../../../../test-helper.js';
 
 describe('Integration | Repository | BadgeForCalculation', function () {
   const campaignSkillsId = [


### PR DESCRIPTION
## :pancakes: Problème

Le repo `BadgeForCalculation` est dans `lib/

## :bacon: Proposition

Déplacer le repository `BadgeForCalculation` vers `src/shared/`. Il contient une méthode utilisée par Prescription et le reste par CErtification.

## 🧃 Remarques

Il faudra sans doute le déplacer chez Certification avec une API interne pour prescription.

## :yum: Pour tester

✅ tests verts
