### PR TITLE
[BUGFIX] Déplacer les modifiers dans le bon sous ensemble css (PIX-OUPSY)

### DIFF
--- a/orga/app/styles/components/campaign/detail/type.scss
+++ b/orga/app/styles/components/campaign/detail/type.scss
@@ -12,6 +12,18 @@
     width: 1.5rem;
     height: 1.5rem;
 
+    &--assessment {
+      fill: var(--pix-tertiary-500);
+    }
+
+    &--profile-collection {
+      fill: var(--pix-primary-500);
+    }
+
+    &--exam {
+      fill: var(--pix-secondary-700);
+    }
+
     &--big {
       width: 3rem;
       height: 3rem;
@@ -23,17 +35,5 @@
         height: 2rem;
       }
     }
-  }
-
-  &--assessment {
-    fill: var(--pix-tertiary-500);
-  }
-
-  &--profile-collection {
-    fill: var(--pix-primary-500);
-  }
-
-  &--exam {
-    fill: var(--pix-secondary-700);
   }
 }


### PR DESCRIPTION
## :pancakes: Problème

Les icons des campagne ont perdu leur couleur. Oh nnooooooooooooooo

## :bacon: Proposition

Déplacer les modifier dans le bon sous ensemble

## 🧃 Remarques

RAS

## :yum: Pour tester

Vérifier que sur PixOrga les icons des campagnes ont des couleurs. 