### PR TITLE
[TECH] :truck: Déplace le service de réconciliation utilisateur vers `src/`

### DIFF
--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -43,6 +43,7 @@ import { config } from '../../../src/shared/config.js';
 import * as codeGenerator from '../../../src/shared/domain/services/code-generator.js';
 import { cryptoService } from '../../../src/shared/domain/services/crypto-service.js';
 import { tokenService } from '../../../src/shared/domain/services/token-service.js';
+import * as userReconciliationService from '../../../src/shared/domain/services/user-reconciliation-service.js';
 import * as userService from '../../../src/shared/domain/services/user-service.js';
 import * as passwordValidator from '../../../src/shared/domain/validators/password-validator.js';
 import * as userValidator from '../../../src/shared/domain/validators/user-validator.js';
@@ -75,7 +76,6 @@ import { certificationCompletedJobRepository } from '../../infrastructure/reposi
 import * as organizationMemberIdentityRepository from '../../infrastructure/repositories/organization-member-identity-repository.js';
 import * as targetProfileShareRepository from '../../infrastructure/repositories/target-profile-share-repository.js';
 import * as learningContentConversionService from '../services/learning-content/learning-content-conversion-service.js';
-import * as userReconciliationService from '../services/user-reconciliation-service.js';
 import * as organizationCreationValidator from '../validators/organization-creation-validator.js';
 import * as organizationValidator from '../validators/organization-with-tags-and-target-profiles-script.js';
 

--- a/api/src/identity-access-management/domain/usecases/index.js
+++ b/api/src/identity-access-management/domain/usecases/index.js
@@ -1,8 +1,8 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import * as userReconciliationService from '../../../../lib/domain/services/user-reconciliation-service.js';
 import { oidcAuthenticationServiceRegistry } from '../../../../lib/domain/usecases/index.js';
+import * as userReconciliationService from '../../../../src/shared/domain/services/user-reconciliation-service.js';
 import * as centerRepository from '../../../certification/enrolment/infrastructure/repositories/center-repository.js';
 import * as userRecommendedTrainingRepository from '../../../devcomp/infrastructure/repositories/user-recommended-training-repository.js';
 import * as campaignRepository from '../../../prescription/campaign/infrastructure/repositories/campaign-repository.js';

--- a/api/src/prescription/learner-management/domain/usecases/index.js
+++ b/api/src/prescription/learner-management/domain/usecases/index.js
@@ -2,11 +2,10 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import * as obfuscationService from '../../../../../lib/domain/services/obfuscation-service.js';
-import * as userReconciliationService from '../../../../../lib/domain/services/user-reconciliation-service.js';
-import * as campaignRepository from '../../../../../src/prescription/campaign/infrastructure/repositories/campaign-repository.js';
 import * as userRepository from '../../../../identity-access-management/infrastructure/repositories/user.repository.js';
 import * as organizationFeatureApi from '../../../../organizational-entities/application/api/organization-features-api.js';
 import * as placementProfileService from '../../../../shared/domain/services/placement-profile-service.js';
+import * as userReconciliationService from '../../../../shared/domain/services/user-reconciliation-service.js';
 import { logErrorWithCorrelationIds } from '../../../../shared/infrastructure/monitoring-tools.js';
 import * as libOrganizationLearnerRepository from '../../../../shared/infrastructure/repositories/organization-learner-repository.js';
 import * as organizationRepository from '../../../../shared/infrastructure/repositories/organization-repository.js';
@@ -14,6 +13,7 @@ import { injectDependencies } from '../../../../shared/infrastructure/utils/depe
 import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 import * as membershipRepository from '../../../../team/infrastructure/repositories/membership.repository.js';
+import * as campaignRepository from '../../../campaign/infrastructure/repositories/campaign-repository.js';
 import * as registrationOrganizationLearnerRepository from '../../../organization-learner/infrastructure/repositories/registration-organization-learner-repository.js';
 import * as campaignParticipationRepository from '../../infrastructure/repositories/campaign-participation-repository.js';
 import { repositories } from '../../infrastructure/repositories/index.js';

--- a/api/src/shared/domain/services/user-reconciliation-service.js
+++ b/api/src/shared/domain/services/user-reconciliation-service.js
@@ -4,19 +4,19 @@ import fp from 'lodash/fp.js';
 const { pipe } = fp;
 import randomString from 'randomstring';
 
