### PR TITLE
[FEATURE] Enregistrer la date de dernière connexion Pix par application pour les méthodes de connexion OIDC (PIX-16623)

### DIFF
--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.admin.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.admin.controller.js
@@ -3,7 +3,7 @@ import { PIX_ADMIN } from '../../../authorization/domain/constants.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { usecases } from '../../domain/usecases/index.js';
 import * as oidcProviderSerializer from '../../infrastructure/serializers/jsonapi/oidc-identity-providers.serializer.js';
-import { getForwardedOrigin } from '../../infrastructure/utils/network.js';
+import { getForwardedOrigin, RequestedApplication } from '../../infrastructure/utils/network.js';
 
 /**
  * @param request
@@ -45,6 +45,7 @@ async function reconcileUserForAdmin(
 ) {
   const { email, identityProvider, authenticationKey } = request.deserializedPayload;
   const origin = getForwardedOrigin(request.headers);
+  const requestedApplication = RequestedApplication.fromOrigin(origin);
 
   await dependencies.oidcAuthenticationServiceRegistry.loadOidcProviderServices();
   await dependencies.oidcAuthenticationServiceRegistry.configureReadyOidcProviderServiceByCode(identityProvider);
@@ -60,6 +61,7 @@ async function reconcileUserForAdmin(
     authenticationKey,
     oidcAuthenticationService,
     audience: origin,
+    requestedApplication,
   });
 
   return h.response({ access_token: accessToken }).code(200);

--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
@@ -62,6 +62,7 @@ async function createUser(request, h, dependencies = { requestResponseUtils }) {
   const localeFromCookie = request.state?.locale;
   const language = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
   const origin = getForwardedOrigin(request.headers);
+  const requestedApplication = RequestedApplication.fromOrigin(origin);
 
   const { accessToken: access_token, logoutUrlUUID: logout_url_uuid } = await usecases.createOidcUser({
     authenticationKey,
@@ -69,6 +70,7 @@ async function createUser(request, h, dependencies = { requestResponseUtils }) {
     localeFromCookie,
     language,
     audience: origin,
+    requestedApplication,
   });
 
   return h.response({ access_token, logout_url_uuid }).code(200);

--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
@@ -3,7 +3,7 @@ import { requestResponseUtils } from '../../../shared/infrastructure/utils/reque
 import { usecases } from '../../domain/usecases/index.js';
 import * as oidcProviderSerializer from '../../infrastructure/serializers/jsonapi/oidc-identity-providers.serializer.js';
 import * as oidcSerializer from '../../infrastructure/serializers/jsonapi/oidc-serializer.js';
-import { getForwardedOrigin } from '../../infrastructure/utils/network.js';
+import { getForwardedOrigin, RequestedApplication } from '../../infrastructure/utils/network.js';
 
 /**
  * @typedef {function} authenticateOidcUser
@@ -152,11 +152,13 @@ async function reconcileUser(request, h) {
   const { identityProvider, authenticationKey } = request.deserializedPayload;
 
   const origin = getForwardedOrigin(request.headers);
+  const requestedApplication = RequestedApplication.fromOrigin(origin);
 
   const result = await usecases.reconcileOidcUser({
     authenticationKey,
     identityProvider,
     audience: origin,
+    requestedApplication,
   });
 
   return h.response({ access_token: result.accessToken, logout_url_uuid: result.logoutUrlUUID }).code(200);

--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
@@ -14,6 +14,7 @@ import { getForwardedOrigin, RequestedApplication } from '../../infrastructure/u
 async function authenticateOidcUser(request, h) {
   const { code, state, iss, identityProvider: identityProviderCode, target } = request.deserializedPayload;
   const origin = getForwardedOrigin(request.headers);
+  const requestedApplication = RequestedApplication.fromOrigin(origin);
 
   const sessionState = request.yar.get('state', true);
   const nonce = request.yar.get('nonce', true);
@@ -32,6 +33,7 @@ async function authenticateOidcUser(request, h) {
     nonce,
     sessionState,
     audience: origin,
+    requestedApplication,
   });
 
   if (result.isAuthenticationComplete) {

--- a/api/src/identity-access-management/domain/usecases/create-oidc-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/create-oidc-user.usecase.js
@@ -13,6 +13,8 @@ import { UserToCreate } from '../models/UserToCreate.js';
  *   authenticationMethodRepository: AuthenticationMethodRepository,
  *   userToCreateRepository: UserToCreateRepository,
  *   userLoginRepository: UserLoginRepository,
+ *   lastUserApplicationConnectionsRepository: LastUserApplicationConnectionsRepository,
+ *   requestedApplication: RequestedApplication,
  * }} params
  * @return {Promise<{accessToken: string, logoutUrlUUID: string}>}
  */
