### PR TITLE
[FEATURE] Alimenter un KE snapshot au fur et à mesure des réponses apportées lors d'une campagne d'interro (PIX-16775)

### DIFF
--- a/api/src/devcomp/infrastructure/repositories/tutorial-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/tutorial-repository.js
@@ -79,7 +79,7 @@ export async function findPaginatedFilteredRecommendedByUserId({
   page,
   locale = FRENCH_FRANCE,
 } = {}) {
-  const invalidatedKnowledgeElements = await knowledgeElementRepository.findInvalidatedAndDirectByUserId(userId);
+  const invalidatedKnowledgeElements = await knowledgeElementRepository.findInvalidatedAndDirectByUserId({ userId });
 
   const [userSavedTutorials, tutorialEvaluations, skills] = await Promise.all([
     userSavedTutorialRepository.find({ userId }),

--- a/api/src/evaluation/domain/usecases/index.js
+++ b/api/src/evaluation/domain/usecases/index.js
@@ -15,7 +15,7 @@ import * as assessmentRepository from '../../../shared/infrastructure/repositori
 import * as badgeForCalculationRepository from '../../../shared/infrastructure/repositories/badge-for-calculation-repository.js';
 import * as challengeRepository from '../../../shared/infrastructure/repositories/challenge-repository.js';
 import * as competenceRepository from '../../../shared/infrastructure/repositories/competence-repository.js';
-import * as knowledgeElementRepository from '../../../shared/infrastructure/repositories/knowledge-element-repository.js';
+import { repositories as injectedSharedRepositories } from '../../../shared/infrastructure/repositories/index.js';
 import * as skillRepository from '../../../shared/infrastructure/repositories/skill-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
@@ -65,7 +65,7 @@ const dependencies = {
   feedbackRepository,
   flashAssessmentResultRepository,
   flashAlgorithmService,
-  knowledgeElementRepository,
+  knowledgeElementRepository: injectedSharedRepositories.knowledgeElementRepository,
   skillRepository,
   stageCollectionForTargetProfileRepository,
   stageAcquisitionRepository,

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-campaign.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-campaign.js
@@ -57,7 +57,9 @@ const saveAndCorrectAnswerForCampaign = withTransaction(async function ({
     const targetSkills = await campaignRepository.findSkillsByCampaignParticipationId({
       campaignParticipationId: assessment.campaignParticipationId,
     });
-    const campaignId = await campaignRepository.getCampaignIdByCampaignParticipationId(campaignParticipationId);
+    const campaignId = await campaignRepository.getCampaignIdByCampaignParticipationId(
+      assessment.campaignParticipationId,
+    );
     const campaign = await campaignRepository.get(campaignId);
     answerSaved = await answerRepository.save({ answer: correctedAnswer });
     const knowledgeElementsToAdd = computeKnowledgeElements({
@@ -171,10 +173,16 @@ async function computeLevelUpInformation({
   const knowledgeElementsForCompetenceBefore = knowledgeElementsBefore.filter(
     (knowledgeElement) => knowledgeElement.competenceId === competenceId,
   );
+  const knowledgeElementsAddedForCompetence = knowledgeElementsAdded.filter(
+    (knowledgeElement) => knowledgeElement.competenceId === competenceId,
+  );
   const knowledgeElementsForCompetenceAfter = [
-    ...knowledgeElementsAdded.filter((knowledgeElement) => knowledgeElement.competenceId === competenceId),
+    ...knowledgeElementsAddedForCompetence,
     ...knowledgeElementsForCompetenceBefore,
   ];
+  const uniqKnowledgeElementsForCompetenceAfter = knowledgeElementsForCompetenceAfter.filter(
+    (ke, index) => knowledgeElementsForCompetenceAfter.findIndex(({ skillId }) => skillId === ke.skillId) === index,
+  );
   return scorecardService.computeLevelUpInformation({
     answer: answerSaved,
     userId,
@@ -182,9 +190,8 @@ async function computeLevelUpInformation({
     competence,
     competenceEvaluationForCompetence,
     knowledgeElementsForCompetenceBefore,
-    knowledgeElementsForCompetenceAfter,
+    knowledgeElementsForCompetenceAfter: uniqKnowledgeElementsForCompetenceAfter,
   });
 }
 
-export { saveAndCorrectAnswerForCampaign };
 export { saveAndCorrectAnswerForCampaign };

--- a/api/src/prescription/campaign/application/api/campaigns-api.js
+++ b/api/src/prescription/campaign/application/api/campaigns-api.js
@@ -57,6 +57,19 @@ export const get = async (campaignId) => {
 };
 
 /**
+ * @function
+ * @name getByCampaignParticipationId
+ *
+ * @param {number} campaignParticipationId
+ * @returns {Promise<Campaign|null>}
+ */
+export const getByCampaignParticipationId = async (campaignParticipationId) => {
+  const campaign = await usecases.getCampaignOfCampaignParticipation({ campaignParticipationId });
+  if (!campaign) return null;
+  return new Campaign(campaign);
+};
+
+/**
  * @typedef UpdateCampaignPayload
  * @type {object}
  * @property {number} campaignId

--- a/api/src/prescription/campaign/application/api/knowledge-element-snapshots-api.js
+++ b/api/src/prescription/campaign/application/api/knowledge-element-snapshots-api.js
@@ -39,8 +39,11 @@ export async function save(knowledgeElementSnapshotPayload) {
  * @returns {Promise<KnowledgeElementSnapshot|null>}
  */
 export async function getByParticipation(campaignParticipationId) {
-  const knowledgeElementSnapshot = await usecases.getKnowledgeElementSnapshotForParticipation({
+  const knowledgeElements = await usecases.getKnowledgeElementSnapshotForParticipation({
     campaignParticipationId,
   });
-  return new KnowledgeElementSnapshot(knowledgeElementSnapshot);
+  return new KnowledgeElementSnapshot({
+    knowledgeElements,
+    campaignParticipationId,
+  });
 }

--- a/api/src/prescription/campaign/application/api/knowledge-element-snapshots-api.js
+++ b/api/src/prescription/campaign/application/api/knowledge-element-snapshots-api.js
@@ -1,0 +1,46 @@
+import { KnowledgeElementCollection } from '../../../shared/domain/models/KnowledgeElementCollection.js';
+import { usecases } from '../../domain/usecases/index.js';
+import { KnowledgeElementSnapshot } from './models/KnowledgeElementSnapshot.js';
+/**
+ * @module KnowledgeElementSnapshotAPI
+ */
+
+/**
+ * @typedef KnowledgeElementSnapshotPayload
+ * @type {object}
+ * @property {number} userId
+ * @property {number} campaignParticipationId
+ * @property {Array<KnowledgeElement>} knowledgeElements
+ */
+
+/**
+ * @function
+ * @name save
+ *
+ * @param {KnowledgeElementSnapshotPayload} knowledgeElementSnapshotPayload
+ * @returns {Promise<Boolean>}
+ */
+export async function save(knowledgeElementSnapshotPayload) {
+  await usecases.saveKnowledgeElementSnapshotForParticipation({
+    userId: knowledgeElementSnapshotPayload.userId,
+    snappedAt: new Date(),
+    KnowledgeElementCollection: new KnowledgeElementCollection(knowledgeElementSnapshotPayload.knowledgeElements),
+    campaignParticipationId: knowledgeElementSnapshotPayload.campaignParticipationId,
+  });
+
+  return true;
+}
+
+/**
+ * @function
+ * @name getByParticipation
+ *
+ * @param {number} campaignParticipationId
+ * @returns {Promise<KnowledgeElementSnapshot|null>}
+ */
+export async function getByParticipation(campaignParticipationId) {
+  const knowledgeElementSnapshot = await usecases.getKnowledgeElementSnapshotForParticipation({
+    campaignParticipationId,
+  });
+  return new KnowledgeElementSnapshot(knowledgeElementSnapshot);
+}

--- a/api/src/prescription/campaign/application/api/knowledge-element-snapshots-api.js
+++ b/api/src/prescription/campaign/application/api/knowledge-element-snapshots-api.js
@@ -24,7 +24,7 @@ export async function save(knowledgeElementSnapshotPayload) {
   await usecases.saveKnowledgeElementSnapshotForParticipation({
     userId: knowledgeElementSnapshotPayload.userId,
     snappedAt: new Date(),
-    KnowledgeElementCollection: new KnowledgeElementCollection(knowledgeElementSnapshotPayload.knowledgeElements),
+    knowledgeElementCollection: new KnowledgeElementCollection(knowledgeElementSnapshotPayload.knowledgeElements),
     campaignParticipationId: knowledgeElementSnapshotPayload.campaignParticipationId,
   });
 

--- a/api/src/prescription/campaign/application/api/models/Campaign.js
+++ b/api/src/prescription/campaign/application/api/models/Campaign.js
@@ -1,5 +1,16 @@
 export class Campaign {
-  constructor({ id, code, name, title, createdAt, archivedAt, customLandingPageText }) {
+  constructor({
+    id,
+    code,
+    name,
+    title,
+    createdAt,
+    archivedAt,
+    customLandingPageText,
+    isExam,
+    isAssessment,
+    isProfilesCollection,
+  }) {
     this.id = id;
     this.code = code;
     this.name = name;
@@ -7,5 +18,8 @@ export class Campaign {
     this.createdAt = createdAt;
     this.archivedAt = archivedAt;
     this.customLandingPageText = customLandingPageText;
+    this.isExam = isExam;
+    this.isAssessment = isAssessment;
+    this.isProfilesCollection = isProfilesCollection;
   }
 }

--- a/api/src/prescription/campaign/application/api/models/KnowledgeElementSnapshot.js
+++ b/api/src/prescription/campaign/application/api/models/KnowledgeElementSnapshot.js
@@ -1,0 +1,6 @@
+export class KnowledgeElementSnapshot {
+  constructor({ knowledgeElements, campaignParticipationId }) {
+    this.knowledgeElements = knowledgeElements;
+    this.campaignParticipationId = campaignParticipationId;
+  }
+}

--- a/api/src/prescription/campaign/domain/usecases/get-campaign-of-campaign-participation.js
+++ b/api/src/prescription/campaign/domain/usecases/get-campaign-of-campaign-participation.js
@@ -1,0 +1,5 @@
+const getCampaignOfCampaignParticipation = async function ({ campaignParticipationId, campaignRepository }) {
+  return campaignRepository.getByCampaignParticipationId(campaignParticipationId);
+};
+
+export { getCampaignOfCampaignParticipation };

--- a/api/src/prescription/campaign/domain/usecases/get-knowledge-element-snapshot-for-participation.js
+++ b/api/src/prescription/campaign/domain/usecases/get-knowledge-element-snapshot-for-participation.js
@@ -1,0 +1,8 @@
+export async function getKnowledgeElementSnapshotForParticipation({
+  campaignParticipationId,
+  knowledgeElementSnapshotRepository,
+}) {
+  const knowledgeElementSnapshotForParticipations =
+    await knowledgeElementSnapshotRepository.findByCampaignParticipationIds([campaignParticipationId]);
+  return knowledgeElementSnapshotForParticipations?.[campaignParticipationId] ?? null;
+}

--- a/api/src/prescription/campaign/domain/usecases/save-knowledge-element-snapshot-for-participation.js
+++ b/api/src/prescription/campaign/domain/usecases/save-knowledge-element-snapshot-for-participation.js
@@ -1,0 +1,20 @@
+import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
+
+export const saveKnowledgeElementSnapshotForParticipation = withTransaction(async function ({
+  userId,
+  snappedAt,
+  knowledgeElementCollection,
+  campaignParticipationId,
+  knowledgeElementSnapshotRepository,
+}) {
+  await knowledgeElementSnapshotRepository.save({
+    userId,
+    snappedAt,
+    snapshot: knowledgeElementCollection.toSnapshot(),
+    campaignParticipationId,
+  });
+
+  const knowledgeElementSnapshotForParticipations =
+    await knowledgeElementSnapshotRepository.findByCampaignParticipationIds([campaignParticipationId]);
+  return knowledgeElementSnapshotForParticipations?.[campaignParticipationId];
+});

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-repository.js
@@ -58,14 +58,20 @@ const checkIfUserOrganizationHasAccessToCampaign = async function (campaignId, u
   return Boolean(campaign);
 };
 
-const getCampaignIdByCampaignParticipationId = async function (campaignParticipationId) {
+const getByCampaignParticipationId = async function (campaignParticipationId) {
   const knexConn = DomainTransaction.getConnection();
   const campaign = await knexConn('campaigns')
-    .select('campaigns.id')
+    .select('campaigns.*')
     .join('campaign-participations', 'campaign-participations.campaignId', 'campaigns.id')
     .where({ 'campaign-participations.id': campaignParticipationId })
     .first();
 
+  if (!campaign) return null;
+  return new Campaign(campaign);
+};
+
+const getCampaignIdByCampaignParticipationId = async function (campaignParticipationId) {
+  const campaign = await getByCampaignParticipationId(campaignParticipationId);
   if (!campaign) return null;
   return campaign.id;
 };
@@ -121,6 +127,7 @@ export {
   findSkillsByCampaignParticipationId,
   findTubes,
   get,
+  getByCampaignParticipationId,
   getByCode,
   getCampaignIdByCampaignParticipationId,
 };

--- a/api/src/prescription/campaign/infrastructure/repositories/knowledge-element-snapshot-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/knowledge-element-snapshot-repository.js
@@ -1,4 +1,3 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { KnowledgeElement } from '../../../../shared/domain/models/KnowledgeElement.js';
 import { CampaignParticipationKnowledgeElementSnapshots } from '../../../shared/domain/read-models/CampaignParticipationKnowledgeElementSnapshots.js';
@@ -52,7 +51,8 @@ export async function findCampaignParticipationKnowledgeElementSnapshots(campaig
  * @returns {Object.<number, KnowledgeElement[]>}
  */
 export async function findByCampaignParticipationIds(campaignParticipationIds) {
-  const results = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const results = await knexConn
     .select('campaignParticipationId', 'snapshot')
     .from('knowledge-element-snapshots')
     .whereIn('campaignParticipationId', campaignParticipationIds);

--- a/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-assessment-export.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-assessment-export.js
@@ -196,9 +196,9 @@ class CampaignAssessmentExport {
       const startedParticipations = campaignParticipationInfoChunk.filter(
         ({ isShared, isCompleted }) => !isShared && !isCompleted,
       );
-      const othersKnowledgeElementsByUserIdAndCompetenceId = await knowledgeElementRepository.findUniqByUserIds(
-        startedParticipations.map(({ userId }) => userId),
-      );
+      const othersKnowledgeElementsByUserIdAndCompetenceId = await knowledgeElementRepository.findUniqByUserIds({
+        userIds: startedParticipations.map(({ userId }) => userId),
+      });
       const othersResultInfo = othersKnowledgeElementsByUserIdAndCompetenceId.find(
         (knowledElementForOtherParticipation) =>
           campaignParticipationInfo.userId === knowledElementForOtherParticipation.userId,

--- a/api/src/shared/domain/models/KnowledgeElement.js
+++ b/api/src/shared/domain/models/KnowledgeElement.js
@@ -64,6 +64,12 @@ class KnowledgeElement {
     });
   }
 
+  /*
+  Historiquement, on force la création d'un KE inferré sur un acquis sur lequel l'utilisateur s'est
+  possiblement déjà positionné par le passé (dans le cadre d'un assessment différent) pour :
+  - forcer la réactualisation du nombre de pix rapportés par acquis (un acquis peut changer de pixValue à mesure que le référentiel évolue)
+  - pour gérer les trous dans le référentiel (avant l'arrivée des cappedtubes)
+   */
   static createKnowledgeElementsForAnswer({
     answer,
     challenge,

--- a/api/src/shared/infrastructure/repositories/index.js
+++ b/api/src/shared/infrastructure/repositories/index.js
@@ -1,4 +1,5 @@
 import * as certificationEvaluationApi from '../../../certification/evaluation/application/api/select-next-certification-challenge-api.js';
+import * as campaignsAPI from '../../../prescription/campaign/application/api/campaigns-api.js';
 import * as knowledgeElementSnapshotAPI from '../../../prescription/campaign/application/api/knowledge-element-snapshots-api.js';
 import { injectDependencies } from '../utils/dependency-injection.js';
 import * as certificationEvaluationRepository from './certification-challenge-repository.js';
@@ -24,6 +25,7 @@ const repositoriesWithoutInjectedDependencies = {
 const dependencies = {
   certificationEvaluationApi,
   knowledgeElementSnapshotAPI,
+  campaignsAPI,
 };
 
 const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies);

--- a/api/src/shared/infrastructure/repositories/index.js
+++ b/api/src/shared/infrastructure/repositories/index.js
@@ -1,23 +1,29 @@
 import * as certificationEvaluationApi from '../../../certification/evaluation/application/api/select-next-certification-challenge-api.js';
+import * as knowledgeElementSnapshotAPI from '../../../prescription/campaign/application/api/knowledge-element-snapshots-api.js';
 import { injectDependencies } from '../utils/dependency-injection.js';
 import * as certificationEvaluationRepository from './certification-challenge-repository.js';
+import * as knowledgeElementRepository from './knowledge-element-repository.js';
 
 /**
  * Using {@link https://jsdoc.app/tags-type "Closure Compiler's syntax"} to document injected dependencies
  *
  * @typedef {certificationEvaluationRepository} CertificationEvaluationRepository
+ * @typedef {knowledgeElementRepository} KnowledgeElementRepository
  */
 const repositoriesWithoutInjectedDependencies = {
   certificationEvaluationRepository,
+  knowledgeElementRepository,
 };
 
 /**
  * Using {@link https://jsdoc.app/tags-type "Closure Compiler's syntax"} to document injected dependencies
  *
  * @typedef {certificationEvaluationApi} CertificationEvaluationApi
+ * @typedef {knowledgeElementSnapshotAPI} KnowledgeElementSnapshotAPI
  */
 const dependencies = {
   certificationEvaluationApi,
+  knowledgeElementSnapshotAPI,
 };
 
 const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies);

--- a/api/src/shared/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/src/shared/infrastructure/repositories/knowledge-element-repository.js
@@ -31,16 +31,16 @@ async function findAssessedByUserIdAndLimitDateQuery({ userId, limitDate, skillI
   return keCollection.latestUniqNonResetKnowledgeElements;
 }
 
-const findUniqByUserIds = function (userIds) {
-  return Promise.all(
-    userIds.map(async (userId) => {
-      const knowledgeElements = await findAssessedByUserIdAndLimitDateQuery({
-        userId,
-      });
+const findUniqByUserIds = async function (userIds) {
+  const results = [];
+  for (const userId of userIds) {
+    const knowledgeElements = await findAssessedByUserIdAndLimitDateQuery({
+      userId,
+    });
 
-      return { userId, knowledgeElements };
-    }),
-  );
+    results.push({ userId, knowledgeElements });
+  }
+  return results;
 };
 
 const batchSave = async function ({ knowledgeElements }) {

--- a/api/src/shared/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/src/shared/infrastructure/repositories/knowledge-element-repository.js
@@ -31,7 +31,7 @@ async function findAssessedByUserIdAndLimitDateQuery({ userId, limitDate, skillI
   return keCollection.latestUniqNonResetKnowledgeElements;
 }
 
-const findUniqByUserIds = async function (userIds) {
+const findUniqByUserIds = async function ({ userIds }) {
   const results = [];
   for (const userId of userIds) {
     const knowledgeElements = await findAssessedByUserIdAndLimitDateQuery({

--- a/api/src/shared/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/src/shared/infrastructure/repositories/knowledge-element-repository.js
@@ -94,7 +94,7 @@ const findUniqByUserIdGroupedByCompetenceId = async function ({ userId, limitDat
   return _.groupBy(knowledgeElements, 'competenceId');
 };
 
-const findInvalidatedAndDirectByUserId = async function (userId) {
+const findInvalidatedAndDirectByUserId = async function ({ userId }) {
   const invalidatedKnowledgeElements = await knex(tableName)
     .where({
       userId,

--- a/api/tests/evaluation/integration/domain/usecases/save-and-correct-answer-for-campaign_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/save-and-correct-answer-for-campaign_test.js
@@ -1,0 +1,135 @@
+import { Answer } from '../../../../../src/evaluation/domain/models/Answer.js';
+import { CompetenceEvaluation } from '../../../../../src/evaluation/domain/models/CompetenceEvaluation.js';
+import { evaluationUsecases } from '../../../../../src/evaluation/domain/usecases/index.js';
+import { CampaignTypes } from '../../../../../src/prescription/shared/domain/constants.js';
+import { PIX_COUNT_BY_LEVEL } from '../../../../../src/shared/domain/constants.js';
+import { AnswerStatus, Assessment, KnowledgeElement } from '../../../../../src/shared/domain/models/index.js';
+import { databaseBuilder, domainBuilder, expect, knex, sinon } from '../../../../test-helper.js';
+
+describe('Integration | Usecase | Save and correct answer for campaign', function () {
+  const skillIds = ['monAcquisA_Id', 'monAcquisB_Id', 'monAcquisC_Id'];
+
+  it('should correct', async function () {
+    // given
+    const locale = 'fr';
+    const userId = databaseBuilder.factory.buildUser().id;
+    const campaignId = databaseBuilder.factory.buildCampaign({
+      type: CampaignTypes.ASSESSMENT,
+    }).id;
+    skillIds.map((skillId) =>
+      databaseBuilder.factory.buildCampaignSkill({
+        campaignId,
+        skillId,
+      }),
+    );
+    const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+      campaignId,
+      sharedAt: null,
+    }).id;
+    const assessmentDB = databaseBuilder.factory.buildAssessment({
+      userId,
+      campaignParticipationId,
+      type: Assessment.types.CAMPAIGN,
+    });
+    databaseBuilder.factory.buildCompetenceEvaluation({
+      userId,
+      status: CompetenceEvaluation.statuses.STARTED,
+    });
+    databaseBuilder.factory.learningContent.buildArea({
+      id: 'monAreaId',
+    });
+    databaseBuilder.factory.learningContent.buildCompetence({
+      id: 'maCompetenceId',
+      areaId: 'monAreaId',
+      name_i18n: {
+        fr: 'nom de la compétence',
+      },
+    });
+    databaseBuilder.factory.learningContent.buildChallenge({
+      id: 'monEpreuveId',
+      skillId: skillIds[2],
+      competenceId: 'maCompetenceId',
+      locales: [locale],
+      status: 'validé',
+      solution: 'correct',
+      proposals: '${a}',
+      type: 'QROC',
+    });
+    skillIds.map((id, index) =>
+      databaseBuilder.factory.learningContent.buildSkill({
+        id,
+        competenceId: 'maCompetenceId',
+        pixValue: PIX_COUNT_BY_LEVEL,
+        status: 'actif',
+        tubeId: 'monTubeId',
+        level: index + 1,
+      }),
+    );
+    const someAnswerId = databaseBuilder.factory.buildAnswer().id;
+    const someOtherAssessmentId = databaseBuilder.factory.buildAssessment({ userId }).id;
+    databaseBuilder.factory.buildKnowledgeElement({
+      skillId: skillIds[0],
+      earnedPix: PIX_COUNT_BY_LEVEL,
+      userId,
+      assessmentId: someOtherAssessmentId,
+      answerId: someAnswerId,
+      status: KnowledgeElement.StatusType.VALIDATED,
+      source: KnowledgeElement.SourceType.DIRECT,
+      competenceId: 'maCompetenceId',
+      createdAt: new Date('2020-01-01'),
+    });
+    await databaseBuilder.commit();
+
+    // when
+    const assessment = domainBuilder.buildAssessment(assessmentDB);
+    const answer = new Answer({
+      value: 'correct',
+      challengeId: 'monEpreuveId',
+      assessmentId: assessment.id,
+    });
+    const savedAnswer = await evaluationUsecases.saveAndCorrectAnswerForCampaign({
+      answer,
+      userId,
+      assessment,
+      locale,
+      forceOKAnswer: false,
+    });
+
+    // then
+    const keData = await knex('knowledge-elements')
+      .select(['source', 'status', 'skillId'])
+      .where({ userId })
+      .orderBy('skillId', 'createdAt');
+    sinon.assert.match(keData[0], {
+      source: KnowledgeElement.SourceType.DIRECT,
+      status: KnowledgeElement.StatusType.VALIDATED,
+      skillId: skillIds[0],
+    });
+    sinon.assert.match(keData[1], {
+      source: KnowledgeElement.SourceType.INFERRED,
+      status: KnowledgeElement.StatusType.VALIDATED,
+      skillId: skillIds[0],
+    });
+    sinon.assert.match(keData[2], {
+      source: KnowledgeElement.SourceType.INFERRED,
+      status: KnowledgeElement.StatusType.VALIDATED,
+      skillId: skillIds[1],
+    });
+    sinon.assert.match(keData[3], {
+      source: KnowledgeElement.SourceType.DIRECT,
+      status: KnowledgeElement.StatusType.VALIDATED,
+      skillId: skillIds[2],
+    });
+    expect(keData.length).to.equal(4);
+    sinon.assert.match(savedAnswer, {
+      id: sinon.match.number,
+      result: AnswerStatus.OK,
+      levelup: {
+        id: savedAnswer.id,
+        competenceName: 'nom de la compétence',
+        level: 3,
+      },
+    });
+    expect(savedAnswer).to.be.instanceOf(Answer);
+  });
+});

--- a/api/tests/evaluation/integration/domain/usecases/save-and-correct-answer-for-campaign_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/save-and-correct-answer-for-campaign_test.js
@@ -1,7 +1,9 @@
 import { Answer } from '../../../../../src/evaluation/domain/models/Answer.js';
 import { CompetenceEvaluation } from '../../../../../src/evaluation/domain/models/CompetenceEvaluation.js';
 import { evaluationUsecases } from '../../../../../src/evaluation/domain/usecases/index.js';
+import * as knowledgeElementSnapshotApi from '../../../../../src/prescription/campaign/application/api/knowledge-element-snapshots-api.js';
 import { CampaignTypes } from '../../../../../src/prescription/shared/domain/constants.js';
+import { KnowledgeElementCollection } from '../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { PIX_COUNT_BY_LEVEL } from '../../../../../src/shared/domain/constants.js';
 import { AnswerStatus, Assessment, KnowledgeElement } from '../../../../../src/shared/domain/models/index.js';
 import { databaseBuilder, domainBuilder, expect, knex, sinon } from '../../../../test-helper.js';
@@ -9,127 +11,255 @@ import { databaseBuilder, domainBuilder, expect, knex, sinon } from '../../../..
 describe('Integration | Usecase | Save and correct answer for campaign', function () {
   const skillIds = ['monAcquisA_Id', 'monAcquisB_Id', 'monAcquisC_Id'];
 
-  it('should correct', async function () {
-    // given
-    const locale = 'fr';
-    const userId = databaseBuilder.factory.buildUser().id;
-    const campaignId = databaseBuilder.factory.buildCampaign({
-      type: CampaignTypes.ASSESSMENT,
-    }).id;
-    skillIds.map((skillId) =>
-      databaseBuilder.factory.buildCampaignSkill({
+  context('for campaign of type assessment with method smart_random', function () {
+    it('should correct answer and save both answer and knowledge-elements', async function () {
+      // given
+      const locale = 'fr';
+      const userId = databaseBuilder.factory.buildUser().id;
+      const campaignId = databaseBuilder.factory.buildCampaign({
+        type: CampaignTypes.ASSESSMENT,
+      }).id;
+      skillIds.map((skillId) =>
+        databaseBuilder.factory.buildCampaignSkill({
+          campaignId,
+          skillId,
+        }),
+      );
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
         campaignId,
-        skillId,
-      }),
-    );
-    const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
-      campaignId,
-      sharedAt: null,
-    }).id;
-    const assessmentDB = databaseBuilder.factory.buildAssessment({
-      userId,
-      campaignParticipationId,
-      type: Assessment.types.CAMPAIGN,
-    });
-    databaseBuilder.factory.buildCompetenceEvaluation({
-      userId,
-      status: CompetenceEvaluation.statuses.STARTED,
-    });
-    databaseBuilder.factory.learningContent.buildArea({
-      id: 'monAreaId',
-    });
-    databaseBuilder.factory.learningContent.buildCompetence({
-      id: 'maCompetenceId',
-      areaId: 'monAreaId',
-      name_i18n: {
-        fr: 'nom de la compétence',
-      },
-    });
-    databaseBuilder.factory.learningContent.buildChallenge({
-      id: 'monEpreuveId',
-      skillId: skillIds[2],
-      competenceId: 'maCompetenceId',
-      locales: [locale],
-      status: 'validé',
-      solution: 'correct',
-      proposals: '${a}',
-      type: 'QROC',
-    });
-    skillIds.map((id, index) =>
-      databaseBuilder.factory.learningContent.buildSkill({
-        id,
+        sharedAt: null,
+      }).id;
+      const assessmentDB = databaseBuilder.factory.buildAssessment({
+        userId,
+        campaignParticipationId,
+        type: Assessment.types.CAMPAIGN,
+      });
+      databaseBuilder.factory.buildCompetenceEvaluation({
+        userId,
+        status: CompetenceEvaluation.statuses.STARTED,
+      });
+      databaseBuilder.factory.learningContent.buildArea({
+        id: 'monAreaId',
+      });
+      databaseBuilder.factory.learningContent.buildCompetence({
+        id: 'maCompetenceId',
+        areaId: 'monAreaId',
+        name_i18n: {
+          fr: 'nom de la compétence',
+        },
+      });
+      databaseBuilder.factory.learningContent.buildChallenge({
+        id: 'monEpreuveId',
+        skillId: skillIds[2],
         competenceId: 'maCompetenceId',
-        pixValue: PIX_COUNT_BY_LEVEL,
-        status: 'actif',
-        tubeId: 'monTubeId',
-        level: index + 1,
-      }),
-    );
-    const someAnswerId = databaseBuilder.factory.buildAnswer().id;
-    const someOtherAssessmentId = databaseBuilder.factory.buildAssessment({ userId }).id;
-    databaseBuilder.factory.buildKnowledgeElement({
-      skillId: skillIds[0],
-      earnedPix: PIX_COUNT_BY_LEVEL,
-      userId,
-      assessmentId: someOtherAssessmentId,
-      answerId: someAnswerId,
-      status: KnowledgeElement.StatusType.VALIDATED,
-      source: KnowledgeElement.SourceType.DIRECT,
-      competenceId: 'maCompetenceId',
-      createdAt: new Date('2020-01-01'),
-    });
-    await databaseBuilder.commit();
+        locales: [locale],
+        status: 'validé',
+        solution: 'correct',
+        proposals: '${a}',
+        type: 'QROC',
+      });
+      skillIds.map((id, index) =>
+        databaseBuilder.factory.learningContent.buildSkill({
+          id,
+          competenceId: 'maCompetenceId',
+          pixValue: PIX_COUNT_BY_LEVEL,
+          status: 'actif',
+          tubeId: 'monTubeId',
+          level: index + 1,
+        }),
+      );
+      const someAnswerId = databaseBuilder.factory.buildAnswer().id;
+      const someOtherAssessmentId = databaseBuilder.factory.buildAssessment({ userId }).id;
+      databaseBuilder.factory.buildKnowledgeElement({
+        skillId: skillIds[0],
+        earnedPix: PIX_COUNT_BY_LEVEL,
+        userId,
+        assessmentId: someOtherAssessmentId,
+        answerId: someAnswerId,
+        status: KnowledgeElement.StatusType.VALIDATED,
+        source: KnowledgeElement.SourceType.DIRECT,
+        competenceId: 'maCompetenceId',
+        createdAt: new Date('2020-01-01'),
+      });
+      await databaseBuilder.commit();
 
-    // when
-    const assessment = domainBuilder.buildAssessment(assessmentDB);
-    const answer = new Answer({
-      value: 'correct',
-      challengeId: 'monEpreuveId',
-      assessmentId: assessment.id,
-    });
-    const savedAnswer = await evaluationUsecases.saveAndCorrectAnswerForCampaign({
-      answer,
-      userId,
-      assessment,
-      locale,
-      forceOKAnswer: false,
-    });
+      // when
+      const assessment = domainBuilder.buildAssessment(assessmentDB);
+      const answer = new Answer({
+        value: 'correct',
+        challengeId: 'monEpreuveId',
+        assessmentId: assessment.id,
+      });
+      const savedAnswer = await evaluationUsecases.saveAndCorrectAnswerForCampaign({
+        answer,
+        userId,
+        assessment,
+        locale,
+        forceOKAnswer: false,
+      });
 
-    // then
-    const keData = await knex('knowledge-elements')
-      .select(['source', 'status', 'skillId'])
-      .where({ userId })
-      .orderBy('skillId', 'createdAt');
-    sinon.assert.match(keData[0], {
-      source: KnowledgeElement.SourceType.DIRECT,
-      status: KnowledgeElement.StatusType.VALIDATED,
-      skillId: skillIds[0],
+      // then
+      const keData = await knex('knowledge-elements')
+        .select(['source', 'status', 'skillId'])
+        .where({ userId })
+        .orderBy('skillId', 'createdAt');
+      sinon.assert.match(keData[0], {
+        source: KnowledgeElement.SourceType.DIRECT,
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId: skillIds[0],
+      });
+      sinon.assert.match(keData[1], {
+        source: KnowledgeElement.SourceType.INFERRED,
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId: skillIds[0],
+      });
+      sinon.assert.match(keData[2], {
+        source: KnowledgeElement.SourceType.INFERRED,
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId: skillIds[1],
+      });
+      sinon.assert.match(keData[3], {
+        source: KnowledgeElement.SourceType.DIRECT,
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId: skillIds[2],
+      });
+      expect(keData.length).to.equal(4);
+      sinon.assert.match(savedAnswer, {
+        id: sinon.match.number,
+        result: AnswerStatus.OK,
+        levelup: {
+          id: savedAnswer.id,
+          competenceName: 'nom de la compétence',
+          level: 3,
+        },
+      });
+      expect(savedAnswer).to.be.instanceOf(Answer);
     });
-    sinon.assert.match(keData[1], {
-      source: KnowledgeElement.SourceType.INFERRED,
-      status: KnowledgeElement.StatusType.VALIDATED,
-      skillId: skillIds[0],
+  });
+  context('for campaign of type exam with method smart_random', function () {
+    it('should correct answer and save both answer and knowledge-elements', async function () {
+      // given
+      const locale = 'fr';
+      const userId = databaseBuilder.factory.buildUser().id;
+      const campaignId = databaseBuilder.factory.buildCampaign({
+        type: CampaignTypes.EXAM,
+      }).id;
+      skillIds.map((skillId) =>
+        databaseBuilder.factory.buildCampaignSkill({
+          campaignId,
+          skillId,
+        }),
+      );
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        sharedAt: null,
+      }).id;
+      const assessmentDB = databaseBuilder.factory.buildAssessment({
+        userId,
+        campaignParticipationId,
+        type: Assessment.types.CAMPAIGN,
+      });
+      databaseBuilder.factory.buildCompetenceEvaluation({
+        userId,
+        status: CompetenceEvaluation.statuses.STARTED,
+      });
+      databaseBuilder.factory.learningContent.buildArea({
+        id: 'monAreaId',
+      });
+      databaseBuilder.factory.learningContent.buildCompetence({
+        id: 'maCompetenceId',
+        areaId: 'monAreaId',
+        name_i18n: {
+          fr: 'nom de la compétence',
+        },
+      });
+      databaseBuilder.factory.learningContent.buildChallenge({
+        id: 'monEpreuveId',
+        skillId: skillIds[2],
+        competenceId: 'maCompetenceId',
+        locales: [locale],
+        status: 'validé',
+        solution: 'correct',
+        proposals: '${a}',
+        type: 'QROC',
+      });
+      skillIds.map((id, index) =>
+        databaseBuilder.factory.learningContent.buildSkill({
+          id,
+          competenceId: 'maCompetenceId',
+          pixValue: PIX_COUNT_BY_LEVEL,
+          status: 'actif',
+          tubeId: 'monTubeId',
+          level: index + 1,
+        }),
+      );
+      const someAnswerId = databaseBuilder.factory.buildAnswer().id;
+      const knowledgeElement = domainBuilder.buildKnowledgeElement({
+        skillId: skillIds[0],
+        earnedPix: PIX_COUNT_BY_LEVEL,
+        userId,
+        assessmentId: assessmentDB.id,
+        answerId: someAnswerId,
+        status: KnowledgeElement.StatusType.VALIDATED,
+        source: KnowledgeElement.SourceType.DIRECT,
+        competenceId: 'maCompetenceId',
+        createdAt: new Date('2020-01-01'),
+      });
+      const knowledgeElementsBefore = new KnowledgeElementCollection([knowledgeElement]);
+      databaseBuilder.factory.buildKnowledgeElementSnapshot({
+        userId,
+        snappedAt: new Date('2019-01-01'),
+        campaignParticipationId,
+        snapshot: knowledgeElementsBefore.toSnapshot(),
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const assessment = domainBuilder.buildAssessment(assessmentDB);
+      const answer = new Answer({
+        value: 'correct',
+        challengeId: 'monEpreuveId',
+        assessmentId: assessment.id,
+      });
+      const savedAnswer = await evaluationUsecases.saveAndCorrectAnswerForCampaign({
+        answer,
+        userId,
+        assessment,
+        locale,
+        forceOKAnswer: false,
+      });
+
+      // then
+      const snapshot = await knowledgeElementSnapshotApi.getByParticipation(campaignParticipationId);
+      expect(snapshot.knowledgeElements.length).to.equal(3);
+      const orderedKnowledgeElements = snapshot.knowledgeElements.sort((keA, keB) =>
+        keA.skillId.localeCompare(keB.skillId),
+      );
+      sinon.assert.match(orderedKnowledgeElements[0], {
+        source: KnowledgeElement.SourceType.DIRECT,
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId: skillIds[0],
+      });
+      sinon.assert.match(orderedKnowledgeElements[1], {
+        source: KnowledgeElement.SourceType.INFERRED,
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId: skillIds[1],
+      });
+      sinon.assert.match(orderedKnowledgeElements[2], {
+        source: KnowledgeElement.SourceType.DIRECT,
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId: skillIds[2],
+      });
+      sinon.assert.match(savedAnswer, {
+        id: sinon.match.number,
+        result: AnswerStatus.OK,
+        levelup: {
+          id: savedAnswer.id,
+          competenceName: 'nom de la compétence',
+          level: 3,
+        },
+      });
+      expect(savedAnswer).to.be.instanceOf(Answer);
     });
-    sinon.assert.match(keData[2], {
-      source: KnowledgeElement.SourceType.INFERRED,
-      status: KnowledgeElement.StatusType.VALIDATED,
-      skillId: skillIds[1],
-    });
-    sinon.assert.match(keData[3], {
-      source: KnowledgeElement.SourceType.DIRECT,
-      status: KnowledgeElement.StatusType.VALIDATED,
-      skillId: skillIds[2],
-    });
-    expect(keData.length).to.equal(4);
-    sinon.assert.match(savedAnswer, {
-      id: sinon.match.number,
-      result: AnswerStatus.OK,
-      levelup: {
-        id: savedAnswer.id,
-        competenceName: 'nom de la compétence',
-        level: 3,
-      },
-    });
-    expect(savedAnswer).to.be.instanceOf(Answer);
   });
 });

--- a/api/tests/integration/scripts/prod/generate-knowledge-element-snapshots-for-campaigns_test.js
+++ b/api/tests/integration/scripts/prod/generate-knowledge-element-snapshots-for-campaigns_test.js
@@ -2,7 +2,8 @@ import {
   generateKnowledgeElementSnapshots,
   getEligibleCampaignParticipations,
 } from '../../../../scripts/prod/generate-knowledge-element-snapshots-for-campaigns.js';
-import { databaseBuilder, expect, sinon } from '../../../test-helper.js';
+import { KnowledgeElementCollection } from '../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
+import { databaseBuilder, domainBuilder, expect, sinon } from '../../../test-helper.js';
 
 describe('Integration | Scripts | generate-knowledge-element-snapshots-for-campaigns.js', function () {
   describe('#getEligibleCampaignParticipations', function () {
@@ -57,6 +58,7 @@ describe('Integration | Scripts | generate-knowledge-element-snapshots-for-campa
       // then
       expect(campaignParticipationData).to.have.lengthOf(1);
       expect(campaignParticipationData[0]).to.deep.equal({
+        id: campaignParticipation.id,
         userId: campaignParticipation.userId,
         sharedAt: campaignParticipation.sharedAt,
       });
@@ -81,6 +83,7 @@ describe('Integration | Scripts | generate-knowledge-element-snapshots-for-campa
       // then
       expect(campaignParticipationData).to.have.lengthOf(1);
       expect(campaignParticipationData[0]).to.deep.equal({
+        id: campaignParticipationWithoutSnapshot.id,
         userId: campaignParticipationWithoutSnapshot.userId,
         sharedAt: campaignParticipationWithoutSnapshot.sharedAt,
       });
@@ -109,6 +112,7 @@ describe('Integration | Scripts | generate-knowledge-element-snapshots-for-campa
       // then
       expect(campaignParticipationData).to.have.lengthOf(1);
       expect(campaignParticipationData[0]).to.deep.equal({
+        id: campaignParticipation.id,
         userId: campaignParticipation.userId,
         sharedAt: campaignParticipation.sharedAt,
       });
@@ -132,7 +136,7 @@ describe('Integration | Scripts | generate-knowledge-element-snapshots-for-campa
       // given
       const concurrency = 1;
       const campaignParticipationData = [{ id: 1, userId: 1, sharedAt: new Date('2020-01-01') }];
-      const expectedKnowledgeElements = ['someKnowledgeElements'];
+      const expectedKnowledgeElements = [domainBuilder.buildKnowledgeElement({ userId: 1 })];
       knowledgeElementRepositoryStub.findUniqByUserId
         .withArgs({
           userId: campaignParticipationData[0].userId,
@@ -150,7 +154,7 @@ describe('Integration | Scripts | generate-knowledge-element-snapshots-for-campa
       expect(knowledgeElementSnapshotRepositoryStub.save).to.have.been.calledWithExactly({
         userId: campaignParticipationData[0].userId,
         snappedAt: campaignParticipationData[0].sharedAt,
-        knowledgeElements: expectedKnowledgeElements,
+        snapshot: new KnowledgeElementCollection(expectedKnowledgeElements).toSnapshot(),
         campaignParticipationId: campaignParticipationData[0].id,
       });
     });

--- a/api/tests/prescription/campaign/integration/domain/usecases/get-campaign-of-campaign-participation_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/get-campaign-of-campaign-participation_test.js
@@ -1,0 +1,17 @@
+import { Campaign } from '../../../../../../src/prescription/campaign/domain/models/Campaign.js';
+import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Integration | UseCase | get-campaign-of-campaign-participation', function () {
+  it('should return campaign linked to the campaign participation the id is passed', async function () {
+    const { id: campaignParticipationId, campaignId } = databaseBuilder.factory.buildCampaignParticipation();
+    await databaseBuilder.commit();
+
+    const campaign = await usecases.getCampaignOfCampaignParticipation({
+      campaignParticipationId,
+    });
+
+    expect(campaign).to.be.instanceOf(Campaign);
+    expect(campaign.id).to.equal(campaignId);
+  });
+});

--- a/api/tests/prescription/campaign/integration/domain/usecases/get-knowledge-element-snapshot-for-participation_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/get-knowledge-element-snapshot-for-participation_test.js
@@ -1,0 +1,26 @@
+import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
+import { KnowledgeElement } from '../../../../../../src/shared/domain/models/KnowledgeElement.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Integration | UseCase | get-knowledge-element-snapshot-for-participation', function () {
+  it('should return null', async function () {
+    const result = await usecases.getKnowledgeElementSnapshotForParticipation({
+      campaignParticipationId: 1,
+    });
+
+    expect(result).to.be.null;
+  });
+
+  it('should return KnowledgeElementSnapshot', async function () {
+    const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation().id;
+    databaseBuilder.factory.buildKnowledgeElementSnapshot({ campaignParticipationId });
+    await databaseBuilder.commit();
+
+    const result = await usecases.getKnowledgeElementSnapshotForParticipation({
+      campaignParticipationId,
+    });
+
+    expect(result).to.be.instanceOf(Array);
+    expect(result[0]).to.be.instanceOf(KnowledgeElement);
+  });
+});

--- a/api/tests/prescription/campaign/integration/domain/usecases/save-knowledge-element-snapshot-for-participation_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/save-knowledge-element-snapshot-for-participation_test.js
@@ -1,0 +1,25 @@
+import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
+import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
+import { KnowledgeElement } from '../../../../../../src/shared/domain/models/KnowledgeElement.js';
+import { databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Integration | UseCase | save-knowledge-element-snapshot-for-participation', function () {
+  it('should persist knowledgeElement', async function () {
+    const knowledgeElement = domainBuilder.buildKnowledgeElement();
+    const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation().id;
+    const userId = databaseBuilder.factory.buildUser().id;
+    await databaseBuilder.commit();
+
+    const knowledgeElementCollection = new KnowledgeElementCollection([knowledgeElement]);
+    const result = await usecases.saveKnowledgeElementSnapshotForParticipation({
+      userId,
+      snappedAt: new Date('2025-03-06'),
+      campaignParticipationId,
+      knowledgeElementCollection,
+    });
+
+    expect(result).to.be.instanceOf(Array);
+    expect(result[0]).to.be.instanceOf(KnowledgeElement);
+    expect(result[0].skillId).to.equal(knowledgeElement.skillId);
+  });
+});

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-repository_test.js
@@ -350,4 +350,49 @@ describe('Integration | Repository | Campaign', function () {
       expect(campaignId).to.equal(campaign.id);
     });
   });
+
+  describe('#getByCampaignParticipationId', function () {
+    it('should return campaign id', async function () {
+      // given
+      const campaign = databaseBuilder.factory.buildCampaign();
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+      }).id;
+      await databaseBuilder.commit();
+
+      // when
+      const result = await campaignRepository.getByCampaignParticipationId(campaignParticipationId);
+
+      // then
+      expect(result).to.deep.equal(new Campaign(campaign));
+    });
+
+    it('should return null when campaignParticipationId does not exist', async function () {
+      // when
+      const campaign = await campaignRepository.getCampaignIdByCampaignParticipationId(123);
+
+      // then
+      expect(campaign).to.be.null;
+    });
+
+    it('should return the campaign id from the given campaignParticipationId', async function () {
+      // given
+      const campaign = databaseBuilder.factory.buildCampaign();
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+      }).id;
+
+      const otherCampaignId = databaseBuilder.factory.buildCampaign().id;
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: otherCampaignId,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await campaignRepository.getByCampaignParticipationId(campaignParticipationId);
+
+      // then
+      expect(result.id).to.equal(campaign.id);
+    });
+  });
 });

--- a/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
+++ b/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
@@ -104,8 +104,52 @@ describe('Unit | API | Campaigns', function () {
       expect(result.title).to.equal(campaignInformation.title);
       expect(result.createdAt).to.equal(campaignInformation.createdAt);
       expect(result.archivedAt).to.equal(campaignInformation.archivedAt);
+      expect(result.archivedAt).to.equal(campaignInformation.archivedAt);
       expect(result.customLandingPageText).to.equal(campaignInformation.customLandingPageText);
       expect(result).not.to.be.instanceOf(Campaign);
+    });
+  });
+
+  describe('#getByCampaignParticipationId', function () {
+    it('should return campaign informations', async function () {
+      const campaignParticipationId = 123;
+      const campaignInformation = domainBuilder.buildCampaign({
+        id: '777',
+        code: 'SOMETHING',
+        name: 'Godzilla',
+        title: 'is Biohazard',
+        customLandingPageText: 'Pika pika pikaCHUUUUUUUUUUUUUUUUUU',
+        createdAt: new Date('2020-01-01'),
+        archivedAt: new Date('2023-01-01'),
+      });
+
+      const getCampaignOfCampaignParticipationStub = sinon.stub(usecases, 'getCampaignOfCampaignParticipation');
+      getCampaignOfCampaignParticipationStub.withArgs({ campaignParticipationId: 123 }).resolves(campaignInformation);
+
+      // when
+      const result = await campaignApi.getByCampaignParticipationId(campaignParticipationId);
+
+      // then
+      expect(result.id).to.equal(campaignInformation.id);
+      expect(result.code).to.equal(campaignInformation.code);
+      expect(result.name).to.equal(campaignInformation.name);
+      expect(result.title).to.equal(campaignInformation.title);
+      expect(result.createdAt).to.equal(campaignInformation.createdAt);
+      expect(result.archivedAt).to.equal(campaignInformation.archivedAt);
+      expect(result.isExam).to.equal(campaignInformation.isExam);
+      expect(result.isAssessment).to.equal(campaignInformation.isAssessment);
+      expect(result.isProfilesCollection).to.equal(campaignInformation.isProfilesCollection);
+      expect(result.customLandingPageText).to.equal(campaignInformation.customLandingPageText);
+      expect(result).not.to.be.instanceOf(Campaign);
+    });
+
+    it('should return null when entities does not exist', async function () {
+      const getCampaignOfCampaignParticipationStub = sinon.stub(usecases, 'getCampaignOfCampaignParticipation');
+      getCampaignOfCampaignParticipationStub.withArgs({ campaignParticipationId: 456 }).resolves(null);
+
+      const result = await campaignApi.getByCampaignParticipationId(456);
+
+      expect(result).to.be.null;
     });
   });
 

--- a/api/tests/prescription/campaign/unit/application/api/knowledge-element-snapshots-api_test.js
+++ b/api/tests/prescription/campaign/unit/application/api/knowledge-element-snapshots-api_test.js
@@ -50,10 +50,7 @@ describe('Unit | API | KnowledgeElementSnapshots', function () {
         .withArgs({
           campaignParticipationId,
         })
-        .resolves({
-          knowledgeElements,
-          campaignParticipationId,
-        });
+        .resolves(knowledgeElements);
 
       // when
       const result = await knowledgeElementSnapshotsApi.getByParticipation(campaignParticipationId);

--- a/api/tests/prescription/campaign/unit/application/api/knowledge-element-snapshots-api_test.js
+++ b/api/tests/prescription/campaign/unit/application/api/knowledge-element-snapshots-api_test.js
@@ -1,0 +1,70 @@
+import * as knowledgeElementSnapshotsApi from '../../../../../../src/prescription/campaign/application/api/knowledge-element-snapshots-api.js';
+import { KnowledgeElementSnapshot } from '../../../../../../src/prescription/campaign/application/api/models/KnowledgeElementSnapshot.js';
+import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
+import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
+import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | API | KnowledgeElementSnapshots', function () {
+  describe('#save', function () {
+    let clock;
+
+    beforeEach(function () {
+      clock = sinon.useFakeTimers({ now: Date.now(), toFake: ['Date'] });
+    });
+
+    afterEach(function () {
+      clock.restore();
+    });
+
+    it('should return true', async function () {
+      const snapshotPayload = {
+        userId: 123,
+        knowledgeElements: [domainBuilder.buildKnowledgeElement()],
+        campaignParticipationId: 789,
+      };
+
+      const saveSnapshotStub = sinon.stub(usecases, 'saveKnowledgeElementSnapshotForParticipation');
+      saveSnapshotStub
+        .withArgs({
+          userId: snapshotPayload.userId,
+          snappedAt: Date.now(),
+          knowledgeElementCollection: new KnowledgeElementCollection(snapshotPayload.knowledgeElements),
+          campaignParticipationId: snapshotPayload.campaignParticipationId,
+        })
+        .resolves();
+
+      // when
+      const result = await knowledgeElementSnapshotsApi.save(snapshotPayload);
+
+      // then
+      expect(result).to.be.true;
+    });
+  });
+
+  describe('#getByParticipation', function () {
+    it('should return the knowledge element snapshot', async function () {
+      const campaignParticipationId = 789;
+      const knowledgeElements = Symbol('knowledgeElements');
+      const getSnapshotStub = sinon.stub(usecases, 'getKnowledgeElementSnapshotForParticipation');
+      getSnapshotStub
+        .withArgs({
+          campaignParticipationId,
+        })
+        .resolves({
+          knowledgeElements,
+          campaignParticipationId,
+        });
+
+      // when
+      const result = await knowledgeElementSnapshotsApi.getByParticipation(campaignParticipationId);
+
+      // then
+      expect(result).to.deepEqualInstance(
+        new KnowledgeElementSnapshot({
+          knowledgeElements,
+          campaignParticipationId,
+        }),
+      );
+    });
+  });
+});

--- a/api/tests/prescription/campaign/unit/application/api/knowledge-element-snapshots-api_test.js
+++ b/api/tests/prescription/campaign/unit/application/api/knowledge-element-snapshots-api_test.js
@@ -24,10 +24,11 @@ describe('Unit | API | KnowledgeElementSnapshots', function () {
       };
 
       const saveSnapshotStub = sinon.stub(usecases, 'saveKnowledgeElementSnapshotForParticipation');
+      saveSnapshotStub.rejects('I was not called with the expected args.');
       saveSnapshotStub
         .withArgs({
           userId: snapshotPayload.userId,
-          snappedAt: Date.now(),
+          snappedAt: new Date(),
           knowledgeElementCollection: new KnowledgeElementCollection(snapshotPayload.knowledgeElements),
           campaignParticipationId: snapshotPayload.campaignParticipationId,
         })

--- a/api/tests/shared/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 
 import { CampaignTypes } from '../../../../../src/prescription/shared/domain/constants.js';
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
-import { KnowledgeElement } from '../../../../../src/shared/domain/models/KnowledgeElement.js';
+import { KnowledgeElement } from '../../../../../src/shared/domain/models/index.js';
 import * as knowledgeElementRepository from '../../../../../src/shared/infrastructure/repositories/knowledge-element-repository.js';
 import { databaseBuilder, domainBuilder, expect, knex } from '../../../../test-helper.js';
 
@@ -540,10 +540,9 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       await databaseBuilder.commit();
 
       // when
-      const knowledgeElementsByUserIdAndCompetenceId = await knowledgeElementRepository.findUniqByUserIds([
-        userId1,
-        userId2,
-      ]);
+      const knowledgeElementsByUserIdAndCompetenceId = await knowledgeElementRepository.findUniqByUserIds({
+        userIds: [userId1, userId2],
+      });
 
       // then
       expect(knowledgeElementsByUserIdAndCompetenceId[0].knowledgeElements).to.have.deep.members([

--- a/api/tests/shared/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -488,7 +488,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       await databaseBuilder.commit();
 
       // When
-      const knowledgeElements = await knowledgeElementRepository.findInvalidatedAndDirectByUserId(userId);
+      const knowledgeElements = await knowledgeElementRepository.findInvalidatedAndDirectByUserId({ userId });
 
       // Then
       expect(knowledgeElements).to.have.lengthOf(2);
@@ -502,7 +502,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       await databaseBuilder.commit();
 
       // When
-      const knowledgeElements = await knowledgeElementRepository.findInvalidatedAndDirectByUserId(userId);
+      const knowledgeElements = await knowledgeElementRepository.findInvalidatedAndDirectByUserId({ userId });
 
       // Then
       expect(knowledgeElements).to.have.lengthOf(0);

--- a/api/tests/shared/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -1,9 +1,10 @@
 import _ from 'lodash';
 
 import { CampaignTypes } from '../../../../../src/prescription/shared/domain/constants.js';
+import { KnowledgeElementCollection } from '../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
-import { KnowledgeElement } from '../../../../../src/shared/domain/models/index.js';
-import * as knowledgeElementRepository from '../../../../../src/shared/infrastructure/repositories/knowledge-element-repository.js';
+import { Assessment, KnowledgeElement } from '../../../../../src/shared/domain/models/index.js';
+import { repositories } from '../../../../../src/shared/infrastructure/repositories/index.js';
 import { databaseBuilder, domainBuilder, expect, knex } from '../../../../test-helper.js';
 
 describe('Integration | Repository | knowledgeElementRepository', function () {
@@ -39,7 +40,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
 
     it('should save all the knowledgeElements in db', async function () {
       // when
-      const savedKnowledgeElements = await knowledgeElementRepository.batchSave({
+      const savedKnowledgeElements = await repositories.knowledgeElementRepository.batchSave({
         knowledgeElements: knowledgeElementsToSave,
       });
 
@@ -84,7 +85,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
     context('when campaign participation is invalid', function () {
       it('should return an empty array without saving anything when campaign participation does not refer to existing entities', async function () {
         // when
-        const res = await knowledgeElementRepository.saveForCampaignParticipation({
+        const res = await repositories.knowledgeElementRepository.saveForCampaignParticipation({
           knowledgeElements: knowledgeElementsToSave,
           campaignParticipationId: 456,
         });
@@ -97,7 +98,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
 
       it('should return an empty array without saving anything when campaign participation is not defined', async function () {
         // when
-        const res = await knowledgeElementRepository.saveForCampaignParticipation({
+        const res = await repositories.knowledgeElementRepository.saveForCampaignParticipation({
           knowledgeElements: knowledgeElementsToSave,
           campaignParticipationId: null,
         });
@@ -120,7 +121,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
           await databaseBuilder.commit();
 
           // when
-          const savedKnowledgeElements = await knowledgeElementRepository.saveForCampaignParticipation({
+          const savedKnowledgeElements = await repositories.knowledgeElementRepository.saveForCampaignParticipation({
             knowledgeElements: knowledgeElementsToSave,
             campaignParticipationId,
           });
@@ -141,7 +142,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
           await databaseBuilder.commit();
 
           // when
-          const savedKnowledgeElements = await knowledgeElementRepository.saveForCampaignParticipation({
+          const savedKnowledgeElements = await repositories.knowledgeElementRepository.saveForCampaignParticipation({
             knowledgeElements: knowledgeElementsToSave,
             campaignParticipationId,
           });
@@ -171,7 +172,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
           await databaseBuilder.commit();
 
           // when
-          const savedKnowledgeElements = await knowledgeElementRepository.saveForCampaignParticipation({
+          const savedKnowledgeElements = await repositories.knowledgeElementRepository.saveForCampaignParticipation({
             knowledgeElements: knowledgeElementsToSave,
             campaignParticipationId,
           });
@@ -251,7 +252,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       // when
       const knowledgeElementsFound = await DomainTransaction.execute(async (domainTransaction) => {
         await domainTransaction.knexTransaction('knowledge-elements').insert(extraKnowledgeElement);
-        return knowledgeElementRepository.findUniqByUserId({ userId });
+        return repositories.knowledgeElementRepository.findUniqByUserId({ userId });
       });
 
       // then
@@ -262,7 +263,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
     context('when there is no limit date', function () {
       it('should find the knowledge elements for campaign assessment associated with a user id', async function () {
         // when
-        const knowledgeElementsFound = await knowledgeElementRepository.findUniqByUserId({ userId });
+        const knowledgeElementsFound = await repositories.knowledgeElementRepository.findUniqByUserId({ userId });
 
         // then
         expect(knowledgeElementsFound).have.lengthOf(3);
@@ -273,7 +274,10 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
     context('when there is a limit date', function () {
       it('should find the knowledge elements for campaign assessment associated with a user id created before limit date', async function () {
         // when
-        const knowledgeElementsFound = await knowledgeElementRepository.findUniqByUserId({ userId, limitDate: today });
+        const knowledgeElementsFound = await repositories.knowledgeElementRepository.findUniqByUserId({
+          userId,
+          limitDate: today,
+        });
 
         // then
         expect(knowledgeElementsFound).to.have.deep.members(knowledgeElementsWantedWithLimitDate);
@@ -285,7 +289,10 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       it('should find the knowledge elements associated with a user id filtered by skill IDs', async function () {
         // when
         const skillIds = ['1', '3'];
-        const knowledgeElementsFound = await knowledgeElementRepository.findUniqByUserId({ userId, skillIds });
+        const knowledgeElementsFound = await repositories.knowledgeElementRepository.findUniqByUserId({
+          userId,
+          skillIds,
+        });
 
         // then
         expect(knowledgeElementsFound).to.have.deep.members(knowledgeElementsWantedWithLimitDate);
@@ -296,7 +303,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
     context('when there are no skill IDs', function () {
       it('should find the knowledge elements associated with a user id', async function () {
         // when
-        const knowledgeElementsFound = await knowledgeElementRepository.findUniqByUserId({ userId });
+        const knowledgeElementsFound = await repositories.knowledgeElementRepository.findUniqByUserId({ userId });
 
         // then
         expect(knowledgeElementsFound).to.have.deep.members(knowledgeElementsWanted);
@@ -337,7 +344,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
 
     it('should find the knowledge elements for assessment associated with a user id', async function () {
       // when
-      const knowledgeElementsFound = await knowledgeElementRepository.findUniqByUserIdAndAssessmentId({
+      const knowledgeElementsFound = await repositories.knowledgeElementRepository.findUniqByUserIdAndAssessmentId({
         userId,
         assessmentId,
       });
@@ -370,7 +377,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
     it('should find the knowledge elements grouped by competence id', async function () {
       // when
       const actualKnowledgeElementsGroupedByCompetenceId =
-        await knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId({ userId });
+        await repositories.knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId({ userId });
 
       // then
       expect(actualKnowledgeElementsGroupedByCompetenceId[1]).to.have.lengthOf(2);
@@ -379,7 +386,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
     });
   });
 
-  describe('findUniqByUserIdAndCompetenceId', function () {
+  describe('#findUniqByUserIdAndCompetenceId', function () {
     let wantedKnowledgeElements;
     let userId;
     let otherUserId;
@@ -417,7 +424,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
 
     it('should find only the knowledge elements matching both userId and competenceId', async function () {
       // when
-      const actualKnowledgeElements = await knowledgeElementRepository.findUniqByUserIdAndCompetenceId({
+      const actualKnowledgeElements = await repositories.knowledgeElementRepository.findUniqByUserIdAndCompetenceId({
         userId,
         competenceId,
       });
@@ -445,7 +452,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
         await databaseBuilder.commit();
 
         // when
-        const knowledgeElementFound = await knowledgeElementRepository.findUniqByUserIdAndCompetenceId({
+        const knowledgeElementFound = await repositories.knowledgeElementRepository.findUniqByUserIdAndCompetenceId({
           userId,
           competenceId: '@comp256',
         });
@@ -488,7 +495,9 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       await databaseBuilder.commit();
 
       // When
-      const knowledgeElements = await knowledgeElementRepository.findInvalidatedAndDirectByUserId({ userId });
+      const knowledgeElements = await repositories.knowledgeElementRepository.findInvalidatedAndDirectByUserId({
+        userId,
+      });
 
       // Then
       expect(knowledgeElements).to.have.lengthOf(2);
@@ -502,14 +511,16 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       await databaseBuilder.commit();
 
       // When
-      const knowledgeElements = await knowledgeElementRepository.findInvalidatedAndDirectByUserId({ userId });
+      const knowledgeElements = await repositories.knowledgeElementRepository.findInvalidatedAndDirectByUserId({
+        userId,
+      });
 
       // Then
       expect(knowledgeElements).to.have.lengthOf(0);
     });
   });
 
-  describe('#findKeForUsers', function () {
+  describe('#findUniqByUserIds', function () {
     let userId1;
     let userId2;
 
@@ -540,7 +551,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       await databaseBuilder.commit();
 
       // when
-      const knowledgeElementsByUserIdAndCompetenceId = await knowledgeElementRepository.findUniqByUserIds({
+      const knowledgeElementsByUserIdAndCompetenceId = await repositories.knowledgeElementRepository.findUniqByUserIds({
         userIds: [userId1, userId2],
       });
 
@@ -552,6 +563,582 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
         user2knowledgeElement1,
         user2knowledgeElement2,
       ]);
+    });
+  });
+
+  describe('#findUniqByUserIdForCampaignParticipation', function () {
+    context('when participation ID does not refer to an existing participation', function () {
+      it('should return null', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const assessmentId = databaseBuilder.factory.buildAssessment().id;
+        const answerId = databaseBuilder.factory.buildAnswer({ assessmentId }).id;
+        const domainKE = domainBuilder.buildKnowledgeElement({
+          userId,
+          skillId: 'acquisABC123',
+          answerId,
+          assessmentId,
+        });
+        databaseBuilder.factory.buildKnowledgeElementSnapshot({
+          userId: userId,
+          snapshot: new KnowledgeElementCollection([domainKE]).toSnapshot(),
+        });
+        databaseBuilder.factory.buildKnowledgeElement(domainKE);
+        await databaseBuilder.commit();
+
+        // when
+        const res = await repositories.knowledgeElementRepository.findUniqByUserIdForCampaignParticipation({
+          userId,
+          campaignParticipationId: 777,
+        });
+
+        // then
+        expect(res).to.be.null;
+      });
+    });
+
+    context('when campaign is of an unknown type', function () {
+      it('should return null', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const campaignId = databaseBuilder.factory.buildCampaign({ type: 'Bouloulou' }).id;
+        const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+        }).id;
+        const assessmentId = databaseBuilder.factory.buildAssessment({ campaignParticipationId }).id;
+        const answerId = databaseBuilder.factory.buildAnswer({ assessmentId }).id;
+        const domainKEInSnapshot = domainBuilder.buildKnowledgeElement({
+          id: 1,
+          userId,
+          skillId: 'acquisABC123',
+          answerId,
+          assessmentId,
+          createdAt: new Date('2021-01-01'),
+        });
+        const domainKENotInSnapshot = domainBuilder.buildKnowledgeElement({
+          id: 2,
+          userId,
+          skillId: 'acquisDEF456',
+          answerId,
+          assessmentId,
+          createdAt: new Date('2022-01-01'),
+        });
+        databaseBuilder.factory.buildKnowledgeElementSnapshot({
+          userId: userId,
+          campaignParticipationId,
+          snapshot: new KnowledgeElementCollection([domainKEInSnapshot]).toSnapshot(),
+        });
+        databaseBuilder.factory.buildKnowledgeElement(domainKEInSnapshot);
+        databaseBuilder.factory.buildKnowledgeElement(domainKENotInSnapshot);
+        await databaseBuilder.commit();
+
+        // when
+        const res = await repositories.knowledgeElementRepository.findUniqByUserIdForCampaignParticipation({
+          userId,
+          campaignParticipationId,
+        });
+
+        // then
+        expect(res).to.be.null;
+      });
+    });
+
+    context('when campaign is of type PROFILES_COLLECTION', function () {
+      context('when a limit date is provided', function () {
+        it('should return the Knowledge Elements of the user before limitdate', async function () {
+          // given
+          const limitDate = new Date('2025-01-01');
+          const userId = databaseBuilder.factory.buildUser().id;
+          const campaignId = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.PROFILES_COLLECTION }).id;
+          const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+            campaignId,
+          }).id;
+          const assessmentId = databaseBuilder.factory.buildAssessment({ campaignParticipationId }).id;
+          const answerId = databaseBuilder.factory.buildAnswer({ assessmentId }).id;
+          const domainKE1 = domainBuilder.buildKnowledgeElement({
+            id: 1,
+            userId,
+            skillId: 'acquisABC123',
+            answerId,
+            assessmentId,
+            createdAt: new Date('2021-01-01'),
+          });
+          const domainKE2 = domainBuilder.buildKnowledgeElement({
+            id: 2,
+            userId,
+            skillId: 'acquisDEF456',
+            answerId,
+            assessmentId,
+            createdAt: new Date('2022-01-01'),
+          });
+          const afterDateKE3 = domainBuilder.buildKnowledgeElement({
+            id: 3,
+            userId,
+            skillId: 'acquisJHI789',
+            answerId,
+            assessmentId,
+            createdAt: new Date('2026-01-01'),
+          });
+          databaseBuilder.factory.buildKnowledgeElement(domainKE1);
+          databaseBuilder.factory.buildKnowledgeElement(domainKE2);
+          databaseBuilder.factory.buildKnowledgeElement(afterDateKE3);
+          await databaseBuilder.commit();
+
+          // when
+          const res = await repositories.knowledgeElementRepository.findUniqByUserIdForCampaignParticipation({
+            userId,
+            campaignParticipationId,
+            limitDate,
+          });
+
+          // then
+          expect(res).to.deep.equal([domainKE2, domainKE1]);
+        });
+      });
+      context('when no limit date is provided', function () {
+        it('should return the Knowledge Elements of the user regardless of date', async function () {
+          // given
+          const userId = databaseBuilder.factory.buildUser().id;
+          const campaignId = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.PROFILES_COLLECTION }).id;
+          const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+            campaignId,
+          }).id;
+          const assessmentId = databaseBuilder.factory.buildAssessment({ campaignParticipationId }).id;
+          const answerId = databaseBuilder.factory.buildAnswer({ assessmentId }).id;
+          const domainKE1 = domainBuilder.buildKnowledgeElement({
+            id: 1,
+            userId,
+            skillId: 'acquisABC123',
+            answerId,
+            assessmentId,
+            createdAt: new Date('2021-01-01'),
+          });
+          const domainKE2 = domainBuilder.buildKnowledgeElement({
+            id: 2,
+            userId,
+            skillId: 'acquisDEF456',
+            answerId,
+            assessmentId,
+            createdAt: new Date('2022-01-01'),
+          });
+          databaseBuilder.factory.buildKnowledgeElement(domainKE1);
+          databaseBuilder.factory.buildKnowledgeElement(domainKE2);
+          await databaseBuilder.commit();
+
+          // when
+          const res = await repositories.knowledgeElementRepository.findUniqByUserIdForCampaignParticipation({
+            userId,
+            campaignParticipationId,
+          });
+
+          // then
+          expect(res).to.deep.equal([domainKE2, domainKE1]);
+        });
+      });
+    });
+
+    context('when campaign is of type ASSESSMENT', function () {
+      context('when a limit date is provided', function () {
+        it('should return the Knowledge Elements of the user before limitdate', async function () {
+          // given
+          const limitDate = new Date('2025-01-01');
+          const userId = databaseBuilder.factory.buildUser().id;
+          const campaignId = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.ASSESSMENT }).id;
+          const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+            campaignId,
+          }).id;
+          const assessmentId = databaseBuilder.factory.buildAssessment({ campaignParticipationId }).id;
+          const answerId = databaseBuilder.factory.buildAnswer({ assessmentId }).id;
+          const domainKE1 = domainBuilder.buildKnowledgeElement({
+            id: 1,
+            userId,
+            skillId: 'acquisABC123',
+            answerId,
+            assessmentId,
+            createdAt: new Date('2021-01-01'),
+          });
+          const domainKE2 = domainBuilder.buildKnowledgeElement({
+            id: 2,
+            userId,
+            skillId: 'acquisDEF456',
+            answerId,
+            assessmentId,
+            createdAt: new Date('2022-01-01'),
+          });
+          const afterDateKE3 = domainBuilder.buildKnowledgeElement({
+            id: 3,
+            userId,
+            skillId: 'acquisJHI789',
+            answerId,
+            assessmentId,
+            createdAt: new Date('2026-01-01'),
+          });
+          databaseBuilder.factory.buildKnowledgeElement(domainKE1);
+          databaseBuilder.factory.buildKnowledgeElement(domainKE2);
+          databaseBuilder.factory.buildKnowledgeElement(afterDateKE3);
+          await databaseBuilder.commit();
+
+          // when
+          const res = await repositories.knowledgeElementRepository.findUniqByUserIdForCampaignParticipation({
+            userId,
+            campaignParticipationId,
+            limitDate,
+          });
+
+          // then
+          expect(res).to.deep.equal([domainKE2, domainKE1]);
+        });
+      });
+      context('when no limit date is provided', function () {
+        it('should return the Knowledge Elements of the user regardless of date', async function () {
+          // given
+          const userId = databaseBuilder.factory.buildUser().id;
+          const campaignId = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.ASSESSMENT }).id;
+          const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+            campaignId,
+          }).id;
+          const assessmentId = databaseBuilder.factory.buildAssessment({ campaignParticipationId }).id;
+          const answerId = databaseBuilder.factory.buildAnswer({ assessmentId }).id;
+          const domainKE1 = domainBuilder.buildKnowledgeElement({
+            id: 1,
+            userId,
+            skillId: 'acquisABC123',
+            answerId,
+            assessmentId,
+            createdAt: new Date('2021-01-01'),
+          });
+          const domainKE2 = domainBuilder.buildKnowledgeElement({
+            id: 2,
+            userId,
+            skillId: 'acquisDEF456',
+            answerId,
+            assessmentId,
+            createdAt: new Date('2022-01-01'),
+          });
+          databaseBuilder.factory.buildKnowledgeElement(domainKE1);
+          databaseBuilder.factory.buildKnowledgeElement(domainKE2);
+          await databaseBuilder.commit();
+
+          // when
+          const res = await repositories.knowledgeElementRepository.findUniqByUserIdForCampaignParticipation({
+            userId,
+            campaignParticipationId,
+          });
+
+          // then
+          expect(res).to.deep.equal([domainKE2, domainKE1]);
+        });
+      });
+    });
+
+    context('when campaign is of type EXAM', function () {
+      context('when there is no snapshot for participation', function () {
+        it('should return an empty array', async function () {
+          // given
+          const userId = databaseBuilder.factory.buildUser().id;
+          const campaignId = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.EXAM }).id;
+          const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+            campaignId,
+          }).id;
+          const assessmentId = databaseBuilder.factory.buildAssessment({ campaignParticipationId }).id;
+          const competenceEvaluationAssessmentId = databaseBuilder.factory.buildAssessment({
+            type: Assessment.types.COMPETENCE_EVALUATION,
+          }).id;
+          const otherAnswerId = databaseBuilder.factory.buildAnswer({ assessmentId }).id;
+          const domainKEOutsideOfParticipation = domainBuilder.buildKnowledgeElement({
+            id: 1,
+            userId,
+            skillId: 'acquisABC123',
+            answerId: otherAnswerId,
+            assessmentId: competenceEvaluationAssessmentId,
+            createdAt: new Date('2021-01-01'),
+          });
+          databaseBuilder.factory.buildKnowledgeElement(domainKEOutsideOfParticipation);
+          await databaseBuilder.commit();
+
+          // when
+          const res = await repositories.knowledgeElementRepository.findUniqByUserIdForCampaignParticipation({
+            userId,
+            campaignParticipationId,
+          });
+
+          // then
+          expect(res).to.deep.equal([]);
+        });
+      });
+
+      context('when there is a snapshot for participation', function () {
+        it('should return the Knowledge Elements in the snapshot', async function () {
+          // given
+          const userId = databaseBuilder.factory.buildUser().id;
+          const campaignId = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.EXAM }).id;
+          const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+            campaignId,
+          }).id;
+          const assessmentId = databaseBuilder.factory.buildAssessment({ campaignParticipationId }).id;
+          const competenceEvaluationAssessmentId = databaseBuilder.factory.buildAssessment({
+            type: Assessment.types.COMPETENCE_EVALUATION,
+          }).id;
+          const answerId = databaseBuilder.factory.buildAnswer({ assessmentId }).id;
+          const otherAnswerId = databaseBuilder.factory.buildAnswer({ assessmentId }).id;
+          const domainKEOutsideOfParticipation = domainBuilder.buildKnowledgeElement({
+            id: 1,
+            userId,
+            skillId: 'acquisABC123',
+            answerId: otherAnswerId,
+            assessmentId: competenceEvaluationAssessmentId,
+            createdAt: new Date('2021-01-01'),
+          });
+          const domainKEInParticipation = domainBuilder.buildKnowledgeElement({
+            id: 'not_a_real_ke',
+            userId,
+            skillId: 'acquisDEF456',
+            answerId,
+            assessmentId,
+            createdAt: new Date('2022-01-01'),
+          });
+          databaseBuilder.factory.buildKnowledgeElementSnapshot({
+            userId: userId,
+            campaignParticipationId,
+            snapshot: new KnowledgeElementCollection([domainKEInParticipation]).toSnapshot(),
+          });
+          databaseBuilder.factory.buildKnowledgeElement(domainKEOutsideOfParticipation);
+          await databaseBuilder.commit();
+
+          // when
+          const res = await repositories.knowledgeElementRepository.findUniqByUserIdForCampaignParticipation({
+            userId,
+            campaignParticipationId,
+          });
+
+          // then
+          expect(res).to.deep.equal([
+            new KnowledgeElement({
+              ...domainKEInParticipation,
+              assessmentId: undefined,
+              id: undefined,
+              userId: undefined,
+            }),
+          ]);
+        });
+      });
+    });
+
+    it('should be DomainTransaction compliant', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const campaignId = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.ASSESSMENT }).id;
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        sharedAt: null,
+      }).id;
+      const assessmentId = databaseBuilder.factory.buildAssessment({ campaignParticipationId }).id;
+      const answerId = databaseBuilder.factory.buildAnswer({ assessmentId }).id;
+      const domainKEInSnapshot = domainBuilder.buildKnowledgeElement({
+        id: 1,
+        userId,
+        skillId: 'acquisABC123',
+        answerId,
+        assessmentId,
+        createdAt: new Date('2021-01-01'),
+      });
+      const domainKENotInSnapshot = domainBuilder.buildKnowledgeElement({
+        id: 2,
+        userId,
+        skillId: 'acquisDEF456',
+        answerId,
+        assessmentId,
+        createdAt: new Date('2022-01-01'),
+      });
+      const extraDomainKE = domainBuilder.buildKnowledgeElement({
+        id: 3,
+        userId,
+        skillId: 'acquisJHI789',
+        answerId,
+        assessmentId,
+        createdAt: new Date('2023-01-01'),
+      });
+      databaseBuilder.factory.buildKnowledgeElementSnapshot({
+        userId: userId,
+        campaignParticipationId,
+        snapshot: new KnowledgeElementCollection([domainKEInSnapshot]).toSnapshot(),
+      });
+      databaseBuilder.factory.buildKnowledgeElement(domainKEInSnapshot);
+      databaseBuilder.factory.buildKnowledgeElement(domainKENotInSnapshot);
+      await databaseBuilder.commit();
+      const knowledgeElementsWantedTrx = [extraDomainKE, domainKENotInSnapshot, domainKEInSnapshot];
+
+      // when
+      const knowledgeElementsFound = await DomainTransaction.execute(async (domainTransaction) => {
+        await domainTransaction.knexTransaction('knowledge-elements').insert(extraDomainKE);
+        return repositories.knowledgeElementRepository.findUniqByUserIdForCampaignParticipation({
+          userId,
+          campaignParticipationId,
+        });
+      });
+
+      // then
+      expect(knowledgeElementsFound).to.deep.equal(knowledgeElementsWantedTrx);
+    });
+
+    context('KE selection', function () {
+      let assessmentId, campaignParticipationId, answerId, userId;
+      beforeEach(async function () {
+        userId = databaseBuilder.factory.buildUser().id;
+        const campaignId = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.ASSESSMENT }).id;
+        campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          sharedAt: null,
+        }).id;
+        assessmentId = databaseBuilder.factory.buildAssessment({ campaignParticipationId }).id;
+        answerId = databaseBuilder.factory.buildAnswer({ assessmentId }).id;
+      });
+
+      it('should chose most recent KE when many KEs exist for a given skill', async function () {
+        // given
+        const keA_old = domainBuilder.buildKnowledgeElement({
+          id: 1,
+          userId,
+          skillId: 'acquisA',
+          answerId,
+          assessmentId,
+          createdAt: new Date('2021-01-01'),
+          status: KnowledgeElement.StatusType.VALIDATED,
+        });
+        const keA_new = domainBuilder.buildKnowledgeElement({
+          id: 2,
+          userId,
+          skillId: 'acquisA',
+          answerId,
+          assessmentId,
+          createdAt: new Date('2022-01-01'),
+          status: KnowledgeElement.StatusType.INVALIDATED,
+        });
+        databaseBuilder.factory.buildKnowledgeElement(keA_old);
+        databaseBuilder.factory.buildKnowledgeElement(keA_new);
+        await databaseBuilder.commit();
+
+        // when
+        const res = await repositories.knowledgeElementRepository.findUniqByUserIdForCampaignParticipation({
+          userId,
+          campaignParticipationId,
+        });
+
+        // then
+        expect(res).to.deep.equal([keA_new]);
+      });
+
+      it('should ignore all KE of a given skill when most recent one is a RESET', async function () {
+        // given
+        const keA_old = domainBuilder.buildKnowledgeElement({
+          id: 1,
+          userId,
+          skillId: 'acquisA',
+          answerId,
+          assessmentId,
+          createdAt: new Date('2021-01-01'),
+          status: KnowledgeElement.StatusType.VALIDATED,
+        });
+        const keA_new = domainBuilder.buildKnowledgeElement({
+          id: 2,
+          userId,
+          skillId: 'acquisA',
+          answerId,
+          assessmentId,
+          createdAt: new Date('2022-01-01'),
+          status: KnowledgeElement.StatusType.RESET,
+        });
+        databaseBuilder.factory.buildKnowledgeElement(keA_old);
+        databaseBuilder.factory.buildKnowledgeElement(keA_new);
+        await databaseBuilder.commit();
+
+        // when
+        const res = await repositories.knowledgeElementRepository.findUniqByUserIdForCampaignParticipation({
+          userId,
+          campaignParticipationId,
+        });
+
+        // then
+        expect(res).to.deep.equal([]);
+      });
+
+      it('should chose most recent KE when many KEs exist for a given skill, even if there are some RESET KEs', async function () {
+        // given
+        const keA_super_old = domainBuilder.buildKnowledgeElement({
+          id: 1,
+          userId,
+          skillId: 'acquisA',
+          answerId,
+          assessmentId,
+          createdAt: new Date('2021-01-01'),
+          status: KnowledgeElement.StatusType.VALIDATED,
+        });
+        const keA_old = domainBuilder.buildKnowledgeElement({
+          id: 2,
+          userId,
+          skillId: 'acquisA',
+          answerId,
+          assessmentId,
+          createdAt: new Date('2022-01-01'),
+          status: KnowledgeElement.StatusType.RESET,
+        });
+        const keA_new = domainBuilder.buildKnowledgeElement({
+          id: 3,
+          userId,
+          skillId: 'acquisA',
+          answerId,
+          assessmentId,
+          createdAt: new Date('2023-01-01'),
+          status: KnowledgeElement.StatusType.INVALIDATED,
+        });
+        databaseBuilder.factory.buildKnowledgeElement(keA_old);
+        databaseBuilder.factory.buildKnowledgeElement(keA_new);
+        databaseBuilder.factory.buildKnowledgeElement(keA_super_old);
+        await databaseBuilder.commit();
+
+        // when
+        const res = await repositories.knowledgeElementRepository.findUniqByUserIdForCampaignParticipation({
+          userId,
+          campaignParticipationId,
+        });
+
+        // then
+        expect(res).to.deep.equal([keA_new]);
+      });
+
+      it('should return knowledge elements ordered by created at date, descending', async function () {
+        // given
+        const keA = domainBuilder.buildKnowledgeElement({
+          id: 1,
+          userId,
+          skillId: 'acquisA',
+          answerId,
+          assessmentId,
+          createdAt: new Date('2021-01-01'),
+          status: KnowledgeElement.StatusType.VALIDATED,
+        });
+        const keB = domainBuilder.buildKnowledgeElement({
+          id: 2,
+          userId,
+          skillId: 'acquisB',
+          answerId,
+          assessmentId,
+          createdAt: new Date('2020-01-01'),
+          status: KnowledgeElement.StatusType.INVALIDATED,
+        });
+        databaseBuilder.factory.buildKnowledgeElement(keA);
+        databaseBuilder.factory.buildKnowledgeElement(keB);
+        await databaseBuilder.commit();
+
+        // when
+        const res = await repositories.knowledgeElementRepository.findUniqByUserIdForCampaignParticipation({
+          userId,
+          campaignParticipationId,
+        });
+
+        // then
+        expect(res).to.deep.equal([keA, keB]);
+      });
     });
   });
 });


### PR DESCRIPTION
## :pancakes: Problème

Aujourd'hui EXAM se comporte comme ASSESSMENT, il faut ajouter le comportement spécifique à EXAM : on cherche à avoir une évaluation qui ne tienne compte que de KEs non persistés propres à la participation en cours.

## :bacon: Proposition

Lorsqu'on répond à une épreuve, on update au fur et à mesure un knowldge element snapshot

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

- Faire de la non régression sur le passage de campagne d'évaluation
- Les campagnes ne sont plus fonctionnelles en attendant la fin de l'Epix. On peut quand même constater en DB que le snapshot est bien alimenté au fur et à mesure des réponses. Cependant les questions risque d'être incohérentes.
