### PR TITLE
[FEATURE] Enregistrer dans Authentication Methods la date de dernière connexion Pix pour les méthodes de connexion Pix (PIX-16620)

### DIFF
--- a/api/db/database-builder/factory/build-authentication-method.js
+++ b/api/db/database-builder/factory/build-authentication-method.js
@@ -108,6 +108,7 @@ buildAuthenticationMethod.withPoleEmploiAsIdentityProvider = function ({
   userId,
   createdAt = new Date('2020-01-01'),
   updatedAt = new Date('2020-01-02'),
+  lastLoggedAt = null,
 } = {}) {
   userId = isUndefined(userId) ? buildUser().id : userId;
 
@@ -127,6 +128,7 @@ buildAuthenticationMethod.withPoleEmploiAsIdentityProvider = function ({
     userId,
     createdAt,
     updatedAt,
+    lastLoggedAt,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'authentication-methods',
@@ -157,6 +159,7 @@ buildAuthenticationMethod.withOidcProviderAsIdentityProvider = function ({
     }),
     createdAt: new Date('2020-01-01'),
     updatedAt: new Date('2020-01-02'),
+    lastLoggedAt: null,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'authentication-methods',
@@ -171,6 +174,7 @@ buildAuthenticationMethod.withIdentityProvider = function ({
   userId,
   createdAt = new Date('2020-01-01'),
   updatedAt = new Date('2020-01-02'),
+  lastLoggedAt = null,
 } = {}) {
   userId = isUndefined(userId) ? buildUser().id : userId;
 
@@ -185,6 +189,7 @@ buildAuthenticationMethod.withIdentityProvider = function ({
     userId,
     createdAt,
     updatedAt,
+    lastLoggedAt,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'authentication-methods',

--- a/api/lib/domain/usecases/authenticate-external-user.js
+++ b/api/lib/domain/usecases/authenticate-external-user.js
@@ -57,7 +57,10 @@ async function authenticateExternalUser({
     const token = tokenService.createAccessTokenForSaml({ userId: userFromCredentials.id, audience });
 
     await userLoginRepository.updateLastLoggedAt({ userId: userFromCredentials.id });
-
+    await authenticationMethodRepository.updateLastLoggedAtByIdentityProvider({
+      userId: userFromCredentials.id,
+      identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
+    });
     return token;
   } catch (error) {
     if (error instanceof UserNotFoundError || error instanceof PasswordNotMatching) {

--- a/api/src/identity-access-management/domain/models/AuthenticationMethod.js
+++ b/api/src/identity-access-management/domain/models/AuthenticationMethod.js
@@ -80,6 +80,7 @@ const validationSchema = Joi.object({
   userId: Joi.number().integer().required(),
   createdAt: Joi.date().optional(),
   updatedAt: Joi.date().optional(),
+  lastLoggedAt: Joi.date().allow(null).optional(),
 });
 
 class AuthenticationMethod {
@@ -91,6 +92,7 @@ class AuthenticationMethod {
     createdAt,
     updatedAt,
     userId,
+    lastLoggedAt,
   } = {}) {
     this.id = id;
     this.identityProvider = identityProvider;
@@ -99,11 +101,20 @@ class AuthenticationMethod {
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
     this.userId = userId;
+    this.lastLoggedAt = lastLoggedAt;
 
     validateEntity(validationSchema, this);
   }
 
-  static buildPixAuthenticationMethod({ id, password, shouldChangePassword = false, createdAt, updatedAt, userId }) {
+  static buildPixAuthenticationMethod({
+    id,
+    password,
+    shouldChangePassword = false,
+    createdAt,
+    updatedAt,
+    userId,
+    lastLoggedAt,
+  }) {
     const authenticationComplement = new PixAuthenticationComplement({ password, shouldChangePassword });
     return new AuthenticationMethod({
       id,
@@ -113,6 +124,7 @@ class AuthenticationMethod {
       createdAt,
       updatedAt,
       userId,
+      lastLoggedAt,
     });
   }
 }

--- a/api/src/identity-access-management/infrastructure/repositories/authentication-method.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/authentication-method.repository.js
@@ -17,6 +17,7 @@ const COLUMNS = Object.freeze([
   'userId',
   'createdAt',
   'updatedAt',
+  'lastLoggedAt',
 ]);
 
 const create = async function ({ authenticationMethod }) {
@@ -121,6 +122,16 @@ const hasIdentityProviderPIX = async function ({ userId }) {
     .first();
 
   return Boolean(authenticationMethodDTO);
+};
+
+const updateLastLoggedAtByIdentityProvider = async function ({ userId, identityProvider }) {
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn(AUTHENTICATION_METHODS_TABLE)
+    .where({
+      userId,
+      identityProvider,
+    })
+    .update({ lastLoggedAt: new Date() });
 };
 
 const removeByUserIdAndIdentityProvider = async function ({ userId, identityProvider }) {
@@ -268,6 +279,7 @@ export {
   updateAuthenticationComplementByUserIdAndIdentityProvider,
   updateAuthenticationMethodUserId,
   updateExternalIdentifierByUserIdAndIdentityProvider,
+  updateLastLoggedAtByIdentityProvider,
   updatePassword,
 };
 

--- a/api/tests/identity-access-management/unit/domain/usecases/authenticate-user_test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/authenticate-user_test.js
@@ -1,4 +1,5 @@
 import { PIX_ADMIN, PIX_CERTIF, PIX_ORGA } from '../../../../../src/authorization/domain/constants.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../../src/identity-access-management/domain/constants/identity-providers.js';
 import { createWarningConnectionEmail } from '../../../../../src/identity-access-management/domain/emails/create-warning-connection.email.js';
 import {
   MissingOrInvalidCredentialsError,
@@ -20,6 +21,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
   let adminMemberRepository;
   let pixAuthenticationService;
   let emailRepository;
+  let authenticationMethodRepository;
   let emailValidationDemandRepository;
   let clock;
 
@@ -45,6 +47,9 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
     userLoginRepository = {
       updateLastLoggedAt: sinon.stub(),
       findByUserId: sinon.stub(),
+    };
+    authenticationMethodRepository = {
+      updateLastLoggedAtByIdentityProvider: sinon.stub(),
     };
     adminMemberRepository = {
       get: sinon.stub(),
@@ -192,6 +197,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
           pixAuthenticationService,
           userRepository,
           userLoginRepository,
+          authenticationMethodRepository,
           adminMemberRepository,
           refreshTokenRepository,
           tokenService,
@@ -243,6 +249,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
             refreshTokenRepository,
             userRepository,
             userLoginRepository,
+            authenticationMethodRepository,
             audience,
           });
 
@@ -267,7 +274,6 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
     const audience = 'https://certif.pix.fr';
 
     pixAuthenticationService.getUserByUsernameAndPassword.resolves(user);
-
     const refreshToken = { value: 'jwt.refresh.token', userId: '456', scope, audience };
     sinon.stub(RefreshToken, 'generate').returns(refreshToken);
 
@@ -286,6 +292,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
       tokenService,
       userRepository,
       userLoginRepository,
+      authenticationMethodRepository,
       audience,
     });
 
@@ -307,7 +314,6 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
     const audience = 'https://certif.pix.fr';
 
     const user = domainBuilder.buildUser({ email: userEmail });
-
     pixAuthenticationService.getUserByUsernameAndPassword.resolves(user);
     tokenService.createAccessTokenFromUser
       .withArgs({ userId: user.id, source, audience })
@@ -324,11 +330,16 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
       tokenService,
       userRepository,
       userLoginRepository,
+      authenticationMethodRepository,
       audience,
     });
 
     // then
     expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWithExactly({ userId: user.id });
+    expect(authenticationMethodRepository.updateLastLoggedAtByIdentityProvider).to.have.been.calledWithExactly({
+      userId: user.id,
+      identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
+    });
   });
 
   it('should rejects an error when given username (email) does not match an existing one', async function () {
@@ -413,6 +424,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
           tokenService,
           userRepository,
           userLoginRepository,
+          authenticationMethodRepository,
           emailRepository,
           emailValidationDemandRepository,
           audience,
@@ -459,6 +471,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
           tokenService,
           userRepository,
           userLoginRepository,
+          authenticationMethodRepository,
           emailRepository,
           audience,
         });
@@ -503,6 +516,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
         tokenService,
         userRepository,
         userLoginRepository,
+        authenticationMethodRepository,
         emailRepository,
         audience,
       });
@@ -577,6 +591,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
           tokenService,
           userRepository,
           userLoginRepository,
+          authenticationMethodRepository,
           audience,
         });
 
@@ -612,6 +627,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
             refreshTokenRepository,
             userRepository,
             userLoginRepository,
+            authenticationMethodRepository,
             audience,
           });
 
@@ -645,6 +661,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
             tokenService,
             userRepository,
             userLoginRepository,
+            authenticationMethodRepository,
             audience,
           });
 