@@ -27,6 +29,8 @@ async function createOidcUser({
   authenticationMethodRepository,
   userToCreateRepository,
   userLoginRepository,
+  lastUserApplicationConnectionsRepository,
+  requestedApplication,
 }) {
   const sessionContentAndUserInfo = await authenticationSessionService.getByKey(authenticationKey);
   if (!sessionContentAndUserInfo) {
@@ -77,6 +81,11 @@ async function createOidcUser({
   }
 
   await userLoginRepository.updateLastLoggedAt({ userId });
+  await lastUserApplicationConnectionsRepository.upsert({
+    userId,
+    application: requestedApplication.applicationName,
+    lastLoggedAt: new Date(),
+  });
 
   return { accessToken, logoutUrlUUID };
 }

--- a/api/src/identity-access-management/domain/usecases/index.js
+++ b/api/src/identity-access-management/domain/usecases/index.js
@@ -33,6 +33,7 @@ import { emailValidationDemandRepository } from '../../infrastructure/repositori
 import { eventLoggingJobRepository } from '../../infrastructure/repositories/jobs/event-logging-job.repository.js';
 import { garAnonymizedBatchEventsLoggingJobRepository } from '../../infrastructure/repositories/jobs/gar-anonymized-batch-events-logging-job-repository.js';
 import { userAnonymizedEventLoggingJobRepository } from '../../infrastructure/repositories/jobs/user-anonymized-event-logging-job-repository.js';
+import { lastUserApplicationConnectionsRepository } from '../../infrastructure/repositories/last-user-application-connections.repository.js';
 import { legalDocumentApiRepository } from '../../infrastructure/repositories/legal-document-api.repository.js';
 import { oidcProviderRepository } from '../../infrastructure/repositories/oidc-provider-repository.js';
 import * as privacyUsersApiRepository from '../../infrastructure/repositories/privacy-users-api.repository.js';
@@ -64,6 +65,7 @@ const repositories = {
   emailValidationDemandRepository,
   emailRepository,
   eventLoggingJobRepository,
+  lastUserApplicationConnectionsRepository,
   legalDocumentApiRepository,
   membershipRepository,
   oidcProviderRepository,

--- a/api/src/identity-access-management/infrastructure/repositories/last-user-application-connections.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/last-user-application-connections.repository.js
@@ -1,0 +1,14 @@
+import { knex } from '../../../../db/knex-database-connection.js';
+const TABLE_NAME = 'last-user-application-connections';
+
+async function upsert({ userId, application, lastLoggedAt }) {
+  const existingConnection = await knex(TABLE_NAME).where({ userId, application }).first();
+
+  if (existingConnection) {
+    return knex(TABLE_NAME).where({ userId, application }).update({ lastLoggedAt });
+  }
+
+  return knex(TABLE_NAME).insert({ userId, application, lastLoggedAt });
+}
+
+export const lastUserApplicationConnectionsRepository = { upsert };

--- a/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
@@ -185,12 +185,14 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
             lastName: 'Doe',
           },
         };
+        const headers = generateAuthenticatedUserRequestHeaders();
+        headers.cookie = cookies[0];
 
         // when
         const response = await server.inject({
           method: 'POST',
           url: '/api/oidc/token',
-          headers: { cookie: cookies[0] },
+          headers,
           payload,
         });
 
@@ -331,11 +333,14 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
           // const getAccessTokenRequest = nock(settings.poleEmploi.tokenUrl).post('/').reply(200, getAccessTokenResponse);
           oidcExampleNetProvider.client.callback.resolves(getAccessTokenResponse);
 
+          const headers = generateAuthenticatedUserRequestHeaders();
+          headers.cookie = cookies[0];
+
           // when
           const response = await server.inject({
             method: 'POST',
             url: '/api/oidc/token',
-            headers: { cookie: cookies[0] },
+            headers,
             payload,
           });
 

--- a/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
@@ -505,6 +505,7 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
         const request = {
           method: 'POST',
           url: '/api/oidc/users',
+          headers: generateAuthenticatedUserRequestHeaders(),
           payload: {
             data: {
               attributes: {

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/last-user-application-connections.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/last-user-application-connections.repository.test.js
@@ -1,0 +1,73 @@
+import { lastUserApplicationConnectionsRepository } from '../../../../../src/identity-access-management/infrastructure/repositories/last-user-application-connections.repository.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Integration | Identity Access Management | Infrastructure | Repository | last-user-application-connections', function () {
+  describe('#upsert', function () {
+    it('saves a last user application connection', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const application = 'orga';
+      const lastLoggedAt = new Date();
+      await databaseBuilder.commit();
+
+      // when
+      await lastUserApplicationConnectionsRepository.upsert({
+        userId,
+        application,
+        lastLoggedAt,
+      });
+
+      // then
+      const lastUserApplicationConnections = await databaseBuilder
+        .knex('last-user-application-connections')
+        .where({ userId, application })
+        .first();
+
+      expect(lastUserApplicationConnections).to.deep.equal({
+        id: lastUserApplicationConnections.id,
+        userId,
+        application,
+        lastLoggedAt,
+      });
+    });
+
+    context('when the last user application connection already exists', function () {
+      it('updates the last user application connection', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const application = 'orga';
+        const formerLastLoggedAt = new Date('2021-01-01');
+        const newLastLoggedAt = new Date('2021-01-02');
+        await databaseBuilder.commit();
+
+        await databaseBuilder.knex('last-user-application-connections').insert({
+          userId,
+          application,
+          lastLoggedAt: formerLastLoggedAt,
+        });
+
+        // when
+        await lastUserApplicationConnectionsRepository.upsert({
+          userId,
+          application,
+          lastLoggedAt: newLastLoggedAt,
+        });
+
+        // then
+        const lastUserApplicationConnections = await databaseBuilder
+          .knex('last-user-application-connections')
+          .where({ userId, application });
+
+        expect(lastUserApplicationConnections).to.have.lengthOf(1);
+        expect(lastUserApplicationConnections).to.deep.equal([
+          {
+            id: lastUserApplicationConnections[0].id,
+            userId,
+            application,
+            lastLoggedAt: newLastLoggedAt,
+          },
+        ]);
+      });
+    });
+  });
+});

--- a/api/tests/identity-access-management/unit/application/oidc-provider.admin.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/oidc-provider.admin.controller.test.js
@@ -1,5 +1,6 @@
 import { oidcProviderAdminController } from '../../../../src/identity-access-management/application/oidc-provider/oidc-provider.admin.controller.js';
 import { usecases } from '../../../../src/identity-access-management/domain/usecases/index.js';
+import { RequestedApplication } from '../../../../src/identity-access-management/infrastructure/utils/network.js';
 import { DomainTransaction } from '../../../../src/shared/domain/DomainTransaction.js';
 import { expect, hFake, sinon } from '../../../test-helper.js';
 
@@ -180,11 +181,22 @@ describe('Unit | Identity Access Management | Application | Controller | Admin |
           email: 'user@example.net',
         },
       };
+      const requestedApplication = new RequestedApplication('admin');
 
       const dependencies = {
         oidcAuthenticationServiceRegistry: oidcAuthenticationServiceRegistryStub,
       };
-      sinon.stub(usecases, 'reconcileOidcUserForAdmin').resolves('accessToken');
+      sinon
+        .stub(usecases, 'reconcileOidcUserForAdmin')
+        .withArgs({
+          email: 'user@example.net',
+          identityProvider,
+          authenticationKey: '123abc',
+          audience: 'https://admin.pix.fr',
+          requestedApplication,
+          oidcAuthenticationService: sinon.match.any,
+        })
+        .resolves('accessToken');
 
       // when
       const result = await oidcProviderAdminController.reconcileUserForAdmin(request, hFake, dependencies);

--- a/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
@@ -149,6 +149,7 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
         localeFromCookie: 'fr-FR',
         language: 'fr',
         audience: 'https://app.pix.fr',
+        requestedApplication: new RequestedApplication('app'),
       });
       expect(response.statusCode).to.equal(200);
       expect(response.source).to.deep.equal({

--- a/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
@@ -1,5 +1,6 @@
 import { oidcProviderController } from '../../../../src/identity-access-management/application/oidc-provider/oidc-provider.controller.js';
 import { usecases } from '../../../../src/identity-access-management/domain/usecases/index.js';
+import { RequestedApplication } from '../../../../src/identity-access-management/infrastructure/utils/network.js';
 import { BadRequestError, UnauthorizedError } from '../../../../src/shared/application/http-errors.js';
 import { catchErr, domainBuilder, expect, hFake, sinon } from '../../../test-helper.js';
 
@@ -322,6 +323,7 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
           authenticationKey: '123abc',
         },
       };
