### PR TITLE
[FEATURE] Créer un centre de certification en pilote V3 par défaut (PIX-16601)

### DIFF
--- a/admin/app/components/certification-centers/creation-form.gjs
+++ b/admin/app/components/certification-centers/creation-form.gjs
@@ -32,11 +32,6 @@ export default class CertificationCenterForm extends Component {
   }
 
   @action
-  handleIsV3PilotChange(event) {
-    this.args.certificationCenter.isV3Pilot = event.target.checked;
-  }
-
-  @action
   handleDataProtectionOfficerFirstNameChange(event) {
     this.args.certificationCenter.dataProtectionOfficerFirstName = event.target.value;
   }
@@ -121,12 +116,6 @@ export default class CertificationCenterForm extends Component {
       >
         <:label>Adresse e-mail du DPO</:label>
       </PixInput>
-
-      <div class="form-field">
-        <PixCheckbox @id="isV3Pilot" @size="small" onChange={{this.handleIsV3PilotChange}}>
-          <:label>{{t "components.certification-centers.is-v3-pilot-label"}}</:label>
-        </PixCheckbox>
-      </div>
 
       <section>
         <h2 class="habilitations-title">Habilitations aux certifications complémentaires</h2>

--- a/admin/app/components/certification-centers/information-edit.gjs
+++ b/admin/app/components/certification-centers/information-edit.gjs
@@ -40,11 +40,6 @@ export default class InformationEdit extends Component {
   }
 
   @action
-  updateIsV3Pilot(event) {
-    this.form.set('isV3Pilot', event.target.checked);
-  }
-
-  @action
   async updateGrantedHabilitation(habilitation) {
     const habilitations = await this.form.habilitations;
     if (habilitations.includes(habilitation)) {
@@ -70,7 +65,6 @@ export default class InformationEdit extends Component {
     this.args.certificationCenter.set('dataProtectionOfficerFirstName', this.form.dataProtectionOfficerFirstName);
     this.args.certificationCenter.set('dataProtectionOfficerLastName', this.form.dataProtectionOfficerLastName);
     this.args.certificationCenter.set('dataProtectionOfficerEmail', this.form.dataProtectionOfficerEmail);
-    this.args.certificationCenter.set('isV3Pilot', this.form.isV3Pilot);
 
     this.args.toggleEditMode();
     return this.args.onSubmit();
@@ -85,7 +79,6 @@ export default class InformationEdit extends Component {
       'dataProtectionOfficerFirstName',
       'dataProtectionOfficerLastName',
       'dataProtectionOfficerEmail',
-      'isV3Pilot',
     );
     this.form.setProperties({ ...properties, habilitations });
   }
@@ -183,10 +176,6 @@ export default class InformationEdit extends Component {
           {{this.form.validations.attrs.dataProtectionOfficerEmail.message}}
         </span>
       {{/if}}
-
-      <PixCheckbox @id="isV3Pilot" @size="small" onChange={{this.updateIsV3Pilot}} @checked={{this.form.isV3Pilot}}>
-        <:label>{{t "components.certification-centers.is-v3-pilot-label"}}</:label>
-      </PixCheckbox>
 
       <span class="field-label">Habilitations aux certifications complémentaires</span>
       <ul class="form-field certification-center-information__edit-form__habilitations-checkbox-list">

--- a/admin/app/controllers/authenticated/certification-centers/get.js
+++ b/admin/app/controllers/authenticated/certification-centers/get.js
@@ -2,7 +2,6 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import get from 'lodash/get';
 
 import { types } from '../../../models/certification-center';
 
@@ -26,14 +25,7 @@ export default class AuthenticatedCertificationCentersGetController extends Cont
     try {
       await this.model.certificationCenter.save();
       this.pixToast.sendSuccessNotification({ message: 'Centre de certification mis à jour avec succès.' });
-    } catch (error) {
-      if (get(error, 'errors[0].code') === 'PILOT_FEATURES_CONFLICT') {
-        return this.pixToast.sendErrorNotification({
-          message: this.intl.t(
-            'pages.certification-centers.notifications.update.errors.pilot-features-incompatibilities',
-          ),
-        });
-      }
+    } catch {
       this.pixToast.sendErrorNotification({
         message: "Une erreur est survenue, le centre de certification n'a pas été mis à jour.",
       });

--- a/admin/tests/acceptance/authenticated/certification-centers/get-test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get-test.js
@@ -197,42 +197,6 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
         .dom(screen.getByText("Une erreur est survenue, le centre de certification n'a pas été mis à jour."))
         .exists();
     });
-
-    module('when the certification is updated with v3Pilot with a feature pilot', function () {
-      test('should display an error notification', async function (assert) {
-        // given
-        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-        const certificationCenter = server.create('certification-center', {
-          name: 'Center 1',
-          externalId: 'ABCDEF',
-          type: 'SCO',
-        });
-        this.server.patch(
-          `/admin/certification-centers/${certificationCenter.id}`,
-          { errors: [{ code: 'PILOT_FEATURES_CONFLICT' }] },
-          403,
-        );
-        const screen = await visit(`/certification-centers/${certificationCenter.id}`);
-        await clickByName('Modifier');
-        await click(
-          screen.getByRole('checkbox', {
-            name: 'Pilote Certification V3 (ce centre de certification ne pourra organiser que des sessions V3)',
-          }),
-        );
-
-        // when
-        await clickByName('Enregistrer');
-
-        // then
-        assert
-          .dom(
-            screen.getByText(
-              'Il y a une incompatibilité entre les fonctionnalités pilotes auxquelles vous souhaitez habiliter le centre. Merci de rafraîchir la page.',
-            ),
-          )
-          .exists();
-      });
-    });
   });
 
   module('tab navigation', function () {

--- a/admin/tests/integration/components/certification-centers/creation-form-test.gjs
+++ b/admin/tests/integration/components/certification-centers/creation-form-test.gjs
@@ -27,45 +27,6 @@ module('Integration | Component | certification-centers/creation-form', function
     assert.dom(screen.getByText('Identifiant externe')).exists();
     assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
     assert.dom(screen.getByText('Ajouter')).exists();
-    assert
-      .dom(
-        screen.getByRole('checkbox', {
-          name: 'Pilote Certification V3 (ce centre de certification ne pourra organiser que des sessions V3)',
-        }),
-      )
-      .exists();
-  });
-
-  module('#handleIsV3PilotChange', function () {
-    test('should add isV3Pilot to certification center on checked checkbox', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const certificationCenter = store.createRecord('certification-center');
-      const habilitations = [];
-      const onSubmit = () => {};
-      const onCancel = () => {};
-
-      const screen = await render(
-        <template>
-          <CreationForm
-            @habilitations={{habilitations}}
-            @certificationCenter={{certificationCenter}}
-            @onSubmit={{onSubmit}}
-            @onCancel={{onCancel}}
-          />
-        </template>,
-      );
-
-      // when
-      await click(
-        screen.getByRole('checkbox', {
-          name: 'Pilote Certification V3 (ce centre de certification ne pourra organiser que des sessions V3)',
-        }),
-      );
-
-      // then
-      assert.true(certificationCenter.isV3Pilot);
-    });
   });
 
   module('#selectCertificationCenterType', function () {

--- a/admin/tests/integration/components/certification-centers/information-edit-test.gjs
+++ b/admin/tests/integration/components/certification-centers/information-edit-test.gjs
@@ -25,22 +25,6 @@ module('Integration | Component | certification-centers/information-edit', funct
   const onSubmit = sinon.stub();
 
   module('certification center edit form validation', function () {
-    test('it should display a checkbox to edit the isV3Pilot certification center status ', async function (assert) {
-      // when
-      const screen = await render(
-        <template><InformationEdit @certificationCenter={{certificationCenter}} /></template>,
-      );
-
-      // then
-      assert
-        .dom(
-          screen.getByRole('checkbox', {
-            name: 'Pilote Certification V3 (ce centre de certification ne pourra organiser que des sessions V3)',
-          }),
-        )
-        .exists();
-    });
-
     test("it should show an error message if certification center's name is empty", async function (assert) {
       // given
       const screen = await render(
@@ -210,11 +194,6 @@ module('Integration | Component | certification-centers/information-edit', funct
         await fillByLabel('Prénom du DPO', 'newFirstname');
         await fillByLabel('Nom du DPO', 'newLastname');
         await fillByLabel('Adresse e-mail du DPO', 'newMail@example.net');
-        await click(
-          screen.getByRole('checkbox', {
-            name: 'Pilote Certification V3 (ce centre de certification ne pourra organiser que des sessions V3)',
-          }),
-        );
 
         await click(screen.getByRole('button', { name: 'Enregistrer' }));
 
@@ -226,7 +205,7 @@ module('Integration | Component | certification-centers/information-edit', funct
         assert.strictEqual(certificationCenter.dataProtectionOfficerFirstName, 'newFirstname');
         assert.strictEqual(certificationCenter.dataProtectionOfficerLastName, 'newLastname');
         assert.strictEqual(certificationCenter.dataProtectionOfficerEmail, 'newMail@example.net');
-        assert.false(certificationCenter.isV3Pilot);
+        assert.true(certificationCenter.isV3Pilot);
       });
 
       test('it should add the habilitation to the certification center', async function (assert) {

--- a/admin/tests/unit/components/certification-centers/information-edit-test.js
+++ b/admin/tests/unit/components/certification-centers/information-edit-test.js
@@ -19,30 +19,6 @@ module('Unit | Component | certification-centers/information-edit', function (ho
     });
   });
 
-  module('#updateIsV3Pilot', function () {
-    test('should add isV3Pilot to certification center on checked checkbox', async function (assert) {
-      // given
-      component.form.isV3Pilot = false;
-
-      // when
-      component.updateIsV3Pilot({ target: { checked: true } });
-
-      // then
-      assert.true(component.form.isV3Pilot);
-    });
-
-    test('should remove isV3Pilot to certification center on unchecked checkbox', async function (assert) {
-      // given
-      component.form.isV3Pilot = true;
-
-      // when
-      component.updateIsV3Pilot({ target: { checked: false } });
-
-      // then
-      assert.false(component.form.isV3Pilot);
-    });
-  });
-
   module('#availableHabilitations', function () {
     test('it should return a sorted list of available habilitations', async function (assert) {
       // given

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -281,7 +281,6 @@
       }
     },
     "certification-centers": {
-      "is-v3-pilot-label": "V3 Certification Pilot (This center will only be able to organize v3 sessions)",
       "membership-item": {
         "actions": {
           "edit-role": "Edit role"
@@ -585,11 +584,6 @@
         },
         "success": {
           "update-certification-center-membership-role": "The member's role has been modified."
-        },
-        "update": {
-          "errors": {
-            "pilot-features-incompatibilities": "There are incompatibilities between the pilot features this center is habilitated to. Please refresh this page."
-          }
         }
       }
     },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -289,7 +289,6 @@
       }
     },
     "certification-centers": {
-      "is-v3-pilot-label": "Pilote Certification V3 (ce centre de certification ne pourra organiser que des sessions V3)",
       "membership-item": {
         "actions": {
           "edit-role": "Modifier le rôle"
@@ -595,11 +594,6 @@
         },
         "success": {
           "update-certification-center-membership-role": "Le rôle du membre a été modifié."
-        },
-        "update": {
-          "errors": {
-            "pilot-features-incompatibilities": "Il y a une incompatibilité entre les fonctionnalités pilotes auxquelles vous souhaitez habiliter le centre. Merci de rafraîchir la page."
-          }
         }
       }
     },

--- a/api/src/organizational-entities/infrastructure/repositories/certification-center-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/certification-center-for-admin.repository.js
@@ -7,7 +7,7 @@ const save = async function (certificationCenter) {
     name: certificationCenter.name,
     type: certificationCenter.type,
     externalId: certificationCenter.externalId,
-    isV3Pilot: certificationCenter.isV3Pilot,
+    isV3Pilot: true,
   });
   return _toDomain(certificationCenterCreated);
 };

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/certification-center-for-admin-repository_test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/certification-center-for-admin-repository_test.js
@@ -20,13 +20,11 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       const certificationCenterId = 1;
       const certificationCenterName = 'CertificationCenterName';
       const certificationCenterType = 'SCO';
-      const certificationCenterIsV3Pilot = true;
 
       const center = databaseBuilder.factory.buildCertificationCenter({
         id: certificationCenterId,
         name: certificationCenterName,
         type: certificationCenterType,
-        isV3Pilot: certificationCenterIsV3Pilot,
       });
 
       const certificationCenterForAdmin = new CenterForAdmin({
@@ -41,7 +39,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       expect(savedCertificationCenter.id).to.exist;
       expect(savedCertificationCenter.name).to.equal(certificationCenterName);
       expect(savedCertificationCenter.type).to.equal(certificationCenterType);
-      expect(savedCertificationCenter.isV3Pilot).to.equal(certificationCenterIsV3Pilot);
+      expect(savedCertificationCenter.isV3Pilot).to.equal(true);
     });
   });
 


### PR DESCRIPTION
## :pancakes: Problème

Lors de la création d'un centre de certification, nous devons penser à cocher la case « certif v3 pilot »

![image](https://github.com/user-attachments/assets/4ea8fbf7-c2ff-4d1c-99e8-3bd9fcf794dc)

## :bacon: Proposition

Ne plus afficher cette case a coché, et la considérée cochée par défaut lors de la création d'un centre.

![image](https://github.com/user-attachments/assets/cbbe04c3-e7de-4b21-9493-436362b0bbe3)


## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

- Créer un nouveau centre de certification dans pixAdmin
- s'assurer qu'il est bien en v3 
- modifier le nom d'un centre de certification v2 dans pixAdmin
- s'assurer qu'il reste bien en v2
- modifier le nom d'un centre de certification v3 dans pixAdmin
- s'assurer qu'il reste bien en v3
