### PR TITLE
[FEATURE] PixAdmin : pouvoir dupliquer les contenus formatifs (PIX-16670)(PIX-16075)

### DIFF
--- a/admin/app/adapters/training.js
+++ b/admin/app/adapters/training.js
@@ -19,4 +19,9 @@ export default class TrainingAdapter extends ApplicationAdapter {
     const url = `${this.host}/${this.namespace}/trainings/${trainingId}/target-profiles/${targetProfileId}`;
     return this.ajax(url, 'DELETE');
   }
+
+  async duplicate(trainingId) {
+    const url = `${this.host}/${this.namespace}/trainings/${trainingId}/duplicate`;
+    return this.ajax(url, 'POST');
+  }
 }

--- a/admin/app/components/trainings/duplicate-training.gjs
+++ b/admin/app/components/trainings/duplicate-training.gjs
@@ -1,0 +1,50 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+
+export default class DuplicateTraining extends Component {
+  @tracked showModal = false;
+
+  @action
+  closeModal() {
+    this.showModal = false;
+  }
+
+  @action
+  openModal() {
+    this.showModal = true;
+  }
+
+  @action
+  validateDuplication() {
+    this.args.onSubmit();
+    this.showModal = false;
+  }
+
+  <template>
+    <PixButton @size="small" @variant="primary" @triggerAction={{this.openModal}}>{{t
+        "pages.trainings.training.duplicate.button.label"
+      }}
+    </PixButton>
+    <PixModal
+      @title={{t "pages.trainings.training.duplicate.modal.title"}}
+      @showModal={{this.showModal}}
+      @onCloseButtonClick={{this.closeModal}}
+    >
+      <:content>
+        <p>
+          {{t "pages.trainings.training.duplicate.modal.instruction"}}
+        </p>
+      </:content>
+      <:footer>
+        <PixButton @variant="secondary" @isBorderVisible={{true}} @triggerAction={{this.closeModal}}>
+          {{t "common.actions.cancel"}}
+        </PixButton>
+        <PixButton @triggerAction={{this.validateDuplication}}>{{t "common.actions.validate"}}</PixButton>
+      </:footer>
+    </PixModal>
+  </template>
+}

--- a/admin/app/controllers/authenticated/trainings/training.js
+++ b/admin/app/controllers/authenticated/trainings/training.js
@@ -31,4 +31,14 @@ export default class Training extends Controller {
       this.pixToast.sendErrorNotification({ message: 'Une erreur est survenue.' });
     }
   }
+
+  @action
+  triggerDuplication() {
+    this.showModal = true;
+  }
+
+  @action
+  closeModal() {
+    this.showModal = false;
+  }
 }

--- a/admin/app/controllers/authenticated/trainings/training.js
+++ b/admin/app/controllers/authenticated/trainings/training.js
@@ -4,8 +4,11 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class Training extends Controller {
+  @service store;
   @service pixToast;
   @service accessControl;
+  @service router;
+  @service intl;
 
   @tracked isEditMode = false;
 
@@ -33,12 +36,23 @@ export default class Training extends Controller {
   }
 
   @action
-  triggerDuplication() {
-    this.showModal = true;
+  async duplicateTraining() {
+    try {
+      const adapter = this.store.adapterFor('training');
+      const { trainingId: newTrainingId } = await adapter.duplicate(this.model.id);
+      this.goToNewTrainingDetails(newTrainingId);
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('pages.trainings.training.duplicate.notifications.success'),
+      });
+    } catch (error) {
+      error.errors.forEach((apiError) => {
+        this.pixToast.sendErrorNotification({ message: apiError.detail });
+      });
+    }
   }
 
   @action
-  closeModal() {
-    this.showModal = false;
+  goToNewTrainingDetails(newTrainingId) {
+    this.router.transitionTo('authenticated.trainings.training', newTrainingId);
   }
 }

--- a/admin/app/styles/components/trainings/training-details-card.scss
+++ b/admin/app/styles/components/trainings/training-details-card.scss
@@ -32,4 +32,10 @@
     width: 100%;
     height: 100%;
   }
+
+  &__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+  }
 }