+      const requestedApplication = new RequestedApplication('app');
 
       sinon.stub(usecases, 'reconcileOidcUser').resolves({
         accessToken: 'accessToken',
@@ -336,6 +338,7 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
         authenticationKey: '123abc',
         identityProvider: 'OIDC',
         audience: 'https://app.pix.fr',
+        requestedApplication,
       });
       expect(result.source).to.deep.equal({ access_token: 'accessToken', logout_url_uuid: 'logoutUrlUUID' });
     });

--- a/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
@@ -14,6 +14,7 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
     const identityProvider = 'OIDC_EXAMPLE_NET';
     const pixAccessToken = 'pixAccessToken';
     const audience = 'https://app.pix.fr';
+    const requestedApplication = new RequestedApplication('app');
 
     let request;
 
@@ -60,6 +61,7 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
         state: identityProviderState,
         iss,
         audience,
+        requestedApplication,
       });
       expect(request.yar.commit).to.have.been.calledOnce;
     });

--- a/api/tests/identity-access-management/unit/domain/usecases/authenticate-oidc-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/authenticate-oidc-user.usecase.test.js
@@ -2,6 +2,7 @@ import * as appMessages from '../../../../../src/authorization/domain/constants.
 import { POLE_EMPLOI } from '../../../../../src/identity-access-management/domain/constants/oidc-identity-providers.js';
 import { AuthenticationMethod } from '../../../../../src/identity-access-management/domain/models/AuthenticationMethod.js';
 import { authenticateOidcUser } from '../../../../../src/identity-access-management/domain/usecases/authenticate-oidc-user.usecase.js';
