### PR TITLE
[FEATURE] Ajouter PixTable dans les tableaux des sessions sur Pix Admin (PIX-16591).

### DIFF
--- a/admin/app/components/certification-centers/list-items.gjs
+++ b/admin/app/components/certification-centers/list-items.gjs
@@ -3,6 +3,7 @@ import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import { fn } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
 import Component from '@glimmer/component';
+import { t } from 'ember-intl';
 
 export default class CertificationCenterListItems extends Component {
   searchedId = this.args.id;
@@ -60,7 +61,7 @@ export default class CertificationCenterListItems extends Component {
       </table>
 
       {{#unless @certificationCenters}}
-        <div class="table__empty">Aucun résultat</div>
+        <div class="table__empty">{{t "common.tables.empty-result"}}</div>
       {{/unless}}
     </div>
 

--- a/admin/app/components/certification-centers/memberships-section.gjs
+++ b/admin/app/components/certification-centers/memberships-section.gjs
@@ -1,3 +1,5 @@
+import { t } from 'ember-intl';
+
 import MembershipItem from './membership-item';
 
 <template>
@@ -36,7 +38,7 @@ import MembershipItem from './membership-item';
         </table>
 
         {{#unless @certificationCenterMemberships}}
-          <div class="table__empty">Aucun résultat</div>
+          <div class="table__empty">{{t "common.tables.empty-result"}}</div>
         {{/unless}}
       </div>
     </div>

--- a/admin/app/components/complementary-certifications/attach-badges/target-profile-selector/searchbar.gjs
+++ b/admin/app/components/complementary-certifications/attach-badges/target-profile-selector/searchbar.gjs
@@ -5,6 +5,7 @@ import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
+import { t } from 'ember-intl';
 import ENV from 'pix-admin/config/environment';
 
 export default class SearchBar extends Component {
@@ -43,7 +44,7 @@ export default class SearchBar extends Component {
 
         {{#if @isNoResult}}
           <span class="attach-target-profile-search__no-result">
-            Aucun résultat
+            {{t "common.tables.empty-result"}}
           </span>
         {{/if}}
 

--- a/admin/app/components/complementary-certifications/list.gjs
+++ b/admin/app/components/complementary-certifications/list.gjs
@@ -10,7 +10,10 @@ export default class List extends Component {
   }
 
   <template>
-    <PixTable @data={{this.sortedComplementaryCertifications}}>
+    <PixTable
+      @data={{this.sortedComplementaryCertifications}}
+      @caption={{t "components.complementary-certifications.list.caption"}}
+    >
       <:columns as |row sortedComplementaryCertification|>
         <PixTableColumn @context={{sortedComplementaryCertification}} class="table__column--medium">
           <:header>

--- a/admin/app/components/complementary-certifications/target-profiles/badges-list.gjs
+++ b/admin/app/components/complementary-certifications/target-profiles/badges-list.gjs
@@ -19,7 +19,10 @@ export default class BadgesList extends Component {
       <h2 class="complementary-certification-details__badges-title">
         {{t "components.complementary-certifications.target-profiles.badges-list.title"}}
       </h2>
-      <PixTable @data={{this.currentTargetProfileBadges}}>
+      <PixTable
+        @data={{this.currentTargetProfileBadges}}
+        @caption={{t "components.complementary-certifications.target-profiles.badges-list.caption"}}
+      >
         <:columns as |row currentTargetProfileBadge|>
           <PixTableColumn @context={{currentTargetProfileBadge}}>
             <:header>

--- a/admin/app/components/complementary-certifications/target-profiles/history.gjs
+++ b/admin/app/components/complementary-certifications/target-profiles/history.gjs
@@ -9,7 +9,10 @@ import { t } from 'ember-intl';
     <h2 class="complementary-certification-details__history-title">
       {{t "components.complementary-certifications.target-profiles.history-list.title"}}
     </h2>
-    <PixTable @data={{@targetProfilesHistory}}>
+    <PixTable
+      @data={{@targetProfilesHistory}}
+      @caption={{t "components.complementary-certifications.target-profiles.history-list.caption"}}
+    >
       <:columns as |row targetProfileHistory|>
         <PixTableColumn @context={{targetProfileHistory}}>
           <:header>

--- a/admin/app/components/organizations/all-tags.gjs
+++ b/admin/app/components/organizations/all-tags.gjs
@@ -149,7 +149,7 @@ export default class OrganizationAllTags extends Component {
           {{/each}}
         </ul>
       {{else}}
-        <p>Aucun résultat.</p>
+        <p>{{t "common.tables.empty-result"}}</p>
       {{/if}}
     </section>
   </template>

--- a/admin/app/components/organizations/list-items.gjs
+++ b/admin/app/components/organizations/list-items.gjs
@@ -121,7 +121,7 @@ export default class ActionsOnUsersRoleInOrganization extends Component {
         </table>
 
         {{#unless @organizations}}
-          <div class="table__empty">Aucun résultat</div>
+          <div class="table__empty">{{t "common.tables.empty-result"}}</div>
         {{/unless}}
       </div>
     </div>

--- a/admin/app/components/organizations/target-profiles-section.gjs
+++ b/admin/app/components/organizations/target-profiles-section.gjs
@@ -198,7 +198,7 @@ export default class OrganizationTargetProfilesSectionComponent extends Componen
           </table>
 
           {{#unless @targetProfileSummaries}}
-            <div class="table__empty">Aucun résultat</div>
+            <div class="table__empty">{{t "common.tables.empty-result"}}</div>
           {{/unless}}
         </div>
       </div>

--- a/admin/app/components/organizations/team-section.gjs
+++ b/admin/app/components/organizations/team-section.gjs
@@ -100,7 +100,7 @@ export default class OrganizationTeamSection extends Component {
           </table>
 
           {{#unless @organizationMemberships}}
-            <div class="table__empty">Aucun résultat</div>
+            <div class="table__empty">{{t "common.tables.empty-result"}}</div>
           {{/unless}}
         </div>
 

--- a/admin/app/components/sessions/list-items.gjs
+++ b/admin/app/components/sessions/list-items.gjs
@@ -6,6 +6,7 @@ import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 import map from 'lodash/map';
 import { statusToDisplayName } from 'pix-admin/models/session';
 
@@ -202,7 +203,7 @@ export default class ListItems extends Component {
       </table>
 
       {{#unless @sessions}}
-        <div class="table__empty">Aucun résultat</div>
+        <div class="table__empty">{{t "common.tables.empty-result"}}</div>
       {{/unless}}
     </div>
 

--- a/admin/app/components/target-profiles/list-summary-items.gjs
+++ b/admin/app/components/target-profiles/list-summary-items.gjs
@@ -108,7 +108,7 @@ export default class TargetProfileListSummaryItems extends Component {
         </table>
 
         {{#unless @summaries}}
-          <div class="table__empty">Aucun résultat</div>
+          <div class="table__empty">{{t "common.tables.empty-result"}}</div>
         {{/unless}}
       </div>
     </div>

--- a/admin/app/components/team/list.gjs
+++ b/admin/app/components/team/list.gjs
@@ -164,7 +164,7 @@ export default class List extends Component {
         {{/if}}
       </table>
       {{#unless @members}}
-        <div class="table__empty">Aucun résultat</div>
+        <div class="table__empty">{{t "common.tables.empty-result"}}</div>
       {{/unless}}
     </div>
 

--- a/admin/app/components/to-be-published-sessions/list-items.gjs
+++ b/admin/app/components/to-be-published-sessions/list-items.gjs
@@ -1,10 +1,13 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 
 import ConfirmPopup from '../confirm-popup';
 
@@ -36,59 +39,73 @@ export default class ToBePublishedSessionsList extends Component {
     this._cancelModalSelection();
   }
   <template>
-    <div class="content-text content-text--small table-admin__wrapper session-list">
-      <table class="table-admin table-admin__auto-width">
-        <thead>
-          <tr>
-            <th class="table__column table__column--id">ID</th>
-            <th>Centre de certification</th>
-            <th>Date de session</th>
-            <th>Date de finalisation</th>
-            {{#if this.accessControl.hasAccessToCertificationActionsScope}}
-              <th>Actions</th>
-            {{/if}}
-          </tr>
-        </thead>
-
-        {{#if @toBePublishedSessions}}
-          <tbody>
-            {{#each @toBePublishedSessions as |toBePublishedSession|}}
-              <tr>
-                <td class="table__column table__column--id">
-                  <LinkTo @route="authenticated.sessions.session" @model={{toBePublishedSession.id}}>
-                    {{toBePublishedSession.id}}
-                  </LinkTo>
-                </td>
-                <td>{{toBePublishedSession.certificationCenterName}}</td>
-                <td>{{toBePublishedSession.printableDateAndTime}}</td>
-                <td>{{toBePublishedSession.printableFinalizationDate}}</td>
-                {{#if this.accessControl.hasAccessToCertificationActionsScope}}
-                  <td>
-                    <PixButton
-                      @triggerAction={{fn this.showConfirmModal toBePublishedSession}}
-                      class="publish-session-button"
-                      @size="small"
-                      aria-label="Publier la session numéro {{toBePublishedSession.id}}"
-                      @iconBefore="session"
-                      @plainIconBefore={{true}}
-                    >
-                      Publier
-                    </PixButton>
-                  </td>
-                {{/if}}
-              </tr>
-            {{/each}}
-          </tbody>
-        {{/if}}
-      </table>
-
-      {{#unless @toBePublishedSessions}}
-        <div class="table__empty">Aucun résultat</div>
-      {{/unless}}
-    </div>
+    {{#if @toBePublishedSessions}}
+      <PixTable @data={{@toBePublishedSessions}}>
+        <:columns as |row toBePublishedSession|>
+          <PixTableColumn @context={{toBePublishedSession}}>
+            <:header>
+              {{t "pages.sessions.table.to-be-published.headers.id"}}
+            </:header>
+            <:cell>
+              <LinkTo @route="authenticated.sessions.session" @model={{toBePublishedSession.id}}>
+                {{row.id}}
+              </LinkTo>
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{toBePublishedSession}}>
+            <:header>
+              {{t "pages.sessions.table.to-be-published.headers.certification-name"}}
+            </:header>
+            <:cell>
+              {{row.certificationCenterName}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{toBePublishedSession}}>
+            <:header>
+              {{t "pages.sessions.table.to-be-published.headers.session-date"}}
+            </:header>
+            <:cell>
+              {{row.printableDateAndTime}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{toBePublishedSession}}>
+            <:header>
+              {{t "pages.sessions.table.to-be-published.headers.finalization-date"}}
+            </:header>
+            <:cell>
+              {{row.printableFinalizationDate}}
+            </:cell>
+          </PixTableColumn>
+          {{#if this.accessControl.hasAccessToCertificationActionsScope}}
+            <PixTableColumn @context={{toBePublishedSession}}>
+              <:header>
+                {{t "pages.sessions.table.to-be-published.headers.actions"}}
+              </:header>
+              <:cell>
+                <PixButton
+                  @triggerAction={{fn this.showConfirmModal row}}
+                  class="publish-session-button"
+                  @size="small"
+                  aria-label={{t
+                    "pages.sessions.table.to-be-published.cell.publish-button.aria-label"
+                    sessionId=row.id
+                  }}
+                  @iconBefore="session"
+                  @plainIconBefore={{true}}
+                >
+                  {{t "pages.sessions.table.to-be-published.cell.publish-button.label"}}
+                </PixButton>
+              </:cell>
+            </PixTableColumn>
+          {{/if}}
+        </:columns>
+      </PixTable>
+    {{else}}
+      <div class="table__empty">Aucun résultat</div>
+    {{/if}}
 
     <ConfirmPopup
-      @message="Souhaitez-vous publier la session ?"
+      @message={{t "pages.sessions.table.to-be-published.modals.publication"}}
       @confirm={{this.publishSession}}
       @cancel={{this.hideConfirmModal}}
       @show={{this.shouldShowModal}}

--- a/admin/app/components/to-be-published-sessions/list-items.gjs
+++ b/admin/app/components/to-be-published-sessions/list-items.gjs
@@ -101,7 +101,7 @@ export default class ToBePublishedSessionsList extends Component {
         </:columns>
       </PixTable>
     {{else}}
-      <div class="table__empty">Aucun résultat</div>
+      <div class="table__empty">{{t "common.tables.empty-result"}}</div>
     {{/if}}
 
     <ConfirmPopup

--- a/admin/app/components/to-be-published-sessions/list-items.gjs
+++ b/admin/app/components/to-be-published-sessions/list-items.gjs
@@ -40,14 +40,14 @@ export default class ToBePublishedSessionsList extends Component {
   }
   <template>
     {{#if @toBePublishedSessions}}
-      <PixTable @data={{@toBePublishedSessions}}>
+      <PixTable @data={{@toBePublishedSessions}} @caption={{t "pages.sessions.table.to-be-published.caption"}}>
         <:columns as |row toBePublishedSession|>
           <PixTableColumn @context={{toBePublishedSession}}>
             <:header>
               {{t "pages.sessions.table.to-be-published.headers.id"}}
             </:header>
             <:cell>
-              <LinkTo @route="authenticated.sessions.session" @model={{toBePublishedSession.id}}>
+              <LinkTo @route="authenticated.sessions.session" @model={{row.id}}>
                 {{row.id}}
               </LinkTo>
             </:cell>

--- a/admin/app/components/users/list-items.gjs
+++ b/admin/app/components/users/list-items.gjs
@@ -1,5 +1,6 @@
 import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import { LinkTo } from '@ember/routing';
+import { t } from 'ember-intl';
 
 <template>
   <div class="content-text content-text--small">
@@ -34,7 +35,7 @@ import { LinkTo } from '@ember/routing';
     </table>
 
     {{#unless @users}}
-      <div class="table__empty">Aucun résultat</div>
+      <div class="table__empty">{{t "common.tables.empty-result"}}</div>
     {{/unless}}
   </div>
 

--- a/admin/app/components/users/user-detail-personal-information/organization-learner-information.gjs
+++ b/admin/app/components/users/user-detail-personal-information/organization-learner-information.gjs
@@ -4,6 +4,7 @@ import { fn } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { t } from 'ember-intl';
 import formatDate from 'pix-admin/helpers/format-date';
 
 export default class OrganizationLearnerInformation extends Component {
@@ -81,7 +82,7 @@ export default class OrganizationLearnerInformation extends Component {
             </tr>
           {{else}}
             <tr>
-              <td colspan="9" class="table-admin-empty">Aucun résultat</td>
+              <td colspan="9" class="table-admin-empty">{{t "common.tables.empty-result"}}</td>
             </tr>
           {{/each}}
         </tbody>

--- a/admin/app/components/users/user-profile.gjs
+++ b/admin/app/components/users/user-profile.gjs
@@ -1,3 +1,5 @@
+import { t } from 'ember-intl';
+
 <template>
   <h2 class="page-section__title">Profil utilisateur</h2>
 
@@ -25,7 +27,7 @@
           </tr>
         {{else}}
           <tr>
-            <td colspan="10" class="table-admin-empty">Aucun résultat</td>
+            <td colspan="10" class="table-admin-empty">{{t "common.tables.empty-result"}}</td>
           </tr>
         {{/each}}
       </tbody>

--- a/admin/app/components/with-required-action-sessions/list-items.gjs
+++ b/admin/app/components/with-required-action-sessions/list-items.gjs
@@ -56,6 +56,6 @@ import { t } from 'ember-intl';
       </:columns>
     </PixTable>
   {{else}}
-    <div class="table__empty">Aucun résultat</div>
+    <div class="table__empty">{{t "common.tables.empty-result"}}</div>
   {{/if}}
 </template>

--- a/admin/app/components/with-required-action-sessions/list-items.gjs
+++ b/admin/app/components/with-required-action-sessions/list-items.gjs
@@ -1,45 +1,61 @@
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { LinkTo } from '@ember/routing';
+import { t } from 'ember-intl';
 
 <template>
-  <div class="content-text content-text--small table-admin__wrapper session-list">
-    <table class="table-admin table-admin__auto-width">
-      <thead>
-        <tr>
-          <th class="table__column table__column--id">ID</th>
-          <th>Centre de certification</th>
-          <th>Date de session</th>
-          <th>Date de finalisation</th>
-          <th>Qui ?</th>
-        </tr>
-      </thead>
-
-      {{#if @withRequiredActionSessions}}
-        <tbody>
-          {{#each @withRequiredActionSessions as |withRequiredActionSession|}}
-            <tr>
-              <td class="table__column table__column--id">
-                <LinkTo @route="authenticated.sessions.session" @model={{withRequiredActionSession.id}}>
-                  {{withRequiredActionSession.id}}
-                </LinkTo>
-              </td>
-              <td>{{withRequiredActionSession.certificationCenterName}}</td>
-              <td>{{withRequiredActionSession.printableDateAndTime}}</td>
-              <td>{{withRequiredActionSession.printableFinalizationDate}}</td>
-              <td class="session-list__item--align-center">
-                {{#if withRequiredActionSession.assignedCertificationOfficerName}}
-                  {{withRequiredActionSession.assignedCertificationOfficerName}}
-                {{else}}
-                  -
-                {{/if}}
-              </td>
-            </tr>
-          {{/each}}
-        </tbody>
-      {{/if}}
-    </table>
-
-    {{#unless @withRequiredActionSessions}}
-      <div class="table__empty">Aucun résultat</div>
-    {{/unless}}
-  </div>
+  {{#if @withRequiredActionSessions}}
+    <PixTable @data={{@withRequiredActionSessions}}>
+      <:columns as |row withRequiredActionSession|>
+        <PixTableColumn @context={{withRequiredActionSession}} class="table__column--medium">
+          <:header>
+            {{t "pages.sessions.table.required-actions.headers.id"}}
+          </:header>
+          <:cell>
+            <LinkTo @route="authenticated.sessions.session" @model={{row.id}}>
+              {{row.id}}
+            </LinkTo>
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{withRequiredActionSession}}>
+          <:header>
+            {{t "pages.sessions.table.required-actions.headers.certification-name"}}
+          </:header>
+          <:cell>
+            {{row.certificationCenterName}}
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{withRequiredActionSession}}>
+          <:header>
+            {{t "pages.sessions.table.required-actions.headers.session-date"}}
+          </:header>
+          <:cell>
+            {{row.printableDateAndTime}}
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{withRequiredActionSession}}>
+          <:header>
+            {{t "pages.sessions.table.required-actions.headers.finalization-date"}}
+          </:header>
+          <:cell>
+            {{row.printableFinalizationDate}}
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{withRequiredActionSession}}>
+          <:header>
+            {{t "pages.sessions.table.required-actions.headers.assigned-officer-name"}}
+          </:header>
+          <:cell>
+            {{#if row.assignedCertificationOfficerName}}
+              {{row.assignedCertificationOfficerName}}
+            {{else}}
+              -
+            {{/if}}
+          </:cell>
+        </PixTableColumn>
+      </:columns>
+    </PixTable>
+  {{else}}
+    <div class="table__empty">Aucun résultat</div>
+  {{/if}}
 </template>

--- a/admin/app/components/with-required-action-sessions/list-items.gjs
+++ b/admin/app/components/with-required-action-sessions/list-items.gjs
@@ -5,7 +5,7 @@ import { t } from 'ember-intl';
 
 <template>
   {{#if @withRequiredActionSessions}}
-    <PixTable @data={{@withRequiredActionSessions}}>
+    <PixTable @data={{@withRequiredActionSessions}} @caption={{t "pages.sessions.table.required-actions.caption"}}>
       <:columns as |row withRequiredActionSession|>
         <PixTableColumn @context={{withRequiredActionSession}} class="table__column--medium">
           <:header>

--- a/admin/app/controllers/authenticated/sessions/list/to-be-published.js
+++ b/admin/app/controllers/authenticated/sessions/list/to-be-published.js
@@ -10,6 +10,11 @@ export default class SessionToBePublishedController extends Controller {
   @service accessControl;
   @tracked shouldShowModal = false;
 
+  get hasSessionsToPublish() {
+    const sessionsToPublish = this.model.length;
+    return sessionsToPublish && this.accessControl.hasAccessToCertificationActionsScope;
+  }
+
   @action
   async publishSession(toBePublishedSession) {
     const adapter = this.store.adapterFor('to-be-published-session');

--- a/admin/app/controllers/authenticated/sessions/list/with-required-action.js
+++ b/admin/app/controllers/authenticated/sessions/list/with-required-action.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 // eslint-disable-next-line ember/no-computed-properties-in-native-classes
-import { computed } from '@ember/object';
+import { action, computed } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
@@ -10,7 +10,7 @@ export default class AuthenticatedSessionsWithRequiredActionListController exten
   @tracked assignedToSelfOnly = false;
 
   @computed('assignedToSelfOnly', 'currentUser.adminMember.fullName', 'model.withRequiredAction')
-  get filteredSessions() {
+  get sessionsList() {
     const sessions = this.model;
     if (this.assignedToSelfOnly) {
       return sessions.filter(
@@ -18,5 +18,14 @@ export default class AuthenticatedSessionsWithRequiredActionListController exten
       );
     }
     return sessions;
+  }
+
+  get hasSessionsToProcess() {
+    return this.model.length;
+  }
+
+  @action filterAssignedSessions() {
+    this.assignedToSelfOnly = !this.assignedToSelfOnly;
+    this.sessionsList;
   }
 }

--- a/admin/app/controllers/authenticated/sessions/list/with-required-action.js
+++ b/admin/app/controllers/authenticated/sessions/list/with-required-action.js
@@ -24,7 +24,7 @@ export default class AuthenticatedSessionsWithRequiredActionListController exten
     return this.model.length;
   }
 
-  @action filterAssignedSessions() {
+  @action toggleAssignedSessionsDisplay() {
     this.assignedToSelfOnly = !this.assignedToSelfOnly;
     this.sessionsList;
   }

--- a/admin/app/styles/authenticated/sessions/list.scss
+++ b/admin/app/styles/authenticated/sessions/list.scss
@@ -25,8 +25,7 @@
 .session-to-be-publish {
   &__publish-all {
     display: flex;
-    flex-direction: row-reverse;
-    width: 100%;
-    margin-bottom: 16px;
+    justify-content: flex-end;
+    margin-bottom: var(--pix-spacing-3x);
   }
 }

--- a/admin/app/styles/authenticated/sessions/list.scss
+++ b/admin/app/styles/authenticated/sessions/list.scss
@@ -7,14 +7,10 @@
     margin: 20px 10px 10px;
   }
 
-  &__self-toogle {
+  &__assigned-to-process-session {
     display: flex;
     justify-content: flex-end;
-    padding-bottom: 10px;
-
-    p {
-      margin: 0;
-    }
+    margin-bottom: var(--pix-spacing-3x);
   }
 
   &__item--align-center {

--- a/admin/app/templates/authenticated/sessions/list.hbs
+++ b/admin/app/templates/authenticated/sessions/list.hbs
@@ -1,31 +1,32 @@
 {{page-title "Toutes les sessions"}}
 <div class="page">
   <header>
-    <h1>Toutes les sessions</h1>
+    <h1>{{t "pages.sessions.title"}}</h1>
     <div class="page-actions">
     </div>
   </header>
 
   <nav class="navbar">
     <LinkTo @route="authenticated.sessions.list.with-required-action" @query={{hash version=2}} class="navbar-item">
-      Sessions à traiter ({{this.sessionsWithRequiredActionCount}})
+      {{t "pages.sessions.list.required-actions.v2"}}
+      ({{this.sessionsWithRequiredActionCount}})
     </LinkTo>
     <LinkTo @route="authenticated.sessions.list.to-be-published" @query={{hash version=2}} class="navbar-item">
-      Sessions à publier
+      {{t "pages.sessions.list.to-be-published.v2"}}
     </LinkTo>
     <LinkTo @route="authenticated.sessions.list.all" class="navbar-item">
-      Toutes les sessions
+      {{t "pages.sessions.list.all"}}
     </LinkTo>
     <LinkTo
       @route="authenticated.sessions.list.with-required-action"
       @query={{hash version=3}}
       class="navbar-item navbar-item--right"
     >
-      {{t "pages.sessions.list.v3-required-actions"}}
+      {{t "pages.sessions.list.required-actions.v3"}}
       ({{this.sessionsWithRequiredActionCountVersion3}})
     </LinkTo>
     <LinkTo @route="authenticated.sessions.list.to-be-published" @query={{hash version=3}} class="navbar-item">
-      {{t "pages.sessions.list.v3-to-be-published"}}
+      {{t "pages.sessions.list.to-be-published.v3"}}
     </LinkTo>
   </nav>
 

--- a/admin/app/templates/authenticated/sessions/list/to-be-published.hbs
+++ b/admin/app/templates/authenticated/sessions/list/to-be-published.hbs
@@ -1,16 +1,17 @@
 {{page-title "Sessions à publier"}}
-{{#if @model.length}}
-  {{#if this.accessControl.hasAccessToCertificationActionsScope}}
-    <div class="session-to-be-publish__publish-all">
-      <PixButton @triggerAction={{this.showConfirmModal}}>Publier toutes les sessions</PixButton>
-    </div>
-  {{/if}}
+
+{{#if this.hasSessionsToPublish}}
+  <div class="session-to-be-publish__publish-all">
+    <PixButton @triggerAction={{this.showConfirmModal}}>{{t
+        "pages.sessions.table.to-be-published.button-label"
+      }}</PixButton>
+  </div>
 {{/if}}
 
 <ToBePublishedSessions::ListItems @toBePublishedSessions={{@model}} @publishSession={{this.publishSession}} />
 
 <ConfirmPopup
-  @message="Vous vous apprêtez à publier {{@model.length}} session(s) de certification, souhaitez vous poursuivre ?"
+  @message={{t "pages.sessions.table.to-be-published.modals.batch-publications" length=@model.length}}
   @confirm={{this.batchPublishSessions}}
   @cancel={{this.hideConfirmModal}}
   @show={{this.shouldShowModal}}

--- a/admin/app/templates/authenticated/sessions/list/with-required-action.hbs
+++ b/admin/app/templates/authenticated/sessions/list/with-required-action.hbs
@@ -1,6 +1,6 @@
 {{page-title "Sessions à traiter"}}
 <span class="session-list__self-toogle">
-  <p>Afficher uniquement mes sessions</p>
+  <p>{{t "pages.sessions.table.required-actions.checkbox-label"}}</p>
   <XToggle
     @size="small"
     @theme="light"

--- a/admin/app/templates/authenticated/sessions/list/with-required-action.hbs
+++ b/admin/app/templates/authenticated/sessions/list/with-required-action.hbs
@@ -1,12 +1,11 @@
 {{page-title "Sessions à traiter"}}
-<span class="session-list__self-toogle">
-  <p>{{t "pages.sessions.table.required-actions.checkbox-label"}}</p>
-  <XToggle
-    @size="small"
-    @theme="light"
-    @value={{this.assignedToSelfOnly}}
-    @onToggle={{fn (mut this.assignedToSelfOnly)}}
-  />
-</span>
 
-<WithRequiredActionSessions::ListItems @withRequiredActionSessions={{this.filteredSessions}} />
+{{#if this.hasSessionsToProcess}}
+  <div class="session-list__assigned-to-process-session">
+    <PixCheckbox @checked={{this.assignedToSelfOnly}} {{on "change" this.filterAssignedSessions}}>
+      <:label>{{t "pages.sessions.table.required-actions.checkbox-label"}}</:label>
+    </PixCheckbox>
+  </div>
+{{/if}}
+
+<WithRequiredActionSessions::ListItems @withRequiredActionSessions={{this.sessionsList}} />

--- a/admin/app/templates/authenticated/sessions/list/with-required-action.hbs
+++ b/admin/app/templates/authenticated/sessions/list/with-required-action.hbs
@@ -2,7 +2,7 @@
 
 {{#if this.hasSessionsToProcess}}
   <div class="session-list__assigned-to-process-session">
-    <PixCheckbox @checked={{this.assignedToSelfOnly}} {{on "change" this.filterAssignedSessions}}>
+    <PixCheckbox @checked={{this.assignedToSelfOnly}} {{on "change" this.toggleAssignedSessionsDisplay}}>
       <:label>{{t "pages.sessions.table.required-actions.checkbox-label"}}</:label>
     </PixCheckbox>
   </div>

--- a/admin/tests/acceptance/authenticated/sessions/list/with-required-action-test.js
+++ b/admin/tests/acceptance/authenticated/sessions/list/with-required-action-test.js
@@ -1,6 +1,7 @@
 import { visit } from '@1024pix/ember-testing-library';
 import { click, currentURL } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 import { module, test } from 'qunit';
@@ -165,8 +166,7 @@ module('Acceptance | authenticated/sessions/list/with required action', function
         const screen = await visit('/sessions/list/with-required-action');
 
         // when
-        await click('.x-toggle-btn');
-
+        await click(screen.getByRole('checkbox', { name: t('pages.sessions.table.required-actions.checkbox-label') }));
         // then
         assert.dom('table tbody tr').exists({ count: 1 });
         assert.dom(screen.getByText('Centre SCO des Anne-Étoiles')).exists();

--- a/admin/tests/integration/components/complementary-certifications/list-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/list-test.gjs
@@ -1,0 +1,34 @@
+import { render, within } from '@1024pix/ember-testing-library';
+import List from 'pix-admin/components/complementary-certifications/list';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest, { t } from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | complementary-certifications/list', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display complementary certification list', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const complementaryCertifications = [
+      store.createRecord('complementary-certification', { id: 0, key: 'DROIT', label: 'Pix+Droit' }),
+      store.createRecord('complementary-certification', { id: 1, key: 'CLEA', label: 'Cléa' }),
+    ];
+
+    // when
+    const screen = await render(
+      <template><List @complementaryCertifications={{complementaryCertifications}} /></template>,
+    );
+
+    // then
+    const table = screen.getByRole('table', { name: t('components.complementary-certifications.list.caption') });
+    assert
+      .dom(within(table).getByRole('columnheader', { name: t('components.complementary-certifications.list.id') }))
+      .exists();
+    assert
+      .dom(within(table).getByRole('columnheader', { name: t('components.complementary-certifications.list.name') }))
+      .exists();
+    assert.dom(within(table).getByRole('row', { name: '0 Pix+Droit' })).exists();
+    assert.dom(within(table).getByRole('row', { name: '1 Cléa' })).exists();
+  });
+});

--- a/admin/tests/integration/components/complementary-certifications/target-profiles/badges-list-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/target-profiles/badges-list-test.gjs
@@ -1,8 +1,8 @@
-import { render } from '@1024pix/ember-testing-library';
+import { render, within } from '@1024pix/ember-testing-library';
 import BadgesList from 'pix-admin/components/complementary-certifications/target-profiles/badges-list';
 import { module, test } from 'qunit';
 
-import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+import setupIntlRenderingTest, { t } from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | complementary-certifications/target-profiles/badges-list', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -30,12 +30,15 @@ module('Integration | Component | complementary-certifications/target-profiles/b
     const screen = await render(<template><BadgesList @currentTargetProfile={{currentTargetProfile}} /></template>);
 
     // then
-    assert.dom(screen.getByRole('columnheader', { name: 'Image du badge certifié' })).exists();
-    assert.dom(screen.getByRole('columnheader', { name: 'Nom du badge certifié' })).exists();
-    assert.dom(screen.getByRole('columnheader', { name: 'Niveau du badge certifié' })).exists();
-    assert.dom(screen.getByRole('columnheader', { name: 'ID du RT certifiant' })).exists();
-    assert.dom(screen.getByRole('row', { name: 'Badge Cascade Badge Cascade 3 1023' })).exists();
-    assert.dom(screen.getByRole('row', { name: 'Badge Volcan Badge Volcan 1 1025' })).exists();
+    const table = screen.getByRole('table', {
+      name: t('components.complementary-certifications.target-profiles.badges-list.caption'),
+    });
+    assert.dom(within(table).getByRole('columnheader', { name: 'Image du badge certifié' })).exists();
+    assert.dom(within(table).getByRole('columnheader', { name: 'Nom du badge certifié' })).exists();
+    assert.dom(within(table).getByRole('columnheader', { name: 'Niveau du badge certifié' })).exists();
+    assert.dom(within(table).getByRole('columnheader', { name: 'ID du RT certifiant' })).exists();
+    assert.dom(within(table).getByRole('row', { name: 'Badge Cascade Badge Cascade 3 1023' })).exists();
+    assert.dom(within(table).getByRole('row', { name: 'Badge Volcan Badge Volcan 1 1025' })).exists();
   });
 
   test('it should contain a link for each target profile badge', async function (assert) {

--- a/admin/tests/integration/components/complementary-certifications/target-profiles/history-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/target-profiles/history-test.gjs
@@ -1,9 +1,9 @@
-import { render } from '@1024pix/ember-testing-library';
+import { render, within } from '@1024pix/ember-testing-library';
 import dayjs from 'dayjs';
 import History from 'pix-admin/components/complementary-certifications/target-profiles/history';
 import { module, test } from 'qunit';
 
-import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+import setupIntlRenderingTest, { t } from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | complementary-certifications/target-profiles/history', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -29,12 +29,15 @@ module('Integration | Component | complementary-certifications/target-profiles/h
     );
 
     // then
-    assert.dom(screen.getByRole('columnheader', { name: 'Nom du profil cible' })).exists();
-    assert.dom(screen.getByRole('columnheader', { name: 'Date de rattachement' })).exists();
-    assert.dom(screen.getByRole('columnheader', { name: 'Date de détachement' })).exists();
-    assert.dom(screen.getByRole('row', { name: 'Target Cascade 10/10/2023 -' })).exists();
-    assert.dom(screen.getByRole('row', { name: 'Target Volcan 08/10/2019 08/10/2020' })).exists();
-    assert.dom(screen.getByRole('link', { name: 'Target Cascade' })).exists();
-    assert.dom(screen.getByRole('link', { name: 'Target Volcan' })).exists();
+    const table = screen.getByRole('table', {
+      name: t('components.complementary-certifications.target-profiles.history-list.caption'),
+    });
+    assert.dom(within(table).getByRole('columnheader', { name: 'Nom du profil cible' })).exists();
+    assert.dom(within(table).getByRole('columnheader', { name: 'Date de rattachement' })).exists();
+    assert.dom(within(table).getByRole('columnheader', { name: 'Date de détachement' })).exists();
+    assert.dom(within(table).getByRole('row', { name: 'Target Cascade 10/10/2023 -' })).exists();
+    assert.dom(within(table).getByRole('row', { name: 'Target Volcan 08/10/2019 08/10/2020' })).exists();
+    assert.dom(within(table).getByRole('link', { name: 'Target Cascade' })).exists();
+    assert.dom(within(table).getByRole('link', { name: 'Target Volcan' })).exists();
   });
 });

--- a/admin/tests/integration/components/routes/authenticated/sessions/list-items-test.gjs
+++ b/admin/tests/integration/components/routes/authenticated/sessions/list-items-test.gjs
@@ -1,12 +1,13 @@
 import { render } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
-import { setupRenderingTest } from 'ember-qunit';
 import ListItems from 'pix-admin/components/sessions/list-items';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | routes/authenticated/sessions | list-items', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   const triggerFiltering = () => {};
 

--- a/admin/tests/integration/components/to-be-published-sessions/list-items-test.gjs
+++ b/admin/tests/integration/components/to-be-published-sessions/list-items-test.gjs
@@ -1,12 +1,12 @@
-import { clickByName, render } from '@1024pix/ember-testing-library';
+import { clickByName, render, within } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import ListItems from 'pix-admin/components/to-be-published-sessions/list-items';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
+import setupIntlRenderingTest, { t } from '../../../helpers/setup-intl-rendering';
 
-module('Integration | Component | routes/authenticated/to-be-published-sessions | list-items', function (hooks) {
+module('Integration | Component | to-be-published-sessions | list-items', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   test('it should display to be published sessions list', async function (assert) {
@@ -43,10 +43,10 @@ module('Integration | Component | routes/authenticated/to-be-published-sessions 
     const screen = await render(<template><ListItems @toBePublishedSessions={{toBePublishedSessions}} /></template>);
 
     // then
-    assert.dom('table tbody tr').exists({ count: 3 });
-    assert.dom(screen.getByText('Centre SCO des Anne-Étoiles')).exists();
-    assert.dom(screen.getByText('Pix Center')).exists();
-    assert.dom(screen.getByText('Hogwarts')).exists();
+    const table = screen.getByRole('table', { name: t('pages.sessions.table.to-be-published.caption') });
+    assert.dom(within(table).getByText('Centre SCO des Anne-Étoiles')).exists();
+    assert.dom(within(table).getByText('Pix Center')).exists();
+    assert.dom(within(table).getByText('Hogwarts')).exists();
   });
 
   test('it should "Aucun résultat" if there are no sessions to show', async function (assert) {

--- a/admin/tests/integration/components/users/user-detail-personal-information/organization-learner-information-test.gjs
+++ b/admin/tests/integration/components/users/user-detail-personal-information/organization-learner-information-test.gjs
@@ -1,14 +1,15 @@
 import { clickByName, render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
-import { setupRenderingTest } from 'ember-qunit';
 import OrganizationLearnerInformation from 'pix-admin/components/users/user-detail-personal-information/organization-learner-information';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
 module(
   'Integration | Component | users | user-detail-personal-information | organization-learner-information',
   function (hooks) {
-    setupRenderingTest(hooks);
+    setupIntlRenderingTest(hooks);
 
     module('When the admin member has access to users actions scope', function () {
       class AccessControlStub extends Service {

--- a/admin/tests/integration/components/users/user-profile-test.gjs
+++ b/admin/tests/integration/components/users/user-profile-test.gjs
@@ -1,10 +1,11 @@
 import { render } from '@1024pix/ember-testing-library';
-import { setupRenderingTest } from 'ember-qunit';
 import UserProfile from 'pix-admin/components/users/user-profile';
 import { module, test } from 'qunit';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | users | user-profile', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('should display user’s profile', async function (assert) {
     // given

--- a/admin/tests/integration/components/with-required-action-sessions/list-items-test.gjs
+++ b/admin/tests/integration/components/with-required-action-sessions/list-items-test.gjs
@@ -1,0 +1,73 @@
+import { render, within } from '@1024pix/ember-testing-library';
+import ListItems from 'pix-admin/components/with-required-action-sessions/list-items';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest, { t } from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | with-required-action-sessions | list-items', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display to be published sessions list', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const firstSession = store.createRecord('with-required-action-session', {
+      id: '1',
+      certificationCenterName: 'Centre SCO des Anne-Étoiles',
+      sessionDate: '2021-01-01',
+      sessionTime: '17:00:00',
+      assignedCertificationOfficerName: 'Officer1',
+      version: 2,
+    });
+    const sessions = [firstSession];
+
+    // when
+    const screen = await render(<template><ListItems @withRequiredActionSessions={{sessions}} /></template>);
+
+    // then
+    const table = screen.getByRole('table', { name: t('pages.sessions.table.required-actions.caption') });
+    assert
+      .dom(within(table).getByRole('columnheader', { name: t('pages.sessions.table.required-actions.headers.id') }))
+      .exists();
+    assert
+      .dom(
+        within(table).getByRole('columnheader', {
+          name: t('pages.sessions.table.required-actions.headers.certification-name'),
+        }),
+      )
+      .exists();
+    assert
+      .dom(
+        within(table).getByRole('columnheader', {
+          name: t('pages.sessions.table.required-actions.headers.session-date'),
+        }),
+      )
+      .exists();
+    assert
+      .dom(
+        within(table).getByRole('columnheader', {
+          name: t('pages.sessions.table.required-actions.headers.finalization-date'),
+        }),
+      )
+      .exists();
+    assert
+      .dom(
+        within(table).getByRole('columnheader', {
+          name: t('pages.sessions.table.required-actions.headers.assigned-officer-name'),
+        }),
+      )
+      .exists();
+  });
+
+  module('when there is no session to display', function () {
+    test('it should display an empty result message', async function (assert) {
+      // given
+      const sessions = [];
+
+      // when
+      const screen = await render(<template><ListItems @withRequiredActionSessions={{sessions}} /></template>);
+
+      // then
+      assert.dom(screen.getByText(t('common.tables.empty-result'))).exists();
+    });
+  });
+});

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -74,6 +74,9 @@
       "auto": "Automatic",
       "member": "Member"
     },
+    "tables": {
+      "empty-result": "Aucun résultat"
+    },
     "words": {
       "no": "No",
       "yes": "Yes"
@@ -779,8 +782,8 @@
             "session-date": "Date de session"
           },
           "modals": {
-            "batch-publications":"Vous vous apprêtez à publier {length} session(s) de certification, souhaitez vous poursuivre ?",
-            "publication":"Souhaitez-vous publier la session ?"
+            "batch-publications": "Vous vous apprêtez à publier {length} session(s) de certification, souhaitez vous poursuivre ?",
+            "publication": "Souhaitez-vous publier la session ?"
           }
         }
       },

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -752,6 +752,18 @@
           "v3": "V3 sessions to be published"
         }
       },
+      "table": {
+        "required-actions": {
+          "checkbox-label": "Afficher uniquement mes sessions",
+          "headers": {
+            "assigned-officer-name": "Qui ?",
+            "certification-name": "Centre de certification",
+            "finalization-date": "Date de finalisation",
+            "id": "ID",
+            "session-date": "Date de session"
+          }
+        }
+      },
       "title": "Toutes les sessions"
     },
     "target-profiles": {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -762,6 +762,26 @@
             "id": "ID",
             "session-date": "Date de session"
           }
+        },
+        "to-be-published": {
+          "button-label": "Publier toutes les sessions",
+          "cell": {
+            "publish-button": {
+              "aria-label": "Publier la session numéro",
+              "label": "Publier"
+            }
+          },
+          "headers": {
+            "actions": "Actions",
+            "certification-name": "Centre de certification",
+            "finalization-date": "Date de finalisation",
+            "id": "ID",
+            "session-date": "Date de session"
+          },
+          "modals": {
+            "batch-publications":"Vous vous apprêtez à publier {length} session(s) de certification, souhaitez vous poursuivre ?",
+            "publication":"Souhaitez-vous publier la session ?"
+          }
         }
       },
       "title": "Toutes les sessions"

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -742,9 +742,17 @@
         "unfinalization-confirmation-modal": "Are you sure you want to unfinalize this session ? Click on confirm to process."
       },
       "list": {
-        "v3-required-actions": "V3 sessions with required actions",
-        "v3-to-be-published": "V3 sessions to be published"
-      }
+        "all": "Toutes les sessions",
+        "required-actions": {
+          "v2": "Sessions with required actions",
+          "v3": "V3 sessions with required actions"
+        },
+        "to-be-published": {
+          "v2": "Sessions to be published",
+          "v3": "V3 sessions to be published"
+        }
+      },
+      "title": "Toutes les sessions"
     },
     "target-profiles": {
       "copy": {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -302,11 +302,13 @@
     },
     "complementary-certifications": {
       "list": {
+        "caption": "Liste des certifications complémentaires, comprenant l'identifiant unique et le nom.",
         "id": "ID",
         "name": "Nom"
       },
       "target-profiles": {
         "badges-list": {
+          "caption": "Liste des résultats thématiques (RT) certifiant liés au profil cible, comprenant l'identifiant unique, l'image associée, le niveau, le nombre de pix minimum pour l'obtenir et le nom du badge.",
           "header": {
             "id": "ID du RT certifiant",
             "image-url": "Image du badge certifié",
@@ -317,6 +319,7 @@
           "title": "Badges certifiés du profil cible actuel"
         },
         "history-list": {
+          "caption": "Liste des profils cibles (actuellement rattaché ou ayant étés rattachés à la complémentaire). Contient la date de rattachement et de détachement et le nom.",
           "headers": {
             "attached-at": "Date de rattachement",
             "detached-at": "Date de détachement",
@@ -757,6 +760,7 @@
       },
       "table": {
         "required-actions": {
+          "caption": "Liste des sessions nécessitant un traitement par un interne Pix. Contient l'identifiant unique de la session, le nom du centre de certification, la date de finalisation et le nom de l'interne en charge du traitement.",
           "checkbox-label": "Afficher uniquement mes sessions",
           "headers": {
             "assigned-officer-name": "Qui ?",
@@ -768,6 +772,7 @@
         },
         "to-be-published": {
           "button-label": "Publier toutes les sessions",
+          "caption": "Liste des sessions pouvant être publiées. Contient l'identifiant unique de la session, le nom du centre de certification, la date de finalisation et un bouton pour publier la session. Ce bouton est disponible uniquement pour les internes Pix ayant les droits.",
           "cell": {
             "publish-button": {
               "aria-label": "Publier la session numéro",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -779,7 +779,26 @@
             "id": "ID",
             "session-date": "Date de session"
           }
-        }
+        },
+        "to-be-published": {
+          "button-label": "Publier toutes les sessions",
+          "cell": {
+            "publish-button": {
+              "aria-label": "Publier la session numéro",
+              "label": "Publier"
+            }
+          },
+          "headers": {
+            "actions": "Actions",
+            "certification-name": "Centre de certification",
+            "finalization-date": "Date de finalisation",
+            "id": "ID",
+            "session-date": "Date de session"
+          },
+          "modals": {
+            "batch-publications":"Vous vous apprêtez à publier {length} session(s) de certification, souhaitez vous poursuivre ?",
+            "publication":"Souhaitez-vous publier la session ?"
+          }        }
       },
       "title": "Toutes les sessions"
     },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -74,6 +74,9 @@
       "auto": "Automatique",
       "member": "Membre"
     },
+    "tables": {
+      "empty-result": "Aucun résultat"
+    },
     "words": {
       "no": "Non",
       "yes": "Oui"
@@ -784,7 +787,7 @@
           "button-label": "Publier toutes les sessions",
           "cell": {
             "publish-button": {
-              "aria-label": "Publier la session numéro",
+              "aria-label": "Publier la session numéro {sessionId}",
               "label": "Publier"
             }
           },
@@ -796,9 +799,10 @@
             "session-date": "Date de session"
           },
           "modals": {
-            "batch-publications":"Vous vous apprêtez à publier {length} session(s) de certification, souhaitez vous poursuivre ?",
-            "publication":"Souhaitez-vous publier la session ?"
-          }        }
+            "batch-publications": "Vous vous apprêtez à publier {length} session(s) de certification, souhaitez vous poursuivre ?",
+            "publication": "Souhaitez-vous publier la session ?"
+          }
+        }
       },
       "title": "Toutes les sessions"
     },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -759,9 +759,17 @@
         "unfinalization-confirmation-modal": "Êtes-vous sûr.e de vouloir définaliser cette session ? Cliquez sur confirmer pour poursuivre."
       },
       "list": {
-        "v3-required-actions": "Sessions à traiter V3",
-        "v3-to-be-published": "Sessions à publier V3"
-      }
+        "all": "Toutes les sessions",
+        "required-actions": {
+          "v2": "Sessions à traiter",
+          "v3": "Sessions à traiter V3"
+        },
+        "to-be-published": {
+          "v2": "Sessions à publier",
+          "v3": "Sessions à publier V3"
+        }
+      },
+      "title": "Toutes les sessions"
     },
     "target-profiles": {
       "copy": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -769,6 +769,18 @@
           "v3": "Sessions à publier V3"
         }
       },
+      "table": {
+        "required-actions": {
+          "checkbox-label": "Afficher uniquement mes sessions",
+          "headers": {
+            "assigned-officer-name": "Qui ?",
+            "certification-name": "Centre de certification",
+            "finalization-date": "Date de finalisation",
+            "id": "ID",
+            "session-date": "Date de session"
+          }
+        }
+      },
       "title": "Toutes les sessions"
     },
     "target-profiles": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -310,11 +310,13 @@
     },
     "complementary-certifications": {
       "list": {
+        "caption": "Liste des certifications complémentaires, comprenant l'identifiant unique et le nom.",
         "id": "ID",
         "name": "Nom"
       },
       "target-profiles": {
         "badges-list": {
+          "caption": "Liste des résultats thématiques (RT) certifiant liés au profil cible, comprenant l'identifiant unique, l'image associée, le niveau, le nombre de pix minimum pour l'obtenir et le nom du badge.",
           "header": {
             "id": "ID du RT certifiant",
             "image-url": "Image du badge certifié",
@@ -325,6 +327,7 @@
           "title": "Badges certifiés du profil cible actuel"
         },
         "history-list": {
+          "caption": "Liste des profils cibles (actuellement rattaché ou ayant étés rattachés à la complémentaire). Contient la date de rattachement et de détachement et le nom.",
           "headers": {
             "attached-at": "Date de rattachement",
             "detached-at": "Date de détachement",
@@ -774,6 +777,7 @@
       },
       "table": {
         "required-actions": {
+          "caption": "Liste des sessions nécessitant un traitement par un interne Pix. Contient l'identifiant unique de la session, le nom du centre de certification, la date de finalisation et le nom de l'interne en charge du traitement.",
           "checkbox-label": "Afficher uniquement mes sessions",
           "headers": {
             "assigned-officer-name": "Qui ?",
@@ -785,6 +789,7 @@
         },
         "to-be-published": {
           "button-label": "Publier toutes les sessions",
+          "caption": "Liste des sessions pouvant être publiées. Contient l'identifiant unique de la session, le nom du centre de certification, la date de finalisation et un bouton pour publier la session. Ce bouton est disponible uniquement pour les internes Pix ayant les droits.",
           "cell": {
             "publish-button": {
               "aria-label": "Publier la session numéro {sessionId}",


### PR DESCRIPTION
## :pancakes: Problème

Le composant PixTable existe mais n'est pas du tout utilisé dans nos applications

## :bacon: Proposition

Commencer par des tableaux simples => sessions (sauf ceux présentant des champs)

## :yum: Pour tester

https://admin-pr11437.review.pix.fr/sessions/list/with-required-action?version=2

- Vérifier que les liens dans les tableaux fonctionnent correctement.
- Vérifier que la checkbox pour ne voir que les sessions assigné fonctionne
- Vérifier que la publication unitaire fonctionne

LES TABLEAUX CONCERNÉS 
<img width="1463" alt="Capture d’écran 2025-02-18 à 12 12 41" src="https://github.com/user-attachments/assets/32b6f07c-1aa8-419d-8925-787739ef173e" />


SESSIONS A PUBLIER : sans les droits de publication
<img width="1646" alt="Capture d’écran 2025-02-17 à 17 17 22" src="https://github.com/user-attachments/assets/ac39aa21-6a0d-43c8-a0dd-17df33a9b5fa" />

SESSIONS A PUBLIER : avec les droits de publication
<img width="1646" alt="Capture d’écran 2025-02-17 à 17 17 49" src="https://github.com/user-attachments/assets/73ca9e67-9de1-411b-84ef-5a1c2b730b50" />

SESSIONS A PUBLIER : aucun résultat
<img width="1646" alt="Capture d’écran 2025-02-17 à 17 17 54" src="https://github.com/user-attachments/assets/1c7f96d4-f310-4c70-934e-1fe1401763fb" />

SESSIONS A TRAITER : toutes les sessions
<img width="1646" alt="Capture d’écran 2025-02-17 à 18 31 06" src="https://github.com/user-attachments/assets/dad17450-c7b3-4db1-9ee3-92c3c4037a07" />

SESSIONS A TRAITER : je coche mes sessions
<img width="1646" alt="Capture d’écran 2025-02-17 à 18 31 09" src="https://github.com/user-attachments/assets/d960d394-5a6c-439a-8719-e989cfea64ba" />

