### PR TITLE
[BUGFIX] Corriger le script d'envoi d'invitation à rejoindre une organisation en masse (PIX-16498)

### DIFF
--- a/api/src/team/scripts/send-organization-invitations-script.js
+++ b/api/src/team/scripts/send-organization-invitations-script.js
@@ -14,7 +14,7 @@ const DEFAULT_THROTTE_DELAY = 1000;
 
 const columnsSchemas = [
   { name: 'Organization ID', schema: Joi.number() },
-  { name: 'email', schema: Joi.string().trim().replace(' ', '').lowercase() },
+  { name: 'email', schema: Joi.string().trim().replace(' ', '').lowercase().email() },
   { name: 'locale', schema: Joi.string().trim().lowercase() },
   {
     name: 'role',

--- a/api/src/team/scripts/send-organization-invitations-script.js
+++ b/api/src/team/scripts/send-organization-invitations-script.js
@@ -21,7 +21,7 @@ const columnsSchemas = [
     schema: Joi.string()
       .trim()
       .optional()
-      .valid(...Object.values(OrganizationInvitation.RoleType)),
+      .valid(...Object.values(OrganizationInvitation.RoleType), ''),
   },
 ];
 

--- a/api/tests/team/unit/scripts/files/send-incorrecte-organization-invitations.csv
+++ b/api/tests/team/unit/scripts/files/send-incorrecte-organization-invitations.csv
@@ -1,0 +1,2 @@
+"Organization ID","email","locale","role"
+1,test@example,fr,MEMBER

--- a/api/tests/team/unit/scripts/send-organization-invitations-script_test.js
+++ b/api/tests/team/unit/scripts/send-organization-invitations-script_test.js
@@ -1,5 +1,7 @@
 import * as url from 'node:url';
 
+import Joi from 'joi';
+
 import { SendOrganizationInvitationsScript } from '../../../../src/team/scripts/send-organization-invitations-script.js';
 import { expect, sinon } from '../../../test-helper.js';
 
@@ -20,6 +22,21 @@ describe('unit | team | scripts | send-organization-invitations-script', functio
       expect(fileData).to.be.deep.equal([
         { 'Organization ID': 1, email: 'test@example.net', locale: 'fr', role: 'MEMBER' },
       ]);
+    });
+
+    it('refuses with an incorrect email', async function () {
+      // given
+      const testCsvFile = `${currentDirectory}files/send-incorrecte-organization-invitations.csv`;
+      const script = new SendOrganizationInvitationsScript();
+
+      // when
+      const { options } = script.metaInfo;
+
+      // then
+      await expect(options.file.coerce(testCsvFile)).to.be.rejectedWith(
+        Joi.ValidationError,
+        /"value" must be a valid email/,
+      );
     });
   });
 


### PR DESCRIPTION
## :pancakes: Problème

En faisant des tests en recette on s'est aperçu qu'il n'y avait pas de vérification pour savoir si les emails étaient valides. Or lorsqu'on lançait le script, les invitations étaient créées dans la table mails (bien évidemment) non envoyés.

## :bacon: Proposition

Rajouter une obligation pour que la colonne email ne contienne que des emails.

## 🧃 Remarques

On a constaté également que si on voulait des colones vide, il fallait les autoriser:)

## :yum: Pour tester
- Récupérer les fichiers csv en pièce jointe 
[fichier_incorrecte.csv](https://github.com/user-attachments/files/18730475/fichier_incorrecte.csv)
[fichier.csv](https://github.com/user-attachments/files/18730476/fichier.csv)
- Exécuter le script sur la RA en important le fichier :
```shell
scalingo -a pix-api-review-pr11379 run --file fichier.csv node src/team/scripts/send-organization-invitations-script.js --dryRun --file /tmp/uploads/fichier.csv
```
- Constater qu'un message indiquant que les X ligne du fichier seront traités
- Réexécuter la commande avec cette fois le fichier incorrecte :
```shell
scalingo -a pix-api-review-pr11379 run --file fichier_incorrecte.csv node src/team/scripts/send-organization-invitations-script.js --dryRun --file /tmp/uploads/fichier_incorrecte.csv
````
- Constater qu'on se prend une erreur de format