+import { RequestedApplication } from '../../../../../src/identity-access-management/infrastructure/utils/network.js';
 import { ForbiddenAccess } from '../../../../../src/shared/domain/errors.js';
 import { AdminMember } from '../../../../../src/shared/domain/models/AdminMember.js';
 import { AuthenticationSessionContent } from '../../../../../src/shared/domain/models/AuthenticationSessionContent.js';
@@ -15,9 +16,11 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
     let userRepository;
     let adminMemberRepository;
     let userLoginRepository;
+    let lastUserApplicationConnectionsRepository;
     let oidcAuthenticationServiceRegistry;
     const externalIdentityId = '094b83ac-2e20-4aa8-b438-0bc91748e4a6';
     const audience = 'https://app.pix.fr';
+    const requestedApplication = new RequestedApplication('app');
 
     beforeEach(function () {
       oidcAuthenticationService = {
@@ -46,6 +49,9 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
       };
       userLoginRepository = {
         updateLastLoggedAt: sinon.stub().resolves(),
+      };
+      lastUserApplicationConnectionsRepository = {
+        upsert: sinon.stub().resolves(),
       };
     });
 
@@ -276,6 +282,8 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
             authenticationMethodRepository,
             userRepository,
             userLoginRepository,
+            lastUserApplicationConnectionsRepository,
+            requestedApplication,
           });
 
           // then
@@ -310,6 +318,8 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
             authenticationMethodRepository,
             userRepository,
             userLoginRepository,
+            requestedApplication,
+            lastUserApplicationConnectionsRepository,
           });
 
           // then
@@ -332,8 +342,10 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
     let userRepository;
     let userLoginRepository;
     let oidcAuthenticationServiceRegistry;
+    let lastUserApplicationConnectionsRepository;
     const externalIdentityId = '094b83ac-2e20-4aa8-b438-0bc91748e4a6';
     const audience = 'https://app.pix.fr';
+    const requestedApplication = new RequestedApplication('app');
 
     beforeEach(function () {
       oidcAuthenticationService = {
@@ -362,6 +374,9 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
       userLoginRepository = {
         updateLastLoggedAt: sinon.stub().resolves(),
       };
+      lastUserApplicationConnectionsRepository = {
+        upsert: sinon.stub().resolves(),
+      };
     });
 
     context('when user has an account', function () {
@@ -387,6 +402,8 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
           userRepository,
           userLoginRepository,
           audience,
+          requestedApplication,
+          lastUserApplicationConnectionsRepository,
         });
 
         // then
@@ -424,6 +441,8 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
           userRepository,
           userLoginRepository,
           audience,
+          requestedApplication,
+          lastUserApplicationConnectionsRepository,
         });
 
         // then
@@ -462,6 +481,8 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
           userRepository,
           userLoginRepository,
           audience,
+          requestedApplication,
+          lastUserApplicationConnectionsRepository,
         });
 
         // then

