### PR TITLE
[FEATURE] Actualiser les fichiers de traduction dans toutes les apps

### DIFF
--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -108,6 +108,14 @@
         "title": "Anonymize GAR Data",
         "upload-button": "Anonymize from a CSV file"
       },
+      "campaigns-import": {
+        "description": "Existing campaigns will not be modified. There is no control to prevent duplicates.",
+        "notifications": {
+          "success": "The campaigns have been created."
+        },
+        "title": "Creation of mass campaigns",
+        "upload-button": "Import a CSV file"
+      },
       "oidc-providers-import": {
         "description": "Note: Trying to import already existing OIDC Providers would produce an error.",
         "notifications": {
@@ -479,6 +487,7 @@
               "select-role": "Select a role"
             }
           },
+          "section-title": "User Certification Centres",
           "table-headers": {
             "actions-label": "Actions",
             "center-external-id": "External ID",
@@ -667,7 +676,12 @@
       "actions": {
         "load": {
           "label": "Charger"
-        }
+        },
+        "publish-session": {
+          "label": "Publish the session",
+          "warning-information": "You cannot publish the session until it is finalized or there are still erroneous certifications."
+        },
+        "unpublish-session": "Unpublish the session"
       },
       "certification": {
         "details": {
@@ -835,6 +849,13 @@
       },
       "title": "Children organisations"
     },
