### PR TITLE
[FEATURE] Ajouter PixTable dans les certifications complémentaires sur Pix Admin (PIX-16588)

### DIFF
--- a/admin/app/components/complementary-certifications/list.gjs
+++ b/admin/app/components/complementary-certifications/list.gjs
@@ -1,5 +1,8 @@
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { LinkTo } from '@ember/routing';
 import Component from '@glimmer/component';
+import { t } from 'ember-intl';
 
 export default class List extends Component {
   get sortedComplementaryCertifications() {
@@ -7,33 +10,27 @@ export default class List extends Component {
   }
 
   <template>
-    <div class="content-text content-text--small">
-      <div class="table-admin">
-        <table>
-          <thead>
-            <tr>
-              <th class="table__column--id">ID</th>
-              <th>Nom</th>
-            </tr>
-          </thead>
-
-          <tbody>
-            {{#each this.sortedComplementaryCertifications as |complementaryCertification|}}
-              <tr>
-                <td class="table__column--id">{{complementaryCertification.id}}</td>
-                <td>
-                  <LinkTo
-                    @route="authenticated.complementary-certifications.complementary-certification"
-                    @model={{complementaryCertification.id}}
-                  >
-                    {{complementaryCertification.label}}
-                  </LinkTo>
-                </td>
-              </tr>
-            {{/each}}
-          </tbody>
-        </table>
-      </div>
-    </div>
+    <PixTable @data={{this.sortedComplementaryCertifications}}>
+      <:columns as |row sortedComplementaryCertification|>
+        <PixTableColumn @context={{sortedComplementaryCertification}} class="table__column--medium">
+          <:header>
+            {{t "components.complementary-certifications.list.id"}}
+          </:header>
+          <:cell>
+            {{row.id}}
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{sortedComplementaryCertification}}>
+          <:header>
+            {{t "components.complementary-certifications.list.name"}}
+          </:header>
+          <:cell>
+            <LinkTo @route="authenticated.complementary-certifications.complementary-certification" @model={{row.id}}>
+              {{row.label}}
+            </LinkTo>
+          </:cell>
+        </PixTableColumn>
+      </:columns>
+    </PixTable>
   </template>
 }

--- a/admin/app/components/complementary-certifications/target-profiles/badges-list.gjs
+++ b/admin/app/components/complementary-certifications/target-profiles/badges-list.gjs
@@ -1,3 +1,5 @@
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { array } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
 import Component from '@glimmer/component';
@@ -14,54 +16,63 @@ export default class BadgesList extends Component {
 
   <template>
     <section class="page-section">
-      <div class="content-text content-text--small">
-        <h2 class="complementary-certification-details__badges-title">
-          {{t "components.complementary-certifications.target-profiles.badges-list.title"}}
-        </h2>
-        <div class="table-admin">
-          <table>
-            <thead>
-              <tr>
-                <th>{{t "components.complementary-certifications.target-profiles.badges-list.header.image-url"}}</th>
-                <th class="complementary-certification-details-table__complementary-certification-badge-name">
-                  {{t "components.complementary-certifications.target-profiles.badges-list.header.name"}}
-                </th>
-                <th>{{t "components.complementary-certifications.target-profiles.badges-list.header.level"}}</th>
-                <th>
-                  {{t "components.complementary-certifications.target-profiles.badges-list.header.minimum-earned-pix"}}
-                </th>
-                <th>{{t "components.complementary-certifications.target-profiles.badges-list.header.id"}}</th>
-              </tr>
-            </thead>
-
-            <tbody>
-              {{#each this.currentTargetProfileBadges as |badge|}}
-                <tr>
-                  <td>
-                    <img
-                      class="complementary-certification-details-table__complementary-certification-badge-image-url"
-                      src={{badge.imageUrl}}
-                      alt="{{badge.label}}"
-                    />
-                  </td>
-                  <td>{{badge.label}}</td>
-                  <td>{{badge.level}}</td>
-                  <td>{{this.getMinimumEarnedPixValue badge.minimumEarnedPix}}</td>
-                  <td>
-                    <LinkTo
-                      @route="authenticated.target-profiles.target-profile.badges.badge"
-                      @models={{array @currentTargetProfile.id badge.id}}
-                      target="_blank"
-                    >
-                      {{badge.id}}
-                    </LinkTo>
-                  </td>
-                </tr>
-              {{/each}}
-            </tbody>
-          </table>
-        </div>
-      </div>
+      <h2 class="complementary-certification-details__badges-title">
+        {{t "components.complementary-certifications.target-profiles.badges-list.title"}}
+      </h2>
+      <PixTable @data={{this.currentTargetProfileBadges}}>
+        <:columns as |row currentTargetProfileBadge|>
+          <PixTableColumn @context={{currentTargetProfileBadge}}>
+            <:header>
+              {{t "components.complementary-certifications.target-profiles.badges-list.header.image-url"}}
+            </:header>
+            <:cell>
+              <img
+                class="complementary-certification-details-table__complementary-certification-badge-image-url"
+                src={{row.imageUrl}}
+                alt="{{row.label}}"
+              />
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{currentTargetProfileBadge}} class="table__column--wide">
+            <:header>
+              {{t "components.complementary-certifications.target-profiles.badges-list.header.name"}}
+            </:header>
+            <:cell>
+              {{row.label}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{currentTargetProfileBadge}}>
+            <:header>
+              {{t "components.complementary-certifications.target-profiles.badges-list.header.level"}}
+            </:header>
+            <:cell>
+              {{row.level}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{currentTargetProfileBadge}}>
+            <:header>
+              {{t "components.complementary-certifications.target-profiles.badges-list.header.minimum-earned-pix"}}
+            </:header>
+            <:cell>
+              {{this.getMinimumEarnedPixValue row.minimumEarnedPix}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{currentTargetProfileBadge}}>
+            <:header>
+              {{t "components.complementary-certifications.target-profiles.badges-list.header.id"}}
+            </:header>
+            <:cell>
+              <LinkTo
+                @route="authenticated.target-profiles.target-profile.badges.badge"
+                @models={{array @currentTargetProfile.id row.id}}
+                target="_blank"
+              >
+                {{row.id}}
+              </LinkTo>
+            </:cell>
+          </PixTableColumn>
+        </:columns>
+      </PixTable>
     </section>
   </template>
 }

--- a/admin/app/components/complementary-certifications/target-profiles/history.gjs
+++ b/admin/app/components/complementary-certifications/target-profiles/history.gjs
@@ -1,42 +1,47 @@
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { LinkTo } from '@ember/routing';
 import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
+import { t } from 'ember-intl';
 
 <template>
   <section class="page-section">
-    <div class="content-text content-text--small">
-      <h2 class="complementary-certification-details__history-title">
-        Historique des profils cibles rattachés
-      </h2>
-      <div class="table-admin">
-        <table>
-          <thead>
-            <tr>
-              <th>Nom du profil cible</th>
-              <th>Date de rattachement</th>
-              <th>Date de détachement</th>
-            </tr>
-          </thead>
-          <tbody>
-            {{#each @targetProfilesHistory as |targetProfileHistory|}}
-              <tr>
-                <td>
-                  <LinkTo
-                    @route="authenticated.target-profiles.target-profile"
-                    @model={{targetProfileHistory.id}}
-                    class="complementary-certification-details-target-profile__link"
-                  >
-                    {{targetProfileHistory.name}}
-                  </LinkTo>
-                </td>
-                <td>{{dayjsFormat targetProfileHistory.attachedAt "DD/MM/YYYY"}}</td>
-                <td>
-                  {{if targetProfileHistory.detachedAt (dayjsFormat targetProfileHistory.detachedAt "DD/MM/YYYY") "-"}}
-                </td>
-              </tr>
-            {{/each}}
-          </tbody>
-        </table>
-      </div>
-    </div>
+    <h2 class="complementary-certification-details__history-title">
+      {{t "components.complementary-certifications.target-profiles.history-list.title"}}
+    </h2>
+    <PixTable @data={{@targetProfilesHistory}}>
+      <:columns as |row targetProfileHistory|>
+        <PixTableColumn @context={{targetProfileHistory}}>
+          <:header>
+            {{t "components.complementary-certifications.target-profiles.history-list.headers.name"}}
+          </:header>
+          <:cell>
+            <LinkTo
+              @route="authenticated.target-profiles.target-profile"
+              @model={{row.id}}
+              class="complementary-certification-details-target-profile__link"
+            >
+              {{row.name}}
+            </LinkTo>
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{targetProfileHistory}}>
+          <:header>
+            {{t "components.complementary-certifications.target-profiles.history-list.headers.attached-at"}}
+          </:header>
+          <:cell>
+            {{dayjsFormat row.attachedAt "DD/MM/YYYY"}}
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{targetProfileHistory}}>
+          <:header>
+            {{t "components.complementary-certifications.target-profiles.history-list.headers.detached-at"}}
+          </:header>
+          <:cell>
+            {{if row.detachedAt (dayjsFormat row.detachedAt "DD/MM/YYYY") "-"}}
+          </:cell>
+        </PixTableColumn>
+      </:columns>
+    </PixTable>
   </section>
 </template>

--- a/admin/app/components/complementary-certifications/target-profiles/information.gjs
+++ b/admin/app/components/complementary-certifications/target-profiles/information.gjs
@@ -28,8 +28,8 @@ export default class Information extends Component {
         {{#if this.isMultipleCurrentTargetProfiles}}
           <PixToggleButton @toggled={{@switchToggle}} @onChange={{@switchTargetProfile}} @screenReaderOnly={{true}}>
             <:label>Accéder aux détails des profils cibles courants</:label>
-            <:on>Profil 1</:on>
-            <:off>Profil 2</:off>
+            <:viewA>Profil 1</:viewA>
+            <:viewB>Profil 2</:viewB>
           </PixToggleButton>
         {{/if}}
         {{#if this.hasAccessToAttachNewTargetProfile}}

--- a/admin/app/templates/authenticated/complementary-certifications/list.hbs
+++ b/admin/app/templates/authenticated/complementary-certifications/list.hbs
@@ -1,5 +1,5 @@
 <header class="page-header">
-  <h1>Toutes les certifications complémentaires</h1>
+  <h1>{{t "components.complementary-certifications.title"}}</h1>
 </header>
 
 <main class="page-body">

--- a/admin/tests/integration/components/complementary-certifications/target-profiles/history-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/target-profiles/history-test.gjs
@@ -1,11 +1,12 @@
 import { render } from '@1024pix/ember-testing-library';
 import dayjs from 'dayjs';
-import { setupRenderingTest } from 'ember-qunit';
 import History from 'pix-admin/components/complementary-certifications/target-profiles/history';
 import { module, test } from 'qunit';
 
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | complementary-certifications/target-profiles/history', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test("it should display history for complementary certification's target profiles", async function (assert) {
     // given

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -298,6 +298,10 @@
       }
     },
     "complementary-certifications": {
+      "list": {
+        "id": "ID",
+        "name": "Nom"
+      },
       "target-profiles": {
         "badges-list": {
           "header": {
@@ -309,7 +313,8 @@
           },
           "title": "Badges certifiés du profil cible actuel"
         }
-      }
+      },
+      "title": "Toutes les certifications complémentaires"
     },
     "layout": {
       "menu-bar": {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -312,6 +312,14 @@
             "name": "Nom du badge certifié"
           },
           "title": "Badges certifiés du profil cible actuel"
+        },
+        "history-list": {
+          "headers": {
+            "attached-at": "Date de rattachement",
+            "detached-at": "Date de détachement",
+            "name": "Nom du profil cible"
+          },
+          "title": "Historique des profils cibles rattachés"
         }
       },
       "title": "Toutes les certifications complémentaires"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -320,6 +320,14 @@
             "name": "Nom du badge certifié"
           },
           "title": "Badges certifiés du profil cible actuel"
+        },
+        "history-list": {
+          "headers": {
+            "attached-at": "Date de rattachement",
+            "detached-at": "Date de détachement",
+            "name": "Nom du profil cible"
+          },
+          "title": "Historique des profils cibles rattachés"
         }
       },
       "title": "Toutes les certifications complémentaires"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -306,6 +306,10 @@
       }
     },
     "complementary-certifications": {
+      "list": {
+        "id": "ID",
+        "name": "Nom"
+      },
       "target-profiles": {
         "badges-list": {
           "header": {
@@ -317,7 +321,8 @@
           },
           "title": "Badges certifiés du profil cible actuel"
         }
-      }
+      },
+      "title": "Toutes les certifications complémentaires"
     },
     "layout": {
       "menu-bar": {


### PR DESCRIPTION
## :pancakes: Problème

Le composant PixTable existe mais n'est pas du tout utilisé dans nos applications

## :bacon: Proposition

Commencer par des tableaux simples => certification complémentaire

## :yum: Pour tester

Vérifier que les liens dans les tableaux fonctionnent correctement.

https://admin-pr11429.review.pix.fr/complementary-certifications/list
cliquer sur une des certifications complémentaires pour voir les autres tables

<img width="1727" alt="Capture d’écran 2025-02-17 à 10 28 44" src="https://github.com/user-attachments/assets/bcc788cf-16a4-45e5-9e0b-9fcea49b39e4" />
<img width="1727" alt="Capture d’écran 2025-02-17 à 10 28 54" src="https://github.com/user-attachments/assets/9fd54db2-087d-4d44-8eb2-050516816ef9" />

