### PR TITLE
[FEATURE] Améliorer les déclenchements d'action de l'écran d'épreuve (PIX-16784).

### DIFF
--- a/mon-pix/app/components/challenge-actions.hbs
+++ b/mon-pix/app/components/challenge-actions.hbs
@@ -71,9 +71,10 @@
     <div class="challenge-actions__group">
       <div class="challenge-actions__buttons">
         <PixButton
-          @isDisabled={{this.areActionButtonsDisabled}}
-          @triggerAction={{@validateAnswer}}
           @variant="success"
+          @triggerAction={{this.handleValidateAction}}
+          @isLoading={{this.isValidateActionLoading}}
+          @isDisabled={{or this.areActionButtonsDisabled this.isSkipActionLoading}}
           @iconAfter="arrowRight"
           class="challenge-actions__action-validate"
           aria-label={{t "pages.challenge.actions.validate-go-to-next"}}
@@ -84,9 +85,11 @@
         </PixButton>
 
         <PixButton
-          @isDisabled={{this.areActionButtonsDisabled}}
-          @triggerAction={{@skipChallenge}}
           @variant="secondary"
+          @triggerAction={{this.handleSkipAction}}
+          @isLoading={{this.isSkipActionLoading}}
+          @loadingColor="grey"
+          @isDisabled={{or this.areActionButtonsDisabled this.isValidateActionLoading}}
           class="challenge-actions__action-skip"
           aria-label={{t "pages.challenge.actions.skip-go-to-next"}}
         >

