### PR TITLE
[FEATURE] Mettre à disposition un webhook pour repliquer les données entre le datawarehouse et le datamart (PIX-16704)

### DIFF
--- a/api/.depcheckrc
+++ b/api/.depcheckrc
@@ -4,6 +4,7 @@ ignores:
     'hapi-swagger',
     'hapi-sentry',
     'mocha-junit-reporter',
+    'pg-query-stream',
   ]
 #  @babel/plugin-syntax-import-attributes is used by eslint
 # see https://github.com/babel/babel/blob/main/packages/babel-plugin-syntax-import-attributes/README.md

--- a/api/eslint.config.mjs
+++ b/api/eslint.config.mjs
@@ -76,10 +76,11 @@ export default [
       ],
     },
   },
-  mocha.configs.flat.recommended,
   {
+    ...mocha.configs.flat.recommended,
     files: ['tests/**/*.js'],
     rules: {
+      ...mocha.configs.flat.recommended.rules,
       'mocha/no-hooks-for-single-case': 'off',
       'mocha/no-exclusive-tests': 'error',
       'mocha/no-pending-tests': 'error',

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -64,6 +64,7 @@
         "pg": "^8.7.3",
         "pg-boss": "^9.0.0",
         "pg-connection-string": "^2.5.0",
+        "pg-query-stream": "^4.7.3",
         "pino": "^9.0.0",
         "pino-pretty": "^13.0.0",
         "randomstring": "^1.2.2",
@@ -10461,6 +10462,15 @@
       "integrity": "sha512-PI2W9mv53rXJQEOb8xNR8lH7Hr+EKa6oJa38zsK0S/ky2er16ios1wLKhZyxzD7jUReiWokc9WK5nxSnC7W1TA==",
       "license": "MIT"
     },
+    "node_modules/pg-cursor": {
+      "version": "2.12.3",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.12.3.tgz",
+      "integrity": "sha512-2koS4+f+oCJnJ6pTdUlp3TkwOCjlPr9lmwcTDPeXZv3eiXDCxZeBC7T0+LldA9+mhqdcO8WDqbuFfdFEJm9YLw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": "^8"
+      }
+    },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -10490,6 +10500,18 @@
       "resolved": "https://registry.npmjs.org/pg-query-emscripten/-/pg-query-emscripten-5.1.0.tgz",
       "integrity": "sha512-H1ZWOzLRddmHuE4GZqFjjo55hA9zMiePz/WDDGANA/EnvILCJps9pcRucyGd+MFvapeYOy6TWSYz6DbtBOaxRQ==",
       "license": "MIT"
