### PR TITLE
[BUGFIX] Corriger la position et couleur du bouton de copie du nouveau mot de passe (PIX-16475).

### DIFF
--- a/orga/app/components/sco-organization-participant/manage-authentication-method-modal.gjs
+++ b/orga/app/components/sco-organization-participant/manage-authentication-method-modal.gjs
@@ -258,7 +258,7 @@ export default class ManageAuthenticationMethodModal extends Component {
                           }}</:label>
                       </PixInput>
                       {{#if (isClipboardSupported)}}
-                        <PixTooltip @id="copy-password-tooltip" @position="top" @isInline={{true}}>
+                        <PixTooltip @id="copy-password-tooltip" @position="bottom-left" @isInline={{true}}>
                           <:triggerElement>
                             <CopyButton
                               @text={{this.generatedPassword}}
@@ -268,7 +268,7 @@ export default class ManageAuthenticationMethodModal extends Component {
                                 "pages.sco-organization-participants.manage-authentication-method-modal.section.password.copy"
                               }}
                               aria-describedby="copy-password-tooltip"
-                              class="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey"
+                              class="pix-icon-button pix-icon-button--small manage-authentication-window__clipboard__copy-password-button"
                             >
                               <PixIcon @name="copy" class="fa-inverse" />
                             </CopyButton>

--- a/orga/app/styles/components/manage-authentication-method-modal.scss
+++ b/orga/app/styles/components/manage-authentication-method-modal.scss
@@ -36,6 +36,7 @@
   &__clipboard {
     display: flex;
     gap: var(--pix-spacing-4x);
+    align-items: flex-end;
 
     .pix-input {
       width: 100%;
@@ -44,6 +45,10 @@
     input {
       box-sizing: border-box;
       background-color: var(--pix-neutral-20);
+    }
+
+    &__copy-password-button {
+      color: var(--pix-neutral-100);
     }
   }
 
@@ -76,7 +81,7 @@
     border-radius: var(--pix-spacing-2x);
 
     button {
-      margin-bottom: var(--pix-spacing-4x);
+      margin-bottom: var(--pix-spacing-1x);
       font-weight: 600;
     }
 


### PR DESCRIPTION
## :pancakes: Problème
Dans Pix Orga, dans la gestion des élèves, pour les élèves qui ont un mode de connexion par Identifiant, depuis le menu Action, on peut réinitialiser le mot de passe de l'élève puis copier ce mot de passe à l'aide d'un bouton. Or la couleur est la même que le fond donc il n'est pas visible. Sa position est également trop haute.

## :bacon: Proposition
Corriger la couleur et la position de ce bouton. 

## :yum: Pour tester
- Se connecter avec allorga@example.net
- Aller sur Eleves
- Choisir un élève ayant un mode de connexion par Identifiant
- Cliquer sur le bouton (...) Actions, Gérer le compte
- Cliquer sur Réinitialiser le mot de passe
- Constater que le bouton de copie du nouveau mot de passe est visible
- Constater qu'il est aligné verticalement avec le champ à sa gauche
