### PR TITLE
[TECH] Rattrapage des certifications annulées (PIX-16047).

### DIFF
--- a/api/scripts/certification/create-assessment-result-for-cancelled-certification.js
+++ b/api/scripts/certification/create-assessment-result-for-cancelled-certification.js
@@ -1,0 +1,178 @@
+import { knex } from '../../db/knex-database-connection.js';
+import { AutoJuryCommentKeys } from '../../src/certification/shared/domain/models/JuryComment.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+import { config } from '../../src/shared/config.js';
+import { AssessmentResult } from '../../src/shared/domain/models/index.js';
+
+export class CreateAssessmentResultForCancelledCertificationScript extends Script {
+  constructor() {
+    super({
+      description: 'Copy certification-course.isCancelled to assessment-results table',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'Commit in the database, or rollback',
+          demandOption: true,
+        },
+        batchSize: {
+          type: 'number',
+          describe: 'Number of certifications to update at once',
+          demandOption: false,
+          default: 1000,
+        },
+        delayBetweenBatch: {
+          type: 'number',
+          describe: 'In ms, force a pause between SQL COMMIT',
+          demandOption: false,
+          default: 100,
+        },
+      },
+    });
+
+    this.totalNumberOfImpactedCertifications = 0;
+  }
+
+  async handle({ options, logger }) {
+    this.logger = logger;
+    const dryRun = options.dryRun;
+    const batchSize = options.batchSize;
+    const delayInMs = options.delayBetweenBatch;
+    this.logger.info(`dryRun=${dryRun} batchSize=${batchSize}`);
+
+    let hasNext = true;
+    let cursorId = 0;
+
+    do {
+      const transaction = await knex.transaction();
+      try {
+        const assessmentResultsToDuplicate = await getNextCancelledAssessmentResultsToDuplicate({
+          cursorId,
+          batchSize,
+          transaction,
+        });
+
+        for (const assessmentResult of assessmentResultsToDuplicate) {
+          const newCancelledAssessmentResultId = await duplicateCancelledAssessmentResult({
+            assessmentResult,
+            transaction,
+          });
+
+          const competenceMarks = await getCompetenceMarks({
+            assessmentResultId: assessmentResult.id,
+            transaction,
+          });
+
+          for (const competenceMark of competenceMarks) {
+            await duplicateCompetenceMark({
+              competenceMark,
+              newCancelledAssessmentResultId,
+              transaction,
+            });
+          }
+        }
+
+        dryRun ? await transaction.rollback() : await transaction.commit();
+
+        // Prepare for next batch
+        hasNext = assessmentResultsToDuplicate.length > 0;
+        cursorId = assessmentResultsToDuplicate?.at(-1)?.id;
+        this.totalNumberOfImpactedCertifications += assessmentResultsToDuplicate.length || 0;
+
+        this.logger.info(`Waiting ${delayInMs}ms before next batch`);
+        await this.delay(delayInMs);
+      } catch (error) {
+        await transaction.rollback();
+        throw error;
+      }
+    } while (hasNext);
+
+    this.logger.info(
+      `Number of impacted certifications:[${this.totalNumberOfImpactedCertifications}] (dryRun:[${dryRun}])`,
+    );
+    return 0;
+  }
+
+  async delay(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}
+
+const getNextCancelledAssessmentResultsToDuplicate = async ({ batchSize, transaction, cursorId = 0 }) => {
+  return transaction
+    .from('certification-courses-last-assessment-results')
+    .select('assessment-results.*')
+    .forUpdate()
+    .innerJoin(
+      'certification-courses',
+      'certification-courses.id',
+      'certification-courses-last-assessment-results.certificationCourseId',
+    )
+    .innerJoin(
+      'assessment-results',
+      'assessment-results.id',
+      'certification-courses-last-assessment-results.lastAssessmentResultId',
+    )
+    .where('certification-courses.isCancelled', '=', true)
+    .andWhere('assessment-results.status', '!=', 'cancelled')
+    .andWhere('certification-courses-last-assessment-results.lastAssessmentResultId', '>', cursorId)
+    .orderBy('assessment-results.id')
+    .limit(batchSize);
+};
+
+const duplicateCancelledAssessmentResult = async ({ assessmentResult, transaction }) => {
+  const [newAssessmentResult] = await transaction('assessment-results')
+    .insert({
+      level: assessmentResult.level,
+      pixScore: assessmentResult.pixScore,
+      commentByJury: assessmentResult.commentByJury,
+      commentForOrganization: assessmentResult.commentForOrganization,
+      commentForCandidate: assessmentResult.commentForCandidate,
+      assessmentId: assessmentResult.assessmentId,
+      reproducibilityRate: assessmentResult.reproducibilityRate,
+      commentByAutoJury: getCommentByAutoJury({ commentByAutoJury: assessmentResult.commentByAutoJury }),
+      emitter: assessmentResult.emitter,
+      status: AssessmentResult.status.CANCELLED,
+      juryId: config.infra.engineeringUserId,
+      createdAt: assessmentResult.createdAt,
+    })
+    .returning('id');
+
+  await transaction('certification-courses-last-assessment-results')
+    .update({ lastAssessmentResultId: newAssessmentResult.id })
+    .where('lastAssessmentResultId', assessmentResult.id);
+
+  return newAssessmentResult.id;
+};
+
+const duplicateCompetenceMark = async ({ competenceMark, newCancelledAssessmentResultId, transaction }) => {
+  await transaction('competence-marks')
+    .insert({
+      level: competenceMark.level,
+      score: competenceMark.score,
+      area_code: competenceMark.area_code,
+      competence_code: competenceMark.competence_code,
+      assessmentResultId: newCancelledAssessmentResultId,
+      competenceId: competenceMark.competenceId,
+      createdAt: competenceMark.createdAt,
+    })
+    .returning('id');
+};
+
+const getCompetenceMarks = async ({ assessmentResultId, transaction }) => {
+  return transaction('competence-marks').where({
+    assessmentResultId,
+  });
+};
+
+const getCommentByAutoJury = ({ commentByAutoJury }) => {
+  const isCancelledCommentByAutoJury = [
+    AutoJuryCommentKeys.CANCELLED_DUE_TO_NEUTRALIZATION,
+    AutoJuryCommentKeys.CANCELLED_DUE_TO_LACK_OF_ANSWERS_FOR_TECHNICAL_REASON,
+  ].includes(commentByAutoJury);
+
+  return isCancelledCommentByAutoJury ? commentByAutoJury : null;
+};
+
+await ScriptRunner.execute(import.meta.url, CreateAssessmentResultForCancelledCertificationScript);

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -350,6 +350,7 @@ const configuration = (function () {
         process.env.INFRA_CHUNK_SIZE_ORGANIZATION_LEARNER_DATA_PROCESSING,
         1000,
       ),
+      engineeringUserId: process.env.ENGINEERING_USER_ID,
       metricsFlushIntervalSecond: _getNumber(process.env.METRICS_FLUSH_INTERVAL_SECOND, 15),
       startJobInWebProcess: toBoolean(process.env.START_JOB_IN_WEB_PROCESS),
     },
