### PR TITLE
[FEATURE] Ajouter les migrations de lastLoggedAt et lastAccessedAt

### DIFF
--- a/api/db/migrations/20250218170901_add-lastLoggedAt-column-to-authentication-methods-table.js
+++ b/api/db/migrations/20250218170901_add-lastLoggedAt-column-to-authentication-methods-table.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'authentication-methods';
+const COLUMN_NAME = 'lastLoggedAt';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dateTime(COLUMN_NAME).defaultTo(null);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/db/migrations/20250218184023_add-lastAccessedAt-column-to-memberships-table.js
+++ b/api/db/migrations/20250218184023_add-lastAccessedAt-column-to-memberships-table.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'memberships';
+const COLUMN_NAME = 'lastAccessedAt';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dateTime(COLUMN_NAME).defaultTo(null);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/db/migrations/20250218184324_add-lastAccessedAt-column-to-certification-center-memberships-table.js
+++ b/api/db/migrations/20250218184324_add-lastAccessedAt-column-to-certification-center-memberships-table.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'certification-center-memberships';
+const COLUMN_NAME = 'lastAccessedAt';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dateTime(COLUMN_NAME).defaultTo(null);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/tests/team/integration/infrastructure/repositories/certification-center-membership.repository.test.js
+++ b/api/tests/team/integration/infrastructure/repositories/certification-center-membership.repository.test.js
@@ -906,6 +906,7 @@ describe('Integration | Team | Infrastructure | Repository | Certification Cente
             disabledAt: now,
             updatedAt: now,
             updatedByUserId,
+            lastAccessedAt: null,
           },
           {
             ...secondMembership,
@@ -913,6 +914,7 @@ describe('Integration | Team | Infrastructure | Repository | Certification Cente
             disabledAt: now,
             updatedAt: now,
             updatedByUserId,
+            lastAccessedAt: null,
           },
         ];
         const disabledMemberships = await knex('certification-center-memberships')
@@ -956,12 +958,14 @@ describe('Integration | Team | Infrastructure | Repository | Certification Cente
         const expectedMemberships = [
           {
             ...secondMembership,
+            lastAccessedAt: null,
           },
           {
             ...firstMembership,
             disabledAt: now,
             updatedAt: now,
             updatedByUserId,
+            lastAccessedAt: null,
           },
         ];
         const disabledMemberships = await knex('certification-center-memberships')

--- a/api/tests/team/integration/infrastructure/repositories/membership-repository.test.js
+++ b/api/tests/team/integration/infrastructure/repositories/membership-repository.test.js
@@ -785,6 +785,7 @@ describe('Integration | Team | Infrastructure | Repository | membership-reposito
               updatedAt: now,
               disabledAt: now,
               updatedByUserId,
+              lastAccessedAt: null,
             },
             {
               ...secondOrganizationMembership,
@@ -792,6 +793,7 @@ describe('Integration | Team | Infrastructure | Repository | membership-reposito
               updatedAt: now,
               disabledAt: now,
               updatedByUserId,
+              lastAccessedAt: null,
             },
           ];
           // when
@@ -840,12 +842,14 @@ describe('Integration | Team | Infrastructure | Repository | membership-reposito
           const expectedMemberships = [
             {
               ...firstMembership,
+              lastAccessedAt: null,
             },
             {
               ...secondMembership,
               disabledAt: now,
               updatedAt: now,
               updatedByUserId: actualDpoId,
+              lastAccessedAt: null,
             },
           ];
           const disabledMemberships = await knex('memberships')


### PR DESCRIPTION
## :pancakes: Problème

Dans le cadre du stockage des dates de dernière connexion et accès à une organisation, on a besoin d'ajouter 3 nouvelles colonnes dans 3 tables :
- La table authentication-methods,
- la table lastAccessedAt dans memberships,
- lastAccessedAt dans certification-center-membership.

## :bacon: Proposition

Créer 3 migrations, une pour chaque modification de la BDD.

## :yum: Pour tester
- Se connecter sur la db en ra:
```shell
scalingo -a pix-api-review-pr11452 psql-console
```
- Regarder le schéma de chaques colones ajoutées:
```sql
SELECT COLUMN_NAME, DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'authentication-methods' AND COLUMN_NAME = 'lastLoggedAt';
```
Doit retourner:
```sql
 column_name  |        data_type         
--------------+--------------------------
 lastLoggedAt | timestamp with time zone
(1 row)
```

```sql
SELECT COLUMN_NAME, DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'memberships' AND COLUMN_NAME = 'lastAccessedAt';
```
doit retourner:
```sql
  column_name   |        data_type         
----------------+--------------------------
 lastAccessedAt | timestamp with time zone
(1 row)
```
Enfin,
```sql
SELECT COLUMN_NAME, DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'certification-center-memberships' AND COLUMN_NAME = 'lastAccessedAt';
```
devrait retourner:
```sql
  column_name   |        data_type         
----------------+--------------------------
 lastAccessedAt | timestamp with time zone
(1 row)
```
- Pour vérifier le rollback, se mettre sur la branche en local et faire:
```shell
npm run db:migrate
```
- Constater que les nouvelles colonnes sont bien présente de la même manière que ci-dessus, on peut se connecter à la db de cette manière:
```shell
docker exec -it pix-api-postgres psql -U postgres pix
```
- Faire le rollback:
```shell
npm run db:rollback:latest
npm run db:rollback:latest
npm run db:rollback:latest
````
- Vérifier que les colonnes ont disparu des tables.