### PR TITLE
[FEATURE] Remise à jour du script `get-modules-csv` (PIX-16132)

### DIFF
--- a/api/scripts/modulix/get-modules-csv.js
+++ b/api/scripts/modulix/get-modules-csv.js
@@ -8,7 +8,8 @@ export async function getModulesListAsCsv(modules) {
     data: modules,
     delimiter: '\t',
     fileHeaders: [
-      { label: 'Module', value: 'slug' },
+      { label: 'ModuleSlug', value: 'slug' },
+      { label: 'ModuleTitle', value: 'title' },
       {
         label: 'ModuleTotalElements',
         value: (row) => _getTotalElementsCount(row.grains),

--- a/api/scripts/modulix/get-modules-csv.js
+++ b/api/scripts/modulix/get-modules-csv.js
@@ -16,6 +16,10 @@ export async function getModulesListAsCsv(modules) {
         label: 'ModuleIsBeta',
         value: (row) => (row.isBeta ? '=TRUE' : '=FALSE'),
       },
+      {
+        label: 'ModuleObjectives',
+        value: (row) => row.details.objectives.join('.'),
+      },
       { label: 'ModuleTotalGrains', value: 'grains.length' },
       {
         label: 'ModuleTotalLessons',

--- a/api/scripts/modulix/get-modules-csv.js
+++ b/api/scripts/modulix/get-modules-csv.js
@@ -10,12 +10,12 @@ export async function getModulesListAsCsv(modules) {
     fileHeaders: [
       { label: 'ModuleSlug', value: 'slug' },
       { label: 'ModuleTitle', value: 'title' },
-      {
-        label: 'ModuleTotalElements',
-        value: (row) => _getTotalElementsCount(row.grains),
-      },
-      { label: 'ModuleLink', value: (row) => `https://app.recette.pix.fr/modules/${row.slug}` },
       { label: 'ModuleLevel', value: 'details.level' },
+      { label: 'ModuleLink', value: (row) => `https://app.recette.pix.fr/modules/${row.slug}` },
+      {
+        label: 'ModuleIsBeta',
+        value: (row) => (row.isBeta ? '=TRUE' : '=FALSE'),
+      },
       { label: 'ModuleTotalGrains', value: 'grains.length' },
       {
         label: 'ModuleTotalLessons',
@@ -39,8 +39,8 @@ export async function getModulesListAsCsv(modules) {
       },
       { label: 'ModuleDuration', value: (row) => `=TEXT(${row.details.duration}/24/60; "mm:ss")` },
       {
-        label: 'ModuleIsBeta',
-        value: (row) => (row.isBeta ? '=TRUE' : '=FALSE'),
+        label: 'ModuleTotalElements',
+        value: (row) => _getTotalElementsCount(row.grains),
       },
     ],
   });

--- a/api/tests/devcomp/acceptance/scripts/get-modules-csv_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-modules-csv_test.js
@@ -409,7 +409,7 @@ describe('Acceptance | Script | Get Modules as CSV', function () {
     // Then
     expect(modulesListAsCsv).to.be.a('string');
     expect(modulesListAsCsv).to
-      .equal(`\ufeff"ModuleSlug"\t"ModuleTitle"\t"ModuleLevel"\t"ModuleLink"\t"ModuleIsBeta"\t"ModuleTotalGrains"\t"ModuleTotalLessons"\t"ModuleTotalActivities"\t"ModuleTotalChallenges"\t"ModuleTotalDiscoveries"\t"ModuleTotalSummaries"\t"ModuleDuration"\t"ModuleTotalElements"
-"didacticiel-modulix"\t"Didacticiel Modulix"\t"Débutant"\t"https://app.recette.pix.fr/modules/didacticiel-modulix"\t"=TRUE"\t9\t1\t5\t1\t1\t1\t"=TEXT(5/24/60; ""mm:ss"")"\t13`);
+      .equal(`\ufeff"ModuleSlug"\t"ModuleTitle"\t"ModuleLevel"\t"ModuleLink"\t"ModuleIsBeta"\t"ModuleObjectives"\t"ModuleTotalGrains"\t"ModuleTotalLessons"\t"ModuleTotalActivities"\t"ModuleTotalChallenges"\t"ModuleTotalDiscoveries"\t"ModuleTotalSummaries"\t"ModuleDuration"\t"ModuleTotalElements"
+"didacticiel-modulix"\t"Didacticiel Modulix"\t"Débutant"\t"https://app.recette.pix.fr/modules/didacticiel-modulix"\t"=TRUE"\t"Naviguer dans Modulix.Découvrir les leçons et les activités"\t9\t1\t5\t1\t1\t1\t"=TEXT(5/24/60; ""mm:ss"")"\t13`);
   });
 });

--- a/api/tests/devcomp/acceptance/scripts/get-modules-csv_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-modules-csv_test.js
@@ -408,8 +408,9 @@ describe('Acceptance | Script | Get Modules as CSV', function () {
 
     // Then
     expect(modulesListAsCsv).to.be.a('string');
-    expect(modulesListAsCsv).to
-      .equal(`\ufeff"Module"\t"ModuleTotalElements"\t"ModuleLink"\t"ModuleLevel"\t"ModuleTotalGrains"\t"ModuleTotalLessons"\t"ModuleTotalActivities"\t"ModuleTotalChallenges"\t"ModuleTotalDiscoveries"\t"ModuleTotalSummaries"\t"ModuleDuration"\t"ModuleIsBeta"
-"didacticiel-modulix"\t13\t"https://app.recette.pix.fr/modules/didacticiel-modulix"\t"Débutant"\t9\t1\t5\t1\t1\t1\t"=TEXT(5/24/60; ""mm:ss"")"\t"=TRUE"`);
+    expect(
+      modulesListAsCsv,
+    ).to.equal(`\ufeff"ModuleSlug"\t"ModuleTitle"\t"ModuleTotalElements"\t"ModuleLink"\t"ModuleLevel"\t"ModuleTotalGrains"\t"ModuleTotalLessons"\t"ModuleTotalActivities"\t"ModuleTotalChallenges"\t"ModuleTotalDiscoveries"\t"ModuleTotalSummaries"\t"ModuleDuration"\t"ModuleIsBeta"
+"didacticiel-modulix"\t"Didacticiel Modulix"\t13\t"https://app.recette.pix.fr/modules/didacticiel-modulix"\t"Débutant"\t9\t1\t5\t1\t1\t1\t"=TEXT(5/24/60; ""mm:ss"")"\t"=TRUE"`);
   });
 });

