### PR TITLE
[FEATURE] Créer la table last-user-application-connections (PIX-16618)

### DIFF
--- a/api/db/migrations/20250220095538_create-table-last-user-application-connections.js
+++ b/api/db/migrations/20250220095538_create-table-last-user-application-connections.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'last-user-application-connections';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.increments('id').primary().notNullable();
+    table.integer('userId').references('users.id').index();
+    table.string('application').notNullable();
+    table.dateTime('lastLoggedAt').notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  return knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };


### PR DESCRIPTION
## :pancakes: Problème

On a besoin d'une table pour stoquer la date de dernière connexion par application d'un utilisateur.

## :bacon: Proposition

Créer la table last_user_connections contenant:
- id,
- userId (identifiant utilisateur),
- application (application utilisée),
- lastLoggedAt (la date de dernière connexion).

## 🧃 Remarques

Faut-il mettre des commentaires pour les colones?

## :yum: Pour tester
En local:
- Faire les migrations:
```shell
npm run db:migrate
````
- Se connecter à la db docker:
```shell
docker exec -it pix-api-postgres psql -U postgres pix
````
- Vérifier la présence de la nouvelle table:
```sql
\d "last_user_application_connections";
```
- Vérifier qu'on a bien le schéma de la table,
- Faire le rollback:
```shell
npm run db:rollback:latest
```
- Vérifier que la table n'est plus présente.