### PR TITLE
[TECH] Ajouter un sous-composant d'affichage des infos du candidat d'une certification (PIX-16580).

### DIFF
--- a/admin/app/components/certifications/candidate-edit-modal.gjs
+++ b/admin/app/components/certifications/candidate-edit-modal.gjs
@@ -13,12 +13,15 @@ import PixRadioButton from '@1024pix/pix-ui/components/pix-radio-button';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
+import { service } from '@ember/service';
 import pick from 'ember-composable-helpers/helpers/pick';
 import EmberFlatpickr from 'ember-flatpickr/components/ember-flatpickr';
 import set from 'ember-set-helper/helpers/set';
-import { eq } from 'ember-truth-helpers';
+import { eq, or } from 'ember-truth-helpers';
 
 export default class CandidateEditModal extends Component {
+  @service store;
+
   @tracked firstName;
   @tracked lastName;
   @tracked birthdate;
@@ -27,6 +30,7 @@ export default class CandidateEditModal extends Component {
   @tracked birthInseeCode;
   @tracked birthPostalCode;
   @tracked birthCountry;
+  @tracked countries = [];
 
   @tracked selectedBirthGeoCodeOption;
   @tracked selectedCountryInseeCode;
@@ -73,7 +77,7 @@ export default class CandidateEditModal extends Component {
   }
 
   get countryOptions() {
-    return this.args.countries.map((country) => {
+    return this.countries.map((country) => {
       return { label: country.name, value: country.code };
     });
   }
@@ -147,7 +151,7 @@ export default class CandidateEditModal extends Component {
     }
   }
 
-  _initForm() {
+  async _initForm() {
     const candidate = this.args.candidate;
     this.firstName = candidate.firstName;
     this.lastName = candidate.lastName;
@@ -155,6 +159,9 @@ export default class CandidateEditModal extends Component {
     this.sex = candidate.sex;
     this.birthCountry = candidate.birthCountry;
     this._initBirthInformation(candidate);
+    this.countries = this.store.peekAll('country').length
+      ? this.store.peekAll('country')
+      : await this.store.findAll('country');
   }
 
   _initBirthInformation(candidate) {
@@ -187,7 +194,7 @@ export default class CandidateEditModal extends Component {
   }
 
   _getCountryName() {
-    const country = this.args.countries.find((country) => country.code === this.selectedCountryInseeCode);
+    const country = this.countries.find((country) => country.code === this.selectedCountryInseeCode);
     return country.name;
   }
 
@@ -254,7 +261,7 @@ export default class CandidateEditModal extends Component {
               @onChange={{this.updateBirthdate}}
               @dateFormat="Y-m-d"
               @locale="fr"
-              @date={{this.birthdate}}
+              @date={{or this.birthdate ""}}
             />
           </div>
 

--- a/admin/app/components/certifications/certification/informations.gjs
+++ b/admin/app/components/certifications/certification/informations.gjs
@@ -1,13 +1,12 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
-import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
 
-import CandidateEditModal from '../candidate-edit-modal';
 import CertificationCompetenceList from '../competence-list';
 import CertificationInfoField from '../info-field';
 import CertificationIssueReports from '../issue-reports';
 import CertificationComments from './comments';
+import CertificationInformationCandidate from './informations/candidate';
 import CertificationInformationGlobalActions from './informations/global-actions';
 import CertificationInformationState from './informations/state';
 
@@ -18,52 +17,7 @@ import CertificationInformationState from './informations/state';
     </div>
     <div class="certification-informations__row">
       <CertificationInformationState @certification={{@certification}} @session={{@session}} />
-
-      <div class="certification-informations__card">
-        <h2 class="certification-informations__card__title">Candidat</h2>
-        <div class="certification-info-field">
-          <span>Prénom :</span>
-          <span>{{@certification.firstName}}</span>
-        </div>
-        <div class="certification-info-field">
-          <span>Nom de famille :</span>
-          <span>{{@certification.lastName}}</span>
-        </div>
-        <div class="certification-info-field">
-          <span>Date de naissance :</span>
-          <span>{{dayjsFormat @certification.birthdate "DD/MM/YYYY" allow-empty=true}}</span>
-        </div>
-        <div class="certification-info-field">
-          <span>Sexe :</span>
-          <span>{{@certification.sex}}</span>
-        </div>
-        <div class="certification-info-field">
-          <span>Commune de naissance :</span>
-          <span>{{@certification.birthplace}}</span>
-        </div>
-        <div class="certification-info-field">
-          <span>Code postal de naissance :</span>
-          <span>{{@certification.birthPostalCode}}</span>
-        </div>
-        <div class="certification-info-field">
-          <span>Code INSEE de naissance :</span>
-          <span>{{@certification.birthInseeCode}}</span>
-        </div>
-        <div class="certification-info-field">
-          <span>Pays de naissance :</span>
-          <span>{{@certification.birthCountry}}</span>
-        </div>
-
-        <div class="candidate-informations__actions">
-          <PixButton
-            @size="small"
-            @triggerAction={{@openCandidateEditModal}}
-            aria-label="Modifier les informations du candidat"
-          >
-            Modifier infos candidat
-          </PixButton>
-        </div>
-      </div>
+      <CertificationInformationCandidate @certification={{@certification}} />
     </div>
 
     {{#if @certification.hasComplementaryCertifications}}
@@ -194,14 +148,4 @@ import CertificationInformationState from './informations/state';
       </div>
     </div>
   </div>
-
-  {{#if @isCandidateEditModalOpen}}
-    <CandidateEditModal
-      @onCancelButtonsClicked={{@closeCandidateEditModal}}
-      @onFormSubmit={{@onCandidateInformationSave}}
-      @candidate={{@certification}}
-      @countries={{@countries}}
-      @isDisplayed={{@isCandidateEditModalOpen}}
-    />
-  {{/if}}
 </template>

--- a/admin/app/components/certifications/certification/informations/candidate.gjs
+++ b/admin/app/components/certifications/certification/informations/candidate.gjs
@@ -1,0 +1,97 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
+
+import CandidateEditModal from '../../candidate-edit-modal';
+
+export default class CertificationInformationCandidate extends Component {
+  @service pixToast;
+
+  @tracked isCandidateEditModalOpen = false;
+
+  @action
+  toggleCandidateEditModal() {
+    this.isCandidateEditModalOpen = !this.isCandidateEditModalOpen;
+  }
+
+  @action
+  async onCandidateInformationSave() {
+    try {
+      await this.args.certification.save({ adapterOptions: { updateJuryComment: false } });
+
+      this.pixToast.sendSuccessNotification({ message: 'Les informations du candidat ont bien été enregistrées.' });
+      this.isCandidateEditModalOpen = false;
+    } catch (error) {
+      if (error.errors && error.errors.length > 0) {
+        error.errors.forEach((error) => {
+          this.pixToast.sendErrorNotification({ message: error.detail });
+        });
+      } else {
+        this.pixToast.sendErrorNotification({ message: error });
+      }
+      throw error;
+    }
+  }
+
+  <template>
+    <div class="certification-informations__card">
+      <h2 class="certification-informations__card__title">Candidat</h2>
+      <div class="certification-info-field">
+        <span>Prénom :</span>
+        <span>{{@certification.firstName}}</span>
+      </div>
+      <div class="certification-info-field">
+        <span>Nom de famille :</span>
+        <span>{{@certification.lastName}}</span>
+      </div>
+      <div class="certification-info-field">
+        <span>Date de naissance :</span>
+        <span>{{if
+            @certification.birthdate
+            (dayjsFormat @certification.birthdate "DD/MM/YYYY" allow-empty=true)
+            ""
+          }}</span>
+      </div>
+      <div class="certification-info-field">
+        <span>Sexe :</span>
+        <span>{{@certification.sex}}</span>
+      </div>
+      <div class="certification-info-field">
+        <span>Commune de naissance :</span>
+        <span>{{@certification.birthplace}}</span>
+      </div>
+      <div class="certification-info-field">
+        <span>Code postal de naissance :</span>
+        <span>{{@certification.birthPostalCode}}</span>
+      </div>
+      <div class="certification-info-field">
+        <span>Code INSEE de naissance :</span>
+        <span>{{@certification.birthInseeCode}}</span>
+      </div>
+      <div class="certification-info-field">
+        <span>Pays de naissance :</span>
+        <span>{{@certification.birthCountry}}</span>
+      </div>
+
+      <div class="candidate-informations__actions">
+        <PixButton
+          @size="small"
+          @triggerAction={{this.toggleCandidateEditModal}}
+          aria-label="Modifier les informations du candidat"
+        >
+          Modifier infos candidat
+        </PixButton>
+      </div>
+    </div>
+
+    <CandidateEditModal
+      @onCancelButtonsClicked={{this.toggleCandidateEditModal}}
+      @onFormSubmit={{this.onCandidateInformationSave}}
+      @candidate={{@certification}}
+      @isDisplayed={{this.isCandidateEditModalOpen}}
+    />
+  </template>
+}

--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -15,11 +15,9 @@ export default class CertificationInformationsController extends Controller {
 
   // Properties
   @alias('model.certification') certification;
-  @alias('model.countries') countries;
   @service pixToast;
   @service intl;
 
-  @tracked isCandidateEditModalOpen = false;
   @tracked displayJuryLevelSelect = false;
 
   @tracked selectedJuryLevel = null;
@@ -102,24 +100,6 @@ export default class CertificationInformationsController extends Controller {
   }
 
   @action
-  async onCandidateInformationSave() {
-    try {
-      await this.saveCertificationCourse();
-      this.pixToast.sendSuccessNotification({ message: 'Les informations du candidat ont bien été enregistrées.' });
-      this.isCandidateEditModalOpen = false;
-    } catch (error) {
-      if (error.errors && error.errors.length > 0) {
-        error.errors.forEach((error) => {
-          this.pixToast.sendErrorNotification({ message: error.detail });
-        });
-      } else {
-        this.pixToast.sendErrorNotification({ message: error });
-      }
-      throw error;
-    }
-  }
-
-  @action
   async onJuryCommentSave(commentByJury) {
     try {
       await this.saveAssessmentResult(commentByJury);
@@ -129,16 +109,6 @@ export default class CertificationInformationsController extends Controller {
       this.pixToast.sendErrorNotification({ message: "Le commentaire du jury n'a pas pu être enregistré." });
       return false;
     }
-  }
-
-  @action
-  openCandidateEditModal() {
-    this.isCandidateEditModalOpen = true;
-  }
-
-  @action
-  closeCandidateEditModal() {
-    this.isCandidateEditModalOpen = false;
   }
 
   @action

--- a/admin/app/routes/authenticated/certifications/certification/informations.js
+++ b/admin/app/routes/authenticated/certifications/certification/informations.js
@@ -14,7 +14,6 @@ export default class CertificationInformationsRoute extends Route {
       session,
       certification,
       certificationIssueReports,
-      countries: this.store.findAll('country'),
     });
   }
 

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -1,7 +1,6 @@
 <Certifications::Certification::Informations
   @certification={{this.certification}}
   @session={{this.model.session}}
-  @openCandidateEditModal={{this.openCandidateEditModal}}
   @displayJuryLevelSelect={{this.displayJuryLevelSelect}}
   @juryLevelOptions={{this.juryLevelOptions}}
   @selectedJuryLevel={{this.selectedJuryLevel}}
@@ -20,8 +19,4 @@
   @shouldDisplayPixScore={{this.shouldDisplayPixScore}}
   @onUpdateScore={{this.onUpdateScore}}
   @onUpdateLevel={{this.onUpdateLevel}}
-  @isCandidateEditModalOpen={{this.isCandidateEditModalOpen}}
-  @closeCandidateEditModal={{this.closeCandidateEditModal}}
-  @onCandidateInformationSave={{this.onCandidateInformationSave}}
-  @countries={{this.countries}}
 />

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations-test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations-test.js
@@ -87,24 +87,6 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
   });
 
   module('certification information read', function () {
-    test('it displays candidate information', async function (assert) {
-      // given
-      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-
-      // when
-      const screen = await visit(`/certifications/${certification.id}`);
-
-      // then
-      assert.dom(_getInfoNodeFromLabel(screen, 'Prénom :').getByText('Bora Horza')).exists();
-      assert.dom(_getInfoNodeFromLabel(screen, 'Nom de famille :').getByText('Gobuchul')).exists();
-      assert.dom(_getInfoNodeFromLabel(screen, 'Date de naissance :').getByText('24/07/1987')).exists();
-      assert.dom(_getInfoNodeFromLabel(screen, 'Sexe :').getByText('M')).exists();
-      assert.dom(_getInfoNodeFromLabel(screen, 'Commune de naissance :').getByText('Sorpen')).exists();
-      assert.dom(_getInfoNodeFromLabel(screen, 'Code INSEE de naissance :').getByText('99217')).exists();
-      assert.dom(_getInfoNodeFromLabel(screen, 'Code postal de naissance :').getByText('')).exists();
-      assert.dom(_getInfoNodeFromLabel(screen, 'Pays de naissance :').getByText('JAPON')).exists();
-    });
-
     test('it displays the score details by competence', async function (assert) {
       // given
       await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
@@ -561,139 +543,6 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
         assert.strictEqual(screen.getAllByText('Pix+ Édu Initié (entrée dans le métier)').length, 2);
         assert.strictEqual(screen.getAllByText('Pix+ Édu Avancé').length, 1);
       });
-
-      module('when candidate certification was enrolled with CPF data', function () {
-        module('when editing candidate information succeeds', function () {
-          test('should save the candidate information data when modifying them', async function (assert) {
-            // given
-            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-            const screen = await visit('/certifications/123');
-            await clickByName('Modifier les informations du candidat');
-            await screen.findByRole('dialog');
-            // when
-            await fillByLabel('Nom de famille', 'Summers');
-            await fillByLabel('Commune de naissance', 'Sunnydale');
-            await clickByName('Enregistrer');
-
-            // then
-            assert.dom(_getInfoNodeFromLabel(screen, 'Prénom :').getByText('Bora Horza')).exists();
-            assert.dom(_getInfoNodeFromLabel(screen, 'Nom de famille :').getByText('Summers')).exists();
-            assert.dom(_getInfoNodeFromLabel(screen, 'Date de naissance :').getByText('24/07/1987')).exists();
-            assert.dom(_getInfoNodeFromLabel(screen, 'Sexe :').getByText('M')).exists();
-            assert.dom(_getInfoNodeFromLabel(screen, 'Commune de naissance :').getByText('Sunnydale')).exists();
-            assert.dom(_getInfoNodeFromLabel(screen, 'Code INSEE de naissance :').getByText('99217')).exists();
-            assert.dom(_getInfoNodeFromLabel(screen, 'Pays de naissance :').getByText('JAPON')).exists();
-          });
-
-          test('should display a success notification', async function (assert) {
-            // given
-            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-            const screen = await visit('/certifications/123');
-            await clickByName('Modifier les informations du candidat');
-            await screen.findByRole('dialog');
-            // when
-            await fillByLabel('Nom de famille', 'Summers');
-            await fillByLabel('Commune de naissance', 'Sunnydale');
-            await clickByName('Enregistrer');
-
-            // then
-            assert.dom(screen.getByText('Les informations du candidat ont bien été enregistrées.')).exists();
-          });
-
-          test('should close the modal', async function (assert) {
-            // given
-            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-            const screen = await visit('/certifications/123');
-            await clickByName('Modifier les informations du candidat');
-            await screen.findByRole('dialog');
-            // when
-            await fillByLabel('Nom de famille', 'Summers');
-            await fillByLabel('Commune de naissance', 'Sunnydale');
-            await clickByName('Enregistrer');
-
-            // then
-            assert.dom(screen.queryByText('Modifier les informations du candidat')).doesNotExist();
-          });
-        });
-
-        module('when editing candidate information fails', function () {
-          test('should display an error notification', async function (assert) {
-            // given
-            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-            this.server.patch(
-              'admin/certification-courses/:id',
-              () => ({
-                errors: [{ detail: "Candidate's first name must not be blank or empty" }],
-              }),
-              422,
-            );
-            const screen = await visit(`/certifications/${certification.id}`);
-            await clickByName('Modifier les informations du candidat');
-            await screen.findByRole('dialog');
-
-            await fillByLabel('Nom de famille', 'Summers');
-
-            // when
-            await clickByName('Enregistrer');
-            // then
-            assert.dom(await screen.findByText("Candidate's first name must not be blank or empty")).exists();
-          });
-
-          test('should leave the modal opened', async function (assert) {
-            // given
-            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-            this.server.patch(
-              'admin/certification-courses/:id',
-              () => ({
-                errors: [{ detail: "Candidate's first name must not be blank or empty" }],
-              }),
-              422,
-            );
-            const screen = await visit(`/certifications/${certification.id}`);
-            await clickByName('Modifier les informations du candidat');
-            await screen.findByRole('dialog');
-
-            await fillByLabel('Nom de famille', 'Summers');
-
-            // when
-            await clickByName('Enregistrer');
-
-            // then
-            assert.dom(screen.getByRole('heading', { name: 'Modifier les informations du candidat' })).exists();
-          });
-
-          test('should leave candidate information untouched when aborting the edition', async function (assert) {
-            // given
-            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-            this.server.patch(
-              'admin/certification-courses/:id',
-              () => ({
-                errors: [{ detail: "Candidate's first name must not be blank or empty" }],
-              }),
-              422,
-            );
-            const screen = await visit(`/certifications/${certification.id}`);
-            await clickByName('Modifier les informations du candidat');
-
-            await screen.findByRole('dialog');
-
-            await fillByLabel('Nom de famille', 'Summers');
-            await clickByName('Enregistrer');
-
-            // when
-            await clickByName('Fermer');
-
-            // then
-            assert.dom(_getInfoNodeFromLabel(screen, 'Prénom :').getByText('Bora Horza')).exists();
-            assert.dom(_getInfoNodeFromLabel(screen, 'Nom de famille :').getByText('Gobuchul')).exists();
-            assert.dom(_getInfoNodeFromLabel(screen, 'Date de naissance :').getByText('24/07/1987')).exists();
-            assert.dom(_getInfoNodeFromLabel(screen, 'Sexe :').getByText('M')).exists();
-            assert.dom(_getInfoNodeFromLabel(screen, 'Commune de naissance :').getByText('Sorpen')).exists();
-            assert.dom(_getInfoNodeFromLabel(screen, 'Code INSEE de naissance :').getByText('99217')).exists();
-            assert.dom(_getInfoNodeFromLabel(screen, 'Pays de naissance :').getByText('JAPON')).exists();
-          });
-        });
-      });
     });
 
     module('Certification issue reports section', function () {
@@ -856,8 +705,4 @@ async function _switchCertificationDetail(screen, sessionId, certificationId) {
   await click(screen.getByRole('link', { name: sessionId }));
   await click(screen.getByLabelText('Liste des certifications de la session'));
   await click(screen.getByRole('link', { name: certificationId }));
-}
-
-function _getInfoNodeFromLabel(screen, label) {
-  return within(screen.getByText(label).nextElementSibling);
 }

--- a/admin/tests/integration/components/certifications/candidate-edit-modal-test.gjs
+++ b/admin/tests/integration/components/certifications/candidate-edit-modal-test.gjs
@@ -1,5 +1,4 @@
 import { clickByName, fillByLabel, render } from '@1024pix/ember-testing-library';
-import EmberObject from '@ember/object';
 import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setFlatpickrDate } from 'ember-flatpickr/test-support/helpers';
@@ -15,17 +14,23 @@ module('Integration | Component | certifications/candidate-edit-modal', function
 
   hooks.beforeEach(async function () {
     store = this.owner.lookup('service:store');
+    sinon
+      .stub(store, 'findAll')
+      .withArgs('country')
+      .resolves([
+        store.createRecord('country', { code: '99101', name: 'DANEMARK' }),
+        store.createRecord('country', { code: '99100', name: 'FRANCE' }),
+      ]);
   });
 
   module('#display', function () {
     test('it should display the modal', async function (assert) {
       // given
       this.candidate = store.createRecord('certification', { birthdate: '2000-12-15' });
-      this.countries = [];
 
       // when
       const screen = await render(
-        hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`,
+        hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} />`,
       );
 
       // then
@@ -46,14 +51,10 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         birthplace: 'Torreilles',
         birthCountry: 'FRANCE',
       });
-      this.countries = [
-        store.createRecord('country', { code: '99101', name: 'DANEMARK' }),
-        store.createRecord('country', { code: '99100', name: 'FRANCE' }),
-      ];
 
       // when
       const screen = await render(
-        hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`,
+        hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} />`,
       );
 
       // then
@@ -75,14 +76,10 @@ module('Integration | Component | certifications/candidate-edit-modal', function
           birthplace: 'Torreilles',
           birthCountry: 'FRANCE',
         });
-        this.countries = [
-          store.createRecord('country', { code: '99101', name: 'DANEMARK' }),
-          store.createRecord('country', { code: '99100', name: 'FRANCE' }),
-        ];
 
         // when
         const screen = await render(
-          hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`,
+          hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} />`,
         );
 
         // then
@@ -101,14 +98,10 @@ module('Integration | Component | certifications/candidate-edit-modal', function
           birthplace: 'Torreilles',
           birthCountry: 'FRANCE',
         });
-        this.countries = [
-          store.createRecord('country', { code: '99101', name: 'DANEMARK' }),
-          store.createRecord('country', { code: '99100', name: 'FRANCE' }),
-        ];
 
         // when
         const screen = await render(
-          hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`,
+          hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} />`,
         );
 
         // then
@@ -129,14 +122,10 @@ module('Integration | Component | certifications/candidate-edit-modal', function
           birthplace: 'Copenhague',
           birthCountry: 'DANEMARK',
         });
-        this.countries = [
-          store.createRecord('country', { code: '99101', name: 'DANEMARK' }),
-          store.createRecord('country', { code: '99100', name: 'FRANCE' }),
-        ];
 
         // when
         const screen = await render(
-          hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`,
+          hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} />`,
         );
 
         // then
@@ -160,14 +149,10 @@ module('Integration | Component | certifications/candidate-edit-modal', function
           birthplace: 'Torreilles',
           birthCountry: 'FRANCE',
         });
-        this.countries = [
-          store.createRecord('country', { code: '99101', name: 'DANEMARK' }),
-          store.createRecord('country', { code: '99100', name: 'FRANCE' }),
-        ];
 
         // when
         const screen = await render(
-          hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`,
+          hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} />`,
         );
 
         // then
@@ -191,14 +176,10 @@ module('Integration | Component | certifications/candidate-edit-modal', function
           birthplace: 'Torreilles',
           birthCountry: 'FRANCE',
         });
-        this.countries = [
-          store.createRecord('country', { code: '99101', name: 'DANEMARK' }),
-          store.createRecord('country', { code: '99100', name: 'FRANCE' }),
-        ];
 
         // when
         const screen = await render(
-          hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`,
+          hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} />`,
         );
 
         // then
@@ -222,17 +203,12 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         birthplace: 'Copenhague',
         birthCountry: 'DANEMARK',
       });
-      this.countries = [
-        store.createRecord('country', { code: '99101', name: 'DANEMARK' }),
-        store.createRecord('country', { code: '99100', name: 'FRANCE' }),
-      ];
       this.onCancelButtonsClickedStub = sinon.stub();
       const screen = await render(
         hbs`<Certifications::CandidateEditModal
   @isDisplayed={{true}}
   @candidate={{this.candidate}}
   @onCancelButtonsClicked={{this.onCancelButtonsClickedStub}}
-  @countries={{this.countries}}
 />`,
       );
 
@@ -275,17 +251,12 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         birthCountry: 'DANEMARK',
       });
       const initialCandidateInformation = this.candidate.getInformation();
-      this.countries = [
-        store.createRecord('country', { code: '99101', name: 'DANEMARK' }),
-        store.createRecord('country', { code: '99100', name: 'FRANCE' }),
-      ];
       this.onCancelButtonsClickedStub = sinon.stub();
       const screen = await render(
         hbs`<Certifications::CandidateEditModal
   @isDisplayed={{true}}
   @candidate={{this.candidate}}
   @onCancelButtonsClicked={{this.onCancelButtonsClickedStub}}
-  @countries={{this.countries}}
 />`,
       );
       await fillByLabel('Nom de famille', 'Belmans');
@@ -312,14 +283,12 @@ module('Integration | Component | certifications/candidate-edit-modal', function
     test('it should call the onCancelButtonsClicked action', async function (assert) {
       // given
       this.candidate = store.createRecord('certification', { birthdate: '2000-12-15' });
-      this.countries = [];
       this.onCancelButtonsClickedStub = sinon.stub();
       await render(
         hbs`<Certifications::CandidateEditModal
   @isDisplayed={{true}}
   @candidate={{this.candidate}}
   @onCancelButtonsClicked={{this.onCancelButtonsClickedStub}}
-  @countries={{this.countries}}
 />`,
       );
 
@@ -335,14 +304,12 @@ module('Integration | Component | certifications/candidate-edit-modal', function
     test('it should not call the onFormSubmit action if a field is not filled', async function (assert) {
       // given
       this.candidate = store.createRecord('certification', { birthdate: '2000-12-15' });
-      this.countries = [];
       this.onFormSubmitStub = sinon.stub();
       await render(
         hbs`<Certifications::CandidateEditModal
   @isDisplayed={{true}}
   @candidate={{this.candidate}}
   @onFormSubmit={{this.onFormSubmitStub}}
-  @countries={{this.countries}}
 />`,
       );
 
@@ -364,17 +331,12 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         birthplace: 'Copenhague',
         birthCountry: 'DANEMARK',
       });
-      this.countries = [
-        EmberObject.create({ code: '99101', name: 'DANEMARK' }),
-        EmberObject.create({ code: '99100', name: 'FRANCE' }),
-      ];
       this.onFormSubmitStub = sinon.stub();
       const screen = await render(
         hbs`<Certifications::CandidateEditModal
   @isDisplayed={{true}}
   @candidate={{this.candidate}}
   @onFormSubmit={{this.onFormSubmitStub}}
-  @countries={{this.countries}}
 />`,
       );
       await fillByLabel('Nom de famille', 'Belmans');
@@ -410,17 +372,12 @@ module('Integration | Component | certifications/candidate-edit-modal', function
           birthplace: 'PARIS 15',
           birthCountry: 'FRANCE',
         });
-        this.countries = [
-          store.createRecord('country', { code: '99101', name: 'DANEMARK' }),
-          store.createRecord('country', { code: '99100', name: 'FRANCE' }),
-        ];
         this.onFormSubmitStub = sinon.stub();
         this.onFormSubmitStub.resolves();
         const screen = await render(
           hbs`<Certifications::CandidateEditModal
   @isDisplayed={{true}}
   @candidate={{this.candidate}}
-  @countries={{this.countries}}
   @onFormSubmit={{this.onFormSubmitStub}}
 />`,
         );
@@ -460,17 +417,12 @@ module('Integration | Component | certifications/candidate-edit-modal', function
           birthplace: 'Copenhague',
           birthCountry: 'DANEMARK',
         });
-        this.countries = [
-          store.createRecord('country', { code: '99101', name: 'DANEMARK' }),
-          store.createRecord('country', { code: '99100', name: 'FRANCE' }),
-        ];
         this.onFormSubmitStub = sinon.stub();
         this.onFormSubmitStub.resolves();
         const screen = await render(
           hbs`<Certifications::CandidateEditModal
   @isDisplayed={{true}}
   @candidate={{this.candidate}}
-  @countries={{this.countries}}
   @onFormSubmit={{this.onFormSubmitStub}}
 />`,
         );
@@ -511,17 +463,12 @@ module('Integration | Component | certifications/candidate-edit-modal', function
           birthplace: 'Copenhague',
           birthCountry: 'DANEMARK',
         });
-        this.countries = [
-          store.createRecord('country', { code: '99101', name: 'DANEMARK' }),
-          store.createRecord('country', { code: '99100', name: 'FRANCE' }),
-        ];
         this.onFormSubmitStub = sinon.stub();
         this.onFormSubmitStub.resolves();
         const screen = await render(
           hbs`<Certifications::CandidateEditModal
   @isDisplayed={{true}}
   @candidate={{this.candidate}}
-  @countries={{this.countries}}
   @onFormSubmit={{this.onFormSubmitStub}}
 />`,
         );
@@ -564,12 +511,8 @@ module('Integration | Component | certifications/candidate-edit-modal', function
           birthplace: 'PARIS 15',
           birthCountry: 'FRANCE',
         });
-        this.countries = [
-          store.createRecord('country', { code: '99101', name: 'DANEMARK' }),
-          store.createRecord('country', { code: '99100', name: 'FRANCE' }),
-        ];
         const screen = await render(
-          hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`,
+          hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} />`,
         );
 
         // when
@@ -596,9 +539,8 @@ module('Integration | Component | certifications/candidate-edit-modal', function
           birthplace: 'PARIS 15',
           birthCountry: 'FRANCE',
         });
-        this.countries = [];
         const screen = await render(
-          hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`,
+          hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} />`,
         );
 
         // when
@@ -623,9 +565,8 @@ module('Integration | Component | certifications/candidate-edit-modal', function
           birthplace: 'PARIS 15',
           birthCountry: 'FRANCE',
         });
-        this.countries = [];
         const screen = await render(
-          hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`,
+          hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} />`,
         );
 
         // when

--- a/admin/tests/integration/components/certifications/certification/informations-test.gjs
+++ b/admin/tests/integration/components/certifications/certification/informations-test.gjs
@@ -1,6 +1,7 @@
 import { render } from '@1024pix/ember-testing-library';
 import CertificationInformations from 'pix-admin/components/certifications/certification/informations';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
@@ -11,6 +12,7 @@ module('Integration | Component | Certifications | Certification | Informations'
 
   hooks.beforeEach(function () {
     store = this.owner.lookup('service:store');
+    sinon.stub(store, 'findAll').withArgs('country').resolves([]);
   });
 
   test('should display the global actions block', async function (assert) {
@@ -26,6 +28,7 @@ module('Integration | Component | Certifications | Certification | Informations'
     // then
     assert.dom(screen.getByRole('link', { name: "Voir les détails de l'utilisateur" })).exists();
   });
+
   test('should display certification state card', async function (assert) {
     // given
     const certification = store.createRecord('certification', { competencesWithMark: [] });
@@ -38,5 +41,19 @@ module('Integration | Component | Certifications | Certification | Informations'
 
     // then
     assert.dom(screen.getByRole('heading', { name: 'État' })).exists();
+  });
+
+  test('should display the certification candidate card', async function (assert) {
+    // given
+    const certification = store.createRecord('certification', { competencesWithMark: [] });
+    const session = store.createRecord('session', { id: 7404 });
+
+    // when
+    const screen = await render(
+      <template><CertificationInformations @certification={{certification}} @session={{session}} /></template>,
+    );
+
+    // then
+    assert.dom(screen.getByRole('heading', { name: 'Candidat' })).exists();
   });
 });

--- a/admin/tests/integration/components/certifications/certification/informations/candidate-test.gjs
+++ b/admin/tests/integration/components/certifications/certification/informations/candidate-test.gjs
@@ -1,0 +1,157 @@
+import { clickByName, fillByLabel, fireEvent, render, within } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import dayjs from 'dayjs';
+import { setupRenderingTest } from 'ember-qunit';
+import CertificationInformationCandidate from 'pix-admin/components/certifications/certification/informations/candidate';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import { waitForDialogClose } from '../../../../../helpers/wait-for';
+
+module('Integration | Component | Certifications | Certification | Information | Candidate', function (hooks) {
+  setupRenderingTest(hooks);
+
+  let store;
+
+  hooks.beforeEach(function () {
+    store = this.owner.lookup('service:store');
+    sinon.stub(store, 'findAll').withArgs('country').resolves([]);
+  });
+
+  test('should display certification candidate informations', async function (assert) {
+    // given
+    const certification = store.createRecord('certification', {
+      firstName: 'Jane',
+      lastName: 'Doe',
+      birthdate: new Date(),
+      sex: 'F',
+      birthplace: 'Paris',
+      birthPostalCode: '75001',
+      birthInseeCode: '75001',
+      birthCountry: 'France',
+    });
+
+    // when
+    const screen = await render(
+      <template><CertificationInformationCandidate @certification={{certification}} /></template>,
+    );
+
+    // then
+    assert.dom(screen.getByRole('heading', { name: 'Candidat' })).exists();
+
+    const firstNameInfo = screen.getByText('Prénom :');
+    assert.dom(firstNameInfo).exists();
+    assert.dom(within(firstNameInfo.parentNode).getByText(certification.firstName)).exists();
+
+    const lastNameInfo = screen.getByText('Nom de famille :');
+    assert.dom(lastNameInfo).exists();
+    assert.dom(within(lastNameInfo.parentNode).getByText(certification.lastName)).exists();
+
+    const birthdateInfo = screen.getByText('Date de naissance :');
+    assert.dom(birthdateInfo).exists();
+    assert
+      .dom(within(birthdateInfo.parentNode).getByText(dayjs(certification.birthdate).format('DD/MM/YYYY')))
+      .exists();
+
+    const sexInfo = screen.getByText('Sexe :');
+    assert.dom(sexInfo).exists();
+    assert.dom(within(sexInfo.parentNode).getByText(certification.sex)).exists();
+
+    const birthplaceInfo = screen.getByText('Commune de naissance :');
+    assert.dom(birthplaceInfo).exists();
+    assert.dom(within(birthplaceInfo.parentNode).getByText(certification.birthplace)).exists();
+
+    const birthPostalCodeInfo = screen.getByText('Code postal de naissance :');
+    assert.dom(birthPostalCodeInfo).exists();
+    assert.dom(within(birthPostalCodeInfo.parentNode).getByText(certification.birthPostalCode)).exists();
+
+    const birthInseeCodeInfo = screen.getByText('Code INSEE de naissance :');
+    assert.dom(birthInseeCodeInfo).exists();
+    assert.dom(within(birthInseeCodeInfo.parentNode).getByText(certification.birthInseeCode)).exists();
+
+    const birthCountryInfo = screen.getByText('Pays de naissance :');
+    assert.dom(birthCountryInfo).exists();
+    assert.dom(within(birthCountryInfo.parentNode).getByText(certification.birthCountry)).exists();
+  });
+
+  module('edit candidate info', function (hooks) {
+    let screen, errorNotificationStub, successNotificationStub;
+
+    hooks.beforeEach(async function () {
+      // given
+      successNotificationStub = sinon.stub();
+      errorNotificationStub = sinon.stub();
+      class NotificationsStub extends Service {
+        sendSuccessNotification = successNotificationStub;
+        sendErrorNotification = errorNotificationStub;
+      }
+      this.owner.register('service:pixToast', NotificationsStub);
+
+      const certification = store.createRecord('certification', {
+        id: 1,
+        firstName: 'Jane',
+        lastName: 'Doe',
+        birthdate: new Date(),
+        sex: 'F',
+        birthplace: 'Paris',
+        birthPostalCode: '75001',
+        birthInseeCode: '75001',
+        birthCountry: 'France',
+      });
+
+      // when
+      screen = await render(
+        <template><CertificationInformationCandidate @certification={{certification}} /></template>,
+      );
+    });
+
+    test('should be possible to edit the candidate through a modal', async function (assert) {
+      // given
+      const currentCertification = store.peekRecord('certification', 1);
+      currentCertification.save = sinon.stub().resolves();
+
+      // when
+      await fireEvent.click(screen.getByRole('button', { name: 'Modifier les informations du candidat' }));
+
+      await screen.findByRole('dialog');
+
+      // then
+      assert.dom(screen.getByRole('heading', { name: 'Modifier les informations du candidat' })).exists();
+      await fillByLabel('Nom de famille', 'Another name');
+
+      await clickByName('Enregistrer');
+      await waitForDialogClose();
+
+      sinon.assert.calledWith(currentCertification.save, {
+        adapterOptions: { updateJuryComment: false },
+      });
+      sinon.assert.calledWith(successNotificationStub, {
+        message: 'Les informations du candidat ont bien été enregistrées.',
+      });
+
+      assert.dom(screen.queryByRole('button', { name: 'Enregistrer' })).doesNotExist();
+
+      const lastNameInfo = screen.getByText('Nom de famille :');
+      assert.dom(within(lastNameInfo.parentNode).getByText('Another name')).exists();
+    });
+
+    test('on error, should display an error notification', async function (assert) {
+      // given
+      const currentCertification = store.peekRecord('certification', 1);
+      currentCertification.save = sinon.stub().rejects();
+
+      // when
+      await fireEvent.click(screen.getByRole('button', { name: 'Modifier les informations du candidat' }));
+
+      await screen.findByRole('dialog');
+
+      // then
+      assert.dom(screen.getByRole('heading', { name: 'Modifier les informations du candidat' })).exists();
+      await fillByLabel('Nom de famille', 'Another name');
+
+      await clickByName('Enregistrer');
+
+      assert.ok(errorNotificationStub.calledOnce);
+    });
+  });
+});

--- a/admin/tests/unit/controllers/authenticated/certifications/certification/informations-test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/certification/informations-test.js
@@ -361,35 +361,6 @@ module('Unit | Controller | authenticated/certifications/certification/informati
     });
   });
 
