### PR TITLE
[TECH] Utiliser la CLI de GitHub pour commenter les pull request de modulix

### DIFF
--- a/.github/workflows/test-modulix-content.yaml
+++ b/.github/workflows/test-modulix-content.yaml
@@ -39,18 +39,13 @@ jobs:
           exit $ERROR_CODE
 
       - name: Comment PR with Test Modulix Error details
-        uses: actions/github-script@v7
         if: ${{ failure() }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `Les tests Modulix ont échoué. Voici les détails :
+        run: |
+          echo -e "Les tests Modulix ont échoué. Voici les détails :
 
-            \`\`\`
-            ${process.env.TEST_ERRORS}
-            \`\`\``
-            })
+          \`\`\`
+          $TEST_ERRORS
+          \`\`\`" > comment-body
+          gh pr comment ${{github.event.pull_request.number}} -F comment-body
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## :pancakes: Problème

On utiliser des endpoint rest pour commenter une pull request qui fait une contribution Modulix. Or, on a la CLI de GitHub qui est déjà installée dans les runners et qui pourrait peut-être faire cela plus simplement.

## :bacon: Proposition

Remplacer la partie qui créé le commentaire en utilisant à la place gh pr comment.

## 🧃 Remarques

Cela ne change pas grand chose, mais utilise la CLI officielle. Le commentaire indiquant qu'un teste n'est pas passé est là pour montrer que ça a marché!!!!!

## :yum: Pour tester

- Aller casser quelquechose dans les testes modulix ou les sources,
- Faire un commit,
- Mettre le label contribution modulix sur la pr,
- Pousser le commit,
- Vérifier qu'un commentaire est créé avec les mêmes erreurs qu'en local,
- Supprimer le commit en l'éclatant ou avec un rebase interractif:
```shell
git reset HEAD~
git add .
git reset --hard
git push --force-with-lease
```
- Vérifier que tout passe de nouveau correctement.