### PR TITLE
[TECH] Ajoute les infos de badges  imageUrl et altMessage dans le serializer de campagne (pix-16689)

### DIFF
--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-report-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-report-serializer.js
@@ -50,7 +50,7 @@ const serialize = function (campaignReports, meta) {
     badges: {
       ref: 'id',
       included: true,
-      attributes: ['title'],
+      attributes: ['title', 'altMessage', 'imageUrl'],
     },
     campaignCollectiveResult: {
       ref: 'id',

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-report-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-report-serializer_test.js
@@ -30,6 +30,8 @@ describe('Unit | Serializer | JSONAPI | campaign-report-serializer', function ()
           {
             id: 123,
             title: 'badge123',
+            imageUrl: 'badge.svg',
+            altMessage: 'message',
           },
         ],
       });
@@ -141,6 +143,8 @@ describe('Unit | Serializer | JSONAPI | campaign-report-serializer', function ()
           {
             attributes: {
               title: report.badges[0].title,
+              'image-url': report.badges[0].imageUrl,
+              'alt-message': report.badges[0].altMessage,
             },
             id: report.badges[0].id.toString(),
             type: 'badges',


### PR DESCRIPTION
## :pancakes: Problème

Dans certains cas, la page résultat de campagne n'affiche pas les badges non-acquis des participations. cela est du au fait que les infos (imageUrl / altMessage) était remontées par le endpoint `/assessment-results` alors que ces infos devraient être présentes dans le endpoint `/campaigns/{id}`

## :bacon: Proposition

Modifier le serializer de `/campaigns/{id}` pour qu'il intègre les infos des badges `imageUrl` et `altMessage`

## 🧃 Remarques

RAS

## :yum: Pour tester

- créer une campagne avec le PC badgeStage
- participer à la campagne (tout passé)
- afficher les résultats dans orga
- voir le badge grisé
