### PR TITLE
[FEATURE] Ajouter un icône dans la liste des profils cible pour afficher le type d'accès au parcours (PIX-16384)

### DIFF
--- a/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-for-specifier-serializer.js
+++ b/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-for-specifier-serializer.js
@@ -12,6 +12,7 @@ const serialize = function (targetProfiles, meta) {
       'description',
       'category',
       'areKnowledgeElementsResettable',
+      'isSimplifiedAccess',
     ],
     meta,
   }).serialize(targetProfiles);

--- a/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-for-specifier-serializer_test.js
+++ b/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-for-specifier-serializer_test.js
@@ -14,6 +14,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-specifier-serializer'
         description: 'description',
         category: 'SUBJECT',
         areKnowledgeElementsResettable: true,
+        isSimplifiedAccess: true,
       });
 
       const meta = { some: 'meta' };
@@ -30,6 +31,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-specifier-serializer'
             description: 'description',
             category: 'SUBJECT',
             'are-knowledge-elements-resettable': true,
+            'is-simplified-access': true,
           },
         },
         meta,

--- a/orga/app/components/campaign/create-form.gjs
+++ b/orga/app/components/campaign/create-form.gjs
@@ -40,6 +40,10 @@ export default class CreateForm extends Component {
         value: targetProfile.id,
         label: targetProfile.name,
         category: this.intl.t(`pages.campaign-creation.tags.${targetProfile.category}`),
+        icon: targetProfile.isSimplifiedAccess ? 'accountOff' : 'users',
+        iconTitle: targetProfile.isSimplifiedAccess
+          ? 'common.target-profile-details.simplified-access.without-account'
+          : 'common.target-profile-details.simplified-access.with-account',
         order: 'OTHER' === targetProfile.category ? 1 : 0,
       };
     });
@@ -301,6 +305,7 @@ export default class CreateForm extends Component {
                     @hasBadges={{gt @campaign.targetProfile.thematicResultCount 0}}
                     @targetProfileTubesCount={{@campaign.targetProfile.tubeCount}}
                     @targetProfileThematicResultCount={{@campaign.targetProfile.thematicResultCount}}
+                    @simplifiedAccess={{@campaign.targetProfile.isSimplifiedAccess}}
                   />
                 </:message>
               </ExplanationCard>

--- a/orga/app/components/campaign/target-profile-details.gjs
+++ b/orga/app/components/campaign/target-profile-details.gjs
@@ -17,6 +17,12 @@ export default class CampaignTargetProfileDetails extends Component {
         };
   }
 
