### PR TITLE
[BUGFIX] Corriger le warning `MaxListenersExceededWarning` lors de l'exécution des tests  

### DIFF
--- a/api/src/monitoring/infrastructure/metrics.js
+++ b/api/src/monitoring/infrastructure/metrics.js
@@ -11,7 +11,7 @@ export class Metrics {
   constructor({ config }) {
     if (!config.featureToggles.isDirectMetricsEnabled) {
       logger.info('Metric initialisation : no reporter => no metrics sent');
-      metrics.init({ reporter: new metrics.reporters.NullReporter() });
+      metrics.init({ reporter: new metrics.reporters.NullReporter(), flushIntervalSeconds: 0 });
     }
 
     if (config.featureToggles.isDirectMetricsEnabled) {


### PR DESCRIPTION
## :pancakes: Problème
Depuis l'ajout des métriques Datadog dans le code, le warning suivant apparaît au lancement des tests d'intégration et d'acceptance: `MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 beforeExit listeners added to [process]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit`. Cela est dû au fait que la libraire attache un handler à l'évènement `beforeExit` (afin de flush les dernières métriques).     

## :bacon: Proposition
Définir le paramètre `flushIntervalSeconds` à 0 lors de l'initialisation des métriques pour les tests ou quand la variable d'env `isDirectMetricsEnabled` est à false.  

## :yum: Pour tester
Vérifier que le warning n'apparaît plus dans les tests.