+    "organizations": {
+      "notifications": {
+        "errors": {
+          "payload-too-large": "The weight of the logo exceeds the authorised limit of {maxSizeInMegaBytes} MB. Please reduce the weight of the logo and try again."
+        }
+      }
+    },
     "sessions": {
       "informations": {
         "assignment-confirmation-modal": "This session is already assigned to the user {fullName}.'<br/>'Do you still want to assign it to yourself?",
@@ -964,6 +985,18 @@
           "status": "Status : ",
           "title": "Public title : "
         },
+        "duplicate": {
+          "button": {
+            "label": "Duplicate this formative content"
+          },
+          "modal": {
+            "instruction": "This action will duplicate the formative content with its triggers.",
+            "title": "Duplicate formative content?"
+          },
+          "notifications": {
+            "success": "The formative content has been duplicated!"
+          }
+        },
         "list": {
           "caption": "Trainings list",
           "goalThreshold": "Goal Threshold",
@@ -975,15 +1008,22 @@
           "targetProfileCount": "Associated Targets Profiles"
         },
         "targetProfiles": {
-          "tabName": "Target Profiles"
+          "tabName": "Target Profiles",
+          "title": "Attach one or more target profiles"
         },
         "triggers": {
           "goal": {
             "alternative-title": "Add a goal threshold to not exceed",
+            "edit": {
+              "description": "If the learner succeeds in the achievements of the selected subjects then the formative content will not be offered to him."
+            },
             "title": "Goal"
           },
           "prerequisite": {
             "alternative-title": "Add a prerequisite threshold to reach",
+            "edit": {
+              "description": "If the learner succeeds in all the achievements of the selected subjects, then the formative content will be offered to him."
+            },
             "title": "Prerequisite"
           },
           "tabName": "Triggers"

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -1,4 +1,16 @@
 {
+  "account-recovery-email": {
+    "params": {
+      "choosePassword": "Choose a password",
+      "context": "*Vous avez demandé la récupération de votre compte Pix.",
+      "doNotAnswer": "*Ceci est un e-mail automatique, merci de ne pas y répondre.",
+      "instruction": "*Choisissez un mot de passe pour finaliser la procédure.",
+      "linkValidFor": "*Ce lien est valide 24 heures. Si vous n'êtes pas à l'origine de cette demande, merci d'ignorer cet e-mail.",
+      "moreOn": "Learn more about",
+      "pixPresentation": "*Pix est le service public en ligne pour évaluer, développer et certifier ses compétences numériques.",
+      "signing": "– The Pix team"
+    }
+  },
   "attendance-sheet": {
     "certification-information": {
       "date": "Date:",
@@ -129,7 +141,6 @@
     "prepayment": "Prepayment code",
     "pricing": "Pricing",
     "pricing-pix": "Pricing of Pix’s share",
-    "title": "Candidates' list",
     "tooltip-line-1": "(Required in particular when purchasing combined credits)",
     "tooltip-line-2": "It must be comprised of the organisation’s SIRET and of the invoice’s number. Ex: 12345678912345/FACT12345. ",
     "tooltip-line-3": "If you don’t have an invoice, a prepayment code must be set with Pix.",
@@ -212,6 +223,8 @@
       "download": "Download the results",
       "emailValidFor": "This link is valid for thirty days.",
       "findOutMore": "Find out more about ",
+      "findOutMoreFranceSuffix": " (France) or ",
+      "findOutMoreInternationalSuffix": " (International)",
       "guidelines": "The reporting transmitted by the certification centre has been taken into account - if need be - by the Pix examining body. You will find guidelines to help you read these results here.",
       "guidelinesLinkName": "Interpretation of specifiers' results",
       "overviewText": "Hello, here are the results of the certifications that you have recommended to your audiences",
@@ -238,6 +251,7 @@
       "JURY_COMMENT_FOR_ORGANIZATION": "Examining body’s comment for the organisation",
       "LASTNAME": "Last name",
       "PIX_SCORE": "Number of pix",
+      "REGISTRATION_STATUS": "Status at registration",
       "SESSION_ID": "Session",
       "SKILL_LABEL": "{skillIndex}",
       "STATUS": "Status"

--- a/api/translations/es.json
+++ b/api/translations/es.json
@@ -343,7 +343,9 @@
     "template-name": "modelo de importación"
   },
   "email-sender-name": {
-    "pix-app": "PIX - No responder"
+    "pix-app": "PIX - No responder",
+    "pix-certif": "Pix Certif - No responder",
+    "pix-orga": "Pix Orga - No responder"
   },
   "entity-validation-errors": {
     "ACCEPT_CGU": "Debes aceptar las condiciones de uso de Pix para crear una cuenta.",

--- a/api/translations/nl.json
+++ b/api/translations/nl.json
@@ -343,7 +343,9 @@
     "template-name": "importmodel"
   },
   "email-sender-name": {
-    "pix-app": "PIX - Niet beantwoorden"
+    "pix-app": "PIX - Niet beantwoorden",
+    "pix-certif": "Pix Certif - Niet reageren",
+    "pix-orga": "Pix Orga - Niet reageren"
   },
   "entity-validation-errors": {
     "ACCEPT_CGU": "Je moet de gebruiksvoorwaarden van Pix accepteren om een account aan te maken.",
@@ -382,6 +384,14 @@
       "REJECTED_DUE_TO_INSUFFICIENT_CORRECT_ANSWERS": {
         "candidate": "Je hebt meer dan 50% van de vragen fout beantwoord, waardoor je hele certificering ongeldig wordt en je een score van 0 pix krijgt.",
         "organization": "De kandidaat beantwoordde meer dan 50% van de vragen fout, waardoor zijn hele certificering ongeldig werd en hij een score van 0 pix kreeg."
+      },
+      "LOWER_LEVEL_COMPLEMENTARY_CERTIFICATION_ACQUIRED": {
+        "candidate": "Gefeliciteerd, met je score heb je je aanvullende certificering goedgekeurd! Het behaalde niveau is het niveau dat lager is dan waarvoor je in aanmerking kwam.",
+        "organization": "De score van de kandidaat was niet voldoende om zijn aanvullende certificering te valideren op het niveau waarvoor hij in aanmerking kwam. Toch heeft hij het direct lagere niveau van deze aanvullende certificering gevalideerd. Het is dus gecertificeerd."
+      },
+      "REJECTED_DUE_TO_LACK_OF_ANSWERS": {
+        "candidate": "Het aantal beantwoorde vragen tijdens je certificeringstoets is onvoldoende en staat ons niet toe om je een Pix-certificering te geven.",
+        "organization": "Het aantal vragen dat de kandidaat tijdens zijn certificeringstest beantwoordt, is onvoldoende en stelt ons niet in staat om hem of haar een Pix-certificering te geven."
       }
     }
   },

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1717,6 +1717,7 @@
           "no-level": "Competence not started"
         }
       },
+      "description": "Evaluate yourself at your own pace on 16 digital skills. Choose a skill and start earning pix.",
       "first-title": "You have 16 competences to test. '<br>'Get your thinking hat on and off we go!",
       "resume-campaign-banner": {
         "accessibility": {
@@ -1942,9 +1943,9 @@
             "content": "Send us your results to enable the customised test organizer to support you.'<br />'After sharing, you'll have access to these training customised tests!",
             "share-error": "There was an error sending your results. Please try again."
           },
-          "sent-results-modal" : {
+          "sent-results-modal": {
             "return-results-action": "Close and return to results",
-            "subtitle": "Ready to expand your knowledge? \uD83C\uDF93",
+            "subtitle": "Ready to expand your knowledge? 🎓",
             "title": "Shared results"
           },
           "tab-label": "Trainings",
@@ -2143,6 +2144,15 @@
       "title": "My account"
     },
     "user-tests": {
+      "anonymised-participations": {
+        "course": "Course",
+        "states": {
+          "completed": "done",
+          "started": "started"
+        },
+        "title": "Deactivated courses"
+      },
+      "description": "Find here the evaluation courses you have started or completed.",
       "title": "My customised tests"
     },
     "user-trainings": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -40,7 +40,6 @@
       "cancel": "Cancelar",
       "close": "Cerrar",
       "confirm": "Confirmar",
-      "continue": "Continuar",
       "download": "Descargar",
       "lets-go": "¡Empecemos!",
       "login": "Iniciar sesión",
@@ -115,8 +114,7 @@
       "test": "Tu prueba se está cargando"
     },
     "new-information-banner": {
-      "close-label": "Cerrar el banner",
-      "lvl-seven": "¡Por fin está disponible el nivel 7! Puedes obtener más información en '<'a href=\"{lvlSevenUrl}\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\"'>'esta noticia'</a>'."
+      "close-label": "Cerrar el banner"
     },
     "or": "o",
     "pagination": {
@@ -171,21 +169,17 @@
         "searchLabel": "Búsqueda por palabras clave"
       },
       "other-authentication-providers": {
-        "continue-with-featured-identity-provider-link": "Continuar con {featuredIdentityProvider}",
-        "login-heading": "Otros métodos de conexión",
         "login": {
           "heading": "Otros medios de conexión",
           "login-with-featured-identity-provider-link": "Conectar con {featuredIdentityProvider}"
         },
         "select-another-organization-link": "Elegir otra organización",
-        "signup-heading": "Otros métodos de conexión",
         "signup": {
           "heading": "Otros medios de registro",
           "signup-with-featured-identity-provider-link": "Regístrese en {featuredIdentityProvider}"
         }
       },
       "password-reset-demand-form": {
-        "404-message": "Esta dirección de correo electrónico no corresponde a ninguna cuenta",
         "actions": {
           "receive-reset-button": "Reiniciar contraseña"
         },
@@ -509,7 +503,6 @@
       "sso-selection": {
         "signin": {
           "button": "Iniciar sesión",
-          "link": "Me conecto",
           "message": "{providerName} Será redirigido a la página de acceso \" \" para identificarse en Pix."
         },
         "signup": {
@@ -633,7 +626,8 @@
         "info": "(?)",
         "title": "Código de comprobación",
         "tooltip": "Facilita este código para que un tercero pueda comprobar la autenticidad de tu certificado"
-      }
+      },
+      "learn-about-certification-results": "Comprender mis resultados de certificación Pix"
     },
     "certification-ender": {
       "candidate": {
@@ -782,15 +776,15 @@
           "session-number": "Número de sesión",
           "session-number-information": "Comunicado únicamente por el supervisor al inicio de la sesión"
         },
-      "placeholders": {
-        "birth-day": "DD",
-        "birth-month": "MM",
-        "birth-name": "ex: Dupont",
-        "birth-year": "YYYY",
-        "first-name": "ex: Jean",
-        "session-number": "ex: 123456"
-      }
-    },
+        "placeholders": {
+          "birth-day": "DD",
+          "birth-month": "MM",
+          "birth-name": "ex: Dupont",
+          "birth-year": "YYYY",
+          "first-name": "ex: Jean",
+          "session-number": "ex: 123456"
+        }
+      },
       "title": "Unirse a una sesión de certificación"
     },
     "certification-not-certifiable": {
@@ -1302,7 +1296,7 @@
         "label": "Descargue los resultados"
       },
       "errors": {
-        "expiration": "El enlace de descarga de los resultados de la sesión ha caducado."
+        "invalid-token": "El enlace de descarga de los resultados de la sesión no es válido."
       },
       "title": "Descargar los resultados de la sesión"
     },
