### PR TITLE
[FEATURE] Créer le tag "En attente" lors d'un signalement d'épreuve ou d'extension sur Pix Certif (PIX-16913).

### DIFF
--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -12,6 +12,9 @@
             <PixTag @color="error">
               {{this.currentLiveAlertLabel}}
             </PixTag>
+            <PixTag @color="secondary">
+              {{t "common.forms.certification-labels.candidate-status.on-hold"}}
+            </PixTag>
           {{else}}
             <PixTag @color="success">
               {{t "common.forms.certification-labels.candidate-status.ongoing"}}

--- a/certif/tests/integration/components/session-supervising/candidate-in-list-test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list-test.js
@@ -1,6 +1,7 @@
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -425,9 +426,12 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
         const screen = await renderScreen(hbs`<SessionSupervising::CandidateInList @candidate={{this.candidate}} />`);
 
         // then
-        assert.dom(screen.getByText('Signalement en cours')).exists();
-        assert.dom(screen.queryByText('En cours')).doesNotExist();
-        assert.dom(screen.queryByText('Terminé')).doesNotExist();
+        assert
+          .dom(screen.getByText(t('common.forms.certification-labels.candidate-status.live-alerts.challenge.ongoing')))
+          .exists();
+        assert.dom(screen.getByText(t('common.forms.certification-labels.candidate-status.on-hold'))).exists();
+        assert.dom(screen.queryByText('common.forms.certification-labels.candidate-status.ongoing')).doesNotExist();
+        assert.dom(screen.queryByText(t('common.forms.certification-labels.candidate-status.finished'))).doesNotExist();
       });
 
       test('it displays the alert', async function (assert) {
@@ -485,8 +489,15 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
         const screen = await renderScreen(hbs`<SessionSupervising::CandidateInList @candidate={{this.candidate}} />`);
 
         // then
-        assert.dom(screen.getByText('Extension non détectée')).exists();
-        assert.dom(screen.queryByText('Signalement en cours')).doesNotExist();
+        assert
+          .dom(screen.getByText(t('common.forms.certification-labels.candidate-status.live-alerts.companion.ongoing')))
+          .exists();
+        assert.dom(screen.getByText(t('common.forms.certification-labels.candidate-status.on-hold'))).exists();
+        assert
+          .dom(
+            screen.queryByText(t('common.forms.certification-labels.candidate-status.live-alerts.challenge.ongoing')),
+          )
+          .doesNotExist();
       });
 
       test('it displays the alert', async function (assert) {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -113,6 +113,7 @@
               "ongoing": "Extension not detected"
             }
           },
+          "on-hold": "On hold",
           "ongoing": "In progress",
           "start": "Start"
         },

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -113,6 +113,7 @@
               "ongoing": "Extension non détectée"
             }
           },
+          "on-hold": "En attente",
           "ongoing": "En cours",
           "start": "Début"
         },


### PR DESCRIPTION
## :pancakes: Problème

Dans une volonté d'améliorer l'espace surveillant et la gestion des signalements, on souhaite pouvoir faire comprendre au surveillant que le candidat ne peut avancer dans sa certification tant qu'il n'a pas traîté son problème.

## :bacon: Proposition

Créer le tag "En attente", qui s'ajoute en plus du tag de signalement (d'épreuve et d'extension)

## :yum: Pour tester

- Créer une session avec certifv3@example.net
- Passer la certification avec certif-success@example.net
- Faire un signalement 
- Constater la présence du tag "En attente" coté espace surveillant
- Valider le signalement
- Retirer l'extension companion de son navigateur
- Constater la présence du tag "En attente" avec le tag extension coté espace surveillant

<img width="864" alt="Capture d’écran 2025-03-06 à 17 17 41" src="https://github.com/user-attachments/assets/8de9e1ce-8f8f-4bbd-ab5d-d2f2ec8d49ff" />