+  get simplifiedAccessInfo() {
+    return this.args.simplifiedAccess
+      ? { icon: 'accountOff', label: 'common.target-profile-details.simplified-access.without-account' }
+      : { icon: 'users', label: 'common.target-profile-details.simplified-access.with-account' };
+  }
+
   <template>
     <span class="target-profile-details" ...attributes>
       {{#if @targetProfileDescription}}
@@ -33,6 +39,11 @@ export default class CampaignTargetProfileDetails extends Component {
             {{t "common.target-profile-details.thematic-results" value=@targetProfileThematicResultCount}}
           </li>
         {{/if}}
+        <li class="target-profile-details__specificity__row target-profile-details__specificity__row--add-separator">
+          <PixIcon @name={{this.simplifiedAccessInfo.icon}} />
+          {{t this.simplifiedAccessInfo.label}}
+        </li>
+
         <li class="target-profile-details__specificity__row target-profile-details__specificity__row--break-line">
           <span class="target-profile-details__specificity__white-space">
             {{t "common.target-profile-details.results.common"}}

--- a/orga/app/models/target-profile.js
+++ b/orga/app/models/target-profile.js
@@ -8,4 +8,5 @@ export default class TargetProfile extends Model {
   @attr('boolean') hasStage;
   @attr('string') category;
   @attr('boolean') areKnowledgeElementsResettable;
+  @attr('boolean') isSimplifiedAccess;
 }

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -579,8 +579,6 @@ function routes() {
 
   this.get('/information-banners/:target', (schema, request) => {
     const { target } = request.params;
-    console.log(target);
-    console.log(schema.informationBanners.all());
     return schema.informationBanners.find(target);
   });
 }

--- a/orga/tests/acceptance/campaign-creation-test.js
+++ b/orga/tests/acceptance/campaign-creation-test.js
@@ -60,7 +60,7 @@ module('Acceptance | Campaign Creation', function (hooks) {
       await fillByLabel('Nom de la campagne *', 'Ma Campagne');
       await clickByName('Évaluer les participants');
       await click(screen.getByLabelText(`${t('pages.campaign-creation.target-profiles-list-label')} *`));
-      await click(await screen.findByRole('option', { name: expectedTargetProfileName }));
+      await click(await screen.findByRole('option', { description: expectedTargetProfileName }));
 
       const externalIdentifier = screen
         .getByText('Souhaitez-vous demander un identifiant externe ?', { selector: 'legend' })
@@ -105,7 +105,7 @@ module('Acceptance | Campaign Creation', function (hooks) {
       await fillByLabel('Nom de la campagne *', 'Ma Campagne');
       await clickByName('Évaluer les participants');
       await click(screen.getByLabelText(`${t('pages.campaign-creation.target-profiles-list-label')} *`));
-      await click(await screen.findByRole('option', { name: expectedTargetProfileName }));
+      await click(await screen.findByRole('option', { description: expectedTargetProfileName }));
 
       const title = `${t('pages.campaign-creation.test-title.label')} ${t('pages.campaign-creation.test-title.sublabel')}`;
 
@@ -127,7 +127,7 @@ module('Acceptance | Campaign Creation', function (hooks) {
       await fillByLabel('Nom de la campagne *', 'Ma Campagne');
       await clickByName('Évaluer les participants');
       await click(screen.getByLabelText(`${t('pages.campaign-creation.target-profiles-list-label')} *`));
-      await click(await screen.findByRole('option', { name: targetProfileName }));
+      await click(await screen.findByRole('option', { description: targetProfileName }));
 
       // when
       await clickByName('Créer la campagne');
@@ -147,7 +147,7 @@ module('Acceptance | Campaign Creation', function (hooks) {
       await fillByLabel('Nom de la campagne *', 'Ma Campagne');
       await clickByName('Évaluer les participants');
       await click(screen.getByLabelText(`${t('pages.campaign-creation.target-profiles-list-label')} *`));
-      await click(await screen.findByRole('option', { name: expectedTargetProfileName }));
+      await click(await screen.findByRole('option', { description: expectedTargetProfileName }));
       const externalIdentifier = screen
         .getByText('Souhaitez-vous demander un identifiant externe ?', { selector: 'legend' })
         .closest('fieldset');

--- a/orga/tests/integration/components/campaign/create-form-test.js
+++ b/orga/tests/integration/components/campaign/create-form-test.js
@@ -371,8 +371,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         await clickByName(t('pages.campaign-creation.purpose.assessment'));
 
         await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
-        await click(await screen.findByRole('option', { name: 'targetProfile1' }));
-
+        await click(await screen.findByRole('option', { description: 'targetProfile1' }));
         // then
         assert.dom(screen.getByText('description1')).exists();
         assert.dom(screen.getByText(t('common.target-profile-details.subjects', { value: 11 }))).exists();
@@ -414,10 +413,73 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         await clickByName(t('pages.campaign-creation.purpose.assessment'));
 
         await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
-        await click(await screen.findByRole('option', { name: 'targetProfile1' }));
+        await click(await screen.findByRole('option', { description: 'targetProfile1' }));
 
         // then
         assert.dom(screen.getByText(t('common.target-profile-details.results.common'))).exists();
+      });
+
+      module('simplified access', function () {
+        test('it should display with simplified access', async function (assert) {
+          // given
+          this.targetProfiles = [
+            store.createRecord('target-profile', {
+              id: '1',
+              name: 'targetProfile1',
+              isSimplifiedAccess: true,
+            }),
+          ];
+
+          // when
+          const screen = await render(
+            hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
+  @targetProfiles={{this.targetProfiles}}
+  @onSubmit={{this.createCampaignSpy}}
+  @onCancel={{this.cancelSpy}}
+  @errors={{this.errors}}
+  @membersSortedByFullName={{this.defaultMembers}}
+/>`,
+          );
+
+          await clickByName(t('pages.campaign-creation.purpose.assessment'));
+
+          await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
+          await click(await screen.findByRole('option', { description: 'targetProfile1' }));
+
+          // then
+          assert.ok(screen.getByText(t('common.target-profile-details.simplified-access.without-account')));
+        });
+
+        test('it should display without simplified access', async function (assert) {
+          // given
+          this.targetProfiles = [
+            store.createRecord('target-profile', {
+              id: '1',
+              name: 'targetProfile1',
+              isSimplifiedAccess: false,
+            }),
+          ];
+
+          // when
+          const screen = await render(
+            hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
+  @targetProfiles={{this.targetProfiles}}
+  @onSubmit={{this.createCampaignSpy}}
+  @onCancel={{this.cancelSpy}}
+  @errors={{this.errors}}
+  @membersSortedByFullName={{this.defaultMembers}}
+/>`,
+          );
+          await clickByName(t('pages.campaign-creation.purpose.assessment'));
+
+          await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
+          await click(await screen.findByRole('option', { description: 'targetProfile1' }));
+
+          // then
+          assert.ok(screen.getByText(t('common.target-profile-details.simplified-access.with-account')));
+        });
       });
 
       module('Displaying options and categories', function () {
@@ -605,7 +667,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         await clickByName(t('pages.campaign-creation.purpose.assessment'));
 
         await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
-        await click(await screen.findByRole('option', { name: 'targetProfile1' }));
+        await click(await screen.findByRole('option', { description: 'targetProfile1' }));
 
         // then
         assert.dom(screen.getByText(t('common.target-profile-details.results.common'))).exists();
@@ -650,7 +712,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           await clickByName(t('pages.campaign-creation.purpose.assessment'));
 
           await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
-          await click(await screen.findByRole('option', { name: 'targetProfile1' }));
+          await click(await screen.findByRole('option', { description: 'targetProfile1' }));
 
           // then
           assert
@@ -701,7 +763,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           await clickByName(t('pages.campaign-creation.purpose.assessment'));
 
           await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
-          await click(await screen.findByRole('option', { name: 'targetProfile1' }));
+          await click(await screen.findByRole('option', { description: 'targetProfile1' }));
 
           // then
           assert
@@ -1029,7 +1091,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     await fillByLabel(`${t('pages.campaign-creation.name.label')} *`, 'Ma campagne');
     await clickByName(t('pages.campaign-creation.purpose.assessment'));
     await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
-    await click(await screen.findByRole('option', { name: targetProfile.name }));
+    await click(await screen.findByRole('option', { description: targetProfile.name }));
 
     // when
     await clickByName(t('pages.campaign-creation.actions.create'));

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -259,6 +259,10 @@
         "percent": "percentage",
         "star": "stars"
       },
+      "simplified-access": {
+        "with-account": "Access with account",
+        "without-account": "Access without account"
+      },
       "subjects": "Topics: {value, number}",
       "thematic-results": "Thematic results: {value, number}"
     }

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -259,6 +259,10 @@
         "percent": "pourcentage",
         "star": "étoile"
       },
+      "simplified-access": {
+        "with-account": "Accès avec compte",
+        "without-account": "Accès sans compte"
+      },
       "subjects": "Sujets : {value, number}",
       "thematic-results": "Résultats thématiques : {value, number}"
     }

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -258,6 +258,10 @@
         "percent": "percentage",
         "star": "ster"
       },
+      "simplified-access": {
+        "with-account": "Toegang account",
+        "without-account": "Toegang zonder account"
+      },
       "subjects": "Onderwerpen: {value, number}",
       "thematic-results": "Thematische resultaten: {value, number}"
     },


### PR DESCRIPTION
## :pancakes: Problème
Aujourd'hui, lorsqu'un prescripteur veut créer un parcours, dans la liste des profils cible, il n'a aucun moyen de savoir si l'accès à celui-ci est avec ou sans compte.
Pour donner cette information, les noms des PC sont souvent suffixés à cette information, ce qui donne des noms potentiellement longs. 
Également, on va utiliser les noms des profils cibles lors d'un futur développement, donc on ne voudrait pas avoir "accès avec/sans compte" dans le titre de celui-ci

## :bacon: Proposition
Ajouter des icônes avant le titre du PC pour identifier rapidement si celui-ci est à accès simplifié ou non. On affiche également dans l'encart d'information l'information complète "Accès avec/sans compte"

## 🧃 Remarques
On fait un dev un peu "simple" pour commencer, et pour débloquer un développement qui arrive. Cette page va être complètement refaite très prochainement

## :yum: Pour tester

- Se connecter à PixOrga
- Choisir l'organisation PRO Classic
- Aller sur la page de création de campagne
- Selectionner l'option `Évaluer les participants`
- Voir dans la liste des profils cibles les icônes pour accès avec/sans compte
- Lors de la sélectionner d'un de ceux ci, voir dans l'encart l'information associée

🐈‍⬛ 