### PR TITLE
[FEATURE] affiche les participations anonymisées dans mes parcours  (Pix-14458)

### DIFF
--- a/api/src/prescription/campaign-participation/application/campaign-participation-controller.js
+++ b/api/src/prescription/campaign-participation/application/campaign-participation-controller.js
@@ -1,6 +1,7 @@
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { extractLocaleFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
+import * as anonymisedCampaignAssessmentSerializer from '../infrastructure/serializers/jsonapi/anonymised-campaign-assessment-serializer.js';
 import * as availableCampaignParticipationsSerializer from '../infrastructure/serializers/jsonapi/available-campaign-participation-serializer.js';
 import * as campaignAnalysisSerializer from '../infrastructure/serializers/jsonapi/campaign-analysis-serializer.js';
 import * as campaignAssessmentParticipationResultSerializer from '../infrastructure/serializers/jsonapi/campaign-assessment-participation-result-serializer.js';
@@ -10,7 +11,6 @@ import * as campaignParticipationSerializer from '../infrastructure/serializers/
 import * as campaignProfileSerializer from '../infrastructure/serializers/jsonapi/campaign-profile-serializer.js';
 import * as participantResultSerializer from '../infrastructure/serializers/jsonapi/participant-result-serializer.js';
 import * as participationForCampaignManagementSerializer from '../infrastructure/serializers/jsonapi/participation-for-campaign-management-serializer.js';
-
 const getUserCampaignParticipationToCampaign = function (
   request,
   h,
@@ -153,6 +153,22 @@ const getCampaignParticipationOverviews = async function (
   );
 };
 
+const getAnonymisedCampaignAssessments = async function (
+  request,
+  h,
+  dependencies = {
+    anonymisedCampaignAssessmentSerializer,
+  },
+) {
+  const authenticatedUserId = request.auth.credentials.userId;
+
+  const assessments = await usecases.findUserAnonymisedCampaignAssessments({
+    userId: authenticatedUserId,
+  });
+
+  return dependencies.anonymisedCampaignAssessmentSerializer.serialize(assessments);
+};
+
 const getUserCampaignAssessmentResult = async function (
   request,
   _,
@@ -179,6 +195,7 @@ const campaignParticipationController = {
   deleteParticipation,
   findPaginatedParticipationsForCampaignManagement,
   getAnalysis,
+  getAnonymisedCampaignAssessments,
   getCampaignAssessmentParticipation,
   getCampaignAssessmentParticipationResult,
   getCampaignParticipationOverviews,

--- a/api/src/prescription/campaign-participation/application/campaign-participation-route.js
+++ b/api/src/prescription/campaign-participation/application/campaign-participation-route.js
@@ -260,6 +260,32 @@ const register = async function (server) {
     },
     {
       method: 'GET',
+      path: '/api/users/{userId}/anonymised-campaign-assessments',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
+            assign: 'requestedUserIsAuthenticatedUser',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            userId: identifiersType.userId,
+          }),
+        },
+        handler: campaignParticipationController.getAnonymisedCampaignAssessments,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            '- Récupération des assessment du type campagnes qui ne sont plus liés à des participations\n' +
+            '- L’id demandé doit correspondre à celui de l’utilisateur authentifié' +
+            '- Les assessments sont triés par ordre inverse de création' +
+            '  (les plus récentes en premier)',
+        ],
+        tags: ['api'],
+      },
+    },
+    {
+      method: 'GET',
       path: '/api/users/{userId}/campaigns/{campaignId}/campaign-participations',
       config: {
         validate: {

--- a/api/src/prescription/campaign-participation/domain/read-models/DetachedAssessment.js
+++ b/api/src/prescription/campaign-participation/domain/read-models/DetachedAssessment.js
@@ -1,0 +1,9 @@
+class DetachedAssessment {
+  constructor({ id, updatedAt, state }) {
+    this.id = id;
+    this.updatedAt = updatedAt;
+    this.state = state;
+  }
+}
+
+export { DetachedAssessment };

--- a/api/src/prescription/campaign-participation/domain/usecases/find-user-anonymised-campaign-assessments.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/find-user-anonymised-campaign-assessments.js
@@ -1,0 +1,4 @@
+const findUserAnonymisedCampaignAssessments = async function ({ userId, campaignAssessmentParticipationRepository }) {
+  return await campaignAssessmentParticipationRepository.getDetachedByUserId({ userId });
+};
+export { findUserAnonymisedCampaignAssessments };

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-assessment-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-assessment-participation-repository.js
@@ -7,6 +7,7 @@ import { Assessment } from '../../../../shared/domain/models/Assessment.js';
 import * as knowledgeElementRepository from '../../../../shared/infrastructure/repositories/knowledge-element-repository.js';
 import * as campaignRepository from '../../../campaign/infrastructure/repositories/campaign-repository.js';
 import { CampaignAssessmentParticipation } from '../../domain/models/CampaignAssessmentParticipation.js';
+import { DetachedAssessment } from '../../domain/read-models/DetachedAssessment.js';
 
 const getByCampaignIdAndCampaignParticipationId = async function ({
   campaignId,
@@ -18,7 +19,17 @@ const getByCampaignIdAndCampaignParticipationId = async function ({
   return _buildCampaignAssessmentParticipation(result, shouldBuildProgression);
 };
 
-export { getByCampaignIdAndCampaignParticipationId };
+const getDetachedByUserId = async ({ userId }) => {
+  const result = await knex('assessments')
+    .select(['id', 'state', 'updatedAt'])
+    .whereNull('campaignParticipationId')
+    .where({ userId, type: Assessment.types.CAMPAIGN })
+    .orderBy('updatedAt', 'DESC');
+
+  return result.map((row) => new DetachedAssessment(row));
+};
+
+export { getByCampaignIdAndCampaignParticipationId, getDetachedByUserId };
 
 async function _fetchCampaignAssessmentAttributesFromCampaignParticipation(campaignId, campaignParticipationId) {
   const knexConn = DomainTransaction.getConnection();

--- a/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/anonymised-campaign-assessment-serializer.js
+++ b/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/anonymised-campaign-assessment-serializer.js
@@ -1,0 +1,12 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (anonymisedCampaignAssessment, meta) {
+  return new Serializer('anonymised-campaign-assessment', {
+    attributes: ['state', 'updatedAt'],
+    meta,
+  }).serialize(anonymisedCampaignAssessment);
+};
+
+export { serialize };

--- a/api/tests/identity-access-management/acceptance/application/user/user.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/user/user.route.test.js
@@ -7,6 +7,7 @@ import * as userRepository from '../../../../../src/identity-access-management/i
 import { userEmailRepository } from '../../../../../src/identity-access-management/infrastructure/repositories/user-email.repository.js';
 import { config } from '../../../../../src/shared/config.js';
 import { constants } from '../../../../../src/shared/domain/constants.js';
+import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import {
   createServer,
   databaseBuilder,
@@ -185,8 +186,18 @@ describe('Acceptance | Identity Access Management | Application | Route | User',
         status: 'TO_SHARE',
         userId: user.id,
       });
-      databaseBuilder.factory.buildCampaignParticipation({
+      databaseBuilder.factory.buildAssessment({
+        campaignParticipationId: campaignParticipationId,
+        type: Assessment.types.CAMPAIGN,
+        userId: user.id,
+      });
+      const participation = databaseBuilder.factory.buildCampaignParticipation({
         campaignId: assessmentCampaign.id,
+        userId: user.id,
+      });
+      databaseBuilder.factory.buildAssessment({
+        campaignParticipationId: participation.id,
+        type: Assessment.types.CAMPAIGN,
         userId: user.id,
       });
       const { id: trainingId } = databaseBuilder.factory.buildTraining();

--- a/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-route_test.js
+++ b/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-route_test.js
@@ -858,6 +858,49 @@ describe('Acceptance | API | Campaign Participations', function () {
     });
   });
 
+  describe('GET /users/{userId}/anonymised-campaign-assessments', function () {
+    let userId;
+    let options;
+    const skillId = 'recSkillId';
+
+    beforeEach(function () {
+      const user = databaseBuilder.factory.buildUser();
+      userId = user.id;
+
+      databaseBuilder.factory.learningContent.buildSkill({ id: skillId });
+
+      return databaseBuilder.commit();
+    });
+
+    it('should return anonymised campaign assessment', async function () {
+      // given
+      const deletedCampaignParticipation =
+        databaseBuilder.factory.campaignParticipationOverviewFactory.buildDeletedAndAnonymised({
+          userId,
+          createdAt: new Date('2021-01-12'),
+          sharedAt: new Date('2021-01-14'),
+          deleted: new Date('2023-12-24'),
+          assessmentCreatedAt: new Date('2021-01-12'),
+          campaignSkills: [skillId],
+        });
+
+      await databaseBuilder.commit();
+      options = {
+        method: 'GET',
+        url: `/api/users/${userId}/anonymised-campaign-assessments`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      const assessmentIds = response.result.data.map(({ id }) => Number(id));
+      expect(assessmentIds).to.deep.equals([deletedCampaignParticipation.assessment.id]);
+    });
+  });
+
   describe('GET /users/{userId}/campaigns/{campaignId}/campaign-participations', function () {
     let options;
 

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/find-user-anonymised-campaign-assessments_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/find-user-anonymised-campaign-assessments_test.js
@@ -1,0 +1,71 @@
+import { DetachedAssessment } from '../../../../../../src/prescription/campaign-participation/domain/read-models/DetachedAssessment.js';
+import { usecases } from '../../../../../../src/prescription/campaign-participation/domain/usecases/index.js';
+import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Integration | UseCase | find-user-anonymised-campaign-assessments', function () {
+  let user, organization, campaign, learner;
+
+  beforeEach(async function () {
+    user = databaseBuilder.factory.buildUser();
+    organization = databaseBuilder.factory.buildOrganization();
+    campaign = databaseBuilder.factory.buildCampaign({ organizationId: organization.id });
+    learner = databaseBuilder.factory.buildOrganizationLearner({ userId: user.id, organization: organization.id });
+    await databaseBuilder.commit();
+  });
+
+  context('when there is no anonymised participation', function () {
+    it('should return an empty array', async function () {
+      // given
+      const participation = databaseBuilder.factory.buildCampaignParticipation({
+        userId: user.id,
+        campaign: campaign.id,
+        organizationLearnerId: learner.id,
+      });
+      databaseBuilder.factory.buildAssessment({
+        type: Assessment.types.CAMPAIGN,
+        userId: user.id,
+        campaignParticipationId: participation.id,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await usecases.findUserAnonymisedCampaignAssessments({ userId: user.id });
+
+      // then
+      expect(result).to.be.empty;
+    });
+  });
+  context('when there is anonymised participation', function () {
+    it('should return results', async function () {
+      // given
+      const assessment1 = databaseBuilder.factory.buildAssessment({
+        type: Assessment.types.CAMPAIGN,
+        userId: user.id,
+        campaignParticipationId: null,
+        createdAt: new Date('2024-03-15'),
+        updatedAt: new Date('2024-03-16'),
+      });
+      const assessment2 = databaseBuilder.factory.buildAssessment({
+        type: Assessment.types.CAMPAIGN,
+        userId: user.id,
+        state: Assessment.states.STARTED,
+        campaignParticipationId: null,
+        createdAt: new Date('2024-03-26'),
+        updatedAt: new Date('2024-03-27'),
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await usecases.findUserAnonymisedCampaignAssessments({ userId: user.id });
+
+      // then
+      expect(result).lengthOf(2);
+      expect(result[0]).instanceOf(DetachedAssessment);
+      expect(result).deep.members([
+        { id: assessment1.id, updatedAt: assessment1.updatedAt, state: assessment1.state },
+        { id: assessment2.id, updatedAt: assessment2.updatedAt, state: assessment2.state },
+      ]);
+    });
+  });
+});

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -940,8 +940,14 @@ describe('Integration | Repository | Campaign Participation', function () {
     it('should return true if the user has participations to campaigns of type assement', async function () {
       // given
       const campaign = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.ASSESSMENT });
-      databaseBuilder.factory.buildCampaignParticipation({
+      const participation = databaseBuilder.factory.buildCampaignParticipation({
         campaignId: campaign.id,
+        userId,
+      });
+      databaseBuilder.factory.buildAssessment({
+        campaignParticipationId: participation.id,
+        type: Assessment.types.CAMPAIGN,
+        createdAt: participation.createdAt,
         userId,
       });
       await databaseBuilder.commit();
@@ -956,8 +962,14 @@ describe('Integration | Repository | Campaign Participation', function () {
     it('should return true if the user has participations to campaigns of type exam', async function () {
       // given
       const campaign = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.EXAM });
-      databaseBuilder.factory.buildCampaignParticipation({
+      const participation = databaseBuilder.factory.buildCampaignParticipation({
         campaignId: campaign.id,
+        userId,
+      });
+      databaseBuilder.factory.buildAssessment({
+        campaignParticipationId: participation.id,
+        type: Assessment.types.CAMPAIGN,
+        createdAt: participation.createdAt,
         userId,
       });
       await databaseBuilder.commit();
@@ -973,9 +985,15 @@ describe('Integration | Repository | Campaign Participation', function () {
       // given
       const otherUser = databaseBuilder.factory.buildUser();
       const campaign = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.ASSESSMENT });
-      databaseBuilder.factory.buildCampaignParticipation({
+      const participation = databaseBuilder.factory.buildCampaignParticipation({
         campaignId: campaign.id,
         userId: otherUser.id,
+      });
+      databaseBuilder.factory.buildAssessment({
+        campaignParticipationId: participation.id,
+        createdAt: participation.createdAt,
+        userId: otherUser.id,
+        type: Assessment.types.CAMPAIGN,
       });
       await databaseBuilder.commit();
 
@@ -1022,6 +1040,23 @@ describe('Integration | Repository | Campaign Participation', function () {
 
       // then
       expect(result).to.equal(false);
+    });
+
+    it('should return true if the user has only anonymised participations', async function () {
+      // given
+      databaseBuilder.factory.campaignParticipationOverviewFactory.buildDeletedAndAnonymised({
+        userId,
+        createdAt: new Date('2020-02-19'),
+        assessmentCreatedAt: new Date('2020-02-19'),
+        campaignSkills: [],
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await campaignParticipationRepository.hasAssessmentParticipations(userId);
+
+      // then
+      expect(result).to.equal(true);
     });
   });
 

--- a/api/tests/prescription/campaign-participation/unit/application/campaign-participation-controller_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/campaign-participation-controller_test.js
@@ -6,6 +6,49 @@ import { expect, hFake, sinon } from '../../../../test-helper.js';
 
 const { FRENCH_SPOKEN } = LOCALE;
 describe('Unit | Application | Controller | Campaign-Participation', function () {
+  describe('#getAnonymisedCampaignAssessments', function () {
+    const userId = '1';
+    let dependencies;
+
+    beforeEach(function () {
+      const anonymisedCampaignAssessmentSerializer = {
+        serialize: sinon.stub(),
+      };
+      sinon.stub(usecases, 'findUserAnonymisedCampaignAssessments');
+      dependencies = {
+        anonymisedCampaignAssessmentSerializer,
+      };
+    });
+
+    it('should return serialized anonymised campaign assessments', async function () {
+      // given
+      const request = {
+        auth: {
+          credentials: {
+            userId: userId,
+          },
+        },
+        params: {
+          id: userId,
+        },
+      };
+      const serializeSymbol = Symbol('serialize');
+      usecases.findUserAnonymisedCampaignAssessments.withArgs({ userId }).resolves([]);
+      dependencies.anonymisedCampaignAssessmentSerializer.serialize.withArgs([]).returns(serializeSymbol);
+
+      // when
+      const response = await campaignParticipationController.getAnonymisedCampaignAssessments(
+        request,
+        hFake,
+        dependencies,
+      );
+
+      // then
+      expect(response).to.equal(serializeSymbol);
+      expect(dependencies.anonymisedCampaignAssessmentSerializer.serialize).to.have.been.calledOnce;
+    });
+  });
+
   describe('#getCampaignParticipationOverviews', function () {
     const userId = '1';
     let dependencies;

--- a/api/tests/prescription/campaign-participation/unit/domain/read-models/DetachedAssessment_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/read-models/DetachedAssessment_test.js
@@ -1,0 +1,20 @@
+import { DetachedAssessment } from '../../../../../../src/prescription/campaign-participation/domain/read-models/DetachedAssessment.js';
+import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | Domain | Read-Models | DetachAssessment', function () {
+  describe('constructor', function () {
+    it('should correctly initialize the information about Detach assessment', function () {
+      const updatedAt = new Date('2012-01-01');
+      const assessment = new DetachedAssessment({
+        id: 1,
+        updatedAt,
+        state: Assessment.states.COMPLETED,
+      });
+
+      expect(assessment.id).equal(1);
+      expect(assessment.updatedAt).equal(updatedAt);
+      expect(assessment.state).equal(Assessment.states.COMPLETED);
+    });
+  });
+});

--- a/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/anonymised-campaign-assessment-serializer_test.js
+++ b/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/anonymised-campaign-assessment-serializer_test.js
@@ -1,0 +1,34 @@
+import * as serializer from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/anonymised-campaign-assessment-serializer.js';
+import { Assessment } from '../../../../../../../src/shared/domain/models/Assessment.js';
+import { domainBuilder, expect } from '../../../../../../test-helper.js';
+
+describe('Unit | Serializer | JSONAPI | anonymised-campaign-assessment-serializer', function () {
+  describe('#serialize()', function () {
+    it('should convert a DetachAssessment model object into JSON API data', function () {
+      // given
+      const assessment = domainBuilder.buildAssessment({
+        id: 123,
+        updatedAt: new Date('2020-10-10'),
+        state: Assessment.states.STARTED,
+        type: Assessment.types.CAMPAIGN,
+      });
+
+      // when
+      const json = serializer.serialize([assessment]);
+
+      // then
+      expect(json).to.deep.equal({
+        data: [
+          {
+            type: 'anonymised-campaign-assessment',
+            id: assessment.id.toString(),
+            attributes: {
+              'updated-at': assessment.updatedAt,
+              state: assessment.state,
+            },
+          },
+        ],
+      });
+    });
+  });
+});

--- a/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/anonymised-campaign-assessment-serializer_test.js
+++ b/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/anonymised-campaign-assessment-serializer_test.js
@@ -20,7 +20,7 @@ describe('Unit | Serializer | JSONAPI | anonymised-campaign-assessment-serialize
       expect(json).to.deep.equal({
         data: [
           {
-            type: 'anonymised-campaign-assessment',
+            type: 'anonymised-campaign-assessments',
             id: assessment.id.toString(),
             attributes: {
               'updated-at': assessment.updatedAt,

--- a/mon-pix/app/adapters/anonymised-campaign-assessment.js
+++ b/mon-pix/app/adapters/anonymised-campaign-assessment.js
@@ -1,0 +1,7 @@
+import ApplicationAdapter from './application';
+
+export default class AnonymisedCampaignAssessment extends ApplicationAdapter {
+  urlForFindAll(modelName, { adapterOptions }) {
+    return `${this.host}/${this.namespace}/users/${adapterOptions.userId}/anonymised-campaign-assessments`;
+  }
+}

--- a/mon-pix/app/components/campaign-participation-overview/card.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card.hbs
@@ -6,4 +6,6 @@
   <CampaignParticipationOverview::Card::Ended @model={{@model}} />
 {{else if (eq @model.cardStatus "DISABLED")}}
   <CampaignParticipationOverview::Card::Disabled @model={{@model}} />
+{{else if (eq @model.cardStatus "DELETED")}}
+  <CampaignParticipationOverview::Card::Deleted @model={{@model}} />
 {{/if}}

--- a/mon-pix/app/components/campaign-participation-overview/card/deleted.gjs
+++ b/mon-pix/app/components/campaign-participation-overview/card/deleted.gjs
@@ -1,0 +1,35 @@
+import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
+import { t } from 'ember-intl';
+
+function getStatusWording(state) {
+  const statusKey = {
+    started: 'started-at',
+    completed: 'finished-at',
+  };
+  return `pages.campaign-participation-overview.card.${statusKey[state]}`;
+}
+
+<template>
+  <article class="campaign-participation-overview-card" role="article">
+    <div class="campaign-participation-overview-card__header">
+      <PixTag class="campaign-participation-overview-card-header__tag" @color="grey-light">
+        {{t "pages.campaign-participation-overview.card.tag.deleted"}}
+      </PixTag>
+      <p>
+        <time class="campaign-participation-overview-card-header__date" datetime="{{@model.updatedAt}}">
+          {{t (getStatusWording @model.state) date=(dayjsFormat @model.updatedAt "DD/MM/YYYY")}}
+        </time>
+      </p>
+    </div>
+    <section class="campaign-participation-overview-card-content">
+      <div
+        class="campaign-participation-overview-card-content__content campaign-participation-overview-card-content__archived-and-not-shared"
+      >
+        <p class="campaign-participation-overview-card-content--archived">
+          {{t "pages.campaign-participation-overview.card.text-deleted" htmlSafe=true}}
+        </p>
+      </div>
+    </section>
+  </article>
+</template>

--- a/mon-pix/app/models/anonymised-campaign-assessment.js
+++ b/mon-pix/app/models/anonymised-campaign-assessment.js
@@ -1,0 +1,10 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class AnonymisedCampaignAssessment extends Model {
+  @attr('string') state;
+  @attr('date') updatedAt;
+
+  get cardStatus() {
+    return 'DELETED';
+  }
+}

--- a/mon-pix/app/routes/authenticated/user-tests.js
+++ b/mon-pix/app/routes/authenticated/user-tests.js
@@ -8,7 +8,7 @@ export default class UserTestsRoute extends Route {
   @service store;
   @service router;
 
-  model() {
+  async model() {
     const user = this.currentUser.user;
     const maximumDisplayed = 100;
     const queryParams = {
@@ -17,8 +17,13 @@ export default class UserTestsRoute extends Route {
       'page[size]': maximumDisplayed,
       'filter[states]': ['ONGOING', 'TO_SHARE', 'ENDED', 'DISABLED'],
     };
+    const campaignParticipationOverviews = await this.store.query('campaign-participation-overview', queryParams);
 
-    return this.store.query('campaign-participation-overview', queryParams);
+    const anonymisedCampaignAssessments = await this.store.findAll('anonymised-campaign-assessment', {
+      adapterOptions: { userId: user.id },
+    });
+
+    return campaignParticipationOverviews.concat(anonymisedCampaignAssessments);
   }
 
   redirect(model) {

--- a/mon-pix/mirage/routes/users/get-anonymised-campaign-assessments.js
+++ b/mon-pix/mirage/routes/users/get-anonymised-campaign-assessments.js
@@ -1,0 +1,3 @@
+export default function (schema) {
+  return schema.anonymisedCampaignAssessments.all();
+}

--- a/mon-pix/mirage/routes/users/index.js
+++ b/mon-pix/mirage/routes/users/index.js
@@ -1,6 +1,7 @@
 import { Response } from 'miragejs';
 
 import findPaginatedUserTrainings from './find-paginated-user-trainings';
+import getAnonymisedCampaignAssessments from './get-anonymised-campaign-assessments';
 import getAuthenticatedUser from './get-authenticated-user';
 import getCampaignParticipationResult from './get-campaign-participation-result';
 import getMyAccount from './get-my-account.js';
@@ -48,6 +49,7 @@ export default function index(config) {
   config.get('/users/:id/profile', getProfile);
   config.get('/users/:id/campaign-participations', getUserCampaignParticipations);
   config.get('/users/:id/campaign-participation-overviews', getUserCampaignParticipationOverviews);
+  config.get('/users/:id/anonymised-campaign-assessments', getAnonymisedCampaignAssessments);
   config.get('/users/:id/trainings', findPaginatedUserTrainings);
 
   config.get('/users/:id/authentication-methods', (schema, request) => {

--- a/mon-pix/mirage/serializers/anonymised-campaign-assessment.js
+++ b/mon-pix/mirage/serializers/anonymised-campaign-assessment.js
@@ -1,0 +1,5 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({
+  attrs: ['updatedAt', 'state'],
+});

--- a/mon-pix/tests/unit/routes/authenticated/user-tests-test.js
+++ b/mon-pix/tests/unit/routes/authenticated/user-tests-test.js
@@ -13,8 +13,11 @@ module('Unit | Route | User-Tests', function (hooks) {
       const currentUserStub = Service.create({ user: { id: '1' } });
       const store = this.owner.lookup('service:store');
       sinon.stub(store, 'query');
+      sinon.stub(store, 'findAll');
 
-      const campaignParticipationOverviews = [EmberObject.create({ id: '10' })];
+      const campaignParticipationOverviews = [{ id: '10' }];
+      const anonymisedCampaignAssessments = [{ id: '12' }];
+
       store.query
         .withArgs('campaign-participation-overview', {
           userId: '1',
@@ -24,6 +27,8 @@ module('Unit | Route | User-Tests', function (hooks) {
         })
         .returns(campaignParticipationOverviews);
 
+      store.findAll.withArgs('anonymised-campaign-assessment').returns(anonymisedCampaignAssessments);
+
       const route = this.owner.lookup('route:authenticated/user-tests');
       route.set('currentUser', currentUserStub);
       route.set('store', store);
@@ -32,7 +37,7 @@ module('Unit | Route | User-Tests', function (hooks) {
       const model = await route.model();
 
       // then
-      assert.deepEqual(model, campaignParticipationOverviews);
+      assert.deepEqual(model, [...campaignParticipationOverviews, ...anonymisedCampaignAssessments]);
     });
   });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -569,10 +569,12 @@
         "started-at": "Started the {date}",
         "tag": {
           "completed": "To be submitted",
-          "disabled": "Inactive",
+          "deleted": "Inactive",
+          "disabled": "Route deactivated by your organization.'<br>'You can no longer act on this route.",
           "finished": "Finished",
           "started": "In progress"
         },
+        "text-deleted": "This customised test has been deactivated by your organization.'<br>'You can no longer act on this test.",
         "text-disabled": "This customised test has been deactivated by your organisation.'<br>'It is no longer possible to submit your results."
       },
       "title": "Customised test"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -564,10 +564,12 @@
         "started-at": "Empezado el {date}",
         "tag": {
           "completed": "Para enviar",
+          "deleted": "Inactivo",
           "disabled": "Inactivo",
           "finished": "Finalizado",
           "started": "En curso"
         },
+        "text-deleted": "Test desactivado por tu organización.'<br>'Ya no puedes actuar sobre este test.",
         "text-disabled": "Test desactivado por tu organización.'<br>'Ya no puedes enviar tus resultados."
       },
       "title": "Test"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -569,10 +569,12 @@
         "started-at": "Commencé le {date}",
         "tag": {
           "completed": "À envoyer",
+          "deleted": "Inactif",
           "disabled": "Inactif",
           "finished": "Terminé",
           "started": "En cours"
         },
+        "text-deleted": "Parcours désactivé par votre organisation.'<br>'Vous ne pouvez plus agir sur ce parcours.",
         "text-disabled": "Parcours désactivé par votre organisation.'<br>'Vous ne pouvez plus envoyer vos résultats."
       },
       "title": "Parcours"
@@ -2126,6 +2128,14 @@
       "title": "Mon compte"
     },
     "user-tests": {
+      "anonymised-participations": {
+        "course": "Parcours",
+        "states": {
+          "completed": "terminé",
+          "started": "commencé"
+        },
+        "title": "Parcours désactivés"
+      },
       "description": "Retrouvez ici les parcours d’évaluation que vous avez commencés ou terminés.",
       "title": "Parcours"
     },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -564,10 +564,12 @@
         "started-at": "Gestart op {date}",
         "tag": {
           "completed": "Om te sturen",
+          "deleted": "Inactief",
           "disabled": "Inactief",
           "finished": "Afgewerkt",
           "started": "Actief"
         },
+        "text-deleted": "Cursus gedeactiveerd door uw organisatie.'<br>'U kunt niet langer op deze cursus handelen.",
         "text-disabled": "Cursus gedeactiveerd door uw organisatie.'<br> 'U kunt uw resultaten niet langer verzenden."
       },
       "title": "Test"


### PR DESCRIPTION
## :pancakes: Problème

On souhaite afficher les participations anonymisées d'un utilisateur

## :bacon: Proposition
Créer une route pour remonter spécifiquement les assessments qui ne sont plus relié à des participations (donc anonymisés)

## 🧃 Remarques

ras
## :yum: Pour tester
- se connecter sur [App (.fr)](https://app-pr11507.review.pix.fr/) avec admin-orga@example.net
- allez dans [mes parcours](https://app-pr11507.review.pix.fr/mes-parcours)
- Vérifier l'affichage des deux assessments anonymisés 
ainsi que les données qui remontent du back. (le 'commencé' doit correspondre au 'createdAt', le 'terminé' doit correspondre au 'updatedAt') en se connectant sur le pg `scalingo -a pix-api-review-pr11507 pgsql-console`
```sql
select id, "userId", "createdAt", "updatedAt", state, type, "isImproving" from assessments where "userId" = 1000;
```