### PR TITLE
[TECH] Script pour fix les certification-challenge-capacities liés à des live-alerts (PIX-16701).

### DIFF
--- a/api/scripts/certification/fix-validated-live-alert-certification-challenge-ids.js
+++ b/api/scripts/certification/fix-validated-live-alert-certification-challenge-ids.js
@@ -1,0 +1,165 @@
+import 'dotenv/config';
+
+import { knex } from '../../db/knex-database-connection.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+
+export class FixValidatedLiveAlertCertificationChallengeIds extends Script {
+  constructor() {
+    super({
+      description: 'Fix certification-challenge-capacities from exact same challenge recorded twice',
+      permanent: false,
+      options: {
+        courseIds: {
+          type: 'array',
+          describe: 'List of certification course to fix',
+          demandOption: true,
+          default: [],
+        },
+        dryRun: {
+          type: 'boolean',
+          describe: 'Commit the UPDATE or not',
+          demandOption: false,
+          default: true,
+        },
+      },
+    });
+
+    this.totalNumberOfUpdatedRows = 0;
+    this.totalNumberOfDeletedRows = 0;
+  }
+
+  async handle({ options, logger }) {
+    this.logger = logger;
+    const dryRun = options.dryRun;
+    const courseIds = options.courseIds;
+    this.logger.info(`dryRun=${dryRun} courseIds=[${courseIds}]`);
+
+    for (const currentCourse of courseIds) {
+      const results = await this.fixCertificationCapacities({ dryRun, courseId: currentCourse });
+
+      this.logger.debug({ results });
+
+      this.totalNumberOfUpdatedRows += results.numberOfUpdates;
+      this.totalNumberOfDeletedRows += results.numberOfDeletes;
+    }
+
+    this.logger.info({
+      totalNumberOfCertifications: courseIds.length,
+      totalNumberOfUpdatedRows: this.totalNumberOfUpdatedRows,
+      totalNumberOfDeletedRows: this.totalNumberOfDeletedRows,
+    });
+
+    return 0;
+  }
+
+  async fixCertificationCapacities({ dryRun, courseId }) {
+    const transaction = await knex.transaction();
+    try {
+      const allCertificationChallenges = await transaction
+        .select({
+          id: 'certification-challenges.id',
+          challengeId: 'certification-challenges.challengeId',
+        })
+        .from('certification-challenges')
+        .where('certification-challenges.courseId', '=', courseId)
+        .orderBy('certification-challenges.createdAt', 'asc');
+
+      // Find all capacities
+      const certificationCapacities = await transaction
+        .select({
+          // table certif-challenges
+          certifCourse_Id: 'certification-challenges.courseId',
+          certifChallenge_Id: 'certification-challenges.id',
+          certifChallenge_ChallengeId: 'certification-challenges.challengeId',
+          // table answers
+          answer_ChallengeId: 'answers.challengeId',
+          // table capacities
+          capacity_CertificationChallengeId: 'certification-challenge-capacities.certificationChallengeId',
+          capacity_AnswerId: 'certification-challenge-capacities.answerId',
+        })
+        .from('certification-challenge-capacities')
+        .innerJoin(
+          'certification-challenges',
+          'certification-challenge-capacities.certificationChallengeId',
+          'certification-challenges.id',
+        )
+        .innerJoin('certification-courses', 'certification-challenges.courseId', 'certification-courses.id')
+        .leftJoin('answers', 'certification-challenge-capacities.answerId', 'answers.id')
+        .where('certification-challenges.courseId', '=', courseId)
+        .orderBy('certification-challenges.createdAt', 'asc');
+
+      this.logger.debug({ certificationCapacities });
+
+      // Now fix capacities
+      const capacitiesToUpdate = [];
+      for (const currentCapacity of certificationCapacities) {
+        this.logger.debug({ currentCapacity });
+        if (currentCapacity.certifChallenge_ChallengeId !== currentCapacity.answer_ChallengeId) {
+          // Copy capacity in error
+          const capacityToModify = { ...currentCapacity };
+          capacityToModify.capacity_CertificationChallengeId = 'REPLACE_ME';
+          // Update also challengeId just to show we gound the right match in logs
+          capacityToModify.certifChallenge_ChallengeId = 'REPLACE_ME';
+
+          // Get the right challenge id for this capacity answer
+          const indexOfCorrectChallenge = allCertificationChallenges.findIndex(
+            (certifChallenge) => certifChallenge.challengeId === currentCapacity.answer_ChallengeId,
+          );
+
+          if (indexOfCorrectChallenge !== -1) {
+            // Update capacity with right answer id
+            capacityToModify.capacity_CertificationChallengeId =
+              allCertificationChallenges.at(indexOfCorrectChallenge).id;
+            // Update also certifChallengeChallengeId just to show we found the right match in logs
+            capacityToModify.certifChallenge_ChallengeId =
+              allCertificationChallenges.at(indexOfCorrectChallenge).challengeId;
+            capacitiesToUpdate.push(capacityToModify);
+          } else {
+            // It is not possible that a capacity has a answer but no challenge
+            throw new Error(`Capacity ${capacityToModify.capacity_AnswerId} do not have a corresponding challenge`);
+          }
+
+          // That answer cannot be used anymore
+          allCertificationChallenges.splice(indexOfCorrectChallenge, 1);
+        } else {
+          // We are on a correct certif challenge, forget about her
+          const correctChallenge = allCertificationChallenges.findIndex(
+            (certifChallenge) => certifChallenge.id === currentCapacity.certifChallenge_Id,
+          );
+          // That certif challenge cannot be used anymore
+          allCertificationChallenges.splice(correctChallenge, 1);
+        }
+      }
+
+      // Now from all remaining challenges, find the ones that HAVE a capacity already (meaning they are a duplicate)
+      const certifChallengesToDelete = allCertificationChallenges.filter((challenge) =>
+        certificationCapacities.find((capacity) => capacity.certifChallenge_Id === challenge.id),
+      );
+
+      // We have to do the update in reverse because certificationChallengeId is the PRIMARY KEY
+      for (const capacityToUpdate of capacitiesToUpdate.reverse()) {
+        await transaction('certification-challenge-capacities')
+          .where('answerId', '=', capacityToUpdate.capacity_AnswerId)
+          .update({
+            certificationChallengeId: capacityToUpdate.capacity_CertificationChallengeId,
+          });
+      }
+
+      this.logger.debug({ capacitiesToUpdate });
+      this.logger.debug({ certifChallengesToDelete });
+
+      dryRun ? await transaction.rollback() : await transaction.commit();
+
+      return {
+        numberOfUpdates: capacitiesToUpdate.length,
+        numberOfDeletes: certifChallengesToDelete.length,
+      };
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, FixValidatedLiveAlertCertificationChallengeIds);

--- a/api/scripts/certification/fix-validated-live-alert-certification-challenge-ids.js
+++ b/api/scripts/certification/fix-validated-live-alert-certification-challenge-ids.js
@@ -1,164 +1,190 @@
 import 'dotenv/config';
 
 import { knex } from '../../db/knex-database-connection.js';
+import { AlgorithmEngineVersion } from '../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { Script } from '../../src/shared/application/scripts/script.js';
 import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
 
 export class FixValidatedLiveAlertCertificationChallengeIds extends Script {
   constructor() {
     super({
-      description: 'Fix certification-challenge-capacities from exact same challenge recorded twice',
+      description: 'Fix certification-challenge-capacities from live alert misalignment',
       permanent: false,
       options: {
-        courseIds: {
-          type: 'array',
-          describe: 'List of certification course to fix',
-          demandOption: true,
-          default: [],
-        },
         dryRun: {
           type: 'boolean',
           describe: 'Commit the UPDATE or not',
+          demandOption: true,
+        },
+        batchSize: {
+          type: 'number',
+          describe: 'Number of rows to update at once',
           demandOption: false,
-          default: true,
+          default: 1000,
+        },
+        delayBetweenBatch: {
+          type: 'number',
+          describe: 'In ms, force a pause between COMMIT',
+          demandOption: false,
+          default: 100,
         },
       },
     });
 
     this.totalNumberOfUpdatedRows = 0;
-    this.totalNumberOfDeletedRows = 0;
   }
 
   async handle({ options, logger }) {
     this.logger = logger;
     const dryRun = options.dryRun;
-    const courseIds = options.courseIds;
-    this.logger.info(`dryRun=${dryRun} courseIds=[${courseIds}]`);
+    const batchSize = options.batchSize;
+    const delayInMs = options.delayBetweenBatch;
+    this.logger.info(`dryRun=${dryRun}`);
 
-    for (const currentCourse of courseIds) {
-      const results = await this.fixCertificationCapacities({ dryRun, courseId: currentCourse });
+    let hasNext = true;
+    let cursorId = 0;
 
-      this.logger.debug({ results });
+    do {
+      const transaction = await knex.transaction();
+      try {
+        const courseIds = await this.#getCourseIds({
+          cursorId,
+          batchSize,
+          transaction,
+        });
 
-      this.totalNumberOfUpdatedRows += results.numberOfUpdates;
-      this.totalNumberOfDeletedRows += results.numberOfDeletes;
-    }
+        for (const currentCourse of courseIds) {
+          const results = await this.fixCertificationCapacities({ courseId: currentCourse.id, transaction });
+
+          this.logger.debug({ results });
+
+          this.totalNumberOfUpdatedRows += results.numberOfUpdates;
+        }
+
+        dryRun ? await transaction.rollback() : await transaction.commit();
+
+        // Prepare for next batch
+        hasNext = courseIds.length > 0;
+        cursorId = courseIds.at(-1)?.id;
+        await this.delay(delayInMs);
+      } catch (error) {
+        await transaction.rollback();
+        throw error;
+      }
+    } while (hasNext);
 
     this.logger.info({
-      totalNumberOfCertifications: courseIds.length,
       totalNumberOfUpdatedRows: this.totalNumberOfUpdatedRows,
-      totalNumberOfDeletedRows: this.totalNumberOfDeletedRows,
     });
 
     return 0;
   }
 
-  async fixCertificationCapacities({ dryRun, courseId }) {
-    const transaction = await knex.transaction();
-    try {
-      const allCertificationChallenges = await transaction
-        .select({
-          id: 'certification-challenges.id',
-          challengeId: 'certification-challenges.challengeId',
-        })
-        .from('certification-challenges')
-        .where('certification-challenges.courseId', '=', courseId)
-        .orderBy('certification-challenges.createdAt', 'asc');
+  async fixCertificationCapacities({ courseId, transaction }) {
+    const allCertificationChallenges = await transaction
+      .select({
+        id: 'certification-challenges.id',
+        challengeId: 'certification-challenges.challengeId',
+      })
+      .from('certification-challenges')
+      .where('certification-challenges.courseId', '=', courseId)
+      .orderBy('certification-challenges.createdAt', 'asc');
 
-      // Find all capacities
-      const certificationCapacities = await transaction
-        .select({
-          // table certif-challenges
-          certifCourse_Id: 'certification-challenges.courseId',
-          certifChallenge_Id: 'certification-challenges.id',
-          certifChallenge_ChallengeId: 'certification-challenges.challengeId',
-          // table answers
-          answer_ChallengeId: 'answers.challengeId',
-          // table capacities
-          capacity_CertificationChallengeId: 'certification-challenge-capacities.certificationChallengeId',
-          capacity_AnswerId: 'certification-challenge-capacities.answerId',
-        })
-        .from('certification-challenge-capacities')
-        .innerJoin(
-          'certification-challenges',
-          'certification-challenge-capacities.certificationChallengeId',
-          'certification-challenges.id',
-        )
-        .innerJoin('certification-courses', 'certification-challenges.courseId', 'certification-courses.id')
-        .leftJoin('answers', 'certification-challenge-capacities.answerId', 'answers.id')
-        .where('certification-challenges.courseId', '=', courseId)
-        .orderBy('certification-challenges.createdAt', 'asc');
+    // Find all capacities
+    const certificationCapacities = await transaction
+      .select({
+        // table certif-challenges
+        certifCourse_Id: 'certification-challenges.courseId',
+        certifChallenge_Id: 'certification-challenges.id',
+        certifChallenge_ChallengeId: 'certification-challenges.challengeId',
+        // table answers
+        answer_ChallengeId: 'answers.challengeId',
+        // table capacities
+        capacity_CertificationChallengeId: 'certification-challenge-capacities.certificationChallengeId',
+        capacity_AnswerId: 'certification-challenge-capacities.answerId',
+      })
+      .from('certification-challenge-capacities')
+      .innerJoin(
+        'certification-challenges',
+        'certification-challenge-capacities.certificationChallengeId',
+        'certification-challenges.id',
+      )
+      .innerJoin('certification-courses', 'certification-challenges.courseId', 'certification-courses.id')
+      .leftJoin('answers', 'certification-challenge-capacities.answerId', 'answers.id')
+      .where('certification-challenges.courseId', '=', courseId)
+      .orderBy('certification-challenges.createdAt', 'asc');
 
-      this.logger.debug({ certificationCapacities });
+    this.logger.debug({ certificationCapacities });
 
-      // Now fix capacities
-      const capacitiesToUpdate = [];
-      for (const currentCapacity of certificationCapacities) {
-        this.logger.debug({ currentCapacity });
-        if (currentCapacity.certifChallenge_ChallengeId !== currentCapacity.answer_ChallengeId) {
-          // Copy capacity in error
-          const capacityToModify = { ...currentCapacity };
-          capacityToModify.capacity_CertificationChallengeId = 'REPLACE_ME';
-          // Update also challengeId just to show we gound the right match in logs
-          capacityToModify.certifChallenge_ChallengeId = 'REPLACE_ME';
+    // Now fix capacities
+    const capacitiesToUpdate = [];
+    for (const currentCapacity of certificationCapacities) {
+      this.logger.debug({ currentCapacity });
+      if (currentCapacity.certifChallenge_ChallengeId !== currentCapacity.answer_ChallengeId) {
+        // Copy capacity in error
+        const capacityToModify = { ...currentCapacity };
+        capacityToModify.capacity_CertificationChallengeId = 'REPLACE_ME';
+        // Update also challengeId just to show we gound the right match in logs
+        capacityToModify.certifChallenge_ChallengeId = 'REPLACE_ME';
 
-          // Get the right challenge id for this capacity answer
-          const indexOfCorrectChallenge = allCertificationChallenges.findIndex(
-            (certifChallenge) => certifChallenge.challengeId === currentCapacity.answer_ChallengeId,
-          );
+        // Get the right challenge id for this capacity answer
+        const indexOfCorrectChallenge = allCertificationChallenges.findIndex(
+          (certifChallenge) => certifChallenge.challengeId === currentCapacity.answer_ChallengeId,
+        );
 
-          if (indexOfCorrectChallenge !== -1) {
-            // Update capacity with right answer id
-            capacityToModify.capacity_CertificationChallengeId =
-              allCertificationChallenges.at(indexOfCorrectChallenge).id;
-            // Update also certifChallengeChallengeId just to show we found the right match in logs
-            capacityToModify.certifChallenge_ChallengeId =
-              allCertificationChallenges.at(indexOfCorrectChallenge).challengeId;
-            capacitiesToUpdate.push(capacityToModify);
-          } else {
-            // It is not possible that a capacity has a answer but no challenge
-            throw new Error(`Capacity ${capacityToModify.capacity_AnswerId} do not have a corresponding challenge`);
-          }
-
-          // That answer cannot be used anymore
-          allCertificationChallenges.splice(indexOfCorrectChallenge, 1);
+        if (indexOfCorrectChallenge !== -1) {
+          // Update capacity with right answer id
+          capacityToModify.capacity_CertificationChallengeId =
+            allCertificationChallenges.at(indexOfCorrectChallenge).id;
+          // Update also certifChallengeChallengeId just to show we found the right match in logs
+          capacityToModify.certifChallenge_ChallengeId =
+            allCertificationChallenges.at(indexOfCorrectChallenge).challengeId;
+          capacitiesToUpdate.push(capacityToModify);
         } else {
-          // We are on a correct certif challenge, forget about her
-          const correctChallenge = allCertificationChallenges.findIndex(
-            (certifChallenge) => certifChallenge.id === currentCapacity.certifChallenge_Id,
-          );
-          // That certif challenge cannot be used anymore
-          allCertificationChallenges.splice(correctChallenge, 1);
+          // It is not possible that a capacity has a answer but no challenge
+          throw new Error(`Capacity ${capacityToModify.capacity_AnswerId} do not have a corresponding challenge`);
         }
+
+        // That answer cannot be used anymore
+        allCertificationChallenges.splice(indexOfCorrectChallenge, 1);
+      } else {
+        // We are on a correct certif challenge, forget about her
+        const correctChallenge = allCertificationChallenges.findIndex(
+          (certifChallenge) => certifChallenge.id === currentCapacity.certifChallenge_Id,
+        );
+        // That certif challenge cannot be used anymore
+        allCertificationChallenges.splice(correctChallenge, 1);
       }
-
-      // Now from all remaining challenges, find the ones that HAVE a capacity already (meaning they are a duplicate)
-      const certifChallengesToDelete = allCertificationChallenges.filter((challenge) =>
-        certificationCapacities.find((capacity) => capacity.certifChallenge_Id === challenge.id),
-      );
-
-      // We have to do the update in reverse because certificationChallengeId is the PRIMARY KEY
-      for (const capacityToUpdate of capacitiesToUpdate.reverse()) {
-        await transaction('certification-challenge-capacities')
-          .where('answerId', '=', capacityToUpdate.capacity_AnswerId)
-          .update({
-            certificationChallengeId: capacityToUpdate.capacity_CertificationChallengeId,
-          });
-      }
-
-      this.logger.debug({ capacitiesToUpdate });
-      this.logger.debug({ certifChallengesToDelete });
-
-      dryRun ? await transaction.rollback() : await transaction.commit();
-
-      return {
-        numberOfUpdates: capacitiesToUpdate.length,
-        numberOfDeletes: certifChallengesToDelete.length,
-      };
-    } catch (error) {
-      await transaction.rollback();
-      throw error;
     }
+
+    // We have to do the update in reverse because certificationChallengeId is the PRIMARY KEY
+    for (const capacityToUpdate of capacitiesToUpdate.reverse()) {
+      await transaction('certification-challenge-capacities')
+        .where('answerId', '=', capacityToUpdate.capacity_AnswerId)
+        .update({
+          certificationChallengeId: capacityToUpdate.capacity_CertificationChallengeId,
+        });
+    }
+
+    this.logger.debug({ capacitiesToUpdate });
+
+    return {
+      numberOfUpdates: capacitiesToUpdate.length,
+    };
+  }
+
+  #getCourseIds({ cursorId, batchSize, transaction }) {
+    return transaction
+      .select('id')
+      .from('certification-courses')
+      .where('certification-courses.id', '>', cursorId)
+      .andWhere('certification-courses.version', '=', AlgorithmEngineVersion.V3)
+      .orderBy('certification-courses.id')
+      .limit(batchSize);
+  }
+
+  async delay(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 }
 

--- a/api/tests/integration/scripts/certification/fix-validated-live-alert-certification-challenge-ids_test.js
+++ b/api/tests/integration/scripts/certification/fix-validated-live-alert-certification-challenge-ids_test.js
@@ -1,4 +1,5 @@
 import { FixValidatedLiveAlertCertificationChallengeIds } from '../../../../scripts/certification/fix-validated-live-alert-certification-challenge-ids.js';
+import { AlgorithmEngineVersion } from '../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { CertificationChallengeLiveAlertStatus } from '../../../../src/certification/shared/domain/models/CertificationChallengeLiveAlert.js';
 import { databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
 
@@ -8,7 +9,7 @@ describe('Integration | Scripts | Certification | fix-validated-live-alert-certi
       it('should fix the capacities challenges ids', async function () {
         // given
         const certificationCourseId = 321;
-        const options = { dryRun: false, courseIds: [certificationCourseId] };
+        const options = { dryRun: false, batchSize: 10 };
         const logger = {
           info: sinon.stub(),
           debug: sinon.stub(),
@@ -18,6 +19,7 @@ describe('Integration | Scripts | Certification | fix-validated-live-alert-certi
         const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
           id: certificationCourseId,
           userId: user.id,
+          version: AlgorithmEngineVersion.V3,
         });
         const assessment = databaseBuilder.factory.buildAssessment({
           certificationCourseId: certificationCourse.id,

--- a/api/tests/integration/scripts/certification/fix-validated-live-alert-certification-challenge-ids_test.js
+++ b/api/tests/integration/scripts/certification/fix-validated-live-alert-certification-challenge-ids_test.js
@@ -1,0 +1,170 @@
+import { FixValidatedLiveAlertCertificationChallengeIds } from '../../../../scripts/certification/fix-validated-live-alert-certification-challenge-ids.js';
+import { CertificationChallengeLiveAlertStatus } from '../../../../src/certification/shared/domain/models/CertificationChallengeLiveAlert.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
+
+describe('Integration | Scripts | Certification | fix-validated-live-alert-certification-challenge-ids', function () {
+  describe('when candidate has completed the test', function () {
+    describe('when there is a live alert', function () {
+      it('should fix the capacities challenges ids', async function () {
+        // given
+        const certificationCourseId = 321;
+        const options = { dryRun: false, courseIds: [certificationCourseId] };
+        const logger = {
+          info: sinon.stub(),
+          debug: sinon.stub(),
+        };
+
+        const user = databaseBuilder.factory.buildUser();
+        const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+          id: certificationCourseId,
+          userId: user.id,
+        });
+        const assessment = databaseBuilder.factory.buildAssessment({
+          certificationCourseId: certificationCourse.id,
+          userId: user.id,
+        });
+        const firstChallenge = databaseBuilder.factory.buildCertificationChallenge({
+          id: 1,
+          challengeId: 'rec123',
+          courseId: certificationCourseId,
+        });
+        const secondChallenge = databaseBuilder.factory.buildCertificationChallenge({
+          id: 2,
+          challengeId: 'rec456',
+          courseId: certificationCourseId,
+        });
+        const thirdChallengeWithLiveAlert = databaseBuilder.factory.buildCertificationChallenge({
+          id: 3,
+          challengeId: 'recWithLiveAlert',
+          courseId: certificationCourseId,
+        });
+        const fourthChallenge = databaseBuilder.factory.buildCertificationChallenge({
+          id: 4,
+          challengeId: 'rec789',
+          courseId: certificationCourseId,
+        });
+        const fifthChallenge = databaseBuilder.factory.buildCertificationChallenge({
+          id: 5,
+          challengeId: 'rec002',
+          courseId: certificationCourseId,
+        });
+
+        const firstAnswer = databaseBuilder.factory.buildAnswer({
+          id: 1,
+          challengeId: 'rec123',
+          assessment: assessment.id,
+        });
+        const secondAnswer = databaseBuilder.factory.buildAnswer({
+          id: 2,
+          challengeId: 'rec456',
+          assessment: assessment.id,
+        });
+        const thirdAnswer = databaseBuilder.factory.buildAnswer({
+          id: 3,
+          challengeId: 'rec789',
+          assessment: assessment.id,
+        });
+        const fourthAnswer = databaseBuilder.factory.buildAnswer({
+          id: 4,
+          challengeId: 'rec002',
+          assessment: assessment.id,
+        });
+
+        databaseBuilder.factory.buildCertificationChallengeLiveAlert({
+          assessmentId: assessment.id,
+          challengeId: 'recWithLiveAlert',
+          status: CertificationChallengeLiveAlertStatus.VALIDATED,
+          questionNumber: 3,
+        });
+
+        databaseBuilder.factory.buildCertificationChallengeCapacity({
+          certificationChallengeId: firstChallenge.id,
+          answerId: firstAnswer.id,
+          capacity: 1,
+          createdAt: new Date('2020-01-01'),
+        });
+        databaseBuilder.factory.buildCertificationChallengeCapacity({
+          certificationChallengeId: secondChallenge.id,
+          answerId: secondAnswer.id,
+          capacity: 2,
+          createdAt: new Date('2020-01-01'),
+        });
+        databaseBuilder.factory.buildCertificationChallengeCapacity({
+          certificationChallengeId: thirdChallengeWithLiveAlert.id,
+          answerId: thirdAnswer.id,
+          capacity: 3,
+          createdAt: new Date('2020-01-01'),
+        });
+
+        databaseBuilder.factory.buildCertificationChallengeCapacity({
+          certificationChallengeId: fourthChallenge.id,
+          answerId: fourthAnswer.id,
+          capacity: 4,
+          createdAt: new Date('2020-01-01'),
+        });
+
+        await databaseBuilder.commit();
+
+        const script = new FixValidatedLiveAlertCertificationChallengeIds();
+
+        // when
+        await script.handle({ options, logger });
+
+        // then
+        const certificationChallengeCapacities = await knex('certification-challenge-capacities').orderBy('answerId');
+        expect(certificationChallengeCapacities).to.deep.equal([
+          {
+            certificationChallengeId: firstChallenge.id,
+            answerId: firstAnswer.id,
+            capacity: 1,
+            createdAt: new Date('2020-01-01'),
+          },
+          {
+            certificationChallengeId: secondChallenge.id,
+            answerId: secondChallenge.id,
+            capacity: 2,
+            createdAt: new Date('2020-01-01'),
+          },
+          {
+            certificationChallengeId: fourthChallenge.id,
+            answerId: thirdAnswer.id,
+            capacity: 3,
+            createdAt: new Date('2020-01-01'),
+          },
+          {
+            certificationChallengeId: fifthChallenge.id,
+            answerId: fourthAnswer.id,
+            capacity: 4,
+            createdAt: new Date('2020-01-01'),
+          },
+        ]);
+
+        const certificationChallenges = await knex('certification-challenges')
+          .select('id', 'challengeId')
+          .orderBy('id');
+        expect(certificationChallenges).to.deep.equal([
+          {
+            challengeId: firstChallenge.challengeId,
+            id: firstChallenge.id,
+          },
+          {
+            challengeId: secondChallenge.challengeId,
+            id: secondChallenge.id,
+          },
+          {
+            challengeId: thirdChallengeWithLiveAlert.challengeId,
+            id: thirdChallengeWithLiveAlert.id,
+          },
+          {
+            challengeId: fourthChallenge.challengeId,
+            id: fourthChallenge.id,
+          },
+          {
+            challengeId: fifthChallenge.challengeId,
+            id: fifthChallenge.id,
+          },
+        ]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :pancakes: Problème

Lorsqu’un candidat termine son test ou lorsque la session est finalisée, le scoring/rescoring est déclenché.
Celui-ci fait matcher les différents certificationChallengeId passés par le candidat avec l' answerId correspondante.
Toutefois, et depuis la création de la V3, nous avons oublié de retirer de ce procédé de scoring les certificationChallengeIds des questions ayant été soumises à des live-alerts validées par le surveillant.
Cet oubli a déclenché un décalage entre les answerIds et certificationChallengeIds que nous venons de mentionner puisque les certificationChallengeIds avec une live-alert validée (et uniquement validée) ne sont associés à aucune réponse.

Cette PR fait suite à la PR #11476 qui fixe le problème pour les nouvelles certifications.

## :bacon: Proposition

Nous devons donc créer un script pour rattraper les données erronnés en BDD.

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

A réaliser en local pour faciliter le test 

Placez-vous sur un commit antérieur au fix (ex: `ac265b13a02908aa490ebb08a829c2724fbb6f2a`)

- Créer une session V3 et ajouter un candidat
- Au cours de la certif, lever une live-alert et la valider côté surveillant
- Aller jusqu'au bout du test ou finaliser après avoir répondu à au moins 20 questions
- Vérifier en BDD que les `certificationChallengeIds` des questions où vous avez levé des alertes se retrouvent dans la table `certification-challenge-capacities`

Retournez sur cette branche

- lancer le script avec 
```shell
LOG_LEVEL=debug node scripts/certification/fix-validated-live-alert-certification-challenge-ids.js --dryRun=true --batchSize=1 --delayBetweenBatch=1000
```

Le nombre de lignes impactées dans le log correspond à au nombre de lignes dans `certification-challenge-capacities` entre celle où se trouve le `certificationChallengeId` de la question liée à l'alerte et la fin de votre test

Relancer avec le dryRun à false

```shell
LOG_LEVEL=debug node scripts/certification/fix-validated-live-alert-certification-challenge-ids.js --dryRun=false --batchSize=1 --delayBetweenBatch=1000
```

Vérifier que le ou les `certificationChallengeIds` liés à des alertes ne sont plus présents en BDD dans la table `certification-challenge-capacities`