--- a/mon-pix/app/components/challenge-actions.js
+++ b/mon-pix/app/components/challenge-actions.js
@@ -1,6 +1,11 @@
+import { action } from '@ember/object';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 
 export default class ChallengeActions extends Component {
+  @tracked isValidateActionLoading = false;
+  @tracked isSkipActionLoading = false;
+
   get areActionButtonsDisabled() {
     return this.args.disabled || this.hasCurrentOngoingLiveAlert;
   }
@@ -23,5 +28,27 @@ export default class ChallengeActions extends Component {
 
   get hasCurrentOngoingLiveAlert() {
     return this.args.hasOngoingCompanionLiveAlert || this.args.hasOngoingChallengeLiveAlert;
+  }
+
+  @action
+  async handleValidateAction(event) {
+    this.isValidateActionLoading = true;
+
+    try {
+      await this.args.validateAnswer(event);
+    } finally {
+      this.isValidateActionLoading = false;
+    }
+  }
+
+  @action
+  async handleSkipAction() {
+    this.isSkipActionLoading = true;
+
+    try {
+      await this.args.skipChallenge();
+    } finally {
+      this.isSkipActionLoading = false;
+    }
   }
 }

--- a/mon-pix/app/components/challenge/content.gjs
+++ b/mon-pix/app/components/challenge/content.gjs
@@ -1,0 +1,70 @@
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+import { eq } from 'ember-truth-helpers';
+
+import AssessmentsLiveAlert from '../assessments/live-alert';
+import FeedbackPanel from '../feedback-panel';
+import FeedbackPanelV3 from '../feedback-panel-v3';
+import ChallengeItem from './item';
+
+export default class ChallengeContent extends Component {
+  @tracked isLiveAlertButtonEnabled = true;
+
+  @action
+  handleChallengeSubmit() {
+    this.isLiveAlertButtonEnabled = false;
+  }
+
+  <template>
+    <div
+      class="focus-zone-warning
+        {{if @isFocusedChallengeAndUserHasFocusedOutOfChallenge 'focus-zone-warning--triggered'}}"
+      data-challenge-id="{{@challenge.id}}"
+      {{on "mouseenter" @hideOutOfFocusBorder}}
+      {{on "mouseleave" @showOutOfFocusBorder}}
+    >
+
+      <ChallengeItem
+        @challenge={{@challenge}}
+        @assessment={{@assessment}}
+        @answer={{@answer}}
+        @timeoutChallenge={{@timeoutChallenge}}
+        @resetAllChallengeInfo={{@resetAllChallengeInfo}}
+        @resetChallengeInfoOnResume={{@resetChallengeInfoOnResume}}
+        @onFocusIntoChallenge={{fn @setFocusedOutOfChallenge false}}
+        @onFocusOutOfChallenge={{fn @setFocusedOutOfChallenge true}}
+        @onFocusOutOfWindow={{@focusedOutOfWindow}}
+        @hasFocusedOutOfWindow={{@hasFocusedOutOfWindow}}
+        @isFocusedChallengeAndUserHasFocusedOutOfChallenge={{@isFocusedChallengeAndUserHasFocusedOutOfChallenge}}
+        @isTextToSpeechActivated={{@isTextToSpeechActivated}}
+        @onChallengeSubmit={{this.handleChallengeSubmit}}
+      />
+
+      {{#unless @assessment.hasOngoingCompanionLiveAlert}}
+        <div class="challenge__feedback" role="complementary">
+          {{#if (eq @assessment.certificationCourse.version 3)}}
+            <FeedbackPanelV3
+              @submitLiveAlert={{@submitLiveAlert}}
+              @assessment={{@assessment}}
+              @isEnabled={{this.isLiveAlertButtonEnabled}}
+            />
+          {{else}}
+            <FeedbackPanel @assessment={{@assessment}} @challenge={{@challenge}} />
+          {{/if}}
+        </div>
+      {{/unless}}
+
+      {{#if @assessment.hasOngoingCompanionLiveAlert}}
+        <AssessmentsLiveAlert @message={{t "pages.challenge.live-alerts.companion.message"}} />
+      {{/if}}
+    </div>
+
+    {{#if @isFocusedChallengeAndUserHasFocusedOutOfChallenge}}
+      <div class="focus-zone-warning__overlay" />
+    {{/if}}
+  </template>
+}

--- a/mon-pix/app/components/challenge/item.js
+++ b/mon-pix/app/components/challenge/item.js
@@ -92,6 +92,8 @@ export default class Item extends Component {
       return;
     }
 
+    this.args.onChallengeSubmit();
+
     const answer = await this._findOrCreateAnswer(challenge, assessment);
     answer.setProperties({
       value: answerValue.trim(),

--- a/mon-pix/app/components/feedback-panel-v3.hbs
+++ b/mon-pix/app/components/feedback-panel-v3.hbs
@@ -4,16 +4,18 @@
 {{else}}
   <div class="feedback-panel-v3">
     <h2 class="screen-reader-only">{{t "pages.challenge.parts.feedback-v3"}}</h2>
-    <button
-      class="feedback-panel-v3__open-button
-        {{if this.isToggleFeedbackFormHidden 'feedback-panel-v3__open-button--hidden'}}"
-      {{on "click" this.toggleFeedbackForm}}
-      aria-expanded={{this.isAriaExpanded}}
-      type="button"
-    >
-      <PixIcon @name="flag" @plainIcon={{true}} @ariaHidden={{true}} />
-      {{t "pages.challenge.feedback-panel-v3.actions.open-close"}}
-    </button>
+
+    {{#unless this.isToggleFeedbackFormHidden}}
+      <PixButton
+        @variant="tertiary"
+        @triggerAction={{this.toggleFeedbackForm}}
+        @isDisabled={{not @isEnabled}}
+        aria-expanded={{this.isAriaExpanded}}
+        @iconBefore="flag"
+      >
+        {{t "pages.challenge.feedback-panel-v3.actions.open-close"}}
+      </PixButton>
+    {{/unless}}
 
     {{#if this.shouldBeExpanded}}
       <div class="feedback-panel-v3__view">

--- a/mon-pix/app/components/feedback-panel-v3.js
+++ b/mon-pix/app/components/feedback-panel-v3.js
@@ -24,7 +24,7 @@ export default class FeedbackPanelV3 extends Component {
   }
 
   get shouldBeExpanded() {
-    return this.isAssessmentPaused || this.isExpanded;
+    return this.args.isEnabled && (this.isAssessmentPaused || this.isExpanded);
   }
 
   get isToggleFeedbackFormHidden() {

--- a/mon-pix/app/styles/components/_feedback-panel-v3.scss
+++ b/mon-pix/app/styles/components/_feedback-panel-v3.scss
@@ -30,39 +30,6 @@
 
 /* "Link" view
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
-
-.feedback-panel-v3__open-button {
-  display: flex;
-  gap: var(--pix-spacing-1x);
-  align-items: center;
-  width: 100%;
-  margin-top: var(--pix-spacing-4x);
-  padding: 0.75rem 0;
-  line-height: 20px;
-  text-align: left;
-  text-decoration: underline;
-
-  svg {
-    width: 1rem;
-    height: 1rem;
-  }
-
-  &[aria-expanded='true'] {
-    color: var(--pix-neutral-900);
-  }
-
-  &--hidden {
-    padding: 0;
-    visibility: hidden;
-  }
-
-  &:hover,
-  &:focus-visible,
-  &:active {
-    color: var(--pix-primary-500);
-  }
-}
-
 .feedback-panel-v3__view {
   display: flex;
   gap: 24px;

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -60,47 +60,22 @@
     {{/if}}
 
     {{#if this.displayChallenge}}
-      <div
-        class="focus-zone-warning
-          {{if this.isFocusedChallengeAndUserHasFocusedOutOfChallenge 'focus-zone-warning--triggered'}}"
-        data-challenge-id="{{@challenge.id}}"
-        {{on "mouseenter" this.hideOutOfFocusBorder}}
-        {{on "mouseleave" this.showOutOfFocusBorder}}
-      >
-
-        <Challenge::Item
-          @challenge={{@model.challenge}}
-          @assessment={{@model.assessment}}
-          @answer={{@model.answer}}
-          @timeoutChallenge={{this.timeoutChallenge}}
-          @resetAllChallengeInfo={{this.resetAllChallengeInfo}}
-          @resetChallengeInfoOnResume={{this.resetChallengeInfoOnResume}}
-          @onFocusIntoChallenge={{fn this.setFocusedOutOfChallenge false}}
-          @onFocusOutOfChallenge={{fn this.setFocusedOutOfChallenge true}}
-          @onFocusOutOfWindow={{this.focusedOutOfWindow}}
-          @hasFocusedOutOfWindow={{this.hasFocusedOutOfWindow}}
-          @isFocusedChallengeAndUserHasFocusedOutOfChallenge={{this.isFocusedChallengeAndUserHasFocusedOutOfChallenge}}
-          @isTextToSpeechActivated={{this.isTextToSpeechActivated}}
-        />
-
-        {{#unless @model.assessment.hasOngoingCompanionLiveAlert}}
-          <div class="challenge__feedback" role="complementary">
-            {{#if (eq @model.assessment.certificationCourse.version 3)}}
-              <FeedbackPanelV3 @submitLiveAlert={{this.submitLiveAlert}} @assessment={{@model.assessment}} />
-            {{else}}
-              <FeedbackPanel @assessment={{@model.assessment}} @challenge={{@model.challenge}} />
-            {{/if}}
-          </div>
-        {{/unless}}
-
-        {{#if @model.assessment.hasOngoingCompanionLiveAlert}}
-          <Assessments::LiveAlert @message={{t "pages.challenge.live-alerts.companion.message"}} />
-        {{/if}}
-      </div>
-
-      {{#if this.isFocusedChallengeAndUserHasFocusedOutOfChallenge}}
-        <div class="focus-zone-warning__overlay" />
-      {{/if}}
+      <Challenge::Content
+        @answer={{@model.answer}}
+        @assessment={{@model.assessment}}
+        @challenge={{@model.challenge}}
+        @focusedOutOfWindow={{this.focusedOutOfWindow}}
+        @hasFocusedOutOfWindow={{this.hasFocusedOutOfWindow}}
+        @hideOutOfFocusBorder={{this.hideOutOfFocusBorder}}
+        @isFocusedChallengeAndUserHasFocusedOutOfChallenge={{this.isFocusedChallengeAndUserHasFocusedOutOfChallenge}}
+        @isTextToSpeechActivated={{this.isTextToSpeechActivated}}
+        @resetAllChallengeInfo={{this.resetAllChallengeInfo}}
+        @resetChallengeInfoOnResume={{this.resetChallengeInfoOnResume}}
+        @setFocusedOutOfChallenge={{this.setFocusedOutOfChallenge}}
+        @showOutOfFocusBorder={{this.showOutOfFocusBorder}}
+        @submitLiveAlert={{this.submitLiveAlert}}
+        @timeoutChallenge={{this.timeoutChallenge}}
+      />
     {{/if}}
   </main>
 

--- a/mon-pix/tests/integration/components/challenge-actions-test.js
+++ b/mon-pix/tests/integration/components/challenge-actions-test.js
@@ -1,6 +1,8 @@
 import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
@@ -10,6 +12,98 @@ module('Integration | Component | challenge actions', function (hooks) {
   test('renders', async function (assert) {
     await render(hbs`<ChallengeActions />`);
     assert.dom('.challenge-actions__group').exists();
+  });
+
+  module('when the validate answer button is clicked', function () {
+    test('it should add a loading state to the button and disable the skip button', async function (assert) {
+      // given
+      this.set('isValidateButtonEnabled', true);
+      this.set('isSkipButtonEnabled', true);
+      this.set('validateActionStub', () => sinon.promise());
+
+      // when
+      const screen = await render(hbs`<ChallengeActions
+  @validateAnswer={{this.validateActionStub}}
+  @isValidateButtonEnabled={{this.isValidateButtonEnabled}}
+  @isSkipButtonEnabled={{this.isSkipButtonEnabled}}
+/>`);
+
+      const validateButton = screen.getByRole('button', { name: /Je valide/ });
+      await click(validateButton);
+
+      // then
+      assert.dom(validateButton).hasAttribute('disabled');
+      assert.dom(screen.getByRole('button', { name: /Je passe/ })).hasAttribute('disabled');
+    });
+
+    module('on request resolution or rejection', function () {
+      test('it should remove the disable states', async function (assert) {
+        // given
+        this.set('isValidateButtonEnabled', true);
+        this.set('isSkipButtonEnabled', true);
+        this.set('validateActionStub', () => sinon.promise().resolve());
+
+        // when
+        const screen = await render(hbs`<ChallengeActions
+  @validateAnswer={{this.validateActionStub}}
+  @isValidateButtonEnabled={{this.isValidateButtonEnabled}}
+  @isSkipButtonEnabled={{this.isSkipButtonEnabled}}
+/>`);
+
+        const validateButton = screen.getByRole('button', { name: /Je valide/ });
+        await click(validateButton);
+
+        // then
+        assert.dom(validateButton).hasNoAttribute('disabled');
+        assert.dom(screen.getByRole('button', { name: /Je passe/ })).hasNoAttribute('disabled');
+      });
+    });
+  });
+
+  module('when the skip button is clicked', function () {
+    test('it should add a loading state to the button and disable the validate button', async function (assert) {
+      // given
+      this.set('isValidateButtonEnabled', true);
+      this.set('isSkipButtonEnabled', true);
+      this.set('skipChallengeStub', () => sinon.promise());
+
+      // when
+      const screen = await render(hbs`<ChallengeActions
+  @skipChallenge={{this.skipChallengeStub}}
+  @isValidateButtonEnabled={{this.isValidateButtonEnabled}}
+  @isSkipButtonEnabled={{this.isSkipButtonEnabled}}
+/>`);
+
+      const skipButton = screen.getByRole('button', { name: /Je passe/ });
+      await click(skipButton);
+
+      // then
+      assert.dom(skipButton).hasAttribute('disabled');
+      assert.dom(screen.getByRole('button', { name: /Je valide/ })).hasAttribute('disabled');
+    });
+
+    module('on request resolution or rejection', function () {
+      test('it should remove the disable states', async function (assert) {
+        // given
+        this.set('isValidateButtonEnabled', true);
+        this.set('isSkipButtonEnabled', true);
+        this.set('skipChallengeStub', () => sinon.promise().reject());
+
+        // when
+        const screen = await render(hbs`<ChallengeActions
+  @skipChallenge={{this.skipChallengeStub}}
+  @isValidateButtonEnabled={{this.isValidateButtonEnabled}}
+  @isSkipButtonEnabled={{this.isSkipButtonEnabled}}
+/>`);
+
+        const skipButton = screen.getByRole('button', { name: /Je passe/ });
+        await click(skipButton);
+
+        // then
+        assert.dom(skipButton).hasNoAttribute('disabled');
+        assert.dom(screen.getByRole('button', { name: /Je valide/ })).hasNoAttribute('disabled');
+      });
+    });
   });
 
   module('Challenge has timed out', function () {

--- a/mon-pix/tests/integration/components/challenge/content-test.js
+++ b/mon-pix/tests/integration/components/challenge/content-test.js
@@ -1,0 +1,87 @@
+import { render } from '@1024pix/ember-testing-library';
+import { click, fillIn } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Challenge | Content', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  let screen;
+
+  hooks.before(function () {
+    sinon.stub(window, 'fetch');
+  });
+
+  hooks.beforeEach(async function () {
+    // given
+    const router = this.owner.lookup('service:router');
+    router.transitionTo = sinon.stub();
+
+    const store = this.owner.lookup('service:store');
+    this.set(
+      'challenge',
+      store.createRecord('challenge', {
+        type: 'QROC',
+        timer: false,
+        format: 'phrase',
+        proposals: '${myInput}',
+      }),
+    );
+    this.set('answer', null);
+    this.set(
+      'assessment',
+      store.createRecord('assessment', {
+        certificationCourse: store.createRecord('certification-course', {
+          version: 3,
+        }),
+        answers: [],
+      }),
+    );
+    this.set('fakeFunction', () => {});
+
+    // when
+    screen = await render(
+      hbs`<Challenge::Content
+  @challenge={{this.challenge}}
+  @answer={{this.answer}}
+  @assessment={{this.assessment}}
+  @hideOutOfFocusBorder={{this.fakeFunction}}
+  @showOutOfFocusBorder={{this.fakeFunction}}
+  @resetAllChallengeInfo={{this.fakeFunction}}
+/>`,
+    );
+  });
+
+  module('on challenge skip', function () {
+    test('should disable the live alert button', async function (assert) {
+      // then
+      await click(screen.getByRole('button', { name: /Signaler un problème avec la question/ }));
+      assert.dom(screen.getByRole('button', { name: /Oui, je suis/ })).exists();
+
+      await click(screen.getByRole('button', { name: /Je passe/ }));
+      assert
+        .dom(screen.getByRole('button', { name: /Signaler un problème avec la question/ }))
+        .hasAttribute('disabled');
+      assert.dom(screen.queryByRole('button', { name: /Oui, je suis/ })).doesNotExist();
+    });
+  });
+
+  module('on challenge answering', function () {
+    test('should disable the live alert button', async function (assert) {
+      // then
+      await click(screen.getByRole('button', { name: /Signaler un problème avec la question/ }));
+      assert.dom(screen.getByRole('button', { name: /Oui, je suis/ })).exists();
+
+      await fillIn(screen.getByRole('textbox'), 'answer');
+      await click(screen.getByRole('button', { name: /Je valide/ }));
+
+      assert
+        .dom(screen.getByRole('button', { name: /Signaler un problème avec la question/ }))
+        .hasAttribute('disabled');
+      assert.dom(screen.queryByRole('button', { name: /Oui, je suis/ })).doesNotExist();
+    });
+  });
+});

--- a/mon-pix/tests/integration/components/feedback-panel-v3-test.js
+++ b/mon-pix/tests/integration/components/feedback-panel-v3-test.js
@@ -35,7 +35,7 @@ module('Integration | Component | feedback-panel-v3', function (hooks) {
         this.set('assessment', mockAssessment);
         this.set('submitLiveAlert', submitLiveAlert);
         const screen = await render(
-          hbs`<FeedbackPanelV3 @submitLiveAlert={{this.submitLiveAlert}} @assessment={{this.assessment}} />`,
+          hbs`<FeedbackPanelV3 @submitLiveAlert={{this.submitLiveAlert}} @assessment={{this.assessment}} @isEnabled={{true}} />`,
         );
 
         // when

--- a/mon-pix/tests/unit/components/challenge/challenge-item-test.js
+++ b/mon-pix/tests/unit/components/challenge/challenge-item-test.js
@@ -36,6 +36,7 @@ module('Unit | Component | Challenge | Item', function (hooks) {
   module('answerValidated', function (hooks) {
     let createRecordStub;
     let queryRecordStub;
+    let onChallengeSubmitStub;
     const challengeOne = EmberObject.create({ id: 'recChallengeOne' });
     const answerValue = 'example';
     let answerToChallengeOne;
@@ -46,7 +47,8 @@ module('Unit | Component | Challenge | Item', function (hooks) {
     hooks.beforeEach(function () {
       createRecordStub = sinon.stub();
       queryRecordStub = sinon.stub();
-      answerToChallengeOne = EmberObject.create({ challenge: challengeOne });
+      onChallengeSubmitStub = sinon.stub();
+      answerToChallengeOne = EmberObject.create({ challenge: challengeOne, onChallengeSubmit: onChallengeSubmitStub });
       answerToChallengeOne.save = sinon.stub().resolves();
       answerToChallengeOne.setProperties = sinon.stub();
       answerToChallengeOne.rollbackAttributes = sinon.stub();
@@ -55,7 +57,10 @@ module('Unit | Component | Challenge | Item', function (hooks) {
     module('when the answer is already known', function () {
       test('should not create a new answer', async function (assert) {
         // given
-        const component = createGlimmerComponent('challenge/item', { challenge: challengeOne });
+        const component = createGlimmerComponent('challenge/item', {
+          challenge: challengeOne,
+          onChallengeSubmit: onChallengeSubmitStub,
+        });
         component.router = { transitionTo: sinon.stub().returns() };
         component.store = {
           createRecord: createRecordStub,
@@ -77,7 +82,10 @@ module('Unit | Component | Challenge | Item', function (hooks) {
         // given
         createRecordStub.returns(answerToChallengeOne);
         queryRecordStub.resolves(nextChallenge);
-        const component = createGlimmerComponent('challenge/item', { challenge: challengeOne });
+        const component = createGlimmerComponent('challenge/item', {
+          challenge: challengeOne,
+          onChallengeSubmit: onChallengeSubmitStub,
+        });
         component.router = { transitionTo: sinon.stub().returns() };
         component.store = {
           createRecord: createRecordStub,
@@ -103,7 +111,10 @@ module('Unit | Component | Challenge | Item', function (hooks) {
       const assessment = EmberObject.create({ answers: [answerToChallengeOne] });
       createRecordStub.returns(answerToChallengeOne);
       queryRecordStub.resolves(nextChallenge);
-      const component = createGlimmerComponent('challenge/item', { challenge: challengeOne });
+      const component = createGlimmerComponent('challenge/item', {
+        challenge: challengeOne,
+        onChallengeSubmit: onChallengeSubmitStub,
+      });
       component.router = { transitionTo: sinon.stub().returns() };
       component.store = {
         createRecord: createRecordStub,
@@ -130,7 +141,10 @@ module('Unit | Component | Challenge | Item', function (hooks) {
       const assessment = EmberObject.create({ answers: [answerToChallengeOne] });
       createRecordStub.returns(answerToChallengeOne);
       queryRecordStub.resolves(nextChallenge);
-      const component = createGlimmerComponent('challenge/item', { challenge: challengeOne });
+      const component = createGlimmerComponent('challenge/item', {
+        challenge: challengeOne,
+        onChallengeSubmit: onChallengeSubmitStub,
+      });
       component.router = { transitionTo: sinon.stub().returns() };
       component.store = {
         createRecord: createRecordStub,
@@ -154,7 +168,10 @@ module('Unit | Component | Challenge | Item', function (hooks) {
       test('it should not save the answer', async function (assert) {
         // given
         const assessment = EmberObject.create({ answers: [answerToChallengeOne], hasOngoingChallengeLiveAlert: true });
-        const component = createGlimmerComponent('challenge/item', { challenge: challengeOne });
+        const component = createGlimmerComponent('challenge/item', {
+          challenge: challengeOne,
+          onChallengeSubmit: onChallengeSubmitStub,
+        });
         component.router = { transitionTo: sinon.stub().returns() };
         component.currentUser = { isAnonymous: false };
         component.store = {
@@ -175,7 +192,10 @@ module('Unit | Component | Challenge | Item', function (hooks) {
       test('should redirect to assessment-resume route', async function (assert) {
         // given
         const assessment = EmberObject.create({ answers: [answerToChallengeOne] });
-        const component = createGlimmerComponent('challenge/item', { challenge: challengeOne });
+        const component = createGlimmerComponent('challenge/item', {
+          challenge: challengeOne,
+          onChallengeSubmit: onChallengeSubmitStub,
+        });
         component.router = { transitionTo: sinon.stub().returns() };
         component.currentUser = { isAnonymous: false };
         component.store = {
@@ -209,7 +229,10 @@ module('Unit | Component | Challenge | Item', function (hooks) {
 
         test('should redirect to assessment-resume route with level up information', async function (assert) {
           //given
-          const component = createGlimmerComponent('challenge/item', { challenge: challengeOne });
+          const component = createGlimmerComponent('challenge/item', {
+            challenge: challengeOne,
+            onChallengeSubmit: onChallengeSubmitStub,
+          });
           component.router = { transitionTo: sinon.stub().returns() };
           component.currentUser = { user: { isAnonymous: false } };
           component.store = {
@@ -233,7 +256,10 @@ module('Unit | Component | Challenge | Item', function (hooks) {
         test('should redirect to assessment-resume route without level up information when user is anonymous', async function (assert) {
           //given
           const expectedQueryParams = { queryParams: {} };
-          const component = createGlimmerComponent('challenge/item', { challenge: challengeOne });
+          const component = createGlimmerComponent('challenge/item', {
+            challenge: challengeOne,
+            onChallengeSubmit: onChallengeSubmitStub,
+          });
           component.router = { transitionTo: sinon.stub().returns() };
           component.currentUser = { user: { isAnonymous: true } };
           component.store = {
@@ -256,7 +282,10 @@ module('Unit | Component | Challenge | Item', function (hooks) {
         test('should redirect to assessment-resume route without level up information when there is no currentUser', async function (assert) {
           //given
           const expectedQueryParams = { queryParams: {} };
-          const component = createGlimmerComponent('challenge/item', { challenge: challengeOne });
+          const component = createGlimmerComponent('challenge/item', {
+            challenge: challengeOne,
+            onChallengeSubmit: onChallengeSubmitStub,
+          });
           component.router = { transitionTo: sinon.stub().returns() };
           component.currentUser = { user: undefined };
           component.store = {
@@ -283,7 +312,10 @@ module('Unit | Component | Challenge | Item', function (hooks) {
         const error = { message: 'error' };
         answerToChallengeOne.save = sinon.stub().rejects(error);
         const assessment = EmberObject.create({ answers: [answerToChallengeOne] });
-        const component = createGlimmerComponent('challenge/item', { challenge: challengeOne });
+        const component = createGlimmerComponent('challenge/item', {
+          challenge: challengeOne,
+          onChallengeSubmit: onChallengeSubmitStub,
+        });
         const transitionToStub = sinon.stub().returns();
         component.router = { transitionTo: transitionToStub };
 
@@ -315,7 +347,10 @@ module('Unit | Component | Challenge | Item', function (hooks) {
         const assessment = EmberObject.create({ answers: [answerToChallengeOne], certificationCourse });
 
         // when
-        const component = createGlimmerComponent('challenge/item', { challenge: challengeOne });
+        const component = createGlimmerComponent('challenge/item', {
+          challenge: challengeOne,
+          onChallengeSubmit: onChallengeSubmitStub,
+        });
         const transitionToStub = sinon.stub().returns();
         component.router = { transitionTo: transitionToStub };
 


### PR DESCRIPTION
## :pancakes: Problème

À l'heure actuelle, rien n'empêche de déclencher plusieurs actions simultanément sur l'écran d'épreuve.

## :bacon: Proposition

1. Si on clique sur "**_Valider_**" :
    - on passe le bouton en `loading`
    - on `disable` les boutons "_Passer_" et "_Signaler un problème avec la question_"
    - Si les sous-actions de signalement étaient visibles, alors elles disparaîssent

2. Si on clique sur "**_Passer_**" :
    - on passe le bouton en `loading`
    - on `disable` les boutons "_Valider_" et "_Signaler un problème avec la question_"
    - Si les sous-actions de signalement étaient visibles, alors elles disparaîssent

## 🧃 Remarques

On en profite aussi pour migrer le bouton "_Signaler un problème avec la question_" sur le composant PixButton.

Aussi : côté PixButton, il faut améliorer l'a11y lors de l'état `loading`.

## :yum: Pour tester

- Aller sur une épreuve en certif
- Sur votre navigateur, passer le réseau en mode 3G pour ralentir la connexion
- Cliquer sur "Je passe" ou "Je valide"
- Constater que les actions de signalements sont plus accessibles
