### PR TITLE
[FEATURE] Enregistrer la date de dernière connexion Pix pour les méthodes de connexion GAR (PIX-16624)

### DIFF
--- a/api/lib/application/sco-organization-learners/sco-organization-learner-controller.js
+++ b/api/lib/application/sco-organization-learners/sco-organization-learner-controller.js
@@ -1,7 +1,10 @@
 import dayjs from 'dayjs';
 
 import * as studentInformationForAccountRecoverySerializer from '../../../src/identity-access-management/infrastructure/serializers/jsonapi/student-information-for-account-recovery-serializer.js';
-import { getForwardedOrigin } from '../../../src/identity-access-management/infrastructure/utils/network.js';
+import {
+  getForwardedOrigin,
+  RequestedApplication,
+} from '../../../src/identity-access-management/infrastructure/utils/network.js';
 import * as scoOrganizationLearnerSerializer from '../../../src/prescription/learner-management/infrastructure/serializers/jsonapi/sco-organization-learner-serializer.js';
 import { DomainTransaction } from '../../../src/shared/domain/DomainTransaction.js';
 import * as requestResponseUtils from '../../../src/shared/infrastructure/utils/request-response-utils.js';
@@ -68,11 +71,13 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
   const { birthdate, 'campaign-code': campaignCode, 'external-user-token': token } = request.payload.data.attributes;
 
   const origin = getForwardedOrigin(request.headers);
+  const requestedApplication = RequestedApplication.fromOrigin(origin);
   const accessToken = await usecases.createUserAndReconcileToOrganizationLearnerFromExternalUser({
     birthdate,
     campaignCode,
     token,
     audience: origin,
+    requestedApplication,
   });
 
   const scoOrganizationLearner = {

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -139,7 +139,6 @@ const dependencies = {
   knowledgeElementRepository,
   lastUserApplicationConnectionsRepository,
   learningContentConversionService,
-  lastUserApplicationConnectionsRepository,
   membershipRepository,
   obfuscationService,
   organizationCreationValidator,

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -103,6 +103,7 @@ const oidcAuthenticationServiceRegistry = new OidcAuthenticationServiceRegistry(
  * @typedef {userRepository} UserRepository
  * @typedef {certificationChallengesService} CertificationChallengesService
  * @typedef {assessmentRepository} AssessmentRepository
+ * @typedef {LastUserApplicationConnectionsRepository} LastUserApplicationConnectionsRepository
  */
 const dependencies = {
   accountRecoveryDemandRepository,
@@ -138,6 +139,7 @@ const dependencies = {
   knowledgeElementRepository,
   lastUserApplicationConnectionsRepository,
   learningContentConversionService,
+  lastUserApplicationConnectionsRepository,
   membershipRepository,
   obfuscationService,
   organizationCreationValidator,

--- a/api/src/identity-access-management/application/saml/saml.controller.js
+++ b/api/src/identity-access-management/application/saml/saml.controller.js
@@ -3,7 +3,7 @@ import { tokenService } from '../../../shared/domain/services/token-service.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { usecases } from '../../domain/usecases/index.js';
 import * as saml from '../../infrastructure/saml.js';
-import { getForwardedOrigin } from '../../infrastructure/utils/network.js';
+import { getForwardedOrigin, RequestedApplication } from '../../infrastructure/utils/network.js';
 
 const metadata = function (request, h) {
   return h.response(saml.getServiceProviderMetadata()).type('application/xml');
@@ -24,11 +24,13 @@ const assert = async function (request, h) {
 
   try {
     const origin = getForwardedOrigin(request.headers);
+    const requestedApplication = RequestedApplication.fromOrigin(origin);
     const redirectionUrl = await usecases.getSamlAuthenticationRedirectionUrl({
       userAttributes,
       tokenService,
       config,
       audience: origin,
+      requestedApplication,
     });
 
     return h.redirect(redirectionUrl);

--- a/api/tests/acceptance/application/sco-organization-learners/sco-organization-learner-controller_test.js
+++ b/api/tests/acceptance/application/sco-organization-learners/sco-organization-learner-controller_test.js
@@ -152,7 +152,7 @@ describe('Acceptance | Controller | sco-organization-learners', function () {
       options = {
         method: 'POST',
         url: '/api/sco-organization-learners/external',
-        headers: {},
+        headers: generateAuthenticatedUserRequestHeaders(),
         payload: {},
       };
 


### PR DESCRIPTION
## :pancakes: Problème

Quand un utilisateur se connecte avec une méthode de connexionGAR, on souhaite stocker la date de dernière connexion pour l’application connecté et par méthode de connexion.

🥓 Proposition
Quand un utilisateur se connecte avec une méthode de connexion GAR, stocker la date de dernière connexion pour l’application connecté et par méthode de connexion.


## :yum: Pour tester

Route POST /api/sco-organization-learners/external

- Depuis l'app pix-saml-idp (localhost:7654), se réconcilier avec un elisa delajungle (01/01/2011), numéro de campagne SCOBADGE1
- Constater en base une écriture sur la table "last-user-application-connections"
- Constater en base une écriture sur la table "authentication-méthods" avec l'identityProvider (GAR) et le lastLoggedAt (date de la réconciliation)

Route POST /api/saml/assert
- Se déconnecter de pix app
- Recommencer l'étape 1 avec le même user ( sans réconciliation )
- Constater en base une écriture sur la table "last-user-application-connections"
- Constater en base une écriture sur la table "authentication-méthods" avec l'identityProvider (GAR) et le lastLoggedAt (date de reconnexion)