--- a/api/tests/devcomp/acceptance/scripts/get-modules-csv_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-modules-csv_test.js
@@ -408,9 +408,8 @@ describe('Acceptance | Script | Get Modules as CSV', function () {
 
     // Then
     expect(modulesListAsCsv).to.be.a('string');
-    expect(
-      modulesListAsCsv,
-    ).to.equal(`\ufeff"ModuleSlug"\t"ModuleTitle"\t"ModuleTotalElements"\t"ModuleLink"\t"ModuleLevel"\t"ModuleTotalGrains"\t"ModuleTotalLessons"\t"ModuleTotalActivities"\t"ModuleTotalChallenges"\t"ModuleTotalDiscoveries"\t"ModuleTotalSummaries"\t"ModuleDuration"\t"ModuleIsBeta"
-"didacticiel-modulix"\t"Didacticiel Modulix"\t13\t"https://app.recette.pix.fr/modules/didacticiel-modulix"\t"Débutant"\t9\t1\t5\t1\t1\t1\t"=TEXT(5/24/60; ""mm:ss"")"\t"=TRUE"`);
+    expect(modulesListAsCsv).to
+      .equal(`\ufeff"ModuleSlug"\t"ModuleTitle"\t"ModuleLevel"\t"ModuleLink"\t"ModuleIsBeta"\t"ModuleTotalGrains"\t"ModuleTotalLessons"\t"ModuleTotalActivities"\t"ModuleTotalChallenges"\t"ModuleTotalDiscoveries"\t"ModuleTotalSummaries"\t"ModuleDuration"\t"ModuleTotalElements"
+"didacticiel-modulix"\t"Didacticiel Modulix"\t"Débutant"\t"https://app.recette.pix.fr/modules/didacticiel-modulix"\t"=TRUE"\t9\t1\t5\t1\t1\t1\t"=TEXT(5/24/60; ""mm:ss"")"\t13`);
   });
 });


### PR DESCRIPTION
## :bacon: Proposition
- Ajouter le champ “moduleTitle” en plus du slug de chaque module
- Revoir l’ordre des colonnes : moduleTitle / module / moduleLevel / moduleLink / ModuleTotalGrains / ModuleTotalLessons... / ModuleTotalDuration / ModuleTotalElements
- Ajouter une colonne contenant objectifs de chaque module

## 🧃 Remarques
On a fait le choix de séparer les objectifs par le caractère `.`. À voir si ça ne créé pas de soucis.

## :yum: Pour tester
Utiliser le script `get-modules-csv.js`

```shell
node scripts/modulix/get-modules-csv.js > modules.csv
```