### PR TITLE
[FEATURE] Utiliser le même style pour l'intitulé Réponse correcte et Réponse incorrecte (PIX-16840).

### DIFF
--- a/mon-pix/app/components/solution-panel/qcu-solution-panel.hbs
+++ b/mon-pix/app/components/solution-panel/qcu-solution-panel.hbs
@@ -42,7 +42,11 @@
   {{/each}}
 
   {{#if this.isAnswerValid}}
-    <div data-test-correct-answer>{{t "pages.comparison-window.results.feedback.correct"}}</div>
+    <div data-test-correct-answer>
+      <p class="qcu-solution-answer-feedback__expected-answer">
+        {{t "pages.comparison-window.results.feedback.correct"}}
+      </p>
+    </div>
   {{else}}
     <MarkdownToHtml
       class="qcu-solution-answer-feedback__expected-answer"


### PR DESCRIPTION
## :pancakes: Problème
Sur l'écran intermédiaire d'un parcours, dans le cas d'une réponse à un QCU, les styles des champs "Réponse correcte" et "Réponse incorrecte" sont différents. 

## :bacon: Proposition
Homogénéiser les affichages en utilisant la police en gras pour les 2 champs.

## :yum: Pour tester
- Répondre à ce [QCU](https://app-pr11569.review.pix.fr/challenges/challenge1OYx9HqFFXVmVS/preview), avec une réponse correcte puis incorrecte, et constater que dans l'affichage de la réponse, les style de police sont similaires. 
