### PR TITLE
[TECH] Suppression du FT_USER_TOKEN_AUD_CONFINEMENT_ENABLED et du reste du code legacy sur scope et target (PIX-16531)

### DIFF
--- a/admin/app/adapters/oidc-identity-provider.js
+++ b/admin/app/adapters/oidc-identity-provider.js
@@ -1,11 +1,9 @@
 import ApplicationAdapter from './application';
 
-const PIX_ADMIN_TARGET = 'admin';
-
 export default class OidcIdentityProviderAdapter extends ApplicationAdapter {
   urlForFindAll(_, snapshot) {
     if (snapshot.adapterOptions?.readyIdentityProviders) {
-      return `${this.host}/${this.namespace}/oidc/identity-providers?target=${PIX_ADMIN_TARGET}`;
+      return `${this.host}/${this.namespace}/oidc/identity-providers`;
     }
     return `${this.host}/${this.namespace}/admin/oidc/identity-providers`;
   }

--- a/admin/app/authenticators/oauth2.js
+++ b/admin/app/authenticators/oauth2.js
@@ -6,8 +6,4 @@ export default class Oauth2 extends OAuth2PasswordGrant {
   serverTokenRevocationEndpoint = `${ENV.APP.API_HOST}/api/revoke`;
   sendClientIdAsQueryParam = true;
   refreshAccessTokensWithScope = true;
-
-  restore(data) {
-    return super.restore({ ...data, scope: ENV.APP.AUTHENTICATION.SCOPE });
-  }
 }

--- a/admin/app/authenticators/oidc.js
+++ b/admin/app/authenticators/oidc.js
@@ -26,7 +26,6 @@ export default class OidcAuthenticator extends BaseAuthenticator {
         identity_provider: identityProvider.code,
         code,
         state: state,
-        target: 'admin',
       };
 
       if (this.session.isAuthenticated) {

--- a/admin/app/components/login-form.gjs
+++ b/admin/app/components/login-form.gjs
@@ -32,9 +32,8 @@ export default class LoginForm extends Component {
     event.preventDefault();
     const identification = this.email ? this.email.trim() : '';
     const password = this.password;
-    const scope = ENV.APP.AUTHENTICATION.SCOPE;
     try {
-      await this.session.authenticate('authenticator:oauth2', identification, password, scope);
+      await this.session.authenticate('authenticator:oauth2', identification, password);
     } catch (responseError) {
       this._handleApiError(responseError);
     }

--- a/admin/app/routes/authentication/login-oidc.js
+++ b/admin/app/routes/authentication/login-oidc.js
@@ -95,7 +95,7 @@ export default class LoginOidcRoute extends Route {
 
   async _handleRedirectRequest(identityProvider) {
     const response = await fetch(
-      `${ENV.APP.API_HOST}/api/oidc/authorization-url?identity_provider=${identityProvider.code}&target=admin`,
+      `${ENV.APP.API_HOST}/api/oidc/authorization-url?identity_provider=${identityProvider.code}`,
     );
     const { redirectTarget } = await response.json();
     this.location.replace(redirectTarget);

--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -83,9 +83,6 @@ module.exports = function (environment) {
         minValue: 6,
       }),
       APP_VERSION: process.env.SOURCE_VERSION || 'development',
-      AUTHENTICATION: {
-        SCOPE: 'pix-admin',
-      },
     },
 
     'ember-cli-notifications': {

--- a/admin/tests/unit/adapters/oidc-identity-provider-test.js
+++ b/admin/tests/unit/adapters/oidc-identity-provider-test.js
@@ -4,7 +4,7 @@ import { module, test } from 'qunit';
 module('Unit | Adapter | OidcIdentityProvider', function (hooks) {
   setupTest(hooks);
   module('#urlForFindAll', function () {
-    test('returns correct url for ready providers including target parameter', function (assert) {
+    test('returns correct url for ready providers', function (assert) {
       // given
       const adapter = this.owner.lookup('adapter:oidc-identity-provider');
 
@@ -16,7 +16,7 @@ module('Unit | Adapter | OidcIdentityProvider', function (hooks) {
       });
 
       // then
-      assert.ok(url.endsWith('/oidc/identity-providers?target=admin'));
+      assert.ok(url.endsWith('/oidc/identity-providers'));
     });
 
     test('returns correct url for all available providers', function (assert) {

--- a/admin/tests/unit/authenticators/oidc-test.js
+++ b/admin/tests/unit/authenticators/oidc-test.js
@@ -27,7 +27,6 @@ module('Unit | Authenticator | oidc', function (hooks) {
           identity_provider: identityProviderCode,
           code: code,
           state,
-          target: 'admin',
         },
       },
     });

--- a/admin/tests/unit/routes/authentication/login-oidc-test.js
+++ b/admin/tests/unit/routes/authentication/login-oidc-test.js
@@ -60,7 +60,7 @@ module('Unit | Route | login-oidc', function (hooks) {
           // then
           sinon.assert.calledWith(
             fetchStub,
-            'http://localhost:3000/api/oidc/authorization-url?identity_provider=OIDC_PARTNER&target=admin',
+            'http://localhost:3000/api/oidc/authorization-url?identity_provider=OIDC_PARTNER',
           );
           sinon.assert.calledWith(route.location.replace, 'https://oidc.example.net/connexion');
           assert.ok(true);

--- a/api/lib/domain/usecases/authenticate-external-user.js
+++ b/api/lib/domain/usecases/authenticate-external-user.js
@@ -12,7 +12,6 @@ import {
 } from '../../../src/shared/domain/errors.js';
 
 /**
- *
  * typedef { function } authenticateExternalUser
  * @param {Object} params
  * @param {string} params.username
@@ -28,10 +27,8 @@ import {
  * @param {UserLoginRepository} params.userLoginRepository
  * @param {LastUserApplicationConnectionsRepository} params.lastUserApplicationConnectionsRepository,
  * @param {RequestedApplication} params.requestedApplication,
- *
  * @returns {Promise<*>}
  */
-
 async function authenticateExternalUser({
   username,
   password,

--- a/api/lib/infrastructure/authentication.js
+++ b/api/lib/infrastructure/authentication.js
@@ -44,8 +44,6 @@ const authentication = {
 };
 
 async function validateUser(decodedAccessToken, { request, revokedUserAccessRepository }) {
-  // Only tokens including user_id are User Access Tokens.
-  // This is why applications Access Tokens are not subject to audience validation for now.
   const userId = decodedAccessToken.user_id;
   if (!userId) {
     return { isValid: false };

--- a/api/lib/infrastructure/authentication.js
+++ b/api/lib/infrastructure/authentication.js
@@ -51,27 +51,25 @@ async function validateUser(decodedAccessToken, { request, revokedUserAccessRepo
     return { isValid: false };
   }
 
-  if (config.featureToggles.isUserTokenAudConfinementEnabled) {
-    const revokedUserAccess = await revokedUserAccessRepository.findByUserId(userId);
-    if (revokedUserAccess.isAccessTokenRevoked(decodedAccessToken)) {
-      monitoringTools.logWarnWithCorrelationIds({
-        message: 'Revoked user AccessToken usage',
-        decodedAccessToken,
-      });
+  const revokedUserAccess = await revokedUserAccessRepository.findByUserId(userId);
+  if (revokedUserAccess.isAccessTokenRevoked(decodedAccessToken)) {
+    monitoringTools.logWarnWithCorrelationIds({
+      message: 'Revoked user AccessToken usage',
+      decodedAccessToken,
+    });
 
-      return { isValid: false };
-    }
+    return { isValid: false };
+  }
 
-    const audience = getForwardedOrigin(request.headers);
-    if (decodedAccessToken.aud !== audience) {
-      monitoringTools.logWarnWithCorrelationIds({
-        message: 'User AccessToken audience mismatch',
-        audience,
-        decodedAccessToken,
-      });
+  const audience = getForwardedOrigin(request.headers);
+  if (decodedAccessToken.aud !== audience) {
+    monitoringTools.logWarnWithCorrelationIds({
+      message: 'User AccessToken audience mismatch',
+      audience,
+      decodedAccessToken,
+    });
 
-      return { isValid: false };
-    }
+    return { isValid: false };
   }
 
   return { isValid: true, credentials: { userId: decodedAccessToken.user_id } };

--- a/api/sample.env
+++ b/api/sample.env
@@ -868,11 +868,6 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: false
 # FT_SELF_ACCOUNT_DELETION=false
 
-# Enable user token aud confinement
-# type: boolean
-# default: false
-# FT_USER_TOKEN_AUD_CONFINEMENT_ENABLED=false
-
 # Enable new PixApp layout
 # type: boolean
 # default: false

--- a/api/src/identity-access-management/domain/models/RefreshToken.js
+++ b/api/src/identity-access-management/domain/models/RefreshToken.js
@@ -22,12 +22,7 @@ export class RefreshToken {
     return config.authentication.refreshTokenLifespanMs / 1000;
   }
 
-  get isLegacyRefreshToken() {
-    return !this.audience;
-  }
-
   hasSameAudience(audience) {
-    if (this.isLegacyRefreshToken) return true;
     return this.audience === audience;
   }
 }

--- a/api/src/identity-access-management/domain/usecases/create-access-token-from-refresh-token.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/create-access-token-from-refresh-token.usecase.js
@@ -1,5 +1,4 @@
 import { UnauthorizedError } from '../../../shared/application/http-errors.js';
-import { config } from '../../../shared/config.js';
 
 const createAccessTokenFromRefreshToken = async function ({
   refreshToken,
@@ -13,8 +12,7 @@ const createAccessTokenFromRefreshToken = async function ({
     throw new UnauthorizedError('Refresh token is invalid', 'INVALID_REFRESH_TOKEN');
   }
 
-  const { isUserTokenAudConfinementEnabled } = config.featureToggles;
-  if (isUserTokenAudConfinementEnabled && !foundRefreshToken.hasSameAudience(audience)) {
+  if (!foundRefreshToken.hasSameAudience(audience)) {
     throw new UnauthorizedError('Refresh token is invalid', 'INVALID_REFRESH_TOKEN');
   }
 

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -306,7 +306,6 @@ const configuration = (function () {
       isPixCompanionEnabled: toBoolean(process.env.FT_PIX_COMPANION_ENABLED),
       isSelfAccountDeletionEnabled: toBoolean(process.env.FT_SELF_ACCOUNT_DELETION),
       isQuestEnabled: toBoolean(process.env.FT_ENABLE_QUESTS),
-      isUserTokenAudConfinementEnabled: toBoolean(process.env.FT_USER_TOKEN_AUD_CONFINEMENT_ENABLED),
       isTextToSpeechButtonEnabled: toBoolean(process.env.FT_ENABLE_TEXT_TO_SPEECH_BUTTON),
       setupEcosystemBeforeStart: toBoolean(process.env.FT_SETUP_ECOSYSTEM_BEFORE_START) || false,
       showExperimentalMissions: toBoolean(process.env.FT_SHOW_EXPERIMENTAL_MISSIONS),
@@ -524,7 +523,6 @@ const configuration = (function () {
     config.featureToggles.isSelfAccountDeletionEnabled = false;
     config.featureToggles.isQuestEnabled = false;
     config.featureToggles.isAsyncQuestRewardingCalculationEnabled = false;
-    config.featureToggles.isUserTokenAudConfinementEnabled = true;
     config.featureToggles.isTextToSpeechButtonEnabled = false;
     config.featureToggles.showNewResultPage = false;
     config.featureToggles.showExperimentalMissions = false;

--- a/api/tests/identity-access-management/integration/domain/usecases/create-access-token-from-refresh-token.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/create-access-token-from-refresh-token.usecase.test.js
@@ -2,9 +2,8 @@ import { RefreshToken } from '../../../../../src/identity-access-management/doma
 import { usecases } from '../../../../../src/identity-access-management/domain/usecases/index.js';
 import { refreshTokenRepository } from '../../../../../src/identity-access-management/infrastructure/repositories/refresh-token.repository.js';
 import { UnauthorizedError } from '../../../../../src/shared/application/http-errors.js';
-import { config } from '../../../../../src/shared/config.js';
 import { temporaryStorage } from '../../../../../src/shared/infrastructure/key-value-storages/index.js';
-import { catchErr, databaseBuilder, expect, sinon } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
 
 describe('Integration | Identity Access Management | Domain | UseCases | create-access-token-from-refresh-token', function () {
   let userId;
@@ -57,53 +56,25 @@ describe('Integration | Identity Access Management | Domain | UseCases | create-
   });
 
   context('when the refresh token audience is not the same', function () {
-    context('when access token confinement feature is enabled', function () {
-      it('throws an unauthorized error', async function () {
-        // given
-        sinon.stub(config.featureToggles, 'isUserTokenAudConfinementEnabled').value(true);
+    it('throws an unauthorized error', async function () {
+      // given
+      const source = 'pix';
+      const audience = 'https://app.pix.fr';
+      const badAudience = 'https://orga.pix.fr';
 
-        const source = 'pix';
-        const audience = 'https://app.pix.fr';
-        const badAudience = 'https://orga.pix.fr';
+      const refreshToken = RefreshToken.generate({ userId, source, audience });
+      await refreshTokenRepository.save({ refreshToken });
 
-        const refreshToken = RefreshToken.generate({ userId, source, audience });
-        await refreshTokenRepository.save({ refreshToken });
-
-        // when
-        const error = await catchErr(usecases.createAccessTokenFromRefreshToken)({
-          refreshToken: refreshToken.value,
-          audience: badAudience,
-        });
-
-        // then
-        expect(error).to.instanceOf(UnauthorizedError);
-        expect(error.message).to.equal('Refresh token is invalid');
-        expect(error.code).to.equal('INVALID_REFRESH_TOKEN');
+      // when
+      const error = await catchErr(usecases.createAccessTokenFromRefreshToken)({
+        refreshToken: refreshToken.value,
+        audience: badAudience,
       });
-    });
 
-    context('when access token confinement feature is disabled', function () {
-      it('creates a new access token', async function () {
-        // given
-        sinon.stub(config.featureToggles, 'isUserTokenAudConfinementEnabled').value(false);
-
-        const source = 'pix';
-        const audience = 'https://app.pix.fr';
-        const badAudience = 'https://orga.pix.fr';
-
-        const refreshToken = RefreshToken.generate({ userId, source, audience });
-        await refreshTokenRepository.save({ refreshToken });
-
-        // when
-        const { accessToken, expirationDelaySeconds } = await usecases.createAccessTokenFromRefreshToken({
-          refreshToken: refreshToken.value,
-          audience: badAudience,
-        });
-
-        // then
-        expect(accessToken).to.be.a('string');
-        expect(expirationDelaySeconds).to.be.a('number');
-      });
+      // then
+      expect(error).to.instanceOf(UnauthorizedError);
+      expect(error.message).to.equal('Refresh token is invalid');
+      expect(error.code).to.equal('INVALID_REFRESH_TOKEN');
     });
   });
 });

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -32,7 +32,6 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-pix-admin-new-sidebar-enabled': false,
             'is-pix-companion-enabled': false,
             'is-quest-enabled': false,
-            'is-user-token-aud-confinement-enabled': true,
             'is-self-account-deletion-enabled': false,
             'is-text-to-speech-button-enabled': false,
             'setup-ecosystem-before-start': false,

--- a/api/tests/unit/infrastructure/authentication_test.js
+++ b/api/tests/unit/infrastructure/authentication_test.js
@@ -2,7 +2,6 @@ import { authentication, validateClientApplication, validateUser } from '../../.
 import { RevokedUserAccess } from '../../../src/identity-access-management/domain/models/RevokedUserAccess.js';
 import { revokedUserAccessRepository } from '../../../src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js';
 import { ForwardedOriginError } from '../../../src/identity-access-management/infrastructure/utils/network.js';
-import { config } from '../../../src/shared/config.js';
 import { tokenService } from '../../../src/shared/domain/services/token-service.js';
 import { expect, sinon } from '../../test-helper.js';
 
@@ -102,8 +101,6 @@ describe('Unit | Infrastructure | Authentication', function () {
           aud: 'https://app.pix.fr',
         });
 
-        sinon.stub(config.featureToggles, 'isUserTokenAudConfinementEnabled').value(false);
-
         // when
         const { authenticate } = authentication.schemes.jwt.scheme(undefined, {
           key: 'dummy-secret',
@@ -124,148 +121,146 @@ describe('Unit | Infrastructure | Authentication', function () {
       });
     });
 
-    describe('when isUserTokenAudConfinementEnabled is enabled', function () {
-      describe('when there is a user Id', function () {
-        describe('when the audience is different from the forwarded origin', function () {
-          it('should throw an error', async function () {
-            // given
-            const request = {
-              headers: {
-                authorization: 'Bearer token',
-                'x-forwarded-proto': 'https',
-                'x-forwarded-host': 'app.pix.fr',
-              },
-            };
-            const h = { authenticated: sinon.stub() };
-            tokenService.extractTokenFromAuthChain.withArgs('Bearer token').returns('token');
-            tokenService.getDecodedToken.withArgs('token', 'dummy-secret').returns({
-              user_id: 'user_id',
-              aud: 'https://wrong.audience.fr',
-            });
+    describe('when there is a user Id', function () {
+      describe('when the audience is different from the forwarded origin', function () {
+        it('should throw an error', async function () {
+          // given
+          const request = {
+            headers: {
+              authorization: 'Bearer token',
+              'x-forwarded-proto': 'https',
+              'x-forwarded-host': 'app.pix.fr',
+            },
+          };
+          const h = { authenticated: sinon.stub() };
+          tokenService.extractTokenFromAuthChain.withArgs('Bearer token').returns('token');
+          tokenService.getDecodedToken.withArgs('token', 'dummy-secret').returns({
+            user_id: 'user_id',
+            aud: 'https://wrong.audience.fr',
+          });
 
-            // when
-            const { authenticate } = authentication.schemes.jwt.scheme(undefined, {
-              key: 'dummy-secret',
-              validate: (decodedAccessToken, options) =>
-                validateUser(decodedAccessToken, {
-                  ...options,
-                  revokedUserAccessRepository,
-                }),
-            });
-            const response = await authenticate(request, h);
+          // when
+          const { authenticate } = authentication.schemes.jwt.scheme(undefined, {
+            key: 'dummy-secret',
+            validate: (decodedAccessToken, options) =>
+              validateUser(decodedAccessToken, {
+                ...options,
+                revokedUserAccessRepository,
+              }),
+          });
+          const response = await authenticate(request, h);
 
-            // then
-            expect(response.output.payload).to.include({
-              statusCode: 401,
-              error: 'Unauthorized',
-              message: 'Unauthorized',
-            });
+          // then
+          expect(response.output.payload).to.include({
+            statusCode: 401,
+            error: 'Unauthorized',
+            message: 'Unauthorized',
           });
         });
+      });
 
-        describe('when the user access is revoked', function () {
-          it('should throw an error', async function () {
-            // given
-            const date = new Date();
-            const revokedUserAccess = new RevokedUserAccess(date.getTime() / 1000);
-            sinon.stub(revokedUserAccessRepository, 'findByUserId').resolves(revokedUserAccess);
-            sinon.stub(revokedUserAccess, 'isAccessTokenRevoked').returns(true);
+      describe('when the user access is revoked', function () {
+        it('should throw an error', async function () {
+          // given
+          const date = new Date();
+          const revokedUserAccess = new RevokedUserAccess(date.getTime() / 1000);
+          sinon.stub(revokedUserAccessRepository, 'findByUserId').resolves(revokedUserAccess);
+          sinon.stub(revokedUserAccess, 'isAccessTokenRevoked').returns(true);
 
-            const request = {
-              headers: {
-                authorization: 'Bearer token',
-                'x-forwarded-proto': 'https',
-                'x-forwarded-host': 'app.pix.fr',
-              },
-            };
-            const h = { authenticated: sinon.stub() };
-            tokenService.extractTokenFromAuthChain.withArgs('Bearer token').returns('token');
-            tokenService.getDecodedToken.withArgs('token', 'dummy-secret').returns({
-              user_id: 'user_id',
-              aud: 'https://app.pix.fr',
-            });
+          const request = {
+            headers: {
+              authorization: 'Bearer token',
+              'x-forwarded-proto': 'https',
+              'x-forwarded-host': 'app.pix.fr',
+            },
+          };
+          const h = { authenticated: sinon.stub() };
+          tokenService.extractTokenFromAuthChain.withArgs('Bearer token').returns('token');
+          tokenService.getDecodedToken.withArgs('token', 'dummy-secret').returns({
+            user_id: 'user_id',
+            aud: 'https://app.pix.fr',
+          });
 
-            // when
-            const { authenticate } = authentication.schemes.jwt.scheme(undefined, {
-              key: 'dummy-secret',
-              validate: (decodedAccessToken, options) =>
-                validateUser(decodedAccessToken, {
-                  ...options,
-                  revokedUserAccessRepository,
-                }),
-            });
-            const response = await authenticate(request, h);
+          // when
+          const { authenticate } = authentication.schemes.jwt.scheme(undefined, {
+            key: 'dummy-secret',
+            validate: (decodedAccessToken, options) =>
+              validateUser(decodedAccessToken, {
+                ...options,
+                revokedUserAccessRepository,
+              }),
+          });
+          const response = await authenticate(request, h);
 
-            // then
-            expect(h.authenticated).to.not.have.been.called;
-            expect(response.output.payload).to.include({
-              statusCode: 401,
-              error: 'Unauthorized',
-              message: 'Unauthorized',
-            });
+          // then
+          expect(h.authenticated).to.not.have.been.called;
+          expect(response.output.payload).to.include({
+            statusCode: 401,
+            error: 'Unauthorized',
+            message: 'Unauthorized',
           });
         });
+      });
 
-        describe('when there is no forwarded origin in the request', function () {
-          it('should throw an error', async function () {
-            // given
-            const request = {
-              headers: {
-                authorization: 'Bearer token',
-              },
-            };
+      describe('when there is no forwarded origin in the request', function () {
+        it('should throw an error', async function () {
+          // given
+          const request = {
+            headers: {
+              authorization: 'Bearer token',
+            },
+          };
 
-            const h = { authenticated: sinon.stub() };
-            tokenService.extractTokenFromAuthChain.withArgs('Bearer token').returns('token');
-            tokenService.getDecodedToken.withArgs('token', 'dummy-secret').returns({
-              user_id: 'user_id',
-              aud: 'https://app.pix.fr',
-            });
-
-            // when & then
-            const { authenticate } = authentication.schemes.jwt.scheme(undefined, {
-              key: 'dummy-secret',
-              validate: (decodedAccessToken, options) =>
-                validateUser(decodedAccessToken, {
-                  ...options,
-                  revokedUserAccessRepository,
-                }),
-            });
-            await expect(authenticate(request, h)).to.be.rejectedWith(ForwardedOriginError);
+          const h = { authenticated: sinon.stub() };
+          tokenService.extractTokenFromAuthChain.withArgs('Bearer token').returns('token');
+          tokenService.getDecodedToken.withArgs('token', 'dummy-secret').returns({
+            user_id: 'user_id',
+            aud: 'https://app.pix.fr',
           });
+
+          // when & then
+          const { authenticate } = authentication.schemes.jwt.scheme(undefined, {
+            key: 'dummy-secret',
+            validate: (decodedAccessToken, options) =>
+              validateUser(decodedAccessToken, {
+                ...options,
+                revokedUserAccessRepository,
+              }),
+          });
+          await expect(authenticate(request, h)).to.be.rejectedWith(ForwardedOriginError);
         });
+      });
 
-        describe('when the audience is the same than the forwarded origin', function () {
-          it('should not throw an error', async function () {
-            // given
-            const request = {
-              headers: {
-                authorization: 'Bearer token',
-                'x-forwarded-proto': 'https',
-                'x-forwarded-host': 'app.pix.fr',
-              },
-            };
-            const h = { authenticated: sinon.stub() };
-            tokenService.extractTokenFromAuthChain.withArgs('Bearer token').returns('token');
-            tokenService.getDecodedToken.withArgs('token', 'dummy-secret').returns({
-              user_id: 'user_id',
-              aud: 'https://app.pix.fr',
-            });
-
-            // when
-            const { authenticate } = authentication.schemes.jwt.scheme(undefined, {
-              key: 'dummy-secret',
-              validate: (decodedAccessToken, options) =>
-                validateUser(decodedAccessToken, {
-                  ...options,
-                  revokedUserAccessRepository,
-                }),
-            });
-            await authenticate(request, h);
-
-            // then
-            expect(h.authenticated).to.have.been.calledWithExactly({ credentials: { userId: 'user_id' } });
+      describe('when the audience is the same than the forwarded origin', function () {
+        it('should not throw an error', async function () {
+          // given
+          const request = {
+            headers: {
+              authorization: 'Bearer token',
+              'x-forwarded-proto': 'https',
+              'x-forwarded-host': 'app.pix.fr',
+            },
+          };
+          const h = { authenticated: sinon.stub() };
+          tokenService.extractTokenFromAuthChain.withArgs('Bearer token').returns('token');
+          tokenService.getDecodedToken.withArgs('token', 'dummy-secret').returns({
+            user_id: 'user_id',
+            aud: 'https://app.pix.fr',
           });
+
+          // when
+          const { authenticate } = authentication.schemes.jwt.scheme(undefined, {
+            key: 'dummy-secret',
+            validate: (decodedAccessToken, options) =>
+              validateUser(decodedAccessToken, {
+                ...options,
+                revokedUserAccessRepository,
+              }),
+          });
+          await authenticate(request, h);
+
+          // then
+          expect(h.authenticated).to.have.been.calledWithExactly({ credentials: { userId: 'user_id' } });
         });
       });
     });

--- a/certif/app/authenticators/oauth2.js
+++ b/certif/app/authenticators/oauth2.js
@@ -6,8 +6,4 @@ export default class OAuth2 extends OAuth2PasswordGrant {
   serverTokenRevocationEndpoint = `${ENV.APP.API_HOST}/api/revoke`;
   sendClientIdAsQueryParam = true;
   refreshAccessTokensWithScope = true;
-
-  restore(data) {
-    return super.restore({ ...data, scope: ENV.APP.AUTHENTICATION.SCOPE });
-  }
 }

--- a/certif/app/components/auth/register-form.js
+++ b/certif/app/components/auth/register-form.js
@@ -4,7 +4,6 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
-import ENV from 'pix-certif/config/environment.js';
 
 import isEmailValid from '../../utils/email-validator';
 import isPasswordValid from '../../utils/password-validator';
@@ -206,7 +205,6 @@ export default class RegisterForm extends Component {
   }
 
   _authenticate(email, password) {
-    const scope = ENV.APP.AUTHENTICATION.SCOPE;
-    return this.session.authenticate('authenticator:oauth2', email, password, scope);
+    return this.session.authenticate('authenticator:oauth2', email, password);
   }
 }

--- a/certif/app/components/auth/toggable-login-form.js
+++ b/certif/app/components/auth/toggable-login-form.js
@@ -4,7 +4,6 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
-import ENV from 'pix-certif/config/environment.js';
 
 import isEmailValid from '../../utils/email-validator';
 
@@ -99,10 +98,8 @@ export default class ToggableLoginForm extends Component {
   }
 
   async _authenticate(password, email) {
-    const scope = ENV.APP.AUTHENTICATION.SCOPE;
-
     try {
-      await this.session.authenticate('authenticator:oauth2', email, password, scope);
+      await this.session.authenticate('authenticator:oauth2', email, password);
     } catch (errorResponse) {
       const errors = get(errorResponse, 'responseJSON');
       this.errorMessage = this._handleResponseError(errors);

--- a/certif/app/components/login/index.gjs
+++ b/certif/app/components/login/index.gjs
@@ -37,9 +37,8 @@ export default class Login extends Component {
     event.preventDefault();
     const email = this.email ? this.email.trim() : '';
     const password = this.password;
-    const scope = ENV.APP.AUTHENTICATION.SCOPE;
     try {
-      await this.session.authenticate('authenticator:oauth2', email, password, scope);
+      await this.session.authenticate('authenticator:oauth2', email, password);
     } catch (responseError) {
       this.isErrorMessagePresent = true;
       this._handleApiError(responseError);

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -98,9 +98,6 @@ module.exports = function (environment) {
       sessionSupervisingPollingRate: process.env.SESSION_SUPERVISING_POLLING_RATE ?? 5000,
       COOKIE_LOCALE_LIFESPAN_IN_SECONDS: 31536000, // 1 year in seconds
       APP_VERSION: process.env.SOURCE_VERSION || 'development',
-      AUTHENTICATION: {
-        SCOPE: 'pix-certif',
-      },
     },
 
     matomo: {},

--- a/certif/tests/integration/components/auth/toggable-login-form-test.js
+++ b/certif/tests/integration/components/auth/toggable-login-form-test.js
@@ -80,11 +80,10 @@ module('Integration | Component | Auth::ToggableLoginForm', function (hooks) {
   module('When there is a valid invitation and user is not member of certification center yet', function (hooks) {
     const acceptCertificationCenterInvitationStub = sinon.stub();
     hooks.beforeEach(function () {
-      SessionStub.prototype.authenticate = function (authenticator, email, password, scope) {
+      SessionStub.prototype.authenticate = function (authenticator, email, password) {
         this.authenticator = authenticator;
         this.email = email;
         this.password = password;
-        this.scope = scope;
         return resolve();
       };
 
@@ -170,11 +169,10 @@ module('Integration | Component | Auth::ToggableLoginForm', function (hooks) {
               accept: acceptCertificationCenterInvitationStub,
             });
 
-            SessionStub.prototype.authenticate = function (authenticator, email, password, scope) {
+            SessionStub.prototype.authenticate = function (authenticator, email, password) {
               this.authenticator = authenticator;
               this.email = email;
               this.password = password;
-              this.scope = scope;
               return resolve();
             };
 
@@ -199,7 +197,6 @@ module('Integration | Component | Auth::ToggableLoginForm', function (hooks) {
             assert.strictEqual(sessionServiceObserver.authenticator, 'authenticator:oauth2');
             assert.strictEqual(sessionServiceObserver.email, 'pix@example.net');
             assert.strictEqual(sessionServiceObserver.password, 'JeMeLoggue1024');
-            assert.strictEqual(sessionServiceObserver.scope, 'pix-certif');
           });
         });
       });

--- a/certif/tests/integration/components/login-test.gjs
+++ b/certif/tests/integration/components/login-test.gjs
@@ -38,11 +38,10 @@ module('Integration | Component | login', function (hooks) {
 
   test('it should call authentication service with appropriate parameters', async function (assert) {
     // given
-    sessionStub.authenticate.callsFake(function (authenticator, email, password, scope) {
+    sessionStub.authenticate.callsFake(function (authenticator, email, password) {
       this.authenticator = authenticator;
       this.email = email;
       this.password = password;
-      this.scope = scope;
       return resolve();
     });
     const sessionServiceObserver = this.owner.lookup('service:session');
@@ -57,7 +56,6 @@ module('Integration | Component | login', function (hooks) {
     assert.strictEqual(sessionServiceObserver.authenticator, 'authenticator:oauth2');
     assert.strictEqual(sessionServiceObserver.email, 'pix@example.net');
     assert.strictEqual(sessionServiceObserver.password, 'JeMeLoggue1024');
-    assert.strictEqual(sessionServiceObserver.scope, 'pix-certif');
   });
 
   test('it should display an invalid credentials message if authentication failed', async function (assert) {
@@ -89,11 +87,10 @@ module('Integration | Component | login', function (hooks) {
 
   test('should authenticate user with trimmed email', async function (assert) {
     // given
-    sessionStub.authenticate.callsFake(function (authenticator, email, password, scope) {
+    sessionStub.authenticate.callsFake(function (authenticator, email, password) {
       this.authenticator = authenticator;
       this.email = email;
       this.password = password;
-      this.scope = scope;
       return resolve();
     });
     const sessionServiceObserver = this.owner.lookup('service:session');
@@ -108,7 +105,6 @@ module('Integration | Component | login', function (hooks) {
     assert.strictEqual(sessionServiceObserver.authenticator, 'authenticator:oauth2');
     assert.strictEqual(sessionServiceObserver.email, 'email@example.net');
     assert.strictEqual(sessionServiceObserver.password, 'JeMeLoggue1024');
-    assert.strictEqual(sessionServiceObserver.scope, 'pix-certif');
   });
 
   test('it displays a should change password message', async function (assert) {

--- a/high-level-tests/e2e/cypress/integration/pix-app/login-logout-app.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/login-logout-app.feature
@@ -12,7 +12,7 @@ Fonctionnalité: Connexion - Déconnexion
     Alors je suis redirigé vers la page "/connexion"
 
   Scénario: Je suis connecté et ma session expire puis je rejoins une nouvelle page
-    Lorsque je suis connecté avec un compte dont le token expire bientôt
+    Lorsque je suis connecté et mon token expire bientôt
     Alors je suis redirigé vers la page d'accueil de "Daenerys"
     Lorsque j'attends 5000 ms
     Et je vais sur la page "/mes-certifications"

--- a/high-level-tests/e2e/cypress/support/commands.js
+++ b/high-level-tests/e2e/cypress/support/commands.js
@@ -2,12 +2,11 @@ const jsonwebtoken = require('jsonwebtoken');
 const { addCompareSnapshotCommand } = require('cypress-visual-regression/dist/command');
 require('@testing-library/cypress/add-commands');
 
-function getLoginBody(username, password, scope) {
+function getLoginBody(username, password) {
   return {
     username,
     password,
     grant_type: 'password',
-    scope,
   };
 }
 
@@ -21,7 +20,6 @@ function setEmberSimpleAuthSession(response) {
         access_token: response.body.access_token,
         user_id: response.body.user_id,
         refresh_token: response.body.refresh_token,
-        scope: response.body.scope,
         expires_in: 1000,
       },
     })
@@ -34,7 +32,7 @@ Cypress.Commands.add("login", (username, password, url) => {
     url: `${Cypress.env('APP_URL')}/api/token`,
     method: 'POST',
     form: true,
-    body: getLoginBody(username, password, 'mon-pix'),
+    body: getLoginBody(username, password),
   }).then(setEmberSimpleAuthSession);
   if (url) cy.visitMonPix(url);
 
@@ -47,7 +45,7 @@ Cypress.Commands.add('loginOrga', (username, password) => {
     url: `${Cypress.env('ORGA_URL')}/api/token`,
     method: 'POST',
     form: true,
-    body: getLoginBody(username, password, 'pix-orga'),
+    body: getLoginBody(username, password),
   }).then(setEmberSimpleAuthSession);
   cy.wait(["@getCurrentUser"]);
 });

--- a/high-level-tests/e2e/cypress/support/commands.js
+++ b/high-level-tests/e2e/cypress/support/commands.js
@@ -71,6 +71,7 @@ Cypress.Commands.add('loginExternalPlatformForTheSecondTime', () => {
     {
       user_id: 1,
       source: 'external',
+      aud: Cypress.env('APP_URL'),
     },
     Cypress.env('AUTH_SECRET'),
     { expiresIn: '1h' }
@@ -81,7 +82,10 @@ Cypress.Commands.add('loginExternalPlatformForTheSecondTime', () => {
 
 Cypress.Commands.add('loginWithAlmostExpiredToken', () => {
   cy.intercept('/api/users/me').as('getCurrentUser');
-  const token = jsonwebtoken.sign({ user_id: 1 }, Cypress.env('AUTH_SECRET'), {
+  const token = jsonwebtoken.sign({
+    user_id: 1,
+    aud: Cypress.env('APP_URL'),
+  }, Cypress.env('AUTH_SECRET'), {
     expiresIn: '4s',
   });
   cy.visitMonPix(`/connexion/gar#${token}`);

--- a/high-level-tests/e2e/cypress/support/step_definitions/login-logout.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/login-logout.js
@@ -42,7 +42,7 @@ When(`je vais sur l'inscription de Pix`, () => {
   cy.visitMonPix(`/inscription`);
 });
 
-When("je suis connecté avec un compte dont le token expire bientôt", () => {
+When("je suis connecté et mon token expire bientôt", () => {
   cy.loginWithAlmostExpiredToken();
 });
 

--- a/high-level-tests/load-testing/scenarios/signup-and-campaign-participation.yaml
+++ b/high-level-tests/load-testing/scenarios/signup-and-campaign-participation.yaml
@@ -37,7 +37,7 @@ scenarios:
           url: "/api/token"
           headers:
             content-type: "application/x-www-form-urlencoded"
-          body: "grant_type=password&scope=mon-pix&username={{ email }}&password={{ password }}"
+          body: "grant_type=password&username={{ email }}&password={{ password }}"
           capture:
             - json: "$.access_token"
               as: "accessToken"

--- a/high-level-tests/load-testing/scenarios/signup-and-competence-evaluation.yaml
+++ b/high-level-tests/load-testing/scenarios/signup-and-competence-evaluation.yaml
@@ -35,7 +35,7 @@ scenarios:
           url: "/api/token"
           headers:
             content-type: "application/x-www-form-urlencoded"
-          body: "grant_type=password&scope=mon-pix&username={{ email }}&password={{ password }}"
+          body: "grant_type=password&username={{ email }}&password={{ password }}"
           capture:
             - json: "$.access_token"
               as: "accessToken"

--- a/high-level-tests/load-testing/scenarios/signup-and-profil.yaml
+++ b/high-level-tests/load-testing/scenarios/signup-and-profil.yaml
@@ -37,7 +37,7 @@ scenarios:
           url: "/api/token"
           headers:
             content-type: "application/x-www-form-urlencoded"
-          body: "grant_type=password&scope=mon-pix&username={{ email }}&password={{ password }}"
+          body: "grant_type=password&username={{ email }}&password={{ password }}"
           capture:
             - json: "$.access_token"
               as: "accessToken"

--- a/mon-pix/app/authenticators/oauth2.js
+++ b/mon-pix/app/authenticators/oauth2.js
@@ -7,7 +7,7 @@ export default class OAuth2 extends OAuth2PasswordGrant {
   serverTokenRevocationEndpoint = `${ENV.APP.API_HOST}/api/revoke`;
   refreshAccessTokensWithScope = true;
 
-  authenticate({ login, password, scope, token }) {
+  authenticate({ login, password, token }) {
     if (token) {
       const token_type = 'bearer';
       const decodedAccessToken = decodeToken(token);
@@ -18,14 +18,9 @@ export default class OAuth2 extends OAuth2PasswordGrant {
         access_token: token,
         user_id,
         source,
-        scope,
       });
     }
 
-    return super.authenticate(login, password, scope);
-  }
-
-  restore(data) {
-    return super.restore({ ...data, scope: ENV.APP.AUTHENTICATION.SCOPE });
+    return super.authenticate(login, password);
   }
 }

--- a/mon-pix/app/components/routes/login-form.js
+++ b/mon-pix/app/components/routes/login-form.js
@@ -52,8 +52,7 @@ export default class LoginForm extends Component {
 
   async _authenticatePixUser(password, login) {
     try {
-      const scope = ENV.APP.AUTHENTICATION.SCOPE;
-      await this.session.authenticate('authenticator:oauth2', { login, password, scope });
+      await this.session.authenticate('authenticator:oauth2', { login, password });
     } catch (response) {
       const shouldChangePassword = get(response, 'responseJSON.errors[0].title') === 'PasswordShouldChange';
       if (shouldChangePassword) {

--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -373,8 +373,7 @@ export default class RegisterForm extends Component {
   }
 
   _authenticate(login, password) {
-    const scope = ENV.APP.AUTHENTICATION.SCOPE;
-    return this.session.authenticate('authenticator:oauth2', { login, password, scope });
+    return this.session.authenticate('authenticator:oauth2', { login, password });
   }
 
   _showErrorMessageByShortCode(meta) {

--- a/mon-pix/app/controllers/account-recovery/update-sco-record.js
+++ b/mon-pix/app/controllers/account-recovery/update-sco-record.js
@@ -2,7 +2,6 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import ENV from 'mon-pix/config/environment';
 
 export default class UpdateScoRecordController extends Controller {
   @service intl;
@@ -32,7 +31,6 @@ export default class UpdateScoRecordController extends Controller {
       await this.session.authenticate('authenticator:oauth2', {
         login: this.model.email,
         password,
-        scope: ENV.APP.AUTHENTICATION.SCOPE,
       });
     } catch (err) {
       this._handleError(err);

--- a/mon-pix/app/services/session.js
+++ b/mon-pix/app/services/session.js
@@ -1,7 +1,6 @@
 import { service } from '@ember/service';
 import SessionService from 'ember-simple-auth/services/session';
 import get from 'lodash/get';
-import ENV from 'mon-pix/config/environment';
 import { FRENCH_FRANCE_LOCALE, FRENCH_INTERNATIONAL_LOCALE } from 'mon-pix/services/locale';
 import { SessionStorageEntry } from 'mon-pix/utils/session-storage-entry.js';
 
@@ -26,8 +25,7 @@ export default class CurrentSessionService extends SessionService {
     this.revokeGarAuthenticationContext();
 
     const trimedLogin = login ? login.trim() : '';
-    const scope = ENV.APP.AUTHENTICATION.SCOPE;
-    return this.authenticate('authenticator:oauth2', { login: trimedLogin, password, scope });
+    return this.authenticate('authenticator:oauth2', { login: trimedLogin, password });
   }
 
   async handleAuthentication() {

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -102,9 +102,6 @@ module.exports = function (environment) {
       COOKIE_LOCALE_LIFESPAN_IN_SECONDS: 31536000, // 1 year in seconds
       AUTONOMOUS_COURSES_ORGANIZATION_ID: parseInt(process.env.AUTONOMOUS_COURSES_ORGANIZATION_ID, 10),
       APP_VERSION: process.env.SOURCE_VERSION || 'development',
-      AUTHENTICATION: {
-        SCOPE: 'mon-pix',
-      },
     },
 
     fontawesome: {

--- a/mon-pix/tests/helpers/service-stubs.js
+++ b/mon-pix/tests/helpers/service-stubs.js
@@ -32,7 +32,7 @@ export function stubSessionService(owner, sessionData = {}) {
 
       if (isAuthenticated) {
         this.data = {
-          authenticated: { user_id: userId, source, access_token: 'access_token!', scope: 'mon-pix' },
+          authenticated: { user_id: userId, source, access_token: 'access_token!' },
         };
       } else {
         this.data = {};

--- a/mon-pix/tests/integration/components/routes/login-form-test.js
+++ b/mon-pix/tests/integration/components/routes/login-form-test.js
@@ -73,7 +73,6 @@ module('Integration | Component | routes/login-form', function (hooks) {
       sinon.assert.calledWith(sessionStub.authenticate, 'authenticator:oauth2', {
         login: 'pix@example.net',
         password: 'JeMeLoggue1024',
-        scope: 'mon-pix',
       });
       assert.ok(true);
     });
@@ -95,7 +94,6 @@ module('Integration | Component | routes/login-form', function (hooks) {
       sinon.assert.calledWith(sessionStub.authenticate, 'authenticator:oauth2', {
         login: 'pix@example.net',
         password: 'JeMeLoggue1024',
-        scope: 'mon-pix',
       });
       assert.ok(true);
     });

--- a/mon-pix/tests/integration/components/routes/register-form-test.js
+++ b/mon-pix/tests/integration/components/routes/register-form-test.js
@@ -87,7 +87,6 @@ module('Integration | Component | routes/register-form', function (hooks) {
       sinon.assert.calledWith(sessionService.authenticate, 'authenticator:oauth2', {
         login: 'shi@fu.me',
         password: 'Mypassword1',
-        scope: 'mon-pix',
       });
       assert.ok(true);
     });
@@ -107,7 +106,6 @@ module('Integration | Component | routes/register-form', function (hooks) {
       sinon.assert.calledWith(sessionService.authenticate, 'authenticator:oauth2', {
         login: 'pix.pix1010',
         password: 'Mypassword1',
-        scope: 'mon-pix',
       });
       assert.ok(true);
     });

--- a/mon-pix/tests/unit/components/register-form-test.js
+++ b/mon-pix/tests/unit/components/register-form-test.js
@@ -165,7 +165,6 @@ module('Unit | Component | register-form', function (hooks) {
         sinon.assert.calledWith(sessionService.authenticate, 'authenticator:oauth2', {
           login: component.username,
           password: component.password,
-          scope: 'mon-pix',
         });
         sinon.assert.called(createdDependentUser.save);
 

--- a/mon-pix/tests/unit/controllers/account-recovery/update-sco-record-test.js
+++ b/mon-pix/tests/unit/controllers/account-recovery/update-sco-record-test.js
@@ -12,7 +12,6 @@ module('Unit | Controller | account-recovery | update-sco-record', function (hoo
         // given
         const email = 'user@example.net';
         const password = 'Password123';
-        const scope = 'mon-pix';
         const temporaryKey = 'temporaryKey';
 
         const updateDemand = {
@@ -44,7 +43,6 @@ module('Unit | Controller | account-recovery | update-sco-record', function (hoo
         sinon.assert.calledWith(controller.session.authenticate, 'authenticator:oauth2', {
           login: email,
           password,
-          scope,
         });
         assert.ok(true);
       });
@@ -55,7 +53,6 @@ module('Unit | Controller | account-recovery | update-sco-record', function (hoo
         // given
         const email = 'user@example.net';
         const password = 'Password123';
-        const scope = 'mon-pix';
         const temporaryKey = 'temporaryKey';
 
         const updateDemand = {
@@ -87,7 +84,6 @@ module('Unit | Controller | account-recovery | update-sco-record', function (hoo
         sinon.assert.calledWith(controller.session.authenticate, 'authenticator:oauth2', {
           login: email,
           password,
-          scope,
         });
         assert.ok(true);
       });

--- a/mon-pix/tests/unit/services/session-test.js
+++ b/mon-pix/tests/unit/services/session-test.js
@@ -36,9 +36,8 @@ module('Unit | Services | session', function (hooks) {
   });
 
   module('#authenticateUser', function () {
-    test('should authenticate the user with oauth2 and mon-pix scope', async function (assert) {
+    test('should authenticate the user with oauth2', async function (assert) {
       // given
-      const expectedScope = 'mon-pix';
       const expectedLogin = 'user';
       const expectedPassword = 'secret';
       sessionService.currentDomain.getExtension.returns(FRANCE_TLD);
@@ -50,7 +49,6 @@ module('Unit | Services | session', function (hooks) {
       sinon.assert.calledWith(oauthAuthenticator.authenticate, {
         login: expectedLogin,
         password: expectedPassword,
-        scope: expectedScope,
       });
       assert.ok(true);
     });

--- a/orga/app/authenticators/oauth2.js
+++ b/orga/app/authenticators/oauth2.js
@@ -6,8 +6,4 @@ export default class Oauth2 extends OAuth2PasswordGrant {
   serverTokenRevocationEndpoint = `${ENV.APP.API_HOST}/api/revoke`;
   sendClientIdAsQueryParam = true;
   refreshAccessTokensWithScope = true;
-
-  restore(data) {
-    return super.restore({ ...data, scope: ENV.APP.AUTHENTICATION.SCOPE });
-  }
 }

--- a/orga/app/components/auth/login-form.gjs
+++ b/orga/app/components/auth/login-form.gjs
@@ -112,11 +112,9 @@ export default class LoginForm extends Component {
   }
 
   async _authenticate(password, email) {
-    const scope = ENV.APP.AUTHENTICATION.SCOPE;
-
     this.errorMessage = null;
     try {
-      await this.session.authenticate('authenticator:oauth2', email, password, scope);
+      await this.session.authenticate('authenticator:oauth2', email, password);
     } catch (responseError) {
       this._handleApiError(responseError);
     } finally {

--- a/orga/app/components/auth/register-form.gjs
+++ b/orga/app/components/auth/register-form.gjs
@@ -10,7 +10,6 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import isEmpty from 'lodash/isEmpty';
-import ENV from 'pix-orga/config/environment';
 
 import isEmailValid from '../../utils/email-validator';
 import isPasswordValid from '../../utils/password-validator';
@@ -236,8 +235,7 @@ export default class RegisterForm extends Component {
   }
 
   _authenticate(email, password) {
-    const scope = ENV.APP.AUTHENTICATION.SCOPE;
-    return this.session.authenticate('authenticator:oauth2', email, password, scope);
+    return this.session.authenticate('authenticator:oauth2', email, password);
   }
 
   <template>

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -100,9 +100,6 @@ module.exports = function (environment) {
       APP_VERSION: process.env.SOURCE_VERSION || 'development',
       SURVEY_LINK: process.env.SURVEY_ORGA_LINK || null,
       SURVEY_BANNER_ENABLED: _isFeatureEnabled(process.env.SURVEY_ORGA_BANNER_ENABLED),
-      AUTHENTICATION: {
-        SCOPE: 'pix-orga',
-      },
     },
 
     fontawesome: {

--- a/orga/tests/integration/components/auth/login-form-test.js
+++ b/orga/tests/integration/components/auth/login-form-test.js
@@ -69,9 +69,7 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
       await clickByName(loginLabel);
 
       // then
-      assert.ok(
-        sessionService.authenticate.calledWith('authenticator:oauth2', 'pix@example.net', 'JeMeLoggue1024', 'pix-orga'),
-      );
+      assert.ok(sessionService.authenticate.calledWith('authenticator:oauth2', 'pix@example.net', 'JeMeLoggue1024'));
     });
   });
 
@@ -91,9 +89,7 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
       await clickByName(loginLabel);
 
       // then
-      assert.ok(
-        sessionService.authenticate.calledWith('authenticator:oauth2', 'pix@example.net', 'JeMeLoggue1024', 'pix-orga'),
-      );
+      assert.ok(sessionService.authenticate.calledWith('authenticator:oauth2', 'pix@example.net', 'JeMeLoggue1024'));
     });
 
     test('should not call authenticate session when form is invalid', async function (assert) {
@@ -136,9 +132,7 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
       await clickByName(loginLabel);
 
       // then
-      assert.ok(
-        sessionService.authenticate.calledWith('authenticator:oauth2', 'pix@example.net', 'JeMeLoggue1024', 'pix-orga'),
-      );
+      assert.ok(sessionService.authenticate.calledWith('authenticator:oauth2', 'pix@example.net', 'JeMeLoggue1024'));
     });
 
     test('should accept organization invitation when form is valid', async function (assert) {

--- a/orga/tests/integration/components/auth/register-form-test.js
+++ b/orga/tests/integration/components/auth/register-form-test.js
@@ -88,11 +88,10 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
           },
         });
       };
-      SessionStub.prototype.authenticate = function (authenticator, email, password, scope) {
+      SessionStub.prototype.authenticate = function (authenticator, email, password) {
         this.authenticator = authenticator;
         this.email = email;
         this.password = password;
-        this.scope = scope;
         return resolve();
       };
     });
@@ -115,7 +114,6 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
       assert.strictEqual(sessionServiceObserver.authenticator, 'authenticator:oauth2');
       assert.strictEqual(sessionServiceObserver.email, 'shi@fu.me');
       assert.strictEqual(sessionServiceObserver.password, 'Mypassword1');
-      assert.strictEqual(sessionServiceObserver.scope, 'pix-orga');
     });
   });
 


### PR DESCRIPTION
## :pancakes: Problème

Le confinement des tokens users a été activé en production le 2025-02-12, ainsi que dans tous les autres environnements plus tôt. La gestion du `FT_USER_TOKEN_AUD_CONFINEMENT_ENABLED` n'est plus nécessaire.

De plus il y a du code legacy utilisant les notions erronées ou obsolètes de `scope` et `target` qui ne sont plus nécessaires depuis #11513.

## :bacon: Proposition

Suppression du `FT_USER_TOKEN_AUD_CONFINEMENT_ENABLED` et des derniers bouts de code utilisant la notion de `scope` et la notion de `target` pour les tokens users, notamment dans les frontaux (Pix App, Pix Orga, Pix Certif, Pix Admin) qui envoient encore un scope dans leurs payloads.

## 🧃 Remarques

RAS

## :yum: Pour tester

* Tests de non-régression sur la connexion+déconnexion par login+mot de passe sur Pix App,
* Tests de non-régression sur le bon fonctionnement des Refresh Tokens sur Pix App,

   (par exemple dans le `.env` mettre `ACCESS_TOKEN_LIFESPAN=20s` et attendre `20s` que la route `/api/token` soit bien appelée avec succès),

* Tests de non-régression sur la connexion+déconnexion par login+mot de passe sur Pix Orga,
* Tests de non-régression sur la connexion+déconnexion par login+mot de passe sur Pix Certif,
* Tests de non-régression sur la connexion+déconnexion par login+mot de passe sur Pix Admin,
* Tests de non-régression sur la connexion+déconnexion par SSO sur Pix App,
* Tests de non-régression sur la connexion+déconnexion par SSO sur Pix Admin.
