### PR TITLE
[FEATURE] Remplacer le PixReturnTo déprécié par le PixButtonLink sur Pix Certif (PIX-16687).

### DIFF
--- a/certif/app/components/sessions/session-details/index.gjs
+++ b/certif/app/components/sessions/session-details/index.gjs
@@ -1,4 +1,4 @@
-import PixReturnTo from '@1024pix/pix-ui/components/pix-return-to';
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -63,9 +63,14 @@ export default class SessionDetails extends Component {
   }
 
   <template>
-    <PixReturnTo @route='authenticated.sessions' class='previous-button hide-on-mobile'>
+    <PixButtonLink
+      @route='authenticated.sessions'
+      @variant='tertiary'
+      @iconBefore='arrowLeft'
+      class='previous-button hide-on-mobile'
+    >
       {{t 'pages.sessions.actions.return'}}
-    </PixReturnTo>
+    </PixButtonLink>
     <SessionDetailsHeader
       @sessionId={{@model.session.id}}
       @sessionDate={{@model.session.date}}

--- a/certif/app/styles/globals/texts.scss
+++ b/certif/app/styles/globals/texts.scss
@@ -58,6 +58,4 @@
 .previous-button {
   width: fit-content;
   margin-bottom: var(--pix-spacing-6x);
-
-  @extend %pix-body-s;
 }

--- a/certif/app/templates/authenticated/sessions/add-student.hbs
+++ b/certif/app/templates/authenticated/sessions/add-student.hbs
@@ -1,13 +1,14 @@
 {{page-title this.pageTitle replace=true}}
 <div class="add-student">
-
-  <PixReturnTo
+  <PixButtonLink
     @route="authenticated.sessions.details.certification-candidates"
     @model={{@model.session.id}}
+    @variant="tertiary"
+    @iconBefore="arrowLeft"
     class="previous-button hide-on-mobile"
   >
     {{t "common.sessions.actions.return-to"}}
-  </PixReturnTo>
+  </PixButtonLink>
 
   <h1 class="page-title">{{t "pages.sco.enrol-candidates-in-session.title"}}</h1>
   <PixNotificationAlert @type="info" @withIcon={{true}} class="add-student__info-message">

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -1,13 +1,15 @@
 {{page-title this.pageTitle replace=true}}
 <div class="finalize">
   <div class="finalize__title">
-    <PixReturnTo
+    <PixButtonLink
       @route="authenticated.sessions.details"
       @model={{this.session.id}}
+      @variant="tertiary"
+      @iconBefore="arrowLeft"
       class="previous-button hide-on-mobile"
     >
       {{t "common.sessions.actions.return-to"}}
-    </PixReturnTo>
+    </PixButtonLink>
     <h1 class="page-title">{{t "pages.session-finalization.title" sessionId=this.session.id}}</h1>
   </div>
   <SessionFinalizationStepContainer

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -1,9 +1,15 @@
 {{! template-lint-disable link-href-attributes }}
 {{page-title (t "pages.sessions.import.title")}}
 <main class="import-page">
-  <PixReturnTo @route="authenticated.sessions" class="previous-button hide-on-mobile">
+  <PixButtonLink
+    @route="authenticated.sessions"
+    @variant="tertiary"
+    @iconBefore="arrowLeft"
+    class="previous-button hide-on-mobile"
+  >
     {{t "pages.sessions.actions.return"}}
-  </PixReturnTo>
+  </PixButtonLink>
+
   <h1 class="page-title">{{t "pages.sessions.import.title"}}</h1>
 
   {{#if this.isImportStepOne}}


### PR DESCRIPTION
## :pancakes: Problème

Le composant Pix UI [PixReturnTo](https://ui.pix.fr/?path=/docs/other-return-to--docs) est voué à disparaître. Il est encore utilisé dans les apps Pix.

## :bacon: Proposition

Utiliser le PixButtonLink en remplacement sur Pix Certif

## :yum: Pour tester

- Se connecter avec certif-sco-v3@example.net
- https://certif-pr11477.review.pix.fr/sessions/7400

<img width="491" alt="Capture d’écran 2025-02-21 à 13 45 17" src="https://github.com/user-attachments/assets/bd6be7b9-7452-4476-8ce7-776f82545369" />

- https://certif-pr11477.review.pix.fr/sessions/7400/inscription-eleves

<img width="454" alt="Capture d’écran 2025-02-21 à 13 46 13" src="https://github.com/user-attachments/assets/18e72059-3a27-4346-b47f-32f21664aae8" />


---

- Se connecter avec certif-pro@example.net
- https://certif-pr11477.review.pix.fr/sessions/7405/finalisation

<img width="441" alt="Capture d’écran 2025-02-21 à 13 45 47" src="https://github.com/user-attachments/assets/21e10095-fc32-45db-963a-58cf8671e133" />

- https://certif-pr11477.review.pix.fr/sessions/import

<img width="406" alt="Capture d’écran 2025-02-21 à 13 46 37" src="https://github.com/user-attachments/assets/4db40555-e136-44ee-8869-ab8fe7fece1e" />

