### PR TITLE
[BUGFIX] Supprimer l'overflow mis par défaut sur les table dans PixOrga

### DIFF
--- a/orga/app/components/campaign/analysis/competences.gjs
+++ b/orga/app/components/campaign/analysis/competences.gjs
@@ -16,6 +16,7 @@ function getCount(campaignCollectiveResult) {
     </h3>
 
     <PixTable
+      @condensed={{true}}
       @variant="orga"
       @caption={{t "pages.campaign-review.table.competences.title"}}
       @data={{@campaignCollectiveResult.campaignCompetenceCollectiveResults}}

--- a/orga/app/components/campaign/analysis/recommendations.gjs
+++ b/orga/app/components/campaign/analysis/recommendations.gjs
@@ -62,6 +62,7 @@ export default class Recommendations extends Component {
         {{this.description}}
       </p>
       <PixTable
+        @condensed={{true}}
         @variant="orga"
         @caption={{t "pages.campaign-review.table.analysis.caption"}}
         @data={{this.sortedRecommendations}}

--- a/orga/app/components/organization-participant/list.gjs
+++ b/orga/app/components/organization-participant/list.gjs
@@ -164,6 +164,7 @@ export default class List extends Component {
         as |toggleParticipant isParticipantSelected allSelected someSelected toggleAll selectedParticipants reset|
       >
         <PixTable
+          @condensed={{true}}
           @variant="orga"
           @caption={{t "pages.organization-participants.table.description"}}
           @data={{@participants}}

--- a/orga/app/components/sco-organization-participant/list.gjs
+++ b/orga/app/components/sco-organization-participant/list.gjs
@@ -195,6 +195,7 @@ export default class ScoList extends Component {
         as |toggleStudent isStudentSelected allSelected someSelected toggleAll selectedStudents reset|
       >
         <PixTable
+          @condensed={{true}}
           @variant="orga"
           @caption={{t "pages.sco-organization-participants.table.description"}}
           @data={{@students}}

--- a/orga/app/components/sup-organization-participant/list.gjs
+++ b/orga/app/components/sup-organization-participant/list.gjs
@@ -111,6 +111,7 @@ export default class ListItems extends Component {
         as |toggleStudent isStudentSelected allSelected someSelected toggleAll selectedStudents reset|
       >
         <PixTable
+          @condensed={{true}}
           @variant="orga"
           @caption={{t "pages.sup-organization-participants.table.description"}}
           @data={{@students}}

--- a/orga/app/styles/globals/tables.scss
+++ b/orga/app/styles/globals/tables.scss
@@ -1,6 +1,5 @@
 .table {
   margin-bottom: var(--pix-spacing-4x);
-  overflow: unset;
 
   &__link-cell {
     display: flex;


### PR DESCRIPTION
## :pancakes: Problème

en modile, c'est cassé. un méchant copy paste c'est glissé dans le css

## :bacon: Proposition

Supprimer la ligne que nous ne souhaitons pas

## 🧃 Remarques

RAS

## :yum: Pour tester

Aller sur un tableau en mode mobile et vérifier que l'on puisse scroll. 