### PR TITLE
[TECH] corrige le test flaky sur admin

### DIFF
--- a/admin/app/components/common/tubes-selection.gjs
+++ b/admin/app/components/common/tubes-selection.gjs
@@ -157,7 +157,7 @@ export default class TubesSelection extends Component {
     );
   }
 
-  _onFileLoad(event) {
+  async _onFileLoad(event) {
     try {
       const data = JSON.parse(event.target.result);
 
@@ -172,7 +172,7 @@ export default class TubesSelection extends Component {
         throw new Error("Le format du fichier n'est pas reconnu.");
       }
 
-      this.refreshAreas();
+      await this.refreshAreas();
       this._triggerOnChange();
       this.pixToast.sendSuccessNotification({ message: 'Fichier bien importé.' });
     } catch (error) {


### PR DESCRIPTION
## :pancakes: Problème

un test [flaky sur admin ](https://app.circleci.com/pipelines/github/1024pix/pix/107537/workflows/0df5f840-7c9d-45a8-8f91-e2319f4056ef/jobs/1198747/tests)


## :bacon: Proposition

on corrige le flaky

## 🧃 Remarques

RAS

## :yum: Pour tester

- sur admin > profils cible > Nouveau profil cible 
- Dans sélection des sujets, tester l'import JSON et vérifier que le placeholder a bien changer de nom