### PR TITLE
[TECH] :recycle: Extraction d'un service à partir d'un modèle plus plus de clarté

### DIFF
--- a/api/src/certification/results/domain/services/find-interval-index-from-score.js
+++ b/api/src/certification/results/domain/services/find-interval-index-from-score.js
@@ -1,0 +1,22 @@
+import { config } from '../../../../shared/config.js';
+// TODO : bounded context violation
+import { CertificationAssessmentScoreV3 } from '../../../scoring/domain/models/CertificationAssessmentScoreV3.js';
+
+const SCORING_CONFIGURATION_WEIGHTS = CertificationAssessmentScoreV3.weightsAndCoefficients.map(({ weight }) => weight);
+
+export function findIntervalIndexFromScore({ score }) {
+  const weights = SCORING_CONFIGURATION_WEIGHTS;
+  let cumulativeSumOfWeights = weights[0];
+  let currentScoringInterval = 0;
+
+  while (_hasNextScoringInterval(score, cumulativeSumOfWeights, currentScoringInterval)) {
+    currentScoringInterval++;
+    cumulativeSumOfWeights += weights[currentScoringInterval];
+  }
+
+  return currentScoringInterval;
+}
+
+function _hasNextScoringInterval(score, nextIntervalMinimumScore, currentInterval) {
+  return score >= nextIntervalMinimumScore && currentInterval < config.v3Certification.maxReachableLevel;
+}

--- a/api/src/certification/results/domain/services/pix-score-to-mesh-level.js
+++ b/api/src/certification/results/domain/services/pix-score-to-mesh-level.js
@@ -2,9 +2,8 @@
  * @typedef {import ('../../../shared/domain/models/V3CertificationScoring.js').V3CertificationScoring} V3CertificationScoring
  */
 
-// TODO : bounded context violation
-import { findIntervalIndexFromScore } from '../../../scoring/domain/models/CapacitySimulator.js';
 import { GlobalCertificationLevel } from '../../../shared/domain/models/GlobalCertificationLevel.js';
