### PR TITLE
[FEATURE] Rendre le champ titre interne obligatoire (PIX-16461) (PIX-16068)

### DIFF
--- a/api/src/devcomp/application/trainings/index.js
+++ b/api/src/devcomp/application/trainings/index.js
@@ -127,7 +127,7 @@ const register = async function (server) {
               attributes: Joi.object({
                 link: Joi.string().uri().required(),
                 title: Joi.string().required(),
-                'internal-title': Joi.string().optional(),
+                'internal-title': Joi.string().required(),
                 duration: Joi.object({
                   days: Joi.number().min(0).default(0),
                   hours: Joi.number().min(0).max(23).default(0),

--- a/api/tests/devcomp/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/trainings/training-controller_test.js
@@ -178,7 +178,7 @@ describe('Acceptance | Controller | training-controller', function () {
             type: 'trainings',
             attributes: {
               title: 'Titre du training',
-              internalTitle: 'Titre interne du training',
+              'internal-title': 'Titre interne du training',
               link: 'https://training-link.org',
               type: 'webinaire',
               duration: {

--- a/api/tests/devcomp/unit/application/trainings/index_test.js
+++ b/api/tests/devcomp/unit/application/trainings/index_test.js
@@ -140,6 +140,7 @@ describe('Unit | Devcomp | Application | Trainings | Router | training-router', 
           attributes: {
             link: 'http://www.example.net',
             title: 'ma formation',
+            'internal-title': 'Ma formation',
             duration: { days: 2, hours: 2, minutes: 2 },
             type: 'webinaire',
             locale: 'fr-fr',
@@ -247,6 +248,7 @@ describe('Unit | Devcomp | Application | Trainings | Router | training-router', 
             attributes: {
               link: 'http://www.example.net',
               title: 'ma formation',
+              'internal-title': 'Ma formation',
               duration: { days: 2, hours: 2, minutes: 2 },
               type: 'webinaire',
               locale: 'fr-fr',
@@ -285,6 +287,7 @@ describe('Unit | Devcomp | Application | Trainings | Router | training-router', 
             attributes: {
               link: 'example',
               title: 'ma formation',
+              'internal-title': 'Ma formation',
               duration: { days: 2, hours: 2, minutes: 2 },
               type: 'webinaire',
               locale: 'fr-fr',
@@ -321,6 +324,7 @@ describe('Unit | Devcomp | Application | Trainings | Router | training-router', 
           data: {
             attributes: {
               title: 'ma formation',
+              'internal-title': 'Ma formation',
               duration: { days: 2, hours: 2, minutes: 2 },
               type: 'webinaire',
               locale: 'fr-fr',
@@ -354,6 +358,42 @@ describe('Unit | Devcomp | Application | Trainings | Router | training-router', 
         const invalidPayload = {
           data: {
             attributes: {
+              'internal-title': 'Ma formation',
+              link: 'http://www.example.net',
+              duration: { days: 2, hours: 2, minutes: 2 },
+              type: 'webinaire',
+              locale: 'fr-fr',
+              'editor-name': 'ministère',
+              'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+            },
+          },
+        };
+        sinon.stub(trainingController, 'create').returns('ok');
+
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
+
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/admin/trainings', invalidPayload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+      it('should return 400 if in the payload there is no internal title', async function () {
+        // given
+        const invalidPayload = {
+          data: {
+            attributes: {
+              title: 'Ma formation',
               link: 'http://www.example.net',
               duration: { days: 2, hours: 2, minutes: 2 },
               type: 'webinaire',


### PR DESCRIPTION
## :pancakes: Problème
On ne valide pas côté API que le titre interne d'un contenu formatif est fourni lors de sa création.

## :bacon: Proposition
Le valider

## 🧃 Remarques
On n'a pas de contrainte plus loin dans les couches de l'API. Pour le moment on utilise un modèle anémique et c'est la BDD qui valide que les champs sont non nuls. Ce n'est pas le cas du titre interne car on l'a emmené progressivement et il devait pouvoir être `null` au départ.

En discutant on s'est dit qu'il faudrait faire ce type de validation côté modèle (training-repository) et que ce n'est pas hyper grave donc on laisse passer comme ça.

## :yum: Pour tester
- Créer un CF via l'API sans `internal-title`, comparer le résultat avec la version sur `dev`. (Edit & Resend dans le navigateur par exemple)