### PR TITLE
[FEATURE] Autoriser la suppression de Quetes via PixAdmin (Pix-16533)

### DIFF
--- a/api/src/quest/domain/usecases/create-or-update-quests-in-batch.js
+++ b/api/src/quest/domain/usecases/create-or-update-quests-in-batch.js
@@ -47,7 +47,7 @@ export const createOrUpdateQuestsInBatch = withTransaction(
     const csvData = csvParser.parse();
 
     csvData.forEach(({ questId, content, deleteQuest }) => {
-      if (deleteQuest && questId) {
+      if (deleteQuest?.toLowerCase() === 'oui' && questId) {
         deleteQuestIds.push(questId);
       } else {
         updatedOrNewQuest.push(new Quest({ id: questId || undefined, ...JSON.parse(content) }));

--- a/api/src/quest/infrastructure/repositories/quest-repository.js
+++ b/api/src/quest/infrastructure/repositories/quest-repository.js
@@ -26,4 +26,9 @@ const saveInBatch = async ({ quests }) => {
   }
 };
 
-export { findAll, saveInBatch };
+const deleteByIds = async ({ questIds }) => {
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn('quests').whereIn('id', questIds).delete();
+};
+
+export { deleteByIds, findAll, saveInBatch };

--- a/api/tests/quest/integration/domain/usecases/create-or-update-quests-in-batch_test.js
+++ b/api/tests/quest/integration/domain/usecases/create-or-update-quests-in-batch_test.js
@@ -17,13 +17,15 @@ describe('Integration | Quest | Domain | UseCases | create-or-update-quests-in-b
       `Quest ID;Json configuration for quest
     ;{"rewardType":"coucou","rewardId":null,"eligibilityRequirements":{"eligibility":"eligibility"},"successRequirements":{"success":"success"}}`,
     );
-    const spy = sinon.spy(repositories.questRepository, 'saveInBatch');
+    const spySave = sinon.spy(repositories.questRepository, 'saveInBatch');
+    const spyDelete = sinon.spy(repositories.questRepository, 'deleteByIds');
 
     // when
     await usecases.createOrUpdateQuestsInBatch({ filePath });
 
     // then
-    expect(spy).to.have.been.calledWithExactly({
+    expect(spyDelete.called).to.be.false;
+    expect(spySave).to.have.been.calledWithExactly({
       quests: [
         new Quest({
           id: undefined,
@@ -35,6 +37,26 @@ describe('Integration | Quest | Domain | UseCases | create-or-update-quests-in-b
           successRequirements: { success: 'success' },
         }),
       ],
+    });
+  });
+
+  it('should delete the passed quests in file', async function () {
+    // given
+    filePath = await createTempFile(
+      'test.csv',
+      `Quest ID;Json configuration for quest;deleteQuest
+    3;{"rewardType":"coucou","rewardId":null,"eligibilityRequirements":{"eligibility":"eligibility"},"successRequirements":{"success":"success"}};true`,
+    );
+    const spySave = sinon.spy(repositories.questRepository, 'saveInBatch');
+    const spyDelete = sinon.spy(repositories.questRepository, 'deleteByIds');
+
+    // when
+    await usecases.createOrUpdateQuestsInBatch({ filePath });
+
+    // then
+    expect(spySave.called).to.be.false;
+    expect(spyDelete).to.have.been.calledWithExactly({
+      questIds: ['3'],
     });
   });
 });

--- a/api/tests/quest/integration/infrastructure/repositories/quest-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/quest-repository_test.js
@@ -90,4 +90,42 @@ describe('Quest | Integration | Repository | quest', function () {
       expect(quests).to.have.lengthOf(3);
     });
   });
+
+  describe('#deleteByIds', function () {
+    it('should delete quest given ids', async function () {
+      // given
+      databaseBuilder.factory.buildQuest({
+        id: 1,
+        rewardType: REWARD_TYPES.ATTESTATION,
+        rewardId: 2,
+        eligibilityRequirements: { toto: 'tata' },
+        successRequirements: { titi: 'tutu' },
+      });
+      databaseBuilder.factory.buildQuest({
+        id: 2,
+        rewardType: REWARD_TYPES.ATTESTATION,
+        rewardId: 2,
+        eligibilityRequirements: { toto: 'tata' },
+        successRequirements: { titi: 'tutu' },
+      });
+      databaseBuilder.factory.buildQuest({
+        id: 3,
+        rewardType: REWARD_TYPES.ATTESTATION,
+        rewardId: 2,
+        eligibilityRequirements: { toto: 'tata' },
+        successRequirements: { titi: 'tutu' },
+      });
+      await databaseBuilder.commit();
+      await databaseBuilder.fixSequences();
+
+      // when
+      await questRepository.deleteByIds({ questIds: ['1', 3] });
+
+      const quests = await questRepository.findAll();
+
+      // then
+      expect(quests).to.have.lengthOf(1);
+      expect(quests[0].id).to.equal(2);
+    });
+  });
 });


### PR DESCRIPTION
## :pancakes: Problème

Suite aux changement de format des quêtes, il est préférable de les supprimer, puis de les rajouter. Or nous n'avons pas la main pour supprimer les quetes actuellement 

## :bacon: Proposition

Permettre la suppression de quetes via l'import de fichier CSV en ajoutant une nouvelle colonne `Delete quest`
## 🧃 Remarques

RAS

## :yum: Pour tester

Se connecter sur PixAdmin. Ajouter une quêtes via l'import CSV. et ensuite la supprimer. 