+    },
+    "node_modules/pg-query-stream": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-4.7.3.tgz",
+      "integrity": "sha512-WvsdwYXrvIXNZJflX/2MEQLjKs5TopZWeiyam1zcaFfhwQtL19ENOvGdzVsihGsbsNGdVRU5yiqg2G5p06UAbg==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-cursor": "^2.12.3"
+      },
+      "peerDependencies": {
+        "pg": "^8"
+      }
     },
     "node_modules/pg-types": {
       "version": "2.2.0",

--- a/api/package.json
+++ b/api/package.json
@@ -70,6 +70,7 @@
     "pg": "^8.7.3",
     "pg-boss": "^9.0.0",
     "pg-connection-string": "^2.5.0",
+    "pg-query-stream": "^4.7.3",
     "pino": "^9.0.0",
     "pino-pretty": "^13.0.0",
     "randomstring": "^1.2.2",

--- a/api/server.maddo.js
+++ b/api/server.maddo.js
@@ -5,6 +5,7 @@ import { parse } from 'neoqs';
 import { setupErrorHandling } from './config/server-setup-error-handling.js';
 import { knex } from './db/knex-database-connection.js';
 import { authentication } from './lib/infrastructure/authentication.js';
+import * as replicationRoutes from './src/maddo/application/replications-routes.js';
 import { Metrics } from './src/monitoring/infrastructure/metrics.js';
 import * as healthcheckRoutes from './src/shared/application/healthcheck/index.js';
 import { config } from './src/shared/config.js';
@@ -177,7 +178,7 @@ const setupAuthentication = function (server) {
 };
 
 const setupRoutesAndPlugins = async function (server) {
-  await server.register([...plugins, healthcheckRoutes]);
+  await server.register([...plugins, healthcheckRoutes, replicationRoutes]);
 };
 
 const setupOpenApiSpecification = async function (server) {

--- a/api/src/maddo/application/replications-controller.js
+++ b/api/src/maddo/application/replications-controller.js
@@ -1,0 +1,46 @@
+import { datamartKnex } from '../../../db/knex-database-connection.js';
+import { logger } from '../../shared/infrastructure/utils/logger.js';
+import { extractTransformAndLoadData } from '../domain/usecases/extract-transform-and-load-data.js';
+import * as replicationRepository from '../infrastructure/repositories/replication-repository.js';
+
+export async function replicate(
+  request,
+  h,
+  dependencies = {
+    extractTransformAndLoadData,
+    replicationRepository,
+    datamartKnex: datamartKnex,
+    datawarehouseKnex: datamartKnex,
+    logger,
+  },
+) {
+  const { replicationName } = request.params;
+
+  const replication = dependencies.replicationRepository.getByName(replicationName);
+
+  if (!replication) {
+    return h.response().code(404);
+  }
+
+  const promise = dependencies
+    .extractTransformAndLoadData({
+      replication,
+      datamartKnex: dependencies.datamartKnex,
+      datawarehouseKnex: dependencies.datawarehouseKnex,
+    })
+    .catch((err) =>
+      dependencies.logger.error(
+        {
+          event: 'replication',
+          err,
+        },
+        'Error during replication',
+      ),
+    );
+
+  if (!request.query.async) {
+    await promise;
+  }
+
+  return h.response().code(204);
+}

--- a/api/src/maddo/application/replications-routes.js
+++ b/api/src/maddo/application/replications-routes.js
@@ -1,0 +1,29 @@
+import Joi from 'joi';
+
+import { replicate } from './replications-controller.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'POST',
+      path: '/api/replications/{replicationName}',
+      config: {
+        auth: { access: { scope: 'replication' } },
+        validate: {
+          params: Joi.object({
+            replicationName: Joi.string().max(255),
+          }),
+          query: Joi.object({
+            async: Joi.boolean().default(true),
+          }),
+        },
+        handler: replicate,
+        notes: ['- Permet à une application de lancer une réplication entre le datawarehouse et le datamart'],
+        tags: ['api', 'replications'],
+      },
+    },
+  ]);
+};
+
+const name = 'admin-campaign-participation-api';
+export { name, register };

--- a/api/src/maddo/domain/usecases/extract-transform-and-load-data.js
+++ b/api/src/maddo/domain/usecases/extract-transform-and-load-data.js
@@ -1,0 +1,29 @@
+const DEFAULT_CHUNK_SIZE = 1_000;
+
+export async function extractTransformAndLoadData({ replication, datawarehouseKnex, datamartKnex }) {
+  let context = { datawarehouseKnex, datamartKnex };
+
+  const additionnalContext = await replication.before?.(context);
+
+  context = { ...additionnalContext, ...context };
+
+  const queryBuilder = replication.from(context);
+  let chunk = [];
+  const chunkSize = replication.chunkSize ?? DEFAULT_CHUNK_SIZE;
+  const connection = await datamartKnex.context.client.acquireConnection();
+  try {
+    for await (const data of queryBuilder.stream()) {
+      chunk.push(replication.transform?.(data) ?? data);
+      if (chunk.length === chunkSize) {
+        await replication.to(context, chunk).connection(connection);
+        chunk = [];
+      }
+    }
+
+    if (chunk.length) {
+      await replication.to(context, chunk).connection(connection);
+    }
+  } finally {
+    await datamartKnex.context.client.releaseConnection(connection);
+  }
+}

