### PR TITLE
[TECH] Déplacer les assets du Didacticiel Modulix vers `assets.pix.org` (PIX-16677)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -96,13 +96,15 @@
             ]
           }
         },
-        {"type":  "element", "element":  {
-          "id": "5c468891-6b50-41c6-bb30-8639b52c5bca",
-          "type": "expand",
-          "title": "Voici un indice pour répondre à la magnifique flashcard",
-          "content": "<p> Souvent, pour s’amuser, les hommes d’équipage<br>Prennent des albatros, vastes oiseaux des mers,<br>Qui suivent, indolents compagnons de voyage,<br>Le navire glissant sur les gouffres amers.<br>À peine les ont-ils déposés sur les planches,<br>Que ces rois de l’azur, maladroits et honteux,<br>Laissent piteusement leurs grandes ailes blanches<br>Comme des avirons traîner à côté d’eux.<br>Ce voyageur ailé, comme il est gauche et veule !<br>Lui, naguère si beau, qu’il est comique et laid !<br>L’un agace son bec avec un brûle-gueule,<br>L’autre mime, en boitant, l’infirme qui volait !<br>Le Poète est semblable au prince des nuées<br>Qui hante la tempête et se rit de l’archer ;<br>Exilé sur le sol au milieu des huées,<br>Ses ailes de géant l’empêchent de marcher. </p>"
-        }
-      },
+        {
+          "type": "element",
+          "element": {
+            "id": "5c468891-6b50-41c6-bb30-8639b52c5bca",
+            "type": "expand",
+            "title": "Voici un indice pour répondre à la magnifique flashcard",
+            "content": "<p> Souvent, pour s’amuser, les hommes d’équipage<br>Prennent des albatros, vastes oiseaux des mers,<br>Qui suivent, indolents compagnons de voyage,<br>Le navire glissant sur les gouffres amers.<br>À peine les ont-ils déposés sur les planches,<br>Que ces rois de l’azur, maladroits et honteux,<br>Laissent piteusement leurs grandes ailes blanches<br>Comme des avirons traîner à côté d’eux.<br>Ce voyageur ailé, comme il est gauche et veule !<br>Lui, naguère si beau, qu’il est comique et laid !<br>L’un agace son bec avec un brûle-gueule,<br>L’autre mime, en boitant, l’infirme qui volait !<br>Le Poète est semblable au prince des nuées<br>Qui hante la tempête et se rit de l’archer ;<br>Exilé sur le sol au milieu des huées,<br>Ses ailes de géant l’empêchent de marcher. </p>"
+          }
+        },
         {
           "type": "element",
           "element": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -4,7 +4,7 @@
   "title": "Didacticiel Modulix",
   "isBeta": true,
   "details": {
-    "image": "https://images.pix.fr/modulix/placeholder-details.svg",
+    "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Découvrez avec ce didacticiel comment fonctionne Modulix !</p>",
     "duration": 5,
     "level": "Débutant",
@@ -51,14 +51,14 @@
             "instruction": "<p><strong>Pour chaque carte</strong>&nbsp;:&nbsp;</p><ol><li>Lisez la question. <span aria-hidden=\"true\">👀</span></li><li>Essayez de trouver la réponse dans votre tête. <span aria-hidden=\"true\">🤔</span></li><li>Retournez la carte en cliquant sur Voir la réponse. <span aria-hidden=\"true\">↪️</span></li></ol><p>Cela permet de <strong>tester votre mémoire</strong>.<span aria-hidden=\"true\">🎯</span></p>",
             "title": "Introduction à la poésie",
             "introImage": {
-              "url": "https://images.pix.fr/modulix/didacticiel/intro-flashcards.png"
+              "url": "https://assets.pix.org/modules/bac-a-sable/intro-flashcards.png"
             },
             "cards": [
               {
                 "id": "e1de6394-ff88-4de3-8834-a40057a50ff4",
                 "recto": {
                   "image": {
-                    "url": "https://images.pix.fr/modulix/didacticiel/icon.svg"
+                    "url": "https://assets.pix.org/modules/bac-a-sable/icon.svg"
                   },
                   "text": "Qui a écrit « Le Dormeur du Val ? »"
                 },
@@ -82,13 +82,13 @@
                 "id": "2611784c-cf3f-4445-998d-d02fa568da0c",
                 "recto": {
                   "image": {
-                    "url": "https://images.pix.fr/modulix/didacticiel/icon.svg"
+                    "url": "https://assets.pix.org/modules/bac-a-sable/icon.svg"
                   },
                   "text": "Quel animal a des yeux « mêlés de métal et d'agathe » selon Charles Baudelaire ?"
                 },
                 "verso": {
                   "image": {
-                    "url": "https://images.pix.fr/modulix/didacticiel/chaton.jpg"
+                    "url": "https://assets.pix.org/modules/bac-a-sable/chaton.jpg"
                   },
                   "text": "<p>Le chat</p>"
                 }
@@ -149,7 +149,7 @@
           "element": {
             "id": "8d7687c8-4a02-4d7e-bf6c-693a6d481c78",
             "type": "image",
-            "url": "https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg",
+            "url": "https://assets.pix.org/modules/bac-a-sable/ordi-spatial.svg",
             "alt": "Dessin détaillé dans l'alternative textuelle",
             "alternativeText": "Dessin d'un ordinateur dans un univers spatial.",
             "legend": "Faite avant le séminaire de juin 2023",
@@ -221,10 +221,10 @@
             "id": "3a9f2269-99ba-4631-b6fd-6802c88d5c26",
             "type": "video",
             "title": "Vidéo de présentation de Pix",
-            "url": "https://videos.pix.fr/modulix/didacticiel/presentation.mp4",
+            "url": "https://assets.pix.org/modules/bac-a-sable/presentation.mp4",
             "subtitles": "",
             "transcription": "<p>Le numérique évolue en permanence, vos compétences aussi, pour travailler, communiquer et s'informer, se déplacer, réaliser des démarches, un enjeu tout au long de la vie.</p><p>Sur <a href=\"https://pix.fr\" target=\"blank\">pix.fr</a>, testez-vous et cultivez vos compétences numériques.</p><p>Les tests Pix sont personnalisés, les questions s'adaptent à votre niveau, réponse après réponse.</p><p>Évaluez vos connaissances et savoir-faire sur 16 compétences, dans 5 domaines, sur 5 niveaux de débutants à confirmer, avec des mises en situation ludiques, recherches en ligne, manipulation de fichiers et de données, culture numérique...</p><p>Allez à votre rythme, vous pouvez arrêter et reprendre quand vous le voulez.</p><p>Toutes les 5 questions, découvrez vos résultats et progressez grâce aux astuces et aux tutos.</p><p>En relevant les défis Pix, vous apprendrez de nouvelles choses et aurez envie d'aller plus loin.</p><p>Vous pensez pouvoir faire mieux&#8239;?</p><p>Retentez les tests et améliorez votre score.</p><p>Faites reconnaître officiellement votre niveau en passant la certification Pix, reconnue par l'État et le monde professionnel.</p><p>Pix&nbsp;: le service public en ligne pour évaluer, développer et certifier ses compétences numériques.</p>",
-            "poster": "https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg"
+            "poster": "https://assets.pix.org/modules/bac-a-sable/ordi-spatial.svg"
           }
         }
       ]


### PR DESCRIPTION
## :pancakes: Problème
Nos assets (fichiers statiques type images, vidéos, fichiers à télécharger...) sont aujourd'hui dispatchés entre plusieurs noms de domaines. Il n'y a aucun intérêt technique à ça. On a mis en place `assets.pix.org` pour centraliser tous ces fichiers.

## :bacon: Proposition
Déplacer les assets du Didacticiel de Modulix vers ce nouveau nom de domaine.

Une fois en production, on pourra supprimer les assets correspondantes, trouvables dans `images.pix.fr` et `videos.pix.fr`.

## 🧃 Remarques
Je propose de synchro le nom du dossier `modules` qui correspond à l'URL de Pix App plutôt que `modulix` utilisé pour le moment. J'en profite pour renommer le dossier `didacticiel` en `bac-a-sable` qui sera le futur slug du module.

## :yum: Pour tester
Vérifier que les assets du Didacticiel Modulix fonctionnent correctement sur la RA.

https://app-pr11469.review.pix.fr/modules/didacticiel-modulix/details