### PR TITLE
[BUGFIX] Correction du problème de largeur d'encart sur la page de résultats de campagnes sans badges (PIX-16786)

### DIFF
--- a/orga/app/styles/components/campaign/charts/campaign-badge-acquisitions.scss
+++ b/orga/app/styles/components/campaign/charts/campaign-badge-acquisitions.scss
@@ -3,7 +3,7 @@
 
 .badge-acquisitions {
   @include breakpoints.device-is('desktop') {
-    width: 33.33%;
+    width: calc(53% - var(--pix-spacing-6x));
   }
 
   width: 100%;

--- a/orga/app/styles/components/campaign/charts/results-distribution.scss
+++ b/orga/app/styles/components/campaign/charts/results-distribution.scss
@@ -13,9 +13,5 @@
 }
 
 .participants {
-  @include breakpoints.device-is('desktop') {
-    width: calc(66.66% - var(--pix-spacing-6x));
-  }
-
   width: 100%;
 }


### PR DESCRIPTION
## :pancakes: Problème

![image](https://github.com/user-attachments/assets/d31ce4eb-3e26-4ce5-a950-73a5775b533c)
## :bacon: Proposition

Corriger ça

## 🧃 Remarques

Ne me demandez pas le pourquoi du comment ces pourcentages marchent mais ça marche ^^'

## :yum: Pour tester

Les résultats d'une campagne avec badges  :
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/442d9ff4-e4df-40ed-b6c0-9723678ac302" />

Les résultats d'une campagne sans badges :
<img width="1439" alt="image" src="https://github.com/user-attachments/assets/559ae279-4d57-45c5-8ce3-08a87e352b01" />
