### PR TITLE
[TECH] Déprécier l'utilisation du `isCancelled` au profit du statut de l'assessment-result (PIX-16046).

### DIFF
--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -32,7 +32,6 @@ import * as sessionSummaryRepository from '../../../src/certification/session-ma
 import * as supervisorAccessRepository from '../../../src/certification/session-management/infrastructure/repositories/supervisor-access-repository.js';
 // Not used in lib
 import * as certificationBadgesService from '../../../src/certification/shared/domain/services/certification-badges-service.js';
-import * as scoringCertificationService from '../../../src/certification/shared/domain/services/scoring-certification-service.js';
 import * as certificationAssessmentRepository from '../../../src/certification/shared/infrastructure/repositories/certification-assessment-repository.js';
 // Not used in lib
 import * as certificationCandidateRepository from '../../../src/certification/shared/infrastructure/repositories/certification-candidate-repository.js';
@@ -302,7 +301,6 @@ const dependencies = {
   schoolRepository,
   scoAccountRecoveryService,
   scorecardService,
-  scoringCertificationService,
   sessionCodeService,
   sessionEnrolmentRepository,
   sessionPublicationService,

--- a/api/src/certification/evaluation/domain/services/scoring/scoring-v2.js
+++ b/api/src/certification/evaluation/domain/services/scoring/scoring-v2.js
@@ -13,7 +13,6 @@
 import _ from 'lodash';
 
 import CertificationCancelled from '../../../../../../src/shared/domain/events/CertificationCancelled.js';
-import { AssessmentResult } from '../../../../../shared/domain/models/index.js';
 import {
   AnswerCollectionForScoring,
   CertificationAssessmentScore,
@@ -291,7 +290,6 @@ function _createV2AssessmentResult({
     return AssessmentResultFactory.buildNotTrustableAssessmentResult({
       pixScore: certificationAssessmentScore.nbPix,
       reproducibilityRate: certificationAssessmentScore.getPercentageCorrectAnswers(),
-      status: certificationAssessmentScore.status,
       assessmentId: certificationAssessment.id,
       emitter,
       juryId,
@@ -306,7 +304,6 @@ function _createV2AssessmentResult({
       pixScore: certificationAssessmentScore.nbPix,
       reproducibilityRate: certificationAssessmentScore.getPercentageCorrectAnswers(),
       assessmentId: certificationAssessment.id,
-      status: AssessmentResult.status.REJECTED,
       juryId,
     });
   }

--- a/api/src/certification/scoring/domain/models/factories/AssessmentResultFactory.js
+++ b/api/src/certification/scoring/domain/models/factories/AssessmentResultFactory.js
@@ -36,7 +36,7 @@ export class AssessmentResultFactory {
     });
   }
 
-  static buildNotTrustableAssessmentResult({ pixScore, reproducibilityRate, status, assessmentId, juryId, emitter }) {
+  static buildNotTrustableAssessmentResult({ pixScore, reproducibilityRate, assessmentId, juryId, emitter }) {
     const commentForCandidate = new JuryComment({
       context: JuryCommentContexts.CANDIDATE,
       commentByAutoJury: AutoJuryCommentKeys.CANCELLED_DUE_TO_NEUTRALIZATION,
@@ -53,7 +53,7 @@ export class AssessmentResultFactory {
       commentForOrganization,
       pixScore,
       reproducibilityRate,
-      status,
+      status: AssessmentResult.status.CANCELLED,
       assessmentId,
       juryId,
     });

--- a/api/src/certification/session-management/domain/usecases/index.js
+++ b/api/src/certification/session-management/domain/usecases/index.js
@@ -64,7 +64,6 @@ import * as sessionPublicationService from '../services/session-publication-serv
  * @typedef {import('../../infrastructure/storage/cpf-receipts-storage.js').cpfReceiptsStorage} CpfReceiptsStorage
  * @typedef {import('../../infrastructure/storage/cpf-exports-storage.js').cpfExportsStorage} CpfExportsStorage
  * @typedef {import('../../../shared/domain/services/certification-badges-service.js')} CertificationBadgesService
- * @typedef {import('../../../shared/domain/services/scoring-certification-service.js')} ScoringCertificationService
  * @typedef {import('../services/session-publication-service.js')} SessionPublicationService
  * @typedef {import('../../../../shared/domain/services/placement-profile-service.js')} PlacementProfileService
  * @typedef {import('../../../shared/domain/services/certification-cpf-service.js')} CertificationCpfService

--- a/api/src/certification/session-management/infrastructure/repositories/cpf-certification-result-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/cpf-certification-result-repository.js
@@ -108,7 +108,7 @@ function _selectCpfCertificationResults(qb = knex) {
 function _filterQuery(qb = knex, startDate, endDate) {
   return qb
     .where('certification-courses.isPublished', true)
-    .where('certification-courses.isCancelled', false)
+    .where('certification-courses.isCancelled', false) // isCancelled will be removed
     .whereNotNull('certification-courses.sex')
     .where('assessment-results.status', AssessmentResult.status.VALIDATED)
     .where('sessions.publishedAt', '>=', startDate)

--- a/api/src/shared/domain/events/handle-certification-rescoring.js
+++ b/api/src/shared/domain/events/handle-certification-rescoring.js
@@ -89,7 +89,9 @@ async function _handleV2CertificationScoring({
         certificationAssessment,
       });
 
-    await _cancelCertificationCourseIfNotTrustableOrLackOfAnswersForTechnicalReason({
+    // isCancelled will be removed
+    // this block will be removed
+    await _toggleCertificationCourseCancellationIfNotTrustableOrLackOfAnswersForTechnicalReason({
       certificationCourse,
       hasEnoughNonNeutralizedChallengesToBeTrusted:
         certificationAssessmentScore.hasEnoughNonNeutralizedChallengesToBeTrusted,
@@ -146,7 +148,7 @@ async function _handleV3CertificationScoring({
   });
 }
 
-async function _cancelCertificationCourseIfNotTrustableOrLackOfAnswersForTechnicalReason({
+async function _toggleCertificationCourseCancellationIfNotTrustableOrLackOfAnswersForTechnicalReason({
   certificationCourse,
   hasEnoughNonNeutralizedChallengesToBeTrusted,
   certificationCourseRepository,

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v2_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v2_test.js
@@ -572,7 +572,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
             emitter: 'PIX-ALGO-NEUTRALIZATION',
             pixScore: 30,
             reproducibilityRate: 80,
-            status: AssessmentResult.status.VALIDATED,
             assessmentId: 123,
             juryId: 7,
           });
@@ -622,7 +621,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
               emitter: 'PIX-ALGO-NEUTRALIZATION',
               pixScore: 0,
               reproducibilityRate: 45,
-              status: AssessmentResult.status.REJECTED,
               assessmentId: 123,
               juryId: 7,
             });
@@ -903,7 +901,6 @@ describe('Certification | Shared | Unit | Domain | Services | Scoring V2', funct
                 domainBuilder.certification.scoring.buildAssessmentResult.lackOfAnswersForTechnicalReason({
                   pixScore: 0,
                   reproducibilityRate: 33,
-                  status: AssessmentResult.status.REJECTED,
                   assessmentId: 123,
                   emitter: CertificationResult.emitters.PIX_ALGO_NEUTRALIZATION,
                   juryId: 7,

--- a/api/tests/certification/scoring/unit/domain/factories/AssessmentResultFactory_test.js
+++ b/api/tests/certification/scoring/unit/domain/factories/AssessmentResultFactory_test.js
@@ -100,7 +100,6 @@ describe('Certification | Scoring | Unit | Domain | Factories | AssessmentResult
       const actualAssessmentResult = AssessmentResultFactory.buildNotTrustableAssessmentResult({
         pixScore: 55,
         reproducibilityRate: 50.25,
-        status: AssessmentResult.status.VALIDATED,
         assessmentId: 123,
         juryId: 456,
         emitter: 'Moi',
@@ -111,7 +110,7 @@ describe('Certification | Scoring | Unit | Domain | Factories | AssessmentResult
         assessmentId: 123,
         juryId: 456,
         emitter: 'Moi',
-        status: AssessmentResult.status.VALIDATED,
+        status: AssessmentResult.status.CANCELLED,
         pixScore: 55,
         reproducibilityRate: 50.25,
         competenceMarks: [],

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
@@ -48,7 +48,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
       });
     });
 
-    context('when the certification course is cancelled', function () {
+    context('when the certification is cancelled', function () {
       it('should return 0', async function () {
         // given
         const startDate = new Date('2022-01-01');
@@ -67,6 +67,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         const count = await cpfCertificationResultRepository.countExportableCertificationCoursesByTimeRange({
           startDate,
           endDate,
+          assessmentResultStatus: AssessmentResult.status.CANCELLED,
         });
 
         // then

--- a/api/tests/tooling/domain-builder/factory/certification/scoring/build-assessment-result.js
+++ b/api/tests/tooling/domain-builder/factory/certification/scoring/build-assessment-result.js
@@ -24,18 +24,10 @@ buildAssessmentResult.standard = function ({
   });
 };
 
-buildAssessmentResult.notTrustable = function ({
-  pixScore,
-  reproducibilityRate,
-  status,
-  assessmentId,
-  juryId,
-  emitter,
-} = {}) {
+buildAssessmentResult.notTrustable = function ({ pixScore, reproducibilityRate, assessmentId, juryId, emitter } = {}) {
   return AssessmentResultFactory.buildNotTrustableAssessmentResult({
     pixScore,
     reproducibilityRate,
-    status,
     assessmentId,
     juryId,
     emitter,
@@ -67,7 +59,6 @@ buildAssessmentResult.insufficientCorrectAnswers = function ({
 buildAssessmentResult.lackOfAnswersForTechnicalReason = function ({
   pixScore,
   reproducibilityRate,
-  status,
   assessmentId,
   juryId,
   competenceMarks,
@@ -76,7 +67,6 @@ buildAssessmentResult.lackOfAnswersForTechnicalReason = function ({
   return AssessmentResultFactory.buildLackOfAnswersForTechnicalReason({
     pixScore,
     reproducibilityRate,
-    status,
     assessmentId,
     juryId,
     competenceMarks,


### PR DESCRIPTION
## :pancakes: Problème

La propriété `isCancelled` du `certification-course` est dépréciée.

## :bacon: Proposition

Utiliser à la place le statut de l'assessment-result associé au certification-course.

Cas gérés dans cette PR : 
- Neutralisation
- CPF

## 🌸 Remarques

- Suppression de conditions dans les méthodes V3 et V2 dans le cas des certifications complétés.
On constate qu'elles ne sont pas pertinente dans le cas des certifications terminées par le candidat.

![Capture d’écran 2025-02-11 à 09 04 08](https://github.com/user-attachments/assets/ad095b3e-3bee-4f2d-b465-50db4d398878)
![Capture d’écran 2025-02-11 à 09 14 13](https://github.com/user-attachments/assets/6fed1101-c7f5-48ee-9176-4a9226415327)


## :yum: Pour tester

☑ Tests verts
