### PR TITLE
[BUGFIX] Convertir la valeur de la variable de certificabilitée en booléen (PIX-16676)

### DIFF
--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -281,7 +281,7 @@ const configuration = (function () {
       scheduleComputeOrganizationLearnersCertificability: {
         cron: process.env.SCHEDULE_COMPUTE_LEARNERS_CERTIFICABILITY_JOB_CRON || '0 21 * * *',
         chunkSize: process.env.SCHEDULE_COMPUTE_LEARNERS_CERTIFICABILITY_CHUNK_SIZE || 1000,
-        synchronously: process.env.SCHEDULE_COMPUTE_LEARNERS_CERTIFICABILITY_SYNCHRONOUSLY || false,
+        synchronously: toBoolean(process.env.SCHEDULE_COMPUTE_LEARNERS_CERTIFICABILITY_SYNCHRONOUSLY),
       },
       scoAccountRecoveryKeyLifetimeMinutes: process.env.SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES,
     },


### PR DESCRIPTION
## :pancakes: Problème
Actuellement si la valeur de la variable est = 'false', le javascript évaluera sa valeur a true comme toute autre chaine de caractère

## :bacon: Proposition
Utiliser la méthode pour forcer a convertir la chaine de caractère en valeur booléenne et eviter d'avoir des bugs en prod 🫤 

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester
🟢 
🐈‍⬛ 
