### PR TITLE
[TECH] Améliorer la récupération du timestamp d'une requête (PIX-16871)

### DIFF
--- a/api/src/shared/infrastructure/utils/request-response-utils.js
+++ b/api/src/shared/infrastructure/utils/request-response-utils.js
@@ -42,7 +42,7 @@ function extractLocaleFromRequest(request) {
 }
 
 function extractTimestampFromRequest(request) {
-  return request.headers?.['X-Request-Start'] ?? new Date().getTime();
+  return request.info.received;
 }
 
 export {

--- a/api/tests/shared/unit/infrastructure/utils/request-response-utils_test.js
+++ b/api/tests/shared/unit/infrastructure/utils/request-response-utils_test.js
@@ -5,7 +5,7 @@ import {
   extractTimestampFromRequest,
   extractUserIdFromRequest,
 } from '../../../../../src/shared/infrastructure/utils/request-response-utils.js';
-import { expect, generateAuthenticatedUserRequestHeaders, sinon } from '../../../../test-helper.js';
+import { expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
 const { ENGLISH_SPOKEN, FRENCH_FRANCE, FRENCH_SPOKEN } = LOCALE;
 
@@ -84,46 +84,20 @@ describe('Unit | Utils | Request Utils', function () {
   });
 
   describe('#extractTimestampFromRequest', function () {
-    context('when "X-Request-Start" header exist', function () {
-      it('returns the value of the header', function () {
-        // given
-        const startDateTimestamp = new Date('2025-01-01').getTime();
-        const request = {
-          headers: {
-            'X-Request-Start': startDateTimestamp,
-          },
-        };
+    it('returns the value of attribute "request.info.received"', function () {
+      // given
+      const startDateTimestamp = new Date('2025-01-01').getTime();
+      const request = {
+        info: {
+          received: startDateTimestamp,
+        },
+      };
 
-        // when
-        const timestamp = extractTimestampFromRequest(request);
+      // when
+      const timestamp = extractTimestampFromRequest(request);
 
-        // then
-        expect(timestamp).to.equal(startDateTimestamp);
-      });
-    });
-
-    context('when "X-Request-Start" header does not exist', function () {
-      let clock, now;
-
-      beforeEach(function () {
-        now = new Date('2023-09-12');
-        clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-      });
-
-      afterEach(function () {
-        clock.restore();
-      });
-
-      it('returns a new date in timestamp', function () {
-        // given
-        const request = {};
-
-        // when
-        const timestamp = extractTimestampFromRequest(request);
-
-        // then
-        expect(timestamp).to.equal(now.getTime());
-      });
+      // then
+      expect(timestamp).to.equal(startDateTimestamp);
     });
   });
 });


### PR DESCRIPTION
## :pancakes: Problème

Actuellement, la récupération du timestamp se fait avec le header `X-Request-Start`. Il nous est fourni par l'infrastructure Scalingo ce qui fait qu'il n'existe pas sans ça. 

Cela provoque un couplage avec l'infrastructure qu'on voudrait éviter car le projet est forké.

## :bacon: Proposition

Utiliser la valeur du champ `[request.info.received](https://hapi.dev/api/?v=21.3.12#request))` disponible nativement avec Hapi pour gérer ça ! 

## 🧃 Remarques

Merci @Steph0 pour la suggestion 🙏 

## :yum: Pour tester

- Aller sur un module https://app-pr11579.review.pix.fr/modules/bac-a-sable
- Le terminer (vous pouvez passer chaque étape) pour arriver sur la page de récap
- Se connecter à la BDD 
- Vérifier, dans la table passage-events, que la ligne correspondant au type `PASSAGE_TERMINATED` contient bien un champ `occurredAt` non vide 😄 
