### PR TITLE
[FEATURE] Enregistrer le début d'un passage en tant qu'événement (PIX-16812)

### DIFF
--- a/api/src/devcomp/application/passages/controller.js
+++ b/api/src/devcomp/application/passages/controller.js
@@ -1,8 +1,8 @@
 import { requestResponseUtils } from '../../../shared/infrastructure/utils/request-response-utils.js';
 
-const create = async function (request, h, { usecases, passageSerializer, extractUserIdFromRequest }) {
+const create = async function (request, h, { usecases, passageSerializer }) {
   const { 'module-id': moduleId } = request.payload.data.attributes;
-  const userId = extractUserIdFromRequest(request);
+  const userId = requestResponseUtils.extractUserIdFromRequest(request);
   const passage = await usecases.createPassage({ moduleId, userId });
 
   const serializedPassage = passageSerializer.serialize(passage);

--- a/api/src/devcomp/application/passages/controller.js
+++ b/api/src/devcomp/application/passages/controller.js
@@ -2,8 +2,9 @@ import { requestResponseUtils } from '../../../shared/infrastructure/utils/reque
 
 const create = async function (request, h, { usecases, passageSerializer }) {
   const { 'module-id': moduleId } = request.payload.data.attributes;
+  const requestTimestamp = requestResponseUtils.extractTimestampFromRequest(request);
   const userId = requestResponseUtils.extractUserIdFromRequest(request);
-  const passage = await usecases.createPassage({ moduleId, userId });
+  const passage = await usecases.createPassage({ moduleId, userId, occurredAt: new Date(requestTimestamp) });
 
   const serializedPassage = passageSerializer.serialize(passage);
   return h.response(serializedPassage).created();

--- a/api/src/devcomp/domain/usecases/create-passage.js
+++ b/api/src/devcomp/domain/usecases/create-passage.js
@@ -2,16 +2,16 @@ import { NotFoundError } from '../../../shared/domain/errors.js';
 import { ModuleDoesNotExistError } from '../errors.js';
 
 const createPassage = async function ({ moduleId, userId, moduleRepository, passageRepository, userRepository }) {
-  await _verifyIfModuleExists({ moduleId, moduleRepository });
+  await _getModule({ moduleId, moduleRepository });
   if (userId !== null) {
     await userRepository.get(userId);
   }
   return passageRepository.save({ moduleId, userId });
 };
 
-async function _verifyIfModuleExists({ moduleId, moduleRepository }) {
+async function _getModule({ moduleId, moduleRepository }) {
   try {
-    await moduleRepository.getBySlug({ slug: moduleId });
+    return await moduleRepository.getBySlug({ slug: moduleId });
   } catch (e) {
     if (e instanceof NotFoundError) {
       throw new ModuleDoesNotExistError();

--- a/api/tests/devcomp/unit/application/passages/controller_test.js
+++ b/api/tests/devcomp/unit/application/passages/controller_test.js
@@ -10,10 +10,6 @@ describe('Unit | Devcomp | Application | Passages | Controller', function () {
       const moduleId = Symbol('module-id');
       const passage = Symbol('passage');
       const userId = Symbol('user-id');
-      const usecases = {
-        createPassage: sinon.stub(),
-      };
-      usecases.createPassage.withArgs({ moduleId, userId }).returns(passage);
       const passageSerializer = {
         serialize: sinon.stub(),
       };
@@ -28,6 +24,15 @@ describe('Unit | Devcomp | Application | Passages | Controller', function () {
 
       const extractUserIdFromRequestStub = sinon.stub(requestResponseUtils, 'extractUserIdFromRequest');
       extractUserIdFromRequestStub.withArgs(request).returns(userId);
+      const requestTimestamp = new Date('2025-01-01').getTime();
+      const extractTimestampStub = sinon
+        .stub(requestResponseUtils, 'extractTimestampFromRequest')
+        .returns(requestTimestamp);
+
+      const usecases = {
+        createPassage: sinon.stub(),
+      };
+      usecases.createPassage.withArgs({ moduleId, userId, occurredAt: new Date(requestTimestamp) }).returns(passage);
 
       // when
       await passageController.create({ payload: { data: { attributes: { 'module-id': moduleId } } } }, hStub, {
@@ -37,6 +42,7 @@ describe('Unit | Devcomp | Application | Passages | Controller', function () {
 
       // then
       expect(created).to.have.been.called;
+      expect(extractTimestampStub).to.have.been.calledOnce;
     });
   });
 

--- a/api/tests/devcomp/unit/application/passages/controller_test.js
+++ b/api/tests/devcomp/unit/application/passages/controller_test.js
@@ -26,14 +26,13 @@ describe('Unit | Devcomp | Application | Passages | Controller', function () {
 
       const request = { payload: { data: { attributes: { 'module-id': moduleId } } } };
 
-      const extractUserIdFromRequest = sinon.stub();
-      extractUserIdFromRequest.withArgs(request).returns(userId);
+      const extractUserIdFromRequestStub = sinon.stub(requestResponseUtils, 'extractUserIdFromRequest');
+      extractUserIdFromRequestStub.withArgs(request).returns(userId);
 
       // when
       await passageController.create({ payload: { data: { attributes: { 'module-id': moduleId } } } }, hStub, {
         passageSerializer,
         usecases,
-        extractUserIdFromRequest,
       });
 
       // then

--- a/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
@@ -1,10 +1,18 @@
 import { ModuleDoesNotExistError } from '../../../../../src/devcomp/domain/errors.js';
+import { Module } from '../../../../../src/devcomp/domain/models/module/Module.js';
+import { Passage } from '../../../../../src/devcomp/domain/models/Passage.js';
+import { PassageStartedEvent } from '../../../../../src/devcomp/domain/models/passage-events/passage-events.js';
 import { createPassage } from '../../../../../src/devcomp/domain/usecases/create-passage.js';
+import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
 import { UserNotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
+  beforeEach(function () {
+    sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
+  });
+
   describe('when module does not exist', function () {
     it('should throw a ModuleDoesNotExist error', async function () {
       // given
@@ -48,11 +56,35 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
     });
   });
 
-  it('should call passage repository to save the passage', async function () {
+  it('should save the passage and record passage started event', async function () {
     // given
     const moduleId = Symbol('moduleId');
+    const passageId = Symbol('passageId');
     const userId = Symbol('userId');
-    const repositoryResult = Symbol('repository-result');
+
+    const slug = 'les-adresses-email';
+    const title = 'Les adresses email';
+    const isBeta = false;
+    const grains = [Symbol('text')];
+    const transitionTexts = [];
+    const details = Symbol('details');
+    const version = Symbol('version');
+    const module = new Module({ id: moduleId, slug, title, isBeta, grains, details, transitionTexts, version });
+
+    const occurredAt = new Date('2025-01-01');
+    const passageCreatedAt = new Date('2025-03-05');
+    const passage = new Passage({
+      id: passageId,
+      moduleId,
+      userId,
+      createdAt: passageCreatedAt,
+    });
+
+    const passageStartedEvent = new PassageStartedEvent({
+      contentHash: version,
+      occurredAt,
+      passageId,
+    });
 
     const userRepositoryStub = {
       get: sinon.stub(),
@@ -61,17 +93,23 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
     const moduleRepositoryStub = {
       getBySlug: sinon.stub(),
     };
-    moduleRepositoryStub.getBySlug.withArgs({ slug: moduleId }).resolves();
+    moduleRepositoryStub.getBySlug.withArgs({ slug: moduleId }).resolves(module);
     const passageRepositoryStub = {
       save: sinon.stub(),
     };
-    passageRepositoryStub.save.resolves(repositoryResult);
+    passageRepositoryStub.save.resolves(passage);
+
+    const passageEventRepositoryStub = {
+      record: sinon.stub(),
+    };
 
     // when
     const result = await createPassage({
+      occurredAt,
       moduleId,
       userId,
       passageRepository: passageRepositoryStub,
+      passageEventRepository: passageEventRepositoryStub,
       moduleRepository: moduleRepositoryStub,
       userRepository: userRepositoryStub,
     });
@@ -81,6 +119,7 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
       moduleId,
       userId,
     });
-    expect(result).to.equal(repositoryResult);
+    expect(passageEventRepositoryStub.record).to.have.been.calledOnceWith(passageStartedEvent);
+    expect(result).to.equal(passage);
   });
 });

--- a/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
@@ -6,7 +6,7 @@ import { catchErr, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
   describe('when module does not exist', function () {
-    it('should throw an ModuleNotExists', async function () {
+    it('should throw a ModuleDoesNotExist error', async function () {
       // given
       const moduleId = Symbol('moduleId');
 
@@ -24,7 +24,7 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
   });
 
   describe('when user does not exist', function () {
-    it('should throw an UserNotExists', async function () {
+    it('should throw an UserNotExists error', async function () {
       // given
       const userId = Symbol('userId');
 


### PR DESCRIPTION
## :pancakes: Contexte

Nous avons mis en place une table `passage-events` pour permettre d'enregistrer les événement Modulix. Des classes `PassageStartedEvent` et `PassageTerminatedEvent` ont été crée pour ça.

## :bacon: Proposition
Enregistrer le début d'un passage comme événement en utilisant les travaux fais précédemment.

## 🧃 Remarques

- La PR https://github.com/1024pix/pix/pull/11560 doit être mergée avant !
- Le champ `occurredAt` se base sur la date de création en base du passage. Il faudrait qu'il soit passé par le front

## :yum: Pour tester

TODO
