### PR TITLE
[TECH] Mise en place d'`Events` liés au passage de module (PIX-16726)

### DIFF
--- a/api/src/devcomp/domain/errors.js
+++ b/api/src/devcomp/domain/errors.js
@@ -18,6 +18,12 @@ class ElementInstantiationError extends DomainError {
   }
 }
 
+class PassageEventInstantiationError extends TypeError {
+  constructor(message = 'A passage event cannot be instantiated directly') {
+    super(message);
+  }
+}
+
 class PassageDoesNotExistError extends DomainError {
   constructor(message = 'The passage does not exist') {
     super(message);
@@ -41,6 +47,7 @@ export {
   ModuleDoesNotExistError,
   ModuleInstantiationError,
   PassageDoesNotExistError,
+  PassageEventInstantiationError,
   PassageTerminatedError,
   UserNotAuthorizedToFindTrainings,
 };

--- a/api/src/devcomp/domain/models/passage-events/PassageEvent.js
+++ b/api/src/devcomp/domain/models/passage-events/PassageEvent.js
@@ -1,0 +1,34 @@
+import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { PassageEventInstantiationError } from '../../errors.js';
+
+/**
+ * @abstract PassageEvent
+ * After the write operation is successful, the system generates events that describe what changed (like "Passage started" or "Video started").
+ * These events serve as notifications about the updates.
+ * See Event sourcing pattern for more information.
+ * https://martinfowler.com/eaaDev/EventSourcing.html
+ *
+ * This is the base class for all PassageEvents. Subclasses should be named in past tense.
+ */
+class PassageEvent {
+  constructor({ id, type, occurredAt, createdAt, passageId, data } = {}) {
+    if (this.constructor === PassageEvent) {
+      throw new PassageEventInstantiationError();
+    }
+
+    assertNotNullOrUndefined(id, 'The id is required for a PassageEvent');
+    assertNotNullOrUndefined(type, 'The type is required for a PassageEvent');
+    assertNotNullOrUndefined(occurredAt, 'The occurredAt is required for a PassageEvent');
+    assertNotNullOrUndefined(createdAt, 'The createdAt is required for a PassageEvent');
+    assertNotNullOrUndefined(passageId, 'The passageId is required for a PassageEvent');
+
+    this.id = id;
+    this.type = type;
+    this.occurredAt = occurredAt;
+    this.createdAt = createdAt;
+    this.passageId = passageId;
+    this.data = data;
+  }
+}
+
+export { PassageEvent };

--- a/api/src/devcomp/domain/models/passage-events/passage-events.js
+++ b/api/src/devcomp/domain/models/passage-events/passage-events.js
@@ -1,4 +1,20 @@
+import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 import { PassageEvent } from './PassageEvent.js';
+
+/**
+ * @class PassageStartedEvent
+ *
+ * A PassageStartedEvent is generated when a Modulix passage is started and saved in DB.
+ */
+class PassageStartedEvent extends PassageEvent {
+  constructor({ id, occurredAt, createdAt, passageId, contentHash }) {
+    super({ id, type: 'PASSAGE_STARTED', occurredAt, createdAt, passageId, data: { contentHash } });
+
+    assertNotNullOrUndefined(contentHash, 'The contentHash is required for a PassageStartedEvent');
+
+    this.contentHash = contentHash;
+  }
+}
 
 /**
  * @class PassageTerminatedEvent
@@ -11,4 +27,4 @@ class PassageTerminatedEvent extends PassageEvent {
   }
 }
 
-export { PassageTerminatedEvent };
+export { PassageStartedEvent, PassageTerminatedEvent };

--- a/api/src/devcomp/domain/models/passage-events/passage-events.js
+++ b/api/src/devcomp/domain/models/passage-events/passage-events.js
@@ -1,0 +1,14 @@
+import { PassageEvent } from './PassageEvent.js';
+
+/**
+ * @class PassageTerminatedEvent
+ *
+ * A PassageTerminatedEvent is generated when a Modulix passage is terminated and saved in DB.
+ */
+class PassageTerminatedEvent extends PassageEvent {
+  constructor({ id, occurredAt, createdAt, passageId }) {
+    super({ id, type: 'PASSAGE_TERMINATED', occurredAt, createdAt, passageId });
+  }
+}
+
+export { PassageTerminatedEvent };

--- a/api/tests/devcomp/integration/domain/models/passage-events/passage-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/passage-events/passage-events_test.js
@@ -1,0 +1,25 @@
+import { PassageTerminatedEvent } from '../../../../../../src/devcomp/domain/models/passage-events/passage-events.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Integration | Devcomp | Domain | Models | passage-events | passage-events', function () {
+  describe('#PassageTerminatedEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = Symbol('date');
+      const createdAt = Symbol('date');
+      const passageId = Symbol('passage');
+
+      // when
+      const passageTerminatedEvent = new PassageTerminatedEvent({ id, occurredAt, createdAt, passageId });
+
+      // then
+      expect(passageTerminatedEvent.id).to.equal(id);
+      expect(passageTerminatedEvent.type).to.equal('PASSAGE_TERMINATED');
+      expect(passageTerminatedEvent.occurredAt).to.equal(occurredAt);
+      expect(passageTerminatedEvent.createdAt).to.equal(createdAt);
+      expect(passageTerminatedEvent.passageId).to.equal(passageId);
+      expect(passageTerminatedEvent.data).to.be.undefined;
+    });
+  });
+});

