### PR TITLE
[BUGFIX] Empêcher la validation d'un live-alert assigné à une épreuve déjà répondue (PIX-16783).

### DIFF
--- a/api/src/certification/evaluation/domain/errors.js
+++ b/api/src/certification/evaluation/domain/errors.js
@@ -1,8 +1,8 @@
 import { DomainError } from '../../../shared/domain/errors.js';
 
 class ChallengeAlreadyAnsweredError extends DomainError {
-  constructor(message) {
-    super(message);
+  constructor() {
+    super('La question a déjà été répondue.', 'ALREADY_ANSWERED_ERROR');
   }
 }
 

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 
 import * as translations from '../../../translations/index.js';
 import { AdminMemberError } from '../../authorization/domain/errors.js';
+import { ChallengeAlreadyAnsweredError } from '../../certification/evaluation/domain/errors.js';
 import {
   CsvWithNoSessionDataError,
   SendingEmailToRefererError,
@@ -174,6 +175,10 @@ function _mapToHttpError(error) {
 
   if (error instanceof DeletedCampaignError) {
     return new HttpErrors.PreconditionFailedError(error.message);
+  }
+
+  if (error instanceof ChallengeAlreadyAnsweredError) {
+    return new HttpErrors.UnprocessableEntityError(error.message, error.code);
   }
 
   if (error instanceof CsvWithNoSessionDataError) {

--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -165,7 +165,7 @@ export default class CandidateInList extends Component {
       this.displayedModal = Modals.HandledLiveAlertSuccess;
     } catch (error) {
       const errorMessage = this.intl.t(
-        'pages.session-supervising.candidate-in-list.handle-live-alert-modal.error-handling-live-alert',
+        'pages.session-supervising.candidate-in-list.handle-live-alert-modal.error-handling.other',
       );
       this.pixToast.sendErrorNotification({ message: errorMessage });
     }
@@ -183,9 +183,12 @@ export default class CandidateInList extends Component {
       this.isLiveAlertValidated = true;
       this.displayedModal = Modals.HandledLiveAlertSuccess;
     } catch (err) {
-      const errorMessage = this.intl.t(
-        'pages.session-supervising.candidate-in-list.handle-live-alert-modal.error-handling-live-alert',
-      );
+      const errorMessage =
+        err.errors[0].code === 'ALREADY_ANSWERED_ERROR'
+          ? this.intl.t(
+              'pages.session-supervising.candidate-in-list.handle-live-alert-modal.error-handling.challenge-already-answered',
+            )
+          : this.intl.t('pages.session-supervising.candidate-in-list.handle-live-alert-modal.error-handling.other');
       this.pixToast.sendErrorNotification({ message: errorMessage });
     }
   }
@@ -207,7 +210,7 @@ export default class CandidateInList extends Component {
     } catch (error) {
       this.pixToast.sendErrorNotification({
         message: this.intl.t(
-          'pages.session-supervising.candidate-in-list.handle-live-alert-modal.error-handling-live-alert',
+          'pages.session-supervising.candidate-in-list.handle-live-alert-modal.error-handling.other',
         ),
       });
     } finally {

--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -165,7 +165,7 @@ export default class CandidateInList extends Component {
       this.displayedModal = Modals.HandledLiveAlertSuccess;
     } catch (error) {
       const errorMessage = this.intl.t(
-        'pages.session-supervising.candidate-in-list.handle-live-alert-modal.error-handling.other',
+        'pages.session-supervising.candidate-in-list.handle-live-alert-modal.error-handling.miscellaneous',
       );
       this.pixToast.sendErrorNotification({ message: errorMessage });
     }
@@ -188,7 +188,9 @@ export default class CandidateInList extends Component {
           ? this.intl.t(
               'pages.session-supervising.candidate-in-list.handle-live-alert-modal.error-handling.challenge-already-answered',
             )
-          : this.intl.t('pages.session-supervising.candidate-in-list.handle-live-alert-modal.error-handling.other');
+          : this.intl.t(
+              'pages.session-supervising.candidate-in-list.handle-live-alert-modal.error-handling.miscellaneous',
+            );
       this.pixToast.sendErrorNotification({ message: errorMessage });
     }
   }
@@ -210,7 +212,7 @@ export default class CandidateInList extends Component {
     } catch (error) {
       this.pixToast.sendErrorNotification({
         message: this.intl.t(
-          'pages.session-supervising.candidate-in-list.handle-live-alert-modal.error-handling.other',
+          'pages.session-supervising.candidate-in-list.handle-live-alert-modal.error-handling.miscellaneous',
         ),
       });
     } finally {

--- a/certif/tests/acceptance/session-supervising-test.js
+++ b/certif/tests/acceptance/session-supervising-test.js
@@ -435,7 +435,7 @@ module('Acceptance | Session supervising', function (hooks) {
             const candidateId = 12345;
             server.patch(
               `/sessions/${sessionId}/candidates/${candidateId}/validate-live-alert`,
-              () => new Response(400),
+              () => new Response(400, {}, { errors: [{ code: 'SOME_CODE' }] }),
             );
             this.sessionForSupervising = server.create('session-for-supervising', {
               id: sessionId,

--- a/certif/tests/unit/components/session-supervising/candidate-in-list-test.js
+++ b/certif/tests/unit/components/session-supervising/candidate-in-list-test.js
@@ -68,7 +68,9 @@ module('Unit | Component | session-supervising/candidate-in-list', function (hoo
 
         // then
         sinon.assert.calledOnceWithExactly(component.pixToast.sendErrorNotification, {
-          message: t('pages.session-supervising.candidate-in-list.handle-live-alert-modal.error-handling.other'),
+          message: t(
+            'pages.session-supervising.candidate-in-list.handle-live-alert-modal.error-handling.miscellaneous',
+          ),
         });
         assert.ok(true);
       });

--- a/certif/tests/unit/components/session-supervising/candidate-in-list-test.js
+++ b/certif/tests/unit/components/session-supervising/candidate-in-list-test.js
@@ -1,4 +1,5 @@
 import Service from '@ember/service';
+import { t } from 'ember-intl/test-support';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -38,31 +39,56 @@ module('Unit | Component | session-supervising/candidate-in-list', function (hoo
       });
     });
 
-    module('when there is an error', function () {
-      test('it should call the notification service', async function (assert) {
-        // given
-        const subcategory = 'EMBED_NOT_WORKING';
-        const component = createGlimmerComponent('component:session-supervising/candidate-in-list');
-        component.args.sessionId = 123;
-        component.args.candidate = { userId: 456 };
-        component.pixToast = { sendErrorNotification: sinon.spy() };
-        const store = this.owner.lookup('service:store');
-        const adapter = store.adapterFor('session-management');
-        adapter.validateLiveAlert = sinon.stub();
-        adapter.validateLiveAlert.rejects();
+    module('when there is an error', function (hooks) {
+      let adapter, component;
 
+      hooks.beforeEach(function () {
+        // given
         class IntlStub extends Service {
           t = sinon.stub();
         }
 
         this.owner.register('service:intl', IntlStub);
 
+        component = createGlimmerComponent('component:session-supervising/candidate-in-list');
+        component.args.sessionId = 123;
+        component.args.candidate = { userId: 456 };
+        component.pixToast = { sendErrorNotification: sinon.spy() };
+        const store = this.owner.lookup('service:store');
+        adapter = store.adapterFor('session-management');
+        adapter.validateLiveAlert = sinon.stub();
+      });
+
+      test('it should call the notification service', async function (assert) {
+        // given
+        adapter.validateLiveAlert.rejects({ errors: [{}] });
+
         // when
-        await component.validateLiveAlert(subcategory);
+        await component.validateLiveAlert('EMBED_NOT_WORKING');
 
         // then
-        sinon.assert.calledOnce(component.pixToast.sendErrorNotification);
+        sinon.assert.calledOnceWithExactly(component.pixToast.sendErrorNotification, {
+          message: t('pages.session-supervising.candidate-in-list.handle-live-alert-modal.error-handling.other'),
+        });
         assert.ok(true);
+      });
+
+      module('when there is a ALREADY_ANSWERED_ERROR error', function () {
+        test('it should call the notification service with the request error message', async function (assert) {
+          // given
+          adapter.validateLiveAlert.rejects({ errors: [{ code: 'ALREADY_ANSWERED_ERROR', detail: 'error message' }] });
+
+          // when
+          await component.validateLiveAlert('EMBED_NOT_WORKING');
+
+          // then
+          sinon.assert.calledOnceWithExactly(component.pixToast.sendErrorNotification, {
+            message: t(
+              'pages.session-supervising.candidate-in-list.handle-live-alert-modal.error-handling.challenge-already-answered',
+            ),
+          });
+          assert.ok(true);
+        });
       });
     });
   });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -486,7 +486,10 @@
             "dismiss-alert-button": "Refuser le signalement",
             "validate-alert-button": "Valider le signalement"
           },
-          "error-handling-live-alert": "Une erreur a eu lieu. Merci de réessayer ultérieurement.",
+          "error-handling": {
+            "challenge-already-answered": "Le candidat a répondu à cette question. Cette alerte sera ignorée.",
+            "other": "Une erreur a eu lieu. Merci de réessayer ultérieurement."
+          },
           "handled": {
             "close-button-label": "Fermer la fenêtre de confirmation",
             "close-button-text": "Fermer",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -487,8 +487,8 @@
             "validate-alert-button": "Valider le signalement"
           },
           "error-handling": {
-            "challenge-already-answered": "Le candidat a répondu à cette question. Cette alerte sera ignorée.",
-            "other": "Une erreur a eu lieu. Merci de réessayer ultérieurement."
+            "challenge-already-answered": "The candidate has already answered this question. This alert will therefore be ignored.",
+            "miscellaneous": "An error occured. Please try again later."
           },
           "handled": {
             "close-button-label": "Fermer la fenêtre de confirmation",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -488,7 +488,7 @@
           },
           "error-handling": {
             "challenge-already-answered": "Le candidat a répondu à cette question. Cette alerte sera ignorée.",
-            "other": "Une erreur a eu lieu. Merci de réessayer ultérieurement."
+            "miscellaneous": "Une erreur a eu lieu. Merci de réessayer ultérieurement."
           },
           "handled": {
             "close-button-label": "Fermer la fenêtre de confirmation",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -486,7 +486,10 @@
             "dismiss-alert-button": "Refuser le signalement",
             "validate-alert-button": "Valider le signalement"
           },
-          "error-handling-live-alert": "Une erreur a eu lieu. Merci de réessayer ultérieurement.",
+          "error-handling": {
+            "challenge-already-answered": "Le candidat a répondu à cette question. Cette alerte sera ignorée.",
+            "other": "Une erreur a eu lieu. Merci de réessayer ultérieurement."
+          },
           "handled": {
             "close-button-label": "Fermer la fenêtre de confirmation",
             "close-button-text": "Fermer",


### PR DESCRIPTION
## :pancakes: Problème

En prod, on a eu le cas de live-alerts acceptées alors qu'en fait l'épreuve avait déjà été répondue.
Ça créait, lors de la finalisation de session, des erreurs 500.

## :bacon: Proposition

Dans le use-case `validate-live-alert`, checker si l'épreuve concernée est déjà répondue.
Si oui, la révoquer et déclencher une erreur.

Celle-ci sera visible par le surveillant via une notification lui indiquant que l'épreuve a déjà été répondue.

## 🧃 Remarques

On veut aussi empêcher la validation + le signalement d'une même épreuve côté front.
Cela sera fait dans une autre PR.

## :yum: Pour tester

- Créer une session de certif
- La commencer avec un utilisateur
- Répondre à une épreuve
- Via SQL, ajouter une live-alert pour cette épreuve déjà répondue
- Côté surveillant, valider cette live-alert
- ✅ Constater l'affichage de l'erreur et, en BDD, vérifier que cette live-alert est bien dismiss.
- ✅ Finaliser la session et vérifier que tout se passe bien !