--- a/api/src/maddo/infrastructure/repositories/replication-repository.js
+++ b/api/src/maddo/infrastructure/repositories/replication-repository.js
@@ -1,4 +1,4 @@
-const replications = [];
+export const replications = [];
 
 export function getByName(name, dependencies = { replications }) {
   return dependencies.replications.find((replication) => replication.name === name);

--- a/api/src/maddo/infrastructure/repositories/replication-repository.js
+++ b/api/src/maddo/infrastructure/repositories/replication-repository.js
@@ -1,0 +1,5 @@
+const replications = [];
+
+export function getByName(name, dependencies = { replications }) {
+  return dependencies.replications.find((replication) => replication.name === name);
+}

--- a/api/tests/maddo/application/acceptance/replications-routes_test.js
+++ b/api/tests/maddo/application/acceptance/replications-routes_test.js
@@ -1,0 +1,62 @@
+import { replications } from '../../../../src/maddo/infrastructure/repositories/replication-repository.js';
+import {
+  createMaddoServer,
+  datamartKnex,
+  expect,
+  generateValidRequestAuthorizationHeaderForApplication,
+} from '../../../test-helper.js';
+
+describe('Maddo | Application | Acceptance | Replications', function () {
+  describe('POST /api/replications/{replication}', function () {
+    let server;
+
+    beforeEach(async function () {
+      const schema = (t) => {
+        t.string('firstName').notNullable();
+        t.string('lastName').notNullable();
+      };
+      await datamartKnex.schema.dropTableIfExists('to-replicate');
+      await datamartKnex.schema.createTable('to-replicate', schema);
+      await datamartKnex.schema.dropTableIfExists('replication');
+      await datamartKnex.schema.createTable('replication', schema);
+      server = await createMaddoServer();
+    });
+
+    it('should run given replication', async function () {
+      // given
+      const replication = 'my-replication';
+      await datamartKnex('to-replicate').insert([
+        { firstName: 'first1', lastName: 'last1' },
+        { firstName: 'first2', lastName: 'last2' },
+      ]);
+
+      replications.push({
+        name: 'my-replication',
+        from: ({ datawarehouseKnex }) => {
+          return datawarehouseKnex('to-replicate').select('*');
+        },
+        to: ({ datamartKnex }, chunk) => {
+          return datamartKnex('replication').insert(chunk);
+        },
+      });
+
+      // when
+      const response = await server.inject({
+        method: 'POST',
+        url: `/api/replications/${replication}?async=false`,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeaderForApplication(
+            'pix-client',
+            'pix-client',
+            'replication',
+          ),
+        },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(204);
+      const { count } = await datamartKnex('replication').count().first();
+      expect(count).to.equal(2);
+    });
+  });
+});

--- a/api/tests/maddo/application/unit/replications-controller_test.js
+++ b/api/tests/maddo/application/unit/replications-controller_test.js
@@ -1,0 +1,125 @@
+import { replicate } from '../../../../src/maddo/application/replications-controller.js';
+import { expect, sinon } from '../../../test-helper.js';
+
+describe('Maddo | Application | Unit | Controller | Replication', function () {
+  describe('#replicate', function () {
+    it('should call use-case with given replication', async function () {
+      // given
+      const replicationName = 'foo';
+      const replication = Symbol('replication');
+      const request = {
+        params: {
+          replicationName,
+        },
+        query: {
+          async: false,
+        },
+      };
+      const codeStub = sinon.stub();
+      const h = {
+        response: () => ({
+          code: codeStub,
+        }),
+      };
+      const extractTransformAndLoadData = sinon.stub().resolves();
+      const replicationRepository = {
+        getByName: sinon.stub().withArgs(replicationName).returns(replication),
+      };
+      const datawarehouseKnex = Symbol('datawarehouse-knex');
+      const datamartKnex = Symbol('datamart-knex');
+
+      // when
+      await replicate(request, h, {
+        extractTransformAndLoadData,
+        replicationRepository,
+        datamartKnex,
+        datawarehouseKnex,
+      });
+
+      // then
+      expect(extractTransformAndLoadData).to.have.been.calledWithExactly({
+        replication,
+        datamartKnex,
+        datawarehouseKnex,
+      });
+      expect(codeStub).to.have.been.calledWithExactly(204);
+    });
+
+    context('when usecase throw an error', function () {
+      it('should log error', async function () {
+        // given
+        const replicationName = 'foo';
+        const replication = Symbol('replication');
+        const request = {
+          params: {
+            replicationName,
+          },
+          query: {
+            async: false,
+          },
+        };
+        const codeStub = sinon.stub();
+        const h = {
+          response: () => ({
+            code: codeStub,
+          }),
+        };
+
+        const error = new Error('extract-error');
+        const extractTransformAndLoadData = sinon.stub().rejects(error);
+        const logger = {
+          error: sinon.stub(),
+        };
+        const replicationRepository = {
+          getByName: sinon.stub().withArgs(replicationName).returns(replication),
+        };
+
+        // when
+        await replicate(request, h, { extractTransformAndLoadData, replicationRepository, logger });
+
+        // then
+        expect(logger.error).to.have.been.calledWithExactly(
+          {
+            event: 'replication',
+            err: error,
+          },
+          'Error during replication',
+        );
+        expect(codeStub).to.have.been.calledWithExactly(204);
+      });
+    });
+
+    context('when replication name is unknown', function () {
+      it('should return 404 status code', async function () {
+        // given
+        const replicationName = 'unknown';
+        const request = {
+          params: {
+            replicationName,
+          },
+          query: {
+            async: false,
+          },
+        };
+        const codeStub = sinon.stub();
+        const h = {
+          response: () => ({
+            code: codeStub,
+          }),
+        };
+
+        const replicationRepository = {
+          getByName: sinon.stub().withArgs(replicationName).returns(undefined),
+        };
+        const extractTransformAndLoadData = sinon.stub();
+
+        // when
+        await replicate(request, h, { extractTransformAndLoadData, replicationRepository });
+
+        // then
+        expect(codeStub).to.have.been.calledWithExactly(404);
+        expect(extractTransformAndLoadData).not.to.have.been.called;
+      });
+    });
+  });
+});

--- a/api/tests/maddo/domain/unit/usecases/extract-transform-and-load-data_test.js
+++ b/api/tests/maddo/domain/unit/usecases/extract-transform-and-load-data_test.js
@@ -1,0 +1,183 @@
+import { extractTransformAndLoadData } from '../../../../../src/maddo/domain/usecases/extract-transform-and-load-data.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Maddo | Domain | Usecases | Unit | extract-transform-and-load-data', function () {
+  let fromQueryBuilder;
+  let fromFunction;
+
+  let toQueryBuilder;
+  let toFunction;
+
+  let connection;
+
+  let datamartKnex;
+  let datawarehouseKnex;
+
+  beforeEach(function () {
+    fromQueryBuilder = {
+      async *stream() {
+        for (let i = 0; i < 5; i++) {
+          yield i;
+        }
+      },
+    };
+    fromFunction = sinon.stub().returns(fromQueryBuilder);
+    toQueryBuilder = {
+      connection: sinon.stub().resolves(),
+    };
+    toFunction = sinon.stub().returns(toQueryBuilder);
+    connection = Symbol('connection');
+    datamartKnex = {
+      context: {
+        client: {
+          acquireConnection: sinon.stub().resolves(connection),
+          releaseConnection: sinon.stub(),
+        },
+      },
+    };
+    datawarehouseKnex = Symbol('datawarehouseKnex');
+  });
+
+  it('should insert into database with given query', async function () {
+    // given
+
+    // when
+    await extractTransformAndLoadData({
+      replication: {
+        from: fromFunction,
+        to: toFunction,
+        chunkSize: 2,
+      },
+      datamartKnex,
+      datawarehouseKnex,
+    });
+
+    // then
+    expect(fromFunction).to.have.been.calledOnce;
+    expect(fromFunction).to.have.been.calledWithExactly({ datawarehouseKnex, datamartKnex });
+    expect(fromFunction).to.have.been.calledBefore(toFunction);
+
+    expect(toFunction).to.have.been.calledThrice;
+    expect(toFunction).to.have.been.calledWithExactly({ datawarehouseKnex, datamartKnex }, [0, 1]);
+    expect(toFunction).to.have.been.calledWithExactly({ datawarehouseKnex, datamartKnex }, [2, 3]);
+    expect(toFunction).to.have.been.calledWithExactly({ datawarehouseKnex, datamartKnex }, [4]);
+
+    expect(toQueryBuilder.connection).to.have.been.calledThrice;
+    expect(toQueryBuilder.connection).to.always.have.been.calledWithExactly(connection);
+
+    expect(datamartKnex.context.client.releaseConnection).to.have.been.calledOnceWithExactly(connection);
+  });
+
+  describe('when chunkSize are not provided', function () {
+    it('should use default chunkSize', async function () {
+      // given
+      await extractTransformAndLoadData({
+        replication: {
+          from: fromFunction,
+          to: toFunction,
+        },
+        datamartKnex,
+        datawarehouseKnex,
+      });
+
+      expect(toFunction).to.have.been.calledOnceWithExactly({ datawarehouseKnex, datamartKnex }, [0, 1, 2, 3, 4]);
+    });
+  });
+
+  describe('when a before function is defined', function () {
+    it('should call before function first', async function () {
+      // given
+      const beforeFunction = sinon.stub().resolves();
+
+      // when
+      await extractTransformAndLoadData({
+        replication: {
+          from: fromFunction,
+          before: beforeFunction,
+          to: toFunction,
+          chunkSize: 2,
+        },
+        datamartKnex,
+        datawarehouseKnex,
+      });
+
+      // then
+      expect(beforeFunction).to.have.been.calledOnceWithExactly({ datawarehouseKnex, datamartKnex });
+      expect(beforeFunction).to.have.been.calledBefore(fromFunction);
+
+      expect(fromFunction).to.have.been.calledOnce;
+      expect(toFunction).to.have.been.calledThrice;
+      expect(toQueryBuilder.connection).to.have.been.calledThrice;
+    });
+
+    describe('when before returns an object', function () {
+      it('should be assigned in context', async function () {
+        // given
+        const beforeFunction = sinon.stub().resolves({ foo: 'foo', bar: 'bar' });
+
+        // when
+        await extractTransformAndLoadData({
+          replication: {
+            from: fromFunction,
+            to: toFunction,
+            before: beforeFunction,
+            chunkSize: 2,
+          },
+          datamartKnex,
+          datawarehouseKnex,
+        });
+
+        // then
+        expect(beforeFunction).to.have.been.calledOnceWithExactly({ datawarehouseKnex, datamartKnex });
+        expect(beforeFunction).to.have.been.calledBefore(fromFunction);
+
+        expect(fromFunction).to.have.been.calledOnceWithExactly({
+          datawarehouseKnex,
+          datamartKnex,
+          foo: 'foo',
+          bar: 'bar',
+        });
+
+        expect(toFunction).to.have.been.calledThrice;
+        expect(toFunction).to.have.been.calledWithExactly(
+          { datawarehouseKnex, datamartKnex, foo: 'foo', bar: 'bar' },
+          [0, 1],
+        );
+        expect(toFunction).to.have.been.calledWithExactly(
+          { datawarehouseKnex, datamartKnex, foo: 'foo', bar: 'bar' },
+          [2, 3],
+        );
+        expect(toFunction).to.have.been.calledWithExactly({ datawarehouseKnex, datamartKnex, foo: 'foo', bar: 'bar' }, [
+          4,
+        ]);
+
+        expect(toQueryBuilder.connection).to.have.been.calledThrice;
+      });
+    });
+  });
+
+  describe('when a transform function is defined', function () {
+    it('should call it for each row', async function () {
+      // given
+      const transform = (row) => row + 1;
+
+      // when
+      await extractTransformAndLoadData({
+        replication: {
+          from: fromFunction,
+          to: toFunction,
+          transform,
+          chunkSize: 2,
+        },
+        datamartKnex,
+        datawarehouseKnex,
+      });
+
+      // then
+      expect(toFunction).to.have.been.calledThrice;
+      expect(toFunction).to.have.been.calledWithExactly({ datawarehouseKnex, datamartKnex }, [1, 2]);
+      expect(toFunction).to.have.been.calledWithExactly({ datawarehouseKnex, datamartKnex }, [3, 4]);
+      expect(toFunction).to.have.been.calledWithExactly({ datawarehouseKnex, datamartKnex }, [5]);
+    });
+  });
+});

--- a/api/tests/maddo/infrastructure/unit/repositories/replication-repository_test.js
+++ b/api/tests/maddo/infrastructure/unit/repositories/replication-repository_test.js
@@ -1,0 +1,30 @@
+import * as replicationRepository from '../../../../../src/maddo/infrastructure/repositories/replication-repository.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Maddo | Infrastructure | Repositories | Unit | replication', function () {
+  describe('#getByName', function () {
+    it('should return replication object', function () {
+      // given
+      const replications = [{ name: 'replication1' }, { name: 'replication2' }, { name: 'replication3' }];
+
+      // when
+      const replication = replicationRepository.getByName('replication2', { replications });
+
+      // then
+      expect(replication).to.equal(replications[1]);
+    });
+
+    describe('when name is unknown', function () {
+      it('should return undefined', function () {
+        // given
+        const replications = [{ name: 'replication1' }, { name: 'replication2' }, { name: 'replication3' }];
+
+        // when
+        const replication = replicationRepository.getByName('unknown', { replications });
+
+        // then
+        expect(replication).to.be.undefined;
+      });
+    });
+  });
+});

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -19,6 +19,7 @@ import sinonChai from 'sinon-chai';
 import { DatamartBuilder } from '../datamart/datamart-builder/datamart-builder.js';
 import { DatabaseBuilder } from '../db/database-builder/database-builder.js';
 import { datamartKnex, disconnect, knex } from '../db/knex-database-connection.js';
