### PR TITLE
[FEATURE] Ajouter une action Détacher dans la liste des Contenus Formatifs (PIX-16511)(PIX-7393)

### DIFF
--- a/admin/app/adapters/training.js
+++ b/admin/app/adapters/training.js
@@ -12,4 +12,11 @@ export default class TrainingAdapter extends ApplicationAdapter {
     const url = `${this.host}/${this.namespace}/trainings/${trainingId}/attach-target-profiles`;
     return this.ajax(url, 'POST', { data: payload });
   }
+
+  async detachTargetProfile(options) {
+    const { targetProfileId, trainingId } = options;
+
+    const url = `${this.host}/${this.namespace}/trainings/${trainingId}/target-profiles/${targetProfileId}`;
+    return this.ajax(url, 'DELETE');
+  }
 }

--- a/admin/app/controllers/authenticated/trainings/training/target-profiles.js
+++ b/admin/app/controllers/authenticated/trainings/training/target-profiles.js
@@ -61,6 +61,26 @@ export default class TrainingDetailsTargetProfilesController extends Controller 
     }
   }
 
+  @action
+  async detachTargetProfile(targetProfileSummary) {
+    const { id: trainingId } = this.model.training;
+    const { targetProfileSummaries } = this.model;
+    const { id: targetProfileId } = targetProfileSummary;
+    try {
+      const adapter = this.store.adapterFor('training');
+      await adapter.detachTargetProfile({
+        trainingId,
+        targetProfileId,
+      });
+      await targetProfileSummaries.reload();
+      return this.pixToast.sendSuccessNotification({
+        message: `Profil cible détaché avec succès !`,
+      });
+    } catch (responseError) {
+      this._handleResponseError(responseError);
+    }
+  }
+
   _handleResponseError({ errors }) {
     if (!errors) {
       return this.pixToast.sendErrorNotification({ message: 'Une erreur est survenue.' });

--- a/admin/app/templates/authenticated/trainings/training/target-profiles.hbs
+++ b/admin/app/templates/authenticated/trainings/training/target-profiles.hbs
@@ -63,6 +63,16 @@
                   {{if row.outdated "Obsolète" "Actif"}}
                 </:cell>
               </PixTableColumn>
+              <PixTableColumn @context={{context}} class="table__column--wide">
+                <:header>
+                  Actions
+                </:header>
+                <:cell>
+                  <PixButton @variant="error" @iconBefore="delete" >
+                    Détacher
+                  </PixButton>
+                </:cell>
+              </PixTableColumn>
             </:columns>
           </PixTable>
         {{/if}}

--- a/admin/app/templates/authenticated/trainings/training/target-profiles.hbs
+++ b/admin/app/templates/authenticated/trainings/training/target-profiles.hbs
@@ -31,28 +31,40 @@
     <div class="content-text content-text--small">
       <div class="table-admin">
         {{#if @model.targetProfileSummaries}}
-          <table aria-labelledby="page-section-title">
-            <thead>
-              <tr>
-                <th scope="col" class="table__column table__column--id">ID</th>
-                <th scope="col">Nom du profil cible</th>
-                <th scope="col">Statut</th>
-              </tr>
-            </thead>
-            <tbody>
-              {{#each @model.training.sortedTargetProfileSummaries as |summary|}}
-                <tr aria-label="Profil cible">
-                  <td class="table__column table__column--id">{{summary.id}}</td>
-                  <td headers="target-profile-name">
-                    <LinkTo @route="authenticated.target-profiles.target-profile" @model={{summary.id}}>
-                      {{summary.name}}
-                    </LinkTo>
-                  </td>
-                  <td>{{if summary.outdated "Obsolète" "Actif"}}</td>
-                </tr>
-              {{/each}}
-            </tbody>
-          </table>
+          <PixTable
+            @variant="primary"
+            @data={{@model.training.sortedTargetProfileSummaries}}
+            @caption="Profil cible associé au contenu"
+          >
+            <:columns as |row context|>
+              <PixTableColumn @context={{context}} class="table__column--wide">
+                <:header>
+                  ID
+                </:header>
+                <:cell>
+                  {{row.id}}
+                </:cell>
+              </PixTableColumn>
+              <PixTableColumn @context={{context}} class="table__column--wide">
+                <:header>
+                  Nom du profil cible
+                </:header>
+                <:cell>
+                  <LinkTo @route="authenticated.target-profiles.target-profile" @model={{row.id}}>
+                    {{row.name}}
+                  </LinkTo>
+                </:cell>
+              </PixTableColumn>
+              <PixTableColumn @context={{context}} class="table__column--wide">
+                <:header>
+                  Statut
+                </:header>
+                <:cell>
+                  {{if row.outdated "Obsolète" "Actif"}}
+                </:cell>
+              </PixTableColumn>
+            </:columns>
+          </PixTable>
         {{/if}}
 
         {{#unless @model.targetProfileSummaries}}

--- a/admin/app/templates/authenticated/trainings/training/target-profiles.hbs
+++ b/admin/app/templates/authenticated/trainings/training/target-profiles.hbs
@@ -68,7 +68,7 @@
                   Actions
                 </:header>
                 <:cell>
-                  <PixButton @variant="error" @iconBefore="delete" >
+                  <PixButton @variant="error" @iconBefore="delete" @triggerAction={{fn this.detachTargetProfile row}}>
                     Détacher
                   </PixButton>
                 </:cell>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -48,6 +48,7 @@ import {
   attachTargetProfilesToTraining,
   createOrUpdateTrainingTrigger,
   createTraining,
+  detachTargetProfileFromTraining,
   findPaginatedTrainingSummaries,
   getTargetProfileSummariesForTraining,
   getTraining,
@@ -395,6 +396,7 @@ function routes() {
   this.patch('/admin/trainings/:id', updateTraining);
   this.get('/admin/trainings/:id/target-profile-summaries', getTargetProfileSummariesForTraining);
   this.post('/admin/trainings/:id/attach-target-profiles', attachTargetProfilesToTraining);
+  this.delete('/admin/trainings/:trainingId/target-profiles/:targetProfileId', detachTargetProfileFromTraining);
   this.put('/admin/trainings/:id/triggers', createOrUpdateTrainingTrigger);
 
   this.get('/admin/certifications/:id');

--- a/admin/mirage/handlers/trainings.js
+++ b/admin/mirage/handlers/trainings.js
@@ -75,6 +75,17 @@ function attachTargetProfilesToTraining(schema, request) {
   return new Response(204);
 }
 
+function detachTargetProfileFromTraining(schema, request) {
+  const { trainingId, targetProfileId } = request.params;
+
+  const training = schema.trainings.find(trainingId);
+
+  const updatedTargetProfiles = training.targetProfileSummaryIds.filter((profileId) => profileId !== targetProfileId);
+  training.update({ targetProfileSummaryIds: updatedTargetProfiles });
+
+  return new Response(204);
+}
+
 function updateTraining(schema, request) {
   const trainingId = request.params.id;
   const params = JSON.parse(request.requestBody);
@@ -127,6 +138,7 @@ export {
   attachTargetProfilesToTraining,
   createOrUpdateTrainingTrigger,
   createTraining,
+  detachTargetProfileFromTraining,
   findPaginatedTrainingSummaries,
   getTargetProfileSummariesForTraining,
   getTraining,

--- a/admin/tests/acceptance/authenticated/trainings/target-profiles-test.js
+++ b/admin/tests/acceptance/authenticated/trainings/target-profiles-test.js
@@ -16,6 +16,7 @@ module('Acceptance | Trainings | Target profiles', function (hooks) {
   hooks.beforeEach(async function () {
     trainingId = 2;
 
+    const targetProfileSummary = server.create('target-profile-summary', { id: 1111, name: 'Super profil cible 2' });
     server.create('training', {
       id: 2,
       title: 'Devenir tailleur de citrouille',
@@ -27,6 +28,7 @@ module('Acceptance | Trainings | Target profiles', function (hooks) {
       editorLogoUrl: 'https://mon-logo.svg',
       prerequisiteThreshold: null,
       goalThreshold: null,
+      targetProfileSummaries: [targetProfileSummary],
     });
     server.create('target-profile', {});
   });
@@ -64,6 +66,17 @@ module('Acceptance | Trainings | Target profiles', function (hooks) {
 
         // then
         assert.dom(await screen.findByRole('link', { name: 'Super profil cible' })).exists();
+      });
+
+      test('it should be able to detach a target profile to a training', async function (assert) {
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+        // when
+        const screen = await visit(`/trainings/${trainingId}/target-profiles`);
+        await clickByName('Détacher');
+
+        // then
+        assert.dom(await screen.findByText('Aucun profil cible associé à ce contenu formatif')).exists();
       });
     });
 

--- a/admin/tests/unit/adapters/training-test.js
+++ b/admin/tests/unit/adapters/training-test.js
@@ -28,4 +28,20 @@ module('Unit | Adapter | Training ', function (hooks) {
       assert.ok(true);
     });
   });
+  module('#detachTargetProfile', function () {
+    test('should trigger an ajax call with the right url, method and payload', async function (assert) {
+      // given
+      sinon.stub(adapter, 'ajax').resolves();
+      const trainingId = 1;
+      const targetProfileId = 2;
+      const expectedUrl = `http://localhost:3000/api/admin/trainings/${trainingId}/target-profiles/${targetProfileId}`;
+
+      // when
+      await adapter.detachTargetProfile({ trainingId, targetProfileId });
+
+      // then
+      sinon.assert.calledWith(adapter.ajax, expectedUrl, 'DELETE');
+      assert.ok(true);
+    });
+  });
 });


### PR DESCRIPTION
## :pancakes: Problème

Il n'y a pour le moment pas de possibilité de délier un contenu formatif d'un profil cible

## :bacon: Proposition
Ajouter un bouton Détacher pour ça sur la page de détails d'un contenu formatif => onglet Profils Cibles Associés 

## 🧃 Remarques

- Utilisation de PixTable dans le tableau de PC rattachés à un CF

## :yum: Pour tester

- Se connecter à [Pix Admin](https://admin-pr11413.review.pix.fr/login)
- Se rendre dans "Contenus Formatifs"
- Ouvrir un CF qui a au moins un PC rattaché
- Vérifier dans le [tableau des PC rattachés](https://admin-pr11413.review.pix.fr/trainings/5000/target-profiles), la colonne "Actions" est présente et contient un bouton "Détacher" pour chaque PC
- Cliquer sur "Détacher". Le PC doit disparaître du tableau, et une pop-up de notification indique que le PC a bien été détaché.