### PR TITLE
[FEATURE] Créer un endpoint pour la duplication d'un CF(PIX-16669)

### DIFF
--- a/api/src/devcomp/application/trainings/index.js
+++ b/api/src/devcomp/application/trainings/index.js
@@ -154,6 +154,29 @@ const register = async function (server) {
       },
     },
     {
+      method: 'POST',
+      path: '/api/admin/trainings/{trainingId}/duplicate',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            trainingId: identifiersType.trainingId,
+          }),
+        },
+        handler: trainingsController.duplicate,
+        tags: ['api', 'admin', 'trainings'],
+        notes: ['- Permet à un administrateur de dupliquer un contenu formatif existant'],
+      },
+    },
+    {
       method: 'PATCH',
       path: '/api/admin/trainings/{trainingId}',
       config: {

--- a/api/src/devcomp/application/trainings/training-controller.js
+++ b/api/src/devcomp/application/trainings/training-controller.js
@@ -35,6 +35,12 @@ const create = async function (request, h, dependencies = { trainingSerializer }
   return h.response(dependencies.trainingSerializer.serialize(createdTraining)).created();
 };
 
+const duplicate = async function (request, h) {
+  const trainingId = request.params.trainingId;
+  const createdTraining = await usecases.duplicateTraining({ trainingId });
+  return h.response({ trainingId: createdTraining.id }).created();
+};
+
 const update = async function (request, h, dependencies = { trainingSerializer }) {
   const { trainingId } = request.params;
   const training = await dependencies.trainingSerializer.deserialize(request.payload);
@@ -98,6 +104,7 @@ const trainingController = {
   findTargetProfileSummaries,
   getById,
   create,
+  duplicate,
   update,
   createOrUpdateTrigger,
   attachTargetProfiles,

--- a/api/src/devcomp/domain/usecases/duplicate-training.js
+++ b/api/src/devcomp/domain/usecases/duplicate-training.js
@@ -2,7 +2,12 @@ import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
 
 const duplicateTraining = withTransaction(async ({ trainingId, trainingRepository, trainingTriggerRepository }) => {
   const training = await trainingRepository.get({ trainingId });
-  const newTraining = await trainingRepository.create({ training });
+  const newTraining = await trainingRepository.create({
+    training: {
+      ...training,
+      internalTitle: `[Copie] ${training.internalTitle}`,
+    },
+  });
   const trainingTriggers = await trainingTriggerRepository.findByTrainingIdForAdmin({ trainingId });
 
   for (const trainingTrigger of trainingTriggers) {

--- a/api/src/devcomp/domain/usecases/duplicate-training.js
+++ b/api/src/devcomp/domain/usecases/duplicate-training.js
@@ -1,9 +1,9 @@
 import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
 
-const duplicateTraining = withTransaction(async ({ trainingId, trainingRepository, trainingTriggersRepository }) => {
+const duplicateTraining = withTransaction(async ({ trainingId, trainingRepository, trainingTriggerRepository }) => {
   const training = await trainingRepository.get({ trainingId });
   const newTraining = await trainingRepository.create({ training });
-  const trainingTriggers = await trainingTriggersRepository.findByTrainingIdForAdmin({ trainingId });
+  const trainingTriggers = await trainingTriggerRepository.findByTrainingIdForAdmin({ trainingId });
 
   for (const trainingTrigger of trainingTriggers) {
     const triggerTubesToDuplicate = [];
@@ -21,7 +21,7 @@ const duplicateTraining = withTransaction(async ({ trainingId, trainingRepositor
       level: triggerTube.level,
     }));
 
-    await trainingTriggersRepository.createOrUpdate({
+    await trainingTriggerRepository.createOrUpdate({
       trainingId: newTraining.id,
       triggerTubesForCreation,
       type: trainingTrigger.type,

--- a/api/tests/devcomp/acceptance/application/trainings/index_test.js
+++ b/api/tests/devcomp/acceptance/application/trainings/index_test.js
@@ -201,6 +201,26 @@ describe('Acceptance | Controller | training-controller', function () {
     });
   });
 
+  describe('POST /api/admin/trainings/{trainingId}/duplicate', function () {
+    it('should duplicate an existing training and response with a 201', async function () {
+      // given
+      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const training = databaseBuilder.factory.buildTraining();
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject({
+        method: 'POST',
+        url: `/api/admin/trainings/${training.id}/duplicate`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+      });
+
+      // then
+      expect(response.statusCode).to.equal(201);
+      expect(response.result.trainingId).to.exist;
+    });
+  });
+
   describe('PATCH /api/admin/trainings/{trainingId}', function () {
     let options;
 

--- a/api/tests/devcomp/integration/application/trainings/index_test.js
+++ b/api/tests/devcomp/integration/application/trainings/index_test.js
@@ -702,6 +702,75 @@ describe('Integration | Devcomp | Application | Trainings | Router | training-ro
     });
   });
 
+  describe('POST /api/admin/trainings/{trainingId}/duplicate', function () {
+    describe('Security Prehandlers', function () {
+      it('should allow user if its role is SUPER_ADMIN', async function () {
+        // given
+        sinon.stub(trainingController, 'duplicate').returns('ok');
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response(true));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        await httpTestServer.request('POST', '/api/admin/trainings/11111/duplicate');
+
+        // then
+        sinon.assert.calledOnce(trainingController.duplicate);
+      });
+
+      it('should allow user if the role is METIER', async function () {
+        // given
+        sinon.stub(trainingController, 'duplicate').returns('ok');
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        await httpTestServer.request('POST', '/api/admin/trainings/11111/duplicate');
+
+        // then
+        sinon.assert.calledOnce(trainingController.duplicate);
+      });
+
+      it('should return 403 it if the role is not allowed', async function () {
+        // given
+        sinon.stub(trainingController, 'duplicate').returns('ok');
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/admin/trainings/11111/duplicate');
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(trainingController.duplicate);
+      });
+    });
+  });
+
   describe('PATCH /api/admin/trainings', function () {
     describe('Security Prehandlers', function () {
       // eslint-disable-next-line mocha/no-setup-in-describe

--- a/api/tests/devcomp/unit/application/trainings/training-controller_test.js
+++ b/api/tests/devcomp/unit/application/trainings/training-controller_test.js
@@ -156,6 +156,34 @@ describe('Unit | Devcomp | Application | Trainings | Controller | training-contr
     });
   });
 
+  describe('#duplicate', function () {
+    const createdTraining = {
+      id: 124,
+      title: 'Training title',
+      internalTitle: '[Copie] Training internal title',
+      duration: {
+        days: 2,
+        hours: 2,
+        minutes: 2,
+      },
+    };
+
+    it('should call the duplicateTraining use-case', async function () {
+      // given
+      sinon.stub(usecases, 'duplicateTraining').resolves(createdTraining);
+      const trainingId = 123;
+      const request = { params: { trainingId } };
+      const expectedSerializedTraining = { trainingId: createdTraining.id };
+
+      // when
+      const response = await trainingController.duplicate(request, hFake);
+
+      // then
+      expect(usecases.duplicateTraining).to.have.been.calledOnceWithExactly({ trainingId });
+      expect(response.source).to.deep.equal(expectedSerializedTraining);
+    });
+  });
+
   describe('#update', function () {
     const deserializedTraining = { title: 'new title' };
     const updatedTraining = { title: 'new title' };

--- a/api/tests/devcomp/unit/domain/usecases/duplicate-training_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/duplicate-training_test.js
@@ -66,7 +66,12 @@ describe('Unit | Devcomp | Domain | UseCases | duplicate-training', function () 
       editorLogoUrl: 'https://editor.logo.url',
       trainingTriggers: [trainingTrigger],
     });
-    const newTraining = { ...training, id: 654321 };
+    const trainingToCreate = {
+      ...training,
+      internalTitle: '[Copie] Training 1 internal title',
+    };
+    const newTrainingId = 654321;
+    const newTraining = { ...trainingToCreate, id: newTrainingId };
 
     const trainingRepositoryStub = {
       get: sinon.stub().resolves(training),
@@ -89,11 +94,11 @@ describe('Unit | Devcomp | Domain | UseCases | duplicate-training', function () 
     // then
     expect(trainingRepositoryStub.get).to.have.been.calledWithExactly({ trainingId });
     expect(trainingRepositoryStub.create).to.have.been.calledWithExactly({
-      training,
+      training: trainingToCreate,
     });
     expect(trainingTriggerRepositoryStub.findByTrainingIdForAdmin).to.have.been.calledWithExactly({ trainingId });
     expect(trainingTriggerRepositoryStub.createOrUpdate).to.have.been.calledWithExactly({
-      trainingId: newTraining.id,
+      trainingId: newTrainingId,
       triggerTubesForCreation: [
         { tubeId: tube1.id, level: 1 },
         { tubeId: tube2.id, level: 2 },
@@ -102,6 +107,6 @@ describe('Unit | Devcomp | Domain | UseCases | duplicate-training', function () 
       type: trainingTrigger.type,
       threshold: trainingTrigger.threshold,
     });
-    expect(result).to.equal(newTraining);
+    expect(result).to.deep.equal(newTraining);
   });
 });

--- a/api/tests/devcomp/unit/domain/usecases/duplicate-training_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/duplicate-training_test.js
@@ -72,7 +72,7 @@ describe('Unit | Devcomp | Domain | UseCases | duplicate-training', function () 
       get: sinon.stub().resolves(training),
       create: sinon.stub().resolves(newTraining),
     };
-    const trainingTriggersRepositoryStub = {
+    const trainingTriggerRepositoryStub = {
       findByTrainingIdForAdmin: sinon.stub().resolves([trainingTrigger]),
       createOrUpdate: sinon.stub(),
     };
@@ -83,7 +83,7 @@ describe('Unit | Devcomp | Domain | UseCases | duplicate-training', function () 
     const result = await duplicateTraining({
       trainingId,
       trainingRepository: trainingRepositoryStub,
-      trainingTriggersRepository: trainingTriggersRepositoryStub,
+      trainingTriggerRepository: trainingTriggerRepositoryStub,
     });
 
     // then
@@ -91,8 +91,8 @@ describe('Unit | Devcomp | Domain | UseCases | duplicate-training', function () 
     expect(trainingRepositoryStub.create).to.have.been.calledWithExactly({
       training,
     });
-    expect(trainingTriggersRepositoryStub.findByTrainingIdForAdmin).to.have.been.calledWithExactly({ trainingId });
-    expect(trainingTriggersRepositoryStub.createOrUpdate).to.have.been.calledWithExactly({
+    expect(trainingTriggerRepositoryStub.findByTrainingIdForAdmin).to.have.been.calledWithExactly({ trainingId });
+    expect(trainingTriggerRepositoryStub.createOrUpdate).to.have.been.calledWithExactly({
       trainingId: newTraining.id,
       triggerTubesForCreation: [
         { tubeId: tube1.id, level: 1 },


### PR DESCRIPTION
## :pancakes: Problème

Le use-case de duplication n'est appelé par aucune route aujourd'hui.

## :bacon: Proposition

Ajouter le controller et la route pour appeler le use-case de duplication.

## 🧃 Remarques

RAS

## :yum: Pour tester
Dans Pix Admin, Edit & resend une modification de CF, remplacer le `PATCH` par un `POST` sur l'URL `/api/admin/trainings/{trainingId}/duplicate` en supprimant la payload.

On devrait constater une 201 qui renvoie le nouveau `trainingId`.