### PR TITLE
[FEATURE] Ne pas afficher les indicateurs de progression, level-up et compteur de question en mode interro (PIX-16490)

### DIFF
--- a/api/src/shared/domain/models/Assessment.js
+++ b/api/src/shared/domain/models/Assessment.js
@@ -126,14 +126,9 @@ class Assessment {
       }
       case Assessment.types.CAMPAIGN: {
         this.campaignCode = campaign.code;
-        this.showProgressBar = false;
-        this.hasCheckpoints = false;
-        this.showLevelup = false;
-        if (!this.isFlash() && (campaign.isAssessment || campaign.isExam)) {
-          this.showProgressBar = true;
-          this.hasCheckpoints = true;
-          this.showLevelup = true;
-        }
+        this.showProgressBar = !this.isFlash() && (campaign.isAssessment || campaign.isExam);
+        this.hasCheckpoints = !this.isFlash() && campaign.isAssessment;
+        this.showLevelup = !this.isFlash() && (campaign.isAssessment || campaign.isExam);
         this.title = campaign.title;
         break;
       }

--- a/api/src/shared/domain/models/Assessment.js
+++ b/api/src/shared/domain/models/Assessment.js
@@ -125,10 +125,11 @@ class Assessment {
         break;
       }
       case Assessment.types.CAMPAIGN: {
+        const isAssessmentCampaignNoFlash = !this.isFlash() && campaign.isAssessment;
         this.campaignCode = campaign.code;
-        this.showProgressBar = !this.isFlash() && (campaign.isAssessment || campaign.isExam);
-        this.hasCheckpoints = !this.isFlash() && campaign.isAssessment;
-        this.showLevelup = !this.isFlash() && campaign.isAssessment;
+        this.showProgressBar = isAssessmentCampaignNoFlash;
+        this.hasCheckpoints = isAssessmentCampaignNoFlash;
+        this.showLevelup = isAssessmentCampaignNoFlash;
         this.title = campaign.title;
         break;
       }

--- a/api/src/shared/domain/models/Assessment.js
+++ b/api/src/shared/domain/models/Assessment.js
@@ -128,7 +128,7 @@ class Assessment {
         this.campaignCode = campaign.code;
         this.showProgressBar = !this.isFlash() && (campaign.isAssessment || campaign.isExam);
         this.hasCheckpoints = !this.isFlash() && campaign.isAssessment;
-        this.showLevelup = !this.isFlash() && (campaign.isAssessment || campaign.isExam);
+        this.showLevelup = !this.isFlash() && campaign.isAssessment;
         this.title = campaign.title;
         break;
       }

--- a/api/src/shared/domain/models/Assessment.js
+++ b/api/src/shared/domain/models/Assessment.js
@@ -100,6 +100,7 @@ class Assessment {
         this.showProgressBar = false;
         this.hasCheckpoints = false;
         this.showLevelup = false;
+        this.showQuestionCounter = true;
         this.title = this.certificationCourseId;
         break;
       }
@@ -108,6 +109,7 @@ class Assessment {
         this.showProgressBar = true;
         this.hasCheckpoints = true;
         this.showLevelup = true;
+        this.showQuestionCounter = true;
         break;
       }
 
@@ -115,12 +117,14 @@ class Assessment {
         this.showProgressBar = true;
         this.hasCheckpoints = false;
         this.showLevelup = false;
+        this.showQuestionCounter = true;
         break;
       }
       case Assessment.types.PREVIEW: {
         this.showProgressBar = false;
         this.hasCheckpoints = false;
         this.showLevelup = false;
+        this.showQuestionCounter = true;
         this.title = 'Preview';
         break;
       }
@@ -130,6 +134,7 @@ class Assessment {
         this.showProgressBar = isAssessmentCampaignNoFlash;
         this.hasCheckpoints = isAssessmentCampaignNoFlash;
         this.showLevelup = isAssessmentCampaignNoFlash;
+        this.showQuestionCounter = this.isFlash() || campaign.isAssessment;
         this.title = campaign.title;
         break;
       }
@@ -138,6 +143,7 @@ class Assessment {
         this.showProgressBar = false;
         this.hasCheckpoints = false;
         this.showLevelup = false;
+        this.showQuestionCounter = false;
         this.title = '';
       }
     }

