### PR TITLE
[FEATURE] Avoir l'envoi multiple activé par défaut à la création d'une organisation (PIX-16684)

### DIFF
--- a/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
+++ b/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
@@ -98,6 +98,12 @@ class OrganizationForAdmin {
       active: showNPS,
       params: showNPS ? { formNPSUrl: formNPSUrl } : null,
     };
+    if (this.features[ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key] === undefined) {
+      this.features[ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key] = {
+        active: true,
+        params: null,
+      };
+    }
     if (this.type === 'SCO' && this.isManagingStudents) {
       this.features[ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key] = {
         active: true,

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -9,6 +9,7 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
+  insertMultipleSendingFeatureForNewOrganization,
   insertUserWithRoleSuperAdmin,
   knex,
   sinon,
@@ -24,6 +25,7 @@ describe('Acceptance | Application | organization-controller', function () {
   beforeEach(async function () {
     server = await createServer();
     await insertUserWithRoleSuperAdmin();
+    await insertMultipleSendingFeatureForNewOrganization();
   });
 
   describe('POST /api/admin/organizations', function () {

--- a/api/tests/integration/domain/usecases/create-organization_test.js
+++ b/api/tests/integration/domain/usecases/create-organization_test.js
@@ -4,12 +4,13 @@ import { OrganizationForAdmin } from '../../../../src/organizational-entities/do
 import * as dataProtectionOfficerRepository from '../../../../src/organizational-entities/infrastructure/repositories/data-protection-officer.repository.js';
 import { organizationForAdminRepository } from '../../../../src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js';
 import * as schoolRepository from '../../../../src/school/infrastructure/repositories/school-repository.js';
-import { databaseBuilder, expect } from '../../../test-helper.js';
+import { databaseBuilder, expect, insertMultipleSendingFeatureForNewOrganization } from '../../../test-helper.js';
 
 describe('Integration | UseCases | create-organization', function () {
   it('returns newly created organization', async function () {
     // given
     const superAdminUserId = databaseBuilder.factory.buildUser().id;
+    await insertMultipleSendingFeatureForNewOrganization();
     await databaseBuilder.commit();
 
     const organization = new OrganizationForAdmin({

--- a/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
+++ b/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
@@ -19,12 +19,18 @@ import { Membership } from '../../../../src/shared/domain/models/Membership.js';
 import * as organizationRepository from '../../../../src/shared/infrastructure/repositories/organization-repository.js';
 import { organizationInvitationService } from '../../../../src/team/domain/services/organization-invitation.service.js';
 import { organizationInvitationRepository } from '../../../../src/team/infrastructure/repositories/organization-invitation.repository.js';
-import { catchErr, databaseBuilder, expect, knex } from '../../../test-helper.js';
+import {
+  catchErr,
+  databaseBuilder,
+  expect,
+  insertMultipleSendingFeatureForNewOrganization,
+  knex,
+} from '../../../test-helper.js';
 
 const { omit } = lodash;
 
 describe('Integration | UseCases | create-organizations-with-tags-and-target-profiles', function () {
-  let missionFeature, oralizationFeature, importStudentsFeature, ondeImportFormat, userId;
+  let missionFeature, oralizationFeature, importStudentsFeature, ondeImportFormat, userId, byDefaultFeatureId;
 
   beforeEach(async function () {
     databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY);
@@ -34,6 +40,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
     ondeImportFormat = databaseBuilder.factory.buildOrganizationLearnerImportFormat({
       name: ORGANIZATION_FEATURE.LEARNER_IMPORT.FORMAT.ONDE,
     });
+    byDefaultFeatureId = await insertMultipleSendingFeatureForNewOrganization();
 
     userId = databaseBuilder.factory.buildUser().id;
     await databaseBuilder.commit();
@@ -739,7 +746,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
       });
 
       // then
-      const savedOrganizationFeatures = await knex('organization-features');
+      const savedOrganizationFeatures = await knex('organization-features').whereNot({ featureId: byDefaultFeatureId });
       expect(savedOrganizationFeatures).to.have.lengthOf(3);
       const organizationId = createdOrganizations[0].id;
       expect(

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -7,6 +7,7 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
+  insertMultipleSendingFeatureForNewOrganization,
   insertUserWithRoleSuperAdmin,
   knex,
 } from '../../../../test-helper.js';
@@ -19,6 +20,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
 
   beforeEach(async function () {
     admin = await insertUserWithRoleSuperAdmin();
+    await insertMultipleSendingFeatureForNewOrganization();
     await databaseBuilder.commit();
 
     server = await createServer();
@@ -65,7 +67,6 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         });
         const tag = databaseBuilder.factory.buildTag({ id: 7, name: 'AEFE' });
         databaseBuilder.factory.buildOrganizationTag({ tagId: tag.id, organizationId: organization.id });
-        databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT);
         await databaseBuilder.commit();
 
         // when

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -26,6 +26,7 @@ import { PIX_ADMIN } from '../src/authorization/domain/constants.js';
 import * as tutorialRepository from '../src/devcomp/infrastructure/repositories/tutorial-repository.js';
 import * as missionRepository from '../src/school/infrastructure/repositories/mission-repository.js';
 import { config } from '../src/shared/config.js';
+import { ORGANIZATION_FEATURE } from '../src/shared/domain/constants.js';
 import { Membership } from '../src/shared/domain/models/index.js';
 import * as tokenService from '../src/shared/domain/services/token-service.js';
 import { featureToggles } from '../src/shared/infrastructure/feature-toggles/index.js';
@@ -192,6 +193,14 @@ async function insertOrganizationUserWithRoleAdmin() {
   return { adminUser, organization };
 }
 
+// We insert a multiple sending feature by default for each new organization created.
+// It is under feature for now because we want to be able to deactivate it when asked.
+async function insertMultipleSendingFeatureForNewOrganization() {
+  const feature = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT);
+  await databaseBuilder.commit();
+  return feature.id;
+}
+
 // Hapi
 const hFake = {
   response(source) {
@@ -348,6 +357,7 @@ export {
   generateValidRequestAuthorizationHeaderForApplication,
   hFake,
   HttpTestServer,
+  insertMultipleSendingFeatureForNewOrganization,
   insertOrganizationUserWithRoleAdmin,
   insertUserWithRoleCertif,
   insertUserWithRoleSuperAdmin,


### PR DESCRIPTION
## :pancakes: Problème

On veut pouvoir, à la création d'une organisation, avoir l'envoi multiple activé par défaut.

## :bacon: Proposition

A l'instanciation du modèle "OrganizationForAdmin", on vérifie que l'objet qui correspond à la feature "MultipleSendingAssessment" n'est pas déjà créé. S'il n'est pas créé, on passe la valeur "active" de cet objet à "true" avec des params à "null".

## 🧃 Remarques
Logiquement, on a touché aux tests qui ont un rapport avec les features d'une organisation ou la création d'une organisation, puisque par défaut les organisations auront cette feature-là activée.

## :yum: Pour tester

Créer une organisation 
Vérifier sur scalingo qu'elle a bien la feature "envoi multiple" activée
Aller la désactiver dans l'admin
Vérifier ensuite que la feature est bien désactivée dans scalingo