### PR TITLE
[FEATURE] Permet au SUPER ADMIN de mettre à jour la colonne params sur les fonctionnalités (PIX-16763)

### DIFF
--- a/api/src/organizational-entities/infrastructure/repositories/organization-feature-repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-feature-repository.js
@@ -21,9 +21,14 @@ async function saveInBatch(organizationFeatures) {
   try {
     const knexConn = DomainTransaction.getConnection();
     await knexConn('organization-features')
-      .insert(organizationFeatures)
+      .insert(
+        organizationFeatures.map((organizationFeature) => ({
+          ...organizationFeature,
+          params: JSON.stringify(organizationFeature.params),
+        })),
+      )
       .onConflict(['featureId', 'organizationId'])
-      .ignore();
+      .merge();
   } catch (err) {
     if (knexUtils.foreignKeyConstraintViolated(err) && err.constraint.includes('featureid')) {
       throw new FeatureNotFound();

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-feature-repository_test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-feature-repository_test.js
@@ -50,6 +50,46 @@ describe('Integration | Repository | Organization-for-admin', function () {
       expect(result[1].params).to.deep.equal(organizationFeatures[1].params);
     });
 
+    it('should update existing rows', async function () {
+      // given
+      const otherOrganization = databaseBuilder.factory.buildOrganization();
+      databaseBuilder.factory.buildOrganizationFeature({
+        featureId: feature.id,
+        organizationId: organization.id,
+        params: `{ "id": 0 }`,
+      });
+      await databaseBuilder.commit();
+
+      const organizationFeatures = [
+        new OrganizationFeature({
+          featureId: feature.id,
+          organizationId: organization.id,
+          params: `["SOMETHING"]`,
+        }),
+        new OrganizationFeature({
+          featureId: feature.id,
+          organizationId: otherOrganization.id,
+          params: `{ "id": 456 }`,
+        }),
+      ];
+
+      // when
+      await organizationFeatureRepository.saveInBatch(organizationFeatures);
+
+      //then
+      const result = await knex('organization-features').where({
+        featureId: feature.id,
+      });
+
+      expect(result).to.have.lengthOf(2);
+      expect(result[0].featureId).to.deep.equal(organizationFeatures[0].featureId);
+      expect(result[0].organizationId).to.deep.equal(organizationFeatures[0].organizationId);
+      expect(result[0].params).to.deep.equal(organizationFeatures[0].params);
+      expect(result[1].featureId).to.deep.equal(organizationFeatures[1].featureId);
+      expect(result[1].organizationId).to.deep.equal(organizationFeatures[1].organizationId);
+      expect(result[1].params).to.deep.equal(organizationFeatures[1].params);
+    });
+
     it('should passe even if organization feature already exists', async function () {
       databaseBuilder.factory.buildOrganizationFeature({ organizationId: organization.id, featureId: feature.id });
       await databaseBuilder.commit();


### PR DESCRIPTION
## :pancakes: Problème

Il n'est pas possible dans la page d'administration de PixAdmin via l'outil "Activation de fonctionnalités" de mettre à jour la configuration de fonctionnalités déjà activées.

## :bacon: Proposition

Permettre via l'import de CSV de mettre à jour la colonne params.

## 🧃 Remarques

On est obligé de stringify les params à cause d'un bug de PG : https://github.com/brianc/node-postgres/issues/442

## :yum: Pour tester

Vérifier via PixAdmin qu'on arrive à mettre à jour une fonctionnalité existante notamment ATTESTATIONS_MANAGEMENT qui posait problème car elle utilise un tableau de chaînes.
