### PR TITLE
Revert "[FEATURE] Utiliser les applications clientes en BdD"

### DIFF
--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -79,7 +79,6 @@ import * as resetPasswordService from '../../../src/identity-access-management/d
 import { scoAccountRecoveryService } from '../../../src/identity-access-management/domain/services/sco-account-recovery.service.js';
 import { accountRecoveryDemandRepository } from '../../../src/identity-access-management/infrastructure/repositories/account-recovery-demand.repository.js';
 import * as authenticationMethodRepository from '../../../src/identity-access-management/infrastructure/repositories/authentication-method.repository.js';
-import { clientApplicationRepository } from '../../../src/identity-access-management/infrastructure/repositories/client-application.repository.js';
 import { emailValidationDemandRepository } from '../../../src/identity-access-management/infrastructure/repositories/email-validation-demand.repository.js';
 // Not used in lib
 import { userAnonymizedEventLoggingJobRepository } from '../../../src/identity-access-management/infrastructure/repositories/jobs/user-anonymized-event-logging-job-repository.js';
@@ -245,7 +244,6 @@ const dependencies = {
   certificationCpfCityRepository,
   certificationOfficerRepository,
   challengeRepository,
-  clientApplicationRepository,
   codeGenerator,
   codeUtils,
   competenceEvaluationRepository,

--- a/api/tests/acceptance/application/authentication/authentication-route_test.js
+++ b/api/tests/acceptance/application/authentication/authentication-route_test.js
@@ -133,14 +133,6 @@ describe('Acceptance | Controller | authentication-controller', function () {
           'x-forwarded-host': 'app.pix.fr',
         },
       };
-
-      databaseBuilder.factory.buildClientApplication({
-        name: 'osmose',
-        clientId: OSMOSE_CLIENT_ID,
-        clientSecret: OSMOSE_CLIENT_SECRET,
-        scopes: [SCOPE],
-      });
-      await databaseBuilder.commit();
     });
 
     it('should return an 200 with accessToken when clientId, client secret and scope are registred', async function () {

--- a/api/tests/prescription/organization-place/acceptance/application/get-data-organization-places_test.js
+++ b/api/tests/prescription/organization-place/acceptance/application/get-data-organization-places_test.js
@@ -1,28 +1,39 @@
-import {
-  createServer,
-  expect,
-  generateValidRequestAuthorizationHeaderForApplication,
-} from '../../../../test-helper.js';
+import querystring from 'node:querystring';
+
+import { createServer, expect } from '../../../../test-helper.js';
 
 describe('Acceptance | Route | Get Data Organization Places', function () {
   describe('GET /api/data/organization-places', function () {
     it('should return 200 HTTP status code', async function () {
       // given
       const PIX_DATA_CLIENT_ID = 'test-pixDataCliendId';
+      const PIX_DATA_CLIENT_SECRET = 'pixDataClientSecret';
       const PIX_DATA_SCOPE = 'statistics';
 
       const server = await createServer();
+
+      const optionsForToken = {
+        method: 'POST',
+        url: `/api/application/token`,
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+        },
+        payload: querystring.stringify({
+          grant_type: 'client_credentials',
+          client_id: PIX_DATA_CLIENT_ID,
+          client_secret: PIX_DATA_CLIENT_SECRET,
+          scope: PIX_DATA_SCOPE,
+        }),
+      };
+      const tokenResponse = await server.inject(optionsForToken);
+      const accessToken = tokenResponse.result.access_token;
 
       // when
       const options = {
         method: 'GET',
         url: `/api/data/organization-places`,
         headers: {
-          authorization: generateValidRequestAuthorizationHeaderForApplication(
-            PIX_DATA_CLIENT_ID,
-            'pix-data',
-            PIX_DATA_SCOPE,
-          ),
+          authorization: `Bearer ${accessToken}`,
         },
       };
 


### PR DESCRIPTION
## :pancakes: Problème

La PR #11434 utilise les applications clientes de la BdD pour générer les JWT, mais rien ne garantit que les applications clientes ont bien été migrées en BdD.

## :bacon: Proposition

Annuler cette modification, et utiliser les applications clientes de la config.

## 🧃 Remarques

N/A

## :yum: Pour tester

Tester que les endpoints partenaires sont bien accessibles via swagger.