@@ -1372,9 +1366,7 @@
         "invalid-external-id": "{ externalIdLabel } El suyo no es válido.",
         "invalid-external-id-email": "La dirección de correo electrónico no es válida.",
         "max-length-external-id": "Tu { externalIdLabel } no debe superar 255 caracteres.",
-        "max-length-id-pix-label": "Tu { externalIdLabel } no debe superar 255 caracteres.",
-        "missing-external-id": "Por favor, introduce tu { externalIdLabel }.",
-        "missing-id-pix-label": "Por favor, introduce tu { externalIdLabel }."
+        "missing-external-id": "Por favor, introduce tu { externalIdLabel }."
       },
       "first-title": "Antes de empezar",
       "title": "Introducir mi nombre de usuario"
@@ -1579,7 +1571,6 @@
           "answers": {
             "almost": "Casi",
             "no": "No, en absoluto.",
-            "notAtAll": "No, en absoluto.",
             "yes": "¡Sí!"
           },
           "nextCard": "Siguiente",
@@ -1709,26 +1700,6 @@
       "username": "Nombre de usuario"
     },
     "password-reset-demand": {
-      "actions": {
-        "back-home": "Volver a la página de inicio",
-        "back-sign-in": "Volver a la página de conexión",
-        "reset": "Restablecer mi contraseña"
-      },
-      "error": {
-        "message": "Esta dirección de correo electrónico no corresponde a ninguna cuenta"
-      },
-      "fields": {
-        "email": {
-          "label": "Dirección de correo electrónico"
-        }
-      },
-      "page-title": "Contraseña olvidada",
-      "subtitle": "Introduce tu dirección de correo electrónico a continuación y ¡a por ello!",
-      "succeed": {
-        "help": "Si no recibes este correo electrónico, comprueba la carpeta de correo no deseado.",
-        "instructions": "Te hemos enviado un correo electrónico con instrucciones para restablecer tu contraseña a la dirección {email}.",
-        "subtitle": "Solicitud de restablecimiento de contraseña"
-      },
       "title": "¿Olvidaste tu contraseña?"
     },
     "profile-already-shared": {
@@ -1779,26 +1750,14 @@
         "icon": "Información sobre los pix",
         "label": "Abrir la información emergente",
         "title": "¿Por qué 1024 pix?"
-      }
+      },
+      "description": "Evalúe a su propio ritmo en 16 habilidades digitales. Elige una habilidad y empieza a ganar pix."
     },
     "reset-password": {
-      "actions": {
-        "sign-in": "Conéctate",
-        "submit": "Enviar"
-      },
       "error": {
-        "expired-demand": "Lo sentimos, pero tu solicitud de restablecimiento de contraseña ya ha sido utilizada o ha caducado. Por favor, vuelve a intentarlo.",
-        "forbidden": "Se ha producido un error, ponte en contacto con el servicio de asistencia.",
-        "wrong-format": "Tu contraseña debe tener al menos 8 caracteres y contener como mínimo una letra mayúscula, una letra minúscula y un dígito."
-      },
-      "fields": {
-        "password": {
-          "label": "Contraseña"
-        }
+        "expired-demand": "Lo sentimos, pero tu solicitud de restablecimiento de contraseña ya ha sido utilizada o ha caducado. Por favor, vuelve a intentarlo."
       },
       "first-title": "Restablecer contraseña",
-      "instruction": "Introduce tu nueva contraseña",
-      "succeed": "Tu contraseña ha sido cambiada con éxito.",
       "title": "Cambiar mi contraseña"
     },
     "result-item": {
@@ -1835,9 +1794,6 @@
       "actions": {
         "submit": "Me conecto"
       },
-      "error": {
-        "message": "La dirección de correo electrónico o el nombre de usuario y/o la contraseña introducidos son incorrectos"
-      },
       "fields": {
         "legend": "Información necesaria para conectarse.",
         "login": {
@@ -1850,23 +1806,6 @@
       },
       "first-title": "Conéctate",
       "forgotten-password": "¿Olvidaste tu contraseña?",
-      "fwb": {
-        "link": {
-          "img": "FWB connect"
-        },
-        "title": "Conectarse a través de la FWB"
-      },
-      "or": "O",
-      "pole-emploi": {
-        "link": {
-          "img": "Pôle Emploi connect"
-        },
-        "title": "Conectarse con Pôle Emploi"
-      },
-      "subtitle": {
-        "link": "Crea una cuenta",
-        "text": "¿Aún no tienes una cuenta Pix?"
-      },
       "title": "Conexión"
     },
     "sign-up": {
@@ -1880,30 +1819,10 @@
       },
       "fields": {
         "email": {
-          "error": "Tu dirección de correo electrónico no es válida.",
-          "help": "(ej. nombre@ejemplo.fr)",
-          "label": "Dirección de correo electrónico"
-        },
-        "firstname": {
-          "error": "No has indicado tu nombre.",
-          "label": "Nombre"
-        },
-        "lastname": {
-          "error": "No has indicado tus apellidos.",
-          "label": "Apellidos"
-        },
-        "legend": "Información necesaria para la inscripción.",
-        "password": {
-          "error": "Tu contraseña debe tener al menos 8 caracteres y contener como mínimo una letra mayúscula, una letra minúscula y un dígito.",
-          "help": "(mínimo 8 caracteres, incluyendo una mayúscula, una minúscula y un dígito)",
-          "label": "Contraseña"
+          "help": "(ej. nombre@ejemplo.fr)"
         }
       },
       "first-title": "Inscríbete",
-      "instructions": "Los campos marcados con '<abbr title=\"obligatorio\" class=\"mandatory-mark\">'*'</abbr>' son obligatorios",
-      "subtitle": {
-        "link": "conéctate a tu cuenta"
-      },
       "title": "Inscripción"
     },
     "sitemap": {
@@ -2024,9 +1943,9 @@
             "content": "Envía tus resultados para que el organizador del curso pueda apoyarte.'<br />'¡Una vez que hayas compartido tus resultados, tendrás acceso a estos cursos de formación!",
             "share-error": "Se ha producido un error al enviar sus resultados. Por favor, inténtalo de nuevo."
           },
