### PR TITLE
[FEATURE] Cacher le bouton "Je retente" lors d'une campagne d'interro (PIX-16496)

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -645,8 +645,15 @@ V3_CERTIFICATION_NUMBER_OF_CHALLENGES_PER_COURSE=
 DEFAULT_PROBABILITY_TO_PICK_CHALLENGE=
 
 # ========
-# MAX REACHABLE LEVEL
+# EVALUATION
 # ========
+
+# Days before a user can be asked again on failed skills in a competence evaluation or a campaign participation
+#
+# presence: optional
+# type: Integer
+# default: 4
+DAY_BEFORE_IMPROVING=
 
 # Max reachable level by competence for a user
 #
@@ -1125,3 +1132,14 @@ EMAIL_VALIDATION_DEMAND_TEMPORARY_STORAGE_LIFESPAN=3d
 # presence: optional
 # type: json
 # API_DATA_QUERIES='{ "coverageRateByAreas": "abc45-67def-89ghi" }'
+
+# ========
+# PRESCRIPTION
+# ========
+
+# Days before a participant can run the campaign again to try to succeed on failed skills
+#
+# presence: optional
+# type: Integer
+# default: 4
+DAY_BEFORE_RETRYING=

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/participant-result-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/participant-result-repository.js
@@ -38,10 +38,11 @@ const getByUserIdAndCampaignId = async function ({ userId, campaignId, badges, r
   if (participationResults.isFlash) {
     flashScoringResults = await _getFlashScoringResults(participationResults.assessmentId, locale);
   }
-  const isCampaignMultipleSendings = await _isCampaignMultipleSendings(campaignId);
+  const campaignDTO = await _getCampaignDTO(campaignId);
+  const isCampaignMultipleSendings = _isCampaignMultipleSendings(campaignDTO);
+  const isCampaignArchived = _isCampaignArchived(campaignDTO);
+  const isCampaignDeleted = _isCampaignDeleted(campaignDTO);
   const isOrganizationLearnerActive = await _isOrganizationLearnerActive(userId, campaignId);
-  const isCampaignArchived = await _isCampaignArchived(campaignId);
-  const isCampaignDeleted = await _isCampaignDeleted(campaignId);
   const competences = await _findTargetedCompetences(campaignId, locale);
   if (stages && stages.length) {
     const skillIds = competences.flatMap(({ targetedSkillIds }) => targetedSkillIds);
@@ -236,19 +237,20 @@ async function _findTargetedCompetences(campaignId, locale) {
   return targetedCompetences;
 }
 
-async function _isCampaignMultipleSendings(campaignId) {
-  const campaign = await knex('campaigns').select('multipleSendings').where({ 'campaigns.id': campaignId }).first();
-  return campaign.multipleSendings;
+function _getCampaignDTO(campaignId) {
+  return knex('campaigns').select('*').where({ 'campaigns.id': campaignId }).first();
 }
 
-async function _isCampaignArchived(campaignId) {
-  const campaign = await knex('campaigns').select('archivedAt').where({ 'campaigns.id': campaignId }).first();
-  return Boolean(campaign.archivedAt);
+function _isCampaignMultipleSendings(campaignDTO) {
+  return campaignDTO.multipleSendings;
 }
 
-async function _isCampaignDeleted(campaignId) {
-  const campaign = await knex('campaigns').select('deletedAt').where({ 'campaigns.id': campaignId }).first();
-  return Boolean(campaign.deletedAt);
+function _isCampaignArchived(campaignDTO) {
+  return Boolean(campaignDTO.archivedAt);
+}
+
+function _isCampaignDeleted(campaignDTO) {
+  return Boolean(campaignDTO.deletedAt);
 }
 
 async function _isOrganizationLearnerActive(userId, campaignId) {

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/participant-result-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/participant-result-repository.js
@@ -68,6 +68,7 @@ const getByUserIdAndCampaignId = async function ({ userId, campaignId, badges, r
     isOrganizationLearnerActive,
     isCampaignArchived,
     isCampaignDeleted,
+    campaignType: campaignDTO.type,
     flashScoringResults,
     isTargetProfileResetAllowed,
   });

--- a/api/src/shared/domain/read-models/participant-results/AssessmentResult.js
+++ b/api/src/shared/domain/read-models/participant-results/AssessmentResult.js
@@ -6,7 +6,7 @@ import {
   MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING,
   MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING,
 } from '../../constants.js';
-import { CampaignParticipationStatuses } from '../../models/index.js';
+import { CampaignParticipationStatuses, CampaignTypes } from '../../models/index.js';
 import { BadgeResult } from './BadgeResult.js';
 import { CompetenceResult } from './CompetenceResult.js';
 
@@ -18,6 +18,7 @@ class AssessmentResult {
     isTargetProfileResetAllowed,
     isCampaignArchived,
     isCampaignDeleted,
+    campaignType,
     competences,
     reachedStage,
     badgeResultsDTO,
@@ -64,7 +65,7 @@ class AssessmentResult {
 
     this.badgeResults = badgeResultsDTO.map((badge) => new BadgeResult(badge, participationResults.acquiredBadgeIds));
     this.reachedStage = reachedStage;
-    this.canImprove = this._computeCanImprove(knowledgeElements, assessmentCreatedAt, this.isShared);
+    this.canImprove = this._computeCanImprove(knowledgeElements, assessmentCreatedAt, this.isShared, campaignType);
     this.isDisabled = this._computeIsDisabled(isCampaignArchived, isCampaignDeleted, participationResults.isDeleted);
     this.canRetry = this._computeCanRetry(
       isCampaignMultipleSendings,
@@ -110,7 +111,10 @@ class AssessmentResult {
     }
   }
 
-  _computeCanImprove(knowledgeElements, assessmentCreatedAt, isShared) {
+  _computeCanImprove(knowledgeElements, assessmentCreatedAt, isShared, campaignType) {
+    if (campaignType === CampaignTypes.EXAM) {
+      return false;
+    }
     const isImprovementPossible =
       knowledgeElements.filter((knowledgeElement) => {
         const isOldEnoughToBeImproved =


### PR DESCRIPTION
## :pancakes: Problème

La feature de retenter n'a pas de sens dans le cadre de campagne d'interro.

## :bacon: Proposition
Impossible de retenter en interro

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester
Procédure en campagne d'éval normalement pour avoir le bouton :
- Créer une campagne avec un profil cible A
- Y participer et tout rater
- Refaire une campagne avec le même profil cible A
- Y participer aussi et voir sur la page de résultats qu'on me propose "Je retente"

Faire pareil avec des campagnes d'exam et voir que "Je retente" n'est pas proposé
