### PR TITLE
[BUGFIX] Empêcher les questions avec live-alerts validées d'être prises en compte dans le scoring (PIX-16482).

### DIFF
--- a/api/src/certification/evaluation/application/jobs/certification-completed-job-controller.js
+++ b/api/src/certification/evaluation/application/jobs/certification-completed-job-controller.js
@@ -113,7 +113,7 @@ async function _handleV3CertificationScoring({
     certificationAssessment,
     emitter,
     locale,
-    dependencies: { findByCertificationCourseId: services.findByCertificationCourseId },
+    dependencies: { findByCertificationCourseIdAndAssessmentId: services.findByCertificationCourseIdAndAssessmentId },
   });
 
   certificationCourse.complete({ now: new Date() });

--- a/api/src/certification/evaluation/domain/services/index.js
+++ b/api/src/certification/evaluation/domain/services/index.js
@@ -6,6 +6,7 @@ import * as flashAlgorithmService from '../../../../certification/flash-certific
 // TODO: cross-bounded context violation
 import * as scoringDegradationService from '../../../../certification/scoring/domain/services/scoring-degradation-service.js';
 import * as scoringCertificationService from '../../../../certification/shared/domain/services/scoring-certification-service.js';
+import * as certificationChallengeLiveAlertRepository from '../../../../certification/shared/infrastructure/repositories/certification-challenge-live-alert-repository.js';
 // TODO: cross-bounded context violation
 import * as scoringService from '../../../../evaluation/domain/services/scoring/scoring-service.js';
 import * as placementProfileService from '../../../../shared/domain/services/placement-profile-service.js';
@@ -32,6 +33,7 @@ import * as challengeCalibrationRepository from '../../infrastructure/repositori
  * @typedef {scoringDegradationService} ScoringDegradationService
  * @typedef {certificationAssessmentHistoryRepository} CertificationAssessmentHistoryRepository
  * @typedef {challengeCalibrationRepository} ChallengeCalibrationRepository
+ * @typedef {certificationChallengeLiveAlertRepository} CertificationChallengeLiveAlertRepository
  * @typedef {scoringConfigurationRepository} ScoringConfigurationRepository
  * @typedef {flashAlgorithmConfigurationRepository} FlashAlgorithmConfigurationRepository
  * @typedef {answerRepository} AnswerRepository