+import { findIntervalIndexFromScore } from './find-interval-index-from-score.js';
 
 /**
  * @param {Object} params

--- a/api/src/certification/scoring/domain/models/CapacitySimulator.js
+++ b/api/src/certification/scoring/domain/models/CapacitySimulator.js
@@ -1,9 +1,8 @@
-import { config } from '../../../../shared/config.js';
+// TODO: bounded context violation
+import { findIntervalIndexFromScore } from '../../../results/domain/services/find-interval-index-from-score.js';
 import { CertificationAssessmentScoreV3 } from './CertificationAssessmentScoreV3.js';
 import { Intervals } from './Intervals.js';
 import { ScoringAndCapacitySimulatorReport } from './ScoringAndCapacitySimulatorReport.js';
-
-const SCORING_CONFIGURATION_WEIGHTS = CertificationAssessmentScoreV3.weightsAndCoefficients.map(({ weight }) => weight);
 
 // TODO change CapacitySimulator model to a service
 export class CapacitySimulator {
@@ -42,22 +41,4 @@ export class CapacitySimulator {
       competences,
     });
   }
-}
-
-// TODO Split function to a service, and change contexte to `results`
-export function findIntervalIndexFromScore({ score }) {
-  const weights = SCORING_CONFIGURATION_WEIGHTS;
-  let cumulativeSumOfWeights = weights[0];
-  let currentScoringInterval = 0;
-
-  while (_hasNextScoringInterval(score, cumulativeSumOfWeights, currentScoringInterval)) {
-    currentScoringInterval++;
-    cumulativeSumOfWeights += weights[currentScoringInterval];
-  }
-
-  return currentScoringInterval;
-}
-
-function _hasNextScoringInterval(score, nextIntervalMinimumScore, currentInterval) {
-  return score >= nextIntervalMinimumScore && currentInterval < config.v3Certification.maxReachableLevel;
 }

--- a/api/tests/certification/results/unit/domain/services/find-interval-index-from-score.test.js
+++ b/api/tests/certification/results/unit/domain/services/find-interval-index-from-score.test.js
@@ -1,0 +1,50 @@
+import { findIntervalIndexFromScore } from '../../../../../../src/certification/results/domain/services/find-interval-index-from-score.js';
+import { CertificationAssessmentScoreV3 } from '../../../../../../src/certification/scoring/domain/models/CertificationAssessmentScoreV3.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | Domain | Models | CapacitySimulator', function () {
+  describe('#findIntervalIndexFromScore', function () {
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    [
+      {
+        score: 0,
+        expectedInterval: 0,
+      },
+      {
+        score: 64,
+        expectedInterval: 1,
+      },
+      {
+        score: 200,
+        expectedInterval: 2,
+      },
+      {
+        score: 896,
+        expectedInterval: 7,
+      },
+    ].forEach(({ score, expectedInterval }) => {
+      it(`returns the interval ${expectedInterval} when score is ${score}`, function () {
+        const certificationScoringIntervals = [
+          { bounds: { max: -2, min: -8 }, meshLevel: 0 }, // Score de 0 à 63
+          { bounds: { max: -0.5, min: -2 }, meshLevel: 1 }, // Score de 64 à 127
+          { bounds: { max: 0.6, min: -0.5 }, meshLevel: 2 }, // score de 128 à 255
+          { bounds: { max: 1.5, min: 0.6 }, meshLevel: 3 }, // score de 256 à 383
+          { bounds: { max: 2.25, min: 1.5 }, meshLevel: 4 }, // score de 384 à 511
+          { bounds: { max: 3.1, min: 2.25 }, meshLevel: 5 }, // score de 512 à 639
+          { bounds: { max: 4, min: 3.1 }, meshLevel: 6 }, // score de 640 à 767
+          { bounds: { max: 8, min: 4 }, meshLevel: 7 }, // score de 768 à 895
+        ];
+        // when
+        const weights = CertificationAssessmentScoreV3.weightsAndCoefficients.map(({ weight }) => weight);
+        const result = findIntervalIndexFromScore({
+          score,
+          weights,
+          scoringIntervalsLength: certificationScoringIntervals.length,
+        });
+
+        // then
+        expect(result).to.equal(expectedInterval);
+      });
+    });
+  });
+});

--- a/api/tests/certification/scoring/unit/domain/models/CapacitySimulator_test.js
+++ b/api/tests/certification/scoring/unit/domain/models/CapacitySimulator_test.js
@@ -1,8 +1,4 @@
-import {
-  CapacitySimulator,
-  findIntervalIndexFromScore,
-} from '../../../../../../src/certification/scoring/domain/models/CapacitySimulator.js';
-import { CertificationAssessmentScoreV3 } from '../../../../../../src/certification/scoring/domain/models/CertificationAssessmentScoreV3.js';
+import { CapacitySimulator } from '../../../../../../src/certification/scoring/domain/models/CapacitySimulator.js';
 import { domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Domain | Models | CapacitySimulator', function () {
@@ -222,41 +218,6 @@ describe('Unit | Domain | Models | CapacitySimulator', function () {
             competences: expectedCompetences,
           }),
         );
-      });
-    });
-  });
-
-  describe('#findIntervalIndexFromScore', function () {
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    [
-      {
-        score: 0,
-        expectedInterval: 0,
-      },
-      {
-        score: 64,
-        expectedInterval: 1,
-      },
-      {
-        score: 200,
-        expectedInterval: 2,
-      },
-      {
-        score: 896,
-        expectedInterval: 7,
-      },
-    ].forEach(({ score, expectedInterval }) => {
-      it(`returns the interval ${expectedInterval} when score is ${score}`, function () {
-        // when
-        const weights = CertificationAssessmentScoreV3.weightsAndCoefficients.map(({ weight }) => weight);
-        const result = findIntervalIndexFromScore({
-          score,
-          weights,
-          scoringIntervalsLength: certificationScoringIntervals.length,
-        });
-
-        // then
-        expect(result).to.equal(expectedInterval);
       });
     });
   });


### PR DESCRIPTION
## :pancakes: Problème

Le modèle `CapacitySimulator` du contexte `scoring` contient une fonction `findIntervalIndexFromScore` utilisée dans le contexte `results`

## :bacon: Proposition

Extraire un service `findIntervalIndexFromScore` placé dans le contexte `results`

## 🧃 Remarques

Cette PR est tiré depuis la PR #11556, il faudra la merger quand la #11556 aura été mergée.

## :yum: Pour tester

S'assurer que le scoring n'a pas changer
S'assurer que le score et toujours le bon dans l'API Parcoursup

