### PR TITLE
[TECH] Ne pas remonter d'erreur à l'utilisateur si les quêtes sont en erreurs (PIX-16706)

### DIFF
--- a/api/src/quest/domain/usecases/get-quest-results-for-campaign-participation.js
+++ b/api/src/quest/domain/usecases/get-quest-results-for-campaign-participation.js
@@ -6,33 +6,39 @@ export const getQuestResultsForCampaignParticipation = async ({
   questRepository,
   eligibilityRepository,
   rewardRepository,
+  logger,
 }) => {
-  const quests = await questRepository.findAll();
+  try {
+    const quests = await questRepository.findAll();
 
-  if (quests.length === 0) {
+    if (quests.length === 0) {
+      return [];
+    }
+
+    const eligibilities = await eligibilityRepository.find({ userId });
+    const dataForQuest = eligibilities
+      .map((eligibility) => new DataForQuest({ eligibility }))
+      .find((dataForQuest) => dataForQuest.hasCampaignParticipation(campaignParticipationId));
+
+    if (!dataForQuest) {
+      return [];
+    }
+
+    const questsRelatedToCampaignParticipation = quests.filter((q) =>
+      q.isCampaignParticipationContributingToQuest({ data: dataForQuest, campaignParticipationId }),
+    );
+
+    const questResults = [];
+    for (const quest of questsRelatedToCampaignParticipation) {
+      const isEligible = quest.isEligible(dataForQuest);
+      if (!isEligible) continue;
+      const questResult = await rewardRepository.getByQuestAndUserId({ userId, quest });
+      questResults.push(questResult);
+    }
+
+    return questResults;
+  } catch (error) {
+    logger.error({ event: 'quest-result' }, error);
     return [];
   }
-
-  const eligibilities = await eligibilityRepository.find({ userId });
-  const dataForQuest = eligibilities
-    .map((eligibility) => new DataForQuest({ eligibility }))
-    .find((dataForQuest) => dataForQuest.hasCampaignParticipation(campaignParticipationId));
-
-  if (!dataForQuest) {
-    return [];
-  }
-
-  const questsRelatedToCampaignParticipation = quests.filter((q) =>
-    q.isCampaignParticipationContributingToQuest({ data: dataForQuest, campaignParticipationId }),
-  );
-
-  const questResults = [];
-  for (const quest of questsRelatedToCampaignParticipation) {
-    const isEligible = quest.isEligible(dataForQuest);
-    if (!isEligible) continue;
-    const questResult = await rewardRepository.getByQuestAndUserId({ userId, quest });
-    questResults.push(questResult);
-  }
-
-  return questResults;
 };

--- a/api/src/quest/domain/usecases/get-quest-results-for-campaign-participation.js
+++ b/api/src/quest/domain/usecases/get-quest-results-for-campaign-participation.js
@@ -38,7 +38,7 @@ export const getQuestResultsForCampaignParticipation = async ({
 
     return questResults;
   } catch (error) {
-    logger.error({ event: 'quest-result' }, error);
+    logger.error({ event: 'quest-result', err: error }, 'Error on quests');
     return [];
   }
 };

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
+import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { repositories } from '../../infrastructure/repositories/index.js';
 
 const path = dirname(fileURLToPath(import.meta.url));
@@ -16,6 +17,7 @@ const dependencies = {
   rewardRepository: repositories.rewardRepository,
   successRepository: repositories.successRepository,
   questRepository: repositories.questRepository,
+  logger,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/quest/domain/usecases/reward-user.js
+++ b/api/src/quest/domain/usecases/reward-user.js
@@ -46,6 +46,6 @@ export const rewardUser = async ({
       }
     }
   } catch (error) {
-    logger.error({ event: 'quest-reward' }, error);
+    logger.error({ event: 'quest-reward', err: error }, 'Error on quests');
   }
 };

