### PR TITLE
[TECH] Ajouter une contrainte sur la table last-user-application-connections assurant l'unicité du couple userId-application (PIX-16769)

### DIFF
--- a/api/db/migrations/20250228155843_add-unicity-constraint-in-last-user-application-connections.js
+++ b/api/db/migrations/20250228155843_add-unicity-constraint-in-last-user-application-connections.js
@@ -1,0 +1,23 @@
+const TABLE_NAME = 'last-user-application-connections';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.unique(['userId', 'application']);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropUnique(['userId', 'application']);
+  });
+};
+
+export { down, up };

--- a/api/src/identity-access-management/infrastructure/repositories/last-user-application-connections.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/last-user-application-connections.repository.js
@@ -2,13 +2,10 @@ import { knex } from '../../../../db/knex-database-connection.js';
 const TABLE_NAME = 'last-user-application-connections';
 
 async function upsert({ userId, application, lastLoggedAt }) {
-  const existingConnection = await knex(TABLE_NAME).where({ userId, application }).first();
-
-  if (existingConnection) {
-    return knex(TABLE_NAME).where({ userId, application }).update({ lastLoggedAt });
-  }
-
-  return knex(TABLE_NAME).insert({ userId, application, lastLoggedAt });
+  return knex(TABLE_NAME)
+    .insert({ userId, application, lastLoggedAt })
+    .onConflict(['userId', 'application'])
+    .merge({ lastLoggedAt });
 }
 
 export const lastUserApplicationConnectionsRepository = { upsert };


### PR DESCRIPTION
## :pancakes: Problème

Un index sur la table last-user-application-connections assurant l'unicité du couple userId-application est nécessaire pour éviter la création d’enregistrements erronés en cas de problèmes dans le code.

## :bacon: Proposition

Ajouter une contrainte sur la table last-user-application-connections assurant l'unicité du couple userId-application

## 🧃 Remarques

- La table "last-user-application-connections" vient d'être créée, l'ajout de la contrainte d'unicité ne devrait pas prendre de temps.

- On en profite dans cette PR pour modifier le repo en conséquence. Cela va contre l'ADR sur les migrations. On peut splitter au besoin @1024pix/team-captains 



## :yum: Pour tester

- Vérifier que les tests passent au vert