### PR TITLE
[TECH] Suppression du message de dépréciation au lancement des tests.

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/module-datasource.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module-datasource.js
@@ -30,7 +30,7 @@ async function importModules() {
 
   for (const file of files) {
     const fileURL = pathToFileURL(join(path, file.name));
-    const module = await import(fileURL, { assert: { type: 'json' } });
+    const module = await import(fileURL, { with: { type: 'json' } });
     imports.modules.push(module.default);
   }
 


### PR DESCRIPTION
## :pancakes: Problème

Suite à [la MAJ de Node en v20.18.3](https://github.com/1024pix/pix/pull/11432), un message de dépréciation apparait entachant le run de la suite de tests.

<img width="1728" alt="Capture d’écran 2025-02-19 à 09 43 59" src="https://github.com/user-attachments/assets/be281f7f-a930-41a5-bea6-a978c989c4e9" />

## :bacon: Proposition

On fait ce qui est dit dans le message d'alerte.

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

Lancer les tests et ne plus voir ce message.
