### PR TITLE
[TECH] :truck: Déplace le cas d'usage `updateLastQuestionState` vers `src/`

### DIFF
--- a/api/src/shared/application/assessments/assessment-controller.js
+++ b/api/src/shared/application/assessments/assessment-controller.js
@@ -14,6 +14,7 @@ import { usecases as questUsecases } from '../../../quest/domain/usecases/index.
 import { config } from '../../config.js';
 import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { AssessmentEndedError } from '../../domain/errors.js';
+import { sharedUsecases } from '../../domain/usecases/index.js';
 import * as assessmentRepository from '../../infrastructure/repositories/assessment-repository.js';
 import { repositories } from '../../infrastructure/repositories/index.js';
 import * as assessmentSerializer from '../../infrastructure/serializers/jsonapi/assessment-serializer.js';
@@ -112,7 +113,7 @@ const updateLastChallengeState = async function (request) {
   const challengeId = request.payload?.data?.attributes?.['challenge-id'];
 
   await DomainTransaction.execute(async () => {
-    await usecases.updateLastQuestionState({ assessmentId, challengeId, lastQuestionState });
+    await sharedUsecases.updateLastQuestionState({ assessmentId, challengeId, lastQuestionState });
   });
 
   return null;

--- a/api/src/shared/domain/usecases/index.js
+++ b/api/src/shared/domain/usecases/index.js
@@ -3,6 +3,8 @@ import { fileURLToPath } from 'node:url';
 
 import * as complementaryCertificationBadgeRepository from '../../../certification/complementary-certification/infrastructure/repositories/complementary-certification-badge-repository.js';
 import * as badgeRepository from '../../../evaluation/infrastructure/repositories/badge-repository.js';
+import * as assessmentRepository from '../../infrastructure/repositories/assessment-repository.js';
+import * as challengeRepository from '../../infrastructure/repositories/challenge-repository.js';
 import { injectDependencies } from '../../infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../infrastructure/utils/import-named-exports-from-directory.js';
 const path = dirname(fileURLToPath(import.meta.url));
@@ -12,8 +14,10 @@ const usecasesWithoutInjectedDependencies = {
 };
 
 const dependencies = {
+  assessmentRepository,
   complementaryCertificationBadgeRepository,
   badgeRepository,
+  challengeRepository,
 };
 
 const sharedUsecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/shared/domain/usecases/update-last-question-state.js
+++ b/api/src/shared/domain/usecases/update-last-question-state.js
@@ -1,5 +1,5 @@
-import { Assessment } from '../../../src/shared/domain/models/Assessment.js';
-import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
+import { logger } from '../../infrastructure/utils/logger.js';
+import { Assessment } from '../models/Assessment.js';
 
 const updateLastQuestionState = async function ({
   assessmentId,

--- a/api/tests/shared/unit/domain/usecases/update-last-question-state_test.js
+++ b/api/tests/shared/unit/domain/usecases/update-last-question-state_test.js
@@ -1,6 +1,6 @@
-import { updateLastQuestionState } from '../../../../lib/domain/usecases/update-last-question-state.js';
-import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
-import { domainBuilder, sinon } from '../../../test-helper.js';
+import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
+import { updateLastQuestionState } from '../../../../../src/shared/domain/usecases/update-last-question-state.js';
+import { domainBuilder, sinon } from '../../../../test-helper.js';
 
 describe('Unit | UseCase | update-last-question-state', function () {
   const assessmentId = 'assessmentId';


### PR DESCRIPTION
## :pancakes: Problème

Le cas d'usage `updateLastQuestionState` est dans `lib/`

## :bacon: Proposition

Déplacer le cas d'usage `updateLastQuestionState` vers `src/`

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