@@ -696,6 +697,8 @@ const configuration = (function () {
     config.identityProviderConfigKey = null;
 
     config.apiManager.url = 'http://external-partners-access/';
+
+    config.infra.engineeringUserId = 800;
   }
 
   return config;

--- a/api/tests/integration/scripts/certification/create-assessment-result-for-cancelled-certification_test.js
+++ b/api/tests/integration/scripts/certification/create-assessment-result-for-cancelled-certification_test.js
@@ -1,0 +1,228 @@
+import { CreateAssessmentResultForCancelledCertificationScript } from '../../../../scripts/certification/create-assessment-result-for-cancelled-certification.js';
+import { AlgorithmEngineVersion } from '../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
+import { AutoJuryCommentKeys } from '../../../../src/certification/shared/domain/models/JuryComment.js';
+import { config } from '../../../../src/shared/config.js';
+import { Assessment } from '../../../../src/shared/domain/models/index.js';
+import { AssessmentResult } from '../../../../src/shared/domain/models/index.js';
+import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
+import { databaseBuilder, expect, knex } from '../../../test-helper.js';
+
+describe('Integration | Scripts | Certification | create-assessment-result-for-cancelled-certification', function () {
+  describe('when certification-course is cancelled', function () {
+    describe('when last related assessment-result is already cancelled', function () {
+      it('should do nothing', async function () {
+        // given
+        const assessmentResult = await _createCertification({
+          isCancelled: true,
+          lastAssessmentResultStatus: AssessmentResult.status.CANCELLED,
+          commentByAutoJury: null,
+        });
+
+        // when
+        const script = new CreateAssessmentResultForCancelledCertificationScript();
+        await script.handle({ logger, options: { dryRun: false, batchSize: 1000 } });
+
+        // then
+        const lastAssessmentResult = await knex('certification-courses-last-assessment-results')
+          .select('assessment-results.*')
+          .innerJoin(
+            'certification-courses',
+            'certification-courses.id',
+            'certification-courses-last-assessment-results.certificationCourseId',
+          )
+          .innerJoin(
+            'assessment-results',
+            'assessment-results.id',
+            'certification-courses-last-assessment-results.lastAssessmentResultId',
+          );
+
+        expect(lastAssessmentResult[0]).to.deep.equal(assessmentResult);
+      });
+    });
+
+    describe('when last related assessment-result is not cancelled', function () {
+      describe('when commentByAutoJury have not a cancelled key', function () {
+        it('should not duplicate commentByAutoJury', async function () {
+          // given
+          await _createCertification({
+            isCancelled: true,
+            lastAssessmentResultStatus: AssessmentResult.status.REJECTED,
+            commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_INSUFFICIENT_CORRECT_ANSWERS,
+          });
+
+          // when
+          const script = new CreateAssessmentResultForCancelledCertificationScript();
+          await script.handle({ logger, options: { dryRun: false, batchSize: 1000 } });
+
+          // then
+          const lastAssessmentResults = await knex('certification-courses-last-assessment-results')
+            .select('assessment-results.commentByAutoJury')
+            .innerJoin(
+              'assessment-results',
+              'assessment-results.id',
+              'certification-courses-last-assessment-results.lastAssessmentResultId',
+            );
+
+          expect(lastAssessmentResults[0].commentByAutoJury).to.be.null;
+        });
+      });
+
+      describe('when commentByAutoJury have already a cancelled key', function () {
+        it('should create a new cancelled assessment-result + competences marks', async function () {
+          // given
+          const assessmentResult = await _createCertification({
+            isCancelled: true,
+            lastAssessmentResultStatus: AssessmentResult.status.REJECTED,
+            commentByAutoJury: AutoJuryCommentKeys.CANCELLED_DUE_TO_LACK_OF_ANSWERS_FOR_TECHNICAL_REASON,
+          });
+
+          // when
+          const script = new CreateAssessmentResultForCancelledCertificationScript();
+          await script.handle({ logger, options: { dryRun: false, batchSize: 1000 } });
+
+          // then
+          const lastAssessmentResults = await knex('certification-courses-last-assessment-results')
+            .select(
+              'assessment-results.id',
+              'assessment-results.level',
+              'assessment-results.pixScore',
+              'assessment-results.commentByJury',
+              'assessment-results.commentForOrganization',
+              'assessment-results.commentForCandidate',
+              'assessment-results.assessmentId',
+              'assessment-results.reproducibilityRate',
+              'assessment-results.commentByAutoJury',
+              'assessment-results.emitter',
+              'assessment-results.status',
+              'assessment-results.juryId',
+              'assessment-results.createdAt',
+            )
+            .innerJoin(
+              'certification-courses',
+              'certification-courses.id',
+              'certification-courses-last-assessment-results.certificationCourseId',
+            )
+            .innerJoin(
+              'assessment-results',
+              'assessment-results.id',
+              'certification-courses-last-assessment-results.lastAssessmentResultId',
+            );
+
+          const previousCompetenceMarks = await knex('competence-marks')
+            .select('level', 'score', 'area_code', 'competence_code', 'competenceId', 'createdAt')
+            .where('competence-marks.assessmentResultId', assessmentResult.id);
+
+          const competenceMarks = await knex('competence-marks')
+            .select('level', 'score', 'area_code', 'competence_code', 'competenceId', 'createdAt')
+            .where('competence-marks.assessmentResultId', lastAssessmentResults[0].id);
+
+          lastAssessmentResults[0].id = null;
+
+          const expectedAssessmentResult = {
+            id: null,
+            level: assessmentResult.level,
+            pixScore: assessmentResult.pixScore,
+            commentByJury: assessmentResult.commentByJury,
+            commentForOrganization: assessmentResult.commentForOrganization,
+            commentForCandidate: assessmentResult.commentForCandidate,
+            assessmentId: assessmentResult.assessmentId,
+            reproducibilityRate: assessmentResult.reproducibilityRate,
+            commentByAutoJury: assessmentResult.commentByAutoJury,
+            emitter: assessmentResult.emitter,
+            status: AssessmentResult.status.CANCELLED,
+            juryId: config.infra.engineeringUserId,
+            createdAt: assessmentResult.createdAt,
+          };
+          expect(lastAssessmentResults[0]).to.deep.equal(expectedAssessmentResult);
+          expect(lastAssessmentResults).to.have.lengthOf(1);
+          expect(previousCompetenceMarks).to.have.deep.members(competenceMarks);
+          expect(competenceMarks).to.have.lengthOf(2);
+        });
+      });
+    });
+  });
+
+  describe('when certification-course is not cancelled', function () {
+    it('should do nothing', async function () {
+      // given
+      const assessmentResult = await _createCertification({
+        isCancelled: false,
+        lastAssessmentResultStatus: AssessmentResult.status.REJECTED,
+        commentByAutoJury: null,
+      });
+
+      // when
+      const script = new CreateAssessmentResultForCancelledCertificationScript();
+      await script.handle({ logger, options: { dryRun: false, batchSize: 1000 } });
+
+      // then
+      const lastAssessmentResult = await knex('certification-courses-last-assessment-results')
+        .select('assessment-results.*')
+        .innerJoin(
+          'certification-courses',
+          'certification-courses.id',
+          'certification-courses-last-assessment-results.certificationCourseId',
+        )
+        .innerJoin(
+          'assessment-results',
+          'assessment-results.id',
+          'certification-courses-last-assessment-results.lastAssessmentResultId',
+        );
+
+      expect(lastAssessmentResult[0]).to.deep.equal(assessmentResult);
+    });
+  });
+});
+
+async function _createCertification({ isCancelled, lastAssessmentResultStatus, commentByAutoJury }) {
+  databaseBuilder.factory.buildUser({
+    id: config.infra.engineeringUserId,
+  });
+  const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+    id: 123,
+    version: AlgorithmEngineVersion.V3,
+    isCancelled,
+  });
+  const assessment = databaseBuilder.factory.buildAssessment({
+    id: 456,
+    type: Assessment.types.CERTIFICATION,
+    userId: certificationCourse.userId,
+    certificationCourseId: certificationCourse.id,
+  });
+  const previousAssessmentResult = databaseBuilder.factory.buildAssessmentResult({
+    status: AssessmentResult.status.VALIDATED,
+    juryId: null,
+  });
+  const assessmentResult = databaseBuilder.factory.buildAssessmentResult({
+    assessmentId: assessment.id,
+    status: lastAssessmentResultStatus,
+    commentByAutoJury,
+    commentByJury: null,
+    juryId: null,
+  });
+  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+    certificationCourseId: certificationCourse.id,
+    lastAssessmentResultId: assessmentResult.id,
+  });
+  databaseBuilder.factory.buildCompetenceMark({ assessmentResultId: previousAssessmentResult.id });
+  databaseBuilder.factory.buildCompetenceMark({
+    score: 10,
+    level: 4,
+    competence_code: '2.3',
+    area_code: '2',
+    competenceId: 'recComp23',
+    assessmentResultId: assessmentResult.id,
+  });
+  databaseBuilder.factory.buildCompetenceMark({
+    score: 56,
+    level: 2,
+    competence_code: '3.1',
+    area_code: 'area1',
+    competenceId: 'recComp1',
+    assessmentResultId: assessmentResult.id,
+  });
+
+  await databaseBuilder.commit();
+
+  return assessmentResult;
+}


