### PR TITLE
[TECH] Mettre à jour la configuration docker pour le local-domains

### DIFF
--- a/scripts/local-domains/compose.yaml
+++ b/scripts/local-domains/compose.yaml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   caddy:
     container_name: caddy


### PR DESCRIPTION
## :pancakes: Problème

On a mis à jour la configuration docker principale de docker à la racine du dépôt, mais pas la configuration des local-domains. Or, l'attribut version a été dépressié et le fichier demandait à être renommé "compose.yaml".

## :bacon: Proposition

- Renommer le fichier en compose.yaml,
- Supprimer l'attribut version au début du fichier.

## 🧃 Remarques

RAS

## :yum: Pour tester
- Se mettre sur la branche,
- Exécuter cette commande:
```shell
sudo npm run domains:install
```
- Exécuter ensuite la commande pour démarrer cady:
```shell
npm run domains:start
```
- Constater que si on lance l'api et un des front, on peut y accéder sur app.dev.pix.fr pour pix-app ou admin.dev.pix.fr pour pix-admin,
- Arêter cady avec cette commande:
```shell
npm run domains:stop
````
- Constater que lors du démarrage et de l'arrêt, il n'y a pas de warning sur l'attribut de version.