### PR TITLE
[TECH] Dans Pix API supprimer les notions erronées ou obsolètes de scope et de target utilisées pour la vérification du droit d’accès d’un utilisateur à une application (PIX-15945)

### DIFF
--- a/api/src/authorization/domain/constants.js
+++ b/api/src/authorization/domain/constants.js
@@ -6,18 +6,11 @@ const PIX_ADMIN = {
     SUPER_ADMIN: 'SUPER_ADMIN',
     SUPPORT: 'SUPPORT',
   },
-  SCOPE: 'pix-admin',
-  TARGET: 'admin',
 };
 
 const PIX_ORGA = {
   NOT_LINKED_ORGANIZATION_MSG:
     "L'accès à Pix Orga est limité aux membres invités. Chaque espace est géré par un administrateur Pix Orga propre à l'organisation qui l'utilise. Contactez-le pour qu'il vous y invite.",
-  SCOPE: 'pix-orga',
 };
 
-const PIX_CERTIF = {
-  SCOPE: 'pix-certif',
-};
-
-export { PIX_ADMIN, PIX_CERTIF, PIX_ORGA };
+export { PIX_ADMIN, PIX_ORGA };

--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.admin.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.admin.controller.js
@@ -1,5 +1,4 @@
 import { oidcAuthenticationServiceRegistry } from '../../../../lib/domain/usecases/index.js';
-import { PIX_ADMIN } from '../../../authorization/domain/constants.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { usecases } from '../../domain/usecases/index.js';
 import * as oidcProviderSerializer from '../../infrastructure/serializers/jsonapi/oidc-identity-providers.serializer.js';
