### PR TITLE
[FEATURE] Enregistrer la date de dernière connexion dans Authentication method pour les connexions OIDC (PIX-16742)

### DIFF
--- a/api/tests/identity-access-management/unit/domain/usecases/authenticate-oidc-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/authenticate-oidc-user.usecase.test.js
@@ -36,6 +36,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
       };
       authenticationMethodRepository = {
         updateAuthenticationComplementByUserIdAndIdentityProvider: sinon.stub(),
+        updateLastLoggedAtByIdentityProvider: sinon.stub(),
       };
       authenticationSessionService = {
         save: sinon.stub(),
@@ -294,6 +295,15 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
             userId: 10,
             identityProvider: oidcAuthenticationService.identityProvider,
           });
+          expect(authenticationMethodRepository.updateLastLoggedAtByIdentityProvider).to.have.been.calledWithExactly({
+            userId: 10,
+            identityProvider: oidcAuthenticationService.identityProvider,
+          });
+          expect(lastUserApplicationConnectionsRepository.upsert).to.have.been.calledWithExactly({
+            userId: 10,
+            application: 'app',
+            lastLoggedAt: sinon.match.instanceOf(Date),
+          });
         });
       });
 
@@ -331,6 +341,15 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
             userId: 10,
             identityProvider: oidcAuthenticationService.identityProvider,
           });
+          expect(authenticationMethodRepository.updateLastLoggedAtByIdentityProvider).to.have.been.calledWithExactly({
+            userId: 10,
+            identityProvider: oidcAuthenticationService.identityProvider,
+          });
+          expect(lastUserApplicationConnectionsRepository.upsert).to.have.been.calledWithExactly({
+            userId: 10,
+            application: 'app',
+            lastLoggedAt: sinon.match.instanceOf(Date),
+          });
         });
       });
     });
@@ -365,6 +384,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
       };
       authenticationMethodRepository = {
         updateAuthenticationComplementByUserIdAndIdentityProvider: sinon.stub(),
+        updateLastLoggedAtByIdentityProvider: sinon.stub(),
       };
 
       authenticationSessionService = {
@@ -415,6 +435,15 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
           authenticationComplement,
           userId: 1,
           identityProvider: oidcAuthenticationService.identityProvider,
+        });
+        expect(authenticationMethodRepository.updateLastLoggedAtByIdentityProvider).to.have.been.calledWithExactly({
+          userId: 1,
+          identityProvider: oidcAuthenticationService.identityProvider,
+        });
+        expect(lastUserApplicationConnectionsRepository.upsert).to.have.been.calledWithExactly({
+          userId: 1,
+          application: 'app',
+          lastLoggedAt: sinon.match.instanceOf(Date),
         });
       });
 
@@ -495,6 +524,15 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
           authenticationComplement,
           userId: 10,
           identityProvider: oidcAuthenticationService.identityProvider,
+        });
+        expect(authenticationMethodRepository.updateLastLoggedAtByIdentityProvider).to.have.been.calledWithExactly({
+          userId: 10,
+          identityProvider: oidcAuthenticationService.identityProvider,
+        });
+        expect(lastUserApplicationConnectionsRepository.upsert).to.have.been.calledWithExactly({
+          userId: 10,
+          application: 'app',
+          lastLoggedAt: sinon.match.instanceOf(Date),
         });
       });
     });

--- a/api/tests/identity-access-management/unit/domain/usecases/create-oidc-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/create-oidc-user.usecase.test.js
@@ -19,6 +19,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-oidc-use
 
     authenticationMethodRepository = {
       findOneByExternalIdentifierAndIdentityProvider: sinon.stub(),
+      updateLastLoggedAtByIdentityProvider: sinon.stub(),
     };
 
     authenticationSessionService = {
@@ -148,12 +149,21 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-oidc-use
       userToCreateRepository,
       authenticationMethodRepository,
     });
