### PR TITLE
[FEATURE] Supprimer le tag "Autorisé à reprendre" de l'espace surveillant sur Pix Certif (PIX-16875).

### DIFF
--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -2,20 +2,14 @@
   <div class="session-supervising-candidate-in-list__candidate-data">
     <div class="session-supervising-candidate-in-list__status-container">
       {{#if @candidate.hasStarted}}
-        {{#if @candidate.isAuthorizedToResume}}
-          <PixTag class="session-supervising-candidate-in-list__status-container--authorized-to-resume">{{t
-              "common.forms.certification-labels.candidate-status.authorized-to-resume"
-            }}</PixTag>
+        {{#if @candidate.currentLiveAlert}}
+          <PixTag class="session-supervising-candidate-in-list__status-container--ongoing-alert">
+            {{this.currentLiveAlertLabel}}
+          </PixTag>
         {{else}}
-          {{#if @candidate.currentLiveAlert}}
-            <PixTag class="session-supervising-candidate-in-list__status-container--ongoing-alert">
-              {{this.currentLiveAlertLabel}}
-            </PixTag>
-          {{else}}
-            <PixTag class="session-supervising-candidate-in-list__status-container--started">{{t
-                "common.forms.certification-labels.candidate-status.ongoing"
-              }}</PixTag>
-          {{/if}}
+          <PixTag class="session-supervising-candidate-in-list__status-container--started">{{t
+              "common.forms.certification-labels.candidate-status.ongoing"
+            }}</PixTag>
         {{/if}}
       {{/if}}
       {{#if @candidate.hasCompleted}}

--- a/certif/app/styles/components/session-supervising/candidate-in-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-in-list.scss
@@ -65,11 +65,6 @@
       color: var(--pix-primary-700);
     }
 
-    &--authorized-to-resume {
-      background-color: var(--pix-tertiary-100);
-      color: var(--pix-tertiary-900);
-    }
-
     > .pix-tag--compact {
       text-transform: none;
     }

--- a/certif/tests/integration/components/session-supervising/candidate-in-list-test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list-test.js
@@ -291,7 +291,6 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
       assert.dom(screen.getByText('Fin théorique :')).exists();
       assert.dom(screen.getByText('+ temps majoré 12 %')).exists();
       assert.dom(screen.queryByText('Signalement en cours')).doesNotExist();
-      assert.dom(screen.queryByText('Autorisé à reprendre')).doesNotExist();
       assert.dom(screen.queryByText('Terminé')).doesNotExist();
     });
 
@@ -366,12 +365,11 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
       const screen = await renderScreen(hbs`<SessionSupervising::CandidateInList @candidate={{this.candidate}} />`);
 
       // then
-      assert.dom(screen.getByText('Autorisé à reprendre')).exists();
       assert.dom(screen.getByText('Début :')).exists();
       assert.dom(screen.getByText('Fin théorique :')).exists();
       assert.dom(screen.getByText('+ temps majoré 12 %')).exists();
+      assert.dom(screen.queryByText('En cours')).exists();
       assert.dom(screen.queryByText('Signalement en cours')).doesNotExist();
-      assert.dom(screen.queryByText('En cours')).doesNotExist();
       assert.dom(screen.queryByText('Terminé')).doesNotExist();
     });
   });
@@ -398,7 +396,6 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
       assert.dom(screen.queryByText('+ temps majoré 12 %')).doesNotExist();
       assert.dom(screen.queryByText('Signalement en cours')).doesNotExist();
       assert.dom(screen.queryByText('En cours')).doesNotExist();
-      assert.dom(screen.queryByText('Autorisé à reprendre')).doesNotExist();
     });
   });
 
@@ -430,7 +427,6 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
         // then
         assert.dom(screen.getByText('Signalement en cours')).exists();
         assert.dom(screen.queryByText('En cours')).doesNotExist();
-        assert.dom(screen.queryByText('Autorisé à reprendre')).doesNotExist();
         assert.dom(screen.queryByText('Terminé')).doesNotExist();
       });
 

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -104,7 +104,6 @@
         "additional-certification": "Certification selection",
         "additional-certification-old": "Additional certification",
         "candidate-status": {
-          "authorized-to-resume": "Allowed to resume",
           "finished": "Finished",
           "live-alerts": {
             "challenge": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -104,7 +104,6 @@
         "additional-certification": "Choix de la certification",
         "additional-certification-old": "Certification complémentaire",
         "candidate-status": {
-          "authorized-to-resume": "Autorisé à reprendre",
           "finished": "Terminé",
           "live-alerts": {
             "challenge": {


### PR DESCRIPTION
## :pancakes: Problème

Plusieurs remontées du support font état de candidats qui n’ont pas pu aller au bout de leur certification.
Lors de l’investigation, on se rend compte que les candidats avaient tous un signalement non traité par le surveillant sur une des questions de leur certification.

Le surveillant avait cliqué sur “Autoriser à reprendre” pensant que cela débloquerait son candidat.
Or actuellement un tag “Autorisé à reprendre” est prioritaire coté front et venait alors masquer le tag “Signalement en cours”.

Les surveillants pensaient donc avoir géré le signalement de leurs candidats.

## :bacon: Proposition

Supprimer le tag “Autorisé à reprendre” car l’information est déjà transmise au surveillant via le toaster de succès.

Si signalement en cours, le tag “Signalement en cours” restera alors visible.
Si pas de signalement, le tag "En cours" restera visible.

## :yum: Pour tester

- Se connecter sur Certif avec certifv3@example.net
- Aller sur l'espace surveillant pour la session 7404
- Sur Pix App, se connecter avec certif-success@example
- Remplir les infos 7404 / lastname0-7404 / lfirstname0-7404 / 04 01 2000

Cas sans signalement => non reg sur l'autorisé à reprendre

https://github.com/user-attachments/assets/fc2fb2d6-0437-4324-afe4-f5d8a5f955bc



Cas avec signalement => le tag Signalement en cours reste visible

https://github.com/user-attachments/assets/eb859a0d-fc37-4b51-a3ff-d291c6e90eb1

