### PR TITLE
[BUGFIX] Permettre d'afficher les notifications avec le nouveau menu sur Pix Admin.

### DIFF
--- a/admin/app/components/layout/index.gjs
+++ b/admin/app/components/layout/index.gjs
@@ -1,6 +1,4 @@
-import PixToastContainer from '@1024pix/pix-ui/components/pix-toast-container';
 import { LinkTo } from '@ember/routing';
-import { t } from 'ember-intl';
 import { pageTitle } from 'ember-page-title';
 
 import MenuBar from './menu-bar';
@@ -23,8 +21,5 @@ import MenuBar from './menu-bar';
         {{yield}}
       </div>
     </div>
-
-    <PixToastContainer @closeButtonAriaLabel={{t "common.notifications.close-button.extra-information"}} />
-
   </div>
 </template>

--- a/admin/app/templates/authenticated.hbs
+++ b/admin/app/templates/authenticated.hbs
@@ -14,3 +14,5 @@
     {{outlet}}
   </Layout>
 {{/if}}
+
+<PixToastContainer @closeButtonAriaLabel={{t "common.notifications.close-button.extra-information"}} />


### PR DESCRIPTION
## :pancakes: Problème
Un nouveau menu est disponible depuis quelques semaines (sous feature toggle)
Or lors de cette mise en place, nous n'avons pas pris attention aux notifications qui ne se voient plus.

## :bacon: Proposition

 Remonter le container du PixToast dans PixAdmin

## 🧃 Remarques

Le nouveau menu est visible sur les RA et sur intégration :) 

## :yum: Pour tester

Sur Pix Admin, changer le rôle d'un membre dans le menu Equipe fait apparaître une notification de succès.
S'assurer qu'elle apparaît avec l'ancien et le nouveau menu.