@@ -52,6 +54,7 @@ const dependencies = {
   scoringConfigurationRepository,
   answerRepository,
   certificationAssessmentHistoryRepository,
+  certificationChallengeLiveAlertRepository,
   flashAlgorithmService,
   challengeCalibrationRepository,
   challengeRepository,

--- a/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
+++ b/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
@@ -7,6 +7,7 @@
  * @typedef {import('../index.js').CertificationChallengeRepository} CertificationChallengeRepository
  * @typedef {import('../index.js').ScoringConfigurationRepository} ScoringConfigurationRepository
  * @typedef {import('../index.js').FlashAlgorithmConfigurationRepository} FlashAlgorithmConfigurationRepository
+ * @typedef {import('../index.js').CertificationChallengeLiveAlertRepository} CertificationChallengeLiveAlertRepository
  * @typedef {import('../index.js').AnswerRepository} AnswerRepository
  * @typedef {import('../index.js').FlashAlgorithmService} FlashAlgorithmService
  * @typedef {import('../index.js').ChallengeRepository} ChallengeRepository
@@ -31,6 +32,7 @@ const debugScoringForV3Certification = Debug('pix:certif:v3:scoring');
  * @param {CompetenceMarkRepository} params.competenceMarkRepository
  * @param {CertificationAssessmentHistoryRepository} params.certificationAssessmentHistoryRepository
  * @param {CertificationChallengeRepository} params.certificationChallengeRepository
+ * @param {CertificationChallengeLiveAlertRepository} params.certificationChallengeLiveAlertRepository
  * @param {ScoringConfigurationRepository} params.scoringConfigurationRepository
  * @param {FlashAlgorithmConfigurationRepository} params.flashAlgorithmConfigurationRepository
  * @param {AnswerRepository} params.answerRepository
@@ -52,6 +54,7 @@ export const handleV3CertificationScoring = async ({
   flashAlgorithmService,
   scoringDegradationService,
   scoringConfigurationRepository,
+  certificationChallengeLiveAlertRepository,
   dependencies,
 }) => {
   const { certificationCourseId, id: assessmentId } = certificationAssessment;
@@ -82,6 +85,14 @@ export const handleV3CertificationScoring = async ({
     date: certificationCourse.getStartDate(),
   });
 
+  const { challengeCalibrationsWithoutLiveAlerts, challengesWithoutLiveAlerts } =
+    await _removeValidatedLiveAlertsFromScoring(
+      challengeCalibrations,
+      assessmentId,
+      askedChallenges,
+      certificationChallengeLiveAlertRepository,
+    );
+
   const certificationAssessmentScore = CertificationAssessmentScoreV3.fromChallengesAndAnswers({
     abortReason,
     algorithm,
@@ -89,7 +100,7 @@ export const handleV3CertificationScoring = async ({
     // so that in can be used during the assessment result creation
     allAnswers: [...candidateAnswers],
     allChallenges,
-    challenges: askedChallenges,
+    challenges: challengesWithoutLiveAlerts,
     maxReachableLevelOnCertificationDate: certificationCourse.getMaxReachableLevelOnCertificationDate(),
     v3CertificationScoring,
     scoringDegradationService,
@@ -112,7 +123,7 @@ export const handleV3CertificationScoring = async ({
 
   const certificationAssessmentHistory = CertificationAssessmentHistory.fromChallengesAndAnswers({
     algorithm,
-    challenges: challengeCalibrations,
+    challenges: challengeCalibrationsWithoutLiveAlerts,
     allAnswers: candidateAnswers,
   });
 
@@ -128,6 +139,26 @@ export const handleV3CertificationScoring = async ({
 
   return certificationCourse;
 };
+
+async function _removeValidatedLiveAlertsFromScoring(
+  challengeCalibrations,
+  assessmentId,
+  askedChallenges,
+  certificationChallengeLiveAlertRepository,
+) {
+  let challengeCalibrationsWithoutLiveAlerts = challengeCalibrations;
+  const validatedLiveAlertChallengeIds =
+    await certificationChallengeLiveAlertRepository.getLiveAlertValidatedChallengeIdsByAssessmentId({
+      assessmentId,
+    });
+  challengeCalibrationsWithoutLiveAlerts = challengeCalibrations.filter(
+    (challengeCalibration) => !validatedLiveAlertChallengeIds.includes(challengeCalibration.id),
+  );
+  const challengesWithoutLiveAlerts = askedChallenges.filter(
+    (askedChallenge) => !validatedLiveAlertChallengeIds.includes(askedChallenge.id),
+  );
+  return { challengeCalibrationsWithoutLiveAlerts, challengesWithoutLiveAlerts };
+}
 
 function _createV3AssessmentResult({
   toBeCancelled,

--- a/api/src/shared/domain/events/handle-certification-rescoring.js
+++ b/api/src/shared/domain/events/handle-certification-rescoring.js
@@ -133,7 +133,7 @@ async function _handleV3CertificationScoring({
     emitter,
     certificationAssessment,
     locale,
-    dependencies: { findByCertificationCourseId: services.findByCertificationCourseId },
+    dependencies: { findByCertificationCourseIdAndAssessmentId: services.findByCertificationCourseIdAndAssessmentId },
   });
 
   // isCancelled will be removed


### PR DESCRIPTION
## :pancakes: Problème

Toute live-alerte levée par un candidat au cours de son test et ensuite validée par le surveillant se voit incluse dans l'association qui est faite entre les `certificationChallengeId` et `answerId` au moment de la sauvegarde des `certification-challenge-capacities` lors du scoring.

## :bacon: Proposition

Exclure les challenge ayant des live-alert validées par le surveillant lors du scoring

## 🧃 Remarques

Un travail de réflexion sur un refacto est probablement à mener en ce qui concerne les tests de `scoring-v3.js`
Je propose de laisser ça à une PR ultérieure afin de mettre un terme à ce bug le plus rapidement possible.

## :yum: Pour tester

- Créer une session V3
- Ajouter un candidat
- Commencer le test
- Créer une alerte sur une question et la valider côté surveillant
- Terminer le test
- Vérifier que la complétion se termine bien
- Vérifier que le certificationChallengeId du challenge où vous avez levé l'alerte ne se trouve pas dans la table `certification-challenge-capacities`

Rescorer la certification via un rejet et vérifier que le certificationChallengeId du challenge où vous avez levé l'alerte ne se trouve toujours pas dans la table `certification-challenge-capacities`
