### PR TITLE
[FEATURE] Remplacer le PixReturnTo déprécié par le PixButtonLink sur Pix App (PIX-16695).

### DIFF
--- a/mon-pix/app/components/scorecard-details.hbs
+++ b/mon-pix/app/components/scorecard-details.hbs
@@ -1,6 +1,8 @@
 <div>
   <div class="scorecard-details__header">
-    <PixReturnTo @route="authenticated.profile">{{t "navigation.back-to-profile"}}</PixReturnTo>
+    <PixButtonLink @route="authenticated.profile" @variant="tertiary" @iconBefore="arrowLeft">
+      {{t "navigation.back-to-profile"}}
+    </PixButtonLink>
   </div>
 
   <div class="scorecard-details__content">

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -65,7 +65,8 @@
   }
 
   &__header {
-    padding: 14px 14px 0;
+    width: fit-content;
+    padding: var(--pix-spacing-3x) var(--pix-spacing-3x) 0;
   }
 
   &__resume-or-start-button,

--- a/mon-pix/app/styles/pages/_user-certifications-get.scss
+++ b/mon-pix/app/styles/pages/_user-certifications-get.scss
@@ -23,6 +23,15 @@
   }
 }
 
+.user-certifications-page {
+
+  &__previous-button {
+    width: fit-content;
+    margin-bottom: var(--pix-spacing-3x);
+    border: 1px solid transparent;
+  }
+}
+
 @mixin contentInColumn() {
 
   .user-certifications-page-get {

--- a/mon-pix/app/templates/authenticated/user-certifications/get.hbs
+++ b/mon-pix/app/templates/authenticated/user-certifications/get.hbs
@@ -1,8 +1,13 @@
 <PixBackgroundHeader class="user-certifications-page-get">
-
-  <PixReturnTo @route="authenticated.user-certifications" @shade="neutral-light">
+  <PixButtonLink
+    @route="authenticated.user-certifications"
+    @variant="transparent-dark"
+    @iconBefore="arrowLeft"
+    class="user-certifications-page__previous-button"
+  >
     {{t "pages.certificate.back-link"}}
-  </PixReturnTo>
+  </PixButtonLink>
+
   <PixBlock class="user-certifications-page-get__header">
     <UserCertificationsDetailHeader @certification={{@model}} />
   </PixBlock>

--- a/mon-pix/app/templates/shared-certification.hbs
+++ b/mon-pix/app/templates/shared-certification.hbs
@@ -1,10 +1,14 @@
 {{page-title (t "pages.shared-certification.title")}}
 
 <PixBackgroundHeader class="user-certifications-page-get">
-
-  <PixReturnTo @route="fill-in-certificate-verification-code" @shade="neutral-light">
+  <PixButtonLink
+    @route="fill-in-certificate-verification-code"
+    @variant="transparent-dark"
+    @iconBefore="arrowLeft"
+    class="user-certifications-page__previous-button"
+  >
     {{t "pages.shared-certification.back-link"}}
-  </PixReturnTo>
+  </PixButtonLink>
 
   <PixBlock class="user-certifications-page-get__header">
     <UserCertificationsDetailHeader @certification={{this.model}} />

--- a/mon-pix/tests/acceptance/competences-details-test.js
+++ b/mon-pix/tests/acceptance/competences-details-test.js
@@ -2,6 +2,7 @@ import { visit } from '@1024pix/ember-testing-library';
 // eslint-disable-next-line no-restricted-imports
 import { click, currentURL, find } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -67,10 +68,10 @@ module("Acceptance | Competence details | Afficher la page de détails d'une co
 
     test('should transition to /competences when the user clicks on return', async function (assert) {
       // given
-      await visit(`/competences/${scorecardWithPoints.description}/details`);
+      const screen = await visit(`/competences/${scorecardWithPoints.description}/details`);
 
       // when
-      await click('.pix-return-to');
+      await click(screen.getByRole('link', { name: t('navigation.back-to-profile') }));
 
       // then
       assert.strictEqual(currentURL(), '/competences');

--- a/mon-pix/tests/acceptance/competences-results-test.js
+++ b/mon-pix/tests/acceptance/competences-results-test.js
@@ -2,14 +2,17 @@ import { visit } from '@1024pix/ember-testing-library';
 // eslint-disable-next-line no-restricted-imports
 import { find } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 import { authenticate } from '../helpers/authentication';
+import setupIntl from '../helpers/setup-intl';
 
 module('Acceptance | competences results', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks);
   let user;
   const competenceId = 10;
   const assessmentId = 10;
@@ -59,11 +62,12 @@ module('Acceptance | competences results', function (hooks) {
 
     test('should display a return link to competences', async function (assert) {
       // when
-      await visit(`/competences/${competenceId}/resultats/${assessmentId}`);
+      const screen = await visit(`/competences/${competenceId}/resultats/${assessmentId}`);
 
       // then
-      assert.dom('.pix-return-to').exists();
-      assert.strictEqual(find('.pix-return-to').getAttribute('href'), '/competences');
+      const previousButton = screen.getByRole('link', { name: t('navigation.back-to-profile') });
+      assert.dom(previousButton).exists();
+      assert.strictEqual(previousButton.getAttribute('href'), '/competences');
     });
 
     module('When user obtained 0 pix', function (hooks) {


### PR DESCRIPTION
## :pancakes: Problème

Le composant Pix UI [PixReturnTo](https://ui.pix.fr/?path=/docs/other-return-to--docs) est voué à disparaître. Il est encore utilisé dans les apps Pix.

## :bacon: Proposition

Utiliser le PixButtonLink en remplacement sur App.

## 🧃 Remarques

Utilisation du variant transparent-dark pour les liens sur fond bleu.

## :yum: Pour tester

- Se connecter avec certif-success@example.net
- https://app-pr11481.review.pix.fr/mes-certifications/127561

<img width="838" alt="Capture d’écran 2025-02-21 à 14 44 59" src="https://github.com/user-attachments/assets/8c4116d9-7e82-446f-a4f0-22edc830c45e" />

- https://app-pr11481.review.pix.fr/verification-certificat
- Entrer `P-12756133`

<img width="838" alt="Capture d’écran 2025-02-21 à 14 45 38" src="https://github.com/user-attachments/assets/3dee2a8e-8052-46cf-a8ff-7a326050451a" />

- https://app-pr11481.review.pix.fr/competences/recIkYm646lrGvLNT/details

<img width="1338" alt="Capture d’écran 2025-02-21 à 14 50 50" src="https://github.com/user-attachments/assets/37e59d55-395e-40ff-a49b-958f843a4cb4" />
