### PR TITLE
[TECH] Ajouter un nom d'evenement pour monitorer les challenges mal formatés (PIX-16747).

### DIFF
--- a/api/src/evaluation/domain/services/solution/solution-service-qrocm-ind.js
+++ b/api/src/evaluation/domain/services/solution/solution-service-qrocm-ind.js
@@ -46,11 +46,10 @@ function _compareAnswersAndSolutions(answers, solutions, enabledTreatments, qroc
   _.map(answers, (answer, answerKey) => {
     const solutionVariants = solutions[answerKey];
     if (!solutionVariants) {
-      logger.warn(
-        `[ERREUR CLE ANSWER] La clé ${answerKey} n'existe pas. Première clé de l'épreuve : ${
-          Object.keys(solutions)[0]
-        }`,
-      );
+      logger.warn({
+        event: 'badly_formatted_challenge',
+        message: `La clé ${answerKey} n'existe pas. Première clé de l'épreuve : ${Object.keys(solutions)[0]}`,
+      });
       throw new YamlParsingError();
     }
     if (useLevenshteinRatio(enabledTreatments) && qrocBlocksTypes[answerKey] != 'select') {


### PR DESCRIPTION
## :pancakes: Problème
Il arrive que certains challenges soient mal formatés. Cela génère des erreurs 500 dans l’api. On souhaite tracker ces mauvais formatages afin de notifier au plus vite l'équipe contenu pour qu’elle entreprenne les actions correctives. Un monitoring a été créé sous datadog, mais à partir d’une regex sur le contenu du message de log, ce qui n’est pas très propre.

## :bacon: Proposition
On va créer une constante explicite et l’assigner à l’attribut `event` du logger.

## 🧃 Remarques
Aucune

## :yum: Pour tester