--- a/api/tests/identity-access-management/unit/domain/usecases/get-saml-authentication-redirection-url_test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/get-saml-authentication-redirection-url_test.js
@@ -157,6 +157,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
           externalIdentifier: 'saml-id',
           createdAt: new Date('2020-01-01'),
           updatedAt: new Date('2020-02-01'),
+          lastLoggedAt: null,
         });
         userRepository.getBySamlId.withArgs('saml-id').resolves(user);
         authenticationMethodRepository.findOneByUserIdAndIdentityProvider
@@ -181,6 +182,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
           userFirstName: 'Vassili',
           userLastName: 'Lisitsa',
           externalIdentifier: 'saml-id',
+          lastLoggedAt: null,
         });
         expect(authenticationMethodRepository.update).to.have.been.calledWithExactly(expectedAuthenticationMethod);
       });

--- a/api/tests/shared/unit/domain/services/user-service_test.js
+++ b/api/tests/shared/unit/domain/services/user-service_test.js
@@ -51,7 +51,7 @@ describe('Unit | Shared | Domain | Service | user-service', function () {
         hashedPassword,
       });
       userToCreateRepository.create.resolves(user);
-      const expectedAuthenticationMethod = omit(authenticationMethod, ['id', 'createdAt', 'updatedAt']);
+      const expectedAuthenticationMethod = omit(authenticationMethod, ['id', 'createdAt', 'updatedAt', 'lastLoggedAt']);
 
       //when
       await userService.createUserWithPassword({

--- a/api/tests/tooling/domain-builder/factory/build-authentication-method.js
+++ b/api/tests/tooling/domain-builder/factory/build-authentication-method.js
@@ -31,6 +31,7 @@ buildAuthenticationMethod.withGarAsIdentityProvider = function ({
   userLastName = 'Saint-James',
   createdAt = new Date('2020-01-01'),
   updatedAt = new Date('2020-02-01'),
+  lastLoggedAt = null,
 } = {}) {
   userId = isUndefined(userId) ? _buildUser().id : userId;
 
@@ -45,6 +46,7 @@ buildAuthenticationMethod.withGarAsIdentityProvider = function ({
     userId,
     createdAt,
     updatedAt,
+    lastLoggedAt,
   });
 };
 
@@ -55,6 +57,7 @@ buildAuthenticationMethod.withPixAsIdentityProviderAndRawPassword = function ({
   userId,
   createdAt,
   updatedAt,
+  lastLoggedAt = null,
 } = {}) {
   userId = isUndefined(userId) ? _buildUser().id : userId;
 
@@ -69,6 +72,7 @@ buildAuthenticationMethod.withPixAsIdentityProviderAndRawPassword = function ({
     userId,
     createdAt,
     updatedAt,
+    lastLoggedAt,
   });
 };
 
@@ -79,6 +83,7 @@ buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword = function 
   userId,
   createdAt = new Date('2020-01-01'),
   updatedAt = new Date('2020-02-01'),
+  lastLoggedAt = null,
 } = {}) {
   const password = hashedPassword;
   userId = isUndefined(userId) ? _buildUser().id : userId;
@@ -94,6 +99,7 @@ buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword = function 
     userId,
     createdAt,
     updatedAt,
+    lastLoggedAt,
   });
 };
 
