### PR TITLE
[FEATURE] Ajout du score global dans les resultats Parcoursup (PIX-16548).

### DIFF
--- a/api/db/seeds/data/common/common-builder.js
+++ b/api/db/seeds/data/common/common-builder.js
@@ -94,7 +94,7 @@ function createClientApplications(databaseBuilder) {
   databaseBuilder.factory.buildClientApplication({
     name: 'parcoursup',
     clientId: 'parcoursup',
-    clientSecret: 'parcoursupsecret',
+    clientSecret: 'parcoursup-secret-de-trente-deux-caracteres',
     scopes: ['parcoursup'],
   });
 }

--- a/api/sample.env
+++ b/api/sample.env
@@ -572,7 +572,7 @@ AUTH_SECRET=the-password-must-be-at-least-32-characters-long
 # Secret salt value used in PARCOURSUP JWT token generation.
 # presence: required for PARCOURSUP authentication, optional otherwise
 # type: String
-# sample: PIX_PARCOURSUP_AUTH_SECRET=secret-parcoursup
+# sample: PIX_PARCOURSUP_AUTH_SECRET=secret-parcoursup-for-pix-review-app-at-least-32-characters-long
 
 
 # ===================

--- a/api/src/certification/results/application/parcoursup-controller.js
+++ b/api/src/certification/results/application/parcoursup-controller.js
@@ -1,15 +1,38 @@
+import { LOCALE } from '../../../shared/domain/constants.js';
+import { getI18n } from '../../../shared/infrastructure/i18n/i18n.js';
+const { FRENCH_FRANCE } = LOCALE;
 import { usecases } from '../domain/usecases/index.js';
+import * as parcoursupCertificationSerializer from '../infrastructure/serializers/parcoursup-certification-serializer.js';
 
