### PR TITLE
[TECH] Simplifier l'usage de stratégie de connexions au sein de l'API (PIX-16585).

### DIFF
--- a/api/lib/infrastructure/authentication.js
+++ b/api/lib/infrastructure/authentication.js
@@ -66,10 +66,6 @@ function validateClientApplication(decoded) {
     return { isValid: false, errorCode: 401 };
   }
 
-  if (decoded.scope !== application.scope) {
-    return { isValid: false, errorCode: 403 };
-  }
-
   return { isValid: true, credentials: { client_id: decoded.clientId, scope: decoded.scope, source: decoded.source } };
 }
 

--- a/api/lib/infrastructure/authentication.js
+++ b/api/lib/infrastructure/authentication.js
@@ -109,7 +109,7 @@ async function validateClientApplication(decodedAccessToken) {
   return {
     isValid: true,
     credentials: {
-      client_id: decodedAccessToken.clientId,
+      client_id: decodedAccessToken.client_id,
       scope: decodedAccessToken.scope,
       source: decodedAccessToken.source,
     },

--- a/api/lib/infrastructure/authentication.js
+++ b/api/lib/infrastructure/authentication.js
@@ -30,6 +30,15 @@ const strategies = {
     },
   },
 
+  jwtApplication: {
+    name: 'jwt-application',
+    schemeName: schemes.jwt.name,
+    configuration: {
+      key: config.authentication.secret,
+      validate: validateClientApplication,
+    },
+  },
+
   jwtLivretScolaire: {
     name: 'jwt-livret-scolaire',
     schemeName: schemes.jwt.name,

--- a/api/lib/infrastructure/authentication.js
+++ b/api/lib/infrastructure/authentication.js
@@ -8,108 +8,133 @@ import { tokenService } from '../../src/shared/domain/services/token-service.js'
 
 const { find } = lodash;
 
-const authentication = {
-  schemeName: 'jwt-scheme',
-
-  scheme(_, { key, validate }) {
-    return { authenticate: (request, h) => _checkIsAuthenticated(request, h, { key, validate }) };
+const schemes = {
+  jwt: {
+    name: 'jwt-scheme',
+    scheme(_, strategyConfiguration) {
+      return {
+        authenticate: authenticateJWT(strategyConfiguration),
+      };
+    },
   },
-
-  strategies: [
-    {
-      name: 'jwt-user',
-      configuration: {
-        key: config.authentication.secret,
-        validate: validateUser,
-      },
-    },
-    {
-      name: 'jwt-livret-scolaire',
-      configuration: {
-        key: config.jwtConfig.livretScolaire.secret,
-        validate: validateClientApplication,
-      },
-    },
-    {
-      name: 'jwt-pole-emploi',
-      configuration: {
-        key: config.jwtConfig.poleEmploi.secret,
-        validate: validateClientApplication,
-      },
-    },
-    {
-      name: 'jwt-pix-data',
-      configuration: {
-        key: config.jwtConfig.pixData.secret,
-        validate: validateClientApplication,
-      },
-    },
-    {
-      name: 'jwt-parcoursup',
-      configuration: {
-        key: config.jwtConfig.parcoursup.secret,
-        validate: validateClientApplication,
-      },
-    },
-  ],
-
-  defaultStrategy: 'jwt-user',
 };
 
-function validateUser(decoded) {
-  return { isValid: true, credentials: { userId: decoded.user_id } };
-}
+const strategies = {
+  jwtUser: {
+    name: 'jwt-user',
+    schemeName: schemes.jwt.name,
+    configuration: {
+      key: config.authentication.secret,
+      validate: (decodedAccessToken, options) =>
+        validateUser(decodedAccessToken, { ...options, revokedUserAccessRepository }),
+    },
+  },
 
-function validateClientApplication(decoded) {
-  const application = find(config.apimRegisterApplicationsCredentials, { clientId: decoded.client_id });
-  if (!application) {
-    return { isValid: false, errorCode: 401 };
-  }
+  jwtLivretScolaire: {
+    name: 'jwt-livret-scolaire',
+    schemeName: schemes.jwt.name,
+    configuration: {
+      key: config.jwtConfig.livretScolaire.secret,
+      validate: validateClientApplication,
+    },
+  },
 
-  return { isValid: true, credentials: { client_id: decoded.clientId, scope: decoded.scope, source: decoded.source } };
-}
+  jwtPoleEmploi: {
+    name: 'jwt-pole-emploi',
+    schemeName: schemes.jwt.name,
+    configuration: {
+      key: config.jwtConfig.poleEmploi.secret,
+      validate: validateClientApplication,
+    },
+  },
 
-async function _checkIsAuthenticated(request, h, { key, validate }) {
-  const authorizationHeader = request.headers.authorization;
-  if (!authorizationHeader) {
-    return boom.unauthorized(null, 'jwt');
-  }
+  jwtPixData: {
+    name: 'jwt-pix-data',
+    schemeName: schemes.jwt.name,
+    configuration: {
+      key: config.jwtConfig.pixData.secret,
+      validate: validateClientApplication,
+    },
+  },
 
-  const accessToken = tokenService.extractTokenFromAuthChain(authorizationHeader);
-  if (!accessToken) {
-    return boom.unauthorized();
-  }
+  jwtParcoursup: {
+    name: 'jwt-parcoursup',
+    schemeName: schemes.jwt.name,
+    configuration: {
+      key: config.jwtConfig.parcoursup.secret,
+      validate: validateClientApplication,
+    },
+  },
+};
 
-  const decodedAccessToken = tokenService.getDecodedToken(accessToken, key);
-  if (!decodedAccessToken) {
-    return boom.unauthorized();
-  }
+const authentication = {
+  schemes,
+  strategies,
+};
 
+async function validateUser(decodedAccessToken, { request, revokedUserAccessRepository }) {
   // Only tokens including user_id are User Access Tokens.
   // This is why applications Access Tokens are not subject to audience validation for now.
   const userId = decodedAccessToken.user_id;
   if (config.featureToggles.isUserTokenAudConfinementEnabled && userId) {
     const revokedUserAccess = await revokedUserAccessRepository.findByUserId(userId);
     if (revokedUserAccess.isAccessTokenRevoked(decodedAccessToken)) {
-      return boom.unauthorized();
+      return { isValid: false };
     }
 
     const audience = getForwardedOrigin(request.headers);
     if (decodedAccessToken.aud !== audience) {
-      return boom.unauthorized();
+      return { isValid: false };
     }
   }
 
-  const { isValid, credentials, errorCode } = validate(decodedAccessToken, request, h);
-  if (isValid) {
-    return h.authenticated({ credentials });
-  }
-
-  if (errorCode === 403) {
-    return boom.forbidden();
-  }
-
-  return boom.unauthorized();
+  return { isValid: true, credentials: { userId: decodedAccessToken.user_id } };
 }
 
-export { authentication };
+async function validateClientApplication(decodedAccessToken) {
+  const application = find(config.apimRegisterApplicationsCredentials, { clientId: decodedAccessToken.client_id });
+  if (!application) {
+    return { isValid: false, errorCode: 401 };
+  }
+
+  return {
+    isValid: true,
+    credentials: {
+      client_id: decodedAccessToken.clientId,
+      scope: decodedAccessToken.scope,
+      source: decodedAccessToken.source,
+    },
+  };
+}
+
+function authenticateJWT({ key, validate }) {
+  return async (request, h) => {
+    const authorizationHeader = request.headers.authorization;
+    if (!authorizationHeader) {
+      return boom.unauthorized(null, 'jwt');
+    }
+
+    const accessToken = tokenService.extractTokenFromAuthChain(authorizationHeader);
+    if (!accessToken) {
+      return boom.unauthorized();
+    }
+
+    const decodedAccessToken = tokenService.getDecodedToken(accessToken, key);
+    if (!decodedAccessToken) {
+      return boom.unauthorized();
+    }
+
+    const { isValid, credentials, errorCode } = await validate(decodedAccessToken, { request, h });
+    if (isValid) {
+      return h.authenticated({ credentials });
+    }
+
+    if (errorCode === 403) {
+      return boom.forbidden();
+    }
+
+    return boom.unauthorized();
+  };
+}
+
+export { authentication, validateUser };

--- a/api/server.js
+++ b/api/server.js
@@ -219,11 +219,11 @@ const setupDeserialization = function (server) {
 };
 
 const setupAuthentication = function (server) {
-  server.auth.scheme(authentication.schemeName, authentication.scheme);
-  authentication.strategies.forEach((strategy) => {
-    server.auth.strategy(strategy.name, authentication.schemeName, strategy.configuration);
+  server.auth.scheme(authentication.schemes.jwt.name, authentication.schemes.jwt.scheme);
+  Object.values(authentication.strategies).forEach((strategy) => {
+    server.auth.strategy(strategy.name, strategy.schemeName, strategy.configuration);
   });
-  server.auth.default(authentication.defaultStrategy);
+  server.auth.default(authentication.strategies.jwtUser.name);
 };
 
 const setupRoutesAndPlugins = async function (server) {

--- a/api/server.maddo.js
+++ b/api/server.maddo.js
@@ -166,11 +166,14 @@ const setupDeserialization = function (server) {
 };
 
 const setupAuthentication = function (server) {
-  server.auth.scheme(authentication.schemeName, authentication.scheme);
-  authentication.strategies.forEach((strategy) => {
-    server.auth.strategy(strategy.name, authentication.schemeName, strategy.configuration);
-  });
-  server.auth.default(authentication.defaultStrategy);
+  server.auth.scheme(authentication.schemes.jwt.name, authentication.schemes.jwt.scheme);
+  const jwtApplicationStrategy = authentication.strategies.jwtApplication;
+  server.auth.strategy(
+    jwtApplicationStrategy.name,
+    jwtApplicationStrategy.schemeName,
+    jwtApplicationStrategy.configuration,
+  );
+  server.auth.default(jwtApplicationStrategy.name);
 };
 
 const setupRoutesAndPlugins = async function (server) {

--- a/api/src/certification/results/application/livret-scolaire-route.js
+++ b/api/src/certification/results/application/livret-scolaire-route.js
@@ -10,7 +10,7 @@ const register = async function (server) {
       method: 'GET',
       path: '/api/organizations/{uai}/certifications',
       config: {
-        auth: 'jwt-livret-scolaire',
+        auth: { strategy: 'jwt-livret-scolaire', access: { scope: ['organizations-certifications-result'] } },
         handler: livretScolaireController.getCertificationsByOrganizationUAI,
         notes: [
           '- **API for LSU/LSL qui nécessite une authentification de type client credential grant**\n' +

--- a/api/src/parcoursup/application/certification-route.js
+++ b/api/src/parcoursup/application/certification-route.js
@@ -13,7 +13,7 @@ const register = async function (server) {
       method: 'POST',
       path: '/api/application/parcoursup/certification/search',
       config: {
-        auth: 'jwt-parcoursup',
+        auth: { strategy: 'jwt-parcoursup', access: { scope: 'parcoursup' } },
         validate: {
           payload: Joi.alternatives()
             .try(

--- a/api/src/prescription/campaign-participation/application/pole-emploi-route.js
+++ b/api/src/prescription/campaign-participation/application/pole-emploi-route.js
@@ -10,7 +10,7 @@ const register = async function (server) {
       method: 'GET',
       path: '/api/pole-emploi/envois',
       config: {
-        auth: 'jwt-pole-emploi',
+        auth: { strategy: 'jwt-pole-emploi', access: { scope: 'pole-emploi-participants-result' } },
         handler: poleEmploiController.getSendings,
         notes: [
           '- **API Pôle emploi qui nécessite une authentification de type client credential grant**\n' +

--- a/api/tests/tooling/server/http-test-server.js
+++ b/api/tests/tooling/server/http-test-server.js
@@ -55,11 +55,11 @@ class HttpTestServer {
   }
 
   setupAuthentication() {
-    this.hapiServer.auth.scheme(authentication.schemeName, authentication.scheme);
-    authentication.strategies.forEach((strategy) =>
-      this.hapiServer.auth.strategy(strategy.name, authentication.schemeName, strategy.configuration),
+    this.hapiServer.auth.scheme(authentication.schemes.jwt.name, authentication.schemes.jwt.scheme);
+    Object.values(authentication.strategies).forEach((strategy) =>
+      this.hapiServer.auth.strategy(strategy.name, strategy.schemeName, strategy.configuration),
     );
-    this.hapiServer.auth.default(authentication.defaultStrategy);
+    this.hapiServer.auth.default(authentication.strategies.jwtUser.name);
   }
 
   setupDeserialization() {


### PR DESCRIPTION
## :pancakes: Problème

Actuellement, nous avons une unique stratégie de connexion pour les utilisateurs et une stratégie pour chaque application, servant en réalité de restriction pour les routes. 

## :bacon: Proposition

Nous proposons d'utiliser le scope à bon escient en protégeant les routes avec grâce à `access: { scope: [] }` [proposé par Hapi.js](https://hapi.dev/api/?v=21.3.12#-routeoptionsauthaccessscope). 
Puis, nous proposons un petit refacto du fichier `authentication` avec deux bénéfices : 
- Rendre l'ancienne méthode `_checkIsAuthenticated` renommé au passage en `authenticateJWT` agnostique du token et déléguer la partie spécifique à la méthode `validate` de la stratégie. 
- Nous permettre à l'avenir dans l'API Maddo d'utiliser facilement qu'une seule stratégie. 

Enfin, nous avons ajouté une configuration unique pour toutes les applications 

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

Essayer de se connecter en tant qu'utilisateur et en tant qu'application