### PR TITLE
[BUGFIX] Ajouter automatiquement un 0 devant le département s'il ne contient que 2 chiffres (PIX-13151)

### DIFF
--- a/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
+++ b/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
@@ -4,8 +4,12 @@ import { ORGANIZATION_FEATURE } from '../../../shared/domain/constants.js';
 import { DataProtectionOfficer } from './DataProtectionOfficer.js';
 
 const CREDIT_DEFAULT_VALUE = 0;
+const PAD_TARGET_LENGTH = 3;
+const PAD_STRING = '0';
 
 class OrganizationForAdmin {
+  #provinceCode;
+
   constructor({
     id,
     name,
@@ -89,6 +93,14 @@ class OrganizationForAdmin {
     this.code = code;
   }
 
+  get provinceCode() {
+    return this.#provinceCode;
+  }
+
+  set provinceCode(provinceCode) {
+    this.#provinceCode = provinceCode ? provinceCode.padStart(PAD_TARGET_LENGTH, PAD_STRING) : '';
+  }
+
   get archivistFullName() {
     return this.archivistFirstName && this.archivistLastName
       ? `${this.archivistFirstName} ${this.archivistLastName}`
@@ -131,10 +143,6 @@ class OrganizationForAdmin {
     this.parentOrganizationId = parentOrganizationId;
   }
 
-  updateProvinceCode(provinceCode) {
-    this.provinceCode = provinceCode;
-  }
-
   updateIdentityProviderForCampaigns(identityProviderForCampaigns) {
     this.identityProviderForCampaigns = identityProviderForCampaigns;
   }
@@ -155,7 +163,7 @@ class OrganizationForAdmin {
     this.email = organization.email;
     this.credit = organization.credit;
     this.externalId = organization.externalId;
-    this.updateProvinceCode(organization.provinceCode);
+    this.provinceCode = organization.provinceCode;
     this.documentationUrl = organization.documentationUrl;
     this.updateIsManagingStudents(organization.isManagingStudents, organization.features);
     this.showSkills = organization.showSkills;

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -85,7 +85,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
               'external-id': organization.externalId,
               'parent-organization-id': organization.parentOrganizationId,
               'parent-organization-name': null,
-              'province-code': organization.provinceCode,
+              'province-code': '045',
               'is-managing-students': organization.isManagingStudents,
               credit: organization.credit,
               email: organization.email,

--- a/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
+++ b/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
@@ -658,7 +658,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
     });
   });
 
-  context('#updateProvinceCode', function () {
+  context('#provinceCode', function () {
     it('updates ProvinceCode', function () {
       // given
       const initialProvinceCode = '44200';
@@ -667,9 +667,26 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
         provinceCode: initialProvinceCode,
       });
       // when
-      givenOrganization.updateProvinceCode(newProvinceCode);
+      givenOrganization.provinceCode = newProvinceCode;
       // then
       expect(givenOrganization.provinceCode).to.equal(newProvinceCode);
+    });
+
+    context('when there is no 3 numbers', function () {
+      it('normalizes provinceCode by padding', function () {
+        // given
+        const initialProvinceCode = '6';
+        const newProvinceCode = '44';
+        const givenOrganization = new OrganizationForAdmin({
+          provinceCode: initialProvinceCode,
+        });
+
+        // when
+        givenOrganization.provinceCode = newProvinceCode;
+
+        // then
+        expect(givenOrganization.provinceCode).to.equal('044');
+      });
     });
   });
 
@@ -746,8 +763,8 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
       );
 
       // then
-      const expectedOrganization = domainBuilder.buildOrganizationForAdmin({ provinceCode });
-      expect(organizationToUpdate.provinceCode).to.equal(provinceCode);
+      const expectedOrganization = domainBuilder.buildOrganizationForAdmin({ provinceCode: `0${provinceCode}` });
+      expect(organizationToUpdate.provinceCode).to.equal(`0${provinceCode}`);
       expect(organizationToUpdate).to.deep.equal(expectedOrganization);
     });
 


### PR DESCRIPTION
## :pancakes: Problème

Lorsqu'on importe des orgas en masse ou qu'on en créé une, on peut mettre 2 chiffres dans la colone provinceCode alors qu'elle doit en contenir 3.

## :bacon: Proposition

Modifier le repository pour qu'à chaque mise à jour ou création un 0 soit ajouté en début de chaîne de caractère si le champ ne contient que 2 chiffres.

## 🧃 Remarques

Faudrait-il également migrer dans la table toutes les orgas?

## :yum: Pour tester
- Se rendre sur Pix admin,
- Se connecter avec le compte"superadmin@example.net",
- Créer une nouvelle organisation,
- Une fois l'organisation créé, la modifiée,
- Dans le champ département, saisir 75,
- Enregistrer les modifications,
- Constater que dans le champ département, un 0 se trouve devant le 75, constituant ainsi: "075".