+import { createMaddoServer } from '../server.maddo.js';
 import { PIX_ADMIN } from '../src/authorization/domain/constants.js';
 import * as tutorialRepository from '../src/devcomp/infrastructure/repositories/tutorial-repository.js';
 import * as missionRepository from '../src/school/infrastructure/repositories/mission-repository.js';
@@ -330,10 +331,12 @@ const testErr = new Error('Fake Error');
 export {
   catchErr,
   catchErrSync,
+  createMaddoServer,
   createServerWithTestOidcProvider as createServer,
   createTempFile,
   databaseBuilder,
   datamartBuilder,
+  datamartKnex,
   domainBuilder,
   EMPTY_BLANK_AND_NULL,
   expect,


### PR DESCRIPTION
## :pancakes: Problème

Actuellement, l'équipe data se charge de copier les données dans le datamart en effectuant un dump/restore, ce qui a différentes problématiques : voir l'ADR #11447. 

Nous souhaitons plutôt que l'API Maddo soit en charge de la réplication des données. 

## :bacon: Proposition

Ajouter un webhook qui sera déclenché par l'orchestrateur de l'équipe Data, afin de lancer la réplication d'une table entre le datawarehouse et le datamart.

## 🧃 Remarques

- Dans cette PR le datawarehouse correspond au datamart afin de simplifier la revue en ajoutant pas la complexité de l'ajout d'une nouvelle connexion. 

- Ne peut pas être lancer en prod actuellement car aucun user a le scope 'replication'

- A l'avenir nous passerons surement sur un job pg-boss pour simplifier l'usage et bénéficier du retry

## :yum: Pour tester

- CI OK 