### PR TITLE
[FEATURE] Traduction en NL et ES de l'e-mail d'alerte si reconnexion après 12 mois

### DIFF
--- a/api/translations/es.json
+++ b/api/translations/es.json
@@ -435,15 +435,15 @@
   },
   "warning-connection-email": {
     "params": {
-      "context": "We noticed a new connection to your Pix account after a period of inactivity of 12 months or more.",
-      "disclaimer": "If this connection really comes from you, no action is necessary.",
-      "hello": "Hello {firstName},",
-      "resetMyPassword": "Set a new password",
-      "signing": "Pix team",
-      "supportContact": "If in doubt or if you have any questions, our support is available to help you.",
-      "thanks": "Thank you for your vigilance,",
-      "warningMessage": "If this is not the case, we invite you to change your password immediately to secure your account by clicking on the button below:"
+      "context": "Nos dimos cuenta de una nueva conexión a su cuenta Pix después de un período de inactividad de 12 meses o más.",
+      "disclaimer": "Si esta conexión procede realmente de ti, no es necesaria ninguna acción.",
+      "hello": "Hola {firstName},",
+      "resetMyPassword": "Establecer una nueva contraseña",
+      "signing": "Equipo Pix",
+      "supportContact": "En caso de duda o si tiene alguna pregunta, nuestro servicio de asistencia está a su disposición para ayudarle.",
+      "thanks": "Gracias por su vigilancia,",
+      "warningMessage": "Gracias por su Si este no es el caso, le invitamos a cambiar su contraseña inmediatamente para asegurar su cuenta haciendo clic en el botón de abajo:"
     },
-    "subject": "Recent activity on your Pix account"
+    "subject": "Actividad reciente en su cuenta Pix"
   }
 }

--- a/api/translations/nl.json
+++ b/api/translations/nl.json
@@ -427,15 +427,15 @@
   },
   "warning-connection-email": {
     "params": {
-      "context": "We noticed a new connection to your Pix account after a period of inactivity of 12 months or more.",
-      "disclaimer": "If this connection really comes from you, no action is necessary.",
-      "hello": "Hello {firstName},",
-      "resetMyPassword": "Set a new password",
+      "context": "We hebben een nieuwe verbinding met je Pix-account opgemerkt na een periode van inactiviteit van 12 maanden of meer.",
+      "disclaimer": "Als deze verbinding echt van jou komt, is er geen actie nodig.",
+      "hello": "Hallo {firstName},",
+      "resetMyPassword": "Een nieuw wachtwoord instellen",
       "signing": "Pix team",
-      "supportContact": "If in doubt or if you have any questions, our support is available to help you.",
+      "supportContact": "Als je twijfelt of vragen hebt, staat onze support klaar om je te helpen.",
       "thanks": "Thank you for your vigilance,",
-      "warningMessage": "If this is not the case, we invite you to change your password immediately to secure your account by clicking on the button below:"
+      "warningMessage": "Als dit niet het geval is, nodigen we je uit om je wachtwoord onmiddellijk te wijzigen om je account te beveiligen door op de onderstaande knop te klikken:"
     },
-    "subject": "Recent activity on your Pix account"
+    "subject": "Recente activiteit op je Pix-account"
   }
 }


### PR DESCRIPTION
## :pancakes: Problème

L'utilisateur reçoit un e-mail si sa dernière connexion remontait à plus de 12 mois. Pour le NL et l'ES, l'e-mail était en anglais.

## :bacon: Proposition

Traduire le contenu de l'e-mail en NL et ES. Ainsi, si l'utilisateur a la langue ES ou NL, il recevra l'e-mail dans la bonne langue.

## 🧃 Remarques

N/A

## :yum: Pour tester

- Avoir un utilisateur néerlandophone avec une date de dernière connexion supérieure à 12 mois
- Se reconnecter avec cet utilisateur
- Vérifier que l'e-mail reçu alertant d'une reconnexion est bien en néerlandais
- Appliquer la même procédure mais en prenant un utilisateur hispanophone
