### PR TITLE
[TECH] Créer le feature toggle pour les attestations PDF V3 (PIX-16441).

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -857,6 +857,13 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: false
 # FT_PIX_ADMIN_NEW_SIDEBAR_ENABLED=false
 
+# Enable V3 certification attestation
+#
+# presence: optional
+# type: boolean
+# default: false
+# FT_V3_CERTIFICATION_ATTESTATION_ENABLED=true
+
 # =====
 # CPF
 # =====

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -134,6 +134,7 @@ const schema = Joi.object({
   FT_ENABLE_NEED_TO_ADJUST_CERTIFICATION_ACCESSIBILITY: Joi.string().optional().valid('true', 'false'),
   FT_ENABLE_TEXT_TO_SPEECH_BUTTON: Joi.string().optional().valid('true', 'false'),
   FT_PIX_COMPANION_ENABLED: Joi.string().optional().valid('true', 'false'),
+  FT_V3_CERTIFICATION_ATTESTATION_ENABLED: Joi.string().optional().valid('true', 'false'),
   KNEX_ASYNC_STACKTRACE_ENABLED: Joi.string().optional().valid('true', 'false'),
   LCMS_API_KEY: Joi.string().requiredForApi(),
   LCMS_API_URL: Joi.string().uri().requiredForApi(),
@@ -310,6 +311,7 @@ const configuration = (function () {
       showExperimentalMissions: toBoolean(process.env.FT_SHOW_EXPERIMENTAL_MISSIONS),
       showNewCampaignPresentationPage: toBoolean(process.env.FT_SHOW_NEW_CAMPAIGN_PRESENTATION_PAGE),
       showNewResultPage: toBoolean(process.env.FT_SHOW_NEW_RESULT_PAGE),
+      isV3CertificationAttestationEnabled: toBoolean(process.env.FT_V3_CERTIFICATION_ATTESTATION_ENABLED),
     },
     hapi: {
       options: {},

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -39,6 +39,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'show-experimental-missions': false,
             'show-new-campaign-presentation-page': false,
             'show-new-result-page': false,
+            'is-v3-certification-attestation-enabled': false,
           },
         },
       };


### PR DESCRIPTION
## :pancakes: Problème
Nous souhaitons implémenter le nouveau certificat V3 mais il nous faut pouvoir développer sereinement sans que le candidat ayant obtenu sa certification Pix v3 puisse voir une version incomplète.

## :bacon: Proposition

Ajouter un FT.

## :yum: Pour tester

Tous les tests passent
