### PR TITLE
[BUGFIX]: Afficher correctement les badges sur l'ecran de resultat de Pix orga (PIX-16909)

### DIFF
--- a/orga/app/components/participant/assessment/header.gjs
+++ b/orga/app/components/participant/assessment/header.gjs
@@ -22,12 +22,6 @@ export default class Header extends Component {
   @service currentUser;
   @service router;
 
-  get displayBadges() {
-    const { campaign, participation } = this.args;
-
-    return campaign.hasBadges && participation.badges.length > 0;
-  }
-
   get breadcrumbLinks() {
     return [
       {
@@ -162,12 +156,12 @@ export default class Header extends Component {
 
         {{#if @participation.isShared}}
           <ul class="panel-header__data panel-header__data--highlight">
-            {{#if this.displayBadges}}
+            {{#if @campaign.hasBadges}}
               <li
                 aria-label={{t "pages.assessment-individual-results.badges"}}
                 class="panel-header-data__content panel-header-data-content__badges"
               >
-                <Badges @badges={{@participation.badges}} />
+                <Badges @badges={{@campaign.badges}} @acquiredBadges={{@participation.badges}} />
               </li>
             {{/if}}
             <li

--- a/orga/tests/integration/components/participant/assessment/header-test.js
+++ b/orga/tests/integration/components/participant/assessment/header-test.js
@@ -336,8 +336,8 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
       });
 
       module('when the campaign has badges', function () {
-        test('it displays badges acquired', async function (assert) {
-          this.campaign = { hasBadges: true };
+        test('it displays acquired badges', async function (assert) {
+          this.campaign = { hasBadges: true, badges: [{ id: '1', title: 'Les bases' }] };
           this.participation = { isShared: true, masteryRate: 0.85, badges: [{ id: '1', title: 'Les bases' }] };
 
           const screen = await render(
@@ -345,8 +345,23 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
           );
 
           assert
-            .dom(screen.queryByLabelText(t('pages.assessment-individual-results.badges')))
-            .containsText('Les bases');
+            .dom(screen.getByText('Les bases - ' + t('pages.campaign-results.table.badge-tooltip.acquired')))
+            .exists();
+          assert.dom(screen.getByLabelText(t('pages.assessment-individual-results.badges'))).containsText('Les bases');
+        });
+
+        test('it displays unacquired badges', async function (assert) {
+          this.campaign = { hasBadges: true, badges: [{ id: '1', title: 'Les bases' }] };
+          this.participation = { isShared: true, masteryRate: 0.85, badges: [] };
+
+          const screen = await render(
+            hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
+          );
+
+          assert
+            .dom(screen.getByText('Les bases - ' + t('pages.campaign-results.table.badge-tooltip.unacquired')))
+            .exists();
+          assert.dom(screen.getByLabelText(t('pages.assessment-individual-results.badges'))).containsText('Les bases');
         });
       });
 
@@ -359,18 +374,6 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
             hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
           );
 
-          assert.notOk(screen.queryByLabelText(t('pages.assessment-individual-results.badges')));
-        });
-      });
-
-      module('when the campaign has badges but the participant has not acquired one', function () {
-        test('it does not display badges', async function (assert) {
-          this.campaign = { hasBadges: true };
-          this.participation = { isShared: true, masteryRate: 0.85, badges: [] };
-
-          const screen = await render(
-            hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
-          );
           assert.notOk(screen.queryByLabelText(t('pages.assessment-individual-results.badges')));
         });
       });


### PR DESCRIPTION
## :pancakes: Problème

![image](https://github.com/user-attachments/assets/302aeb82-e6de-4d38-92b9-64cfd2a623a7)

Petit oubli de parametre.

## :bacon: Proposition
![image](https://github.com/user-attachments/assets/57944ea7-043f-47a3-b591-dbccb783a6f9)

Ajouter le parametre. 

## :yum: Pour tester

Ecran de detail resultat utilisateur.