### PR TITLE
[FEATURE] Permettre de créer une Campagne de type EXAM (Pix-16488)

### DIFF
--- a/api/src/prescription/campaign/application/http-error-mapper-configuration.js
+++ b/api/src/prescription/campaign/application/http-error-mapper-configuration.js
@@ -5,8 +5,10 @@ import {
   CampaignUniqueCodeError,
   IsForAbsoluteNoviceUpdateError,
   MultipleSendingsUpdateError,
+  OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError,
   SwapCampaignMismatchOrganizationError,
   UnknownCampaignId,
+  UserNotAuthorizedToCreateCampaignError,
 } from '../../campaign/domain/errors.js';
 
 const campaignDomainErrorMappingConfiguration = [
@@ -39,6 +41,14 @@ const campaignDomainErrorMappingConfiguration = [
   {
     name: CampaignParticipationDoesNotBelongToUser.name,
     httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message, error.code, error.meta),
+  },
+  {
+    name: UserNotAuthorizedToCreateCampaignError.name,
+    httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message),
+  },
+  {
+    name: OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError.name,
+    httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message),
   },
 ];
 

--- a/api/src/prescription/campaign/application/http-error-mapper-configuration.js
+++ b/api/src/prescription/campaign/application/http-error-mapper-configuration.js
@@ -6,6 +6,7 @@ import {
   IsForAbsoluteNoviceUpdateError,
   MultipleSendingsUpdateError,
   OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError,
+  OrganizationNotAuthorizedToCreateCampaignError,
   SwapCampaignMismatchOrganizationError,
   UnknownCampaignId,
   UserNotAuthorizedToCreateCampaignError,
@@ -48,6 +49,10 @@ const campaignDomainErrorMappingConfiguration = [
   },
   {
     name: OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError.name,
+    httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message),
+  },
+  {
+    name: OrganizationNotAuthorizedToCreateCampaignError.name,
     httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message),
   },
 ];

--- a/api/src/prescription/campaign/domain/errors.js
+++ b/api/src/prescription/campaign/domain/errors.js
@@ -58,6 +58,19 @@ class CampaignParticipationDoesNotBelongToUser extends DomainError {
   }
 }
 
+class OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError extends DomainError {
+  constructor(organizationId) {
+    const message = `L'organisation ${organizationId}, n'est pas autorisée à créer une campagne d'évaluation à envoi multiple.`;
+    super(message);
+  }
+}
+
+class UserNotAuthorizedToCreateCampaignError extends DomainError {
+  constructor(message = "Cet utilisateur n'est pas autorisé à créer une campagne.") {
+    super(message);
+  }
+}
+
 export {
   ArchivedCampaignError,
   CampaignCodeFormatError,
@@ -66,6 +79,8 @@ export {
   DeletedCampaignError,
   IsForAbsoluteNoviceUpdateError,
   MultipleSendingsUpdateError,
+  OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError,
   SwapCampaignMismatchOrganizationError,
   UnknownCampaignId,
+  UserNotAuthorizedToCreateCampaignError,
 };

--- a/api/src/prescription/campaign/domain/errors.js
+++ b/api/src/prescription/campaign/domain/errors.js
@@ -65,6 +65,13 @@ class OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError ex
   }
 }
 