-import { isOneStringCloseEnoughFromMultipleStrings } from '../../../src/evaluation/domain/services/string-comparison-service.js';
+import { isOneStringCloseEnoughFromMultipleStrings } from '../../../evaluation/domain/services/string-comparison-service.js';
 import {
   normalizeAndRemoveAccents,
   removeSpecialCharacters,
-} from '../../../src/evaluation/domain/services/validation-treatments.js';
-import { LEVENSHTEIN_DISTANCE_MAX_RATE, STUDENT_RECONCILIATION_ERRORS } from '../../../src/shared/domain/constants.js';
+} from '../../../evaluation/domain/services/validation-treatments.js';
+import { LEVENSHTEIN_DISTANCE_MAX_RATE, STUDENT_RECONCILIATION_ERRORS } from '../../../shared/domain/constants.js';
 import {
   AlreadyRegisteredUsernameError,
   NotFoundError,
   OrganizationLearnerAlreadyLinkedToInvalidUserError,
   OrganizationLearnerAlreadyLinkedToUserError,
-} from '../../../src/shared/domain/errors.js';
-import { areTwoStringsCloseEnough } from '../../../src/shared/domain/services/string-comparison-service.js';
+} from '../../../shared/domain/errors.js';
+import { areTwoStringsCloseEnough } from '../../../shared/domain/services/string-comparison-service.js';
 
 const STRICT_MATCH_RATIO = 0;
 

--- a/api/tests/integration/domain/usecases/create-and-reconcile-user-to-organization-learner_test.js
+++ b/api/tests/integration/domain/usecases/create-and-reconcile-user-to-organization-learner_test.js
@@ -2,7 +2,6 @@ import lodash from 'lodash';
 const { pick } = lodash;
 
 import * as obfuscationService from '../../../../lib/domain/services/obfuscation-service.js';
-import * as userReconciliationService from '../../../../lib/domain/services/user-reconciliation-service.js';
 import { createAndReconcileUserToOrganizationLearner } from '../../../../lib/domain/usecases/create-and-reconcile-user-to-organization-learner.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
 import * as authenticationMethodRepository from '../../../../src/identity-access-management/infrastructure/repositories/authentication-method.repository.js';
@@ -17,6 +16,7 @@ import {
 import { EntityValidationError } from '../../../../src/shared/domain/errors.js';
 import { cryptoService } from '../../../../src/shared/domain/services/crypto-service.js';
 import * as mailService from '../../../../src/shared/domain/services/mail-service.js';
+import * as userReconciliationService from '../../../../src/shared/domain/services/user-reconciliation-service.js';
 import * as userService from '../../../../src/shared/domain/services/user-service.js';
 import * as passwordValidator from '../../../../src/shared/domain/validators/password-validator.js';
 import * as userValidator from '../../../../src/shared/domain/validators/user-validator.js';

--- a/api/tests/integration/domain/usecases/generate-organization-learners-username-and-temporary-password_test.js
+++ b/api/tests/integration/domain/usecases/generate-organization-learners-username-and-temporary-password_test.js
@@ -2,7 +2,6 @@ import {
   ORGANIZATION_LEARNER_DOES_NOT_BELONG_TO_ORGANIZATION_CODE,
   ORGANIZATION_LEARNER_WITHOUT_USERNAME_CODE,
 } from '../../../../lib/domain/constants/generate-organization-learners-username-and-temporary-password-errors.js';
-import * as userReconciliationService from '../../../../lib/domain/services/user-reconciliation-service.js';
 import { generateOrganizationLearnersUsernameAndTemporaryPassword } from '../../../../lib/domain/usecases/generate-organization-learners-username-and-temporary-password.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../src/identity-access-management/domain/constants/identity-providers.js';
 import * as authenticationMethodRepository from '../../../../src/identity-access-management/infrastructure/repositories/authentication-method.repository.js';
@@ -10,6 +9,7 @@ import { organizationLearnerIdentityRepository } from '../../../../src/identity-
 import * as userRepository from '../../../../src/identity-access-management/infrastructure/repositories/user.repository.js';
 import { UserNotAuthorizedToUpdatePasswordError } from '../../../../src/shared/domain/errors.js';
 import { OrganizationLearnerPasswordResetDTO } from '../../../../src/shared/domain/models/OrganizationLearnerPasswordResetDTO.js';
+import * as userReconciliationService from '../../../../src/shared/domain/services/user-reconciliation-service.js';
 import * as organizationRepository from '../../../../src/shared/infrastructure/repositories/organization-repository.js';
 import { catchErr, databaseBuilder, domainBuilder, expect, sinon } from '../../../test-helper.js';
 

--- a/api/tests/shared/unit/domain/services/user-reconciliation-service_test.js
+++ b/api/tests/shared/unit/domain/services/user-reconciliation-service_test.js
@@ -1,11 +1,11 @@
-import * as userReconciliationService from '../../../../lib/domain/services/user-reconciliation-service.js';
 import {
   AlreadyRegisteredUsernameError,
   NotFoundError,
   OrganizationLearnerAlreadyLinkedToInvalidUserError,
   OrganizationLearnerAlreadyLinkedToUserError,
-} from '../../../../src/shared/domain/errors.js';
-import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';
+} from '../../../../../src/shared/domain/errors.js';
+import * as userReconciliationService from '../../../../../src/shared/domain/services/user-reconciliation-service.js';
+import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Service | user-reconciliation-service', function () {
   let organizationLearners;


### PR DESCRIPTION
## :pancakes: Problème

Le service de réconciliation utilisateur est dans `lib/`

## :bacon: Proposition

Déplacer le service de réconciliation utilisateur vers `src/`

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
