### PR TITLE
[TECH] Limiter les 500 en cas de mauvais URL et/ou de mauvaise utilisation de l'API (PIX-16830)

### DIFF
--- a/api/src/shared/application/healthcheck/healthcheck-controller.js
+++ b/api/src/shared/application/healthcheck/healthcheck-controller.js
@@ -39,8 +39,12 @@ const checkRedisStatus = async function () {
 };
 
 const checkForwardedOriginStatus = async function (request, h) {
-  const forwardedOrigin = network.getForwardedOrigin(request.headers);
-  if (!forwardedOrigin) {
+  let forwardedOrigin;
+  try {
+    // network.getForwardedOrigin throws ForwardedOriginError which maps to a HTTP status code 400,
+    // but for monitoring purpose we want this error to produce a 500.
+    forwardedOrigin = network.getForwardedOrigin(request.headers);
+  } catch {
     return h.response('Obtaining Forwarded Origin failed').code(500);
   }
 

--- a/api/src/shared/infrastructure/plugins/pino.js
+++ b/api/src/shared/infrastructure/plugins/pino.js
@@ -22,9 +22,14 @@ function requestSerializer(req) {
   const context = monitoringTools.getContext();
   if (context?.request?.route?.path === '/api/token') {
     const { username, refresh_token, grant_type } = context.request.payload || {};
-    const origin = getForwardedOrigin(context.request.headers);
+    let origin;
+    try {
+      origin = getForwardedOrigin(context.request.headers);
+    } catch {
+      origin = '-';
+    }
+    enhancedReq.audience = origin;
     enhancedReq.grantType = grant_type || '-';
-    enhancedReq.audience = origin || '-';
     enhancedReq.usernameHash = generateHash(username) || '-';
     enhancedReq.refreshTokenHash = generateHash(refresh_token) || '-';
   }

--- a/api/tests/identity-access-management/unit/infrastructure/utils/network.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/utils/network.test.js
@@ -1,4 +1,5 @@
 import {
+  ForwardedOriginError,
   getForwardedOrigin,
   RequestedApplication,
 } from '../../../../../src/identity-access-management/infrastructure/utils/network.js';
@@ -75,15 +76,12 @@ describe('Unit | Identity Access Management | Infrastructure | Utils | network',
     });
 
     context('when x-forwarded-proto and x-forwarded-port are not defined', function () {
-      it('doesn’t choke and returns an empty string', async function () {
+      it('throws a ForwardedOriginError', function () {
         // given
         const headers = {};
 
-        // when
-        const origin = getForwardedOrigin(headers);
-
-        // then
-        expect(origin).to.equal('');
+        // when & then
+        expect(() => getForwardedOrigin(headers)).to.throw(ForwardedOriginError, 'Missing forwarded header(s)');
       });
     });
   });
@@ -233,6 +231,19 @@ describe('Unit | Identity Access Management | Infrastructure | Utils | network',
             expect(requestedApplication.isPixCertif).to.be.false;
             expect(requestedApplication.isPixJunior).to.be.true;
           });
+        });
+      });
+
+      context('when the origin is unsupported', function () {
+        it('throws a ForwardedOriginError', function () {
+          // given
+          const origin = 'https://someUnsupportedName';
+
+          // when & then
+          expect(() => RequestedApplication.fromOrigin(origin)).to.throw(
+            ForwardedOriginError,
+            'Unsupported hostname: "someunsupportedname"',
+          );
         });
       });
     });


### PR DESCRIPTION
## :pancakes: Problème

Les requêtes d'utilisateurs envoyées directement à l'API ne sont maintenant plus acceptées, il faut donc passer obligatoirement par un des frontaux. Et ces requêtes d'utilisateurs envoyées directement à l'API ne sont plus censées être faites puisqu'elles ne sont plus acceptées. Néanmoins si une requête est envoyée directement à l'API, cette requête va produire des erreurs `500`, et donc des alarmes au niveau du monitoring, car le bloc suivant va générer des `TypeError: Invalid URL` :
```javascript
RequestedApplication.fromOrigin(origin)
```

## :bacon: Proposition

Gérer une erreur `ForwardedOriginError` dédiée (au lieu d'avoir l'erreur générique `TypeError: Invalid URL`) et l'attraper en renvoyant un HTTP code status `400`.

## 🧃 Remarques

De manière un peu contre-intuitive cette PR attrape maintenant toutes les erreurs dans `healthcheckController.checkForwardedOriginStatus` et renvoie alors des erreurs `500` justement pour générer des alarmes au niveau du monitoring en cas de problème.

## :yum: Pour tester

On ne peut tester cela qu'en _local_, en _intégration_, en _recette_ et en _production_. Mais pas en _RA_. En effet les RA ont une configuration particulière qui fait que toutes les RA ont les forwarded headers définis, y compris la RA dédiée à Pix API.

* Vérifier qu'une route appelée directement sur Pix API renvoie maintenant une `400` (remplacer `XXX` par le bon mot de passe) : 

   ```shell
   curl -X POST \
   'http://localhost:3000/api/token' \
   -d 'grant_type=password&username=james-paledroits@example.net&password=XXX'
   ```

* Vérifier que la route `/api/healthcheck/forwarded-origin` (en local c'est  `https://app.dev.pix.fr/api/healthcheck/forwarded-origin`) renvoie bien toujours `200` quand elle est appelée à travers un frontal (Pix App, Pix Orga, etc.)
* Vérifier que la route `/api/healthcheck/forwarded-origin` (en local c'est `http://localhost:3000/api/healthcheck/forwarded-orig`) renvoie bien toujours `500` quand elle est appelée directement sur Pix API

