### PR TITLE
[TECH] Ajoute un éditeur de quêtes

### DIFF
--- a/admin/app/components/administration/common/upsert-quests-in-batch.gjs
+++ b/admin/app/components/administration/common/upsert-quests-in-batch.gjs
@@ -1,4 +1,6 @@
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -49,14 +51,20 @@ export default class UpsertQuestsInBatch extends Component {
       @title={{t "components.administration.upsert-quests-in-batch.title"}}
       @description={{t "components.administration.upsert-quests-in-batch.description"}}
     >
-      <PixButtonUpload
-        @id="quests-batch-update-file-upload"
-        @onChange={{this.upsertQuestsInBatch}}
-        @variant="secondary"
-        accept=".csv"
-      >
-        {{t "components.administration.upsert-quests-in-batch.upload-button"}}
-      </PixButtonUpload>
+      <div class="upsert-quests">
+        <PixButtonUpload
+          @id="quests-batch-update-file-upload"
+          @onChange={{this.upsertQuestsInBatch}}
+          @variant="secondary"
+          accept=".csv"
+        >
+          {{t "components.administration.upsert-quests-in-batch.upload-button"}}
+        </PixButtonUpload>
+        <PixButtonLink @route="authenticated.quest-editor" @variant="tertiary">
+          <p>{{t "components.administration.upsert-quests-in-batch.editor-link"}}</p>
+          <PixIcon @name="edit" @ariaHidden={{true}} />
+        </PixButtonLink>
+      </div>
     </AdministrationBlockLayout>
   </template>
 }

