### PR TITLE
[BUGFIX] Corriger une traduction anglaise sur le mail d'invitation à rejoindre un centre de certification (PIX-16587)

### DIFF
--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -166,7 +166,7 @@
       "needHelp": "Need help, contact us",
       "oneTimeLink": "This is a one-time use link",
       "pixCertifPresentation": "The Pix Certif space is a tool dedicated to the organisation of certification sessions.",
-      "title": "Invitation to join the Pix Certif space",
+      "title": "Invitation to join the space",
       "yourCertificationCenter": "Your certification centre"
     },
     "subject": "Invitation to join Pix Certif"


### PR DESCRIPTION
## :pancakes: Problème

Il a été remonté suite à une démo que le terme anglais du titre du mail d'invitation à rejoindre un centre de certification n'était pas correcte.

## :bacon: Proposition

Modifier ce terme en le remplaçant par un plus approprié.

## 🧃 Remarques

Pourquoi le problème n'a-t-il pas été remonté plus tôt?

## :yum: Pour tester
- Se rendre sur Pix admin,
- Se connecter avec le compte superadmin@example.net,
- Aller sur la page des centre de certifs,
- Envoyer une invitation,
- Vérifier dans ses mail que le titre es désormais "Invitation to join the space".