### PR TITLE
[TECH] Corriger les warnings lors des tests unitaires

### DIFF
--- a/api/tests/prescription/learner-management/unit/domain/usecases/upload-csv-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/upload-csv-file_test.js
@@ -1,3 +1,5 @@
+import iconv from 'iconv-lite';
+
 import { OrganizationImportStatus } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationImportStatus.js';
 import { uploadCsvFile } from '../../../../../../src/prescription/learner-management/domain/usecases/upload-csv-file.js';
 import { SupOrganizationLearnerImportHeader } from '../../../../../../src/prescription/learner-management/infrastructure/serializers/csv/sup-organization-learner-import-header.js';
@@ -36,9 +38,12 @@ describe('Unit | UseCase | uploadCsvFile', function () {
     organizationImportId = Symbol('organizationImportId');
 
     s3Filename = Symbol('filename');
-    csvContent = `${supOrganizationLearnerImportHeader}
+    csvContent = iconv.encode(
+      `${supOrganizationLearnerImportHeader}
     Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;12346;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;
-    O-Ren;;;Ishii;Cottonmouth;01/01/1980;ishii@example.net;789;Assassination Squad;Bill;Deadly Viper Assassination Squad;DUT;;`;
+    O-Ren;;;Ishii;Cottonmouth;01/01/1980;ishii@example.net;789;Assassination Squad;Bill;Deadly Viper Assassination Squad;DUT;;`,
+      'utf-8',
+    );
     filepath = await createTempFile('file.csv', csvContent);
     payload = { path: filepath };
     fakeDate = new Date('2019-01-10');

--- a/api/tests/prescription/learner-management/unit/domain/usecases/validate-csv-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/validate-csv-file_test.js
@@ -1,3 +1,5 @@
+import iconv from 'iconv-lite';
+
 import { IMPORT_STATUSES } from '../../../../../../src/prescription/learner-management/domain/constants.js';
 import { AggregateImportError } from '../../../../../../src/prescription/learner-management/domain/errors.js';
 import { ImportScoCsvOrganizationLearnersJob } from '../../../../../../src/prescription/learner-management/domain/models/ImportScoCsvOrganizationLearnersJob.js';
@@ -28,9 +30,12 @@ describe('Unit | UseCase | validateCsvFile', function () {
   beforeEach(function () {
     organizationImportId = Symbol('organizationImportId');
     organizationId = 1234;
-    csvContent = `${supOrganizationLearnerImportHeader}
+    csvContent = iconv.encode(
+      `${supOrganizationLearnerImportHeader}
     Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;BAD;BAD;
-    `.trim();
+    `.trim(),
+      'utf-8',
+    );
 
     expectedWarnings = [
       {
@@ -235,10 +240,13 @@ describe('Unit | UseCase | validateCsvFile', function () {
     it('should save VALIDATION_ERROR status', async function () {
       // given
       organizationImportRepositoryStub.get.withArgs(organizationImportId).resolves(organizationImport);
-      const csvContent = `${supOrganizationLearnerImportHeader}
+      const csvContent = iconv.encode(
+        `${supOrganizationLearnerImportHeader}
           Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;BAD;BAD;
           Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;BAD;BAD;
-          `.trim();
+          `.trim(),
+        'utf-8',
+      );
       importStorageStub.getParser
         .withArgs({ Parser: SupOrganizationLearnerParser, filename: organizationImport.filename }, organizationId, i18n)
         .resolves(SupOrganizationLearnerParser.buildParser(csvContent, organizationId, i18n));


### PR DESCRIPTION
## :pancakes: Problème
Depuis #6752, de nouveaux tests n'ont pas respecté le contrat d'interface de l'encodage dans le `CsvOrganizationLearnerParser`. Lors des tests unitaires, on se retrouve de nouveau avec ces logs de warning :
```
Iconv-lite warning: decode()-ing strings is deprecated. Refer to https://github.com/ashtuchkin/iconv-lite/wiki/Use-Buffers-when-decoding.
```

## :bacon: Proposition
Encoder la string en utf8 avec iconv.encode avant de la passer en input.

## :yum: Pour tester
Tests auto OK et plus de logs dans les tests unitaires.