### PR TITLE
[BUGFIX] Remplacement des UUIDs dupliqués des contenus de modules (PIX-16819)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
@@ -348,12 +348,8 @@
                 "placeholder": "",
                 "ariaLabel": "Nom du pays :",
                 "defaultValue": "",
-                "tolerances": [
-                  "t1"
-                ],
-                "solutions": [
-                  "Japon", "Tokyo"
-                ]
+                "tolerances": ["t1"],
+                "solutions": ["Japon", "Tokyo"]
               }
             ],
             "feedbacks": {
@@ -368,7 +364,6 @@
             "id": "0856af53-1060-478f-8416-ddbc5ed3940c",
             "type": "text",
             "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p><details><summary>Indice n°1&nbsp;:</summary><p>Vous pouvez faire une recherche en ligne : des sites internet existent pour cela.</p></details><details><summary>Indice n°2&nbsp;:</summary><p>Pour votre recherche, utilisez les mots-clés \"localisation\" et \"adresse IP\".</p></details>"
-
           }
         }
       ]
@@ -533,7 +528,6 @@
             "id": "dc49fa68-dcdf-4a3e-ac3a-475d027fc789",
             "type": "text",
             "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p><details><summary>Indice n°1&nbsp;:</summary><p>Vous pouvez faire une recherche en ligne : des sites internet existent pour cela.</p></details><details><summary>Indice n°2&nbsp;:</summary><p>Pour votre recherche, utilisez les mots-clés \"trouver\" et \"mon adresse IP\".</p></details>"
