### PR TITLE
[FEATURE] Ajouter un nom interne pour les profils cibles (PIX-16685)

### DIFF
--- a/admin/app/components/badges/badge.gjs
+++ b/admin/app/components/badges/badge.gjs
@@ -116,7 +116,9 @@ export default class Badge extends Component {
     <header class="page-header">
       <div>
         <p>
-          <LinkTo @route="authenticated.target-profiles.target-profile.insights">{{@targetProfile.name}}</LinkTo>
+          <LinkTo
+            @route="authenticated.target-profiles.target-profile.insights"
+          >{{@targetProfile.internalName}}</LinkTo>
           <span class="wire">&nbsp;>&nbsp;</span>
           <h1>Résultat thématique {{@badge.id}}</h1>
         </p>

--- a/admin/app/components/organizations/target-profiles-section.gjs
+++ b/admin/app/components/organizations/target-profiles-section.gjs
@@ -165,7 +165,7 @@ export default class OrganizationTargetProfilesSectionComponent extends Componen
             <thead>
               <tr>
                 <th class="table__column table__column--id">ID</th>
-                <th>Nom du profil cible</th>
+                <th>Nom interne du profil cible</th>
                 {{#if this.accessControl.hasAccessToOrganizationActionsScope}}
                   <th>Actions</th>
                 {{/if}}
@@ -179,7 +179,7 @@ export default class OrganizationTargetProfilesSectionComponent extends Componen
                     <td class="table__column table__column--id">{{summary.id}}</td>
                     <td headers="target-profile-name">
                       <LinkTo @route="authenticated.target-profiles.target-profile" @model={{summary.id}}>
-                        {{summary.name}}
+                        {{summary.internalName}}
                       </LinkTo>
                     </td>
                     {{#if this.accessControl.hasAccessToOrganizationActionsScope}}

--- a/admin/app/components/target-profiles/edit-target-profile-form.gjs
+++ b/admin/app/components/target-profiles/edit-target-profile-form.gjs
@@ -15,7 +15,7 @@ import { optionsCategoryList } from '../../models/target-profile';
 import Card from '../card';
 import TubesSelection from '../common/tubes-selection';
 
-export default class CreateTargetProfileForm extends Component {
+export default class EditTargetProfileForm extends Component {
   @tracked submitting = false;
   selectedTubes = [];
 
@@ -65,7 +65,19 @@ export default class CreateTargetProfileForm extends Component {
         {{t "common.forms.mandatory-fields" htmlSafe=true}}
       </p>
       <section class="admin-form__content admin-form__content--with-counters">
+
         <Card class="admin-form__card" @title="Information sur le profil cible">
+          <PixInput
+            @id="targetProfileInternalName"
+            required={{true}}
+            @requiredLabel={{t "common.forms.mandatory"}}
+            aria-required={{true}}
+            @value={{@targetProfile.internalName}}
+            {{on "change" (fn this.handleInputValue "internalName")}}
+          >
+            <:label>Nom interne :</:label>
+          </PixInput>
+
           <PixInput
             @id="targetProfileName"
             required={{true}}
@@ -74,7 +86,7 @@ export default class CreateTargetProfileForm extends Component {
             @value={{@targetProfile.name}}
             {{on "change" (fn this.handleInputValue "name")}}
           >
-            <:label>Nom :</:label>
+            <:label>Nom externe :</:label>
           </PixInput>
 
           <PixSelect
@@ -161,6 +173,7 @@ export default class CreateTargetProfileForm extends Component {
           </PixTextarea>
         </Card>
       </section>
+
       <section class="admin-form__actions">
         <PixButton @variant="secondary" @size="large" @triggerAction={{@onCancel}}>
           {{t "common.actions.cancel"}}

--- a/admin/app/components/target-profiles/list-summary-items.gjs
+++ b/admin/app/components/target-profiles/list-summary-items.gjs
@@ -18,7 +18,7 @@ export default class TargetProfileListSummaryItems extends Component {
   @tracked selectedValues = [];
 
   get isClearFiltersButtonDisabled() {
-    return !this.args.id && !this.args.name && this.args.categories?.length === 0;
+    return !this.args.id && !this.args.internalName && this.args.categories?.length === 0;
   }
 
   get categoryOptions() {
@@ -52,13 +52,14 @@ export default class TargetProfileListSummaryItems extends Component {
 
       <PixInput
         type="text"
-        value={{@name}}
-        placeholder={{t "pages.target-profiles.filters.search-by-name.placeholder"}}
-        oninput={{fn @triggerFiltering "name"}}
+        value={{@internalName}}
+        placeholder={{t "pages.target-profiles.filters.search-by-internal-name.placeholder"}}
+        oninput={{fn @triggerFiltering "internalName"}}
         @screenReaderOnly={{true}}
       >
-        <:label>{{t "pages.target-profiles.filters.search-by-name.name"}}</:label>
+        <:label>{{t "pages.target-profiles.filters.search-by-internal-name.name"}}</:label>
       </PixInput>
+
       <PixMultiSelect
         @id="categories"
         @screenReaderOnly={{true}}
@@ -79,7 +80,7 @@ export default class TargetProfileListSummaryItems extends Component {
           <thead>
             <tr>
               <th class="table__column table__column--id">{{t "common.fields.id"}}</th>
-              <th>{{t "common.fields.name"}}</th>
+              <th>{{t "common.fields.internalName"}}</th>
               <th>{{t "common.fields.target-profile.category.name"}}</th>
               <th class="col-date">{{t "common.fields.createdAt"}}</th>
               <th class="col-status">{{t "common.fields.status"}}</th>
@@ -93,7 +94,7 @@ export default class TargetProfileListSummaryItems extends Component {
                   <td class="table__column table__column--id">{{summary.id}}</td>
                   <td>
                     <LinkTo @route="authenticated.target-profiles.target-profile" @model={{summary.id}}>
-                      {{summary.name}}
+                      {{summary.internalName}}
                     </LinkTo>
                   </td>
                   <td class="table__column table__column--id">{{t summary.translationKeyCategory}}</td>

--- a/admin/app/components/target-profiles/organizations.gjs
+++ b/admin/app/components/target-profiles/organizations.gjs
@@ -182,7 +182,7 @@ export default class Organizations extends Component {
         @triggerFiltering={{@triggerFiltering}}
         @goToOrganizationPage={{@goToOrganizationPage}}
         @detachOrganizations={{@detachOrganizations}}
-        @targetProfileName={{@targetProfile.name}}
+        @targetProfileName={{@targetProfile.internalName}}
         @showDetachColumn={{this.isSuperAdminOrMetier}}
       />
     </section>

--- a/admin/app/components/target-profiles/target-profile.gjs
+++ b/admin/app/components/target-profiles/target-profile.gjs
@@ -178,19 +178,21 @@ export default class TargetProfile extends Component {
       <div>
         <LinkTo @route="authenticated.target-profiles.list">Tous les profils cibles</LinkTo>
         <span class="wire">&nbsp;>&nbsp;</span>
-        <h1>{{@model.name}}</h1>
+        <h1>{{@model.internalName}}</h1>
       </div>
     </header>
 
     <main class="page-body">
       <section class="page-section target-profile-section">
         <div class="page-section__header">
-          <h2 class="page-section__title target-profile__title">{{@model.name}}</h2>
+          <h2 class="page-section__title target-profile__title">{{@model.internalName}}</h2>
           <Category @category={{@model.category}} />
         </div>
         <div class="target-profile-section__container">
           <ul>
             <li><span class="bold">ID&#x20;:&#x20;</span>{{@model.id}}</li>
+            <li><span class="bold">Nom interne&#x20;:&#x20;</span>{{@model.internalName}}</li>
+            <li><span class="bold">Nom externe&#x20;:&#x20;</span>{{@model.name}}</li>
             <li><span class="bold">Organisation de référence&#x20;:&#x20;</span><LinkTo
                 @route="authenticated.organizations.get"
                 @model={{@model.ownerOrganizationId}}

--- a/admin/app/controllers/authenticated/target-profiles/list.js
+++ b/admin/app/controllers/authenticated/target-profiles/list.js
@@ -7,13 +7,13 @@ import config from 'pix-admin/config/environment';
 const DEFAULT_PAGE_NUMBER = 1;
 
 export default class ListController extends Controller {
-  queryParams = ['pageNumber', 'pageSize', 'id', 'name', 'categories'];
+  queryParams = ['pageNumber', 'pageSize', 'id', 'internalName', 'categories'];
   DEBOUNCE_MS = config.pagination.debounce;
 
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
   @tracked pageSize = 10;
   @tracked id = null;
-  @tracked name = null;
+  @tracked internalName = null;
   @tracked categories = [];
 
   updateFilters(filters) {
@@ -31,7 +31,7 @@ export default class ListController extends Controller {
   @action
   onResetFilter() {
     this.id = null;
-    this.name = null;
+    this.internalName = null;
     this.categories = [];
   }
 }

--- a/admin/app/models/target-profile-form.js
+++ b/admin/app/models/target-profile-form.js
@@ -16,6 +16,20 @@ const Validations = buildValidations({
       }),
     ],
   },
+  internalName: {
+    validators: [
+      validator('presence', {
+        presence: true,
+        ignoreBlank: true,
+        message: 'Le nom interne ne peut pas être vide',
+      }),
+      validator('length', {
+        min: 1,
+        max: 255,
+        message: 'La longueur du nom ne doit pas excéder 255 caractères',
+      }),
+    ],
+  },
   description: {
     validators: [
       validator('length', {
@@ -43,6 +57,7 @@ const Validations = buildValidations({
 
 export default class TargetProfileForm extends Model.extend(Validations) {
   @attr('string') name;
+  @attr('string') internalName;
   @attr('string') description;
   @attr('string') comment;
   @attr('string') category;

--- a/admin/app/models/target-profile-summary.js
+++ b/admin/app/models/target-profile-summary.js
@@ -2,7 +2,7 @@ import Model, { attr } from '@ember-data/model';
 
 import { categories } from '../helpers/target-profile-categories';
 export default class TargetProfileSummary extends Model {
-  @attr() name;
+  @attr() internalName;
   @attr() outdated;
   @attr() category;
   @attr() createdAt;

--- a/admin/app/models/target-profile.js
+++ b/admin/app/models/target-profile.js
@@ -21,6 +21,7 @@ export default class TargetProfile extends Model {
   @service session;
 
   @attr('nullable-string') name;
+  @attr('nullable-string') internalName;
   @attr('date') createdAt;
   @attr('nullable-string') imageUrl;
   @attr('boolean') outdated;

--- a/admin/app/routes/authenticated/target-profiles/list.js
+++ b/admin/app/routes/authenticated/target-profiles/list.js
@@ -11,7 +11,7 @@ export default class ListRoute extends Route {
     pageNumber: { refreshModel: true },
     pageSize: { refreshModel: true },
     id: { refreshModel: true },
-    name: { refreshModel: true },
+    internalName: { refreshModel: true },
     categories: { refreshModel: true },
   };
 
@@ -25,7 +25,7 @@ export default class ListRoute extends Route {
       targetProfileSummaries = await this.store.query('target-profile-summary', {
         filter: {
           id: params.id ? params.id.trim() : '',
-          name: params.name ? params.name.trim() : '',
+          internalName: params.internalName ? params.internalName.trim() : '',
           categories: params.categories ?? [],
         },
         page: {
@@ -47,7 +47,7 @@ export default class ListRoute extends Route {
       controller.pageNumber = 1;
       controller.pageSize = 10;
       controller.id = null;
-      controller.name = null;
+      controller.internalName = null;
       controller.categories = [];
     }
   }

--- a/admin/app/serializers/target-profile.js
+++ b/admin/app/serializers/target-profile.js
@@ -15,6 +15,7 @@ export default class TargetProfileSerializer extends ApplicationSerializer {
           description: attributes.description,
           'image-url': attributes['image-url'],
           name: attributes.name,
+          'internal-name': attributes['internal-name'],
           'owner-organization-id': attributes['owner-organization-id'],
         },
       },
@@ -25,6 +26,7 @@ export default class TargetProfileSerializer extends ApplicationSerializer {
     }
 
     const isUpdateMode = options?.update;
+
     if (isUpdateMode) {
       delete json.data.attributes['owner-organization-id'];
     }

--- a/admin/app/templates/authenticated/target-profiles/edit.hbs
+++ b/admin/app/templates/authenticated/target-profiles/edit.hbs
@@ -1,8 +1,9 @@
-{{page-title "Modification du profil cible : " @model.targetProfile.name}}
+{{page-title "Modification du profil cible : " @model.targetProfile.internalName}}
+
 <header class="page-header">
   <div>
     <LinkTo @route="authenticated.target-profiles.target-profile" @model={{@model.targetProfile.id}}>
-      {{@model.targetProfile.name}}
+      {{@model.targetProfile.internalName}}
     </LinkTo>
     <span role="presentation" class="wire">&nbsp;>&nbsp;</span>
     <h1>Modification du profil cible</h1>

--- a/admin/app/templates/authenticated/target-profiles/list.hbs
+++ b/admin/app/templates/authenticated/target-profiles/list.hbs
@@ -14,7 +14,7 @@
     <TargetProfiles::ListSummaryItems
       @summaries={{@model}}
       @id={{this.id}}
-      @name={{this.name}}
+      @internalName={{this.internalName}}
       @categories={{this.categories}}
       @triggerFiltering={{this.triggerFiltering}}
       @onResetFilter={{this.onResetFilter}}

--- a/admin/app/templates/authenticated/target-profiles/target-profile/stages/stage.hbs
+++ b/admin/app/templates/authenticated/target-profiles/target-profile/stages/stage.hbs
@@ -1,6 +1,6 @@
 <Stages::Stage
   @stage={{@model.stage}}
-  @targetProfileName={{@model.targetProfile.name}}
+  @targetProfileName={{@model.targetProfile.internalName}}
   @availableLevels={{this.availableLevels}}
   @unavailableThresholds={{this.unavailableThresholds}}
   @hasLinkedCampaign={{this.hasLinkedCampaign}}

--- a/admin/app/templates/authenticated/trainings/training/target-profiles.hbs
+++ b/admin/app/templates/authenticated/trainings/training/target-profiles.hbs
@@ -47,11 +47,11 @@
               </PixTableColumn>
               <PixTableColumn @context={{context}} class="table__column--wide">
                 <:header>
-                  Nom du profil cible
+                  Nom interne du profil cible
                 </:header>
                 <:cell>
                   <LinkTo @route="authenticated.target-profiles.target-profile" @model={{row.id}}>
-                    {{row.name}}
+                    {{row.internalName}}
                   </LinkTo>
                 </:cell>
               </PixTableColumn>

--- a/admin/mirage/factories/target-profile.js
+++ b/admin/mirage/factories/target-profile.js
@@ -7,6 +7,10 @@ export default Factory.extend({
     return 'Mon Super Profil Cible Trop Biengggg';
   },
 
+  internalName() {
+    return 'Mon Super Profil Cible interne Trop Biengggg';
+  },
+
   createdAt() {
     return new Date('2020-01-01');
   },

--- a/admin/mirage/handlers/target-profiles.js
+++ b/admin/mirage/handlers/target-profiles.js
@@ -6,7 +6,7 @@ function attachTargetProfiles(schema, request) {
   const params = JSON.parse(request.requestBody);
   const targetProfilesToAttach = params['target-profile-ids'];
   targetProfilesToAttach.forEach((targetProfileId) => {
-    schema.targetProfileSummaries.create({ name: `Profil ${targetProfileId}` });
+    schema.targetProfileSummaries.create({ internalName: `Profil ${targetProfileId}` });
   });
   return new Response(204);
 }
@@ -36,6 +36,7 @@ function copyTargetProfile(schema, request) {
   const { id } = schema.create('target-profile', {
     ...targetProfile.attrs,
     name: '[Copie] ' + targetProfile.attrs.name,
+    internalName: '[Copie] ' + targetProfile.attrs.internalName,
   });
 
   return id;

--- a/admin/tests/acceptance/authenticated/organizations/target-profiles-management-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/target-profiles-management-test.js
@@ -15,7 +15,7 @@ module('Acceptance | Organizations | Target profiles management', function (hook
   test('should display organization target profiles', async function (assert) {
     // given
     const ownerOrganizationId = this.server.create('organization').id;
-    this.server.create('target-profile-summary', { name: 'Profil cible du ghetto' });
+    this.server.create('target-profile-summary', { internalName: 'Profil cible du ghetto' });
 
     // when
     const screen = await visit(`/organizations/${ownerOrganizationId}/target-profiles`);
@@ -36,6 +36,7 @@ module('Acceptance | Organizations | Target profiles management', function (hook
 
     await fillByLabel('ID du ou des profil(s) cible(s)', '66');
     await clickByName('Valider');
+
     // then
     assert.dom(await screen.findByLabelText('Profil cible')).includesText('66');
     assert.dom(await within(parentInput).findByDisplayValue('')).hasAria('label', 'ID du ou des profil(s) cible(s)');
@@ -45,7 +46,7 @@ module('Acceptance | Organizations | Target profiles management', function (hook
     // given
     await authenticateAdminMemberWithRole({ isCertif: true })(server);
     const ownerOrganizationId = this.server.create('organization').id;
-    this.server.create('target-profile-summary', { name: 'Profil cible du ghetto', ownerOrganizationId });
+    this.server.create('target-profile-summary', { internalName: 'Profil cible du ghetto', ownerOrganizationId });
 
     // when
     const screen = await visit(`/organizations/${ownerOrganizationId}/target-profiles`);

--- a/admin/tests/acceptance/authenticated/target-profiles/list-test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/list-test.js
@@ -47,8 +47,8 @@ module('Acceptance | Target Profiles | List', function (hooks) {
 
       test('it should list target profile summaries', async function (assert) {
         // given
-        server.create('target-profile-summary', { id: 1, name: 'COUCOU', outdated: true });
-        server.create('target-profile-summary', { id: 2, name: 'CAVA', outdated: false });
+        server.create('target-profile-summary', { id: 1, internalName: 'COUCOU', outdated: true });
+        server.create('target-profile-summary', { id: 2, internalName: 'CAVA', outdated: false });
 
         // when
         const screen = await visit('/target-profiles/list');
@@ -67,7 +67,7 @@ module('Acceptance | Target Profiles | List', function (hooks) {
           name: 'Profil Cible',
           areas: [area],
         });
-        server.create('target-profile-summary', { id: 1, name: 'Profil Cible', outdated: true });
+        server.create('target-profile-summary', { id: 1, internalName: 'Profil Cible', outdated: true });
         const screen = await visit('/target-profiles/list');
 
         // when
@@ -97,10 +97,12 @@ module('Acceptance | Target Profiles | List', function (hooks) {
 
         test('it should display the current filter when target profiles are filtered by name', async function (assert) {
           // when
-          const screen = await visit('/target-profiles/list?name=sav');
+          const screen = await visit('/target-profiles/list?internalName=sav');
 
           // then
-          assert.dom(screen.getByRole('textbox', { name: 'Filtrer les profils cible par un nom' })).hasValue('sav');
+          assert
+            .dom(screen.getByRole('textbox', { name: 'Filtrer les profils cible par le nom interne' }))
+            .hasValue('sav');
         });
 
         test('it should display the current filter when target profiles are filtered by id', async function (assert) {

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/copy-test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/copy-test.js
@@ -22,6 +22,7 @@ module('Acceptance | Target Profile copy', function (hooks) {
     server.create('target-profile', {
       id: 1,
       name: 'nom initial',
+      internalName: 'nom initial interne',
       description: 'description initiale',
       comment: 'commentaire initial',
       category: 'OTHER',
@@ -36,9 +37,12 @@ module('Acceptance | Target Profile copy', function (hooks) {
     // then
     await screen.findByRole('button', { name: 'Valider' });
     await clickByName('Valider');
-    await screen.findByRole('heading', { name: '[Copie] nom initial', level: 1 });
-    assert.dom(screen.getByRole('heading', { name: '[Copie] nom initial', level: 1 })).exists();
-    assert.dom(screen.getByRole('heading', { name: '[Copie] nom initial', level: 2 })).exists();
+
+    await screen.findByRole('heading', { name: '[Copie] nom initial interne', level: 1 });
+
+    assert.dom(screen.getByRole('heading', { name: '[Copie] nom initial interne', level: 1 })).exists();
+    assert.dom(screen.getByRole('heading', { name: '[Copie] nom initial interne', level: 2 })).exists();
+
     await clickByName('1 · areaUn');
     await clickByName('1.1 competenceUn');
     assert.dom(screen.getByText('@tubeNiveauDeux : Mon tube de niveau deux')).exists();

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/creation-test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/creation-test.js
@@ -75,7 +75,8 @@ module('Acceptance | Target profile creation', function (hooks) {
       server.get('/admin/frameworks', (schema) => schema.frameworks.all());
       const screen = await visit('/target-profiles/list');
       await clickByName('Nouveau profil cible');
-      await fillByLabel(/Nom/, 'Un profil cible, et vite !');
+      await fillByLabel(/Nom externe/, 'Un profil cible, et vite !');
+      await fillByLabel(/Nom interne/, 'Un profil cible interne, et vite !');
       await fillByLabel(/Identifiant de l'organisation de référence/, 1);
       await clickByName(/Permettre la remise à zéro des acquis du profil cible/);
 
@@ -96,7 +97,7 @@ module('Acceptance | Target profile creation', function (hooks) {
       assert.dom(screen.getByText('Le profil cible a été créé avec succès.')).exists();
 
       await _unfoldLearningContent();
-      assert.dom(screen.getByRole('heading', { name: 'Un profil cible, et vite !', level: 2 })).exists();
+      assert.dom(screen.getByRole('heading', { name: 'Un profil cible interne, et vite !', level: 2 })).exists();
       let isMobileCompliant = screen.getByTestId('mobile-compliant-tube_f1_a1_c1_th1_tu1').getAttribute('aria-label');
       let isTabletCompliant = screen.getByTestId('tablet-compliant-tube_f1_a1_c1_th1_tu1').getAttribute('aria-label');
       assert.deepEqual(

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/edition-test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/edition-test.js
@@ -8,7 +8,7 @@ import { module, test } from 'qunit';
 import { createLearningContent } from '../../../../../mirage/helpers/create-learning-content';
 import setupIntl from '../../../../helpers/setup-intl';
 
-module('Acceptance | Target Profile Management', function (hooks) {
+module('Acceptance | Target Profile Edition', function (hooks) {
   setupApplicationTest(hooks);
   setupIntl(hooks);
   setupMirage(hooks);
@@ -37,7 +37,7 @@ module('Acceptance | Target Profile Management', function (hooks) {
   });
 
   test('it should edit target profile informations and selected tubes', async function (assert) {
-    await fillByLabel(/Nom/, 'Un nouveau nom');
+    await fillByLabel(/Nom interne/, 'Un nouveau nom interne');
 
     await fillByLabel(/Référentiel/, 'Pi');
     await click(screen.getByLabelText('Pix + Cuisine'));
@@ -58,7 +58,7 @@ module('Acceptance | Target Profile Management', function (hooks) {
     // then
     assert.dom(screen.getByText('Le profil cible a été modifié avec succès.')).exists();
 
-    assert.strictEqual(screen.getAllByRole('heading', { name: 'Un nouveau nom' }).length, 2);
+    assert.strictEqual(screen.getAllByRole('heading', { name: 'Un nouveau nom interne' }).length, 2);
     assert.dom(screen.getByText('Une nouvelle description')).exists();
 
     await clickByName('area_f2_a1 code · area_f2_a1 title');

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights-test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights-test.js
@@ -17,7 +17,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
       const stageCollection = server.create('stage-collection', { id: 1, stages: [stage] });
       server.create('target-profile', {
         id: 1,
-        name: 'Profil cible extra croustillant',
+        internalName: 'Profil cible extra croustillant',
         badges: [badge],
         stageCollection,
       });
@@ -86,7 +86,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
       stageCollection = server.create('stage-collection', { id: 1, stages: [] });
       targetProfile = server.create('target-profile', {
         id: 1,
-        name: 'Profil cible extra croustillant',
+        internalName: 'Profil cible extra croustillant',
         stageCollection,
       });
       await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/management-test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/management-test.js
@@ -27,7 +27,7 @@ module('Acceptance | Target Profile Management', function (hooks) {
       module('when admin member has role "SUPER_ADMIN", "SUPPORT" or "METIER"', function (hooks) {
         hooks.beforeEach(async function () {
           await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-          server.create('target-profile', { id: 1, name: 'Mon super profil cible' });
+          server.create('target-profile', { id: 1, internalName: 'Mon super profil cible' });
         });
 
         test('it should be accessible for an authenticated user', async function (assert) {
@@ -72,7 +72,8 @@ module('Acceptance | Target Profile Management', function (hooks) {
       // given
       server.create('target-profile', {
         id: 1,
-        name: 'Profil Cible Fantastix',
+        name: 'Profil Cible Fantastix externe',
+        internalName: 'Profil Cible Fantastix',
         outdated: false,
         ownerOrganizationId: 456,
         description: 'Top profil cible.',

--- a/admin/tests/acceptance/authenticated/trainings/target-profiles-test.js
+++ b/admin/tests/acceptance/authenticated/trainings/target-profiles-test.js
@@ -16,7 +16,10 @@ module('Acceptance | Trainings | Target profiles', function (hooks) {
   hooks.beforeEach(async function () {
     trainingId = 2;
 
-    const targetProfileSummary = server.create('target-profile-summary', { id: 1111, name: 'Super profil cible 2' });
+    const targetProfileSummary = server.create('target-profile-summary', {
+      id: 1111,
+      internalName: 'Super profil cible 2',
+    });
     server.create('training', {
       id: 2,
       title: 'Devenir tailleur de citrouille',
@@ -57,7 +60,7 @@ module('Acceptance | Trainings | Target profiles', function (hooks) {
     module('when admin role is "SUPER_ADMIN" or "METIER"', function () {
       test('is should attach a target profile to a training', async function (assert) {
         await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-        server.create('target-profile-summary', { id: 1, name: 'Super profil cible' });
+        server.create('target-profile-summary', { id: 1, internalName: 'Super profil cible' });
 
         // when
         const screen = await visit(`/trainings/${trainingId}/target-profiles`);
@@ -84,7 +87,7 @@ module('Acceptance | Trainings | Target profiles', function (hooks) {
       test('is should not be able to attach a target profile to a training', async function (assert) {
         // given
         await authenticateAdminMemberWithRole({ isSupport: true })(server);
-        server.create('target-profile-summary', { id: 1, name: 'Super profil cible' });
+        server.create('target-profile-summary', { id: 1, internalName: 'Super profil cible' });
 
         // when
         const screen = await visit(`/trainings/${trainingId}/target-profiles`);

--- a/admin/tests/acceptance/authenticated/trainings/training-test.js
+++ b/admin/tests/acceptance/authenticated/trainings/training-test.js
@@ -18,7 +18,7 @@ module('Acceptance | Trainings | Training', function (hooks) {
     let prerequisiteTriggerHeading;
     let goalTriggerHeading;
     let trainingId;
-    let targetProfileName;
+    let targetProfileInternalName;
 
     hooks.beforeEach(async function () {
       triggersTabName = t('pages.trainings.training.triggers.tabName');
@@ -26,7 +26,7 @@ module('Acceptance | Trainings | Training', function (hooks) {
       prerequisiteTriggerHeading = t('pages.trainings.training.triggers.prerequisite.title');
       goalTriggerHeading = t('pages.trainings.training.triggers.goal.title');
       trainingId = 2;
-      targetProfileName = 'Profile Cible 1';
+      targetProfileInternalName = 'Profile Cible 1';
 
       await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
@@ -59,7 +59,7 @@ module('Acceptance | Trainings | Training', function (hooks) {
         targetProfileSummaries: [
           server.create('target-profile-summary', {
             id: 1,
-            name: targetProfileName,
+            internalName: targetProfileInternalName,
             outdated: true,
           }),
         ],
@@ -154,7 +154,7 @@ module('Acceptance | Trainings | Training', function (hooks) {
       assert.dom(screen.getByRole('link', { name: targetProfilesTabName })).exists();
       assert.dom(screen.getByRole('link', { name: targetProfilesTabName })).hasClass('active');
       assert.dom(screen.getByRole('heading', { name: targetProfilesTabName })).exists();
-      assert.dom(screen.getByRole('link', { name: targetProfileName })).exists();
+      assert.dom(screen.getByRole('link', { name: targetProfileInternalName })).exists();
       assert.ok(screen.getByText('Obsolète'));
     });
 

--- a/admin/tests/integration/components/organizations/target-profiles-section-test.gjs
+++ b/admin/tests/integration/components/organizations/target-profiles-section-test.gjs
@@ -46,7 +46,7 @@ module('Integration | Component | organizations/target-profiles-section', functi
       this.owner.register('service:pixToast', NotificationsStub);
       const targetProfileSummary = store.createRecord('target-profile-summary', {
         id: 666,
-        name: 'Number of The Beast',
+        internalName: 'Number of The Beast',
       });
       const organization = EmberObject.create({
         id: 1,
@@ -72,7 +72,7 @@ module('Integration | Component | organizations/target-profiles-section', functi
     test('it should have a link to redirect on target profile page', async function (assert) {
       const targetProfileSummary = store.createRecord('target-profile-summary', {
         id: 666,
-        name: 'Number of The Beast',
+        internalName: 'Number of The Beast',
       });
 
       const targetProfileSummaries = [targetProfileSummary];
@@ -99,12 +99,12 @@ module('Integration | Component | organizations/target-profiles-section', functi
         // given
         const publicTargetProfileSummary = store.createRecord('target-profile-summary', {
           id: 666,
-          name: 'Number of The Beast',
+          internalName: 'Number of The Beast',
           canDetach: false,
         });
         const privateTargetProfileSummary = store.createRecord('target-profile-summary', {
           id: 777,
-          name: 'Super Lucky',
+          internalName: 'Super Lucky',
           canDetach: true,
         });
         const organization = store.createRecord('organization', {
@@ -130,7 +130,7 @@ module('Integration | Component | organizations/target-profiles-section', functi
         // given
         const targetProfileSummary = store.createRecord('target-profile-summary', {
           id: 666,
-          name: 'Number of The Beast',
+          internalName: 'Number of The Beast',
           canDetach: true,
         });
         const organization = store.createRecord('organization', {
@@ -162,7 +162,7 @@ module('Integration | Component | organizations/target-profiles-section', functi
         const detachOrganizationsTargetProfileStub = sinon.stub(adapter, 'detachOrganizations').resolves();
         const targetProfileSummary = store.createRecord('target-profile-summary', {
           id: 666,
-          name: 'Number of The Beast',
+          internalName: 'Number of The Beast',
           canDetach: true,
         });
         const organization = store.createRecord('organization', {
@@ -201,7 +201,7 @@ module('Integration | Component | organizations/target-profiles-section', functi
         const targetProfileSummaries = [
           store.createRecord('target-profile-summary', {
             id: 666,
-            name: 'Number of The Beast',
+            internalName: 'Number of The Beast',
             canDetach: true,
           }),
         ];

--- a/admin/tests/integration/components/routes/authenticated/target-profiles/list-summary-items-test.gjs
+++ b/admin/tests/integration/components/routes/authenticated/target-profiles/list-summary-items-test.gjs
@@ -4,7 +4,7 @@ import { module, test } from 'qunit';
 
 import setupIntlRenderingTest, { t } from '../../../../../helpers/setup-intl-rendering';
 
-module('Integration | Component | routes/authenticated/target-profiles | list-items', function (hooks) {
+module('Integration | Component | routes/authenticated/target-profiles | list-summary-items', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   const triggerFiltering = function () {};
@@ -20,7 +20,7 @@ module('Integration | Component | routes/authenticated/target-profiles | list-it
 
     // then
     assert.ok(screen.getByText(t('common.fields.id')));
-    assert.ok(screen.getByText(t('common.fields.name')));
+    assert.ok(screen.getByText(t('common.fields.internalName')));
     assert.ok(screen.getByText(t('common.fields.status')));
   });
 
@@ -34,7 +34,9 @@ module('Integration | Component | routes/authenticated/target-profiles | list-it
 
     // then
     assert.dom(screen.getByRole('textbox', { name: t('pages.target-profiles.filters.search-by-id.name') })).exists();
-    assert.dom(screen.getByRole('textbox', { name: t('pages.target-profiles.filters.search-by-name.name') })).exists();
+    assert
+      .dom(screen.getByRole('textbox', { name: t('pages.target-profiles.filters.search-by-internal-name.name') }))
+      .exists();
   });
 
   test('it should display target profile summaries list', async function (assert) {
@@ -62,7 +64,7 @@ module('Integration | Component | routes/authenticated/target-profiles | list-it
 
   test('it should display target profile summaries data', async function (assert) {
     // given
-    const summaries = [{ id: 123, name: 'Profile Cible 1' }];
+    const summaries = [{ id: 123, internalName: 'Profile Cible 1' }];
     summaries.meta = {
       rowCount: 2,
     };
@@ -86,7 +88,7 @@ module('Integration | Component | routes/authenticated/target-profiles | list-it
 
   test('it should display target profile status as "Obsolète" when target profile is outdated', async function (assert) {
     // given
-    const summaries = [{ id: 123, name: 'Profile Cible - outdated', outdated: true }];
+    const summaries = [{ id: 123, internalName: 'Profile Cible - outdated', outdated: true }];
     summaries.meta = {
       rowCount: 2,
     };
@@ -109,7 +111,7 @@ module('Integration | Component | routes/authenticated/target-profiles | list-it
 
   test('it should display target profile status as "Actif" when target profile is not outdated', async function (assert) {
     // given
-    const summaries = [{ id: 123, name: 'Profile Cible - active', outdated: false }];
+    const summaries = [{ id: 123, internalName: 'Profile Cible - active', outdated: false }];
     summaries.meta = {
       rowCount: 2,
     };

--- a/admin/tests/integration/components/target-profiles/edit-target-profile-form-test.gjs
+++ b/admin/tests/integration/components/target-profiles/edit-target-profile-form-test.gjs
@@ -66,6 +66,7 @@ module('Integration | Component | TargetProfiles::EditTargetProfileForm', functi
       comment: '',
       imageUrl: '',
       name: 'A name',
+      internalName: 'An internal name',
       ownerOrganizationId: 1000,
     };
   });
@@ -93,7 +94,8 @@ module('Integration | Component | TargetProfiles::EditTargetProfileForm', functi
       );
       // then
       assert.dom(screen.getByText(/Information sur le profil cible/)).exists();
-      assert.dom(screen.getByLabelText(/Nom/)).exists();
+      assert.dom(screen.getByLabelText(/Nom interne/)).exists();
+      assert.dom(screen.getByLabelText(/Nom externe/)).exists();
       assert.dom(screen.getByLabelText(/Catégorie/)).exists();
       assert.dom(screen.getByLabelText(/Identifiant de l'organisation de référence/)).exists();
       assert.dom(screen.getByLabelText(/Permettre la remise à zéro des acquis du profil cible/)).exists();

--- a/admin/tests/integration/components/target-profiles/list-summary-items-test.gjs
+++ b/admin/tests/integration/components/target-profiles/list-summary-items-test.gjs
@@ -16,7 +16,7 @@ module('Integration | Component | TargetProfiles::ListSummaryItems', function (h
     // given
     const summary = {
       id: 123,
-      name: 'Profile Cible',
+      internalName: 'Profile Cible',
       oudated: false,
       isDisabled: true,
       createdAt: new Date('2021-01-01'),

--- a/admin/tests/unit/controllers/authenticated/target-profiles/list-test.js
+++ b/admin/tests/unit/controllers/authenticated/target-profiles/list-test.js
@@ -70,7 +70,7 @@ module('Unit | Controller | authenticated/target-profiles/list', function (hooks
   module('#onResetFilter', function () {
     test('it should reset controller filter', async function (assert) {
       // given
-      controller.name = 'someName';
+      controller.internalName = 'someName';
       controller.id = 'someId';
       controller.categories = ['someCategories'];
 
@@ -78,7 +78,7 @@ module('Unit | Controller | authenticated/target-profiles/list', function (hooks
       await controller.onResetFilter();
 
       // then
-      assert.strictEqual(controller.name, null);
+      assert.strictEqual(controller.internalName, null);
       assert.strictEqual(controller.id, null);
       assert.strictEqual(controller.categories.length, 0);
     });

--- a/admin/tests/unit/routes/authenticated/target-profiles/list-test.js
+++ b/admin/tests/unit/routes/authenticated/target-profiles/list-test.js
@@ -35,7 +35,7 @@ module('Unit | Route | authenticated/target-profiles/list', function (hooks) {
         // when
         await route.model(params);
         expectedQueryArgs.filter = {
-          name: '',
+          internalName: '',
           id: '',
           categories: [],
         };
@@ -49,11 +49,11 @@ module('Unit | Route | authenticated/target-profiles/list', function (hooks) {
     module('when queryParams filters are truthy', function () {
       test('it should call store.query with filters containing trimmed values', async function (assert) {
         // given
-        params.name = ' someName';
+        params.internalName = ' someName';
         params.id = 'someId ';
         params.categories = ['OTHER'];
         expectedQueryArgs.filter = {
-          name: 'someName',
+          internalName: 'someName',
           id: 'someId',
           categories: ['OTHER'],
         };
@@ -74,7 +74,7 @@ module('Unit | Route | authenticated/target-profiles/list', function (hooks) {
       controller = {
         pageNumber: 'somePageNumber',
         pageSize: 'somePageSize',
-        name: 'someName',
+        internalName: 'someName',
         id: 'someId',
         categories: ['OTHER'],
       };
@@ -88,7 +88,7 @@ module('Unit | Route | authenticated/target-profiles/list', function (hooks) {
         // then
         assert.strictEqual(controller.pageNumber, 1);
         assert.strictEqual(controller.pageSize, 10);
-        assert.strictEqual(controller.name, null);
+        assert.strictEqual(controller.internalName, null);
         assert.strictEqual(controller.id, null);
         assert.strictEqual(controller.categories.length, 0);
       });
@@ -102,7 +102,7 @@ module('Unit | Route | authenticated/target-profiles/list', function (hooks) {
         // then
         assert.strictEqual(controller.pageNumber, 'somePageNumber');
         assert.strictEqual(controller.pageSize, 'somePageSize');
-        assert.strictEqual(controller.name, 'someName');
+        assert.strictEqual(controller.internalName, 'someName');
         assert.strictEqual(controller.id, 'someId');
         assert.deepEqual(controller.categories, ['OTHER']);
       });

--- a/admin/tests/unit/serializers/target-profile-test.js
+++ b/admin/tests/unit/serializers/target-profile-test.js
@@ -16,6 +16,7 @@ module('Unit | Serializer | Target Profile', function (hooks) {
           description: 'desc',
           imageUrl: 'some-url',
           name: 'name',
+          internalName: 'internalName',
           ownerOrganizationId: 1,
         };
         const tubes = Symbol('tubes');
@@ -30,6 +31,7 @@ module('Unit | Serializer | Target Profile', function (hooks) {
           description: targetProfileData.description,
           'image-url': targetProfileData.imageUrl,
           name: targetProfileData.name,
+          'internal-name': targetProfileData.internalName,
           'owner-organization-id': String(targetProfileData.ownerOrganizationId),
           tubes,
         });
@@ -47,6 +49,7 @@ module('Unit | Serializer | Target Profile', function (hooks) {
           description: 'desc',
           imageUrl: 'some-url',
           name: 'name',
+          internalName: 'internalName',
           ownerOrganizationId: 1,
         };
 
@@ -60,6 +63,7 @@ module('Unit | Serializer | Target Profile', function (hooks) {
           description: targetProfileData.description,
           'image-url': targetProfileData.imageUrl,
           name: targetProfileData.name,
+          'internal-name': targetProfileData.internalName,
           'owner-organization-id': String(targetProfileData.ownerOrganizationId),
         });
       });
@@ -79,6 +83,7 @@ module('Unit | Serializer | Target Profile', function (hooks) {
           description: 'desc',
           imageUrl: 'some-url',
           name: 'name',
+          internalName: 'internalName',
         };
         const tubes = Symbol('tubes');
 
@@ -95,6 +100,7 @@ module('Unit | Serializer | Target Profile', function (hooks) {
           description: targetProfileData.description,
           'image-url': targetProfileData.imageUrl,
           name: targetProfileData.name,
+          'internal-name': targetProfileData.internalName,
           tubes,
         });
       });
@@ -111,6 +117,7 @@ module('Unit | Serializer | Target Profile', function (hooks) {
           description: 'desc',
           imageUrl: 'some-url',
           name: 'name',
+          internalName: 'internalName',
         };
 
         const record = store.createRecord('target-profile', targetProfileData);
@@ -123,6 +130,7 @@ module('Unit | Serializer | Target Profile', function (hooks) {
           description: targetProfileData.description,
           'image-url': targetProfileData.imageUrl,
           name: targetProfileData.name,
+          'internal-name': targetProfileData.internalName,
         });
       });
     });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -21,6 +21,7 @@
     "fields": {
       "createdAt": "creation date",
       "id": "id",
+      "internalName": "internal name",
       "name": "name",
       "status": "status",
       "target-profile": {
@@ -879,9 +880,9 @@
           "name": "Filter target profiles by ID",
           "placeholder": "Search by ID"
         },
-        "search-by-name": {
-          "name": "Filter target profiles by name",
-          "placeholder": "Search by name"
+        "search-by-internal-name": {
+          "name": "Filter target profiles by internal name",
+          "placeholder": "Search by internal name"
         }
       },
       "resettable-checkbox": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -21,6 +21,7 @@
     "fields": {
       "createdAt": "date de création",
       "id": "ID",
+      "internalName": "nom interne",
       "name": "nom",
       "status": "statut",
       "target-profile": {
@@ -901,9 +902,9 @@
           "name": "Filtrer les profils cible par un ID",
           "placeholder": "Rechercher par ID"
         },
-        "search-by-name": {
-          "name": "Filtrer les profils cible par un nom",
-          "placeholder": "Rechercher par nom"
+        "search-by-internal-name": {
+          "name": "Filtrer les profils cible par le nom interne",
+          "placeholder": "Rechercher par nom interne"
         }
       },
       "resettable-checkbox": {

--- a/api/db/database-builder/factory/build-target-profile.js
+++ b/api/db/database-builder/factory/build-target-profile.js
@@ -6,6 +6,7 @@ import { buildOrganization } from './build-organization.js';
 const buildTargetProfile = function ({
   id = databaseBuffer.getNextId(),
   name = 'Remplir un tableur',
+  internalName = name || 'Remplir un tableur',
   imageUrl = 'https://images.pix.fr/profil-cible/Illu_GEN.svg',
   isSimplifiedAccess = false,
   ownerOrganizationId,
@@ -22,6 +23,7 @@ const buildTargetProfile = function ({
   const values = {
     id,
     name,
+    internalName,
     imageUrl,
     isSimplifiedAccess,
     ownerOrganizationId,

--- a/api/db/migrations/20250227142425_add-internal-name-column-on-target-profile-table.js
+++ b/api/db/migrations/20250227142425_add-internal-name-column-on-target-profile-table.js
@@ -1,0 +1,38 @@
+const TABLE_NAME = 'target-profiles';
+const INTERNAL_NAME_COLUMN = 'internalName';
+const NAME_COLUMN = 'name';
+
+const up = async function (knex) {
+  // add column
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table
+      .string(INTERNAL_NAME_COLUMN)
+      .comment('Internal name of the target profile, used for target profiles administration, not displayed to users');
+  });
+
+  // copy data from name to internalName
+  await knex.raw(
+    `
+      UPDATE :tableName:
+      SET :internalNameColumn: = :columnName:
+    `,
+    {
+      tableName: TABLE_NAME,
+      internalNameColumn: INTERNAL_NAME_COLUMN,
+      columnName: NAME_COLUMN,
+    },
+  );
+
+  // add not null constraint on internalName column
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.string(INTERNAL_NAME_COLUMN).notNullable().alter();
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.dropColumn(INTERNAL_NAME_COLUMN);
+  });
+};
+
+export { down, up };

--- a/api/scripts/data-generation/generate-campaign-with-participants.js
+++ b/api/scripts/data-generation/generate-campaign-with-participants.js
@@ -207,7 +207,7 @@ async function _getTargetProfileAndSkills(targetProfileId, profileType) {
         : competences;
   const [{ id: createdTargetProfileId }] = await knex('target-profiles')
     .returning('id')
-    .insert({ name: 'SomeTargetProfile' });
+    .insert({ name: 'SomeTargetProfile', internalName: 'SomeTargetProfile' });
   for (const competence of competencesInProfile) {
     const skills = await skillRepository.findOperativeByCompetenceId(competence.id);
     const tubeIds = _.uniq(_.map(skills, 'tubeId'));

--- a/api/src/prescription/target-profile/application/admin-target-profile-route.js
+++ b/api/src/prescription/target-profile/application/admin-target-profile-route.js
@@ -61,6 +61,7 @@ const register = async function (server) {
             data: {
               attributes: {
                 name: Joi.string().required(),
+                'internal-name': Joi.string().required(),
                 category: Joi.string().required(),
                 description: Joi.string().allow(null).max(500).required(),
                 comment: Joi.string().allow(null).max(500).required(),
@@ -457,7 +458,7 @@ const register = async function (server) {
           query: Joi.object({
             filter: Joi.object({
               id: Joi.number().integer().empty('').allow(null).optional(),
-              name: Joi.string().empty('').allow(null).optional(),
+              internalName: Joi.string().empty('').allow(null).optional(),
               categories: [filterType.targetProfileCategory, Joi.array().items(filterType.targetProfileCategory)],
             }).default({}),
             page: Joi.object({
@@ -506,6 +507,7 @@ const register = async function (server) {
                 description: Joi.string().allow(null).max(500),
                 'image-url': Joi.string().uri().allow(null),
                 name: Joi.string(),
+                'internal-name': Joi.string(),
                 tubes: Joi.array()
                   .optional()
                   .items(

--- a/api/src/prescription/target-profile/domain/models/TargetProfileForAdmin.js
+++ b/api/src/prescription/target-profile/domain/models/TargetProfileForAdmin.js
@@ -6,6 +6,7 @@ class TargetProfileForAdmin {
   constructor({
     id,
     name,
+    internalName,
     outdated,
     createdAt,
     ownerOrganizationId,
@@ -27,6 +28,7 @@ class TargetProfileForAdmin {
   } = {}) {
     this.id = id;
     this.name = name;
+    this.internalName = internalName;
     this.outdated = outdated;
     this.createdAt = createdAt;
     this.ownerOrganizationId = ownerOrganizationId;
@@ -78,11 +80,13 @@ class TargetProfileForAdmin {
     }
 
     const validCategories = Object.values(categories);
+
     if (!validCategories.includes(attributes.category)) {
       throw new DomainError("La catégorie de profil cible renseignée n'est pas valide");
     }
 
     this.name = attributes.name;
+    this.internalName = attributes.internalName;
     this.imageUrl = attributes.imageUrl;
     this.description = attributes.description;
     this.comment = attributes.comment;

--- a/api/src/prescription/target-profile/domain/models/TargetProfileForCreation.js
+++ b/api/src/prescription/target-profile/domain/models/TargetProfileForCreation.js
@@ -6,6 +6,7 @@ const DEFAULT_IMAGE_URL = 'https://images.pix.fr/profil-cible/Illu_GEN.svg';
 class TargetProfileForCreation {
   constructor({
     name,
+    internalName,
     category,
     description,
     comment,
@@ -15,6 +16,7 @@ class TargetProfileForCreation {
     areKnowledgeElementsResettable,
   }) {
     this.name = name;
+    this.internalName = internalName;
     this.category = category;
     this.description = description;
     this.comment = comment;
@@ -28,6 +30,7 @@ class TargetProfileForCreation {
     validate(creationCommand);
     return new TargetProfileForCreation({
       name: creationCommand.name,
+      internalName: creationCommand.internalName,
       category: creationCommand.category,
       description: creationCommand.description,
       comment: creationCommand.comment,
@@ -40,9 +43,11 @@ class TargetProfileForCreation {
 
   static copyTargetProfile(targetProfileToCopy) {
     const copiedTargetProfileName = TARGET_PROFILE_COPY_NAME_PREFIX + targetProfileToCopy.name;
+    const copiedTargetProfileInternalName = TARGET_PROFILE_COPY_NAME_PREFIX + targetProfileToCopy.internalName;
 
     return new TargetProfileForCreation({
       name: copiedTargetProfileName,
+      internalName: copiedTargetProfileInternalName,
       category: targetProfileToCopy.category,
       description: targetProfileToCopy.description,
       comment: targetProfileToCopy.comment,

--- a/api/src/prescription/target-profile/domain/models/TargetProfileSummaryForAdmin.js
+++ b/api/src/prescription/target-profile/domain/models/TargetProfileSummaryForAdmin.js
@@ -4,7 +4,7 @@ class TargetProfileSummaryForAdmin {
 
   constructor(params = {}) {
     this.id = params.id;
-    this.name = params.name;
+    this.internalName = params.internalName;
     this.outdated = params.outdated;
     this.category = params.category;
     this.createdAt = params.createdAt;

--- a/api/src/prescription/target-profile/domain/validators/creation-command-validation.js
+++ b/api/src/prescription/target-profile/domain/validators/creation-command-validation.js
@@ -5,6 +5,7 @@ import { schema as base } from './base-validation.js';
 
 const schema = base.keys({
   description: Joi.string().allow(null),
+  internalName: Joi.string(),
   comment: Joi.string().allow(null),
   imageUrl: Joi.string().allow(null),
   ownerOrganizationId: Joi.number().allow(null).default(null),

--- a/api/src/prescription/target-profile/infrastructure/repositories/target-profile-administration-repository.js
+++ b/api/src/prescription/target-profile/infrastructure/repositories/target-profile-administration-repository.js
@@ -25,6 +25,7 @@ const get = async function ({ id, locale = FRENCH_FRANCE }) {
     .select(
       'target-profiles.id',
       'target-profiles.name',
+      'target-profiles.internalName',
       'target-profiles.outdated',
       'target-profiles.imageUrl',
       'target-profiles.createdAt',
@@ -47,9 +48,17 @@ const get = async function ({ id, locale = FRENCH_FRANCE }) {
     .where('targetProfileId', targetProfileDTO.id);
   return _toDomain(targetProfileDTO, tubesData, locale);
 };
+
 const update = async function (targetProfile) {
   let results;
-  const editedAttributes = _.pick(targetProfile, ['name', 'outdated', 'description', 'comment', 'isSimplifiedAccess']);
+  const editedAttributes = _.pick(targetProfile, [
+    'name',
+    'internalName',
+    'outdated',
+    'description',
+    'comment',
+    'isSimplifiedAccess',
+  ]);
 
   try {
     results = await knex('target-profiles')
@@ -71,6 +80,7 @@ const create = async function ({ targetProfileForCreation }) {
   const knexConn = DomainTransaction.getConnection();
   const targetProfileRawData = _.pick(targetProfileForCreation, [
     'name',
+    'internalName',
     'category',
     'description',
     'comment',
@@ -99,7 +109,7 @@ const findByOrganization = async function ({ organizationId }) {
   const results = await knex('target-profiles')
     .select({
       id: 'target-profiles.id',
-      name: 'target-profiles.name',
+      internalName: 'target-profiles.internalName',
       outdated: 'target-profiles.outdated',
       ownerOrganizationId: 'target-profiles.ownerOrganizationId',
       sharedOrganizationId: 'target-profile-shares.organizationId',

--- a/api/src/prescription/target-profile/infrastructure/repositories/target-profile-for-update-repository.js
+++ b/api/src/prescription/target-profile/infrastructure/repositories/target-profile-for-update-repository.js
@@ -9,6 +9,7 @@ const update = async function (targetProfile) {
   const {
     id: targetProfileId,
     name,
+    internalName,
     imageUrl,
     description,
     comment,
@@ -18,6 +19,7 @@ const update = async function (targetProfile) {
 
   await knexConn(TARGET_PROFILE_TABLE_NAME).where({ id: targetProfileId }).update({
     name,
+    internalName,
     imageUrl,
     description,
     comment,

--- a/api/src/prescription/target-profile/infrastructure/repositories/target-profile-summary-for-admin-repository.js
+++ b/api/src/prescription/target-profile/infrastructure/repositories/target-profile-summary-for-admin-repository.js
@@ -5,9 +5,9 @@ import { TargetProfileSummaryForAdmin } from '../../domain/models/TargetProfileS
 
 const findPaginatedFiltered = async function ({ filter, page }) {
   const query = knex('target-profiles')
-    .select('id', 'name', 'outdated', 'category', 'createdAt')
+    .select('id', 'internalName', 'outdated', 'category', 'createdAt')
     .orderBy('outdated', 'ASC')
-    .orderBy('name', 'ASC')
+    .orderBy('internalName', 'ASC')
     .modify(_applyFilters, filter);
 
   const { results, pagination } = await fetchPage(query, page);
@@ -22,7 +22,7 @@ const findByTraining = async function ({ trainingId }) {
   const results = await knexConn('target-profiles')
     .select({
       id: 'target-profiles.id',
-      name: 'target-profiles.name',
+      internalName: 'target-profiles.internalName',
       outdated: 'target-profiles.outdated',
       ownerOrganizationId: 'target-profiles.ownerOrganizationId',
     })
@@ -36,9 +36,9 @@ const findByTraining = async function ({ trainingId }) {
 export { findByTraining, findPaginatedFiltered };
 
 function _applyFilters(qb, filter) {
-  const { name, id, categories } = filter;
-  if (name) {
-    qb.whereILike('name', `%${name}%`);
+  const { internalName, id, categories } = filter;
+  if (internalName) {
+    qb.whereILike('internalName', `%${internalName}%`);
   }
   if (id) {
     qb.where({ id });

--- a/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer.js
+++ b/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer.js
@@ -29,6 +29,7 @@ const serialize = function ({ targetProfile, filter }) {
     },
     attributes: [
       'name',
+      'internalName',
       'outdated',
       'createdAt',
       'ownerOrganizationId',

--- a/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-serializer.js
+++ b/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-serializer.js
@@ -19,6 +19,7 @@ const deserialize = function (json) {
   const deserializedData = {};
 
   if (attributes.name !== undefined) deserializedData.name = attributes.name;
+  if (attributes['internal-name'] !== undefined) deserializedData.internalName = attributes['internal-name'];
   if (attributes.category !== undefined) deserializedData.category = attributes.category;
   if (attributes.description !== undefined) deserializedData.description = attributes.description;
   if (attributes.comment !== undefined) deserializedData.comment = attributes.comment;

--- a/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer.js
+++ b/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer.js
@@ -4,7 +4,7 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (targetProfileSummaries, meta) {
   return new Serializer('target-profile-summary', {
-    attributes: ['name', 'outdated', 'createdAt', 'category', 'canDetach'],
+    attributes: ['internalName', 'outdated', 'createdAt', 'category', 'canDetach'],
     meta,
   }).serialize(targetProfileSummaries);
 };

--- a/api/src/shared/domain/models/TargetProfile.js
+++ b/api/src/shared/domain/models/TargetProfile.js
@@ -14,6 +14,7 @@ class TargetProfile {
   constructor({
     id,
     name,
+    internalName,
     imageUrl,
     category,
     isSimplifiedAccess,
@@ -25,6 +26,7 @@ class TargetProfile {
   } = {}) {
     this.id = id;
     this.name = name;
+    this.internalName = internalName;
     this.imageUrl = imageUrl;
     this.category = category;
     this.isSimplifiedAccess = isSimplifiedAccess;

--- a/api/tests/devcomp/acceptance/application/trainings/index_test.js
+++ b/api/tests/devcomp/acceptance/application/trainings/index_test.js
@@ -463,6 +463,7 @@ describe('Acceptance | Controller | training-controller', function () {
       const targetProfile = databaseBuilder.factory.buildTargetProfile({
         id: 1,
         name: 'Super profil cible',
+        internalName: 'Super profil cible interne',
         outdated: false,
         'created-at': undefined,
       });
@@ -476,7 +477,7 @@ describe('Acceptance | Controller | training-controller', function () {
         type: 'target-profile-summaries',
         id: `${targetProfile.id}`,
         attributes: {
-          name: targetProfile.name,
+          'internal-name': targetProfile.internalName,
           outdated: false,
           'created-at': undefined,
           'can-detach': false,

--- a/api/tests/prescription/target-profile/acceptance/application/admin-target-profile-route_test.js
+++ b/api/tests/prescription/target-profile/acceptance/application/admin-target-profile-route_test.js
@@ -76,6 +76,7 @@ describe('Acceptance | TargetProfile | Application | Route | admin-target-profil
             data: {
               attributes: {
                 name: 'CoolPixer',
+                'internal-name': 'CoolPixer internal',
                 description: 'Amazing description',
                 comment: 'Amazing comment',
                 category: 'OTHER',
@@ -113,6 +114,7 @@ describe('Acceptance | TargetProfile | Application | Route | admin-target-profil
             data: {
               attributes: {
                 name: 'nom changé',
+                'internal-name': 'nom changé',
                 category: 'COMPETENCES',
                 description: 'description changée.',
                 comment: 'commentaire changé.',
@@ -182,6 +184,7 @@ describe('Acceptance | TargetProfile | Application | Route | admin-target-profil
       // given
       const targetProfile = databaseBuilder.factory.buildTargetProfile({
         name: 'Savoir tout faire',
+        internalName: 'Savoir tout faire',
         imageUrl: 'https://test',
         isSimplifiedAccess: false,
         createdAt: new Date('2020-01-01'),
@@ -209,6 +212,7 @@ describe('Acceptance | TargetProfile | Application | Route | admin-target-profil
         'image-url': 'https://test',
         'is-simplified-access': false,
         name: 'Savoir tout faire',
+        'internal-name': 'Savoir tout faire',
         outdated: false,
         'owner-organization-id': targetProfile.ownerOrganizationId,
         'max-level': -Infinity,
@@ -881,6 +885,7 @@ describe('Acceptance | TargetProfile | Application | Route | admin-target-profil
           data: {
             attributes: {
               name: 'targetProfileName',
+              'internal-name': 'internalTargetProfileName',
               category: 'OTHER',
               description: 'coucou maman',
               comment: 'coucou papa',

--- a/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-administration-repository_test.js
+++ b/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-administration-repository_test.js
@@ -738,9 +738,12 @@ describe('Integration | Repository | Target-profile', function () {
       await targetProfileAdministrationRepository.update(targetProfile);
 
       // then
-      const { name } = await knex('target-profiles').select('name').where('id', targetProfile.id).first();
+      const { name, internalName } = await knex('target-profiles')
+        .select('name', 'internalName')
+        .where('id', targetProfile.id)
+        .first();
       expect(name).to.equal(targetProfile.name);
-      expect(name).to.equal(targetProfile.name);
+      expect(internalName).to.equal(targetProfile.internalName);
     });
 
     it('should update the target profile description', async function () {

--- a/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-administration-repository_test.js
+++ b/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-administration-repository_test.js
@@ -127,6 +127,7 @@ describe('Integration | Repository | Target-profile', function () {
         const targetProfileDB = databaseBuilder.factory.buildTargetProfile({
           id: 1,
           name: 'Mon Super Profil Cible qui déchire',
+          internalName: 'Mon Super Profil Cible qui déchire en interne',
           outdated: false,
           createdAt: new Date('2020-01-01'),
           ownerOrganizationId: 66,
@@ -457,6 +458,7 @@ describe('Integration | Repository | Target-profile', function () {
         const expectedTargetProfile = new TargetProfileForAdmin({
           id: targetProfileDB.id,
           name: targetProfileDB.name,
+          internalName: targetProfileDB.internalName,
           createdAt: targetProfileDB.createdAt,
           outdated: targetProfileDB.outdated,
           ownerOrganizationId: targetProfileDB.ownerOrganizationId,
@@ -611,6 +613,7 @@ describe('Integration | Repository | Target-profile', function () {
         const expectedTargetProfile = new TargetProfileForAdmin({
           id: targetProfileDB.id,
           name: targetProfileDB.name,
+          internalName: targetProfileDB.internalName,
           createdAt: targetProfileDB.createdAt,
           outdated: targetProfileDB.outdated,
           ownerOrganizationId: targetProfileDB.ownerOrganizationId,
@@ -731,10 +734,12 @@ describe('Integration | Repository | Target-profile', function () {
 
       // when
       targetProfile.name = 'Karam';
+      targetProfile.internalName = 'Karam';
       await targetProfileAdministrationRepository.update(targetProfile);
 
       // then
       const { name } = await knex('target-profiles').select('name').where('id', targetProfile.id).first();
+      expect(name).to.equal(targetProfile.name);
       expect(name).to.equal(targetProfile.name);
     });
 
@@ -1023,8 +1028,8 @@ describe('Integration | Repository | Target-profile', function () {
 
           // then
           const expectedTargetProfileSummaries = [
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 10, name: 'B_tp', outdated: false }),
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'A_tp', outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 10, internalName: 'B_tp', outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, internalName: 'A_tp', outdated: false }),
           ];
           expect(actualTargetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);
         });
@@ -1034,7 +1039,7 @@ describe('Integration | Repository | Target-profile', function () {
           databaseBuilder.factory.buildOrganization({ id: 1 });
           databaseBuilder.factory.buildTargetProfile({
             id: 11,
-            name: 'A_tp',
+            internalName: 'A_tp',
             ownerOrganizationId: 1,
             outdated: false,
           });
@@ -1051,7 +1056,7 @@ describe('Integration | Repository | Target-profile', function () {
 
           // then
           const expectedTargetProfileSummaries = [
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'A_tp', outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, internalName: 'A_tp', outdated: false }),
           ];
           expect(actualTargetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);
         });
@@ -1062,17 +1067,17 @@ describe('Integration | Repository | Target-profile', function () {
           databaseBuilder.factory.buildOrganization({ id: 2 });
           databaseBuilder.factory.buildTargetProfile({
             id: 11,
-            name: 'A_tp',
+            internalName: 'A_tp',
             outdated: false,
           });
           databaseBuilder.factory.buildTargetProfile({
             id: 10,
-            name: 'B_tp',
+            internalName: 'B_tp',
             outdated: false,
           });
           databaseBuilder.factory.buildTargetProfile({
             id: 12,
-            name: 'Not_Mine',
+            internalName: 'Not_Mine',
             outdated: false,
           });
           databaseBuilder.factory.buildTargetProfileShare({ targetProfileId: 10, organizationId: 1 });
@@ -1087,8 +1092,8 @@ describe('Integration | Repository | Target-profile', function () {
 
           // then
           const expectedTargetProfileSummaries = [
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 10, name: 'B_tp', outdated: false }),
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'A_tp', outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 10, internalName: 'B_tp', outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, internalName: 'A_tp', outdated: false }),
           ];
           expect(actualTargetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);
         });
@@ -1116,8 +1121,8 @@ describe('Integration | Repository | Target-profile', function () {
 
           // then
           const expectedTargetProfileSummaries = [
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 10, name: 'B_tp', outdated: false }),
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'A_tp', outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 10, internalName: 'B_tp', outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, internalName: 'A_tp', outdated: false }),
           ];
           expect(actualTargetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);
         });
@@ -1170,8 +1175,8 @@ describe('Integration | Repository | Target-profile', function () {
 
           // then
           const expectedTargetProfileSummaries = [
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'B_tp', outdated: false }),
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 12, name: 'C_tp', outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, internalName: 'B_tp', outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 12, internalName: 'C_tp', outdated: false }),
           ];
           expect(actualTargetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);
         });

--- a/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-summary-for-admin-repository_test.js
+++ b/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-summary-for-admin-repository_test.js
@@ -8,7 +8,7 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
       // given
       const targetProfile = {
         id: 1,
-        name: 'Go go target profile',
+        internalName: 'Go go target profile',
         outdated: false,
         createdAt: new Date('2021-01-01'),
         category: TargetProfile.categories.PREDEFINED,
@@ -35,11 +35,11 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
       it('return sorted active target profile first', async function () {
         // given
         const targetProfileData = [
-          { id: 1, name: 'TPA', outdated: false },
-          { id: 2, name: 'TPA', outdated: true },
-          { id: 5, name: 'TPA', outdated: true },
-          { id: 6, name: 'TPA', outdated: true },
-          { id: 7, name: 'TPA', outdated: false },
+          { id: 1, internalName: 'TPA', outdated: false },
+          { id: 2, internalName: 'TPA', outdated: true },
+          { id: 5, internalName: 'TPA', outdated: true },
+          { id: 6, internalName: 'TPA', outdated: true },
+          { id: 7, internalName: 'TPA', outdated: false },
         ];
         targetProfileData.map(databaseBuilder.factory.buildTargetProfile);
         await databaseBuilder.commit();
@@ -63,11 +63,11 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
       it('return sorted by name target profile first', async function () {
         // given
         const targetProfileData = [
-          { id: 2, name: 'TPE', outdated: true },
-          { id: 4, name: 'TPD', outdated: true },
-          { id: 5, name: 'TPC', outdated: false },
-          { id: 6, name: 'TPB', outdated: true },
-          { id: 7, name: 'TPA', outdated: false },
+          { id: 2, internalName: 'TPE', outdated: true },
+          { id: 4, internalName: 'TPD', outdated: true },
+          { id: 5, internalName: 'TPC', outdated: false },
+          { id: 6, internalName: 'TPB', outdated: true },
+          { id: 7, internalName: 'TPA', outdated: false },
         ];
         targetProfileData.map(databaseBuilder.factory.buildTargetProfile);
         await databaseBuilder.commit();
@@ -84,8 +84,8 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
 
         // then
         expect(actualTargetProfileSummaries).to.have.lengthOf(5);
-        expect(actualTargetProfileSummaries[0].name).to.equal('TPA');
-        expect(actualTargetProfileSummaries[1].name).to.equal('TPC');
+        expect(actualTargetProfileSummaries[0].internalName).to.equal('TPA');
+        expect(actualTargetProfileSummaries[1].internalName).to.equal('TPC');
       });
     });
 
@@ -93,9 +93,9 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
       it('return TargetProfileSummariesForAdmin in the page', async function () {
         // given
         const targetProfileData = [
-          { id: 1, name: 'TPA', outdated: false },
-          { id: 2, name: 'TPB', outdated: true },
-          { id: 3, name: 'TPC', outdated: false },
+          { id: 1, internalName: 'TPA', outdated: false },
+          { id: 2, internalName: 'TPB', outdated: true },
+          { id: 3, internalName: 'TPC', outdated: false },
         ];
         targetProfileData.map(databaseBuilder.factory.buildTargetProfile);
         await databaseBuilder.commit();
@@ -121,11 +121,11 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
       it('return TargetProfileSummariesForAdmin in the page', async function () {
         // given
         const targetProfileData = [
-          { id: 1, name: 'TPA', outdated: false },
-          { id: 2, name: 'TPB', outdated: true },
-          { id: 3, name: 'TPC', outdated: false },
-          { id: 5, name: 'TPE', outdated: true },
-          { id: 4, name: 'TPD', outdated: false },
+          { id: 1, internalName: 'TPA', outdated: false },
+          { id: 2, internalName: 'TPB', outdated: true },
+          { id: 3, internalName: 'TPC', outdated: false },
+          { id: 5, internalName: 'TPE', outdated: true },
+          { id: 4, internalName: 'TPD', outdated: false },
         ];
         targetProfileData.map(databaseBuilder.factory.buildTargetProfile);
         await databaseBuilder.commit();
@@ -152,21 +152,21 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
       beforeEach(function () {
         disciplineTargetProfile = {
           id: 1,
-          name: 'TP DISCIPLINE',
+          internalName: 'TP DISCIPLINE',
           outdated: false,
           createdAt: new Date('2021-01-01'),
           category: TargetProfile.categories.DISCIPLINE,
         };
         otherTargetProfile = {
           id: 2,
-          name: 'TP OTHER',
+          internalName: 'TP OTHER',
           outdated: true,
           createdAt: new Date('2021-01-01'),
           category: TargetProfile.categories.OTHER,
         };
         backToSchoolTargetProfile = {
           id: 3,
-          name: 'TP BACK_TO_SCHOOL',
+          internalName: 'TP BACK_TO_SCHOOL',
           outdated: false,
           createdAt: new Date('2021-01-01'),
           category: TargetProfile.categories.BACK_TO_SCHOOL,
@@ -177,10 +177,10 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
         );
         return databaseBuilder.commit();
       });
-      context('name filter', function () {
-        it('should return only target profiles matching "name" discipline in filter', async function () {
+      context('internalName filter', function () {
+        it('should return only target profiles matching "internalName" discipline in filter', async function () {
           // given
-          const filter = { name: 'discipline' };
+          const filter = { internalName: 'discipline' };
           const page = { number: 1, size: 10 };
 
           // when
@@ -262,7 +262,7 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
       context('no match', function () {
         it('should return an empty array when no records match the filter', async function () {
           // given
-          const filter = { name: 'COUCOU' };
+          const filter = { internalName: 'COUCOU' };
           const page = { number: 1, size: 10 };
 
           // when

--- a/api/tests/prescription/target-profile/unit/application/admin-target-profiles-route_test.js
+++ b/api/tests/prescription/target-profile/unit/application/admin-target-profiles-route_test.js
@@ -1393,6 +1393,7 @@ describe('Unit | Application | Admin Target Profiles | Routes', function () {
         data: {
           attributes: {
             name: 'targetProfileName',
+            'internal-name': 'targetProfileInternalName',
             category: 'OTHER',
             description: 'coucou maman',
             comment: 'coucou papa',

--- a/api/tests/prescription/target-profile/unit/domain/models/TargetProfileForCreation_test.js
+++ b/api/tests/prescription/target-profile/unit/domain/models/TargetProfileForCreation_test.js
@@ -12,6 +12,7 @@ describe('Unit | Domain | Models | TargetProfileForCreation', function () {
         description: 'a description',
         imageUrl: 'old url',
         name: 'original name',
+        internalName: 'original internal name',
         tubes: [
           {
             id: 'recTubeId',
@@ -25,6 +26,7 @@ describe('Unit | Domain | Models | TargetProfileForCreation', function () {
 
       // then
       expect(copiedTargetProfile.name).to.equal('[Copie] original name');
+      expect(copiedTargetProfile.internalName).to.equal('[Copie] original internal name');
       expect(copiedTargetProfile.areKnowledgeElementsResettable).to.be.false;
       expect(copiedTargetProfile.category).to.equal('CUSTOM');
       expect(copiedTargetProfile.comment).to.equal('a comment');

--- a/api/tests/prescription/target-profile/unit/domain/usecases/create-target-profile_test.js
+++ b/api/tests/prescription/target-profile/unit/domain/usecases/create-target-profile_test.js
@@ -48,6 +48,7 @@ describe('Unit | UseCase | create-target-profile', function () {
 
     const expectedTargetProfileForCreation = domainBuilder.buildTargetProfileForCreation({
       name: 'myFirstTargetProfile',
+      internalName: 'myFirstInternalTargetProfile',
       category: categories.SUBJECT,
       description: 'la description',
       comment: 'le commentaire',
@@ -60,6 +61,7 @@ describe('Unit | UseCase | create-target-profile', function () {
     // when
     const targetProfileCreationCommand = {
       name: 'myFirstTargetProfile',
+      internalName: 'myFirstInternalTargetProfile',
       category: categories.SUBJECT,
       description: 'la description',
       comment: 'le commentaire',
@@ -86,6 +88,7 @@ describe('Unit | UseCase | create-target-profile', function () {
 
     const expectedTargetProfileForCreation = domainBuilder.buildTargetProfileForCreation({
       name: 'myFirstTargetProfile',
+      internalName: 'myFirstTargetProfileInternal',
       category: categories.SUBJECT,
       description: 'la description',
       comment: 'le commentaire',
@@ -102,6 +105,7 @@ describe('Unit | UseCase | create-target-profile', function () {
     // when
     const targetProfileCreationCommand = {
       name: 'myFirstTargetProfile',
+      internalName: 'myFirstTargetProfileInternal',
       category: categories.SUBJECT,
       description: 'la description',
       comment: 'le commentaire',

--- a/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer_test.js
+++ b/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer_test.js
@@ -94,6 +94,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-admin-serializer', fu
       const targetProfile = new TargetProfileForAdmin({
         id: 132,
         name: 'Mon Super profil cible',
+        internalName: 'Mon Super profil cible interne',
         outdated: true,
         createdAt: new Date('2021-03-02'),
         ownerOrganizationId: 12,
@@ -197,6 +198,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-admin-serializer', fu
             'are-knowledge-elements-resettable': false,
             'max-level': 7,
             name: 'Mon Super profil cible',
+            'internal-name': 'Mon Super profil cible interne',
             outdated: true,
             'owner-organization-id': 12,
             'has-linked-campaign': false,

--- a/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer_test.js
+++ b/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer_test.js
@@ -8,14 +8,14 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
       const targetProfileSummaries = [
         domainBuilder.buildTargetProfileSummaryForAdmin({
           id: 1,
-          name: 'TPA',
+          internalName: 'TPA',
           outdated: false,
           category: 'OTHER',
           createdAt: new Date('2021-01-01'),
         }),
         domainBuilder.buildTargetProfileSummaryForAdmin({
           id: 2,
-          name: 'TPB',
+          internalName: 'TPB',
           category: 'POUET',
           outdated: true,
           createdAt: new Date('2021-01-01'),
@@ -33,7 +33,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
             type: 'target-profile-summaries',
             id: '1',
             attributes: {
-              name: 'TPA',
+              'internal-name': 'TPA',
               outdated: false,
               category: 'OTHER',
               'created-at': new Date('2021-01-01'),
@@ -44,7 +44,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
             type: 'target-profile-summaries',
             id: '2',
             attributes: {
-              name: 'TPB',
+              'internal-name': 'TPB',
               category: 'POUET',
               outdated: true,
               'created-at': new Date('2021-01-01'),

--- a/api/tests/tooling/domain-builder/factory/build-target-profile-for-creation.js
+++ b/api/tests/tooling/domain-builder/factory/build-target-profile-for-creation.js
@@ -2,6 +2,7 @@ import { TargetProfileForCreation } from '../../../../src/prescription/target-pr
 
 const buildTargetProfileForCreation = function ({
   name = 'Profil cible super cool',
+  internalName = name,
   category = 'some_category',
   description = 'description',
   comment = 'commentaire',
@@ -12,6 +13,7 @@ const buildTargetProfileForCreation = function ({
 } = {}) {
   return new TargetProfileForCreation({
     name,
+    internalName,
     category,
     description,
     comment,

--- a/api/tests/tooling/domain-builder/factory/build-target-profile-summary-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-target-profile-summary-for-admin.js
@@ -2,7 +2,7 @@ import { TargetProfileSummaryForAdmin } from '../../../../src/prescription/targe
 
 const buildTargetProfileSummaryForAdmin = function ({
   id = 123,
-  name = 'Profil cible super cool',
+  internalName = 'Profil cible super cool interne',
   category,
   outdated = false,
   createdAt,
@@ -11,7 +11,7 @@ const buildTargetProfileSummaryForAdmin = function ({
 } = {}) {
   return new TargetProfileSummaryForAdmin({
     id,
-    name,
+    internalName,
     outdated,
     category,
     createdAt,

--- a/high-level-tests/e2e/cypress/fixtures/target-profiles.json
+++ b/high-level-tests/e2e/cypress/fixtures/target-profiles.json
@@ -2,6 +2,7 @@
   {
     "id": 1,
     "name": "Compétences pour un Mestre",
+    "internalName": "Nom interne pour un Mestre",
     "ownerOrganizationId": 1
   }
 ]


### PR DESCRIPTION
## :pancakes: Problème

Il y a beaucoup de profils cibles et apparemment il devient complique de s'y retrouver. 

## :bacon: Proposition

Ajouter un nom interne aux profil cibles uniquement visibles sur l'interface d'administration pour aider le tri.

## 🧃 Remarques

Il y a une copie de la colonne nom en nom interne dans la migration. Ainsi il est possible par la suite d'appliquer un contrainte "not null" sur le champ internalName. Cette migration est a surveiller a la mise en integration/prod.
Je ne sais pas si il existe d'autres moyens de créer des profils cibles que via l'administration ( script ? autre étrangeté ? )

Dans l'administration, le nom affiche au prescripteur apparaît seulement au détail du profil cible et n'est pas beaucoup mis en valeur.


## :yum: Pour tester

Cas de tests:
- créer un profil cible.
- modifier un profil cible.
- afficher les profils cible lies aux organisations.
- afficher les profiles cibles attaches aux contenus formatifs.
- Utiliser un profil cible dans orga pour vérifier que le nom interne n'apparaisse pas. 