--- a/api/tests/identity-access-management/unit/domain/usecases/create-oidc-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/create-oidc-user.usecase.test.js
@@ -1,10 +1,14 @@
 import { AuthenticationKeyExpired } from '../../../../../src/identity-access-management/domain/errors.js';
 import { createOidcUser } from '../../../../../src/identity-access-management/domain/usecases/create-oidc-user.usecase.js';
+import { RequestedApplication } from '../../../../../src/identity-access-management/infrastructure/utils/network.js';
 import { UserAlreadyExistsWithAuthenticationMethodError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Domain | UseCase | create-oidc-user', function () {
-  let authenticationMethodRepository, userToCreateRepository, userLoginRepository;
+  let authenticationMethodRepository,
+    userToCreateRepository,
+    userLoginRepository,
+    lastUserApplicationConnectionsRepository;
   let authenticationSessionService, oidcAuthenticationService, oidcAuthenticationServiceRegistry;
   let clock;
   let now;
@@ -36,6 +40,10 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-oidc-use
 
     userLoginRepository = {
       updateLastLoggedAt: sinon.stub(),
+    };
+
+    lastUserApplicationConnectionsRepository = {
+      upsert: sinon.stub(),
     };
   });
 
@@ -95,6 +103,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-oidc-use
     const idToken = 'idToken';
     const language = 'nl';
     const audience = 'htttps://app.pix.fr';
+    const requestedApplication = new RequestedApplication('app');
     authenticationSessionService.getByKey.withArgs('AUTHENTICATION_KEY').resolves({
       sessionContent: { idToken, accessToken: 'accessToken' },
       userInfo: { firstName: 'Jean', lastName: 'Heymar', externalIdentityId: 'externalId' },
@@ -120,6 +129,8 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-oidc-use
       authenticationMethodRepository,
       userToCreateRepository,
       userLoginRepository,
+      lastUserApplicationConnectionsRepository,
+      requestedApplication,
     });
 
     // then


### PR DESCRIPTION
## :pancakes: Problème

Quand un utilisateur se connecte avec une méthode de connexion SSO, on souhaite stocker la date de dernière connexion pour l’application connecté.

## :bacon: Proposition

Quand un utilisateur se connecte avec une méthode de connexion SSO, stocker la date de dernière connexion pour l’application connecté.

## 🧃 Remarques

Cela concerne les use cases:

- reconcileOidcUser

- reconcileOidcUserForAdmin

- createOidcUser

- authenticateOidcUser

## :yum: Pour tester

:information_source: Cette PR ne met pas à jour `lastLoggedAt` de la table `authentication-methods`. Ce sera fait dans une PR à venir.

Route api/oidc/user/reconcile
- Depuis app, se réconcilier avec un SSO (ex pays de la loire)
- Constater en base une écriture sur la table "last-user-application-connections"

![Capture d'écran de la ligne en base avec les données renseignées (id: 1, userId: 7105, , application: 'app', lastLoggedAt: '2025-02-26 15:29:32.621 +0100')](https://github.com/user-attachments/assets/741ce281-e373-47e6-bb7c-b003b6222b41)

Route /api/admin/oidc/user/reconcile
- Modifier le mail du user Superadmin pour y mettre votre addresse mail pix
- Depuis https://admin.dev.pix.fr/ se connecter via sso
- Constater en base une écriture sur la table "last-user-application-connections"

![Capture d'écran de la ligne en base avec les données renseignées (id: 2, userId: 90 000, , application: 'admin', lastLoggedAt: '2025-02-26 15:38:49.221 +0100'](https://github.com/user-attachments/assets/7fb8fcaf-4171-48fd-a45a-79c9bea6098f)

Route /api/oidc/token
- Depuis app, se connecter via SSO (ex pays de la loire) avec l'utilisateur récédement réconcilié à l'étape 1
- Constater en base une écriture sur la table "last-user-application-connections"

![Capture d'écran de la ligne en base avec les données renseignées (id: 3, userId: 7105, , application: 'app', lastLoggedAt: '2025-02-26 15:44:50.463 +0100'](https://github.com/user-attachments/assets/5f80e2fa-6f88-4227-9c5b-76130ccb08c4)

Route /api/oidc/users
- Depuis app, se connecter via SSO (ex pays de la loire) avec un utilisateur n'ayant pas de compte Pix
- Constater en base une écriture sur la table "last-user-application-connections"

![Capture d'écran de la ligne en base avec les données renseignées (id: 4, userId: 1000003, , application: 'app', lastLoggedAt: '2025-02-26 15:51:21.208 +0100'](https://github.com/user-attachments/assets/6acd3590-8b4a-4e0c-b7a3-a2d364277d6e)