--- a/admin/app/components/quest-editor.gjs
+++ b/admin/app/components/quest-editor.gjs
@@ -1,0 +1,325 @@
+// Import the default blocks. (It is mandatory)
+import 'blockly/blocks';
+
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import * as Blockly from 'blockly/core';
+import * as En from 'blockly/msg/en';
+import CopyButton from 'ember-cli-clipboard/components/copy-button';
+import isClipboardSupported from 'ember-cli-clipboard/helpers/is-clipboard-supported';
+import { modifier } from 'ember-modifier';
+
+Blockly.setLocale(En);
+
+Blockly.defineBlocksWithJsonArray([
+  {
+    type: 'quest',
+    tooltip: '',
+    helpUrl: '',
+    message0: 'rewardType %1 rewardId %2 eligilityRequirements %3 successRequirements %4',
+    args0: [
+      {
+        type: 'input_value',
+        name: 'REWARD_TYPE',
+        check: 'String',
+      },
+      {
+        type: 'input_value',
+        name: 'REWARD_ID',
+        check: 'Number',
+      },
+      {
+        type: 'input_statement',
+        name: 'ELIGIBILITY_REQUIREMENTS',
+        check: 'requirement',
+      },
+      {
+        type: 'input_statement',
+        name: 'SUCCESS_REQUIREMENTS',
+        check: 'requirement',
+      },
+    ],
+    colour: 75,
+    inputsInline: false,
+  },
+  {
+    type: 'requirement',
+    tooltip: '',
+    helpUrl: '',
+    message0: 'requirement_type %1 %2 comparison %3 %4 data %5',
+    args0: [
+      {
+        type: 'field_dropdown',
+        name: 'REQUIREMENT_TYPE',
+        options: [
+          ['compose', 'compose'],
+          ['organization', 'organization'],
+          ['campaignParticipations', 'campaignParticipations'],
+          ['skill', 'skill'],
+        ],
+      },
+      {
+        type: 'input_dummy',
+        name: '1',
+      },
+      {
+        type: 'field_dropdown',
+        name: 'COMPARISON',
+        options: [
+          ['one of', 'one-of'],
+          ['all', 'all'],
+          ['equal', 'equal'],
+        ],
+      },
+      {
+        type: 'input_dummy',
+        name: '2',
+      },
+      {
+        type: 'input_statement',
+        name: 'DATA',
+        check: 'criterion_property',
+      },
+    ],
+    previousStatement: null,
+    nextStatement: null,
+    colour: 225,
+    inputsInline: false,
+  },
+  {
+    type: 'criterion_property',
+    tooltip: '',
+    helpUrl: '',
+    message0: '%1 %2 %3 %4 %5 %6 data %7',
+    args0: [
+      {
+        type: 'field_label_serializable',
+        text: 'comparison',
+        name: '',
+      },
+      {
+        type: 'field_dropdown',
+        name: 'COMPARISON',
+        options: [
+          ['one of', 'one-of'],
+          ['all', 'all'],
+          ['equal', 'equal'],
+        ],
+      },
+      {
+        type: 'input_dummy',
+        name: '1',
+      },
+      {
+        type: 'field_label_serializable',
+        text: 'key',
+        name: '',
+      },
+      {
+        type: 'field_input',
+        name: 'KEY',
+        text: 'default',
+      },
+      {
+        type: 'input_dummy',
+        name: '2',
+      },
+      {
+        type: 'input_value',
+        name: 'VALUE',
+      },
+    ],
+    previousStatement: null,
+    nextStatement: null,
+    colour: 345,
+  },
+]);
+
+const blocklyModifier = modifier((element, [setWorkspace]) => {
+  const toolbox = {
+    kind: 'flyoutToolbox',
+    contents: [
+      { kind: 'block', type: 'quest' },
+      { kind: 'block', type: 'criterion_property' },
+      { kind: 'block', type: 'requirement' },
+      { type: 'lists_create_with', kind: 'block' },
+      { type: 'logic_null', kind: 'block' },
+      { type: 'text', kind: 'block' },
+      { type: 'math_number', kind: 'block' },
+      {
+        type: 'logic_boolean',
+        kind: 'block',
+        fields: {
+          BOOL: 'TRUE',
+        },
+      },
+    ],
+  };
+
+  const workspace = Blockly.inject(element, {
+    toolbox,
+    move: {
+      scrollbars: {
+        horizontal: true,
+        vertical: true,
+      },
+      drag: true,
+      wheel: false,
+    },
+  });
+  setWorkspace(workspace);
+});
+
+const Order = {
+  ATOMIC: 0,
+};
+
+function checkBlockValidity(block, output) {
+  try {
+    JSON.parse(output);
+    block.setWarningText('');
+  } catch {
+    block.setWarningText('Ce block est soit incomplet soit invalide');
+  }
+}
+
+export const jsonGenerator = new Blockly.Generator('JSON');
+
+jsonGenerator.scrub_ = function (block, code, thisOnly) {
+  const nextBlock = block.nextConnection && block.nextConnection.targetBlock();
+  if (nextBlock && !thisOnly) {
+    return code + ',' + jsonGenerator.blockToCode(nextBlock);
+  }
+  return code;
+};
+
+jsonGenerator.forBlock['requirement'] = function (block, generator) {
+  const requirement_type = block.getFieldValue('REQUIREMENT_TYPE');
+  const comparison = block.getFieldValue('COMPARISON');
+  const statement_members = generator.statementToCode(block, 'DATA');
+  let data;
+  if (requirement_type === 'compose') {
+    data = `[${statement_members}]`;
+  } else {
+    data = `{${statement_members}}`;
+  }
+  const output = `{
+"requirement_type": "${requirement_type}",
+"comparison": "${comparison}",
+"data":
+${data}
+}`;
+  checkBlockValidity(block, output);
+  return output;
+};
+
+jsonGenerator.forBlock['quest'] = function (block, generator) {
+  const reward_type = generator.valueToCode(block, 'REWARD_TYPE', Order.ATOMIC);
+  const reward_id = generator.valueToCode(block, 'REWARD_ID', Order.ATOMIC);
+  const eligibility_members = generator.statementToCode(block, 'ELIGIBILITY_REQUIREMENTS');
+  const success_members = generator.statementToCode(block, 'SUCCESS_REQUIREMENTS');
+  const output = `{
+"rewardType": ${reward_type},
+"rewardId": ${reward_id},
+"eligibilityRequirements": [
+${eligibility_members}
+],
+"successRequirements": [
+${success_members}
+]
+}`;
+  checkBlockValidity(block, output);
+  return output;
+};
+
+jsonGenerator.forBlock['criterion_property'] = function (block, generator) {
+  const key = block.getFieldValue('KEY');
+  const comparison = block.getFieldValue('COMPARISON');
+  const value = generator.valueToCode(block, 'VALUE', Order.ATOMIC);
+  return `"${key}": { "comparison": "${comparison}", "data": ${value} }`;
+};
+
+jsonGenerator.forBlock['logic_boolean'] = function (block) {
+  const code = block.getFieldValue('BOOL') === 'TRUE' ? 'true' : 'false';
+  return [code, Order.ATOMIC];
+};
+
+jsonGenerator.forBlock['math_number'] = function (block) {
+  const code = String(block.getFieldValue('NUM'));
+  return [code, Order.ATOMIC];
+};
+
+jsonGenerator.forBlock['logic_null'] = function () {
+  return ['null', Order.ATOMIC];
+};
+
+jsonGenerator.forBlock['text'] = function (block) {
+  const textValue = block.getFieldValue('TEXT');
+  const code = `"${textValue}"`;
+  return [code, Order.ATOMIC];
+};
+
+jsonGenerator.forBlock['lists_create_with'] = function (block, generator) {
+  const values = [];
+  for (let i = 0; i < block.itemCount_; i++) {
+    const valueCode = generator.valueToCode(block, 'ADD' + i, Order.ATOMIC);
+    if (valueCode) {
+      values.push(valueCode);
+    }
+  }
+  const valueString = values.join(',');
+  const indentedValueString = generator.prefixLines(valueString, generator.INDENT);
+  const codeString = '[' + indentedValueString + ']';
+  return [codeString, Order.ATOMIC];
+};
+
+import Component from '@glimmer/component';
+
+export default class extends Component {
+  @tracked workspace = null;
+  @tracked code = '';
+  @tracked isValid = true;
+
+  @action
+  setWorkspace(value) {
+    this.workspace = value;
+    this.workspace.addChangeListener(() => {
+      try {
+        const generated = jsonGenerator.workspaceToCode(this.workspace);
+        console.log(generated);
+        this.code = JSON.stringify(JSON.parse(generated), undefined, 2);
+        this.isValid = true;
+      } catch (err) {
+        console.error(err);
+        this.isValid = false;
+      }
+    });
+  }
+
+  <template>
+    <div class="quest-editor">
+      <div class="quest-editor__workspace" {{blocklyModifier this.setWorkspace}}></div>
+      <div class="quest-editor__output">
+        <div class="quest-editor__actions">
+          {{#if this.isValid}}
+            {{#if (isClipboardSupported)}}
+              <CopyButton
+                @text={{this.code}}
+                aria-label="Copier le JSON de la quête"
+                class="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey"
+              >
+                <PixIcon @name="copy" @ariaHidden={{true}} />
+              </CopyButton>
+            {{/if}}
+          {{else}}
+            <PixNotificationAlert @type="error" @withIcon={{true}}>La configuration de blocs n'est pas valide ou
+              incomplète.</PixNotificationAlert>
+          {{/if}}
+        </div>
+        <pre>{{this.code}}</pre>
+      </div>
+    </div>
+  </template>
+}

--- a/admin/app/components/quest-editor.gjs
+++ b/admin/app/components/quest-editor.gjs
@@ -288,7 +288,6 @@ export default class extends Component {
     this.workspace.addChangeListener(() => {
       try {
         const generated = jsonGenerator.workspaceToCode(this.workspace);
-        console.log(generated);
         this.code = JSON.stringify(JSON.parse(generated), undefined, 2);
         this.isValid = true;
       } catch (err) {

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -23,6 +23,7 @@ Router.map(function () {
   // private routes
   this.route('authenticated', { path: '' }, function () {
     // all routes that require the session to be authenticated
+    this.route('quest-editor');
     this.route('organizations', function () {
       this.route('new');
       this.route('list');

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -71,6 +71,7 @@
 @use 'components/organizations/places-lot-creation-form' as *;
 @use 'components/participation-row' as *;
 @use 'components/publish-session-button' as *;
+@use 'components/quest-editor' as *;
 @use 'components/sessions/jury-comment' as *;
 @use 'components/sessions/list-items' as *;
 @use 'components/smart-random-simulator/current-challenge' as *;

--- a/admin/app/styles/components/administration/common.scss
+++ b/admin/app/styles/components/administration/common.scss
@@ -1,3 +1,8 @@
 p.description {
   margin-bottom: var(--pix-spacing-8x);
 }
+
+.upsert-quests {
+  display: flex;
+  gap: var(--pix-spacing-4x)
+}

--- a/admin/app/styles/components/quest-editor.scss
+++ b/admin/app/styles/components/quest-editor.scss
@@ -1,0 +1,20 @@
+.quest-editor {
+  width: 100%;
+  height: 100vh;
+
+  &__workspace {
+    height: 80%;
+  }
+
+  &__output {
+    position: relative;
+    height: 20%;
+    overflow: scroll;
+  }
+
+  &__actions {
+    position: absolute;
+    top: var(--pix-spacing-2x);
+    right: var(--pix-spacing-2x);
+  }
+}

--- a/admin/app/templates/authenticated/quest-editor.hbs
+++ b/admin/app/templates/authenticated/quest-editor.hbs
@@ -1,0 +1,1 @@
+<QuestEditor />

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -24,6 +24,7 @@
         "@formatjs/intl": "^3.0.0",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
+        "blockly": "^11.2.1",
         "dayjs": "^1.11.7",
         "ember-auto-import": "^2.5.0",
         "ember-cli": "^6.0.0",
@@ -11137,6 +11138,19 @@
       "integrity": "sha512-kXQ19Xhoghiyw66CUiGypnuRpWlbHAzY/+NyvqTEdTfhfQGH1/dbEMYiXju7fYKIFePpzp/y9dsu5Cu/PkmawQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/blockly": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.2.1.tgz",
+      "integrity": "sha512-20sCwSwX2Z6UxR/er0B5y6wRFukuIdvOjc7jMuIwyCO/yT35+UbAqYueMga3JFA9NoWPwQc+3s6/XnLkyceAww==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsdom": "25.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/bluebird": {
       "version": "3.7.2",

--- a/admin/package.json
+++ b/admin/package.json
@@ -56,6 +56,7 @@
     "@formatjs/intl": "^3.0.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
+    "blockly": "^11.2.1",
     "dayjs": "^1.11.7",
     "ember-auto-import": "^2.5.0",
     "ember-cli": "^6.0.0",

--- a/admin/tests/acceptance/administration-test.js
+++ b/admin/tests/acceptance/administration-test.js
@@ -1,6 +1,7 @@
 import { clickByName, fillByLabel, visit, within } from '@1024pix/ember-testing-library';
 import { click, currentURL, fillIn } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 import { module, test } from 'qunit';
@@ -83,6 +84,17 @@ module('Acceptance | administration | common ', function (hooks) {
         )
         .exists();
     });
+  });
+
+  test('navigate to quest editor', async function (assert) {
+    // given
+    const screen = await visit('/administration/common');
+
+    // when
+    await click(screen.getByRole('link', { name: t('components.administration.upsert-quests-in-batch.editor-link') }));
+
+    // then
+    assert.strictEqual(currentURL(), '/quest-editor');
   });
 
   test('displays a navigation with tabs', async function (assert) {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -190,6 +190,7 @@
       },
       "upsert-quests-in-batch": {
         "description": "Beware: there are no validation when importing a CSV file. Check with a spécialiste in the doubt ;)",
+        "editor-link": "Quest editor",
         "notifications": {
           "success": "Quests have been imported."
         },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -198,6 +198,7 @@
       },
       "upsert-quests-in-batch": {
         "description": "Attention: aucune validation n'est effectuée lors de l'import. Consultez un spécialiste dans le doute ;)",
+        "editor-link": "Editeur de quête",
         "notifications": {
           "success": "Les quêtes ont bien été importées."
         },


### PR DESCRIPTION
## :pancakes: Problème

C'est assez fastidieux d'écrire les quêtes pour les POs et elles peuvent devenir rapidement très longue comme celle des attestations pour les 6ème. Le format JSON peut être source de typos qu'il devient difficile de retrouver quand la quête fait plusieurs centaines de lignes.

## :bacon: Proposition

Ajouter un éditeur de quête dans PixAdmin qui utilise un modalité d'expression via des blocs. Cela semble particulièrement adapté aux quêtes donc la profondeur (blocs nestés) peut être importante.

## 🧃 Remarques

Etant un petit outil à part fait en après-midi tech, il n'y a pas spécialement de tests automatiques qui ont été fait. D'autant que ça reviendrait en partie à tester la librairie. Le risque par contre est que l'outil soit cassé par une montée de version sans qu'on s'en rend compte. Cependant, en l'état cela apporte déjà de la valeur en interne.

Pour faire les blocks spécifiques, j'ai utilisé cet éditeur de blocks : https://google.github.io/blockly-samples/examples/developer-tools/index.html. Malheureusement, je n'ai pas trouvé de moyen pour enregistrer la configuration des blocks. On a accès uniquement à la définition du block elle-même...

J'ai suivi ce codelab pour faire le générateur de JSON : https://blocklycodelabs.dev/codelabs/custom-generator/index.html?index=..%2F..index#0.

## :yum: Pour tester

Se rendre dans la partie "Commun" de l'"Administration" et constater la présence dans bouton "Editeur de quête" dans la section "Création et modification de quêtes".
Constater quand on clique dessus qu'on arrive dans un environnement Blockly. 
Essayer de refaire les quêtes existantes avec l'éditeur et vérifier qu'elles sont valident.
