### PR TITLE
[FEATURE] Les iframes autorisent l'utilisation du presse papier de l'utilisateur (PIX-16746)

### DIFF
--- a/mon-pix/app/components/challenge-embed-simulator.hbs
+++ b/mon-pix/app/components/challenge-embed-simulator.hbs
@@ -29,6 +29,7 @@
         {{modifier-did-insert this.configureIframe @embedDocument.url this}}
         frameBorder="0"
         style="{{this.embedDocumentHeightStyle}}"
+        allow="{{this.permissionToClipboardWrite}}"
       ></iframe>
     </div>
 

--- a/mon-pix/app/components/challenge-embed-simulator.js
+++ b/mon-pix/app/components/challenge-embed-simulator.js
@@ -31,6 +31,13 @@ export default class ChallengeEmbedSimulator extends Component {
     return '';
   }
 
+  get permissionToClipboardWrite() {
+    if (!this.args.embedDocument?.url) {
+      return null;
+    }
+    return isEmbedAllowedOrigin(this.args.embedDocument.url) ? 'clipboard-write' : null;
+  }
+
   configureIframe = (iframe, embedUrl, thisComponent) => {
     thisComponent.isLoadingEmbed = true;
     thisComponent.isSimulatorLaunched = false;

--- a/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
+++ b/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
@@ -3,6 +3,7 @@ import { render } from '@1024pix/ember-testing-library';
 import { find } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
+import ENV from 'mon-pix/config/environment';
 import { module, test } from 'qunit';
 
 import { clickByLabel } from '../../helpers/click-by-label';
@@ -170,6 +171,37 @@ module('Integration | Component | Challenge Embed Simulator', function (hooks) {
           assert.dom(screen.queryByText(t('pages.challenge.embed-simulator.actions.reset'))).doesNotExist();
         });
       });
+    });
+  });
+
+  module('allow clipboard-write', function () {
+    test('it should allow `clipboard-write` when the embed origin is allowed ', async function (assert) {
+      // given
+      this.set('embedDocument', {
+        url: `${ENV.APP.EMBED_ALLOWED_ORIGINS[0]}/embed-simulator.url`,
+        title: 'Embed simulator',
+        height: 200,
+      });
+
+      // when
+      await render(hbs`<ChallengeEmbedSimulator @embedDocument={{this.embedDocument}} />`);
+
+      // then
+      assert.strictEqual(find('.embed__iframe').allow, 'clipboard-write');
+    });
+    test('it should not allow `clipboard-write` when the embed origin is not allowed', async function (assert) {
+      // given
+      this.set('embedDocument', {
+        url: 'http://notAllowedOrigin/embed-simulator.url',
+        title: 'Embed simulator',
+        height: 200,
+      });
+
+      // when
+      await render(hbs`<ChallengeEmbedSimulator @embedDocument={{this.embedDocument}} />`);
+
+      // then
+      assert.notOk(find('.embed__iframe').allow);
     });
   });
 });


### PR DESCRIPTION
## :pancakes: Problème
Dans un nouvel embed nous avons un bouton permettant de copier du text. 
Mais cette fonctionnalité est bloquée si l’epreuve est dans un iframe.

![image](https://github.com/user-attachments/assets/5d7f61a5-6906-45ad-822e-7a61da516d58)


## :bacon: Proposition

Ajouter l’attribut `allow="clipboard-write"` sur les iframes provenant d'une origine autorisée pour permettre l’utilisation de l'api clipboard


## :yum: Pour tester
?????