### PR TITLE
[FEATURE] Ajouter un endpoint pour supprimer la liaison entre un Profil Cible et un Contenu Formatif (PIX-16512)

### DIFF
--- a/api/lib/infrastructure/repositories/target-profile-training-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-training-repository.js
@@ -15,4 +15,10 @@ const create = async function ({ trainingId, targetProfileIds }) {
   return attachedTargetProfileIds.map(({ targetProfileId }) => targetProfileId);
 };
 
-export { create };
+const remove = async function ({ trainingId, targetProfileId }) {
+  const knexConn = DomainTransaction.getConnection();
+  const removedLines = await knexConn(TABLE_NAME).delete().where({ trainingId, targetProfileId });
+  return removedLines > 0;
+};
+
+export { create, remove };

--- a/api/src/devcomp/application/trainings/index.js
+++ b/api/src/devcomp/application/trainings/index.js
@@ -286,6 +286,34 @@ const register = async function (server) {
         ],
       },
     },
+    {
+      method: 'DELETE',
+      path: '/api/admin/trainings/{trainingId}/target-profiles/{targetProfileId}',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            trainingId: identifiersType.trainingId,
+            targetProfileId: identifiersType.targetProfileId,
+          }),
+        },
+        handler: (request, h) => trainingsController.detachTargetProfile(request, h),
+        tags: ['api', 'admin', 'target-profiles', 'trainings'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
+            '- Elle permet de détacher un contenu formatif d’un profil cible',
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/src/devcomp/application/trainings/training-controller.js
+++ b/api/src/devcomp/application/trainings/training-controller.js
@@ -68,6 +68,15 @@ const attachTargetProfiles = async function (request, h) {
   return h.response({}).code(204);
 };
 
+const detachTargetProfile = async function (request, h) {
+  const { trainingId, targetProfileId } = request.params;
+  await usecases.detachTargetProfilesFromTraining({
+    trainingId,
+    targetProfileId,
+  });
+  return h.response({}).code(204);
+};
+
 const trainingController = {
   findPaginatedTrainingSummaries,
   findTargetProfileSummaries,
@@ -76,6 +85,7 @@ const trainingController = {
   update,
   createOrUpdateTrigger,
   attachTargetProfiles,
+  detachTargetProfile,
 };
 
 export { trainingController };

--- a/api/src/devcomp/domain/usecases/detach-target-profiles-from-training.js
+++ b/api/src/devcomp/domain/usecases/detach-target-profiles-from-training.js
@@ -1,0 +1,14 @@
+import { NotFoundError } from '../../../shared/domain/errors.js';
+
+const detachTargetProfilesFromTraining = async function ({
+  trainingId,
+  targetProfileId,
+  targetProfileTrainingRepository,
+}) {
+  const hasBeenDetached = await targetProfileTrainingRepository.remove({ trainingId, targetProfileId });
+  if (!hasBeenDetached) {
+    throw new NotFoundError('Target profile training not found');
+  }
+};
+
+export { detachTargetProfilesFromTraining };

--- a/api/tests/devcomp/acceptance/application/trainings/index_test.js
+++ b/api/tests/devcomp/acceptance/application/trainings/index_test.js
@@ -523,4 +523,33 @@ describe('Acceptance | Controller | training-controller', function () {
       });
     });
   });
+
+  describe('DELETE /api/admin/trainings/{trainingId}/target-profiles/{targetProfileId}', function () {
+    it('should detach target profile from given training', async function () {
+      // given
+      const adminUser = await insertUserWithRoleSuperAdmin();
+      const userId = adminUser.id;
+      const trainingId = databaseBuilder.factory.buildTraining().id;
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      databaseBuilder.factory.buildTargetProfileTraining({
+        trainingId,
+        targetProfileId,
+      });
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'DELETE',
+        url: `/api/admin/trainings/${trainingId}/target-profiles/${targetProfileId}`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      const result = await knex('target-profile-trainings').where({ trainingId, targetProfileId });
+      expect(response.statusCode).to.equal(204);
+      expect(result).to.deepEqualArray([]);
+    });
+  });
 });

