### PR TITLE
[FEATURE] Forcer une longueur minimum sur la solution des QROCM (PIX-16609)

### DIFF
--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qrocm-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qrocm-schema.js
@@ -15,7 +15,7 @@ const blockInputSchema = Joi.object({
     .unique()
     .items(Joi.string().valid('t1', 't2', 't3'))
     .required(),
-  solutions: Joi.array().items(Joi.string().required()).required(),
+  solutions: Joi.array().items(Joi.string().min(1).required()).required(),
 }).required();
 
 const blockSelectSchema = Joi.object({


### PR DESCRIPTION
## :pancakes: Problème
Dans la validation de schéma utilisée par Modulix Editor, on oblige à avoir une solution pour les QCU et les QCM. Ce n'est pas le cas pour le champ solution des QROCM.

## :bacon: Proposition
Ajouter une longueur minimum sur la solution des QROCM.

## 🧃 Remarques
Modulix Editor est à jour via https://github.com/1024pix/modulix-editor/commit/f27499cb208bb7a690c6b80cfe59002fe048dcec

## :yum: Pour tester
Vérifier l'avant après sur le contenu d'un QROCM avec une solution vide.
