### PR TITLE
[TECH] Ajouter le niveau global dans la documentation Parcoursup (PIX-16471).

### DIFF
--- a/api/src/parcoursup/application/certification-route.js
+++ b/api/src/parcoursup/application/certification-route.js
@@ -63,8 +63,11 @@ const register = async function (server) {
               firstName: Joi.string().description('Prénom de l‘élève'),
               birthdate: Joi.date().description('Date de naissance au format AAAA-MM-JJ'),
               status: Joi.string().description('Statut de la certification'),
-              pixScore: Joi.number().min(0).max(1024).description('Score en nombre de pix'),
+              pixScore: Joi.number().min(0).max(1024).description('Score global en nombre de pix'),
               certificationDate: Joi.date().description('Date de passage de la certification'),
+              globalLevel: Joi.string().description(
+                'Niveau global de la certification, défini en fonction du score global Pix obtenu',
+              ),
               competences: Joi.array()
                 .items(
                   Joi.object({

--- a/api/src/parcoursup/domain/read-models/CertificationResult.js
+++ b/api/src/parcoursup/domain/read-models/CertificationResult.js
@@ -13,6 +13,7 @@ export class CertificationResult {
    * @param {string} props.status
    * @param {string} props.pixScore
    * @param {Date} props.certificationDate
+   * @param {string} props.globalLevel
    * @param {Array<Competence>} props.competences
    */
   constructor({
@@ -24,6 +25,7 @@ export class CertificationResult {
     status,
     pixScore,
     certificationDate,
+    globalLevel = '',
     competences,
   }) {
     this.ine = ine;
@@ -34,6 +36,7 @@ export class CertificationResult {
     this.status = status;
     this.pixScore = pixScore;
     this.certificationDate = certificationDate;
+    this.globalLevel = globalLevel;
     this.competences = competences;
   }
 }

--- a/api/tests/parcoursup/acceptance/application/certification-route_test.js
+++ b/api/tests/parcoursup/acceptance/application/certification-route_test.js
@@ -51,6 +51,7 @@ describe('Parcoursup | Acceptance | Application | certification-route', function
       status: 'validated',
       pixScore: 327,
       certificationDate: new Date('2024-11-22T09:39:54Z'),
+      globalLevel: '',
       competences: [
         {
           code: '1.1',
@@ -194,6 +195,7 @@ describe('Parcoursup | Acceptance | Application | certification-route', function
         status: 'validated',
         pixScore: 327,
         certificationDate: new Date('2024-11-22T09:39:54Z'),
+        globalLevel: '',
         competences: [
           {
             code: '1.1',


### PR DESCRIPTION
## :pancakes: Problème

Pour les certification V3, on veut mentionner le niveau global associé. Même si ce n'est pas encore implémenté, il faut que Parcoursup puisse à minima le voir dans la documentation.

## :bacon: Proposition

Ajouter le niveau global dans la documentation.
Elle est vide car non implémenté.

## 🧃 Remarques

Le niveau global est défini selon une fourchette de nombre de pix, par exemple : Pour un score compris entre 64 et 127 pix on obtient le niveau global **Novice 1**

 Plus de détails ici : https://pix.fr/certification-comprendre-score-niveau

## :yum: Pour tester

https://api-pr11410.review.pix.fr/documentation/parcoursup

Trouver le globalLevel ici 
<img width="415" alt="Capture d’écran 2025-02-12 à 17 11 32" src="https://github.com/user-attachments/assets/07ad94de-7938-499d-8b2f-6d70b64e2d72" />


<img width="396" alt="Capture d’écran 2025-02-14 à 13 45 18" src="https://github.com/user-attachments/assets/b561479f-bc1c-4329-b96f-42f920aa9f36" />


