### PR TITLE
[TECH] Créer nouvel usecase de duplication d'un CF (PIX-16643)

### DIFF
--- a/api/src/devcomp/domain/usecases/duplicate-training.js
+++ b/api/src/devcomp/domain/usecases/duplicate-training.js
@@ -1,0 +1,35 @@
+import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
+
+const duplicateTraining = withTransaction(async ({ trainingId, trainingRepository, trainingTriggersRepository }) => {
+  const training = await trainingRepository.get({ trainingId });
+  const newTraining = await trainingRepository.create({ training });
+  const trainingTriggers = await trainingTriggersRepository.findByTrainingIdForAdmin({ trainingId });
+
+  for (const trainingTrigger of trainingTriggers) {
+    const triggerTubesToDuplicate = [];
+    for (const area of trainingTrigger.areas) {
+      for (const competence of area.competences) {
+        for (const thematic of competence.thematics) {
+          for (const triggerTube of thematic.triggerTubes) {
+            triggerTubesToDuplicate.push(triggerTube);
+          }
+        }
+      }
+    }
+    const triggerTubesForCreation = triggerTubesToDuplicate.map((triggerTube) => ({
+      tubeId: triggerTube.tube.id,
+      level: triggerTube.level,
+    }));
+
+    await trainingTriggersRepository.createOrUpdate({
+      trainingId: newTraining.id,
+      triggerTubesForCreation,
+      type: trainingTrigger.type,
+      threshold: trainingTrigger.threshold,
+    });
+  }
+
+  return newTraining;
+});
+
+export { duplicateTraining };

--- a/api/tests/devcomp/unit/domain/usecases/duplicate-training_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/duplicate-training_test.js
@@ -1,0 +1,107 @@
+import { TrainingTriggerForAdmin } from '../../../../../src/devcomp/domain/read-models/TrainingTriggerForAdmin.js';
+import { duplicateTraining } from '../../../../../src/devcomp/domain/usecases/duplicate-training.js';
+import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
+import { domainBuilder, expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | UseCases | duplicate-training', function () {
+  it('should duplicate provided training with same training-triggers', async function () {
+    // given
+    const trainingId = 123456;
+    const area1 = domainBuilder.buildArea({ id: 'recArea1' });
+    const area2 = domainBuilder.buildArea({ id: 'recArea2' });
+    const competence1 = domainBuilder.buildCompetence({ id: 'recCompetence1', areaId: 'recArea1' });
+    const competence2InAnotherArea = domainBuilder.buildCompetence({ id: 'recCompetence2', areaId: 'recArea2' });
+    const thematic1 = domainBuilder.buildThematic({ id: 'recThematic1', competenceId: 'recCompetence1' });
+    const thematic2 = domainBuilder.buildThematic({ id: 'recThematic2', competenceId: 'recCompetence1' });
+    const thematic3InAnotherCompetence = domainBuilder.buildThematic({
+      id: 'recThematic3',
+      competenceId: 'recCompetence2',
+    });
+    const tube1 = domainBuilder.buildTube({
+      id: 'recTube1',
+      thematicId: thematic1.id,
+    });
+    const tube2 = domainBuilder.buildTube({
+      id: 'recTube2',
+      thematicId: thematic2.id,
+    });
+    const tube3 = domainBuilder.buildTube({
+      id: 'recTube3',
+      thematicId: thematic3InAnotherCompetence.id,
+    });
+    const trainingTriggerTube1 = domainBuilder.buildTrainingTriggerTube({
+      id: 'recTrainingTriggerTube1',
+      level: 1,
+      tube: tube1,
+    });
+    const trainingTriggerTube2 = domainBuilder.buildTrainingTriggerTube({
+      id: 'recTrainingTriggerTube2',
+      level: 2,
+      tube: tube2,
+    });
+    const trainingTriggerTube3 = domainBuilder.buildTrainingTriggerTube({
+      id: 'recTrainingTriggerTube3',
+      level: 3,
+      tube: tube3,
+    });
+
+    const trainingTrigger = domainBuilder.buildTrainingTriggerForAdmin({
+      type: TrainingTriggerForAdmin.types.PREREQUISITE,
+      areas: [area1, area2],
+      competences: [competence1, competence2InAnotherArea],
+      thematics: [thematic1, thematic2, thematic3InAnotherCompetence],
+      triggerTubes: [trainingTriggerTube1, trainingTriggerTube2, trainingTriggerTube3],
+    });
+
+    const training = domainBuilder.buildTrainingForAdmin({
+      id: trainingId,
+      title: 'Training 1',
+      internalTitle: 'Training 1 internal title',
+      link: 'https://example.net',
+      type: 'webinar',
+      duration: { hours: 5 },
+      locale: 'fr-fr',
+      targetProfileIds: [1, 2, 3],
+      editorName: 'Editor name',
+      editorLogoUrl: 'https://editor.logo.url',
+      trainingTriggers: [trainingTrigger],
+    });
+    const newTraining = { ...training, id: 654321 };
+
+    const trainingRepositoryStub = {
+      get: sinon.stub().resolves(training),
+      create: sinon.stub().resolves(newTraining),
+    };
+    const trainingTriggersRepositoryStub = {
+      findByTrainingIdForAdmin: sinon.stub().resolves([trainingTrigger]),
+      createOrUpdate: sinon.stub(),
+    };
+
+    sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
+
+    // when
+    const result = await duplicateTraining({
+      trainingId,
+      trainingRepository: trainingRepositoryStub,
+      trainingTriggersRepository: trainingTriggersRepositoryStub,
+    });
+
+    // then
+    expect(trainingRepositoryStub.get).to.have.been.calledWithExactly({ trainingId });
+    expect(trainingRepositoryStub.create).to.have.been.calledWithExactly({
+      training,
+    });
+    expect(trainingTriggersRepositoryStub.findByTrainingIdForAdmin).to.have.been.calledWithExactly({ trainingId });
+    expect(trainingTriggersRepositoryStub.createOrUpdate).to.have.been.calledWithExactly({
+      trainingId: newTraining.id,
+      triggerTubesForCreation: [
+        { tubeId: tube1.id, level: 1 },
+        { tubeId: tube2.id, level: 2 },
+        { tubeId: tube3.id, level: 3 },
+      ],
+      type: trainingTrigger.type,
+      threshold: trainingTrigger.threshold,
+    });
+    expect(result).to.equal(newTraining);
+  });
+});


