### PR TITLE
[FEATURE] Initier un data repository pour enregistrer des passages events (PIX-16728)

### DIFF
--- a/api/src/devcomp/domain/models/passage-events/PassageEvent.js
+++ b/api/src/devcomp/domain/models/passage-events/PassageEvent.js
@@ -16,10 +16,8 @@ class PassageEvent {
       throw new PassageEventInstantiationError();
     }
 
-    assertNotNullOrUndefined(id, 'The id is required for a PassageEvent');
     assertNotNullOrUndefined(type, 'The type is required for a PassageEvent');
     assertNotNullOrUndefined(occurredAt, 'The occurredAt is required for a PassageEvent');
-    assertNotNullOrUndefined(createdAt, 'The createdAt is required for a PassageEvent');
     assertNotNullOrUndefined(passageId, 'The passageId is required for a PassageEvent');
 
     this.id = id;

--- a/api/src/devcomp/infrastructure/repositories/passage-event-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/passage-event-repository.js
@@ -1,0 +1,13 @@
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+
+async function record(event) {
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn('passage-events').insert({
+    passageId: event.passageId,
+    occurredAt: event.occurredAt,
+    type: event.type,
+    data: event.data,
+  });
+}
+
+export { record };

--- a/api/tests/devcomp/integration/repositories/passage-event-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/passage-event-repository_test.js
@@ -1,0 +1,38 @@
+import { PassageStartedEvent } from '../../../../src/devcomp/domain/models/passage-events/passage-events.js';
+import * as passageEventRepository from '../../../../src/devcomp/infrastructure/repositories/passage-event-repository.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
+
+describe('Integration | DevComp | Repositories | PassageEventRepository', function () {
+  describe('#record', function () {
+    let clock;
+
+    beforeEach(function () {
+      clock = sinon.useFakeTimers(new Date('2023-12-31'), 'Date');
+    });
+
+    afterEach(function () {
+      clock.restore();
+    });
+
+    it('should record a passage event', async function () {
+      // given
+      const passage = databaseBuilder.factory.buildPassage();
+      await databaseBuilder.commit();
+      const event = new PassageStartedEvent({
+        occurredAt: new Date('2019-04-28'),
+        passageId: passage.id,
+        contentHash: 'abcd1234',
+      });
+
+      // when
+      await passageEventRepository.record(event);
+
+      // then
+      const recordedEvent = await knex('passage-events')
+        .where({ type: 'PASSAGE_STARTED', passageId: passage.id })
+        .first();
+      expect(recordedEvent.data.contentHash).to.equal('abcd1234');
+      expect(recordedEvent.occurredAt).to.deep.equal(new Date('2019-04-28'));
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/models/module/PassageEvent_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/PassageEvent_test.js
@@ -13,24 +13,6 @@ describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
       expect(error).to.be.instanceOf(PassageEventInstantiationError);
     });
 
-    describe('if a passage event does not have an id', function () {
-      it('should throw an error', function () {
-        // given
-        class FakeEvent extends PassageEvent {
-          constructor() {
-            super({});
-          }
-        }
-
-        // when
-        const error = catchErrSync(() => new FakeEvent())();
-
-        // then
-        expect(error).to.be.instanceOf(DomainError);
-        expect(error.message).to.equal('The id is required for a PassageEvent');
-      });
-    });
-
     describe('if a passage event does not have a type', function () {
       it('should throw an error', function () {
         // given
@@ -64,24 +46,6 @@ describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
         // then
         expect(error).to.be.instanceOf(DomainError);
         expect(error.message).to.equal('The occurredAt is required for a PassageEvent');
-      });
-    });
-
-    describe('if a passage event does not have a createdAt', function () {
-      it('should throw an error', function () {
-        // given
-        class FakeEvent extends PassageEvent {
-          constructor() {
-            super({ id: 1, type: 'FAKE', occurredAt: Symbol('date') });
-          }
-        }
-
-        // when
-        const error = catchErrSync(() => new FakeEvent())();
-
-        // then
-        expect(error).to.be.instanceOf(DomainError);
-        expect(error.message).to.equal('The createdAt is required for a PassageEvent');
       });
     });
 


### PR DESCRIPTION
## :bacon: Proposition

Ajouter un Repository pour stocker les `passage-events` en base.

## 🧃 Remarques

- Les vérifications sur les champs id et createdAt dans le modèle ont été enlevé car optionnels.

## :yum: Pour tester
- Vérifier que les tests passent 😄 
