### PR TITLE
[TECH] Faire fonctionner l'inspecteur Ember avec ember-source 6.1 (PIX-16664)

### DIFF
--- a/orga/app/app.js
+++ b/orga/app/app.js
@@ -1,8 +1,23 @@
+import { RSVP } from '@ember/-internals/runtime';
 import Application from '@ember/application';
+import * as runtime from '@glimmer/runtime';
+import * as tracking from '@glimmer/tracking';
+import * as validator from '@glimmer/validator';
+import Ember from 'ember';
 import loadInitializers from 'ember-load-initializers';
 import Resolver from 'ember-resolver';
 
 import config from './config/environment';
+
+// This is a temporary solution, see https://github.com/emberjs/ember-inspector/issues/2612
+window.define('@glimmer/tracking', () => tracking);
+window.define('@glimmer/runtime', () => runtime);
+window.define('@glimmer/validator', () => validator);
+window.define('rsvp', () => RSVP);
+window.define('ember', () => ({ default: Ember }));
+window.define('<my-app>/config/environment', () => ({
+  default: config,
+}));
 
 export default class App extends Application {
   modulePrefix = config.modulePrefix;


### PR DESCRIPTION
## :pancakes: Problème

Depuis Ember source 6.1 [l'inspecteur Ember ne fonctionne plus](https://github.com/emberjs/ember-inspector/issues/2612). 

## :bacon: Proposition

Implementer la solution temporaire [proposée ici](https://github.com/emberjs/ember-inspector/issues/2612#issuecomment-2582258343)

## 🧃 Remarques

C'est une solution temporaire, il faut surveiller l'issue pour voir si une solution plus pérenne est proposé à terme. 

## :yum: Pour tester

Verifier que l'inspecteur est de nouveau disponible.