### PR TITLE
[FEATURE] Migrer les applications en BDD (PIX-16590).

### DIFF
--- a/api/db/database-builder/factory/build-client-application.js
+++ b/api/db/database-builder/factory/build-client-application.js
@@ -1,0 +1,20 @@
+import { databaseBuffer } from '../database-buffer.js';
+
+export function buildClientApplication({
+  id = databaseBuffer.getNextId(),
+  name = 'clientApplication',
+  clientId = 'client-id',
+  clientSecret = 'super-secret',
+  scopes = ['scope1', 'scope2'],
+} = {}) {
+  return databaseBuffer.pushInsertable({
+    tableName: 'client_applications',
+    values: {
+      id,
+      name,
+      clientId,
+      clientSecret,
+      scopes,
+    },
+  });
+}

--- a/api/db/database-builder/factory/build-client-application.js
+++ b/api/db/database-builder/factory/build-client-application.js
@@ -1,3 +1,4 @@
+import { cryptoService } from '../../../src/shared/domain/services/crypto-service.js';
 import { databaseBuffer } from '../database-buffer.js';
 
 export function buildClientApplication({
@@ -7,13 +8,15 @@ export function buildClientApplication({
   clientSecret = 'super-secret',
   scopes = ['scope1', 'scope2'],
 } = {}) {
+  // eslint-disable-next-line no-sync
+  const hashedSecret = cryptoService.hashPasswordSync(clientSecret);
   return databaseBuffer.pushInsertable({
     tableName: 'client_applications',
     values: {
       id,
       name,
       clientId,
-      clientSecret,
+      clientSecret: hashedSecret,
       scopes,
     },
   });

--- a/api/db/migrations/20250213133525_create-table-client-applications.js
+++ b/api/db/migrations/20250213133525_create-table-client-applications.js
@@ -1,0 +1,25 @@
+const TABLE_NAME = 'client_applications';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.increments('id').primary().notNullable().comment('Identifiant d’une application tierce');
+    table.string('name').notNullable().unique().comment('Nom de l’application tierce');
+    table.string('clientId').notNullable().unique().comment('ID du client de l’application tierce');
+    table.string('clientSecret').notNullable().comment('Secret du client de l’application tierce');
+    table.specificType('scopes', 'varchar(255)[]').notNullable().comment('Scopes autorisés pour l’application');
+    table.timestamps(false, true, true);
+    table.comment('Applications tierces');
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+}

--- a/api/db/seeds/data/common/common-builder.js
+++ b/api/db/seeds/data/common/common-builder.js
@@ -11,6 +11,8 @@ export const commonBuilder = async function ({ databaseBuilder }) {
   _createSupportAdmin(databaseBuilder);
   _createMetierAdmin(databaseBuilder);
 
+  createClientApplications(databaseBuilder);
+
   await _createPublicTargetProfile(databaseBuilder);
   await databaseBuilder.commit();
 };
@@ -57,6 +59,33 @@ function _createCertifAdmin(databaseBuilder) {
     rawPassword: DEFAULT_PASSWORD,
   });
   databaseBuilder.factory.buildPixAdminRole({ userId: REAL_PIX_SUPER_ADMIN_ID + 3, role: ROLES.CERTIF });
+}
+
+function createClientApplications(databaseBuilder) {
+  databaseBuilder.factory.buildClientApplication({
+    name: 'livretScolaire',
+    clientId: 'livretScolaire',
+    clientSecret: 'livretScolaireSecret',
+    scopes: ['organizations-certifications-result'],
+  });
+  databaseBuilder.factory.buildClientApplication({
+    name: 'poleEmploi',
+    clientId: 'poleEmploi',
+    clientSecret: 'poleemploisecret',
+    scopes: ['pole-emploi-participants-result'],
+  });
+  databaseBuilder.factory.buildClientApplication({
+    name: 'pixData',
+    clientId: 'pixData',
+    clientSecret: 'pixdatasecret',
+    scopes: ['statistics'],
+  });
+  databaseBuilder.factory.buildClientApplication({
+    name: 'parcoursup',
+    clientId: 'parcoursup',
+    clientSecret: 'parcoursupsecret',
+    scopes: ['parcoursup'],
+  });
 }
 
 function _createPublicTargetProfile(databaseBuilder) {

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -79,6 +79,7 @@ import * as resetPasswordService from '../../../src/identity-access-management/d
 import { scoAccountRecoveryService } from '../../../src/identity-access-management/domain/services/sco-account-recovery.service.js';
 import { accountRecoveryDemandRepository } from '../../../src/identity-access-management/infrastructure/repositories/account-recovery-demand.repository.js';
 import * as authenticationMethodRepository from '../../../src/identity-access-management/infrastructure/repositories/authentication-method.repository.js';
+import { clientApplicationRepository } from '../../../src/identity-access-management/infrastructure/repositories/client-application.repository.js';
 import { emailValidationDemandRepository } from '../../../src/identity-access-management/infrastructure/repositories/email-validation-demand.repository.js';
 // Not used in lib
 import { userAnonymizedEventLoggingJobRepository } from '../../../src/identity-access-management/infrastructure/repositories/jobs/user-anonymized-event-logging-job-repository.js';
@@ -244,6 +245,7 @@ const dependencies = {
   certificationCpfCityRepository,
   certificationOfficerRepository,
   challengeRepository,
+  clientApplicationRepository,
   codeGenerator,
   codeUtils,
   competenceEvaluationRepository,

--- a/api/scripts/prod/migrate-client-application.js
+++ b/api/scripts/prod/migrate-client-application.js
@@ -1,0 +1,44 @@
+import { knex } from '../../db/knex-database-connection.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+import { config } from '../../src/shared/config.js';
+import { cryptoService } from '../../src/shared/domain/services/crypto-service.js';
+
+export class MigrateClientApplicationScript extends Script {
+  constructor() {
+    super({
+      description: 'This script will migrate client application from environment variables (config) to database.',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          default: true,
+          description: 'when true does not insert to database',
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    await knex.transaction(async (trx) => {
+      const { apimRegisterApplicationsCredentials } = config;
+
+      for (const clientApplication of apimRegisterApplicationsCredentials) {
+        const query = trx('client_applications').insert({
+          clientId: clientApplication.clientId,
+          clientSecret: await cryptoService.hashPassword(clientApplication.clientSecret),
+          name: clientApplication.source,
+          scopes: [clientApplication.scope],
+        });
+        logger.info({ event: 'MigrateClientApplicationScript' }, query.toString());
+        await query;
+      }
+      if (options.dryRun) {
+        logger.info({ event: 'MigrateClientApplicationScript' }, 'Dry run, rolling back insertions');
+        await trx.rollback();
+      }
+    });
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, MigrateClientApplicationScript);

--- a/api/src/identity-access-management/domain/models/ClientApplication.js
+++ b/api/src/identity-access-management/domain/models/ClientApplication.js
@@ -1,0 +1,9 @@
+export class ClientApplication {
+  constructor({ id, name, clientId, clientSecret, scopes }) {
+    this.id = id;
+    this.name = name;
+    this.clientId = clientId;
+    this.clientSecret = clientSecret;
+    this.scopes = scopes;
+  }
+}

--- a/api/src/identity-access-management/infrastructure/repositories/client-application.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/client-application.repository.js
@@ -1,0 +1,16 @@
+import { knex } from '../../../../db/knex-database-connection.js';
+import { ClientApplication } from '../../domain/models/ClientApplication.js';
+
+const TABLE_NAME = 'client_applications';
+
+export const clientApplicationRepository = {
+  async findByClientId(clientId) {
+    const dto = await knex.select().from(TABLE_NAME).where({ clientId }).first();
+    if (!dto) return undefined;
+    return toDomain(dto);
+  },
+};
+
+function toDomain(dto) {
+  return new ClientApplication(dto);
+}

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -658,6 +658,7 @@ const configuration = (function () {
     };
 
     config.jwtConfig.livretScolaire.secret = 'test-secretOsmose';
+    config.jwtConfig.livretScolaire.tokenLifespan = '4h';
     config.jwtConfig.poleEmploi.secret = 'test-secretPoleEmploi';
     config.jwtConfig.pixData.secret = 'test-secretPixData';
     config.jwtConfig.parcoursup.secret = 'test-secretPixParcoursup';

--- a/api/tests/acceptance/application/authentication/authentication-route_test.js
+++ b/api/tests/acceptance/application/authentication/authentication-route_test.js
@@ -133,6 +133,14 @@ describe('Acceptance | Controller | authentication-controller', function () {
           'x-forwarded-host': 'app.pix.fr',
         },
       };
+
+      databaseBuilder.factory.buildClientApplication({
+        name: 'osmose',
+        clientId: OSMOSE_CLIENT_ID,
+        clientSecret: OSMOSE_CLIENT_SECRET,
+        scopes: [SCOPE],
+      });
+      await databaseBuilder.commit();
     });
 
     it('should return an 200 with accessToken when clientId, client secret and scope are registred', async function () {

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/client-application.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/client-application.repository.test.js
@@ -1,0 +1,51 @@
+import { clientApplicationRepository } from '../../../../../src/identity-access-management/infrastructure/repositories/client-application.repository.js';
+import { databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
+
+describe('Integration | Identity Access Management | Infrastructure | Repository | client-application', function () {
+  describe('#findByClientId', function () {
+    let application2;
+
+    beforeEach(async function () {
+      databaseBuilder.factory.buildClientApplication({
+        name: 'appli1',
+        clientId: 'clientId-appli1',
+        clientSecret: 'secret-app1',
+        scopes: ['scope1', 'scope2'],
+      });
+      application2 = databaseBuilder.factory.buildClientApplication({
+        name: 'appli2',
+        clientId: 'clientId-appli2',
+        clientSecret: 'secret-app2',
+        scopes: ['scope3', 'scope4', 'scope5'],
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    context('when application name is not found', function () {
+      it('should return undefined', async function () {
+        // given
+        const clientId = 'clientId-appli3';
+
+        // when
+        const application = await clientApplicationRepository.findByClientId(clientId);
+
+        // then
+        expect(application).to.be.undefined;
+      });
+    });
+
+    context('when application name is found', function () {
+      it('should return the application model', async function () {
+        // given
+        const clientId = 'clientId-appli2';
+
+        // when
+        const application = await clientApplicationRepository.findByClientId(clientId);
+
+        // then
+        expect(application).to.deepEqualInstance(domainBuilder.buildClientApplication(application2));
+      });
+    });
+  });
+});

--- a/api/tests/integration/scripts/prod/migrate-client-application_test.js
+++ b/api/tests/integration/scripts/prod/migrate-client-application_test.js
@@ -1,0 +1,78 @@
+import { MigrateClientApplicationScript } from '../../../../scripts/prod/migrate-client-application.js';
+import { cryptoService } from '../../../../src/shared/domain/services/crypto-service.js';
+import { expect, knex, sinon } from '../../../test-helper.js';
+
+let logger;
+
+describe('Script | Prod | migrate client application', function () {
+  describe('Options', function () {
+    it('has the correct options', function () {
+      // when
+      const script = new MigrateClientApplicationScript();
+      const { options, description, permanent } = script.metaInfo;
+      expect(permanent).to.be.false;
+      expect(description).to.equal(
+        'This script will migrate client application from environment variables (config) to database.',
+      );
+      // then
+      expect(options.dryRun).to.deep.include({
+        type: 'boolean',
+        default: true,
+        description: 'when true does not insert to database',
+      });
+    });
+  });
+
+  describe('Handle', function () {
+    beforeEach(function () {
+      logger = { info: sinon.spy() };
+    });
+
+    describe('when dryRun is false', function () {
+      it('inserts client application to database', async function () {
+        const script = new MigrateClientApplicationScript();
+
+        await script.handle({ options: { dryRun: false }, logger });
+
+        const clientApplications = await knex('client_applications').select('*');
+        expect(clientApplications).to.have.lengthOf(4);
+        expect(clientApplications[0].clientId).to.equal('test-apimOsmoseClientId');
+        await cryptoService.checkPassword({
+          password: 'test-apimOsmoseClientSecret',
+          passwordHash: clientApplications[0].clientSecret,
+        });
+        expect(clientApplications[0].scopes).to.deep.equal(['organizations-certifications-result']);
+        expect(clientApplications[0].name).to.equal('livretScolaire');
+      });
+
+      it('logs progress', async function () {
+        const script = new MigrateClientApplicationScript();
+
+        await script.handle({ options: { dryRun: false }, logger });
+
+        expect(logger.info).to.have.callCount(4);
+        expect(logger.info).to.have.been.always.calledWith({ event: 'MigrateClientApplicationScript' });
+      });
+    });
+
+    describe('when dryRun is true', function () {
+      it('does not insert any client application to database', async function () {
+        const script = new MigrateClientApplicationScript();
+
+        await script.handle({ options: { dryRun: true }, logger });
+
+        const clientApplications = await knex('client_applications').select('*');
+        expect(clientApplications).to.have.lengthOf(0);
+      });
+
+      it('logs progress', async function () {
+        const script = new MigrateClientApplicationScript();
+
+        await script.handle({ options: { dryRun: true }, logger });
+
+        expect(logger.info).to.have.callCount(5);
+        expect(logger.info).to.have.been.always.calledWith({ event: 'MigrateClientApplicationScript' });
+      });
+    });
+  });
+});

--- a/api/tests/prescription/organization-place/acceptance/application/get-data-organization-places_test.js
+++ b/api/tests/prescription/organization-place/acceptance/application/get-data-organization-places_test.js
@@ -1,39 +1,28 @@
-import querystring from 'node:querystring';
-
-import { createServer, expect } from '../../../../test-helper.js';
+import {
+  createServer,
+  expect,
+  generateValidRequestAuthorizationHeaderForApplication,
+} from '../../../../test-helper.js';
 
 describe('Acceptance | Route | Get Data Organization Places', function () {
   describe('GET /api/data/organization-places', function () {
     it('should return 200 HTTP status code', async function () {
       // given
       const PIX_DATA_CLIENT_ID = 'test-pixDataCliendId';
-      const PIX_DATA_CLIENT_SECRET = 'pixDataClientSecret';
       const PIX_DATA_SCOPE = 'statistics';
 
       const server = await createServer();
-
-      const optionsForToken = {
-        method: 'POST',
-        url: `/api/application/token`,
-        headers: {
-          'content-type': 'application/x-www-form-urlencoded',
-        },
-        payload: querystring.stringify({
-          grant_type: 'client_credentials',
-          client_id: PIX_DATA_CLIENT_ID,
-          client_secret: PIX_DATA_CLIENT_SECRET,
-          scope: PIX_DATA_SCOPE,
-        }),
-      };
-      const tokenResponse = await server.inject(optionsForToken);
-      const accessToken = tokenResponse.result.access_token;
 
       // when
       const options = {
         method: 'GET',
         url: `/api/data/organization-places`,
         headers: {
-          authorization: `Bearer ${accessToken}`,
+          authorization: generateValidRequestAuthorizationHeaderForApplication(
+            PIX_DATA_CLIENT_ID,
+            'pix-data',
+            PIX_DATA_SCOPE,
+          ),
         },
       };
 

--- a/api/tests/tooling/chai-custom-helpers/deep-equal-instance.js
+++ b/api/tests/tooling/chai-custom-helpers/deep-equal-instance.js
@@ -10,7 +10,7 @@ const deepEqualInstance = function () {
 };
 
 function _assertAreSameType(value1, value2) {
-  const instanceClassName1 = value1.constructor.name;
+  const instanceClassName1 = value1?.constructor.name;
   const instanceClassName2 = value2.constructor.name;
   new Assertion(instanceClassName1).to.equal(instanceClassName2);
 }

--- a/api/tests/tooling/domain-builder/factory/build-client-application.js
+++ b/api/tests/tooling/domain-builder/factory/build-client-application.js
@@ -1,0 +1,11 @@
+import { ClientApplication } from '../../../../src/identity-access-management/domain/models/ClientApplication.js';
+
+export function buildClientApplication({
+  id = 123,
+  name = 'clientApplication',
+  clientId = 'client-id',
+  clientSecret = 'super-secret',
+  scopes = ['scope1', 'scope2'],
+} = {}) {
+  return new ClientApplication({ id, name, clientId, clientSecret, scopes });
+}

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -65,6 +65,7 @@ import { buildCertifiedTube } from './build-certified-tube.js';
 import { buildChallenge, buildChallengeWithWebComponent } from './build-challenge.js';
 import { buildChallengeLearningContentDataObject } from './build-challenge-learning-content-data-object.js';
 import { buildCleaCertifiedCandidate } from './build-clea-certified-candidate.js';
+import { buildClientApplication } from './build-client-application.js';
 import { buildCompetence } from './build-competence.js';
 import { buildCompetenceEvaluation } from './build-competence-evaluation.js';
 import { buildCompetenceMark } from './build-competence-mark.js';
@@ -351,6 +352,7 @@ export {
   buildChallengeLearningContentDataObject,
   buildChallengeWithWebComponent,
   buildCleaCertifiedCandidate,
+  buildClientApplication,
   buildCompetence,
   buildCompetenceEvaluation,
   buildCompetenceForScoring,

--- a/api/tests/unit/domain/usecases/authenticate-application_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-application_test.js
@@ -1,20 +1,27 @@
 import { authenticateApplication } from '../../../../lib/domain/usecases/authenticate-application.js';
+import { PasswordNotMatching } from '../../../../src/identity-access-management/domain/errors.js';
+import { config } from '../../../../src/shared/config.js';
 import {
   ApplicationScopeNotAllowedError,
   ApplicationWithInvalidClientIdError,
   ApplicationWithInvalidClientSecretError,
 } from '../../../../src/shared/domain/errors.js';
-import { catchErr, expect, sinon } from '../../../test-helper.js';
+import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';
 
 describe('Unit | Usecase | authenticate-application', function () {
   context('when application is not found', function () {
     it('should throw an error', async function () {
-      const client = {
+      const payload = {
         clientId: Symbol('id'),
         clientSecret: Symbol('secret'),
       };
 
-      const err = await catchErr(authenticateApplication)(client);
+      const clientApplicationRepository = {
+        findByClientId: sinon.stub(),
+      };
+      clientApplicationRepository.findByClientId.withArgs(payload.clientId).resolves(undefined);
+
+      const err = await catchErr(authenticateApplication)({ ...payload, clientApplicationRepository });
 
       expect(err).to.be.instanceOf(ApplicationWithInvalidClientIdError);
     });
@@ -23,12 +30,29 @@ describe('Unit | Usecase | authenticate-application', function () {
   context('when application is found', function () {
     context('when client secrets are different', function () {
       it('should throw an error', async function () {
-        const client = {
+        const payload = {
           clientId: 'test-apimOsmoseClientId',
-          clientSecret: Symbol('toto'),
+          clientSecret: 'mauvais-secret',
         };
 
-        const err = await catchErr(authenticateApplication)(client);
+        const clientApplicationRepository = {
+          findByClientId: sinon.stub(),
+        };
+        const application = domainBuilder.buildClientApplication({
+          name: 'test-apimOsmoseClientId',
+          clientSecret: 'mon-secret',
+          scopes: [],
+        });
+        clientApplicationRepository.findByClientId.withArgs(payload.clientId).resolves(application);
+
+        const cryptoService = {
+          checkPassword: sinon.stub(),
+        };
+        cryptoService.checkPassword
+          .withArgs({ password: payload.clientSecret, passwordHash: application.clientSecret })
+          .rejects(new PasswordNotMatching());
+
+        const err = await catchErr(authenticateApplication)({ ...payload, clientApplicationRepository, cryptoService });
 
         expect(err).to.be.instanceOf(ApplicationWithInvalidClientSecretError);
       });
@@ -36,13 +60,30 @@ describe('Unit | Usecase | authenticate-application', function () {
 
     context('when client scopes are different', function () {
       it('should throw an error', async function () {
-        const client = {
+        const payload = {
           clientId: 'test-apimOsmoseClientId',
-          clientSecret: 'test-apimOsmoseClientSecret',
+          clientSecret: 'bon-secret',
           scope: 'mauvais-scope',
         };
 
-        const err = await catchErr(authenticateApplication)(client);
+        const clientApplicationRepository = {
+          findByClientId: sinon.stub(),
+        };
+        const application = domainBuilder.buildClientApplication({
+          name: 'test-apimOsmoseClientId',
+          clientSecret: 'bon-secret',
+          scopes: ['bon-scope'],
+        });
+        clientApplicationRepository.findByClientId.withArgs(payload.clientId).resolves(application);
+
+        const cryptoService = {
+          checkPassword: sinon.stub(),
+        };
+        cryptoService.checkPassword
+          .withArgs({ password: payload.clientSecret, passwordHash: application.clientSecret })
+          .resolves();
+
+        const err = await catchErr(authenticateApplication)({ ...payload, clientApplicationRepository, cryptoService });
 
         expect(err).to.be.instanceOf(ApplicationScopeNotAllowedError);
       });
@@ -50,21 +91,50 @@ describe('Unit | Usecase | authenticate-application', function () {
 
     context('when given information is correct', function () {
       it('should return created token', async function () {
-        const client = {
+        const payload = {
           clientId: 'test-apimOsmoseClientId',
-          clientSecret: 'test-apimOsmoseClientSecret',
-          scope: 'organizations-certifications-result',
+          clientSecret: 'bon-secret',
+          scope: 'bon-scope',
         };
+
+        const clientApplicationRepository = {
+          findByClientId: sinon.stub(),
+        };
+        const application = domainBuilder.buildClientApplication({
+          name: 'mon-application',
+          clientId: 'test-apimOsmoseClientId',
+          clientSecret: 'bon-secret',
+          scopes: ['bon-scope'],
+        });
+        clientApplicationRepository.findByClientId.withArgs(payload.clientId).resolves(application);
+
+        const cryptoService = {
+          checkPassword: sinon.stub(),
+        };
+        cryptoService.checkPassword
+          .withArgs({ password: payload.clientSecret, passwordHash: application.clientSecret })
+          .resolves();
 
         const tokenService = {
           createAccessTokenFromApplication: sinon.stub(),
         };
         const expectedToken = Symbol('Mon Super token');
         tokenService.createAccessTokenFromApplication
-          .withArgs(client.clientId, 'livretScolaire', client.scope, 'test-secretOsmose', '4h')
+          .withArgs(
+            application.clientId,
+            application.name,
+            payload.scope,
+            config.authentication.secret,
+            config.authentication.accessTokenLifespanMs,
+          )
           .resolves(expectedToken);
 
-        const token = await authenticateApplication({ ...client, tokenService });
+        const token = await authenticateApplication({
+          ...payload,
+          tokenService,
+          clientApplicationRepository,
+          cryptoService,
+        });
 
         expect(token).to.be.equal(expectedToken);
       });

--- a/api/tests/unit/domain/usecases/authenticate-application_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-application_test.js
@@ -1,0 +1,73 @@
+import { authenticateApplication } from '../../../../lib/domain/usecases/authenticate-application.js';
+import {
+  ApplicationScopeNotAllowedError,
+  ApplicationWithInvalidClientIdError,
+  ApplicationWithInvalidClientSecretError,
+} from '../../../../src/shared/domain/errors.js';
+import { catchErr, expect, sinon } from '../../../test-helper.js';
+
+describe('Unit | Usecase | authenticate-application', function () {
+  context('when application is not found', function () {
+    it('should throw an error', async function () {
+      const client = {
+        clientId: Symbol('id'),
+        clientSecret: Symbol('secret'),
+      };
+
+      const err = await catchErr(authenticateApplication)(client);
+
+      expect(err).to.be.instanceOf(ApplicationWithInvalidClientIdError);
+    });
+  });
+
+  context('when application is found', function () {
+    context('when client secrets are different', function () {
+      it('should throw an error', async function () {
+        const client = {
+          clientId: 'test-apimOsmoseClientId',
+          clientSecret: Symbol('toto'),
+        };
+
+        const err = await catchErr(authenticateApplication)(client);
+
+        expect(err).to.be.instanceOf(ApplicationWithInvalidClientSecretError);
+      });
+    });
+
+    context('when client scopes are different', function () {
+      it('should throw an error', async function () {
+        const client = {
+          clientId: 'test-apimOsmoseClientId',
+          clientSecret: 'test-apimOsmoseClientSecret',
+          scope: 'mauvais-scope',
+        };
+
+        const err = await catchErr(authenticateApplication)(client);
+
+        expect(err).to.be.instanceOf(ApplicationScopeNotAllowedError);
+      });
+    });
+
+    context('when given information is correct', function () {
+      it('should return created token', async function () {
+        const client = {
+          clientId: 'test-apimOsmoseClientId',
+          clientSecret: 'test-apimOsmoseClientSecret',
+          scope: 'organizations-certifications-result',
+        };
+
+        const tokenService = {
+          createAccessTokenFromApplication: sinon.stub(),
+        };
+        const expectedToken = Symbol('Mon Super token');
+        tokenService.createAccessTokenFromApplication
+          .withArgs(client.clientId, 'livretScolaire', client.scope, 'test-secretOsmose', '4h')
+          .resolves(expectedToken);
+
+        const token = await authenticateApplication({ ...client, tokenService });
+
+        expect(token).to.be.equal(expectedToken);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :pancakes: Problème
Actuellement, toutes les applications sont définies directement dans la configuration grâce à des variables d'environnement. C'est par conséquent chronophage d'ajouter de nouveau client et ce n'est pas très scalable.  

## :bacon: Proposition

Stocker les applications en BDD.

## 🧃 Remarques

- Nous migrons les clients existants directement dans la migration. 
- Nous utilisons désormais le `AUTH_SECRET` pour signer les jwt des clients au lieu d'avoir un SECRET par client.

## :yum: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->