### PR TITLE
[FEATURE] Enregistrer la date de dernière connexion Pix par application (PIX-16721)

### DIFF
--- a/api/lib/application/authentication/authentication-controller.js
+++ b/api/lib/application/authentication/authentication-controller.js
@@ -1,6 +1,9 @@
 import { randomUUID } from 'node:crypto';
 
-import { getForwardedOrigin } from '../../../src/identity-access-management/infrastructure/utils/network.js';
+import {
+  getForwardedOrigin,
+  RequestedApplication,
+} from '../../../src/identity-access-management/infrastructure/utils/network.js';
 import { usecases } from '../../domain/usecases/index.js';
 
 const authenticateExternalUser = async function (request, h) {
@@ -12,6 +15,7 @@ const authenticateExternalUser = async function (request, h) {
   } = request.payload.data.attributes;
 
   const origin = getForwardedOrigin(request.headers);
+  const requestedApplication = RequestedApplication.fromOrigin(origin);
 
   const accessToken = await usecases.authenticateExternalUser({
     username,
@@ -19,6 +23,7 @@ const authenticateExternalUser = async function (request, h) {
     externalUserToken,
     expectedUserId,
     audience: origin,
+    requestedApplication,
   });
 
   const response = {

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -23,6 +23,7 @@ import { accountRecoveryDemandRepository } from '../../../src/identity-access-ma
 import * as authenticationMethodRepository from '../../../src/identity-access-management/infrastructure/repositories/authentication-method.repository.js';
 import { clientApplicationRepository } from '../../../src/identity-access-management/infrastructure/repositories/client-application.repository.js';
 import { emailValidationDemandRepository } from '../../../src/identity-access-management/infrastructure/repositories/email-validation-demand.repository.js';
+import { lastUserApplicationConnectionsRepository } from '../../../src/identity-access-management/infrastructure/repositories/last-user-application-connections.repository.js';
 import * as oidcProviderRepository from '../../../src/identity-access-management/infrastructure/repositories/oidc-provider-repository.js';
 import { organizationLearnerIdentityRepository } from '../../../src/identity-access-management/infrastructure/repositories/organization-learner-identity.repository.js';
 import * as userRepository from '../../../src/identity-access-management/infrastructure/repositories/user.repository.js';
@@ -135,6 +136,7 @@ const dependencies = {
   frameworkRepository,
   userToCreateRepository,
   knowledgeElementRepository,
+  lastUserApplicationConnectionsRepository,
   learningContentConversionService,
   membershipRepository,
   obfuscationService,

--- a/api/tests/identity-access-management/unit/domain/usecases/authenticate-user_test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/authenticate-user_test.js
@@ -16,6 +16,7 @@ import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.
 
 describe('Unit | Identity Access Management | Domain | UseCases | authenticate-user', function () {
   let refreshTokenRepository;
+  let lastUserApplicationConnectionsRepository;
   let tokenService;
   let userRepository;
   let userLoginRepository;
@@ -48,6 +49,9 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
     userLoginRepository = {
       updateLastLoggedAt: sinon.stub(),
       findByUserId: sinon.stub(),
+    };
+    lastUserApplicationConnectionsRepository = {
+      upsert: sinon.stub(),
     };
     authenticationMethodRepository = {
       updateLastLoggedAtByIdentityProvider: sinon.stub(),
@@ -84,6 +88,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
           pixAuthenticationService,
           userRepository,
           userLoginRepository,
+          lastUserApplicationConnectionsRepository,
           refreshTokenRepository,
           audience,
           requestedApplication,
@@ -114,6 +119,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
           pixAuthenticationService,
           userRepository,
           userLoginRepository,
+          lastUserApplicationConnectionsRepository,
           adminMemberRepository,
           refreshTokenRepository,
           audience,
@@ -153,6 +159,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
           pixAuthenticationService,
           userRepository,
           userLoginRepository,
+          lastUserApplicationConnectionsRepository,
           adminMemberRepository,
           refreshTokenRepository,
           audience,
@@ -205,6 +212,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
           pixAuthenticationService,
           userRepository,
           userLoginRepository,
+          lastUserApplicationConnectionsRepository,
           authenticationMethodRepository,
           adminMemberRepository,
           refreshTokenRepository,
@@ -257,6 +265,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
             refreshTokenRepository,
             userRepository,
             userLoginRepository,
+            lastUserApplicationConnectionsRepository,
             authenticationMethodRepository,
             audience,
             requestedApplication,
@@ -301,6 +310,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
       tokenService,
       userRepository,
       userLoginRepository,
+      lastUserApplicationConnectionsRepository,
       authenticationMethodRepository,
       audience,
       requestedApplication,
@@ -341,6 +351,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
       tokenService,
       userRepository,
       userLoginRepository,
+      lastUserApplicationConnectionsRepository,
       authenticationMethodRepository,
       audience,
       requestedApplication,
@@ -351,6 +362,11 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
     expect(authenticationMethodRepository.updateLastLoggedAtByIdentityProvider).to.have.been.calledWithExactly({
       userId: user.id,
       identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
+    });
+    expect(lastUserApplicationConnectionsRepository.upsert).to.have.been.calledWithExactly({
+      userId: user.id,
+      application: requestedApplication.applicationName,
+      lastLoggedAt: new Date(),
     });
   });
 
@@ -366,6 +382,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
       password,
       userRepository,
       userLoginRepository,
+      lastUserApplicationConnectionsRepository,
       refreshTokenRepository,
       pixAuthenticationService,
       audience,
@@ -386,6 +403,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
       password,
       userRepository,
       userLoginRepository,
+      lastUserApplicationConnectionsRepository,
       refreshTokenRepository,
       pixAuthenticationService,
       audience,
@@ -437,6 +455,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
           tokenService,
           userRepository,
           userLoginRepository,
+          lastUserApplicationConnectionsRepository,
           authenticationMethodRepository,
           emailRepository,
           emailValidationDemandRepository,
@@ -486,6 +505,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
           tokenService,
           userRepository,
           userLoginRepository,
+          lastUserApplicationConnectionsRepository,
           authenticationMethodRepository,
           emailRepository,
           audience,
@@ -533,6 +553,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
         tokenService,
         userRepository,
         userLoginRepository,
+        lastUserApplicationConnectionsRepository,
         authenticationMethodRepository,
         emailRepository,
         audience,
@@ -573,6 +594,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
         password: 'Password1234',
         userRepository,
         userLoginRepository,
+        lastUserApplicationConnectionsRepository,
         pixAuthenticationService,
         refreshTokenRepository,
         tokenService,
@@ -610,6 +632,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
           tokenService,
           userRepository,
           userLoginRepository,
+          lastUserApplicationConnectionsRepository,
           authenticationMethodRepository,
           audience,
           requestedApplication,
@@ -648,6 +671,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
             refreshTokenRepository,
             userRepository,
             userLoginRepository,
+            lastUserApplicationConnectionsRepository,
             authenticationMethodRepository,
             audience,
             requestedApplication,
@@ -684,6 +708,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
             tokenService,
             userRepository,
             userLoginRepository,
+            lastUserApplicationConnectionsRepository,
             authenticationMethodRepository,
             audience,
             requestedApplication,

--- a/api/tests/identity-access-management/unit/domain/usecases/authenticate-user_test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/authenticate-user_test.js
@@ -68,7 +68,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
 
   context('check acces by pix scope', function () {
     context('when scope is pix-orga', function () {
-      it('should rejects an error when user is not linked to any organizations', async function () {
+      it('rejects an error when user is not linked to any organizations', async function () {
         // given
         const scope = PIX_ORGA.SCOPE;
         const user = new User({ email: userEmail, memberships: [] });
@@ -96,7 +96,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
     });
 
     context('when scope is pix-admin', function () {
-      it('should throw an error when user has no role and is therefore not an admin member', async function () {
+      it('throws an error when user has no role and is therefore not an admin member', async function () {
         // given
         const scope = PIX_ADMIN.SCOPE;
         const user = new User({ email: userEmail });
@@ -125,7 +125,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
         expect(error.message).to.be.equal(PIX_ADMIN.NOT_ALLOWED_MSG);
       });
 
-      it('should throw an error when user has a role but admin membership is disabled', async function () {
+      it('throws an error when user has a role but admin membership is disabled', async function () {
         // given
         const scope = PIX_ADMIN.SCOPE;
         const user = new User({ email: userEmail });
@@ -164,7 +164,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
         expect(error.message).to.be.equal(PIX_ADMIN.NOT_ALLOWED_MSG);
       });
 
-      it('should resolve a valid JWT access token when admin member is not disabled and has a valid role', async function () {
+      it('resolves a valid JWT access token when admin member is not disabled and has a valid role', async function () {
         // given
         const scope = PIX_ADMIN.SCOPE;
         const source = 'pix';
@@ -225,7 +225,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
 
     context('when application is Pix Certif', function () {
       context('when user is not linked to any certification centers', function () {
-        it('should resolves a valid JWT access token when feature toggle is enabled', async function () {
+        it('resolves a valid JWT access token when feature toggle is enabled', async function () {
           // given
           const accessToken = 'jwt.access.token';
           const expirationDelaySeconds = 1;
@@ -273,7 +273,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
     });
   });
 
-  it('should resolves a valid JWT access token when authentication succeeded', async function () {
+  it('resolves a valid JWT access token when authentication succeeded', async function () {
     // given
     const accessToken = 'jwt.access.token';
     const source = 'pix';
@@ -315,7 +315,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
     expect(result).to.deep.equal({ accessToken, refreshToken: refreshToken.value, expirationDelaySeconds });
   });
 
-  it('should save the last date of login when authentication succeeded', async function () {
+  it('saves the last date of login when authentication succeeded', async function () {
     // given
     const accessToken = 'jwt.access.token';
     const source = 'pix';
@@ -354,7 +354,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
     });
   });
 
-  it('should rejects an error when given username (email) does not match an existing one', async function () {
+  it('rejects an error when given username (email) does not match an existing one', async function () {
     // given
     const unknownUserEmail = 'unknown_user_email@example.net';
     pixAuthenticationService.getUserByUsernameAndPassword.rejects(new UserNotFoundError());
@@ -375,7 +375,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
     expect(error).to.be.an.instanceOf(MissingOrInvalidCredentialsError);
   });
 
-  it('should rejects an error when given password does not match the found user’s one', async function () {
+  it('rejects an error when given password does not match the found user’s one', async function () {
     // given
     pixAuthenticationService.getUserByUsernameAndPassword.rejects(new MissingOrInvalidCredentialsError());
     const audience = 'https://certif.pix.fr';
@@ -397,7 +397,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
 
   context('when user has connected after a long period since last connection date', function () {
     context('when user has an email', function () {
-      it('should send a connection warning email', async function () {
+      it('sends a connection warning email', async function () {
         // given
         const accessToken = 'jwt.access.token';
         const source = 'pix';
@@ -545,7 +545,7 @@ describe('Unit | Identity Access Management | Domain | UseCases | authenticate-u
   });
 
   context('when user should change password', function () {
-    it('should throw UserShouldChangePasswordError', async function () {
+    it('throws UserShouldChangePasswordError', async function () {
       // given
       const tokenService = { createPasswordResetToken: sinon.stub() };
       const audience = 'https://certif.pix.fr';

--- a/api/tests/unit/application/authentication/authentication-controller_test.js
+++ b/api/tests/unit/application/authentication/authentication-controller_test.js
@@ -1,5 +1,6 @@
 import { authenticationController } from '../../../../lib/application/authentication/authentication-controller.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
+import { RequestedApplication } from '../../../../src/identity-access-management/infrastructure/utils/network.js';
 import { expect, hFake, sinon } from '../../../test-helper.js';
 
 describe('Unit | Application | Controller | Authentication', function () {
@@ -14,6 +15,7 @@ describe('Unit | Application | Controller | Authentication', function () {
       const externalUserToken = 'SamlJacksonToken';
       const expectedUserId = 1;
       const audience = 'https://app.pix.fr';
+      const requestedApplication = new RequestedApplication('app');
 
       const request = {
         headers: {
@@ -41,6 +43,7 @@ describe('Unit | Application | Controller | Authentication', function () {
           externalUserToken,
           expectedUserId,
           audience,
+          requestedApplication,
         })
         .resolves(accessToken);
 

--- a/api/tests/unit/application/authentication/authentication-controller_test.js
+++ b/api/tests/unit/application/authentication/authentication-controller_test.js
@@ -4,7 +4,7 @@ import { expect, hFake, sinon } from '../../../test-helper.js';
 
 describe('Unit | Application | Controller | Authentication', function () {
   describe('#authenticateExternalUser', function () {
-    it('should return an access token', async function () {
+    it('returns an access token', async function () {
       // given
       const accessToken = 'jwt.access.token';
       const user = {
@@ -54,7 +54,7 @@ describe('Unit | Application | Controller | Authentication', function () {
   });
 
   describe('#authenticateApplication', function () {
-    it('should return an OAuth 2 token response', async function () {
+    it('returns an OAuth 2 token response', async function () {
       // given
       const access_token = 'jwt.access.token';
       const client_id = Symbol('clientId');

--- a/api/tests/unit/domain/usecases/authenticate-external-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-external-user_test.js
@@ -48,7 +48,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
   });
 
   context('when credentials are valid', function () {
-    it('should resolve a valid JWT token when authentication succeeds (should not change password)', async function () {
+    it('resolves a valid JWT token when authentication succeeds (should not change password)', async function () {
       // given
       const password = 'Azerty123*';
       const user = createUserWithValidCredentials({
@@ -88,7 +88,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
       expect(token).to.be.deep.equal(expectedToken);
     });
 
-    it('should save last login date when authentication succeeds', async function () {
+    it('saves last login date when authentication succeeds', async function () {
       // given
       const password = 'Azerty123*';
       const user = createUserWithValidCredentials({
@@ -131,7 +131,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
       });
     });
 
-    it("should throw an UnexpectedUserAccountError (with expected user's username or email) when the authenticated user does not match the expected one", async function () {
+    it("throws an UnexpectedUserAccountError (with expected user's username or email) when the authenticated user does not match the expected one", async function () {
       // given
       const password = 'Azerty123*';
       const user = createUserWithValidCredentials({
@@ -173,7 +173,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
     });
 
     context('when adding GAR authentication method', function () {
-      it('should throw an error if user from external user token is not the same as found user from credentials', async function () {
+      it('throws an error if user from external user token is not the same as found user from credentials', async function () {
         // given
         const password = 'Azerty123*';
         const userFromCredentials = createUserWithValidCredentials({
@@ -206,7 +206,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
         expect(error).to.be.instanceOf(UserAlreadyExistsWithAuthenticationMethodError);
       });
 
-      it('should add GAR authentication method', async function () {
+      it('adds GAR authentication method', async function () {
         // given
         const password = 'Azerty123*';
         const user = createUserWithValidCredentials({
@@ -258,7 +258,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
     });
 
     context('when user should change password', function () {
-      it('should also add GAR authentication method', async function () {
+      it('also adds GAR authentication method', async function () {
         // given
         const oneTimePassword = 'Azerty123*';
         const user = createUserWithValidCredentialsWhoShouldChangePassword({
@@ -308,7 +308,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
         });
       });
 
-      it('should create and return password reset token', async function () {
+      it('creates and return password reset token', async function () {
         // given
         tokenService.createPasswordResetToken.returns('token');
         const oneTimePassword = 'Azerty123*';
@@ -350,7 +350,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
   });
 
   context('when credentials are invalid', function () {
-    it('should reject when user not found', async function () {
+    it('rejects when user not found', async function () {
       // given
       const unknownUserEmail = 'foo@example.net';
       const password = 'Azerty123*';
@@ -377,7 +377,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
       expect(error).to.be.an.instanceOf(MissingOrInvalidCredentialsError);
     });
 
-    it('should reject when password does not match', async function () {
+    it('rejects when password does not match', async function () {
       // given
       const email = 'foo@example.net';
       const invalidPassword = 'oups123*';


### PR DESCRIPTION
## :pancakes: Problème

Quand un utilisateur se connecte avec une méthode de connexion PIX, on souhaite stocker la date de dernière connexion pour l’application connectée.

## :bacon: Proposition

Quand un utilisateur se connecte avec une méthode de connexion PIX, stocker la date de dernière connexion pour l’application connectée.

## 🧃 Remarques

Cela concerne les use cases:

- authenticateUser

- authenticate External User

## :yum: Pour tester

suivre la procédure de https://github.com/1024pix/pix/pull/11514, en vérifiant cette fois l'écriture dans la table `last-user-application-connection`