-    sinon.assert.calledOnce(oidcAuthenticationService.createAccessToken);
-    sinon.assert.calledOnce(oidcAuthenticationService.saveIdToken);
-    sinon.assert.calledOnceWithExactly(userLoginRepository.updateLastLoggedAt, { userId: 10 });
+    expect(oidcAuthenticationService.createAccessToken).to.have.been.calledOnce;
+    expect(oidcAuthenticationService.saveIdToken).to.have.been.calledOnce;
+    expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWithExactly({ userId: 10 });
     expect(result).to.deep.equal({
       accessToken: 'accessTokenForExistingExternalUser',
       logoutUrlUUID: 'logoutUrlUUID',
+    });
+    expect(authenticationMethodRepository.updateLastLoggedAtByIdentityProvider).to.have.been.calledWithExactly({
+      userId: 10,
+      identityProvider: oidcAuthenticationService.identityProvider,
+    });
+    expect(lastUserApplicationConnectionsRepository.upsert).to.have.been.calledWithExactly({
+      userId: 10,
+      application: 'app',
+      lastLoggedAt: sinon.match.instanceOf(Date),
     });
   });
 });

--- a/api/tests/identity-access-management/unit/domain/usecases/reconcile-oidc-user-for-admin.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/reconcile-oidc-user-for-admin.usecase.test.js
@@ -19,7 +19,11 @@ describe('Unit | Identity Access Management | Domain | UseCase | reconcile-oidc-
   const requestedApplication = new RequestedApplication('admin');
 
   beforeEach(function () {
-    authenticationMethodRepository = { create: sinon.stub(), findOneByUserIdAndIdentityProvider: sinon.stub() };
+    authenticationMethodRepository = {
+      create: sinon.stub(),
+      findOneByUserIdAndIdentityProvider: sinon.stub(),
+      updateLastLoggedAtByIdentityProvider: sinon.stub(),
+    };
     userRepository = { getByEmail: sinon.stub() };
     userLoginRepository = { updateLastLoggedAt: sinon.stub() };
     authenticationSessionService = { getByKey: sinon.stub() };
@@ -144,7 +148,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | reconcile-oidc-
     expect(result).to.equal('accessToken');
   });
 
-  it('saves the last user application connection', async function () {
+  it('saves the last user connection', async function () {
     // given
     const email = 'anne@example.net';
     const externalIdentifier = 'external_id';
@@ -181,6 +185,10 @@ describe('Unit | Identity Access Management | Domain | UseCase | reconcile-oidc-
       userId,
       application: 'admin',
       lastLoggedAt: sinon.match.instanceOf(Date),
+    });
+    expect(authenticationMethodRepository.updateLastLoggedAtByIdentityProvider).to.be.calledWithMatch({
+      userId,
+      identityProvider: oidcAuthenticationService.identityProvider,
     });
   });
 


### PR DESCRIPTION
## :pancakes: Problème

Quand un utilisateur se connecte avec une méthode de connexion SSO, on souhaite stocker la date de dernière connexion pour la méthode de connexion.

## :bacon: Proposition

Quand un utilisateur se connecte avec une méthode de connexion SSO, stocker la date de dernière connexion pour la méthode de connexion

## 🧃 Remarques

suite de #11505 

Cela concerne les use cases:

- reconcileOidcUser

- reconcileOidcUserForAdmin

- createOidcUser

- authenticateOidcUser

## :yum: Pour tester

Route api/oidc/user/reconcile
- Depuis app, se réconcilier avec un SSO (ex pays de la loire)
- Constater en base une écriture sur la table "authentication-méthods" avec l'identityProvider (PAYSDELALOIRE) et le lastLoggedAt (date de la réconciliation)


Route /api/admin/oidc/user/reconcile
- Modifier le mail du user Superadmin pour y mettre votre addresse mail pix
- Depuis https://admin.dev.pix.fr/ se connecter via sso
- Constater en base une écriture sur la table "authentication-méthods" avec l'identityProvider (GOOGLE) et le lastLoggedAt (date de la connexion)


Route /api/oidc/token
- Depuis app, se connecter via SSO (ex pays de la loire) avec l'utilisateur récédement réconcilié à l'étape 1
- Constater en base une écriture sur la table "authentication-méthods" avec l'identityProvider (PAYSDELALOIRE) et le lastLoggedAt (date de la nouvelle connexion)


Route /api/oidc/users
- Depuis app, se connecter via SSO (ex pays de la loire) avec un utilisateur n'ayant pas de compte Pix
- Constater en base une écriture sur la table "authentication-méthods" avec l'identityProvider (PAYSDELALOIRE) et le lastLoggedAt (date de la connexion/création du user)
