### PR TITLE
[TECH] Script pour relier des réponses en doublon à un autre assessment (PIX-16235).

### DIFF
--- a/api/scripts/certification/fix-doubled-answers.js
+++ b/api/scripts/certification/fix-doubled-answers.js
@@ -1,0 +1,122 @@
+import 'dotenv/config';
+
+import Joi from 'joi';
+
+import { knex } from '../../db/knex-database-connection.js';
+import { csvFileParser } from '../../src/shared/application/scripts/parsers.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+import { Assessment } from '../../src/shared/domain/models/index.js';
+
+const columnsSchemas = [
+  { name: 'certificationChallengeId', schema: Joi.number() },
+  { name: 'answerId', schema: Joi.number() },
+  { name: 'completionDate', schema: Joi.string() },
+];
+
+export class FixDoubledAnswers extends Script {
+  constructor() {
+    super({
+      description: 'Fix doubled answers in certification',
+      permanent: false,
+      options: {
+        file: {
+          type: 'string',
+          describe:
+            'CSV File with three columns with certificationChallengeIds (integer), answerIds (integer) and completion date (string) to process',
+          demandOption: true,
+          coerce: csvFileParser(columnsSchemas),
+        },
+        assessmentId: {
+          type: 'integer',
+          describe: 'Id of the assessment answers should be linked to',
+          demandOption: true,
+        },
+        dryRun: {
+          type: 'boolean',
+          describe: 'Commit the UPDATE or not',
+          demandOption: false,
+          default: true,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    const { file: certifChallengeAndAnswerIds, assessmentId, dryRun } = options;
+    this.logger = logger;
+
+    this.logger.info(`dryRun=${dryRun}`);
+
+    for (const line of certifChallengeAndAnswerIds) {
+      const transaction = await knex.transaction();
+
+      const { certificationChallengeId, answerId, completionDate } = line;
+      try {
+        // Retrieving the certification-course for upcoming update
+        const certificationChallenge = await transaction('certification-challenges')
+          .where({
+            id: certificationChallengeId,
+          })
+          .first();
+        const certificationCourse = await transaction('certification-courses')
+          .where({
+            id: certificationChallenge.courseId,
+          })
+          .first();
+
+        // Update of the certification-course
+        await transaction('certification-courses').where({ id: certificationCourse.id }).update({
+          abortReason: null,
+          completedAt: completionDate,
+          endedAt: completionDate,
+          updatedAt: completionDate,
+        });
+
+        // Retrieving the assessment for upcoming update
+        const assessment = await transaction('assessments')
+          .where({ certificationCourseId: certificationCourse.id })
+          .first();
+
+        // Removing the certification-challenge-capacity that is not supposed to exist
+        await transaction('certification-challenge-capacities').where({ certificationChallengeId, answerId }).delete();
+        this.logger.info(
+          `certification-challenge-capacity with certificationChallengeId:${certificationChallengeId} deleted`,
+        );
+
+        // Removing the certification-challenge that is not supposed to exist
+        await transaction('certification-challenges').where('id', '=', certificationChallengeId).delete();
+        this.logger.info(`certification-challenge: ${certificationChallengeId} deleted`);
+
+        // assessment update
+        const newLastCertificationChallenge = await transaction('certification-challenges')
+          .where({
+            courseId: certificationCourse.id,
+          })
+          .orderBy('id', 'desc')
+          .first();
+
+        await transaction('assessments').where({ id: assessment.id }).update({
+          state: Assessment.states.COMPLETED,
+          lastChallengeId: newLastCertificationChallenge.challengeId,
+          updatedAt: completionDate,
+          lastQuestionDate: completionDate,
+        });
+
+        // Link the answer that is not supposed to exist to an assessment created for this purpose
+        await transaction('answers').where('id', '=', answerId).update({
+          assessmentId,
+        });
+        this.logger.info(`answer: ${answerId} moved to assessment ${assessmentId}`);
+
+        dryRun ? await transaction.rollback() : await transaction.commit();
+      } catch (error) {
+        await transaction.rollback();
+        throw error;
+      }
+    }
+    return 0;
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, FixDoubledAnswers);

--- a/api/tests/integration/scripts/certification/fix-doubled-answers_test.js
+++ b/api/tests/integration/scripts/certification/fix-doubled-answers_test.js
@@ -1,0 +1,196 @@
+import { FixDoubledAnswers } from '../../../../scripts/certification/fix-doubled-answers.js';
+import { CertificationAssessment } from '../../../../src/certification/session-management/domain/models/CertificationAssessment.js';
+import { AlgorithmEngineVersion } from '../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
+import { ABORT_REASONS } from '../../../../src/certification/shared/domain/models/CertificationCourse.js';
+import { Assessment } from '../../../../src/shared/domain/models/index.js';
+import { createTempFile, databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
+
+describe('Integration | Scripts | Certification | fix-doubled-answers', function () {
+  it('should parse input file', async function () {
+    const script = new FixDoubledAnswers();
+    const { options } = script.metaInfo;
+    const file = 'doubled-answers.csv';
+    const data =
+      'certificationChallengeId,answerId,completionDate\n1,2,2021-01-02 8:20:45.000000+01:00\n3,4,2021-01-02 9:20:45.000000+01:00\n5,6,2021-01-02 10:20:45.000000+01:00\n';
+    const csvFilePath = await createTempFile(file, data);
+
+    const parsedData = await options.file.coerce(csvFilePath);
+
+    expect(parsedData).to.deep.equal([
+      { certificationChallengeId: 1, answerId: 2, completionDate: '2021-01-02 8:20:45.000000+01:00' },
+      { certificationChallengeId: 3, answerId: 4, completionDate: '2021-01-02 9:20:45.000000+01:00' },
+      { certificationChallengeId: 5, answerId: 6, completionDate: '2021-01-02 10:20:45.000000+01:00' },
+    ]);
+  });
+
+  it('should link doubled answers to another assessment', async function () {
+    // given
+    const certificationCourseId = 123;
+    const secondCertificationCourseId = 456;
+    const logger = {
+      info: sinon.stub(),
+      debug: sinon.stub(),
+    };
+
+    const assessmentToUseForUpdate = await databaseBuilder.factory.buildAssessment({
+      id: 123,
+      type: Assessment.types.COMPETENCE_EVALUATION,
+    });
+    const user = databaseBuilder.factory.buildUser();
+
+    const firstCertificationCourse = databaseBuilder.factory.buildCertificationCourse({
+      id: certificationCourseId,
+      userId: user.id,
+      version: AlgorithmEngineVersion.V3,
+      abortReason: ABORT_REASONS.TECHNICAL,
+      completedAt: null,
+      finalizedAt: new Date('2021-01-01'),
+    });
+    const secondCertificationCourse = databaseBuilder.factory.buildCertificationCourse({
+      id: secondCertificationCourseId,
+      userId: user.id,
+      version: AlgorithmEngineVersion.V3,
+      abortReason: ABORT_REASONS.TECHNICAL,
+      completedAt: null,
+      finalizedAt: new Date('2021-01-01'),
+    });
+
+    const firstAssessmentId = databaseBuilder.factory.buildAssessment({
+      certificationCourseId: firstCertificationCourse.id,
+      userId: user.id,
+      type: Assessment.types.CERTIFICATION,
+      state: 'endedDueToFinalization',
+    }).id;
+    const secondAssessmentId = databaseBuilder.factory.buildAssessment({
+      certificationCourseId: secondCertificationCourse.id,
+      userId: user.id,
+      type: Assessment.types.CERTIFICATION,
+      state: 'endedDueToFinalization',
+    }).id;
+
+    const firstCertificationChallengeToKeep = databaseBuilder.factory.buildCertificationChallenge({
+      id: 1,
+      challengeId: 'recYYYY',
+      courseId: certificationCourseId,
+    });
+    const firstCertificationChallengeToBeRemoved = databaseBuilder.factory.buildCertificationChallenge({
+      id: 2,
+      challengeId: 'rec123',
+      courseId: certificationCourseId,
+    });
+
+    const secondCertificationChallengeToKeep = databaseBuilder.factory.buildCertificationChallenge({
+      id: 3,
+      challengeId: 'recXXXX',
+      courseId: secondCertificationCourseId,
+    });
+    const secondCertificationChallengeToBeRemoved = databaseBuilder.factory.buildCertificationChallenge({
+      id: 4,
+      challengeId: 'rec456',
+      courseId: secondCertificationCourseId,
+    });
+
+    const firstAnswerToBeUpdated = databaseBuilder.factory.buildAnswer({
+      id: 1,
+      challengeId: 'rec123',
+      assessmentId: firstAssessmentId,
+    });
+    const secondAnswerToBeUpdated = databaseBuilder.factory.buildAnswer({
+      id: 2,
+      challengeId: 'rec456',
+      assessmentId: secondAssessmentId,
+    });
+
+    databaseBuilder.factory.buildCertificationChallengeCapacity({
+      certificationChallengeId: firstCertificationChallengeToBeRemoved.id,
+      answerId: firstAnswerToBeUpdated.id,
+      capacity: 1,
+    });
+    databaseBuilder.factory.buildCertificationChallengeCapacity({
+      certificationChallengeId: secondCertificationChallengeToBeRemoved.id,
+      answerId: secondAnswerToBeUpdated.id,
+      capacity: 2,
+    });
+
+    await databaseBuilder.commit();
+
+    const file = [
+      {
+        certificationChallengeId: firstCertificationChallengeToBeRemoved.id,
+        answerId: firstAnswerToBeUpdated.id,
+        completionDate: '2021-01-02 8:20:45.000000+01:00',
+      },
+      {
+        certificationChallengeId: secondCertificationChallengeToBeRemoved.id,
+        answerId: secondAnswerToBeUpdated.id,
+        completionDate: '2021-01-02 9:20:45.000000+01:00',
+      },
+    ];
+    const script = new FixDoubledAnswers();
+
+    // when
+    await script.handle({ options: { file, assessmentId: assessmentToUseForUpdate.id, dryRun: false }, logger });
+
+    // then
+    const answers = await knex('answers').select('id', 'assessmentId').orderBy('id');
+    expect(answers).to.deep.equal([
+      {
+        id: firstAnswerToBeUpdated.id,
+        assessmentId: assessmentToUseForUpdate.id,
+      },
+      {
+        id: secondAnswerToBeUpdated.id,
+        assessmentId: assessmentToUseForUpdate.id,
+      },
+    ]);
+    const certificationChallenges = await knex('certification-challenges').select('id');
+    expect(certificationChallenges).to.deep.equal([{ id: 1 }, { id: 3 }]);
+
+    const certificationChallengeCapacities = await knex('certification-challenge-capacities');
+    expect(certificationChallengeCapacities).to.deep.equal([]);
+
+    const assessments = await knex('assessments')
+      .select('id', 'updatedAt', 'state', 'lastChallengeId', 'lastQuestionDate')
+      .where({ type: Assessment.types.CERTIFICATION });
+    expect(assessments).to.deep.equal([
+      {
+        id: firstAssessmentId,
+        state: CertificationAssessment.states.COMPLETED,
+        updatedAt: new Date('2021-01-02T07:20:45Z'),
+        lastChallengeId: firstCertificationChallengeToKeep.challengeId,
+        lastQuestionDate: new Date('2021-01-02T07:20:45Z'),
+      },
+      {
+        id: secondAssessmentId,
+        state: CertificationAssessment.states.COMPLETED,
+        updatedAt: new Date('2021-01-02T08:20:45Z'),
+        lastChallengeId: secondCertificationChallengeToKeep.challengeId,
+        lastQuestionDate: new Date('2021-01-02T08:20:45Z'),
+      },
+    ]);
+
+    const certificationCourses = await knex('certification-courses').select(
+      'id',
+      'completedAt',
+      'updatedAt',
+      'endedAt',
+      'abortReason',
+    );
+    expect(certificationCourses).to.deep.equal([
+      {
+        id: certificationCourseId,
+        completedAt: new Date('2021-01-02T07:20:45Z'),
+        updatedAt: new Date('2021-01-02T07:20:45Z'),
+        endedAt: new Date('2021-01-02T07:20:45Z'),
+        abortReason: null,
+      },
+      {
+        id: secondCertificationCourseId,
+        completedAt: new Date('2021-01-02T08:20:45Z'),
+        updatedAt: new Date('2021-01-02T08:20:45Z'),
+        endedAt: new Date('2021-01-02T08:20:45Z'),
+        abortReason: null,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## :pancakes: Problème

La dernière question posée à certains des candidats de certification s'est retrouvée enregistrée deux fois en BDD, et ceux-ci ont répondu à cette question supplémentaire.
Cela entraine la création de données inutiles en BDD.

La suppression des answers via une requête SQL nous est impossible, nous passons donc par un script.

## :bacon: Proposition

Nous listons dans un fichier CSV les id des certification-challenges, ainsi que les id des answers afin de supprimer les `certification-challenge-capacities` et `certification-challenges` créés en trop.
En ce qui concerne les `answers`, nous les rattachons vers un autre `assessment` dédié à cela et qui voit ses propriétés `lastQuestionDate`, `lastChallengeId` mises à jour.

## 🧃 Remarques

## :yum: Pour tester

NB: Il est également possible (et recommandé) de réaliser ce test avec plusieurs `answerId` et `certificationChallengeId` (donc passer plusieurs tests de certification)

- Créer une nouvelle session avec `sup-center-member@example.net`
- Ajouter un candidat
- Démarrer le test avec `certif-success@example.net` et aller jusqu'à la dernière question sans y répondre
- En BDD, dupliquer le `certification-challenge` en modifiant les colonnes `createdAt` et `updatedAt` de façon à montrer que le doublon a été enregistré un peu après le premier (=réplique d'un enregistrement concurrentiel) et **SURTOUT** en modifiant le `challengeId` en proposant une variante de la question initiale.
⚠️  Noter quelque part la valeur de la colonne `createdAt` de ce doublon nouvellement créé, cela sera utile pour la fin du test fonctionnel
- Répondre à la 32ème question
- Normalement, la 33ème question vous sera proposée, y répondre également finaliser le test afin de générer un `assessment-result` (Qui ne sera pas créé à la complétion du test suite à une erreur lors du scoring)

Une fois cela fait, récupérer l'`id` du `certification-challenge` en trop, ainsi que l'`id` de l'`answer`  qui lui est associé.
Dans un CSV au format qui suit, veuillez utiliser les valeurs correspondantes:

```
certificationChallengeId,answerId,completionDate
123,456,2021-01-02 8:20:45.000000+01:00
```

- Lancer un `assessment` de type évaluation avec le compte Pix que vous souhaitez de façon à créer un nouvel assessment en BDD
- Récupérer l'id de l'`assessment` nouvellement créé
- Lancer le script avec le fichier et assessmentId en paramètres

```
scalingo -a pix-api-review-pr11391 run --file="<csvFilePath>" "node scripts/certification/fix-doubled-answers.js --file /tmp/uploads/<fileName> --assessmentId <assessmentId>"
```

- Vérifier que le certification-challenge en trop a bien été supprimé
- Vérifier que la certification-challenge-capacities en trop a bien été supprimée
- Vérifier que l'answer pointe désormais vers l'assessment de type evaluation
- Vérifier que l'assessment lié aux données supprimées ait les colonnes `state` à `completed` et `updatedAt` correspondant au `createdAt` du certification-challenge n°33 du candidat
- Vérifier que le `certification-course` lié aux données supprimées ait les colonnes `abortReason` à `null` et `completedAt` correspondant au `createdAt` du certification-challenge n°33 du candidat.
