### PR TITLE
[FEATURE] Sauvegarder les événements `PASSAGE_TERMINATED`(PIX-16811)

### DIFF
--- a/api/src/devcomp/application/passages/controller.js
+++ b/api/src/devcomp/application/passages/controller.js
@@ -20,7 +20,7 @@ const verifyAndSaveAnswer = async function (request, h, { usecases, elementAnswe
 const terminate = async function (request, h, { usecases, passageSerializer }) {
   const { passageId } = request.params;
   const requestTimestamp = requestResponseUtils.extractTimestampFromRequest(request);
-  const updatedPassage = await usecases.terminatePassage({ passageId, requestTimestamp });
+  const updatedPassage = await usecases.terminatePassage({ passageId, occurredAt: new Date(requestTimestamp) });
   return passageSerializer.serialize(updatedPassage);
 };
 

--- a/api/src/devcomp/application/passages/controller.js
+++ b/api/src/devcomp/application/passages/controller.js
@@ -1,3 +1,5 @@
+import { requestResponseUtils } from '../../../shared/infrastructure/utils/request-response-utils.js';
+
 const create = async function (request, h, { usecases, passageSerializer, extractUserIdFromRequest }) {
   const { 'module-id': moduleId } = request.payload.data.attributes;
   const userId = extractUserIdFromRequest(request);
@@ -17,7 +19,8 @@ const verifyAndSaveAnswer = async function (request, h, { usecases, elementAnswe
 
 const terminate = async function (request, h, { usecases, passageSerializer }) {
   const { passageId } = request.params;
-  const updatedPassage = await usecases.terminatePassage({ passageId });
+  const requestTimestamp = requestResponseUtils.extractTimestampFromRequest(request);
+  const updatedPassage = await usecases.terminatePassage({ passageId, requestTimestamp });
   return passageSerializer.serialize(updatedPassage);
 };
 

--- a/api/src/devcomp/domain/usecases/terminate-passage.js
+++ b/api/src/devcomp/domain/usecases/terminate-passage.js
@@ -5,7 +5,7 @@ import { PassageTerminatedEvent } from '../models/passage-events/passage-events.
 
 const terminatePassage = withTransaction(async function ({
   passageId,
-  requestTimestamp,
+  occurredAt,
   passageRepository,
   passageEventRepository,
 }) {
@@ -15,10 +15,7 @@ const terminatePassage = withTransaction(async function ({
   }
   passage.terminate();
   const terminatedPassage = await passageRepository.update({ passage });
-  const event = new PassageTerminatedEvent({
-    passageId: terminatedPassage.id,
-    occurredAt: new Date(requestTimestamp),
-  });
+  const event = new PassageTerminatedEvent({ passageId, occurredAt });
   await passageEventRepository.record(event);
   return terminatedPassage;
 });

--- a/api/src/devcomp/domain/usecases/terminate-passage.js
+++ b/api/src/devcomp/domain/usecases/terminate-passage.js
@@ -1,8 +1,14 @@
+import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { PassageDoesNotExistError, PassageTerminatedError } from '../errors.js';
 import { PassageTerminatedEvent } from '../models/passage-events/passage-events.js';
 
-async function terminatePassage({ passageId, requestTimestamp, passageRepository, passageEventRepository }) {
+const terminatePassage = withTransaction(async function ({
+  passageId,
+  requestTimestamp,
+  passageRepository,
+  passageEventRepository,
+}) {
   const passage = await _getPassage({ passageId, passageRepository });
   if (passage.terminatedAt) {
     throw new PassageTerminatedError();
@@ -15,7 +21,7 @@ async function terminatePassage({ passageId, requestTimestamp, passageRepository
   });
   await passageEventRepository.record(event);
   return terminatedPassage;
-}
+});
 
 async function _getPassage({ passageId, passageRepository }) {
   try {

--- a/api/src/devcomp/domain/usecases/terminate-passage.js
+++ b/api/src/devcomp/domain/usecases/terminate-passage.js
@@ -1,13 +1,20 @@
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { PassageDoesNotExistError, PassageTerminatedError } from '../errors.js';
+import { PassageTerminatedEvent } from '../models/passage-events/passage-events.js';
 
-async function terminatePassage({ passageId, passageRepository }) {
+async function terminatePassage({ passageId, passageRepository, passageEventRepository }) {
   const passage = await _getPassage({ passageId, passageRepository });
   if (passage.terminatedAt) {
     throw new PassageTerminatedError();
   }
   passage.terminate();
-  return passageRepository.update({ passage });
+  const terminatedPassage = await passageRepository.update({ passage });
+  const event = new PassageTerminatedEvent({
+    passageId: terminatedPassage.id,
+    occurredAt: terminatedPassage.terminatedAt,
+  });
+  await passageEventRepository.record(event);
+  return terminatedPassage;
 }
 
 async function _getPassage({ passageId, passageRepository }) {

--- a/api/src/devcomp/domain/usecases/terminate-passage.js
+++ b/api/src/devcomp/domain/usecases/terminate-passage.js
@@ -2,7 +2,7 @@ import { NotFoundError } from '../../../shared/domain/errors.js';
 import { PassageDoesNotExistError, PassageTerminatedError } from '../errors.js';
 import { PassageTerminatedEvent } from '../models/passage-events/passage-events.js';
 
-async function terminatePassage({ passageId, passageRepository, passageEventRepository }) {
+async function terminatePassage({ passageId, requestTimestamp, passageRepository, passageEventRepository }) {
   const passage = await _getPassage({ passageId, passageRepository });
   if (passage.terminatedAt) {
     throw new PassageTerminatedError();
@@ -11,7 +11,7 @@ async function terminatePassage({ passageId, passageRepository, passageEventRepo
   const terminatedPassage = await passageRepository.update({ passage });
   const event = new PassageTerminatedEvent({
     passageId: terminatedPassage.id,
-    occurredAt: terminatedPassage.terminatedAt,
+    occurredAt: new Date(requestTimestamp),
   });
   await passageEventRepository.record(event);
   return terminatedPassage;

--- a/api/src/devcomp/infrastructure/repositories/index.js
+++ b/api/src/devcomp/infrastructure/repositories/index.js
@@ -3,6 +3,7 @@ import moduleDatasource from '../datasources/learning-content/module-datasource.
 import * as elementAnswerRepository from './element-answer-repository.js';
 import * as elementRepository from './element-repository.js';
 import * as moduleRepository from './module-repository.js';
+import * as passageEventRepository from './passage-event-repository.js';
 import * as passageRepository from './passage-repository.js';
 import * as trainingRepository from './training-repository.js';
 import * as trainingTriggerRepository from './training-trigger-repository.js';
@@ -15,6 +16,7 @@ const repositoriesWithoutInjectedDependencies = {
   elementAnswerRepository,
   elementRepository,
   moduleRepository,
+  passageEventRepository,
   passageRepository,
   trainingRepository,
   trainingTriggerRepository,

--- a/api/src/shared/infrastructure/utils/request-response-utils.js
+++ b/api/src/shared/infrastructure/utils/request-response-utils.js
@@ -6,9 +6,12 @@ import { tokenService } from '../../../shared/domain/services/token-service.js';
 
 const { ENGLISH_SPOKEN, FRENCH_FRANCE, FRENCH_SPOKEN } = LOCALE;
 const { DUTCH, SPANISH } = LANGUAGES_CODE;
-const requestResponseUtils = { escapeFileName, extractUserIdFromRequest, extractLocaleFromRequest };
-
-export { escapeFileName, extractLocaleFromRequest, extractUserIdFromRequest, requestResponseUtils };
+const requestResponseUtils = {
+  escapeFileName,
+  extractUserIdFromRequest,
+  extractLocaleFromRequest,
+  extractTimestampFromRequest,
+};
 
 function escapeFileName(fileName) {
   return fileName
@@ -37,3 +40,15 @@ function extractLocaleFromRequest(request) {
   const acceptedLanguages = [ENGLISH_SPOKEN, FRENCH_SPOKEN, FRENCH_FRANCE, DUTCH, SPANISH];
   return accept.language(languageHeader, acceptedLanguages) || defaultLocale;
 }
+
+function extractTimestampFromRequest(request) {
+  return request.headers?.['X-Request-Start'] ?? new Date().getTime();
+}
+
+export {
+  escapeFileName,
+  extractLocaleFromRequest,
+  extractTimestampFromRequest,
+  extractUserIdFromRequest,
+  requestResponseUtils,
+};

--- a/api/tests/devcomp/unit/application/passages/controller_test.js
+++ b/api/tests/devcomp/unit/application/passages/controller_test.js
@@ -1,4 +1,5 @@
 import { passageController } from '../../../../../src/devcomp/application/passages/controller.js';
+import { requestResponseUtils } from '../../../../../src/shared/infrastructure/utils/request-response-utils.js';
 import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Devcomp | Application | Passages | Controller', function () {
@@ -90,13 +91,15 @@ describe('Unit | Devcomp | Application | Passages | Controller', function () {
   describe('#terminate', function () {
     it('should call terminate use-case and return serialized passage', async function () {
       // given
+      const requestDate = new Date('2025-01-01').getTime();
       const serializedPassage = Symbol('serialized modules');
       const passageId = Symbol('passage-id');
       const passage = Symbol('passage');
+      const extractTimestampStub = sinon.stub(requestResponseUtils, 'extractTimestampFromRequest').returns(requestDate);
       const usecases = {
         terminatePassage: sinon.stub(),
       };
-      usecases.terminatePassage.withArgs({ passageId }).returns(passage);
+      usecases.terminatePassage.withArgs({ passageId, requestTimestamp: requestDate }).returns(passage);
       const passageSerializer = {
         serialize: sinon.stub(),
       };
@@ -110,6 +113,7 @@ describe('Unit | Devcomp | Application | Passages | Controller', function () {
 
       // then
       expect(returned).to.deep.equal(serializedPassage);
+      expect(extractTimestampStub).to.have.been.calledOnce;
     });
   });
 });

--- a/api/tests/devcomp/unit/application/passages/controller_test.js
+++ b/api/tests/devcomp/unit/application/passages/controller_test.js
@@ -91,15 +91,17 @@ describe('Unit | Devcomp | Application | Passages | Controller', function () {
   describe('#terminate', function () {
     it('should call terminate use-case and return serialized passage', async function () {
       // given
-      const requestDate = new Date('2025-01-01').getTime();
+      const requestTimestamp = new Date('2025-01-01').getTime();
       const serializedPassage = Symbol('serialized modules');
       const passageId = Symbol('passage-id');
       const passage = Symbol('passage');
-      const extractTimestampStub = sinon.stub(requestResponseUtils, 'extractTimestampFromRequest').returns(requestDate);
+      const extractTimestampStub = sinon
+        .stub(requestResponseUtils, 'extractTimestampFromRequest')
+        .returns(requestTimestamp);
       const usecases = {
         terminatePassage: sinon.stub(),
       };
-      usecases.terminatePassage.withArgs({ passageId, requestTimestamp: requestDate }).returns(passage);
+      usecases.terminatePassage.withArgs({ passageId, occurredAt: new Date(requestTimestamp) }).returns(passage);
       const passageSerializer = {
         serialize: sinon.stub(),
       };

--- a/api/tests/devcomp/unit/domain/usecases/terminate-passage_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/terminate-passage_test.js
@@ -1,4 +1,5 @@
 import { PassageDoesNotExistError, PassageTerminatedError } from '../../../../../src/devcomp/domain/errors.js';
+import { PassageTerminatedEvent } from '../../../../../src/devcomp/domain/models/passage-events/passage-events.js';
 import { terminatePassage } from '../../../../../src/devcomp/domain/usecases/terminate-passage.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, expect, sinon } from '../../../../test-helper.js';
@@ -45,7 +46,7 @@ describe('Unit | Devcomp | Domain | UseCases | terminate-passage', function () {
         expect(error).to.be.instanceof(PassageTerminatedError);
       });
 
-      it('should call terminate method and update passage and return it', async function () {
+      it('should call terminate method and update passage and return it, then record an event', async function () {
         // given
         const passageId = Symbol('passageId');
 
@@ -53,24 +54,38 @@ describe('Unit | Devcomp | Domain | UseCases | terminate-passage', function () {
           get: sinon.stub(),
           update: sinon.stub(),
         };
+        const passageEventRepository = {
+          record: sinon.stub(),
+        };
+
         const passage = {
           terminatedAt: null,
           terminate: sinon.stub(),
         };
         passageRepository.get.withArgs({ passageId }).resolves(passage);
 
-        const updatedPassage = Symbol();
+        const updatedPassage = {
+          terminatedAt: new Date('2025-03-04'),
+          id: passageId,
+        };
         passageRepository.update.withArgs({ passage }).resolves(updatedPassage);
+
+        const event = new PassageTerminatedEvent({
+          passageId: updatedPassage.id,
+          occurredAt: updatedPassage.terminatedAt,
+        });
 
         // when
         const returnedPassage = await terminatePassage({
           passageId,
           passageRepository,
+          passageEventRepository,
         });
 
         // then
         expect(passage.terminate).to.have.been.calledOnce;
         expect(returnedPassage).to.equal(updatedPassage);
+        expect(passageEventRepository.record).to.have.been.calledOnceWithExactly(event);
       });
     });
   });

--- a/api/tests/devcomp/unit/domain/usecases/terminate-passage_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/terminate-passage_test.js
@@ -54,7 +54,7 @@ describe('Unit | Devcomp | Domain | UseCases | terminate-passage', function () {
       it('should call terminate method and update passage and return it, then record an event', async function () {
         // given
         const passageId = Symbol('passageId');
-        const requestTimestamp = new Date('2025-01-01').getTime();
+        const occurredAt = new Date('2025-01-01');
 
         const passageRepository = {
           get: sinon.stub(),
@@ -76,15 +76,12 @@ describe('Unit | Devcomp | Domain | UseCases | terminate-passage', function () {
         };
         passageRepository.update.withArgs({ passage }).resolves(updatedPassage);
 
-        const event = new PassageTerminatedEvent({
-          passageId: updatedPassage.id,
-          occurredAt: new Date(requestTimestamp),
-        });
+        const event = new PassageTerminatedEvent({ passageId, occurredAt });
 
         // when
         const returnedPassage = await terminatePassage({
           passageId,
-          requestTimestamp,
+          occurredAt,
           passageRepository,
           passageEventRepository,
         });

--- a/api/tests/devcomp/unit/domain/usecases/terminate-passage_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/terminate-passage_test.js
@@ -49,6 +49,7 @@ describe('Unit | Devcomp | Domain | UseCases | terminate-passage', function () {
       it('should call terminate method and update passage and return it, then record an event', async function () {
         // given
         const passageId = Symbol('passageId');
+        const requestTimestamp = new Date('2025-01-01').getTime();
 
         const passageRepository = {
           get: sinon.stub(),
@@ -72,12 +73,13 @@ describe('Unit | Devcomp | Domain | UseCases | terminate-passage', function () {
 
         const event = new PassageTerminatedEvent({
           passageId: updatedPassage.id,
-          occurredAt: updatedPassage.terminatedAt,
+          occurredAt: new Date(requestTimestamp),
         });
 
         // when
         const returnedPassage = await terminatePassage({
           passageId,
+          requestTimestamp,
           passageRepository,
           passageEventRepository,
         });

--- a/api/tests/devcomp/unit/domain/usecases/terminate-passage_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/terminate-passage_test.js
@@ -1,10 +1,15 @@
 import { PassageDoesNotExistError, PassageTerminatedError } from '../../../../../src/devcomp/domain/errors.js';
 import { PassageTerminatedEvent } from '../../../../../src/devcomp/domain/models/passage-events/passage-events.js';
 import { terminatePassage } from '../../../../../src/devcomp/domain/usecases/terminate-passage.js';
+import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | UseCases | terminate-passage', function () {
+  beforeEach(function () {
+    sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
+  });
+
   describe('#terminatePassage', function () {
     describe('when passage is not found', function () {
       it('should throw a PassageDoesNotExistError', async function () {

--- a/api/tests/shared/unit/infrastructure/utils/request-response-utils_test.js
+++ b/api/tests/shared/unit/infrastructure/utils/request-response-utils_test.js
@@ -2,9 +2,10 @@ import { LOCALE } from '../../../../../src/shared/domain/constants.js';
 import {
   escapeFileName,
   extractLocaleFromRequest,
+  extractTimestampFromRequest,
   extractUserIdFromRequest,
 } from '../../../../../src/shared/infrastructure/utils/request-response-utils.js';
-import { expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
+import { expect, generateAuthenticatedUserRequestHeaders, sinon } from '../../../../test-helper.js';
 
 const { ENGLISH_SPOKEN, FRENCH_FRANCE, FRENCH_SPOKEN } = LOCALE;
 
@@ -78,6 +79,50 @@ describe('Unit | Utils | Request Utils', function () {
 
         // then
         expect(locale).to.equal(data.expectedLocale);
+      });
+    });
+  });
+
+  describe('#extractTimestampFromRequest', function () {
+    context('when "X-Request-Start" header exist', function () {
+      it('returns the value of the header', function () {
+        // given
+        const startDateTimestamp = new Date('2025-01-01').getTime();
+        const request = {
+          headers: {
+            'X-Request-Start': startDateTimestamp,
+          },
+        };
+
+        // when
+        const timestamp = extractTimestampFromRequest(request);
+
+        // then
+        expect(timestamp).to.equal(startDateTimestamp);
+      });
+    });
+
+    context('when "X-Request-Start" header does not exist', function () {
+      let clock, now;
+
+      beforeEach(function () {
+        now = new Date('2023-09-12');
+        clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+      });
+
+      afterEach(function () {
+        clock.restore();
+      });
+
+      it('returns a new date in timestamp', function () {
+        // given
+        const request = {};
+
+        // when
+        const timestamp = extractTimestampFromRequest(request);
+
+        // then
+        expect(timestamp).to.equal(now.getTime());
       });
     });
   });


### PR DESCRIPTION
## :bacon: Proposition

Une fois le passage terminé, on enregistre un event `passage-terminated` dans la DB.

## 🧃 Remarques
- La date enregistrée dans `occurredAt` de l'event est la même que la date `terminatedAt` du passage terminé.

## :yum: Pour tester

- Ouvrir un [Module](https://app-pr11559.review.pix.fr/modules/bac-a-sable/details)
- Parcourir le module jusqu'à cliquer sur Terminer
- Vérifier en base que l'event "passage-terminated" correspondant à ce passage a bien été créé