-const getCertificationResultForParcoursup = async function (request) {
+const getCertificationResultForParcoursup = async function (
+  request,
+  h,
+  dependencies = {
+    parcoursupCertificationSerializer,
+  },
+) {
+  const i18n = getI18n(FRENCH_FRANCE);
   const { ine, organizationUai, lastName, firstName, birthdate, verificationCode } = request.payload;
 
-  return usecases.getCertificationResultForParcoursup({
+  const certificationResult = await usecases.getCertificationResultForParcoursup({
     ine,
     organizationUai,
     lastName,
     firstName,
     birthdate,
     verificationCode,
+  });
+
+  const globalMeshLevel = await usecases.getGlobalMeshLevel({
+    pixScore: certificationResult.pixScore,
+    certificationDate: certificationResult.certificationDate,
+    i18n,
+  });
+
+  return dependencies.parcoursupCertificationSerializer.serialize({
+    certificationResult,
+    globalMeshLevel,
+    translate: i18n.__,
   });
 };
 

--- a/api/src/certification/results/application/parcoursup-route.js
+++ b/api/src/certification/results/application/parcoursup-route.js
@@ -64,10 +64,10 @@ const register = async function (server) {
               birthdate: Joi.date().description('Date de naissance au format AAAA-MM-JJ'),
               status: Joi.string().description('Statut de la certification'),
               pixScore: Joi.number().min(0).max(1024).description('Score global en nombre de pix'),
-              certificationDate: Joi.date().description('Date de passage de la certification'),
               globalLevel: Joi.string().description(
                 'Niveau global de la certification, défini en fonction du score global Pix obtenu',
               ),
+              certificationDate: Joi.date().description('Date de passage de la certification'),
               competences: Joi.array()
                 .items(
                   Joi.object({

--- a/api/src/certification/results/domain/services/pix-score-to-mesh-level.js
+++ b/api/src/certification/results/domain/services/pix-score-to-mesh-level.js
@@ -5,6 +5,7 @@
 import { findIntervalIndexFromScore } from '../../../scoring/domain/models/CapacitySimulator.js';
 // TODO : bounded context violation
 import { CertificationAssessmentScoreV3 } from '../../../scoring/domain/models/CertificationAssessmentScoreV3.js';
+import { GlobalCertificationLevel } from '../../../shared/domain/models/GlobalCertificationLevel.js';
 
 const SCORING_CONFIGURATION_WEIGHT = CertificationAssessmentScoreV3.weightsAndCoefficients.map(({ weight }) => weight);
 
@@ -14,9 +15,11 @@ const SCORING_CONFIGURATION_WEIGHT = CertificationAssessmentScoreV3.weightsAndCo
  * @param {V3CertificationScoring} params.scoringConfiguration
  */
 export const getMeshLevel = ({ pixScore, scoringConfiguration }) => {
-  return findIntervalIndexFromScore({
-    score: pixScore,
-    weights: SCORING_CONFIGURATION_WEIGHT,
-    scoringIntervalsLength: scoringConfiguration.getNumberOfIntervals(),
+  return new GlobalCertificationLevel({
+    meshLevel: findIntervalIndexFromScore({
+      score: pixScore,
+      weights: SCORING_CONFIGURATION_WEIGHT,
+      scoringIntervalsLength: scoringConfiguration.getNumberOfIntervals(),
+    }),
   });
 };

--- a/api/src/certification/results/domain/services/pix-score-to-mesh-level.js
+++ b/api/src/certification/results/domain/services/pix-score-to-mesh-level.js
@@ -1,0 +1,22 @@
+/**
+ * @typedef {import ('../../../shared/domain/models/V3CertificationScoring.js').V3CertificationScoring} V3CertificationScoring
+ */
+
+import { findIntervalIndexFromScore } from '../../../scoring/domain/models/CapacitySimulator.js';
+// TODO : bounded context violation
+import { CertificationAssessmentScoreV3 } from '../../../scoring/domain/models/CertificationAssessmentScoreV3.js';
+
+const SCORING_CONFIGURATION_WEIGHT = CertificationAssessmentScoreV3.weightsAndCoefficients.map(({ weight }) => weight);
+
+/**
+ * @param {Object} params
+ * @param {number} params.pixScore
+ * @param {V3CertificationScoring} params.scoringConfiguration
+ */
+export const getMeshLevel = ({ pixScore, scoringConfiguration }) => {
+  return findIntervalIndexFromScore({
+    score: pixScore,
+    weights: SCORING_CONFIGURATION_WEIGHT,
+    scoringIntervalsLength: scoringConfiguration.getNumberOfIntervals(),
+  });
+};

--- a/api/src/certification/results/domain/usecases/get-global-mesh-level.js
+++ b/api/src/certification/results/domain/usecases/get-global-mesh-level.js
@@ -1,0 +1,27 @@
+/**
+ * @typedef {import ('./index.js').ScoringConfigurationRepository} ScoringConfigurationRepository
+ * @typedef {import ('./index.js').PixScoreToMeshLevelService} PixScoreToMeshLevelService
+ */
+
+/**
+ * @param {Object} params
+ * @param {number} params.pixScore
+ * @param {Date} params.certificationDate - the mesh levels depends on the configuration at date
+ * @param {Object} params.i18n
+ * @param {ScoringConfigurationRepository} params.scoringConfigurationRepository
+ * @param {PixScoreToMeshLevelService} params.pixScoreToMeshLevelService
+ */
+export const getGlobalMeshLevel = async ({
+  pixScore,
+  certificationDate,
+  i18n,
+  scoringConfigurationRepository,
+  pixScoreToMeshLevelService,
+}) => {
+  const scoringConfiguration = await scoringConfigurationRepository.getLatestByDateAndLocale({
+    date: certificationDate,
+    locale: i18n.getLocale(),
+  });
+
+  return pixScoreToMeshLevelService.getMeshLevel({ pixScore, scoringConfiguration });
+};

--- a/api/src/certification/results/domain/usecases/index.js
+++ b/api/src/certification/results/domain/usecases/index.js
@@ -7,6 +7,7 @@ import { importNamedExportsFromDirectory } from '../../../../shared/infrastructu
 import * as sessionEnrolmentRepository from '../../../enrolment/infrastructure/repositories/session-repository.js';
 import * as certificationCourseRepository from '../../../shared/infrastructure/repositories/certification-course-repository.js';
 import * as certificationReportRepository from '../../../shared/infrastructure/repositories/certification-report-repository.js';
+import * as scoringConfigurationRepository from '../../../shared/infrastructure/repositories/scoring-configuration-repository.js';
 import * as sharedSessionRepository from '../../../shared/infrastructure/repositories/session-repository.js';
 import * as certificateRepository from '../../infrastructure/repositories/certificate-repository.js';
 import * as certificationLivretScolaireRepository from '../../infrastructure/repositories/certification-livret-scolaire-repository.js';
@@ -15,6 +16,7 @@ import * as certificationResultRepository from '../../infrastructure/repositorie
 import * as cleaCertifiedCandidateRepository from '../../infrastructure/repositories/clea-certified-candidate-repository.js';
 import * as competenceTreeRepository from '../../infrastructure/repositories/competence-tree-repository.js';
 import * as scoCertificationCandidateRepository from '../../infrastructure/repositories/sco-certification-candidate-repository.js';
+import * as pixScoreToMeshLevelService from '../services/pix-score-to-mesh-level.js';
 
 /**
  * Using {@link https://jsdoc.app/tags-type "Closure Compiler's syntax"} to document injected dependencies
@@ -30,6 +32,8 @@ import * as scoCertificationCandidateRepository from '../../infrastructure/repos
  * @typedef {sharedSessionRepository} SharedSessionRepository
  * @typedef {certificationLivretScolaireRepository} CertificationLivretScolaireRepository
  * @typedef {competenceTreeRepository} CompetenceTreeRepository
+ * @typedef {scoringConfigurationRepository} ScoringConfigurationRepository
+ * @typedef {pixScoreToMeshLevelService} PixScoreToMeshLevelService
  **/
 
 const dependencies = {
@@ -44,6 +48,8 @@ const dependencies = {
   sharedSessionRepository,
   competenceTreeRepository,
   certificationLivretScolaireRepository,
+  scoringConfigurationRepository,
+  pixScoreToMeshLevelService,
 };
 
 const path = dirname(fileURLToPath(import.meta.url));

--- a/api/src/certification/results/infrastructure/serializers/parcoursup-certification-serializer.js
+++ b/api/src/certification/results/infrastructure/serializers/parcoursup-certification-serializer.js
@@ -10,18 +10,17 @@
  * @param {Object} params.translate
  */
 const serialize = ({ certificationResult, globalMeshLevel, translate }) => {
-  // TODO: tests
   return {
-    ine: certificationResult.ine,
     organizationUai: certificationResult.organizationUai,
-    lastName: certificationResult.lastName,
+    ine: certificationResult.ine,
     firstName: certificationResult.firstName,
+    lastName: certificationResult.lastName,
     birthdate: certificationResult.birthdate,
     status: certificationResult.status,
     pixScore: certificationResult.pixScore,
+    globalLevel: globalMeshLevel.getLevelLabel(translate),
     certificationDate: certificationResult.certificationDate,
     competences: certificationResult.competences,
-    globalLevel: globalMeshLevel.getLevelLabel(translate),
   };
 };
 

--- a/api/src/certification/results/infrastructure/serializers/parcoursup-certification-serializer.js
+++ b/api/src/certification/results/infrastructure/serializers/parcoursup-certification-serializer.js
@@ -1,0 +1,28 @@
+/**
+ * @typedef {import('../../domain/read-models/parcoursup/CertificationResult.js').CertificationResult} CertificationResult
+ * @typedef {import('../../../shared/domain/models/GlobalCertificationLevel.js').GlobalCertificationLevel} GlobalCertificationLevel
+ */
+
+/**
+ * @param {Object} params
+ * @param {CertificationResult} params.certificationResult
+ * @param {GlobalCertificationLevel} params.globalMeshLevel
+ * @param {Object} params.translate
+ */
+const serialize = ({ certificationResult, globalMeshLevel, translate }) => {
+  // TODO: tests
+  return {
+    ine: certificationResult.ine,
+    organizationUai: certificationResult.organizationUai,
+    lastName: certificationResult.lastName,
+    firstName: certificationResult.firstName,
+    birthdate: certificationResult.birthdate,
+    status: certificationResult.status,
+    pixScore: certificationResult.pixScore,
+    certificationDate: certificationResult.certificationDate,
+    competences: certificationResult.competences,
+    globalLevel: globalMeshLevel.getLevelLabel(translate),
+  };
+};
+
+export { serialize };

--- a/api/src/certification/shared/domain/models/GlobalCertificationLevel.js
+++ b/api/src/certification/shared/domain/models/GlobalCertificationLevel.js
@@ -16,7 +16,12 @@ export class GlobalCertificationLevel {
   }
 
   getLevelLabel(translate) {
-    return translate(`certification.global.meshlevel.${this.meshLevel}`);
+    const translationKey = `certification.global.meshlevel.${this.meshLevel}`;
+    const translation = translate(translationKey);
+    if (translation === translationKey) {
+      return '';
+    }
+    return translation;
   }
 
   #validate() {

--- a/api/src/certification/shared/domain/models/GlobalCertificationLevel.js
+++ b/api/src/certification/shared/domain/models/GlobalCertificationLevel.js
@@ -1,0 +1,28 @@
+import Joi from 'joi';
+
+import { EntityValidationError } from '../../../../shared/domain/errors.js';
+
+export class GlobalCertificationLevel {
+  static #schema = Joi.object({ meshLevel: Joi.number().required() });
+
+  /**
+   * @param {Object} props
+   * @param {number} props.meshLevel - interval index
+   * @param {Object} props.translate - translation service
+   */
+  constructor({ meshLevel }) {
+    this.meshLevel = meshLevel;
+    this.#validate();
+  }
+
+  getLevelLabel(translate) {
+    return translate(`certification.global.meshlevel.${this.meshLevel}`);
+  }
+
+  #validate() {
+    const { error } = GlobalCertificationLevel.#schema.validate(this, { allowUnknown: false });
+    if (error) {
+      throw EntityValidationError.fromJoiErrors(error.details);
+    }
+  }
+}

--- a/api/tests/certification/results/acceptance/application/parcoursup-route_test.js
+++ b/api/tests/certification/results/acceptance/application/parcoursup-route_test.js
@@ -1,5 +1,7 @@
+import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
 import {
   createServer,
+  databaseBuilder,
   datamartBuilder,
   expect,
   generateValidRequestAuthorizationHeaderForApplication,
@@ -51,7 +53,7 @@ describe('Certification | Results | Acceptance | Application | parcoursup-route'
       status: 'validated',
       pixScore: 327,
       certificationDate: new Date('2024-11-22T09:39:54Z'),
-      globalLevel: '',
+      globalLevel: 'Indépendant 1',
       competences: [
         {
           code: '1.1',
@@ -84,6 +86,18 @@ describe('Certification | Results | Acceptance | Application | parcoursup-route'
     });
 
     await datamartBuilder.commit();
+
+    const superAdmin = databaseBuilder.factory.buildUser.withRole({
+      role: PIX_ADMIN.ROLES.SUPER_ADMIN,
+    });
+    databaseBuilder.factory.buildCompetenceScoringConfiguration({
+      createdByUserId: superAdmin.id,
+      configuration: [],
+    });
+    databaseBuilder.factory.buildScoringConfiguration({
+      createdByUserId: superAdmin.id,
+    });
+    await databaseBuilder.commit();
   });
 
   describe('POST /api/application/parcoursup/certification/search', function () {
@@ -195,7 +209,7 @@ describe('Certification | Results | Acceptance | Application | parcoursup-route'
         status: 'validated',
         pixScore: 327,
         certificationDate: new Date('2024-11-22T09:39:54Z'),
-        globalLevel: '',
+        globalLevel: 'Indépendant 1',
         competences: [
           {
             code: '1.1',

--- a/api/tests/certification/results/unit/domain/services/pix-score-to-mesh-level_test.js
+++ b/api/tests/certification/results/unit/domain/services/pix-score-to-mesh-level_test.js
@@ -1,0 +1,17 @@
+import { getMeshLevel } from '../../../../../../src/certification/results/domain/services/pix-score-to-mesh-level.js';
+import { domainBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Certification | Results | Unit | Domain | Service | pix-score-to-mesh-level', function () {
+  it('should return a mesh level', function () {
+    // given
+    const v3CertificationScoring = domainBuilder.buildV3CertificationScoring();
+    const pixScore = 520;
+    const expectedResult = domainBuilder.certification.results.buildGlobalCertificationLevel({ meshLevel: 5 });
+
+    // when
+    const result = getMeshLevel({ pixScore, scoringConfiguration: v3CertificationScoring });
+
+    // then
+    expect(result).to.deep.equal(expectedResult);
+  });
+});

--- a/api/tests/certification/results/unit/domain/usecases/get-global-mesh-level_test.js
+++ b/api/tests/certification/results/unit/domain/usecases/get-global-mesh-level_test.js
@@ -1,0 +1,49 @@
+import { getGlobalMeshLevel } from '../../../../../../src/certification/results/domain/usecases/get-global-mesh-level.js';
+import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
+import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+
+describe('Certification | Results | Unit | Domain | UseCases | get-global-mesh-level', function () {
+  let scoringConfigurationRepository, pixScoreToMeshLevelService;
+
+  beforeEach(function () {
+    scoringConfigurationRepository = {
+      getLatestByDateAndLocale: sinon.stub(),
+    };
+
+    pixScoreToMeshLevelService = {
+      getMeshLevel: sinon.stub(),
+    };
+  });
+
+  it('should return the global mesh level', async function () {
+    // given
+    const i18n = getI18n();
+    const certificationDate = new Date();
+
+    const scoringConfiguration = domainBuilder.buildV3CertificationScoring({});
+    scoringConfigurationRepository.getLatestByDateAndLocale.resolves(scoringConfiguration);
+
+    const globalMeshLevel = domainBuilder.certification.results.buildGlobalCertificationLevel();
+    pixScoreToMeshLevelService.getMeshLevel.returns(globalMeshLevel);
+
+    // when
+    const result = await getGlobalMeshLevel({
+      pixScore: 12,
+      certificationDate,
+      i18n,
+      scoringConfigurationRepository,
+      pixScoreToMeshLevelService,
+    });
+
+    // then
+    expect(result).to.deep.equal(globalMeshLevel);
+    expect(scoringConfigurationRepository.getLatestByDateAndLocale).to.have.been.calledOnceWithExactly({
+      date: certificationDate,
+      locale: i18n.getLocale(),
+    });
+    expect(pixScoreToMeshLevelService.getMeshLevel).to.have.been.calledOnceWithExactly({
+      pixScore: 12,
+      scoringConfiguration,
+    });
+  });
+});

--- a/api/tests/certification/results/unit/domain/usecases/get-global-mesh-level_test.js
+++ b/api/tests/certification/results/unit/domain/usecases/get-global-mesh-level_test.js
@@ -18,6 +18,7 @@ describe('Certification | Results | Unit | Domain | UseCases | get-global-mesh-l
   it('should return the global mesh level', async function () {
     // given
     const i18n = getI18n();
+    const pixScore = 12;
     const certificationDate = new Date();
 
     const scoringConfiguration = domainBuilder.buildV3CertificationScoring({});
@@ -28,7 +29,7 @@ describe('Certification | Results | Unit | Domain | UseCases | get-global-mesh-l
 
     // when
     const result = await getGlobalMeshLevel({
-      pixScore: 12,
+      pixScore,
       certificationDate,
       i18n,
       scoringConfigurationRepository,
@@ -42,7 +43,7 @@ describe('Certification | Results | Unit | Domain | UseCases | get-global-mesh-l
       locale: i18n.getLocale(),
     });
     expect(pixScoreToMeshLevelService.getMeshLevel).to.have.been.calledOnceWithExactly({
-      pixScore: 12,
+      pixScore,
       scoringConfiguration,
     });
   });

--- a/api/tests/certification/results/unit/infrastructure/serializers/parcoursup-certification-serializer_test.js
+++ b/api/tests/certification/results/unit/infrastructure/serializers/parcoursup-certification-serializer_test.js
@@ -1,0 +1,50 @@
+import * as serializer from '../../../../../../src/certification/results/infrastructure/serializers/parcoursup-certification-serializer.js';
+import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
+import { domainBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Unit | Serializer | Json | parcoursup-certification-serializer', function () {
+  describe('#serialize', function () {
+    it('should serialize to Json', function () {
+      // given
+      const certificationResult = domainBuilder.certification.results.parcoursup.buildCertificationResult({
+        ine: 'INE123',
+        organizationUai: 'UAI ETAB ELEVE',
+        lastName: 'NOM-ELEVE',
+        firstName: 'PRENOM-ELEVE',
+        birthdate: '2000-01-01',
+        status: 'validated',
+        pixScore: 327,
+        certificationDate: new Date('2024-11-22T09:39:54Z'),
+        competences: [
+          domainBuilder.certification.results.parcoursup.buildCompetence({
+            code: '1.1',
+            name: 'Mener une recherche et une veille d’information',
+            areaName: 'Informations et données',
+            level: 3,
+          }),
+          domainBuilder.certification.results.parcoursup.buildCompetence({
+            code: '1.2',
+            name: 'Gérer des données',
+            areaName: 'Informations et données',
+            level: 5,
+          }),
+        ],
+      });
+      const globalMeshLevel = domainBuilder.certification.results.buildGlobalCertificationLevel();
+      const translate = getI18n().__;
+
+      // when
+      const actualCertifiedProfileSerialized = serializer.serialize({
+        certificationResult,
+        globalMeshLevel,
+        translate,
+      });
+
+      // then
+      return expect(actualCertifiedProfileSerialized).to.deep.equal({
+        ...certificationResult,
+        globalLevel: globalMeshLevel.getLevelLabel(translate),
+      });
+    });
+  });
+});

--- a/api/tests/certification/shared/unit/domain/models/GlobalCertificationLevel_test.js
+++ b/api/tests/certification/shared/unit/domain/models/GlobalCertificationLevel_test.js
@@ -19,5 +19,21 @@ describe('Unit | Domain | Models | GlobalCertificationLevel', function () {
       // then
       expect(translatedLabel).to.equal(translate('certification.global.meshlevel.1'));
     });
+
+    context('when there is no translation', function () {
+      it('should return an empty string', function () {
+        // given
+        const aMeshLevelWihoutranslation = 0;
+        const globalMeshLevel = domainBuilder.certification.results.buildGlobalCertificationLevel({
+          meshLevel: aMeshLevelWihoutranslation,
+        });
+
+        // when
+        const translatedLabel = globalMeshLevel.getLevelLabel(translate);
+
+        // then
+        expect(translatedLabel).to.equal('');
+      });
+    });
   });
 });

--- a/api/tests/certification/shared/unit/domain/models/GlobalCertificationLevel_test.js
+++ b/api/tests/certification/shared/unit/domain/models/GlobalCertificationLevel_test.js
@@ -1,0 +1,24 @@
+import { GlobalCertificationLevel } from '../../../../../../src/certification/shared/domain/models/GlobalCertificationLevel.js';
+import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | Domain | Models | GlobalCertificationLevel', function () {
+  let translate;
+
+  beforeEach(function () {
+    translate = getI18n().__;
+  });
+
+  describe('#getLevelLabel', function () {
+    it('should return the translated comment matching the key', function () {
+      // given
+      const globalMeshLevel = new GlobalCertificationLevel({ meshLevel: 0 });
+
+      // when
+      const translatedLabel = globalMeshLevel.getLevelLabel(translate);
+
+      // then
+      expect(translatedLabel).to.equal(translate('certification.global.meshlevel.0'));
+    });
+  });
+});

--- a/api/tests/certification/shared/unit/domain/models/GlobalCertificationLevel_test.js
+++ b/api/tests/certification/shared/unit/domain/models/GlobalCertificationLevel_test.js
@@ -1,6 +1,5 @@
-import { GlobalCertificationLevel } from '../../../../../../src/certification/shared/domain/models/GlobalCertificationLevel.js';
 import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
-import { expect } from '../../../../../test-helper.js';
+import { domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Domain | Models | GlobalCertificationLevel', function () {
   let translate;
@@ -12,13 +11,13 @@ describe('Unit | Domain | Models | GlobalCertificationLevel', function () {
   describe('#getLevelLabel', function () {
     it('should return the translated comment matching the key', function () {
       // given
-      const globalMeshLevel = new GlobalCertificationLevel({ meshLevel: 0 });
+      const globalMeshLevel = domainBuilder.certification.results.buildGlobalCertificationLevel();
 
       // when
       const translatedLabel = globalMeshLevel.getLevelLabel(translate);
 
       // then
-      expect(translatedLabel).to.equal(translate('certification.global.meshlevel.0'));
+      expect(translatedLabel).to.equal(translate('certification.global.meshlevel.1'));
     });
   });
 });

--- a/api/tests/tooling/domain-builder/factory/certification/results/build-global-mesh-level.js
+++ b/api/tests/tooling/domain-builder/factory/certification/results/build-global-mesh-level.js
@@ -1,0 +1,7 @@
+import { GlobalCertificationLevel } from '../../../../../../src/certification/shared/domain/models/GlobalCertificationLevel.js';
+
+export const buildGlobalCertificationLevel = function ({ meshLevel = 1 } = {}) {
+  return new GlobalCertificationLevel({
+    meshLevel,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -189,6 +189,7 @@ import { buildUserCertificationEligibility } from './certification/enrolment/bui
 import { buildV3CertificationEligibility } from './certification/enrolment/build-v3-certification-eligibility.js';
 import { buildEvaluationCandidate } from './certification/evaluation/build-candidate.js';
 import { buildFlashAssessmentAlgorithm } from './certification/flash-certification/build-flash-assessment-algorithm.js';
+import { buildGlobalCertificationLevel } from './certification/results/build-global-mesh-level.js';
 import { buildCertificationResult as parcoursupCertificationResult } from './certification/results/parcoursup/build-certification-result.js';
 import { buildCompetence as parcoursupCompetence } from './certification/results/parcoursup/build-competence.js';
 import { buildAssessmentResult as buildCertificationScoringAssessmentResult } from './certification/scoring/build-assessment-result.js';
@@ -262,6 +263,7 @@ const certification = {
     buildComplementaryCertificationBadge: buildCertificationComplementaryCertificationBadge,
   },
   results: {
+    buildGlobalCertificationLevel,
     parcoursup: {
       buildCertificationResult: parcoursupCertificationResult,
       buildCompetence: parcoursupCompetence,

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -143,6 +143,20 @@
     "yes": "Yes",
     "yes-or-empty": "(\"yes\" or leave blank)"
   },
+  "certification": {
+    "global": {
+      "meshlevel": {
+        "1": "Beginner 1",
+        "2": "Beginner 2",
+        "3": "Independent 1",
+        "4": "Independent 2",
+        "5": "Advanced 1",
+        "6": "Advanced 2",
+        "7": "Expert 1",
+        "8": "Expert 2"
+      }
+    }
+  },
   "certification-center-invitation-email": {
     "params": {
       "acceptInvitation": "Accept the invitation",

--- a/api/translations/es.json
+++ b/api/translations/es.json
@@ -11,6 +11,20 @@
       "signing": "- El equipo Pix"
     }
   },
+  "certification": {
+    "global": {
+      "meshlevel": {
+        "1": "Beginner 1",
+        "2": "Beginner 2",
+        "3": "Independent 1",
+        "4": "Independent 2",
+        "5": "Advanced 1",
+        "6": "Advanced 2",
+        "7": "Expert 1",
+        "8": "Expert 2"
+      }
+    }
+  },
   "attendance-sheet": {
     "certification-information": {
       "date": "Fecha :",

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -154,6 +154,20 @@
     "yes": "Oui",
     "yes-or-empty": "(\"oui\" ou laisser vide)"
   },
+  "certification": {
+    "global": {
+      "meshlevel": {
+        "1": "Novice 1",
+        "2": "Novice 2",
+        "3": "Indépendant 1",
+        "4": "Indépendant 2",
+        "5": "Avancé 1",
+        "6": "Avancé 2",
+        "7": "Expert 1",
+        "8": "Expert 2"
+      }
+    }
+  },
   "certification-center-invitation-email": {
     "params": {
       "acceptInvitation": "Accepter l’invitation",

--- a/api/translations/nl.json
+++ b/api/translations/nl.json
@@ -11,6 +11,20 @@
       "signing": "- Het Pix-team"
     }
   },
+  "certification": {
+    "global": {
+      "meshlevel": {
+        "1": "Beginner 1",
+        "2": "Beginner 2",
+        "3": "Zelfstandig 1",
+        "4": "Zelfstandig 2",
+        "5": "Gevorderde 1",
+        "6": "Gevorderde 2",
+        "7": "Expert 1",
+        "8": "Expert 2"
+      }
+    }
+  },
   "attendance-sheet": {
     "certification-information": {
       "date": "Datum :",


### PR DESCRIPTION
## :pancakes: Problème

On veut ajouter le [niveau global de Pix](https://pix.fr/certification-comprendre-score-niveau) dans les remontees Parcoursup.

Il est admis que pas de traductions pour le niveau zero
Prendre en compte que le score depend de la configuration des mailles et que c'est la maille qui donne le niveau

## :bacon: Proposition

* Creer un usecase qui fait appel au service qui permet de retrouver la maille a partir du score Pix
* Ajouter la traduction equivalente de cette maille en un niveau global, dans la reponse Parcoursup

## 🧃 Remarques

* **Il va falloir voir avec l'equipe DATA car on utilise pas la base froide**
* Le service qui est dans 'scoring' (contexte qui doit disparaitre) n'a pas ete migre vers result dans cette PR, mais il faudrait le faire un jour
  * @alexandrecoin est en phase de deplacer dans results le  simulateur associe 

## :yum: Pour tester

* Dans le DATAMART, il faut reperer les cas suivants, et verifier le champ globalLevel
  * certification valide
    * doit donner lieu a une traduction en Niveau X selon la maille auquel appartient le score 
  * certification rejete avec un score < niveau 1
    * ne doit pas donner de global level (pas de niveau zero) 
  * certification annulee avec un pix score > maille zero
    * ne doit pas donner de globalLevel meme si il y a une maille autre que zero