### PR DESCRIPTION
## :pancakes: Problème

Maintenant que l’on supporte le assesment-result cancelled partout, on peut demarrer une bascule au niveau de la DATA, c'est a dire transformer les "certification-courses.isCancelled" en "assessment-results.status = cancelled"

A noter, on veut garder exactement les memes données que le precedent "assessment-result", au delta près du commentaire jury (car il y avait ou pas commentaire selon les cas de isCancelled ou non)

## :bacon: Proposition

* Script de rattrapage

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

### Cas nominal

* Creer une session, avec un candidat, faire passer la certif **en la reussissant**
* ASur pix Admin annuler la certification (bouton annuler sur Pix Admin), puis publier (pour voir le message candidat sur Pix App)
* En base de donnée
  * supprimer le dernier assessment-result avec status **cancelled** (rappele : on supporte deja la feature)
  * supprimer aussi les competences marks associees
  * et modifier le certification-courses-last-assessment-result  (**etape sans doute la plus importante**)

pour verifier que vous etes bien dans le bon etat, sur Pix Admin, la certification va du coup ressembler a quelque chose comme cela (l'etat avant que l'on cree notre nouvelle feature)
![image](https://github.com/user-attachments/assets/9b2532fb-c68f-472a-8921-47e97f3e3229)

verifier aussi que l'etat candidat sur Pix App est OK


* Sur un one-off sur la RA, declencher le script avec la commande `LOG_FOR_HUMANS=true LOG_LEVEL=debug DEBUG="knex:*" node scripts/certification/create-assessment-result-for-cancelled-certification.js --dryRun=true`
* Vous devriez voir dans les resultats apparaitre le assessment-result que vous aviez supprime
* Puis relancer le script en mettant `dryRun=false`
  * verifier ensuite en base la reapparition de votre assessment-result en cancelled

### Cas deja assessment-result deja annule automatiquement

* Creer une session, avec un candidat, faire passer la certif en "manque de reponse pour cause de probleme technique"
* Aller jusqu'a publier la certification, elle doit etre deja en statut annulee
* Verifier en base la presence d'un assessment-result avec le statut cancelled
* Sur un one-off sur la RA, declencher le script avec la commande `LOG_LEVEL=debug DEBUG="knex:*" node scripts/certification/create-assessment-result-for-cancelled-certification.js --dryRun=true`
* **Il ne doit rien se passer**
