### PR TITLE
[FEATURE] Ajouter une validation de l'email dans les liens de l'email d'avertissement de connexion après un an d'inactivité (PIX-16127)

### DIFF
--- a/api/db/seeds/data/team-acces/build-users.js
+++ b/api/db/seeds/data/team-acces/build-users.js
@@ -48,6 +48,15 @@ function _buildUsers(databaseBuilder) {
     email: 'chrono.post@example.net',
     createdAt: new Date('2000-12-31'),
   });
+
+  // user with an old last logged-at date (>1 year) and no email confirmation date
+  const userWithOldLastLoggedAt = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Old',
+    lastName: 'Connexion',
+    email: 'old-connexion@example.net',
+    emailConfirmedAt: null,
+  });
+  databaseBuilder.factory.buildUserLogin({ userId: userWithOldLastLoggedAt.id, lastLoggedAt: new Date('1970-01-01') });
 }
 
 export function buildUsers(databaseBuilder) {

--- a/api/src/identity-access-management/domain/emails/create-warning-connection.email.js
+++ b/api/src/identity-access-management/domain/emails/create-warning-connection.email.js
@@ -16,7 +16,14 @@ import { mailer } from '../../../shared/mail/infrastructure/services/mailer.js';
 export function createWarningConnectionEmail({ locale, email, firstName, validationToken }) {
   locale = locale || LOCALE.FRENCH_FRANCE;
   const lang = new Intl.Locale(locale).language;
-  const factory = new EmailFactory({ app: 'pix-app', locale });
+  let localeSupport;
+  if (locale.toLowerCase() === LOCALE.FRENCH_FRANCE) {
+    localeSupport = LOCALE.FRENCH_FRANCE;
+  } else {
+    localeSupport = lang;
+  }
+
+  const factory = new EmailFactory({ app: 'pix-app', locale: localeSupport });
 
   const { i18n, defaultVariables } = factory;
   const pixAppUrl = urlBuilder.getPixAppBaseUrl(locale);
@@ -30,7 +37,7 @@ export function createWarningConnectionEmail({ locale, email, firstName, validat
       homeName: defaultVariables.homeName,
       homeUrl: defaultVariables.homeUrl,
       helpDeskUrl: urlBuilder.getEmailValidationUrl({
-        locale,
+        locale: localeSupport,
         redirectUrl: defaultVariables.helpdeskUrl,
         token: validationToken,
       }),
@@ -44,7 +51,11 @@ export function createWarningConnectionEmail({ locale, email, firstName, validat
       disclaimer: i18n.__('warning-connection-email.params.disclaimer'),
       warningMessage: i18n.__('warning-connection-email.params.warningMessage'),
       resetMyPassword: i18n.__('warning-connection-email.params.resetMyPassword'),
-      resetUrl: urlBuilder.getEmailValidationUrl({ locale, redirectUrl: resetUrl, token: validationToken }),
+      resetUrl: urlBuilder.getEmailValidationUrl({
+        locale: localeSupport,
+        redirectUrl: resetUrl,
+        token: validationToken,
+      }),
       supportContact: i18n.__('warning-connection-email.params.supportContact'),
       thanks: i18n.__('warning-connection-email.params.thanks'),
       signing: i18n.__('warning-connection-email.params.signing'),

--- a/api/src/identity-access-management/domain/emails/create-warning-connection.email.js
+++ b/api/src/identity-access-management/domain/emails/create-warning-connection.email.js
@@ -10,9 +10,10 @@ import { mailer } from '../../../shared/mail/infrastructure/services/mailer.js';
  * @param {string} params.locale - The locale for the email.
  * @param {string} params.email - The recipient's email address.
  * @param {string} params.firstName - The recipient's first name.
+ * @param {string} params.validationToken - The token for email validation.
  * @returns {Email} The email object.
  */
-export function createWarningConnectionEmail({ locale, email, firstName }) {
+export function createWarningConnectionEmail({ locale, email, firstName, validationToken }) {
   locale = locale || LOCALE.FRENCH_FRANCE;
   const lang = new Intl.Locale(locale).language;
   const factory = new EmailFactory({ app: 'pix-app', locale });
@@ -28,7 +29,11 @@ export function createWarningConnectionEmail({ locale, email, firstName }) {
     variables: {
       homeName: defaultVariables.homeName,
       homeUrl: defaultVariables.homeUrl,
-      helpDeskUrl: defaultVariables.helpdeskUrl,
+      helpDeskUrl: urlBuilder.getEmailValidationUrl({
+        locale,
+        redirectUrl: defaultVariables.helpdeskUrl,
+        token: validationToken,
+      }),
       displayNationalLogo: defaultVariables.displayNationalLogo,
       contactUs: i18n.__('common.email.contactUs'),
       doNotAnswer: i18n.__('common.email.doNotAnswer'),
@@ -39,7 +44,7 @@ export function createWarningConnectionEmail({ locale, email, firstName }) {
       disclaimer: i18n.__('warning-connection-email.params.disclaimer'),
       warningMessage: i18n.__('warning-connection-email.params.warningMessage'),
       resetMyPassword: i18n.__('warning-connection-email.params.resetMyPassword'),
-      resetUrl,
+      resetUrl: urlBuilder.getEmailValidationUrl({ locale, redirectUrl: resetUrl, token: validationToken }),
       supportContact: i18n.__('warning-connection-email.params.supportContact'),
       thanks: i18n.__('warning-connection-email.params.thanks'),
       signing: i18n.__('warning-connection-email.params.signing'),

--- a/api/src/identity-access-management/domain/usecases/authenticate-user.js
+++ b/api/src/identity-access-management/domain/usecases/authenticate-user.js
@@ -17,6 +17,7 @@ const authenticateUser = async function ({
   userLoginRepository,
   adminMemberRepository,
   emailRepository,
+  emailValidationDemandRepository,
   audience,
 }) {
   try {
@@ -49,11 +50,15 @@ const authenticateUser = async function ({
 
     const userLogin = await userLoginRepository.findByUserId(foundUser.id);
     if (foundUser.email && userLogin?.shouldSendConnectionWarning()) {
+      const validationToken = !foundUser.emailConfirmedAt
+        ? await emailValidationDemandRepository.save(foundUser.id)
+        : null;
       await emailRepository.sendEmailAsync(
         createWarningConnectionEmail({
           locale: foundUser.locale,
           email: foundUser.email,
           firstName: foundUser.firstName,
+          validationToken,
         }),
       );
     }

--- a/api/src/shared/infrastructure/utils/url-builder.js
+++ b/api/src/shared/infrastructure/utils/url-builder.js
@@ -50,7 +50,8 @@ function getEmailValidationUrl({ locale, redirectUrl, token } = {}) {
   const baseUrl = getPixAppBaseUrl(locale);
 
   const params = new URLSearchParams();
-  if (token) params.append('token', token);
+  if (!token) return redirectUrl;
+  params.append('token', token);
   if (redirectUrl) params.append('redirect_url', redirectUrl);
 
   return `${baseUrl}/api/users/validate-email?${params.toString()}`;

--- a/api/tests/identity-access-management/unit/domain/emails/create-warning-connection.email.test.js
+++ b/api/tests/identity-access-management/unit/domain/emails/create-warning-connection.email.test.js
@@ -41,7 +41,7 @@ describe('Unit | Identity Access Management | Domain | Email | create-warning-co
   });
 
   describe('when the locale is en', function () {
-    it('provides the correct reset password URL', function () {
+    it('provides the correct urls', function () {
       // given
       const emailParams = {
         email: 'toto@example.net',
@@ -54,34 +54,19 @@ describe('Unit | Identity Access Management | Domain | Email | create-warning-co
       const email = createWarningConnectionEmail(emailParams);
 
       // then
-      const { resetUrl } = email.variables;
-      const expectedUrl =
-        'https://app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Fapp.pix.org%2Fmot-de-passe-oublie%3Flang%3Den';
-      expect(resetUrl).to.equal(expectedUrl);
-    });
+      const { helpDeskUrl, resetUrl } = email.variables;
+      const expectedSupportUrl =
+        'https://test.app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Fpix.org%2Fen%2Fsupport';
 
-    it('provides the correct help desk URL', function () {
-      // given
-      const emailParams = {
-        email: 'toto@example.net',
-        locale: 'en',
-        firstName: 'John',
-        validationToken: 'token',
-      };
-
-      // when
-      const email = createWarningConnectionEmail(emailParams);
-
-      // then
-      const { helpDeskUrl } = email.variables;
-      const expectedUrl =
-        'https://app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Fpix.org%2Fen%2Fsupport';
-      expect(helpDeskUrl).to.equal(expectedUrl);
+      const expectedResetUrl =
+        'https://test.app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Ftest.app.pix.org%2Fmot-de-passe-oublie%3Flang%3Den';
+      expect(resetUrl).to.equal(expectedResetUrl);
+      expect(helpDeskUrl).to.equal(expectedSupportUrl);
     });
   });
 
   describe('when the locale is fr-fr', function () {
-    it('provides the correct reset password URL', function () {
+    it('provides the correct urls', function () {
       // given
       const emailParams = {
         email: 'toto@example.net',
@@ -94,17 +79,22 @@ describe('Unit | Identity Access Management | Domain | Email | create-warning-co
       const email = createWarningConnectionEmail(emailParams);
 
       // then
-      const { resetUrl } = email.variables;
-      const expectedUrl =
-        'https://app.pix.fr/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Fapp.pix.fr%2Fmot-de-passe-oublie%3Flang%3Dfr';
-      expect(resetUrl).to.equal(expectedUrl);
+      const { helpDeskUrl, resetUrl } = email.variables;
+      const expectedSupportUrl =
+        'https://test.app.pix.fr/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Fpix.fr%2Fsupport';
+      const expectedResetUrl =
+        'https://test.app.pix.fr/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Ftest.app.pix.fr%2Fmot-de-passe-oublie%3Flang%3Dfr';
+      expect(resetUrl).to.equal(expectedResetUrl);
+      expect(helpDeskUrl).to.equal(expectedSupportUrl);
     });
+  });
 
-    it('provides the correct help desk URL', function () {
+  describe('when the locale is fr', function () {
+    it('provides the correct urls', function () {
       // given
       const emailParams = {
         email: 'toto@example.net',
-        locale: 'fr-fr',
+        locale: 'fr',
         firstName: 'John',
         validationToken: 'token',
       };
@@ -113,15 +103,18 @@ describe('Unit | Identity Access Management | Domain | Email | create-warning-co
       const email = createWarningConnectionEmail(emailParams);
 
       // then
-      const { helpDeskUrl } = email.variables;
-      const expectedUrl =
-        'https://app.pix.fr/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Fpix.fr%2Fsupport';
-      expect(helpDeskUrl).to.equal(expectedUrl);
+      const { helpDeskUrl, resetUrl } = email.variables;
+      const expectedSupportUrl =
+        'https://test.app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Fpix.org%2Ffr%2Fsupport';
+      const expectedResetUrl =
+        'https://test.app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Ftest.app.pix.org%2Fmot-de-passe-oublie%3Flang%3Dfr';
+      expect(resetUrl).to.equal(expectedResetUrl);
+      expect(helpDeskUrl).to.equal(expectedSupportUrl);
     });
   });
 
   describe('when the locale is nl-BE', function () {
-    it('provides the correct reset password URL', function () {
+    it('provides the correct urls', function () {
       // given
       const emailParams = {
         email: 'toto@example.net',
@@ -134,11 +127,14 @@ describe('Unit | Identity Access Management | Domain | Email | create-warning-co
       const email = createWarningConnectionEmail(emailParams);
 
       // then
-      const { resetUrl } = email.variables;
-      const expectedUrl =
-        'https://app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Fapp.pix.org%2Fmot-de-passe-oublie%3Flang%3Dnl';
+      const { resetUrl, helpDeskUrl } = email.variables;
+      const expectedResetUrl =
+        'https://test.app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Ftest.app.pix.org%2Fmot-de-passe-oublie%3Flang%3Dnl';
 
-      expect(resetUrl).to.equal(expectedUrl);
+      const expectedSupportUrl =
+        'https://test.app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Fpix.org%2Fnl-be%2Fsupport';
+      expect(resetUrl).to.equal(expectedResetUrl);
+      expect(helpDeskUrl).to.equal(expectedSupportUrl);
     });
   });
 });

--- a/api/tests/identity-access-management/unit/domain/emails/create-warning-connection.email.test.js
+++ b/api/tests/identity-access-management/unit/domain/emails/create-warning-connection.email.test.js
@@ -9,6 +9,7 @@ describe('Unit | Identity Access Management | Domain | Email | create-warning-co
       email: 'test@example.com',
       locale: 'fr',
       firstName: 'John',
+      validationToken: 'token',
     };
 
     const email = createWarningConnectionEmail(emailParams);
@@ -46,14 +47,36 @@ describe('Unit | Identity Access Management | Domain | Email | create-warning-co
         email: 'toto@example.net',
         locale: 'en',
         firstName: 'John',
+        validationToken: 'token',
       };
 
       // when
       const email = createWarningConnectionEmail(emailParams);
 
       // then
-      const resetUrl = email.variables.resetUrl;
-      expect(resetUrl).to.equal('https://test.app.pix.org/mot-de-passe-oublie?lang=en');
+      const { resetUrl } = email.variables;
+      const expectedUrl =
+        'https://app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Fapp.pix.org%2Fmot-de-passe-oublie%3Flang%3Den';
+      expect(resetUrl).to.equal(expectedUrl);
+    });
+
+    it('provides the correct help desk URL', function () {
+      // given
+      const emailParams = {
+        email: 'toto@example.net',
+        locale: 'en',
+        firstName: 'John',
+        validationToken: 'token',
+      };
+
+      // when
+      const email = createWarningConnectionEmail(emailParams);
+
+      // then
+      const { helpDeskUrl } = email.variables;
+      const expectedUrl =
+        'https://app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Fpix.org%2Fen%2Fsupport';
+      expect(helpDeskUrl).to.equal(expectedUrl);
     });
   });
 
@@ -64,14 +87,36 @@ describe('Unit | Identity Access Management | Domain | Email | create-warning-co
         email: 'toto@example.net',
         locale: 'fr-fr',
         firstName: 'John',
+        validationToken: 'token',
       };
 
       // when
       const email = createWarningConnectionEmail(emailParams);
 
       // then
-      const resetUrl = email.variables.resetUrl;
-      expect(resetUrl).to.equal('https://test.app.pix.fr/mot-de-passe-oublie?lang=fr');
+      const { resetUrl } = email.variables;
+      const expectedUrl =
+        'https://app.pix.fr/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Fapp.pix.fr%2Fmot-de-passe-oublie%3Flang%3Dfr';
+      expect(resetUrl).to.equal(expectedUrl);
+    });
+
+    it('provides the correct help desk URL', function () {
+      // given
+      const emailParams = {
+        email: 'toto@example.net',
+        locale: 'fr-fr',
+        firstName: 'John',
+        validationToken: 'token',
+      };
+
+      // when
+      const email = createWarningConnectionEmail(emailParams);
+
+      // then
+      const { helpDeskUrl } = email.variables;
+      const expectedUrl =
+        'https://app.pix.fr/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Fpix.fr%2Fsupport';
+      expect(helpDeskUrl).to.equal(expectedUrl);
     });
   });
 
@@ -82,14 +127,18 @@ describe('Unit | Identity Access Management | Domain | Email | create-warning-co
         email: 'toto@example.net',
         locale: 'nl-BE',
         firstName: 'John',
+        validationToken: 'token',
       };
 
       // when
       const email = createWarningConnectionEmail(emailParams);
 
       // then
-      const resetUrl = email.variables.resetUrl;
-      expect(resetUrl).to.equal('https://test.app.pix.org/mot-de-passe-oublie?lang=nl');
+      const { resetUrl } = email.variables;
+      const expectedUrl =
+        'https://app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Fapp.pix.org%2Fmot-de-passe-oublie%3Flang%3Dnl';
+
+      expect(resetUrl).to.equal(expectedUrl);
     });
   });
 });

--- a/api/tests/shared/unit/infrastructure/utils/url-builder_test.js
+++ b/api/tests/shared/unit/infrastructure/utils/url-builder_test.js
@@ -119,25 +119,25 @@ describe('Unit | Shared | Infrastructure | Utils | url-builder', function () {
       it('returns email validation URL with domain .fr', function () {
         // given
         const redirectUrl = 'https://app.pix.fr/connexion';
-        const expectedParams = new URLSearchParams({ redirect_url: redirectUrl });
 
         // when
         const url = urlBuilder.getEmailValidationUrl({ redirectUrl });
 
         // then
-        expect(url).to.equal(
-          `${config.domain.pixApp + config.domain.tldFr}/api/users/validate-email?${expectedParams.toString()}`,
-        );
+        expect(url).to.equal(redirectUrl);
       });
     });
 
     context('when redirect_url is not given', function () {
       it('returns email validation URL with domain .fr', function () {
+        // given
+        const token = '00000000-0000-0000-0000-000000000000';
+
         // when
-        const url = urlBuilder.getEmailValidationUrl();
+        const url = urlBuilder.getEmailValidationUrl({ token });
 
         // then
-        expect(url).to.equal(`${config.domain.pixApp + config.domain.tldFr}/api/users/validate-email?`);
+        expect(url).to.equal(`${config.domain.pixApp + config.domain.tldFr}/api/users/validate-email?token=${token}`);
       });
     });
   });


### PR DESCRIPTION
## :pancakes: Problème

Lorsque l'utilisateur reçoit l'email lui indiquant une reconnexion après 1 an, on souhaite que, s'il clique sur le lien de réinitialisation de son mot de passe ou sur le lien du support, on en profite pour valider son email. 
Cela est utile notamment pour les personnes n'ayant jamais confirmé leur email à leur inscription.

## :bacon: Proposition

Ajouter une validation d'email avec la redirection sur la page de réinitialisation du mot de passe, ou bien sur la page du support. Au clic sur ces liens, la valeur emailConfirmedAt sera mise à jour et l'adresse mail validée. 

## 🧃 Remarques

Pour cet email, on a fait en sorte que la locale de l'utilisateur détermine si l'email renvoie vers pix.fr ou pix.org. Cependant, cette solution ne s'applique qu'à un seul élément et ne peut pas perdurer dans le temps.

## :yum: Pour tester
- Se connecter à scalingo en sql:
```shell
scalingo -a pix-api-review-pr11420 psql-console
````
- Modifier l'adresse email pour qu'elle pointe vers une adresse email valide:
```sql
UPDATE "users" SET "email" = '<votre_email@pixmail.org' WHERE "email" = 'old-connexion@example.net';
````
- Se rendre sur Pix admin et se connecter avec le compte superadmin@example.net,
- Aller sur la page des utilisateurs et rechercher son email,
- Afficher l'utilisateur "Old Connexion" et aller dans les méthodes des connexion,
- Constater que l'email n'est pas confirmé,
- Ouvrir une autre page sur Pix app,
- Se connecter avec son email (celui qui a été utilisé dans la commande sql),
- Constater qu'on arrive bien sur la page d'accueil,
- Sur Pix admin, constater que la date de connexion a changé, mais pas la confirmation de l'email,
- Ouvrir sa boîte mail,
- Constater la présence du mail de Pix indiquant une nouvelle connexion,
- Cliquer sur le lien pour réinitialiser son mot de passe ou celui du support juste en dessous,
- Retourner sur Pix admin,
- Constater que la date actuelle est au niveau du champ de la confirmation d'email,
- Remettre les seeds pour ceux qui passeront derrière:
```shell
scalingo -a pix-api-review-pr11420 run npm run db:seed
```