@@ -106,6 +112,7 @@ buildAuthenticationMethod.withPoleEmploiAsIdentityProvider = function ({
   userId,
   createdAt = new Date('2020-01-01'),
   updatedAt = new Date('2020-02-01'),
+  lastLoggedAt = null,
 } = {}) {
   userId = isUndefined(userId) ? _buildUser().id : userId;
 
@@ -121,6 +128,7 @@ buildAuthenticationMethod.withPoleEmploiAsIdentityProvider = function ({
     userId,
     createdAt,
     updatedAt,
+    lastLoggedAt,
   });
 };
 
@@ -131,6 +139,7 @@ buildAuthenticationMethod.withIdentityProvider = function ({
   userId,
   createdAt = new Date('2020-01-01'),
   updatedAt = new Date('2020-02-01'),
+  lastLoggedAt = null,
 } = {}) {
   userId = isUndefined(userId) ? _buildUser().id : userId;
 
@@ -141,6 +150,7 @@ buildAuthenticationMethod.withIdentityProvider = function ({
     userId,
     createdAt,
     updatedAt,
+    lastLoggedAt,
   });
 };
 

--- a/api/tests/unit/domain/models/AuthenticationMethod_test.js
+++ b/api/tests/unit/domain/models/AuthenticationMethod_test.js
@@ -14,6 +14,7 @@ describe('Unit | Domain | Models | AuthenticationMethod', function () {
       const shouldChangePassword = true;
       const createdAt = Date.now();
       const updatedAt = Date.now();
+      const lastLoggedAt = Date.now();
 
       // when
       const result = AuthenticationMethod.buildPixAuthenticationMethod({
@@ -23,6 +24,7 @@ describe('Unit | Domain | Models | AuthenticationMethod', function () {
         createdAt,
         updatedAt,
         userId,
+        lastLoggedAt,
       });
 
       // then
@@ -39,6 +41,7 @@ describe('Unit | Domain | Models | AuthenticationMethod', function () {
         userId,
         createdAt,
         updatedAt,
+        lastLoggedAt,
       };
       expect(result).to.deep.equal(expectedResult);
     });

--- a/api/tests/unit/domain/usecases/authenticate-external-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-external-user_test.js
@@ -36,6 +36,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
     };
     authenticationMethodRepository = {
       create: sinon.stub(),
+      updateLastLoggedAtByIdentityProvider: sinon.stub(),
     };
     userRepository = {
       getBySamlId: sinon.stub(),
@@ -107,7 +108,6 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
 
       const expectedToken = 'expected returned token';
       tokenService.createAccessTokenForSaml.withArgs({ userId: user.id, audience }).resolves(expectedToken);
-
       // when
       await authenticateExternalUser({
         username: user.email,
@@ -125,6 +125,10 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
 
       // then
       expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWithExactly({ userId: user.id });
+      expect(authenticationMethodRepository.updateLastLoggedAtByIdentityProvider).to.have.been.calledWithExactly({
+        userId: user.id,
+        identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
+      });
     });
 
     it("should throw an UnexpectedUserAccountError (with expected user's username or email) when the authenticated user does not match the expected one", async function () {


### PR DESCRIPTION
## :pancakes: Problème

Quand un utilisateur se connecte avec une méthode de connexion Pix (login et mot de passe), on souhaite stocker la date de dernière connexion pour la méthode de connexion utilisée.


## :bacon: Proposition 

Cela concerne les use cases:

_ authenticateUser

_ authenticateExternalUser


La date de dernière connexion est à stocker dans authentication_methods.lastLoggedAt, sur la ligne correspondant à la méthode de connexion Pix de l’utilisateur.

## 🧃 Remarques

Le stockage de la dernière connexion **pour l'application concernée** fera l'objet d'un ticket suivant

## :yum: Pour tester

authenticateUser

- se connecter sur Pix App
- Constater que dans la table authentication methods,  le champ lastLoggedAt de l'entrée contenant votre utilisateur et l'identityProvider PIX a été correctement renseigné.
- Refaire la même opération quelques minutes plus tard pour tester la mise à jour du champ LastLoggedAt


authenticateExternalUser (en local)

- Lancer le faux GAR 
- sur http://localhost:7654 renseigner les prénom et nom d'un élève ayant déjà un compte PIX comme Hermione Granger
- Renseigner ensuite le code de la campagne SCOBADGE1
- Rejoindre l'organisation Collège House of the Dragon (date de naissance 05/05/2013)
- Une modale indique que vous possédez déjà un compte PIX, continuez avec le compte Pix d'Hermione
- Remplir la partie droite de la double mire SCO avec les identifiants (mail/mot de passe) d'Hermione
- Constater que dans la table authentication methods,  le champ lastLoggedAt de l'entrée contenant l'id d'Hermione Granger et l'identityProvider PIX a été correctement renseigné.
- Refaire la même opération quelques minutes plus tard (en se connectant avec le mail d'Hermione) pour tester la mise à jour du champ LastLoggedAt
