### PR TITLE
[FEATURE] Remplacer le PixReturnTo déprécié par le PixButtonLink sur Pix Orga (PIX-16694).

### DIFF
--- a/orga/app/styles/components/import.scss
+++ b/orga/app/styles/components/import.scss
@@ -6,6 +6,10 @@
   flex-direction: column;
   gap: var(--pix-spacing-10x);
 
+  &__previous-page-button {
+    width: fit-content;
+  }
+
   &__header {
     @extend %pix-title-m;
 

--- a/orga/app/templates/authenticated/import-organization-participants.hbs
+++ b/orga/app/templates/authenticated/import-organization-participants.hbs
@@ -1,8 +1,13 @@
 {{page-title (t "pages.organization-participants-import.title")}}
 
-<PixReturnTo @route={{this.participantListRoute}}>
+<PixButtonLink
+  @route={{this.participantListRoute}}
+  @variant="tertiary"
+  @iconBefore="arrowLeft"
+  class="import-students-page__previous-page-button"
+>
   {{t "common.actions.back"}}
-</PixReturnTo>
+</PixButtonLink>
 
 <Import
   @onImportScoStudents={{this.importScoStudents}}


### PR DESCRIPTION
## :pancakes: Problème

Le composant Pix UI [PixReturnTo](https://ui.pix.fr/?path=/docs/other-return-to--docs) est voué à disparaître. Il est encore utilisé dans les apps Pix.

## :bacon: Proposition

Utiliser le PixButtonLink en remplacement sur Orga.

## :yum: Pour tester

- Se connecter avec allorga@example.net
- https://orga-pr11478.review.pix.fr/import-participants

<img width="791" alt="Capture d’écran 2025-02-21 à 14 07 58" src="https://github.com/user-attachments/assets/56e1454b-88a4-459c-bf11-45c3f4716a30" />

