### PR TITLE
[FEATURE] Ajouter la durée du code de validation du changement d'email sur Pix-app (PIX-14088)

### DIFF
--- a/mon-pix/app/components/user-account/email-verification-code.hbs
+++ b/mon-pix/app/components/user-account/email-verification-code.hbs
@@ -2,6 +2,9 @@
 <div class="email-verification-code">
   <p class="email-verification-code__description">{{t "pages.user-account.email-verification.description"}}</p>
   <p class="email-verification-code__email">{{@email}}</p>
+  <p class="email-verification-code__time-code-validation">{{t
+      "pages.user-account.email-verification.time-code-validation"
+    }}</p>
   <div class="email-verification-code__input-code">
     <PixInputCode
       @ariaLabel={{t "pages.user-account.email-verification.code-label"}}

--- a/mon-pix/app/styles/components/user-account/_email-verification-code.scss
+++ b/mon-pix/app/styles/components/user-account/_email-verification-code.scss
@@ -10,6 +10,12 @@
     font-size: 0.875rem;
   }
 
+  &__time-code-validation {
+    margin-top: var(--pix-spacing-4x);
+    font-weight: bold;
+    font-size: 0.875rem;
+  }
+
   &__input-code {
     margin: 24px 0;
   }

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2099,6 +2099,7 @@
           "unknown-error": "An error has occurred. Please try again or contact the support."
         },
         "send-back-the-code": "Send the code again",
+        "time-code-validation": "The code received is valid for 10 minutes",
         "title": "Verify your email address",
         "update-successful": "Your email address has been changed!"
       },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2181,6 +2181,7 @@
           "unknown-error": "Se ha producido un error. Vuelve a intentarlo o ponte en contacto con el servicio de asistencia."
         },
         "send-back-the-code": "volver a enviarme el código",
+        "time-code-validation": "El código recibido es válido durante 10 minutos",
         "title": "Comprobación de tu dirección de correo electrónico",
         "update-successful": "Tu dirección de correo electrónico ha sido modificada."
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2100,6 +2100,7 @@
           "unknown-error": "Une erreur est survenue. Veuillez recommencer ou contacter le support."
         },
         "send-back-the-code": "me renvoyer le code",
+        "time-code-validation": "Le code reçu est valide pendant 10 minutes",
         "title": "Vérification de votre adresse e-mail",
         "update-successful": "Votre adresse e-mail a été changée !"
       },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2182,6 +2182,7 @@
           "unknown-error": "Er is een fout opgetreden. Probeer het opnieuw of neem contact op met de klantenservice."
         },
         "send-back-the-code": "stuur me de code",
+        "time-code-validation": "De ontvangen code is 10 minuten geldig",
         "title": "Je e-mailadres controleren",
         "update-successful": "Je e-mailadres is gewijzigd!"
       },


### PR DESCRIPTION
## :egg: Problème
Sur Pix app, lorsqu'on souhaite changer son adresse email, le code de validation est utilisable durant 10 minutes. Passé ce délai, il devient obsolète. Or, l'utilisateur n'est pas informé de la durée de ce code.

## :bowl_with_spoon: Proposition
Rajouter une ligne avec l'information: "Le code reçu est valide pendant 10 minutes".

## :milk_glass: Remarques
Il faudrait changer le template de l'email car le code est placé dans un h2 ce qui n'est pas normal et pas pratique.

## :butter: Pour tester
- Se rendre sur Pix app,
- Se connecter avec un compte (par exemple "allorga@example.net"),
- Aller dans "Mon compte",
- Cliquer sur "Mes méthodes de connexion",
- Modifier l'email et en entrer un nouveau,
- Valider,
- Constater que la phrase indiquant la durée du code de validation est présente sous l'adresse email.