--- a/api/tests/devcomp/integration/domain/models/passage-events/passage-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/passage-events/passage-events_test.js
@@ -1,7 +1,51 @@
-import { PassageTerminatedEvent } from '../../../../../../src/devcomp/domain/models/passage-events/passage-events.js';
-import { expect } from '../../../../../test-helper.js';
+import {
+  PassageStartedEvent,
+  PassageTerminatedEvent,
+} from '../../../../../../src/devcomp/domain/models/passage-events/passage-events.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Integration | Devcomp | Domain | Models | passage-events | passage-events', function () {
+  describe('#PassageStartedEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = Symbol('date');
+      const createdAt = Symbol('date');
+      const passageId = Symbol('passage');
+      const contentHash = Symbol('contentHash');
+
+      // when
+      const passageStartedEvent = new PassageStartedEvent({ id, occurredAt, createdAt, passageId, contentHash });
+
+      // then
+      expect(passageStartedEvent.id).to.equal(id);
+      expect(passageStartedEvent.type).to.equal('PASSAGE_STARTED');
+      expect(passageStartedEvent.occurredAt).to.equal(occurredAt);
+      expect(passageStartedEvent.createdAt).to.equal(createdAt);
+      expect(passageStartedEvent.passageId).to.equal(passageId);
+      expect(passageStartedEvent.contentHash).to.equal(contentHash);
+      expect(passageStartedEvent.data).to.deep.equal({ contentHash });
+    });
+
+    describe('when contentHash is not given', function () {
+      it('should throw an error', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = Symbol('date');
+        const createdAt = Symbol('date');
+        const passageId = Symbol('passage');
+
+        // when
+        const error = catchErrSync(() => new PassageStartedEvent({ id, occurredAt, createdAt, passageId }))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The contentHash is required for a PassageStartedEvent');
+      });
+    });
+  });
+
   describe('#PassageTerminatedEvent', function () {
     it('should init and keep attributes', function () {
       // given

--- a/api/tests/devcomp/unit/domain/models/module/PassageEvent_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/PassageEvent_test.js
@@ -1,0 +1,222 @@
+import { PassageEventInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
+import { PassageEvent } from '../../../../../../src/devcomp/domain/models/passage-events/PassageEvent.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
+  describe('#constructor', function () {
+    it('should not be able to create a PassageEvent directly', function () {
+      // given & when
+      const error = catchErrSync(() => new PassageEvent({}))();
+
+      // then
+      expect(error).to.be.instanceOf(PassageEventInstantiationError);
+    });
+
+    describe('if a passage event does not have an id', function () {
+      it('should throw an error', function () {
+        // given
+        class FakeEvent extends PassageEvent {
+          constructor() {
+            super({});
+          }
+        }
+
+        // when
+        const error = catchErrSync(() => new FakeEvent())();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The id is required for a PassageEvent');
+      });
+    });
+
+    describe('if a passage event does not have a type', function () {
+      it('should throw an error', function () {
+        // given
+        class FakeEvent extends PassageEvent {
+          constructor() {
+            super({ id: 1 });
+          }
+        }
+
+        // when
+        const error = catchErrSync(() => new FakeEvent())();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The type is required for a PassageEvent');
+      });
+    });
+
+    describe('if a passage event does not have a occurredAt', function () {
+      it('should throw an error', function () {
+        // given
+        class FakeEvent extends PassageEvent {
+          constructor() {
+            super({ id: 1, type: 'FAKE' });
+          }
+        }
+
+        // when
+        const error = catchErrSync(() => new FakeEvent())();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The occurredAt is required for a PassageEvent');
+      });
+    });
+
+    describe('if a passage event does not have a createdAt', function () {
+      it('should throw an error', function () {
+        // given
+        class FakeEvent extends PassageEvent {
+          constructor() {
+            super({ id: 1, type: 'FAKE', occurredAt: Symbol('date') });
+          }
+        }
+
+        // when
+        const error = catchErrSync(() => new FakeEvent())();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The createdAt is required for a PassageEvent');
+      });
+    });
+
+    describe('if a passage event does not have a passageId', function () {
+      it('should throw an error', function () {
+        // given
+        class FakeEvent extends PassageEvent {
+          constructor() {
+            super({ id: 1, type: 'FAKE', occurredAt: Symbol('date'), createdAt: Symbol('date') });
+          }
+        }
+
+        // when
+        const error = catchErrSync(() => new FakeEvent())();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The passageId is required for a PassageEvent');
+      });
+    });
+
+    describe('if a passage event has minimal required attributes', function () {
+      it('should create a PassageEvent and set id attribute', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = Symbol('date');
+        const createdAt = Symbol('date');
+        const passageId = Symbol('passage');
+        class FakeEvent extends PassageEvent {
+          constructor() {
+            super({ id, type: 'FAKE', occurredAt, createdAt, passageId });
+          }
+        }
+
+        // when
+        const event = new FakeEvent();
+
+        // then
+        expect(event.id).to.equal(id);
+      });
+
+      it('should create a PassageEvent and set type attribute', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = Symbol('date');
+        const createdAt = Symbol('date');
+        const passageId = Symbol('passage');
+        class FakeEvent extends PassageEvent {
+          constructor() {
+            super({ id, type: 'FAKE', occurredAt, createdAt, passageId });
+          }
+        }
+
+        // when
+        const event = new FakeEvent();
+
+        // then
+        expect(event.type).to.equal('FAKE');
+      });
+
+      it('should create a PassageEvent and set occurredAt attribute', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = Symbol('date');
+        const createdAt = Symbol('date');
+        const passageId = Symbol('passage');
+        class FakeEvent extends PassageEvent {
+          constructor() {
+            super({ id, type: 'FAKE', occurredAt, createdAt, passageId });
+          }
+        }
+
+        // when
+        const event = new FakeEvent();
+
+        // then
+        expect(event.occurredAt).to.equal(occurredAt);
+      });
+
+      it('should create a PassageEvent and set createdAt attribute', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = Symbol('date');
+        const createdAt = Symbol('date');
+        const passageId = Symbol('passage');
+        class FakeEvent extends PassageEvent {
+          constructor() {
+            super({ id, type: 'FAKE', occurredAt, createdAt, passageId });
+          }
+        }
+
+        // when
+        const event = new FakeEvent();
+
+        // then
+        expect(event.createdAt).to.equal(createdAt);
+      });
+
+      it('should create a PassageEvent and set passageId attribute', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = Symbol('date');
+        const createdAt = Symbol('date');
+        const passageId = Symbol('passage');
+        class FakeEvent extends PassageEvent {
+          constructor() {
+            super({ id, type: 'FAKE', occurredAt, createdAt, passageId });
+          }
+        }
+
+        // when
+        const event = new FakeEvent();
+
+        // then
+        expect(event.passageId).to.equal(passageId);
+      });
+
+      it('should create a PassageEvent and set data to undefined', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = Symbol('date');
+        const createdAt = Symbol('date');
+        const passageId = Symbol('passage');
+        class FakeEvent extends PassageEvent {
+          constructor() {
+            super({ id, type: 'FAKE', occurredAt, createdAt, passageId });
+          }
+        }
+
+        // when
+        const event = new FakeEvent();
+
+        // then
+        expect(event.data).to.be.undefined;
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :bacon: Proposition
Pour les besoins de consommations de données de Modulix, on souhaite enregistrer certaines actions de l'utilisateurice.

En s'inspirant du pattern [Event sourcing](https://martinfowler.com/eaaDev/EventSourcing.html), nous mettons en place un Event Store.

Cet événement
- est identifiable grace à un `id`,
- un `type`,
- possède une date d'enregistrement `createdAt`,
- une date de demande `occurredAt`,
- un identifiant de passage de module `passageId`.

L'Event peut éventuellement contenir des données supplémentaires selon son type.

Cette PR contient la mise en place d'un modèle métier générique `PassageEvent` ainsi que de 2 exemples métier `PassageTerminatedEvent` et `PassageStartedEvent`.

## 🧃 Remarques
On n'est pas encore certain de qui sera responsable de créer une instance de cet event, on est pas 100% convaincu que mettre les données supplémentaires "à plat" soit la bonne approche dans ce contexte. On en reparle dans une prochaine PR sur la mise en place du repo.

Voir aussi [la PR sur la mise en place de Command qu'on a cloturée](https://github.com/1024pix/pix/pull/11535).

## :yum: Pour tester
CI 🍏 