### PR DESCRIPTION
## :bacon: Proposition
On souhaite permettre la duplication de contenus formatifs dans Pix Admin. On ajoute ici un usecase qui permettra de le faire. Il prends en paramètre d'entrée l'identifiant du CF qu'on souhaite dupliquer et renvoie le nouveau CF créé.

## 🧃 Remarques
On s'est questionné sur : 
- est-ce qu'une transaction commune est utilisée entre la copie du CF et la copie des `training-triggers`+`training-trigger-tubes` ? Oui, en utilisant `withTransaction`, il y a un rollback qui se fait si erreur pendant les appels aux différents repo.
- que se passerait-il en cas de suppression d'un tube ? A priori rien car training-trigger-tubes ne référence que des identifiants sous forme de chaine de caractères, donc la problématique est à déporter dans le mécanisme d'acquisition de CF par l'apprenant·e.

## :yum: Pour tester
En local, enregistrer ce bout de code dans le dossier `api` (dans un fichier `.js`) : 
```node
const main = async () => {
  const trainingRepository = await import('./src/devcomp/infrastructure/repositories/training-repository.js');
  const trainingTriggersRepository = await import(
    './src/devcomp/infrastructure/repositories/training-trigger-repository.js'
  );
  const { duplicateTraining } = await import('./src/devcomp/domain/usecases/duplicate-training.js');
  const result = await duplicateTraining({ trainingId: 100055, trainingRepository, trainingTriggersRepository });
  console.log(result);
};
main();
```

L’exécuter dans un terminal avec `node <mon-fichier.js>` et constater que le training `100055` a été dupliqué, ainsi que ses triggers, ainsi que ses trigger-tubes.