### PR TITLE
[TECH] Déplacer et factoriser le code dédié au calcul du levelup après avoir répondu positivement à une épreuve (PIX-16847)

### DIFF
--- a/api/src/evaluation/domain/services/scorecard-service.js
+++ b/api/src/evaluation/domain/services/scorecard-service.js
@@ -5,7 +5,7 @@ import { KnowledgeElement } from '../../../shared/domain/models/KnowledgeElement
 import { CompetenceEvaluation } from '../models/CompetenceEvaluation.js';
 import { Scorecard } from '../models/Scorecard.js';
 
-async function computeScorecard({
+export async function computeScorecard({
   userId,
   competenceId,
   competenceRepository,
@@ -34,7 +34,47 @@ async function computeScorecard({
   });
 }
 
-async function resetScorecard({
+export function computeLevelUpInformation({
+  answer,
+  userId,
+  area,
+  competence,
+  competenceEvaluationForCompetence,
+  knowledgeElementsForCompetenceBefore,
+  knowledgeElementsForCompetenceAfter,
+  allowExcessPix = false,
+  allowExcessLevel = false,
+}) {
+  const scorecardBefore = Scorecard.buildFrom({
+    userId,
+    knowledgeElements: knowledgeElementsForCompetenceBefore,
+    competenceEvaluation: competenceEvaluationForCompetence,
+    competence,
+    area,
+    allowExcessPix,
+    allowExcessLevel,
+  });
+  const scorecardAfter = Scorecard.buildFrom({
+    userId,
+    knowledgeElements: knowledgeElementsForCompetenceAfter,
+    competenceEvaluation: competenceEvaluationForCompetence,
+    competence,
+    area,
+    allowExcessPix,
+    allowExcessLevel,
+  });
+
+  if (scorecardBefore.level < scorecardAfter.level) {
+    return {
+      id: answer.id,
+      competenceName: scorecardAfter.name,
+      level: scorecardAfter.level,
+    };
+  }
+  return {};
+}
+
+export async function resetScorecard({
   userId,
   competenceId,
   shouldResetCompetenceEvaluation,
@@ -152,8 +192,6 @@ async function _resetCampaignAssessment({
   return await assessmentRepository.save({ assessment: newAssessment });
 }
 
-function _computeResetSkillsNotIncludedInCampaign({ skillIds, resetSkillIds }) {
+export function _computeResetSkillsNotIncludedInCampaign({ skillIds, resetSkillIds }) {
   return _(skillIds).intersection(resetSkillIds).isEmpty();
 }
-
-export { _computeResetSkillsNotIncludedInCampaign, computeScorecard, resetScorecard };

--- a/api/tests/evaluation/unit/domain/services/scorecard-service_test.js
+++ b/api/tests/evaluation/unit/domain/services/scorecard-service_test.js
@@ -514,6 +514,108 @@ describe('Unit | Service | ScorecardService', function () {
     });
   });
 
+  describe('#computeLevelUpInformation', function () {
+    const userId = 789;
+    let area, answer, competence, competenceEvaluationForCompetence;
+
+    beforeEach(function () {
+      area = domainBuilder.buildArea({ id: 'areaABC123' });
+      competence = domainBuilder.buildCompetence({
+        id: 'competenceABC123',
+        name: 'Nom de ma competence pour le levelup',
+      });
+      answer = domainBuilder.buildAnswer({ id: 777 });
+      competenceEvaluationForCompetence = domainBuilder.buildCompetenceEvaluation({
+        id: 555,
+        status: CompetenceEvaluation.statuses.STARTED,
+      });
+    });
+
+    it('should return a levelup information when a level up has occurred', function () {
+      // given
+      const knowledgeElementsForCompetenceBefore = [
+        domainBuilder.buildKnowledgeElement({
+          competenceId: 'competenceABC123',
+          status: KnowledgeElement.StatusType.VALIDATED,
+          earnedPix: 1,
+          skillId: 'skillA',
+        }),
+      ];
+      const knowledgeElementsForCompetenceAfter = [
+        domainBuilder.buildKnowledgeElement({
+          competenceId: 'competenceABC123',
+          status: KnowledgeElement.StatusType.VALIDATED,
+          earnedPix: 1,
+          skillId: 'skillA',
+        }),
+        domainBuilder.buildKnowledgeElement({
+          competenceId: 'competenceABC123',
+          status: KnowledgeElement.StatusType.VALIDATED,
+          earnedPix: 10,
+          skillId: 'skillB',
+        }),
+      ];
+
+      // when
+      const levelupInformation = scorecardService.computeLevelUpInformation({
+        answer,
+        userId,
+        area,
+        competence,
+        competenceEvaluationForCompetence,
+        knowledgeElementsForCompetenceBefore,
+        knowledgeElementsForCompetenceAfter,
+      });
+
+      // then
+      expect(levelupInformation).to.deep.equal({
+        id: answer.id,
+        competenceName: 'Nom de ma competence pour le levelup',
+        level: 1,
+      });
+    });
+
+    it('should return an empty object when no level up has occurred', function () {
+      // given
+      const knowledgeElementsForCompetenceBefore = [
+        domainBuilder.buildKnowledgeElement({
+          competenceId: 'competenceABC123',
+          status: KnowledgeElement.StatusType.VALIDATED,
+          earnedPix: 1,
+          skillId: 'skillA',
+        }),
+      ];
+      const knowledgeElementsForCompetenceAfter = [
+        domainBuilder.buildKnowledgeElement({
+          competenceId: 'competenceABC123',
+          status: KnowledgeElement.StatusType.VALIDATED,
+          earnedPix: 1,
+          skillId: 'skillA',
+        }),
+        domainBuilder.buildKnowledgeElement({
+          competenceId: 'competenceABC123',
+          status: KnowledgeElement.StatusType.VALIDATED,
+          earnedPix: 1,
+          skillId: 'skillB',
+        }),
+      ];
+
+      // when
+      const levelupInformation = scorecardService.computeLevelUpInformation({
+        answer,
+        userId,
+        area,
+        competence,
+        competenceEvaluationForCompetence,
+        knowledgeElementsForCompetenceBefore,
+        knowledgeElementsForCompetenceAfter,
+      });
+
+      // then
+      expect(levelupInformation).to.deep.equal({});
+    });
+  });
+
   describe('#_computeResetSkillsNotIncludedInTargetProfile', function () {
     it('should return true when no skill is in common between target profile and reset skills', function () {
       // given

--- a/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-campaign_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-campaign_test.js
@@ -369,7 +369,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
           savedAnswer.result = AnswerStatus.KO;
 
           // when
-          await saveAndCorrectAnswerForCampaign({
+          const result = await saveAndCorrectAnswerForCampaign({
             answer,
             userId,
             assessment,
@@ -379,6 +379,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
 
           // then
           expect(scorecardService.computeLevelUpInformation).to.not.have.been.called;
+          expect(result.levelup).to.deep.equal({});
         });
       });
     });

--- a/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-campaign_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-campaign_test.js
@@ -31,7 +31,6 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
 
   const nowDate = new Date('2021-03-11T11:00:04Z');
   const locale = 'fr';
-  const assessmentId = 789789;
   const forceOKAnswer = false;
 
   let dependencies;
@@ -62,7 +61,6 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
     ]);
     const challengeId = 'oneChallengeId';
     assessment = domainBuilder.buildAssessment({
-      id: assessmentId,
       userId,
       lastQuestionDate: nowDate,
       type: Assessment.types.CAMPAIGN,
@@ -615,47 +613,6 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
       const expectedAnswer = domainBuilder.buildAnswer(answer);
       expectedAnswer.timeSpent = 5;
       expect(answerRepository.saveWithKnowledgeElements).to.be.calledWith(expectedAnswer);
-    });
-  });
-
-  context('when the challenge is not focused', function () {
-    let focusedOutAnswer;
-    let answerSaved;
-
-    beforeEach(function () {
-      // Given
-      focusedOutAnswer = domainBuilder.buildAnswer({ isFocusedOut: true });
-      const nonFocusedChallenge = domainBuilder.buildChallenge({
-        id: focusedOutAnswer.challengeId,
-        validator,
-        focused: false,
-      });
-      challengeRepository.get.resolves(nonFocusedChallenge);
-      assessment = domainBuilder.buildAssessment({
-        userId,
-        lastQuestionDate: new Date('2021-03-11T11:00:00Z'),
-        type: Assessment.types.CAMPAIGN,
-        method: Assessment.methods.SMART_RANDOM,
-      });
-      answerSaved = domainBuilder.buildAnswer(focusedOutAnswer);
-      answerRepository.saveWithKnowledgeElements.resolves(answerSaved);
-      KnowledgeElement.createKnowledgeElementsForAnswer.returns([]);
-      knowledgeElementRepository.findUniqByUserId.withArgs({ userId: assessment.userId }).resolves([]);
-    });
-
-    it('should not return focused out answer', async function () {
-      // When
-      const { result } = await saveAndCorrectAnswerForCampaign({
-        answer: focusedOutAnswer,
-        userId,
-        assessment,
-        locale,
-        ...dependencies,
-      });
-
-      // Then
-      expect(result).not.to.equal(AnswerStatus.FOCUSEDOUT);
-      expect(result).to.deep.equal(AnswerStatus.OK);
     });
   });
 });


### PR DESCRIPTION
## :pancakes: Problème

La logique de calcul de level up après avoir répondu à une épreuve est dupliquée.

## :bacon: Proposition

Exposer une fonction dans le service `scorecard-service` pour calculer si il y a level up ou pas.
La fonction est synchrone et prend plusieurs arguments en entrée.
C'est volontaire cette manière de fonctionner car ça la rend plus facile à utiliser dans des contextes différents (en mode interro par exemple quand les KEs d'entrée sont différents d'une campagne d'évaluation...)

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

Non régression sur campagne d'évaluation et positionnement sur l'enchaînement des épreuves, les corrections et le score.
Notif de levelup OK
