### PR TITLE
[TECH] Ajouter un nouveau requirement de type CappedTubes pour pouvoir exprimer une quête à l'aide de sujets cappés en niveau (PIX-16539)

### DIFF
--- a/api/src/evaluation/application/api/models/KnowledgeElementDTO.js
+++ b/api/src/evaluation/application/api/models/KnowledgeElementDTO.js
@@ -1,6 +1,7 @@
 export class KnowledgeElementDTO {
-  constructor({ status, skillId }) {
+  constructor({ status, skillId, createdAt }) {
     this.status = status;
     this.skillId = skillId;
+    this.createdAt = createdAt;
   }
 }

--- a/api/src/learning-content/application/api/models/SkillDTO.js
+++ b/api/src/learning-content/application/api/models/SkillDTO.js
@@ -1,0 +1,7 @@
+export class SkillDTO {
+  constructor({ id, difficulty, tubeId }) {
+    this.id = id;
+    this.difficulty = difficulty;
+    this.tubeId = tubeId;
+  }
+}

--- a/api/src/learning-content/application/api/skills-api.js
+++ b/api/src/learning-content/application/api/skills-api.js
@@ -1,0 +1,29 @@
+import { usecases } from '../../domain/usecases/index.js';
+import { SkillDTO } from './models/SkillDTO.js';
+
+/**
+ * @typedef SkillDTO
+ * @type {object}
+ * @property {string} id
+ * @property {number} difficulty
+ * @property {string} tubeId
+ */
+
+/**
+ * @function
+ * @name findByIds
+ *
+ * @param {Object} params
+ * @param {Array<string>} params.ids
+ * @returns {Promise<Array<SkillDTO>>}
+ */
+export async function findByIds({ ids = [] }) {
+  if (!ids?.length) {
+    return [];
+  }
+  const skills = await usecases.findSkillsByIds({ ids });
+
+  return skills.map(_toApi);
+}
+
+const _toApi = (skill) => new SkillDTO(skill);

--- a/api/src/learning-content/domain/usecases/dependencies.js
+++ b/api/src/learning-content/domain/usecases/dependencies.js
@@ -1,4 +1,5 @@
 import { lcmsClient } from '../../../shared/infrastructure/lcms-client.js';
+import * as sharedSkillRepository from '../../../shared/infrastructure/repositories/skill-repository.js';
 import { areaRepository } from '../../infrastructure/repositories/area-repository.js';
 import { challengeRepository } from '../../infrastructure/repositories/challenge-repository.js';
 import { competenceRepository } from '../../infrastructure/repositories/competence-repository.js';
@@ -19,6 +20,7 @@ export const dependencies = {
   thematicRepository,
   tubeRepository,
   skillRepository,
+  sharedSkillRepository,
   challengeRepository,
   courseRepository,
   tutorialRepository,

--- a/api/src/learning-content/domain/usecases/find-skills-by-ids.js
+++ b/api/src/learning-content/domain/usecases/find-skills-by-ids.js
@@ -1,0 +1,3 @@
+export function findSkillsByIds({ ids, sharedSkillRepository }) {
+  return sharedSkillRepository.findByRecordIds(ids);
+}

--- a/api/src/prescription/campaign/application/api/campaigns-api.js
+++ b/api/src/prescription/campaign/application/api/campaigns-api.js
@@ -137,3 +137,16 @@ export const findAllForOrganization = async (payload) => {
 
   return { models: campaignsList, meta };
 };
+
+/**
+ * @function
+ * @name findCampaignSkillIdsForCampaignParticipations
+ *
+ * @param {Array<Number>} campaignParticipationIds
+ * @returns {Promise<Array<Number>>}
+ */
+export const findCampaignSkillIdsForCampaignParticipations = async (campaignParticipationIds) => {
+  return usecases.findCampaignSkillIdsForCampaignParticipations({
+    campaignParticipationIds,
+  });
+};

--- a/api/src/prescription/campaign/domain/usecases/find-campaign-skill-ids-for-campaign-participations.js
+++ b/api/src/prescription/campaign/domain/usecases/find-campaign-skill-ids-for-campaign-participations.js
@@ -1,0 +1,8 @@
+const findCampaignSkillIdsForCampaignParticipations = async function ({
+  campaignParticipationIds,
+  campaignRepository,
+}) {
+  return campaignRepository.findSkillIdsByCampaignParticipationIds({ campaignParticipationIds });
+};
+
+export { findCampaignSkillIdsForCampaignParticipations };

--- a/api/src/prescription/target-profile/application/api/TargetProfileSkill.js
+++ b/api/src/prescription/target-profile/application/api/TargetProfileSkill.js
@@ -1,0 +1,6 @@
+export class TargetProfileSkill {
+  constructor({ id, difficulty }) {
+    this.id = id;
+    this.difficulty = difficulty;
+  }
+}

--- a/api/src/prescription/target-profile/application/api/target-profile-api.js
+++ b/api/src/prescription/target-profile/application/api/target-profile-api.js
@@ -1,5 +1,6 @@
 import { usecases } from '../../domain/usecases/index.js';
 import { TargetProfile } from './TargetProfile.js';
+import { TargetProfileSkill } from './TargetProfileSkill.js';
 
 /**
  * @module TargetProfileApi
@@ -29,4 +30,17 @@ export const getById = async (id) => {
   const targetProfileForAdmin = await usecases.getTargetProfileForAdmin({ targetProfileId: id });
 
   return new TargetProfile(targetProfileForAdmin);
+};
+
+/**
+ * @function
+ * @name findSkillByTargetProfileIds
+ *
+ * @param {Array<number>} targetProfilsIds
+ * @returns {Promise<<Array<TargetProfileSkill>>}
+ */
+export const findSkillsByTargetProfileIds = async (targetProfileIds) => {
+  const skillsData = await usecases.findSkillsByTargetProfileIds({ targetProfileIds });
+
+  return skillsData.map((skill) => new TargetProfileSkill(skill));
 };

--- a/api/src/prescription/target-profile/domain/usecases/find-skills-by-target-profile-ids.js
+++ b/api/src/prescription/target-profile/domain/usecases/find-skills-by-target-profile-ids.js
@@ -1,0 +1,5 @@
+const findSkillsByTargetProfileIds = async function ({ targetProfileIds, targetProfileRepository }) {
+  return targetProfileRepository.findSkillsByIds({ targetProfileIds });
+};
+
+export { findSkillsByTargetProfileIds };

--- a/api/src/prescription/target-profile/infrastructure/repositories/target-profile-repository.js
+++ b/api/src/prescription/target-profile/infrastructure/repositories/target-profile-repository.js
@@ -66,8 +66,11 @@ const findSkillsByIds = async function ({ targetProfileIds, dependencies = { ski
   const knexConn = DomainTransaction.getConnection();
 
   const cappedTubes = await knexConn('target-profile_tubes')
-    .select('tubeId', 'level')
+    .select('tubeId')
+    .max('level as level')
+    .groupBy('tubeId')
     .whereIn('targetProfileId', targetProfileIds);
+
   const skillData = [];
   for (const cappedTube of cappedTubes) {
     const allLevelSkills = await dependencies.skillRepository.findActiveByTubeId(cappedTube.tubeId);

--- a/api/src/quest/domain/models/DataForQuest.js
+++ b/api/src/quest/domain/models/DataForQuest.js
@@ -52,7 +52,13 @@ export class DataForQuest {
     return this.#success.knowledgeElements;
   }
 
+  // TODO :  stop using this mystical args ?
   getMasteryPercentageForSkills(...args) {
     return this.#success.getMasteryPercentageForSkills(...args);
+  }
+
+  // TODO :  stop using this mystical args ?
+  getMasteryPercentageForCappedTubes(...args) {
+    return this.#success.getMasteryPercentageForCappedTubes(...args);
   }
 }

--- a/api/src/quest/domain/models/Quest.js
+++ b/api/src/quest/domain/models/Quest.js
@@ -44,6 +44,26 @@ class Quest {
   /**
    * @param {DataForQuest} data
    */
+  findTargetProfileIdsWithoutCampaignParticipationContributingToQuest(data) {
+    const campaignParticipationRequirements = this.#flattenRequirementsByType(
+      this.#eligibilityRequirements.data,
+      REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+    );
+    if (campaignParticipationRequirements.length === 0) return [];
+
+    const targetProfileIds = campaignParticipationRequirements
+      // TODO: requirement.criterion.data.targetProfileId.data would be more explicit
+      .map((requirement) => requirement.data.data?.targetProfileId?.data)
+      .filter(Boolean);
+
+    return targetProfileIds.filter(
+      (targetProfileId) => data.campaignParticipations.findIndex((p) => p.targetProfileId === targetProfileId) === -1,
+    );
+  }
+
+  /**
+   * @param {DataForQuest} data
+   */
   findCampaignParticipationIdsContributingToQuest(data) {
     const campaignParticipationRequirements = this.#flattenRequirementsByType(
       this.#eligibilityRequirements.data,

--- a/api/src/quest/domain/models/Quest.js
+++ b/api/src/quest/domain/models/Quest.js
@@ -46,7 +46,7 @@ class Quest {
    */
   findTargetProfileIdsWithoutCampaignParticipationContributingToQuest(data) {
     const campaignParticipationRequirements = this.#flattenRequirementsByType(
-      this.#eligibilityRequirements.data,
+      [...this.#eligibilityRequirements.data, ...this.#successRequirements.data],
       REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
     );
     if (campaignParticipationRequirements.length === 0) return [];
@@ -66,7 +66,7 @@ class Quest {
    */
   findCampaignParticipationIdsContributingToQuest(data) {
     const campaignParticipationRequirements = this.#flattenRequirementsByType(
-      this.#eligibilityRequirements.data,
+      [...this.#eligibilityRequirements.data, ...this.#successRequirements.data],
       REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
     );
     const oneOfCampaignParticipationsRequirement = new ComposedRequirement({
@@ -98,7 +98,7 @@ class Quest {
     const scopedData = data.buildDataForQuestScopedByCampaignParticipationId({ campaignParticipationId });
 
     const campaignParticipationRequirements = this.#flattenRequirementsByType(
-      this.#eligibilityRequirements.data,
+      [...this.#eligibilityRequirements.data, ...this.#successRequirements.data],
       REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
     );
 

--- a/api/src/quest/domain/models/Quest.js
+++ b/api/src/quest/domain/models/Quest.js
@@ -43,7 +43,36 @@ class Quest {
 
   /**
    * @param {DataForQuest} data
-   * @param {number} campaignParticipationId
+   */
+  findCampaignParticipationIdsContributingToQuest(data) {
+    const campaignParticipationRequirements = this.#flattenRequirementsByType(
+      this.#eligibilityRequirements.data,
+      REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+    );
+    const oneOfCampaignParticipationsRequirement = new ComposedRequirement({
+      data: campaignParticipationRequirements,
+      comparison: REQUIREMENT_COMPARISONS.ONE_OF,
+    });
+    if (campaignParticipationRequirements.length > 0) {
+      return data.campaignParticipations
+        .map((campaignParticipation) => {
+          const scopedData = data.buildDataForQuestScopedByCampaignParticipationId({
+            campaignParticipationId: campaignParticipation.id,
+          });
+          if (oneOfCampaignParticipationsRequirement.isFulfilled(scopedData)) {
+            return campaignParticipation.id;
+          }
+          return null;
+        })
+        .filter(Boolean);
+    }
+    return [];
+  }
+
+  /**
+   * @param {object} params
+   * @param {DataForQuest} params.data
+   * @param {number} params.campaignParticipationId
    */
   isCampaignParticipationContributingToQuest({ data, campaignParticipationId }) {
     const scopedData = data.buildDataForQuestScopedByCampaignParticipationId({ campaignParticipationId });
@@ -54,11 +83,11 @@ class Quest {
     );
 
     if (campaignParticipationRequirements.length > 0) {
-      const a = new ComposedRequirement({
+      const oneOfCampaignParticipationsRequirement = new ComposedRequirement({
         data: campaignParticipationRequirements,
         comparison: REQUIREMENT_COMPARISONS.ONE_OF,
       });
-      return a.isFulfilled(scopedData);
+      return oneOfCampaignParticipationsRequirement.isFulfilled(scopedData);
     }
 
     return false;

--- a/api/src/quest/domain/models/Quest.js
+++ b/api/src/quest/domain/models/Quest.js
@@ -54,7 +54,8 @@ class Quest {
     const targetProfileIds = campaignParticipationRequirements
       // TODO: requirement.criterion.data.targetProfileId.data would be more explicit
       .map((requirement) => requirement.data.data?.targetProfileId?.data)
-      .filter(Boolean);
+      .filter(Boolean)
+      .flat();
 
     return targetProfileIds.filter(
       (targetProfileId) => data.campaignParticipations.findIndex((p) => p.targetProfileId === targetProfileId) === -1,

--- a/api/src/quest/domain/models/Requirement.js
+++ b/api/src/quest/domain/models/Requirement.js
@@ -8,6 +8,7 @@ export const COMPARISONS = {
 export const TYPES = {
   COMPOSE: 'compose',
   SKILL_PROFILE: 'skillProfile',
+  CAPPED_TUBES: 'cappedTubes',
   OBJECT: {
     ORGANIZATION_LEARNER: 'organizationLearner',
     ORGANIZATION: 'organization',
@@ -167,6 +168,48 @@ export class SkillProfileRequirement extends BaseRequirement {
   }
 }
 
+export class CappedTubesRequirement extends BaseRequirement {
+  #cappedTubes;
+  #threshold;
+
+  constructor({ data }) {
+    super({ requirement_type: TYPES.CAPPED_TUBES, comparison: null });
+    this.#cappedTubes = data.cappedTubes;
+    this.#threshold = data.threshold;
+  }
+
+  /**
+   * @returns {Object}
+   */
+  get data() {
+    return {
+      cappedTubes: Object.freeze(this.#cappedTubes),
+      threshold: this.#threshold,
+    };
+  }
+
+  /**
+   * @param {Eligibility|Success} dataInput
+   * @returns {Boolean}
+   */
+  isFulfilled(dataInput) {
+    const masteryPercentage = dataInput.getMasteryPercentageForCappedTubes(this.#cappedTubes);
+    return masteryPercentage >= this.#threshold;
+  }
+
+  /**
+   * @returns {Object}
+   */
+  toDTO() {
+    const superDto = super.toDTO();
+    delete superDto.comparison;
+    return {
+      ...superDto,
+      data: this.data,
+    };
+  }
+}
+
 /**
  * @param {Object} params
  * @param {string} params.requirement_type
@@ -182,6 +225,8 @@ export function buildRequirement({ requirement_type, data, comparison }) {
     return new ObjectRequirement({ requirement_type, data, comparison });
   } else if (requirement_type === TYPES.SKILL_PROFILE) {
     return new SkillProfileRequirement({ data });
+  } else if (requirement_type === TYPES.CAPPED_TUBES) {
+    return new CappedTubesRequirement({ data });
   }
   throw new Error(`Unknown requirement_type "${requirement_type}"`);
 }

--- a/api/src/quest/domain/models/Success.js
+++ b/api/src/quest/domain/models/Success.js
@@ -1,3 +1,5 @@
+import uniqBy from 'lodash/uniqBy.js';
+
 import { KnowledgeElement } from '../../../shared/domain/models/index.js';
 
 export class Success {
@@ -28,26 +30,31 @@ export class Success {
    * @param {Array<{tubeId: string, level: number}>} cappedTubes
    * @returns {number}
    */
-  // Pour cette implémentation, ne tient pas compte des versions d'acquis obtenus dans les campagnes
-  // potentiellement effectuées dans le cadre de la quête, mais seulement du profil de l'utilisateur
-  // pour que ça marche efficacement, ajouter une condition d'éligibilité qui impose d'être allé au bout
-  // de la participation, on s'assure ainsi qu'il a bien un KE pour chaque acquis des campagnes et qu'il
-  // n'obtienne pas l'attestation sans avoir effectivement participé
-
-  // L'autre solution serait de baser les cappedTubes sur l'ensemble des lots d'acquis des campagnes
-  // concernées peut-être ?
-  /*getMasteryPercentageForCappedTubes(cappedTubes) {
-    if (!cappedTubes?.length) {
+  getMasteryPercentageForCappedTubes(cappedTubes) {
+    if (!Array.isArray(cappedTubes)) {
       return 0;
     }
-
-    let sumTotal = 0;
-    let sumValidated = 0;
-    for (const { tubeId, level } of cappedTubes) {
-      sumTotal += level; // ceci est très cavalier, je présuppose que le référentiel n'a aucun trou \o/
-      const dataForTubeId = this.#dataByTubeId[tubeId] ?? [];
-      sumValidated += dataForTubeId.filter(({ isValidated, difficulty }) => isValidated && difficulty <= level).length;
+    const uniqCampaignSkills = uniqBy(this.campaignSkills, 'id');
+    const sortedKEByDateDesc = this.knowledgeElements.sort((keA, keB) => keB.createdAt - keA.createdAt);
+    let total = 0;
+    let validated = 0;
+    for (const cappedTube of cappedTubes) {
+      const skillsInTubeWithinMaxDifficulty = uniqCampaignSkills.filter(
+        ({ tubeId, difficulty }) => tubeId === cappedTube.tubeId && difficulty <= cappedTube.level,
+      );
+      const skillsByDifficulty = Object.groupBy(skillsInTubeWithinMaxDifficulty, ({ difficulty }) => difficulty);
+      for (const skills of Object.values(skillsByDifficulty)) {
+        ++total;
+        const skillIds = skills.map(({ id }) => id);
+        const ke = sortedKEByDateDesc.find(({ skillId }) => skillIds.includes(skillId));
+        if (ke?.status === KnowledgeElement.StatusType.VALIDATED) {
+          ++validated;
+        }
+      }
     }
-    return Math.round((sumValidated * 100) / sumTotal);
-  }*/
+
+    if (total === 0) return 0;
+
+    return (validated / total) * 100;
+  }
 }

--- a/api/src/quest/domain/models/Success.js
+++ b/api/src/quest/domain/models/Success.js
@@ -3,9 +3,14 @@ import uniqBy from 'lodash/uniqBy.js';
 import { KnowledgeElement } from '../../../shared/domain/models/index.js';
 
 export class Success {
-  constructor({ knowledgeElements, campaignSkills }) {
+  constructor({ knowledgeElements, campaignSkills = [], targetProfileSkills = [] }) {
     this.knowledgeElements = knowledgeElements;
     this.campaignSkills = campaignSkills;
+    this.targetProfileSkills = targetProfileSkills;
+  }
+
+  get skills() {
+    return uniqBy([...this.campaignSkills, ...this.targetProfileSkills], 'id');
   }
 
   /**
@@ -34,7 +39,7 @@ export class Success {
     if (!Array.isArray(cappedTubes)) {
       return 0;
     }
-    const uniqCampaignSkills = uniqBy(this.campaignSkills, 'id');
+    const uniqCampaignSkills = this.skills;
     const sortedKEByDateDesc = this.knowledgeElements.sort((keA, keB) => keB.createdAt - keA.createdAt);
     let total = 0;
     let validated = 0;

--- a/api/src/quest/domain/models/Success.js
+++ b/api/src/quest/domain/models/Success.js
@@ -1,10 +1,16 @@
 import { KnowledgeElement } from '../../../shared/domain/models/index.js';
 
 export class Success {
-  constructor({ knowledgeElements }) {
+  constructor({ knowledgeElements, campaignSkills }) {
     this.knowledgeElements = knowledgeElements;
+    this.campaignSkills = campaignSkills;
   }
 
+  /**
+   *
+   * @param {Array<string>} skillIds
+   * @returns {number}
+   */
   getMasteryPercentageForSkills(skillIds) {
     // genre de doublon avec api/src/shared/domain/models/CampaignParticipationResult.js:64
     const totalSkillsCount = skillIds?.length;
@@ -16,4 +22,32 @@ export class Success {
     ).length;
     return Math.round((validatedSkillsCount * 100) / totalSkillsCount);
   }
+
+  /**
+   *
+   * @param {Array<{tubeId: string, level: number}>} cappedTubes
+   * @returns {number}
+   */
+  // Pour cette implémentation, ne tient pas compte des versions d'acquis obtenus dans les campagnes
+  // potentiellement effectuées dans le cadre de la quête, mais seulement du profil de l'utilisateur
+  // pour que ça marche efficacement, ajouter une condition d'éligibilité qui impose d'être allé au bout
+  // de la participation, on s'assure ainsi qu'il a bien un KE pour chaque acquis des campagnes et qu'il
+  // n'obtienne pas l'attestation sans avoir effectivement participé
+
+  // L'autre solution serait de baser les cappedTubes sur l'ensemble des lots d'acquis des campagnes
+  // concernées peut-être ?
+  /*getMasteryPercentageForCappedTubes(cappedTubes) {
+    if (!cappedTubes?.length) {
+      return 0;
+    }
+
+    let sumTotal = 0;
+    let sumValidated = 0;
+    for (const { tubeId, level } of cappedTubes) {
+      sumTotal += level; // ceci est très cavalier, je présuppose que le référentiel n'a aucun trou \o/
+      const dataForTubeId = this.#dataByTubeId[tubeId] ?? [];
+      sumValidated += dataForTubeId.filter(({ isValidated, difficulty }) => isValidated && difficulty <= level).length;
+    }
+    return Math.round((sumValidated * 100) / sumTotal);
+  }*/
 }

--- a/api/src/quest/domain/usecases/reward-user.js
+++ b/api/src/quest/domain/usecases/reward-user.js
@@ -35,8 +35,9 @@ export const rewardUser = async ({
       if (rewardIds.includes(quest.rewardId)) {
         continue;
       }
-
-      const success = await successRepository.find({ userId });
+      const campaignParticipationIds = quest.findCampaignParticipationIdsContributingToQuest(dataForQuest);
+      const targetProfileIds = quest.findTargetProfileIdsWithoutCampaignParticipationContributingToQuest(dataForQuest);
+      const success = await successRepository.find({ userId, campaignParticipationIds, targetProfileIds });
       dataForQuest.success = success;
       const userHasSucceedQuest = quest.isSuccessful(dataForQuest);
 

--- a/api/src/quest/infrastructure/repositories/index.js
+++ b/api/src/quest/infrastructure/repositories/index.js
@@ -2,6 +2,7 @@ import * as knowledgeElementsApi from '../../../evaluation/application/api/knowl
 import * as skillsApi from '../../../learning-content/application/api/skills-api.js';
 import * as campaignsApi from '../../../prescription/campaign/application/api/campaigns-api.js';
 import * as organizationLearnerWithParticipationApi from '../../../prescription/organization-learner/application/api/organization-learners-with-participations-api.js';
+import * as targetProfilesApi from '../../../prescription/target-profile/application/api/target-profile-api.js';
 import * as profileRewardApi from '../../../profile/application/api/profile-reward-api.js';
 import * as rewardApi from '../../../profile/application/api/reward-api.js';
 import { temporaryStorage } from '../../../shared/infrastructure/key-value-storages/index.js';
@@ -26,6 +27,7 @@ const dependencies = {
   campaignsApi,
   skillsApi,
   profileRewardApi,
+  targetProfilesApi,
   profileRewardTemporaryStorage,
   rewardApi,
 };

--- a/api/src/quest/infrastructure/repositories/index.js
+++ b/api/src/quest/infrastructure/repositories/index.js
@@ -1,4 +1,6 @@
 import * as knowledgeElementsApi from '../../../evaluation/application/api/knowledge-elements-api.js';
+import * as skillsApi from '../../../learning-content/application/api/skills-api.js';
+import * as campaignsApi from '../../../prescription/campaign/application/api/campaigns-api.js';
 import * as organizationLearnerWithParticipationApi from '../../../prescription/organization-learner/application/api/organization-learners-with-participations-api.js';
 import * as profileRewardApi from '../../../profile/application/api/profile-reward-api.js';
 import * as rewardApi from '../../../profile/application/api/reward-api.js';
@@ -21,6 +23,8 @@ const repositoriesWithoutInjectedDependencies = {
 const dependencies = {
   organizationLearnerWithParticipationApi,
   knowledgeElementsApi,
+  campaignsApi,
+  skillsApi,
   profileRewardApi,
   profileRewardTemporaryStorage,
   rewardApi,

--- a/api/src/quest/infrastructure/repositories/success-repository.js
+++ b/api/src/quest/infrastructure/repositories/success-repository.js
@@ -1,6 +1,8 @@
 import { Success } from '../../domain/models/Success.js';
 
-export const find = async ({ userId, knowledgeElementsApi }) => {
+export const find = async ({ userId, campaignParticipationIds, knowledgeElementsApi, skillsApi, campaignsApi }) => {
   const knowledgeElements = await knowledgeElementsApi.findFilteredMostRecentByUser({ userId });
-  return new Success({ knowledgeElements });
+  const campaignSkillIds = await campaignsApi.findCampaignSkillIdsForCampaignParticipations(campaignParticipationIds);
+  const campaignSkills = await skillsApi.findByIds({ ids: campaignSkillIds });
+  return new Success({ knowledgeElements, campaignSkills });
 };

--- a/api/src/quest/infrastructure/repositories/success-repository.js
+++ b/api/src/quest/infrastructure/repositories/success-repository.js
@@ -1,8 +1,19 @@
 import { Success } from '../../domain/models/Success.js';
 
-export const find = async ({ userId, campaignParticipationIds, knowledgeElementsApi, skillsApi, campaignsApi }) => {
+export const find = async ({
+  userId,
+  campaignParticipationIds,
+  targetProfileIds,
+  knowledgeElementsApi,
+  skillsApi,
+  campaignsApi,
+  targetProfilesApi,
+}) => {
+  const targetProfileSkills = await targetProfilesApi.findSkillsByTargetProfileIds(targetProfileIds);
   const knowledgeElements = await knowledgeElementsApi.findFilteredMostRecentByUser({ userId });
   const campaignSkillIds = await campaignsApi.findCampaignSkillIdsForCampaignParticipations(campaignParticipationIds);
-  const campaignSkills = await skillsApi.findByIds({ ids: campaignSkillIds });
-  return new Success({ knowledgeElements, campaignSkills });
+  const campaignSkills = await skillsApi.findByIds({
+    ids: campaignSkillIds,
+  });
+  return new Success({ knowledgeElements, campaignSkills, targetProfileSkills });
 };

--- a/api/tests/evaluation/unit/application/api/knowledge-elements-api_test.js
+++ b/api/tests/evaluation/unit/application/api/knowledge-elements-api_test.js
@@ -10,7 +10,11 @@ describe('Evaluation | Unit | Application | API | knowledge-elements-api', funct
       // given
       const userId = Symbol('userId');
       const skillIds = Symbol('skillIds');
-      const knowledgeElement = domainBuilder.buildKnowledgeElement({ status: KnowledgeElement.StatusType.VALIDATED });
+      const knowledgeElement = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.VALIDATED,
+        createdAt: new Date('2024-10-27'),
+        skillId: 'recSkill1',
+      });
 
       sinon.stub(evaluationUsecases, 'findFilteredMostRecentKnowledgeElementsByUser');
       evaluationUsecases.findFilteredMostRecentKnowledgeElementsByUser
@@ -22,7 +26,9 @@ describe('Evaluation | Unit | Application | API | knowledge-elements-api', funct
 
       // then
       expect(result).to.be.instanceOf(KnowledgeElementDTO);
+      expect(result.skillId).to.equal(knowledgeElement.skillId);
       expect(result.status).to.equal(KnowledgeElement.StatusType.VALIDATED);
+      expect(result.createdAt).to.equal(knowledgeElement.createdAt);
     });
   });
 });

--- a/api/tests/evaluation/unit/domain/services/smart-random/smart-random_test.js
+++ b/api/tests/evaluation/unit/domain/services/smart-random/smart-random_test.js
@@ -29,6 +29,7 @@ describe('Integration | Domain | Algorithm-methods | SmartRandom', function () {
     locale,
     web1,
     web2,
+    web2_v2,
     web3,
     web4,
     web5,
@@ -46,6 +47,7 @@ describe('Integration | Domain | Algorithm-methods | SmartRandom', function () {
     cnil2,
     challengeWeb_1,
     challengeWeb_2,
+    challengeWeb_2_v2,
     challengeWeb_2_3,
     challengeWeb_3,
     challengeWeb_4,
@@ -73,6 +75,7 @@ describe('Integration | Domain | Algorithm-methods | SmartRandom', function () {
     // Acquis (skills)
     web1 = domainBuilder.buildSkill({ id: 'rec01', name: '@web1', difficulty: 1 });
     web2 = domainBuilder.buildSkill({ id: 'rec02', name: '@web2', difficulty: 2 });
+    web2_v2 = domainBuilder.buildSkill({ id: 'rec02v2', name: '@web2', difficulty: 2 });
     web3 = domainBuilder.buildSkill({ id: 'rec03', name: '@web3', difficulty: 3 });
     web4 = domainBuilder.buildSkill({ id: 'rec04', name: '@web4', difficulty: 4 });
     web5 = domainBuilder.buildSkill({ id: 'rec05', name: '@web5', difficulty: 5 });
@@ -92,6 +95,7 @@ describe('Integration | Domain | Algorithm-methods | SmartRandom', function () {
     // Challenges
     challengeWeb_1 = domainBuilder.buildChallenge({ id: 'recweb1', skill: web1, locales: ['fr'] });
     challengeWeb_2 = domainBuilder.buildChallenge({ id: 'recweb2', skill: web2, locales: ['fr'] });
+    challengeWeb_2_v2 = domainBuilder.buildChallenge({ id: 'recweb2v2', skill: web2_v2, locales: ['fr'] });
     challengeWeb_2_3 = domainBuilder.buildChallenge({ id: 'recweb23', skill: web3, locales: ['fr'] });
     challengeWeb_3 = domainBuilder.buildChallenge({ id: 'recweb3', skill: web3, locales: ['fr'] });
     challengeWeb_4 = domainBuilder.buildChallenge({ id: 'recweb4', skill: web4, locales: ['fr'] });
@@ -689,6 +693,42 @@ describe('Integration | Domain | Algorithm-methods | SmartRandom', function () {
         expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
         expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web1.id);
         expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_1.id);
+      });
+
+      it('should ask again for a skill, even if user has a knowledge element for another skill of the same tube and same difficulty', function () {
+        // given
+        targetSkills = [web1, web2_v2];
+        challenges = [challengeWeb_1, challengeWeb_2_v2];
+        lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeWeb_1.id, result: AnswerStatus.OK });
+        allAnswers = [lastAnswer];
+        knowledgeElements = [
+          domainBuilder.buildKnowledgeElement({
+            skillId: web1.id,
+            status: KNOWLEDGE_ELEMENT_STATUS.VALIDATED,
+            source: 'direct',
+          }),
+          domainBuilder.buildKnowledgeElement({
+            skillId: web2.id,
+            status: KNOWLEDGE_ELEMENT_STATUS.VALIDATED,
+            source: 'direct',
+          }),
+        ];
+
+        // when
+        const { possibleSkillsForNextChallenge } = SmartRandom.getPossibleSkillsForNextChallenge({
+          targetSkills,
+          challenges,
+          knowledgeElements,
+          allAnswers,
+          lastAnswer,
+          locale,
+        });
+
+        // then
+        expect(possibleSkillsForNextChallenge.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web2_v2.id);
+        expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_2_v2.id);
       });
     });
 

--- a/api/tests/learning-content/integration/domain/find-skills-by-ids_test.js
+++ b/api/tests/learning-content/integration/domain/find-skills-by-ids_test.js
@@ -1,0 +1,32 @@
+import { usecases } from '../../../../src/learning-content/domain/usecases/index.js';
+import { Skill } from '../../../../src/shared/domain/models/index.js';
+import { databaseBuilder, expect } from '../../../test-helper.js';
+
+describe('Learning Content | Integration | Domain | Usecase | Find skills by ids', function () {
+  beforeEach(async function () {
+    databaseBuilder.factory.learningContent.buildSkill({
+      id: 'acquisC',
+    });
+    databaseBuilder.factory.learningContent.buildSkill({
+      id: 'acquisA',
+    });
+    databaseBuilder.factory.learningContent.buildSkill({
+      id: 'acquisB',
+    });
+    await databaseBuilder.commit();
+  });
+
+  it('should return the skills given by IDS', async function () {
+    // when
+    const skills = await usecases.findSkillsByIds({
+      ids: ['acquisC', 'acquisB', 'acquisQuiNexistePas'],
+    });
+
+    // then
+    expect(skills.length).to.equal(2);
+    expect(skills[0].id).to.equal('acquisB');
+    expect(skills[0]).to.be.instanceOf(Skill);
+    expect(skills[1].id).to.equal('acquisC');
+    expect(skills[1]).to.be.instanceOf(Skill);
+  });
+});

--- a/api/tests/learning-content/unit/application/api/skills-api_test.js
+++ b/api/tests/learning-content/unit/application/api/skills-api_test.js
@@ -1,0 +1,54 @@
+import { SkillDTO } from '../../../../../src/learning-content/application/api/models/SkillDTO.js';
+import * as skillsApi from '../../../../../src/learning-content/application/api/skills-api.js';
+import { usecases } from '../../../../../src/learning-content/domain/usecases/index.js';
+import { domainBuilder, expect, preventStubsToBeCalledUnexpectedly, sinon } from '../../../../test-helper.js';
+
+describe('LearningContent | Unit | Application | Api | skills', function () {
+  describe('#findByIds', function () {
+    let findByIdsStub;
+
+    beforeEach(function () {
+      findByIdsStub = sinon.stub(usecases, 'findSkillsByIds');
+      preventStubsToBeCalledUnexpectedly([findByIdsStub]);
+    });
+
+    it('should return an empty array when skillIds given as param are empty or invalid', async function () {
+      // given
+      const emptySkillIds = [];
+      const brokenSkillIds = null;
+
+      // when
+      const resultForEmpty = await skillsApi.findByIds({ ids: emptySkillIds });
+      const resultForBroken = await skillsApi.findByIds({ ids: brokenSkillIds });
+
+      // then
+      expect(resultForEmpty).to.deepEqualArray([]);
+      expect(resultForBroken).to.deepEqualArray([]);
+    });
+
+    it('should return skillDTOs created from skills returned by usecase', async function () {
+      // given
+      findByIdsStub.withArgs({ ids: ['acquisA', 'acquisB'] }).resolves([
+        domainBuilder.buildSkill({
+          id: 'acquisA',
+          tubeId: 'tubeA',
+          difficulty: 5,
+        }),
+        domainBuilder.buildSkill({
+          id: 'acquisB',
+          tubeId: 'tubeB',
+          difficulty: 3,
+        }),
+      ]);
+
+      // when
+      const result = await skillsApi.findByIds({ ids: ['acquisA', 'acquisB'] });
+
+      // then
+      expect(result).to.deepEqualArray([
+        new SkillDTO({ id: 'acquisA', difficulty: 5, tubeId: 'tubeA' }),
+        new SkillDTO({ id: 'acquisB', difficulty: 3, tubeId: 'tubeB' }),
+      ]);
+    });
+  });
+});

--- a/api/tests/prescription/campaign/integration/domain/usecases/find-campaign-skill-ids-for-campaign-participations.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/find-campaign-skill-ids-for-campaign-participations.js
@@ -1,0 +1,25 @@
+import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Integration | UseCase | find-campaign-skill-ids-for-campaign-participations', function () {
+  it('should return campaign skill ids for campaign participations', async function () {
+    // given
+    const campaignId1 = databaseBuilder.factory.buildCampaign().id;
+    databaseBuilder.factory.buildCampaignSkill({ skillId: 'skillId1', campaignId: campaignId1 });
+    const campaignId2 = databaseBuilder.factory.buildCampaign().id;
+    databaseBuilder.factory.buildCampaignSkill({ skillId: 'skillId2', campaignId: campaignId2 });
+
+    const campaignParticipationIds = [
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaignId1 }).id,
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaignId2 }).id,
+    ];
+    await databaseBuilder.commit();
+
+    // when
+    const skillIds = await usecases.findCampaignSkillIdsForCampaignParticipations({ campaignParticipationIds });
+
+    // then
+    expect(skillIds).to.have.lengthOf(2);
+    expect(skillIds).to.have.members(['skillId1', 'skillId2']);
+  });
+});

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-repository_test.js
@@ -39,6 +39,88 @@ describe('Integration | Repository | Campaign', function () {
     });
   });
 
+  describe('#findSkillIdsByCampaignParticipationIds', function () {
+    it('should return empty array', async function () {
+      const skillIds = await campaignRepository.findSkillIdsByCampaignParticipationIds({
+        campaignParticipationIds: [123, 456],
+      });
+
+      // then
+      expect(skillIds).to.have.lengthOf(0);
+    });
+
+    it('should return the operative skillIds for the campaign participations', async function () {
+      // given
+      databaseBuilder.factory.learningContent.buildSkill({ id: 'skillId1', status: 'actif' });
+      databaseBuilder.factory.learningContent.buildSkill({ id: 'skillId2', status: 'actif' });
+      databaseBuilder.factory.learningContent.buildSkill({ id: 'skillId3', status: 'archivé' });
+      databaseBuilder.factory.learningContent.buildSkill({ id: 'skillId4', status: 'périmé' });
+
+      const campaignId1 = databaseBuilder.factory.buildCampaign().id;
+      databaseBuilder.factory.buildCampaignSkill({ skillId: 'skillId1', campaignId: campaignId1 });
+      databaseBuilder.factory.buildCampaignSkill({ skillId: 'skillId2', campaignId: campaignId1 });
+      const campaignId2 = databaseBuilder.factory.buildCampaign().id;
+      databaseBuilder.factory.buildCampaignSkill({ skillId: 'skillId1', campaignId: campaignId2 });
+      databaseBuilder.factory.buildCampaignSkill({ skillId: 'skillId3', campaignId: campaignId2 });
+      databaseBuilder.factory.buildCampaignSkill({ skillId: 'skillId4', campaignId: campaignId2 });
+
+      const campaignParticipationIds = [
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaignId1 }).id,
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaignId2 }).id,
+      ];
+      await databaseBuilder.commit();
+
+      // when
+      const skillIds = await campaignRepository.findSkillIdsByCampaignParticipationIds({ campaignParticipationIds });
+
+      // then
+      expect(skillIds).to.have.lengthOf(3);
+      expect(skillIds).to.have.members(['skillId1', 'skillId2', 'skillId3']);
+    });
+  });
+
+  describe('#findSkillIdsByCampaignParticipationId', function () {
+    it('should return empty array', async function () {
+      const skillIds = await campaignRepository.findSkillIdsByCampaignParticipationId({
+        campaignParticipationId: 123,
+      });
+
+      // then
+      expect(skillIds).to.have.lengthOf(0);
+    });
+
+    it('should return the skillIds for the campaign participation', async function () {
+      // given
+      databaseBuilder.factory.learningContent.buildSkill({ id: 'skillId1', status: 'actif' });
+      databaseBuilder.factory.learningContent.buildSkill({ id: 'skillId2', status: 'archivé' });
+      databaseBuilder.factory.learningContent.buildSkill({ id: 'skillId3', status: 'actif' });
+      databaseBuilder.factory.learningContent.buildSkill({ id: 'skillId4', status: 'périmé' });
+
+      const campaignId1 = databaseBuilder.factory.buildCampaign().id;
+      databaseBuilder.factory.buildCampaignSkill({ skillId: 'skillId1', campaignId: campaignId1 });
+      databaseBuilder.factory.buildCampaignSkill({ skillId: 'skillId2', campaignId: campaignId1 });
+      databaseBuilder.factory.buildCampaignSkill({ skillId: 'skillId4', campaignId: campaignId1 });
+      const campaignId2 = databaseBuilder.factory.buildCampaign().id;
+      databaseBuilder.factory.buildCampaignSkill({ skillId: 'skillId1', campaignId: campaignId2 });
+      databaseBuilder.factory.buildCampaignSkill({ skillId: 'skillId3', campaignId: campaignId2 });
+
+      const campaignParticipationIds = [
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaignId1 }).id,
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaignId2 }).id,
+      ];
+      await databaseBuilder.commit();
+
+      // when
+      const skillIds = await campaignRepository.findSkillIdsByCampaignParticipationId({
+        campaignParticipationId: campaignParticipationIds[0],
+      });
+
+      // then
+      expect(skillIds).to.have.lengthOf(2);
+      expect(skillIds).to.have.members(['skillId1', 'skillId2']);
+    });
+  });
+
   describe('#findTubes', function () {
     it('should return the tubes for the campaign', async function () {
       // given

--- a/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
+++ b/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
@@ -3,7 +3,7 @@ import { UserNotAuthorizedToCreateCampaignError } from '../../../../../../src/pr
 import { Campaign } from '../../../../../../src/prescription/campaign/domain/models/Campaign.js';
 import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
 import { CampaignReport } from '../../../../../../src/shared/domain/read-models/CampaignReport.js';
-import { catchErr, expect, sinon } from '../../../../../test-helper.js';
+import { catchErr, expect, preventStubsToBeCalledUnexpectedly, sinon } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
 describe('Unit | API | Campaigns', function () {
@@ -186,6 +186,20 @@ describe('Unit | API | Campaigns', function () {
       // then
       expect(result).not.to.be.instanceOf(Campaign);
       expect(result.customLandingPageText).to.equal(campaignInformation.customLandingPageText);
+    });
+  });
+
+  describe('#findCampaignSkillIdsForCampaignPartipicipations', function () {
+    it('should return an array of campaign skill ids for campaign participations', async function () {
+      const skillIds = Symbol('skillIds');
+      const campaignParticipationIds = [123, 456];
+      const usecaseStub = sinon.stub(usecases, 'findCampaignSkillIdsForCampaignParticipations');
+      preventStubsToBeCalledUnexpectedly([usecaseStub]);
+      usecaseStub.withArgs({ campaignParticipationIds }).resolves(skillIds);
+
+      const result = await campaignApi.findCampaignSkillIdsForCampaignParticipations(campaignParticipationIds);
+
+      expect(result).to.equal(skillIds);
     });
   });
 

--- a/api/tests/prescription/target-profile/acceptance/application/api/target-profile-api_test.js
+++ b/api/tests/prescription/target-profile/acceptance/application/api/target-profile-api_test.js
@@ -14,6 +14,17 @@ describe('Acceptance | Application | target-profile-api', function () {
     });
   });
 
+  describe('#getById', function () {
+    it('should not fail', async function () {
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+
+      await databaseBuilder.commit();
+
+      const result = await targetProfileApi.getById(targetProfileId);
+      expect(result).to.be.ok;
+    });
+  });
+
   describe('#findSkillsByTargetProfileIds', function () {
     it('should not fail', async function () {
       const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;

--- a/api/tests/prescription/target-profile/acceptance/application/api/target-profile-api_test.js
+++ b/api/tests/prescription/target-profile/acceptance/application/api/target-profile-api_test.js
@@ -2,13 +2,26 @@ import * as targetProfileApi from '../../../../../../src/prescription/target-pro
 import { databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Acceptance | Application | target-profile-api', function () {
-  it('should not fail', async function () {
-    const organizationId = databaseBuilder.factory.buildOrganization().id;
-    databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organizationId });
+  describe('#getByOrganizationId', function () {
+    it('should not fail', async function () {
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organizationId });
 
-    await databaseBuilder.commit();
+      await databaseBuilder.commit();
 
-    const result = await targetProfileApi.getByOrganizationId(organizationId);
-    expect(result).to.be.ok;
+      const result = await targetProfileApi.getByOrganizationId(organizationId);
+      expect(result).to.be.ok;
+    });
+  });
+
+  describe('#findSkillsByTargetProfileIds', function () {
+    it('should not fail', async function () {
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+
+      await databaseBuilder.commit();
+
+      const result = await targetProfileApi.findSkillsByTargetProfileIds([targetProfileId]);
+      expect(result).to.be.ok;
+    });
   });
 });

--- a/api/tests/prescription/target-profile/integration/domain/usecases/find-skills-by-target-profile-ids_test.js
+++ b/api/tests/prescription/target-profile/integration/domain/usecases/find-skills-by-target-profile-ids_test.js
@@ -1,0 +1,46 @@
+import { usecases } from '../../../../../../src/prescription/target-profile/domain/usecases/index.js';
+import { Skill } from '../../../../../../src/shared/domain/models/Skill.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Integration | Prescription | Target Profile | Domain | usecases | find-skills-by-target-profile-ids', function () {
+  it('works', async function () {
+    const firstTPId = databaseBuilder.factory.buildTargetProfile().id;
+    const secondTPId = databaseBuilder.factory.buildTargetProfile().id;
+
+    databaseBuilder.factory.buildTargetProfileTube({ targetProfileId: firstTPId, tubeId: 'firstTube', level: 5 });
+    databaseBuilder.factory.buildTargetProfileTube({ targetProfileId: secondTPId, tubeId: 'firstTube', level: 1 });
+    databaseBuilder.factory.buildTargetProfileTube({ targetProfileId: secondTPId, tubeId: 'secondTube', level: 3 });
+
+    databaseBuilder.factory.learningContent.buildTube({
+      id: 'firstTube',
+    });
+    databaseBuilder.factory.learningContent.buildTube({
+      id: 'secondTube',
+    });
+    databaseBuilder.factory.learningContent.buildSkill({
+      id: 'firstSkill_firstTube',
+      tubeId: 'firstTube',
+      status: 'actif',
+      level: 1,
+    });
+    databaseBuilder.factory.learningContent.buildSkill({
+      id: 'firstSkill_secondTube',
+      tubeId: 'secondTube',
+      status: 'actif',
+      level: 3,
+    });
+    databaseBuilder.factory.learningContent.buildSkill({
+      id: 'secondSkill_secondTube',
+      tubeId: 'secondTube',
+      status: 'actif',
+      level: 5,
+    });
+
+    await databaseBuilder.commit();
+
+    const result = await usecases.findSkillsByTargetProfileIds({ targetProfileIds: [firstTPId, secondTPId] });
+
+    expect(result).lengthOf(2);
+    expect(result[0]).instanceOf(Skill);
+  });
+});

--- a/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-repository_test.js
+++ b/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-repository_test.js
@@ -1,3 +1,5 @@
+import { describe } from 'node:test';
+
 import _ from 'lodash';
 
 import * as targetProfileRepository from '../../../../../../src/prescription/target-profile/infrastructure/repositories/target-profile-repository.js';
@@ -6,7 +8,7 @@ import { TargetProfile } from '../../../../../../src/shared/domain/models/index.
 import { catchErr, databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | Repository | Target-profile', function () {
-  describe('#get', function () {
+  xdescribe('#get', function () {
     let targetProfile;
     let organizationId;
 
@@ -36,7 +38,7 @@ describe('Integration | Repository | Target-profile', function () {
     });
   });
 
-  describe('#findByIds', function () {
+  xdescribe('#findByIds', function () {
     let targetProfile1;
     let targetProfileIds;
     const targetProfileIdNotExisting = 999;
@@ -101,7 +103,7 @@ describe('Integration | Repository | Target-profile', function () {
     });
   });
 
-  describe('#findOrganizationIds', function () {
+  xdescribe('#findOrganizationIds', function () {
     let targetProfileId;
     const expectedOrganizationIds = [];
 
@@ -150,6 +152,59 @@ describe('Integration | Repository | Target-profile', function () {
 
         expect(error).to.be.instanceOf(NotFoundError);
       });
+    });
+  });
+
+  describe.only('#findSkillsByIds', function () {
+    let firstTargetProfilId, secondTargetProfilId, thirdTargetProfilId;
+
+    beforeEach(async function () {
+      firstTargetProfilId = databaseBuilder.factory.buildTargetProfile().id;
+
+      databaseBuilder.factory.buildTargetProfileTube({
+        targetProfileId: firstTargetProfilId,
+        tubeId: 'firstTube',
+        level: 3,
+      });
+      databaseBuilder.factory.buildTargetProfileTube({
+        targetProfileId: firstTargetProfilId,
+        tubeId: 'secondTube',
+        level: 1,
+      });
+
+      secondTargetProfilId = databaseBuilder.factory.buildTargetProfile().id;
+
+      databaseBuilder.factory.buildTargetProfileTube({
+        targetProfileId: secondTargetProfilId,
+        tubeId: 'firstTube',
+        level: 5,
+      });
+      databaseBuilder.factory.buildTargetProfileTube({
+        targetProfileId: secondTargetProfilId,
+        tubeId: 'secondTube',
+        level: 3,
+      });
+
+      thirdTargetProfilId = databaseBuilder.factory.buildTargetProfile().id;
+
+      databaseBuilder.factory.buildTargetProfileTube({
+        targetProfileId: thirdTargetProfilId,
+        tubeId: 'thirdTube',
+        level: 5,
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    it('should return empty when given non existing targetProfileId', async function () {
+      // given
+      const targetProfileId = 789;
+
+      // when
+      const result = await targetProfileRepository.findSkillsByIds({ targetProfileIds: [targetProfileId] });
+
+      // then
+      expect(result).lengthOf(0);
     });
   });
 });

--- a/api/tests/prescription/target-profile/unit/application/api/target-profile-api_test.js
+++ b/api/tests/prescription/target-profile/unit/application/api/target-profile-api_test.js
@@ -1,5 +1,6 @@
 import * as targetProfileApi from '../../../../../../src/prescription/target-profile/application/api/target-profile-api.js';
 import { TargetProfile } from '../../../../../../src/prescription/target-profile/application/api/TargetProfile.js';
+import { TargetProfileSkill } from '../../../../../../src/prescription/target-profile/application/api/TargetProfileSkill.js';
 import { TargetProfileForSpecifier } from '../../../../../../src/prescription/target-profile/domain/read-models/TargetProfileForSpecifier.js';
 import { usecases } from '../../../../../../src/prescription/target-profile/domain/usecases/index.js';
 import { catchErr, expect, sinon } from '../../../../../test-helper.js';
@@ -83,6 +84,37 @@ describe('Unit | API | TargetProfile', function () {
 
       // then
       expect(result).to.have.lengthOf(0);
+    });
+  });
+
+  describe('#findSkillsByTargetProfileIds', function () {
+    it('should return empty array if no skill found', async function () {
+      const findSkillsByTargetProfileIdsStub = sinon.stub(usecases, 'findSkillsByTargetProfileIds');
+      findSkillsByTargetProfileIdsStub.rejects();
+      findSkillsByTargetProfileIdsStub.withArgs({ targetProfileIds: ['targetProfileId'] }).resolves([]);
+
+      // when
+      const result = await targetProfileApi.findSkillsByTargetProfileIds(['targetProfileId']);
+
+      // then
+      expect(result).to.have.lengthOf(0);
+    });
+
+    it('should return an array of TargetProfileSkill', async function () {
+      const findSkillsByTargetProfileIdsStub = sinon.stub(usecases, 'findSkillsByTargetProfileIds');
+      findSkillsByTargetProfileIdsStub.rejects();
+      findSkillsByTargetProfileIdsStub
+        .withArgs({ targetProfileIds: ['targetProfileId'] })
+        .resolves([domainBuilder.buildSkill({ id: 'monSkillId', difficulty: 18 })]);
+
+      // when
+      const result = await targetProfileApi.findSkillsByTargetProfileIds(['targetProfileId']);
+
+      // then
+      expect(result).to.have.lengthOf(1);
+      expect(result[0]).instanceOf(TargetProfileSkill);
+      expect(result[0].id).equals('monSkillId');
+      expect(result[0].difficulty).equals(18);
     });
   });
 });

--- a/api/tests/quest/integration/domain/usecases/reward-user_test.js
+++ b/api/tests/quest/integration/domain/usecases/reward-user_test.js
@@ -8,14 +8,14 @@ import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { KnowledgeElement } from '../../../../../src/shared/domain/models/index.js';
 import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
 const { INVALIDATED, VALIDATED } = KnowledgeElement.StatusType;
-
 const userId = 1234;
-const setupContext = async (
+
+const setupContextWithProfileSkillQuest = async ({
   userId,
   isEligible = true,
   hasValidatedKnowledgeElements = true,
   hasAlreadySucceededTheQuest = false,
-) => {
+}) => {
   databaseBuilder.factory.buildUser({ id: userId });
   const questOrganization = 'PRO';
   const userOrganization = isEligible ? questOrganization : 'SCO';
@@ -55,6 +55,16 @@ const setupContext = async (
     userId,
   });
 
+  const successRequirements = [
+    {
+      requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
+      data: {
+        skillIds: ['skillId1', 'skillId2', 'skillId3'],
+        threshold: 50,
+      },
+    },
+  ];
+
   const quest = databaseBuilder.factory.buildQuest({
     eligibilityRequirements: [
       {
@@ -68,11 +78,133 @@ const setupContext = async (
         },
       },
     ],
+    successRequirements,
+  });
+
+  if (hasAlreadySucceededTheQuest) {
+    databaseBuilder.factory.buildProfileReward({
+      rewardId: quest.rewardId,
+      userId,
+    });
+  }
+
+  await databaseBuilder.commit();
+};
+
+const setupContextWithCappedTubesQuest = async ({
+  userId,
+  isEligible = true,
+  hasValidatedKnowledgeElements = true,
+  hasAlreadySucceededTheQuest = false,
+  buildCampaignParticipation = true,
+}) => {
+  databaseBuilder.factory.buildUser({ id: userId });
+  const questOrganization = 'PRO';
+  const userOrganization = isEligible ? questOrganization : 'SCO';
+
+  const userKnowledgeElements = [
+    {
+      userId,
+      skillId: 'skillId1_tube1',
+      status: hasValidatedKnowledgeElements ? VALIDATED : INVALIDATED,
+    },
+    {
+      userId,
+      skillId: 'skillId2_tube1',
+      status: hasValidatedKnowledgeElements ? VALIDATED : INVALIDATED,
+    },
+    {
+      userId,
+      skillId: 'skillId1_tube2',
+      status: hasValidatedKnowledgeElements ? VALIDATED : INVALIDATED,
+    },
+  ];
+  userKnowledgeElements.map(databaseBuilder.factory.buildKnowledgeElement);
+
+  const organization = databaseBuilder.factory.buildOrganization({ type: userOrganization });
+  const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({
+    userId,
+    organizationId: organization.id,
+  });
+
+  const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+
+  databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'firstTube', level: 2 });
+  databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'secondTube', level: 1 });
+
+  databaseBuilder.factory.learningContent.buildTube({
+    id: 'firstTube',
+  });
+  databaseBuilder.factory.learningContent.buildTube({
+    id: 'secondTube',
+  });
+  databaseBuilder.factory.learningContent.buildSkill({
+    id: 'skillId1_tube1',
+    tubeId: 'firstTube',
+    status: 'actif',
+    level: 1,
+  });
+  databaseBuilder.factory.learningContent.buildSkill({
+    id: 'skillId2_tube1',
+    tubeId: 'secondTube',
+    status: 'actif',
+    level: 2,
+  });
+  databaseBuilder.factory.learningContent.buildSkill({
+    id: 'skillId1_tube2',
+    tubeId: 'secondTube',
+    status: 'actif',
+    level: 1,
+  });
+
+  const { id: campaignId } = databaseBuilder.factory.buildCampaign({
+    organizationId: organization.id,
+    targetProfileId,
+  });
+
+  databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'skillId1_tube2' });
+  databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'skillId2_tube1' });
+  databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'skillId1_tube1' });
+
+  if (buildCampaignParticipation) {
+    databaseBuilder.factory.buildCampaignParticipation({
+      campaignId,
+      organizationLearnerId,
+      userId,
+    });
+  }
+
+  const quest = databaseBuilder.factory.buildQuest({
+    eligibilityRequirements: [
+      {
+        requirement_type: REQUIREMENT_TYPES.OBJECT.ORGANIZATION,
+        comparison: REQUIREMENT_COMPARISONS.ALL,
+        data: {
+          type: {
+            data: questOrganization,
+            comparison: CRITERION_COMPARISONS.EQUAL,
+          },
+        },
+      },
+      {
+        requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+        comparison: REQUIREMENT_COMPARISONS.ALL,
+        data: {
+          targetProfileId: {
+            data: targetProfileId,
+            comparison: CRITERION_COMPARISONS.EQUAL,
+          },
+        },
+      },
+    ],
     successRequirements: [
       {
-        requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
+        requirement_type: REQUIREMENT_TYPES.CAPPED_TUBES,
         data: {
-          skillIds: ['skillId1', 'skillId2', 'skillId3'],
+          cappedTubes: [
+            { tubeId: 'firstTube', level: 2 },
+            { tubeId: 'secondTube', level: 1 },
+          ],
           threshold: 50,
         },
       },
@@ -90,176 +222,368 @@ const setupContext = async (
 };
 
 describe('Quest | Integration | Domain | Usecases | RewardUser', function () {
-  context('when user is eligible and meets success requirements', function () {
-    beforeEach(async function () {
-      await setupContext(userId);
+  describe('skillProfile', function () {
+    context('when user is eligible and meets success requirements', function () {
+      beforeEach(async function () {
+        await setupContextWithProfileSkillQuest({ userId });
+      });
+
+      it('should reward the user', async function () {
+        //when
+        await usecases.rewardUser({ userId });
+
+        // then
+        const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
+        expect(profileRewards).to.have.lengthOf(1);
+        expect(profileRewards[0].userId).to.equal(userId);
+      });
     });
 
-    it('should reward the user', async function () {
-      //when
-      await usecases.rewardUser({ userId });
-
-      // then
-      const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
-      expect(profileRewards).to.have.lengthOf(1);
-      expect(profileRewards[0].userId).to.equal(userId);
-    });
-  });
-
-  context('when user is eligible at two quests with the same rewardId', function () {
-    let userId;
-    beforeEach(async function () {
-      userId = databaseBuilder.factory.buildUser().id;
-      const questOrganization = 'PRO';
-      const userKnowledgeElements = [
-        {
-          userId,
-          skillId: 'skillId1',
-          status: VALIDATED,
-        },
-        {
-          userId,
-          skillId: 'skillId2',
-          status: VALIDATED,
-        },
-        {
-          userId,
-          skillId: 'skillId3',
-          status: VALIDATED,
-        },
-      ];
-      userKnowledgeElements.map(databaseBuilder.factory.buildKnowledgeElement);
-
-      const organization = databaseBuilder.factory.buildOrganization({ type: questOrganization });
-      const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({
-        userId,
-        organizationId: organization.id,
-      });
-
-      const { id: campaignId } = databaseBuilder.factory.buildCampaign({
-        organizationId: organization.id,
-      });
-      const { id: secondCampaignId } = databaseBuilder.factory.buildCampaign({
-        organizationId: organization.id,
-      });
-
-      databaseBuilder.factory.buildCampaignParticipation({
-        campaignId,
-        organizationLearnerId,
-        userId,
-      });
-      databaseBuilder.factory.buildCampaignParticipation({
-        campaignId: secondCampaignId,
-        organizationLearnerId,
-        userId,
-      });
-      const rewardId = databaseBuilder.factory.buildAttestation().id;
-
-      databaseBuilder.factory.buildQuest({
-        rewardId,
-        eligibilityRequirements: [
+    context('when user is eligible at two quests with the same rewardId', function () {
+      let userId;
+      beforeEach(async function () {
+        userId = databaseBuilder.factory.buildUser().id;
+        const questOrganization = 'PRO';
+        const userKnowledgeElements = [
           {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.ORGANIZATION,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              type: {
-                data: questOrganization,
-                comparison: CRITERION_COMPARISONS.EQUAL,
+            userId,
+            skillId: 'skillId1',
+            status: VALIDATED,
+          },
+          {
+            userId,
+            skillId: 'skillId2',
+            status: VALIDATED,
+          },
+          {
+            userId,
+            skillId: 'skillId3',
+            status: VALIDATED,
+          },
+        ];
+        userKnowledgeElements.map(databaseBuilder.factory.buildKnowledgeElement);
+
+        const organization = databaseBuilder.factory.buildOrganization({ type: questOrganization });
+        const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({
+          userId,
+          organizationId: organization.id,
+        });
+
+        const { id: campaignId } = databaseBuilder.factory.buildCampaign({
+          organizationId: organization.id,
+        });
+        const { id: secondCampaignId } = databaseBuilder.factory.buildCampaign({
+          organizationId: organization.id,
+        });
+
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          organizationLearnerId,
+          userId,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: secondCampaignId,
+          organizationLearnerId,
+          userId,
+        });
+        const rewardId = databaseBuilder.factory.buildAttestation().id;
+
+        databaseBuilder.factory.buildQuest({
+          rewardId,
+          eligibilityRequirements: [
+            {
+              requirement_type: REQUIREMENT_TYPES.OBJECT.ORGANIZATION,
+              comparison: REQUIREMENT_COMPARISONS.ALL,
+              data: {
+                type: {
+                  data: questOrganization,
+                  comparison: CRITERION_COMPARISONS.EQUAL,
+                },
               },
             },
-          },
-        ],
-        successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
-            data: {
-              skillIds: ['skillId1', 'skillId2', 'skillId3'],
-              threshold: 50,
-            },
-          },
-        ],
-      });
-      databaseBuilder.factory.buildQuest({
-        rewardId,
-        eligibilityRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.ORGANIZATION,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              type: {
-                data: questOrganization,
-                comparison: CRITERION_COMPARISONS.EQUAL,
+          ],
+          successRequirements: [
+            {
+              requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
+              data: {
+                skillIds: ['skillId1', 'skillId2', 'skillId3'],
+                threshold: 50,
               },
             },
-          },
-        ],
-        successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
-            data: {
-              skillIds: ['skillId1', 'skillId2', 'skillId3'],
-              threshold: 50,
+          ],
+        });
+        databaseBuilder.factory.buildQuest({
+          rewardId,
+          eligibilityRequirements: [
+            {
+              requirement_type: REQUIREMENT_TYPES.OBJECT.ORGANIZATION,
+              comparison: REQUIREMENT_COMPARISONS.ALL,
+              data: {
+                type: {
+                  data: questOrganization,
+                  comparison: CRITERION_COMPARISONS.EQUAL,
+                },
+              },
             },
-          },
-        ],
+          ],
+          successRequirements: [
+            {
+              requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
+              data: {
+                skillIds: ['skillId1', 'skillId2', 'skillId3'],
+                threshold: 50,
+              },
+            },
+          ],
+        });
+
+        await databaseBuilder.commit();
       });
 
-      await databaseBuilder.commit();
+      it('should reward the user only once', async function () {
+        //when
+        await usecases.rewardUser({ userId });
+
+        // then
+        const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
+        expect(profileRewards).to.have.lengthOf(1);
+      });
     });
 
-    it('should reward the user only once', async function () {
-      //when
-      await usecases.rewardUser({ userId });
+    context('when user is not eligible', function () {
+      beforeEach(async function () {
+        await setupContextWithProfileSkillQuest({ userId, isEligible: false });
+      });
 
-      // then
-      const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
-      expect(profileRewards).to.have.lengthOf(1);
+      it('should not reward the user', async function () {
+        //when
+        await usecases.rewardUser({ userId });
+
+        // then
+        const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
+        expect(profileRewards).to.have.lengthOf(0);
+      });
+    });
+
+    context('when user is eligible but does not meet success requirements', function () {
+      beforeEach(async function () {
+        await setupContextWithProfileSkillQuest({ userId, hasValidatedKnowledgeElements: false });
+      });
+
+      it('should not reward the user', async function () {
+        //when
+        await usecases.rewardUser({ userId });
+
+        // then
+        const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
+        expect(profileRewards).to.have.lengthOf(0);
+      });
+    });
+
+    context('when user has already earned a reward for the quest', function () {
+      beforeEach(async function () {
+        await setupContextWithProfileSkillQuest({
+          userId,
+          isEligible: true,
+          hasAlreadySucceededTheQuest: true,
+          hasValidatedKnowledgeElements: true,
+        });
+      });
+
+      it('should not reward the user a second time', async function () {
+        //when
+        await usecases.rewardUser({ userId });
+
+        // then
+        const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
+        expect(profileRewards).to.have.lengthOf(1);
+        expect(profileRewards[0].userId).to.equal(userId);
+      });
     });
   });
 
-  context('when user is not eligible', function () {
-    beforeEach(async function () {
-      await setupContext(userId, false);
+  describe('cappedTube', function () {
+    context('when user is eligible and meets success requirements', function () {
+      beforeEach(async function () {
+        await setupContextWithCappedTubesQuest({ userId });
+      });
+
+      it('should reward the user with campaignSkills informations', async function () {
+        //when
+        await usecases.rewardUser({ userId });
+
+        // then
+        const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
+        expect(profileRewards).to.have.lengthOf(1);
+        expect(profileRewards[0].userId).to.equal(userId);
+      });
+
+      it('should reward the user with targetProfileTube informations', async function () {
+        //when
+        await usecases.rewardUser({ userId, buildCampaignParticipation: false });
+
+        // then
+        const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
+        expect(profileRewards).to.have.lengthOf(1);
+        expect(profileRewards[0].userId).to.equal(userId);
+      });
     });
 
-    it('should not reward the user', async function () {
-      //when
-      await usecases.rewardUser({ userId });
+    context('when user is eligible at two quests with the same rewardId', function () {
+      let userId;
+      beforeEach(async function () {
+        userId = databaseBuilder.factory.buildUser().id;
+        const questOrganization = 'PRO';
+        const userKnowledgeElements = [
+          {
+            userId,
+            skillId: 'skillId1',
+            status: VALIDATED,
+          },
+          {
+            userId,
+            skillId: 'skillId2',
+            status: VALIDATED,
+          },
+          {
+            userId,
+            skillId: 'skillId3',
+            status: VALIDATED,
+          },
+        ];
+        userKnowledgeElements.map(databaseBuilder.factory.buildKnowledgeElement);
 
-      // then
-      const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
-      expect(profileRewards).to.have.lengthOf(0);
+        const organization = databaseBuilder.factory.buildOrganization({ type: questOrganization });
+        const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({
+          userId,
+          organizationId: organization.id,
+        });
+
+        const { id: campaignId } = databaseBuilder.factory.buildCampaign({
+          organizationId: organization.id,
+        });
+        const { id: secondCampaignId } = databaseBuilder.factory.buildCampaign({
+          organizationId: organization.id,
+        });
+
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          organizationLearnerId,
+          userId,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: secondCampaignId,
+          organizationLearnerId,
+          userId,
+        });
+        const rewardId = databaseBuilder.factory.buildAttestation().id;
+
+        databaseBuilder.factory.buildQuest({
+          rewardId,
+          eligibilityRequirements: [
+            {
+              requirement_type: REQUIREMENT_TYPES.OBJECT.ORGANIZATION,
+              comparison: REQUIREMENT_COMPARISONS.ALL,
+              data: {
+                type: {
+                  data: questOrganization,
+                  comparison: CRITERION_COMPARISONS.EQUAL,
+                },
+              },
+            },
+          ],
+          successRequirements: [
+            {
+              requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
+              data: {
+                skillIds: ['skillId1', 'skillId2', 'skillId3'],
+                threshold: 50,
+              },
+            },
+          ],
+        });
+        databaseBuilder.factory.buildQuest({
+          rewardId,
+          eligibilityRequirements: [
+            {
+              requirement_type: REQUIREMENT_TYPES.OBJECT.ORGANIZATION,
+              comparison: REQUIREMENT_COMPARISONS.ALL,
+              data: {
+                type: {
+                  data: questOrganization,
+                  comparison: CRITERION_COMPARISONS.EQUAL,
+                },
+              },
+            },
+          ],
+          successRequirements: [
+            {
+              requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
+              data: {
+                skillIds: ['skillId1', 'skillId2', 'skillId3'],
+                threshold: 50,
+              },
+            },
+          ],
+        });
+
+        await databaseBuilder.commit();
+      });
+
+      it('should reward the user only once', async function () {
+        //when
+        await usecases.rewardUser({ userId });
+
+        // then
+        const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
+        expect(profileRewards).to.have.lengthOf(1);
+      });
     });
-  });
 
-  context('when user is eligible but does not meet success requirements', function () {
-    beforeEach(async function () {
-      await setupContext(userId, true, false);
+    context('when user is not eligible', function () {
+      beforeEach(async function () {
+        await setupContextWithCappedTubesQuest({ userId, isEligible: false });
+      });
+
+      it('should not reward the user', async function () {
+        //when
+        await usecases.rewardUser({ userId });
+
+        // then
+        const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
+        expect(profileRewards).to.have.lengthOf(0);
+      });
     });
 
-    it('should not reward the user', async function () {
-      //when
-      await usecases.rewardUser({ userId });
+    context('when user is eligible but does not meet success requirements', function () {
+      beforeEach(async function () {
+        await setupContextWithCappedTubesQuest({ userId, hasValidatedKnowledgeElements: false });
+      });
 
-      // then
-      const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
-      expect(profileRewards).to.have.lengthOf(0);
+      it('should not reward the user', async function () {
+        //when
+        await usecases.rewardUser({ userId });
+
+        // then
+        const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
+        expect(profileRewards).to.have.lengthOf(0);
+      });
     });
-  });
 
-  context('when user has already earned a reward for the quest', function () {
-    beforeEach(async function () {
-      await setupContext(userId, true, true, true);
-    });
+    context('when user has already earned a reward for the quest', function () {
+      beforeEach(async function () {
+        await setupContextWithCappedTubesQuest({ userId, hasAlreadySucceededTheQuest: true });
+      });
 
-    it('should not reward the user a second time', async function () {
-      //when
-      await usecases.rewardUser({ userId });
+      it('should not reward the user a second time', async function () {
+        //when
+        await usecases.rewardUser({ userId });
 
-      // then
-      const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
-      expect(profileRewards).to.have.lengthOf(1);
-      expect(profileRewards[0].userId).to.equal(userId);
+        // then
+        const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
+        expect(profileRewards).to.have.lengthOf(1);
+        expect(profileRewards[0].userId).to.equal(userId);
+      });
     });
   });
 });

--- a/api/tests/quest/unit/domain/models/Quest_test.js
+++ b/api/tests/quest/unit/domain/models/Quest_test.js
@@ -214,8 +214,23 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
           comparison: REQUIREMENT_COMPARISONS.ALL,
         },
       ];
-      const quest = new Quest({ eligibilityRequirements, successRequirements: [] });
-      const campaignParticipations = [{ id: 10, targetProfileId: 123 }];
+      const successRequirements = [
+        {
+          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          data: {
+            targetProfileId: {
+              data: 456,
+              comparison: CRITERION_COMPARISONS.EQUAL,
+            },
+          },
+          comparison: REQUIREMENT_COMPARISONS.ALL,
+        },
+      ];
+      const quest = new Quest({ eligibilityRequirements, successRequirements });
+      const campaignParticipations = [
+        { id: 10, targetProfileId: 123 },
+        { id: 10, targetProfileId: 456 },
+      ];
       const eligibility = new Eligibility({ organization: {}, organizationLearner: {}, campaignParticipations });
       const dataForQuest = new DataForQuest({ eligibility });
 
@@ -270,6 +285,8 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
           },
           comparison: REQUIREMENT_COMPARISONS.ALL,
         },
+      ];
+      const successRequirements = [
         {
           requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
           data: {
@@ -281,7 +298,7 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
           comparison: REQUIREMENT_COMPARISONS.ALL,
         },
       ];
-      const quest = new Quest({ eligibilityRequirements, successRequirements: [] });
+      const quest = new Quest({ eligibilityRequirements, successRequirements });
       const campaignParticipations = [{ id: 10, targetProfileId: 123 }];
       const eligibility = new Eligibility({ organization: {}, organizationLearner: {}, campaignParticipations });
       const dataForQuest = new DataForQuest({ eligibility });
@@ -307,7 +324,19 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
           comparison: REQUIREMENT_COMPARISONS.ALL,
         },
       ];
-      const quest = new Quest({ eligibilityRequirements, successRequirements: [] });
+      const successRequirements = [
+        {
+          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          data: {
+            targetProfileId: {
+              data: 2,
+              comparison: CRITERION_COMPARISONS.EQUAL,
+            },
+          },
+          comparison: REQUIREMENT_COMPARISONS.ALL,
+        },
+      ];
+      const quest = new Quest({ eligibilityRequirements, successRequirements });
       const campaignParticipations = [{ id: 10, targetProfileId: 123 }];
       const eligibility = new Eligibility({ organization: {}, organizationLearner: {}, campaignParticipations });
       const dataForQuest = new DataForQuest({ eligibility });
@@ -351,6 +380,8 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
           },
           comparison: REQUIREMENT_COMPARISONS.ALL,
         },
+      ];
+      const successRequirements = [
         {
           requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
           data: {
@@ -362,7 +393,7 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
           comparison: REQUIREMENT_COMPARISONS.ALL,
         },
       ];
-      const quest = new Quest({ eligibilityRequirements, successRequirements: [] });
+      const quest = new Quest({ eligibilityRequirements, successRequirements });
       const campaignParticipations = [
         { id: 10, targetProfileId: 123 },
         { id: 100, targetProfileId: 456 },
@@ -384,7 +415,7 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
     const organizationLearner = { id: 123 };
 
     context('at least one eligibilityRequirements is type of "campaignParticipations"', function () {
-      it('return false if none of campaignParticipation eligibilityRequirement is valid given campaignParticipationId', function () {
+      it('return false if none of campaignParticipation eligibilityRequirement or successRequirement is valid given campaignParticipationId', function () {
         // given
         const eligibilityRequirements = [
           {
@@ -407,6 +438,8 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
             },
             comparison: REQUIREMENT_COMPARISONS.ALL,
           },
+        ];
+        const successRequirements = [
           {
             requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
             data: {
@@ -418,7 +451,7 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
             comparison: REQUIREMENT_COMPARISONS.ALL,
           },
         ];
-        const quest = new Quest({ eligibilityRequirements, successRequirements: [] });
+        const quest = new Quest({ eligibilityRequirements, successRequirements });
         const campaignParticipations = [
           { id: 10, targetProfileId: 1 },
           { id: 11, targetProfileId: 3 },
@@ -472,6 +505,61 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
           },
         ];
         const quest = new Quest({ eligibilityRequirements, successRequirements: [] });
+        const campaignParticipations = [
+          { id: 10, targetProfileId: 1 },
+          { id: 11, targetProfileId: 3 },
+        ];
+        const eligibility = new Eligibility({ organization, organizationLearner, campaignParticipations });
+        const data = new DataForQuest({ eligibility });
+        const campaignParticipationIdToCheck = 10;
+
+        // when
+        const isContributing = quest.isCampaignParticipationContributingToQuest({
+          data,
+          campaignParticipationId: campaignParticipationIdToCheck,
+        });
+
+        // then
+        expect(isContributing).to.be.true;
+      });
+
+      it('return true if one of campaignParticipation successRequirement is valid given campaignParticipationId', function () {
+        // given
+        const eligibilityRequirements = [
+          {
+            requirement_type: REQUIREMENT_TYPES.OBJECT.ORGANIZATION,
+            data: {
+              type: {
+                data: 'SCO',
+                comparison: CRITERION_COMPARISONS.EQUAL,
+              },
+            },
+            comparison: REQUIREMENT_COMPARISONS.ALL,
+          },
+        ];
+        const successRequirements = [
+          {
+            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+            data: {
+              targetProfileId: {
+                data: 1,
+                comparison: CRITERION_COMPARISONS.EQUAL,
+              },
+            },
+            comparison: REQUIREMENT_COMPARISONS.ALL,
+          },
+          {
+            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+            data: {
+              targetProfileId: {
+                data: 2,
+                comparison: CRITERION_COMPARISONS.EQUAL,
+              },
+            },
+            comparison: REQUIREMENT_COMPARISONS.ALL,
+          },
+        ];
+        const quest = new Quest({ eligibilityRequirements, successRequirements });
         const campaignParticipations = [
           { id: 10, targetProfileId: 1 },
           { id: 11, targetProfileId: 3 },

--- a/api/tests/quest/unit/domain/models/Quest_test.js
+++ b/api/tests/quest/unit/domain/models/Quest_test.js
@@ -107,6 +107,12 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
           { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillC' },
           { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillD' },
         ],
+        skills: [
+          { id: 'skillA', tubeId: 'tubeA', difficulty: 1 },
+          { id: 'skillB', tubeId: 'tubeA', difficulty: 1 },
+          { id: 'skillC', tubeId: 'tubeA', difficulty: 1 },
+          { id: 'skillD', tubeId: 'tubeA', difficulty: 1 },
+        ],
       });
       const data = new DataForQuest({ success });
 
@@ -141,6 +147,12 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
           { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillC' },
           { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillD' },
         ],
+        skills: [
+          { id: 'skillA', tubeId: 'tubeA', difficulty: 1 },
+          { id: 'skillB', tubeId: 'tubeA', difficulty: 1 },
+          { id: 'skillC', tubeId: 'tubeA', difficulty: 1 },
+          { id: 'skillD', tubeId: 'tubeA', difficulty: 1 },
+        ],
       });
       const data = new DataForQuest({ success });
 
@@ -174,6 +186,12 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
           { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillB' },
           { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillC' },
           { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillD' },
+        ],
+        skills: [
+          { id: 'skillA', tubeId: 'tubeA', difficulty: 1 },
+          { id: 'skillB', tubeId: 'tubeA', difficulty: 1 },
+          { id: 'skillC', tubeId: 'tubeA', difficulty: 1 },
+          { id: 'skillD', tubeId: 'tubeA', difficulty: 1 },
         ],
       });
       const data = new DataForQuest({ success });

--- a/api/tests/quest/unit/domain/models/Quest_test.js
+++ b/api/tests/quest/unit/domain/models/Quest_test.js
@@ -200,6 +200,92 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
     });
   });
 
+  describe('#findCampaignParticipationIdsContributingToQuest', function () {
+    it('returns an empty array when there are no campaign participations contributing to quest', function () {
+      const eligibilityRequirements = [
+        {
+          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          data: {
+            targetProfileId: {
+              data: 1,
+              comparison: CRITERION_COMPARISONS.EQUAL,
+            },
+          },
+          comparison: REQUIREMENT_COMPARISONS.ALL,
+        },
+      ];
+      const quest = new Quest({ eligibilityRequirements, successRequirements: [] });
+      const campaignParticipations = [{ id: 10, targetProfileId: 123 }];
+      const eligibility = new Eligibility({ organization: {}, organizationLearner: {}, campaignParticipations });
+      const dataForQuest = new DataForQuest({ eligibility });
+
+      expect(quest.findCampaignParticipationIdsContributingToQuest(dataForQuest)).to.have.length(0);
+    });
+
+    it('returns an array with one id when there is a campaign participation contributing to quest', function () {
+      const eligibilityRequirements = [
+        {
+          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          data: {
+            targetProfileId: {
+              data: 123,
+              comparison: CRITERION_COMPARISONS.EQUAL,
+            },
+          },
+          comparison: REQUIREMENT_COMPARISONS.ALL,
+        },
+      ];
+      const quest = new Quest({ eligibilityRequirements, successRequirements: [] });
+      const campaignParticipations = [{ id: 10, targetProfileId: 123 }];
+      const eligibility = new Eligibility({ organization: {}, organizationLearner: {}, campaignParticipations });
+      const dataForQuest = new DataForQuest({ eligibility });
+
+      const result = quest.findCampaignParticipationIdsContributingToQuest(dataForQuest);
+
+      expect(result).to.have.length(1);
+      expect(result[0]).to.equal(10);
+    });
+
+    it('returns an array with only ids of campaign participations contributing to quest', function () {
+      const eligibilityRequirements = [
+        {
+          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          data: {
+            targetProfileId: {
+              data: 123,
+              comparison: CRITERION_COMPARISONS.EQUAL,
+            },
+          },
+          comparison: REQUIREMENT_COMPARISONS.ALL,
+        },
+        {
+          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          data: {
+            targetProfileId: {
+              data: 789,
+              comparison: CRITERION_COMPARISONS.EQUAL,
+            },
+          },
+          comparison: REQUIREMENT_COMPARISONS.ALL,
+        },
+      ];
+      const quest = new Quest({ eligibilityRequirements, successRequirements: [] });
+      const campaignParticipations = [
+        { id: 10, targetProfileId: 123 },
+        { id: 100, targetProfileId: 456 },
+        { id: 1000, targetProfileId: 789 },
+      ];
+      const eligibility = new Eligibility({ organization: {}, organizationLearner: {}, campaignParticipations });
+      const dataForQuest = new DataForQuest({ eligibility });
+
+      const result = quest.findCampaignParticipationIdsContributingToQuest(dataForQuest);
+
+      expect(result).to.have.length(2);
+      expect(result[0]).to.equal(10);
+      expect(result[1]).to.equal(1000);
+    });
+  });
+
   describe('#isCampaignParticipationContributingToQuest', function () {
     const organization = { type: 'SCO' };
     const organizationLearner = { id: 123 };

--- a/api/tests/quest/unit/domain/models/Quest_test.js
+++ b/api/tests/quest/unit/domain/models/Quest_test.js
@@ -200,6 +200,99 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
     });
   });
 
+  describe('#findTargetProfileIdsWithoutCampaignParticipationContributingToQuest', function () {
+    it('returns an empty array when there is a campaign participation contributing to quest', function () {
+      const eligibilityRequirements = [
+        {
+          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          data: {
+            targetProfileId: {
+              data: 123,
+              comparison: CRITERION_COMPARISONS.EQUAL,
+            },
+          },
+          comparison: REQUIREMENT_COMPARISONS.ALL,
+        },
+      ];
+      const quest = new Quest({ eligibilityRequirements, successRequirements: [] });
+      const campaignParticipations = [{ id: 10, targetProfileId: 123 }];
+      const eligibility = new Eligibility({ organization: {}, organizationLearner: {}, campaignParticipations });
+      const dataForQuest = new DataForQuest({ eligibility });
+
+      const result = quest.findTargetProfileIdsWithoutCampaignParticipationContributingToQuest(dataForQuest);
+
+      expect(result).to.have.length(0);
+    });
+
+    it('returns an array with a targetProfileId when there are no campaign participations contributing to quest', function () {
+      const eligibilityRequirements = [
+        {
+          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          data: {
+            targetProfileId: {
+              data: 1,
+              comparison: CRITERION_COMPARISONS.EQUAL,
+            },
+          },
+          comparison: REQUIREMENT_COMPARISONS.ALL,
+        },
+        {
+          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          data: {
+            status: {
+              data: 'SHARED',
+              comparison: CRITERION_COMPARISONS.EQUAL,
+            },
+          },
+          comparison: REQUIREMENT_COMPARISONS.ALL,
+        },
+      ];
+      const quest = new Quest({ eligibilityRequirements, successRequirements: [] });
+      const campaignParticipations = [{ id: 10, targetProfileId: 789 }];
+      const eligibility = new Eligibility({ organization: {}, organizationLearner: {}, campaignParticipations });
+      const dataForQuest = new DataForQuest({ eligibility });
+
+      const result = quest.findTargetProfileIdsWithoutCampaignParticipationContributingToQuest(dataForQuest);
+
+      expect(result).to.have.length(1);
+      expect(result[0]).to.equal(1);
+    });
+
+    it('returns an array with only target profiles ids without campaign participations contributing to quest', function () {
+      const eligibilityRequirements = [
+        {
+          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          data: {
+            targetProfileId: {
+              data: 123,
+              comparison: CRITERION_COMPARISONS.EQUAL,
+            },
+          },
+          comparison: REQUIREMENT_COMPARISONS.ALL,
+        },
+        {
+          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          data: {
+            targetProfileId: {
+              data: 789,
+              comparison: CRITERION_COMPARISONS.EQUAL,
+            },
+          },
+          comparison: REQUIREMENT_COMPARISONS.ALL,
+        },
+      ];
+      const quest = new Quest({ eligibilityRequirements, successRequirements: [] });
+      const campaignParticipations = [{ id: 10, targetProfileId: 123 }];
+      const eligibility = new Eligibility({ organization: {}, organizationLearner: {}, campaignParticipations });
+      const dataForQuest = new DataForQuest({ eligibility });
+
+      const result = quest.findTargetProfileIdsWithoutCampaignParticipationContributingToQuest(dataForQuest);
+
+      expect(result).to.have.length(1);
+      expect(result[0]).to.equal(789);
+    });
+  });
+
   describe('#findCampaignParticipationIdsContributingToQuest', function () {
     it('returns an empty array when there are no campaign participations contributing to quest', function () {
       const eligibilityRequirements = [

--- a/api/tests/quest/unit/domain/models/Quest_test.js
+++ b/api/tests/quest/unit/domain/models/Quest_test.js
@@ -273,13 +273,48 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
       expect(result[0]).to.equal(1);
     });
 
+    it('returns a flatten array with a targetProfileIds when there are arrays in targetProfileId properties', function () {
+      const eligibilityRequirements = [
+        {
+          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          data: {
+            targetProfileId: {
+              data: [1, 2],
+              comparison: CRITERION_COMPARISONS.EQUAL,
+            },
+          },
+          comparison: REQUIREMENT_COMPARISONS.ALL,
+        },
+        {
+          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          data: {
+            status: {
+              data: 'SHARED',
+              comparison: CRITERION_COMPARISONS.EQUAL,
+            },
+          },
+          comparison: REQUIREMENT_COMPARISONS.ALL,
+        },
+      ];
+      const quest = new Quest({ eligibilityRequirements, successRequirements: [] });
+      const campaignParticipations = [{ id: 10, targetProfileId: 789 }];
+      const eligibility = new Eligibility({ organization: {}, organizationLearner: {}, campaignParticipations });
+      const dataForQuest = new DataForQuest({ eligibility });
+
+      const result = quest.findTargetProfileIdsWithoutCampaignParticipationContributingToQuest(dataForQuest);
+
+      expect(result).to.have.length(2);
+      expect(result[0]).to.equal(1);
+      expect(result[1]).to.equal(2);
+    });
+
     it('returns an array with only target profiles ids without campaign participations contributing to quest', function () {
       const eligibilityRequirements = [
         {
           requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
           data: {
             targetProfileId: {
-              data: 123,
+              data: [123, 456],
               comparison: CRITERION_COMPARISONS.EQUAL,
             },
           },
@@ -305,8 +340,9 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
 
       const result = quest.findTargetProfileIdsWithoutCampaignParticipationContributingToQuest(dataForQuest);
 
-      expect(result).to.have.length(1);
-      expect(result[0]).to.equal(789);
+      expect(result).to.have.length(2);
+      expect(result[0]).to.equal(456);
+      expect(result[1]).to.equal(789);
     });
   });
 

--- a/api/tests/quest/unit/domain/models/Requirement_test.js
+++ b/api/tests/quest/unit/domain/models/Requirement_test.js
@@ -2,6 +2,7 @@ import { COMPARISONS as CRITERION_PROPERTY_COMPARISONS } from '../../../../../sr
 import { Eligibility } from '../../../../../src/quest/domain/models/Eligibility.js';
 import {
   buildRequirement,
+  CappedTubesRequirement,
   COMPARISONS,
   ComposedRequirement,
   ObjectRequirement,
@@ -96,6 +97,23 @@ describe('Quest | Unit | Domain | Models | Requirement ', function () {
 
         // then
         expect(requirement instanceof SkillProfileRequirement).to.be.true;
+      });
+    });
+
+    context('when requirement_type is "cappedTubes"', function () {
+      it('should build an CappedTubesRequirement', function () {
+        // given
+        const buildData = {
+          requirement_type: TYPES.CAPPED_TUBES,
+          comparison: 'irrelevant',
+          data: {},
+        };
+
+        // when
+        const requirement = buildRequirement(buildData);
+
+        // then
+        expect(requirement instanceof CappedTubesRequirement).to.be.true;
       });
     });
 
@@ -543,6 +561,12 @@ describe('Quest | Unit | Domain | Models | Requirement ', function () {
               { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillC' },
               { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillD' },
             ],
+            skills: [
+              { id: 'skillA', tubeId: 'tubeA', difficulty: 1 },
+              { id: 'skillB', tubeId: 'tubeA', difficulty: 1 },
+              { id: 'skillC', tubeId: 'tubeA', difficulty: 1 },
+              { id: 'skillD', tubeId: 'tubeA', difficulty: 1 },
+            ],
           });
 
           expect(requirement.isFulfilled(successWith50MasteryPercentage)).to.be.false;
@@ -564,6 +588,12 @@ describe('Quest | Unit | Domain | Models | Requirement ', function () {
               { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillC' },
               { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillD' },
             ],
+            skills: [
+              { id: 'skillA', tubeId: 'tubeA', difficulty: 1 },
+              { id: 'skillB', tubeId: 'tubeA', difficulty: 1 },
+              { id: 'skillC', tubeId: 'tubeA', difficulty: 1 },
+              { id: 'skillD', tubeId: 'tubeA', difficulty: 1 },
+            ],
           });
 
           expect(requirement.isFulfilled(successWith50MasteryPercentage)).to.be.true;
@@ -584,6 +614,12 @@ describe('Quest | Unit | Domain | Models | Requirement ', function () {
               { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillB' },
               { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillC' },
               { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillD' },
+            ],
+            skills: [
+              { id: 'skillA', tubeId: 'tubeA', difficulty: 1 },
+              { id: 'skillB', tubeId: 'tubeA', difficulty: 1 },
+              { id: 'skillC', tubeId: 'tubeA', difficulty: 1 },
+              { id: 'skillD', tubeId: 'tubeA', difficulty: 1 },
             ],
           });
 
@@ -610,6 +646,219 @@ describe('Quest | Unit | Domain | Models | Requirement ', function () {
           requirement_type: TYPES.SKILL_PROFILE,
           data: {
             skillIds: ['id1', 'id2'],
+            threshold: 70,
+          },
+        });
+      });
+    });
+  });
+
+  describe('CappedTubesRequirement', function () {
+    describe('isFulfilled', function () {
+      let successWith60MasteryPercentage;
+      const cappedTubes = [
+        { tubeId: 'tubeA', level: 2 },
+        { tubeId: 'tubeB', level: 3 },
+      ];
+
+      beforeEach(function () {
+        successWith60MasteryPercentage = new Success({
+          knowledgeElements: [
+            {
+              status: KnowledgeElement.StatusType.VALIDATED,
+              skillId: 'skill1tubeA_V1',
+              createdAt: new Date('2025-03-17'),
+            },
+            {
+              status: KnowledgeElement.StatusType.INVALIDATED,
+              skillId: 'skill2tubeA',
+              createdAt: new Date('2025-03-17'),
+            },
+            {
+              status: KnowledgeElement.StatusType.VALIDATED,
+              skillId: 'skill3tubeA',
+              createdAt: new Date('2025-03-17'),
+            },
+            {
+              status: KnowledgeElement.StatusType.VALIDATED,
+              skillId: 'skill4tubeA',
+              createdAt: new Date('2025-03-17'),
+            },
+            {
+              status: KnowledgeElement.StatusType.VALIDATED,
+              skillId: 'skill1tubeB',
+              createdAt: new Date('2025-03-17'),
+            },
+            {
+              status: KnowledgeElement.StatusType.VALIDATED,
+              skillId: 'skill2tubeB',
+              createdAt: new Date('2025-03-17'),
+            },
+            {
+              status: KnowledgeElement.StatusType.INVALIDATED,
+              skillId: 'skill3tubeB',
+              createdAt: new Date('2025-03-17'),
+            },
+            { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillTubeC', createdAt: new Date('2025-03-17') },
+            { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillTubeD', createdAt: new Date('2025-03-17') },
+          ],
+          campaignSkills: [
+            { id: 'skill1tubeA_V1', tubeId: 'tubeA', difficulty: 1 },
+            { id: 'skill2tubeA', tubeId: 'tubeA', difficulty: 2 },
+            { id: 'skill3tubeA', tubeId: 'tubeA', difficulty: 3 },
+            { id: 'skill4tubeA', tubeId: 'tubeA', difficulty: 4 },
+            { id: 'skill1tubeB', tubeId: 'tubeB', difficulty: 1 },
+            { id: 'skill2tubeB', tubeId: 'tubeB', difficulty: 2 },
+            { id: 'skill3tubeB', tubeId: 'tubeB', difficulty: 3 },
+            { id: 'skillTubeC', tubeId: 'tubeC', difficulty: 1 },
+            { id: 'skillTubeD', tubeId: 'tubeD', difficulty: 1 },
+          ],
+        });
+      });
+      context(
+        'when two skills exist for a tube and a difficulty compute fulfillement taking in account only most recent knowledge element',
+        function () {
+          it('return true', function () {
+            // given
+            const success = new Success({
+              knowledgeElements: [
+                ...successWith60MasteryPercentage.knowledgeElements,
+                {
+                  status: KnowledgeElement.StatusType.INVALIDATED,
+                  skillId: 'skill1tubeA_V2',
+                  createdAt: new Date('2024-06-10'),
+                },
+              ],
+              campaignSkills: [
+                ...successWith60MasteryPercentage.campaignSkills,
+                { id: 'skill1tubeA_V2', tubeId: 'tubeA', difficulty: 1 },
+              ],
+            });
+            const requirement = new CappedTubesRequirement({
+              data: {
+                cappedTubes,
+                threshold: 60,
+              },
+            });
+
+            // when
+            const isFulfilled = requirement.isFulfilled(success);
+
+            // then
+            expect(isFulfilled).to.be.true;
+          });
+
+          it('return false', function () {
+            // given
+            const success = new Success({
+              knowledgeElements: [
+                ...successWith60MasteryPercentage.knowledgeElements,
+                {
+                  status: KnowledgeElement.StatusType.INVALIDATED,
+                  skillId: 'skill1tubeA_V2',
+                  createdAt: new Date('2025-12-24'),
+                },
+              ],
+              campaignSkills: [
+                ...successWith60MasteryPercentage.campaignSkills,
+                { id: 'skill1tubeA_V2', tubeId: 'tubeA', difficulty: 1 },
+              ],
+            });
+            const requirement = new CappedTubesRequirement({
+              data: {
+                cappedTubes,
+                threshold: 60,
+              },
+            });
+
+            // when
+            const isFulfilled = requirement.isFulfilled(success);
+
+            // then
+            expect(isFulfilled).to.be.false;
+          });
+        },
+      );
+
+      context("when dataInput's masteryPercentage is below threshold", function () {
+        it('should return false', function () {
+          // given
+          const requirement = new CappedTubesRequirement({
+            data: {
+              cappedTubes,
+              threshold: 61,
+            },
+          });
+
+          // when
+          const isFulfilled = requirement.isFulfilled(successWith60MasteryPercentage);
+
+          // then
+          expect(isFulfilled).to.be.false;
+        });
+      });
+
+      context("when dataInput's masteryPercentage is equal to threshold", function () {
+        it('should return true', function () {
+          // given
+          const requirement = new CappedTubesRequirement({
+            data: {
+              cappedTubes,
+              threshold: 60,
+            },
+          });
+
+          // when
+          const isFulfilled = requirement.isFulfilled(successWith60MasteryPercentage);
+
+          // then
+          expect(isFulfilled).to.be.true;
+        });
+      });
+
+      context("when dataInput's masteryPercentage is above threshold", function () {
+        it('should return true', function () {
+          // given
+          const requirement = new CappedTubesRequirement({
+            data: {
+              cappedTubes,
+              threshold: 59,
+            },
+          });
+
+          // when
+          const isFulfilled = requirement.isFulfilled(successWith60MasteryPercentage);
+
+          // then
+          expect(isFulfilled).to.be.true;
+        });
+      });
+    });
+
+    describe('toDTO', function () {
+      it('should transform into a DTO', function () {
+        // given
+        const requirement = new CappedTubesRequirement({
+          data: {
+            cappedTubes: [
+              { tubeId: 'tubeA', level: 2 },
+              { tubeId: 'tubeB', level: 5 },
+            ],
+            threshold: 70,
+          },
+        });
+
+        // when
+        const DTO = requirement.toDTO();
+
+        // then
+        expect(DTO).to.deep.equal({
+          requirement_type: TYPES.CAPPED_TUBES,
+          data: {
+            cappedTubes: [
+              { tubeId: 'tubeA', level: 2 },
+              { tubeId: 'tubeB', level: 5 },
+            ],
             threshold: 70,
           },
         });

--- a/api/tests/quest/unit/domain/models/Success_test.js
+++ b/api/tests/quest/unit/domain/models/Success_test.js
@@ -60,6 +60,70 @@ describe('Quest | Unit | Domain | Models | Success ', function () {
     });
   });
 
+  describe('#skills', function () {
+    it('should return empty array when there are no campaignSkills or targetProfileSkills', function () {
+      const success = new Success({
+        knowledgeElements: [],
+        campaignSkills: [],
+      });
+
+      expect(success.skills).to.have.length(0);
+    });
+
+    it('should return an array when there are campaignSkills', function () {
+      const success = new Success({
+        knowledgeElements: [],
+        campaignSkills: [
+          { id: 'skillA', tubeId: 'tubeA', difficulty: 1 },
+          { id: 'skillB', tubeId: 'tubeB', difficulty: 1 },
+        ],
+      });
+
+      expect(success.skills).to.have.length(2);
+      expect(success.skills).to.have.deep.members([
+        { id: 'skillA', tubeId: 'tubeA', difficulty: 1 },
+        { id: 'skillB', tubeId: 'tubeB', difficulty: 1 },
+      ]);
+    });
+
+    it('should return an array when there are targetProfileSkills', function () {
+      const success = new Success({
+        knowledgeElements: [],
+        targetProfileSkills: [
+          { id: 'skillA', tubeId: 'tubeA', difficulty: 1 },
+          { id: 'skillB', tubeId: 'tubeB', difficulty: 1 },
+        ],
+      });
+
+      expect(success.skills).to.have.length(2);
+      expect(success.skills).to.have.deep.members([
+        { id: 'skillA', tubeId: 'tubeA', difficulty: 1 },
+        { id: 'skillB', tubeId: 'tubeB', difficulty: 1 },
+      ]);
+    });
+
+    it('should return an array when there are campaignSkills and targetProfileSkills', function () {
+      const success = new Success({
+        knowledgeElements: [],
+        targetProfileSkills: [
+          { id: 'skillA', tubeId: 'tubeA', difficulty: 1 },
+          { id: 'skillB', tubeId: 'tubeB', difficulty: 1 },
+        ],
+        campaignSkills: [
+          { id: 'skillA', tubeId: 'tubeA', difficulty: 1 },
+          { id: 'skillC', tubeId: 'tubeC', difficulty: 1 },
+        ],
+      });
+
+      expect(success.skills).to.have.length(3);
+      expect(success.skills).to.have.deep.members([
+        { id: 'skillA', tubeId: 'tubeA', difficulty: 1 },
+        { id: 'skillB', tubeId: 'tubeB', difficulty: 1 },
+        { id: 'skillC', tubeId: 'tubeC', difficulty: 1 },
+      ]);
+    });
+  });
+
   describe('#getMasteryPercentageForCappedTubes', function () {
     context('when no cappedTubes provided', function () {
       it('should return 0 when cappedTubes is empty', function () {
@@ -135,6 +199,9 @@ describe('Quest | Unit | Domain | Models | Success ', function () {
               { id: 'skill1tubeB', tubeId: 'tubeB', difficulty: 1 },
               { id: 'skill2tubeB', tubeId: 'tubeB', difficulty: 2 },
               { id: 'skill3tubeB', tubeId: 'tubeB', difficulty: 3 },
+              { id: 'skillTubeC', tubeId: 'tubeC', difficulty: 1 },
+            ],
+            targetProfileSkills: [
               { id: 'skillTubeC', tubeId: 'tubeC', difficulty: 1 },
               { id: 'skillTubeD', tubeId: 'tubeD', difficulty: 1 },
             ],

--- a/api/tests/quest/unit/domain/models/Success_test.js
+++ b/api/tests/quest/unit/domain/models/Success_test.js
@@ -59,20 +59,19 @@ describe('Quest | Unit | Domain | Models | Success ', function () {
       });
     });
   });
-  /*
+
   describe('#getMasteryPercentageForCappedTubes', function () {
     context('when no cappedTubes provided', function () {
-      it('should return 0', function () {
+      it('should return 0 when cappedTubes is empty', function () {
         // given
         const cappedTubesEmpty = [];
-        const brokenCappedTubes = null;
         const success = new Success({
           knowledgeElements: [
             { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillA' },
             { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillB' },
             { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillC' },
           ],
-          skills: [
+          campaignSkills: [
             { id: 'skillA', tubeId: 'tubeA', difficulty: 1 },
             { id: 'skillB', tubeId: 'tubeB', difficulty: 1 },
             { id: 'skillC', tubeId: 'tubeC', difficulty: 1 },
@@ -81,56 +80,145 @@ describe('Quest | Unit | Domain | Models | Success ', function () {
 
         // when
         const masteryPercentageEmpty = success.getMasteryPercentageForCappedTubes(cappedTubesEmpty);
-        const masteryPercentageBroken = success.getMasteryPercentageForCappedTubes(brokenCappedTubes);
 
         // then
         expect(masteryPercentageEmpty).to.equal(0);
-        expect(masteryPercentageBroken).to.equal(0);
       });
-    });
-    context('when cappedTubes are provided', function () {
-      it('should return the expected mastery percentage according to knowledge elements by tube in Success model', function () {
+
+      it('should return 0 when cappedTubes is invalid', function () {
         // given
+        const brokenCappedTubes = null;
         const success = new Success({
-          // 1/2 sur tubeA cappé 2
-          // 2/3 sur tubeB cappé 3
-          // au final ça donne 3 / 5 -> 60%
           knowledgeElements: [
-            { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill1tubeA' },
-            { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skill2tubeA' },
-            { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill3tubeA' }, // ignoré, hors cap
-            { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill4tubeA' }, // ignoré, hors cap
-            { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill1tubeB' },
-            { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill2tubeB' },
-            { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skill3tubeB' },
-            { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillTubeC' }, // ignoré, hors scope
-            { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillTubeD' }, // ignoré, hors scope
+            { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillA' },
+            { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillB' },
+            { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillC' },
           ],
-          skills: [
-            { id: 'skill1tubeA', tubeId: 'tubeA', difficulty: 1 },
-            { id: 'skill2tubeA', tubeId: 'tubeA', difficulty: 2 },
-            { id: 'skill3tubeA', tubeId: 'tubeA', difficulty: 3 },
-            { id: 'skill4tubeA', tubeId: 'tubeA', difficulty: 4 },
-            { id: 'skill1tubeB', tubeId: 'tubeB', difficulty: 1 },
-            { id: 'skill2tubeB', tubeId: 'tubeB', difficulty: 2 },
-            { id: 'skill3tubeB', tubeId: 'tubeB', difficulty: 3 },
-            { id: 'skillTubeC', tubeId: 'tubeC', difficulty: 1 },
-            { id: 'skillTubeD', tubeId: 'tubeD', difficulty: 1 },
+          campaignSkills: [
+            { id: 'skillA', tubeId: 'tubeA', difficulty: 1 },
+            { id: 'skillB', tubeId: 'tubeB', difficulty: 1 },
+            { id: 'skillC', tubeId: 'tubeC', difficulty: 1 },
           ],
         });
 
         // when
-        const cappedTubes = [
-          { tubeId: 'tubeA', level: 2 },
-          { tubeId: 'tubeB', level: 3 },
-        ];
-        const masteryPercentage = success.getMasteryPercentageForCappedTubes(cappedTubes);
+        const masteryPercentageBroken = success.getMasteryPercentageForCappedTubes(brokenCappedTubes);
 
         // then
-        const expectedMasteryPercentage = 60;
-        expect(masteryPercentage).to.be.equal(expectedMasteryPercentage);
+        expect(masteryPercentageBroken).to.equal(0);
+      });
+    });
+    context('when cappedTubes are provided', function () {
+      context('when there are no dupes in tubeId/difficulty', function () {
+        it('should return the expected mastery percentage according to knowledge elements by tube in Success model', function () {
+          // given
+          const success = new Success({
+            // 1/2 sur tubeA cappé 2
+            // 2/3 sur tubeB cappé 3
+            // au final ça donne 3 / 5 -> 60%
+            knowledgeElements: [
+              { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill1tubeA' },
+              { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skill2tubeA' },
+              { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill3tubeA' }, // ignoré, hors cap
+              { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill4tubeA' }, // ignoré, hors cap
+              { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill1tubeB' },
+              { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill2tubeB' },
+              { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skill3tubeB' },
+              { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillTubeC' }, // ignoré, hors scope
+              { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillTubeD' }, // ignoré, hors scope
+            ],
+            campaignSkills: [
+              { id: 'skill1tubeA', tubeId: 'tubeA', difficulty: 1 },
+              { id: 'skill2tubeA', tubeId: 'tubeA', difficulty: 2 },
+              { id: 'skill3tubeA', tubeId: 'tubeA', difficulty: 3 },
+              { id: 'skill4tubeA', tubeId: 'tubeA', difficulty: 4 },
+              { id: 'skill1tubeB', tubeId: 'tubeB', difficulty: 1 },
+              { id: 'skill2tubeB', tubeId: 'tubeB', difficulty: 2 },
+              { id: 'skill3tubeB', tubeId: 'tubeB', difficulty: 3 },
+              { id: 'skillTubeC', tubeId: 'tubeC', difficulty: 1 },
+              { id: 'skillTubeD', tubeId: 'tubeD', difficulty: 1 },
+            ],
+          });
+
+          // when
+          const cappedTubes = [
+            { tubeId: 'tubeA', level: 2 },
+            { tubeId: 'tubeB', level: 3 },
+          ];
+          const masteryPercentage = success.getMasteryPercentageForCappedTubes(cappedTubes);
+
+          // then
+          const expectedMasteryPercentage = 60;
+          expect(masteryPercentage).to.be.equal(expectedMasteryPercentage);
+        });
+      });
+      context('when there are several skills for the same tubeId/difficulty', function () {
+        it('should only count as if there were one skill for the same tubeId/difficulty', function () {
+          // given
+          const success = new Success({
+            knowledgeElements: [{ status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill1_v2' }],
+            campaignSkills: [
+              { id: 'skill1_v1', tubeId: 'tubeA', difficulty: 1 },
+              { id: 'skill1_v2', tubeId: 'tubeA', difficulty: 1 },
+            ],
+          });
+          const cappedTubes = [{ tubeId: 'tubeA', level: 2 }];
+
+          // when
+          const masteryPercentage = success.getMasteryPercentageForCappedTubes(cappedTubes);
+
+          // then
+          expect(masteryPercentage).to.be.equal(100);
+        });
+
+        context('when none of them have been assessed to the user yet', function () {
+          it('should count as if the skill is not validated', function () {});
+        });
+        context('when one of them have been assessed to the user', function () {});
+        context('when some of them have been assessed to the user', function () {});
+        context('when all of them have been assessed to the user', function () {});
+        it('should return the expected mastery percentage according to knowledge elements by tube in Success model', function () {
+          // given
+          const success = new Success({
+            // 1/2 sur tubeA cappé 2
+            // 2/3 sur tubeB cappé 3
+            // au final ça donne 3 / 5 -> 60%
+            knowledgeElements: [
+              { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill1tubeA' },
+              { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skill2tubeA' },
+              { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill3tubeA' }, // ignoré, hors cap
+              { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill4tubeA' }, // ignoré, hors cap
+              { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill1tubeB' },
+              { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill2tubeB' },
+              { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skill3tubeB' },
+              { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillTubeC' }, // ignoré, hors scope
+              { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillTubeD' }, // ignoré, hors scope
+            ],
+            campaignSkills: [
+              { id: 'skill1tubeA', tubeId: 'tubeA', difficulty: 1 },
+              { id: 'skill2tubeA', tubeId: 'tubeA', difficulty: 2 },
+              { id: 'skill3tubeA', tubeId: 'tubeA', difficulty: 3 },
+              { id: 'skill4tubeA', tubeId: 'tubeA', difficulty: 4 },
+              { id: 'skill1tubeB', tubeId: 'tubeB', difficulty: 1 },
+              { id: 'skill2tubeB', tubeId: 'tubeB', difficulty: 2 },
+              { id: 'skill3tubeB', tubeId: 'tubeB', difficulty: 3 },
+              { id: 'skillTubeC', tubeId: 'tubeC', difficulty: 1 },
+              { id: 'skillTubeD', tubeId: 'tubeD', difficulty: 1 },
+            ],
+          });
+
+          // when
+          const cappedTubes = [
+            { tubeId: 'tubeA', level: 2 },
+            { tubeId: 'tubeB', level: 3 },
+          ];
+          const masteryPercentage = success.getMasteryPercentageForCappedTubes(cappedTubes);
+
+          // then
+          const expectedMasteryPercentage = 60;
+          expect(masteryPercentage).to.be.equal(expectedMasteryPercentage);
+        });
       });
     });
   });
-  */
 });

--- a/api/tests/quest/unit/domain/models/Success_test.js
+++ b/api/tests/quest/unit/domain/models/Success_test.js
@@ -177,9 +177,6 @@ describe('Quest | Unit | Domain | Models | Success ', function () {
         it('should return the expected mastery percentage according to knowledge elements by tube in Success model', function () {
           // given
           const success = new Success({
-            // 1/2 sur tubeA cappé 2
-            // 2/3 sur tubeB cappé 3
-            // au final ça donne 3 / 5 -> 60%
             knowledgeElements: [
               { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill1tubeA' },
               { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skill2tubeA' },
@@ -239,19 +236,96 @@ describe('Quest | Unit | Domain | Models | Success ', function () {
         });
 
         context('when none of them have been assessed to the user yet', function () {
-          it('should count as if the skill is not validated', function () {});
+          it('should count as if the skill is not validated', function () {
+            // given
+            const success = new Success({
+              knowledgeElements: [],
+              campaignSkills: [
+                { id: 'skill1_v1', tubeId: 'tubeA', difficulty: 1 },
+                { id: 'skill1_v2', tubeId: 'tubeA', difficulty: 1 },
+              ],
+            });
+            const cappedTubes = [{ tubeId: 'tubeA', level: 2 }];
+
+            // when
+            const masteryPercentage = success.getMasteryPercentageForCappedTubes(cappedTubes);
+
+            // then
+            expect(masteryPercentage).to.be.equal(0);
+          });
         });
-        context('when one of them have been assessed to the user', function () {});
-        context('when some of them have been assessed to the user', function () {});
-        context('when all of them have been assessed to the user', function () {});
+        context('when one of them have been assessed to the user', function () {
+          it('should count as if the skill is validated', function () {
+            // given
+            const success = new Success({
+              knowledgeElements: [{ status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill1_v2' }],
+              campaignSkills: [
+                { id: 'skill1_v1', tubeId: 'tubeA', difficulty: 1 },
+                { id: 'skill1_v2', tubeId: 'tubeA', difficulty: 1 },
+                { id: 'skill1_v3', tubeId: 'tubeA', difficulty: 1 },
+              ],
+            });
+            const cappedTubes = [{ tubeId: 'tubeA', level: 2 }];
+
+            // when
+            const masteryPercentage = success.getMasteryPercentageForCappedTubes(cappedTubes);
+
+            // then
+            expect(masteryPercentage).to.be.equal(100);
+          });
+        });
+        context('when some of them have been assessed to the user', function () {
+          it('should count as if the skill is validated', function () {
+            // given
+            const success = new Success({
+              knowledgeElements: [
+                { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill1_v1' },
+                { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill1_v2' },
+              ],
+              campaignSkills: [
+                { id: 'skill1_v1', tubeId: 'tubeA', difficulty: 1 },
+                { id: 'skill1_v2', tubeId: 'tubeA', difficulty: 1 },
+                { id: 'skill1_v3', tubeId: 'tubeA', difficulty: 1 },
+              ],
+            });
+            const cappedTubes = [{ tubeId: 'tubeA', level: 2 }];
+
+            // when
+            const masteryPercentage = success.getMasteryPercentageForCappedTubes(cappedTubes);
+
+            // then
+            expect(masteryPercentage).to.be.equal(100);
+          });
+        });
+        context('when all of them have been assessed to the user', function () {
+          it('should count as if the skill is validated', function () {
+            // given
+            const success = new Success({
+              knowledgeElements: [
+                { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill1_v1' },
+                { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill1_v2' },
+                { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill1_v3' },
+              ],
+              campaignSkills: [
+                { id: 'skill1_v1', tubeId: 'tubeA', difficulty: 1 },
+                { id: 'skill1_v2', tubeId: 'tubeA', difficulty: 1 },
+                { id: 'skill1_v3', tubeId: 'tubeA', difficulty: 1 },
+              ],
+            });
+            const cappedTubes = [{ tubeId: 'tubeA', level: 2 }];
+
+            // when
+            const masteryPercentage = success.getMasteryPercentageForCappedTubes(cappedTubes);
+
+            // then
+            expect(masteryPercentage).to.be.equal(100);
+          });
+        });
         it('should return the expected mastery percentage according to knowledge elements by tube in Success model', function () {
           // given
           const success = new Success({
-            // 1/2 sur tubeA cappé 2
-            // 2/3 sur tubeB cappé 3
-            // au final ça donne 3 / 5 -> 60%
             knowledgeElements: [
-              { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill1tubeA' },
+              { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill1tubeA_v1' },
               { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skill2tubeA' },
               { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill3tubeA' }, // ignoré, hors cap
               { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill4tubeA' }, // ignoré, hors cap
@@ -262,7 +336,8 @@ describe('Quest | Unit | Domain | Models | Success ', function () {
               { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillTubeD' }, // ignoré, hors scope
             ],
             campaignSkills: [
-              { id: 'skill1tubeA', tubeId: 'tubeA', difficulty: 1 },
+              { id: 'skill1tubeA_v1', tubeId: 'tubeA', difficulty: 1 },
+              { id: 'skill1tubeA_v2', tubeId: 'tubeA', difficulty: 1 },
               { id: 'skill2tubeA', tubeId: 'tubeA', difficulty: 2 },
               { id: 'skill3tubeA', tubeId: 'tubeA', difficulty: 3 },
               { id: 'skill4tubeA', tubeId: 'tubeA', difficulty: 4 },

--- a/api/tests/quest/unit/domain/models/Success_test.js
+++ b/api/tests/quest/unit/domain/models/Success_test.js
@@ -15,6 +15,11 @@ describe('Quest | Unit | Domain | Models | Success ', function () {
             { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillB' },
             { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillC' },
           ],
+          skills: [
+            { id: 'skillA', tubeId: 'tubeA', difficulty: 1 },
+            { id: 'skillB', tubeId: 'tubeB', difficulty: 1 },
+            { id: 'skillC', tubeId: 'tubeC', difficulty: 1 },
+          ],
         });
 
         // when
@@ -37,6 +42,12 @@ describe('Quest | Unit | Domain | Models | Success ', function () {
             { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillC' },
             { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillD' },
           ],
+          skills: [
+            { id: 'skillA', tubeId: 'tubeA', difficulty: 1 },
+            { id: 'skillB', tubeId: 'tubeB', difficulty: 1 },
+            { id: 'skillC', tubeId: 'tubeC', difficulty: 1 },
+            { id: 'skillD', tubeId: 'tubeD', difficulty: 1 },
+          ],
         });
 
         // when
@@ -48,4 +59,78 @@ describe('Quest | Unit | Domain | Models | Success ', function () {
       });
     });
   });
+  /*
+  describe('#getMasteryPercentageForCappedTubes', function () {
+    context('when no cappedTubes provided', function () {
+      it('should return 0', function () {
+        // given
+        const cappedTubesEmpty = [];
+        const brokenCappedTubes = null;
+        const success = new Success({
+          knowledgeElements: [
+            { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillA' },
+            { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillB' },
+            { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skillC' },
+          ],
+          skills: [
+            { id: 'skillA', tubeId: 'tubeA', difficulty: 1 },
+            { id: 'skillB', tubeId: 'tubeB', difficulty: 1 },
+            { id: 'skillC', tubeId: 'tubeC', difficulty: 1 },
+          ],
+        });
+
+        // when
+        const masteryPercentageEmpty = success.getMasteryPercentageForCappedTubes(cappedTubesEmpty);
+        const masteryPercentageBroken = success.getMasteryPercentageForCappedTubes(brokenCappedTubes);
+
+        // then
+        expect(masteryPercentageEmpty).to.equal(0);
+        expect(masteryPercentageBroken).to.equal(0);
+      });
+    });
+    context('when cappedTubes are provided', function () {
+      it('should return the expected mastery percentage according to knowledge elements by tube in Success model', function () {
+        // given
+        const success = new Success({
+          // 1/2 sur tubeA cappé 2
+          // 2/3 sur tubeB cappé 3
+          // au final ça donne 3 / 5 -> 60%
+          knowledgeElements: [
+            { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill1tubeA' },
+            { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skill2tubeA' },
+            { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill3tubeA' }, // ignoré, hors cap
+            { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill4tubeA' }, // ignoré, hors cap
+            { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill1tubeB' },
+            { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skill2tubeB' },
+            { status: KnowledgeElement.StatusType.INVALIDATED, skillId: 'skill3tubeB' },
+            { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillTubeC' }, // ignoré, hors scope
+            { status: KnowledgeElement.StatusType.VALIDATED, skillId: 'skillTubeD' }, // ignoré, hors scope
+          ],
+          skills: [
+            { id: 'skill1tubeA', tubeId: 'tubeA', difficulty: 1 },
+            { id: 'skill2tubeA', tubeId: 'tubeA', difficulty: 2 },
+            { id: 'skill3tubeA', tubeId: 'tubeA', difficulty: 3 },
+            { id: 'skill4tubeA', tubeId: 'tubeA', difficulty: 4 },
+            { id: 'skill1tubeB', tubeId: 'tubeB', difficulty: 1 },
+            { id: 'skill2tubeB', tubeId: 'tubeB', difficulty: 2 },
+            { id: 'skill3tubeB', tubeId: 'tubeB', difficulty: 3 },
+            { id: 'skillTubeC', tubeId: 'tubeC', difficulty: 1 },
+            { id: 'skillTubeD', tubeId: 'tubeD', difficulty: 1 },
+          ],
+        });
+
+        // when
+        const cappedTubes = [
+          { tubeId: 'tubeA', level: 2 },
+          { tubeId: 'tubeB', level: 3 },
+        ];
+        const masteryPercentage = success.getMasteryPercentageForCappedTubes(cappedTubes);
+
+        // then
+        const expectedMasteryPercentage = 60;
+        expect(masteryPercentage).to.be.equal(expectedMasteryPercentage);
+      });
+    });
+  });
+  */
 });

--- a/api/tests/quest/unit/infrastructure/repositories/success-repository_test.js
+++ b/api/tests/quest/unit/infrastructure/repositories/success-repository_test.js
@@ -9,6 +9,7 @@ describe('Quest | Unit | Infrastructure | repositories | success', function () {
     let knowledgeElementsApi_findFilteredMostRecentByUserStub;
     let skillsApi_findByIdsStub;
     let campaignsApi_findCampaignSkillIdsForCampaignParticipationsStub;
+    let targetProfilesApi_findSkillsByTargetProfileIdsStub;
 
     beforeEach(function () {
       knowledgeElementsApi_findFilteredMostRecentByUserStub = sinon.stub().named('findFilteredMostRecentByUser');
@@ -16,10 +17,12 @@ describe('Quest | Unit | Infrastructure | repositories | success', function () {
       campaignsApi_findCampaignSkillIdsForCampaignParticipationsStub = sinon
         .stub()
         .named('findCampaignSkillIdsForCampaignParticipations');
+      targetProfilesApi_findSkillsByTargetProfileIdsStub = sinon.stub();
       preventStubsToBeCalledUnexpectedly([
         knowledgeElementsApi_findFilteredMostRecentByUserStub,
         skillsApi_findByIdsStub,
         campaignsApi_findCampaignSkillIdsForCampaignParticipationsStub,
+        targetProfilesApi_findSkillsByTargetProfileIdsStub,
       ]);
     });
 
@@ -28,7 +31,10 @@ describe('Quest | Unit | Infrastructure | repositories | success', function () {
       const userId = Symbol('userId');
       const knowledgeElements = [{ skillId: 'A' }, { skillId: 'B' }];
       const campaignParticipationIds = Symbol('campaignParticipationIds');
+      const targetProfileIds = Symbol('targetProfileIds');
       const campaignSkillIds = Symbol('campaignSkillIds');
+      const campaignSkills = [{ id: 'A', tubeId: 'AA' }];
+      const targetProfileSkills = [{ id: 'B', tubeId: 'BB' }];
       const skills = [
         { id: 'A', tubeId: 'AA' },
         { id: 'B', tubeId: 'BB' },
@@ -39,6 +45,9 @@ describe('Quest | Unit | Infrastructure | repositories | success', function () {
       const skillsApi = {
         findByIds: skillsApi_findByIdsStub,
       };
+      const targetProfilesApi = {
+        findSkillsByTargetProfileIds: targetProfilesApi_findSkillsByTargetProfileIdsStub,
+      };
       const campaignsApi = {
         findCampaignSkillIdsForCampaignParticipations: campaignsApi_findCampaignSkillIdsForCampaignParticipationsStub,
       };
@@ -46,12 +55,15 @@ describe('Quest | Unit | Infrastructure | repositories | success', function () {
       campaignsApi.findCampaignSkillIdsForCampaignParticipations
         .withArgs(campaignParticipationIds)
         .resolves(campaignSkillIds);
-      skillsApi_findByIdsStub.withArgs({ ids: campaignSkillIds }).resolves(skills);
+      skillsApi_findByIdsStub.withArgs({ ids: campaignSkillIds }).resolves(campaignSkills);
+      targetProfilesApi_findSkillsByTargetProfileIdsStub.withArgs(targetProfileIds).resolves(targetProfileSkills);
 
       // when
       const result = await successRepository.find({
         userId,
+        targetProfileIds,
         campaignParticipationIds,
+        targetProfilesApi,
         knowledgeElementsApi,
         campaignsApi,
         skillsApi,
@@ -60,7 +72,7 @@ describe('Quest | Unit | Infrastructure | repositories | success', function () {
       // then
       expect(result).to.be.an.instanceof(Success);
       expect(result.knowledgeElements).to.deepEqualArray(knowledgeElements);
-      expect(result.skillsForKnowledgeElements).to.equal(skills);
+      expect(result.skills).to.deepEqualArray(skills);
     });
   });
 });

--- a/api/tests/quest/unit/infrastructure/repositories/success-repository_test.js
+++ b/api/tests/quest/unit/infrastructure/repositories/success-repository_test.js
@@ -2,28 +2,65 @@ import sinon from 'sinon';
 
 import { Success } from '../../../../../src/quest/domain/models/Success.js';
 import * as successRepository from '../../../../../src/quest/infrastructure/repositories/success-repository.js';
-import { expect } from '../../../../test-helper.js';
+import { expect, preventStubsToBeCalledUnexpectedly } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Infrastructure | repositories | success', function () {
   describe('#find', function () {
-    it('should call Knowledge Elements API', async function () {
+    let knowledgeElementsApi_findFilteredMostRecentByUserStub;
+    let skillsApi_findByIdsStub;
+    let campaignsApi_findCampaignSkillIdsForCampaignParticipationsStub;
+
+    beforeEach(function () {
+      knowledgeElementsApi_findFilteredMostRecentByUserStub = sinon.stub().named('findFilteredMostRecentByUser');
+      skillsApi_findByIdsStub = sinon.stub().named('findByIds');
+      campaignsApi_findCampaignSkillIdsForCampaignParticipationsStub = sinon
+        .stub()
+        .named('findCampaignSkillIdsForCampaignParticipations');
+      preventStubsToBeCalledUnexpectedly([
+        knowledgeElementsApi_findFilteredMostRecentByUserStub,
+        skillsApi_findByIdsStub,
+        campaignsApi_findCampaignSkillIdsForCampaignParticipationsStub,
+      ]);
+    });
+
+    it('should return a Success model according to data fetched from diverse APIs', async function () {
       // given
       const userId = Symbol('userId');
-      const knowledgeElements = Symbol('knowledgeElements');
+      const knowledgeElements = [{ skillId: 'A' }, { skillId: 'B' }];
+      const campaignParticipationIds = Symbol('campaignParticipationIds');
+      const campaignSkillIds = Symbol('campaignSkillIds');
+      const skills = [
+        { id: 'A', tubeId: 'AA' },
+        { id: 'B', tubeId: 'BB' },
+      ];
       const knowledgeElementsApi = {
-        findFilteredMostRecentByUser: sinon.stub(),
+        findFilteredMostRecentByUser: knowledgeElementsApi_findFilteredMostRecentByUserStub,
       };
-      knowledgeElementsApi.findFilteredMostRecentByUser.withArgs({ userId }).resolves(knowledgeElements);
+      const skillsApi = {
+        findByIds: skillsApi_findByIdsStub,
+      };
+      const campaignsApi = {
+        findCampaignSkillIdsForCampaignParticipations: campaignsApi_findCampaignSkillIdsForCampaignParticipationsStub,
+      };
+      knowledgeElementsApi_findFilteredMostRecentByUserStub.withArgs({ userId }).resolves(knowledgeElements);
+      campaignsApi.findCampaignSkillIdsForCampaignParticipations
+        .withArgs(campaignParticipationIds)
+        .resolves(campaignSkillIds);
+      skillsApi_findByIdsStub.withArgs({ ids: campaignSkillIds }).resolves(skills);
 
       // when
       const result = await successRepository.find({
         userId,
+        campaignParticipationIds,
         knowledgeElementsApi,
+        campaignsApi,
+        skillsApi,
       });
 
       // then
       expect(result).to.be.an.instanceof(Success);
-      expect(result.knowledgeElements).to.equal(knowledgeElements);
+      expect(result.knowledgeElements).to.deepEqualArray(knowledgeElements);
+      expect(result.skillsForKnowledgeElements).to.equal(skills);
     });
   });
 });

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -337,7 +337,15 @@ global.chaiErr = function globalErr(fn, val) {
   throw new AssertionError('Expected an error');
 };
 
-const testErr = new Error('Fake Error');
+const preventStubsToBeCalledUnexpectedly = (stubs) => {
+  for (const stub of stubs) {
+    stub.rejects(
+      new Error(
+        `Unexpected call to stub "${stub.toString()}" (whether because it should not have been called OR called with wrong arguments)`,
+      ),
+    );
+  }
+};
 // eslint-disable-next-line mocha/no-exports
 export {
   catchErr,
@@ -367,9 +375,9 @@ export {
   mockLearningContent,
   nock,
   parseJsonStream,
+  preventStubsToBeCalledUnexpectedly,
   removeTempFile,
   sinon,
   streamToPromise,
-  testErr,
   toStream,
 };


### PR DESCRIPTION
## :pancakes: Problème

Le requirement sur les skills rend les quêtes sensibles aux évolutions du référentiel notamment aux acquis qui périment. Pour corriger ce soucis sur les profil cibles la notion sujets cappés a emergé.

## :bacon: Proposition

On propose donc d'ajouter un requirement CappedTubes pour rendre les quêtes résistantes aux changements du référentiels

## 🧃 Remarques

On a rencontré plusieurs soucis sur l'implémentation des capped tubes. Ils ont initialement été prévu pour fonctionner dans le cadre d'une seule campagne. On a donc eu deux soucis : 
- La duplication de acquis par niveau au travers des différentes campagnes (différentes version d'un même acquis)
- Pour gérer les trous du référentiel les capped tubes utilisent les acquis stockés dans campaignSkills sauf qu'au moment d'évaluer les succès de la quête, l'utilisateur n'a potentiellement pas encore passé l'ensemble des campagnes. On calculait donc un pourcentage de succès non pertinent.

Pour solutionner le premier problème nous avons décidé de nous baser sur les KEs comme source de vérité. Pour un tubeId et un level donné on utilise donc le KE le plus récent. Peu importe qu'il soit valide ou non. L'idée est d'avoir un résultat le plus cohérent possible avec les actions de l'utilisateur.

Pour le deuxième problème, on a décidé de faire une photo à l'instant T des profiles cibles pour lesquels l'utilisateur n'a pas encore passé de campagnes. C'est ce qui se rapproche le plus de ce sur quoi l'utilisateur est sensé être évalué. Il est possible qu'au final les campagnes qu'il passe porte sur des acquis plus anciens. Cependant la différence de pourcentage sur le résultat devrait être négligeable.

## :yum: Pour tester


- Avec un utilisateur vierge
- Passer le niveau 1 sur la comptéence 1.1
- Faire la campagne `HDDWHC481` . qui couvre la compétence 2.1

⚠️ il doit répondre à sa dernière question sans le bouton magique sinon nous ne passerons pas dans les requirement reward-user ⚠️ 


l'attestation sera disponible sur l'orga PRO Classic