### PR TITLE
[TECH] Corriger le warning `valid integer` des tests d'intég

### DIFF
--- a/api/src/certification/configuration/infrastructure/repositories/candidate-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/candidate-repository.js
@@ -8,7 +8,7 @@ import { Candidate } from '../../domain/models/Candidate.js';
  * @param {number} [params.limit] - number of candidates to limit to
  * @returns {Array<Candidate>} - Candidates returned have a reconciledAt built from certification-course
  */
-export const findCandidateWithoutReconciledAt = async function ({ limit } = {}) {
+export const findCandidateWithoutReconciledAt = async function ({ limit } = { limit: 1 }) {
   const knexConn = DomainTransaction.getConnection();
   const data = await knexConn('certification-candidates')
     .select('certification-candidates.id', 'certification-courses.createdAt')

--- a/api/src/certification/configuration/infrastructure/repositories/candidate-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/candidate-repository.js
@@ -5,7 +5,7 @@ import { Candidate } from '../../domain/models/Candidate.js';
  * This function find candidates with a certification-course but no reconciledAt
  *
  * @param {Object} params
- * @param {number} params.[limit] - number of candidates to limit to
+ * @param {number} [params.limit] - number of candidates to limit to
  * @returns {Array<Candidate>} - Candidates returned have a reconciledAt built from certification-course
  */
 export const findCandidateWithoutReconciledAt = async function ({ limit } = {}) {


### PR DESCRIPTION
## :pancakes: Problème
Dans l'appel de `knex.limit`, `undefined` n'est pas un integer et ça cause un log dans le test d'intégration correspondant :
```
A valid integer must be provided to limit
```

C'était déjà arrivé et corrigé dans #6747.

## :bacon: Proposition
Mettre une valeur par défaut à la limite. (la fonction est toujours appelée avec une limite hors test)

## 🧃 Remarques
Mini correction de JSDoc au passage.

## :yum: Pour tester
CI 🟢 et disparation du log dans les tests d'intég.