### PR TITLE
[FEATURE] Corriger l'espace entre le menu et l'alert en format mobile (PIX-16665)

### DIFF
--- a/orga/app/styles/components/banner/top-banners.scss
+++ b/orga/app/styles/components/banner/top-banners.scss
@@ -1,5 +1,11 @@
+@use 'pix-design-tokens/breakpoints';
+
 .top-banners {
   & > * {
     margin-bottom: var(--pix-spacing-2x);
+  }
+
+  @include breakpoints.device-is('mobile') {
+    margin-top: var(--pix-spacing-2x);
   }
 }


### PR DESCRIPTION
## :pancakes: Problème

![Capture d’écran du 2025-02-28 11-15-36](https://github.com/user-attachments/assets/814bf348-fdb8-4ba0-92df-7327e52039cd)

## :bacon: Proposition

![Capture d’écran du 2025-02-28 11-15-42](https://github.com/user-attachments/assets/9b4630cb-5a1b-401b-9ebc-3cdd2defbacd)

## :yum: Pour tester

![Capture d’écran du 2025-02-28 11-15-42](https://github.com/user-attachments/assets/8c1c8af9-3e43-4b6b-9502-5b900836edf8)