-  module('#onCandidateInformationSave', () => {
-    test('it closes the modal', async function (assert) {
-      // given
-      controller.saveCertificationCourse = sinon.stub().resolves();
-      controller.isCandidateEditModalOpen = true;
-
-      // when
-      await controller.onCandidateInformationSave();
-
-      // then
-      assert.false(controller.isCandidateEditModalOpen);
-    });
-
-    test('it saves candidates infos', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const certification = store.createRecord('certification', { competencesWithMark });
-      certification.save = sinon.stub().resolves();
-      controller.certification = certification;
-
-      // when
-      await controller.onCandidateInformationSave();
-
-      // then
-      sinon.assert.calledWith(certification.save, { adapterOptions: { updateJuryComment: false } });
-      assert.ok(true);
-    });
-  });
-
   module('#editJury', function () {
     test('it should set displayJuryLevelSelect to true', function (assert) {
       // given


### PR DESCRIPTION
## :pancakes: Problème

Dans l'objectif d'alléger le template `admin/app/templates/authenticated/certifications/certification/informations.hbs`, il est nécessaire de réussir à alléger son unique composant `admin/app/components/certifications/certification/informations.gjs`.

## :bacon: Proposition

Faire de la composition en créant un sous-composant qui gérera l'affichage des informations utilisateur de la page "Certification > Informations".

## :yum: Pour tester

- Aller sur une page de détails d'une certification [sur Admin en RA](https://admin-pr11426.review.pix.fr/certifications/128968/).
- Constater la non-régression de l'encart "utilisateur"