--- a/api/src/shared/infrastructure/repositories/assessment-repository.js
+++ b/api/src/shared/infrastructure/repositories/assessment-repository.js
@@ -224,5 +224,6 @@ function _adaptModelToDb(assessment) {
     'showProgressBar',
     'hasCheckpoints',
     'showLevelup',
+    'showQuestionCounter',
   ]);
 }

--- a/api/src/shared/infrastructure/serializers/jsonapi/assessment-serializer.js
+++ b/api/src/shared/infrastructure/serializers/jsonapi/assessment-serializer.js
@@ -54,6 +54,7 @@ const serialize = function (assessments) {
       'showProgressBar',
       'hasCheckpoints',
       'showLevelup',
+      'showQuestionCounter',
     ],
     answers: {
       ref: 'id',

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get_test.js
@@ -172,6 +172,7 @@ describe('Acceptance | API | assessment-controller-get', function () {
           'has-checkpoints': false,
           'show-levelup': false,
           'show-progress-bar': false,
+          'show-question-counter': true,
         },
         relationships: {
           course: {
@@ -298,6 +299,7 @@ describe('Acceptance | API | assessment-controller-get', function () {
           'has-checkpoints': false,
           'show-levelup': false,
           'show-progress-bar': false,
+          'show-question-counter': true,
         },
         relationships: {
           course: { data: { type: 'courses', id: courseId } },

--- a/api/tests/shared/integration/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/assessment-repository_test.js
@@ -3,8 +3,7 @@ import _ from 'lodash';
 import { Answer } from '../../../../../src/evaluation/domain/models/Answer.js';
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
-import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
-import { AssessmentResult } from '../../../../../src/shared/domain/models/AssessmentResult.js';
+import { Assessment, AssessmentResult } from '../../../../../src/shared/domain/models/index.js';
 import * as assessmentRepository from '../../../../../src/shared/infrastructure/repositories/assessment-repository.js';
 import { catchErr, databaseBuilder, domainBuilder, expect, knex } from '../../../../test-helper.js';
 

--- a/api/tests/shared/unit/domain/models/Assessment_test.js
+++ b/api/tests/shared/unit/domain/models/Assessment_test.js
@@ -68,7 +68,7 @@ describe('Unit | Domain | Models | Assessment', function () {
         type: Assessment.types.CAMPAIGN,
         hasCheckpoints: false,
         showProgressBar: true,
-        showLevelup: true,
+        showLevelup: false,
         expectedTitle: 'Ma Campagne',
         // eslint-disable-next-line mocha/no-setup-in-describe
         attributes: { campaign: domainBuilder.buildCampaign({ title: 'Ma Campagne', type: CampaignTypes.EXAM }) },

--- a/api/tests/shared/unit/domain/models/Assessment_test.js
+++ b/api/tests/shared/unit/domain/models/Assessment_test.js
@@ -67,7 +67,7 @@ describe('Unit | Domain | Models | Assessment', function () {
         // eslint-disable-next-line mocha/no-setup-in-describe
         type: Assessment.types.CAMPAIGN,
         hasCheckpoints: false,
-        showProgressBar: true,
+        showProgressBar: false,
         showLevelup: false,
         expectedTitle: 'Ma Campagne',
         // eslint-disable-next-line mocha/no-setup-in-describe

--- a/api/tests/shared/unit/domain/models/Assessment_test.js
+++ b/api/tests/shared/unit/domain/models/Assessment_test.js
@@ -66,7 +66,7 @@ describe('Unit | Domain | Models | Assessment', function () {
       {
         // eslint-disable-next-line mocha/no-setup-in-describe
         type: Assessment.types.CAMPAIGN,
-        hasCheckpoints: true,
+        hasCheckpoints: false,
         showProgressBar: true,
         showLevelup: true,
         expectedTitle: 'Ma Campagne',

--- a/api/tests/shared/unit/domain/models/Assessment_test.js
+++ b/api/tests/shared/unit/domain/models/Assessment_test.js
@@ -23,6 +23,7 @@ describe('Unit | Domain | Models | Assessment', function () {
         hasCheckpoints: true,
         showProgressBar: true,
         showLevelup: true,
+        showQuestionCounter: true,
         expectedTitle: 'Ma Compétence',
         attributes: { title: 'Ma Compétence' },
       },
@@ -32,6 +33,7 @@ describe('Unit | Domain | Models | Assessment', function () {
         hasCheckpoints: false,
         showProgressBar: false,
         showLevelup: false,
+        showQuestionCounter: true,
         expectedTitle: 'certificationCourseId',
         attributes: { certificationCourseId: 'certificationCourseId' },
       },
@@ -41,6 +43,7 @@ describe('Unit | Domain | Models | Assessment', function () {
         hasCheckpoints: false,
         showProgressBar: true,
         showLevelup: false,
+        showQuestionCounter: true,
         expectedTitle: 'Mon Course',
         attributes: { title: 'Mon Course' },
       },
@@ -50,6 +53,7 @@ describe('Unit | Domain | Models | Assessment', function () {
         hasCheckpoints: false,
         showProgressBar: false,
         showLevelup: false,
+        showQuestionCounter: true,
         expectedTitle: 'Preview',
         attributes: {},
       },
@@ -59,6 +63,7 @@ describe('Unit | Domain | Models | Assessment', function () {
         hasCheckpoints: true,
         showProgressBar: true,
         showLevelup: true,
+        showQuestionCounter: true,
         expectedTitle: 'Ma Campagne',
         // eslint-disable-next-line mocha/no-setup-in-describe
         attributes: { campaign: domainBuilder.buildCampaign({ title: 'Ma Campagne', type: CampaignTypes.ASSESSMENT }) },
@@ -69,6 +74,7 @@ describe('Unit | Domain | Models | Assessment', function () {
         hasCheckpoints: false,
         showProgressBar: false,
         showLevelup: false,
+        showQuestionCounter: false,
         expectedTitle: 'Ma Campagne',
         // eslint-disable-next-line mocha/no-setup-in-describe
         attributes: { campaign: domainBuilder.buildCampaign({ title: 'Ma Campagne', type: CampaignTypes.EXAM }) },
@@ -79,6 +85,7 @@ describe('Unit | Domain | Models | Assessment', function () {
         hasCheckpoints: false,
         showProgressBar: false,
         showLevelup: false,
+        showQuestionCounter: true,
         expectedTitle: 'Ma Campagne',
         attributes: {
           // eslint-disable-next-line mocha/no-setup-in-describe

--- a/api/tests/shared/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
@@ -12,6 +12,7 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
       assessment.hasCheckpoints = false;
       assessment.showProgressBar = false;
       assessment.showLevelup = false;
+      assessment.showQuestionCounter = true;
       const expectedJson = {
         data: {
           id: assessment.id.toString(),
@@ -29,6 +30,7 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
             'show-progress-bar': false,
             'show-levelup': false,
             'has-checkpoints': false,
+            'show-question-counter': true,
             'code-campaign': undefined,
           },
           relationships: {

--- a/mon-pix/app/components/progress-bar.hbs
+++ b/mon-pix/app/components/progress-bar.hbs
@@ -1,38 +1,42 @@
-{{#if this.showProgressBar}}
-  <div class="progress-bar-container">
-    <div
-      class="progress-bar-current-step"
-      role="progressbar"
-      aria-valuenow={{this.currentStepNumber}}
-      aria-valuemin="1"
-      aria-valuemax="5"
-      aria-label="{{t 'pages.challenge.parts.progress'}}"
-    >
-      {{t "pages.challenge.progress-bar.label"}}
-      {{this.currentStepNumber}}
-      /
-      {{this.maxStepsNumber}}
-    </div>
+<div class="progress-bar">
+  {{#if this.showProgressBar}}
+    <div class="progress-bar-container">
+      {{#if this.showQuestionCounterInsideProgressBar}}
+        <div
+          class="progress-bar-current-step"
+          role="progressbar"
+          aria-valuenow={{this.currentStepNumber}}
+          aria-valuemin="1"
+          aria-valuemax="5"
+          aria-label="{{t 'pages.challenge.parts.progress'}}"
+        >
+          {{t "pages.challenge.progress-bar.label"}}
+          {{this.currentStepNumber}}
+          /
+          {{this.maxStepsNumber}}
+        </div>
+      {{/if}}
 
-    <div class="progress-bar-content">
-      <div class="progress-bar-background"></div>
+      <div class="progress-bar-content">
+        <div class="progress-bar-background"></div>
 
-      <div class="progress-bar-progression" style={{this.progressionWidth}}></div>
+        <div class="progress-bar-progression" style={{this.progressionWidth}}></div>
 
-      <div class="progress-bar-steps">
-        {{#each this.steps as |step|}}
-          <span class="progress-bar-step" style={{step.background}}></span>
-        {{/each}}
+        <div class="progress-bar-steps">
+          {{#each this.steps as |step|}}
+            <span class="progress-bar-step" style={{step.background}}></span>
+          {{/each}}
+        </div>
       </div>
     </div>
-  </div>
-{{else}}
-  <div class="assessment-progress" role="progressbar" aria-label="{{t 'pages.challenge.parts.progress'}}">
-    <div class="assessment-progress__label">{{t "pages.challenge.progress-bar.label"}}</div>
-    <div class="assessment-progress__value">
-      {{this.currentStepNumber}}
-      /
-      {{this.maxStepsNumber}}
+  {{else if this.showQuestionCounterOutside}}
+    <div class="assessment-progress" role="progressbar" aria-label="{{t 'pages.challenge.parts.progress'}}">
+      <div class="assessment-progress__label">{{t "pages.challenge.progress-bar.label"}}</div>
+      <div class="assessment-progress__value">
+        {{this.currentStepNumber}}
+        /
+        {{this.maxStepsNumber}}
+      </div>
     </div>
-  </div>
-{{/if}}
+  {{/if}}
+</div>

--- a/mon-pix/app/components/progress-bar.hbs
+++ b/mon-pix/app/components/progress-bar.hbs
@@ -1,4 +1,4 @@
-<div class="progress-bar">
+<div class="assessment-progress-bar">
   {{#if this.showProgressBar}}
     <div class="progress-bar-container">
       {{#if this.showQuestionCounterInsideProgressBar}}

--- a/mon-pix/app/components/progress-bar.js
+++ b/mon-pix/app/components/progress-bar.js
@@ -14,6 +14,14 @@ export default class ProgressBar extends Component {
     return this.args.assessment.showProgressBar && this.media.isDesktop;
   }
 
+  get showQuestionCounterInsideProgressBar() {
+    return this.showProgressBar && this.args.assessment.showQuestionCounter;
+  }
+
+  get showQuestionCounterOutside() {
+    return !this.showProgressBar && this.args.assessment.showQuestionCounter;
+  }
+
   get currentStepIndex() {
     return progressInAssessment.getCurrentStepIndex(this.args.assessment, this.args.currentChallengeNumber);
   }

--- a/mon-pix/app/models/assessment.js
+++ b/mon-pix/app/models/assessment.js
@@ -25,6 +25,7 @@ export default class Assessment extends Model {
   @attr('boolean') hasCheckpoints;
   @attr('boolean') showProgressBar;
   @attr('boolean') showLevelup;
+  @attr('boolean') showQuestionCounter;
 
   // references
   @attr('string') competenceId;

--- a/mon-pix/app/styles/components/_progress-bar.scss
+++ b/mon-pix/app/styles/components/_progress-bar.scss
@@ -58,3 +58,7 @@
     font-size: 1.875rem;
   }
 }
+
+.progress-bar {
+  min-height: var(--pix-spacing-4x);
+}

--- a/mon-pix/app/styles/components/_progress-bar.scss
+++ b/mon-pix/app/styles/components/_progress-bar.scss
@@ -59,6 +59,6 @@
   }
 }
 
-.progress-bar {
+.assessment-progress-bar {
   min-height: var(--pix-spacing-4x);
 }

--- a/mon-pix/mirage/factories/assessment.js
+++ b/mon-pix/mirage/factories/assessment.js
@@ -21,6 +21,10 @@ export default Factory.extend({
     return true;
   },
 
+  showQuestionCounter() {
+    return true;
+  },
+
   withStartedState: trait({
     state: 'started',
   }),

--- a/mon-pix/mirage/factories/assessment.js
+++ b/mon-pix/mirage/factories/assessment.js
@@ -54,6 +54,7 @@ export default Factory.extend({
     type: 'CAMPAIGN',
     method: 'FLASH',
     showProgressBar: false,
+    showQuestionCounter: true,
   }),
 
   withCurrentChallengeTimeout: trait({

--- a/mon-pix/mirage/factories/certification-course.js
+++ b/mon-pix/mirage/factories/certification-course.js
@@ -23,6 +23,7 @@ export default Factory.extend({
           hasCheckpoints: false,
           showProgressBar: false,
           showLevelup: false,
+          showQuestionCounter: true,
         }),
       });
     }

--- a/mon-pix/mirage/routes/assessments/post-assessments.js
+++ b/mon-pix/mirage/routes/assessments/post-assessments.js
@@ -15,6 +15,7 @@ export default function (schema, request) {
       hasCheckpoints: false,
       showProgressBar: true,
       showLevelup: false,
+      showQuestionCounter: true,
     });
   }
 

--- a/mon-pix/mirage/routes/campaign-participations/post-campaign-participation.js
+++ b/mon-pix/mirage/routes/campaign-participations/post-campaign-participation.js
@@ -43,9 +43,10 @@ export default function (schema, request) {
   const newAssessment = {
     type: 'CAMPAIGN',
     codeCampaign: campaign.code,
-    hasCheckpoints: true,
-    showProgressBar: true,
-    showLevelup: true,
+    hasCheckpoints: campaign.type === 'ASSESSMENT',
+    showProgressBar: campaign.type === 'ASSESSMENT',
+    showLevelup: campaign.type === 'ASSESSMENT',
+    showQuestionCounter: campaign.type === 'ASSESSMENT',
   };
 
   const assessment = schema.assessments.create(newAssessment);

--- a/mon-pix/mirage/routes/post-competence-evaluation.js
+++ b/mon-pix/mirage/routes/post-competence-evaluation.js
@@ -15,6 +15,7 @@ export default function (schema, request) {
     hasCheckpoints: true,
     showProgressBar: true,
     showLevelup: true,
+    showQuestionCounter: true,
   });
   return schema.competenceEvaluations.create({ assessment, competenceId });
 }

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-exam-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-exam-test.js
@@ -21,6 +21,7 @@ module('Acceptance | Campaigns | Start Campaigns with type Exam', function (hook
     this.server.schema.users.create({
       mustValidateTermsOfService: true,
     });
+    server.create('challenge', { id: 'recSMARPLA' });
   });
 
   module('Start a campaign', function (hooks) {

--- a/mon-pix/tests/integration/components/progress-bar-test.js
+++ b/mon-pix/tests/integration/components/progress-bar-test.js
@@ -7,34 +7,145 @@ import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 module('Integration | Component | progress-bar', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('should render the progress bar current step', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
+  module('when should show the progress bar', function () {
+    module('when should show the question counter inside the progress bar', function () {
+      test('should display both the progress bar and the question counter above', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
 
-    const answers = [
-      store.createRecord('answer'),
-      store.createRecord('answer'),
-      store.createRecord('answer'),
-      store.createRecord('answer'),
-      store.createRecord('answer'),
-    ];
-    const mockAssessment = store.createRecord('assessment', {
-      type: 'CAMPAIGN',
-      showProgressBar: true,
-      hasCheckpoints: true,
-      showQuestionCounter: true,
+        const answers = [
+          store.createRecord('answer'),
+          store.createRecord('answer'),
+          store.createRecord('answer'),
+          store.createRecord('answer'),
+          store.createRecord('answer'),
+        ];
+        const mockAssessment = store.createRecord('assessment', {
+          type: 'CAMPAIGN',
+          showProgressBar: true,
+          hasCheckpoints: true,
+          showQuestionCounter: true,
+        });
+        mockAssessment.answers = answers;
+
+        this.set('assessment', mockAssessment);
+        this.set('currentChallengeNumber', 2);
+
+        // when
+        const screen = await render(
+          hbs`<ProgressBar @assessment={{this.assessment}} @currentChallengeNumber={{this.currentChallengeNumber}} />`,
+        );
+
+        // then
+        assert.ok(screen.getByText('Question 3 / 5'));
+        assert.dom('.progress-bar-container').exists();
+      });
     });
-    mockAssessment.answers = answers;
+    module('when should not show the question counter inside the progress bar', function () {
+      test('should display both the progress bar and the question counter above', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
 
-    this.set('assessment', mockAssessment);
-    this.set('currentChallengeNumber', 2);
+        const answers = [
+          store.createRecord('answer'),
+          store.createRecord('answer'),
+          store.createRecord('answer'),
+          store.createRecord('answer'),
+          store.createRecord('answer'),
+        ];
+        const mockAssessment = store.createRecord('assessment', {
+          type: 'CAMPAIGN',
+          showProgressBar: true,
+          hasCheckpoints: true,
+          showQuestionCounter: false,
+        });
+        mockAssessment.answers = answers;
 
-    // when
-    const screen = await render(
-      hbs`<ProgressBar @assessment={{this.assessment}} @currentChallengeNumber={{this.currentChallengeNumber}} />`,
-    );
+        this.set('assessment', mockAssessment);
+        this.set('currentChallengeNumber', 2);
 
-    // then
-    assert.ok(screen.getByText('Question 3 / 5'));
+        // when
+        const screen = await render(
+          hbs`<ProgressBar @assessment={{this.assessment}} @currentChallengeNumber={{this.currentChallengeNumber}} />`,
+        );
+
+        // then
+        assert.dom(screen.queryByText('Question 3 / 5')).doesNotExist();
+        assert.dom('.progress-bar-container').exists();
+      });
+    });
+  });
+
+  module('when should not show the progress bar', function () {
+    module('when should show the question counter outside', function () {
+      test('should display the question counter but not the progress bar', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+
+        const answers = [
+          store.createRecord('answer'),
+          store.createRecord('answer'),
+          store.createRecord('answer'),
+          store.createRecord('answer'),
+          store.createRecord('answer'),
+        ];
+        const mockAssessment = store.createRecord('assessment', {
+          type: 'CERTIFICATION',
+          showProgressBar: false,
+          hasCheckpoints: false,
+          showQuestionCounter: true,
+          certificationCourse: store.createRecord('certification-course', {
+            nbChallenges: 15,
+          }),
+        });
+        mockAssessment.answers = answers;
+
+        this.set('assessment', mockAssessment);
+        this.set('currentChallengeNumber', 2);
+
+        // when
+        const screen = await render(
+          hbs`<ProgressBar @assessment={{this.assessment}} @currentChallengeNumber={{this.currentChallengeNumber}} />`,
+        );
+
+        // then
+        assert.dom(screen.getByText('Question')).exists();
+        assert.dom(screen.getByText('3 / 15')).exists();
+        assert.dom('.progress-bar-container').doesNotExist();
+      });
+    });
+    module('when should not show the question counter outside', function () {
+      test('should neither display the question counter nor progress bar', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+
+        const answers = [
+          store.createRecord('answer'),
+          store.createRecord('answer'),
+          store.createRecord('answer'),
+          store.createRecord('answer'),
+          store.createRecord('answer'),
+        ];
+        const mockAssessment = store.createRecord('assessment', {
+          type: 'CAMPAIGN',
+          showProgressBar: false,
+          hasCheckpoints: false,
+          showQuestionCounter: false,
+        });
+        mockAssessment.answers = answers;
+
+        this.set('assessment', mockAssessment);
+        this.set('currentChallengeNumber', 2);
+
+        // when
+        const screen = await render(
+          hbs`<ProgressBar @assessment={{this.assessment}} @currentChallengeNumber={{this.currentChallengeNumber}} />`,
+        );
+
+        // then
+        assert.dom(screen.queryByText('Question 3 / 15')).doesNotExist();
+        assert.dom('.progress-bar-container').doesNotExist();
+      });
+    });
   });
 });

--- a/mon-pix/tests/integration/components/progress-bar-test.js
+++ b/mon-pix/tests/integration/components/progress-bar-test.js
@@ -22,6 +22,7 @@ module('Integration | Component | progress-bar', function (hooks) {
       type: 'CAMPAIGN',
       showProgressBar: true,
       hasCheckpoints: true,
+      showQuestionCounter: true,
     });
     mockAssessment.answers = answers;
 


### PR DESCRIPTION
## :pancakes: Problème
En exam, les indicateurs de progression ne doivent pas être affichés

## :bacon: Proposition

les cacher.
Checkpoints, levelup, progress bar et compteur de questions

## 🧃 Remarques

## :yum: Pour tester

Non rég sur TOUS les indicateurs de progression de TOUTES les modalités d'évaluation. MERCI
