### PR TITLE
[FEATURE] Ne pas afficher la progression sur les campagnes de type EXAM (Pix-16493)

### DIFF
--- a/orga/app/components/participant/assessment/header.gjs
+++ b/orga/app/components/participant/assessment/header.gjs
@@ -84,6 +84,12 @@ export default class Header extends Component {
     return options;
   }
 
+  get displayProgression() {
+    const { participation, campaign } = this.args;
+
+    return !campaign.isTypeExam && !participation.isShared;
+  }
+
   get selectedParticipation() {
     return this.participationsListOptions.find((participation) => participation.value === this.args.participation.id);
   }
@@ -140,12 +146,12 @@ export default class Header extends Component {
             <:title>{{t "pages.campaign-individual-results.start-date"}}</:title>
             <:content>{{dayjsFormat @participation.createdAt "DD MMM YYYY"}}</:content>
           </Information>
-          {{#unless @participation.isShared}}
+          {{#if this.displayProgression}}
             <Information>
               <:title>{{t "pages.assessment-individual-results.progression"}}</:title>
               <:content>{{t "common.result.percentage" value=@participation.progression}}</:content>
             </Information>
-          {{/unless}}
+          {{/if}}
           {{#if @participation.isShared}}
             <Information>
               <:title>{{t "pages.campaign-individual-results.shared-date"}}</:title>

--- a/orga/tests/integration/components/participant/assessment/header-test.js
+++ b/orga/tests/integration/components/participant/assessment/header-test.js
@@ -1,4 +1,4 @@
-import { render, within } from '@1024pix/ember-testing-library';
+import { getDefaultNormalizer, render, within } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
@@ -199,6 +199,50 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
         );
 
         assert.notOk(screen.queryByText(t('pages.campaign-individual-results.shared-date')));
+      });
+
+      test('displays participant progression on campaign of type not equal to exam', async function (assert) {
+        this.participation = {
+          isShared: false,
+          progression: 0.8,
+        };
+
+        this.campaign = {
+          isTypeExam: false,
+        };
+
+        const screen = await render(
+          hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
+        );
+
+        assert.ok(screen.queryByText(t('pages.assessment-individual-results.progression')));
+        assert.ok(
+          screen.queryByText(t('common.result.percentage', { value: 0.8 }), {
+            normalizer: getDefaultNormalizer({ collapseWhitespace: false }),
+          }),
+        );
+      });
+
+      test('hides participant progression on campaign of type exam', async function (assert) {
+        this.participation = {
+          isShared: false,
+          progression: 0.8,
+        };
+
+        this.campaign = {
+          isTypeExam: true,
+        };
+
+        const screen = await render(
+          hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
+        );
+
+        assert.notOk(screen.queryByText(t('pages.assessment-individual-results.progression')));
+        assert.notOk(
+          screen.queryByText(t('common.result.percentage', { value: 0.8 }), {
+            normalizer: getDefaultNormalizer({ collapseWhitespace: false }),
+          }),
+        );
       });
     });
   });


### PR DESCRIPTION
## :pancakes: Problème

La progression est calculé sur le nombre d'acquis répondu du participation par rapport aux acquis qu'il a dans sont profile utilisateur. Or la campagne de type EXAM ne générera pas de KE . il nous sera donc impossible de savoir à quel % d'avancement il se situe

## :bacon: Proposition

Cacher cette indication dans le  cas des campagnes de type EXAM

## 🧃 Remarques

RAS

## :yum: Pour tester

CI au vert. Faire une seed de participation de type EXAM ne serait pas réel avec l'état actuel du code.  côté PixApp ( mais je peux en faire une si vraiment vous le voulez )