### PR TITLE
[FEATURE] Afficher le bouton de gestion du signalement en dehors du menu sur Pix Certif (PIX-16884).

### DIFF
--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -1,29 +1,31 @@
 <li class="session-supervising-candidate-in-list">
   <div class="session-supervising-candidate-in-list__candidate-data">
-    <div class="session-supervising-candidate-in-list__status-container">
-      {{#if @candidate.hasStarted}}
-        {{#if @candidate.currentLiveAlert}}
-          <PixTag class="session-supervising-candidate-in-list__status-container--ongoing-alert">
-            {{this.currentLiveAlertLabel}}
-          </PixTag>
-        {{else}}
-          <PixTag class="session-supervising-candidate-in-list__status-container--started">{{t
-              "common.forms.certification-labels.candidate-status.ongoing"
-            }}</PixTag>
+
+    <div class="session-supervising-candidate-in-list__top-information">
+      <div class="session-supervising-candidate-in-list__full-name">
+        {{@candidate.lastName}}
+        {{@candidate.firstName}}
+      </div>
+      <div>
+        {{#if @candidate.hasStarted}}
+          {{#if @candidate.currentLiveAlert}}
+            <PixTag @color="error">
+              {{this.currentLiveAlertLabel}}
+            </PixTag>
+          {{else}}
+            <PixTag @color="success">
+              {{t "common.forms.certification-labels.candidate-status.ongoing"}}
+            </PixTag>
+          {{/if}}
         {{/if}}
-      {{/if}}
-      {{#if @candidate.hasCompleted}}
-        <PixTag class="session-supervising-candidate-in-list__status-container--completed">{{t
-            "common.forms.certification-labels.candidate-status.finished"
-          }}</PixTag>
-      {{/if}}
+        {{#if @candidate.hasCompleted}}
+          <PixTag @color="tertiary">{{t "common.forms.certification-labels.candidate-status.finished"}}</PixTag>
+        {{/if}}
+      </div>
     </div>
-    <div class="session-supervising-candidate-in-list__full-name">
-      {{@candidate.lastName}}
-      {{@candidate.firstName}}
-    </div>
-    <div class="session-supervising-candidate-in-list__details">
-      {{dayjs-format @candidate.birthdate "DD/MM/YYYY"}}
+
+    <div class="session-supervising-candidate-in-list__middle-information">
+      <p>{{dayjs-format @candidate.birthdate "DD/MM/YYYY"}}</p>
       {{#if this.shouldDisplayEnrolledComplementaryCertification}}
         <p class="session-supervising-candidate-in-list-details__enrolment">
           <PixIcon
@@ -37,18 +39,16 @@
           }}
         </p>
       {{/if}}
-
       {{#if this.shouldDisplayNonEligibilityWarning}}
-        <PixNotificationAlert
-          @type="warning"
-          @withIcon={{true}}
-          class="session-supervising-candidate-in-list-details__eligibility"
-        >
+        <PixNotificationAlert @type="warning" @withIcon={{true}}>
           {{t "pages.session-supervising.candidate-in-list.complementary-certification-non-eligibility-warning"}}
         </PixNotificationAlert>
       {{/if}}
-      {{#if @candidate.hasStarted}}
-        <p class="session-supervising-candidate-in-list-details-time">
+    </div>
+
+    {{#if @candidate.hasStarted}}
+      <div class="session-supervising-candidate-in-list__bottom-information">
+        <div class="session-supervising-candidate-in-list-details-time">
           <div class="session-supervising-candidate-in-list-details-time__text">
             <PixIcon
               @name="time"
@@ -72,10 +72,15 @@
               }}
             </PixTag>
           {{/if}}
-        </p>
-      {{/if}}
+        </div>
 
-    </div>
+        {{#if @candidate.hasOngoingChallengeLiveAlert}}
+          <PixButton @triggerAction={{this.askUserToHandleLiveAlert}} @variant="error">
+            {{t "pages.session-supervising.candidate-in-list.resume-test-modal.live-alerts.handle-challenge"}}
+          </PixButton>
+        {{/if}}
+      </div>
+    {{/if}}
     {{#if this.isConfirmButtonToBeDisplayed}}
       <PixButton
         aria-label={{this.authorizationButtonAriaLabel}}
@@ -88,6 +93,7 @@
       </PixButton>
     {{/if}}
   </div>
+
   {{#if this.optionsMenuShouldBeDisplayed}}
     <div class="session-supervising-candidate-in-list__menu">
       <PixIconButton
@@ -102,12 +108,6 @@
         @close={{this.closeMenu}}
         aria-label={{t "pages.session-supervising.candidate-in-list.candidate-options"}}
       >
-        {{#if @candidate.hasOngoingChallengeLiveAlert}}
-          <Dropdown::Item @onClick={{this.askUserToHandleLiveAlert}}>
-            {{t "pages.session-supervising.candidate-in-list.resume-test-modal.live-alerts.handle-challenge"}}
-          </Dropdown::Item>
-        {{/if}}
-
         {{#if @candidate.hasOngoingCompanionLiveAlert}}
           <Dropdown::Item @onClick={{this.askUserToHandleCompanionLiveAlert}}>
             {{t "pages.session-supervising.candidate-in-list.resume-test-modal.live-alerts.handle-companion"}}

--- a/certif/app/styles/components/session-supervising/candidate-in-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-in-list.scss
@@ -1,83 +1,70 @@
 @use 'pix-design-tokens/breakpoints';
+@use 'pix-design-tokens/typography';
 
 .session-supervising-candidate-in-list {
-  margin-bottom: 8px;
+  margin-bottom: var(--pix-spacing-3x);
   border-radius: 4px;
   display: flex;
-  position: relative;
+  @extend %pix-body-s;
+  color: var(--pix-neutral-0);
+
+  @include breakpoints.device-is('tablet') {
+    position: relative;
+  }
 
   &__candidate-data {
-    width: calc(100% - 32px);
-    padding: 12px 16px;
-
-    @include breakpoints.device-is('tablet') {
-      position: relative;
-    }
-  }
-
-  &__confirm-button {
-    margin-top: var(--pix-spacing-4x);
-  }
-
-  &__details {
-    color: var(--pix-neutral-100);
-    font-size: 0.75rem;
+    width: calc(100% - var(--pix-spacing-8x));
+    padding: var(--pix-spacing-2x) var(--pix-spacing-4x);
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-2x);
   }
 
   &__full-name {
     color: var(--pix-secondary-500);
-    margin-bottom: 4px;
     text-transform: capitalize;
+    font-weight: bold;
+
+    @extend %pix-body-m;
   }
 
-  &__checkbox[type='checkbox'] {
-    width: 32px;
-    height: 32px;
-    margin: 16px;
-  }
-
-  &__status-container {
-    border-radius: 12px;
-    font-size: 0.75rem;
-    font-weight: var(--pix-font-normal);
-    margin-top: var(--pix-spacing-2x);
-    padding: var(--pix-spacing-1x) 0;
+  &__top-information {
+    display: flex;
+    flex-direction: column-reverse;
+    gap: var(--pix-spacing-2x);
 
     @include breakpoints.device-is('tablet') {
-      margin-top: 0;
-      position: absolute;
-      right: var(--pix-spacing-4x);
-      top: var(--pix-spacing-1x);
-    }
-
-    &--ongoing-alert {
-      background-color: var(--pix-error-100);
-      color: var(--pix-error-700);
-    }
-
-    &--started {
-      background-color: var(--pix-success-50);
-      color: var(--pix-success-900);
-    }
-
-    &--completed {
-      background-color: var(--pix-primary-100);
-      color: var(--pix-primary-700);
-    }
-
-    > .pix-tag--compact {
-      text-transform: none;
+      flex-direction: row;
+      justify-content: space-between;
     }
   }
 
-  &__start-time {
-    color: var(--pix-neutral-20);
-    font-size: 0.75rem;
+  &__middle-information {
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-1x);
+  }
+
+  &__bottom-information {
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-3x);
+    width: fit-content;
+
+    @include breakpoints.device-is('tablet') {
+      flex-direction: row;
+      justify-content: space-between;
+      width: auto;
+    }
+  }
+
+  &__confirm-button {
+    width: fit-content;
   }
 
   &__menu {
-    border-left: solid var(--pix-neutral-500) 1px;
-    padding: 2px;
+    border-left: 1px solid var(--pix-neutral-100);
+    padding: var(--pix-spacing-2x);
   }
 
   .dropdown__content {
@@ -91,23 +78,14 @@
   &__enrolment {
     display: flex;
     align-items: center;
-    color: var(--pix-neutral-0);
-    font-size: 0.875rem;
-    font-weight: normal;
-    line-height: 1.3125rem;
-  }
-
-  &__eligibility {
-    margin-top: var(--pix-spacing-1x);
+    gap: var(--pix-spacing-1x);
   }
 }
 
 .session-supervising-candidate-in-list-details-enrolment {
   &__icon {
-    margin-right: var(--pix-spacing-1x);
     width: 1rem;
     height: 1rem;
-    fill: var(--pix-neutral-0);
   }
 }
 

--- a/certif/app/styles/components/session-supervising/candidate-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-list.scss
@@ -8,14 +8,10 @@
   padding: 32px 16px;
 
   .session-supervising-candidate-list {
-    @include breakpoints.device-is("tablet") {
-      padding: 0 48px;
       margin: auto;
-    }
 
-    @include breakpoints.device-is("desktop") {
-      max-width: 672px;
-      margin: auto;
+    @include breakpoints.device-is("tablet") {
+      max-width: 800px;
     }
 
     &__description {

--- a/certif/app/styles/components/session-supervising/header.scss
+++ b/certif/app/styles/components/session-supervising/header.scss
@@ -3,15 +3,12 @@
 
 .session-supervising-header {
   background: var(--pix-neutral-20);
-  padding: 16px;
-
-  @include breakpoints.device-is("tablet") {
-    padding: var(--pix-spacing-10x) var(--pix-spacing-12x) var(--pix-spacing-8x) var(--pix-spacing-12x);
-  }
+  padding: var(--pix-spacing-10x) var(--pix-spacing-6x);
 
   @include breakpoints.device-is("desktop") {
     align-self: center;
-    width: 672px;
+    padding: var(--pix-spacing-10x) 0 var(--pix-spacing-8x) 0;
+    width: 800px;
   }
 
   &__quit {

--- a/certif/tests/acceptance/session-supervising-test.js
+++ b/certif/tests/acceptance/session-supervising-test.js
@@ -259,10 +259,9 @@ module('Acceptance | Session supervising', function (hooks) {
       const screen = await visit('/connexion-espace-surveillant');
       await fillIn(screen.getByRole('spinbutton', { name: 'Numéro de la session' }), '12345');
       await fillIn(screen.getByLabelText('Mot de passe de la session Exemple : C-12345'), '6789');
-      await click(screen.getByRole('button', { name: 'Surveiller la session' }));
 
       // when
-      await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
+      await click(screen.getByRole('button', { name: 'Surveiller la session' }));
 
       // then
       assert.dom(screen.queryByRole('button', { name: 'Gérer le signalement' })).doesNotExist();
@@ -305,7 +304,6 @@ module('Acceptance | Session supervising', function (hooks) {
             await click(screen.getByRole('button', { name: 'Surveiller la session' }));
 
             // when
-            await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
             await click(screen.getByRole('button', { name: 'Gérer le signalement' }));
             await click(screen.getByText('Refuser le signalement'));
 
@@ -352,7 +350,6 @@ module('Acceptance | Session supervising', function (hooks) {
             await click(screen.getByRole('button', { name: 'Surveiller la session' }));
 
             // when
-            await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
             await click(screen.getByRole('button', { name: 'Gérer le signalement' }));
             await click(screen.getByText('Refuser le signalement'));
             await settled();
@@ -407,7 +404,6 @@ module('Acceptance | Session supervising', function (hooks) {
             await click(screen.getByRole('button', { name: 'Surveiller la session' }));
 
             // when
-            await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
             await click(screen.getByRole('button', { name: 'Gérer le signalement' }));
 
             await click(
@@ -466,7 +462,6 @@ module('Acceptance | Session supervising', function (hooks) {
             await click(screen.getByRole('button', { name: 'Surveiller la session' }));
 
             // when
-            await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
             await click(screen.getByRole('button', { name: 'Gérer le signalement' }));
             await click(
               screen.getByLabelText(
@@ -517,7 +512,6 @@ module('Acceptance | Session supervising', function (hooks) {
             await click(screen.getByRole('button', { name: 'Surveiller la session' }));
 
             // when
-            await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
             await click(screen.getByRole('button', { name: 'Gérer le signalement' }));
             await click(screen.getByLabelText('Le site à visiter est indisponible/en maintenance/inaccessible'));
             await click(screen.getByText('Refuser le signalement'));
@@ -527,7 +521,6 @@ module('Acceptance | Session supervising', function (hooks) {
 
             const visibleCloseButton = closeButtons.filter((element) => isVisible(element))[0];
             await click(visibleCloseButton);
-            await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
             await click(screen.getByRole('button', { name: 'Gérer le signalement' }));
             // then
             const checkedRadioButtons = screen.queryAllByRole('radio', { checked: true });
@@ -567,7 +560,6 @@ module('Acceptance | Session supervising', function (hooks) {
             await click(screen.getByRole('button', { name: 'Surveiller la session' }));
 
             // when
-            await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
             await click(screen.getByRole('button', { name: 'Gérer le signalement' }));
             await click(screen.getByLabelText('Le site à visiter est indisponible/en maintenance/inaccessible'));
 

--- a/certif/tests/integration/components/session-supervising/candidate-in-list-test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list-test.js
@@ -313,7 +313,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
         // then
         assert.dom(screen.getByText('Autoriser la reprise du test')).exists();
         assert.dom(screen.getByText('Terminer le test')).exists();
-        assert.dom(screen.queryByText('Gérer le signalement')).doesNotExist();
+        assert.dom(screen.queryByRole('button', { name: 'Gérer le signalement' })).doesNotExist();
       });
     });
 
@@ -339,11 +339,11 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
 
         // when
         const screen = await renderScreen(hbs`<SessionSupervising::CandidateInList @candidate={{this.candidate}} />`);
-        await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
 
         // then
+        assert.dom(screen.getByRole('button', { name: 'Gérer le signalement' })).exists();
+        await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
         assert.dom(screen.getByText('Autoriser la reprise du test')).exists();
-        assert.dom(screen.getByText('Gérer le signalement')).exists();
         assert.dom(screen.getByText('Terminer le test')).exists();
       });
     });
@@ -451,7 +451,6 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
 
         // when
         const screen = await renderScreen(hbs`<SessionSupervising::CandidateInList @candidate={{this.candidate}} />`);
-        await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
         await click(screen.getByRole('button', { name: 'Gérer le signalement' }));
 
         // then


### PR DESCRIPTION
## :pancakes: Problème

> [!IMPORTANT]
>  PR à review avant => https://github.com/1024pix/pix/pull/11583

Plusieurs remontées du support font état de candidats qui n’ont pas pu aller au bout de leur certification.
Lors de l’investigation, on se rend compte que les candidats avaient tous un signalement non traité par le surveillant sur une des questions de leur certification.

Le surveillant avait cliqué sur “Autoriser à reprendre” pensant que cela débloquerait son candidat.
Or actuellement un tag “Autorisé à reprendre” est prioritaire coté front et venait alors masquer le tag “Signalement en cours”.

Les surveillants pensaient donc avoir géré le signalement de leurs candidats.

## :bacon: Proposition

Après le tag “Autorisé à reprendre” retiré, on veut pouvoir rendre le bouton de gestion d'un signalement beaucoup plus visible que caché dans le menu.

## 🧃 Remarques

Lorsque j'ai ajouté le bouton en dehors du menu, j'ai testé d'afficher l'entièreté de ce que l'on pouvait trouver dans cette section. 
En effet, il est possible d'y retrouver un bandeau de warning pour l'éligibilité à une complémentaire ou bien un tag pour le temps majoré.

https://github.com/user-attachments/assets/305736bb-69c7-450f-ac2b-6a9df06ae69d

L'espace était beaucoup trop petit pour accueillir ce bouton supplémentaire.

D'après la maquette, la largeur des lignes est de 800px. J'en ai donc profité pour agrandir tout ça.

Pour des besoins de responsive, j'ai également fait un nettoyage de l'existant, tant coté html que css.

## :yum: Pour tester

- Créer une session avec certifv3@example.net
- Passer la certification avec certif-success@example.net
- Faire un signalement 

https://github.com/user-attachments/assets/1733b00b-5a47-444a-8edb-86a91524ca02


Jouer avec le responsive pour voir le comportement