### PR TITLE
[FEATURE] Renommage du didacticiel de Modulix en bac-a-sable (PIX-16674)

### DIFF
--- a/api/db/seeds/data/team-devcomp/build-trainings.js
+++ b/api/db/seeds/data/team-devcomp/build-trainings.js
@@ -46,8 +46,8 @@ export function buildTrainings(databaseBuilder) {
   });
 
   const frFrTrainingId2 = databaseBuilder.factory.buildTraining({
-    title: 'Didacticiel Module Pix',
-    link: '/modules/didacticiel-modulix/details',
+    title: 'Bac à sable Pix',
+    link: '/modules/bac-a-sable/details',
     duration: '00:10:00',
     editorName: 'Pix',
     editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/pix-logo.svg',

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -1,19 +1,19 @@
 {
   "id": "6282925d-4775-4bca-b513-4c3009ec5886",
-  "slug": "didacticiel-modulix",
-  "title": "Didacticiel Modulix",
+  "slug": "bac-a-sable",
+  "title": "Bac à sable",
   "isBeta": true,
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
-    "description": "<p>Découvrez avec ce didacticiel comment fonctionne Modulix !</p>",
+    "description": "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il contient normalement l'intégralité des fonctionnalités disponibles à date.</p>",
     "duration": 5,
     "level": "Débutant",
     "tabletSupport": "inconvenient",
-    "objectives": ["Naviguer dans Modulix", "Découvrir les leçons et les activités"]
+    "objectives": ["Non régression fonctionnelle"]
   },
   "transitionTexts": [
     {
-      "content": "<p>Bonjour et bienvenue dans ce didacticiel Modulix. Vous allez pouvoir facilement découvrir comment fonctionne ce nouveau produit Pix.<br>C'est partix&#8239;!</p>",
+      "content": "<p>Bonjour et bienvenue dans le bac à sable de Modulix. Vous allez pouvoir facilement découvrir comment fonctionne ce nouveau produit Pix.<br>C'est partix&#8239;!</p>",
       "grainId": "f312c33d-e7c9-4a69-9ba0-913957b8f7dd"
     },
     {
@@ -33,7 +33,7 @@
       "grainId": "2a77a10f-19a3-4544-80f9-8012dad6506a"
     },
     {
-      "content": "<p>Vous arrivez à la fin de ce didacticiel. Une dernière activité et vous serez prêt à explorer tous les modules que vous souhaitez&#8239;!<span aria-hidden=\"true\">🌟</span> </p>",
+      "content": "<p>Vous arrivez à la fin de ce module. Une dernière activité et vous serez prêt à explorer tous les modules que vous souhaitez&#8239;!<span aria-hidden=\"true\">🌟</span> </p>",
       "grainId": "7cf75e70-8749-4392-8081-f2c02badb0fb"
     }
   ],

--- a/api/src/devcomp/infrastructure/datasources/learning-content/readme.md
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/readme.md
@@ -20,7 +20,7 @@ Les modules sont accessibles via l'URL : `http://localhost:4200/modules/<slug-du
 
 ### Mise à jour des contenus
 
-Les contenus sont placés dans des fichiers [au format `.json`](http://www.json.org/json-fr.html). Chaque fichier `.json` correspond à un module de formation. Ces fichiers respectent une structure commune. Le [didacticiel](./modules/didacticiel-modulix.json) sert de démo technique et utilise donc toutes les fonctionnalités existantes.
+Les contenus sont placés dans des fichiers [au format `.json`](http://www.json.org/json-fr.html). Chaque fichier `.json` correspond à un module de formation. Ces fichiers respectent une structure commune. Le [bac à sable](./modules/bac-a-sable.json) sert de démo technique et utilise donc toutes les fonctionnalités existantes.
 
 > [!IMPORTANT]
 > Le format et la structure des fichiers n'est pas finalisé. Il est tout à fait possible qu'un autre format soit utilisé après l'expérimentation.

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -112,7 +112,7 @@ describe('Acceptance | Controller | passage-controller', function () {
         },
         {
           case: 'QCM',
-          moduleId: 'didacticiel-modulix',
+          moduleId: 'bac-a-sable',
           elementId: '30701e93-1b4d-4da4-b018-fa756c07d53f',
           userResponse: ['1', '3', '4'],
           expectedUserResponseValue: ['1', '3', '4'],

--- a/api/tests/devcomp/acceptance/scripts/get-elements-csv_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-elements-csv_test.js
@@ -37,8 +37,8 @@ describe('Acceptance | Script | Get Elements as CSV', function () {
       };
       const moduleWithUnknownType = {
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
-        slug: 'didacticiel-modulix',
-        title: 'Didacticiel Modulix',
+        slug: 'bac-a-sable',
+        title: 'Bac à sable',
         isBeta: true,
         details: {
           image: 'https://images.pix.fr/modulix/placeholder-details.svg',
@@ -87,19 +87,19 @@ describe('Acceptance | Script | Get Elements as CSV', function () {
       expect(elementsListAsCsv).to.be.a('string');
       expect(elementsListAsCsv).to
         .equal(`\ufeff"ElementId"\t"ElementType"\t"ElementPosition"\t"ElementGrainPosition"\t"ElementGrainId"\t"ElementGrainTitle"\t"ElementModuleSlug"
-"47823e8f-a4af-44d6-96f7-5b6fc7bc6b51"\t"flashcards"\t1\t1\t"f312c33d-e7c9-4a69-9ba0-913957b8f7dd"\t"Voici une leçon"\t"didacticiel-modulix"
-"e9aef60c-f18a-471e-85c7-e50b4731b86b"\t"text"\t2\t1\t"f312c33d-e7c9-4a69-9ba0-913957b8f7dd"\t"Voici une leçon"\t"didacticiel-modulix"
-"048e5319-5e81-44cc-ad71-c6c0d3be611f"\t"separator"\t3\t1\t"f312c33d-e7c9-4a69-9ba0-913957b8f7dd"\t"Voici une leçon"\t"didacticiel-modulix"
-"8d7687c8-4a02-4d7e-bf6c-693a6d481c78"\t"image"\t4\t1\t"f312c33d-e7c9-4a69-9ba0-913957b8f7dd"\t"Voici une leçon"\t"didacticiel-modulix"
-"84726001-1665-457d-8f13-4a74dc4768ea"\t"expand"\t5\t1\t"f312c33d-e7c9-4a69-9ba0-913957b8f7dd"\t"Voici une leçon"\t"didacticiel-modulix"
-"901ccbaa-f4e6-4322-b863-8e8eab08a33a"\t"download"\t6\t2\t"b14df125-82d5-4d55-a660-7b34cd9ea1ab"\t"Un fichier à télécharger"\t"didacticiel-modulix"
-"31106aeb-8346-44a6-8ed4-ebaa2106a373"\t"qcu"\t7\t2\t"b14df125-82d5-4d55-a660-7b34cd9ea1ab"\t"Un fichier à télécharger"\t"didacticiel-modulix"
-"3a9f2269-99ba-4631-b6fd-6802c88d5c26"\t"video"\t8\t3\t"73ac3644-7637-4cee-86d4-1a75f53f0b9c"\t"Vidéo de présentation de Pix"\t"didacticiel-modulix"
-"71de6394-ff88-4de3-8834-a40057a50ff4"\t"qcu"\t9\t4\t"533c69b8-a836-41be-8ffc-8d4636e31224"\t"Voici un vrai-faux"\t"didacticiel-modulix"
-"79dc17f9-142b-4e19-bcbe-bfde4e170d3f"\t"qcu"\t10\t4\t"533c69b8-a836-41be-8ffc-8d4636e31224"\t"Voici un vrai-faux"\t"didacticiel-modulix"
-"30701e93-1b4d-4da4-b018-fa756c07d53f"\t"qcm"\t11\t5\t"0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c"\t"Les 3 piliers de Pix"\t"didacticiel-modulix"
-"c23436d4-6261-49f1-b50d-13a547529c29"\t"qrocm"\t12\t6\t"4ce2a31a-6584-4dae-87c6-d08b58d0f3b9"\t"Connaissez-vous bien Pix"\t"didacticiel-modulix"
-"0e3315fd-98ad-492f-9046-4aa867495d84"\t"embed"\t13\t7\t"46577fb1-aadb-49ba-b3fd-721a11da8eb4"\t"Embed non-auto"\t"didacticiel-modulix"`);
+"47823e8f-a4af-44d6-96f7-5b6fc7bc6b51"\t"flashcards"\t1\t1\t"f312c33d-e7c9-4a69-9ba0-913957b8f7dd"\t"Voici une leçon"\t"bac-a-sable"
+"e9aef60c-f18a-471e-85c7-e50b4731b86b"\t"text"\t2\t1\t"f312c33d-e7c9-4a69-9ba0-913957b8f7dd"\t"Voici une leçon"\t"bac-a-sable"
+"048e5319-5e81-44cc-ad71-c6c0d3be611f"\t"separator"\t3\t1\t"f312c33d-e7c9-4a69-9ba0-913957b8f7dd"\t"Voici une leçon"\t"bac-a-sable"
+"8d7687c8-4a02-4d7e-bf6c-693a6d481c78"\t"image"\t4\t1\t"f312c33d-e7c9-4a69-9ba0-913957b8f7dd"\t"Voici une leçon"\t"bac-a-sable"
+"84726001-1665-457d-8f13-4a74dc4768ea"\t"expand"\t5\t1\t"f312c33d-e7c9-4a69-9ba0-913957b8f7dd"\t"Voici une leçon"\t"bac-a-sable"
+"901ccbaa-f4e6-4322-b863-8e8eab08a33a"\t"download"\t6\t2\t"b14df125-82d5-4d55-a660-7b34cd9ea1ab"\t"Un fichier à télécharger"\t"bac-a-sable"
+"31106aeb-8346-44a6-8ed4-ebaa2106a373"\t"qcu"\t7\t2\t"b14df125-82d5-4d55-a660-7b34cd9ea1ab"\t"Un fichier à télécharger"\t"bac-a-sable"
+"3a9f2269-99ba-4631-b6fd-6802c88d5c26"\t"video"\t8\t3\t"73ac3644-7637-4cee-86d4-1a75f53f0b9c"\t"Vidéo de présentation de Pix"\t"bac-a-sable"
+"71de6394-ff88-4de3-8834-a40057a50ff4"\t"qcu"\t9\t4\t"533c69b8-a836-41be-8ffc-8d4636e31224"\t"Voici un vrai-faux"\t"bac-a-sable"
+"79dc17f9-142b-4e19-bcbe-bfde4e170d3f"\t"qcu"\t10\t4\t"533c69b8-a836-41be-8ffc-8d4636e31224"\t"Voici un vrai-faux"\t"bac-a-sable"
+"30701e93-1b4d-4da4-b018-fa756c07d53f"\t"qcm"\t11\t5\t"0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c"\t"Les 3 piliers de Pix"\t"bac-a-sable"
+"c23436d4-6261-49f1-b50d-13a547529c29"\t"qrocm"\t12\t6\t"4ce2a31a-6584-4dae-87c6-d08b58d0f3b9"\t"Connaissez-vous bien Pix"\t"bac-a-sable"
+"0e3315fd-98ad-492f-9046-4aa867495d84"\t"embed"\t13\t7\t"46577fb1-aadb-49ba-b3fd-721a11da8eb4"\t"Embed non-auto"\t"bac-a-sable"`);
     });
   });
 });

--- a/api/tests/devcomp/acceptance/scripts/get-modules-csv_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-modules-csv_test.js
@@ -7,8 +7,8 @@ describe('Acceptance | Script | Get Modules as CSV', function () {
     const modulesListAsJs = [
       {
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
-        slug: 'didacticiel-modulix',
-        title: 'Didacticiel Modulix',
+        slug: 'bac-a-sable',
+        title: 'Bac à sable',
         isBeta: true,
         details: {
           image: 'https://images.pix.fr/modulix/placeholder-details.svg',
@@ -410,6 +410,6 @@ describe('Acceptance | Script | Get Modules as CSV', function () {
     expect(modulesListAsCsv).to.be.a('string');
     expect(modulesListAsCsv).to
       .equal(`\ufeff"ModuleSlug"\t"ModuleTitle"\t"ModuleLevel"\t"ModuleLink"\t"ModuleIsBeta"\t"ModuleObjectives"\t"ModuleTotalGrains"\t"ModuleTotalLessons"\t"ModuleTotalActivities"\t"ModuleTotalChallenges"\t"ModuleTotalDiscoveries"\t"ModuleTotalSummaries"\t"ModuleDuration"\t"ModuleTotalElements"
-"didacticiel-modulix"\t"Didacticiel Modulix"\t"Débutant"\t"https://app.recette.pix.fr/modules/didacticiel-modulix"\t"=TRUE"\t"Naviguer dans Modulix.Découvrir les leçons et les activités"\t9\t1\t5\t1\t1\t1\t"=TEXT(5/24/60; ""mm:ss"")"\t13`);
+"bac-a-sable"\t"Bac à sable"\t"Débutant"\t"https://app.recette.pix.fr/modules/bac-a-sable"\t"=TRUE"\t"Naviguer dans Modulix.Découvrir les leçons et les activités"\t9\t1\t5\t1\t1\t1\t"=TEXT(5/24/60; ""mm:ss"")"\t13`);
   });
 });

--- a/api/tests/devcomp/acceptance/scripts/get-proposals_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-proposals_test.js
@@ -6,8 +6,8 @@ describe('Acceptance | Script | Get Proposals as CSV', function () {
   const modulesListAsJs = [
     {
       id: '6282925d-4775-4bca-b513-4c3009ec5886',
-      slug: 'didacticiel-modulix',
-      title: 'Didacticiel Modulix',
+      slug: 'bac-a-sable',
+      title: 'Bac à sable',
       details: {
         image: 'https://images.pix.fr/modulix/placeholder-details.svg',
         description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',
@@ -381,16 +381,16 @@ describe('Acceptance | Script | Get Proposals as CSV', function () {
       expect(proposalsListAsCsv).to.be.a('string');
       expect(proposalsListAsCsv).to
         .equal(`\ufeff"ProposalElementId"\t"ProposalElementType"\t"ProposalActivityElementPosition"\t"ProposalElementInstruction"\t"ProposalId"\t"ProposalContent"\t"ProposalIsSolution"\t"ProposalGrainPosition"\t"ProposalGrainId"\t"ProposalGrainTitle"\t"ProposalModuleSlug"
-"71de6394-ff88-4de3-8834-a40057a50ff4"\t"qcu"\t1\t"<p>Pix évalue 16 compétences numériques différentes.</p>"\t"'1"\t"'Vrai"\t"=TRUE"\t4\t"533c69b8-a836-41be-8ffc-8d4636e31224"\t"Voici un vrai-faux"\t"didacticiel-modulix"
-"71de6394-ff88-4de3-8834-a40057a50ff4"\t"qcu"\t1\t"<p>Pix évalue 16 compétences numériques différentes.</p>"\t"'2"\t"'Faux"\t"=FALSE"\t4\t"533c69b8-a836-41be-8ffc-8d4636e31224"\t"Voici un vrai-faux"\t"didacticiel-modulix"
-"30701e93-1b4d-4da4-b018-fa756c07d53f"\t"qcm"\t2\t"<p>Quels sont les 3 piliers de Pix&#8239;?</p>"\t"'1"\t"'Evaluer ses connaissances et savoir-faire sur 16 compétences du numérique"\t"=TRUE"\t5\t"0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c"\t"Les 3 piliers de Pix"\t"didacticiel-modulix"
-"30701e93-1b4d-4da4-b018-fa756c07d53f"\t"qcm"\t2\t"<p>Quels sont les 3 piliers de Pix&#8239;?</p>"\t"'2"\t"'Développer son savoir-faire sur les jeux de type TPS"\t"=FALSE"\t5\t"0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c"\t"Les 3 piliers de Pix"\t"didacticiel-modulix"
-"30701e93-1b4d-4da4-b018-fa756c07d53f"\t"qcm"\t2\t"<p>Quels sont les 3 piliers de Pix&#8239;?</p>"\t"'3"\t"'Développer ses compétences numériques"\t"=TRUE"\t5\t"0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c"\t"Les 3 piliers de Pix"\t"didacticiel-modulix"
-"30701e93-1b4d-4da4-b018-fa756c07d53f"\t"qcm"\t2\t"<p>Quels sont les 3 piliers de Pix&#8239;?</p>"\t"'4"\t"'Certifier ses compétences Pix"\t"=TRUE"\t5\t"0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c"\t"Les 3 piliers de Pix"\t"didacticiel-modulix"
-"30701e93-1b4d-4da4-b018-fa756c07d53f"\t"qcm"\t2\t"<p>Quels sont les 3 piliers de Pix&#8239;?</p>"\t"'5"\t"'Evaluer ses compétences de logique et compréhension mathématique"\t"=FALSE"\t5\t"0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c"\t"Les 3 piliers de Pix"\t"didacticiel-modulix"
-"0a5e77e8-1c8e-4cb6-a41d-cf6ad7935447"\t"qcu"\t3\t"<p>Remontez la page pour trouver le premier mot de ce module.<br>Quel est ce mot&#8239;?</p>"\t"'1"\t"'Bienvenue"\t"=FALSE"\t6\t"2a77a10f-19a3-4544-80f9-8012dad6506a"\t"Activité remonter dans la page"\t"didacticiel-modulix"
-"0a5e77e8-1c8e-4cb6-a41d-cf6ad7935447"\t"qcu"\t3\t"<p>Remontez la page pour trouver le premier mot de ce module.<br>Quel est ce mot&#8239;?</p>"\t"'2"\t"'Bonjour"\t"=TRUE"\t6\t"2a77a10f-19a3-4544-80f9-8012dad6506a"\t"Activité remonter dans la page"\t"didacticiel-modulix"
-"0a5e77e8-1c8e-4cb6-a41d-cf6ad7935447"\t"qcu"\t3\t"<p>Remontez la page pour trouver le premier mot de ce module.<br>Quel est ce mot&#8239;?</p>"\t"'3"\t"'Nous"\t"=FALSE"\t6\t"2a77a10f-19a3-4544-80f9-8012dad6506a"\t"Activité remonter dans la page"\t"didacticiel-modulix"`);
+"71de6394-ff88-4de3-8834-a40057a50ff4"\t"qcu"\t1\t"<p>Pix évalue 16 compétences numériques différentes.</p>"\t"'1"\t"'Vrai"\t"=TRUE"\t4\t"533c69b8-a836-41be-8ffc-8d4636e31224"\t"Voici un vrai-faux"\t"bac-a-sable"
+"71de6394-ff88-4de3-8834-a40057a50ff4"\t"qcu"\t1\t"<p>Pix évalue 16 compétences numériques différentes.</p>"\t"'2"\t"'Faux"\t"=FALSE"\t4\t"533c69b8-a836-41be-8ffc-8d4636e31224"\t"Voici un vrai-faux"\t"bac-a-sable"
+"30701e93-1b4d-4da4-b018-fa756c07d53f"\t"qcm"\t2\t"<p>Quels sont les 3 piliers de Pix&#8239;?</p>"\t"'1"\t"'Evaluer ses connaissances et savoir-faire sur 16 compétences du numérique"\t"=TRUE"\t5\t"0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c"\t"Les 3 piliers de Pix"\t"bac-a-sable"
+"30701e93-1b4d-4da4-b018-fa756c07d53f"\t"qcm"\t2\t"<p>Quels sont les 3 piliers de Pix&#8239;?</p>"\t"'2"\t"'Développer son savoir-faire sur les jeux de type TPS"\t"=FALSE"\t5\t"0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c"\t"Les 3 piliers de Pix"\t"bac-a-sable"
+"30701e93-1b4d-4da4-b018-fa756c07d53f"\t"qcm"\t2\t"<p>Quels sont les 3 piliers de Pix&#8239;?</p>"\t"'3"\t"'Développer ses compétences numériques"\t"=TRUE"\t5\t"0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c"\t"Les 3 piliers de Pix"\t"bac-a-sable"
+"30701e93-1b4d-4da4-b018-fa756c07d53f"\t"qcm"\t2\t"<p>Quels sont les 3 piliers de Pix&#8239;?</p>"\t"'4"\t"'Certifier ses compétences Pix"\t"=TRUE"\t5\t"0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c"\t"Les 3 piliers de Pix"\t"bac-a-sable"
+"30701e93-1b4d-4da4-b018-fa756c07d53f"\t"qcm"\t2\t"<p>Quels sont les 3 piliers de Pix&#8239;?</p>"\t"'5"\t"'Evaluer ses compétences de logique et compréhension mathématique"\t"=FALSE"\t5\t"0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c"\t"Les 3 piliers de Pix"\t"bac-a-sable"
+"0a5e77e8-1c8e-4cb6-a41d-cf6ad7935447"\t"qcu"\t3\t"<p>Remontez la page pour trouver le premier mot de ce module.<br>Quel est ce mot&#8239;?</p>"\t"'1"\t"'Bienvenue"\t"=FALSE"\t6\t"2a77a10f-19a3-4544-80f9-8012dad6506a"\t"Activité remonter dans la page"\t"bac-a-sable"
+"0a5e77e8-1c8e-4cb6-a41d-cf6ad7935447"\t"qcu"\t3\t"<p>Remontez la page pour trouver le premier mot de ce module.<br>Quel est ce mot&#8239;?</p>"\t"'2"\t"'Bonjour"\t"=TRUE"\t6\t"2a77a10f-19a3-4544-80f9-8012dad6506a"\t"Activité remonter dans la page"\t"bac-a-sable"
+"0a5e77e8-1c8e-4cb6-a41d-cf6ad7935447"\t"qcu"\t3\t"<p>Remontez la page pour trouver le premier mot de ce module.<br>Quel est ce mot&#8239;?</p>"\t"'3"\t"'Nous"\t"=FALSE"\t6\t"2a77a10f-19a3-4544-80f9-8012dad6506a"\t"Activité remonter dans la page"\t"bac-a-sable"`);
     });
   });
 });

--- a/api/tests/devcomp/acceptance/scripts/test-module.json
+++ b/api/tests/devcomp/acceptance/scripts/test-module.json
@@ -1,7 +1,7 @@
 {
   "id": "6282925d-4775-4bca-b513-4c3009ec5886",
-  "slug": "didacticiel-modulix",
-  "title": "Didacticiel Modulix",
+  "slug": "bac-a-sable",
+  "title": "Bac à sable",
   "isBeta": true,
   "details": {
     "image": "https://images.pix.fr/modulix/placeholder-details.svg",
@@ -9,10 +9,7 @@
     "duration": 5,
     "level": "Débutant",
     "tabletSupport": "inconvenient",
-    "objectives": [
-      "Naviguer dans Modulix",
-      "Découvrir les leçons et les activités"
-    ]
+    "objectives": ["Naviguer dans Modulix", "Découvrir les leçons et les activités"]
   },
   "transitionTexts": [
     {
@@ -301,11 +298,7 @@
               "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p>Vous nous avez bien cernés&nbsp;:)</p>",
               "invalid": "<span class=\"feedback__state\">Et non&#8239;!</span><p> Pix sert à évaluer, certifier et développer ses compétences numériques.</p>"
             },
-            "solutions": [
-              "1",
-              "3",
-              "4"
-            ]
+            "solutions": ["1", "3", "4"]
           }
         }
       ]
@@ -335,13 +328,8 @@
                 "placeholder": "",
                 "ariaLabel": "Mot à trouver",
                 "defaultValue": "",
-                "tolerances": [
-                  "t1",
-                  "t3"
-                ],
-                "solutions": [
-                  "Groupement"
-                ]
+                "tolerances": ["t1", "t3"],
+                "solutions": ["Groupement"]
               },
               {
                 "type": "text",
@@ -357,9 +345,7 @@
                 "ariaLabel": "Année à trouver",
                 "defaultValue": "",
                 "tolerances": [],
-                "solutions": [
-                  "2016"
-                ]
+                "solutions": ["2016"]
               }
             ],
             "feedbacks": {

--- a/api/tests/devcomp/acceptance/scripts/utils/get-answerable-elements_test.js
+++ b/api/tests/devcomp/acceptance/scripts/utils/get-answerable-elements_test.js
@@ -5,8 +5,8 @@ describe('Acceptance | Script | Get Answerable Elements as CSV', function () {
   const modulesListAsJs = [
     {
       id: '6282925d-4775-4bca-b513-4c3009ec5886',
-      slug: 'didacticiel-modulix',
-      title: 'Didacticiel Modulix',
+      slug: 'bac-a-sable',
+      title: 'Bac à sable',
       details: {
         image: 'https://images.pix.fr/modulix/placeholder-details.svg',
         description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',

--- a/api/tests/devcomp/integration/repositories/element-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/element-repository_test.js
@@ -8,7 +8,7 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
   describe('#getByIdForAnswerVerification', function () {
     it('should return an element from a component element', async function () {
       // given
-      const moduleId = 'didacticiel-modulix';
+      const moduleId = 'bac-a-sable';
       const elementId = '71de6394-ff88-4de3-8834-a40057a50ff4';
       const element = new QCUForAnswerVerification({
         id: elementId,
@@ -37,8 +37,8 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
       };
       moduleDatasourceStub.getBySlug.withArgs(moduleId).resolves({
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
-        slug: 'didacticiel-modulix',
-        title: 'Didacticiel Modulix',
+        slug: 'bac-a-sable',
+        title: 'Bac à sable',
         details: {
           image: 'https://images.pix.fr/modulix/placeholder-details.svg',
           description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',
@@ -97,7 +97,7 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
 
     it('should return an element from a component stepper', async function () {
       // given
-      const moduleId = 'didacticiel-modulix';
+      const moduleId = 'bac-a-sable';
       const elementId = '71de6394-ff88-4de3-8834-a40057a50ff4';
       const element = new QCUForAnswerVerification({
         id: elementId,
@@ -126,8 +126,8 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
       };
       moduleDatasourceStub.getBySlug.withArgs(moduleId).resolves({
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
-        slug: 'didacticiel-modulix',
-        title: 'Didacticiel Modulix',
+        slug: 'bac-a-sable',
+        title: 'Bac à sable',
         details: {
           image: 'https://images.pix.fr/modulix/placeholder-details.svg',
           description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',
@@ -259,8 +259,8 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
       // given
       const moduleData = {
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
-        slug: 'didacticiel-modulix',
-        title: 'Didacticiel Modulix',
+        slug: 'bac-a-sable',
+        title: 'Bac à sable',
         details: {
           image: 'https://images.pix.fr/modulix/placeholder-details.svg',
           description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -228,8 +228,8 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
       // given
       const invalidModule = {
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
-        slug: 'didacticiel-modulix',
-        title: '<h1>Didacticiel Modulix</h1>',
+        slug: 'bac-a-sable',
+        title: '<h1>Bac à sable</h1>',
         isBeta: true,
         details: {
           image: 'https://images.pix.fr/modulix/placeholder-details.svg',

--- a/high-level-tests/e2e/cypress/integration/pix-app/a11y-not-authenticated.test.js
+++ b/high-level-tests/e2e/cypress/integration/pix-app/a11y-not-authenticated.test.js
@@ -1,44 +1,44 @@
-describe("a11y", () => {
+describe('a11y', () => {
   beforeEach(() => {
-    cy.task("db:fixture", "users");
-    cy.task("db:fixture", "authentication-methods");
-    cy.task("db:fixture", "organizations");
-    cy.task("db:fixture", "memberships");
-    cy.task("db:fixture", "organization-invitations");
-    cy.task("db:fixture", "user-orga-settings");
-    cy.task("db:fixture", "target-profiles");
-    cy.task("db:fixture", "target-profile_tubes");
-    cy.task("db:fixture", "campaigns");
-    cy.task("db:fixture", "campaign_skills");
-    cy.task("db:fixture", "organization-learners");
-    cy.task("db:fixture", "campaign-participations");
-    cy.task("db:fixture", "assessments");
-    cy.task("db:fixture", "answers");
-    cy.task("db:fixture", "knowledge-elements");
-    cy.task("db:fixture", "legal-document-versions");
-    cy.task("db:fixture", "legal-document-version-user-acceptances");
+    cy.task('db:fixture', 'users');
+    cy.task('db:fixture', 'authentication-methods');
+    cy.task('db:fixture', 'organizations');
+    cy.task('db:fixture', 'memberships');
+    cy.task('db:fixture', 'organization-invitations');
+    cy.task('db:fixture', 'user-orga-settings');
+    cy.task('db:fixture', 'target-profiles');
+    cy.task('db:fixture', 'target-profile_tubes');
+    cy.task('db:fixture', 'campaigns');
+    cy.task('db:fixture', 'campaign_skills');
+    cy.task('db:fixture', 'organization-learners');
+    cy.task('db:fixture', 'campaign-participations');
+    cy.task('db:fixture', 'assessments');
+    cy.task('db:fixture', 'answers');
+    cy.task('db:fixture', 'knowledge-elements');
+    cy.task('db:fixture', 'legal-document-versions');
+    cy.task('db:fixture', 'legal-document-version-user-acceptances');
   });
 
-  describe("Not authenticated pages", () => {
+  describe('Not authenticated pages', () => {
     const notAuthenticatedPages = [
-      { url: "/campagnes" },
-      { url: "/campagnes/WALL/presentation" },
-      { url: "/changer-de-mot-passe" },
-      { url: "/connexion" },
-      { url: "/inscription" },
-      { url: "/mot-de-passe-oublie" },
-      { url: "/nonconnecte" },
-      { url: "/recuperer-mon-compte", skipFailures: true },
-      { url: "/verification-certificat" },
-      { url: "/modules/didacticiel-modulix/details" },
-      { url: "/modules/didacticiel-modulix/passage" },
+      { url: '/campagnes' },
+      { url: '/campagnes/WALL/presentation' },
+      { url: '/changer-de-mot-passe' },
+      { url: '/connexion' },
+      { url: '/inscription' },
+      { url: '/mot-de-passe-oublie' },
+      { url: '/nonconnecte' },
+      { url: '/recuperer-mon-compte', skipFailures: true },
+      { url: '/verification-certificat' },
+      { url: '/modules/bac-a-sable/details' },
+      { url: '/modules/bac-a-sable/passage' },
     ];
 
     notAuthenticatedPages.forEach(({ url, skipFailures = false }) => {
       it(`${url} should be accessible`, () => {
         // when
         cy.visitMonPix(url);
-        cy.get(".app-loader").should("not.exist");
+        cy.get('.app-loader').should('not.exist');
         cy.injectAxe();
 
         // then

--- a/high-level-tests/e2e/cypress/integration/pix-app/modulix-a11y.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/modulix-a11y.feature
@@ -2,7 +2,7 @@
 Fonctionnalité: Accessibilité de Modulix
 
   Contexte:
-    Étant donné que je lance le module "didacticiel-modulix"
+    Étant donné que je lance le module "bac-a-sable"
 
   Scénario: Je valide l'accessibilité de la page de détails
     Quand j'attends 500 ms


### PR DESCRIPTION
## :pancakes: Problème
`didacticiel-modulix` nous semble mal nommé. on l'a totalement accaparé pour des besoins techniques/fonctionnels : on y met tous les types de contenus qu'on est capable de gérer. ça nous sert pour de la non régression principalement.

## :bacon: Proposition
Renommer `didacticiel-modulix` en `bac-a-sable`.

## 🧃 Remarques
RAS

## :yum: Pour tester
Constater en RA que [`/modules/bac-a-sable`](https://app-pr11486.review.pix.fr/modules/bac-a-sable) est accessible et que [`/modules/didacticiel-modulix`](https://app-pr11486.review.pix.fr/modules/didacticiel-modulix) ne l'est plus.