### PR TITLE
[BUGFIX] Corriger le decalage entre capacities et certification-challenges (PIX-16457).

### DIFF
--- a/api/scripts/certification/remove-exact-same-challenge-recorded-twice.js
+++ b/api/scripts/certification/remove-exact-same-challenge-recorded-twice.js
@@ -1,0 +1,172 @@
+import 'dotenv/config';
+
+import { knex } from '../../db/knex-database-connection.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+
+export class FixDuplicatedChallengeScript extends Script {
+  constructor() {
+    super({
+      description: 'Fix certification-challenge-capacities from exact same challenge recorded twice',
+      permanent: false,
+      options: {
+        courseIds: {
+          type: 'array',
+          describe: 'List of certification course to fix',
+          demandOption: true,
+          default: [],
+        },
+        dryRun: {
+          type: 'boolean',
+          describe: 'Commit the UPDATE or not',
+          demandOption: false,
+          default: true,
+        },
+      },
+    });
+
+    this.totalNumberOfUpdatedRows = 0;
+    this.totalNumberOfDeletedRows = 0;
+  }
+
+  async handle({ options, logger }) {
+    this.logger = logger;
+    const dryRun = options.dryRun;
+    const courseIds = options.courseIds;
+    this.logger.info(`dryRun=${dryRun} courseIds=[${courseIds}]`);
+
+    for (const currentCourse of courseIds) {
+      const results = await this.fixCertificationCapacities({ dryRun, courseId: currentCourse });
+
+      this.logger.debug({ results });
+
+      this.totalNumberOfUpdatedRows += results.numberOfUpdates;
+      this.totalNumberOfDeletedRows += results.numberOfDeletes;
+    }
+
+    this.logger.info({
+      totalNumberOfCertifications: courseIds.length,
+      totalNumberOfUpdatedRows: this.totalNumberOfUpdatedRows,
+      totalNumberOfDeletedRows: this.totalNumberOfDeletedRows,
+    });
+
+    return 0;
+  }
+
+  async fixCertificationCapacities({ dryRun, courseId }) {
+    const transaction = await knex.transaction();
+    try {
+      const allCertificationChallenges = await transaction
+        .select({
+          id: 'certification-challenges.id',
+          challengeId: 'certification-challenges.challengeId',
+        })
+        .from('certification-challenges')
+        .where('certification-challenges.courseId', '=', courseId)
+        .orderBy('certification-challenges.createdAt', 'asc');
+
+      // Find all capacities
+      const certificationCapacities = await transaction
+        .select({
+          // table certif-challenges
+          certifCourse_Id: 'certification-challenges.courseId',
+          certifChallenge_Id: 'certification-challenges.id',
+          certifChallenge_ChallengeId: 'certification-challenges.challengeId',
+          // table answers
+          answer_ChallengeId: 'answers.challengeId',
+          // table capacities
+          capacity_CertificationChallengeId: 'certification-challenge-capacities.certificationChallengeId',
+          capacity_AnswerId: 'certification-challenge-capacities.answerId',
+        })
+        .from('certification-challenge-capacities')
+        .innerJoin(
+          'certification-challenges',
+          'certification-challenge-capacities.certificationChallengeId',
+          'certification-challenges.id',
+        )
+        .innerJoin('certification-courses', 'certification-challenges.courseId', 'certification-courses.id')
+        .leftJoin('answers', 'certification-challenge-capacities.answerId', 'answers.id')
+        .where('certification-challenges.courseId', '=', courseId)
+        .orderBy('certification-challenges.createdAt', 'asc');
+
+      this.logger.debug({ certificationCapacities });
+
+      // Now fix capacities
+      const capacitiesToUpdate = [];
+      for (const currentCapacity of certificationCapacities) {
+        this.logger.debug({ currentCapacity });
+        if (currentCapacity.certifChallenge_ChallengeId !== currentCapacity.answer_ChallengeId) {
+          // Copy capacity in error
+          const capacityToModify = { ...currentCapacity };
+          capacityToModify.capacity_CertificationChallengeId = 'REPLACE_ME';
+          // Update also challengeId just to show we gound the right match in logs
+          capacityToModify.certifChallenge_ChallengeId = 'REPLACE_ME';
+
+          // Get the right challenge id for this capacity answer
+          const indexOfCorrectChallenge = allCertificationChallenges.findIndex(
+            (certifChallenge) => certifChallenge.challengeId === currentCapacity.answer_ChallengeId,
+          );
+
+          if (indexOfCorrectChallenge !== -1) {
+            // Update capacity with right answer id
+            capacityToModify.capacity_CertificationChallengeId =
+              allCertificationChallenges.at(indexOfCorrectChallenge).id;
+            // Update also certifChallengeChallengeId just to show we found the right match in logs
+            capacityToModify.certifChallenge_ChallengeId =
+              allCertificationChallenges.at(indexOfCorrectChallenge).challengeId;
+            capacitiesToUpdate.push(capacityToModify);
+          } else {
+            // It is not possible that a capacity has a answer but no challenge
+            throw new Error(`Capacity ${capacityToModify.capacity_AnswerId} do not have a corresponding challenge`);
+          }
+
+          // That answer cannot be used anymore
+          allCertificationChallenges.splice(indexOfCorrectChallenge, 1);
+        } else {
+          // We are on a correct certif challenge, forget about her
+          const correctChallenge = allCertificationChallenges.findIndex(
+            (certifChallenge) => certifChallenge.id === currentCapacity.certifChallenge_Id,
+          );
+          // That certif challenge cannot be used anymore
+          allCertificationChallenges.splice(correctChallenge, 1);
+        }
+      }
+
+      // Now from all remaining challenges, find the ones that HAVE a capacity already (meaning they are a duplicate)
+      const certifChallengesToDelete = allCertificationChallenges.filter((challenge) =>
+        certificationCapacities.find((capacity) => capacity.certifChallenge_Id === challenge.id),
+      );
+
+      // We have to do the update in reverse because certificationChallengeId is the PRIMARY KEY
+      for (const capacityToUpdate of capacitiesToUpdate.reverse()) {
+        await transaction('certification-challenge-capacities')
+          .where('answerId', '=', capacityToUpdate.capacity_AnswerId)
+          .update({
+            certificationChallengeId: capacityToUpdate.capacity_CertificationChallengeId,
+          });
+      }
+
+      await transaction('certification-challenges')
+        .whereIn(
+          'id',
+          certifChallengesToDelete.map((challenge) => challenge.id),
+        )
+        .delete();
+
+      this.logger.debug({ capacitiesToUpdate });
+      this.logger.debug({ certifChallengesToDelete });
+
+      dryRun ? await transaction.rollback() : await transaction.commit();
+
+      return {
+        numberOfUpdates: capacitiesToUpdate.length,
+        numberOfDeletes: certifChallengesToDelete.length,
+      };
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, FixDuplicatedChallengeScript);

--- a/api/tests/integration/scripts/certification/remove-exact-same-challenge-recorded-twice_test.js
+++ b/api/tests/integration/scripts/certification/remove-exact-same-challenge-recorded-twice_test.js
@@ -1,0 +1,354 @@
+import { FixDuplicatedChallengeScript } from '../../../../scripts/certification/remove-exact-same-challenge-recorded-twice.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
+
+describe('Integration | Scripts | Certification | remove-exact-same-challenge-recorded-twice', function () {
+  describe('when candidate has completed the test', function () {
+    describe('when there is only one duplicated challenge', function () {
+      it('should fix the capacities challenges ids', async function () {
+        // given
+        const certificationCourseId = 321;
+        const options = { dryRun: false, courseIds: [certificationCourseId] };
+        const logger = {
+          info: sinon.stub(),
+          debug: sinon.stub(),
+        };
+
+        const user = databaseBuilder.factory.buildUser();
+        const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+          id: certificationCourseId,
+          userId: user.id,
+        });
+        const assessment = databaseBuilder.factory.buildAssessment({
+          certificationCourseId: certificationCourse.id,
+          userId: user.id,
+        });
+        const firstChallengeSeenByCandidate = databaseBuilder.factory.buildCertificationChallenge({
+          id: 1,
+          challengeId: 'rec123',
+          courseId: certificationCourseId,
+        });
+        const secondChallengeSeenByCandidate = databaseBuilder.factory.buildCertificationChallenge({
+          id: 2,
+          challengeId: 'rec456',
+          courseId: certificationCourseId,
+        });
+        const doubledChallengeNotSeenByCandidate = databaseBuilder.factory.buildCertificationChallenge({
+          id: 22,
+          challengeId: 'rec456',
+          courseId: certificationCourseId,
+        });
+        const thirdChallengeSeenByCandidate = databaseBuilder.factory.buildCertificationChallenge({
+          id: 3,
+          challengeId: 'rec789',
+          courseId: certificationCourseId,
+        });
+        const fourthChallengeSeenByCandidate = databaseBuilder.factory.buildCertificationChallenge({
+          id: 5,
+          challengeId: 'rec002',
+          courseId: certificationCourseId,
+        });
+
+        const firstAnswer = databaseBuilder.factory.buildAnswer({
+          id: 1,
+          challengeId: 'rec123',
+          assessment: assessment.id,
+        });
+        const secondAnswer = databaseBuilder.factory.buildAnswer({
+          id: 2,
+          challengeId: 'rec456',
+          assessment: assessment.id,
+        });
+        const thirdAnswer = databaseBuilder.factory.buildAnswer({
+          id: 3,
+          challengeId: 'rec789',
+          assessment: assessment.id,
+        });
+        const fourthAnswer = databaseBuilder.factory.buildAnswer({
+          id: 4,
+          challengeId: 'rec002',
+          assessment: assessment.id,
+        });
+
+        databaseBuilder.factory.buildCertificationChallengeCapacity({
+          certificationChallengeId: firstChallengeSeenByCandidate.id,
+          answerId: firstAnswer.id,
+          capacity: 1,
+          createdAt: new Date('2020-01-01'),
+        });
+        databaseBuilder.factory.buildCertificationChallengeCapacity({
+          certificationChallengeId: secondChallengeSeenByCandidate.id,
+          answerId: secondAnswer.id,
+          capacity: 2,
+          createdAt: new Date('2020-01-01'),
+        });
+        databaseBuilder.factory.buildCertificationChallengeCapacity({
+          certificationChallengeId: doubledChallengeNotSeenByCandidate.id,
+          answerId: thirdAnswer.id,
+          capacity: 3,
+          createdAt: new Date('2020-01-01'),
+        });
+
+        databaseBuilder.factory.buildCertificationChallengeCapacity({
+          certificationChallengeId: thirdChallengeSeenByCandidate.id,
+          answerId: fourthAnswer.id,
+          capacity: 4,
+          createdAt: new Date('2020-01-01'),
+        });
+
+        await databaseBuilder.commit();
+
+        const script = new FixDuplicatedChallengeScript();
+
+        // when
+        await script.handle({ options, logger });
+
+        // then
+        const certificationChallenges = await knex('certification-challenges');
+        expect(certificationChallenges).to.deep.equal([
+          {
+            associatedSkillId: 'recSKIL123',
+            associatedSkillName: '@twi8',
+            certifiableBadgeKey: null,
+            challengeId: firstAnswer.challengeId,
+            competenceId: 'recCOMP789',
+            courseId: 321,
+            createdAt: new Date('2020-01-01'),
+            difficulty: null,
+            discriminant: null,
+            hasBeenSkippedAutomatically: false,
+            id: firstChallengeSeenByCandidate.id,
+            isNeutralized: false,
+            updatedAt: new Date('2020-01-02'),
+          },
+          {
+            associatedSkillId: 'recSKIL123',
+            associatedSkillName: '@twi8',
+            certifiableBadgeKey: null,
+            challengeId: secondAnswer.challengeId,
+            competenceId: 'recCOMP789',
+            courseId: 321,
+            createdAt: new Date('2020-01-01'),
+            difficulty: null,
+            discriminant: null,
+            hasBeenSkippedAutomatically: false,
+            id: secondChallengeSeenByCandidate.id,
+            isNeutralized: false,
+            updatedAt: new Date('2020-01-02'),
+          },
+          {
+            associatedSkillId: 'recSKIL123',
+            associatedSkillName: '@twi8',
+            certifiableBadgeKey: null,
+            challengeId: thirdAnswer.challengeId,
+            competenceId: 'recCOMP789',
+            courseId: 321,
+            createdAt: new Date('2020-01-01'),
+            difficulty: null,
+            discriminant: null,
+            hasBeenSkippedAutomatically: false,
+            id: thirdChallengeSeenByCandidate.id,
+            isNeutralized: false,
+            updatedAt: new Date('2020-01-02'),
+          },
+          {
+            associatedSkillId: 'recSKIL123',
+            associatedSkillName: '@twi8',
+            certifiableBadgeKey: null,
+            challengeId: fourthAnswer.challengeId,
+            competenceId: 'recCOMP789',
+            courseId: 321,
+            createdAt: new Date('2020-01-01'),
+            difficulty: null,
+            discriminant: null,
+            hasBeenSkippedAutomatically: false,
+            id: fourthChallengeSeenByCandidate.id,
+            isNeutralized: false,
+            updatedAt: new Date('2020-01-02'),
+          },
+        ]);
+        const certificationChallengeCapacities = await knex('certification-challenge-capacities');
+        expect(certificationChallengeCapacities).to.have.deep.members([
+          {
+            certificationChallengeId: firstChallengeSeenByCandidate.id,
+            answerId: firstAnswer.id,
+            createdAt: new Date('2020-01-01'),
+            capacity: 1,
+          },
+          {
+            certificationChallengeId: secondChallengeSeenByCandidate.id,
+            answerId: secondAnswer.id,
+            createdAt: new Date('2020-01-01'),
+            capacity: 2,
+          },
+          {
+            certificationChallengeId: thirdChallengeSeenByCandidate.id,
+            answerId: thirdAnswer.id,
+            createdAt: new Date('2020-01-01'),
+            capacity: 3,
+          },
+          {
+            certificationChallengeId: fourthChallengeSeenByCandidate.id,
+            answerId: fourthAnswer.id,
+            createdAt: new Date('2020-01-01'),
+            capacity: 4,
+          },
+        ]);
+      });
+    });
+  });
+
+  describe('when candidate has not completed the test', function () {
+    it('should fix the capacities challenges ids', async function () {
+      // given
+      const certificationCourseId = 321;
+      const options = { dryRun: false, courseIds: [certificationCourseId] };
+      const logger = {
+        info: sinon.stub(),
+        debug: sinon.stub(),
+      };
+
+      databaseBuilder.factory.buildCertificationCourse({ id: certificationCourseId });
+      const firstChallengeSeenByCandidate = databaseBuilder.factory.buildCertificationChallenge({
+        id: 1,
+        challengeId: 'rec123',
+        courseId: certificationCourseId,
+      });
+      const secondChallengeSeenByCandidate = databaseBuilder.factory.buildCertificationChallenge({
+        id: 2,
+        challengeId: 'rec456',
+        courseId: certificationCourseId,
+      });
+      const doubledChallengeNotSeenByCandidate = databaseBuilder.factory.buildCertificationChallenge({
+        id: 3,
+        challengeId: 'rec456',
+        courseId: certificationCourseId,
+      });
+      const thirdChallengeSeenByCandidate = databaseBuilder.factory.buildCertificationChallenge({
+        id: 4,
+        challengeId: 'rec789',
+        courseId: certificationCourseId,
+      });
+      const fourthChallengeSeenByCandidate = databaseBuilder.factory.buildCertificationChallenge({
+        id: 5,
+        challengeId: 'rec001',
+        courseId: certificationCourseId,
+      });
+
+      const firstAnswer = databaseBuilder.factory.buildAnswer({ id: 1, challengeId: 'rec123' });
+      const secondAnswer = databaseBuilder.factory.buildAnswer({ id: 2, challengeId: 'rec456' });
+      const thirdAnswer = databaseBuilder.factory.buildAnswer({ id: 3, challengeId: 'rec789' });
+
+      databaseBuilder.factory.buildCertificationChallengeCapacity({
+        certificationChallengeId: firstChallengeSeenByCandidate.id,
+        answerId: firstAnswer.id,
+        capacity: 1,
+        createdAt: new Date('2020-01-01'),
+      });
+      databaseBuilder.factory.buildCertificationChallengeCapacity({
+        certificationChallengeId: secondChallengeSeenByCandidate.id,
+        answerId: secondAnswer.id,
+        capacity: 2,
+        createdAt: new Date('2020-01-01'),
+      });
+      databaseBuilder.factory.buildCertificationChallengeCapacity({
+        certificationChallengeId: doubledChallengeNotSeenByCandidate.id,
+        answerId: thirdAnswer.id,
+        capacity: 3,
+        createdAt: new Date('2020-01-01'),
+      });
+
+      await databaseBuilder.commit();
+
+      const script = new FixDuplicatedChallengeScript();
+
+      // when
+      await script.handle({ options, logger });
+
+      // then
+      const certificationChallenges = await knex('certification-challenges');
+      expect(certificationChallenges).to.deep.equal([
+        {
+          associatedSkillId: 'recSKIL123',
+          associatedSkillName: '@twi8',
+          certifiableBadgeKey: null,
+          challengeId: firstAnswer.challengeId,
+          competenceId: 'recCOMP789',
+          courseId: 321,
+          createdAt: new Date('2020-01-01'),
+          difficulty: null,
+          discriminant: null,
+          hasBeenSkippedAutomatically: false,
+          id: firstChallengeSeenByCandidate.id,
+          isNeutralized: false,
+          updatedAt: new Date('2020-01-02'),
+        },
+        {
+          associatedSkillId: 'recSKIL123',
+          associatedSkillName: '@twi8',
+          certifiableBadgeKey: null,
+          challengeId: secondAnswer.challengeId,
+          competenceId: 'recCOMP789',
+          courseId: 321,
+          createdAt: new Date('2020-01-01'),
+          difficulty: null,
+          discriminant: null,
+          hasBeenSkippedAutomatically: false,
+          id: secondChallengeSeenByCandidate.id,
+          isNeutralized: false,
+          updatedAt: new Date('2020-01-02'),
+        },
+        {
+          associatedSkillId: 'recSKIL123',
+          associatedSkillName: '@twi8',
+          certifiableBadgeKey: null,
+          challengeId: thirdAnswer.challengeId,
+          competenceId: 'recCOMP789',
+          courseId: 321,
+          createdAt: new Date('2020-01-01'),
+          difficulty: null,
+          discriminant: null,
+          hasBeenSkippedAutomatically: false,
+          id: thirdChallengeSeenByCandidate.id,
+          isNeutralized: false,
+          updatedAt: new Date('2020-01-02'),
+        },
+        {
+          associatedSkillId: 'recSKIL123',
+          associatedSkillName: '@twi8',
+          certifiableBadgeKey: null,
+          challengeId: fourthChallengeSeenByCandidate.challengeId,
+          competenceId: 'recCOMP789',
+          courseId: 321,
+          createdAt: new Date('2020-01-01'),
+          difficulty: null,
+          discriminant: null,
+          hasBeenSkippedAutomatically: false,
+          id: fourthChallengeSeenByCandidate.id,
+          isNeutralized: false,
+          updatedAt: new Date('2020-01-02'),
+        },
+      ]);
+      const certificationChallengeCapacities = await knex('certification-challenge-capacities');
+      expect(certificationChallengeCapacities).to.deep.equal([
+        {
+          certificationChallengeId: firstChallengeSeenByCandidate.id,
+          answerId: firstAnswer.id,
+          createdAt: new Date('2020-01-01'),
+          capacity: 1,
+        },
+        {
+          certificationChallengeId: secondChallengeSeenByCandidate.id,
+          answerId: secondAnswer.id,
+          createdAt: new Date('2020-01-01'),
+          capacity: 2,
+        },
+        {
+          certificationChallengeId: thirdChallengeSeenByCandidate.id,
+          answerId: thirdAnswer.id,
+          createdAt: new Date('2020-01-01'),
+          capacity: 3,
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## :pancakes: Problème

Pendant leur test de certification, des candidats ont rencontré des problèmes de concurrence menant à la création de deux certification-challenges identiques (non variants) en BDD.
L’algo de sélection de questions considérant à raison que la deuxième question enregistrée en BDD a déjà été jouée par le candidat ne lui propose pas une seconde fois et va charger une nouvelle question à la place.
L’absence de réponse à la question enregistrée et non jouée va créer un décalage au niveau de la BDD lors de l’enregistrement des certification-challenge-capacities.

## :bacon: Proposition

* Un script qui refait l'alignement entre la capacite et son challenge
  * suivi d'une suppression du challenge "en doublon" qui n'a aucune utilite 

## 🧃 Remarques

Impact sur les tables "certification-challenge-capacities" et "certification-challenges".

## :yum: Pour tester

* Demarrer une certification sur Pix, s'arreter en plein milieu (par exemple question 20/32)
* En BDD pour une certification donnee, creer un duplicat de challenge dans `certification-challenges` avec une date de creation superieure a son duplicat
* Puis terminer son test (ou pas mais au moins avancer d'un ou deux questions apres le  duplicat) pour constater la presence du decalage entre certification-challenge-capacities et certification-challenges
* Enfin pour ce certification-course, lancer le script `LOG_LEVEL=info node scripts/certification/remove-exact-same-challenge-recorded-twice.js --courseIds <MON_CERTIF_COURSE_ID>`
* Verifier que le nom de UPDATE est egal a la difference entre question en doublon et la fin (exemple : si arrete question 20/32 alors la difference est de 12 UPDATE)
* Verifier que un DELETE qui est uniquement sur le duplicat que vous avez genere
