### PR TITLE
[FEATURE] Liste blanche ouverture SCO via BDD (PIX-15544).

### DIFF
--- a/api/src/certification/configuration/domain/models/Center.js
+++ b/api/src/certification/configuration/domain/models/Center.js
@@ -1,9 +1,6 @@
 import Joi from 'joi';
 
-import { config } from '../../../../shared/config.js';
 import { EntityValidationError } from '../../../../shared/domain/errors.js';
-import { _ } from '../../../../shared/infrastructure/utils/lodash-utils.js';
-import { CenterTypes } from './CenterTypes.js';
 
 export class Center {
   static #schema = Joi.object({
@@ -24,18 +21,6 @@ export class Center {
     this.externalId = externalId;
 
     this.#validate();
-  }
-
-  isInWhitelist() {
-    if (this.type !== CenterTypes.SCO) {
-      return true;
-    }
-
-    if (this.type == CenterTypes.SCO && _.isBlank(this.externalId)) {
-      return false;
-    }
-
-    return config.features.pixCertifScoBlockedAccessWhitelist.includes(this.externalId.toUpperCase());
   }
 
   #validate() {

--- a/api/src/identity-access-management/infrastructure/repositories/certification-point-of-contact.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/certification-point-of-contact.repository.js
@@ -21,6 +21,7 @@ const getAllowedCenterAccesses = async function (centerList) {
       id: 'certification-centers.id',
       externalId: 'certification-centers.externalId',
       type: 'certification-centers.type',
+      isInWhitelist: 'certification-centers.isScoBlockedAccessWhitelist',
       isRelatedToManagingStudentsOrganization: 'organizations.isManagingStudents',
       tags: knex.raw('array_agg(?? order by ??)', ['tags.name', 'tags.name']),
       habilitations: knex.raw(
@@ -125,6 +126,7 @@ function _toDomain({ allowedAccessDTOs, centerList }) {
     return new AllowedCertificationCenterAccess({
       center: {
         ...center,
+        isInWhitelist: allowedCenterAccessDTO.isInWhitelist,
         habilitations: _cleanHabilitations(allowedCenterAccessDTO),
       },
       isRelatedToManagingStudentsOrganization: Boolean(allowedCenterAccessDTO.isRelatedToManagingStudentsOrganization),

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -6,9 +6,6 @@ import * as url from 'node:url';
 import dayjs from 'dayjs';
 import ms from 'ms';
 
-import { _ } from './infrastructure/utils/lodash-utils.js';
-import { getArrayOfUpperStrings } from './infrastructure/utils/string-utils.js';
-
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 function parseJSONEnv(varName) {
@@ -235,9 +232,6 @@ const configuration = (function () {
       newYearOrganizationLearnersImportDate: _getDate(process.env.NEW_YEAR_ORGANIZATION_LEARNERS_IMPORT_DATE),
       numberOfChallengesForFlashMethod: _getNumber(process.env.NUMBER_OF_CHALLENGES_FOR_FLASH_METHOD),
       successProbabilityThreshold: parseFloat(process.env.SUCCESS_PROBABILITY_THRESHOLD ?? '0.95'),
-      pixCertifScoBlockedAccessWhitelist: getArrayOfUpperStrings(
-        process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_WHITELIST,
-      ).filter((externalId) => !_.isBlank(externalId)),
       pixCertifScoBlockedAccessDateLycee: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_LYCEE,
       pixCertifScoBlockedAccessDateCollege: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_COLLEGE,
       scheduleComputeOrganizationLearnersCertificability: {

--- a/api/src/shared/domain/read-models/AllowedCertificationCenterAccess.js
+++ b/api/src/shared/domain/read-models/AllowedCertificationCenterAccess.js
@@ -3,6 +3,8 @@ import { config } from '../../config.js';
 
 const { features } = config;
 class AllowedCertificationCenterAccess {
+  #isInWhitelist = false;
+
   constructor({ center, isRelatedToManagingStudentsOrganization, relatedOrganizationTags }) {
     this.id = center.id;
     this.name = center.name;
@@ -11,6 +13,7 @@ class AllowedCertificationCenterAccess {
     this.type = center.type;
     this.habilitations = center.habilitations;
     this.isV3Pilot = center.isV3Pilot;
+    this.#isInWhitelist = !!center.isInWhitelist;
     this.isRelatedToManagingStudentsOrganization = isRelatedToManagingStudentsOrganization;
     this.relatedOrganizationTags = relatedOrganizationTags;
   }
@@ -63,7 +66,7 @@ class AllowedCertificationCenterAccess {
   }
 
   isInWhitelist() {
-    return features.pixCertifScoBlockedAccessWhitelist.includes(this.externalId.toUpperCase());
+    return this.#isInWhitelist;
   }
 
   get pixCertifScoBlockedAccessDateLycee() {

--- a/api/tests/certification/configuration/unit/domain/models/Center_test.js
+++ b/api/tests/certification/configuration/unit/domain/models/Center_test.js
@@ -1,6 +1,5 @@
 import { Center } from '../../../../../../src/certification/configuration/domain/models/Center.js';
 import { CenterTypes } from '../../../../../../src/certification/configuration/domain/models/CenterTypes.js';
-import { config } from '../../../../../../src/shared/config.js';
 import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
 
@@ -30,110 +29,6 @@ describe('Unit | Certification | Configuration | Domain | Models | Center', func
 
       // then
       expect(error).to.be.an.instanceOf(EntityValidationError);
-    });
-  });
-
-  context('#isInWhitelist', function () {
-    let originalEnvValueWhitelist;
-
-    beforeEach(function () {
-      originalEnvValueWhitelist = config.features.pixCertifScoBlockedAccessWhitelist;
-      config.features.pixCertifScoBlockedAccessWhitelist = [];
-    });
-
-    afterEach(function () {
-      config.features.pixCertifScoBlockedAccessWhitelist = originalEnvValueWhitelist;
-    });
-
-    it('should consider centers other than SCO as always whitelisted', function () {
-      // given
-      config.features.pixCertifScoBlockedAccessWhitelist = ['hello'];
-      const center = new Center({
-        id: 12,
-        type: CenterTypes.PRO,
-        externalId: 'hello',
-      });
-      // when
-      const isInWhitelist = center.isInWhitelist();
-
-      // then
-      expect(isInWhitelist).to.be.true;
-    });
-    context('when center is SCO', function () {
-      it('should consider blank externalId as not whitelisted', function () {
-        // given
-        const center = new Center({
-          id: 12,
-          type: CenterTypes.SCO,
-          externalId: '  ',
-        });
-        // when
-        const isInWhitelist = center.isInWhitelist();
-
-        // then
-        expect(isInWhitelist).to.be.false;
-      });
-
-      it('should consider center without externalId as not whitelisted', function () {
-        // given
-        const center = new Center({
-          id: 12,
-          type: CenterTypes.SCO,
-          externalId: undefined,
-        });
-        // when
-        const isInWhitelist = center.isInWhitelist();
-
-        // then
-        expect(isInWhitelist).to.be.false;
-      });
-
-      it('should consider center in whitelist as whitelisted', function () {
-        // given
-        const externalId = 'WHITELISTED';
-        config.features.pixCertifScoBlockedAccessWhitelist = [externalId];
-        const center = new Center({
-          id: 12,
-          type: CenterTypes.SCO,
-          externalId: externalId,
-        });
-        // when
-        const isInWhitelist = center.isInWhitelist();
-
-        // then
-        expect(isInWhitelist).to.be.true;
-      });
-
-      it('should consider center NOT in whitelist as NOT whitelisted', function () {
-        // given
-        config.features.pixCertifScoBlockedAccessWhitelist = ['WHITELISTED'];
-        const center = new Center({
-          id: 12,
-          type: CenterTypes.SCO,
-          externalId: 'not_whitelisted',
-        });
-        // when
-        const isInWhitelist = center.isInWhitelist();
-
-        // then
-        expect(isInWhitelist).to.be.false;
-      });
-
-      it('should not be case sensitive on externalId', function () {
-        // given
-        // config is already uppercased + trimmed
-        config.features.pixCertifScoBlockedAccessWhitelist = ['WHITELISTED12'];
-        const center = new Center({
-          id: 12,
-          type: CenterTypes.SCO,
-          externalId: 'whiteLISTed12',
-        });
-        // when
-        const isInWhitelist = center.isInWhitelist();
-
-        // then
-        expect(isInWhitelist).to.be.true;
-      });
     });
   });
 });

--- a/api/tests/tooling/domain-builder/factory/build-allowed-certification-center-access.js
+++ b/api/tests/tooling/domain-builder/factory/build-allowed-certification-center-access.js
@@ -12,6 +12,7 @@ function buildAllowedCertificationCenterAccess({
   habilitations = [],
   isV3Pilot = false,
   features = [],
+  isInWhitelist,
 } = {}) {
   return new AllowedCertificationCenterAccess({
     center: {
@@ -22,6 +23,7 @@ function buildAllowedCertificationCenterAccess({
       habilitations,
       isV3Pilot,
       features,
+      isInWhitelist,
     },
     isRelatedToManagingStudentsOrganization,
     relatedOrganizationTags,

--- a/api/tests/unit/domain/read-models/AllowedCertificationCenterAccess_test.js
+++ b/api/tests/unit/domain/read-models/AllowedCertificationCenterAccess_test.js
@@ -17,7 +17,6 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return true when certification center is in whitelist', function () {
       // given
-      settings.features.pixCertifScoBlockedAccessWhitelist = ['EXAMPLE1', 'EXAMPLE2'];
       const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
         isInWhitelist: true,
       });
@@ -31,7 +30,6 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return false when certification center is not in whitelist', function () {
       // given
-      settings.features.pixCertifScoBlockedAccessWhitelist = ['EXAMPLE1', 'EXAMPLE2'];
       const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
         externalId: 'EXAMPLE3',
       });
@@ -321,7 +319,6 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
     let clock;
 
     beforeEach(function () {
-      settings.features.pixCertifScoBlockedAccessWhitelist = ['WHITELISTED'];
       settings.features.pixCertifScoBlockedAccessDateCollege = '2021-01-01';
       validData = {
         externalId: 'NOT_WHITELISTED',
@@ -410,7 +407,6 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
     let clock;
 
     beforeEach(function () {
-      settings.features.pixCertifScoBlockedAccessWhitelist = ['WHITELISTED'];
       settings.features.pixCertifScoBlockedAccessDateLycee = '2021-01-01';
       validData = {
         externalId: 'NOT_WHITELISTED',
@@ -493,7 +489,6 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
     let clock;
 
     beforeEach(function () {
-      settings.features.pixCertifScoBlockedAccessWhitelist = ['WHITELISTED'];
       settings.features.pixCertifScoBlockedAccessDateLycee = '2021-01-01';
       validData = {
         externalId: 'NOT_WHITELISTED',
@@ -570,7 +565,6 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
     let clock;
 
     beforeEach(function () {
-      settings.features.pixCertifScoBlockedAccessWhitelist = ['WHITELISTED'];
       settings.features.pixCertifScoBlockedAccessDateLycee = '2021-01-01';
       validData = {
         externalId: 'NOT_WHITELISTED',

--- a/api/tests/unit/domain/read-models/AllowedCertificationCenterAccess_test.js
+++ b/api/tests/unit/domain/read-models/AllowedCertificationCenterAccess_test.js
@@ -3,16 +3,14 @@ import { domainBuilder, expect, sinon } from '../../../test-helper.js';
 
 describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', function () {
   context('#isInWhitelist', function () {
-    let originalEnvValueWhitelist, originalEnvValueDateCollege, originalEnvValueDateLycee;
+    let originalEnvValueDateCollege, originalEnvValueDateLycee;
 
     beforeEach(function () {
-      originalEnvValueWhitelist = settings.features.pixCertifScoBlockedAccessWhitelist;
       originalEnvValueDateCollege = settings.features.pixCertifScoBlockedAccessDateCollege;
       originalEnvValueDateLycee = settings.features.pixCertifScoBlockedAccessDateLycee;
     });
 
     afterEach(function () {
-      settings.features.pixCertifScoBlockedAccessWhitelist = originalEnvValueWhitelist;
       settings.features.pixCertifScoBlockedAccessDateCollege = originalEnvValueDateCollege;
       settings.features.pixCertifScoBlockedAccessDateLycee = originalEnvValueDateLycee;
     });
@@ -21,7 +19,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
       // given
       settings.features.pixCertifScoBlockedAccessWhitelist = ['EXAMPLE1', 'EXAMPLE2'];
       const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
-        externalId: 'EXAMPLE2',
+        isInWhitelist: true,
       });
 
       // when
@@ -43,20 +41,6 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
       // then
       expect(isInWhiteList).to.be.false;
-    });
-
-    it('should be case insensitive', function () {
-      // given
-      settings.features.pixCertifScoBlockedAccessWhitelist = ['EXAMPLE1', 'EXAMPLE2'];
-      const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
-        externalId: 'exAmpLe1',
-      });
-
-      // when
-      const isInWhiteList = allowedCertificationCenterAccess.isInWhitelist();
-
-      // then
-      expect(isInWhiteList).to.be.true;
     });
   });
 
@@ -386,7 +370,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
       clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
         ...validData,
-        externalId: 'WHITELISTED',
+        isInWhitelist: true,
       });
 
       // when
@@ -460,7 +444,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
       clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
         ...validData,
-        externalId: 'WHITELISTED',
+        isInWhitelist: true,
       });
 
       // when
@@ -543,7 +527,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
       clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
         ...validData,
-        externalId: 'WHITELISTED',
+        isInWhitelist: true,
       });
 
       // when
@@ -620,7 +604,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
       clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
         ...validData,
-        externalId: 'WHITELISTED',
+        isInWhitelist: true,
       });
 
       // when


### PR DESCRIPTION
## :pancakes: Problème

A la base en variable d'env, les captains ont remontes que l'on atteint la limite de stockage de cette variable.
Par ailleurs c'est une difficulte pour tous (tech et metier) de maintenir cette liste blanche.
On a tout implemente pour pouvoir la gerer via un front et un stockage en base de donnee, mais on ne l'utilise pas encore.

## :bacon: Proposition

Finir de basculer sur la colonne BDD et dire au revoir a la variable d'env `PIX_CERTIF_SCO_BLOCKED_ACCESS_WHITELIST`

## 🧃 Remarques

J'ai supprime la variable PIX_CERTIF_SCO_BLOCKED_ACCESS_WHITELIST sur le container de la RA

## :yum: Pour tester

* Vous pouvez recuperer la liste blanche sur Pix Admin (url : `/administration/certification`)
* Verifier l'ouverture ou non du centre, et ne pas hesiter a importer une nouvelle liste
  * ⚠️ Il existe un certain nombre de regles pour la fermeture, voir ticket pour avoir le lien de la procedure de fermeture d'un centre
