### PR TITLE
[TECH] :construction_worker: Ne pas déployer d'addon REDIS ou PG pour les fronts

### DIFF
--- a/api/scalingo.json
+++ b/api/scalingo.json
@@ -29,6 +29,20 @@
   "scripts": {
     "first-deploy": "./scripts/scalingo-post-ra-creation.sh"
   },
+  "addons": [
+    {
+      "plan": "postgresql:postgresql-sandbox",
+      "options": {
+        "version": "15.10"
+      }
+    },
+    {
+      "plan": "redis:redis-sandbox",
+      "options": {
+        "version": "7.2.5"
+      }
+    }
+  ],
   "formation": {
     "web": {
       "amount": 1,

--- a/audit-logger/scalingo.json
+++ b/audit-logger/scalingo.json
@@ -1,0 +1,53 @@
+{
+  "name": "Pix Review App",
+  "env": {
+    "REVIEW_APP": {
+      "description": "Indicates that the application is a review app",
+      "value": "true"
+    },
+    "DOMAIN_PIX_APP": {
+      "generator": "template",
+      "template": "https://app-pr%PR_NUMBER%.review.pix"
+    },
+    "DOMAIN_PIX_ORGA": {
+      "generator": "template",
+      "template": "https://orga-pr%PR_NUMBER%.review.pix"
+    },
+    "DOMAIN_PIX_CERTIF": {
+      "generator": "template",
+      "template": "https://certif-pr%PR_NUMBER%.review.pix"
+    },
+    "PIX_API_URL": {
+      "generator": "template",
+      "template": "https://api-pr%PR_NUMBER%.review.pix.fr"
+    },
+    "PR_NUMBER": {
+      "generator": "template",
+      "template": "%PR_NUMBER%"
+    }
+  },
+  "scripts": {
+    "first-deploy": "./scripts/scalingo-post-ra-creation.sh"
+  },
+  "addons": [
+    {
+      "plan": "postgresql:postgresql-sandbox",
+      "options": {
+        "version": "15.10"
+      }
+    },
+    {
+      "plan": "redis:redis-sandbox",
+      "options": {
+        "version": "7.2.5"
+      }
+    }
+  ],
+  "formation": {
+    "web": {
+      "amount": 1,
+      "size": "S"
+    }
+  },
+  "stack": "scalingo-22"
+}


### PR DESCRIPTION
## :pancakes: Problème

> Pourquoi les applies front-review-prxxxx ont un addon pg et un addon redis ?

> Je ne pense pas que ce soit normal, les fronts n'ont pas besoin d'addon pg/redis (seul l'api en a besoin)

(https://1024pix.slack.com/archives/C658LDBAQ/p1738761384021799 lien discussion slack privée)

## :bacon: Proposition

Ne pas ajouter d'addon PG et Redis sur les app front de scalingo.

## 🧃 Remarques

Nous changeons le `scalingo.json` à la racine comme un fichie de configuration par défaut. Il y a un fichier spécifique dans le répertoire `api/` qui n'a pas de raison de changer. Est-ce que ça fera le boulot ?

## :yum: Pour tester

S'assurer que le déploiement des fronts et OK et que les applications fonctionnent, sans add-on PG ni Redis
