### PR TITLE
[TECH] :broom: Utilisations de valeurs déjà présente dans le code pour le calcul du niveau de maille (PIX-16718)

### DIFF
--- a/api/src/certification/results/application/parcoursup-controller.js
+++ b/api/src/certification/results/application/parcoursup-controller.js
@@ -25,8 +25,6 @@ const getCertificationResultForParcoursup = async function (
 
   const globalMeshLevel = await usecases.getGlobalMeshLevel({
     pixScore: certificationResult.pixScore,
-    certificationDate: certificationResult.certificationDate,
-    i18n,
   });
 
   return dependencies.parcoursupCertificationSerializer.serialize({

--- a/api/src/certification/results/domain/services/pix-score-to-mesh-level.js
+++ b/api/src/certification/results/domain/services/pix-score-to-mesh-level.js
@@ -2,24 +2,18 @@
  * @typedef {import ('../../../shared/domain/models/V3CertificationScoring.js').V3CertificationScoring} V3CertificationScoring
  */
 
-import { findIntervalIndexFromScore } from '../../../scoring/domain/models/CapacitySimulator.js';
 // TODO : bounded context violation
-import { CertificationAssessmentScoreV3 } from '../../../scoring/domain/models/CertificationAssessmentScoreV3.js';
+import { findIntervalIndexFromScore } from '../../../scoring/domain/models/CapacitySimulator.js';
 import { GlobalCertificationLevel } from '../../../shared/domain/models/GlobalCertificationLevel.js';
-
-const SCORING_CONFIGURATION_WEIGHT = CertificationAssessmentScoreV3.weightsAndCoefficients.map(({ weight }) => weight);
 
 /**
  * @param {Object} params
  * @param {number} params.pixScore
- * @param {V3CertificationScoring} params.scoringConfiguration
  */
-export const getMeshLevel = ({ pixScore, scoringConfiguration }) => {
+export const getMeshLevel = ({ pixScore }) => {
   return new GlobalCertificationLevel({
     meshLevel: findIntervalIndexFromScore({
       score: pixScore,
-      weights: SCORING_CONFIGURATION_WEIGHT,
-      scoringIntervalsLength: scoringConfiguration.getNumberOfIntervals(),
     }),
   });
 };

--- a/api/src/certification/results/domain/usecases/get-global-mesh-level.js
+++ b/api/src/certification/results/domain/usecases/get-global-mesh-level.js
@@ -1,27 +1,12 @@
 /**
- * @typedef {import ('./index.js').ScoringConfigurationRepository} ScoringConfigurationRepository
  * @typedef {import ('./index.js').PixScoreToMeshLevelService} PixScoreToMeshLevelService
  */
 
 /**
  * @param {Object} params
  * @param {number} params.pixScore
- * @param {Date} params.certificationDate - the mesh levels depends on the configuration at date
- * @param {Object} params.i18n
- * @param {ScoringConfigurationRepository} params.scoringConfigurationRepository
  * @param {PixScoreToMeshLevelService} params.pixScoreToMeshLevelService
  */
-export const getGlobalMeshLevel = async ({
-  pixScore,
-  certificationDate,
-  i18n,
-  scoringConfigurationRepository,
-  pixScoreToMeshLevelService,
-}) => {
-  const scoringConfiguration = await scoringConfigurationRepository.getLatestByDateAndLocale({
-    date: certificationDate,
-    locale: i18n.getLocale(),
-  });
-
-  return pixScoreToMeshLevelService.getMeshLevel({ pixScore, scoringConfiguration });
+export const getGlobalMeshLevel = async ({ pixScore, pixScoreToMeshLevelService }) => {
+  return pixScoreToMeshLevelService.getMeshLevel({ pixScore });
 };

--- a/api/src/certification/results/domain/usecases/index.js
+++ b/api/src/certification/results/domain/usecases/index.js
@@ -7,7 +7,6 @@ import { importNamedExportsFromDirectory } from '../../../../shared/infrastructu
 import * as sessionEnrolmentRepository from '../../../enrolment/infrastructure/repositories/session-repository.js';
 import * as certificationCourseRepository from '../../../shared/infrastructure/repositories/certification-course-repository.js';
 import * as certificationReportRepository from '../../../shared/infrastructure/repositories/certification-report-repository.js';
-import * as scoringConfigurationRepository from '../../../shared/infrastructure/repositories/scoring-configuration-repository.js';
 import * as sharedSessionRepository from '../../../shared/infrastructure/repositories/session-repository.js';
 import * as certificateRepository from '../../infrastructure/repositories/certificate-repository.js';
 import * as certificationLivretScolaireRepository from '../../infrastructure/repositories/certification-livret-scolaire-repository.js';
@@ -32,7 +31,6 @@ import * as pixScoreToMeshLevelService from '../services/pix-score-to-mesh-level
  * @typedef {sharedSessionRepository} SharedSessionRepository
  * @typedef {certificationLivretScolaireRepository} CertificationLivretScolaireRepository
  * @typedef {competenceTreeRepository} CompetenceTreeRepository
- * @typedef {scoringConfigurationRepository} ScoringConfigurationRepository
  * @typedef {pixScoreToMeshLevelService} PixScoreToMeshLevelService
  **/
 
@@ -48,7 +46,6 @@ const dependencies = {
   sharedSessionRepository,
   competenceTreeRepository,
   certificationLivretScolaireRepository,
-  scoringConfigurationRepository,
   pixScoreToMeshLevelService,
 };
 

--- a/api/src/certification/scoring/domain/models/CapacitySimulator.js
+++ b/api/src/certification/scoring/domain/models/CapacitySimulator.js
@@ -5,7 +5,7 @@ import { ScoringAndCapacitySimulatorReport } from './ScoringAndCapacitySimulator
 
 const SCORING_CONFIGURATION_WEIGHTS = CertificationAssessmentScoreV3.weightsAndCoefficients.map(({ weight }) => weight);
 
-// TODO change this model to a service
+// TODO change CapacitySimulator model to a service
 export class CapacitySimulator {
   static compute({ certificationScoringIntervals, competencesForScoring, score }) {
     const scoringIntervals = new Intervals({ intervals: certificationScoringIntervals });
@@ -44,8 +44,7 @@ export class CapacitySimulator {
   }
 }
 
-// TODO move this to result
-// TODO Split this to a service
+// TODO Split function to a service, and change contexte to `results`
 export function findIntervalIndexFromScore({ score }) {
   const weights = SCORING_CONFIGURATION_WEIGHTS;
   let cumulativeSumOfWeights = weights[0];

--- a/api/src/certification/scoring/domain/models/CapacitySimulator.js
+++ b/api/src/certification/scoring/domain/models/CapacitySimulator.js
@@ -1,7 +1,11 @@
+import { config } from '../../../../shared/config.js';
 import { CertificationAssessmentScoreV3 } from './CertificationAssessmentScoreV3.js';
 import { Intervals } from './Intervals.js';
 import { ScoringAndCapacitySimulatorReport } from './ScoringAndCapacitySimulatorReport.js';
 
+const SCORING_CONFIGURATION_WEIGHTS = CertificationAssessmentScoreV3.weightsAndCoefficients.map(({ weight }) => weight);
+
+// TODO change this model to a service
 export class CapacitySimulator {
   static compute({ certificationScoringIntervals, competencesForScoring, score }) {
     const scoringIntervals = new Intervals({ intervals: certificationScoringIntervals });
@@ -40,14 +44,14 @@ export class CapacitySimulator {
   }
 }
 
-export function findIntervalIndexFromScore({ score, scoringIntervalsLength, weights }) {
+// TODO move this to result
+// TODO Split this to a service
+export function findIntervalIndexFromScore({ score }) {
+  const weights = SCORING_CONFIGURATION_WEIGHTS;
   let cumulativeSumOfWeights = weights[0];
   let currentScoringInterval = 0;
 
-  while (
-    _isPixScoreOfAnHigherInterval(score, cumulativeSumOfWeights) &&
-    _hasANextInterval(currentScoringInterval, scoringIntervalsLength)
-  ) {
+  while (_hasNextScoringInterval(score, cumulativeSumOfWeights, currentScoringInterval)) {
     currentScoringInterval++;
     cumulativeSumOfWeights += weights[currentScoringInterval];
   }
@@ -55,10 +59,6 @@ export function findIntervalIndexFromScore({ score, scoringIntervalsLength, weig
   return currentScoringInterval;
 }
 
-function _isPixScoreOfAnHigherInterval(score, nextIntervalMinimumScore) {
-  return score >= nextIntervalMinimumScore;
-}
-
-function _hasANextInterval(currentInterval, scoringIntervalsLength) {
-  return currentInterval < scoringIntervalsLength - 1;
+function _hasNextScoringInterval(score, nextIntervalMinimumScore, currentInterval) {
+  return score >= nextIntervalMinimumScore && currentInterval < config.v3Certification.maxReachableLevel;
 }

--- a/api/tests/certification/results/acceptance/application/parcoursup-route_test.js
+++ b/api/tests/certification/results/acceptance/application/parcoursup-route_test.js
@@ -1,7 +1,5 @@
-import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
 import {
   createServer,
-  databaseBuilder,
   datamartBuilder,
   expect,
   generateValidRequestAuthorizationHeaderForApplication,
@@ -86,18 +84,6 @@ describe('Certification | Results | Acceptance | Application | parcoursup-route'
     });
 
     await datamartBuilder.commit();
-
-    const superAdmin = databaseBuilder.factory.buildUser.withRole({
-      role: PIX_ADMIN.ROLES.SUPER_ADMIN,
-    });
-    databaseBuilder.factory.buildCompetenceScoringConfiguration({
-      createdByUserId: superAdmin.id,
-      configuration: [],
-    });
-    databaseBuilder.factory.buildScoringConfiguration({
-      createdByUserId: superAdmin.id,
-    });
-    await databaseBuilder.commit();
   });
 
   describe('POST /api/application/parcoursup/certification/search', function () {

--- a/api/tests/certification/results/unit/application/parcoursup-controller_test.js
+++ b/api/tests/certification/results/unit/application/parcoursup-controller_test.js
@@ -20,8 +20,10 @@ describe('Certification | Results | Unit | Application | parcoursup-controller',
         },
       };
 
+      const pixScore = Symbol('pixScore');
+
       const certificationResultForParcoursup = {
-        pixScore: Symbol('pixScore'),
+        pixScore,
         certificationDate: Symbol('certificationDate'),
       };
       sinon.stub(usecases, 'getCertificationResultForParcoursup');
@@ -31,9 +33,7 @@ describe('Certification | Results | Unit | Application | parcoursup-controller',
 
       const globalMeshLevel = Symbol('globalMeshLevel');
       sinon.stub(usecases, 'getGlobalMeshLevel');
-      usecases.getGlobalMeshLevel
-        .withArgs({ ...certificationResultForParcoursup, i18n: getI18n(FRENCH_FRANCE) })
-        .resolves(globalMeshLevel);
+      usecases.getGlobalMeshLevel.withArgs({ pixScore }).resolves(globalMeshLevel);
 
       const dependencies = {
         parcoursupCertificationSerializer: {

--- a/api/tests/certification/results/unit/domain/usecases/get-global-mesh-level_test.js
+++ b/api/tests/certification/results/unit/domain/usecases/get-global-mesh-level_test.js
@@ -1,28 +1,13 @@
 import { getGlobalMeshLevel } from '../../../../../../src/certification/results/domain/usecases/get-global-mesh-level.js';
-import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Certification | Results | Unit | Domain | UseCases | get-global-mesh-level', function () {
-  let scoringConfigurationRepository, pixScoreToMeshLevelService;
-
-  beforeEach(function () {
-    scoringConfigurationRepository = {
-      getLatestByDateAndLocale: sinon.stub(),
-    };
-
-    pixScoreToMeshLevelService = {
+  it('should return the global mesh level', async function () {
+    const pixScoreToMeshLevelService = {
       getMeshLevel: sinon.stub(),
     };
-  });
-
-  it('should return the global mesh level', async function () {
     // given
-    const i18n = getI18n();
     const pixScore = 12;
-    const certificationDate = new Date();
-
-    const scoringConfiguration = domainBuilder.buildV3CertificationScoring({});
-    scoringConfigurationRepository.getLatestByDateAndLocale.resolves(scoringConfiguration);
 
     const globalMeshLevel = domainBuilder.certification.results.buildGlobalCertificationLevel();
     pixScoreToMeshLevelService.getMeshLevel.returns(globalMeshLevel);
@@ -30,21 +15,11 @@ describe('Certification | Results | Unit | Domain | UseCases | get-global-mesh-l
     // when
     const result = await getGlobalMeshLevel({
       pixScore,
-      certificationDate,
-      i18n,
-      scoringConfigurationRepository,
       pixScoreToMeshLevelService,
     });
 
     // then
     expect(result).to.deep.equal(globalMeshLevel);
-    expect(scoringConfigurationRepository.getLatestByDateAndLocale).to.have.been.calledOnceWithExactly({
-      date: certificationDate,
-      locale: i18n.getLocale(),
-    });
-    expect(pixScoreToMeshLevelService.getMeshLevel).to.have.been.calledOnceWithExactly({
-      pixScore,
-      scoringConfiguration,
-    });
+    expect(pixScoreToMeshLevelService.getMeshLevel).to.have.been.calledOnceWithExactly({ pixScore });
   });
 });


### PR DESCRIPTION
## :pancakes: Problème

On utilisait la base live pour la configuration du scoring pour ParcourSup

## :bacon: Proposition

Ne plus utiliser d'éléments provenant de la configuration en base de donnée pour ne plus solliciter la base de donnée « live » de Pix.

## 🧃 Remarques

Il faudrait peut-être prévenir l'équipe autour du Datamart que nous n'avons plus besoin de cette donnée dans la base froide ?

## :yum: Pour tester

_À étoffer_

Faire un appel Parcoursup via https://api-pr11556.review.pix.fr/documentation/parcoursup
- générer un token 
- faire un appel API sur le endpoint (paramètre au choix)

Puis vérifier que le score remonté correspond bien au niveau de la certificaiton

| Score | Niveau |
| --- | --- |
| 0 -> 63 | Pré novice |
| 64 -> 127 | Novice 1 |
| 128 -> 255 | Novice 2 |
| 256 -> 383 | Indépendant 1 |
| 384 -> 511 | Indépendant 2 |
| 512 -> 639 | Avancé 1 |
| 640 -> 767 | Avancé 2 |
| 768 -> 895 | Expert 1 |



