### PR TITLE
[BUGFIX] Correction du layout shift sur la bannière de nouvelle information du dashboard Pix App

### DIFF
--- a/mon-pix/app/styles/components/_new-information.scss
+++ b/mon-pix/app/styles/components/_new-information.scss
@@ -118,6 +118,10 @@
     line-height: 1.375rem;
     letter-spacing: 0.009rem;
 
+    span {
+      border-bottom: 1px solid transparent;
+    }
+
     svg {
       width: 1rem;
       height: 1rem;


### PR DESCRIPTION
## :pancakes: Problème
Lors qu'on passe la souris sur le lien de la bannière de nouvelle information en haut du dashboard de Pix App, une bordure apparaît sous le lien qui décale le reste du contenu vers le bas.

https://github.com/user-attachments/assets/7d99df07-6695-439b-80c2-377fca60c91a

## :bacon: Proposition
Placer une bordure transparente systématiquement de la même taille que la bordure de base pour éviter le [layout shift](https://web.dev/articles/cls?hl=fr).

## 🧃 Remarques
RAS

## :yum: Pour tester
Sur la RA, en se connectant sur Pix App cette bannière devrait être affichée par défaut tant qu'elle n'a pas été quittée. Comparer avec l'état sur l'[intégration](https://app.integration.pix.fr/accueil).