### PR TITLE
[BUGFIX] Réparer l'apparence de la liste déroulante de SSO pour qu'elle retrouve son style pyjama (PIX-16535)

### DIFF
--- a/mon-pix/app/components/authentication/oidc-provider-selector.scss
+++ b/mon-pix/app/components/authentication/oidc-provider-selector.scss
@@ -46,16 +46,12 @@
     padding: var(--pix-spacing-3x) var(--pix-spacing-2x);
     white-space: normal;
 
-    &:hover, &:focus {
-      background: var(--pix-primary-100);
-    }
-
     &:nth-child(even) {
       background: var(--pix-neutral-0);
+    }
 
-      &:hover, &:focus {
-        background: var(--pix-primary-100);
-      }
+    &:hover, &:focus {
+      background: var(--pix-primary-100);
     }
   }
 }

--- a/mon-pix/app/components/authentication/oidc-provider-selector.scss
+++ b/mon-pix/app/components/authentication/oidc-provider-selector.scss
@@ -42,7 +42,7 @@
     background-color : var(--pix-neutral-20);
   }
 
-  .pix-select-options-category__option {
+  .pix-select-list-category__option {
     padding: var(--pix-spacing-3x) var(--pix-spacing-2x);
     white-space: normal;
 

--- a/mon-pix/app/components/authentication/oidc-provider-selector.scss
+++ b/mon-pix/app/components/authentication/oidc-provider-selector.scss
@@ -46,10 +46,6 @@
     padding: var(--pix-spacing-3x) var(--pix-spacing-2x);
     white-space: normal;
 
-    &:first-child {
-      display: none;
-    }
-
     &:hover, &:focus {
       background: var(--pix-primary-100);
     }


### PR DESCRIPTION
## :pancakes: Problème

Le style original du `OidcProviderSelector` a été perdu (régression) sûrement suite à une montée de version de Pix-UI : 

![Screenshot_2025-02-11_oidc-provider-selector-buggy](https://github.com/user-attachments/assets/45d3b6fe-f0c4-4c81-b0b1-a43432a7ceb2)


## :bacon: Proposition

Corriger le style du `OidcProviderSelector` : 

![Screenshot_2025-02-11_oidc-provider-selector-correct-A](https://github.com/user-attachments/assets/4120705e-7cf9-4eae-9df0-2faaa36aca97)

![Screenshot_2025-02-11_oidc-provider-selector-correct-C](https://github.com/user-attachments/assets/1d7c61fe-0b75-4ad4-ba26-b6f380bd2426)


## 🧃 Remarques

RAS

## :yum: Pour tester

1. Charger plusieurs OIDC Providers, au minimum 2
2. Constater que tous les OIDC Providers qui doivent s'afficher selon les différentes contraintes, s'affichent bien. Ni plus, ni moins. C'est important car il y avait des instructions CSS `&:first-child { display: none; }` qui étaient présentes mais qui ne sont plus adaptées au code actuel.
3. Constater que les lignes de la liste d’OIDC Providers ont des couleurs différentes formant une bande de couleur rayée plus facile à lire et correspondant au design original
4. Constater que l'effet de survol en violet (par CSS) d'une ligne est effectif qu'on survole une ligne blanche ou une ligne grise