--- a/api/src/quest/domain/usecases/reward-user.js
+++ b/api/src/quest/domain/usecases/reward-user.js
@@ -6,41 +6,46 @@ export const rewardUser = async ({
   eligibilityRepository,
   successRepository,
   rewardRepository,
+  logger,
 }) => {
-  if (!userId) {
-    return;
-  }
-  const quests = await questRepository.findAll();
+  try {
+    if (!userId) {
+      return;
+    }
+    const quests = await questRepository.findAll();
 
-  if (quests.length === 0) {
-    return;
-  }
-
-  const eligibilities = await eligibilityRepository.find({ userId });
-  const rewards = await rewardRepository.getByUserId({ userId });
-
-  const rewardIds = rewards.map((reward) => reward.rewardId);
-
-  for (const quest of quests) {
-    const dataForQuest = eligibilities
-      .map((eligibility) => new DataForQuest({ eligibility }))
-      .find((dataForQuest) => quest.isEligible(dataForQuest));
-
-    if (!dataForQuest) {
-      continue;
+    if (quests.length === 0) {
+      return;
     }
 
-    if (rewardIds.includes(quest.rewardId)) {
-      continue;
-    }
+    const eligibilities = await eligibilityRepository.find({ userId });
+    const rewards = await rewardRepository.getByUserId({ userId });
 
-    const success = await successRepository.find({ userId });
-    dataForQuest.success = success;
-    const userHasSucceedQuest = quest.isSuccessful(dataForQuest);
+    const rewardIds = rewards.map((reward) => reward.rewardId);
 
-    if (userHasSucceedQuest) {
-      await rewardRepository.reward({ userId, rewardId: quest.rewardId });
-      rewardIds.push(quest.rewardId);
+    for (const quest of quests) {
+      const dataForQuest = eligibilities
+        .map((eligibility) => new DataForQuest({ eligibility }))
+        .find((dataForQuest) => quest.isEligible(dataForQuest));
+
+      if (!dataForQuest) {
+        continue;
+      }
+
+      if (rewardIds.includes(quest.rewardId)) {
+        continue;
+      }
+
+      const success = await successRepository.find({ userId });
+      dataForQuest.success = success;
+      const userHasSucceedQuest = quest.isSuccessful(dataForQuest);
+
+      if (userHasSucceedQuest) {
+        await rewardRepository.reward({ userId, rewardId: quest.rewardId });
+        rewardIds.push(quest.rewardId);
+      }
     }
+  } catch (error) {
+    logger.error({ event: 'quest-reward' }, error);
   }
 };

--- a/api/tests/quest/unit/domain/usecases/get-quest-results-for-campaign-participation_test.js
+++ b/api/tests/quest/unit/domain/usecases/get-quest-results-for-campaign-participation_test.js
@@ -9,11 +9,12 @@ import { getQuestResultsForCampaignParticipation } from '../../../../../src/ques
 import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Domain | Usecases | getQuestResultsForCampaignParticipation', function () {
-  let questRepository, eligibilityRepository, rewardRepository, campaignParticipationId, userId;
+  let questRepository, eligibilityRepository, rewardRepository, campaignParticipationId, userId, logger;
 
   beforeEach(function () {
     userId = 1;
     campaignParticipationId = 2;
+    logger = { error: sinon.stub() };
     questRepository = { findAll: sinon.stub() };
     eligibilityRepository = { find: sinon.stub() };
     rewardRepository = { getByQuestAndUserId: sinon.stub() };
@@ -111,5 +112,22 @@ describe('Quest | Unit | Domain | Usecases | getQuestResultsForCampaignParticipa
 
     // then
     expect(result).to.have.lengthOf(0);
+  });
+
+  it('ensure that quest system does not throw error', async function () {
+    const error = new Error('my error');
+    questRepository.findAll.throws(error);
+
+    const result = await getQuestResultsForCampaignParticipation({
+      userId,
+      campaignParticipationId,
+      questRepository,
+      eligibilityRepository,
+      rewardRepository,
+      logger,
+    });
+
+    expect(logger.error).have.been.calledWithExactly({ event: 'quest-result' }, error);
+    expect(result).lengthOf(0);
   });
 });

--- a/api/tests/quest/unit/domain/usecases/get-quest-results-for-campaign-participation_test.js
+++ b/api/tests/quest/unit/domain/usecases/get-quest-results-for-campaign-participation_test.js
@@ -127,7 +127,7 @@ describe('Quest | Unit | Domain | Usecases | getQuestResultsForCampaignParticipa
       logger,
     });
 
-    expect(logger.error).have.been.calledWithExactly({ event: 'quest-result' }, error);
+    expect(logger.error).have.been.calledWithExactly({ event: 'quest-result', err: error }, 'Error on quests');
     expect(result).lengthOf(0);
   });
 });

--- a/api/tests/quest/unit/domain/usecases/reward-user_test.js
+++ b/api/tests/quest/unit/domain/usecases/reward-user_test.js
@@ -136,6 +136,6 @@ describe('Quest | Unit | Domain | Usecases | RewardUser', function () {
       ...dependencies,
     });
 
-    expect(logger.error).have.been.calledWithExactly({ event: 'quest-reward' }, error);
+    expect(logger.error).have.been.calledWithExactly({ event: 'quest-reward', err: error }, 'Error on quests');
   });
 });

--- a/api/tests/quest/unit/domain/usecases/reward-user_test.js
+++ b/api/tests/quest/unit/domain/usecases/reward-user_test.js
@@ -9,12 +9,17 @@ describe('Quest | Unit | Domain | Usecases | RewardUser', function () {
   let rewardRepository;
 
   let dependencies;
+  let logger;
 
   beforeEach(function () {
     userId = 1;
 
     questRepository = {
       findAll: sinon.stub(),
+    };
+
+    logger = {
+      error: sinon.stub(),
     };
 
     eligibilityRepository = {
@@ -30,6 +35,7 @@ describe('Quest | Unit | Domain | Usecases | RewardUser', function () {
       eligibilityRepository,
       successRepository,
       rewardRepository,
+      logger,
     };
   });
 
@@ -119,5 +125,17 @@ describe('Quest | Unit | Domain | Usecases | RewardUser', function () {
       });
       expect(successRepository.find).to.not.have.been.called;
     });
+  });
+
+  it('ensure that quest system does not throw error', async function () {
+    const error = new Error('my error');
+    dependencies.questRepository.findAll.throws(error);
+
+    await rewardUser({
+      userId,
+      ...dependencies,
+    });
+
+    expect(logger.error).have.been.calledWithExactly({ event: 'quest-reward' }, error);
   });
 });


### PR DESCRIPTION
## :pancakes: Problème

Actuellement, si les quêtes sont mal configurés ou que quelque chose, quelque part dans l'univers tourne mal, les utilisateurs sont coupés dans leur élan de la course au Pix

## :bacon: Proposition

Faire en sorte que le usecase remonte une erreur dans le logger, sans perturber la vie paisible de nos usagers ( palam palam )

## 🧃 Remarques

RAS

## :yum: Pour tester

CI au vert, modifier la config des quêtes pour faire tout casser. et vérifier que le log part mais que l'usager reste :) 