-          "sent-results-modal" : {
+          "sent-results-modal": {
             "return-results-action": "Close and return to results",
-            "subtitle": "Ready to expand your knowledge? \uD83C\uDF93",
+            "subtitle": "Ready to expand your knowledge? 🎓",
             "title": "Shared results"
           },
           "tab-label": "Formación",
@@ -2225,7 +2144,16 @@
       "title": "Mi cuenta"
     },
     "user-tests": {
-      "title": "Mis tests"
+      "title": "Mis tests",
+      "description": "Encuentre aquí los cursos de evaluación que ha comenzado o completado.",
+      "anonymised-participations": {
+        "course": "Recorrido",
+        "states": {
+          "completed": "terminado",
+          "started": "comenzado"
+        },
+        "title": "rutas desactivadas"
+      }
     },
     "user-trainings": {
       "description": "Sigue progresando gracias a las formaciones recomendadas al final de tu evaluación.",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -40,7 +40,6 @@
       "cancel": "Annuleer",
       "close": "Sluit",
       "confirm": "Bevestig",
-      "continue": "Ga verder met",
       "download": "Downloaden",
       "lets-go": "Laten we gaan!",
       "login": "Inloggen",
@@ -115,8 +114,7 @@
       "test": "Je test wordt geladen"
     },
     "new-information-banner": {
-      "close-label": "Sluit de banner",
-      "lvl-seven": "Pix wordt geleidelijk aan vertaald naar het Nederlands! De vertaling van al onze vaardigheden zal binnenkort beschikbaar zijn. '<'a href=\"https://pix.org/nl-be/de-planning-voor-de-uitrol-van-pix-in-het-nederlan\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\"'>'Meer informatie'</a>'"
+      "close-label": "Sluit de banner"
     },
     "or": "of",
     "pagination": {
@@ -171,21 +169,17 @@
         "searchLabel": "Zoeken op trefwoorden"
       },
       "other-authentication-providers": {
-        "continue-with-featured-identity-provider-link": "Doorgaan met {featuredIdentityProvider}",
-        "login-heading": "Andere verbindingsmethoden",
         "login": {
           "heading": "Andere verbindingsmethoden",
           "login-with-featured-identity-provider-link": "Maak verbinding met {featuredIdentityProvider}"
         },
         "select-another-organization-link": "Kies een andere organisatie",
-        "signup-heading": "Andere manieren van registratie",
         "signup": {
           "heading": "Andere manieren van registratie",
           "signup-with-featured-identity-provider-link": "Registreren bij {featuredIdentityProvider}"
         }
       },
       "password-reset-demand-form": {
-        "404-message": "Dit e-mailadres komt niet overeen met een account",
         "actions": {
           "receive-reset-button": "Een reset-link ontvangen"
         },
@@ -509,7 +503,6 @@
       "sso-selection": {
         "signin": {
           "button": "Ik log in",
-          "link": "Ik log in",
           "message": "{providerName} Je wordt doorgestuurd naar de \" \" inlogpagina om je te identificeren op Pix."
         },
         "signup": {
@@ -633,7 +626,8 @@
         "info": "(?)",
         "title": "Verificatie code",
         "tooltip": "Geef deze code om een derde partij de echtheid van je certificaat te laten controleren"
-      }
+      },
+      "learn-about-certification-results": "Inzicht in mijn Pix-certificeringsresultaten"
     },
     "certification-ender": {
       "candidate": {
@@ -782,15 +776,15 @@
           "session-number": "Sessienummer",
           "session-number-information": "Alleen meegedeeld door de surveillant aan het begin van de sessie"
         },
-      "placeholders": {
-        "birth-day": "DD",
-        "birth-month": "MM",
-        "birth-name": "ex: Dupont",
-        "birth-year": "JJJJ",
-        "first-name": "ex: Jean",
-        "session-number": "ex: 123456"
-      }
-    },
+        "placeholders": {
+          "birth-day": "DD",
+          "birth-month": "MM",
+          "birth-name": "ex: Dupont",
+          "birth-year": "JJJJ",
+          "first-name": "ex: Jean",
+          "session-number": "ex: 123456"
+        }
+      },
       "title": "Doe mee aan een certificeringssessie"
     },
     "certification-not-certifiable": {
@@ -1302,7 +1296,7 @@
         "label": "Download de resultaten"
       },
       "errors": {
-        "expiration": "De downloadlink voor de sessieresultaten is verlopen."
+        "invalid-token": "De downloadlink voor sessieresultaten is ongeldig."
       },
       "title": "Download sessie resultaten"
     },