@@ -52,7 +51,7 @@ async function reconcileUserForAdmin(
 
   const oidcAuthenticationService = dependencies.oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({
     identityProviderCode: identityProvider,
-    target: PIX_ADMIN.TARGET,
+    requestedApplication,
   });
 
   const accessToken = await usecases.reconcileOidcUserForAdmin({

--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.route.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.route.js
@@ -10,7 +10,7 @@ export const oidcProviderRoutes = [
     options: {
       validate: {
         query: Joi.object({
-          target: Joi.string().optional().default('app'),
+          target: Joi.string().optional().default('app'), // Now useless, will soon be removed
         }),
       },
       auth: false,
@@ -49,7 +49,7 @@ export const oidcProviderRoutes = [
       validate: {
         query: Joi.object({
           identity_provider: Joi.string().required(),
-          target: Joi.string().valid('app', 'admin').optional(),
+          target: Joi.string().valid('app', 'admin').optional(), // Now useless, will soon be removed
         }),
       },
       handler: (request, h) => oidcProviderController.getAuthorizationUrl(request, h),
@@ -73,7 +73,7 @@ export const oidcProviderRoutes = [
               code: Joi.string().required(),
               state: Joi.string().required(),
               iss: Joi.string().optional(),
-              target: Joi.string().valid('app', 'admin').optional(),
+              target: Joi.string().valid('app', 'admin').optional(), // Now useless, will soon be removed
             },
           },
         }),

--- a/api/src/identity-access-management/application/token/token.controller.js
+++ b/api/src/identity-access-management/application/token/token.controller.js
@@ -1,6 +1,6 @@
 import { tokenService } from '../../../shared/domain/services/token-service.js';
 import { usecases } from '../../domain/usecases/index.js';
-import { getForwardedOrigin } from '../../infrastructure/utils/network.js';
+import { getForwardedOrigin, RequestedApplication } from '../../infrastructure/utils/network.js';
 
 const authenticateAnonymousUser = async function (request, h) {
   const { campaign_code: campaignCode, lang } = request.payload;
@@ -28,21 +28,22 @@ const createToken = async function (request, h, dependencies = { tokenService })
   let expirationDelaySeconds;
 
   const origin = getForwardedOrigin(request.headers);
+  const requestedApplication = RequestedApplication.fromOrigin(origin);
 
   const grantType = request.payload.grant_type;
 
   if (grantType === 'password') {
-    const { username, password, scope } = request.payload;
+    const { username, password } = request.payload;
     const localeFromCookie = request.state?.locale;
     const source = 'pix';
 
     const tokensInfo = await usecases.authenticateUser({
       username,
       password,
-      scope,
       source,
       localeFromCookie,
       audience: origin,
+      requestedApplication,
     });
 
     accessToken = tokensInfo.accessToken;

--- a/api/src/identity-access-management/application/token/token.route.js
+++ b/api/src/identity-access-management/application/token/token.route.js
@@ -21,7 +21,7 @@ export const tokenRoutes = [
               grant_type: Joi.string().valid('password').required(),
               username: Joi.string().required(),
               password: Joi.string().required(),
-              scope: Joi.string(),
+              scope: Joi.string().optional(), // Now useless, will soon be removed
             }),
           Joi.object()
             .required()

--- a/api/src/identity-access-management/domain/services/oidc-authentication-service-registry.js
+++ b/api/src/identity-access-management/domain/services/oidc-authentication-service-registry.js
@@ -44,8 +44,10 @@ export class OidcAuthenticationServiceRegistry {
     return this.#readyOidcProviderServicesForPixAdmin;
   }
 
-  getOidcProviderServiceByCode({ identityProviderCode, target = 'app' }) {
-    const services = target === 'admin' ? this.#readyOidcProviderServicesForPixAdmin : this.#readyOidcProviderServices;
+  getOidcProviderServiceByCode({ identityProviderCode, requestedApplication }) {
+    const services = requestedApplication?.isPixAdmin
+      ? this.#readyOidcProviderServicesForPixAdmin
+      : this.#readyOidcProviderServices;
     const oidcProviderService = services.find((service) => identityProviderCode === service.code);
 
     if (!oidcProviderService) {

--- a/api/src/identity-access-management/domain/usecases/authenticate-oidc-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/authenticate-oidc-user.usecase.js
@@ -69,7 +69,7 @@ async function authenticateOidcUser({
     return { authenticationKey, givenName, familyName, email, isAuthenticationComplete: false };
   }
 
-  await _assertUserWithPixAdminAccess({ target, userId: user.id, adminMemberRepository });
+  await _assertUserHasAccessToApplication({ target, user, adminMemberRepository });
 
   await _updateAuthenticationMethodWithComplement({
     userInfo,
@@ -120,9 +120,9 @@ async function _updateAuthenticationMethodWithComplement({
   });
 }
 
-async function _assertUserWithPixAdminAccess({ target, userId, adminMemberRepository }) {
+async function _assertUserHasAccessToApplication({ target, user, adminMemberRepository }) {
   if (target === PIX_ADMIN.TARGET) {
-    const adminMember = await adminMemberRepository.get({ userId });
+    const adminMember = await adminMemberRepository.get({ userId: user.id });
     if (!adminMember?.hasAccessToAdminScope) {
       throw new ForbiddenAccess(
         'User does not have the rights to access the application',

--- a/api/src/identity-access-management/domain/usecases/authenticate-user.js
+++ b/api/src/identity-access-management/domain/usecases/authenticate-user.js
@@ -23,50 +23,49 @@ const authenticateUser = async function ({
   audience,
 }) {
   try {
-    const foundUser = await pixAuthenticationService.getUserByUsernameAndPassword({
+    const user = await pixAuthenticationService.getUserByUsernameAndPassword({
       username,
       password,
       userRepository,
     });
 
-    if (foundUser.shouldChangePassword) {
-      const passwordResetToken = tokenService.createPasswordResetToken(foundUser.id);
+    if (user.shouldChangePassword) {
+      const passwordResetToken = tokenService.createPasswordResetToken(user.id);
       throw new UserShouldChangePasswordError(undefined, passwordResetToken);
     }
 
-    await _checkUserAccessScope(scope, foundUser, adminMemberRepository);
+    await _assertUserHasAccessToApplication({ scope, user, adminMemberRepository });
 
-    const refreshToken = RefreshToken.generate({ userId: foundUser.id, source, audience });
+    const refreshToken = RefreshToken.generate({ userId: user.id, source, audience });
     await refreshTokenRepository.save({ refreshToken });
 
     const { accessToken, expirationDelaySeconds } = await tokenService.createAccessTokenFromUser({
-      userId: foundUser.id,
+      userId: user.id,
       source,
       audience,
     });
 
-    foundUser.setLocaleIfNotAlreadySet(localeFromCookie);
-    if (foundUser.hasBeenModified) {
-      await userRepository.update({ id: foundUser.id, locale: foundUser.locale });
+    user.setLocaleIfNotAlreadySet(localeFromCookie);
+    if (user.hasBeenModified) {
+      await userRepository.update({ id: user.id, locale: user.locale });
     }
-    const userLogin = await userLoginRepository.findByUserId(foundUser.id);
-    if (foundUser.email && userLogin?.shouldSendConnectionWarning()) {
-      const validationToken = !foundUser.emailConfirmedAt
-        ? await emailValidationDemandRepository.save(foundUser.id)
-        : null;
+
+    const userLogin = await userLoginRepository.findByUserId(user.id);
+    if (user.email && userLogin?.shouldSendConnectionWarning()) {
+      const validationToken = !user.emailConfirmedAt ? await emailValidationDemandRepository.save(user.id) : null;
       await emailRepository.sendEmailAsync(
         createWarningConnectionEmail({
-          locale: foundUser.locale,
-          email: foundUser.email,
-          firstName: foundUser.firstName,
+          locale: user.locale,
+          email: user.email,
+          firstName: user.firstName,
           validationToken,
         }),
       );
     }
-    await userLoginRepository.updateLastLoggedAt({ userId: foundUser.id });
+    await userLoginRepository.updateLastLoggedAt({ userId: user.id });
 
     await authenticationMethodRepository.updateLastLoggedAtByIdentityProvider({
-      userId: foundUser.id,
+      userId: user.id,
       identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
     });
 
@@ -80,7 +79,7 @@ const authenticateUser = async function ({
   }
 };
 
-async function _checkUserAccessScope(scope, user, adminMemberRepository) {
+async function _assertUserHasAccessToApplication({ scope, user, adminMemberRepository }) {
   if (scope === PIX_ORGA.SCOPE && !user.isLinkedToOrganizations()) {
     throw new ForbiddenAccess(PIX_ORGA.NOT_LINKED_ORGANIZATION_MSG);
   }

--- a/api/src/identity-access-management/domain/usecases/get-authorization-url.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/get-authorization-url.usecase.js
@@ -1,18 +1,18 @@
 /**
  * @typedef {function} getAuthorizationUrl
  * @param {Object} params
- * @param {string} params.audience
  * @param {string} params.identityProvider
+ * @param {RequestedApplication} params.requestedApplication
  * @param {OidcAuthenticationServiceRegistry} params.oidcAuthenticationServiceRegistry
  * @return {Promise<string>}
  */
-async function getAuthorizationUrl({ target, identityProvider, oidcAuthenticationServiceRegistry }) {
+async function getAuthorizationUrl({ identityProvider, requestedApplication, oidcAuthenticationServiceRegistry }) {
   await oidcAuthenticationServiceRegistry.loadOidcProviderServices();
   await oidcAuthenticationServiceRegistry.configureReadyOidcProviderServiceByCode(identityProvider);
 
   const oidcAuthenticationService = oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({
     identityProviderCode: identityProvider,
-    target,
+    requestedApplication,
   });
 
   return oidcAuthenticationService.getAuthorizationUrl();

--- a/api/src/identity-access-management/domain/usecases/get-ready-identity-providers.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/get-ready-identity-providers.usecase.js
@@ -1,14 +1,14 @@
 /**
  * @typedef {function} getReadyIdentityProviders
  * @param {Object} params
- * @param {string} [params.audience=app]
+ * @param {RequestedApplication} params.requestedApplication
  * @param {OidcAuthenticationServiceRegistry} params.oidcAuthenticationServiceRegistry
  * @return {Promise<OidcAuthenticationService[]|null>}
  */
-const getReadyIdentityProviders = async function ({ target = 'app', oidcAuthenticationServiceRegistry }) {
+const getReadyIdentityProviders = async function ({ requestedApplication, oidcAuthenticationServiceRegistry }) {
   await oidcAuthenticationServiceRegistry.loadOidcProviderServices();
 
-  if (target === 'admin') {
+  if (requestedApplication?.isPixAdmin) {
     return oidcAuthenticationServiceRegistry.getReadyOidcProviderServicesForPixAdmin();
   }
 

--- a/api/src/identity-access-management/domain/usecases/reconcile-oidc-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/reconcile-oidc-user.usecase.js
@@ -7,6 +7,7 @@ import { AuthenticationMethod } from '../models/AuthenticationMethod.js';
  * @param {string} params.authenticationKey
  * @param {string} params.identityProvider
  * @param {string} params.audience
+ * @param {RequestedApplication} params.requestedApplication
  * @param {AuthenticationSessionService} params.authenticationSessionService
  * @param {AuthenticationMethodRepository} params.authenticationMethodRepository
  * @param {OidcAuthenticationServiceRegistry} params.oidcAuthenticationServiceRegistry
@@ -31,6 +32,7 @@ export const reconcileOidcUser = async function ({
 
   const oidcAuthenticationService = oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({
     identityProviderCode: identityProvider,
+    requestedApplication,
   });
 
   const sessionContentAndUserInfo = await authenticationSessionService.getByKey(authenticationKey);

--- a/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
@@ -30,6 +30,10 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
       const options = {
         method: 'GET',
         url: '/api/oidc/identity-providers',
+        headers: {
+          'x-forwarded-proto': 'https',
+          'x-forwarded-host': 'app.pix.fr',
+        },
       };
 
       // when
@@ -79,13 +83,16 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
       // given
       const query = querystring.stringify({
         identity_provider: 'OIDC_EXAMPLE_NET',
-        target: 'app',
       });
 
       // when
       const response = await server.inject({
         method: 'GET',
         url: `/api/oidc/authorization-url?${query}`,
+        headers: {
+          'x-forwarded-proto': 'https',
+          'x-forwarded-host': 'app.pix.fr',
+        },
       });
 
       // then
@@ -119,6 +126,10 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
       const authUrlResponse = await server.inject({
         method: 'GET',
         url: `/api/oidc/authorization-url?${query}`,
+        headers: {
+          'x-forwarded-proto': 'https',
+          'x-forwarded-host': 'app.pix.fr',
+        },
       });
       cookies = authUrlResponse.headers['set-cookie'];
 
@@ -192,7 +203,11 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
         const response = await server.inject({
           method: 'POST',
           url: '/api/oidc/token',
-          headers,
+          headers: {
+            cookie: cookies[0],
+            'x-forwarded-proto': 'https',
+            'x-forwarded-host': 'app.pix.fr',
+          },
           payload,
         });
 
@@ -285,15 +300,13 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
       });
     });
 
-    context('when target is admin', function () {
+    context('when the requestedApplication is admin', function () {
       context('when user does not have an admin role', function () {
         it('returns 403', async function () {
           // given
           const firstName = 'John';
           const lastName = 'Doe';
           const externalIdentifier = 'sub';
-
-          payload.data.attributes.target = 'admin';
 
           const userId = databaseBuilder.factory.buildUser({
             firstName,
@@ -340,7 +353,11 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
           const response = await server.inject({
             method: 'POST',
             url: '/api/oidc/token',
-            headers,
+            headers: {
+              cookie: cookies[0],
+              'x-forwarded-proto': 'https',
+              'x-forwarded-host': 'admin.pix.fr',
+            },
             payload,
           });
 
@@ -363,8 +380,6 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
           const firstName = 'John';
           const lastName = 'Doe';
           const externalIdentifier = 'sub';
-
-          payload.data.attributes.target = 'admin';
 
           const userId = databaseBuilder.factory.buildUser.withRole({
             firstName,

--- a/api/tests/identity-access-management/acceptance/application/token.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/token.route.test.js
@@ -32,21 +32,15 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
     });
 
     it('returns a 200 with an access token and a refresh token when authentication is ok', async function () {
-      // given / when
-      const response = await server.inject({
-        method: 'POST',
+      // given
+      const options = _getPostFormOptions({
         url: '/api/token',
-        headers: {
-          'content-type': 'application/x-www-form-urlencoded',
-          'x-forwarded-proto': 'https',
-          'x-forwarded-host': 'orga.pix.fr',
-        },
-        payload: querystring.stringify({
-          grant_type: 'password',
-          username: userEmailAddress,
-          password: userPassword,
-        }),
+        dataToPost: { grant_type: 'password', username: userEmailAddress, password: userPassword },
+        applicationName: 'orga',
       });
+
+      // when
+      const response = await server.inject(options);
 
       // then
       const result = response.result;
@@ -72,21 +66,14 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
 
       await databaseBuilder.commit();
 
-      // when
-      const response = await server.inject({
-        method: 'POST',
+      const options = _getPostFormOptions({
         url: '/api/token',
-        headers: {
-          'content-type': 'application/x-www-form-urlencoded',
-          'x-forwarded-proto': 'https',
-          'x-forwarded-host': 'orga.pix.fr',
-        },
-        payload: querystring.stringify({
-          grant_type: 'password',
-          username: 'beth.rave1212',
-          password: userPassword,
-        }),
+        dataToPost: { grant_type: 'password', username: 'beth.rave1212', password: userPassword },
+        applicationName: 'orga',
       });
+
+      // when
+      const response = await server.inject(options);
 
       // then
       expect(response.statusCode).to.equal(401);
@@ -97,35 +84,28 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
     context('when user needs to refresh his access token', function () {
       it('returns a 200 with a new access token', async function () {
         // given
-        const { result: accessTokenResult } = await server.inject({
-          method: 'POST',
+        const optionsForAccessToken = _getPostFormOptions({
           url: '/api/token',
-          headers: {
-            'content-type': 'application/x-www-form-urlencoded',
-            'x-forwarded-proto': 'https',
-            'x-forwarded-host': 'orga.pix.fr',
-          },
-          payload: querystring.stringify({
+          dataToPost: {
             grant_type: 'password',
             username: userEmailAddress,
             password: userPassword,
-          }),
+          },
+          applicationName: 'orga',
+        });
+        const { result: accessTokenResult } = await server.inject(optionsForAccessToken);
+
+        const options = _getPostFormOptions({
+          url: '/api/token',
+          dataToPost: {
+            grant_type: 'refresh_token',
+            refresh_token: accessTokenResult.refresh_token,
+          },
+          applicationName: 'orga',
         });
 
         // when
-        const response = await server.inject({
-          method: 'POST',
-          url: '/api/token',
-          headers: {
-            'content-type': 'application/x-www-form-urlencoded',
-            'x-forwarded-proto': 'https',
-            'x-forwarded-host': 'orga.pix.fr',
-          },
-          payload: querystring.stringify({
-            grant_type: 'refresh_token',
-            refresh_token: accessTokenResult.refresh_token,
-          }),
-        });
+        const response = await server.inject(options);
 
         // then
         const result = response.result;
@@ -144,7 +124,7 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
     context('when requestedApplication is admin', function () {
       context('when admin member has allowed role but has been disabled', function () {
         it('returns http code 403', async function () {
-          //given
+          // given
           const user = databaseBuilder.factory.buildUser.withRawPassword({
             email: 'email@example.net',
             rawPassword: userPassword,
@@ -157,7 +137,11 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
           });
           await databaseBuilder.commit();
 
-          const options = _getServerOptions({ username: user.email, password: userPassword, applicationName: 'admin' });
+          const options = _getPostFormOptions({
+            url: '/api/token',
+            dataToPost: { grant_type: 'password', username: user.email, password: userPassword },
+            applicationName: 'admin',
+          });
 
           // when
           const response = await server.inject(options);
@@ -170,7 +154,7 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
 
     context('when application is Pix Certif', function () {
       it('returns http code 200 with accessToken when authentication is ok', async function () {
-        //given
+        // given
         databaseBuilder.factory.buildCertificationCenter({ id: 345 });
         databaseBuilder.factory.buildSession({ id: 121, certificationCenterId: 345 });
         const candidate = databaseBuilder.factory.buildCertificationCandidate({ sessionId: 121 });
@@ -178,13 +162,12 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
         databaseBuilder.factory.buildSupervisorAccess({ userId, sessionId: 121 });
         await databaseBuilder.commit();
 
-        const options = _getServerOptions({
-          username: userEmailAddress,
-          password: userPassword,
+        const options = _getPostFormOptions({
+          url: '/api/token',
+          dataToPost: { grant_type: 'password', username: userEmailAddress, password: userPassword },
           applicationName: 'certif',
         });
 
-        await databaseBuilder.commit();
         // when
         const response = await server.inject(options);
 
@@ -214,9 +197,9 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
           databaseBuilder.factory.buildUserLogin({ userId, failureCount: 9 });
           await databaseBuilder.commit();
 
-          const options = _getServerOptions({
-            username: 'email@without.mb',
-            password: 'wrongPassword',
+          const options = _getPostFormOptions({
+            url: '/api/token',
+            dataToPost: { grant_type: 'password', username: 'email@without.mb', password: 'wrongPassword' },
             applicationName: 'app',
           });
 
@@ -246,9 +229,9 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
           });
           await databaseBuilder.commit();
 
-          const options = _getServerOptions({
-            username: 'email@without.mb',
-            password: userPassword,
+          const options = _getPostFormOptions({
+            url: '/api/token',
+            dataToPost: { grant_type: 'password', username: 'email@without.mb', password: userPassword },
             applicationName: 'app',
           });
 
@@ -275,9 +258,9 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
           });
           await databaseBuilder.commit();
 
-          const options = _getServerOptions({
-            username: 'email@without.mb',
-            password: userPassword,
+          const options = _getPostFormOptions({
+            url: '/api/token',
+            dataToPost: { grant_type: 'password', username: 'email@without.mb', password: userPassword },
             applicationName: 'app',
           });
 
@@ -306,22 +289,15 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
           });
           await databaseBuilder.commit();
 
-          // when
-          const response = await server.inject({
-            method: 'POST',
+          const options = _getPostFormOptions({
             url: '/api/token',
-            headers: {
-              'content-type': 'application/x-www-form-urlencoded',
-              cookie: `locale=${localeFromCookie}`,
-              'x-forwarded-proto': 'https',
-              'x-forwarded-host': 'app.pix.fr',
-            },
-            payload: querystring.stringify({
-              grant_type: 'password',
-              username: userWithoutLocale.email,
-              password: userPassword,
-            }),
+            dataToPost: { grant_type: 'password', username: userWithoutLocale.email, password: userPassword },
+            applicationName: 'app',
+            localeFromCookie,
           });
+
+          // when
+          const response = await server.inject(options);
 
           // then
           expect(response.statusCode).to.equal(200);
@@ -343,22 +319,19 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
           });
           await databaseBuilder.commit();
 
-          // when
-          const response = await server.inject({
-            method: 'POST',
+          const options = _getPostFormOptions({
             url: '/api/token',
-            headers: {
-              'content-type': 'application/x-www-form-urlencoded',
-              cookie: `locale=${localeFromCookie}`,
-              'x-forwarded-proto': 'https',
-              'x-forwarded-host': 'app.pix.fr',
-            },
-            payload: querystring.stringify({
+            dataToPost: {
               grant_type: 'password',
               username: userWithLocale.email,
               password: userPassword,
-            }),
+            },
+            applicationName: 'app',
+            localeFromCookie,
           });
+
+          // when
+          const response = await server.inject(options);
 
           // then
           expect(response.statusCode).to.equal(200);
@@ -380,22 +353,16 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
       beforeEach(async function () {
         const targetProfile = databaseBuilder.factory.buildTargetProfile({ isSimplifiedAccess: false });
         databaseBuilder.factory.buildCampaign({ code: campaignCode, targetProfile });
+        await databaseBuilder.commit();
 
-        options = {
-          method: 'POST',
+        options = _getPostFormOptions({
           url: '/api/token/anonymous',
-          headers: {
-            'content-type': 'application/x-www-form-urlencoded',
-            'x-forwarded-proto': 'https',
-            'x-forwarded-host': 'app.pix.fr',
-          },
-          payload: querystring.stringify({
+          dataToPost: {
             campaign_code: campaignCode,
             lang,
-          }),
-        };
-
-        await databaseBuilder.commit();
+          },
+          applicationName: 'app',
+        });
       });
 
       it('returns an 401', async function () {
@@ -418,22 +385,16 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
       beforeEach(async function () {
         const targetProfileId = databaseBuilder.factory.buildTargetProfile({ isSimplifiedAccess: true }).id;
         databaseBuilder.factory.buildCampaign({ code: simplifiedAccessCampaignCode, targetProfileId });
+        await databaseBuilder.commit();
 
-        options = {
-          method: 'POST',
+        options = _getPostFormOptions({
           url: '/api/token/anonymous',
-          headers: {
-            'content-type': 'application/x-www-form-urlencoded',
-            'x-forwarded-proto': 'https',
-            'x-forwarded-host': 'app.pix.fr',
-          },
-          payload: querystring.stringify({
+          dataToPost: {
             campaign_code: simplifiedAccessCampaignCode,
             lang,
-          }),
-        };
-
-        await databaseBuilder.commit();
+          },
+          applicationName: 'app',
+        });
       });
 
       it('returns a 200 with accessToken', async function () {
@@ -540,19 +501,16 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
   });
 });
 
-function _getServerOptions({ username, password, applicationName }) {
+function _getPostFormOptions({ url, dataToPost, applicationName, localeFromCookie }) {
   return {
     method: 'POST',
-    url: '/api/token',
+    url,
     headers: {
       'content-type': 'application/x-www-form-urlencoded',
       'x-forwarded-proto': 'https',
       'x-forwarded-host': `${applicationName}.pix.fr`,
+      ...(localeFromCookie && { cookie: `locale=${localeFromCookie}` }),
     },
-    payload: querystring.stringify({
-      grant_type: 'password',
-      username,
-      password,
-    }),
+    payload: querystring.stringify(dataToPost),
   };
 }

--- a/api/tests/identity-access-management/integration/domain/services/oidc-authentication-service-registry.test.js
+++ b/api/tests/identity-access-management/integration/domain/services/oidc-authentication-service-registry.test.js
@@ -1,6 +1,6 @@
-import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
 import { OidcAuthenticationServiceRegistry } from '../../../../../src/identity-access-management/domain/services/oidc-authentication-service-registry.js';
 import { oidcProviderRepository } from '../../../../../src/identity-access-management/infrastructure/repositories/oidc-provider-repository.js';
+import { RequestedApplication } from '../../../../../src/identity-access-management/infrastructure/utils/network.js';
 import { InvalidIdentityProviderError } from '../../../../../src/shared/domain/errors.js';
 import { catchErrSync, databaseBuilder, expect } from '../../../../test-helper.js';
 
@@ -164,15 +164,16 @@ describe('Integration | Identity Access Management | Domain | Service | oidc-aut
       expect(service.code).to.equal('OIDC_EXAMPLE');
     });
 
-    describe('when the target is admin', function () {
+    describe('when the requestedApplication is admin', function () {
       it('returns a ready OIDC provider for Pix Admin', async function () {
         // given
+        const requestedApplication = new RequestedApplication('admin');
         await oidcAuthenticationServiceRegistry.loadOidcProviderServices();
 
         // when
         const service = oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({
           identityProviderCode: 'OIDC_EXAMPLE_FOR_PIX_ADMIN',
-          target: PIX_ADMIN.TARGET,
+          requestedApplication,
         });
 
         // then

--- a/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
@@ -80,27 +80,6 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
       });
     });
 
-    context('when authentication is complete', function () {
-      it('returns PIX access token and logout url uuid', async function () {
-        // given
-        usecases.authenticateOidcUser.resolves({
-          pixAccessToken,
-          logoutUrlUUID: '0208f50b-f612-46aa-89a0-7cdb5fb0d312',
-          isAuthenticationComplete: true,
-        });
-
-        // when
-        const response = await oidcProviderController.authenticateOidcUser(request, hFake);
-
-        // then
-        const expectedResult = {
-          access_token: pixAccessToken,
-          logout_url_uuid: '0208f50b-f612-46aa-89a0-7cdb5fb0d312',
-        };
-        expect(response.source).to.deep.equal(expectedResult);
-      });
-    });
-
     context('when pix access token does not exist', function () {
       it('returns UnauthorizedError', async function () {
         // given
@@ -244,71 +223,6 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
       expect(response.statusCode).to.equal(200);
       expect(response.source).to.deep.equal({
         redirectTarget: 'https://idp.net/oidc/authorization',
-      });
-    });
-  });
-
-  describe('#getIdentityProviders', function () {
-    it('returns the list of oidc identity providers', async function () {
-      // given
-      sinon.stub(usecases, 'getReadyIdentityProviders').returns([
-        {
-          code: 'SOME_OIDC_PROVIDER',
-          source: 'some_oidc_provider',
-          isVisible: true,
-          organizationName: 'Some OIDC Provider',
-          slug: 'some-oidc-provider',
-          shouldCloseSession: false,
-        },
-      ]);
-
-      // when
-      const response = await oidcProviderController.getIdentityProviders({ query: { target: null } }, hFake);
-
-      // then
-      expect(usecases.getReadyIdentityProviders).to.have.been.called;
-      expect(response.statusCode).to.equal(200);
-      expect(response.source.data).to.have.lengthOf(1);
-      expect(response.source.data).to.deep.contain({
-        type: 'oidc-identity-providers',
-        id: 'some-oidc-provider',
-        attributes: {
-          code: 'SOME_OIDC_PROVIDER',
-          source: 'some_oidc_provider',
-          'organization-name': 'Some OIDC Provider',
-          slug: 'some-oidc-provider',
-          'should-close-session': false,
-          'is-visible': true,
-        },
-      });
-    });
-  });
-
-  describe('#getRedirectLogoutUrl', function () {
-    it('calls the oidc authentication service retrieved from his code to generate the redirect logout url', async function () {
-      // given
-      const request = {
-        auth: { credentials: { userId: '123' } },
-        query: {
-          identity_provider: 'OIDC',
-          logout_url_uuid: '1f3dbb71-f399-4c1c-85ae-0a863c78aeea',
-        },
-      };
-
-      sinon.stub(usecases, 'getRedirectLogoutUrl').resolves('https://idp.net/oidc/logout?id_token_hint=ID_TOKEN');
-
-      // when
-      const response = await oidcProviderController.getRedirectLogoutUrl(request, hFake);
-
-      // then
-      expect(usecases.getRedirectLogoutUrl).to.have.been.calledWithExactly({
-        identityProvider: 'OIDC',
-        logoutUrlUUID: '1f3dbb71-f399-4c1c-85ae-0a863c78aeea',
-        userId: '123',
-      });
-      expect(response.statusCode).to.equal(200);
-      expect(response.source).to.deep.equal({
-        redirectLogoutUrl: 'https://idp.net/oidc/logout?id_token_hint=ID_TOKEN',
       });
     });
   });

--- a/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
@@ -53,7 +53,6 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
 
       // then
       expect(usecases.authenticateOidcUser).to.have.been.calledWithExactly({
-        target: undefined,
         code,
         identityProviderCode: identityProvider,
         nonce: 'nonce',
@@ -193,6 +192,10 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
     it('returns the generated authorization url', async function () {
       // given
       const request = {
+        headers: {
+          'x-forwarded-proto': 'https',
+          'x-forwarded-host': 'app.pix.fr',
+        },
         query: { identity_provider: 'OIDC' },
         yar: { set: sinon.stub(), commit: sinon.stub() },
       };
@@ -207,8 +210,8 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
 
       //then
       expect(usecases.getAuthorizationUrl).to.have.been.calledWithExactly({
-        target: undefined,
         identityProvider: 'OIDC',
+        requestedApplication: new RequestedApplication('app'),
       });
       expect(request.yar.set).to.have.been.calledTwice;
       expect(request.yar.set.getCall(0)).to.have.been.calledWithExactly(

--- a/api/tests/identity-access-management/unit/application/token.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/token.controller.test.js
@@ -1,5 +1,6 @@
 import { tokenController } from '../../../../src/identity-access-management/application/token/token.controller.js';
 import { usecases } from '../../../../src/identity-access-management/domain/usecases/index.js';
+import { RequestedApplication } from '../../../../src/identity-access-management/infrastructure/utils/network.js';
 import { expect, hFake, sinon } from '../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Application | Controller | Token', function () {
@@ -39,9 +40,9 @@ describe('Unit | Identity Access Management | Application | Controller | Token',
     const accessToken = 'jwt.access.token';
     const username = 'user@email.com';
     const password = 'user_password';
-    const scope = 'pix-orga';
     const source = 'pix';
     const audience = 'https://app.pix.fr';
+    const requestedApplication = new RequestedApplication('app');
 
     /**
      * @see https://www.oauth.com/oauth2-servers/access-tokens/access-token-response/
@@ -62,7 +63,6 @@ describe('Unit | Identity Access Management | Application | Controller | Token',
             grant_type: 'password',
             username,
             password,
-            scope,
           },
           state: {
             locale: localeFromCookie,
@@ -71,7 +71,7 @@ describe('Unit | Identity Access Management | Application | Controller | Token',
 
         sinon
           .stub(usecases, 'authenticateUser')
-          .withArgs({ username, password, scope, source, localeFromCookie, audience })
+          .withArgs({ username, password, source, localeFromCookie, audience, requestedApplication })
           .resolves({ accessToken, refreshToken, expirationDelaySeconds });
 
         const tokenServiceStub = { extractUserId: sinon.stub() };
@@ -111,7 +111,7 @@ describe('Unit | Identity Access Management | Application | Controller | Token',
             'x-forwarded-proto': 'https',
             'x-forwarded-host': 'app.pix.fr',
           },
-          payload: { grant_type: 'refresh_token', refresh_token: refreshToken, scope },
+          payload: { grant_type: 'refresh_token', refresh_token: refreshToken },
         };
 
         sinon

--- a/api/tests/identity-access-management/unit/domain/usecases/get-authorization-url.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/get-authorization-url.usecase.test.js
@@ -4,7 +4,6 @@ import { expect, sinon } from '../../../../test-helper.js';
 describe('Unit | Identity Access Management | Domain | UseCases | get-authorization-url', function () {
   it('returns the generated authorization url', async function () {
     // given
-    const target = 'app';
     const identityProvider = 'OIDC';
     const oidcAuthenticationService = {
       getAuthorizationUrl: sinon.stub().returns('https://authorization.url'),
@@ -21,7 +20,6 @@ describe('Unit | Identity Access Management | Domain | UseCases | get-authorizat
 
     // when
     const authorizationUrl = await getAuthorizationUrl({
-      target,
       identityProvider,
       oidcAuthenticationServiceRegistry,
     });
@@ -33,7 +31,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | get-authorizat
     );
     expect(oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode).to.have.been.calledWithExactly({
       identityProviderCode: 'OIDC',
-      target: 'app',
+      requestedApplication: undefined,
     });
     expect(oidcAuthenticationService.getAuthorizationUrl).to.have.been.calledOnce;
     expect(authorizationUrl).to.equal('https://authorization.url');

--- a/api/tests/identity-access-management/unit/domain/usecases/get-ready-identity-providers.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/get-ready-identity-providers.usecase.test.js
@@ -1,5 +1,5 @@
-import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
 import { getReadyIdentityProviders } from '../../../../../src/identity-access-management/domain/usecases/get-ready-identity-providers.usecase.js';
+import { RequestedApplication } from '../../../../../src/identity-access-management/infrastructure/utils/network.js';
 import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Domain | UseCases | get-ready-identity-providers', function () {
@@ -19,13 +19,16 @@ describe('Unit | Identity Access Management | Domain | UseCases | get-ready-iden
     };
   });
 
-  describe('when a target is provided', function () {
-    describe('when the provided target is equal to "admin"', function () {
+  describe('when requestedApplication is provided', function () {
+    describe('when the provided requestedApplication is Pix Admin', function () {
       it('returns oidc providers from getReadyOidcProviderServicesForPixAdmin', async function () {
+        // given
+        const requestedApplication = new RequestedApplication('admin');
+
         // when
         const identityProviders = await getReadyIdentityProviders({
-          target: PIX_ADMIN.TARGET,
           oidcAuthenticationServiceRegistry: oidcAuthenticationServiceRegistryStub,
+          requestedApplication,
         });
 
         // then
@@ -39,7 +42,6 @@ describe('Unit | Identity Access Management | Domain | UseCases | get-ready-iden
   it('returns oidc providers from getReadyOidcProviderServices', async function () {
     // when
     const identityProviders = await getReadyIdentityProviders({
-      target: null,
       oidcAuthenticationServiceRegistry: oidcAuthenticationServiceRegistryStub,
     });
 

--- a/high-level-tests/e2e/cypress.config.cjs
+++ b/high-level-tests/e2e/cypress.config.cjs
@@ -56,7 +56,6 @@ async function setupNodeEvents(on, config) {
 module.exports = defineConfig({
   env: {
     APP_URL: "http://localhost:4200",
-    API_URL: "http://localhost:3000",
     ORGA_URL: "http://localhost:4201",
     visualRegressionType: "regression",
   },

--- a/high-level-tests/e2e/cypress/support/commands.js
+++ b/high-level-tests/e2e/cypress/support/commands.js
@@ -31,7 +31,7 @@ function setEmberSimpleAuthSession(response) {
 Cypress.Commands.add("login", (username, password, url) => {
   cy.intercept("/api/users/me").as("getCurrentUser");
   cy.request({
-    url: `${Cypress.env('API_URL')}/api/token`,
+    url: `${Cypress.env('APP_URL')}/api/token`,
     method: 'POST',
     form: true,
     body: getLoginBody(username, password, 'mon-pix'),
@@ -44,7 +44,7 @@ Cypress.Commands.add("login", (username, password, url) => {
 Cypress.Commands.add('loginOrga', (username, password) => {
   cy.intercept('/api/prescription/prescribers/**').as('getCurrentUser');
   cy.request({
-    url: `${Cypress.env('API_URL')}/api/token`,
+    url: `${Cypress.env('ORGA_URL')}/api/token`,
     method: 'POST',
     form: true,
     body: getLoginBody(username, password, 'pix-orga'),


### PR DESCRIPTION
## :pancakes: Problème

Les usecases `authenticateUser` et `authenticateOidcUser` se basent encore sur des notions de `scope` et de `target` qui sont erronées ou maintenant obsolètes et que nous voulons supprimer du code de Pix.

De plus, les usecases `authenticateUser` et `authenticateOidcUser` sont très proches mais ont du code légèrement différent, ce qui empêchent du travail de factorisation présent et futur.

## :bacon: Proposition

* Rendre le code des 2 usecases `authenticateUser` et `authenticateOidcUser` plus cohérent en utilisant les mêmes noms de variables et les mêmes noms de fonction,
* Utiliser une nouvelle notion générique de `RequestedApplication`, déduite à partir de l'_origin_, pour remplacer les notions de `scope` et de `target`.

PS : On aurait aimé utiliser un security prehandler en commun, mais ce n’est pas possible car dans le cas du usecase  `authenticateOidcUser` l'utilisateur n'est trouvé qu'à l'intérieur du usecase lors des échanges OIDC.


## 🧃 Remarques

RAS


## :yum: Pour tester

### Tester la connexion par login + mot de passe

Ces tests permettent de valider le bon fonctionnement du usecase `authenticateUser`.

1. Se connecter sur Pix App avec un utilisateur ayant un compte et constater l'authentification réussie,
2. Se connecter sur Pix Orga avec n'importe quel utilisateur n'ayant aucun droit sur des orgas (par exemple `hermione@school.net`) et constater l'échec de l'authentification avec l'affichage du message : 

   > L'accès à Pix Orga est limité aux membres invités. Chaque espace est géré par un administrateur Pix Orga propre à l'organisation qui l'utilise. Contactez-le pour qu'il vous y invite`

3. Se connecter sur Pix Orga avec un utilisateur ayant des droits sur une orga (par exemple `allorga@example.net`) et constater l'authentification réussie,
4. Se connecter sur Pix Admin avec n'importe quel utilisateur n'ayant aucun droit sur Pix Admin (par exemple `hermione@school.net`) et constater l'échec de l'authentification avec l'affichage du message : 

   > Vous n'avez pas les droits pour vous connecter.

5. Se connecter sur Pix Admin avec un utilisateur `SUPER_ADMIN` (par exemple `superadmin@example.net`) et constater l'authentification réussie.
 
### Tester la connexion par SSO

Ces tests permettent de valider le bon fonctionnement du usecase `authenticateOidcUser`.

1. Se connecter sur Pix App .fr par SSO avec un utilisateur approprié,
2. Se connecter sur Pix App .org par SSO avec un utilisateur approprié,
3. Se connecter sur Pix Admin par SSO avec un utilisateur approprié.
