### PR TITLE
[TECH] Ajouter des logs spécifiques pour certains tokens problématiques (audience mismatch, revoked token) (PIX-16551)

### DIFF
--- a/api/src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js
@@ -14,7 +14,7 @@ const revokedUserAccessLifespanMs = config.authentication.revokedUserAccessLifes
  * @param {string} params.userId - The ID of the user to revoke access for.
  * @param {Date} params.revokeUntil - The date until the user's access should be revoked.
  */
-export const saveForUser = async function ({ userId, revokeUntil }) {
+const saveForUser = async function ({ userId, revokeUntil }) {
   if (!userId) {
     throw new UserIdIsRequiredError();
   }

--- a/api/src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js
@@ -34,7 +34,7 @@ const saveForUser = async function ({ userId, revokeUntil }) {
  * Retrieves the revoked access for a user from the temporary storage.
  *
  * @param {string} userId - The ID of the user to retrieve the revocation date for.
- * @returns {RevokedUserAccess} - The revoked user access object.
+ * @returns {Promise<RevokedUserAccess>} - The revoked user access object.
  */
 const findByUserId = async function (userId) {
   const value = await revokedUserAccessTemporaryStorage.get(userId);


### PR DESCRIPTION
## :pancakes: Problème

On veut avoir des logs spécifiques pour certains tokens problématiques (audience mismatch, revoked token).

## :bacon: Proposition

Voici les logs additionnels qui sont maintenant générés : 

```
WARN: User AccessToken audience mismatch
    user_id: 803572
    request_id: "-"
    id: "1739444405800:system:26536:m7387bl1:10009"
    audience: "https://admin.dev.pix.fr"
    decodedAccessToken: {
      "user_id": 803572,
      "source": "pix",
      "aud": "https://app.dev.pix.fr",
      "iat": 1739444379,
      "exp": 1739445579
    }
```

```
WARN: Revoked user AccessToken usage
    user_id: 803572
    request_id: "-"
    id: "1739445284103:system:29521:m738rzn5:10014"
    decodedAccessToken: {
      "user_id": 803572,
      "source": "pix",
      "aud": "https://app.dev.pix.fr",
      "iat": 1739444379,
      "exp": 1739445579
    }
```

## 🧃 Remarques

RAS

## :yum: Pour tester

1. Reproduire un scénario avec un token utilisé sur une mauvaise application et constater la présence du nouveau log spécifique `User AccessToken audience mismatch`
2. Reproduire un scénario avec un token révoqué (cf. #11269)  et constater la présence du nouveau log spécifique `Revoked user AccessToken usage`