@@ -1372,9 +1366,7 @@
         "invalid-external-id": "{ externalIdLabel } De jouwe is ongeldig.",
         "invalid-external-id-email": "Het e-mailadres is ongeldig.",
         "max-length-external-id": "Uw { externalIdLabel } mag niet langer zijn dan 255 tekens.",
-        "max-length-id-pix-label": "Uw { externalIdLabel } mag niet langer zijn dan 255 tekens.",
-        "missing-external-id": "Voer uw { externalIdLabel } in.",
-        "missing-id-pix-label": "Voer uw { externalIdLabel } in."
+        "missing-external-id": "Voer uw { externalIdLabel } in."
       },
       "first-title": "Voordat u begint",
       "title": "Mijn login invoeren"
@@ -1579,7 +1571,6 @@
           "answers": {
             "almost": "Bijna",
             "no": "Helemaal niet.",
-            "notAtAll": "Helemaal niet.",
             "yes": "Ja!"
           },
           "nextCard": "Volgende",
@@ -1709,26 +1700,6 @@
       "username": "Inloggen"
     },
     "password-reset-demand": {
-      "actions": {
-        "back-home": "Terug naar de homepage",
-        "back-sign-in": "Terug naar de inlogpagina",
-        "reset": "Mijn wachtwoord resetten"
-      },
-      "error": {
-        "message": "Dit e-mailadres komt niet overeen met een account"
-      },
-      "fields": {
-        "email": {
-          "label": "E-mail adres"
-        }
-      },
-      "page-title": "Wachtwoord vergeten",
-      "subtitle": "Voer hieronder je e-mailadres in en je kunt aan de slag!",
-      "succeed": {
-        "help": "Als je deze e-mail niet ontvangt, controleer dan je spamfolder.",
-        "instructions": "Er is een e-mail met instructies voor het opnieuw instellen van uw wachtwoord\nverzonden naar het e-mailadres {email}.",
-        "subtitle": "Wachtwoord opnieuw instellen"
-      },
       "title": "Bent u uw wachtwoord vergeten?"
     },
     "profile-already-shared": {
@@ -1783,23 +1754,10 @@
       }
     },
     "reset-password": {
-      "actions": {
-        "sign-in": "Log in op",
-        "submit": "Stuur naar"
-      },
       "error": {
-        "expired-demand": "Het spijt ons, maar uw wachtwoordaanvraag is al gebruikt of verlopen. Probeer het opnieuw.",
-        "forbidden": "Er is een fout opgetreden, neem contact op met ondersteuning.",
-        "wrong-format": "Je wachtwoord moet minstens 8 tekens lang zijn en minstens één hoofdletter, één kleine letter en één cijfer bevatten."
-      },
-      "fields": {
-        "password": {
-          "label": "Wachtwoord"
-        }
+        "expired-demand": "Het spijt ons, maar uw wachtwoordaanvraag is al gebruikt of verlopen. Probeer het opnieuw."
       },
       "first-title": "Wachtwoord opnieuw instellen",
-      "instruction": "Voer uw nieuwe wachtwoord in",
-      "succeed": "Uw wachtwoord is gewijzigd.",
       "title": "Mijn wachtwoord wijzigen"
     },
     "result-item": {
@@ -1836,9 +1794,6 @@
       "actions": {
         "submit": "Ik ben online"
       },
-      "error": {
-        "message": "Het e-mailadres of de ingevoerde gebruikersnaam en/of wachtwoord zijn onjuist"
-      },
       "fields": {
         "legend": "Informatie die nodig is om in te loggen.",
         "login": {
@@ -1851,23 +1806,6 @@
       },
       "first-title": "Log in op",
       "forgotten-password": "Bent u uw wachtwoord vergeten?",
-      "fwb": {
-        "link": {
-          "img": "FWB verbinden"
-        },
-        "title": "Verbinding maken via het FWB"
-      },
-      "or": "OF",
-      "pole-emploi": {
-        "link": {
-          "img": "pôle Emploi connect"
-        },
-        "title": "Contact maken met Pôle Emploi"
-      },
-      "subtitle": {
-        "link": "Een account aanmaken",
-        "text": "Heb je nog geen Pix-account?"
-      },
       "title": "Verbinding"
     },
     "sign-up": {
@@ -1881,30 +1819,10 @@
       },
       "fields": {
         "email": {
-          "error": "Uw e-mailadres is ongeldig.",
-          "help": "(voorbeeld: naam.voornaam@voorbeeld.org)",
-          "label": "E-mail adres"
-        },
-        "firstname": {
-          "error": "Je voornaam is niet ingevuld.",
-          "label": "Voornaam"
-        },
-        "lastname": {
-          "error": "Je naam is niet ingevuld.",
-          "label": "Achternaam"
-        },
-        "legend": "Vereiste informatie voor registratie.",
-        "password": {
-          "error": "Je wachtwoord moet minstens 8 tekens lang zijn en minstens één hoofdletter, één kleine letter en één cijfer bevatten.",
-          "help": "(minimaal 8 tekens, waaronder een hoofdletter, een kleine letter en een cijfer)",
-          "label": "Wachtwoord"
+          "help": "(voorbeeld: naam.voornaam@voorbeeld.org)"
         }
       },
       "first-title": "Aanmelden",
-      "instructions": "Velden gemarkeerd met '<abbr title=\"mandatory\" class=\"mandatory-mark\">'*'</abbr>' zijn verplicht.",
-      "subtitle": {
-        "link": "inloggen op uw account"
-      },
       "title": "Registratie"
     },
     "sitemap": {
@@ -2025,9 +1943,9 @@
             "content": "Stuur je resultaten op zodat de cursusorganisator je kan ondersteunen.'<br />'Zodra je je resultaten hebt gedeeld, heb je toegang tot deze trainingen!",
             "share-error": "Er is een fout opgetreden bij het verzenden van uw resultaten. Probeer het opnieuw."
           },