+class OrganizationNotAuthorizedToCreateCampaignError extends DomainError {
+  constructor(organizationId, type) {
+    const message = `L'organisation ${organizationId}, n'est pas autorisée à créer une campagne de type ${type}.`;
+    super(message);
+  }
+}
+
 class UserNotAuthorizedToCreateCampaignError extends DomainError {
   constructor(message = "Cet utilisateur n'est pas autorisé à créer une campagne.") {
     super(message);
@@ -80,6 +87,7 @@ export {
   IsForAbsoluteNoviceUpdateError,
   MultipleSendingsUpdateError,
   OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError,
+  OrganizationNotAuthorizedToCreateCampaignError,
   SwapCampaignMismatchOrganizationError,
   UnknownCampaignId,
   UserNotAuthorizedToCreateCampaignError,

--- a/api/src/prescription/campaign/domain/models/CampaignCreator.js
+++ b/api/src/prescription/campaign/domain/models/CampaignCreator.js
@@ -2,6 +2,7 @@ import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants
 import { CampaignTypes } from '../../../shared/domain/constants.js';
 import {
   OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError,
+  OrganizationNotAuthorizedToCreateCampaignError,
   UserNotAuthorizedToCreateCampaignError,
 } from '../errors.js';
 import { CampaignForCreation } from './CampaignForCreation.js';
@@ -11,18 +12,20 @@ class CampaignCreator {
     this.availableTargetProfileIds = availableTargetProfileIds;
     this.isMultipleSendingsAssessmentEnable =
       organizationFeatures[ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key];
+    this.isCampaignWithoutUserProfileEnable =
+      organizationFeatures[ORGANIZATION_FEATURE.CAMPAIGN_WITHOUT_USER_PROFILE.key];
   }
 
   createCampaign(campaignAttributes) {
     const { type, targetProfileId, multipleSendings, organizationId } = campaignAttributes;
 
     if (type === CampaignTypes.ASSESSMENT) {
-      _checkAssessmentCampaignCreationAllowed(targetProfileId, this.availableTargetProfileIds);
-      _checkAssessmentCampaignMultipleSendingsCreationAllowed(
-        multipleSendings,
-        this.isMultipleSendingsAssessmentEnable,
-        organizationId,
-      );
+      this.#checkAssessmentCampaignCreationAllowed(targetProfileId);
+      this.#checkAssessmentCampaignMultipleSendingsCreationAllowed(multipleSendings, organizationId);
+    }
+
+    if (type === CampaignTypes.EXAM) {
+      this.#checkCampaignTypeExamCreationAllowed(organizationId);
     }
 
     return new CampaignForCreation(campaignAttributes);
@@ -39,6 +42,12 @@ class CampaignCreator {
   #checkAssessmentCampaignMultipleSendingsCreationAllowed(multipleSendings, organizationId) {
     if (!this.isMultipleSendingsAssessmentEnable && multipleSendings) {
       throw new OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError(organizationId);
+    }
+  }
+
+  #checkCampaignTypeExamCreationAllowed(organizationId) {
+    if (!this.isCampaignWithoutUserProfileEnable) {
+      throw new OrganizationNotAuthorizedToCreateCampaignError(organizationId, CampaignTypes.EXAM);
     }
   }
 }

--- a/api/src/prescription/campaign/domain/models/CampaignCreator.js
+++ b/api/src/prescription/campaign/domain/models/CampaignCreator.js
@@ -27,23 +27,19 @@ class CampaignCreator {
 
     return new CampaignForCreation(campaignAttributes);
   }
-}
 
-function _checkAssessmentCampaignCreationAllowed(targetProfileId, availableTargetProfileIds) {
-  if (targetProfileId && !availableTargetProfileIds.includes(targetProfileId)) {
-    throw new UserNotAuthorizedToCreateCampaignError(
-      `Organization does not have an access to the profile ${targetProfileId}`,
-    );
+  #checkAssessmentCampaignCreationAllowed(targetProfileId) {
+    if (targetProfileId && !this.availableTargetProfileIds.includes(targetProfileId)) {
+      throw new UserNotAuthorizedToCreateCampaignError(
+        `Organization does not have an access to the profile ${targetProfileId}`,
+      );
+    }
   }
-}
 
-function _checkAssessmentCampaignMultipleSendingsCreationAllowed(
-  multipleSendings,
-  isMultipleSendingsAssessmentEnable,
-  organizationId,
-) {
-  if (!isMultipleSendingsAssessmentEnable && multipleSendings) {
-    throw new OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError(organizationId);
+  #checkAssessmentCampaignMultipleSendingsCreationAllowed(multipleSendings, organizationId) {
+    if (!this.isMultipleSendingsAssessmentEnable && multipleSendings) {
+      throw new OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError(organizationId);
+    }
   }
 }
 

--- a/api/src/prescription/campaign/domain/models/CampaignCreator.js
+++ b/api/src/prescription/campaign/domain/models/CampaignCreator.js
@@ -1,9 +1,9 @@
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
+import { CampaignTypes } from '../../../shared/domain/constants.js';
 import {
   OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError,
   UserNotAuthorizedToCreateCampaignError,
-} from '../../../../shared/domain/errors.js';
-import { CampaignTypes } from '../../../shared/domain/constants.js';
+} from '../errors.js';
 import { CampaignForCreation } from './CampaignForCreation.js';
 
 class CampaignCreator {

--- a/api/src/prescription/campaign/domain/usecases/create-campaign.js
+++ b/api/src/prescription/campaign/domain/usecases/create-campaign.js
@@ -1,4 +1,4 @@
-import { UserNotAuthorizedToCreateCampaignError } from '../../../../shared/domain/errors.js';
+import { UserNotAuthorizedToCreateCampaignError } from '../errors.js';
 
 const createCampaign = async function ({
   campaign,

--- a/api/src/prescription/campaign/domain/validators/campaign-creation-validator.js
+++ b/api/src/prescription/campaign/domain/validators/campaign-creation-validator.js
@@ -7,7 +7,7 @@ import { CampaignExternalIdTypes, CampaignTypes } from '../../../shared/domain/c
 const { first } = lodash;
 const schema = Joi.object({
   type: Joi.string()
-    .valid(CampaignTypes.ASSESSMENT, CampaignTypes.PROFILES_COLLECTION)
+    .valid(...Object.values(CampaignTypes))
     .required()
     .error((errors) => first(errors))
     .messages({
@@ -89,7 +89,7 @@ const schema = Joi.object({
           then: Joi.valid(null).optional(),
         },
         {
-          is: Joi.string().required().valid(CampaignTypes.ASSESSMENT),
+          is: Joi.string().required().valid(CampaignTypes.ASSESSMENT, CampaignTypes.EXAM),
           then: Joi.required(),
         },
       ],

--- a/api/src/prescription/organization-learner/domain/read-models/OrganizationLearnerActivity.js
+++ b/api/src/prescription/organization-learner/domain/read-models/OrganizationLearnerActivity.js
@@ -8,35 +8,37 @@ class OrganizationLearnerActivity {
   constructor({ organizationLearnerId, participations }) {
     this.organizationLearnerId = organizationLearnerId;
     this.participations = participations;
-    this.statistics = _statistics(participations);
+    this.statistics = this.#statistics(participations);
   }
-}
 
-function _getStatisticsForType(participations, campaignType) {
-  const participationsForCampaignType = participations.filter(
-    (participation) => participation.campaignType === campaignType,
-  );
+  #getStatisticsForType(participations, campaignType) {
+    const participationsForCampaignType = participations.filter(
+      (participation) => participation.campaignType === campaignType,
+    );
 
-  const { SHARED = 0, TO_SHARE = 0, STARTED = 0 } = countBy(participationsForCampaignType, 'status');
+    const { SHARED = 0, TO_SHARE = 0, STARTED = 0 } = countBy(participationsForCampaignType, 'status');
 
-  const statisticForCampaignType = {
-    campaignType,
-    shared: SHARED,
-    to_share: TO_SHARE,
-    total: participationsForCampaignType.length,
-  };
-
-  if (campaignType === CampaignTypes.ASSESSMENT) {
-    return {
-      ...statisticForCampaignType,
-      started: STARTED,
+    const statisticForCampaignType = {
+      campaignType,
+      shared: SHARED,
+      to_share: TO_SHARE,
+      total: participationsForCampaignType.length,
     };
-  }
-  return statisticForCampaignType;
-}
 
-function _statistics(participations) {
-  return Object.values(CampaignTypes).map((campaignType) => _getStatisticsForType(participations, campaignType));
+    if (campaignType === CampaignTypes.ASSESSMENT) {
+      return {
+        ...statisticForCampaignType,
+        started: STARTED,
+      };
+    }
+    return statisticForCampaignType;
+  }
+
+  #statistics(participations) {
+    return [CampaignTypes.ASSESSMENT, CampaignTypes.PROFILES_COLLECTION].map((campaignType) =>
+      this.#getStatisticsForType(participations, campaignType),
+    );
+  }
 }
 
 export { OrganizationLearnerActivity };

--- a/api/src/prescription/shared/domain/constants.js
+++ b/api/src/prescription/shared/domain/constants.js
@@ -6,6 +6,7 @@ const CampaignParticipationStatuses = {
 
 const CampaignTypes = {
   ASSESSMENT: 'ASSESSMENT',
+  EXAM: 'EXAM',
   PROFILES_COLLECTION: 'PROFILES_COLLECTION',
 };
 

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -284,9 +284,7 @@ function _mapToHttpError(error) {
   if (error instanceof SharedDomainErrors.UserNotAuthorizedToUpdateResourceError) {
     return new HttpErrors.ForbiddenError(error.message);
   }
-  if (error instanceof SharedDomainErrors.UserNotAuthorizedToCreateCampaignError) {
-    return new HttpErrors.ForbiddenError(error.message);
-  }
+
   if (error instanceof SharedDomainErrors.UserNotAuthorizedToGenerateUsernamePasswordError) {
     return new HttpErrors.ForbiddenError(error.message);
   }

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -711,19 +711,6 @@ class UserNotAuthorizedToUpdateCampaignError extends DomainError {
   }
 }
 
-class UserNotAuthorizedToCreateCampaignError extends DomainError {
-  constructor(message = "Cet utilisateur n'est pas autorisé à créer une campagne.") {
-    super(message);
-  }
-}
-
-class OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError extends DomainError {
-  constructor(organizationId) {
-    const message = `L'organisation ${organizationId}, n'est pas autorisée à créer une campagne d'évaluation à envoi multiple.`;
-    super(message);
-  }
-}
-
 class UserNotAuthorizedToUpdateResourceError extends DomainError {
   constructor(message = "Cet utilisateur n'est pas autorisé à mettre à jour la ressource.") {
     super(message);
@@ -1141,7 +1128,6 @@ export {
   OrganizationLearnerNotFound,
   OrganizationLearnersConstraintError,
   OrganizationLearnersCouldNotBeSavedError,
-  OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError,
   OrganizationNotFoundError,
   OrganizationTagNotFound,
   OrganizationWithoutEmailError,
@@ -1160,7 +1146,6 @@ export {
   UserIsTemporaryBlocked,
   UserNotAuthorizedToAccessEntityError,
   UserNotAuthorizedToCertifyError,
-  UserNotAuthorizedToCreateCampaignError,
   UserNotAuthorizedToCreateResourceError,
   UserNotAuthorizedToGenerateUsernamePasswordError,
   UserNotAuthorizedToGetCampaignResultsError,

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -290,16 +290,6 @@ describe('Integration | API | Controller Error', function () {
       expect(responseDetail(response)).to.equal('Utilisateur non autorisé à mettre à jour à la ressource');
     });
 
-    it('responds Forbidden when a UserNotAuthorizedToCreateCampaignError error occurs', async function () {
-      routeHandler.throws(
-        new DomainErrors.UserNotAuthorizedToCreateCampaignError('Utilisateur non autorisé à créer une campagne'),
-      );
-      const response = await server.requestObject(request);
-
-      expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
-      expect(responseDetail(response)).to.equal('Utilisateur non autorisé à créer une campagne');
-    });
-
     it('responds Forbidden when a CandidateAlreadyLinkedToUserError error occurs', async function () {
       routeHandler.throws(new DomainErrors.CandidateAlreadyLinkedToUserError());
       const response = await server.requestObject(request);

--- a/api/tests/prescription/campaign/integration/domain/usecases/create-campaign_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/create-campaign_test.js
@@ -6,7 +6,7 @@ import { createCampaign } from '../../../../../../src/prescription/campaign/doma
 import * as campaignAdministrationRepository from '../../../../../../src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js';
 import * as campaignCreatorRepository from '../../../../../../src/prescription/campaign/infrastructure/repositories/campaign-creator-repository.js';
 import { CampaignTypes } from '../../../../../../src/prescription/shared/domain/constants.js';
-import { CAMPAIGN_FEATURES } from '../../../../../../src/shared/domain/constants.js';
+import { CAMPAIGN_FEATURES, ORGANIZATION_FEATURE } from '../../../../../../src/shared/domain/constants.js';
 import * as codeGenerator from '../../../../../../src/shared/domain/services/code-generator.js';
 import { databaseBuilder, expect, mockLearningContent } from '../../../../../test-helper.js';
 
@@ -42,6 +42,42 @@ describe('Integration | UseCases | create-campaign', function () {
     const campaign = {
       name: 'a name',
       type: CampaignTypes.ASSESSMENT,
+      title: 'a title',
+      externalIdLabel: 'id Pix label',
+      externalIdType: 'STRING',
+      customLandingPageText: 'Hello',
+      creatorId: userId,
+      ownerId: userId,
+      organizationId,
+      targetProfileId,
+    };
+
+    const expectedAttributes = ['type', 'title', 'externalIdLabel', 'name', 'customLandingPageText'];
+
+    // when
+    const result = await createCampaign({
+      campaign,
+      userRepository,
+      campaignAdministrationRepository,
+      campaignCreatorRepository,
+      codeGenerator,
+    });
+
+    // then
+    expect(result).to.be.an.instanceOf(Campaign);
+
+    expect(_.pick(result, expectedAttributes)).to.deep.equal(_.pick(campaign, expectedAttributes));
+  });
+
+  it('should save a new campaign of type EXAM', async function () {
+    const featureId = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.CAMPAIGN_WITHOUT_USER_PROFILE).id;
+
+    databaseBuilder.factory.buildOrganizationFeature({ featureId, organizationId });
+    await databaseBuilder.commit();
+    // given
+    const campaign = {
+      name: 'a name',
+      type: CampaignTypes.EXAM,
       title: 'a title',
       externalIdLabel: 'id Pix label',
       externalIdType: 'STRING',

--- a/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
+++ b/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
@@ -1,6 +1,6 @@
 import * as campaignApi from '../../../../../../src/prescription/campaign/application/api/campaigns-api.js';
+import { UserNotAuthorizedToCreateCampaignError } from '../../../../../../src/prescription/campaign/domain/errors.js';
 import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
-import { UserNotAuthorizedToCreateCampaignError } from '../../../../../../src/shared/domain/errors.js';
 import { Campaign } from '../../../../../../src/shared/domain/models/Campaign.js';
 import { CampaignReport } from '../../../../../../src/shared/domain/read-models/CampaignReport.js';
 import { catchErr, expect, sinon } from '../../../../../test-helper.js';

--- a/api/tests/prescription/campaign/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/prescription/campaign/unit/application/http-error-mapper-configuration_test.js
@@ -2,6 +2,7 @@ import { campaignDomainErrorMappingConfiguration } from '../../../../../src/pres
 import {
   CampaignParticipationDoesNotBelongToUser,
   OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError,
+  OrganizationNotAuthorizedToCreateCampaignError,
   UserNotAuthorizedToCreateCampaignError,
 } from '../../../../../src/prescription/campaign/domain/errors.js';
 import { HttpErrors } from '../../../../../src/shared/application/http-errors.js';
@@ -45,6 +46,19 @@ describe('Prescription | Campaign | Unit | Application | HttpErrorMapperConfigur
     const error = httpErrorMapper.httpErrorFn(
       new OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError(),
     );
+
+    //then
+    expect(error).to.be.instanceOf(HttpErrors.ForbiddenError);
+  });
+
+  it('instantiates ForbiddenError when OrganizationNotAuthorizedToCreateCampaignError', async function () {
+    //given
+    const httpErrorMapper = campaignDomainErrorMappingConfiguration.find(
+      (httpErrorMapper) => httpErrorMapper.name === OrganizationNotAuthorizedToCreateCampaignError.name,
+    );
+
+    //when
+    const error = httpErrorMapper.httpErrorFn(new OrganizationNotAuthorizedToCreateCampaignError());
 
     //then
     expect(error).to.be.instanceOf(HttpErrors.ForbiddenError);

--- a/api/tests/prescription/campaign/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/prescription/campaign/unit/application/http-error-mapper-configuration_test.js
@@ -1,5 +1,9 @@
 import { campaignDomainErrorMappingConfiguration } from '../../../../../src/prescription/campaign/application/http-error-mapper-configuration.js';
-import { CampaignParticipationDoesNotBelongToUser } from '../../../../../src/prescription/campaign/domain/errors.js';
+import {
+  CampaignParticipationDoesNotBelongToUser,
+  OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError,
+  UserNotAuthorizedToCreateCampaignError,
+} from '../../../../../src/prescription/campaign/domain/errors.js';
 import { HttpErrors } from '../../../../../src/shared/application/http-errors.js';
 import { expect } from '../../../../test-helper.js';
 
@@ -12,6 +16,35 @@ describe('Prescription | Campaign | Unit | Application | HttpErrorMapperConfigur
 
     //when
     const error = httpErrorMapper.httpErrorFn(new CampaignParticipationDoesNotBelongToUser());
+
+    //then
+    expect(error).to.be.instanceOf(HttpErrors.ForbiddenError);
+  });
+
+  it('instantiates ForbiddenError when UserNotAuthorizedToCreateCampaignError', async function () {
+    //given
+    const httpErrorMapper = campaignDomainErrorMappingConfiguration.find(
+      (httpErrorMapper) => httpErrorMapper.name === UserNotAuthorizedToCreateCampaignError.name,
+    );
+
+    //when
+    const error = httpErrorMapper.httpErrorFn(new UserNotAuthorizedToCreateCampaignError());
+
+    //then
+    expect(error).to.be.instanceOf(HttpErrors.ForbiddenError);
+  });
+
+  it('instantiates ForbiddenError when OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError', async function () {
+    //given
+    const httpErrorMapper = campaignDomainErrorMappingConfiguration.find(
+      (httpErrorMapper) =>
+        httpErrorMapper.name === OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError.name,
+    );
+
+    //when
+    const error = httpErrorMapper.httpErrorFn(
+      new OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError(),
+    );
 
     //then
     expect(error).to.be.instanceOf(HttpErrors.ForbiddenError);

--- a/api/tests/prescription/campaign/unit/domain/models/CampaignCreator_test.js
+++ b/api/tests/prescription/campaign/unit/domain/models/CampaignCreator_test.js
@@ -1,11 +1,11 @@
+import {
+  OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError,
+  UserNotAuthorizedToCreateCampaignError,
+} from '../../../../../../src/prescription/campaign/domain/errors.js';
 import { CampaignCreator } from '../../../../../../src/prescription/campaign/domain/models/CampaignCreator.js';
 import { CampaignForCreation } from '../../../../../../src/prescription/campaign/domain/models/CampaignForCreation.js';
 import { CampaignTypes } from '../../../../../../src/prescription/shared/domain/constants.js';
 import { ORGANIZATION_FEATURE } from '../../../../../../src/shared/domain/constants.js';
-import {
-  OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError,
-  UserNotAuthorizedToCreateCampaignError,
-} from '../../../../../../src/shared/domain/errors.js';
 import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErr, expect } from '../../../../../test-helper.js';
 

--- a/api/tests/prescription/campaign/unit/domain/models/CampaignCreator_test.js
+++ b/api/tests/prescription/campaign/unit/domain/models/CampaignCreator_test.js
@@ -1,5 +1,6 @@
 import {
   OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError,
+  OrganizationNotAuthorizedToCreateCampaignError,
   UserNotAuthorizedToCreateCampaignError,
 } from '../../../../../../src/prescription/campaign/domain/errors.js';
 import { CampaignCreator } from '../../../../../../src/prescription/campaign/domain/models/CampaignCreator.js';
@@ -109,6 +110,44 @@ describe('Unit | Domain | Models | CampaignCreator', function () {
           const error = await catchErr(creator.createCampaign, creator)(campaignData);
 
           expect(error).to.be.instanceOf(OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError);
+        });
+      });
+
+      describe('campaign without user profile', function () {
+        it('throws an error when campaign without user profile is not available', async function () {
+          organizationFeatures[ORGANIZATION_FEATURE.CAMPAIGN_WITHOUT_USER_PROFILE.key] = false;
+          const availableTargetProfileIds = [1, 2];
+          const creator = new CampaignCreator({ availableTargetProfileIds, organizationFeatures });
+          const campaignData = {
+            name: 'campagne utilisateur',
+            type: CampaignTypes.EXAM,
+            creatorId: 1,
+            ownerId: 1,
+            organizationId: 2,
+            targetProfileId: 2,
+          };
+
+          const error = await catchErr(creator.createCampaign, creator)(campaignData);
+
+          expect(error).to.be.instanceOf(OrganizationNotAuthorizedToCreateCampaignError);
+        });
+
+        it('should create a campaign if type exam when feature is enable', async function () {
+          organizationFeatures[ORGANIZATION_FEATURE.CAMPAIGN_WITHOUT_USER_PROFILE.key] = true;
+          const availableTargetProfileIds = [1, 2];
+          const creator = new CampaignCreator({ availableTargetProfileIds, organizationFeatures });
+          const campaignData = {
+            name: 'campagne utilisateur',
+            type: CampaignTypes.EXAM,
+            creatorId: 1,
+            ownerId: 1,
+            organizationId: 2,
+            targetProfileId: 2,
+          };
+
+          const result = creator.createCampaign(campaignData);
+
+          expect(result.type).to.be.equal(CampaignTypes.EXAM);
         });
       });
 

--- a/api/tests/prescription/campaign/unit/domain/models/CampaignForCreation_test.js
+++ b/api/tests/prescription/campaign/unit/domain/models/CampaignForCreation_test.js
@@ -168,6 +168,169 @@ describe('Unit | Domain | Models | CampaignForCreation', function () {
       });
     });
 
+    context('when the campaign type is EXAM', function () {
+      context('when the every required field is present', function () {
+        it('creates the campaign', function () {
+          const attributes = {
+            name: 'CampaignName',
+            type: CampaignTypes.EXAM,
+            targetProfileId: 1,
+            creatorId: 2,
+            ownerId: 2,
+            organizationId: 3,
+            title: '',
+            customLandingPageText: '',
+            customResultPageButtonText: null,
+            customResultPageButtonUrl: null,
+          };
+
+          expect(() => new CampaignForCreation(attributes)).to.not.throw();
+        });
+      });
+
+      context('when attributes are invalid', function () {
+        let attributes;
+        beforeEach(function () {
+          attributes = {
+            name: 'CampaignName',
+            type: CampaignTypes.EXAM,
+            targetProfileId: 1,
+            creatorId: 2,
+            ownerId: 2,
+            organizationId: 3,
+          };
+        });
+
+        context('name is missing', function () {
+          it('throws an error', async function () {
+            attributes.name = undefined;
+
+            const error = await catchErr(() => new CampaignForCreation(attributes))();
+            expect(error.message).to.equal("Échec de validation de l'entité.");
+            expect(error.invalidAttributes).to.deep.equal([{ attribute: 'name', message: '"name" is required' }]);
+          });
+        });
+
+        context('creatorId is missing', function () {
+          it('throws an error', async function () {
+            attributes.creatorId = undefined;
+
+            const error = await catchErr(() => new CampaignForCreation(attributes))();
+            expect(error.message).to.equal("Échec de validation de l'entité.");
+            expect(error.invalidAttributes).to.deep.equal([{ attribute: 'creatorId', message: 'MISSING_CREATOR' }]);
+          });
+        });
+
+        context('ownerId is missing', function () {
+          it('throws an error', async function () {
+            attributes.ownerId = undefined;
+
+            const error = await catchErr(() => new CampaignForCreation(attributes))();
+            expect(error.message).to.equal("Échec de validation de l'entité.");
+            expect(error.invalidAttributes).to.deep.equal([{ attribute: 'ownerId', message: 'MISSING_OWNER' }]);
+          });
+        });
+
+        context('organizationId is missing', function () {
+          it('throws an error', async function () {
+            attributes.organizationId = undefined;
+
+            const error = await catchErr(() => new CampaignForCreation(attributes))();
+            expect(error.message).to.equal("Échec de validation de l'entité.");
+            expect(error.invalidAttributes).to.deep.equal([
+              { attribute: 'organizationId', message: 'MISSING_ORGANIZATION' },
+            ]);
+          });
+        });
+
+        context('targetProfileId is missing', function () {
+          it('throws an error', async function () {
+            attributes.targetProfileId = undefined;
+
+            const error = await catchErr(() => new CampaignForCreation(attributes))();
+            expect(error.message).to.equal("Échec de validation de l'entité.");
+            expect(error.invalidAttributes).to.deep.equal([
+              { attribute: 'targetProfileId', message: 'TARGET_PROFILE_IS_REQUIRED' },
+            ]);
+          });
+        });
+
+        context('customLandingPageText max length over 5000 character', function () {
+          it('throws an error', async function () {
+            // given
+            attributes.customLandingPageText = 'Godzilla vs Kong'.repeat(335);
+
+            const error = await catchErr(() => new CampaignForCreation(attributes))();
+            expect(error.message).to.equal("Échec de validation de l'entité.");
+            expect(error.invalidAttributes).to.deep.equal([
+              { attribute: 'customLandingPageText', message: 'CUSTOM_LANDING_PAGE_TEXT_IS_TOO_LONG' },
+            ]);
+          });
+        });
+
+        context('customResultPageText max length over 5000 character', function () {
+          it('throws an error', async function () {
+            // given
+            attributes.customResultPageText = 'Godzilla vs Kong'.repeat(335);
+
+            const error = await catchErr(() => new CampaignForCreation(attributes))();
+            expect(error.message).to.equal("Échec de validation de l'entité.");
+            expect(error.invalidAttributes).to.deep.equal([
+              { attribute: 'customResultPageText', message: 'CUSTOM_RESULT_PAGE_TEXT_IS_TOO_LONG' },
+            ]);
+          });
+        });
+
+        context('customResultPageButtonUrl is required if customResultPageButtonText is defined', function () {
+          it('throws an error', async function () {
+            // given
+            attributes.customResultPageButtonText = 'Godzilla vs Kong';
+            attributes.customResultPageButtonUrl = null;
+
+            const error = await catchErr(() => new CampaignForCreation(attributes))();
+            expect(error.message).to.equal("Échec de validation de l'entité.");
+            expect(error.invalidAttributes).to.deep.equal([
+              {
+                attribute: 'customResultPageButtonUrl',
+                message: 'CUSTOM_RESULT_PAGE_BUTTON_URL_IS_REQUIRED_WHEN_CUSTOM_RESULT_PAGE_BUTTON_TEXT_IS_FILLED',
+              },
+            ]);
+          });
+        });
+
+        context('customResultPageButtonText is required if customResultPageButtonUrl is defined', function () {
+          it('throws an error', async function () {
+            // given
+            attributes.customResultPageButtonUrl = 'https://http.dog/';
+            attributes.customResultPageButtonText = null;
+
+            const error = await catchErr(() => new CampaignForCreation(attributes))();
+            expect(error.message).to.equal("Échec de validation de l'entité.");
+            expect(error.invalidAttributes).to.deep.equal([
+              {
+                attribute: 'customResultPageButtonText',
+                message: 'CUSTOM_RESULT_PAGE_BUTTON_TEXT_IS_REQUIRED_WHEN_CUSTOM_RESULT_PAGE_BUTTON_URL_IS_FILLED',
+              },
+            ]);
+          });
+        });
+
+        context('customResultPageButtonUrl must be an URL', function () {
+          it('throws an error', async function () {
+            // given
+            attributes.customResultPageButtonText = 'Godzilla vs Kong';
+            attributes.customResultPageButtonUrl = 'Godzilla vs Kong';
+
+            const error = await catchErr(() => new CampaignForCreation(attributes))();
+            expect(error.message).to.equal("Échec de validation de l'entité.");
+            expect(error.invalidAttributes).to.deep.equal([
+              { attribute: 'customResultPageButtonUrl', message: 'CUSTOM_RESULT_PAGE_BUTTON_URL_MUST_BE_A_URL' },
+            ]);
+          });
+        });
+      });
+    });
+
     context('when the campaign type is PROFILES_COLLECTION', function () {
       context('when the every required field is present', function () {
         it('should create the campaign', function () {

--- a/api/tests/prescription/campaign/unit/domain/models/CampaignForCreation_test.js
+++ b/api/tests/prescription/campaign/unit/domain/models/CampaignForCreation_test.js
@@ -5,327 +5,167 @@ import { catchErr, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Domain | Models | CampaignForCreation', function () {
   describe('#create', function () {
-    context('when the campaign type is ASSESSEMENT', function () {
-      context('when the every required field is present', function () {
-        it('creates the campaign', function () {
-          const attributes = {
-            name: 'CampaignName',
-            type: CampaignTypes.ASSESSMENT,
-            targetProfileId: 1,
-            creatorId: 2,
-            ownerId: 2,
-            organizationId: 3,
-            title: '',
-            customLandingPageText: '',
-            customResultPageButtonText: null,
-            customResultPageButtonUrl: null,
-          };
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    [CampaignTypes.ASSESSMENT, CampaignTypes.EXAM].forEach((type) => {
+      context(`when the campaign type is ${type}`, function () {
+        context('when the every required field is present', function () {
+          it('creates the campaign', function () {
+            const attributes = {
+              name: 'CampaignName',
+              type,
+              targetProfileId: 1,
+              creatorId: 2,
+              ownerId: 2,
+              organizationId: 3,
+              title: '',
+              customLandingPageText: '',
+              customResultPageButtonText: null,
+              customResultPageButtonUrl: null,
+            };
 
-          expect(() => new CampaignForCreation(attributes)).to.not.throw();
-        });
-      });
-
-      context('when attributes are invalid', function () {
-        let attributes;
-        beforeEach(function () {
-          attributes = {
-            name: 'CampaignName',
-            type: CampaignTypes.ASSESSMENT,
-            targetProfileId: 1,
-            creatorId: 2,
-            ownerId: 2,
-            organizationId: 3,
-          };
-        });
-
-        context('name is missing', function () {
-          it('throws an error', async function () {
-            attributes.name = undefined;
-
-            const error = await catchErr(() => new CampaignForCreation(attributes))();
-            expect(error.message).to.equal("Échec de validation de l'entité.");
-            expect(error.invalidAttributes).to.deep.equal([{ attribute: 'name', message: '"name" is required' }]);
+            expect(() => new CampaignForCreation(attributes)).to.not.throw();
           });
         });
 
-        context('creatorId is missing', function () {
-          it('throws an error', async function () {
-            attributes.creatorId = undefined;
-
-            const error = await catchErr(() => new CampaignForCreation(attributes))();
-            expect(error.message).to.equal("Échec de validation de l'entité.");
-            expect(error.invalidAttributes).to.deep.equal([{ attribute: 'creatorId', message: 'MISSING_CREATOR' }]);
+        context('when attributes are invalid', function () {
+          let attributes;
+          beforeEach(function () {
+            attributes = {
+              name: 'CampaignName',
+              type,
+              targetProfileId: 1,
+              creatorId: 2,
+              ownerId: 2,
+              organizationId: 3,
+            };
           });
-        });
 
-        context('ownerId is missing', function () {
-          it('throws an error', async function () {
-            attributes.ownerId = undefined;
+          context('name is missing', function () {
+            it('throws an error', async function () {
+              attributes.name = undefined;
 
-            const error = await catchErr(() => new CampaignForCreation(attributes))();
-            expect(error.message).to.equal("Échec de validation de l'entité.");
-            expect(error.invalidAttributes).to.deep.equal([{ attribute: 'ownerId', message: 'MISSING_OWNER' }]);
+              const error = await catchErr(() => new CampaignForCreation(attributes))();
+              expect(error.message).to.equal("Échec de validation de l'entité.");
+              expect(error.invalidAttributes).to.deep.equal([{ attribute: 'name', message: '"name" is required' }]);
+            });
           });
-        });
 
-        context('organizationId is missing', function () {
-          it('throws an error', async function () {
-            attributes.organizationId = undefined;
+          context('creatorId is missing', function () {
+            it('throws an error', async function () {
+              attributes.creatorId = undefined;
 
-            const error = await catchErr(() => new CampaignForCreation(attributes))();
-            expect(error.message).to.equal("Échec de validation de l'entité.");
-            expect(error.invalidAttributes).to.deep.equal([
-              { attribute: 'organizationId', message: 'MISSING_ORGANIZATION' },
-            ]);
+              const error = await catchErr(() => new CampaignForCreation(attributes))();
+              expect(error.message).to.equal("Échec de validation de l'entité.");
+              expect(error.invalidAttributes).to.deep.equal([{ attribute: 'creatorId', message: 'MISSING_CREATOR' }]);
+            });
           });
-        });
 
-        context('targetProfileId is missing', function () {
-          it('throws an error', async function () {
-            attributes.targetProfileId = undefined;
+          context('ownerId is missing', function () {
+            it('throws an error', async function () {
+              attributes.ownerId = undefined;
 
-            const error = await catchErr(() => new CampaignForCreation(attributes))();
-            expect(error.message).to.equal("Échec de validation de l'entité.");
-            expect(error.invalidAttributes).to.deep.equal([
-              { attribute: 'targetProfileId', message: 'TARGET_PROFILE_IS_REQUIRED' },
-            ]);
+              const error = await catchErr(() => new CampaignForCreation(attributes))();
+              expect(error.message).to.equal("Échec de validation de l'entité.");
+              expect(error.invalidAttributes).to.deep.equal([{ attribute: 'ownerId', message: 'MISSING_OWNER' }]);
+            });
           });
-        });
 
-        context('customLandingPageText max length over 5000 character', function () {
-          it('throws an error', async function () {
-            // given
-            attributes.customLandingPageText = 'Godzilla vs Kong'.repeat(335);
+          context('organizationId is missing', function () {
+            it('throws an error', async function () {
+              attributes.organizationId = undefined;
 
-            const error = await catchErr(() => new CampaignForCreation(attributes))();
-            expect(error.message).to.equal("Échec de validation de l'entité.");
-            expect(error.invalidAttributes).to.deep.equal([
-              { attribute: 'customLandingPageText', message: 'CUSTOM_LANDING_PAGE_TEXT_IS_TOO_LONG' },
-            ]);
+              const error = await catchErr(() => new CampaignForCreation(attributes))();
+              expect(error.message).to.equal("Échec de validation de l'entité.");
+              expect(error.invalidAttributes).to.deep.equal([
+                { attribute: 'organizationId', message: 'MISSING_ORGANIZATION' },
+              ]);
+            });
           });
-        });
 
-        context('customResultPageText max length over 5000 character', function () {
-          it('throws an error', async function () {
-            // given
-            attributes.customResultPageText = 'Godzilla vs Kong'.repeat(335);
+          context('targetProfileId is missing', function () {
+            it('throws an error', async function () {
+              attributes.targetProfileId = undefined;
 
-            const error = await catchErr(() => new CampaignForCreation(attributes))();
-            expect(error.message).to.equal("Échec de validation de l'entité.");
-            expect(error.invalidAttributes).to.deep.equal([
-              { attribute: 'customResultPageText', message: 'CUSTOM_RESULT_PAGE_TEXT_IS_TOO_LONG' },
-            ]);
+              const error = await catchErr(() => new CampaignForCreation(attributes))();
+              expect(error.message).to.equal("Échec de validation de l'entité.");
+              expect(error.invalidAttributes).to.deep.equal([
+                { attribute: 'targetProfileId', message: 'TARGET_PROFILE_IS_REQUIRED' },
+              ]);
+            });
           });
-        });
 
-        context('customResultPageButtonUrl is required if customResultPageButtonText is defined', function () {
-          it('throws an error', async function () {
-            // given
-            attributes.customResultPageButtonText = 'Godzilla vs Kong';
-            attributes.customResultPageButtonUrl = null;
+          context('customLandingPageText max length over 5000 character', function () {
+            it('throws an error', async function () {
+              // given
+              attributes.customLandingPageText = 'Godzilla vs Kong'.repeat(335);
 
-            const error = await catchErr(() => new CampaignForCreation(attributes))();
-            expect(error.message).to.equal("Échec de validation de l'entité.");
-            expect(error.invalidAttributes).to.deep.equal([
-              {
-                attribute: 'customResultPageButtonUrl',
-                message: 'CUSTOM_RESULT_PAGE_BUTTON_URL_IS_REQUIRED_WHEN_CUSTOM_RESULT_PAGE_BUTTON_TEXT_IS_FILLED',
-              },
-            ]);
+              const error = await catchErr(() => new CampaignForCreation(attributes))();
+              expect(error.message).to.equal("Échec de validation de l'entité.");
+              expect(error.invalidAttributes).to.deep.equal([
+                { attribute: 'customLandingPageText', message: 'CUSTOM_LANDING_PAGE_TEXT_IS_TOO_LONG' },
+              ]);
+            });
           });
-        });
 
-        context('customResultPageButtonText is required if customResultPageButtonUrl is defined', function () {
-          it('throws an error', async function () {
-            // given
-            attributes.customResultPageButtonUrl = 'https://http.dog/';
-            attributes.customResultPageButtonText = null;
+          context('customResultPageText max length over 5000 character', function () {
+            it('throws an error', async function () {
+              // given
+              attributes.customResultPageText = 'Godzilla vs Kong'.repeat(335);
 
-            const error = await catchErr(() => new CampaignForCreation(attributes))();
-            expect(error.message).to.equal("Échec de validation de l'entité.");
-            expect(error.invalidAttributes).to.deep.equal([
-              {
-                attribute: 'customResultPageButtonText',
-                message: 'CUSTOM_RESULT_PAGE_BUTTON_TEXT_IS_REQUIRED_WHEN_CUSTOM_RESULT_PAGE_BUTTON_URL_IS_FILLED',
-              },
-            ]);
+              const error = await catchErr(() => new CampaignForCreation(attributes))();
+              expect(error.message).to.equal("Échec de validation de l'entité.");
+              expect(error.invalidAttributes).to.deep.equal([
+                { attribute: 'customResultPageText', message: 'CUSTOM_RESULT_PAGE_TEXT_IS_TOO_LONG' },
+              ]);
+            });
           });
-        });
 
-        context('customResultPageButtonUrl must be an URL', function () {
-          it('throws an error', async function () {
-            // given
-            attributes.customResultPageButtonText = 'Godzilla vs Kong';
-            attributes.customResultPageButtonUrl = 'Godzilla vs Kong';
+          context('customResultPageButtonUrl is required if customResultPageButtonText is defined', function () {
+            it('throws an error', async function () {
+              // given
+              attributes.customResultPageButtonText = 'Godzilla vs Kong';
+              attributes.customResultPageButtonUrl = null;
 
-            const error = await catchErr(() => new CampaignForCreation(attributes))();
-            expect(error.message).to.equal("Échec de validation de l'entité.");
-            expect(error.invalidAttributes).to.deep.equal([
-              { attribute: 'customResultPageButtonUrl', message: 'CUSTOM_RESULT_PAGE_BUTTON_URL_MUST_BE_A_URL' },
-            ]);
+              const error = await catchErr(() => new CampaignForCreation(attributes))();
+              expect(error.message).to.equal("Échec de validation de l'entité.");
+              expect(error.invalidAttributes).to.deep.equal([
+                {
+                  attribute: 'customResultPageButtonUrl',
+                  message: 'CUSTOM_RESULT_PAGE_BUTTON_URL_IS_REQUIRED_WHEN_CUSTOM_RESULT_PAGE_BUTTON_TEXT_IS_FILLED',
+                },
+              ]);
+            });
           });
-        });
-      });
-    });
 
-    context('when the campaign type is EXAM', function () {
-      context('when the every required field is present', function () {
-        it('creates the campaign', function () {
-          const attributes = {
-            name: 'CampaignName',
-            type: CampaignTypes.EXAM,
-            targetProfileId: 1,
-            creatorId: 2,
-            ownerId: 2,
-            organizationId: 3,
-            title: '',
-            customLandingPageText: '',
-            customResultPageButtonText: null,
-            customResultPageButtonUrl: null,
-          };
+          context('customResultPageButtonText is required if customResultPageButtonUrl is defined', function () {
+            it('throws an error', async function () {
+              // given
+              attributes.customResultPageButtonUrl = 'https://http.dog/';
+              attributes.customResultPageButtonText = null;
 
-          expect(() => new CampaignForCreation(attributes)).to.not.throw();
-        });
-      });
-
-      context('when attributes are invalid', function () {
-        let attributes;
-        beforeEach(function () {
-          attributes = {
-            name: 'CampaignName',
-            type: CampaignTypes.EXAM,
-            targetProfileId: 1,
-            creatorId: 2,
-            ownerId: 2,
-            organizationId: 3,
-          };
-        });
-
-        context('name is missing', function () {
-          it('throws an error', async function () {
-            attributes.name = undefined;
-
-            const error = await catchErr(() => new CampaignForCreation(attributes))();
-            expect(error.message).to.equal("Échec de validation de l'entité.");
-            expect(error.invalidAttributes).to.deep.equal([{ attribute: 'name', message: '"name" is required' }]);
+              const error = await catchErr(() => new CampaignForCreation(attributes))();
+              expect(error.message).to.equal("Échec de validation de l'entité.");
+              expect(error.invalidAttributes).to.deep.equal([
+                {
+                  attribute: 'customResultPageButtonText',
+                  message: 'CUSTOM_RESULT_PAGE_BUTTON_TEXT_IS_REQUIRED_WHEN_CUSTOM_RESULT_PAGE_BUTTON_URL_IS_FILLED',
+                },
+              ]);
+            });
           });
-        });
 
-        context('creatorId is missing', function () {
-          it('throws an error', async function () {
-            attributes.creatorId = undefined;
+          context('customResultPageButtonUrl must be an URL', function () {
+            it('throws an error', async function () {
+              // given
+              attributes.customResultPageButtonText = 'Godzilla vs Kong';
+              attributes.customResultPageButtonUrl = 'Godzilla vs Kong';
 
-            const error = await catchErr(() => new CampaignForCreation(attributes))();
-            expect(error.message).to.equal("Échec de validation de l'entité.");
-            expect(error.invalidAttributes).to.deep.equal([{ attribute: 'creatorId', message: 'MISSING_CREATOR' }]);
-          });
-        });
-
-        context('ownerId is missing', function () {
-          it('throws an error', async function () {
-            attributes.ownerId = undefined;
-
-            const error = await catchErr(() => new CampaignForCreation(attributes))();
-            expect(error.message).to.equal("Échec de validation de l'entité.");
-            expect(error.invalidAttributes).to.deep.equal([{ attribute: 'ownerId', message: 'MISSING_OWNER' }]);
-          });
-        });
-
-        context('organizationId is missing', function () {
-          it('throws an error', async function () {
-            attributes.organizationId = undefined;
-
-            const error = await catchErr(() => new CampaignForCreation(attributes))();
-            expect(error.message).to.equal("Échec de validation de l'entité.");
-            expect(error.invalidAttributes).to.deep.equal([
-              { attribute: 'organizationId', message: 'MISSING_ORGANIZATION' },
-            ]);
-          });
-        });
-
-        context('targetProfileId is missing', function () {
-          it('throws an error', async function () {
-            attributes.targetProfileId = undefined;
-
-            const error = await catchErr(() => new CampaignForCreation(attributes))();
-            expect(error.message).to.equal("Échec de validation de l'entité.");
-            expect(error.invalidAttributes).to.deep.equal([
-              { attribute: 'targetProfileId', message: 'TARGET_PROFILE_IS_REQUIRED' },
-            ]);
-          });
-        });
-
-        context('customLandingPageText max length over 5000 character', function () {
-          it('throws an error', async function () {
-            // given
-            attributes.customLandingPageText = 'Godzilla vs Kong'.repeat(335);
-
-            const error = await catchErr(() => new CampaignForCreation(attributes))();
-            expect(error.message).to.equal("Échec de validation de l'entité.");
-            expect(error.invalidAttributes).to.deep.equal([
-              { attribute: 'customLandingPageText', message: 'CUSTOM_LANDING_PAGE_TEXT_IS_TOO_LONG' },
-            ]);
-          });
-        });
-
-        context('customResultPageText max length over 5000 character', function () {
-          it('throws an error', async function () {
-            // given
-            attributes.customResultPageText = 'Godzilla vs Kong'.repeat(335);
-
-            const error = await catchErr(() => new CampaignForCreation(attributes))();
-            expect(error.message).to.equal("Échec de validation de l'entité.");
-            expect(error.invalidAttributes).to.deep.equal([
-              { attribute: 'customResultPageText', message: 'CUSTOM_RESULT_PAGE_TEXT_IS_TOO_LONG' },
-            ]);
-          });
-        });
-
-        context('customResultPageButtonUrl is required if customResultPageButtonText is defined', function () {
-          it('throws an error', async function () {
-            // given
-            attributes.customResultPageButtonText = 'Godzilla vs Kong';
-            attributes.customResultPageButtonUrl = null;
-
-            const error = await catchErr(() => new CampaignForCreation(attributes))();
-            expect(error.message).to.equal("Échec de validation de l'entité.");
-            expect(error.invalidAttributes).to.deep.equal([
-              {
-                attribute: 'customResultPageButtonUrl',
-                message: 'CUSTOM_RESULT_PAGE_BUTTON_URL_IS_REQUIRED_WHEN_CUSTOM_RESULT_PAGE_BUTTON_TEXT_IS_FILLED',
-              },
-            ]);
-          });
-        });
-
-        context('customResultPageButtonText is required if customResultPageButtonUrl is defined', function () {
-          it('throws an error', async function () {
-            // given
-            attributes.customResultPageButtonUrl = 'https://http.dog/';
-            attributes.customResultPageButtonText = null;
-
-            const error = await catchErr(() => new CampaignForCreation(attributes))();
-            expect(error.message).to.equal("Échec de validation de l'entité.");
-            expect(error.invalidAttributes).to.deep.equal([
-              {
-                attribute: 'customResultPageButtonText',
-                message: 'CUSTOM_RESULT_PAGE_BUTTON_TEXT_IS_REQUIRED_WHEN_CUSTOM_RESULT_PAGE_BUTTON_URL_IS_FILLED',
-              },
-            ]);
-          });
-        });
-
-        context('customResultPageButtonUrl must be an URL', function () {
-          it('throws an error', async function () {
-            // given
-            attributes.customResultPageButtonText = 'Godzilla vs Kong';
-            attributes.customResultPageButtonUrl = 'Godzilla vs Kong';
-
-            const error = await catchErr(() => new CampaignForCreation(attributes))();
-            expect(error.message).to.equal("Échec de validation de l'entité.");
-            expect(error.invalidAttributes).to.deep.equal([
-              { attribute: 'customResultPageButtonUrl', message: 'CUSTOM_RESULT_PAGE_BUTTON_URL_MUST_BE_A_URL' },
-            ]);
+              const error = await catchErr(() => new CampaignForCreation(attributes))();
+              expect(error.message).to.equal("Échec de validation de l'entité.");
+              expect(error.invalidAttributes).to.deep.equal([
+                { attribute: 'customResultPageButtonUrl', message: 'CUSTOM_RESULT_PAGE_BUTTON_URL_MUST_BE_A_URL' },
+              ]);
+            });
           });
         });
       });

--- a/api/tests/prescription/campaign/unit/domain/usecases/create-campaign_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/create-campaign_test.js
@@ -1,7 +1,7 @@
+import { UserNotAuthorizedToCreateCampaignError } from '../../../../../../src/prescription/campaign/domain/errors.js';
 import { CampaignCreator } from '../../../../../../src/prescription/campaign/domain/models/CampaignCreator.js';
 import { createCampaign } from '../../../../../../src/prescription/campaign/domain/usecases/create-campaign.js';
 import { CampaignTypes } from '../../../../../../src/prescription/shared/domain/constants.js';
-import { UserNotAuthorizedToCreateCampaignError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErr, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | create-campaign', function () {

--- a/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/organization-learner-activity-serializer_test.js
+++ b/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/organization-learner-activity-serializer_test.js
@@ -1,6 +1,7 @@
 import { OrganizationLearnerActivity } from '../../../../../../../src/prescription/organization-learner/domain/read-models/OrganizationLearnerActivity.js';
 import { OrganizationLearnerParticipation } from '../../../../../../../src/prescription/organization-learner/domain/read-models/OrganizationLearnerParticipation.js';
 import * as serializer from '../../../../../../../src/prescription/organization-learner/infrastructure/serializers/jsonapi/organization-learner-activity-serializer.js';
+import { CampaignTypes } from '../../../../../../../src/prescription/shared/domain/constants.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | organization-learner-participation-serialize', function () {
@@ -13,7 +14,7 @@ describe('Unit | Serializer | JSONAPI | organization-learner-participation-seria
           new OrganizationLearnerParticipation({
             id: '99999',
             campaignId: '123',
-            campaignType: 'PROFILES_COLLECTION',
+            campaignType: CampaignTypes.PROFILES_COLLECTION,
             campaignName: 'La 1ère campagne',
             createdAt: '2000-01-01T10:00:00Z',
             sharedAt: '2000-02-01T10:00:00Z',
@@ -24,7 +25,7 @@ describe('Unit | Serializer | JSONAPI | organization-learner-participation-seria
           new OrganizationLearnerParticipation({
             id: '100000',
             campaignId: '456',
-            campaignType: 'ASSESSMENT',
+            campaignType: CampaignTypes.ASSESSMENT,
             campaignName: 'La 2ème campagne',
             createdAt: '2000-03-01T10:00:00Z',
             sharedAt: '2000-04-01T10:00:00Z',
@@ -35,14 +36,14 @@ describe('Unit | Serializer | JSONAPI | organization-learner-participation-seria
         ],
         statistics: [
           {
-            campaignType: 'ASSESSMENT',
+            campaignType: CampaignTypes.ASSESSMENT,
             shared: 0,
             started: 1,
             to_share: 0,
             total: 1,
           },
           {
-            campaignType: 'PROFILES_COLLECTION',
+            campaignType: CampaignTypes.PROFILES_COLLECTION,
             shared: 1,
             to_share: 0,
             total: 1,

--- a/orga/app/components/campaign/detail/type.gjs
+++ b/orga/app/components/campaign/detail/type.gjs
@@ -5,17 +5,25 @@ import Component from '@glimmer/component';
 export default class CampaignType extends Component {
   @service intl;
 
-  get picto() {
+  get iconConfig() {
     const { campaignType } = this.args;
-    return campaignType === 'ASSESSMENT' ? 'speed' : 'profileShare';
+    switch (campaignType) {
+      case 'ASSESSMENT':
+        return { icon: 'speed', class: 'campaign-type__icon--assessment' };
+      case 'PROFILES_COLLECTION':
+        return { icon: 'profileShare', class: 'campaign-type__icon--profile-collection' };
+      case 'EXAM':
+        return { icon: 'school', class: 'campaign-type__icon--exam' };
+      default:
+        return { icon: 'close', class: '' };
+    }
   }
 
   get pictoCssClass() {
-    const classes = [];
-    const { campaignType } = this.args;
-    classes.push(
-      campaignType === 'ASSESSMENT' ? 'campaign-type__icon-assessment' : 'campaign-type__icon-profile-collection',
-    );
+    const classes = ['campaign-type__icon'];
+
+    classes.push(this.iconConfig.class);
+
     if (this.args.big) {
       classes.push(classes[0] + '--big');
     }
@@ -31,18 +39,30 @@ export default class CampaignType extends Component {
   }
 
   get label() {
-    const { campaignType, labels } = this.args;
+    const informationLabels = {
+      ASSESSMENT: 'components.campaign.type.information.ASSESSMENT',
+      PROFILES_COLLECTION: 'components.campaign.type.information.PROFILES_COLLECTION',
+      EXAM: 'components.campaign.type.information.EXAM',
+    };
 
-    return this.intl.t(labels[campaignType]);
+    const explanationLabels = {
+      ASSESSMENT: 'components.campaign.type.explanation.ASSESSMENT',
+      PROFILES_COLLECTION: 'components.campaign.type.explanation.PROFILES_COLLECTION',
+      EXAM: 'components.campaign.type.explanation.EXAM',
+    };
+
+    const { campaignType, displayInformationLabel } = this.args;
+
+    return this.intl.t(displayInformationLabel ? informationLabels[campaignType] : explanationLabels[campaignType]);
   }
 
   <template>
     <span class="campaign-type">
       <PixIcon
         class={{this.pictoCssClass}}
-        @name={{this.picto}}
-        aria-hidden="{{this.pictoAriaHidden}}"
-        aria-label={{this.pictoTitle}}
+        @name={{this.iconConfig.icon}}
+        @ariaHidden={{this.pictoAriaHidden}}
+        @title={{this.pictoTitle}}
         ...attributes
       />
       {{#unless @hideLabel}}

--- a/orga/app/components/campaign/header/title.gjs
+++ b/orga/app/components/campaign/header/title.gjs
@@ -26,13 +26,6 @@ export default class Header extends Component {
     ];
   }
 
-  get labels() {
-    return {
-      ASSESSMENT: 'components.campaign.type.explanation.ASSESSMENT',
-      PROFILES_COLLECTION: 'components.campaign.type.explanation.PROFILES_COLLECTION',
-    };
-  }
-
   get shouldShowMultipleSending() {
     return this.args.campaign.isProfilesCollection || this.isMultipleSendingsForAssessmentEnabled;
   }
@@ -53,7 +46,7 @@ export default class Header extends Component {
         <Breadcrumb @links={{this.breadcrumbLinks}} class="campaign-header-title__breadcrumb" />
       </:breadcrumb>
       <:title>
-        <CampaignType @big={{true}} @labels={{this.labels}} @campaignType={{@campaign.type}} @hideLabel={{true}} />
+        <CampaignType @big={{true}} @campaignType={{@campaign.type}} @hideLabel={{true}} />
         <span class="page-title__name">{{@campaign.name}}</span>
       </:title>
       <:tools>

--- a/orga/app/components/campaign/list.gjs
+++ b/orga/app/components/campaign/list.gjs
@@ -39,13 +39,6 @@ export default class List extends Component {
     return this.args.canDelete ?? false;
   }
 
-  get labels() {
-    return {
-      ASSESSMENT: 'components.campaign.type.explanation.ASSESSMENT',
-      PROFILES_COLLECTION: 'components.campaign.type.explanation.PROFILES_COLLECTION',
-    };
-  }
-
   @action
   toggleDeletionModal() {
     this.showDeletionModal = !this.showDeletionModal;
@@ -227,7 +220,7 @@ const Row = <template>
     {{yield}}
     <td>
       <span class="campaign-list__campaign-link-cell">
-        <CampaignType @labels={{@labels}} @campaignType={{@campaign.type}} @hideLabel={{true}} />
+        <CampaignType @campaignType={{@campaign.type}} @hideLabel={{true}} />
         <LinkTo @route="authenticated.campaigns.campaign" @model={{@campaign.id}}>
           {{@campaign.name}}
         </LinkTo>

--- a/orga/app/components/campaign/settings/view.gjs
+++ b/orga/app/components/campaign/settings/view.gjs
@@ -39,9 +39,13 @@ export default class CampaignView extends Component {
   }
 
   get campaignType() {
-    return this.args.campaign.isTypeAssessment
-      ? this.intl.t('pages.campaign-settings.campaign-type.assessment')
-      : this.intl.t('pages.campaign-settings.campaign-type.profiles-collection');
+    if (this.args.campaign.isTypeAssessment) {
+      return this.intl.t('pages.campaign-settings.campaign-type.assessment');
+    } else if (this.args.campaign.isProfilesCollection) {
+      return this.intl.t('pages.campaign-settings.campaign-type.profiles-collection');
+    } else if (this.args.campaign.isTypeExam) {
+      return this.intl.t('pages.campaign-settings.campaign-type.exam');
+    } else return null;
   }
 
   get multipleSendingsText() {

--- a/orga/app/components/organization-learner/activity/participation-row.gjs
+++ b/orga/app/components/organization-learner/activity/participation-row.gjs
@@ -19,13 +19,6 @@ export default class ParticipationRow extends Component {
       : 'authenticated.campaigns.participant-profile';
   }
 
-  get labels() {
-    return {
-      ASSESSMENT: 'components.campaign.type.information.ASSESSMENT',
-      PROFILES_COLLECTION: 'components.campaign.type.information.PROFILES_COLLECTION',
-    };
-  }
-
   @action
   goToParticipationDetail(event) {
     event.preventDefault();
@@ -48,7 +41,7 @@ export default class ParticipationRow extends Component {
         </LinkTo>
       </td>
       <td class="ellipsis">
-        <CampaignType @labels={{this.labels}} @campaignType={{@participation.campaignType}} />
+        <CampaignType @campaignType={{@participation.campaignType}} @displayInformationLabel={{true}} />
       </td>
       <td class="table__column--left">
         <Date @date={{@participation.createdAt}} />

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -65,6 +65,10 @@ export default class Campaign extends Model {
     return this.type === 'ASSESSMENT';
   }
 
+  get isTypeExam() {
+    return this.type === 'EXAM';
+  }
+
   get urlToResult() {
     if (this.isTypeAssessment) {
       return `${ENV.APP.API_HOST}/api/campaigns/${this.id}/csv-assessment-results`;
@@ -91,13 +95,13 @@ export default class Campaign extends Model {
   }
 
   setType(type) {
-    if (type === 'ASSESSMENT') {
+    if (['ASSESSMENT', 'EXAM'].includes(type)) {
       this.multipleSendings = false;
     }
     if (type === 'PROFILES_COLLECTION') {
       this.multipleSendings = true;
       this.title = null;
-      this.targetProfile = null;
+      this.targetProfileId = null;
     }
     this.type = type;
   }

--- a/orga/app/models/prescriber.js
+++ b/orga/app/models/prescriber.js
@@ -22,6 +22,7 @@ export default class Prescriber extends Model {
       LEARNER_IMPORT: 'LEARNER_IMPORT',
       ORALIZATION: 'ORALIZATION',
       COVER_RATE: 'COVER_RATE',
+      CAMPAIGN_WITHOUT_USER_PROFILE: 'CAMPAIGN_WITHOUT_USER_PROFILE',
     };
   }
 
@@ -35,6 +36,10 @@ export default class Prescriber extends Model {
 
   get enableMultipleSendingAssessment() {
     return this.features[Prescriber.featureList.MULTIPLE_SENDING_ASSESSMENT];
+  }
+
+  get enableCampaignWithoutUserProfile() {
+    return this.features[Prescriber.featureList.CAMPAIGN_WITHOUT_USER_PROFILE];
   }
 
   get computeOrganizationLearnerCertificability() {

--- a/orga/app/styles/components/campaign/detail/type.scss
+++ b/orga/app/styles/components/campaign/detail/type.scss
@@ -8,7 +8,7 @@
     margin-left: var(--pix-spacing-2x);
   }
 
-  &__icon-assessment, &__icon-profile-collection {
+  &__icon {
     width: 1.5rem;
     height: 1.5rem;
 
@@ -25,11 +25,15 @@
     }
   }
 
-  &__icon-assessment {
+  &--assessment {
     fill: var(--pix-tertiary-500);
   }
 
-  &__icon-profile-collection {
+  &--profile-collection {
     fill: var(--pix-primary-500);
+  }
+
+  &--exam {
+    fill: var(--pix-secondary-700);
   }
 }

--- a/orga/tests/integration/components/campaign/settings/view-test.js
+++ b/orga/tests/integration/components/campaign/settings/view-test.js
@@ -53,6 +53,20 @@ module('Integration | Component | Campaign::Settings::View', function (hooks) {
         assert.dom(screen.getByText(t('pages.campaign-settings.campaign-type.profiles-collection'))).exists();
       });
     });
+
+    module('when type is EXAM', function () {
+      test('it should display profile collection campaign', async function (assert) {
+        this.campaign = store.createRecord('campaign', {
+          type: 'EXAM',
+        });
+
+        // when
+        const screen = await render(hbs`<Campaign::Settings::View @campaign={{this.campaign}} />`);
+
+        // then
+        assert.dom(screen.getByText(t('pages.campaign-settings.campaign-type.exam'))).exists();
+      });
+    });
   });
 
   module('on TargetProfile display', function () {

--- a/orga/tests/unit/models/campaign-test.js
+++ b/orga/tests/unit/models/campaign-test.js
@@ -110,6 +110,83 @@ module('Unit | Model | campaign', function (hooks) {
     });
   });
 
+  module('#setType', function () {
+    test('set default to false multiple sending to false on ASSESSMENT type', function (assert) {
+      //given
+      const store = this.owner.lookup('service:store');
+
+      const model = store.createRecord('campaign', {
+        multipleSendings: true,
+      });
+
+      //when
+      model.setType('ASSESSMENT');
+
+      assert.false(model.multipleSendings);
+      assert.strictEqual(model.type, 'ASSESSMENT');
+    });
+
+    test('set default to false multiple sending on EXAM type', function (assert) {
+      //given
+      const store = this.owner.lookup('service:store');
+
+      const model = store.createRecord('campaign', {
+        multipleSendings: true,
+      });
+
+      //when
+      model.setType('EXAM');
+
+      assert.false(model.multipleSendings);
+      assert.strictEqual(model.type, 'EXAM');
+    });
+
+    test('set default to true multiple sending on PROFILES_COLLECTION type', function (assert) {
+      //given
+      const store = this.owner.lookup('service:store');
+
+      const model = store.createRecord('campaign', {
+        multipleSendings: false,
+      });
+
+      //when
+      model.setType('PROFILES_COLLECTION');
+
+      assert.true(model.multipleSendings);
+      assert.strictEqual(model.type, 'PROFILES_COLLECTION');
+    });
+
+    test('set default to null target profile on PROFILES_COLLECTION type', function (assert) {
+      //given
+      const store = this.owner.lookup('service:store');
+
+      const model = store.createRecord('campaign', {
+        targetProfileId: 18,
+      });
+
+      //when
+      model.setType('PROFILES_COLLECTION');
+
+      assert.strictEqual(model.targetProfileId, null);
+      assert.strictEqual(model.type, 'PROFILES_COLLECTION');
+    });
+
+    test('set default to null title on PROFILES_COLLECTION type', function (assert) {
+      //given
+      const store = this.owner.lookup('service:store');
+
+      const model = store.createRecord('campaign', {
+        title: 'wahout',
+      });
+
+      //when
+      model.setType('PROFILES_COLLECTION');
+
+      assert.strictEqual(model.title, null);
+      assert.strictEqual(model.type, 'PROFILES_COLLECTION');
+    });
+  });
+
   module('#ownerFullName', function () {
     test('it should return the fullname, combination of last and first name', function (assert) {
       const store = this.owner.lookup('service:store');

--- a/orga/tests/unit/models/prescriber-test.js
+++ b/orga/tests/unit/models/prescriber-test.js
@@ -106,6 +106,30 @@ module('Unit | Model | prescriber', function (hooks) {
     });
   });
 
+  module('#enableCampaignWithoutUserProfile', function () {
+    test('it returns true when feature is enabled', function (assert) {
+      // given && when
+      const store = this.owner.lookup('service:store');
+      const model = store.createRecord('prescriber', {
+        features: { ['CAMPAIGN_WITHOUT_USER_PROFILE']: true },
+      });
+
+      // then
+      assert.true(model.enableCampaignWithoutUserProfile);
+    });
+
+    test('it returns false when feature is disabled', function (assert) {
+      // given && when
+      const store = this.owner.lookup('service:store');
+      const model = store.createRecord('prescriber', {
+        features: { ['CAMPAIGN_WITHOUT_USER_PROFILE']: false },
+      });
+
+      // then
+      assert.false(model.enableCampaignWithoutUserProfile);
+    });
+  });
+
   module('#computeOrganizationLearnerCertificability', function () {
     test('it returns true when feature is enabled', function (assert) {
       // given

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -742,6 +742,7 @@
       },
       "campaign-type": {
         "assessment": "Assessment campaign",
+        "exam": "Campagne de type examen",
         "profiles-collection": "Profiles collection campaign",
         "title": "Type of campaign"
       },

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -277,10 +277,12 @@
       "type": {
         "explanation": {
           "ASSESSMENT": "Campaign of type assessment",
+          "EXAM": "exam",
           "PROFILES_COLLECTION": "Campaign of type profiles collection"
         },
         "information": {
           "ASSESSMENT": "Assessment",
+          "EXAM": "exam",
           "PROFILES_COLLECTION": "Profiles collection"
         }
       }
@@ -559,10 +561,10 @@
         "title": "Campaign owner"
       },
       "purpose": {
-        "exam": "exam",
-        "exam-info": "Une campagne d’évaluation permet de tester les participants sur des sujets précis, sans prendre en compte le profil utilisateur.",
         "assessment": "Assess participants",
         "assessment-info": "An assessment campaign tests participants on specific topics.",
+        "exam": "exam",
+        "exam-info": "Une campagne d’évaluation permet de tester les participants sur des sujets précis, sans prendre en compte le profil utilisateur.",
         "label": "What is the purpose of your campaign?",
         "profiles-collection": "Collect the participants' Pix profiles",
         "profiles-collection-info": "A profile collection campaign retrieves the participants’ Pix profile: their level for each competence and their pix score.",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -559,6 +559,8 @@
         "title": "Campaign owner"
       },
       "purpose": {
+        "exam": "exam",
+        "exam-info": "Une campagne d’évaluation permet de tester les participants sur des sujets précis, sans prendre en compte le profil utilisateur.",
         "assessment": "Assess participants",
         "assessment-info": "An assessment campaign tests participants on specific topics.",
         "label": "What is the purpose of your campaign?",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -277,10 +277,12 @@
       "type": {
         "explanation": {
           "ASSESSMENT": "Campagne d'évaluation",
+          "EXAM": "exam",
           "PROFILES_COLLECTION": "Campagne de collecte de profil"
         },
         "information": {
           "ASSESSMENT": "Évaluation",
+          "EXAM": "exam",
           "PROFILES_COLLECTION": "Collecte de profil"
         }
       }
@@ -566,9 +568,9 @@
       },
       "purpose": {
         "assessment": "Évaluer les participants",
+        "assessment-info": "Une campagne d’évaluation permet de tester les participants sur des sujets précis.",
         "exam": "exam",
         "exam-info": "Une campagne d’évaluation permet de tester les participants sur des sujets précis, sans prendre en compte le profil utilisateur.",
-        "assessment-info": "Une campagne d’évaluation permet de tester les participants sur des sujets précis.",
         "label": "Quel est l'objectif de votre campagne ?",
         "profiles-collection": "Collecter les profils Pix des participants",
         "profiles-collection-info": "Une campagne de collecte de profils permet de récupérer le profil des participants : niveaux par compétence et score pix.",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -566,6 +566,8 @@
       },
       "purpose": {
         "assessment": "Évaluer les participants",
+        "exam": "exam",
+        "exam-info": "Une campagne d’évaluation permet de tester les participants sur des sujets précis, sans prendre en compte le profil utilisateur.",
         "assessment-info": "Une campagne d’évaluation permet de tester les participants sur des sujets précis.",
         "label": "Quel est l'objectif de votre campagne ?",
         "profiles-collection": "Collecter les profils Pix des participants",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -748,6 +748,7 @@
       },
       "campaign-type": {
         "assessment": "Campagne d'évaluation",
+        "exam": "Campagne de type examen",
         "profiles-collection": "Campagne de collecte de profils",
         "title": "Type de la campagne"
       },

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -706,6 +706,7 @@
       },
       "campaign-type": {
         "assessment": "Beoordelingscampagne",
+        "exam": "Campagne de type examen",
         "profiles-collection": "Verzamelcampagne profielen",
         "title": "Soort campagne"
       },

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -523,6 +523,8 @@
         "title": "Eigenaar van de campagne"
       },
       "purpose": {
+        "exam": "exam",
+        "exam-info": "Une campagne d’évaluation permet de tester les participants sur des sujets précis, sans prendre en compte le profil utilisateur.",
         "assessment": "Deelnemers evalueren",
         "assessment-info": "Een beoordelingscampagne stelt deelnemers in staat om getest te worden op specifieke onderwerpen.",
         "label": "Wat is het doel van je campagne?",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -277,10 +277,12 @@
       "type": {
         "explanation": {
           "ASSESSMENT": "Beoordelingscampagne",
-          "PROFILES_COLLECTION": "Campagne profielverzameling"
+          "PROFILES_COLLECTION": "Campagne profielverzameling",
+          "EXAM": "exam"
         },
         "information": {
           "ASSESSMENT": "Beoordeling",
+          "EXAM": "exam",
           "PROFILES_COLLECTION": "Profielverzameling"
         }
       }


### PR DESCRIPTION
## :pancakes: Problème

Il n'y a pas la possibilité de créer une campagne de type EXAM via PixOrga

## :bacon: Proposition

le faire

## 🧃 Remarques

Petit refacto/rangement par ci par là. ( Quoi ? j'ai pas le droit ? )

On n'a pas encore les Trads, mais c'est pas grave. On est loin d'être OK PROD, il reste toute la partie PixApp à faire :)

## :yum: Pour tester

admin-orga@example.net

Essayer de créer une campagne de Type EXAM dans PixOrga et vérifier que c'est possible . ( Bon pour le moment rien n'est implémenter pour faire le parcours, mais comme dirait la chanson. step by step.