### PR TITLE
[TECH] Utiliser partout la même logique explicite MissingOrInvalidCredentialsError qui ne fait pas fuiter les informations (PIX-16543)

### DIFF
--- a/api/src/identity-access-management/domain/usecases/authenticate-user.js
+++ b/api/src/identity-access-management/domain/usecases/authenticate-user.js
@@ -1,6 +1,6 @@
 import { PIX_ADMIN, PIX_ORGA } from '../../../authorization/domain/constants.js';
-import { ForbiddenAccess, LocaleFormatError, LocaleNotSupportedError } from '../../../shared/domain/errors.js';
-import { MissingOrInvalidCredentialsError, UserShouldChangePasswordError } from '../errors.js';
+import { ForbiddenAccess, UserNotFoundError } from '../../../shared/domain/errors.js';
+import { MissingOrInvalidCredentialsError, PasswordNotMatching, UserShouldChangePasswordError } from '../errors.js';
 import { RefreshToken } from '../models/RefreshToken.js';
 
 const authenticateUser = async function ({
@@ -49,15 +49,11 @@ const authenticateUser = async function ({
 
     return { accessToken, refreshToken: refreshToken.value, expirationDelaySeconds };
   } catch (error) {
-    if (
-      error instanceof ForbiddenAccess ||
-      error instanceof UserShouldChangePasswordError ||
-      error instanceof LocaleFormatError ||
-      error instanceof LocaleNotSupportedError
-    ) {
+    if (error instanceof UserNotFoundError || error instanceof PasswordNotMatching) {
+      throw new MissingOrInvalidCredentialsError();
+    } else {
       throw error;
     }
-    throw new MissingOrInvalidCredentialsError();
   }
 };
 

--- a/api/tests/identity-access-management/unit/domain/usecases/authenticate-user_test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/authenticate-user_test.js
@@ -329,6 +329,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
       userRepository,
       userLoginRepository,
       refreshTokenRepository,
+      pixAuthenticationService,
       audience,
     });
 
@@ -348,6 +349,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
       userRepository,
       userLoginRepository,
       refreshTokenRepository,
+      pixAuthenticationService,
       audience,
     });
 


### PR DESCRIPTION
## :pancakes: Problème

Le usecase `api/src/identity-access-management/domain/usecases/authenticate-user.js` : 
* n'explicite pas quelles exceptions sont transformées en `MissingOrInvalidCredentialsError`, il explicite exactement le contraire : les exceptions qui ne sont pas  transformées en `MissingOrInvalidCredentialsError`, ce qui empêche de parfaitement maitriser et de comprendre ce qu'il fait
* ne suit pas le même motif de programmation que les autres usecases d'authentification : 
   * `api/src/identity-access-management/domain/usecases/find-user-for-oidc-reconciliation.usecase.js`
   * `api/lib/domain/usecases/authenticate-external-user.js`

## :bacon: Proposition

Rendre explicite que les erreurs transformées en `MissingOrInvalidCredentialsError` sont les erreurs de type `UserNotFoundError` et `PasswordNotMatching`.

## 🧃 Remarques

Cette modification a permis de se rendre compte qu'un test était mal écrit, preuve que la nouvelle implémentation est plus résistante.

## :yum: Pour tester

1. Vérifier qu'une authentification par login+mot de passe fonctionne
2. Vérifier qu'une authentification par login+mot de passe avec un mauvais login ou mauvais mot de passe est bien bloquée avec le bon message d'erreur _« L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects. »_
3. Modifier le fait qu'un utilisateur doive changer son mot de passe et vérifier que cela est bien exigé à la connexion

Exemple de requête SQL pour forcer tous les utilisateurs à changer leur mot de passe : 
```sql
update "authentication-methods"
  set "authenticationComplement"=jsonb_set("authenticationComplement", '{shouldChangePassword}', to_jsonb(true))
  where "authenticationComplement" ? 'password';
```