--- a/admin/app/templates/authenticated/trainings/training.hbs
+++ b/admin/app/templates/authenticated/trainings/training.hbs
@@ -35,15 +35,11 @@
     {{else}}
       <Trainings::TrainingDetailsCard @training={{@model}} />
       {{#if this.canEdit}}
-      <div class="training-details-card__actions">
-        <PixButton @size="small" @variant="secondary" @triggerAction={{this.toggleEditMode}}>Modifier
-        </PixButton>
-        <Trainings::DuplicateTraining
-          @isOpen={{this.showModal}}
-          @onClose={{this.closeModal}}
-          @onDuplicate={{this.triggerDuplication}}>
-        </Trainings::DuplicateTraining>
-      </div>
+        <div class="training-details-card__actions">
+          <PixButton @size="small" @variant="secondary" @triggerAction={{this.toggleEditMode}}>Modifier
+          </PixButton>
+          <Trainings::DuplicateTraining @onSubmit={{this.duplicateTraining}} />
+        </div>
       {{/if}}
     {{/if}}
   </section>

--- a/admin/app/templates/authenticated/trainings/training.hbs
+++ b/admin/app/templates/authenticated/trainings/training.hbs
@@ -38,8 +38,11 @@
       <div class="training-details-card__actions">
         <PixButton @size="small" @variant="secondary" @triggerAction={{this.toggleEditMode}}>Modifier
         </PixButton>
-        <PixButton @size="small" @variant="primary" @triggerAction={{this.triggerDuplication}}>Dupliquer ce contenu formatif
-        </PixButton>
+        <Trainings::DuplicateTraining
+          @isOpen={{this.showModal}}
+          @onClose={{this.closeModal}}
+          @onDuplicate={{this.triggerDuplication}}>
+        </Trainings::DuplicateTraining>
       </div>
       {{/if}}
     {{/if}}

--- a/admin/app/templates/authenticated/trainings/training.hbs
+++ b/admin/app/templates/authenticated/trainings/training.hbs
@@ -35,8 +35,12 @@
     {{else}}
       <Trainings::TrainingDetailsCard @training={{@model}} />
       {{#if this.canEdit}}
+      <div class="training-details-card__actions">
         <PixButton @size="small" @variant="secondary" @triggerAction={{this.toggleEditMode}}>Modifier
         </PixButton>
+        <PixButton @size="small" @variant="primary" @triggerAction={{this.triggerDuplication}}>Dupliquer ce contenu formatif
+        </PixButton>
+      </div>
       {{/if}}
     {{/if}}
   </section>

--- a/admin/app/templates/authenticated/trainings/training.hbs
+++ b/admin/app/templates/authenticated/trainings/training.hbs
@@ -36,7 +36,7 @@
       <Trainings::TrainingDetailsCard @training={{@model}} />
       {{#if this.canEdit}}
         <div class="training-details-card__actions">
-          <PixButton @size="small" @variant="secondary" @triggerAction={{this.toggleEditMode}}>Modifier
+          <PixButton @size="small" @variant="primary" @triggerAction={{this.toggleEditMode}}>{{t "common.actions.edit"}}
           </PixButton>
           <Trainings::DuplicateTraining @onSubmit={{this.duplicateTraining}} />
         </div>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -49,6 +49,7 @@ import {
   createOrUpdateTrainingTrigger,
   createTraining,
   detachTargetProfileFromTraining,
+  duplicateTraining,
   findPaginatedTrainingSummaries,
   getTargetProfileSummariesForTraining,
   getTraining,
@@ -398,6 +399,7 @@ function routes() {
   this.post('/admin/trainings/:id/attach-target-profiles', attachTargetProfilesToTraining);
   this.delete('/admin/trainings/:trainingId/target-profiles/:targetProfileId', detachTargetProfileFromTraining);
   this.put('/admin/trainings/:id/triggers', createOrUpdateTrainingTrigger);
+  this.post('/admin/trainings/:id/duplicate', duplicateTraining);
 
   this.get('/admin/certifications/:id');
   this.get('/admin/certifications/:id/certified-profile', (schema, request) => {

--- a/admin/mirage/handlers/trainings.js
+++ b/admin/mirage/handlers/trainings.js
@@ -134,11 +134,24 @@ function createOrUpdateTrainingTrigger(schema, request) {
   return trainingTrigger;
 }
 
+function duplicateTraining(schema, request) {
+  const trainingId = request.params.id;
+  const training = schema.trainings.find(trainingId);
+  delete training.attrs.id;
+
+  const { id } = schema.create('training', {
+    ...training.attrs,
+    internalTitle: '[Copie] ' + training.attrs.internalTitle,
+  });
+  return { trainingId: id };
+}
+
 export {
   attachTargetProfilesToTraining,
   createOrUpdateTrainingTrigger,
   createTraining,
   detachTargetProfileFromTraining,
+  duplicateTraining,
   findPaginatedTrainingSummaries,
   getTargetProfileSummariesForTraining,
   getTraining,

--- a/admin/tests/acceptance/authenticated/trainings/training-test.js
+++ b/admin/tests/acceptance/authenticated/trainings/training-test.js
@@ -180,10 +180,18 @@ module('Acceptance | Trainings | Training', function (hooks) {
         await visit(`/trainings/${trainingId}`);
 
         // when
-        const duplicateButton = await screen.getByRole('button', { name: 'Dupliquer ce contenu formatif' });
+        await clickByName('Dupliquer ce contenu formatif');
+        await screen.findByRole('button', { name: 'Valider' });
+        await clickByName('Valider');
 
         // then
-        assert.dom(duplicateButton).exists();
+        assert.strictEqual(currentURL(), '/trainings/3/details');
+        const title = await screen.findByRole('heading', {
+          name: `[Copie] Apprendre à piloter des chauves-souris comme Batman`,
+          level: 1,
+        });
+        assert.dom(title).exists();
+        assert.strictEqual(currentURL(), '/trainings/3/triggers');
       });
     });
 

--- a/admin/tests/acceptance/authenticated/trainings/training-test.js
+++ b/admin/tests/acceptance/authenticated/trainings/training-test.js
@@ -185,7 +185,6 @@ module('Acceptance | Trainings | Training', function (hooks) {
         await clickByName('Valider');
 
         // then
-        assert.strictEqual(currentURL(), '/trainings/3/details');
         const title = await screen.findByRole('heading', {
           name: `[Copie] Apprendre à piloter des chauves-souris comme Batman`,
           level: 1,

--- a/admin/tests/acceptance/authenticated/trainings/training-test.js
+++ b/admin/tests/acceptance/authenticated/trainings/training-test.js
@@ -173,6 +173,18 @@ module('Acceptance | Trainings | Training', function (hooks) {
         // then
         assert.dom(screen.getByRole('heading', { name: 'Mon titre interne' })).exists();
       });
+
+      test('should be possible to duplicate displayed training', async function (assert) {
+        // given
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+        await visit(`/trainings/${trainingId}`);
+
+        // when
+        const duplicateButton = await screen.getByRole('button', { name: 'Dupliquer ce contenu formatif' });
+
+        // then
+        assert.dom(duplicateButton).exists();
+      });
     });
 
     module('when admin role is "SUPPORT', function () {

--- a/admin/tests/integration/components/trainings/duplicate-training-test.gjs
+++ b/admin/tests/integration/components/trainings/duplicate-training-test.gjs
@@ -1,0 +1,38 @@
+import { clickByText, render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import DuplicateTraining from 'pix-admin/components/trainings/duplicate-training';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Trainings | Duplicate training', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  const duplicateTraining = sinon.stub().resolves(true);
+
+  test('it should render the duplicate training modal', async function (assert) {
+    // when
+    const screen = await render(<template><DuplicateTraining @onSubmit={{duplicateTraining}} /></template>);
+    const duplicateButton = screen.getByRole('button', { name: 'Dupliquer ce contenu formatif' });
+    await click(duplicateButton);
+
+    // then
+    assert.dom(await screen.findByText('Dupliquer le contenu formatif ?')).exists();
+    assert.dom(screen.getByText('Cette action dupliquera le contenu formatif avec ses déclencheurs.')).exists();
+    assert.dom(await screen.findByRole('button', { name: 'Valider' })).exists();
+    assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
+    assert.dom(screen.getByRole('button', { name: 'Fermer' })).exists();
+  });
+
+  test('it should call the duplicate method on click on submit', async function (assert) {
+    await render(<template><DuplicateTraining @onSubmit={{duplicateTraining}} /></template>);
+
+    // when
+    await clickByText('Valider');
+
+    // then
+    sinon.assert.calledOnce(duplicateTraining);
+    assert.ok(true);
+  });
+});

--- a/admin/tests/unit/adapters/training-test.js
+++ b/admin/tests/unit/adapters/training-test.js
@@ -44,4 +44,19 @@ module('Unit | Adapter | Training ', function (hooks) {
       assert.ok(true);
     });
   });
+  module('#duplicate', function () {
+    test('should trigger an ajax call with the right url and method', async function (assert) {
+      // given
+      const trainingId = 1;
+      sinon.stub(adapter, 'ajax').resolves();
+      const expectedUrl = `http://localhost:3000/api/admin/trainings/${trainingId}/duplicate`;
+
+      // when
+      await adapter.duplicate(trainingId);
+
+      // then
+      sinon.assert.calledWith(adapter.ajax, expectedUrl, 'POST');
+      assert.ok(true);
+    });
+  });
 });

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -848,6 +848,18 @@
           "status": "Statut :",
           "title": "Titre public :"
         },
+        "duplicate": {
+          "button": {
+            "label": "Dupliquer ce contenu formatif"
+          },
+          "modal": {
+            "instruction": "Cette action dupliquera le contenu formatif avec ses déclencheurs.",
+            "title": "Dupliquer le contenu formatif ?"
+          },
+          "notifications": {
+            "success": "Le contenu formatif a bien été dupliqué !"
+          }
+        },
         "list": {
           "caption": "Liste des contenus formatifs",
           "goalThreshold": "Objectif à ne pas dépasser",

--- a/api/src/devcomp/infrastructure/repositories/training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/training-repository.js
@@ -133,6 +133,9 @@ async function findWithTriggersByCampaignParticipationIdAndLocale({ campaignPart
 
 async function create({ training }) {
   const knexConn = DomainTransaction.getConnection();
+  if (typeof training.duration !== 'string') {
+    training.duration = _transformDurationFormat(training.duration);
+  }
   const pickedAttributes = pick(training, [
     'title',
     'internalTitle',
@@ -184,6 +187,10 @@ async function findPaginatedByUserId({ userId, locale, page }) {
     (userRecommendedTraining) => new UserRecommendedTraining(userRecommendedTraining),
   );
   return { userRecommendedTrainings, pagination };
+}
+
+function _transformDurationFormat(durationObject) {
+  return `${durationObject.days ?? 0}d${durationObject.hours ?? 0}h${durationObject.minutes ?? 0}m${durationObject.seconds ?? 0}s`;
 }
 
 export {

--- a/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
@@ -616,6 +616,33 @@ describe('Integration | Repository | training-repository', function () {
       expect(createdTraining.id).to.exist;
       expect(createdTraining).to.deep.include({ ...training, duration: { hours: 6 } });
     });
+
+    it('should handle other duration‘s format', async function () {
+      // given
+      const training = {
+        title: 'Titre du training',
+        internalTitle: 'Titre interne du training',
+        link: 'https://training-link.org',
+        type: 'webinaire',
+        duration: {
+          hours: 5,
+          minutes: 30,
+        },
+        locale: 'fr',
+        editorName: 'Un ministère',
+        editorLogoUrl: 'https://mon-logo.svg',
+      };
+
+      // when
+      const createdTraining = await trainingRepository.create({
+        training,
+      });
+
+      // then
+      expect(createdTraining).to.be.instanceOf(TrainingForAdmin);
+      expect(createdTraining.id).to.exist;
+      expect(createdTraining).to.deep.include({ ...training, duration: { hours: 5, minutes: 30 } });
+    });
   });
 
   describe('#update', function () {


### PR DESCRIPTION
## :pancakes: Problème

Aujourd'hui, on ne peut pas dupliquer un contenu formatif depuis PixAdmin. Il faut le recréer entièrement.

## :bacon: Proposition

Ajouter un bouton "Dupliquer ce contenu formatif" sur le détail d'un CF, à l'image du bouton "Dupliquer ce profil cible" sur la page détails d'un PC.
Une modale doit s'ouvrir pour confirmer la duplication.
On veut afficher ensuite la page d'édition du nouveau CF créé. Si pas possible, afficher la page de détails du nouveau CF.

## 🧃 Remarques

- Je me demande si c'est judicieux que la route `POST trainings/:id/duplicate` renvoie un objet `trainingId` plutôt que directement la valeur de l'id du nouveau contenu formatif

## :yum: Pour tester

- Se connecter dans PixAdmin
- [Aller sur la page de détails](https://admin-pr11504.review.pix.fr/trainings/5000/triggers) de n'importe quel contenu formatif
- Cliquer sur "Dupliquer ce contenu formatif"
- Vérifier que la modale s'ouvre. Si oui, cliquer sur "Valider"
- La modale disparaît. Une pop-up en bas à droite indique si la duplication a réussi ou non
- La page de détails du CF dupliqué s'affiche à l'écran.