### PR TITLE
[FEATURE] Pouvoir visualiser les résultats d'une campagne d'interro côté PixOrga, à la manière d'une campagne d'évaluation pour le moment (PIX-16829)

### DIFF
--- a/api/src/prescription/campaign/domain/usecases/get-campaign.js
+++ b/api/src/prescription/campaign/domain/usecases/get-campaign.js
@@ -6,7 +6,7 @@ const getCampaign = async function ({
 }) {
   const campaignReport = await campaignReportRepository.get(campaignId);
 
-  if (campaignReport.isAssessment) {
+  if (campaignReport.isAssessment || campaignReport.isExam) {
     const [badges, stageCollection, aggregatedResults] = await Promise.all([
       badgeRepository.findByCampaignId(campaignId),
       stageCollectionRepository.findStageCollection({ campaignId: campaignId }),

--- a/api/src/prescription/campaign/domain/validators/campaign-update-validator.js
+++ b/api/src/prescription/campaign/domain/validators/campaign-update-validator.js
@@ -15,7 +15,7 @@ const campaignValidationJoiSchema = Joi.object({
   }),
 
   type: Joi.string()
-    .valid(CampaignTypes.ASSESSMENT, CampaignTypes.PROFILES_COLLECTION)
+    .valid(...Object.values(CampaignTypes))
     .required()
     .error((errors) => first(errors))
     .messages({

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
@@ -66,7 +66,7 @@ const get = async function (id) {
     id,
   });
 
-  if (campaignReport.isAssessment) {
+  if (campaignReport.isAssessment || campaignReport.isExam) {
     const skillIds = await knex('campaign_skills').where({ campaignId: id }).pluck('skillId');
     const skills = await skillRepository.findByRecordIds(skillIds);
 

--- a/api/src/shared/domain/read-models/CampaignReport.js
+++ b/api/src/shared/domain/read-models/CampaignReport.js
@@ -51,6 +51,10 @@ class CampaignReport {
     return this.type === CampaignTypes.ASSESSMENT;
   }
 
+  get isExam() {
+    return this.type === CampaignTypes.EXAM;
+  }
+
   get isProfilesCollection() {
     return this.type === CampaignTypes.PROFILES_COLLECTION;
   }

--- a/api/tests/prescription/campaign/integration/domain/usecases/get-campaign_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/get-campaign_test.js
@@ -2,6 +2,7 @@ import * as badgeRepository from '../../../../../../src/evaluation/infrastructur
 import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
 import * as campaignReportRepository from '../../../../../../src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js';
 import * as campaignRepository from '../../../../../../src/prescription/campaign/infrastructure/repositories/campaign-repository.js';
+import { CampaignTypes } from '../../../../../../src/prescription/shared/domain/constants.js';
 import { databaseBuilder, expect, mockLearningContent } from '../../../../../test-helper.js';
 
 describe('Integration | UseCase | get-campaign', function () {
@@ -58,6 +59,168 @@ describe('Integration | UseCase | get-campaign', function () {
         targetProfileId,
         organizationId,
         type: 'ASSESSMENT',
+      });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId });
+      databaseBuilder.factory.buildMembership({
+        organizationId,
+        userId,
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    it('should get the campaign with no participation', async function () {
+      // when
+      const resultCampaign = await usecases.getCampaign({
+        campaignId: campaign.id,
+        userId,
+        badgeRepository,
+        campaignRepository,
+        campaignReportRepository,
+      });
+
+      // then
+      expect(resultCampaign.name).to.equal(campaign.name);
+      expect(resultCampaign.badges).to.have.lengthOf(0);
+      expect(resultCampaign.stages).to.have.lengthOf(0);
+      expect(resultCampaign.reachedStage).to.be.null;
+      expect(resultCampaign.totalStage).to.be.null;
+    });
+
+    it('should get the campaign stages', async function () {
+      //given
+      databaseBuilder.factory.buildStage({ targetProfileId, threshold: 0 });
+
+      await databaseBuilder.commit();
+
+      // when
+      const resultCampaign = await usecases.getCampaign({
+        campaignId: campaign.id,
+        userId,
+        badgeRepository,
+        campaignRepository,
+        campaignReportRepository,
+      });
+
+      // then
+      expect(resultCampaign.stages).to.have.lengthOf(1);
+      expect(resultCampaign.reachedStage).to.equal(1);
+      expect(resultCampaign.totalStage).to.equal(1);
+    });
+
+    it('should get the campaign badges', async function () {
+      //given
+      databaseBuilder.factory.buildBadge({ targetProfileId });
+      await databaseBuilder.commit();
+
+      // when
+      const resultCampaign = await usecases.getCampaign({
+        campaignId: campaign.id,
+        userId,
+        badgeRepository,
+        campaignRepository,
+        campaignReportRepository,
+      });
+
+      // then
+      expect(resultCampaign.badges).to.have.lengthOf(1);
+    });
+
+    it('should get the average result of participations', async function () {
+      //given
+      databaseBuilder.factory.buildStage({ targetProfileId, threshold: 0 });
+      databaseBuilder.factory.buildStage({ targetProfileId, threshold: 25 });
+      databaseBuilder.factory.buildStage({ targetProfileId, threshold: 75 });
+      databaseBuilder.factory.buildStage({ targetProfileId, threshold: 100 });
+
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        masteryRate: 0.3,
+        validatedSkillsCount: 4,
+      });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        masteryRate: 0.5,
+        validatedSkillsCount: 12,
+      });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        masteryRate: 0.5,
+        validatedSkillsCount: 12,
+        status: 'TO_SHARE',
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const resultCampaign = await usecases.getCampaign({
+        campaignId: campaign.id,
+        userId,
+        badgeRepository,
+        campaignRepository,
+        campaignReportRepository,
+      });
+
+      // then
+      expect(resultCampaign.averageResult).to.equal(0.4);
+      expect(resultCampaign.reachedStage).to.equal(2);
+      expect(resultCampaign.totalStage).to.equal(4);
+    });
+  });
+
+  context('Type EXAM', function () {
+    let userId;
+    let campaign;
+    let targetProfileId;
+
+    beforeEach(async function () {
+      const skillId = 'recArea1_Competence1_Tube1_Skill1';
+      const learningContent = {
+        areas: [{ id: 'recArea1', competenceIds: ['recArea1_Competence1'] }],
+        competences: [
+          {
+            id: 'recArea1_Competence1',
+            areaId: 'recArea1',
+            skillIds: [skillId],
+            origin: 'Pix',
+          },
+        ],
+        thematics: [],
+        tubes: [
+          {
+            id: 'recArea1_Competence1_Tube1',
+            competenceId: 'recArea1_Competence1',
+          },
+        ],
+        skills: [
+          {
+            id: skillId,
+            name: '@recArea1_Competence1_Tube1_Skill1',
+            status: 'actif',
+            tubeId: 'recArea1_Competence1_Tube1',
+            competenceId: 'recArea1_Competence1',
+          },
+        ],
+        challenges: [
+          {
+            id: 'recArea1_Competence1_Tube1_Skill1_Challenge1',
+            skillId: skillId,
+            competenceId: 'recArea1_Competence1',
+            status: 'validé',
+            locales: ['fr-fr'],
+          },
+        ],
+      };
+      await mockLearningContent(learningContent);
+
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      userId = databaseBuilder.factory.buildUser().id;
+      targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      campaign = databaseBuilder.factory.buildCampaign({
+        name: 'TroTro',
+        targetProfileId,
+        organizationId,
+        type: CampaignTypes.EXAM,
       });
       databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId });
       databaseBuilder.factory.buildMembership({

--- a/api/tests/prescription/campaign/unit/domain/validators/campaign-update-validator_test.js
+++ b/api/tests/prescription/campaign/unit/domain/validators/campaign-update-validator_test.js
@@ -39,9 +39,23 @@ describe('Unit | Domain | Validators | campaign-validator', function () {
     multipleSendings: false,
   };
 
+  const campaignOfTypeExam = {
+    name: "campagne d'interro",
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    type: CampaignTypes.EXAM,
+    title: "Campagne d'interro",
+    creatorId: 4,
+    organizationId: 12,
+    targetProfileId: 44,
+    customResultPageButtonText: null,
+    customResultPageButtonUrl: null,
+    multipleSendings: false,
+  };
+
   describe('#validate', function () {
     // eslint-disable-next-line mocha/no-setup-in-describe
-    [campaignOfTypeAssessment, campaignOfTypeProfilesCollection].forEach((campaign) => {
+    [campaignOfTypeAssessment, campaignOfTypeProfilesCollection, campaignOfTypeExam].forEach((campaign) => {
       // TODO: Fix this the next time the file is edited.
       // eslint-disable-next-line mocha/no-setup-in-describe
       context(`when campaign is of type ${campaign.type}`, function () {

--- a/api/tests/unit/domain/read-models/CampaignReport_test.js
+++ b/api/tests/unit/domain/read-models/CampaignReport_test.js
@@ -2,59 +2,62 @@ import { CampaignTypes } from '../../../../src/prescription/shared/domain/consta
 import { domainBuilder, expect } from '../../../test-helper.js';
 
 describe('Unit | Domain | Models | CampaignReport', function () {
-  it('should define target profile informations', function () {
-    const targetProfileForSpecifier = {
-      name: 'target profile',
-      description: 'description',
-      TubesCount: 2,
-      hasStage: false,
-      thematicResult: 3,
-    };
+  describe('getters', function () {
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    [
+      {
+        getter: 'isAssessment',
+        // eslint-disable-next-line mocha/no-setup-in-describe
+        isTrueForType: CampaignTypes.ASSESSMENT,
+      },
+      {
+        getter: 'isExam',
+        // eslint-disable-next-line mocha/no-setup-in-describe
+        isTrueForType: CampaignTypes.EXAM,
+      },
+      {
+        getter: 'isProfilesCollection',
+        // eslint-disable-next-line mocha/no-setup-in-describe
+        isTrueForType: CampaignTypes.PROFILES_COLLECTION,
+      },
+    ].forEach(({ getter, isTrueForType }) => {
+      describe('#' + getter, function () {
+        // eslint-disable-next-line mocha/no-setup-in-describe
+        Object.values(CampaignTypes).forEach((campaignType) => {
+          const expected = campaignType === isTrueForType;
+          it(`should return ${expected} when campaign is of type ${campaignType}`, function () {
+            // given
+            const campaignReport = domainBuilder.buildCampaignReport({
+              type: campaignType,
+            });
 
-    const campaignReport = domainBuilder.buildCampaignReport();
-
-    campaignReport.setTargetProfileInformation(targetProfileForSpecifier);
-
-    expect(campaignReport.targetProfileName).to.equal(targetProfileForSpecifier.name);
-    expect(campaignReport.targetProfileDescription).to.equal(targetProfileForSpecifier.description);
-    expect(campaignReport.targetProfileTubesCount).to.equal(targetProfileForSpecifier.tubeCount);
-    expect(campaignReport.targetProfileThematicResult).to.equal(targetProfileForSpecifier.thematicResultCount);
-    expect(campaignReport.targetProfileHasStage).to.equal(targetProfileForSpecifier.hasStage);
+            // when / then
+            expect(campaignReport[getter]).to.equal(expected);
+          });
+        });
+      });
+    });
   });
 
-  describe('#isAssessment', function () {
-    it('should return true if the campaign is of type ASSESSMENT', function () {
-      // given
-      const campaignReport = domainBuilder.buildCampaignReport({ type: CampaignTypes.ASSESSMENT });
+  describe('#setTargetProfileInformation', function () {
+    it('should define target profile informations', function () {
+      const targetProfileForSpecifier = {
+        name: 'target profile',
+        description: 'description',
+        TubesCount: 2,
+        hasStage: false,
+        thematicResult: 3,
+      };
 
-      // when / then
-      expect(campaignReport.isAssessment).to.be.true;
-    });
+      const campaignReport = domainBuilder.buildCampaignReport();
 
-    it('should return false if the campaign is not of type ASSESSMENT', function () {
-      // given
-      const campaignReport = domainBuilder.buildCampaignReport({ type: CampaignTypes.PROFILES_COLLECTION });
+      campaignReport.setTargetProfileInformation(targetProfileForSpecifier);
 
-      // when / then
-      expect(campaignReport.isAssessment).to.be.false;
-    });
-  });
-
-  describe('#isProfilesCollection', function () {
-    it('should return true if the campaign is of type PROFILES_COLLECTION', function () {
-      // given
-      const campaignReport = domainBuilder.buildCampaignReport({ type: CampaignTypes.PROFILES_COLLECTION });
-
-      // when / then
-      expect(campaignReport.isProfilesCollection).to.be.true;
-    });
-
-    it('should return false if the campaign is not of type PROFILES_COLLECTION', function () {
-      // given
-      const campaignReport = domainBuilder.buildCampaignReport({ type: CampaignTypes.ASSESSMENT });
-
-      // when / then
-      expect(campaignReport.isProfilesCollection).to.be.false;
+      expect(campaignReport.targetProfileName).to.equal(targetProfileForSpecifier.name);
+      expect(campaignReport.targetProfileDescription).to.equal(targetProfileForSpecifier.description);
+      expect(campaignReport.targetProfileTubesCount).to.equal(targetProfileForSpecifier.tubeCount);
+      expect(campaignReport.targetProfileThematicResult).to.equal(targetProfileForSpecifier.thematicResultCount);
+      expect(campaignReport.targetProfileHasStage).to.equal(targetProfileForSpecifier.hasStage);
     });
   });
 

--- a/orga/app/components/campaign/activity/dashboard.gjs
+++ b/orga/app/components/campaign/activity/dashboard.gjs
@@ -1,7 +1,7 @@
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
-import { or } from 'ember-truth-helpers';
 import { tracked } from '@glimmer/tracking';
+import { or } from 'ember-truth-helpers';
 import sumBy from 'lodash/sumBy';
 
 import ParticipantsCount from '../cards/participants-count';

--- a/orga/app/components/campaign/activity/dashboard.gjs
+++ b/orga/app/components/campaign/activity/dashboard.gjs
@@ -1,5 +1,6 @@
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { or } from 'ember-truth-helpers';
 import { tracked } from '@glimmer/tracking';
 import sumBy from 'lodash/sumBy';
 
@@ -52,7 +53,7 @@ export default class Dashboard extends Component {
         <ParticipantsByStatus
           @loading={{this.participantsByStatusLoading}}
           @participantCountByStatus={{this.participantCountByStatus}}
-          @isTypeAssessment={{@campaign.isTypeAssessment}}
+          @shouldDisplayAssessmentLabels={{or @campaign.isTypeAssessment @campaign.isTypeExam}}
           class="activity-dashboard__participations-by-status"
         />
       </div>

--- a/orga/app/components/campaign/activity/dashboard.gjs
+++ b/orga/app/components/campaign/activity/dashboard.gjs
@@ -47,7 +47,7 @@ export default class Dashboard extends Component {
         <ParticipantsByDay
           @campaignId={{@campaign.id}}
           @totalParticipations={{@totalParticipations}}
-          @isTypeAssessment={{@campaign.isTypeAssessment}}
+          @shouldDisplayAssessmentLabels={{or @campaign.isTypeAssessment @campaign.isTypeExam}}
           class="activity-dashboard__participations-by-day"
         />
         <ParticipantsByStatus

--- a/orga/app/components/campaign/activity/dashboard.gjs
+++ b/orga/app/components/campaign/activity/dashboard.gjs
@@ -40,7 +40,7 @@ export default class Dashboard extends Component {
         <SharedCount
           @value={{this.shared}}
           @isLoading={{this.participantsByStatusLoading}}
-          @isTypeAssessment={{@campaign.isTypeAssessment}}
+          @shouldDisplayAssessmentLabels={{or @campaign.isTypeAssessment @campaign.isTypeExam}}
         />
       </div>
       <div class="activity-dashboard__row">

--- a/orga/app/components/campaign/activity/participants-list.gjs
+++ b/orga/app/components/campaign/activity/participants-list.gjs
@@ -3,6 +3,8 @@ import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { array, fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { or } from 'ember-truth-helpers';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
@@ -81,7 +83,7 @@ export default class ParticipantsList extends Component {
           <:cell>
             <LinkTo
               @route={{if
-                @campaign.isTypeAssessment
+                (or @campaign.isTypeAssessment @campaign.isTypeExam)
                 "authenticated.campaigns.participant-assessment"
                 "authenticated.campaigns.participant-profile"
               }}

--- a/orga/app/components/campaign/activity/participants-list.gjs
+++ b/orga/app/components/campaign/activity/participants-list.gjs
@@ -4,13 +4,13 @@ import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { array, fn } from '@ember/helper';
 import { on } from '@ember/modifier';
-import { or } from 'ember-truth-helpers';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
+import { or } from 'ember-truth-helpers';
 
 import ParticipationStatus from '../../ui/participation-status';
 import ParticipationFilters from '../filter/participation-filters';

--- a/orga/app/components/campaign/activity/participants-list.gjs
+++ b/orga/app/components/campaign/activity/participants-list.gjs
@@ -3,7 +3,6 @@ import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { array, fn } from '@ember/helper';
-import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';

--- a/orga/app/components/campaign/cards/shared-count.gjs
+++ b/orga/app/components/campaign/cards/shared-count.gjs
@@ -3,7 +3,7 @@ import { t } from 'ember-intl';
 
 <template>
   <PixIndicatorCard
-    @title={{if @isTypeAssessment (t "cards.submitted-count.title") (t "cards.submitted-count.title-profiles")}}
+    @title={{if @shouldDisplayAssessmentLabels (t "cards.submitted-count.title") (t "cards.submitted-count.title-profiles")}}
     @iconName="inboxIn"
     @color="green"
     @info={{t "cards.submitted-count.information"}}

--- a/orga/app/components/campaign/cards/shared-count.gjs
+++ b/orga/app/components/campaign/cards/shared-count.gjs
@@ -3,7 +3,11 @@ import { t } from 'ember-intl';
 
 <template>
   <PixIndicatorCard
-    @title={{if @shouldDisplayAssessmentLabels (t "cards.submitted-count.title") (t "cards.submitted-count.title-profiles")}}
+    @title={{if
+      @shouldDisplayAssessmentLabels
+      (t "cards.submitted-count.title")
+      (t "cards.submitted-count.title-profiles")
+    }}
     @iconName="inboxIn"
     @color="green"
     @info={{t "cards.submitted-count.information"}}

--- a/orga/app/components/campaign/charts/participants-by-day.gjs
+++ b/orga/app/components/campaign/charts/participants-by-day.gjs
@@ -57,7 +57,7 @@ export default class ParticipantsByDay extends Component {
   }
 
   get labels() {
-    return this.args.isTypeAssessment ? LABELS_ASSESSMENT : LABELS_PROFILE_COLLECTIONS;
+    return this.args.shouldDisplayAssessmentLabels ? LABELS_ASSESSMENT : LABELS_PROFILE_COLLECTIONS;
   }
 
   get data() {
@@ -138,7 +138,7 @@ export default class ParticipantsByDay extends Component {
     let startedCaption = '';
     let sharedCaption = '';
 
-    if (this.args.isTypeAssessment) {
+    if (this.args.shouldDisplayAssessmentLabels) {
       startedCaption = LABELS_ASSESSMENT.started.caption;
       startedLabel = LABELS_ASSESSMENT.started.a11y;
       sharedCaption = LABELS_ASSESSMENT.shared.caption;

--- a/orga/app/components/campaign/charts/participants-by-status.gjs
+++ b/orga/app/components/campaign/charts/participants-by-status.gjs
@@ -20,7 +20,7 @@ export default class ParticipantsByStatus extends Component {
 
   get datasets() {
     return this.args.participantCountByStatus.map(([key, count]) => {
-      const datasetLabels = this.getDatasetLabels(key, count, this.args.isTypeAssessment);
+      const datasetLabels = this.getDatasetLabels(key, count, this.args.shouldDisplayAssessmentLabels);
       return { key, count, ...datasetLabels };
     });
   }
@@ -64,8 +64,8 @@ export default class ParticipantsByStatus extends Component {
     };
   }
 
-  getDatasetLabels(key, count, isTypeAssessment) {
-    const datasetLabels = isTypeAssessment ? LABELS_ASSESSMENT[key] : LABELS_PROFILE_COLLECTIONS[key];
+  getDatasetLabels(key, count, shouldDisplayAssessmentLabels) {
+    const datasetLabels = shouldDisplayAssessmentLabels ? LABELS_ASSESSMENT[key] : LABELS_PROFILE_COLLECTIONS[key];
     const percentage = this.total !== 0 ? count / this.total : 0;
     const canvas = pattern.draw(datasetLabels.shape, datasetLabels.color);
 

--- a/orga/app/components/campaign/filter/participation-filters.gjs
+++ b/orga/app/components/campaign/filter/participation-filters.gjs
@@ -125,9 +125,9 @@ export default class ParticipationFilters extends Component {
   get statusOptions() {
     const { isTypeAssessment, isTypeExam, type } = this.args.campaign;
 
-    const statuses = (isTypeAssessment || isTypeExam) ? ['STARTED', 'TO_SHARE', 'SHARED'] : ['TO_SHARE', 'SHARED'];
+    const statuses = isTypeAssessment || isTypeExam ? ['STARTED', 'TO_SHARE', 'SHARED'] : ['TO_SHARE', 'SHARED'];
 
-    let finalType = type === 'EXAM' ? 'ASSESSMENT': type;
+    const finalType = type === 'EXAM' ? 'ASSESSMENT' : type;
     return statuses.map((status) => {
       const label = this.intl.t(`components.participation-status.${status}-${finalType}`);
       return { value: status, label };

--- a/orga/app/components/campaign/filter/participation-filters.gjs
+++ b/orga/app/components/campaign/filter/participation-filters.gjs
@@ -76,20 +76,20 @@ export default class ParticipationFilters extends Component {
   }
 
   get displayCertificabilityFilter() {
-    const { isTypeAssessment } = this.args.campaign;
-    return !isTypeAssessment && !this.args.isHiddenCertificability;
+    const { isTypeAssessment, isTypeExam } = this.args.campaign;
+    return !isTypeAssessment && !isTypeExam && !this.args.isHiddenCertificability;
   }
 
   get displayStagesFilter() {
     if (this.isStagesLoading) return false;
-    const { isTypeAssessment, hasStages } = this.args.campaign;
-    return !this.args.isHiddenStages && isTypeAssessment && hasStages;
+    const { isTypeAssessment, isTypeExam, hasStages } = this.args.campaign;
+    return !this.args.isHiddenStages && (isTypeAssessment || isTypeExam) && hasStages;
   }
 
   get displayBadgesFilter() {
     if (this.isBadgesLoading) return false;
-    const { isTypeAssessment, hasBadges } = this.args.campaign;
-    return !this.args.isHiddenBadges && isTypeAssessment && hasBadges;
+    const { isTypeAssessment, isTypeExam, hasBadges } = this.args.campaign;
+    return !this.args.isHiddenBadges && (isTypeAssessment || isTypeExam) && hasBadges;
   }
 
   get displayDivisionFilter() {
@@ -123,12 +123,13 @@ export default class ParticipationFilters extends Component {
   }
 
   get statusOptions() {
-    const { isTypeAssessment, type } = this.args.campaign;
+    const { isTypeAssessment, isTypeExam, type } = this.args.campaign;
 
-    const statuses = isTypeAssessment ? ['STARTED', 'TO_SHARE', 'SHARED'] : ['TO_SHARE', 'SHARED'];
+    const statuses = (isTypeAssessment || isTypeExam) ? ['STARTED', 'TO_SHARE', 'SHARED'] : ['TO_SHARE', 'SHARED'];
 
+    let finalType = type === 'EXAM' ? 'ASSESSMENT': type;
     return statuses.map((status) => {
-      const label = this.intl.t(`components.participation-status.${status}-${type}`);
+      const label = this.intl.t(`components.participation-status.${status}-${finalType}`);
       return { value: status, label };
     });
   }

--- a/orga/app/components/campaign/header/tabs.gjs
+++ b/orga/app/components/campaign/header/tabs.gjs
@@ -1,5 +1,6 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import { action } from '@ember/object';
+import { or } from 'ember-truth-helpers';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -37,7 +38,7 @@ export default class CampaignTabs extends Component {
 
         <LinkTo
           @route={{if
-            @campaign.isTypeAssessment
+            (or @campaign.isTypeAssessment @campaign.isTypeExam)
             "authenticated.campaigns.campaign.assessment-results"
             "authenticated.campaigns.campaign.profile-results"
           }}
@@ -47,7 +48,7 @@ export default class CampaignTabs extends Component {
           {{t "pages.campaign.tab.results" count=@campaign.sharedParticipationsCount}}
         </LinkTo>
 
-        {{#if @campaign.isTypeAssessment}}
+        {{#if (or @campaign.isTypeAssessment @campaign.isTypeExam)}}
           <LinkTo @route="authenticated.campaigns.campaign.analysis" class="navbar-item" @model={{@campaign}}>
             {{t "pages.campaign.tab.review"}}
           </LinkTo>

--- a/orga/app/components/campaign/header/tabs.gjs
+++ b/orga/app/components/campaign/header/tabs.gjs
@@ -1,10 +1,10 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import { action } from '@ember/object';
-import { or } from 'ember-truth-helpers';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
+import { or } from 'ember-truth-helpers';
 
 export default class CampaignTabs extends Component {
   @service intl;

--- a/orga/app/components/campaign/header/title.gjs
+++ b/orga/app/components/campaign/header/title.gjs
@@ -31,7 +31,10 @@ export default class Header extends Component {
   }
 
   get isMultipleSendingsForAssessmentEnabled() {
-    return (this.args.campaign.isTypeAssessment || this.args.campaign.isTypeExam) && this.currentUser.prescriber.enableMultipleSendingAssessment;
+    return (
+      (this.args.campaign.isTypeAssessment || this.args.campaign.isTypeExam) &&
+      this.currentUser.prescriber.enableMultipleSendingAssessment
+    );
   }
 
   get multipleSendingText() {

--- a/orga/app/components/campaign/header/title.gjs
+++ b/orga/app/components/campaign/header/title.gjs
@@ -31,7 +31,7 @@ export default class Header extends Component {
   }
 
   get isMultipleSendingsForAssessmentEnabled() {
-    return this.args.campaign.isTypeAssessment && this.currentUser.prescriber.enableMultipleSendingAssessment;
+    return (this.args.campaign.isTypeAssessment || this.args.campaign.isTypeExam) && this.currentUser.prescriber.enableMultipleSendingAssessment;
   }
 
   get multipleSendingText() {

--- a/orga/app/components/campaign/results/assessment-cards.gjs
+++ b/orga/app/components/campaign/results/assessment-cards.gjs
@@ -15,9 +15,6 @@ import CampaignStageAverage from '../cards/stage-average';
       <CampaignResultAverage @value={{@averageResult}} class="assessment-cards__average-card" />
     {{/if}}
 
-    <CampaignSharedCount
-      @value={{@sharedParticipationsCount}}
-      @shouldDisplayAssessmentLabels={{true}}
-    />
+    <CampaignSharedCount @value={{@sharedParticipationsCount}} @shouldDisplayAssessmentLabels={{true}} />
   </div>
 </template>

--- a/orga/app/components/campaign/results/assessment-cards.gjs
+++ b/orga/app/components/campaign/results/assessment-cards.gjs
@@ -15,6 +15,9 @@ import CampaignStageAverage from '../cards/stage-average';
       <CampaignResultAverage @value={{@averageResult}} class="assessment-cards__average-card" />
     {{/if}}
 
-    <CampaignSharedCount @value={{@sharedParticipationsCount}} @isTypeAssessment={{true}} />
+    <CampaignSharedCount
+      @value={{@sharedParticipationsCount}}
+      @shouldDisplayAssessmentLabels={{true}}
+    />
   </div>
 </template>

--- a/orga/app/components/campaign/settings/view.gjs
+++ b/orga/app/components/campaign/settings/view.gjs
@@ -3,11 +3,11 @@ import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { fn } from '@ember/helper';
-import { or } from 'ember-truth-helpers';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
+import { or } from 'ember-truth-helpers';
 
 import { ID_PIX_TYPES } from '../../../helpers/id-pix-types';
 import CopyPasteButton from '../../copy-paste-button';
@@ -64,7 +64,10 @@ export default class CampaignView extends Component {
   }
 
   get isMultipleSendingsForAssessmentEnabled() {
-    return (this.args.campaign.isTypeAssessment || this.args.campaign.isTypeExam) && this.currentUser.prescriber.enableMultipleSendingAssessment;
+    return (
+      (this.args.campaign.isTypeAssessment || this.args.campaign.isTypeExam) &&
+      this.currentUser.prescriber.enableMultipleSendingAssessment
+    );
   }
 
   get displayResetToZero() {

--- a/orga/app/components/campaign/settings/view.gjs
+++ b/orga/app/components/campaign/settings/view.gjs
@@ -3,6 +3,7 @@ import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { fn } from '@ember/helper';
+import { or } from 'ember-truth-helpers';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -59,11 +60,11 @@ export default class CampaignView extends Component {
   }
 
   get isMultipleSendingsEnable() {
-    return !this.args.campaign.isTypeAssessment || this.isMultipleSendingsForAssessmentEnabled;
+    return this.args.campaign.isProfilesCollection || this.isMultipleSendingsForAssessmentEnabled;
   }
 
   get isMultipleSendingsForAssessmentEnabled() {
-    return this.args.campaign.isTypeAssessment && this.currentUser.prescriber.enableMultipleSendingAssessment;
+    return (this.args.campaign.isTypeAssessment || this.args.campaign.isTypeExam) && this.currentUser.prescriber.enableMultipleSendingAssessment;
   }
 
   get displayResetToZero() {
@@ -153,7 +154,7 @@ export default class CampaignView extends Component {
           {{/if}}
         </div>
         <div class="campaign-settings-row">
-          {{#if @campaign.isTypeAssessment}}
+          {{#if (or @campaign.isTypeAssessment @campaign.isTypeExam)}}
             <div class="campaign-settings-content">
               <dt class="label-text campaign-settings-content__label">
                 {{t "pages.campaign-settings.target-profile.title"}}
@@ -195,7 +196,7 @@ export default class CampaignView extends Component {
             </div>
           {{/if}}
         </div>
-        {{#if @campaign.isTypeAssessment}}
+        {{#if (or @campaign.isTypeAssessment @campaign.isTypeExam)}}
           <div class="campaign-settings-row">
             <div class="campaign-settings-content campaign-settings-content--single">
               <dt class="label-text campaign-settings-content__label">{{t

--- a/orga/app/components/campaign/update-form.gjs
+++ b/orga/app/components/campaign/update-form.gjs
@@ -4,6 +4,7 @@ import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
 import { fn } from '@ember/helper';
+import { or } from 'ember-truth-helpers';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
@@ -140,7 +141,7 @@ export default class UpdateForm extends Component {
         </div>
       </div>
 
-      {{#if @campaign.isTypeAssessment}}
+      {{#if (or @campaign.isTypeAssessment @campaign.isTypeExam)}}
         <div class="form__field">
           <PixInput
             @id="campaign-title"

--- a/orga/app/components/campaign/update-form.gjs
+++ b/orga/app/components/campaign/update-form.gjs
@@ -4,13 +4,13 @@ import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
 import { fn } from '@ember/helper';
-import { or } from 'ember-truth-helpers';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
+import { or } from 'ember-truth-helpers';
 
 import displayCampaignErrors from '../../helpers/display-campaign-errors';
 

--- a/orga/app/components/ui/participation-status.gjs
+++ b/orga/app/components/ui/participation-status.gjs
@@ -12,7 +12,7 @@ export default class ParticipationStatus extends Component {
 
   get label() {
     const { status, campaignType } = this.args;
-    return this.intl.t(`components.participation-status.${status}-${campaignType}`);
+    return this.intl.t(`components.participation-status.${status}-${campaignType === 'EXAM' ? 'ASSESSMENT' : campaignType}`);
   }
 
   <template>

--- a/orga/app/components/ui/participation-status.gjs
+++ b/orga/app/components/ui/participation-status.gjs
@@ -12,7 +12,9 @@ export default class ParticipationStatus extends Component {
 
   get label() {
     const { status, campaignType } = this.args;
-    return this.intl.t(`components.participation-status.${status}-${campaignType === 'EXAM' ? 'ASSESSMENT' : campaignType}`);
+    return this.intl.t(
+      `components.participation-status.${status}-${campaignType === 'EXAM' ? 'ASSESSMENT' : campaignType}`,
+    );
   }
 
   <template>

--- a/orga/app/controllers/authenticated/campaigns/campaign/activity.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/activity.js
@@ -24,9 +24,10 @@ export default class ActivityController extends Controller {
 
   @action
   goToParticipantPage(participant) {
-    const route = this.model.campaign.isTypeAssessment || this.model.campaign.isTypeExam
-      ? 'authenticated.campaigns.participant-assessment'
-      : 'authenticated.campaigns.participant-profile';
+    const route =
+      this.model.campaign.isTypeAssessment || this.model.campaign.isTypeExam
+        ? 'authenticated.campaigns.participant-assessment'
+        : 'authenticated.campaigns.participant-profile';
 
     this.router.transitionTo(route, this.model.campaign.id, participant.lastCampaignParticipationId);
   }

--- a/orga/app/controllers/authenticated/campaigns/campaign/activity.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/activity.js
@@ -24,7 +24,7 @@ export default class ActivityController extends Controller {
 
   @action
   goToParticipantPage(participant) {
-    const route = this.model.campaign.isTypeAssessment
+    const route = this.model.campaign.isTypeAssessment || this.model.campaign.isTypeExam
       ? 'authenticated.campaigns.participant-assessment'
       : 'authenticated.campaigns.participant-profile';
 

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -70,7 +70,7 @@ export default class Campaign extends Model {
   }
 
   get urlToResult() {
-    if (this.isTypeAssessment) {
+    if (this.isTypeAssessment || this.isTypeExam) {
       return `${ENV.APP.API_HOST}/api/campaigns/${this.id}/csv-assessment-results`;
     }
     return `${ENV.APP.API_HOST}/api/campaigns/${this.id}/csv-profiles-collection-results`;

--- a/orga/tests/integration/components/campaign/cards/shared-count-test.js
+++ b/orga/tests/integration/components/campaign/cards/shared-count-test.js
@@ -8,12 +8,12 @@ import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 module('Integration | Component | Campaign::Cards::SharedCount', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  module('When campaign is type assessment', () => {
+  module('When shouldDisplayAssessmentLabels is true', () => {
     test('it should display shared participations count card', async function (assert) {
       this.sharedCount = 10;
 
       const screen = await render(
-        hbs`<Campaign::Cards::SharedCount @value={{this.sharedCount}} @isTypeAssessment={{true}} />`,
+        hbs`<Campaign::Cards::SharedCount @value={{this.sharedCount}} @shouldDisplayAssessmentLabels={{true}} />`,
       );
 
       assert.dom(screen.getByText(t('cards.submitted-count.title'))).exists();
@@ -21,12 +21,12 @@ module('Integration | Component | Campaign::Cards::SharedCount', function (hooks
     });
   });
 
-  module('When campaign is type profile collection', () => {
+  module('When shouldDisplayAssessmentLabels is false', () => {
     test('it should display shared profiles count card', async function (assert) {
       this.sharedCount = 10;
 
       const screen = await render(
-        hbs`<Campaign::Cards::SharedCount @value={{this.sharedCount}} @isTypeAssessment={{false}} />`,
+        hbs`<Campaign::Cards::SharedCount @value={{this.sharedCount}} @shouldDisplayAssessmentLabels={{false}} />`,
       );
 
       assert.dom(screen.getByText(t('cards.submitted-count.title-profiles'))).exists();

--- a/orga/tests/integration/components/campaign/charts/participants-by-day-test.js
+++ b/orga/tests/integration/components/campaign/charts/participants-by-day-test.js
@@ -33,7 +33,7 @@ module('Integration | Component | Campaign::Charts::ParticipantsByDay', function
 
     // when
     const screen = await render(
-      hbs`<Campaign::Charts::ParticipantsByDay @campaignId={{this.campaignId}} @isTypeAssessment={{true}} />`,
+      hbs`<Campaign::Charts::ParticipantsByDay @campaignId={{this.campaignId}} @shouldDisplayAssessmentLabels={{true}} />`,
     );
 
     assert.strictEqual(screen.getAllByText('Date').length, 2);
@@ -54,7 +54,7 @@ module('Integration | Component | Campaign::Charts::ParticipantsByDay', function
 
     // when
     const screen = await render(
-      hbs`<Campaign::Charts::ParticipantsByDay @campaignId={{this.campaignId}} @isTypeAssessment={{false}} />`,
+      hbs`<Campaign::Charts::ParticipantsByDay @campaignId={{this.campaignId}} @shouldDisplayAssessmentLabels={{false}} />`,
     );
 
     assert.strictEqual(screen.getAllByText('Date').length, 2);
@@ -75,7 +75,7 @@ module('Integration | Component | Campaign::Charts::ParticipantsByDay', function
 
     // when
     const screen = await render(
-      hbs`<Campaign::Charts::ParticipantsByDay @campaignId={{this.campaignId}} @isTypeAssessment={{true}} />`,
+      hbs`<Campaign::Charts::ParticipantsByDay @campaignId={{this.campaignId}} @shouldDisplayAssessmentLabels={{true}} />`,
     );
 
     const { startedTable, sharedTable } = getTables(screen);
@@ -97,7 +97,7 @@ module('Integration | Component | Campaign::Charts::ParticipantsByDay', function
 
     // when
     const screen = await render(
-      hbs`<Campaign::Charts::ParticipantsByDay @campaignId={{this.campaignId}} @isTypeAssessment={{true}} />`,
+      hbs`<Campaign::Charts::ParticipantsByDay @campaignId={{this.campaignId}} @shouldDisplayAssessmentLabels={{true}} />`,
     );
 
     const { sharedTable } = getTables(screen);
@@ -123,7 +123,7 @@ module('Integration | Component | Campaign::Charts::ParticipantsByDay', function
 
       // when
       const screen = await render(
-        hbs`<Campaign::Charts::ParticipantsByDay @campaignId={{this.campaignId}} @isTypeAssessment={{true}} />`,
+        hbs`<Campaign::Charts::ParticipantsByDay @campaignId={{this.campaignId}} @shouldDisplayAssessmentLabels={{true}} />`,
       );
 
       const { sharedTable } = getTables(screen);
@@ -150,7 +150,7 @@ module('Integration | Component | Campaign::Charts::ParticipantsByDay', function
 
       // when
       const screen = await render(
-        hbs`<Campaign::Charts::ParticipantsByDay @campaignId={{this.campaignId}} @isTypeAssessment={{true}} />`,
+        hbs`<Campaign::Charts::ParticipantsByDay @campaignId={{this.campaignId}} @shouldDisplayAssessmentLabels={{true}} />`,
       );
 
       const { startedTable } = getTables(screen);

--- a/orga/tests/integration/components/campaign/charts/participants-by-status-test.js
+++ b/orga/tests/integration/components/campaign/charts/participants-by-status-test.js
@@ -18,7 +18,7 @@ module('Integration | Component | Campaign::Charts::ParticipantsByStatus', funct
     const screen = await render(
       hbs`<Campaign::Charts::ParticipantsByStatus
   @participantCountByStatus={{this.participantCountByStatus}}
-  @isTypeAssessment={{true}}
+  @shouldDisplayAssessmentLabels={{true}}
 />`,
     );
     assert
@@ -40,7 +40,7 @@ module('Integration | Component | Campaign::Charts::ParticipantsByStatus', funct
     const screen = await render(
       hbs`<Campaign::Charts::ParticipantsByStatus
   @participantCountByStatus={{this.participantCountByStatus}}
-  @isTypeAssessment={{true}}
+  @shouldDisplayAssessmentLabels={{true}}
 />`,
     );
 
@@ -60,7 +60,7 @@ module('Integration | Component | Campaign::Charts::ParticipantsByStatus', funct
     const screen = await render(
       hbs`<Campaign::Charts::ParticipantsByStatus
   @participantCountByStatus={{this.participantCountByStatus}}
-  @isTypeAssessment={{false}}
+  @shouldDisplayAssessmentLabels={{false}}
 />`,
     );
 
@@ -84,7 +84,7 @@ module('Integration | Component | Campaign::Charts::ParticipantsByStatus', funct
     const screen = await render(
       hbs`<Campaign::Charts::ParticipantsByStatus
   @participantCountByStatus={{this.participantCountByStatus}}
-  @isTypeAssessment={{false}}
+  @shouldDisplayAssessmentLabels={{false}}
 />`,
     );
 

--- a/orga/tests/integration/components/campaign/filter/participation-filters-test.gjs
+++ b/orga/tests/integration/components/campaign/filter/participation-filters-test.gjs
@@ -176,21 +176,21 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
 
           //when
           const screen = await render(
-          <template>
-            <ParticipationFilters
-              @campaign={{campaign}}
-              @onResetFilter={{resetFiltering}}
-              @searchFilter={{searchFilter}}
-              @searchBadges={{searchBadges}}
-              @searchStages={{searchStages}}
-              @selectedStages={{selectedStages}}
-              @selectedUnacquiredBadges={{selectedUnacquiredBadges}}
-              @selectedBadges={{selectedBadges}}
-              @isHiddenGroups={{true}}
-              @isHiddenDivisions={{true}}
-              @onFilter={{noop}}
-            />
-          </template>,
+            <template>
+              <ParticipationFilters
+                @campaign={{campaign}}
+                @onResetFilter={{resetFiltering}}
+                @searchFilter={{searchFilter}}
+                @searchBadges={{searchBadges}}
+                @searchStages={{searchStages}}
+                @selectedStages={{selectedStages}}
+                @selectedUnacquiredBadges={{selectedUnacquiredBadges}}
+                @selectedBadges={{selectedBadges}}
+                @isHiddenGroups={{true}}
+                @isHiddenDivisions={{true}}
+                @onFilter={{noop}}
+              />
+            </template>,
           );
 
           //then
@@ -394,17 +394,17 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
 
         // when
         const screen = await render(
-        <template>
-          <ParticipationFilters
-            @campaign={{campaign}}
-            @onFilter={{noop}}
-            @isHiddenStages={{false}}
-            @isHiddenBadges={{true}}
-            @isHiddenDivisions={{true}}
-            @isHiddenGroups={{true}}
-            @selectedStages={{selectedStages}}
-          />
-        </template>,
+          <template>
+            <ParticipationFilters
+              @campaign={{campaign}}
+              @onFilter={{noop}}
+              @isHiddenStages={{false}}
+              @isHiddenBadges={{true}}
+              @isHiddenDivisions={{true}}
+              @isHiddenGroups={{true}}
+              @selectedStages={{selectedStages}}
+            />
+          </template>,
         );
 
         // then
@@ -422,16 +422,16 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
 
         // when
         const screen = await render(
-        <template>
-          <ParticipationFilters
-            @campaign={{campaign}}
-            @onFilter={{noop}}
-            @isHiddenStages={{true}}
-            @isHiddenBadges={{true}}
-            @isHiddenDivisions={{true}}
-            @isHiddenGroups={{true}}
-          />
-        </template>,
+          <template>
+            <ParticipationFilters
+              @campaign={{campaign}}
+              @onFilter={{noop}}
+              @isHiddenStages={{true}}
+              @isHiddenBadges={{true}}
+              @isHiddenDivisions={{true}}
+              @isHiddenGroups={{true}}
+            />
+          </template>,
         );
 
         // then
@@ -453,17 +453,17 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
 
         // when
         const screen = await render(
-        <template>
-          <ParticipationFilters
-            @campaign={{campaign}}
-            @onFilter={{triggerFiltering}}
-            @isHiddenStages={{false}}
-            @isHiddenBadges={{true}}
-            @isHiddenDivisions={{true}}
-            @isHiddenGroups={{true}}
-            @selectedStages={{selectedStages}}
-          />
-        </template>,
+          <template>
+            <ParticipationFilters
+              @campaign={{campaign}}
+              @onFilter={{triggerFiltering}}
+              @isHiddenStages={{false}}
+              @isHiddenBadges={{true}}
+              @isHiddenDivisions={{true}}
+              @isHiddenGroups={{true}}
+              @selectedStages={{selectedStages}}
+            />
+          </template>,
         );
 
         await click(screen.getByLabelText(t('pages.campaign-results.filters.type.stages')));
@@ -651,18 +651,18 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
 
         // when
         const screen = await render(
-        <template>
-          <ParticipationFilters
-            @campaign={{campaign}}
-            @onFilter={{noop}}
-            @isHiddenStages={{true}}
-            @isHiddenBadges={{false}}
-            @isHiddenDivisions={{true}}
-            @isHiddenGroups={{true}}
-            @selectedBadges={{selectedBadges}}
-            @selectedUnacquiredBadges={{selectedUnacquiredBadges}}
-          />
-        </template>,
+          <template>
+            <ParticipationFilters
+              @campaign={{campaign}}
+              @onFilter={{noop}}
+              @isHiddenStages={{true}}
+              @isHiddenBadges={{false}}
+              @isHiddenDivisions={{true}}
+              @isHiddenGroups={{true}}
+              @selectedBadges={{selectedBadges}}
+              @selectedUnacquiredBadges={{selectedUnacquiredBadges}}
+            />
+          </template>,
         );
 
         // then
@@ -682,17 +682,17 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
 
         // when
         const screen = await render(
-        <template>
-          <ParticipationFilters
-            @campaign={{campaign}}
-            @onFilter={{noop}}
-            @isHiddenStages={{true}}
-            @isHiddenBadges={{true}}
-            @isHiddenDivisions={{true}}
-            @isHiddenGroups={{true}}
-            @selectedBadges={{selectedBadges}}
-          />
-        </template>,
+          <template>
+            <ParticipationFilters
+              @campaign={{campaign}}
+              @onFilter={{noop}}
+              @isHiddenStages={{true}}
+              @isHiddenBadges={{true}}
+              @isHiddenDivisions={{true}}
+              @isHiddenGroups={{true}}
+              @selectedBadges={{selectedBadges}}
+            />
+          </template>,
         );
 
         // then
@@ -718,18 +718,18 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
 
         // when
         const screen = await render(
-        <template>
-          <ParticipationFilters
-            @campaign={{campaign}}
-            @onFilter={{triggerFiltering}}
-            @isHiddenStages={{true}}
-            @isHiddenBadges={{false}}
-            @isHiddenDivisions={{true}}
-            @isHiddenGroups={{true}}
-            @selectedBadges={{selectedBadges}}
-            @selectedUnacquiredBadges={{selectedUnacquiredBadges}}
-          />
-        </template>,
+          <template>
+            <ParticipationFilters
+              @campaign={{campaign}}
+              @onFilter={{triggerFiltering}}
+              @isHiddenStages={{true}}
+              @isHiddenBadges={{false}}
+              @isHiddenDivisions={{true}}
+              @isHiddenGroups={{true}}
+              @selectedBadges={{selectedBadges}}
+              @selectedUnacquiredBadges={{selectedUnacquiredBadges}}
+            />
+          </template>,
         );
         const button = await screen.findByRole('button', {
           name: t('pages.campaign-results.filters.type.unacquired-badges'),
@@ -767,18 +767,18 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
 
         // when
         const screen = await render(
-        <template>
-          <ParticipationFilters
-            @campaign={{campaign}}
-            @onFilter={{triggerFiltering}}
-            @isHiddenStages={{true}}
-            @isHiddenBadges={{false}}
-            @isHiddenDivisions={{true}}
-            @isHiddenGroups={{true}}
-            @selectedBadges={{selectedBadges}}
-            @selectedUnacquiredBadges={{selectedUnacquiredBadges}}
-          />
-        </template>,
+          <template>
+            <ParticipationFilters
+              @campaign={{campaign}}
+              @onFilter={{triggerFiltering}}
+              @isHiddenStages={{true}}
+              @isHiddenBadges={{false}}
+              @isHiddenDivisions={{true}}
+              @isHiddenGroups={{true}}
+              @selectedBadges={{selectedBadges}}
+              @selectedUnacquiredBadges={{selectedUnacquiredBadges}}
+            />
+          </template>,
         );
 
         await click(screen.getByLabelText(t('pages.campaign-results.filters.type.badges')));
@@ -905,7 +905,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
 
       // when
       const screen = await render(
-      <template><ParticipationFilters @campaign={{campaign}} @onFilter={{noop}} /></template>,
+        <template><ParticipationFilters @campaign={{campaign}} @onFilter={{noop}} /></template>,
       );
 
       // then
@@ -1089,18 +1089,18 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
       });
 
       const screen = await render(
-      <template>
-        <ParticipationFilters
-          @campaign={{campaign}}
-          @isHiddenSearch={{true}}
-          @isHiddenStatus={{true}}
-          @isHiddenBadges={{true}}
-          @isHiddenDivisions={{true}}
-          @isHiddenGroups={{true}}
-          @onResetFilter={{noop}}
-          @onFilter={{noop}}
-        />
-      </template>,
+        <template>
+          <ParticipationFilters
+            @campaign={{campaign}}
+            @isHiddenSearch={{true}}
+            @isHiddenStatus={{true}}
+            @isHiddenBadges={{true}}
+            @isHiddenDivisions={{true}}
+            @isHiddenGroups={{true}}
+            @onResetFilter={{noop}}
+            @onFilter={{noop}}
+          />
+        </template>,
       );
 
       // then

--- a/orga/tests/integration/components/campaign/filter/participation-filters-test.gjs
+++ b/orga/tests/integration/components/campaign/filter/participation-filters-test.gjs
@@ -8,7 +8,7 @@ import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
-module.only('Integration | Component | Campaign::Filter::ParticipationFilters', function (hooks) {
+module('Integration | Component | Campaign::Filter::ParticipationFilters', function (hooks) {
   setupIntlRenderingTest(hooks);
   let store;
   const campaignId = '1';

--- a/orga/tests/integration/components/campaign/header/title-test.js
+++ b/orga/tests/integration/components/campaign/header/title-test.js
@@ -131,7 +131,7 @@ module('Integration | Component | Campaign::Header::Title', function (hooks) {
           test("it should display 'oui'", async function (assert) {
             // given
             this.campaign = store.createRecord('campaign', {
-              type: 'PROFILES_COLLECTION',
+              type: 'ASSESSMENT',
               multipleSendings: true,
             });
 
@@ -147,7 +147,84 @@ module('Integration | Component | Campaign::Header::Title', function (hooks) {
           test("it should display 'non'", async function (assert) {
             // given
             this.campaign = store.createRecord('campaign', {
-              type: 'PROFILES_COLLECTION',
+              type: 'ASSESSMENT',
+              multipleSendings: false,
+            });
+
+            // when
+            const screen = await render(hbs`<Campaign::Header::Title @campaign={{this.campaign}} />`);
+
+            // then
+            assert.ok(screen.getByText(t('pages.campaign.multiple-sendings.status.disabled')));
+          });
+        });
+      });
+    });
+
+    module('when type is EXAM', function () {
+      module('when organization feature enableMultipleSending is false', function () {
+        test('it should not display multiple sendings label', async function (assert) {
+          // given
+          const currentUser = this.owner.lookup('service:currentUser');
+          currentUser.prescriber = {
+            enableMultipleSendingAssessment: false,
+          };
+          this.campaign = store.createRecord('campaign', {
+            type: 'EXAM',
+          });
+
+          // when
+          const screen = await render(hbs`<Campaign::Header::Title @campaign={{this.campaign}} />`);
+
+          // then
+          assert.notOk(screen.queryByText(t('pages.campaign.multiple-sendings.title')));
+        });
+      });
+
+      module('when organization feature enableMultipleSending is true', function (hooks) {
+        hooks.beforeEach(function () {
+          const currentUser = this.owner.lookup('service:currentUser');
+          currentUser.prescriber = {
+            enableMultipleSendingAssessment: true,
+          };
+        });
+
+        test('it should display multiple sendings label', async function (assert) {
+          // given
+          const currentUser = this.owner.lookup('service:currentUser');
+          currentUser.prescriber = {
+            enableMultipleSendingAssessment: true,
+          };
+          this.campaign = store.createRecord('campaign', {
+            type: 'EXAM',
+          });
+          // when
+          const screen = await render(hbs`<Campaign::Header::Title @campaign={{this.campaign}} />`);
+          // then
+          assert.ok(screen.getByText(t('pages.campaign.multiple-sendings.title')));
+        });
+
+        module('when the campaign multiple sending is true', function () {
+          test("it should display 'oui'", async function (assert) {
+            // given
+            this.campaign = store.createRecord('campaign', {
+              type: 'EXAM',
+              multipleSendings: true,
+            });
+
+            // when
+            const screen = await render(hbs`<Campaign::Header::Title @campaign={{this.campaign}} />`);
+
+            // then
+            assert.ok(screen.getByText(t('pages.campaign.multiple-sendings.status.enabled')));
+          });
+        });
+
+        module('when the campaign multiple sending is false', function () {
+          test("it should display 'non'", async function (assert) {
+            // given
+            this.campaign = store.createRecord('campaign', {
+              type: 'EXAM',
               multipleSendings: false,
             });
 

--- a/orga/tests/integration/components/campaign/settings/view-test.js
+++ b/orga/tests/integration/components/campaign/settings/view-test.js
@@ -196,6 +196,132 @@ module('Integration | Component | Campaign::Settings::View', function (hooks) {
       });
     });
 
+    module('when type is EXAM', function () {
+      test('it should display target profile related to campaign', async function (assert) {
+        // given
+        this.campaign = store.createRecord('campaign', {
+          type: 'EXAM',
+          targetProfileName: 'profil cible de la campagne 1',
+        });
+
+        // when
+        const screen = await render(hbs`<Campaign::Settings::View @campaign={{this.campaign}} />`);
+
+        // then
+        assert.dom(screen.getByText('profil cible de la campagne 1')).exists();
+      });
+
+      test('it should display target profile description related to campaign', async function (assert) {
+        // given
+        this.campaign = store.createRecord('campaign', {
+          type: 'EXAM',
+          targetProfileDescription: 'Description du profile cible',
+        });
+
+        // when
+        const screen = await render(hbs`<Campaign::Settings::View @campaign={{this.campaign}} />`);
+
+        // then
+        assert.dom(screen.getByText('Description du profile cible')).exists();
+      });
+
+      test('it should display target profile tubes count related to campaign', async function (assert) {
+        // given
+        this.campaign = store.createRecord('campaign', {
+          type: 'EXAM',
+          targetProfileTubesCount: 3,
+        });
+
+        // when
+        const screen = await render(hbs`<Campaign::Settings::View @campaign={{this.campaign}} />`);
+
+        // then
+        assert
+          .dom(
+            screen.getByText(
+              t('common.target-profile-details.subjects', { value: this.campaign.targetProfileTubesCount }),
+            ),
+          )
+          .exists();
+      });
+
+      module('Badge context', function () {
+        test('it should not display target profile thematic result when empty related to campaign', async function (assert) {
+          // given
+          this.campaign = store.createRecord('campaign', {
+            type: 'EXAM',
+            targetProfileThematicResultCount: 0,
+          });
+
+          // when
+          const screen = await render(hbs`<Campaign::Settings::View @campaign={{this.campaign}} />`);
+
+          // then
+          assert
+            .dom(
+              screen.queryByText(
+                t('common.target-profile-details.thematic-results', {
+                  value: this.campaign.targetProfileThematicResultCount,
+                }),
+              ),
+            )
+            .doesNotExist();
+        });
+
+        test('it should display target profile thematic result related to campaign', async function (assert) {
+          // given
+          this.campaign = store.createRecord('campaign', {
+            type: 'EXAM',
+            targetProfileThematicResultCount: 1,
+          });
+
+          // when
+          const screen = await render(hbs`<Campaign::Settings::View @campaign={{this.campaign}} />`);
+
+          // then
+          assert
+            .dom(
+              screen.getByText(
+                t('common.target-profile-details.thematic-results', {
+                  value: this.campaign.targetProfileThematicResultCount,
+                }),
+              ),
+            )
+            .exists();
+        });
+      });
+
+      module('Display Result', function () {
+        test('it should display target profile result with stars when stages related to campaign', async function (assert) {
+          // given
+          this.campaign = store.createRecord('campaign', {
+            type: 'EXAM',
+            targetProfileHasStage: true,
+          });
+
+          // when
+          const screen = await render(hbs`<Campaign::Settings::View @campaign={{this.campaign}} />`);
+
+          // then
+          assert.dom(screen.getByLabelText(t('common.target-profile-details.results.star'))).exists();
+        });
+
+        test('it should display target profile result with percentage when no stages related to campaign', async function (assert) {
+          // given
+          this.campaign = store.createRecord('campaign', {
+            type: 'EXAM',
+            targetProfileHasStage: false,
+          });
+
+          // when
+          const screen = await render(hbs`<Campaign::Settings::View @campaign={{this.campaign}} />`);
+
+          // then
+          assert.dom(screen.getByLabelText(t('common.target-profile-details.results.percent'))).exists();
+        });
+      });
+    });
+
     module('when type is PROFILES_COLLECTION', function () {
       test('it should not display target profile', async function (assert) {
         this.campaign = store.createRecord('campaign', {
@@ -304,6 +430,22 @@ module('Integration | Component | Campaign::Settings::View', function (hooks) {
         // given
         this.campaign = store.createRecord('campaign', {
           type: 'ASSESSMENT',
+          title: 'Mon titre de Campagne',
+        });
+
+        // when
+        const screen = await render(hbs`<Campaign::Settings::View @campaign={{this.campaign}} />`);
+
+        // then
+        assert.dom(screen.getByText('Mon titre de Campagne')).exists();
+      });
+    });
+
+    module('when type is EXAM', function () {
+      test('it should display the campaign title', async function (assert) {
+        // given
+        this.campaign = store.createRecord('campaign', {
+          type: 'EXAM',
           title: 'Mon titre de Campagne',
         });
 
@@ -601,6 +743,163 @@ module('Integration | Component | Campaign::Settings::View', function (hooks) {
           // given
           this.campaign = store.createRecord('campaign', {
             type: 'ASSESSMENT',
+            multipleSendings: false,
+            targetProfileAreKnowledgeElementsResettable: false,
+          });
+          // when
+          const screen = await render(hbs`<Campaign::Settings::View @campaign={{this.campaign}} />`);
+          // then
+          assert.dom(screen.queryByText(t('pages.campaign-settings.reset-to-zero.title'))).doesNotExist();
+        });
+      });
+    });
+
+    module('when type is EXAM', function () {
+      module('when organization feature enableMultipleSending is false', function () {
+        test('it should not display multiple sendings label or tooltip', async function (assert) {
+          // given
+          this.campaign = store.createRecord('campaign', {
+            type: 'EXAM',
+          });
+
+          // when
+          const screen = await render(hbs`<Campaign::Settings::View @campaign={{this.campaign}} />`);
+
+          // then
+          assert.dom(screen.queryByText(t('pages.campaign-settings.multiple-sendings.title'))).doesNotExist();
+          assert
+            .dom(screen.queryByLabelText(t('pages.campaign-settings.multiple-sendings.tooltip.aria-label')))
+            .doesNotExist();
+        });
+
+        test('it should not display reset to zero label or tooltip', async function (assert) {
+          // given
+          this.campaign = store.createRecord('campaign', {
+            type: 'EXAM',
+            targetProfileAreKnowledgeElementsResettable: true,
+          });
+
+          // when
+          const screen = await render(hbs`<Campaign::Settings::View @campaign={{this.campaign}} />`);
+
+          // then
+          assert.dom(screen.queryByText(t('pages.campaign-settings.reset-to-zero.title'))).doesNotExist();
+          assert
+            .dom(screen.queryByLabelText(t('pages.campaign-settings.reset-to-zero.tooltip.aria-label')))
+            .doesNotExist();
+        });
+      });
+      module('when organization feature enableMultipleSending is true', function (hooks) {
+        hooks.beforeEach(function () {
+          class CurrentUserStub extends Service {
+            prescriber = { isAdminOfTheCurrentOrganization: true, enableMultipleSendingAssessment: true };
+          }
+          this.owner.register('service:currentUser', CurrentUserStub);
+        });
+
+        test('it should display multiple sendings label', async function (assert) {
+          // given
+          this.campaign = store.createRecord('campaign', {
+            type: 'EXAM',
+          });
+          // when
+          const screen = await render(hbs`<Campaign::Settings::View @campaign={{this.campaign}} />`);
+          // then
+          assert.dom(screen.getByText(t('pages.campaign-settings.multiple-sendings.title'))).exists();
+        });
+
+        test('it should display tooltip with multiple sendings explanatory text', async function (assert) {
+          // given
+          this.campaign = store.createRecord('campaign', {
+            type: 'EXAM',
+          });
+          // when
+          const screen = await render(hbs`<Campaign::Settings::View @campaign={{this.campaign}} />`);
+
+          // then
+          assert.dom(screen.getByText(t('pages.campaign-settings.multiple-sendings.tooltip.text'))).exists();
+        });
+      });
+
+      module('when the campaign has multiple sending enabled', function (hooks) {
+        hooks.beforeEach(function () {
+          class CurrentUserStub extends Service {
+            prescriber = { isAdminOfTheCurrentOrganization: true, enableMultipleSendingAssessment: true };
+          }
+          this.owner.register('service:currentUser', CurrentUserStub);
+        });
+        test('it should display reset to zero label as enabled when targetProfileAreKnowledgeElementsResettable is true', async function (assert) {
+          // given
+          this.campaign = store.createRecord('campaign', {
+            type: 'EXAM',
+            multipleSendings: true,
+            targetProfileAreKnowledgeElementsResettable: true,
+          });
+          // when
+          const screen = await render(hbs`<Campaign::Settings::View @campaign={{this.campaign}} />`);
+          // then
+          const resetToZeroNode = screen.getByText(t('pages.campaign-settings.reset-to-zero.title')).parentNode
+            .parentNode;
+          assert
+            .dom(within(resetToZeroNode).getByText(t('pages.campaign-settings.reset-to-zero.status.enabled')))
+            .exists();
+        });
+
+        test('it should display the reset to zero label as disabled when targetProfileAreKnowledgeElementsResettable is false', async function (assert) {
+          // given
+          this.campaign = store.createRecord('campaign', {
+            type: 'EXAM',
+            multipleSendings: true,
+            targetProfileAreKnowledgeElementsResettable: false,
+          });
+          // when
+          const screen = await render(hbs`<Campaign::Settings::View @campaign={{this.campaign}} />`);
+          // then
+          const resetToZeroNode = screen.getByText(t('pages.campaign-settings.reset-to-zero.title')).parentNode
+            .parentNode;
+          assert
+            .dom(within(resetToZeroNode).getByText(t('pages.campaign-settings.reset-to-zero.status.disabled')))
+            .exists();
+        });
+
+        test('it should display tooltip with reset to zero explanatory text', async function (assert) {
+          // given
+          this.campaign = store.createRecord('campaign', {
+            type: 'EXAM',
+            multipleSendings: true,
+          });
+          // when
+          const screen = await render(hbs`<Campaign::Settings::View @campaign={{this.campaign}} />`);
+
+          // then
+          assert.dom(screen.getByText(t('pages.campaign-settings.reset-to-zero.tooltip.text'))).exists();
+        });
+      });
+
+      module('when the campaign has multiple sending disabled', function (hooks) {
+        hooks.beforeEach(function () {
+          class CurrentUserStub extends Service {
+            prescriber = { isAdminOfTheCurrentOrganization: true, enableMultipleSendingAssessment: true };
+          }
+          this.owner.register('service:currentUser', CurrentUserStub);
+        });
+        test('it should not display reset to zero label when targetProfileAreKnowledgeElementsResettable is true', async function (assert) {
+          // given
+          this.campaign = store.createRecord('campaign', {
+            type: 'EXAM',
+            multipleSendings: false,
+            targetProfileAreKnowledgeElementsResettable: true,
+          });
+          // when
+          const screen = await render(hbs`<Campaign::Settings::View @campaign={{this.campaign}} />`);
+          // then
+          assert.dom(screen.queryByText(t('pages.campaign-settings.reset-to-zero.title'))).doesNotExist();
+        });
+
+        test('it should not display the reset to zero label when targetProfileAreKnowledgeElementsResettable is false', async function (assert) {
+          // given
+          this.campaign = store.createRecord('campaign', {
+            type: 'EXAM',
             multipleSendings: false,
             targetProfileAreKnowledgeElementsResettable: false,
           });

--- a/orga/tests/integration/components/campaign/update-form-test.js
+++ b/orga/tests/integration/components/campaign/update-form-test.js
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
-module('Integration | Component | Campaign::UpdateForm', function (hooks) {
+module.only('Integration | Component | Campaign::UpdateForm', function (hooks) {
   setupIntlRenderingTest(hooks);
   let store;
 
@@ -30,6 +30,99 @@ module('Integration | Component | Campaign::UpdateForm', function (hooks) {
   });
 
   module('When campaign type is ASSESSMENT', function () {
+    test('it should display campaign title input', async function (assert) {
+      // when
+      const screen = await renderScreen(
+        hbs`<Campaign::UpdateForm @campaign={{this.campaign}} @onSubmit={{this.updateCampaignSpy}} @onCancel={{this.cancelSpy}} />`,
+      );
+
+      // then
+      assert.dom(screen.getByLabelText('Titre du parcours', { exact: false })).exists();
+      assert.dom(screen.getByLabelText('Titre du parcours', { exact: false })).hasAttribute('maxLength', '50');
+    });
+
+    test('it should contain inputs, attributes, information block, validation and cancel buttons', async function (assert) {
+      // when
+      const screen = await renderScreen(
+        hbs`<Campaign::UpdateForm @campaign={{this.campaign}} @onSubmit={{this.updateCampaignSpy}} @onCancel={{this.cancelSpy}} />`,
+      );
+
+      // then
+      assert.dom(screen.getByLabelText('Nom de la campagne *')).exists();
+      assert.dom(screen.getByLabelText('Propriétaire de la campagne *')).exists();
+      assert.dom(screen.getByLabelText("Texte de la page d'accueil", { exact: false })).exists();
+      assert.dom(screen.getByLabelText('Titre du parcours', { exact: false })).exists();
+      assert.dom(screen.getByText('Modifier')).exists();
+      assert.dom(screen.getByText('Annuler')).exists();
+    });
+
+    test('it should send campaign update action when submitted', async function (assert) {
+      // given
+      this.campaign = await store.createRecord('campaign', {
+        name: 'campaign',
+        type: 'ASSESSMENT',
+        ownerFirstName: 'Jon',
+        ownerLastName: 'snow',
+        ownerId: 666,
+      });
+
+      this.updateCampaignSpy = sinon.stub();
+
+      await renderScreen(
+        hbs`<Campaign::UpdateForm @campaign={{this.campaign}} @onSubmit={{this.updateCampaignSpy}} @onCancel={{this.cancelSpy}} />`,
+      );
+
+      // when
+      await fillByLabel('Nom de la campagne *', 'New name');
+      await clickByName('Modifier');
+
+      //then
+      sinon.assert.called(this.updateCampaignSpy);
+      assert.ok(true);
+    });
+
+    test('it should display campaign custom landing page input', async function (assert) {
+      //when
+      const screen = await renderScreen(
+        hbs`<Campaign::UpdateForm @campaign={{this.campaign}} @onSubmit={{this.updateCampaignSpy}} @onCancel={{this.cancelSpy}} />`,
+      );
+
+      //then
+      assert
+        .dom(screen.getByLabelText("Texte de la page d'accueil", { exact: false }))
+        .hasAttribute('maxLength', '5000');
+    });
+
+    test('it should explain which informations will be visible to organization-learners', async function (assert) {
+      //when
+      const screen = await renderScreen(
+        hbs`<Campaign::UpdateForm @campaign={{this.campaign}} @onSubmit={{this.updateCampaignSpy}} @onCancel={{this.cancelSpy}} />`,
+      );
+
+      //then
+      const testTitleSublabel = screen.getAllByLabelText(
+        t('pages.campaign-modification.personalised-test-title.sublabel'),
+        {
+          exact: false,
+        },
+      )[0];
+      const landingPageSublabel = screen.getAllByLabelText(
+        t('pages.campaign-modification.landing-page-text.sublabel'),
+        {
+          exact: false,
+        },
+      )[1];
+
+      assert.ok(testTitleSublabel);
+      assert.ok(landingPageSublabel);
+    });
+  });
+
+  module('When campaign type is EXAM', function (hooks) {
+    hooks.beforeEach(async function () {
+      this.campaign = await store.createRecord('campaign', { name: 'campaign', type: 'EXAM', ownerId: 666 });
+    });
+
     test('it should display campaign title input', async function (assert) {
       // when
       const screen = await renderScreen(

--- a/orga/tests/integration/components/campaign/update-form-test.js
+++ b/orga/tests/integration/components/campaign/update-form-test.js
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
-module.only('Integration | Component | Campaign::UpdateForm', function (hooks) {
+module('Integration | Component | Campaign::UpdateForm', function (hooks) {
   setupIntlRenderingTest(hooks);
   let store;
 

--- a/orga/tests/unit/models/campaign-test.js
+++ b/orga/tests/unit/models/campaign-test.js
@@ -28,6 +28,17 @@ module('Unit | Model | campaign', function (hooks) {
       assert.strictEqual(model.urlToResult, 'http://localhost:3000/api/campaigns/1/csv-assessment-results');
     });
 
+    test('it should construct the url to result of the campaign with type exam', function (assert) {
+      const store = this.owner.lookup('service:store');
+      const model = store.createRecord('campaign', {
+        id: '1',
+        name: 'Fake name',
+        code: 'ABC123',
+        type: 'EXAM',
+      });
+      assert.strictEqual(model.urlToResult, 'http://localhost:3000/api/campaigns/1/csv-assessment-results');
+    });
+
     test('it should construct the url to result of the campaign with type profiles collection', function (assert) {
       const store = this.owner.lookup('service:store');
       const model = store.createRecord('campaign', {


### PR DESCRIPTION
## :pancakes: Problème

Les campagnes EXAM ne sont pas bien prises en compte côté PixOrga

## :bacon: Proposition

Faire fonctionner toutes les features PixOrga avec les campagnes de type EXAM.
Pour le moment, le comportement doit être le même qu'avec les campagnes de type ASSESSMENT

## 🧃 Remarques

Provient de : https://github.com/1024pix/pix/pull/11541

## :yum: Pour tester

Tester toutes les features et voir que ça fait comme les campagnes d'évaluation
