### PR TITLE
[TECH] Mise en place de `Commands` liées au passage de module (PIX-16724)

### DIFF
--- a/api/src/devcomp/domain/errors.js
+++ b/api/src/devcomp/domain/errors.js
@@ -18,6 +18,12 @@ class ElementInstantiationError extends DomainError {
   }
 }
 
+class PassageCommandInstantiationError extends TypeError {
+  constructor(message = 'A passage command cannot be instantiated directly') {
+    super(message);
+  }
+}
+
 class PassageDoesNotExistError extends DomainError {
   constructor(message = 'The passage does not exist') {
     super(message);
@@ -40,6 +46,7 @@ export {
   ElementInstantiationError,
   ModuleDoesNotExistError,
   ModuleInstantiationError,
+  PassageCommandInstantiationError,
   PassageDoesNotExistError,
   PassageTerminatedError,
   UserNotAuthorizedToFindTrainings,

--- a/api/src/devcomp/domain/models/passage-commands/PassageCommand.js
+++ b/api/src/devcomp/domain/models/passage-commands/PassageCommand.js
@@ -1,0 +1,30 @@
+import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { PassageCommandInstantiationError } from '../../errors.js';
+
+/**
+ * @abstract PassageCommand
+ * A PassageCommand is an instruction that indicate a desired change in the state of a Modulix passage.
+ * See CQRS pattern for more information.
+ *
+ * This is the base class for all PassageCommands. Sub classes should be named in present tense.
+ *
+ * It becomes a PassageEvent when saved to the DB.
+ */
+class PassageCommand {
+  constructor({ type, occuredAt, passageId, commandData } = {}) {
+    if (this.constructor === PassageCommand) {
+      throw new PassageCommandInstantiationError();
+    }
+
+    assertNotNullOrUndefined(type, 'The type is required for a PassageCommand');
+    assertNotNullOrUndefined(occuredAt, 'The occuredAt is required for a PassageCommand');
+    assertNotNullOrUndefined(passageId, 'The passageId is required for a PassageCommand');
+
+    this.type = type;
+    this.occuredAt = occuredAt;
+    this.passageId = passageId;
+    this.commandData = commandData;
+  }
+}
+
+export { PassageCommand };

--- a/api/src/devcomp/domain/models/passage-commands/passage-commands.js
+++ b/api/src/devcomp/domain/models/passage-commands/passage-commands.js
@@ -1,0 +1,17 @@
+import { PassageCommand } from './PassageCommand.js';
+
+/**
+ * @class TerminatePassageCommand
+ *
+ * A TerminatePassageCommand is an instruction to terminate a Modulix passage.
+ * See CQRS pattern for more information.
+ *
+ * It becomes a PassageTerminatedEvent when saved to the DB.
+ */
+class TerminatePassageCommand extends PassageCommand {
+  constructor({ occuredAt, passageId }) {
+    super({ type: 'TERMINATE_PASSAGE', occuredAt, passageId });
+  }
+}
+
+export { TerminatePassageCommand };

--- a/api/src/devcomp/domain/models/passage-commands/passage-commands.js
+++ b/api/src/devcomp/domain/models/passage-commands/passage-commands.js
@@ -1,4 +1,24 @@
+import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 import { PassageCommand } from './PassageCommand.js';
+
+/**
+ * @class StartPassageCommand
+ *
+ * A StartPassageCommand is an instruction to start a Modulix passage.
+ * See CQRS pattern for more information.
+ *
+ * It becomes a PassageStartedEvent when saved to the DB.
+ * It takes a contentHash as a parameter.
+ */
+class StartPassageCommand extends PassageCommand {
+  constructor({ occuredAt, passageId, contentHash }) {
+    super({ type: 'START_PASSAGE', occuredAt, passageId, commandData: { contentHash } });
+
+    assertNotNullOrUndefined(contentHash, 'The contentHash is required for a StartPassageCommand');
+
+    this.contentHash = contentHash;
+  }
+}
 
 /**
  * @class TerminatePassageCommand
@@ -14,4 +34,4 @@ class TerminatePassageCommand extends PassageCommand {
   }
 }
 
-export { TerminatePassageCommand };
+export { StartPassageCommand, TerminatePassageCommand };

--- a/api/tests/devcomp/integration/domain/models/passage-commands/passage-commands_test.js
+++ b/api/tests/devcomp/integration/domain/models/passage-commands/passage-commands_test.js
@@ -1,0 +1,21 @@
+import { TerminatePassageCommand } from '../../../../../../src/devcomp/domain/models/passage-commands/passage-commands.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Integration | Devcomp | Domain | Models | passage-commands | passage-commands', function () {
+  describe('#TerminatePassageCommand', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const occuredAt = Symbol('date');
+      const passageId = Symbol('passage');
+
+      // when
+      const terminatePassageCommand = new TerminatePassageCommand({ occuredAt, passageId });
+
+      // then
+      expect(terminatePassageCommand.type).to.equal('TERMINATE_PASSAGE');
+      expect(terminatePassageCommand.occuredAt).to.equal(occuredAt);
+      expect(terminatePassageCommand.passageId).to.equal(passageId);
+      expect(terminatePassageCommand.commandData).to.be.undefined;
+    });
+  });
+});

--- a/api/tests/devcomp/integration/domain/models/passage-commands/passage-commands_test.js
+++ b/api/tests/devcomp/integration/domain/models/passage-commands/passage-commands_test.js
@@ -1,7 +1,45 @@
-import { TerminatePassageCommand } from '../../../../../../src/devcomp/domain/models/passage-commands/passage-commands.js';
-import { expect } from '../../../../../test-helper.js';
+import {
+  StartPassageCommand,
+  TerminatePassageCommand,
+} from '../../../../../../src/devcomp/domain/models/passage-commands/passage-commands.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Integration | Devcomp | Domain | Models | passage-commands | passage-commands', function () {
+  describe('#StartPassageCommand', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const occuredAt = Symbol('date');
+      const passageId = Symbol('passage');
+      const contentHash = Symbol('contentHash');
+
+      // when
+      const startPassageCommand = new StartPassageCommand({ occuredAt, passageId, contentHash });
+
+      // then
+      expect(startPassageCommand.type).to.equal('START_PASSAGE');
+      expect(startPassageCommand.occuredAt).to.equal(occuredAt);
+      expect(startPassageCommand.passageId).to.equal(passageId);
+      expect(startPassageCommand.contentHash).to.equal(contentHash);
+      expect(startPassageCommand.commandData).to.deep.equal({ contentHash });
+    });
+
+    describe('when contentHash is not given', function () {
+      it('should throw an error', function () {
+        // given
+        const occuredAt = Symbol('date');
+        const passageId = Symbol('passage');
+
+        // when
+        const error = catchErrSync(() => new StartPassageCommand({ occuredAt, passageId }))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The contentHash is required for a StartPassageCommand');
+      });
+    });
+  });
+
   describe('#TerminatePassageCommand', function () {
     it('should init and keep attributes', function () {
       // given

--- a/api/tests/devcomp/unit/domain/models/module/PassageCommand_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/PassageCommand_test.js
@@ -1,0 +1,140 @@
+import { PassageCommandInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
+import { PassageCommand } from '../../../../../../src/devcomp/domain/models/passage-commands/PassageCommand.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | PassageCommand', function () {
+  describe('#constructor', function () {
+    it('should not be able to create a PassageCommand directly', function () {
+      // given & when
+      const error = catchErrSync(() => new PassageCommand({}))();
+
+      // then
+      expect(error).to.be.instanceOf(PassageCommandInstantiationError);
+    });
+
+    describe('if a passage command does not have a type', function () {
+      it('should throw an error', function () {
+        // given
+        class FakeCommand extends PassageCommand {
+          constructor() {
+            super({});
+          }
+        }
+
+        // when
+        const error = catchErrSync(() => new FakeCommand())();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The type is required for a PassageCommand');
+      });
+    });
+
+    describe('if a passage command does not have a occuredAt', function () {
+      it('should throw an error', function () {
+        // given
+        class FakeCommand extends PassageCommand {
+          constructor() {
+            super({ type: 'FAKE' });
+          }
+        }
+
+        // when
+        const error = catchErrSync(() => new FakeCommand())();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The occuredAt is required for a PassageCommand');
+      });
+    });
+
+    describe('if a passage command does not have a passageId', function () {
+      it('should throw an error', function () {
+        // given
+        class FakeCommand extends PassageCommand {
+          constructor() {
+            super({ type: 'FAKE', occuredAt: Symbol('date') });
+          }
+        }
+
+        // when
+        const error = catchErrSync(() => new FakeCommand())();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The passageId is required for a PassageCommand');
+      });
+    });
+
+    describe('if a passage command has minimal required attributes', function () {
+      it('should create a PassageCommand and set type attribute', function () {
+        // given
+        const occuredAt = Symbol('date');
+        const passageId = Symbol('passage');
+        class FakeCommand extends PassageCommand {
+          constructor() {
+            super({ type: 'FAKE', occuredAt, passageId });
+          }
+        }
+
+        // when
+        const command = new FakeCommand();
+
+        // then
+        expect(command.type).to.equal('FAKE');
+      });
+
+      it('should create a PassageCommand and set occuredAt attribute', function () {
+        // given
+        const occuredAt = Symbol('date');
+        const passageId = Symbol('passage');
+        class FakeCommand extends PassageCommand {
+          constructor() {
+            super({ type: 'FAKE', occuredAt, passageId });
+          }
+        }
+
+        // when
+        const command = new FakeCommand();
+
+        // then
+        expect(command.occuredAt).to.equal(occuredAt);
+      });
+
+      it('should create a PassageCommand and set passageId attribute', function () {
+        // given
+        const occuredAt = Symbol('date');
+        const passageId = Symbol('passage');
+        class FakeCommand extends PassageCommand {
+          constructor() {
+            super({ type: 'FAKE', occuredAt, passageId });
+          }
+        }
+
+        // when
+        const command = new FakeCommand();
+
+        // then
+        expect(command.passageId).to.equal(passageId);
+      });
+
+      it('should create a PassageCommand and set commandData to undefined', function () {
+        // given
+        const occuredAt = Symbol('date');
+        const passageId = Symbol('passage');
+        class FakeCommand extends PassageCommand {
+          constructor() {
+            super({ type: 'FAKE', occuredAt, passageId });
+          }
+        }
+
+        // when
+        const command = new FakeCommand();
+
+        // then
+        expect(command.commandData).to.be.undefined;
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :bacon: Proposition
Pour les besoins de consommations de données de Modulix, on souhaite enregistrer certaines actions de l'utilisateurice.

En s'inspirant du pattern [CQRS](https://www.geeksforgeeks.org/cqrs-command-query-responsibility-segregation/), nous mettons en place un Event Store.

Avant d'être enregistré comme événement, on parle de "Command". On peut la définir comme une "instruction" de l'utilisateur pour changer un état dans le contexte d'un passage de module.

Chaque Command possède a minima : 
- un `type`,
- une date de demande `occuredAt`,
- un identifiant de passage de module `passageId`.

Elle peut éventuellement contenir des données supplémentaires selon le type d'événement.

Cette PR contient la mise en place d'un modèle métier générique `PassageCommand` ainsi que de 2 exemples métier `TerminatePassageCommand` qui ne nécessite pas de données supplémentaires et `StartPassageCommand` qui prend un paramètre supplémentaire.

## 🧃 Remarques
Voir également [la PR sur la mise en place de l'événement](https://github.com/1024pix/pix/pull/11536).

## :yum: Pour tester
CI 🍏 
