### PR TITLE
[BUGFIX] Augmente la durée maximum du job de calcul de la certificabilité.

### DIFF
--- a/api/src/prescription/learner-management/application/jobs/schedule-compute-organization-learners-certificability-job-controller.js
+++ b/api/src/prescription/learner-management/application/jobs/schedule-compute-organization-learners-certificability-job-controller.js
@@ -5,6 +5,7 @@ import { ComputeCertificabilityJob } from '../../../../prescription/learner-mana
 import { JobScheduleController } from '../../../../shared/application/jobs/job-schedule-controller.js';
 import { config } from '../../../../shared/config.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { JobExpireIn } from '../../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import * as organizationLearnerRepository from '../../../../shared/infrastructure/repositories/organization-learner-repository.js';
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 import { computeCertificabilityJobRepository } from '../../../learner-management/infrastructure/repositories/jobs/compute-certificability-job-repository.js';
@@ -14,6 +15,7 @@ class ScheduleComputeOrganizationLearnersCertificabilityJobController extends Jo
   constructor() {
     super('ScheduleComputeOrganizationLearnersCertificabilityJob', {
       jobCron: config.features.scheduleComputeOrganizationLearnersCertificability.cron,
+      expireIn: JobExpireIn.FOUR_HOURS,
     });
   }
 

--- a/api/src/shared/application/jobs/job-controller.js
+++ b/api/src/shared/application/jobs/job-controller.js
@@ -2,6 +2,7 @@ import Joi from 'joi';
 
 import { config } from '../../config.js';
 import { EntityValidationError } from '../../domain/errors.js';
+import { JobExpireIn } from '../../infrastructure/repositories/jobs/job-repository.js';
 
 export const JobGroup = {
   DEFAULT: 'default',
@@ -11,7 +12,8 @@ export const JobGroup = {
 export class JobController {
   constructor(jobName, options = {}) {
     this.jobName = jobName;
-    this.jobGroup = options.jobGroup || JobGroup.DEFAULT;
+    this.jobGroup = options.jobGroup ?? JobGroup.DEFAULT;
+    this.expireIn = options.expireIn ?? JobExpireIn.DEFAULT;
 
     this.#validate();
   }

--- a/api/src/shared/infrastructure/repositories/jobs/job-repository.js
+++ b/api/src/shared/infrastructure/repositories/jobs/job-repository.js
@@ -131,4 +131,5 @@ export const JobRetry = Object.freeze({
 export const JobExpireIn = Object.freeze({
   DEFAULT: '00:15:00',
   HIGH: '00:30:00',
+  FOUR_HOURS: '04:00:00',
 });

--- a/api/tests/shared/unit/application/jobs/job-controller_test.js
+++ b/api/tests/shared/unit/application/jobs/job-controller_test.js
@@ -1,5 +1,6 @@
 import { JobController, JobGroup } from '../../../../../src/shared/application/jobs/job-controller.js';
 import { EntityValidationError } from '../../../../../src/shared/domain/errors.js';
+import { JobExpireIn } from '../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
 import { catchErrSync, expect } from '../../../../test-helper.js';
 
 describe('Unit | Shared | Application | Jobs | JobController', function () {
@@ -29,6 +30,7 @@ describe('Unit | Shared | Application | Jobs | JobController', function () {
     // given
     const jobName = 'jobName';
     const jobGroup = JobGroup.DEFAULT;
+    const expireIn = JobExpireIn.DEFAULT;
 
     // when
     const controller = new JobController(jobName);
@@ -37,6 +39,7 @@ describe('Unit | Shared | Application | Jobs | JobController', function () {
     expect(controller).to.be.instanceOf(JobController).and.to.deep.equal({
       jobName,
       jobGroup,
+      expireIn,
     });
   });
 

--- a/api/tests/unit/worker_test.js
+++ b/api/tests/unit/worker_test.js
@@ -6,6 +6,7 @@ import { ValidateOrganizationImportFileJob } from '../../src/prescription/learne
 import { UserAnonymizedEventLoggingJobController } from '../../src/shared/application/jobs/audit-log/user-anonymized-event-logging-job-controller.js';
 import { JobGroup } from '../../src/shared/application/jobs/job-controller.js';
 import { config } from '../../src/shared/config.js';
+import { JobExpireIn } from '../../src/shared/infrastructure/repositories/jobs/job-repository.js';
 import { registerJobs } from '../../worker.js';
 import { catchErr, expect, sinon } from '../test-helper.js';
 
@@ -136,7 +137,7 @@ describe('#registerJobs', function () {
       expect(jobQueueStub.scheduleCronJob).to.have.been.calledWithExactly({
         name: 'ScheduleComputeOrganizationLearnersCertificabilityJob',
         cron: '0 21 * * *',
-        options: { tz: 'Europe/Paris' },
+        options: { tz: 'Europe/Paris', expireIn: JobExpireIn.FOUR_HOURS },
       });
     });
 

--- a/api/worker.js
+++ b/api/worker.js
@@ -105,7 +105,11 @@ export async function registerJobs({ jobGroup, dependencies = { startPgBoss, cre
       }
 
       if (job.jobCron) {
-        await jobQueues.scheduleCronJob({ name: job.jobName, cron: job.jobCron, options: { tz: 'Europe/Paris' } });
+        await jobQueues.scheduleCronJob({
+          name: job.jobName,
+          cron: job.jobCron,
+          options: { tz: 'Europe/Paris', expireIn: job.expireIn },
+        });
         logger.info(`Cron for job "${job.jobName}" scheduled "${job.jobCron}"`);
 
         // For cronJob we need to unschedule older cron


### PR DESCRIPTION
## :pancakes: Problème

Suite au changement du calcul de certificabilité pour le rendre synchrone, le job, qui s'occupait auparavant uniquement de planifier les calculs, dépasse le temps par défaut de 15 minutes.

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## :bacon: Proposition

On modifie le constructeur du `JobScheduleController` pour accepter comme option un `expireIn` permettant de modifier la durée d'expiration d'un job planifié.
On ajuste cette option à 4h pour le job de calcul de la certificabilité.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

A voir avec @1024pix/team-prescription 

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