-          "sent-results-modal" : {
+          "sent-results-modal": {
             "return-results-action": "Close and return to results",
-            "subtitle": "Ready to expand your knowledge? \uD83C\uDF93",
+            "subtitle": "Ready to expand your knowledge? 🎓",
             "title": "Shared results"
           },
           "tab-label": "Training",
@@ -2226,7 +2144,16 @@
       "title": "Mijn account"
     },
     "user-tests": {
-      "title": "Mijn carrièrepaden"
+      "title": "Mijn carrièrepaden",
+      "description": "Bekijk hier de beoordelingstrajecten die je bent begonnen of afgerond.",
+      "anonymised-participations": {
+        "course": "Route",
+        "states": {
+          "completed": "afgeroeid",
+          "started": "begonnen"
+        },
+        "title": "Uitgeschakelde trajecten"
+      }
     },
     "user-trainings": {
       "description": "Blijf vooruitgang boeken dankzij de trainingen die aan het einde van je assessment worden aanbevolen.",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -311,7 +311,13 @@
       "success": "Participants have been imported."
     },
     "organization-participants-header": {
+      "default": {
+        "title": "{count, plural, =0 {Participants} =1 {Participant ({count})} other {Participants ({count})}}"
+      },
       "import-button": "Import",
+      "sco": {
+        "title": "{count, plural, =0 {Students} =1 {Students ({count})} other {Students ({count})}}"
+      },
       "sco-title": "{count, plural, =0 {Students} =1 {Student ({count})} other {Students ({count})}}",
       "title": "{count, plural, =0 {Participants} =1 {Participant ({count})} other {Participants ({count})}}"
     },

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -313,7 +313,13 @@
     "organization-participants-header": {
       "import-button": "Importeren",
       "sco-title": "{count, plural, =0 {Leerling} =1 {Leerling ({count})} other {Leerlingen ({count})}}",
-      "title": "{count, plural, =0 {Deelnemer} =1 {Deelnemer ({count})} other {Deelnemers ({count})}}"
+      "title": "{count, plural, =0 {Deelnemer} =1 {Deelnemer ({count})} other {Deelnemers ({count})}}",
+      "default": {
+        "title": "{count, plural, =0 {Deelnemers} =1 {Participant ({count})} other {Deelnemers ({count})}}"
+      },
+      "sco": {
+        "title": "{count, plural, =0 {Leerlingen} =1 {Leerlingen ({count})} other {Leerlingen ({count})}}"
+      }
     },
     "participation-status": {
       "SHARED-ASSESSMENT": "Ontvangen resultaten",
@@ -603,9 +609,9 @@
           "status": {
             "empty": "Alle statussen",
             "title": "Status"
-          }
-        },
-        "unacquired-badges": "Niet verkregen onderwerpen"
+          },
+          "unacquired-badges": "Thema's niet verkregen"
+        }
       },
       "result": "Resultaat",
       "table": {
@@ -1496,8 +1502,8 @@
         "headers": {
           "positioning": "positionering",
           "reached-level": "Bereikt niveau",
-          "skills": "Vaardigheden",
-          "topics": "Onderwerpen"
+          "topics": "Onderwerpen",
+          "competences": "Vaardigheden"
         }
       }
     },


### PR DESCRIPTION
## :pancakes: Problème

On a désormais un script dans l'API qu'on peut faire tourner partout dans le mono-repo pour actualiser les différents fichiers de traduction. Cependant, on ne peut pas s'en servir à l'heure actuelle, carr le script actualise toutes les clefs. Or, certains fichier ne sont pas à jour.

## :bacon: Proposition

Faire tourner le script sur toutes les applications pour actualiser et traduire ce qui ne l'a pas encore été.

## 🧃 Remarques

Seule Certif était intégralement traduite.

## :yum: Pour tester

- Vérifier dans chaque fichier de traduction qu'il ne reste pas de traduction française,
- Faire tourner le script sur chaques app et vérifier qu'il ny a pas d'actualisation en utilisant le dryRun.