--- a/api/tests/devcomp/integration/application/trainings/index_test.js
+++ b/api/tests/devcomp/integration/application/trainings/index_test.js
@@ -3,7 +3,7 @@ import { trainingController } from '../../../../../src/devcomp/application/train
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
-describe('Unit | Devcomp | Application | Trainings | Router | training-router', function () {
+describe('Integration | Devcomp | Application | Trainings | Router | training-router', function () {
   describe('GET /api/admin/trainings/${trainingId}', function () {
     describe('Security Prehandlers', function () {
       it('should allow user if its role is SUPER_ADMIN', async function () {

--- a/api/tests/devcomp/integration/application/trainings/index_test.js
+++ b/api/tests/devcomp/integration/application/trainings/index_test.js
@@ -1400,145 +1400,227 @@ describe('Integration | Devcomp | Application | Trainings | Router | training-ro
         expect(response.statusCode).to.equal(400);
       });
     });
+  });
 
-    describe('POST /api/admin/trainings/{id}/attach-target-profiles', function () {
-      describe('Security PreHandlers', function () {
-        it('should verify user identity and reach controller if user has role SUPER_ADMIN', async function () {
-          // given
-          sinon.stub(trainingController, 'attachTargetProfiles').returns('ok');
-          sinon
-            .stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier')
-            .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-          sinon
-            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-            .callsFake((request, h) => h.response(true));
-          const httpTestServer = new HttpTestServer();
-          await httpTestServer.register(moduleUnderTest);
+  describe('POST /api/admin/trainings/{id}/attach-target-profiles', function () {
+    describe('Security PreHandlers', function () {
+      it('should verify user identity and reach controller if user has role SUPER_ADMIN', async function () {
+        // given
+        sinon.stub(trainingController, 'attachTargetProfiles').returns('ok');
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response(true));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
 
-          const payload = {
-            'target-profile-ids': [1, 2],
-          };
+        const payload = {
+          'target-profile-ids': [1, 2],
+        };
 
-          // when
-          await httpTestServer.request('POST', '/api/admin/trainings/1/attach-target-profiles', payload);
+        // when
+        await httpTestServer.request('POST', '/api/admin/trainings/1/attach-target-profiles', payload);
 
-          // then
-          sinon.assert.calledOnce(trainingController.attachTargetProfiles);
-        });
-
-        it('should verify user identity and reach controller if user has role METIER', async function () {
-          // given
-          sinon.stub(trainingController, 'attachTargetProfiles').returns('ok');
-          sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
-          sinon
-            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-            .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-
-          const httpTestServer = new HttpTestServer();
-          await httpTestServer.register(moduleUnderTest);
-
-          const payload = {
-            'target-profile-ids': [1, 2],
-          };
-
-          // when
-          await httpTestServer.request('POST', '/api/admin/trainings/1/attach-target-profiles', payload);
-
-          // then
-          sinon.assert.calledOnce(trainingController.attachTargetProfiles);
-        });
-
-        it('should return 403 without reaching controller if user has not an allowed role', async function () {
-          // given
-          sinon.stub(trainingController, 'attachTargetProfiles').returns('ok');
-          sinon
-            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-            .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-          sinon
-            .stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier')
-            .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-          const httpTestServer = new HttpTestServer();
-          await httpTestServer.register(moduleUnderTest);
-
-          const payload = {
-            'target-profile-ids': [1, 2],
-          };
-
-          // when
-          const response = await httpTestServer.request(
-            'POST',
-            '/api/admin/trainings/1/attach-target-profiles',
-            payload,
-          );
-
-          // then
-          expect(response.statusCode).to.equal(403);
-          sinon.assert.notCalled(trainingController.attachTargetProfiles);
-        });
+        // then
+        sinon.assert.calledOnce(trainingController.attachTargetProfiles);
       });
 
-      describe('Param validation', function () {
-        it('should return a 404 HTTP response when target-profile-ids do not contain only numbers', async function () {
-          // given
-          sinon.stub(trainingController, 'attachTargetProfiles').returns('ok');
-          sinon
-            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-            .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-          sinon
-            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
-            .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-          sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
-          const httpTestServer = new HttpTestServer();
-          await httpTestServer.register(moduleUnderTest);
+      it('should verify user identity and reach controller if user has role METIER', async function () {
+        // given
+        sinon.stub(trainingController, 'attachTargetProfiles').returns('ok');
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
 
-          const payload = {
-            'target-profile-ids': ['a', 2],
-          };
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
 
-          // when
-          const response = await httpTestServer.request(
-            'POST',
-            '/api/admin/trainings/1/attach-target-profiles',
-            payload,
-          );
+        const payload = {
+          'target-profile-ids': [1, 2],
+        };
 
-          // then
-          expect(response.statusCode).to.equal(404);
-          expect(response.payload).to.have.string(
-            "L'id d'un des profils cible ou du contenu formatif n'est pas valide",
-          );
-        });
+        // when
+        await httpTestServer.request('POST', '/api/admin/trainings/1/attach-target-profiles', payload);
 
-        it('should return a 404 HTTP response when training id is not valid', async function () {
-          // given
-          sinon.stub(trainingController, 'attachTargetProfiles').returns('ok');
-          sinon
-            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-            .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-          sinon
-            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
-            .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-          sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
-          const httpTestServer = new HttpTestServer();
-          await httpTestServer.register(moduleUnderTest);
+        // then
+        sinon.assert.calledOnce(trainingController.attachTargetProfiles);
+      });
 
-          const payload = {
-            'target-profile-ids': [1, 2],
-          };
+      it('should return 403 without reaching controller if user has not an allowed role', async function () {
+        // given
+        sinon.stub(trainingController, 'attachTargetProfiles').returns('ok');
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
 
-          // when
-          const response = await httpTestServer.request(
-            'POST',
-            '/api/admin/trainings/chaton/attach-target-profiles',
-            payload,
-          );
+        const payload = {
+          'target-profile-ids': [1, 2],
+        };
 
-          // then
-          expect(response.statusCode).to.equal(404);
-          expect(response.payload).to.have.string(
-            "L'id d'un des profils cible ou du contenu formatif n'est pas valide",
-          );
-        });
+        // when
+        const response = await httpTestServer.request('POST', '/api/admin/trainings/1/attach-target-profiles', payload);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(trainingController.attachTargetProfiles);
+      });
+    });
+
+    describe('Param validation', function () {
+      it('should return a 404 HTTP response when target-profile-ids do not contain only numbers', async function () {
+        // given
+        sinon.stub(trainingController, 'attachTargetProfiles').returns('ok');
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const payload = {
+          'target-profile-ids': ['a', 2],
+        };
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/admin/trainings/1/attach-target-profiles', payload);
+
+        // then
+        expect(response.statusCode).to.equal(404);
+        expect(response.payload).to.have.string("L'id d'un des profils cible ou du contenu formatif n'est pas valide");
+      });
+
+      it('should return a 404 HTTP response when training id is not valid', async function () {
+        // given
+        sinon.stub(trainingController, 'attachTargetProfiles').returns('ok');
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const payload = {
+          'target-profile-ids': [1, 2],
+        };
+
+        // when
+        const response = await httpTestServer.request(
+          'POST',
+          '/api/admin/trainings/chaton/attach-target-profiles',
+          payload,
+        );
+
+        // then
+        expect(response.statusCode).to.equal(404);
+        expect(response.payload).to.have.string("L'id d'un des profils cible ou du contenu formatif n'est pas valide");
+      });
+    });
+  });
+
+  describe('DELETE /api/admin/trainings/{trainingId}/target-profiles/{targetProfileId}', function () {
+    describe('Security Prehandlers', function () {
+      let checkAdminMemberHasRoleMetierStub;
+      let checkAdminMemberHasRoleSuperAdminStub;
+      let httpTestServer;
+
+      beforeEach(async function () {
+        checkAdminMemberHasRoleMetierStub = sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier');
+        checkAdminMemberHasRoleSuperAdminStub = sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin');
+
+        httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+      });
+
+      it('should verify user identity and return success update when user role is SUPER_ADMIN', async function () {
+        // given
+        sinon.stub(trainingController, 'detachTargetProfile').returns('ok');
+        checkAdminMemberHasRoleSuperAdminStub.callsFake((request, h) => h.response(true));
+
+        // when
+        await httpTestServer.request('DELETE', '/api/admin/trainings/1/target-profiles/2');
+
+        // then
+        sinon.assert.calledOnce(trainingController.detachTargetProfile);
+      });
+
+      it('should verify user identity and return success update when user role is METIER', async function () {
+        // given
+        sinon.stub(trainingController, 'detachTargetProfile').returns('ok');
+        checkAdminMemberHasRoleSuperAdminStub.callsFake((request, h) =>
+          h.response({ errors: new Error('forbidden') }).code(403),
+        );
+        checkAdminMemberHasRoleMetierStub.callsFake((request, h) => h.response(true));
+
+        // when
+        await httpTestServer.request('DELETE', '/api/admin/trainings/1/target-profiles/2');
+
+        // then
+        sinon.assert.calledOnce(trainingController.detachTargetProfile);
+      });
+
+      it('should return 403 without reaching controller if user has not an allowed role', async function () {
+        // given
+        sinon.stub(trainingController, 'detachTargetProfile').returns('ok');
+        checkAdminMemberHasRoleSuperAdminStub.callsFake((request, h) =>
+          h.response({ errors: new Error('forbidden') }).code(403),
+        );
+        checkAdminMemberHasRoleMetierStub.callsFake((request, h) =>
+          h.response({ errors: new Error('forbidden') }).code(403),
+        );
+
+        // when
+        const response = await httpTestServer.request('DELETE', '/api/admin/trainings/1/target-profiles/2');
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(trainingController.detachTargetProfile);
+      });
+    });
+
+    describe('Param validation', function () {
+      let httpTestServer;
+
+      beforeEach(async function () {
+        sinon.stub(trainingController, 'findTargetProfileSummaries').callsFake((request, h) => h.response('ok'));
+
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport').callsFake((request, h) => h.response(false));
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(false));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response(true));
+
+        httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+      });
+
+      it('should return 400 if the trainingId param is not a number', async function () {
+        // when
+        const response = await httpTestServer.request('DELETE', '/api/admin/trainings/blabla/target-profiles/3');
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+      it('should return 400 if the targetProfileId param is not a number', async function () {
+        // when
+        const response = await httpTestServer.request('DELETE', '/api/admin/trainings/3/target-profiles/azerty');
+
+        // then
+        expect(response.statusCode).to.equal(400);
       });
     });
   });

--- a/api/tests/devcomp/unit/domain/usecases/detach-target-profiles-from-training_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/detach-target-profiles-from-training_test.js
@@ -1,0 +1,46 @@
+import { detachTargetProfilesFromTraining } from '../../../../../src/devcomp/domain/usecases/detach-target-profiles-from-training.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { catchErr, expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | UseCases | detach-target-profiles-from-training', function () {
+  let targetProfileTrainingRepository;
+  const trainingId = 1;
+  const targetProfileId = 55;
+
+  beforeEach(function () {
+    targetProfileTrainingRepository = {
+      remove: sinon.stub(),
+    };
+  });
+
+  it('should call repository method to detach target profile from training, and return undefined', async function () {
+    // given
+    targetProfileTrainingRepository.remove.withArgs({ trainingId, targetProfileId }).resolves(true);
+
+    // when
+    const result = await detachTargetProfilesFromTraining({
+      trainingId,
+      targetProfileId,
+      targetProfileTrainingRepository,
+    });
+
+    // then
+    expect(targetProfileTrainingRepository.remove).to.have.been.calledOnce;
+    expect(result).to.be.undefined;
+  });
+
+  it('should throw NotFoundError if target profile/training is not found', async function () {
+    // given
+    targetProfileTrainingRepository.remove.withArgs({ trainingId, targetProfileId }).resolves(false);
+
+    // when
+    const result = await catchErr(detachTargetProfilesFromTraining)({
+      trainingId,
+      targetProfileId,
+      targetProfileTrainingRepository,
+    });
+
+    // then
+    expect(result).to.be.instanceOf(NotFoundError);
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/target-profile-training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-training-repository_test.js
@@ -57,4 +57,37 @@ describe('Integration | Repository | target-profile-training-repository', functi
       expect(exisitingTargetProfileTraining[0].updatedAt).to.deep.equal(now);
     });
   });
+
+  describe('#remove', function () {
+    it('should return true when training/target-profile is removed', async function () {
+      // given
+      const targetProfile = databaseBuilder.factory.buildTargetProfile();
+      const training = databaseBuilder.factory.buildTraining();
+      databaseBuilder.factory.buildTargetProfileTraining({
+        trainingId: training.id,
+        targetProfileId: targetProfile.id,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const removedResult = await targetProfileTrainingRepository.remove({
+        trainingId: training.id,
+        targetProfileId: targetProfile.id,
+      });
+
+      // then
+      expect(removedResult).to.be.true;
+    });
+
+    it('should return false when training/target-profile is not found', async function () {
+      // when
+      const removedResult = await targetProfileTrainingRepository.remove({
+        trainingId: 1,
+        targetProfileId: 2,
+      });
+
+      // then
+      expect(removedResult).to.be.false;
+    });
+  });
 });


### PR DESCRIPTION
## :pancakes: Problème

Aujourd'hui, on peut rattacher plusieurs Profils Cible à un Contenu Formatif, mais on ne peut pas les détacher.

## :bacon: Proposition

Ajouter un endpoint dans l'API pour pouvoir supprimer le lien entre un Contenu Formatif et un Profil Cible (lien stocké dans une table de jointure).

## 🧃 Remarques

- Renommage d'un fichier de test pour suivre le standard du projet API

## :yum: Pour tester

- Se connecter à Pix Admin
- Ouvrir le Devtool de votre navigateur. Afficher l'onglet Network
- Aller dans l'onglet Contenu Formatif, et afficher les Profils Cibles associés 
- Récupérer la requête pour afficher les profils cibles, et remplacer la route avec méthode `DELETE` et le chemin : `api/admin/trainings/{trainingId}/target-profiles/{targerProfileId}`, en remplaçant les IDs avec les valeurs de votre cas de test
- Lancer la requête (avec cUrl ou autre)
- Vérifier que le profil cible avec id = targetProfileId a été supprimé des PC associés au Contenu Formatif