### PR TITLE
[TECH] Créer la table `passage-events` (migration) (PIX-16727)

### DIFF
--- a/api/db/migrations/20250303133924_create-passage-events-table.js
+++ b/api/db/migrations/20250303133924_create-passage-events-table.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'passage-events';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.bigIncrements('id').primary();
+    table.string('type').notNullable();
+    table.datetime('createdAt').notNullable().defaultTo(knex.fn.now());
+    table.datetime('occurredAt').notNullable();
+    table.integer('passageId').notNullable().references('id').inTable('passages');
+    table.jsonb('data').nullable();
+  });
+};
+
+const down = async function (knex) {
+  return knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };


### PR DESCRIPTION
## :bacon: Proposition

Créer le fichier de migration pour créer la table `passage-events`.

## 🧃 Remarques

- Contacter les capt'ains pour organiser le jeu de ce fichier de migration dans tous les environnements Pix.

## :yum: Pour tester

Pour tester en local, lancer `api/db:migrate` et vérifier que la table a été créée avec les bonnes colonnes et la clé étrangère vers passages.