-
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
@@ -530,7 +530,7 @@
         {
           "type": "element",
           "element": {
-            "id": "0856af53-1060-478f-8416-ddbc5ed3940c",
+            "id": "dc49fa68-dcdf-4a3e-ac3a-475d027fc789",
             "type": "text",
             "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p><details><summary>Indice n°1&nbsp;:</summary><p>Vous pouvez faire une recherche en ligne : des sites internet existent pour cela.</p></details><details><summary>Indice n°2&nbsp;:</summary><p>Pour votre recherche, utilisez les mots-clés \"trouver\" et \"mon adresse IP\".</p></details>"
 

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-1.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-1.json
@@ -308,7 +308,7 @@
         {
           "type": "element",
           "element": {
-            "id": "f42a1f10-87a9-4607-bb81-9cde56c1d047",
+            "id": "fdba280f-e339-4999-befd-33ab52885043",
             "type": "image",
             "url": "https://i.imgur.com/wr3plig.png",
             "alt": "",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-1.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-1.json
@@ -254,9 +254,7 @@
                       "ariaLabel": "Cliquer ici",
                       "defaultValue": "",
                       "tolerances": [],
-                      "solutions": [
-                        "cornichons"
-                      ]
+                      "solutions": ["cornichons"]
                     },
                     {
                       "type": "text",
@@ -272,9 +270,7 @@
                       "ariaLabel": "Cliquer ici",
                       "defaultValue": "",
                       "tolerances": [],
-                      "solutions": [
-                        "vide"
-                      ]
+                      "solutions": ["vide"]
                     },
                     {
                       "type": "text",
@@ -519,9 +515,7 @@
                       "ariaLabel": "Cliquer ici",
                       "defaultValue": "",
                       "tolerances": [],
-                      "solutions": [
-                        "céleri"
-                      ]
+                      "solutions": ["céleri"]
                     }
                   ],
                   "feedbacks": {
@@ -538,7 +532,7 @@
                   "type": "qrocm",
                   "instruction": "pastèque",
                   "proposals": [
-                     {
+                    {
                       "input": "2",
                       "type": "input",
                       "inputType": "text",
@@ -548,9 +542,7 @@
                       "ariaLabel": "Cliquer ici",
                       "defaultValue": "",
                       "tolerances": [],
-                      "solutions": [
-                        "pastèque"
-                      ]
+                      "solutions": ["pastèque"]
                     }
                   ],
                   "feedbacks": {
@@ -577,9 +569,7 @@
                       "ariaLabel": "Cliquer ici",
                       "defaultValue": "",
                       "tolerances": [],
-                      "solutions": [
-                        "bac à glaçons"
-                      ]
+                      "solutions": ["bac à glaçons"]
                     }
                   ],
                   "feedbacks": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -42,7 +42,7 @@
         {
           "type": "element",
           "element": {
-            "id": "3a9f2269-99ba-4631-b6fd-6802c88d5c26",
+            "id": "e959af9d-9963-471b-aedb-c234d465b868",
             "type": "video",
             "title": "Le format des adresses mail",
             "url": "https://videos.pix.fr/modulix/bien-ecrire-adresse-mail/chat_animation.mp4",
@@ -87,7 +87,7 @@
             {
               "elements": [
                 {
-                  "id": "8d7687c8-4a02-4d7e-bf6c-693a6d481c78",
+                  "id": "40a6e8a8-e92b-4e96-80e8-b74971a0c285",
                   "type": "image",
                   "url": "https://i.imgur.com/lLEwbG6.png",
                   "alt": "Première partie, décrite dans l'alternative textuelle",
@@ -183,7 +183,7 @@
             {
               "elements": [
                 {
-                  "id": "98c51fa7-03b7-49b1-8c5e-49341d35909c",
+                  "id": "2789cba3-02f5-4c89-8b1c-187e291db8f7",
                   "type": "qrocm",
                   "instruction": "<p>Quelles sont les deux parties d'une adresse mail&nbsp;?</p>",
                   "proposals": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -174,9 +174,9 @@
                   }
                 },
                 {
-                    "id": "e494d292-21a8-4b33-affa-96763dbe10e6",
-                    "type": "text",
-                    "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'<strong>aide pour écrire ce symbole</strong>, cliquez sur l'indice ci-dessous&nbsp;:</p><details><summary>Indice</summary>Pour écrire le symbole arobase,<ul><li>sur PC, appuyez et maintenez la touche <code>Alt Gr</code> puis appuyez sur la touche <code>à</code> (même touche que le 0)</li><li>sur Mac, appuyez sur la touche @ déjà prévue, en haut à gauche (même touche que #)</li></ul></details>"
+                  "id": "e494d292-21a8-4b33-affa-96763dbe10e6",
+                  "type": "text",
+                  "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'<strong>aide pour écrire ce symbole</strong>, cliquez sur l'indice ci-dessous&nbsp;:</p><details><summary>Indice</summary>Pour écrire le symbole arobase,<ul><li>sur PC, appuyez et maintenez la touche <code>Alt Gr</code> puis appuyez sur la touche <code>à</code> (même touche que le 0)</li><li>sur Mac, appuyez sur la touche @ déjà prévue, en haut à gauche (même touche que #)</li></ul></details>"
                 }
               ]
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-vraiment-neutre.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-vraiment-neutre.json
@@ -227,7 +227,7 @@
             {
               "elements": [
                 {
-                  "id": "700c674c-f7a7-4eba-bd00-de74ca8c77f7",
+                  "id": "cac9d75d-c447-465f-b5de-d7b3994b9b82",
                   "type": "text",
                   "content": "<p>Erica est <strong>romancière</strong> et demande à un LLM d'imaginer un personnage. Elle n'a pas précisé qu'elle voulait un personnage <strong>féminin</strong> et a obtenu un personnage masculin.<span aria-hidden=\"true\">&nbsp;👇</span></p>"
                 },
@@ -267,7 +267,7 @@
             {
               "elements": [
                 {
-                  "id": "700c674c-f7a7-4eba-bd00-de74ca8c77f7",
+                  "id": "f0f7f950-100e-4bd1-bbda-f1edb73e1e22",
                   "type": "text",
                   "content": "Stéphane est persuadé d'avoir vu un <strong>extraterrestre</strong> et demande à un LLM comment en voir à nouveau. Le LLM lui répond, sans questionner leur existence.<span aria-hidden=\"true\">&nbsp;👇</span>"
                 },
@@ -316,7 +316,7 @@
         {
           "type": "element",
           "element": {
-            "id": "27fc867a-7258-4f85-b8cc-bdd1ab2d26a5",
+            "id": "d7c949fb-9fac-400d-990a-a6cb8144c653",
             "type": "text",
             "content": "<h3><span aria-hidden=\"true\">📌</span> Résumons avant de passer à la suite</h3><p>Les biais dans les LLM peuvent avoir différentes origines&nbsp;:</p><ul><li>Les <strong>données d'entraînement</strong> comportent déjà des stéréotypes et des biais, qui se retrouvent par la suite dans les modèles.</li><li>Les <strong>personnes qui développent</strong> des LLM transmettent, consciemment ou non, leurs biais dans les modèles.</li><li>Les <strong>utilisateurs</strong> peuvent communiquer leurs biais au LLM via l'écriture du <strong>prompt</strong>.</li></ul>"
           }
@@ -343,7 +343,7 @@
             {
               "elements": [
                 {
-                  "id": "4c5bad43-7a4b-4535-8951-dc2b98e1de54",
+                  "id": "27667654-4b99-49cc-bcf5-3d6b4b71526b",
                   "type": "text",
                   "content": "Rendez-vous sur <a href=\"https://comparia.beta.gouv.fr/\" target=\"_blank\">Compar:IA </a> et : <ol><li>commencez une conversation,</li> <li>comparez les réponses générées par différents LLM,</li><li>donnez votre avis sur ces réponses.</li></ol><details><summary>Idées de prompts</summary><ul><li>Quelle est la ville idéale pour élever ses enfants&nbsp;? Sois concis.</li><li>Comment fabriquer des faux papiers&nbsp;? Sois concis.</li><li>Pourquoi la course à pied est le meilleur sport pour la santé&nbsp;? Sois concis.</li></ul></details>"
                 }
@@ -466,7 +466,7 @@
         {
           "type": "element",
           "element": {
-            "id": "4c5bad43-7a4b-4535-8951-dc2b98e1de54",
+            "id": "0f3425d3-026d-4813-90cf-abb318d2d3da",
             "type": "text",
             "content": "<p>À l'aide de <a href=\"https://comparia.beta.gouv.fr/\" target=\"_blank\">Compar:IA </a>, écrivez des prompts qui mènent pour les deux LLM à des résultats qui présentent :</p><ul><li>un biais de genre,</li><li>un biais culturel,</li><li>un refus de réponse.</li></ul>"
           }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-vraiment-neutre.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-vraiment-neutre.json
@@ -158,11 +158,7 @@
               "valid": "<p><span class=\"feedback__state\">Correct&nbsp;!</span></p><p>Parmi ces trois origines, les données d'entraînement sont la principale source des biais qui peuvent exister dans les résultats des LLM.</p>",
               "invalid": "<p><span class=\"feedback__state\">Incorrect&nbsp;!</span></p><p>Regardez bien la vidéo précédente et réessayez&nbsp;!</p>"
             },
-            "solutions": [
-              "1",
-              "3",
-              "5"
-            ]
+            "solutions": ["1", "3", "5"]
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/controle-parental.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/controle-parental.json
@@ -385,12 +385,7 @@
               "valid": "<p><span class=\"feedback__state\">Bonne réponse !&nbsp;🎉</span></p><p>Pour accompagner au mieux Max, Nina peut activer des options de contrôle parental sur les appareils et les plateformes en ligne.</p>",
               "invalid": "<p><span class=\"feedback__state\">Mauvaise réponse.</span></p><p>🤔 Peut-être que vous n'avez pas sélectionné toutes les bonnes réponses. Relisez l’infographie et essayez à nouveau !</p>"
             },
-            "solutions": [
-              "1",
-              "2",
-              "3",
-              "5"
-            ]
+            "solutions": ["1", "2", "3", "5"]
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/controle-parental.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/controle-parental.json
@@ -259,14 +259,14 @@
         {
           "type": "element",
           "element": {
-            "id": "37ff3330-b8df-47e0-80d2-e382671dc3dd",
+            "id": "4c48c54b-9845-4de6-a1d9-674c97432a46",
             "type": "separator"
           }
         },
         {
           "type": "element",
           "element": {
-            "id": "37ff3330-b8df-47e0-80d2-e382671dc3dd",
+            "id": "5432d74b-3bcd-44f6-a031-8e0ba0cdceda",
             "type": "text",
             "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p><details><summary>Indice 1</summary><p>Le contrôle parental fait partie des paramètres de l’appareil. ⚙️</p></details><details><summary>Indice 2</summary><p>Ici, le contrôle parental s’active sur l’appareil de l’enfant.</p></details><details><summary>Solution</summary><p>Voici les étapes à suivre : </p><iframe id=\"inlineFrameExample\" title=\"Inline Frame Example\" width=\"425\" height=\"790\" src=\"https://www.image-heberg.fr/files/1733406264146730843.gif\"></iframe></details>"
           }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
@@ -165,7 +165,7 @@
         {
           "type": "element",
           "element": {
-            "id": "342183f7-af51-4e4e-ab4c-ebed1e195063",
+            "id": "0b024dad-bcf3-4358-956a-febfb0b0ead6",
             "type": "text",
             "content": "<p>Après cette vidéo, vous devrez trouver dans des exemples concrets s'il s'agit d'une <strong>opinion</strong>, d'une <strong>rumeur</strong>, d'une <strong>anecdote</strong>, d'une <strong>information</strong>.</p>"
           }
@@ -173,7 +173,7 @@
         {
           "type": "element",
           "element": {
-            "id": "3a9f2269-99ba-4631-b6fd-6802c88d5c26",
+            "id": "e8938c8f-ecf2-4518-8789-1006eb8e97d4",
             "type": "video",
             "title": "-",
             "url": "https://videos.pix.fr/modulix/distinguer-vrai-faux-sur-internet/vocabulaire.mp4",
@@ -636,14 +636,14 @@
       ]
     },
     {
-      "id": "84f9134e-6a19-4673-a673-d4577355796a",
+      "id": "47eed162-0543-44d3-a719-cd477690985b",
       "type": "summary",
       "title": "Conclusion",
       "components": [
         {
           "type": "element",
           "element": {
-            "id": "5a4495bc-22f5-4a9a-aad5-531071bf33c9",
+            "id": "bfcc88ad-0061-4729-8b94-8f60bc92a57d",
             "type": "text",
             "content": "<p><strong>Pour chaque carte</strong> :</p><ol><li>Lisez la question. <span aria-hidden=\"true\">👀</span></li><li>Essayez de trouver la réponse dans votre tête. <span aria-hidden=\"true\">🤔</span></li><li>Retourner la carte en cliquant sur <i>Voir la réponse</i>. <span aria-hidden=\"true\">↪️</span></li></ol><p>Cela permet de <strong>tester votre mémoire</strong>.<span aria-hidden=\"true\">🎯</span></p>"
           }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
@@ -192,7 +192,7 @@
         {
           "type": "stepper",
           "steps": [
-                        {
+            {
               "elements": [
                 {
                   "id": "5c6ec12a-f5b4-4683-ae7a-11b79fddd0a5",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/jeux-video-enfant.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/jeux-video-enfant.json
@@ -262,7 +262,7 @@
                   "alternativeText": ""
                 },
                 {
-                  "id": "a5bc3ebf-2417-445c-96ed-8b199ecbff52",
+                  "id": "dd17d894-7c5e-467e-a3f8-ee6710bba415",
                   "type": "text",
                   "content": "<p><br><span aria-hidden=\"true\">📦</span> Une loot box (boîte à butins) est un <strong>objet virtuel </strong> (un coffre, une boîte, ...) qu’un joueur peut acheter dans le jeu.<br>Chaque loot box contient des objets, communs ou très rares, à utiliser dans le jeu.<br><strong>Ce contenu est aléatoire, comme pour une pochette-surprise ou des cartes à collectionner.</strong><br>Le joueur est souvent incité à acheter des loot boxes lors des parties, pour obtenir l'objet qu'il souhaite ou pour avancer plus efficacement dans le jeu.</p><p><br><span aria-hidden=\"true\">🤔</span> <strong>Bon à savoir</strong>&nbsp;<br>Depuis mai 2020, un jeu qui propose des loot boxes doit obligatoirement indiquer «&nbsp;<strong>Inclut des contenus aléatoires</strong>&nbsp;» sur la boîte ou la fiche du jeu.</p>"
                 }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
@@ -284,7 +284,7 @@
         {
           "type": "element",
           "element": {
-            "id": "3f4354a6-3243-4b5a-a459-58b3f3d1ecb8",
+            "id": "a3730b39-ff34-4744-a5dc-5d4687def82d",
             "type": "text",
             "content": "<p>Pour chaque affimation, choisissez si elle est vraie ou fausse.</p>"
           }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
@@ -579,7 +579,7 @@
         {
           "type": "element",
           "element": {
-            "id": "e6730d81-c115-4821-a415-4f719a252746",
+            "id": "029cdc04-5fc3-4d1a-8127-6d5ad9084002",
             "type": "text",
             "content": "<p>Cherchez et nommez tous les ports de connexion de votre ordinateur.</p>"
           }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
@@ -53,7 +53,7 @@
             {
               "elements": [
                 {
-                  "id": "30b9ada4-a87a-4dfb-baa2-d97925b0bba5",
+                  "id": "70598c0e-6292-48a2-8729-401978cc7003",
                   "type": "text",
                   "content": "<p>Lancez la vidéo pour voir le début de leur discussion.<br>En regardant cette vidéo, posez-vous la question suivante&nbsp;: <strong>est-ce que l'information donnée par Elias est plutôt vraie ou plutôt fausse&nbsp;?</strong></p>"
                 },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-1.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-1.json
@@ -313,7 +313,7 @@
         {
           "type": "element",
           "element": {
-            "id": "d96505a1-c5c0-4dbf-af9d-900453586d45",
+            "id": "c0479cb0-c160-452a-89a8-c9fa6dbd74e8",
             "type": "separator"
           }
         },

--- a/api/src/devcomp/infrastructure/repositories/module-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-repository.js
@@ -15,4 +15,9 @@ async function getBySlug({ slug, moduleDatasource }) {
   }
 }
 
-export { getBySlug };
+async function list({ moduleDatasource }) {
+  const modulesData = await moduleDatasource.list();
+  return modulesData.map((moduleData) => ModuleFactory.build(moduleData));
+}
+
+export { getBySlug, list };

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -98,4 +98,60 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       expect(module).to.be.instanceof(Module);
     });
   });
+
+  describe('#list', function () {
+    it('should return a list of Module instances', async function () {
+      const existingModuleSlug = 'bien-ecrire-son-adresse-mail';
+      const expectedFoundModule = {
+        id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
+        slug: existingModuleSlug,
+        title: 'Bien écrire son adresse mail',
+        isBeta: true,
+        details: {
+          image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+          description:
+            'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
+          duration: 12,
+          level: 'Débutant',
+          tabletSupport: 'comfortable',
+          objectives: [
+            'Écrire une adresse mail correctement, en évitant les erreurs courantes',
+            'Connaître les parties d’une adresse mail et les identifier sur des exemples',
+            'Comprendre les fonctions des parties d’une adresse mail',
+          ],
+        },
+        grains: [
+          {
+            id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
+            type: 'lesson',
+            title: 'Explications : les parties d’une adresse mail',
+            components: [
+              {
+                type: 'element',
+                element: {
+                  id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
+                  type: 'text',
+                  content:
+                    "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+                },
+              },
+            ],
+          },
+        ],
+      };
+      const moduleDatasourceStub = {
+        list: sinon.stub(),
+      };
+      moduleDatasourceStub.list.resolves([expectedFoundModule]);
+      sinon.spy(ModuleFactory, 'build');
+
+      // when
+      const modules = await moduleRepository.list({ moduleDatasource: moduleDatasourceStub });
+
+      // then
+      expect(ModuleFactory.build).to.have.been.calledWith(expectedFoundModule);
+      expect(modules).to.be.an('array');
+      expect(modules[0]).to.be.instanceof(Module);
+    });
+  });
 });

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -100,6 +100,47 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
   });
 
   describe('#list', function () {
+    describe('errors', function () {
+      describe('if there are no duplicated IDs in modules content', function () {
+        it('should result an empty array of duplicated IDs ', async function () {
+          const modules = await moduleDatasource.list();
+          const ids = [];
+          const duplicateIds = new Set();
+          for (const module of modules) {
+            for (const grain of module.grains) {
+              if (ids.includes(grain.id)) {
+                duplicateIds.add(grain.id);
+              }
+              ids.push(grain.id);
+
+              for (const component of grain.components) {
+                switch (component.type) {
+                  case 'element':
+                    if (ids.includes(component.element.id)) {
+                      duplicateIds.add(component.element.id);
+                    }
+                    ids.push(component.element.id);
+                    break;
+                  case 'stepper':
+                    for (const step of component.steps) {
+                      for (const element of step.elements) {
+                        if (ids.includes(element.id)) {
+                          duplicateIds.add(element.id);
+                        }
+                        ids.push(element.id);
+                      }
+                    }
+                    break;
+                }
+              }
+            }
+          }
+
+          expect([...duplicateIds]).to.deep.equal([]);
+        });
+      });
+    });
+
     it('should return a list of Module instances', async function () {
       const existingModuleSlug = 'bien-ecrire-son-adresse-mail';
       const expectedFoundModule = {


### PR DESCRIPTION
## :pancakes: Problème
Nous avons 17 UUIDs copié/collé dans les contenus des modules.

## :bacon: Proposition
Les remplacer pour éviter d'autres soucis type lecteur vidéo cassé ou plus gênant...

On met aussi en place un test pour éviter que ça ne réarrive.

Il y a majoritairement des éléments non répondables donc pas très grave, mais il y a quand même un élément de type QROCM avec des réponses enregistrées. On prévoit donc de corriger certaines données des `element-answers`.

## 🧃 Remarques
RAS

## :yum: Pour tester
Vérifier qu'il n'y a plus d'UUIDs dupliqués dans les contenus de modules, que la CI passe et que les test `modulix:test` appellent bien ce nouveau test.
