### PR TITLE
[FEATURE] Remplacer skills par competences dans le tableau de la page statistiques (PIX-16411)

### DIFF
--- a/orga/app/components/statistics/index.gjs
+++ b/orga/app/components/statistics/index.gjs
@@ -139,7 +139,7 @@ export default class Statistics extends Component {
           <caption class="screen-reader-only">{{t "pages.statistics.table.caption"}}</caption>
           <thead>
             <tr>
-              <Header @size="wide" scope="col">{{t "pages.statistics.table.headers.skills"}}</Header>
+              <Header @size="wide" scope="col">{{t "pages.statistics.table.headers.competences"}}</Header>
               <Header @size="medium" scope="col">{{t "pages.statistics.table.headers.topics"}}</Header>
               <Header @size="medium" @align="center" scope="col">{{t
                   "pages.statistics.table.headers.positioning"

--- a/orga/tests/integration/components/statistics/index-test.gjs
+++ b/orga/tests/integration/components/statistics/index-test.gjs
@@ -55,7 +55,7 @@ module('Integration | Component | Statistics | Index', function (hooks) {
       const screen = await render(<template><Statistics @model={{model}} /></template>);
 
       //then
-      assert.ok(screen.getByRole('columnheader', { name: t('pages.statistics.table.headers.skills') }));
+      assert.ok(screen.getByRole('columnheader', { name: t('pages.statistics.table.headers.competences') }));
       assert.ok(screen.getByRole('columnheader', { name: t('pages.statistics.table.headers.topics') }));
       assert.ok(screen.getByRole('columnheader', { name: t('pages.statistics.table.headers.reached-level') }));
       assert.ok(screen.getByRole('columnheader', { name: t('pages.statistics.table.headers.positioning') }));

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1484,9 +1484,9 @@
       "table": {
         "caption": "This table displays the analysis of all participants' results by topic. For each line, it shows the skill, the topic, the coverage rate and the level achieved.",
         "headers": {
+          "competences": "Competences",
           "positioning": "Positioning",
           "reached-level": "Reached level",
-          "skills": "Skills",
           "topics": "Topics"
         }
       },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1490,9 +1490,9 @@
       "table": {
         "caption": "Ce tableau affiche l'analyse des résultats de tous les participants par sujets. Il indique pour chaque ligne la compétence, le sujet, le taux de couverture ainsi que le niveau atteint",
         "headers": {
+          "competences": "Compétences",
           "positioning": "Positionnement",
           "reached-level": "Niveau atteint",
-          "skills": "Compétences",
           "topics": "Sujets"
         }
       },


### PR DESCRIPTION
## :pancakes: Problème
On a nommé les compétences des skills dans le tableau et dans les trads EN sur la page Statistiques de PixOrga
<img width="944" alt="Capture d’écran 2025-02-13 à 14 05 16" src="https://github.com/user-attachments/assets/7cbdb44c-2909-423d-a642-6d6309636c81" />

## :bacon: Proposition
Nommer les compétences "competences" 

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester
