### PR TITLE
[TECH] Permettre de hasher le contenu d'un module (PIX-16810)

### DIFF
--- a/api/src/devcomp/domain/models/module/Module.js
+++ b/api/src/devcomp/domain/models/module/Module.js
@@ -2,7 +2,7 @@ import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asser
 import { ModuleInstantiationError } from '../../errors.js';
 
 class Module {
-  constructor({ id, slug, title, isBeta, grains, details, transitionTexts = [] }) {
+  constructor({ id, slug, title, isBeta, grains, details, transitionTexts = [], version }) {
     assertNotNullOrUndefined(id, 'The id is required for a module');
     assertNotNullOrUndefined(slug, 'The slug is required for a module');
     assertNotNullOrUndefined(title, 'The title is required for a module');
@@ -19,6 +19,7 @@ class Module {
     this.grains = grains;
     this.transitionTexts = transitionTexts;
     this.details = details;
+    this.version = version;
   }
 
   #assertTransitionTextsLinkedToGrain(transitionTexts, grains) {

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -33,6 +33,7 @@ export class ModuleFactory {
         id: moduleData.id,
         slug: moduleData.slug,
         title: moduleData.title,
+        version: moduleData.version,
         isBeta: moduleData.isBeta,
         transitionTexts: moduleData.transitionTexts?.map((transitionText) => new TransitionText(transitionText)) ?? [],
         details: new Details(moduleData.details),

--- a/api/src/devcomp/infrastructure/repositories/module-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-repository.js
@@ -1,3 +1,5 @@
+import crypto from 'node:crypto';
+
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { LearningContentResourceNotFound } from '../../../shared/domain/errors.js';
 import { ModuleFactory } from '../factories/module-factory.js';
@@ -5,8 +7,9 @@ import { ModuleFactory } from '../factories/module-factory.js';
 async function getBySlug({ slug, moduleDatasource }) {
   try {
     const moduleData = await moduleDatasource.getBySlug(slug);
+    const version = _computeModuleVersion(moduleData);
 
-    return ModuleFactory.build(moduleData);
+    return ModuleFactory.build({ ...moduleData, version });
   } catch (e) {
     if (e instanceof LearningContentResourceNotFound) {
       throw new NotFoundError();
@@ -18,6 +21,12 @@ async function getBySlug({ slug, moduleDatasource }) {
 async function list({ moduleDatasource }) {
   const modulesData = await moduleDatasource.list();
   return modulesData.map((moduleData) => ModuleFactory.build(moduleData));
+}
+
+function _computeModuleVersion(moduleData) {
+  const hash = crypto.createHash('sha256');
+  hash.update(JSON.stringify(moduleData));
+  return hash.copy().digest('hex');
 }
 
 export { getBySlug, list };

--- a/api/tests/devcomp/unit/domain/models/module/Module_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/Module_test.js
@@ -14,9 +14,10 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
       const grains = [Symbol('text')];
       const transitionTexts = [];
       const details = Symbol('details');
+      const version = Symbol('version');
 
       // when
-      const module = new Module({ id, slug, title, isBeta, grains, details, transitionTexts });
+      const module = new Module({ id, slug, title, isBeta, grains, details, transitionTexts, version });
 
       // then
       expect(module.id).to.equal(id);
@@ -26,6 +27,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
       expect(module.transitionTexts).to.equal(transitionTexts);
       expect(module.grains).to.have.lengthOf(grains.length);
       expect(module.details).to.deep.equal(details);
+      expect(module.version).to.deep.equal(version);
     });
 
     describe('if a module does not have an id', function () {

--- a/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
@@ -229,10 +229,12 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
 
     it('should instantiate a Module with a grain containing components', function () {
       // given
+      const version = Symbol('version');
       const moduleData = {
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
         slug: 'title',
         title: 'title',
+        version,
         isBeta: true,
         details: {
           image: 'https://images.pix.fr/modulix/placeholder-details.svg',
@@ -268,6 +270,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
 
       // then
       expect(module).to.be.an.instanceOf(Module);
+      expect(module.version).to.equal(version);
       expect(module.grains).not.to.be.empty;
       for (const grain of module.grains) {
         expect(grain).to.be.instanceof(Grain);


### PR DESCRIPTION
## :bacon: Proposition

Une méthode `_computeModuleVersion()` a été ajoutée dans le Model Repository afin de pouvoir chiffrer le contenu d'un module, le stocker dans le Model Module sous le champ `version`, et l'ajouter dans un passage-event.

## 🧃 Remarques

RAS

## :yum: Pour tester

- Vérifier que les tests unitaires passent
- On pourra finaliser les tests quand on enregistrera le hash dans un PassageEvent