### PR TITLE
[FEATURE] Utiliser PixCode dans la page de connexion sur Pix Junior (PIX-16536).

### DIFF
--- a/junior/app/components/challenge/content/challenge-actions.gjs
+++ b/junior/app/components/challenge/content/challenge-actions.gjs
@@ -11,12 +11,7 @@ export default class ChallengeActions extends Component {
   <template>
     <div class="challenge-actions">
       {{#unless (or this.hideSkipButton @isLesson)}}
-        <PixButton
-          class="pix1d-button pix1d-button--skip"
-          @triggerAction={{@skipChallenge}}
-          @shape="rounded"
-          @size="large"
-        >
+        <PixButton class="pix1d-button pix1d-button--skip" @triggerAction={{@skipChallenge}} @size="large">
           <span>
             {{t "pages.challenge.actions.skip"}}
           </span>

--- a/junior/app/controllers/organization-code.js
+++ b/junior/app/controllers/organization-code.js
@@ -12,8 +12,8 @@ export default class Home extends Controller {
   }
 
   @action
-  updateCode(code) {
-    this.schoolCode = code;
+  handleCode(event) {
+    this.schoolCode = event.target.value;
   }
 
   @action

--- a/junior/app/styles/pages/organization-code.scss
+++ b/junior/app/styles/pages/organization-code.scss
@@ -35,8 +35,8 @@
   }
 
   &__input {
-    font-family: fonts.$font-nunito;
-    text-transform: uppercase;
+    display: flex;
+    padding-top: var(--pix-spacing-4x);
   }
 
   &__rotated-bubble {

--- a/junior/app/templates/assessment/results.hbs
+++ b/junior/app/templates/assessment/results.hbs
@@ -32,7 +32,7 @@
           {{/each}}
         </ul>
 
-        <PixButtonLink @route="identified.missions" @shape="rounded" class="details-action">
+        <PixButtonLink @route="identified.missions" class="details-action">
           <p>{{t "pages.missions.end-page.back-to-missions"}}</p>
           <PixIcon @name="arrowRight" class="details-action__icon" @ariaHidden={{true}} />
         </PixButtonLink>

--- a/junior/app/templates/organization-code.hbs
+++ b/junior/app/templates/organization-code.hbs
@@ -6,17 +6,19 @@
     <p class="school-code__welcome">{{t "pages.home.welcome"}}</p>
   </div>
   <p class="school-code__instructions">{{t "pages.home.code-instruction"}}</p>
-  <label for="organization-code" class="school-code__label">{{t "pages.home.code-label"}}</label>
-  <PixInputCode
-    @ariaLabel={{t "pages.home.field-description"}}
-    @legend={{t "pages.home.code-description"}}
-    @numInputs={{9}}
-    @inputType="text"
-    @onAllInputsFilled={{this.updateCode}}
-    class="school-code__input"
-  />
+  <div class="school-code__input">
+    <PixCode
+      @length="9"
+      @requiredLabel={{t "common.forms.mandatory"}}
+      @value={{this.schoolCode}}
+      aria-label={{t "pages.home.code-description"}}
+      {{on "input" this.handleCode}}
+    >
+      <:label>{{t "pages.home.code-label"}}</:label>
+    </PixCode>
+  </div>
 
-  <PixButton class="pix1d-button" @type="submit" @shape="rounded" @size="large">
+  <PixButton class="pix1d-button" @type="submit" @size="large">
     {{t "pages.home.go-to-school"}}
   </PixButton>
   <img src="/images/logo.svg" alt="Pix Junior" class="logo" />

--- a/junior/tests/acceptance/access-school-test.js
+++ b/junior/tests/acceptance/access-school-test.js
@@ -73,9 +73,7 @@ module('Acceptance | School', function (hooks) {
         // when
         const screen = await visit('/organization-code');
 
-        const code = ['M', 'I', 'N', 'I', 'P', 'I', 'X', 'O', 'U'];
-
-        code.forEach((element, index) => fillIn(screen.getByLabelText(`Champ numéro ${index + 1}`), element));
+        fillIn(screen.getByRole('textbox', { name: t('pages.home.code-description') }), 'MINIPIXOU');
         await clickByText(t('pages.home.go-to-school'));
         // then
         assert.strictEqual(currentURL(), '/schools/MINIPIXOU');

--- a/junior/translations/fr.json
+++ b/junior/translations/fr.json
@@ -74,10 +74,9 @@
     },
     "home": {
       "beta": "Version Bêta",
-      "code-description": "Le code de l'école est composé de 6 chiffres et 3 lettres.",
+      "code-description": "Remplir le code de l'école, composé de 6 chiffres et 3 lettres.",
       "code-instruction": "Saisis le code de ton école pour accéder à ta classe",
       "code-label": "Code de l'école",
-      "field-description": "Champ numéro",
       "go-to-school": "Je valide le code",
       "page-title": "Page d'accueil",
       "welcome": "Bienvenue sur Pix Junior !"


### PR DESCRIPTION
## :pancakes: Problème
Le PixInputCode présent dans la page de connexion sur PixJunior n'est pas adapté.

## :bacon: Proposition

Utiliser le nouveau composant [PixCode](https://ui.pix.fr/?path=/docs/forms-code--docs)

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

Tests de non régression à faire. https://junior-pr11484.review.pix.fr/organization-code

CAS NON PASSANT
- Mettre un code bidon
=> On accède à une page d'erreur

CAS PASSANT
- Mettre le code `MINIPIXOU`
=> Accéder à Pix Junior

<img width="864" alt="Capture d’écran 2025-02-21 à 16 14 28" src="https://github.com/user-attachments/assets/eb637d26-a052-46d2-a3dc-6ae2bde2d299" />
