### PR TITLE
[FEATURE] Afficher la date de dernière connexion par rapport à la méthode de connexion utilisée (PIX-16631)

### DIFF
--- a/admin/app/components/users/user-detail-personal-information/authentication-method.gjs
+++ b/admin/app/components/users/user-detail-personal-information/authentication-method.gjs
@@ -5,6 +5,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import dayjs from 'dayjs';
 import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
 import { t } from 'ember-intl';
 
@@ -15,6 +16,7 @@ import ReassignOidcAuthenticationMethodModal from './reassign-oidc-authenticatio
 export default class AuthenticationMethod extends Component {
   @service pixToast;
   @service accessControl;
+  @service intl;
   @service oidcIdentityProviders;
 
   @tracked showAddAuthenticationMethodModal = false;
@@ -87,12 +89,15 @@ export default class AuthenticationMethod extends Component {
   get emailAuthenticationMethod() {
     return { code: 'EMAIL', name: 'Adresse e-mail' };
   }
+
   get userNameAuthenticationMethod() {
     return { code: 'USERNAME', name: 'Identifiant' };
   }
+
   get garAuthenticationMethod() {
     return { code: 'GAR', name: 'Médiacentre' };
   }
+
   get userOidcAuthenticationMethods() {
     return this.oidcIdentityProviders.list.map((oidcIdentityProvider) => {
       const userHasThisOidcAuthenticationMethod = this.authenticationMethods.any(
@@ -108,6 +113,29 @@ export default class AuthenticationMethod extends Component {
         canBeReassignedToAnotherUser: userHasThisOidcAuthenticationMethod,
       };
     });
+  }
+
+  get pixLastLoggedAtAuthenticationMethod() {
+    const method = this.authenticationMethods.find((method) => method.identityProvider === 'PIX');
+    return method ? this._displayAuthenticationMethodDate(method.lastLoggedAt) : null;
+  }
+
+  get garLastLoggedAtAuthenticationMethod() {
+    const method = this.authenticationMethods.find((method) => method.identityProvider === 'GAR');
+    return method ? this._displayAuthenticationMethodDate(method.lastLoggedAt) : null;
+  }
+
+  _displayAuthenticationMethodDate(date) {
+    if (!date) return null;
+    return this.intl.t('components.users.user-detail-personal-information.authentication-method.last-logged-at', {
+      date: dayjs(date).format('DD/MM/YYYY'),
+    });
+  }
+
+  @action
+  oidcLastLoggedAtAuthenticationMethod(oidc) {
+    const method = this.authenticationMethods.find((method) => method.identityProvider === oidc.code);
+    return method ? this._displayAuthenticationMethodDate(method.lastLoggedAt) : null;
   }
 
   @action
@@ -244,6 +272,7 @@ export default class AuthenticationMethod extends Component {
               />
             {{/if}}
           </td>
+          <td>{{this.pixLastLoggedAtAuthenticationMethod}}</td>
           <td>
             {{#if this.accessControl.hasAccessToUsersActionsScope}}
               {{#if this.isAllowedToRemoveEmailAuthenticationMethod}}
@@ -284,6 +313,7 @@ export default class AuthenticationMethod extends Component {
               />
             {{/if}}
           </td>
+          <td>{{this.pixLastLoggedAtAuthenticationMethod}}</td>
           <td>
             {{#if this.accessControl.hasAccessToUsersActionsScope}}
               {{#if this.isAllowedToRemoveUsernameAuthenticationMethod}}
@@ -319,6 +349,7 @@ export default class AuthenticationMethod extends Component {
               />
             {{/if}}
           </td>
+          <td>{{this.garLastLoggedAtAuthenticationMethod}}</td>
           <td class="authentication-method-table__actions-column">
             {{#if this.accessControl.hasAccessToUsersActionsScope}}
               <div>
@@ -361,6 +392,7 @@ export default class AuthenticationMethod extends Component {
                 />
               {{/if}}
             </td>
+            <td>{{this.oidcLastLoggedAtAuthenticationMethod userOidcAuthenticationMethod}}</td>
             <td class="authentication-method-table__actions-column">
               {{#if this.accessControl.hasAccessToUsersActionsScope}}
                 <div>

--- a/admin/app/components/users/user-detail-personal-information/authentication-method.gjs
+++ b/admin/app/components/users/user-detail-personal-information/authentication-method.gjs
@@ -216,34 +216,30 @@ export default class AuthenticationMethod extends Component {
       <h2 class="page-section__title">Méthodes de connexion</h2>
     </header>
 
-    <ul>
-      <li class="authentication-method__connexions-information">
-        Date de dernière connexion :
+    <ul class="authentication-method__connexions-information">
+      <li>
+        <strong>Date de dernière connexion :</strong>
         {{#if @user.lastLoggedAt}}{{dayjsFormat @user.lastLoggedAt "DD/MM/YYYY"}}{{/if}}
       </li>
       {{#if @user.emailConfirmedAt}}
-        <li class="authentication-method__connexions-information">
-          Adresse e-mail confirmée le :
+        <li>
+          <strong>Adresse e-mail confirmée le :</strong>
           {{dayjsFormat @user.emailConfirmedAt "DD/MM/YYYY"}}
         </li>
       {{else}}
-        <li class="authentication-method__connexions-information">
-          Adresse e-mail non confirmée
+        <li>
+          <strong>Adresse e-mail non confirmée</strong>
+        </li>
+      {{/if}}
+      {{#if this.hasPixAuthenticationMethod}}
+        <li>
+          <strong>{{t
+              "components.users.user-detail-personal-information.authentication-method.should-change-password-status"
+            }}</strong>
+          {{#if this.shouldChangePassword}}{{t "common.words.yes"}}{{else}}{{t "common.words.no"}}{{/if}}
         </li>
       {{/if}}
     </ul>
-
-    {{#if this.hasPixAuthenticationMethod}}
-      <br />
-      <ul>
-        <li class="authentication-method__connexions-information">
-          {{t "components.users.user-detail-personal-information.authentication-method.should-change-password-status"}}
-          {{#if this.shouldChangePassword}}{{t "common.words.yes"}}{{else}}{{t "common.words.no"}}{{/if}}
-        </li>
-      </ul>
-    {{/if}}
-
-    <br />
 
     <table class="authentication-method-table">
 

--- a/admin/app/models/authentication-method.js
+++ b/admin/app/models/authentication-method.js
@@ -3,4 +3,5 @@ import Model, { attr } from '@ember-data/model';
 export default class AuthenticationMethod extends Model {
   @attr() identityProvider;
   @attr() authenticationComplement;
+  @attr() lastLoggedAt;
 }

--- a/admin/app/styles/components/users/authentication-method.scss
+++ b/admin/app/styles/components/users/authentication-method.scss
@@ -1,15 +1,9 @@
 .authentication-method {
-
   &__connexions-information {
     display: flex;
-
-    dt {
-      font-weight: normal;
-    }
-
-    dd {
-      margin-left: 6px;
-    }
+    flex-direction: column;
+    margin-bottom: var(--pix-spacing-6x);
+    margin-left: var(--pix-spacing-6x);
   }
 }
 
@@ -21,37 +15,32 @@
   }
 
   &__name-column {
-    min-width: 200px;
+    padding-left: var(--pix-spacing-6x);
   }
 
   &__actions-column {
-
     > div {
       display: flex;
 
       button:not(:first-child) {
-        margin-left: 10px;
+        margin-left: var(--pix-spacing-3x);
       }
     }
   }
 
   &__check {
-    margin: 0 20px;
     color: var(--pix-success-700);
   }
 
   &__uncheck {
-    margin: 0 20px;
     color: var(--pix-neutral-100);
   }
 }
 
 .reassign-authentication-method-modal {
-
   &__form-body {
-
     p {
-      margin-bottom: 40px;
+      margin-bottom: var(--pix-spacing-10x);
       padding: 0;
     }
   }

--- a/admin/tests/integration/components/users/user-detail-personal-information/authentication-method-test.gjs
+++ b/admin/tests/integration/components/users/user-detail-personal-information/authentication-method-test.gjs
@@ -133,6 +133,7 @@ module('Integration | Component | users | user-detail-personal-information | aut
             )
             .exists();
         });
+
         test('it displays user has not to change password', async function (assert) {
           // given
           const user = {
@@ -154,6 +155,37 @@ module('Integration | Component | users | user-detail-personal-information | aut
             'components.users.user-detail-personal-information.authentication-method.should-change-password-status',
           );
           const expectedValue = t('common.words.no');
+          assert
+            .dom(
+              screen.getAllByRole('listitem').find((listItem) => {
+                const childrenText = listItem.textContent.trim().split('\n');
+                return childrenText[0]?.trim() === expectedLabel && childrenText[1]?.trim() === expectedValue;
+              }),
+            )
+            .exists();
+        });
+
+        test('it displays the last logged at with PIX authentication method', async function (assert) {
+          // given
+          const user = {
+            authenticationMethods: [
+              {
+                identityProvider: 'PIX',
+                authenticationComplement: {},
+                lastLoggedAt: new Date('2022-07-01T00:00:00Z'),
+              },
+            ],
+          };
+          this.owner.register('service:access-control', AccessControlStub);
+
+          // when
+          const screen = await render(<template><AuthenticationMethod @user={{user}} /></template>);
+
+          // then
+          const expectedLabel = t(
+            'components.users.user-detail-personal-information.authentication-method.last-logged-at',
+          );
+          const expectedValue = '01/07/2022';
           assert
             .dom(
               screen.getAllByRole('listitem').find((listItem) => {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -440,6 +440,7 @@
           "copy-username": "Copy user id"
         },
         "authentication-method": {
+          "last-logged-at": "Last logged at {date}",
           "should-change-password-status": "Temporary password :"
         },
         "cgu": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -450,6 +450,7 @@
           "copy-username": "Copier l’identifiant"
         },
         "authentication-method": {
+          "last-logged-at": "Dernière connexion le {date}",
           "should-change-password-status": "Mot de passe temporaire :"
         },
         "cgu": {

--- a/api/db/database-builder/factory/build-authentication-method.js
+++ b/api/db/database-builder/factory/build-authentication-method.js
@@ -22,6 +22,7 @@ buildAuthenticationMethod.withGarAsIdentityProvider = function ({
   userLastName = 'Saint-James',
   createdAt = new Date('2020-01-01'),
   updatedAt = new Date('2020-01-02'),
+  lastLoggedAt = new Date(),
 } = {}) {
   userId = isUndefined(userId) ? buildUser().id : userId;
 
@@ -36,6 +37,7 @@ buildAuthenticationMethod.withGarAsIdentityProvider = function ({
     userId,
     createdAt,
     updatedAt,
+    lastLoggedAt,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'authentication-methods',
@@ -50,6 +52,7 @@ buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword = function 
   userId,
   createdAt = new Date('2020-01-01'),
   updatedAt = new Date('2020-01-02'),
+  lastLoggedAt = new Date(),
 } = {}) {
   userId = isUndefined(userId) ? buildUser().id : userId;
 
@@ -64,6 +67,7 @@ buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword = function 
     userId,
     createdAt,
     updatedAt,
+    lastLoggedAt,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'authentication-methods',
@@ -78,6 +82,7 @@ buildAuthenticationMethod.withPixAsIdentityProviderAndPassword = function ({
   userId,
   createdAt = new Date('2020-01-01'),
   updatedAt = new Date('2020-01-02'),
+  lastLoggedAt = new Date(),
 } = {}) {
   userId = isUndefined(userId) ? buildUser().id : userId;
 
@@ -92,6 +97,7 @@ buildAuthenticationMethod.withPixAsIdentityProviderAndPassword = function ({
     userId,
     createdAt,
     updatedAt,
+    lastLoggedAt,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'authentication-methods',
@@ -108,7 +114,7 @@ buildAuthenticationMethod.withPoleEmploiAsIdentityProvider = function ({
   userId,
   createdAt = new Date('2020-01-01'),
   updatedAt = new Date('2020-01-02'),
-  lastLoggedAt = null,
+  lastLoggedAt = new Date(),
 } = {}) {
   userId = isUndefined(userId) ? buildUser().id : userId;
 
@@ -141,6 +147,7 @@ buildAuthenticationMethod.withOidcProviderAsIdentityProvider = function ({
   externalIdentifier,
   userId,
   identityProvider,
+  lastLoggedAt = new Date(),
 }) {
   userId = isUndefined(userId) ? buildUser().id : userId;
 
@@ -159,7 +166,7 @@ buildAuthenticationMethod.withOidcProviderAsIdentityProvider = function ({
     }),
     createdAt: new Date('2020-01-01'),
     updatedAt: new Date('2020-01-02'),
-    lastLoggedAt: null,
+    lastLoggedAt,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'authentication-methods',
@@ -174,7 +181,7 @@ buildAuthenticationMethod.withIdentityProvider = function ({
   userId,
   createdAt = new Date('2020-01-01'),
   updatedAt = new Date('2020-01-02'),
-  lastLoggedAt = null,
+  lastLoggedAt = new Date(),
 } = {}) {
   userId = isUndefined(userId) ? buildUser().id : userId;
 

--- a/api/db/seeds/data/team-acces/build-users.js
+++ b/api/db/seeds/data/team-acces/build-users.js
@@ -12,6 +12,18 @@ function _buildUserWithPoleEmploiAuthenticationMethod(databaseBuilder) {
   });
 }
 
+function _buildGarUser(databaseBuilder) {
+  const user = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Gar',
+    lastName: 'User',
+    email: 'gar.user@example.net',
+  });
+
+  databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
+    userId: user.id,
+  });
+}
+
 function _buildOidcUser(databaseBuilder) {
   const user = databaseBuilder.factory.buildUser({
     firstName: 'Oidc',
@@ -62,5 +74,6 @@ function _buildUsers(databaseBuilder) {
 export function buildUsers(databaseBuilder) {
   _buildUsers(databaseBuilder);
   _buildUserWithPoleEmploiAuthenticationMethod(databaseBuilder);
+  _buildGarUser(databaseBuilder);
   _buildOidcUser(databaseBuilder);
 }

--- a/api/src/identity-access-management/infrastructure/repositories/user.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user.repository.js
@@ -134,6 +134,7 @@ const getUserDetailsForAdmin = async function (userId) {
       'authentication-methods.id',
       'authentication-methods.identityProvider',
       'authentication-methods.authenticationComplement',
+      'authentication-methods.lastLoggedAt',
     ])
     .join('users', 'users.id', 'authentication-methods.userId')
     .where({ userId });

--- a/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-details-for-admin.serializer.js
+++ b/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-details-for-admin.serializer.js
@@ -61,7 +61,7 @@ const serialize = function (usersDetailsForAdmin) {
     authenticationMethods: {
       ref: 'id',
       includes: true,
-      attributes: ['identityProvider', 'authenticationComplement'],
+      attributes: ['identityProvider', 'authenticationComplement', 'lastLoggedAt'],
     },
     userLogin: {
       ref: 'id',

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/authentication-method.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/authentication-method.repository.test.js
@@ -689,6 +689,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
           expiredDate,
           userId,
           updatedAt: new Date(),
+          lastLoggedAt: new Date(),
         });
         expect(updatedAuthenticationMethod).to.deepEqualInstance(expectedAuthenticationMethod);
       });

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
@@ -1344,6 +1344,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
             },
             id: expectedPixAuthenticationMethod.id,
             identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
+            lastLoggedAt: new Date(),
           });
         });
       });

--- a/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-details-for-admin.serializer.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-details-for-admin.serializer.test.js
@@ -19,7 +19,12 @@ describe('Unit | Serializer | JSONAPI | user-details-for-admin-serializer', func
         anonymisedByFullName: null,
         organizationLearners: [domainBuilder.buildOrganizationLearnerForAdmin()],
         authenticationMethods: [
-          { id: 1, identityProvider: 'PIX', authenticationComplement: { shouldChangePassword: true } },
+          {
+            id: 1,
+            identityProvider: 'PIX',
+            authenticationComplement: { shouldChangePassword: true },
+            lastLoggedAt: null,
+          },
         ],
         userLogin: [{ id: 123, failureCount: 8 }],
       });
@@ -122,6 +127,7 @@ describe('Unit | Serializer | JSONAPI | user-details-for-admin-serializer', func
             attributes: {
               'identity-provider': userDetailsForAdmin.authenticationMethods[0].identityProvider,
               'authentication-complement': { shouldChangePassword: true },
+              'last-logged-at': null,
             },
             id: `${userDetailsForAdmin.authenticationMethods[0].id}`,
             type: 'authenticationMethods',


### PR DESCRIPTION
## :pancakes: Problème

On a ajouté la colone lastLoggedAt dans la table authentication-methods, et on souhaite maintenant afficher la date de dernière connexion effectué par un utilisateur, en affichant la date par méthode de connexion.

## :bacon: Proposition

Dans Pix admin > Utilisateur > Méthodes de connexion, on ajoute une colone au tableau avec la date de dernière connexion.

## 🧃 Remarques

On ne distingue actuellement pas l'email et l'identifiant de l'utilisateur.
Afin de faciliter les testes, on a ajouté des lastLoggedAt sur les seeds.

## :yum: Pour tester
- Se rendre sur Pix admin,
- Se connecter avec superadmin@example.net,
- Aller sur la page des utilisateurs,
#### Pour la méthode Pix
- Rechercher l'utilisateur superadmin@example.net,
- Cliquer sur l'onglet Méthode de connexion,
- Constater que dans le tableau, 2 dates sont présentes (une à côté de l'email et l'autre de l'identifiant),
#### Pour la méthode GAR
- Revenir sur la page des utilisateurs,
- Rechercher l'utilisateur gar.user@example.net,
- Aller dans l'onglet Méthode de connexion,
- Constater qu'une date est présente sur la Ligne Média-centre,
#### Pour l'OIDC
- Revenir sur la page des utilisateurs,
- Rechercher oidc-user@example.net,
- Aller dans les méthodes de connexion,
- Constater qu'une date est présente sur la ligne de l'un des OIDC.