### PR TITLE
[TECH] Déclenche la CI sur les commits de la branche dev.

### DIFF
--- a/.github/workflows/trigger-ci.yaml
+++ b/.github/workflows/trigger-ci.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   trigger-ci:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false && github.event.pull_request.state == 'open'
+    if: (!github.event.pull_request.draft && github.event.pull_request.state == 'open') || github.ref == 'refs/heads/dev'
 
     steps:
       - name: Extract branch name


### PR DESCRIPTION
## :pancakes: Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Les jobs de la CI ne sont pas lancés sur la branche `dev`.

## :bacon: Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

Le filtrage actuel n'autorise que les Pull Requests non draft à déclencher la CI.
On ajoute une condition pour déclencher la CI si la branche courante est la branche `dev`.

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

Au merge de la PR, la CI doit être déclenchée sur la branche `dev`.

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
